### PR TITLE
another clang-format iteration for FWCore/Framework

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,109 @@
+---
+Language:        Cpp
+BasedOnStyle:  Google
+ColumnLimit:     120
+#didn't we want to change this?
+NamespaceIndentation: All
+SortIncludes:    false
+IndentWidth:     2
+AccessModifierOffset: -2
+PenaltyBreakComment: 30
+PenaltyExcessCharacter: 100
+AlignAfterOpenBracket: Align
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackParameters: false
+AlwaysBreakTemplateDeclarations: false
+ReflowComments: false
+#above are changes from CMSSW core sw meeting discussions (last 171128)
+
+#things unchanged
+#AccessModifierOffset: -1
+#AlignAfterOpenBracket: Align
+#AlignConsecutiveAssignments: false
+#AlignConsecutiveDeclarations: false
+#AlignEscapedNewlinesLeft: true
+#AlignOperands:   true
+#AlignTrailingComments: true
+#AllowAllParametersOfDeclarationOnNextLine: true
+#AllowShortBlocksOnASingleLine: false
+#AllowShortCaseLabelsOnASingleLine: false
+#AllowShortFunctionsOnASingleLine: All
+#AllowShortIfStatementsOnASingleLine: true
+#AllowShortLoopsOnASingleLine: true
+#AlwaysBreakAfterDefinitionReturnType: None
+#AlwaysBreakAfterReturnType: None
+#AlwaysBreakBeforeMultilineStrings: true
+#AlwaysBreakTemplateDeclarations: true
+#BinPackArguments: true
+#BinPackParameters: true
+#BraceWrapping:   
+#  AfterClass:      false
+#  AfterControlStatement: false
+#  AfterEnum:       false
+#  AfterFunction:   false
+#  AfterNamespace:  false
+#  AfterObjCDeclaration: false
+#  AfterStruct:     false
+#  AfterUnion:      false
+#  BeforeCatch:     false
+#  BeforeElse:      false
+#  IndentBraces:    false
+#BreakBeforeBinaryOperators: None
+#BreakBeforeBraces: Attach
+#BreakBeforeTernaryOperators: true
+#BreakConstructorInitializersBeforeComma: false
+#BreakAfterJavaFieldAnnotations: false
+#BreakStringLiterals: true
+#CommentPragmas:  '^ IWYU pragma:'
+#ConstructorInitializerAllOnOneLineOrOnePerLine: true
+#ConstructorInitializerIndentWidth: 4
+#ContinuationIndentWidth: 4
+#Cpp11BracedListStyle: true
+#DerivePointerAlignment: true
+#DisableFormat:   false
+#ExperimentalAutoDetectBinPacking: false
+#ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+#IncludeCategories: 
+#  - Regex:           '^<.*\.h>'
+#    Priority:        1
+#  - Regex:           '^<.*'
+#    Priority:        2
+#  - Regex:           '.*'
+#    Priority:        3
+#IncludeIsMainRegex: '([-_](test|unittest))?$'
+#IndentCaseLabels: true
+#IndentWidth:     2
+#IndentWrappedFunctionNames: false
+#JavaScriptQuotes: Leave
+#JavaScriptWrapImports: true
+#KeepEmptyLinesAtTheStartOfBlocks: false
+#MacroBlockBegin: ''
+#MacroBlockEnd:   ''
+#MaxEmptyLinesToKeep: 1
+#ObjCBlockIndentWidth: 2
+#ObjCSpaceAfterProperty: false
+#ObjCSpaceBeforeProtocolList: false
+#PenaltyBreakBeforeFirstCallParameter: 1
+#PenaltyBreakComment: 300
+#PenaltyBreakFirstLessLess: 120
+#PenaltyBreakString: 1000
+#PenaltyExcessCharacter: 1000000
+#PenaltyReturnTypeOnItsOwnLine: 200
+#PointerAlignment: Left
+#ReflowComments:  true
+#SpaceAfterCStyleCast: false
+#SpaceAfterTemplateKeyword: true
+#SpaceBeforeAssignmentOperators: true
+#SpaceBeforeParens: ControlStatements
+#SpaceInEmptyParentheses: false
+#SpacesBeforeTrailingComments: 2
+#SpacesInAngles:  false
+#SpacesInContainerLiterals: true
+#SpacesInCStyleCastParentheses: false
+#SpacesInParentheses: false
+#SpacesInSquareBrackets: false
+#Standard:        Auto
+#TabWidth:        8
+#UseTab:          Never
+...

--- a/FWCore/Framework/interface/Callback.h
+++ b/FWCore/Framework/interface/Callback.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     Callback
-// 
+//
 /**\class Callback Callback.h FWCore/Framework/interface/Callback.h
 
  Description: Functional object used as the 'callback' for the CallbackProxy
@@ -27,91 +27,81 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
-      
-      //need a virtual distructor since owner of callback only knows
-      // about the base class.  Other users of callback know the specific
-      // type
-      struct CallbackBase { virtual ~CallbackBase() {} };
-      
-      // The default decorator that does nothing
-      template< typename TRecord>
-      struct CallbackSimpleDecorator {
-         void pre(const TRecord&) {}
-         void post(const TRecord&) {}
-      };
-      
-      template<typename T,         //producer's type
-               typename TReturn,   //return type of the producer's method
-               typename TRecord,   //the record passed in as an argument
-               typename TDecorator //allows customization using pre/post calls 
-                             =CallbackSimpleDecorator<TRecord> >
-      class Callback : public CallbackBase {
-       public:
-         using  method_type = TReturn (T ::*)(const TRecord&);
-         
-         Callback(T* iProd, 
-                   method_type iMethod,
-                   const TDecorator& iDec = TDecorator()) :
-            proxyData_{},
-            producer_(iProd), 
-            method_(iMethod),
-            wasCalledForThisRecord_(false),
-            decorator_(iDec) {}
-         
-         
-         // ---------- const member functions ---------------------
-         
-         // ---------- static member functions --------------------
-         
-         // ---------- member functions ---------------------------
-         
-         
-         void operator()(const TRecord& iRecord) { 
-            if(!wasCalledForThisRecord_) {
-               decorator_.pre(iRecord);
-               storeReturnedValues((producer_->*method_)(iRecord));                  
-               wasCalledForThisRecord_ = true;
-               decorator_.post(iRecord);
-            }
-         }
-         
-         template<class DataT>
-            void holdOntoPointer(DataT* iData) {
-               proxyData_[produce::find_index<TReturn,DataT>::value] = iData;
-            }
-         
-         void storeReturnedValues(TReturn iReturn) {
-            //std::cout <<" storeReturnedValues "<< iReturn <<" " <<iReturn->value_ <<std::endl;
-            using type = typename produce::product_traits<TReturn>::type;
-            setData<typename type::head_type, typename type::tail_type>(iReturn);
-         }
-         
-         template<class RemainingContainerT, class DataT, class ProductsT>
-            void setData(ProductsT& iProducts) {
-               DataT* temp = reinterpret_cast< DataT*>(proxyData_[produce::find_index<TReturn,DataT>::value]) ;
-               if(nullptr != temp) { moveFromTo(iProducts, *temp); }
-               if constexpr( not std::is_same_v<produce::Null,RemainingContainerT> ) {
-                 setData<typename RemainingContainerT::head_type,
-                       typename RemainingContainerT::tail_type>(iProducts);
-               }
-            }
-         void newRecordComing() {
-            wasCalledForThisRecord_ = false;
-         }
-         
-     private:
-         Callback(const Callback&) = delete; // stop default
-         
-         const Callback& operator=(const Callback&) = delete; // stop default
+  namespace eventsetup {
 
-        std::array<void*, produce::size< TReturn >::value> proxyData_;
-         edm::propagate_const<T*> producer_;
-         method_type method_;
-         bool wasCalledForThisRecord_;
-         TDecorator decorator_;
-      };
-   }
-}
+    //need a virtual distructor since owner of callback only knows
+    // about the base class.  Other users of callback know the specific
+    // type
+    struct CallbackBase {
+      virtual ~CallbackBase() {}
+    };
+
+    // The default decorator that does nothing
+    template <typename TRecord> struct CallbackSimpleDecorator {
+      void pre(const TRecord&) {}
+      void post(const TRecord&) {}
+    };
+
+    template <typename T,          //producer's type
+              typename TReturn,    //return type of the producer's method
+              typename TRecord,    //the record passed in as an argument
+              typename TDecorator  //allows customization using pre/post calls
+              = CallbackSimpleDecorator<TRecord> >
+    class Callback : public CallbackBase {
+    public:
+      using method_type = TReturn (T ::*)(const TRecord&);
+
+      Callback(T* iProd, method_type iMethod, const TDecorator& iDec = TDecorator())
+          : proxyData_{}, producer_(iProd), method_(iMethod), wasCalledForThisRecord_(false), decorator_(iDec) {}
+
+      // ---------- const member functions ---------------------
+
+      // ---------- static member functions --------------------
+
+      // ---------- member functions ---------------------------
+
+      void operator()(const TRecord& iRecord) {
+        if (!wasCalledForThisRecord_) {
+          decorator_.pre(iRecord);
+          storeReturnedValues((producer_->*method_)(iRecord));
+          wasCalledForThisRecord_ = true;
+          decorator_.post(iRecord);
+        }
+      }
+
+      template <class DataT> void holdOntoPointer(DataT* iData) {
+        proxyData_[produce::find_index<TReturn, DataT>::value] = iData;
+      }
+
+      void storeReturnedValues(TReturn iReturn) {
+        //std::cout <<" storeReturnedValues "<< iReturn <<" " <<iReturn->value_ <<std::endl;
+        using type = typename produce::product_traits<TReturn>::type;
+        setData<typename type::head_type, typename type::tail_type>(iReturn);
+      }
+
+      template <class RemainingContainerT, class DataT, class ProductsT> void setData(ProductsT& iProducts) {
+        DataT* temp = reinterpret_cast<DataT*>(proxyData_[produce::find_index<TReturn, DataT>::value]);
+        if (nullptr != temp) {
+          moveFromTo(iProducts, *temp);
+        }
+        if constexpr (not std::is_same_v<produce::Null, RemainingContainerT>) {
+          setData<typename RemainingContainerT::head_type, typename RemainingContainerT::tail_type>(iProducts);
+        }
+      }
+      void newRecordComing() { wasCalledForThisRecord_ = false; }
+
+    private:
+      Callback(const Callback&) = delete;  // stop default
+
+      const Callback& operator=(const Callback&) = delete;  // stop default
+
+      std::array<void*, produce::size<TReturn>::value> proxyData_;
+      edm::propagate_const<T*> producer_;
+      method_type method_;
+      bool wasCalledForThisRecord_;
+      TDecorator decorator_;
+    };
+  }  // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/CallbackProxy.h
+++ b/FWCore/Framework/interface/CallbackProxy.h
@@ -33,15 +33,13 @@
 // forward declarations
 namespace edm::eventsetup {
 
-  template<class CallbackT, class RecordT, class DataT>
-  class CallbackProxy : public DataProxy {
+  template <class CallbackT, class RecordT, class DataT> class CallbackProxy : public DataProxy {
   public:
     using smart_pointer_traits = produce::smart_pointer_traits<DataT>;
     using value_type = typename smart_pointer_traits::type;
     using record_type = RecordT;
 
-    CallbackProxy(std::shared_ptr<CallbackT>& iCallback) :
-      callback_{iCallback} {
+    CallbackProxy(std::shared_ptr<CallbackT>& iCallback) : callback_{iCallback} {
       //The callback fills the data directly.  This is done so that the callback does not have to
       //  hold onto a temporary copy of the result of the callback since the callback is allowed
       //  to return multiple items where only one item is needed by this Proxy
@@ -75,6 +73,6 @@ namespace edm::eventsetup {
     edm::propagate_const<std::shared_ptr<CallbackT>> callback_;
   };
 
-}
+}  // namespace edm::eventsetup
 
 #endif

--- a/FWCore/Framework/interface/CommonParams.h
+++ b/FWCore/Framework/interface/CommonParams.h
@@ -12,24 +12,15 @@ namespace edm {
   //
 
   struct CommonParams {
-    CommonParams() :
-      maxEventsInput_(),
-      maxLumisInput_(),
-      maxSecondsUntilRampdown_() {
-    }
+    CommonParams() : maxEventsInput_(), maxLumisInput_(), maxSecondsUntilRampdown_() {}
 
-    CommonParams(int maxEvents,
-                 int maxLumis,
-                 int maxSecondsUntilRampdown) :
-      maxEventsInput_(maxEvents),
-      maxLumisInput_(maxLumis),
-      maxSecondsUntilRampdown_(maxSecondsUntilRampdown) {
-    }
-      
+    CommonParams(int maxEvents, int maxLumis, int maxSecondsUntilRampdown)
+        : maxEventsInput_(maxEvents), maxLumisInput_(maxLumis), maxSecondsUntilRampdown_(maxSecondsUntilRampdown) {}
+
     int maxEventsInput_;
     int maxLumisInput_;
     int maxSecondsUntilRampdown_;
-  }; // struct CommonParams
-}
+  };  // struct CommonParams
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ComponentDescription.h
+++ b/FWCore/Framework/interface/ComponentDescription.h
@@ -26,44 +26,30 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
-      struct ComponentDescription {
-         std::string label_; // A human friendly string that uniquely identifies the label
-         std::string type_;  // A human friendly string that uniquely identifies the name
-         bool isSource_;
-         bool isLooper_;
+  namespace eventsetup {
+    struct ComponentDescription {
+      std::string label_;  // A human friendly string that uniquely identifies the label
+      std::string type_;   // A human friendly string that uniquely identifies the name
+      bool isSource_;
+      bool isLooper_;
 
-         // ID of parameter set of the creator
-         ParameterSetID pid_;
+      // ID of parameter set of the creator
+      ParameterSetID pid_;
 
-         /* ----------- end of provenance information ------------- */
+      /* ----------- end of provenance information ------------- */
 
-         ComponentDescription() :
-             label_(),
-             type_(),
-             isSource_(false),
-             isLooper_(false),
-             pid_() {}
+      ComponentDescription() : label_(), type_(), isSource_(false), isLooper_(false), pid_() {}
 
-         ComponentDescription(std::string const& iType,
-                              std::string const& iLabel,
-                              bool iIsSource,
-                              bool iIsLooper = false) :
-                                label_(iLabel),
-                                type_(iType),
-                                isSource_(iIsSource),
-                                isLooper_(iIsLooper),
-                                pid_() {}
+      ComponentDescription(std::string const& iType, std::string const& iLabel, bool iIsSource, bool iIsLooper = false)
+          : label_(iLabel), type_(iType), isSource_(iIsSource), isLooper_(iIsLooper), pid_() {}
 
-         bool operator<(ComponentDescription const& iRHS) const {
-            return (type_ == iRHS.type_) ? (label_ < iRHS.label_) : (type_<iRHS.type_);
-         }
-         bool operator==(ComponentDescription const& iRHS) const {
-            return label_ == iRHS.label_ &&
-            type_ == iRHS.type_ &&
-            isSource_ == iRHS.isSource_;
-         }
-      };
-   }
-}
+      bool operator<(ComponentDescription const& iRHS) const {
+        return (type_ == iRHS.type_) ? (label_ < iRHS.label_) : (type_ < iRHS.type_);
+      }
+      bool operator==(ComponentDescription const& iRHS) const {
+        return label_ == iRHS.label_ && type_ == iRHS.type_ && isSource_ == iRHS.isSource_;
+      }
+    };
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ComponentFactory.h
+++ b/FWCore/Framework/interface/ComponentFactory.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ComponentFactory
-// 
+//
 /**\class ComponentFactory ComponentFactory.h FWCore/Framework/interface/ComponentFactory.h
 
  Description: Factory for building the Factories for the various 'plug-in' components needed for the EventSetup
@@ -34,100 +34,94 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
-      class EventSetupProvider;
-      class EventSetupsController;
-      
-template<typename T>
-  class ComponentFactory
-{
+  namespace eventsetup {
+    class EventSetupProvider;
+    class EventSetupsController;
 
-   public:
-   ComponentFactory(): makers_() {}
-   //~ComponentFactory();
+    template <typename T> class ComponentFactory {
+    public:
+      ComponentFactory() : makers_() {}
+      //~ComponentFactory();
 
-   typedef  ComponentMakerBase<T> Maker;
-   typedef std::map<std::string, std::shared_ptr<Maker> > MakerMap;
-   typedef typename T::base_type base_type;
+      typedef ComponentMakerBase<T> Maker;
+      typedef std::map<std::string, std::shared_ptr<Maker> > MakerMap;
+      typedef typename T::base_type base_type;
       // ---------- const member functions ---------------------
-   std::shared_ptr<base_type> addTo(EventSetupsController& esController,
-                                      EventSetupProvider& iProvider,
-                                      edm::ParameterSet const& iConfiguration,
-                                      bool replaceExisting = false) const
-      {
-         std::string modtype = iConfiguration.template getParameter<std::string>("@module_type");
-         //cerr << "Factory: module_type = " << modtype << endl;
-         typename MakerMap::iterator it = makers_.find(modtype);
-         
-         if(it == makers_.end())
-         {
-            std::shared_ptr<Maker> wm(edmplugin::PluginFactory<ComponentMakerBase<T>* ()>::get()->create(modtype));
-            
-            if(wm.get() == nullptr) {
-	      Exception::throwThis(errors::Configuration,
-	      "UnknownModule",
-	       T::name().c_str(),
-              " of type ",
-              modtype.c_str(),
-              " has not been registered.\n"
-              "Perhaps your module type is misspelled or is not a "
-              "framework plugin.\n"
-              "Try running EdmPluginDump to obtain a list of "
-              "available Plugins.");            
-            }
-            
-            //cerr << "Factory: created the worker" << endl;
-            
-            std::pair<typename MakerMap::iterator,bool> ret =
-               makers_.insert(std::pair<std::string,std::shared_ptr<Maker> >(modtype,wm));
-            
-            if(ret.second == false) {
-	      Exception::throwThis(errors::Configuration,"Maker Factory map insert failed");
-            }
-            
-            it = ret.first;
-         }
-         
-         try {
-           return convertException::wrap([&]() -> std::shared_ptr<base_type> {
-             return it->second->addTo(esController, iProvider, iConfiguration, replaceExisting);
-           });
-         }
-         catch(cms::Exception & iException) {
-           std::string edmtype = iConfiguration.template getParameter<std::string>("@module_edm_type");
-           std::string label = iConfiguration.template getParameter<std::string>("@module_label");
-           std::ostringstream ost;
-           ost << "Constructing " << edmtype << ": class=" << modtype << " label='" << label << "'";
-           iException.addContext(ost.str());
-           throw;
-         }
-         return std::shared_ptr<base_type>();
+      std::shared_ptr<base_type> addTo(EventSetupsController& esController,
+                                       EventSetupProvider& iProvider,
+                                       edm::ParameterSet const& iConfiguration,
+                                       bool replaceExisting = false) const {
+        std::string modtype = iConfiguration.template getParameter<std::string>("@module_type");
+        //cerr << "Factory: module_type = " << modtype << endl;
+        typename MakerMap::iterator it = makers_.find(modtype);
+
+        if (it == makers_.end()) {
+          std::shared_ptr<Maker> wm(edmplugin::PluginFactory<ComponentMakerBase<T>*()>::get()->create(modtype));
+
+          if (wm.get() == nullptr) {
+            Exception::throwThis(errors::Configuration, "UnknownModule", T::name().c_str(), " of type ",
+                                 modtype.c_str(),
+                                 " has not been registered.\n"
+                                 "Perhaps your module type is misspelled or is not a "
+                                 "framework plugin.\n"
+                                 "Try running EdmPluginDump to obtain a list of "
+                                 "available Plugins.");
+          }
+
+          //cerr << "Factory: created the worker" << endl;
+
+          std::pair<typename MakerMap::iterator, bool> ret =
+              makers_.insert(std::pair<std::string, std::shared_ptr<Maker> >(modtype, wm));
+
+          if (ret.second == false) {
+            Exception::throwThis(errors::Configuration, "Maker Factory map insert failed");
+          }
+
+          it = ret.first;
+        }
+
+        try {
+          return convertException::wrap([&]() -> std::shared_ptr<base_type> {
+            return it->second->addTo(esController, iProvider, iConfiguration, replaceExisting);
+          });
+        } catch (cms::Exception& iException) {
+          std::string edmtype = iConfiguration.template getParameter<std::string>("@module_edm_type");
+          std::string label = iConfiguration.template getParameter<std::string>("@module_label");
+          std::ostringstream ost;
+          ost << "Constructing " << edmtype << ": class=" << modtype << " label='" << label << "'";
+          iException.addContext(ost.str());
+          throw;
+        }
+        return std::shared_ptr<base_type>();
       }
-   
+
       // ---------- static member functions --------------------
       static ComponentFactory<T> const* get();
 
       // ---------- member functions ---------------------------
 
-   private:
-      
-      ComponentFactory(const ComponentFactory&); // stop default
+    private:
+      ComponentFactory(const ComponentFactory&);  // stop default
 
-      const ComponentFactory& operator=(const ComponentFactory&); // stop default
+      const ComponentFactory& operator=(const ComponentFactory&);  // stop default
 
       // ---------- member data --------------------------------
       mutable MakerMap makers_;
-};
+    };
 
-   }
-}
-#define COMPONENTFACTORY_GET(_type_) \
-EDM_REGISTER_PLUGINFACTORY(edmplugin::PluginFactory<edm::eventsetup::ComponentMakerBase<_type_>* ()>,_type_::name()); \
-static edm::eventsetup::ComponentFactory<_type_> const s_dummyfactory; \
-namespace edm { namespace eventsetup { \
-template<> edm::eventsetup::ComponentFactory<_type_> const* edm::eventsetup::ComponentFactory<_type_>::get() \
-{ return &s_dummyfactory; } \
-  } } \
-typedef int componentfactory_get_needs_semicolon
+  }  // namespace eventsetup
+}  // namespace edm
+#define COMPONENTFACTORY_GET(_type_)                                                                                  \
+  EDM_REGISTER_PLUGINFACTORY(edmplugin::PluginFactory<edm::eventsetup::ComponentMakerBase<_type_>*()>,                \
+                             _type_::name());                                                                         \
+  static edm::eventsetup::ComponentFactory<_type_> const s_dummyfactory;                                              \
+  namespace edm {                                                                                                     \
+    namespace eventsetup {                                                                                            \
+      template <> edm::eventsetup::ComponentFactory<_type_> const* edm::eventsetup::ComponentFactory<_type_>::get() { \
+        return &s_dummyfactory;                                                                                       \
+      }                                                                                                               \
+    }                                                                                                                 \
+  }                                                                                                                   \
+  typedef int componentfactory_get_needs_semicolon
 
 #endif

--- a/FWCore/Framework/interface/ComponentMaker.h
+++ b/FWCore/Framework/interface/ComponentMaker.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ComponentMaker
-// 
+//
 /**\class ComponentMaker ComponentMaker.h FWCore/Framework/interface/ComponentMaker.h
 
  Description: <one line class summary>
@@ -30,51 +30,47 @@
 // forward declarations
 
 namespace edm {
-   namespace eventsetup {
-      class EventSetupProvider;
-      class EventSetupsController;
-      class DataProxyProvider;
-    
-      class ComponentMakerBaseHelper
-      {
-      public:
-        virtual ~ComponentMakerBaseHelper() {}
-      protected:
-        ComponentDescription createComponentDescription(ParameterSet const& iConfiguration) const;
-      };
- 
-      template <class T>
-      class ComponentMakerBase : public ComponentMakerBaseHelper {
-      public:
-         typedef typename T::base_type base_type;
-         virtual std::shared_ptr<base_type> addTo(EventSetupsController& esController,
-                                                  EventSetupProvider& iProvider,
-                                                  ParameterSet const& iConfiguration,
-                                                  bool replaceExisting) const = 0;
-      };
-      
-   template <class T, class TComponent>
-   class ComponentMaker : public ComponentMakerBase<T>
-   {
+  namespace eventsetup {
+    class EventSetupProvider;
+    class EventSetupsController;
+    class DataProxyProvider;
 
-   public:
-   ComponentMaker() {}
+    class ComponentMakerBaseHelper {
+    public:
+      virtual ~ComponentMakerBaseHelper() {}
+
+    protected:
+      ComponentDescription createComponentDescription(ParameterSet const& iConfiguration) const;
+    };
+
+    template <class T> class ComponentMakerBase : public ComponentMakerBaseHelper {
+    public:
+      typedef typename T::base_type base_type;
+      virtual std::shared_ptr<base_type> addTo(EventSetupsController& esController,
+                                               EventSetupProvider& iProvider,
+                                               ParameterSet const& iConfiguration,
+                                               bool replaceExisting) const = 0;
+    };
+
+    template <class T, class TComponent> class ComponentMaker : public ComponentMakerBase<T> {
+    public:
+      ComponentMaker() {}
       //virtual ~ComponentMaker();
-   typedef typename T::base_type base_type;
+      typedef typename T::base_type base_type;
 
       // ---------- const member functions ---------------------
-   std::shared_ptr<base_type> addTo(EventSetupsController& esController,
-                                              EventSetupProvider& iProvider,
-                                              ParameterSet const& iConfiguration,
-                                              bool replaceExisting) const override;
-   
+      std::shared_ptr<base_type> addTo(EventSetupsController& esController,
+                                       EventSetupProvider& iProvider,
+                                       ParameterSet const& iConfiguration,
+                                       bool replaceExisting) const override;
+
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
-   private:
-      ComponentMaker(const ComponentMaker&) = delete; // stop default
+    private:
+      ComponentMaker(const ComponentMaker&) = delete;  // stop default
 
-      const ComponentMaker& operator=(const ComponentMaker&) = delete; // stop default
+      const ComponentMaker& operator=(const ComponentMaker&) = delete;  // stop default
 
       void setDescription(DataProxyProvider* iProv, const ComponentDescription& iDesc) const {
         iProv->setDescription(iDesc);
@@ -87,69 +83,65 @@ namespace edm {
         // the ParameterSet is not sent to the base class we must set the value after construction
         iProv->setAppendToDataLabel(iPSet);
       }
-      void setDescription(void*, const ComponentDescription&) const {
-      }
-      void setDescriptionForFinder(void*, const ComponentDescription&) const {
-      }
-      void setPostConstruction(void*, const edm::ParameterSet&) const {
-      }
+      void setDescription(void*, const ComponentDescription&) const {}
+      void setDescriptionForFinder(void*, const ComponentDescription&) const {}
+      void setPostConstruction(void*, const edm::ParameterSet&) const {}
       // ---------- member data --------------------------------
+    };
 
-};
+    template <class T, class TComponent>
+    std::shared_ptr<typename ComponentMaker<T, TComponent>::base_type> ComponentMaker<T, TComponent>::addTo(
+        EventSetupsController& esController,
+        EventSetupProvider& iProvider,
+        ParameterSet const& iConfiguration,
+        bool replaceExisting) const {
+      // This adds components to the EventSetupProvider for the process. It might
+      // make a new component then add it or reuse a component from an earlier
+      // SubProcess or the top level process and add that.
 
-template< class T, class TComponent>
-std::shared_ptr<typename ComponentMaker<T,TComponent>::base_type>
-ComponentMaker<T,TComponent>::addTo(EventSetupsController& esController,
-                                    EventSetupProvider& iProvider,
-                                    ParameterSet const& iConfiguration,
-                                    bool replaceExisting) const
-{
-   // This adds components to the EventSetupProvider for the process. It might
-   // make a new component then add it or reuse a component from an earlier
-   // SubProcess or the top level process and add that.
+      if (!replaceExisting) {
+        std::shared_ptr<typename T::base_type> alreadyMadeComponent =
+            T::getComponentAndRegisterProcess(esController, iConfiguration);
 
-   if (!replaceExisting) {
-      std::shared_ptr<typename T::base_type> alreadyMadeComponent = T::getComponentAndRegisterProcess(esController, iConfiguration);
-
-      if (alreadyMadeComponent) {
-         // This is for the case when a component is shared between
-         // a SubProcess and a previous SubProcess or the top level process
-         // because the component has an identical configuration to a component
-         // from the top level process or earlier SubProcess.
-         std::shared_ptr<TComponent> component(std::static_pointer_cast<TComponent, typename T::base_type>(alreadyMadeComponent));
-         T::addTo(iProvider, component, iConfiguration, true);
-         return component;
+        if (alreadyMadeComponent) {
+          // This is for the case when a component is shared between
+          // a SubProcess and a previous SubProcess or the top level process
+          // because the component has an identical configuration to a component
+          // from the top level process or earlier SubProcess.
+          std::shared_ptr<TComponent> component(
+              std::static_pointer_cast<TComponent, typename T::base_type>(alreadyMadeComponent));
+          T::addTo(iProvider, component, iConfiguration, true);
+          return component;
+        }
       }
-   }
 
-   std::shared_ptr<TComponent> component = std::make_shared<TComponent>(iConfiguration);
-   ComponentDescription description =
-      this->createComponentDescription(iConfiguration);
+      std::shared_ptr<TComponent> component = std::make_shared<TComponent>(iConfiguration);
+      ComponentDescription description = this->createComponentDescription(iConfiguration);
 
-   this->setDescription(component.get(),description);
-   this->setDescriptionForFinder(component.get(),description);
-   this->setPostConstruction(component.get(),iConfiguration);
+      this->setDescription(component.get(), description);
+      this->setDescriptionForFinder(component.get(), description);
+      this->setPostConstruction(component.get(), iConfiguration);
 
-   if (replaceExisting) {
-      // This case is for ESProducers where in the first pass
-      // the algorithm thought the component could be shared
-      // across SubProcess's because there was an ESProducer
-      // from a previous process with an identical configuration.
-      // But in a later check it was determined that sharing was not
-      // possible because other components associated with the
-      // same record or records that record depends on had
-      // differing configurations.
-      T::replaceExisting(iProvider, component);
-   } else {
-      // This is for the case when a new component is being constructed.
-      // All components for the top level process fall in this category.
-      // Or it could be a SubProcess where neither the top level process
-      // nor any prior SubProcess had a component with exactly the same configuration.
-      T::addTo(iProvider, component, iConfiguration, false);
-      T::putComponent(esController, iConfiguration, component);
-   }
-   return component;
-}
-   }
-}
+      if (replaceExisting) {
+        // This case is for ESProducers where in the first pass
+        // the algorithm thought the component could be shared
+        // across SubProcess's because there was an ESProducer
+        // from a previous process with an identical configuration.
+        // But in a later check it was determined that sharing was not
+        // possible because other components associated with the
+        // same record or records that record depends on had
+        // differing configurations.
+        T::replaceExisting(iProvider, component);
+      } else {
+        // This is for the case when a new component is being constructed.
+        // All components for the top level process fall in this category.
+        // Or it could be a SubProcess where neither the top level process
+        // nor any prior SubProcess had a component with exactly the same configuration.
+        T::addTo(iProvider, component, iConfiguration, false);
+        T::putComponent(esController, iConfiguration, component);
+      }
+      return component;
+    }
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ConstProductRegistry.h
+++ b/FWCore/Framework/interface/ConstProductRegistry.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ConstProductRegistry
-// 
+//
 /**\class ConstProductRegistry ConstProductRegistry.h FWCore/Framework/interface/ConstProductRegistry.h
 
 Description: Provides a 'service' interface to the ProductRegistry
@@ -29,54 +29,45 @@ Usage:
 
 // forward declarations
 namespace edm {
-  class ConstProductRegistry
-  {
-
+  class ConstProductRegistry {
   public:
     typedef ProductRegistry::ProductList ProductList;
-     
-    ConstProductRegistry(SignallingProductRegistry& iReg) : reg_(&iReg) { }
 
-    ConstProductRegistry(ConstProductRegistry const&) = delete; // Disallow copying and moving
-    ConstProductRegistry& operator=(ConstProductRegistry const&) = delete; // Disallow copying and moving
-     
+    ConstProductRegistry(SignallingProductRegistry& iReg) : reg_(&iReg) {}
+
+    ConstProductRegistry(ConstProductRegistry const&) = delete;             // Disallow copying and moving
+    ConstProductRegistry& operator=(ConstProductRegistry const&) = delete;  // Disallow copying and moving
+
     // ---------- const member functions ---------------------
-    ProductRegistry const& productRegistry() const {return *reg_;}
+    ProductRegistry const& productRegistry() const { return *reg_; }
 
-    ProductList const& productList() const {return reg_->productList();}
+    ProductList const& productList() const { return reg_->productList(); }
 
     // Return all the branch names currently known to *this.  This
     // does a return-by-value of the vector so that it may be used in
     // a colon-initialization list.
-    std::vector<std::string> allBranchNames() const {return reg_->allBranchNames();}
+    std::vector<std::string> allBranchNames() const { return reg_->allBranchNames(); }
 
     // Return pointers to (const) BranchDescriptions for all the
     // BranchDescriptions known to *this.  This does a
     // return-by-value of the vector so that it may be used in a
     // colon-initialization list.
-    std::vector<BranchDescription const*> allBranchDescriptions() const {return reg_->allBranchDescriptions();}
+    std::vector<BranchDescription const*> allBranchDescriptions() const { return reg_->allBranchDescriptions(); }
 
-    bool anyProductProduced() const {return reg_->anyProductProduced();}
-     
-    template< class T>
-    void watchProductAdditions(const T& iFunc)
-    {
-      serviceregistry::connect_but_block_self(reg_->productAddedSignal_, 
-					      iFunc);
+    bool anyProductProduced() const { return reg_->anyProductProduced(); }
+
+    template <class T> void watchProductAdditions(const T& iFunc) {
+      serviceregistry::connect_but_block_self(reg_->productAddedSignal_, iFunc);
     }
-    template< class T, class TMethod>
-    void watchProductAdditions(T const& iObj, TMethod iMethod)
-    {
+    template <class T, class TMethod> void watchProductAdditions(T const& iObj, TMethod iMethod) {
       using std::placeholders::_1;
-      serviceregistry::connect_but_block_self(reg_->productAddedSignal_, 
-					      std::bind(iMethod, iObj,_1));
+      serviceregistry::connect_but_block_self(reg_->productAddedSignal_, std::bind(iMethod, iObj, _1));
     }
-     
-  private:
 
+  private:
     // ---------- member data --------------------------------
     edm::propagate_const<SignallingProductRegistry*> reg_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ConsumesCollector.h
+++ b/FWCore/Framework/interface/ConsumesCollector.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     edm::ConsumesCollector
-// 
+//
 /**\class edm::ConsumesCollector ConsumesCollector.h "FWCore/Framework/interface/ConsumesCollector.h"
 
  Description: Helper class to gather consumes information for EDConsumerBase class.
@@ -35,12 +35,9 @@ a functor passed to the Framework with a call to callWhenNewProductsRegistered.
 // forward declarations
 namespace edm {
   class EDConsumerBase;
-  
-  class ConsumesCollector
-  {
-    
-  public:
 
+  class ConsumesCollector {
+  public:
     ConsumesCollector() = delete;
     ConsumesCollector(ConsumesCollector const&) = default;
     ConsumesCollector(ConsumesCollector&&) = default;
@@ -48,81 +45,60 @@ namespace edm {
     ConsumesCollector& operator=(ConsumesCollector&&) = default;
 
     // ---------- member functions ---------------------------
-    template <typename ProductType, BranchType B=InEvent>
+    template <typename ProductType, BranchType B = InEvent>
     EDGetTokenT<ProductType> consumes(edm::InputTag const& tag) {
-      return m_consumer->consumes<ProductType,B>(tag);
+      return m_consumer->consumes<ProductType, B>(tag);
     }
-    
-    EDGetToken consumes(const TypeToGet& id, edm::InputTag const& tag) {
-      return m_consumer->consumes(id,tag);
+
+    EDGetToken consumes(const TypeToGet& id, edm::InputTag const& tag) { return m_consumer->consumes(id, tag); }
+
+    template <BranchType B> EDGetToken consumes(TypeToGet const& id, edm::InputTag const& tag) {
+      return m_consumer->consumes<B>(id, tag);
     }
-    
-    template <BranchType B>
-    EDGetToken consumes(TypeToGet const& id, edm::InputTag const& tag) {
-      return m_consumer->consumes<B>(id,tag);
-    }
-    
-    template <typename ProductType, BranchType B=InEvent>
+
+    template <typename ProductType, BranchType B = InEvent>
     EDGetTokenT<ProductType> mayConsume(edm::InputTag const& tag) {
-      return m_consumer->mayConsume<ProductType,B>(tag);
+      return m_consumer->mayConsume<ProductType, B>(tag);
     }
-    
-    
-    EDGetToken mayConsume(const TypeToGet& id, edm::InputTag const& tag) {
-      return m_consumer->mayConsume(id,tag);
+
+    EDGetToken mayConsume(const TypeToGet& id, edm::InputTag const& tag) { return m_consumer->mayConsume(id, tag); }
+
+    template <BranchType B> EDGetToken mayConsume(const TypeToGet& id, edm::InputTag const& tag) {
+      return m_consumer->mayConsume<B>(id, tag);
     }
-    
-    template <BranchType B>
-    EDGetToken mayConsume(const TypeToGet& id, edm::InputTag const& tag) {
-      return m_consumer->mayConsume<B>(id,tag);
+
+    template <typename ProductType, BranchType B = InEvent> void consumesMany() {
+      m_consumer->consumesMany<ProductType, B>();
     }
-    
-    template <typename ProductType, BranchType B=InEvent>
-    void consumesMany() {
-      m_consumer->consumesMany<ProductType,B>();
-    }
-    
-    
-    void consumesMany(const TypeToGet& id) {
-      m_consumer->consumesMany(id);
-    }
-    
-    template <BranchType B>
-    void consumesMany(const TypeToGet& id) {
-      m_consumer->consumesMany<B>(id);
-    }
-    
+
+    void consumesMany(const TypeToGet& id) { m_consumer->consumesMany(id); }
+
+    template <BranchType B> void consumesMany(const TypeToGet& id) { m_consumer->consumesMany<B>(id); }
+
     // For consuming event-setup products
-    template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event>
-    auto esConsumes()
-    {
+    template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event> auto esConsumes() {
       return esConsumes<ESProduct, ESRecord, Tr>(ESInputTag{});
     }
 
     template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event>
-    auto esConsumes(ESInputTag const& tag)
-    {
+    auto esConsumes(ESInputTag const& tag) {
       return m_consumer->esConsumes<ESProduct, ESRecord, Tr>(tag);
     }
 
     template <typename ESProduct, Transition Tr = Transition::Event>
-    auto esConsumes(eventsetup::EventSetupRecordKey const& key, ESInputTag const& tag)
-    {
+    auto esConsumes(eventsetup::EventSetupRecordKey const& key, ESInputTag const& tag) {
       return m_consumer->esConsumes<ESProduct, Tr>(key, tag);
     }
 
   private:
     //only EDConsumerBase is allowed to make an instance of this class
     friend class EDConsumerBase;
-    
-    ConsumesCollector(EDConsumerBase* iConsumer):
-    m_consumer(iConsumer) {}
+
+    ConsumesCollector(EDConsumerBase* iConsumer) : m_consumer(iConsumer) {}
 
     // ---------- member data --------------------------------
     edm::propagate_const<EDConsumerBase*> m_consumer;
-    
   };
-}
-
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/DataKey.h
+++ b/FWCore/Framework/interface/DataKey.h
@@ -26,35 +26,18 @@
 
 // forward declarations
 namespace edm::eventsetup {
-  class DataKey
-  {
-
+  class DataKey {
     friend void swap(DataKey&, DataKey&);
+
   public:
     enum DoNotCopyMemory { kDoNotCopyMemory };
 
     DataKey();
-    DataKey(const TypeTag& iType,
-            const IdTags& iId) :
-      type_(iType),
-      name_(iId),
-      ownMemory_() {
-      makeCopyOfMemory();
-    }
+    DataKey(const TypeTag& iType, const IdTags& iId) : type_(iType), name_(iId), ownMemory_() { makeCopyOfMemory(); }
 
-    DataKey(const TypeTag& iType,
-            const IdTags& iId,
-            DoNotCopyMemory) :
-      type_(iType),
-      name_(iId),
-      ownMemory_(false) {}
+    DataKey(const TypeTag& iType, const IdTags& iId, DoNotCopyMemory) : type_(iType), name_(iId), ownMemory_(false) {}
 
-    DataKey(const DataKey& iRHS) :
-      type_(iRHS.type_),
-      name_(iRHS.name_),
-      ownMemory_() {
-      makeCopyOfMemory();
-    }
+    DataKey(const DataKey& iRHS) : type_(iRHS.type_), name_(iRHS.name_), ownMemory_() { makeCopyOfMemory(); }
 
     DataKey& operator=(const DataKey&);
 
@@ -65,23 +48,18 @@ namespace edm::eventsetup {
     const NameTag& name() const { return name_; }
 
     bool operator==(const DataKey& iRHS) const;
-    inline bool operator!=(const DataKey& iRHS) const {
-      return not (*this == iRHS);
-    }
+    inline bool operator!=(const DataKey& iRHS) const { return not(*this == iRHS); }
     bool operator<(const DataKey& iRHS) const;
 
     // ---------- static member functions --------------------
-    template<class T>
-    static TypeTag makeTypeTag() {
-      return heterocontainer::HCTypeTag::make<T>();
-    }
+    template <class T> static TypeTag makeTypeTag() { return heterocontainer::HCTypeTag::make<T>(); }
 
     // ---------- member functions ---------------------------
 
   private:
     void makeCopyOfMemory();
     void releaseMemory() {
-      if(ownMemory_) {
+      if (ownMemory_) {
         deleteMemory();
         ownMemory_ = false;
       }
@@ -96,11 +74,6 @@ namespace edm::eventsetup {
   };
 
   // Free swap function
-  inline
-  void
-  swap(DataKey& a, DataKey& b)
-  {
-    a.swap(b);
-  }
-}
+  inline void swap(DataKey& a, DataKey& b) { a.swap(b); }
+}  // namespace edm::eventsetup
 #endif

--- a/FWCore/Framework/interface/DataKeyTags.h
+++ b/FWCore/Framework/interface/DataKeyTags.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     DataKeyTags
-// 
+//
 /**\class DataKeyTags DataKeyTags.h FWCore/Framework/interface/DataKeyTags.h
 
  Description: <one line class summary>
@@ -25,30 +25,30 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
-      
-      typedef heterocontainer::HCTypeTag TypeTag;
-      
-      class SimpleStringTag {
-        public:
-         SimpleStringTag(const char* iString) : tag_(iString) {}
-         SimpleStringTag() : tag_("") {}
-         bool operator==(const SimpleStringTag& iRHS) const ;
-         bool operator<(const SimpleStringTag& iRHS) const ;
-         
-         const char* value() const { return tag_; }
-         
-        private:
-         const char* tag_;
-      };
+  namespace eventsetup {
 
-      class NameTag : public SimpleStringTag {
-       public:
-         NameTag(const char* iUsage) : SimpleStringTag(iUsage) {}
-         NameTag() : SimpleStringTag() {}
-      };
-      
-      typedef NameTag IdTags;
-   }
-}
+    typedef heterocontainer::HCTypeTag TypeTag;
+
+    class SimpleStringTag {
+    public:
+      SimpleStringTag(const char* iString) : tag_(iString) {}
+      SimpleStringTag() : tag_("") {}
+      bool operator==(const SimpleStringTag& iRHS) const;
+      bool operator<(const SimpleStringTag& iRHS) const;
+
+      const char* value() const { return tag_; }
+
+    private:
+      const char* tag_;
+    };
+
+    class NameTag : public SimpleStringTag {
+    public:
+      NameTag(const char* iUsage) : SimpleStringTag(iUsage) {}
+      NameTag() : SimpleStringTag() {}
+    };
+
+    typedef NameTag IdTags;
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -27,75 +27,78 @@
 
 // forward declarations
 namespace edm {
-   class ActivityRegistry;
+  class ActivityRegistry;
 
-   namespace eventsetup {
-      struct ComponentDescription;
-      class DataKey;
-      class EventSetupRecordImpl;
+  namespace eventsetup {
+    struct ComponentDescription;
+    class DataKey;
+    class EventSetupRecordImpl;
 
-      class DataProxy {
+    class DataProxy {
+    public:
+      DataProxy();
+      virtual ~DataProxy();
 
-      public:
-         DataProxy();
-         virtual ~DataProxy();
+      // ---------- const member functions ---------------------
+      bool cacheIsValid() const { return cacheIsValid_.load(std::memory_order_acquire); }
 
-         // ---------- const member functions ---------------------
-         bool cacheIsValid() const { return cacheIsValid_.load(std::memory_order_acquire); }
+      void doGet(EventSetupRecordImpl const& iRecord,
+                 DataKey const& iKey,
+                 bool iTransiently,
+                 ActivityRegistry const*) const;
+      void const* get(EventSetupRecordImpl const&,
+                      DataKey const& iKey,
+                      bool iTransiently,
+                      ActivityRegistry const*) const;
 
-         void doGet(EventSetupRecordImpl const& iRecord, DataKey const& iKey, bool iTransiently, ActivityRegistry const*) const;
-         void const* get(EventSetupRecordImpl const&, DataKey const& iKey, bool iTransiently, ActivityRegistry const*) const;
+      ///returns the description of the DataProxyProvider which owns this Proxy
+      ComponentDescription const* providerDescription() const { return description_; }
+      // ---------- static member functions --------------------
 
-         ///returns the description of the DataProxyProvider which owns this Proxy
-         ComponentDescription const* providerDescription() const {
-            return description_;
-         }
-         // ---------- static member functions --------------------
+      // ---------- member functions ---------------------------
+      void invalidate() {
+        clearCacheIsValid();
+        invalidateCache();
+      }
 
-         // ---------- member functions ---------------------------
-         void invalidate() {
-            clearCacheIsValid();
-            invalidateCache();
-         }
+      void resetIfTransient();
 
-         void resetIfTransient();
+      void setProviderDescription(ComponentDescription const* iDesc) { description_ = iDesc; }
 
-         void setProviderDescription(ComponentDescription const* iDesc) {
-            description_ = iDesc;
-         }
-      protected:
-         /**This is the function which does the real work of getting the data if it is not
+    protected:
+      /**This is the function which does the real work of getting the data if it is not
           already cached.  The returning 'void const*' must point to an instance of the class
           type corresponding to the type designated in iKey. So if iKey refers to a base class interface
           the pointer must be a pointer to that base class interface and not a pointer to an inheriting class
           instance.
           */
-         virtual void const* getImpl(EventSetupRecordImpl const&, DataKey const& iKey) =0;
+      virtual void const* getImpl(EventSetupRecordImpl const&, DataKey const& iKey) = 0;
 
-         /** indicates that the Proxy should invalidate any cached information
+      /** indicates that the Proxy should invalidate any cached information
           as that information has 'expired' (i.e. we have moved to a new IOV)
           */
-         virtual void invalidateCache() = 0;
+      virtual void invalidateCache() = 0;
 
-         /** indicates that the Proxy should invalidate any cached information
+      /** indicates that the Proxy should invalidate any cached information
           as that information was accessed transiently and therefore is not
           intended to be kept over the entire IOV.  Default is to call
           invalidateCache().
           */
-         virtual void invalidateTransientCache();
+      virtual void invalidateTransientCache();
 
-         void clearCacheIsValid();
-      private:
-         DataProxy(DataProxy const&) = delete; // stop default
+      void clearCacheIsValid();
 
-         DataProxy const& operator=(DataProxy const&) = delete; // stop default
+    private:
+      DataProxy(DataProxy const&) = delete;  // stop default
 
-         // ---------- member data --------------------------------
-         CMS_THREAD_SAFE mutable void const* cache_; //protected by a global mutex
-         mutable std::atomic<bool> cacheIsValid_;
-         mutable std::atomic<bool> nonTransientAccessRequested_;
-         ComponentDescription const* description_;
-      };
-   }
-}
+      DataProxy const& operator=(DataProxy const&) = delete;  // stop default
+
+      // ---------- member data --------------------------------
+      CMS_THREAD_SAFE mutable void const* cache_;  //protected by a global mutex
+      mutable std::atomic<bool> cacheIsValid_;
+      mutable std::atomic<bool> nonTransientAccessRequested_;
+      ComponentDescription const* description_;
+    };
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/DataProxyProvider.h
+++ b/FWCore/Framework/interface/DataProxyProvider.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     DataProxyProvider
-// 
+//
 /**\class DataProxyProvider DataProxyProvider.h FWCore/Framework/interface/DataProxyProvider.h
 
  Description: <one line class summary>
@@ -33,93 +33,80 @@
 
 // forward declarations
 namespace edm {
-   class ValidityInterval;
-   class ParameterSet;
-   class ConfigurationDescriptions;
-   namespace eventsetup {
-      class DataProxy;
-      
-      
-class DataProxyProvider
-{
+  class ValidityInterval;
+  class ParameterSet;
+  class ConfigurationDescriptions;
+  namespace eventsetup {
+    class DataProxy;
 
-   public:   
-      typedef std::vector< EventSetupRecordKey> Keys;
+    class DataProxyProvider {
+    public:
+      typedef std::vector<EventSetupRecordKey> Keys;
       typedef std::vector<std::pair<DataKey, edm::propagate_const<std::shared_ptr<DataProxy>>>> KeyedProxies;
       typedef std::map<EventSetupRecordKey, KeyedProxies> RecordProxies;
-      
+
       DataProxyProvider();
       virtual ~DataProxyProvider() noexcept(false);
 
       // ---------- const member functions ---------------------
       bool isUsingRecord(const EventSetupRecordKey&) const;
-      
+
       std::set<EventSetupRecordKey> usingRecords() const;
-      
-      const KeyedProxies& keyedProxies(const EventSetupRecordKey& iRecordKey) const ;
-      
-      const ComponentDescription& description() const { return description_;}
+
+      const KeyedProxies& keyedProxies(const EventSetupRecordKey& iRecordKey) const;
+
+      const ComponentDescription& description() const { return description_; }
       // ---------- static member functions --------------------
       /**Used to add parameters available to all inheriting classes
       */
       static void prevalidate(ConfigurationDescriptions&);
 
       // ---------- member functions ---------------------------
-      
+
       ///called when a new interval of validity occurs for iRecordType
-      virtual void newInterval(const EventSetupRecordKey& iRecordType,
-                                const ValidityInterval& iInterval) = 0;
-      
-      void setDescription(const ComponentDescription& iDescription) {
-         description_ = iDescription;
-      }
-      
+      virtual void newInterval(const EventSetupRecordKey& iRecordType, const ValidityInterval& iInterval) = 0;
+
+      void setDescription(const ComponentDescription& iDescription) { description_ = iDescription; }
+
       /**This method is only to be called by the framework, it sets the string
         which will be appended to the labels of all data products being produced
       **/
       void setAppendToDataLabel(const edm::ParameterSet&);
-      
+
       void resetProxies(const EventSetupRecordKey& iRecordType);
       void resetProxiesIfTransient(const EventSetupRecordKey& iRecordType);
 
-   protected:
-      template< class T>
-      void usingRecord() {
-         usingRecordWithKey(EventSetupRecordKey::makeKey<T>());
-      }
-      
+    protected:
+      template <class T> void usingRecord() { usingRecordWithKey(EventSetupRecordKey::makeKey<T>()); }
+
       void usingRecordWithKey(const EventSetupRecordKey&);
 
-      void invalidateProxies(const EventSetupRecordKey& iRecordKey) ;
+      void invalidateProxies(const EventSetupRecordKey& iRecordKey);
 
-      virtual void registerProxies(const EventSetupRecordKey& iRecordKey ,
-                                    KeyedProxies& aProxyList) = 0 ;
-      
+      virtual void registerProxies(const EventSetupRecordKey& iRecordKey, KeyedProxies& aProxyList) = 0;
+
       ///deletes all the Proxies in aStream
-      void eraseAll(const EventSetupRecordKey& iRecordKey) ;
+      void eraseAll(const EventSetupRecordKey& iRecordKey);
 
-   private:
-      DataProxyProvider(const DataProxyProvider&); // stop default
+    private:
+      DataProxyProvider(const DataProxyProvider&);  // stop default
 
-      const DataProxyProvider& operator=(const DataProxyProvider&); // stop default
+      const DataProxyProvider& operator=(const DataProxyProvider&);  // stop default
 
       // ---------- member data --------------------------------
       RecordProxies recordProxies_;
       ComponentDescription description_;
       std::string appendToDataLabel_;
-};
+    };
 
-template<class ProxyT>
-inline void insertProxy(DataProxyProvider::KeyedProxies& iList,
-                        std::shared_ptr<ProxyT> iProxy,
-                        const char* iName="") {
-   iList.push_back(DataProxyProvider::KeyedProxies::value_type(
-                                             DataKey(DataKey::makeTypeTag<typename ProxyT::value_type>(),
-                                                     iName),
-                                             iProxy));
-   
-}
+    template <class ProxyT>
+    inline void insertProxy(DataProxyProvider::KeyedProxies& iList,
+                            std::shared_ptr<ProxyT> iProxy,
+                            const char* iName = "") {
+      iList.push_back(DataProxyProvider::KeyedProxies::value_type(
+          DataKey(DataKey::makeTypeTag<typename ProxyT::value_type>(), iName), iProxy));
+    }
 
-   }
-}
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/DataProxyTemplate.h
+++ b/FWCore/Framework/interface/DataProxyTemplate.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     DataProxyTemplate
-// 
+//
 /**\class DataProxyTemplate DataProxyTemplate.h FWCore/Framework/interface/DataProxyTemplate.h
 
  Description: A DataProxy base class which allows one to write type-safe proxies
@@ -28,16 +28,13 @@
 // forward declarations
 
 namespace edm {
-   namespace eventsetup {
-template<class RecordT, class DataT>
-class DataProxyTemplate : public DataProxy
-{
-
-   public:
+  namespace eventsetup {
+    template <class RecordT, class DataT> class DataProxyTemplate : public DataProxy {
+    public:
       typedef DataT value_type;
       typedef RecordT record_type;
-   
-      DataProxyTemplate(){}
+
+      DataProxyTemplate() {}
       //virtual ~DataProxyTemplate();
 
       // ---------- const member functions ---------------------
@@ -45,25 +42,24 @@ class DataProxyTemplate : public DataProxy
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
-      const void* getImpl(const EventSetupRecordImpl& iRecord,
-                                  const DataKey& iKey) override {
-         assert(iRecord.key() == RecordT::keyForClass());
-         RecordT rec;
-         rec.setImpl(&iRecord);
-         return this->make(rec, iKey);
+      const void* getImpl(const EventSetupRecordImpl& iRecord, const DataKey& iKey) override {
+        assert(iRecord.key() == RecordT::keyForClass());
+        RecordT rec;
+        rec.setImpl(&iRecord);
+        return this->make(rec, iKey);
       }
-      
-   protected:
-      virtual const DataT* make(const RecordT&, const DataKey&) = 0;
-      
-   private:
-      DataProxyTemplate(const DataProxyTemplate&) = delete; // stop default
 
-      const DataProxyTemplate& operator=(const DataProxyTemplate&) = delete; // stop default
+    protected:
+      virtual const DataT* make(const RecordT&, const DataKey&) = 0;
+
+    private:
+      DataProxyTemplate(const DataProxyTemplate&) = delete;  // stop default
+
+      const DataProxyTemplate& operator=(const DataProxyTemplate&) = delete;  // stop default
 
       // ---------- member data --------------------------------
-};
+    };
 
-   }
-}
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/DelayedReader.h
+++ b/FWCore/Framework/interface/DelayedReader.h
@@ -32,25 +32,22 @@ namespace edm {
                                             EDProductGetter const* ep,
                                             ModuleCallingContext const* mcc = nullptr);
 
-    void mergeReaders(DelayedReader* other) {mergeReaders_(other);}
-    void reset() {reset_();}
-    
-    std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> sharedResources() const {
-      return sharedResources_();
-    }
-    
+    void mergeReaders(DelayedReader* other) { mergeReaders_(other); }
+    void reset() { reset_(); }
 
-    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal() const = 0;
-    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal() const = 0;
+    std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> sharedResources() const { return sharedResources_(); }
 
-    
+    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const*
+    preEventReadFromSourceSignal() const = 0;
+    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const*
+    postEventReadFromSourceSignal() const = 0;
+
   private:
     virtual std::unique_ptr<WrapperBase> getProduct_(BranchID const& k, EDProductGetter const* ep) = 0;
     virtual void mergeReaders_(DelayedReader*) = 0;
     virtual void reset_() = 0;
     virtual std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> sharedResources_() const;
-
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     DependentRecordImplementation
-// 
+//
 /**\class DependentRecordImplementation DependentRecordImplementation.h FWCore/Framework/interface/DependentRecordImplementation.h
 
  Description: <one line class summary>
@@ -36,41 +36,41 @@
 
 // forward declarations
 namespace edm {
-namespace eventsetup {
-   
-template< class RecordT, class ListT>
-class DependentRecordImplementation : public EventSetupRecordImplementation<RecordT>, public DependentRecordTag
-{
+  namespace eventsetup {
 
-   public:
+    template <class RecordT, class ListT>
+    class DependentRecordImplementation : public EventSetupRecordImplementation<RecordT>, public DependentRecordTag {
+    public:
       DependentRecordImplementation() {}
       typedef ListT list_type;
       //virtual ~DependentRecordImplementation();
-      
+
       // ---------- const member functions ---------------------
-      template<class DepRecordT>
-      const DepRecordT getRecord() const {
+      template <class DepRecordT> const DepRecordT getRecord() const {
         //Make sure that DepRecordT is a type in ListT
-        typedef typename boost::mpl::end< ListT >::type EndItrT;
-        typedef typename boost::mpl::find< ListT, DepRecordT>::type FoundItrT;
-        static_assert(! std::is_same<FoundItrT, EndItrT>::value, "Trying to get a Record from another Record where the second Record is not dependent on the first Record.");
+        typedef typename boost::mpl::end<ListT>::type EndItrT;
+        typedef typename boost::mpl::find<ListT, DepRecordT>::type FoundItrT;
+        static_assert(
+            !std::is_same<FoundItrT, EndItrT>::value,
+            "Trying to get a Record from another Record where the second Record is not dependent on the first Record.");
         try {
           EventSetupImpl const& eventSetupT = this->eventSetup();
           return eventSetupT.get<DepRecordT>();
-        } catch(cms::Exception& e) {
+        } catch (cms::Exception& e) {
           std::ostringstream sstrm;
-          sstrm <<"While getting dependent Record from Record "<<this->key().type().name();
+          sstrm << "While getting dependent Record from Record " << this->key().type().name();
           e.addContext(sstrm.str());
           throw;
         }
       }
 
-      template<class DepRecordT>
-      std::optional<DepRecordT> tryToGetRecord() const {
+      template <class DepRecordT> std::optional<DepRecordT> tryToGetRecord() const {
         //Make sure that DepRecordT is a type in ListT
-        typedef typename boost::mpl::end< ListT >::type EndItrT;
-        typedef typename boost::mpl::find< ListT, DepRecordT>::type FoundItrT;
-        static_assert(! std::is_same<FoundItrT, EndItrT>::value, "Trying to get a Record from another Record where the second Record is not dependent on the first Record.");
+        typedef typename boost::mpl::end<ListT>::type EndItrT;
+        typedef typename boost::mpl::find<ListT, DepRecordT>::type FoundItrT;
+        static_assert(
+            !std::is_same<FoundItrT, EndItrT>::value,
+            "Trying to get a Record from another Record where the second Record is not dependent on the first Record.");
         EventSetupImpl const& eventSetupT = this->eventSetup();
         return eventSetupT.tryToGet<DepRecordT>();
       }
@@ -79,13 +79,11 @@ class DependentRecordImplementation : public EventSetupRecordImplementation<Reco
 
       // ---------- member functions ---------------------------
 
-   private:
-
+    private:
       // ---------- member data --------------------------------
+    };
 
-};
-
-  }
-}
+  }  // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/DependentRecordIntervalFinder.h
+++ b/FWCore/Framework/interface/DependentRecordIntervalFinder.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     DependentRecordIntervalFinder
-// 
+//
 /**\class DependentRecordIntervalFinder DependentRecordIntervalFinder.h FWCore/Framework/interface/DependentRecordIntervalFinder.h
 
  Description: Finds the intersection of the ValidityInterval for several Providers
@@ -30,45 +30,40 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
-      class EventSetupRecordProvider;
-      
-class DependentRecordIntervalFinder : public EventSetupRecordIntervalFinder
-{
+  namespace eventsetup {
+    class EventSetupRecordProvider;
 
-   public:
+    class DependentRecordIntervalFinder : public EventSetupRecordIntervalFinder {
+    public:
       DependentRecordIntervalFinder(const EventSetupRecordKey&);
       ~DependentRecordIntervalFinder() override;
 
       // ---------- const member functions ---------------------
-      bool haveProviders() const {
-        return !providers_.empty();
-      }
+      bool haveProviders() const { return !providers_.empty(); }
 
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
       void addProviderWeAreDependentOn(std::shared_ptr<EventSetupRecordProvider>);
-      
-      void setAlternateFinder(std::shared_ptr<EventSetupRecordIntervalFinder>);
-   protected:
-      void setIntervalFor(const EventSetupRecordKey&,
-                                   const IOVSyncValue& , 
-                                   ValidityInterval&) override;
-      
-   private:
-      DependentRecordIntervalFinder(const DependentRecordIntervalFinder&) = delete; // stop default
 
-      const DependentRecordIntervalFinder& operator=(const DependentRecordIntervalFinder&) = delete; // stop default
+      void setAlternateFinder(std::shared_ptr<EventSetupRecordIntervalFinder>);
+
+    protected:
+      void setIntervalFor(const EventSetupRecordKey&, const IOVSyncValue&, ValidityInterval&) override;
+
+    private:
+      DependentRecordIntervalFinder(const DependentRecordIntervalFinder&) = delete;  // stop default
+
+      const DependentRecordIntervalFinder& operator=(const DependentRecordIntervalFinder&) = delete;  // stop default
 
       // ---------- member data --------------------------------
       typedef std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordProvider>>> Providers;
       Providers providers_;
-      
+
       edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>> alternate_;
       std::vector<ValidityInterval> previousIOVs_;
-};
+    };
 
-   }
-}
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/DependentRecordTag.h
+++ b/FWCore/Framework/interface/DependentRecordTag.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     DependentRecordTag
-// 
+//
 /**\class DependentRecordTag DependentRecordTag.h FWCore/Framework/interface/DependentRecordTag.h
 
  Description: Identifies a Record as being dependent upon other Records
@@ -24,9 +24,9 @@
 
 // forward declarations
 namespace edm {
-namespace eventsetup {
-   struct DependentRecordTag {};
-  }
-}
+  namespace eventsetup {
+    struct DependentRecordTag {};
+  }  // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -22,7 +22,7 @@ namespace edm {
   class WaitingTask;
 
   namespace maker {
-    template<typename T> class ModuleHolderT;
+    template <typename T> class ModuleHolderT;
   }
 
   class EDAnalyzer : public EDConsumerBase {
@@ -33,78 +33,77 @@ namespace edm {
 
     EDAnalyzer();
     ~EDAnalyzer() override;
-    
-    std::string workerType() const {return "WorkerT<EDAnalyzer>";}
+
+    std::string workerType() const { return "WorkerT<EDAnalyzer>"; }
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
     static const std::string& baseType();
-    static   void prevalidate(ConfigurationDescriptions& );
+    static void prevalidate(ConfigurationDescriptions&);
 
     // Warning: the returned moduleDescription will be invalid during construction
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
-    
-    static bool wantsGlobalRuns() {return true;}
-    static bool wantsGlobalLuminosityBlocks() {return true;}
-    static bool wantsStreamRuns() {return false;}
-    static bool wantsStreamLuminosityBlocks() {return false;};
+
+    static bool wantsGlobalRuns() { return true; }
+    static bool wantsGlobalLuminosityBlocks() { return true; }
+    static bool wantsStreamRuns() { return false; }
+    static bool wantsStreamLuminosityBlocks() { return false; };
 
     void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func);
 
-    SerialTaskQueue* globalRunsQueue() { return &runQueue_;}
-    SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_;}
+    SerialTaskQueue* globalRunsQueue() { return &runQueue_; }
+    SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_; }
+
   private:
-    bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
+    bool doEvent(EventPrincipal const& ep,
+                 EventSetupImpl const& c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     //Needed by Worker but not something supported
-    void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+    void preActionBeforeRunEventAsync(WaitingTask* iTask,
+                                      ModuleCallingContext const& iModuleCallingContext,
+                                      Principal const& iPrincipal) const {}
 
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
     void doEndJob();
-    bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
-                    ModuleCallingContext const* mcc);
-    bool doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
-                  ModuleCallingContext const* mcc);
-    bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
+    bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    bool doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                EventSetupImpl const& c,
                                 ModuleCallingContext const* mcc);
-    bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
+    bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                              EventSetupImpl const& c,
                               ModuleCallingContext const* mcc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
-    void doRegisterThinnedAssociations(ProductRegistry const&,
-                                       ThinnedAssociationsHelper&) { }
+    void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
     void registerProductsAndCallbacks(EDAnalyzer const*, ProductRegistry* reg);
-    
-    SharedResourcesAcquirer& sharedResourcesAcquirer() {
-      return resourceAcquirer_;
-    }
+
+    SharedResourcesAcquirer& sharedResourcesAcquirer() { return resourceAcquirer_; }
 
     virtual void analyze(Event const&, EventSetup const&) = 0;
-    virtual void beginJob(){}
-    virtual void endJob(){}
-    virtual void beginRun(Run const&, EventSetup const&){}
-    virtual void endRun(Run const&, EventSetup const&){}
-    virtual void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&){}
-    virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&){}
+    virtual void beginJob() {}
+    virtual void endJob() {}
+    virtual void beginRun(Run const&, EventSetup const&) {}
+    virtual void endRun(Run const&, EventSetup const&) {}
+    virtual void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) {}
+    virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&) {}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
 
     bool hasAcquire() const { return false; }
     bool hasAccumulator() const { return false; }
 
-    void setModuleDescription(ModuleDescription const& md) {
-      moduleDescription_ = md;
-    }
+    void setModuleDescription(ModuleDescription const& md) { moduleDescription_ = md; }
     ModuleDescription moduleDescription_;
     SharedResourcesAcquirer resourceAcquirer_;
 
     SerialTaskQueue runQueue_;
     SerialTaskQueue luminosityBlockQueue_;
-    
+
     std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -41,7 +41,6 @@
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/ProductLabels.h"
 
-
 // forward declarations
 
 namespace edm {
@@ -49,11 +48,9 @@ namespace edm {
   class ProductResolverIndexHelper;
   class ProductRegistry;
   class ConsumesCollector;
-  template<typename T> class WillGetIfMatch;
+  template <typename T> class WillGetIfMatch;
 
-  class EDConsumerBase
-  {
-
+  class EDConsumerBase {
   public:
     EDConsumerBase() : frozen_(false), containsCurrentProcessAlias_(false) {}
     virtual ~EDConsumerBase() noexcept(false);
@@ -73,7 +70,9 @@ namespace edm {
     void itemsToGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const;
     void itemsMayGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const;
 
-    std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFrom(BranchType iType) const { return itemsToGetFromBranch_[iType]; }
+    std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFrom(BranchType iType) const {
+      return itemsToGetFromBranch_[iType];
+    }
 
     ///\return true if the product corresponding to the index was registered via consumes or mayConsume call
     bool registeredToConsume(ProductResolverIndex, bool, BranchType) const;
@@ -83,9 +82,7 @@ namespace edm {
     // ---------- static member functions --------------------
 
     // ---------- member functions ---------------------------
-    void updateLookup(BranchType iBranchType,
-                      ProductResolverIndexHelper const&,
-                      bool iPrefetchMayGet);
+    void updateLookup(BranchType iBranchType, ProductResolverIndexHelper const&, bool iPrefetchMayGet);
 
     typedef ProductLabels Labels;
     void labelsForToken(EDGetToken iToken, Labels& oLabels) const;
@@ -102,65 +99,52 @@ namespace edm {
 
   protected:
     friend class ConsumesCollector;
-    template<typename T> friend class WillGetIfMatch;
+    template <typename T> friend class WillGetIfMatch;
     ///Use a ConsumesCollector to gather consumes information from helper functions
     ConsumesCollector consumesCollector();
 
-    template <typename ProductType, BranchType B=InEvent>
+    template <typename ProductType, BranchType B = InEvent>
     EDGetTokenT<ProductType> consumes(edm::InputTag const& tag) {
-      TypeToGet tid=TypeToGet::make<ProductType>();
-      return EDGetTokenT<ProductType>{recordConsumes(B,tid, checkIfEmpty(tag),true)};
+      TypeToGet tid = TypeToGet::make<ProductType>();
+      return EDGetTokenT<ProductType>{recordConsumes(B, tid, checkIfEmpty(tag), true)};
     }
 
     EDGetToken consumes(const TypeToGet& id, edm::InputTag const& tag) {
       return EDGetToken{recordConsumes(InEvent, id, checkIfEmpty(tag), true)};
     }
 
-    template <BranchType B>
-    EDGetToken consumes(TypeToGet const& id, edm::InputTag const& tag) {
+    template <BranchType B> EDGetToken consumes(TypeToGet const& id, edm::InputTag const& tag) {
       return EDGetToken{recordConsumes(B, id, checkIfEmpty(tag), true)};
     }
 
-    template <typename ProductType, BranchType B=InEvent>
+    template <typename ProductType, BranchType B = InEvent>
     EDGetTokenT<ProductType> mayConsume(edm::InputTag const& tag) {
-      TypeToGet tid=TypeToGet::make<ProductType>();
+      TypeToGet tid = TypeToGet::make<ProductType>();
       return EDGetTokenT<ProductType>{recordConsumes(B, tid, checkIfEmpty(tag), false)};
     }
 
-    EDGetToken mayConsume(const TypeToGet& id, edm::InputTag const& tag) {
-      return mayConsume<InEvent>(id,tag);
+    EDGetToken mayConsume(const TypeToGet& id, edm::InputTag const& tag) { return mayConsume<InEvent>(id, tag); }
+
+    template <BranchType B> EDGetToken mayConsume(const TypeToGet& id, edm::InputTag const& tag) {
+      return EDGetToken{recordConsumes(B, id, checkIfEmpty(tag), false)};
     }
 
-    template <BranchType B>
-    EDGetToken mayConsume(const TypeToGet& id, edm::InputTag const& tag) {
-      return EDGetToken{recordConsumes(B,id,checkIfEmpty(tag),false)};
-    }
-
-    template <typename ProductType, BranchType B=InEvent>
-    void consumesMany() {
-      TypeToGet tid=TypeToGet::make<ProductType>();
+    template <typename ProductType, BranchType B = InEvent> void consumesMany() {
+      TypeToGet tid = TypeToGet::make<ProductType>();
       consumesMany<B>(tid);
     }
 
-    void consumesMany(const TypeToGet& id) {
-      consumesMany<InEvent>(id);
-    }
+    void consumesMany(const TypeToGet& id) { consumesMany<InEvent>(id); }
 
-    template <BranchType B>
-    void consumesMany(const TypeToGet& id) {
-      recordConsumes(B,id,edm::InputTag{},true);
-    }
+    template <BranchType B> void consumesMany(const TypeToGet& id) { recordConsumes(B, id, edm::InputTag{}, true); }
 
     // For consuming event-setup products
-    template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event>
-    auto esConsumes()
-    {
+    template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event> auto esConsumes() {
       return esConsumes<ESProduct, ESRecord, Tr>(ESInputTag{});
     }
 
     template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event>
-    auto esConsumes(ESInputTag const& tag)
-    {
+    auto esConsumes(ESInputTag const& tag) {
       return ESGetToken<ESProduct, ESRecord>{tag};
     }
 
@@ -176,11 +160,8 @@ namespace edm {
     // ---------- member data --------------------------------
 
     struct TokenLookupInfo {
-      TokenLookupInfo(edm::TypeID const& iID,
-                      ProductResolverIndex iIndex,
-                      bool skipCurrentProcess,
-                      BranchType iBranch):
-        m_type(iID),m_index(iIndex, skipCurrentProcess), m_branchType(iBranch){}
+      TokenLookupInfo(edm::TypeID const& iID, ProductResolverIndex iIndex, bool skipCurrentProcess, BranchType iBranch)
+          : m_type(iID), m_index(iIndex, skipCurrentProcess), m_branchType(iBranch) {}
       edm::TypeID m_type;
       ProductResolverIndexAndSkipBit m_index;
       BranchType m_branchType;
@@ -189,18 +170,18 @@ namespace edm {
     struct LabelPlacement {
       LabelPlacement(unsigned int iStartOfModuleLabel,
                      unsigned short iDeltaToProductInstance,
-                     unsigned short iDeltaToProcessName):
-      m_startOfModuleLabel(iStartOfModuleLabel),
-      m_deltaToProductInstance(iDeltaToProductInstance),
-      m_deltaToProcessName(iDeltaToProcessName) {}
+                     unsigned short iDeltaToProcessName)
+          : m_startOfModuleLabel(iStartOfModuleLabel),
+            m_deltaToProductInstance(iDeltaToProductInstance),
+            m_deltaToProcessName(iDeltaToProcessName) {}
       unsigned int m_startOfModuleLabel;
       unsigned short m_deltaToProductInstance;
       unsigned short m_deltaToProcessName;
     };
 
     //define the purpose of each 'column' in m_tokenInfo
-    enum {kLookupInfo,kAlwaysGets,kLabels,kKind};
-    edm::SoATuple<TokenLookupInfo,bool,LabelPlacement,edm::KindOfType> m_tokenInfo;
+    enum { kLookupInfo, kAlwaysGets, kLabels, kKind };
+    edm::SoATuple<TokenLookupInfo, bool, LabelPlacement, edm::KindOfType> m_tokenInfo;
 
     //m_tokenStartOfLabels holds the entries into this container
     // for each of the 3 labels needed to id the data
@@ -211,6 +192,6 @@ namespace edm {
     bool frozen_;
     bool containsCurrentProcessAlias_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -25,7 +25,7 @@ These products should be informational products about the filter decision.
 
 namespace edm {
   namespace maker {
-    template<typename T> class ModuleHolderT;
+    template <typename T> class ModuleHolderT;
   }
 
   class ModuleCallingContext;
@@ -40,75 +40,74 @@ namespace edm {
     template <typename T> friend class maker::ModuleHolderT;
     template <typename T> friend class WorkerT;
     typedef EDFilter ModuleType;
-    
+
     EDFilter();
     ~EDFilter() override;
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
-    static void prevalidate(ConfigurationDescriptions& );
+    static void prevalidate(ConfigurationDescriptions&);
 
     static const std::string& baseType();
 
     // Warning: the returned moduleDescription will be invalid during construction
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
-    static bool wantsGlobalRuns() {return true;}
-    static bool wantsGlobalLuminosityBlocks() {return true;}
-    static bool wantsStreamRuns() {return false;}
-    static bool wantsStreamLuminosityBlocks() {return false;};
+    static bool wantsGlobalRuns() { return true; }
+    static bool wantsGlobalLuminosityBlocks() { return true; }
+    static bool wantsStreamRuns() { return false; }
+    static bool wantsStreamLuminosityBlocks() { return false; };
 
-    SerialTaskQueue* globalRunsQueue() { return &runQueue_;}
-    SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_;}
+    SerialTaskQueue* globalRunsQueue() { return &runQueue_; }
+    SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_; }
+
   private:
-    bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
+    bool doEvent(EventPrincipal const& ep,
+                 EventSetupImpl const& c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     //Needed by WorkerT but not supported
-    void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+    void preActionBeforeRunEventAsync(WaitingTask* iTask,
+                                      ModuleCallingContext const& iModuleCallingContext,
+                                      Principal const& iPrincipal) const {}
 
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
-    void doEndJob();    
-    void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
-                    ModuleCallingContext const* mcc);
-    void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
-                  ModuleCallingContext const* mcc);
-    void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
+    void doEndJob();
+    void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                EventSetupImpl const& c,
                                 ModuleCallingContext const* mcc);
-    void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
+    void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                              EventSetupImpl const& c,
                               ModuleCallingContext const* mcc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
-    void doRegisterThinnedAssociations(ProductRegistry const&,
-                                       ThinnedAssociationsHelper&) { }
+    void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
     void registerProductsAndCallbacks(EDFilter* module, ProductRegistry* reg) {
       registerProducts(module, reg, moduleDescription_);
     }
 
-    std::string workerType() const {return "WorkerT<EDFilter>";}
-    
-    SharedResourcesAcquirer& sharedResourcesAcquirer() {
-      return resourceAcquirer_;
-    }
+    std::string workerType() const { return "WorkerT<EDFilter>"; }
+
+    SharedResourcesAcquirer& sharedResourcesAcquirer() { return resourceAcquirer_; }
 
     virtual bool filter(Event&, EventSetup const&) = 0;
-    virtual void beginJob(){}
-    virtual void endJob(){}
+    virtual void beginJob() {}
+    virtual void endJob() {}
 
-    virtual void beginRun(Run const&, EventSetup const&){}
-    virtual void endRun(Run const&, EventSetup const&){}
-    virtual void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&){}
-    virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&){}
+    virtual void beginRun(Run const&, EventSetup const&) {}
+    virtual void endRun(Run const&, EventSetup const&) {}
+    virtual void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) {}
+    virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&) {}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
 
     bool hasAcquire() const { return false; }
     bool hasAccumulator() const { return false; }
 
-    void setModuleDescription(ModuleDescription const& md) {
-      moduleDescription_ = md;
-    }
+    void setModuleDescription(ModuleDescription const& md) { moduleDescription_ = md; }
     ModuleDescription moduleDescription_;
     std::vector<BranchID> previousParentage_;
     SharedResourcesAcquirer resourceAcquirer_;
@@ -116,6 +115,6 @@ namespace edm {
     SerialTaskQueue luminosityBlockQueue_;
     ParentageID previousParentageId_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/EDLooper.h
+++ b/FWCore/Framework/interface/EDLooper.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Module:      EDLooper
-// 
+//
 /**\class EDLooper EDLooper.h FWCore/Framework/interface/EDLooper.h
 
  Description: Standard base class for looping components
@@ -24,28 +24,23 @@
 
 namespace edm {
 
-  class EDLooper : public EDLooperBase
-  {
-    public:
+  class EDLooper : public EDLooperBase {
+  public:
+    EDLooper();
+    ~EDLooper() override;
 
-      EDLooper();
-      ~EDLooper() override;
+    EDLooper(EDLooper const&) = delete;             // Disallow copying and moving
+    EDLooper& operator=(EDLooper const&) = delete;  // Disallow copying and moving
 
-      EDLooper(EDLooper const&) = delete; // Disallow copying and moving
-      EDLooper& operator=(EDLooper const&) = delete; // Disallow copying and moving
-
-    private:
-
+  private:
     /**Called after all event modules have had a chance to process the edm::Event.
      */
-    virtual Status duringLoop(const edm::Event&, const edm::EventSetup&) = 0; 
-    
+    virtual Status duringLoop(const edm::Event&, const edm::EventSetup&) = 0;
+
     /**override base class interface and just call the above duringLoop
      */
-    Status duringLoop(const edm::Event&, const edm::EventSetup&, ProcessingController& ) override;
-    
-    
+    Status duringLoop(const edm::Event&, const edm::EventSetup&, ProcessingController&) override;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/EDLooperBase.h
+++ b/FWCore/Framework/interface/EDLooperBase.h
@@ -65,7 +65,7 @@ namespace edm {
   namespace eventsetup {
     class EventSetupRecordKey;
     class EventSetupProvider;
-  }
+  }  // namespace eventsetup
   class ExceptionToActionTable;
   class ProcessContext;
   class ScheduleInfo;
@@ -75,86 +75,85 @@ namespace edm {
   class ActivityRegistry;
 
   class EDLooperBase {
-    public:
-      enum Status {kContinue, kStop};
+  public:
+    enum Status { kContinue, kStop };
 
-      EDLooperBase();
-      virtual ~EDLooperBase() noexcept(false);
+    EDLooperBase();
+    virtual ~EDLooperBase() noexcept(false);
 
-      EDLooperBase(EDLooperBase const&) = delete; // Disallow copying and moving
-      EDLooperBase& operator=(EDLooperBase const&) = delete; // Disallow copying and moving
+    EDLooperBase(EDLooperBase const&) = delete;             // Disallow copying and moving
+    EDLooperBase& operator=(EDLooperBase const&) = delete;  // Disallow copying and moving
 
-      void doStartingNewLoop();
-      Status doDuringLoop(EventPrincipal& eventPrincipal, EventSetupImpl const&  es, ProcessingController&, StreamContext*);
-      Status doEndOfLoop(EventSetupImpl const&  es);
-      void prepareForNextLoop(eventsetup::EventSetupProvider* esp);
-      void doBeginRun(RunPrincipal&, EventSetupImpl const& , ProcessContext*);
-      void doEndRun(RunPrincipal&, EventSetupImpl const& , ProcessContext*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal&, EventSetupImpl const& , ProcessContext*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal&, EventSetupImpl const& , ProcessContext*);
+    void doStartingNewLoop();
+    Status doDuringLoop(EventPrincipal& eventPrincipal, EventSetupImpl const& es, ProcessingController&, StreamContext*);
+    Status doEndOfLoop(EventSetupImpl const& es);
+    void prepareForNextLoop(eventsetup::EventSetupProvider* esp);
+    void doBeginRun(RunPrincipal&, EventSetupImpl const&, ProcessContext*);
+    void doEndRun(RunPrincipal&, EventSetupImpl const&, ProcessContext*);
+    void doBeginLuminosityBlock(LuminosityBlockPrincipal&, EventSetupImpl const&, ProcessContext*);
+    void doEndLuminosityBlock(LuminosityBlockPrincipal&, EventSetupImpl const&, ProcessContext*);
 
-      void beginOfJob(EventSetupImpl const& );
-      //This interface is deprecated
-      virtual void beginOfJob(EventSetup const& );
-      virtual void beginOfJob();
+    void beginOfJob(EventSetupImpl const&);
+    //This interface is deprecated
+    virtual void beginOfJob(EventSetup const&);
+    virtual void beginOfJob();
 
-      virtual void endOfJob();
+    virtual void endOfJob();
 
-      ///Override this method if you need to monitor the state of the processing
-      virtual void attachTo(ActivityRegistry&);
+    ///Override this method if you need to monitor the state of the processing
+    virtual void attachTo(ActivityRegistry&);
 
-      void setActionTable(ExceptionToActionTable const* actionTable) { act_table_ = actionTable; }
+    void setActionTable(ExceptionToActionTable const* actionTable) { act_table_ = actionTable; }
 
-      virtual std::set<eventsetup::EventSetupRecordKey> modifyingRecords() const;
+    virtual std::set<eventsetup::EventSetupRecordKey> modifyingRecords() const;
 
-      void copyInfo(ScheduleInfo const&);
-      void setModuleChanger(ModuleChanger*);
+    void copyInfo(ScheduleInfo const&);
+    void setModuleChanger(ModuleChanger*);
 
-    protected:
-      ///This only returns a non-zero value during the call to endOfLoop
-      ModuleChanger* moduleChanger();
-      ///This returns a non-zero value after the constructor has been called
-      ScheduleInfo const* scheduleInfo() const;
-    private:
+  protected:
+    ///This only returns a non-zero value during the call to endOfLoop
+    ModuleChanger* moduleChanger();
+    ///This returns a non-zero value after the constructor has been called
+    ScheduleInfo const* scheduleInfo() const;
 
-      /**Called before system starts to loop over the events. The argument is a count of
+  private:
+    /**Called before system starts to loop over the events. The argument is a count of
        how many loops have been processed.  For the first time through the events the argument
        will be 0.
        */
-      virtual void startingNewLoop(unsigned int ) = 0;
+    virtual void startingNewLoop(unsigned int) = 0;
 
-      /**Called after all event modules have had a chance to process the Event.
+    /**Called after all event modules have had a chance to process the Event.
        */
-      virtual Status duringLoop(Event const&, EventSetup const&, ProcessingController&) = 0;
+    virtual Status duringLoop(Event const&, EventSetup const&, ProcessingController&) = 0;
 
-      /**Called after the system has finished one loop over the events. Thar argument is a
+    /**Called after the system has finished one loop over the events. Thar argument is a
        count of how many loops have been processed before this loo.  For the first time through
        the events the argument will be 0.
        */
-      virtual Status endOfLoop(EventSetup const&, unsigned int iCounter) = 0;
+    virtual Status endOfLoop(EventSetup const&, unsigned int iCounter) = 0;
 
-      ///Called after all event modules have processed the begin of a Run
-      virtual void beginRun(Run const&, EventSetup const&);
+    ///Called after all event modules have processed the begin of a Run
+    virtual void beginRun(Run const&, EventSetup const&);
 
-      ///Called after all event modules have processed the end of a Run
-      virtual void endRun(Run const&, EventSetup const&);
+    ///Called after all event modules have processed the end of a Run
+    virtual void endRun(Run const&, EventSetup const&);
 
-      ///Called after all event modules have processed the begin of a LuminosityBlock
-      virtual void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&);
+    ///Called after all event modules have processed the begin of a LuminosityBlock
+    virtual void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&);
 
-      ///Called after all event modules have processed the end of a LuminosityBlock
-      virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&);
+    ///Called after all event modules have processed the end of a LuminosityBlock
+    virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&);
 
+    unsigned int iCounter_;
+    ExceptionToActionTable const* act_table_;
 
-      unsigned int iCounter_;
-      ExceptionToActionTable const* act_table_;
+    edm::propagate_const<std::unique_ptr<ScheduleInfo>> scheduleInfo_;
+    edm::propagate_const<ModuleChanger*> moduleChanger_;
 
-      edm::propagate_const<std::unique_ptr<ScheduleInfo>> scheduleInfo_;
-      edm::propagate_const<ModuleChanger*> moduleChanger_;
-
-      ModuleDescription moduleDescription_;
-      ModuleCallingContext moduleCallingContext_;
+    ModuleDescription moduleDescription_;
+    ModuleCallingContext moduleCallingContext_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -29,7 +29,7 @@ namespace edm {
   class WaitingTask;
 
   namespace maker {
-    template<typename T> class ModuleHolderT;
+    template <typename T> class ModuleHolderT;
   }
 
   class EDProducer : public ProducerBase, public EDConsumerBase {
@@ -38,7 +38,7 @@ namespace edm {
     template <typename T> friend class WorkerT;
     typedef EDProducer ModuleType;
 
-    EDProducer ();
+    EDProducer();
     ~EDProducer() override;
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
@@ -47,63 +47,62 @@ namespace edm {
 
     // Warning: the returned moduleDescription will be invalid during construction
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
-    
-    static bool wantsGlobalRuns() {return true;}
-    static bool wantsGlobalLuminosityBlocks() {return true;}
-    static bool wantsStreamRuns() {return false;}
-    static bool wantsStreamLuminosityBlocks() {return false;};
 
-    SerialTaskQueue* globalRunsQueue() { return &runQueue_;}
-    SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_;}
+    static bool wantsGlobalRuns() { return true; }
+    static bool wantsGlobalLuminosityBlocks() { return true; }
+    static bool wantsStreamRuns() { return false; }
+    static bool wantsStreamLuminosityBlocks() { return false; };
+
+    SerialTaskQueue* globalRunsQueue() { return &runQueue_; }
+    SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_; }
+
   private:
-    bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
+    bool doEvent(EventPrincipal const& ep,
+                 EventSetupImpl const& c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     //Needed by WorkerT but not supported
-    void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+    void preActionBeforeRunEventAsync(WaitingTask* iTask,
+                                      ModuleCallingContext const& iModuleCallingContext,
+                                      Principal const& iPrincipal) const {}
 
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
     void doEndJob();
-    void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
-                    ModuleCallingContext const* mcc);
-    void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
-                  ModuleCallingContext const* mcc);
-    void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
+    void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                EventSetupImpl const& c,
                                 ModuleCallingContext const* mcc);
-    void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
+    void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                              EventSetupImpl const& c,
                               ModuleCallingContext const* mcc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
-    void doRegisterThinnedAssociations(ProductRegistry const&,
-                                       ThinnedAssociationsHelper&) { }
+    void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
     void registerProductsAndCallbacks(EDProducer* module, ProductRegistry* reg) {
       registerProducts(module, reg, moduleDescription_);
     }
 
-    std::string workerType() const {return "WorkerT<EDProducer>";}
-    
-    SharedResourcesAcquirer& sharedResourcesAcquirer() {
-      return resourceAcquirer_;
-    }
+    std::string workerType() const { return "WorkerT<EDProducer>"; }
+
+    SharedResourcesAcquirer& sharedResourcesAcquirer() { return resourceAcquirer_; }
 
     virtual void produce(Event&, EventSetup const&) = 0;
     virtual void beginJob() {}
-    virtual void endJob(){}
+    virtual void endJob() {}
 
-    virtual void beginRun(Run const& /* iR */, EventSetup const& /* iE */){}
-    virtual void endRun(Run const& /* iR */, EventSetup const& /* iE */){}
-    virtual void beginLuminosityBlock(LuminosityBlock const& /* iL */, EventSetup const& /* iE */){}
-    virtual void endLuminosityBlock(LuminosityBlock const& /* iL */, EventSetup const& /* iE */){}
+    virtual void beginRun(Run const& /* iR */, EventSetup const& /* iE */) {}
+    virtual void endRun(Run const& /* iR */, EventSetup const& /* iE */) {}
+    virtual void beginLuminosityBlock(LuminosityBlock const& /* iL */, EventSetup const& /* iE */) {}
+    virtual void endLuminosityBlock(LuminosityBlock const& /* iL */, EventSetup const& /* iE */) {}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
 
     bool hasAcquire() const { return false; }
     bool hasAccumulator() const { return false; }
 
-    void setModuleDescription(ModuleDescription const& md) {
-      moduleDescription_ = md;
-    }
+    void setModuleDescription(ModuleDescription const& md) { moduleDescription_ = md; }
     ModuleDescription moduleDescription_;
     std::vector<BranchID> previousParentage_;
     SharedResourcesAcquirer resourceAcquirer_;
@@ -111,6 +110,6 @@ namespace edm {
     SerialTaskQueue luminosityBlockQueue_;
     ParentageID previousParentageId_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ESConsumesCollector.h
+++ b/FWCore/Framework/interface/ESConsumesCollector.h
@@ -37,7 +37,6 @@
 namespace edm {
   class ESConsumesCollector {
   public:
-
     ESConsumesCollector() = delete;
     ESConsumesCollector(ESConsumesCollector const&) = default;
     ESConsumesCollector(ESConsumesCollector&&) = default;
@@ -45,50 +44,37 @@ namespace edm {
     ESConsumesCollector& operator=(ESConsumesCollector&&) = default;
 
     // ---------- member functions ---------------------------
-    template <typename Product, typename Record>
-    auto consumesFrom(ESInputTag const& tag) {
-      return ESGetToken<Product,Record>{tag};
+    template <typename Product, typename Record> auto consumesFrom(ESInputTag const& tag) {
+      return ESGetToken<Product, Record>{tag};
     }
 
   protected:
-    explicit ESConsumesCollector(ESProducer* const iConsumer) :
-    m_consumer{iConsumer}
-    {}
+    explicit ESConsumesCollector(ESProducer* const iConsumer) : m_consumer{iConsumer} {}
 
   private:
-
     // ---------- member data --------------------------------
     edm::propagate_const<ESProducer*> m_consumer{nullptr};
   };
-  
-  template<typename RECORD>
-  class ESConsumesCollectorT : public ESConsumesCollector {
+
+  template <typename RECORD> class ESConsumesCollectorT : public ESConsumesCollector {
   public:
-    
     ESConsumesCollectorT() = delete;
     ESConsumesCollectorT(ESConsumesCollectorT<RECORD> const&) = default;
     ESConsumesCollectorT(ESConsumesCollectorT<RECORD>&&) = default;
     ESConsumesCollectorT<RECORD>& operator=(ESConsumesCollectorT<RECORD> const&) = default;
     ESConsumesCollectorT<RECORD>& operator=(ESConsumesCollectorT<RECORD>&&) = default;
-    
+
     // ---------- member functions ---------------------------
-    
-    template <typename Product>
-    auto consumes(ESInputTag const& tag) {
-      return consumesFrom<Product, RECORD>(tag);
-    }
-    
+
+    template <typename Product> auto consumes(ESInputTag const& tag) { return consumesFrom<Product, RECORD>(tag); }
+
   private:
     //only ESProducer is allowed to make an instance of this class
     friend class ESProducer;
-    
-    explicit ESConsumesCollectorT(ESProducer* const iConsumer) :
-    ESConsumesCollector(iConsumer)
-    {}
-    
+
+    explicit ESConsumesCollectorT(ESProducer* const iConsumer) : ESConsumesCollector(iConsumer) {}
   };
 
-}
-
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ESHandle.h
+++ b/FWCore/Framework/interface/ESHandle.h
@@ -30,86 +30,72 @@
 
 namespace edm {
 
-class ESHandleBase {
-   public:
-      ESHandleBase() = default;
-      ESHandleBase(void const* iData, edm::eventsetup::ComponentDescription const* desc)
-           : data_(iData), description_(desc) {}
+  class ESHandleBase {
+  public:
+    ESHandleBase() = default;
+    ESHandleBase(void const* iData, edm::eventsetup::ComponentDescription const* desc)
+        : data_(iData), description_(desc) {}
 
-      ///Used when the attempt to get the data failed
-      ESHandleBase(std::shared_ptr<ESHandleExceptionFactory>&& iWhyFailed) :
-        whyFailedFactory_(std::move(iWhyFailed)) {}
+    ///Used when the attempt to get the data failed
+    ESHandleBase(std::shared_ptr<ESHandleExceptionFactory>&& iWhyFailed) : whyFailedFactory_(std::move(iWhyFailed)) {}
 
-      edm::eventsetup::ComponentDescription const* description() const;
+    edm::eventsetup::ComponentDescription const* description() const;
 
-      bool isValid() const { return nullptr != data_ && nullptr != description_; }
+    bool isValid() const { return nullptr != data_ && nullptr != description_; }
 
-      bool failedToGet() const { return bool(whyFailedFactory_); }
+    bool failedToGet() const { return bool(whyFailedFactory_); }
 
-      explicit operator bool () const {
-         return isValid();
+    explicit operator bool() const { return isValid(); }
+
+    bool operator!() const { return not isValid(); }
+
+    void swap(ESHandleBase& iOther) {
+      std::swap(data_, iOther.data_);
+      std::swap(description_, iOther.description_);
+      std::swap(whyFailedFactory_, iOther.whyFailedFactory_);
+    }
+
+    std::shared_ptr<ESHandleExceptionFactory> const& whyFailedFactory() const { return whyFailedFactory_; }
+
+  protected:
+    void const* productStorage() const {
+      if (whyFailedFactory_) {
+        std::rethrow_exception(whyFailedFactory_->make());
       }
-  
-      bool operator!() const {
-        return not isValid();
-      }
+      return data_;
+    }
 
-      void swap(ESHandleBase& iOther) {
-         std::swap(data_, iOther.data_);
-         std::swap(description_, iOther.description_);
-         std::swap(whyFailedFactory_, iOther.whyFailedFactory_);
-      }
+  private:
+    // ---------- member data --------------------------------
+    void const* data_{nullptr};
+    edm::eventsetup::ComponentDescription const* description_{nullptr};
+    std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory_{nullptr};
+  };
 
-      std::shared_ptr<ESHandleExceptionFactory> const&
-      whyFailedFactory() const { return whyFailedFactory_;}
+  template <typename T> class ESHandle : public ESHandleBase {
+  public:
+    typedef T value_type;
 
-   protected:
-      void const *productStorage() const {
-        if (whyFailedFactory_) {
-          std::rethrow_exception(whyFailedFactory_->make());
-        }
-        return data_;
-      }
+    ESHandle() = default;
+    ESHandle(T const* iData) : ESHandleBase(iData, nullptr) {}
+    ESHandle(T const* iData, edm::eventsetup::ComponentDescription const* desc) : ESHandleBase(iData, desc) {}
+    ESHandle(std::shared_ptr<ESHandleExceptionFactory>&&);
 
-   private:
-      // ---------- member data --------------------------------
-      void const* data_{nullptr};
-      edm::eventsetup::ComponentDescription const* description_{nullptr};
-      std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory_{nullptr};
-};
+    // ---------- const member functions ---------------------
+    T const* product() const { return static_cast<T const*>(productStorage()); }
+    T const* operator->() const { return product(); }
+    T const& operator*() const { return *product(); }
+    // ---------- static member functions --------------------
+    static constexpr bool transientAccessOnly = false;
 
-template<typename T>
-class ESHandle : public ESHandleBase {
-   public:
-      typedef T value_type;
+    // ---------- member functions ---------------------------
+  };
 
-      ESHandle() = default;
-      ESHandle(T const* iData) : ESHandleBase(iData, nullptr) {}
-      ESHandle(T const* iData, edm::eventsetup::ComponentDescription const* desc) : ESHandleBase(iData, desc) {}
-      ESHandle(std::shared_ptr<ESHandleExceptionFactory> &&);
-
-      // ---------- const member functions ---------------------
-      T const* product() const { return static_cast<T const *>(productStorage()); }
-      T const* operator->() const { return product(); }
-      T const& operator*() const { return *product(); }
-      // ---------- static member functions --------------------
-      static constexpr bool transientAccessOnly = false;
-
-      // ---------- member functions ---------------------------
-
-};
-
-template <class T>
-ESHandle<T>::ESHandle(std::shared_ptr<edm::ESHandleExceptionFactory> && iWhyFailed) :
-  ESHandleBase(std::move(iWhyFailed))
-{ }
+  template <class T>
+  ESHandle<T>::ESHandle(std::shared_ptr<edm::ESHandleExceptionFactory>&& iWhyFailed)
+      : ESHandleBase(std::move(iWhyFailed)) {}
 
   // Free swap function
-  inline
-  void
-  swap(ESHandleBase& a, ESHandleBase& b)
-  {
-    a.swap(b);
-  }
-}
+  inline void swap(ESHandleBase& a, ESHandleBase& b) { a.swap(b); }
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ESHandleExceptionFactory.h
+++ b/FWCore/Framework/interface/ESHandleExceptionFactory.h
@@ -28,14 +28,12 @@
 
 namespace edm {
 
-  class ESHandleExceptionFactory
-  {
-
+  class ESHandleExceptionFactory {
   public:
     ESHandleExceptionFactory();
     virtual ~ESHandleExceptionFactory();
 
     virtual std::exception_ptr make() const = 0;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ESOutlet.h
+++ b/FWCore/Framework/interface/ESOutlet.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ESOutlet
-// 
+//
 /**\class ESOutlet ESOutlet.h FWCore/Framework/interface/ESOutlet.h
 
  Description: An outlet which gets its data from the EventSetup and passes it to an edm::ExtensionCord
@@ -31,52 +31,40 @@ from the EDProducer to the object which needs the data.
 // forward declarations
 
 namespace edm {
-  template <class T, class TRec>
-  class ESOutlet :private OutletBase<T>
-  {
+  template <class T, class TRec> class ESOutlet : private OutletBase<T> {
     class Getter : public extensioncord::ECGetterBase<T> {
-public:
-      Getter(const edm::EventSetup& iES,
-             const std::string& iLabel = std::string()) :
-      es_(&iES),
-      label_(iLabel) {}
-private:
+    public:
+      Getter(const edm::EventSetup& iES, const std::string& iLabel = std::string()) : es_(&iES), label_(iLabel) {}
+
+    private:
       virtual const T* getImpl() const {
         ESHandle<T> data;
-        es_->template get<TRec>().get(label_,data);
+        es_->template get<TRec>().get(label_, data);
         return &(*data);
       }
       const edm::EventSetup* es_;
       const std::string label_;
     };
-    
-    
-   public:
-      ESOutlet(const edm::EventSetup& iES,
-               ExtensionCord<T>& iCord):
-       OutletBase<T>(iCord),
-       getter_(iES)  {
-         this->setGetter(&getter_);
-      }
 
-      ESOutlet( const edm::EventSetup& iES,
-              const std::string& iLabel,
-              ExtensionCord<T>& iCord):
-       getter_(iES,iLabel) {
-         this->setGetter( &getter_);
-      }
-    
+  public:
+    ESOutlet(const edm::EventSetup& iES, ExtensionCord<T>& iCord) : OutletBase<T>(iCord), getter_(iES) {
+      this->setGetter(&getter_);
+    }
+
+    ESOutlet(const edm::EventSetup& iES, const std::string& iLabel, ExtensionCord<T>& iCord) : getter_(iES, iLabel) {
+      this->setGetter(&getter_);
+    }
+
     //virtual ~ESOutlet();
 
-   private:
-      ESOutlet(const ESOutlet&); // stop default
+  private:
+    ESOutlet(const ESOutlet&);  // stop default
 
-      const ESOutlet& operator=(const ESOutlet&); // stop default
+    const ESOutlet& operator=(const ESOutlet&);  // stop default
 
-      // ---------- member data --------------------------------
-      Getter getter_;
-
+    // ---------- member data --------------------------------
+    Getter getter_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ESPreFunctorDecorator.h
+++ b/FWCore/Framework/interface/ESPreFunctorDecorator.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ESPreFunctorDecorator
-// 
+//
 /**\class ESPreFunctorDecorator ESPreFunctorDecorator.h FWCore/Framework/interface/ESPreFunctorDecorator.h
 
  Description: A Decorator that works as a adapter to call a Functor before each call to the decorated method
@@ -27,15 +27,11 @@ the ESProducer's 'produce' method.
 // forward declarations
 
 namespace edm {
-   namespace eventsetup {
+  namespace eventsetup {
 
-template<class TRecord, class TFunctor >
-class ESPreFunctorDecorator
-{
-
-   public:
-      ESPreFunctorDecorator(const TFunctor& iCaller) :
-         caller_(iCaller) {}
+    template <class TRecord, class TFunctor> class ESPreFunctorDecorator {
+    public:
+      ESPreFunctorDecorator(const TFunctor& iCaller) : caller_(iCaller) {}
       //virtual ~ESPreFunctorDecorator();
 
       // ---------- const member functions ---------------------
@@ -43,23 +39,20 @@ class ESPreFunctorDecorator
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
-      void pre(const TRecord& iRecord) {
-         caller_(iRecord);
-      }
-   
-      void post(const TRecord&) {
-      }
-   
-   private:
+      void pre(const TRecord& iRecord) { caller_(iRecord); }
+
+      void post(const TRecord&) {}
+
+    private:
       //ESPreFunctorDecorator(const ESPreFunctorDecorator&); // stop default
 
-      const ESPreFunctorDecorator& operator=(const ESPreFunctorDecorator&) = delete; // stop default
+      const ESPreFunctorDecorator& operator=(const ESPreFunctorDecorator&) = delete;  // stop default
 
       // ---------- member data --------------------------------
       TFunctor caller_;
-};
+    };
 
-   }
-}
+  }  // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -90,14 +90,12 @@ namespace edm {
     //used by ESProducer to create the proper Decorator based on the
     //  argument type passed.  The default it to just 'pass through'
     //  the argument as the decorator itself
-    template< typename T, typename TRecord, typename TDecorator >
+    template <typename T, typename TRecord, typename TDecorator>
     inline const TDecorator& createDecoratorFrom(T*, const TRecord*, const TDecorator& iDec) {
       return iDec;
     }
-  }
-  class ESProducer : public ESProxyFactoryProducer
-  {
-
+  }  // namespace eventsetup
+  class ESProducer : public ESProxyFactoryProducer {
   public:
     ESProducer();
     ~ESProducer() noexcept(false) override;
@@ -112,34 +110,29 @@ namespace edm {
         The method determines the Record argument and return value of the 'produce'
         method in order to do the registration with the EventSetup
     */
-    template<typename T>
-    auto setWhatProduced(T* iThis, const es::Label& iLabel = {}) {
-      return setWhatProduced(iThis , &T::produce, iLabel);
+    template <typename T> auto setWhatProduced(T* iThis, const es::Label& iLabel = {}) {
+      return setWhatProduced(iThis, &T::produce, iLabel);
     }
 
-    template<typename T>
-    auto setWhatProduced(T* iThis, const char* iLabel) {
-      return setWhatProduced(iThis , es::Label(iLabel));
+    template <typename T> auto setWhatProduced(T* iThis, const char* iLabel) {
+      return setWhatProduced(iThis, es::Label(iLabel));
     }
-    template<typename T>
-    auto setWhatProduced(T* iThis, const std::string& iLabel) {
-      return setWhatProduced(iThis , es::Label(iLabel));
+    template <typename T> auto setWhatProduced(T* iThis, const std::string& iLabel) {
+      return setWhatProduced(iThis, es::Label(iLabel));
     }
 
-    template<typename T, typename TDecorator >
+    template <typename T, typename TDecorator>
     auto setWhatProduced(T* iThis, const TDecorator& iDec, const es::Label& iLabel = {}) {
-      return setWhatProduced(iThis , &T::produce, iDec, iLabel);
+      return setWhatProduced(iThis, &T::produce, iDec, iLabel);
     }
     /** \param iThis the 'this' pointer to an inheriting class instance
         \param iMethod a member method of then inheriting class
         The method determines the Record argument and return value of the iMethod argument
         method in order to do the registration with the EventSetup
     */
-    template<typename T, typename TReturn, typename TRecord>
-    auto setWhatProduced(T* iThis,
-                         TReturn (T ::* iMethod)(const TRecord&),
-                         const es::Label& iLabel = {}) {
-      return setWhatProduced(iThis, iMethod, eventsetup::CallbackSimpleDecorator<TRecord>(),iLabel);
+    template <typename T, typename TReturn, typename TRecord>
+    auto setWhatProduced(T* iThis, TReturn (T ::*iMethod)(const TRecord&), const es::Label& iLabel = {}) {
+      return setWhatProduced(iThis, iMethod, eventsetup::CallbackSimpleDecorator<TRecord>(), iLabel);
     }
     /** \param iThis the 'this' pointer to an inheriting class instance
         \param iMethod a member method of then inheriting class
@@ -147,64 +140,59 @@ namespace edm {
         The method determines the Record argument and return value of the iMethod argument
         method in order to do the registration with the EventSetup
     */
-    template<typename T, typename TReturn, typename TRecord, typename TArg>
+    template <typename T, typename TReturn, typename TRecord, typename TArg>
     ESConsumesCollectorT<TRecord> setWhatProduced(T* iThis,
-                         TReturn (T ::* iMethod)(const TRecord&),
-                         const TArg& iDec,
-                         const es::Label& iLabel = {}) {
-      auto callback = std::make_shared<eventsetup::Callback<T,
-                                                            TReturn,
-                                                            TRecord,
-                                                            typename eventsetup::DecoratorFromArg<T,TRecord,TArg>::Decorator_t>>(iThis,
-                                                                                                                                 iMethod,
-                                                                                                                                 createDecoratorFrom(iThis,
-                                                                                                                                                     static_cast<const TRecord*>(nullptr),
-                                                                                                                                                     iDec));
+                                                  TReturn (T ::*iMethod)(const TRecord&),
+                                                  const TArg& iDec,
+                                                  const es::Label& iLabel = {}) {
+      auto callback =
+          std::make_shared<eventsetup::Callback<T, TReturn, TRecord,
+                                                typename eventsetup::DecoratorFromArg<T, TRecord, TArg>::Decorator_t>>(
+              iThis, iMethod, createDecoratorFrom(iThis, static_cast<const TRecord*>(nullptr), iDec));
       registerProducts(callback,
-                       static_cast<const typename eventsetup::produce::product_traits<TReturn>::type *>(nullptr),
-                       static_cast<const TRecord*>(nullptr),
-                       iLabel);
+                       static_cast<const typename eventsetup::produce::product_traits<TReturn>::type*>(nullptr),
+                       static_cast<const TRecord*>(nullptr), iLabel);
       return ESConsumesCollectorT<TRecord>{iThis};
     }
 
-    ESProducer(const ESProducer&) = delete; // stop default
-    ESProducer const& operator=(const ESProducer&) = delete; // stop default
+    ESProducer(const ESProducer&) = delete;                   // stop default
+    ESProducer const& operator=(const ESProducer&) = delete;  // stop default
 
   private:
-
-    template<typename CallbackT, typename TList, typename TRecord>
-    void registerProducts(std::shared_ptr<CallbackT> iCallback, const TList*, const TRecord* iRecord,
+    template <typename CallbackT, typename TList, typename TRecord>
+    void registerProducts(std::shared_ptr<CallbackT> iCallback,
+                          const TList*,
+                          const TRecord* iRecord,
                           const es::Label& iLabel) {
       registerProduct(iCallback, static_cast<const typename TList::tail_type*>(nullptr), iRecord, iLabel);
       registerProducts(iCallback, static_cast<const typename TList::head_type*>(nullptr), iRecord, iLabel);
     }
 
-    template<typename T, typename TRecord>
-    void registerProducts(std::shared_ptr<T>, const eventsetup::produce::Null*, const TRecord*,const es::Label&) {
+    template <typename T, typename TRecord>
+    void registerProducts(std::shared_ptr<T>, const eventsetup::produce::Null*, const TRecord*, const es::Label&) {
       //do nothing
     }
 
-    template<typename T, typename TProduct, typename TRecord>
-    void registerProduct(std::shared_ptr<T> iCallback, const TProduct*, const TRecord*,const es::Label& iLabel) {
+    template <typename T, typename TProduct, typename TRecord>
+    void registerProduct(std::shared_ptr<T> iCallback, const TProduct*, const TRecord*, const es::Label& iLabel) {
       typedef eventsetup::CallbackProxy<T, TRecord, TProduct> ProxyType;
       typedef eventsetup::ProxyArgumentFactoryTemplate<ProxyType, std::shared_ptr<T>> FactoryType;
       registerFactory(std::make_unique<FactoryType>(iCallback), iLabel.default_);
     }
 
-    template<typename T, typename TProduct, typename TRecord, int IIndex>
-    void registerProduct(std::shared_ptr<T> iCallback, const es::L<TProduct,IIndex>*, const TRecord*,const es::Label& iLabel) {
-      if(iLabel.labels_.size() <= IIndex ||
-         iLabel.labels_[IIndex] == es::Label::def()) {
-        Exception::throwThis(errors::Configuration,
-                             "Unnamed Label\nthe index ",
-                             IIndex,
+    template <typename T, typename TProduct, typename TRecord, int IIndex>
+    void registerProduct(std::shared_ptr<T> iCallback,
+                         const es::L<TProduct, IIndex>*,
+                         const TRecord*,
+                         const es::Label& iLabel) {
+      if (iLabel.labels_.size() <= IIndex || iLabel.labels_[IIndex] == es::Label::def()) {
+        Exception::throwThis(errors::Configuration, "Unnamed Label\nthe index ", IIndex,
                              " was never assigned a name in the 'setWhatProduced' method");
       }
       typedef eventsetup::CallbackProxy<T, TRecord, es::L<TProduct, IIndex>> ProxyType;
       typedef eventsetup::ProxyArgumentFactoryTemplate<ProxyType, std::shared_ptr<T>> FactoryType;
       registerFactory(std::make_unique<FactoryType>(iCallback), iLabel.labels_[IIndex]);
     }
-
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ESProducerLooper.h
+++ b/FWCore/Framework/interface/ESProducerLooper.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ESProducerLooper
-// 
+//
 /**\class ESProducerLooper ESProducerLooper.h FWCore/Framework/interface/ESProducerLooper.h
 
  Description: <one line class summary>
@@ -30,37 +30,35 @@
 
 // forward declarations
 namespace edm {
-  class ESProducerLooper : public ESProducer, public EventSetupRecordIntervalFinder, public EDLooper
-{
+  class ESProducerLooper : public ESProducer, public EventSetupRecordIntervalFinder, public EDLooper {
+  public:
+    ESProducerLooper();
+    //virtual ~ESProducerLooper();
 
-   public:
-      ESProducerLooper();
-      //virtual ~ESProducerLooper();
+    // ---------- const member functions ---------------------
 
-      // ---------- const member functions ---------------------
+    // ---------- static member functions --------------------
 
-      // ---------- static member functions --------------------
+    std::set<eventsetup::EventSetupRecordKey> modifyingRecords() const override;
+    // ---------- member functions ---------------------------
 
-      std::set<eventsetup::EventSetupRecordKey> modifyingRecords() const override;
-      // ---------- member functions ---------------------------
+  protected:
+    void setIntervalFor(const eventsetup::EventSetupRecordKey& iKey,
+                        const IOVSyncValue& iTime,
+                        ValidityInterval& oInterval) override;
 
-   protected:
-      void setIntervalFor(const eventsetup::EventSetupRecordKey& iKey,
-                          const IOVSyncValue& iTime, 
-                          ValidityInterval& oInterval) override;
-        
-      //use this to 'snoop' on what records are being used by the Producer
-      void registerFactoryWithKey(const eventsetup::EventSetupRecordKey& iRecord ,
-                                          std::unique_ptr<eventsetup::ProxyFactoryBase> iFactory,
-                                          const std::string& iLabel= std::string() ) override;
-private:
-      ESProducerLooper(const ESProducerLooper&) = delete; // stop default
+    //use this to 'snoop' on what records are being used by the Producer
+    void registerFactoryWithKey(const eventsetup::EventSetupRecordKey& iRecord,
+                                std::unique_ptr<eventsetup::ProxyFactoryBase> iFactory,
+                                const std::string& iLabel = std::string()) override;
 
-      const ESProducerLooper& operator=(const ESProducerLooper&) = delete; // stop default
+  private:
+    ESProducerLooper(const ESProducerLooper&) = delete;  // stop default
 
-      // ---------- member data --------------------------------
+    const ESProducerLooper& operator=(const ESProducerLooper&) = delete;  // stop default
 
-};
-}
+    // ---------- member data --------------------------------
+  };
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ESProductHost.h
+++ b/FWCore/Framework/interface/ESProductHost.h
@@ -89,23 +89,18 @@ namespace edm {
   // selected does not mattter, just that some order exists
   // so we know which cacheID corresponds to which type.
 
-  template <typename Product, typename ... RecordTypes>
-  class ESProductHost final : public Product {
-
+  template <typename Product, typename... RecordTypes> class ESProductHost final : public Product {
   public:
-
     template <typename... Args>
-    ESProductHost(Args&&... args) : Product(std::forward<Args>(args)...),
-                                    cacheIDs_(numberOfRecordTypes(), 0) { }
+    ESProductHost(Args&&... args) : Product(std::forward<Args>(args)...), cacheIDs_(numberOfRecordTypes(), 0) {}
 
     // Execute FUNC if the cacheIdentifier in the EventSetup RecordType
     // has changed since the last time we called FUNC for
     // this EventSetup product.
 
     template <typename RecordType, typename ContainingRecordType, typename FUNC>
-    void ifRecordChanges(ContainingRecordType const& containingRecord,
-                         FUNC func) {
-      RecordType const& record = containingRecord. template getRecord<RecordType>();
+    void ifRecordChanges(ContainingRecordType const& containingRecord, FUNC func) {
+      RecordType const& record = containingRecord.template getRecord<RecordType>();
       unsigned long long cacheIdentifier = record.cacheIdentifier();
       std::size_t iRecord = index<RecordType>();
       if (cacheIdentifier != cacheIDs_[iRecord]) {
@@ -129,29 +124,26 @@ namespace edm {
     // (There must be at least one type after Product if you want to call the
     // "ifRecordChanges" function).
 
-    template <typename U>
-    constexpr static std::size_t index() {
+    template <typename U> constexpr static std::size_t index() {
       static_assert(numberOfRecordTypes() > 0, "no record types in ESProductHost");
       return indexLoop<0, U, RecordTypes...>();
     }
 
-    template <std::size_t I, typename U, typename TST, typename... M>
-    constexpr static std::size_t indexLoop() {
+    template <std::size_t I, typename U, typename TST, typename... M> constexpr static std::size_t indexLoop() {
       if constexpr (std::is_same_v<U, TST>) {
         return I;
       } else {
         static_assert(I + 1 < numberOfRecordTypes(), "unknown record type passed to ESProductHost::index");
-        return indexLoop<I+1, U, M...>();
+        return indexLoop<I + 1, U, M...>();
       }
     }
 
   private:
-
     // Data member, this holds the cache identifiers from the record which
     // are used to determine whether the EventSetup cache for that record has
     // been updated since this Product was lasted updated.
 
     std::vector<unsigned long long> cacheIDs_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ESProducts.h
+++ b/FWCore/Framework/interface/ESProducts.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ESProducts
-// 
+//
 /**\class ESProducts ESProducts.h FWCore/Framework/interface/ESProducts.h
 
  Description: Container for multiple products created by an ESProducer
@@ -28,115 +28,89 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {      
-      namespace produce {
-         template<typename T1, typename... TArgs>
-            struct ProductHolder : public ProductHolder<TArgs...> {
-              using parent_type = ProductHolder<TArgs...>;
-              
-              ProductHolder() : value() {}
-              ProductHolder(ProductHolder<T1,TArgs...>&&) = default;
-              ProductHolder(ProductHolder<T1,TArgs...> const&) = default;
-              ProductHolder<T1, TArgs...>& operator=(ProductHolder<T1,TArgs...>&&) = default;
-              ProductHolder<T1, TArgs...>& operator=(ProductHolder<T1,TArgs...> const&) = default;
+  namespace eventsetup {
+    namespace produce {
+      template <typename T1, typename... TArgs> struct ProductHolder : public ProductHolder<TArgs...> {
+        using parent_type = ProductHolder<TArgs...>;
 
-               template<typename T>
-                  void setAllValues(T& iValuesFrom) {
-                     iValuesFrom.setFromRecursive(*this);
-                  }
-               using parent_type::moveTo;
-               void moveTo(T1& oValue) { oValue = std::move(value); }
+        ProductHolder() : value() {}
+        ProductHolder(ProductHolder<T1, TArgs...>&&) = default;
+        ProductHolder(ProductHolder<T1, TArgs...> const&) = default;
+        ProductHolder<T1, TArgs...>& operator=(ProductHolder<T1, TArgs...>&&) = default;
+        ProductHolder<T1, TArgs...>& operator=(ProductHolder<T1, TArgs...> const&) = default;
 
-               using parent_type::setFrom;
-               void setFrom(T1& iValue) { value = iValue ; }
-               void setFrom(T1&& iValue) { value = std::move(iValue) ; }
+        template <typename T> void setAllValues(T& iValuesFrom) { iValuesFrom.setFromRecursive(*this); }
+        using parent_type::moveTo;
+        void moveTo(T1& oValue) { oValue = std::move(value); }
 
-               template<typename T>
-                  void setFromRecursive(T& iValuesTo) {
-                     iValuesTo.setFrom(value);
-                     parent_type::setFromRecursive(iValuesTo);
-                  }
+        using parent_type::setFrom;
+        void setFrom(T1& iValue) { value = iValue; }
+        void setFrom(T1&& iValue) { value = std::move(iValue); }
 
-               template<typename T>
-                  void moveToRecursive(T& iValuesTo) {
-                     iValuesTo.moveTo(value);
-                     parent_type::moveToRecursive(iValuesTo);
-                  }
-               T1 value;
-               
-               using tail_type = T1;
-               using head_type = parent_type;
-            };
-         
-         template<typename T1>
-            struct ProductHolder<T1> {
-               
-              ProductHolder() : value() {}
-              ProductHolder(ProductHolder<T1>&&) = default;
-              ProductHolder(ProductHolder<T1> const&) = default;
-              ProductHolder<T1>& operator=(ProductHolder<T1>&&) = default;
-              ProductHolder<T1>& operator=(ProductHolder<T1> const&) = default;
+        template <typename T> void setFromRecursive(T& iValuesTo) {
+          iValuesTo.setFrom(value);
+          parent_type::setFromRecursive(iValuesTo);
+        }
 
-              template<typename T>
-               void setAllValues(T& iValuesFrom) {
-                  iValuesFrom.moveToRecursive(*this);
-               }
-               void moveTo(T1& oValue) { oValue = std::move(value); }
-               void setFrom(T1& iValue) { value = iValue ; }
-               void setFrom(T1&& iValue) { value = std::move(iValue) ; }
-               template<typename T>
-               void moveToRecursive(T& iValuesTo) {
-                  iValuesTo.moveTo(value);
-               }
-               template<typename T>
-               void setFromRecursive(T& iValuesTo) {
-                  iValuesTo.setFrom(value);
-               }
-               T1 value;
-               
-               using tail_type = T1;
-               using head_type = Null;
-            };
-         
-      }
-   }
-   struct ESFillDirectly {};
+        template <typename T> void moveToRecursive(T& iValuesTo) {
+          iValuesTo.moveTo(value);
+          parent_type::moveToRecursive(iValuesTo);
+        }
+        T1 value;
 
-   template<typename ...TArgs>
-   struct ESProducts : public eventsetup::produce::ProductHolder<TArgs...> {
-      typedef eventsetup::produce::ProductHolder<TArgs...> parent_type;
-      template<typename... S>
-      ESProducts(ESProducts<S...>&& iProducts) {
-         parent_type::setAllValues(iProducts);
-      }
-      template<typename T>
-      /*explicit*/ ESProducts(T&& iValues) {
-         parent_type::setAllValues(iValues);
-      }
-      template<typename ...Vars>
-      ESProducts(ESFillDirectly, Vars&&... vars) {
-         (this->setFrom(std::forward<Vars>(vars)), ...);
-      }
+        using tail_type = T1;
+        using head_type = parent_type;
+      };
 
-      ESProducts(ESProducts<TArgs...> const&) = default;
-      ESProducts(ESProducts<TArgs...>&&) = default;
-      ESProducts<TArgs...>& operator=(ESProducts<TArgs...> const&) = default;
-      ESProducts<TArgs...>& operator=(ESProducts<TArgs...>&&) = default;
-   };
+      template <typename T1> struct ProductHolder<T1> {
+        ProductHolder() : value() {}
+        ProductHolder(ProductHolder<T1>&&) = default;
+        ProductHolder(ProductHolder<T1> const&) = default;
+        ProductHolder<T1>& operator=(ProductHolder<T1>&&) = default;
+        ProductHolder<T1>& operator=(ProductHolder<T1> const&) = default;
 
-   namespace es {
-      template<typename ...TArgs>
-      ESProducts<std::remove_reference_t<TArgs>...> products(TArgs&&... args) {
-         return ESProducts<std::remove_reference_t<TArgs>...>(edm::ESFillDirectly{}, std::forward<TArgs>(args)...);
-      }
-   }
+        template <typename T> void setAllValues(T& iValuesFrom) { iValuesFrom.moveToRecursive(*this); }
+        void moveTo(T1& oValue) { oValue = std::move(value); }
+        void setFrom(T1& iValue) { value = iValue; }
+        void setFrom(T1&& iValue) { value = std::move(iValue); }
+        template <typename T> void moveToRecursive(T& iValuesTo) { iValuesTo.moveTo(value); }
+        template <typename T> void setFromRecursive(T& iValuesTo) { iValuesTo.setFrom(value); }
+        T1 value;
 
-   template<typename ...TArgs, typename ToT>
-     void moveFromTo(ESProducts<TArgs...>& iFrom,
-                     ToT& iTo) {
-       iFrom.moveTo(iTo);
-     }
-}
+        using tail_type = T1;
+        using head_type = Null;
+      };
 
+    }  // namespace produce
+  }    // namespace eventsetup
+  struct ESFillDirectly {};
+
+  template <typename... TArgs> struct ESProducts : public eventsetup::produce::ProductHolder<TArgs...> {
+    typedef eventsetup::produce::ProductHolder<TArgs...> parent_type;
+    template <typename... S> ESProducts(ESProducts<S...>&& iProducts) { parent_type::setAllValues(iProducts); }
+    template <typename T>
+    /*explicit*/ ESProducts(T&& iValues) {
+      parent_type::setAllValues(iValues);
+    }
+    template <typename... Vars> ESProducts(ESFillDirectly, Vars&&... vars) {
+      (this->setFrom(std::forward<Vars>(vars)), ...);
+    }
+
+    ESProducts(ESProducts<TArgs...> const&) = default;
+    ESProducts(ESProducts<TArgs...>&&) = default;
+    ESProducts<TArgs...>& operator=(ESProducts<TArgs...> const&) = default;
+    ESProducts<TArgs...>& operator=(ESProducts<TArgs...>&&) = default;
+  };
+
+  namespace es {
+    template <typename... TArgs> ESProducts<std::remove_reference_t<TArgs>...> products(TArgs&&... args) {
+      return ESProducts<std::remove_reference_t<TArgs>...>(edm::ESFillDirectly{}, std::forward<TArgs>(args)...);
+    }
+  }  // namespace es
+
+  template <typename... TArgs, typename ToT> void moveFromTo(ESProducts<TArgs...>& iFrom, ToT& iTo) {
+    iFrom.moveTo(iTo);
+  }
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ESProxyFactoryProducer.h
+++ b/FWCore/Framework/interface/ESProxyFactoryProducer.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ESProxyFactoryProducer
-// 
+//
 /**\class ESProxyFactoryProducer ESProxyFactoryProducer.h FWCore/Framework/interface/ESProxyFactoryProducer.h
 
  Description: An EventSetup algorithmic Provider that manages Factories of Proxies
@@ -62,72 +62,60 @@ BarProd::BarProd(const edm::ParameterSet& iPS) {
 #include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace edm {
-   namespace eventsetup {
-      class ProxyFactoryBase;
-      
-      struct FactoryInfo {
-         FactoryInfo() : key_(), factory_() {}
-         FactoryInfo(const DataKey& iKey, 
-                      std::shared_ptr<ProxyFactoryBase> iFactory)
-         : key_(iKey), 
-         factory_(iFactory) {} 
-         DataKey key_;
-         edm::propagate_const<std::shared_ptr<ProxyFactoryBase>> factory_;
-      };
-   }      
-   
-class ESProxyFactoryProducer : public eventsetup::DataProxyProvider
-{
+  namespace eventsetup {
+    class ProxyFactoryBase;
 
-   public:
-      ESProxyFactoryProducer();
-      ~ESProxyFactoryProducer() noexcept(false) override;
+    struct FactoryInfo {
+      FactoryInfo() : key_(), factory_() {}
+      FactoryInfo(const DataKey& iKey, std::shared_ptr<ProxyFactoryBase> iFactory) : key_(iKey), factory_(iFactory) {}
+      DataKey key_;
+      edm::propagate_const<std::shared_ptr<ProxyFactoryBase>> factory_;
+    };
+  }  // namespace eventsetup
 
-      // ---------- const member functions ---------------------
+  class ESProxyFactoryProducer : public eventsetup::DataProxyProvider {
+  public:
+    ESProxyFactoryProducer();
+    ~ESProxyFactoryProducer() noexcept(false) override;
 
-      // ---------- static member functions --------------------
+    // ---------- const member functions ---------------------
 
-      // ---------- member functions ---------------------------
-      ///overrides DataProxyProvider method
-      void newInterval(const eventsetup::EventSetupRecordKey& iRecordType,
-                                const ValidityInterval& iInterval) override ;
+    // ---------- static member functions --------------------
 
-   protected:
-      ///override DataProxyProvider method
-      void registerProxies(const eventsetup::EventSetupRecordKey& iRecord ,
-                                    KeyedProxies& aProxyList) override ;
+    // ---------- member functions ---------------------------
+    ///overrides DataProxyProvider method
+    void newInterval(const eventsetup::EventSetupRecordKey& iRecordType, const ValidityInterval& iInterval) override;
 
-      /** \param iFactory unique_ptr holding a new instance of a Factory
+  protected:
+    ///override DataProxyProvider method
+    void registerProxies(const eventsetup::EventSetupRecordKey& iRecord, KeyedProxies& aProxyList) override;
+
+    /** \param iFactory unique_ptr holding a new instance of a Factory
          \param iLabel extra string label used to get data (optional)
          Producer takes ownership of the Factory and uses it create the appropriate
          Proxy which is then registered with the EventSetup.  If used, this method should
          be called in inheriting class' constructor.
       */
-      template< class TFactory>
-         void registerFactory(std::unique_ptr<TFactory> iFactory,
-                              const std::string& iLabel = std::string()) {
-            std::unique_ptr<eventsetup::ProxyFactoryBase> temp(iFactory.release());
-            registerFactoryWithKey(
-                                   eventsetup::EventSetupRecordKey::makeKey<typename TFactory::record_type>(),
-                                   std::move(temp),
-                                   iLabel);
-         }
-      
-      virtual void registerFactoryWithKey(const eventsetup::EventSetupRecordKey& iRecord ,
-                                          std::unique_ptr<eventsetup::ProxyFactoryBase> iFactory,
-                                          const std::string& iLabel= std::string() );
+    template <class TFactory>
+    void registerFactory(std::unique_ptr<TFactory> iFactory, const std::string& iLabel = std::string()) {
+      std::unique_ptr<eventsetup::ProxyFactoryBase> temp(iFactory.release());
+      registerFactoryWithKey(eventsetup::EventSetupRecordKey::makeKey<typename TFactory::record_type>(),
+                             std::move(temp), iLabel);
+    }
 
-   private:
-      ESProxyFactoryProducer(const ESProxyFactoryProducer&) = delete; // stop default
+    virtual void registerFactoryWithKey(const eventsetup::EventSetupRecordKey& iRecord,
+                                        std::unique_ptr<eventsetup::ProxyFactoryBase> iFactory,
+                                        const std::string& iLabel = std::string());
 
-      const ESProxyFactoryProducer& operator=(const ESProxyFactoryProducer&) = delete; // stop default
+  private:
+    ESProxyFactoryProducer(const ESProxyFactoryProducer&) = delete;  // stop default
 
-      
-      // ---------- member data --------------------------------
-      std::multimap< eventsetup::EventSetupRecordKey, eventsetup::FactoryInfo > record2Factories_;
+    const ESProxyFactoryProducer& operator=(const ESProxyFactoryProducer&) = delete;  // stop default
 
-};
+    // ---------- member data --------------------------------
+    std::multimap<eventsetup::EventSetupRecordKey, eventsetup::FactoryInfo> record2Factories_;
+  };
 
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ESTransientHandle.h
+++ b/FWCore/Framework/interface/ESTransientHandle.h
@@ -35,34 +35,32 @@ the end of the actual IOV for the data.  In this way the system can claim back s
 // forward declarations
 namespace edm {
 
-class ESHandleExceptionFactory;
+  class ESHandleExceptionFactory;
 
-template<typename T>
-class ESTransientHandle : public ESHandleBase {
-   public:
-      typedef T value_type;
+  template <typename T> class ESTransientHandle : public ESHandleBase {
+  public:
+    typedef T value_type;
 
-      ESTransientHandle() : ESHandleBase() {}
-      ESTransientHandle(T const* iData) : ESHandleBase(iData, 0) {}
-      ESTransientHandle(T const* iData, edm::eventsetup::ComponentDescription const* desc) : ESHandleBase(iData, desc) {}
-      ESTransientHandle(std::shared_ptr<ESHandleExceptionFactory> &&);
+    ESTransientHandle() : ESHandleBase() {}
+    ESTransientHandle(T const* iData) : ESHandleBase(iData, 0) {}
+    ESTransientHandle(T const* iData, edm::eventsetup::ComponentDescription const* desc) : ESHandleBase(iData, desc) {}
+    ESTransientHandle(std::shared_ptr<ESHandleExceptionFactory>&&);
 
-      // ---------- const member functions ---------------------
-      T const* product() const { return static_cast<T const *>(productStorage()); }
-      T const* operator->() const { return product(); }
-      T const& operator*() const { return *product(); }
-      // ---------- static member functions --------------------
-      static constexpr bool transientAccessOnly = true;
+    // ---------- const member functions ---------------------
+    T const* product() const { return static_cast<T const*>(productStorage()); }
+    T const* operator->() const { return product(); }
+    T const& operator*() const { return *product(); }
+    // ---------- static member functions --------------------
+    static constexpr bool transientAccessOnly = true;
 
-      // ---------- member functions ---------------------------
+    // ---------- member functions ---------------------------
 
-   private:
-};
+  private:
+  };
 
-template <class T>
-ESTransientHandle<T>::ESTransientHandle(std::shared_ptr<edm::ESHandleExceptionFactory> && iWhyFailed) :
-  ESHandleBase(std::move(iWhyFailed))
-{ }
+  template <class T>
+  ESTransientHandle<T>::ESTransientHandle(std::shared_ptr<edm::ESHandleExceptionFactory>&& iWhyFailed)
+      : ESHandleBase(std::move(iWhyFailed)) {}
 
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ESValidHandle.h
+++ b/FWCore/Framework/interface/ESValidHandle.h
@@ -33,46 +33,41 @@ namespace edm {
     void throwIfNotValid(const void*) noexcept(false);
   }
 
-template<typename T>
-class ESValidHandle {
-   public:
-      typedef T value_type;
+  template <typename T> class ESValidHandle {
+  public:
+    typedef T value_type;
 
-      ESValidHandle() = delete;
-      ESValidHandle(T const& iData, edm::eventsetup::ComponentDescription const* desc) noexcept :
-      data_{&iData},
-      description_{desc} {}
+    ESValidHandle() = delete;
+    ESValidHandle(T const& iData, edm::eventsetup::ComponentDescription const* desc) noexcept
+        : data_{&iData}, description_{desc} {}
 
-      ESValidHandle(ESValidHandle<T> const&) = default;
-      ESValidHandle(ESValidHandle<T>&&) = default;
-      ESValidHandle& operator=(ESValidHandle<T> const&) = default;
-      ESValidHandle& operator=(ESValidHandle<T>&&) = default;
+    ESValidHandle(ESValidHandle<T> const&) = default;
+    ESValidHandle(ESValidHandle<T>&&) = default;
+    ESValidHandle& operator=(ESValidHandle<T> const&) = default;
+    ESValidHandle& operator=(ESValidHandle<T>&&) = default;
 
-      // ---------- const member functions ---------------------
-      T const* product() const noexcept { return data_; }
-      T const* operator->() const noexcept { return product(); }
-      T const& operator*() const noexcept { return *product(); }
-      // ---------- static member functions --------------------
-      static constexpr bool transientAccessOnly = false;
+    // ---------- const member functions ---------------------
+    T const* product() const noexcept { return data_; }
+    T const* operator->() const noexcept { return product(); }
+    T const& operator*() const noexcept { return *product(); }
+    // ---------- static member functions --------------------
+    static constexpr bool transientAccessOnly = false;
 
-      // ---------- member functions ---------------------------
-   private:
-      T const* data_{nullptr};
-      edm::eventsetup::ComponentDescription const* description_{nullptr};
-
-};
+    // ---------- member functions ---------------------------
+  private:
+    T const* data_{nullptr};
+    edm::eventsetup::ComponentDescription const* description_{nullptr};
+  };
 
   /** Take a handle (e.g. edm::ESHandle<T>) and
    create a edm::ESValidHandle<T>. If the argument is an invalid handle,
    an exception will be thrown.
    */
-  template<typename U>
-  auto
-  makeESValid(const U& iOtherHandleType) noexcept(false) {
+  template <typename U> auto makeESValid(const U& iOtherHandleType) noexcept(false) {
     esvhhelper::throwIfNotValid(iOtherHandleType.product());
     //because of the check, we know this is valid and do not have to check again
     return ESValidHandle<typename U::value_type>(*iOtherHandleType.product(), iOtherHandleType.description());
   }
 
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ESWatcher.h
+++ b/FWCore/Framework/interface/ESWatcher.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ESWatcher
-// 
+//
 /**\class ESWatcher ESWatcher.h FWCore/Framework/interface/ESWatcher.h
 
  Description: Watches an EventSetup Record and reports when it changes
@@ -27,51 +27,45 @@
 // forward declarations
 
 namespace edm {
-  template <class T>
-  class ESWatcher
-  {
-
-   public:
-    
+  template <class T> class ESWatcher {
+  public:
     struct NullFunction {
-      void operator()(const T& ) {}
+      void operator()(const T&) {}
     };
-    
-    ESWatcher() :callback_(NullFunction()), cacheId_(0) {}
-    
-    template <class TFunc>
-    ESWatcher(TFunc iFunctor):callback_(iFunctor),cacheId_(0) {}
-    
+
+    ESWatcher() : callback_(NullFunction()), cacheId_(0) {}
+
+    template <class TFunc> ESWatcher(TFunc iFunctor) : callback_(iFunctor), cacheId_(0) {}
+
     template <class TObj, class TMemFunc>
-    ESWatcher(TObj const& iObj, TMemFunc iFunc):
-    callback_(std::bind(iFunc,iObj,std::placeholders::_1)),
-    cacheId_(0)
-     {}
-      //virtual ~ESWatcher();
+    ESWatcher(TObj const& iObj, TMemFunc iFunc)
+        : callback_(std::bind(iFunc, iObj, std::placeholders::_1)), cacheId_(0) {}
+    //virtual ~ESWatcher();
 
-      // ---------- const member functions ---------------------
-    
-      // ---------- static member functions --------------------
+    // ---------- const member functions ---------------------
 
-      // ---------- member functions ---------------------------
-      bool check(const edm::EventSetup& iSetup) {
-        const T& record = iSetup.template get<T>();
-        bool result = cacheId_ != record.cacheIdentifier();
-        if(result) {
-          callback_(record);
-        }
-        cacheId_ = record.cacheIdentifier();
-        return result;
+    // ---------- static member functions --------------------
+
+    // ---------- member functions ---------------------------
+    bool check(const edm::EventSetup& iSetup) {
+      const T& record = iSetup.template get<T>();
+      bool result = cacheId_ != record.cacheIdentifier();
+      if (result) {
+        callback_(record);
       }
-   private:
-      ESWatcher(const ESWatcher&) = delete; // stop default
+      cacheId_ = record.cacheIdentifier();
+      return result;
+    }
 
-      const ESWatcher& operator=(const ESWatcher&) = delete; // stop default
+  private:
+    ESWatcher(const ESWatcher&) = delete;  // stop default
 
-      // ---------- member data --------------------------------
-      std::function<void (const T&)> callback_;
-      unsigned long long cacheId_;
-};
-}
+    const ESWatcher& operator=(const ESWatcher&) = delete;  // stop default
+
+    // ---------- member data --------------------------------
+    std::function<void(const T&)> callback_;
+    unsigned long long cacheId_;
+  };
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -64,22 +64,20 @@ namespace edm {
   class SharedResourcesAcquirer;
 
   namespace stream {
-    template< typename T> class ProducingModuleAdaptorBase;
+    template <typename T> class ProducingModuleAdaptorBase;
   }
 
   class Event : public EventBase {
   public:
-    Event(EventPrincipal const& ep, ModuleDescription const& md,
-          ModuleCallingContext const*);
+    Event(EventPrincipal const& ep, ModuleDescription const& md, ModuleCallingContext const*);
     ~Event() override;
 
     //Used in conjunction with EDGetToken
     void setConsumer(EDConsumerBase const* iConsumer);
 
-    void setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer);
+    void setSharedResourcesAcquirer(SharedResourcesAcquirer* iResourceAcquirer);
 
-    void setProducerCommon(ProducerBase const* iProd,
-                           std::vector<BranchID>* previousParentage);
+    void setProducerCommon(ProducerBase const* iProd, std::vector<BranchID>* previousParentage);
 
     void setProducer(ProducerBase const* iProd,
                      std::vector<BranchID>* previousParentage,
@@ -90,23 +88,16 @@ namespace edm {
                                std::vector<BranchID>& gotBranchIDsFromAcquire);
 
     // AUX functions are defined in EventBase
-    EventAuxiliary const& eventAuxiliary() const override {return aux_;}
+    EventAuxiliary const& eventAuxiliary() const override { return aux_; }
 
     ///\return The id for the particular Stream processing the Event
-    StreamID streamID() const {
-      return streamID_;
-    }
+    StreamID streamID() const { return streamID_; }
 
-    LuminosityBlock const&
-    getLuminosityBlock() const {
-      return *luminosityBlock_;
-    }
+    LuminosityBlock const& getLuminosityBlock() const { return *luminosityBlock_; }
 
-    Run const&
-    getRun() const;
+    Run const& getRun() const;
 
-    RunNumber_t
-    run() const {return id().run();}
+    RunNumber_t run() const { return id().run(); }
 
     /**If you are caching data from the Event, you should also keep
      this number.  If this number changes then you know that
@@ -115,165 +106,104 @@ namespace edm {
      denote that you have not yet checked the value.
      */
     typedef unsigned long CacheIdentifier_t;
-    CacheIdentifier_t
-    cacheIdentifier() const;
+    CacheIdentifier_t cacheIdentifier() const;
 
-    template<typename PROD>
-    bool
-    get(ProductID const& oid, Handle<PROD>& result) const;
+    template <typename PROD> bool get(ProductID const& oid, Handle<PROD>& result) const;
 
     // Template member overload to deal with Views.
-    template<typename ELEMENT>
-    bool
-    get(ProductID const& oid, Handle<View<ELEMENT> >& result) const ;
+    template <typename ELEMENT> bool get(ProductID const& oid, Handle<View<ELEMENT>>& result) const;
 
     EventSelectionIDVector const& eventSelectionIDs() const;
 
     ProcessHistoryID const& processHistoryID() const;
 
     ///Put a new product.
-    template<typename PROD>
-    OrphanHandle<PROD>
-    put(std::unique_ptr<PROD> product) {return put<PROD>(std::move(product), std::string());}
+    template <typename PROD> OrphanHandle<PROD> put(std::unique_ptr<PROD> product) {
+      return put<PROD>(std::move(product), std::string());
+    }
 
     ///Put a new product with a 'product instance name'
-    template<typename PROD>
-    OrphanHandle<PROD>
-    put(std::unique_ptr<PROD> product, std::string const& productInstanceName);
+    template <typename PROD>
+    OrphanHandle<PROD> put(std::unique_ptr<PROD> product, std::string const& productInstanceName);
 
-    template<typename PROD>
-    OrphanHandle<PROD>
-    put(EDPutToken token, std::unique_ptr<PROD> product);
+    template <typename PROD> OrphanHandle<PROD> put(EDPutToken token, std::unique_ptr<PROD> product);
 
-    template<typename PROD>
-    OrphanHandle<PROD>
-    put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product);
+    template <typename PROD> OrphanHandle<PROD> put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product);
 
     ///puts a new product
-    template<typename PROD, typename... Args>
-    OrphanHandle<PROD>
-    emplace(EDPutTokenT<PROD> token, Args&&... args);
+    template <typename PROD, typename... Args> OrphanHandle<PROD> emplace(EDPutTokenT<PROD> token, Args&&... args);
 
-    template<typename PROD, typename... Args>
-    OrphanHandle<PROD>
-    emplace(EDPutToken token, Args&&... args);
-
+    template <typename PROD, typename... Args> OrphanHandle<PROD> emplace(EDPutToken token, Args&&... args);
 
     ///Returns a RefProd to a product before that product has been placed into the Event.
     /// The RefProd (and any Ref's made from it) will no work properly until after the
     /// Event has been committed (which happens after leaving the EDProducer::produce method)
-    template<typename PROD>
-    RefProd<PROD>
-    getRefBeforePut() {return getRefBeforePut<PROD>(std::string());}
+    template <typename PROD> RefProd<PROD> getRefBeforePut() { return getRefBeforePut<PROD>(std::string()); }
 
-    template<typename PROD>
-    RefProd<PROD>
-    getRefBeforePut(std::string const& productInstanceName);
+    template <typename PROD> RefProd<PROD> getRefBeforePut(std::string const& productInstanceName);
 
-    template<typename PROD>
-    RefProd<PROD>
-    getRefBeforePut(EDPutTokenT<PROD>);
+    template <typename PROD> RefProd<PROD> getRefBeforePut(EDPutTokenT<PROD>);
 
-    template<typename PROD>
-    RefProd<PROD>
-    getRefBeforePut(EDPutToken);
+    template <typename PROD> RefProd<PROD> getRefBeforePut(EDPutToken);
 
-    template<typename PROD>
-    bool
-    getByLabel(InputTag const& tag, Handle<PROD>& result) const;
+    template <typename PROD> bool getByLabel(InputTag const& tag, Handle<PROD>& result) const;
 
-    template<typename PROD>
-    bool
-    getByLabel(std::string const& label, Handle<PROD>& result) const;
+    template <typename PROD> bool getByLabel(std::string const& label, Handle<PROD>& result) const;
 
-    template<typename PROD>
-    bool
-    getByLabel(std::string const& label, std::string const& productInstanceName, Handle<PROD>& result) const;
+    template <typename PROD>
+    bool getByLabel(std::string const& label, std::string const& productInstanceName, Handle<PROD>& result) const;
 
-    template<typename PROD>
-    void
-    getManyByType(std::vector<Handle<PROD> >& results) const;
+    template <typename PROD> void getManyByType(std::vector<Handle<PROD>>& results) const;
 
-    template<typename PROD>
-    bool
-    getByToken(EDGetToken token, Handle<PROD>& result) const;
+    template <typename PROD> bool getByToken(EDGetToken token, Handle<PROD>& result) const;
 
-    template<typename PROD>
-    bool
-    getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
+    template <typename PROD> bool getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
 
-    template<typename PROD>
-    Handle<PROD>
-    getHandle(EDGetTokenT<PROD> token) const;
+    template <typename PROD> Handle<PROD> getHandle(EDGetTokenT<PROD> token) const;
 
-    template<typename PROD>
-    PROD const &
-    get(EDGetTokenT<PROD> token) const noexcept(false);
+    template <typename PROD> PROD const& get(EDGetTokenT<PROD> token) const noexcept(false);
 
     // Template member overload to deal with Views.
-    template<typename ELEMENT>
-    bool
-    getByLabel(std::string const& label,
-               Handle<View<ELEMENT> >& result) const;
+    template <typename ELEMENT> bool getByLabel(std::string const& label, Handle<View<ELEMENT>>& result) const;
 
-    template<typename ELEMENT>
-    bool
-    getByLabel(std::string const& label,
-               std::string const& productInstanceName,
-               Handle<View<ELEMENT> >& result) const;
+    template <typename ELEMENT>
+    bool getByLabel(std::string const& label,
+                    std::string const& productInstanceName,
+                    Handle<View<ELEMENT>>& result) const;
 
-    template<typename ELEMENT>
-    bool
-    getByLabel(InputTag const& tag, Handle<View<ELEMENT> >& result) const;
+    template <typename ELEMENT> bool getByLabel(InputTag const& tag, Handle<View<ELEMENT>>& result) const;
 
-    template<typename ELEMENT>
-    bool
-    getByToken(EDGetToken token, Handle<View<ELEMENT>>& result) const;
+    template <typename ELEMENT> bool getByToken(EDGetToken token, Handle<View<ELEMENT>>& result) const;
 
-    template<typename ELEMENT>
-    bool
-    getByToken(EDGetTokenT<View<ELEMENT>> token, Handle<View<ELEMENT>>& result) const;
+    template <typename ELEMENT> bool getByToken(EDGetTokenT<View<ELEMENT>> token, Handle<View<ELEMENT>>& result) const;
 
-    template<typename ELEMENT>
-    Handle<View<ELEMENT>>
-    getHandle(EDGetTokenT<View<ELEMENT>> token) const;
+    template <typename ELEMENT> Handle<View<ELEMENT>> getHandle(EDGetTokenT<View<ELEMENT>> token) const;
 
-    template<typename ELEMENT>
-    View<ELEMENT> const &
-    get(EDGetTokenT<View<ELEMENT>> token) const noexcept(false);
+    template <typename ELEMENT> View<ELEMENT> const& get(EDGetTokenT<View<ELEMENT>> token) const noexcept(false);
 
-    template<typename ELEMENT>
-    Handle<View<ELEMENT> >
-    fillView_(BasicHandle& bh) const;
+    template <typename ELEMENT> Handle<View<ELEMENT>> fillView_(BasicHandle& bh) const;
 
-    Provenance
-    getProvenance(BranchID const& theID) const;
+    Provenance getProvenance(BranchID const& theID) const;
 
-    Provenance
-    getProvenance(ProductID const& theID) const;
+    Provenance getProvenance(ProductID const& theID) const;
 
     // Get the provenance for all products that may be in the event
-    void
-    getAllProvenance(std::vector<Provenance const*>& provenances) const;
+    void getAllProvenance(std::vector<Provenance const*>& provenances) const;
 
     // Get the provenance for all products that may be in the event,
     // excluding the per-event provenance (the parentage information).
     // The excluded information may change from event to event.
-    void
-    getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
+    void getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
 
     // Return true if this Event has been subjected to a process with
     // the given processName, and false otherwise.
     // If true is returned, then ps is filled with the ParameterSet
     // used to configure the identified process.
-    bool
-    getProcessParameterSet(std::string const& processName, ParameterSet& ps) const;
+    bool getProcessParameterSet(std::string const& processName, ParameterSet& ps) const;
 
-    ProcessHistory const&
-    processHistory() const override;
+    ProcessHistory const& processHistory() const override;
 
-    edm::ParameterSet const*
-    parameterSet(edm::ParameterSetID const& psID) const override;
+    edm::ParameterSet const* parameterSet(edm::ParameterSetID const& psID) const override;
 
     size_t size() const;
 
@@ -282,37 +212,35 @@ namespace edm {
 
     ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
 
-    void labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const { provRecorder_.labelsForToken(iToken, oLabels); }
+    void labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const {
+      provRecorder_.labelsForToken(iToken, oLabels);
+    }
 
     typedef std::vector<edm::propagate_const<std::unique_ptr<WrapperBase>>> ProductPtrVec;
 
-    EDProductGetter const&
-    productGetter() const;
+    EDProductGetter const& productGetter() const;
 
   private:
     //for testing
     friend class ::testEventGetRefBeforePut;
     friend class ::testEvent;
-    
-    EventPrincipal const&
-    eventPrincipal() const;
 
-    ProductID
-    makeProductID(BranchDescription const& desc) const;
+    EventPrincipal const& eventPrincipal() const;
+
+    ProductID makeProductID(BranchDescription const& desc) const;
 
     //override used by EventBase class
-    BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const override;
+    BasicHandle getByLabelImpl(std::type_info const& iWrapperType,
+                               std::type_info const& iProductType,
+                               InputTag const& iTag) const override;
 
     //override used by EventBase class
     BasicHandle getImpl(std::type_info const& iProductType, ProductID const& pid) const override;
 
-    template<typename PROD>
-    OrphanHandle<PROD>
-    putImpl(EDPutToken::value_type token, std::unique_ptr<PROD> product);
+    template <typename PROD> OrphanHandle<PROD> putImpl(EDPutToken::value_type token, std::unique_ptr<PROD> product);
 
-    template<typename PROD, typename... Args>
-    OrphanHandle<PROD>
-    emplaceImpl(EDPutToken::value_type token, Args&&... args);
+    template <typename PROD, typename... Args>
+    OrphanHandle<PROD> emplaceImpl(EDPutToken::value_type token, Args&&... args);
 
     // commit_() is called to complete the transaction represented by
     // this PrincipalGetAdapter. The friendships required seems gross, but any
@@ -322,16 +250,15 @@ namespace edm {
     friend class InputSource;
     friend class RawInputSource;
     friend class ProducerBase;
-    template<typename T> friend class stream::ProducingModuleAdaptorBase;
+    template <typename T> friend class stream::ProducingModuleAdaptorBase;
 
     void commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut, ParentageID* previousParentageId = nullptr);
     void commit_aux(ProductPtrVec& products, ParentageID* previousParentageId = nullptr);
 
-    BasicHandle
-    getByProductID_(ProductID const& oid) const;
+    BasicHandle getByProductID_(ProductID const& oid) const;
 
-    ProductPtrVec& putProducts() {return putProducts_;}
-    ProductPtrVec const& putProducts() const {return putProducts_;}
+    ProductPtrVec& putProducts() { return putProducts_; }
+    ProductPtrVec const& putProducts() const { return putProducts_; }
 
     PrincipalGetAdapter provRecorder_;
 
@@ -357,7 +284,7 @@ namespace edm {
     void addToGotBranchIDs(BranchID const& branchID) const;
 
     // We own the retrieved Views, and have to destroy them.
-    mutable std::vector<std::shared_ptr<ViewBase> > gotViews_;
+    mutable std::vector<std::shared_ptr<ViewBase>> gotViews_;
 
     StreamID streamID_;
     ModuleCallingContext const* moduleCallingContext_;
@@ -365,401 +292,336 @@ namespace edm {
     static const std::string emptyString_;
   };
 
-  template<typename PROD>
-  bool
-  Event::get(ProductID const& oid, Handle<PROD>& result) const {
+  template <typename PROD> bool Event::get(ProductID const& oid, Handle<PROD>& result) const {
     result.clear();
     BasicHandle bh = this->getByProductID_(oid);
     result = convert_handle_check_type<PROD>(std::move(bh));  // throws on conversion error
-    if(result.failedToGet()) {
+    if (result.failedToGet()) {
       return false;
     }
     addToGotBranchIDs(*bh.provenance());
     return true;
   }
 
-  template<typename ELEMENT>
-  bool
-  Event::get(ProductID const& oid, Handle<View<ELEMENT> >& result) const {
-      result.clear();
-      BasicHandle bh = this->getByProductID_(oid);
+  template <typename ELEMENT> bool Event::get(ProductID const& oid, Handle<View<ELEMENT>>& result) const {
+    result.clear();
+    BasicHandle bh = this->getByProductID_(oid);
 
-      if(bh.failedToGet()) {
-          result = Handle<View<ELEMENT> >(makeHandleExceptionFactory([oid]()->std::shared_ptr<cms::Exception> {
-            std::shared_ptr<cms::Exception> whyFailed = std::make_shared<edm::Exception>(edm::errors::ProductNotFound);
-            *whyFailed
-            << "get View by ID failed: no product with ID = " << oid <<"\n";
-            return whyFailed;
-          }));
-          return false;
-      }
+    if (bh.failedToGet()) {
+      result = Handle<View<ELEMENT>>(makeHandleExceptionFactory([oid]() -> std::shared_ptr<cms::Exception> {
+        std::shared_ptr<cms::Exception> whyFailed = std::make_shared<edm::Exception>(edm::errors::ProductNotFound);
+        *whyFailed << "get View by ID failed: no product with ID = " << oid << "\n";
+        return whyFailed;
+      }));
+      return false;
+    }
 
-      result = fillView_<ELEMENT>(bh);
-      return true;
+    result = fillView_<ELEMENT>(bh);
+    return true;
   }
 
-  template<typename PROD>
-  OrphanHandle<PROD>
-  Event::putImpl(EDPutToken::value_type index, std::unique_ptr<PROD> product) {
+  template <typename PROD>
+  OrphanHandle<PROD> Event::putImpl(EDPutToken::value_type index, std::unique_ptr<PROD> product) {
     // The following will call post_insert if T has such a function,
     // and do nothing if T has no such function.
-    std::conditional_t<detail::has_postinsert<PROD>::value,
-    DoPostInsert<PROD>,
-    DoNotPostInsert<PROD>> maybe_inserter;
+    std::conditional_t<detail::has_postinsert<PROD>::value, DoPostInsert<PROD>, DoNotPostInsert<PROD>> maybe_inserter;
     maybe_inserter(product.get());
-    
+
     assert(index < putProducts().size());
-    
-    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(std::move(product)));
+
+    std::unique_ptr<Wrapper<PROD>> wp(new Wrapper<PROD>(std::move(product)));
     PROD const* prod = wp->product();
-    
-    putProducts()[index]=std::move(wp);
+
+    putProducts()[index] = std::move(wp);
     auto const& prodID = provRecorder_.getProductID(index);
-    return(OrphanHandle<PROD>(prod, prodID));
+    return (OrphanHandle<PROD>(prod, prodID));
   }
 
-  template<typename PROD>
-  OrphanHandle<PROD>
-  Event::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
-    if(UNLIKELY(product.get() == nullptr)) {                // null pointer is illegal
+  template <typename PROD>
+  OrphanHandle<PROD> Event::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
+    if (UNLIKELY(product.get() == nullptr)) {  // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, productInstanceName);
     }
 
-    auto index =
-      provRecorder_.getPutTokenIndex(TypeID(*product), productInstanceName);
+    auto index = provRecorder_.getPutTokenIndex(TypeID(*product), productInstanceName);
     return putImpl(index, std::move(product));
   }
 
-  template<typename PROD>
-  OrphanHandle<PROD>
-  Event::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
-    if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
+  template <typename PROD> OrphanHandle<PROD> Event::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
+    if (UNLIKELY(product.get() == 0)) {  // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
     }
-    if(UNLIKELY(token.isUninitialized())) {
+    if (UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
-    return putImpl(token.index(),std::move(product));
+    return putImpl(token.index(), std::move(product));
   }
 
-  template<typename PROD>
-  OrphanHandle<PROD>
-  Event::put(EDPutToken token, std::unique_ptr<PROD> product) {
-    if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
+  template <typename PROD> OrphanHandle<PROD> Event::put(EDPutToken token, std::unique_ptr<PROD> product) {
+    if (UNLIKELY(product.get() == 0)) {  // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
     }
-    if(UNLIKELY(token.isUninitialized())) {
+    if (UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
-    if(UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
-      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    if (UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD),
+                                                          provRecorder_.getTypeIDForPutTokenIndex(token.index()));
     }
 
-    return putImpl(token.index(),std::move(product));
+    return putImpl(token.index(), std::move(product));
   }
 
-  template<typename PROD, typename... Args>
-  OrphanHandle<PROD>
-  Event::emplace(EDPutTokenT<PROD> token, Args&&... args) {
-    if(UNLIKELY(token.isUninitialized())) {
+  template <typename PROD, typename... Args>
+  OrphanHandle<PROD> Event::emplace(EDPutTokenT<PROD> token, Args&&... args) {
+    if (UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
-    return emplaceImpl<PROD>(token.index(),std::forward<Args>(args)...);
+    return emplaceImpl<PROD>(token.index(), std::forward<Args>(args)...);
   }
 
-  template<typename PROD, typename... Args>
-  OrphanHandle<PROD>
-  Event::emplace(EDPutToken token, Args&&... args) {
-    if(UNLIKELY(token.isUninitialized())) {
+  template <typename PROD, typename... Args> OrphanHandle<PROD> Event::emplace(EDPutToken token, Args&&... args) {
+    if (UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
-    if(UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
-      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    if (UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD),
+                                                          provRecorder_.getTypeIDForPutTokenIndex(token.index()));
     }
-    
-    return emplaceImpl(token.index(),std::forward<Args>(args)...);
+
+    return emplaceImpl(token.index(), std::forward<Args>(args)...);
   }
 
-  template<typename PROD, typename... Args>
-  OrphanHandle<PROD>
-  Event::emplaceImpl(EDPutToken::value_type index, Args&&... args) {
-    
+  template <typename PROD, typename... Args>
+  OrphanHandle<PROD> Event::emplaceImpl(EDPutToken::value_type index, Args&&... args) {
     assert(index < putProducts().size());
-    
-    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(WrapperBase::Emplace{}, std::forward<Args>(args)...));
+
+    std::unique_ptr<Wrapper<PROD>> wp(new Wrapper<PROD>(WrapperBase::Emplace{}, std::forward<Args>(args)...));
 
     // The following will call post_insert if T has such a function,
     // and do nothing if T has no such function.
-    std::conditional_t<detail::has_postinsert<PROD>::value,
-    DoPostInsert<PROD>,
-    DoNotPostInsert<PROD>> maybe_inserter;
+    std::conditional_t<detail::has_postinsert<PROD>::value, DoPostInsert<PROD>, DoNotPostInsert<PROD>> maybe_inserter;
     maybe_inserter(&(wp->bareProduct()));
 
     PROD const* prod = wp->product();
-    
-    putProducts()[index]=std::move(wp);
+
+    putProducts()[index] = std::move(wp);
     auto const& prodID = provRecorder_.getProductID(index);
-    return(OrphanHandle<PROD>(prod, prodID));
+    return (OrphanHandle<PROD>(prod, prodID));
   }
 
-  
-  template<typename PROD>
-  RefProd<PROD>
-  Event::getRefBeforePut(std::string const& productInstanceName) {
-    auto index =
-    provRecorder_.getPutTokenIndex(TypeID{typeid(PROD)},
-                                   productInstanceName);
+  template <typename PROD> RefProd<PROD> Event::getRefBeforePut(std::string const& productInstanceName) {
+    auto index = provRecorder_.getPutTokenIndex(TypeID{typeid(PROD)}, productInstanceName);
 
     //should keep track of what Ref's have been requested and make sure they are 'put'
-    return RefProd<PROD>(provRecorder_.getProductID(index),
-                         provRecorder_.prodGetter());
+    return RefProd<PROD>(provRecorder_.getProductID(index), provRecorder_.prodGetter());
   }
 
-  template<typename PROD>
-  RefProd<PROD>
-  Event::getRefBeforePut(EDPutTokenT<PROD> token)
-  {
-    if(UNLIKELY(token.isUninitialized())) {
+  template <typename PROD> RefProd<PROD> Event::getRefBeforePut(EDPutTokenT<PROD> token) {
+    if (UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
-   return RefProd<PROD>(provRecorder_.getProductID(token.index()),
-                         provRecorder_.prodGetter());
-  }
-  
-  template<typename PROD>
-  RefProd<PROD>
-  Event::getRefBeforePut(EDPutToken token)
-  {
-    if(UNLIKELY(token.isUninitialized())) {
-      principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
-    }
-    if(UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
-      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
-    }
-    return RefProd<PROD>(provRecorder_.getProductID(token.index()),
-                         provRecorder_.prodGetter());
+    return RefProd<PROD>(provRecorder_.getProductID(token.index()), provRecorder_.prodGetter());
   }
 
-  template<typename PROD>
-  bool
-  Event::getByLabel(InputTag const& tag, Handle<PROD>& result) const {
+  template <typename PROD> RefProd<PROD> Event::getRefBeforePut(EDPutToken token) {
+    if (UNLIKELY(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
+    }
+    if (UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD),
+                                                          provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    }
+    return RefProd<PROD>(provRecorder_.getProductID(token.index()), provRecorder_.prodGetter());
+  }
+
+  template <typename PROD> bool Event::getByLabel(InputTag const& tag, Handle<PROD>& result) const {
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag, moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
-    if UNLIKELY(result.failedToGet()) {
-      return false;
-    }
+    if
+      UNLIKELY(result.failedToGet()) { return false; }
     addToGotBranchIDs(*result.provenance());
     return true;
   }
 
-  template<typename PROD>
-  bool
-  Event::getByLabel(std::string const& label,
-                    std::string const& productInstanceName,
-                    Handle<PROD>& result) const {
+  template <typename PROD>
+  bool Event::getByLabel(std::string const& label, std::string const& productInstanceName, Handle<PROD>& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_,
+                                               moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
-    if UNLIKELY(result.failedToGet()) {
-      return false;
-    }
+    if
+      UNLIKELY(result.failedToGet()) { return false; }
     addToGotBranchIDs(*result.provenance());
     return true;
   }
 
-  template<typename PROD>
-  bool
-  Event::getByLabel(std::string const& label, Handle<PROD>& result) const {
+  template <typename PROD> bool Event::getByLabel(std::string const& label, Handle<PROD>& result) const {
     return getByLabel(label, emptyString_, result);
   }
 
-  template<typename PROD>
-  void
-  Event::getManyByType(std::vector<Handle<PROD> >& results) const {
+  template <typename PROD> void Event::getManyByType(std::vector<Handle<PROD>>& results) const {
     provRecorder_.getManyByType(results, moduleCallingContext_);
-    for(typename std::vector<Handle<PROD> >::const_iterator it = results.begin(), itEnd = results.end();
-        it != itEnd; ++it) {
+    for (typename std::vector<Handle<PROD>>::const_iterator it = results.begin(), itEnd = results.end(); it != itEnd;
+         ++it) {
       addToGotBranchIDs(*it->provenance());
     }
   }
 
-  template<typename PROD>
-  bool
-  Event::getByToken(EDGetToken token, Handle<PROD>& result) const {
+  template <typename PROD> bool Event::getByToken(EDGetToken token, Handle<PROD>& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
-    if UNLIKELY(result.failedToGet()) {
-      return false;
-    }
+    if
+      UNLIKELY(result.failedToGet()) { return false; }
     addToGotBranchIDs(*result.provenance());
     return true;
   }
 
-  template<typename PROD>
-  bool
-  Event::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {
+  template <typename PROD> bool Event::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));
-    if UNLIKELY(result.failedToGet()) {
-      return false;
-    }
+    if
+      UNLIKELY(result.failedToGet()) { return false; }
     addToGotBranchIDs(*result.provenance());
     return true;
   }
 
-  template<typename PROD>
-  Handle<PROD>
-  Event::getHandle(EDGetTokenT<PROD> token) const {
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+  template <typename PROD> Handle<PROD> Event::getHandle(EDGetTokenT<PROD> token) const {
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     auto result = convert_handle<PROD>(std::move(bh));
-    if LIKELY(not result.failedToGet()) {
-      addToGotBranchIDs(*result.provenance());
-    }
+    if
+      LIKELY(not result.failedToGet()) { addToGotBranchIDs(*result.provenance()); }
     return result;
   }
 
-  template<typename PROD>
-  PROD const&
-  Event::get(EDGetTokenT<PROD> token) const noexcept(false) {
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+  template <typename PROD> PROD const& Event::get(EDGetTokenT<PROD> token) const noexcept(false) {
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     auto result = convert_handle<PROD>(std::move(bh));
-    if LIKELY(not result.failedToGet()) {
-      addToGotBranchIDs(*result.provenance());
-    }
+    if
+      LIKELY(not result.failedToGet()) { addToGotBranchIDs(*result.provenance()); }
     return *result;
   }
 
-
-  template<typename ELEMENT>
-  bool
-  Event::getByLabel(InputTag const& tag, Handle<View<ELEMENT> >& result) const {
+  template <typename ELEMENT> bool Event::getByLabel(InputTag const& tag, Handle<View<ELEMENT>>& result) const {
     result.clear();
     BasicHandle bh = provRecorder_.getMatchingSequenceByLabel_(TypeID(typeid(ELEMENT)), tag, moduleCallingContext_);
-    if UNLIKELY(bh.failedToGet()) {
-      Handle<View<ELEMENT> > h(std::move(bh.whyFailedFactory()));
-      h.swap(result);
-      return false;
-    }
+    if
+      UNLIKELY(bh.failedToGet()) {
+        Handle<View<ELEMENT>> h(std::move(bh.whyFailedFactory()));
+        h.swap(result);
+        return false;
+      }
     result = fillView_<ELEMENT>(bh);
     return true;
   }
 
-  template<typename ELEMENT>
-  bool
-  Event::getByLabel(std::string const& moduleLabel,
-                    std::string const& productInstanceName,
-                    Handle<View<ELEMENT> >& result) const {
+  template <typename ELEMENT>
+  bool Event::getByLabel(std::string const& moduleLabel,
+                         std::string const& productInstanceName,
+                         Handle<View<ELEMENT>>& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getMatchingSequenceByLabel_(TypeID(typeid(ELEMENT)), moduleLabel, productInstanceName, emptyString_, moduleCallingContext_);
-    if UNLIKELY(bh.failedToGet()) {
-      Handle<View<ELEMENT> > h(std::move(bh.whyFailedFactory()));
-      h.swap(result);
-      return false;
-    }
+    BasicHandle bh = provRecorder_.getMatchingSequenceByLabel_(
+        TypeID(typeid(ELEMENT)), moduleLabel, productInstanceName, emptyString_, moduleCallingContext_);
+    if
+      UNLIKELY(bh.failedToGet()) {
+        Handle<View<ELEMENT>> h(std::move(bh.whyFailedFactory()));
+        h.swap(result);
+        return false;
+      }
     result = fillView_<ELEMENT>(bh);
     return true;
   }
 
-  template<typename ELEMENT>
-  bool
-  Event::getByLabel(std::string const& moduleLabel, Handle<View<ELEMENT> >& result) const {
+  template <typename ELEMENT>
+  bool Event::getByLabel(std::string const& moduleLabel, Handle<View<ELEMENT>>& result) const {
     return getByLabel(moduleLabel, emptyString_, result);
   }
 
-  template<typename ELEMENT>
-  bool
-  Event::getByToken(EDGetToken token, Handle<View<ELEMENT>>& result) const {
+  template <typename ELEMENT> bool Event::getByToken(EDGetToken token, Handle<View<ELEMENT>>& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)),ELEMENT_TYPE, token, moduleCallingContext_);
-    if UNLIKELY(bh.failedToGet()) {
-      Handle<View<ELEMENT> > h(std::move(bh.whyFailedFactory()));
-      h.swap(result);
-      return false;
-    }
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)), ELEMENT_TYPE, token, moduleCallingContext_);
+    if
+      UNLIKELY(bh.failedToGet()) {
+        Handle<View<ELEMENT>> h(std::move(bh.whyFailedFactory()));
+        h.swap(result);
+        return false;
+      }
     result = fillView_<ELEMENT>(bh);
     return true;
   }
 
-  template<typename ELEMENT>
-  bool
-  Event::getByToken(EDGetTokenT<View<ELEMENT>> token, Handle<View<ELEMENT>>& result) const {
+  template <typename ELEMENT>
+  bool Event::getByToken(EDGetTokenT<View<ELEMENT>> token, Handle<View<ELEMENT>>& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)),ELEMENT_TYPE, token, moduleCallingContext_);
-    if UNLIKELY(bh.failedToGet()) {
-      Handle<View<ELEMENT> > h(std::move(bh.whyFailedFactory()));
-      h.swap(result);
-      return false;
-    }
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)), ELEMENT_TYPE, token, moduleCallingContext_);
+    if
+      UNLIKELY(bh.failedToGet()) {
+        Handle<View<ELEMENT>> h(std::move(bh.whyFailedFactory()));
+        h.swap(result);
+        return false;
+      }
     result = fillView_<ELEMENT>(bh);
     return true;
   }
 
-  template<typename ELEMENT>
-  Handle<View<ELEMENT>>
-  Event::getHandle(EDGetTokenT<View<ELEMENT>> token) const {
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)),ELEMENT_TYPE, token, moduleCallingContext_);
-    if UNLIKELY(bh.failedToGet()) {
-      return Handle<View<ELEMENT> >(std::move(bh.whyFailedFactory()));;
-    }
+  template <typename ELEMENT> Handle<View<ELEMENT>> Event::getHandle(EDGetTokenT<View<ELEMENT>> token) const {
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)), ELEMENT_TYPE, token, moduleCallingContext_);
+    if
+      UNLIKELY(bh.failedToGet()) {
+        return Handle<View<ELEMENT>>(std::move(bh.whyFailedFactory()));
+        ;
+      }
     return fillView_<ELEMENT>(bh);
   }
 
-  template<typename ELEMENT>
-  View<ELEMENT> const &
-  Event::get(EDGetTokenT<View<ELEMENT>> token) const noexcept(false) {
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)),ELEMENT_TYPE, token, moduleCallingContext_);
-    if UNLIKELY(bh.failedToGet()) {
-      bh.whyFailedFactory()->make()->raise();
-    }
+  template <typename ELEMENT> View<ELEMENT> const& Event::get(EDGetTokenT<View<ELEMENT>> token) const noexcept(false) {
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)), ELEMENT_TYPE, token, moduleCallingContext_);
+    if
+      UNLIKELY(bh.failedToGet()) { bh.whyFailedFactory()->make()->raise(); }
     return *fillView_<ELEMENT>(bh);
   }
 
-  template<typename ELEMENT>
-  Handle<View<ELEMENT> >
-  Event::fillView_(BasicHandle& bh) const {
+  template <typename ELEMENT> Handle<View<ELEMENT>> Event::fillView_(BasicHandle& bh) const {
     std::vector<void const*> pointersToElements;
     FillViewHelperVector helpers;
     // the following must initialize the
     //  fill the helper vector
     bh.wrapper()->fillView(bh.id(), pointersToElements, helpers);
 
-    auto newview = std::make_shared<View<ELEMENT> >(pointersToElements, helpers, &(productGetter()));
+    auto newview = std::make_shared<View<ELEMENT>>(pointersToElements, helpers, &(productGetter()));
 
     addToGotBranchIDs(*bh.provenance());
     gotViews_.push_back(newview);
-    return Handle<View<ELEMENT> >(newview.get(), bh.provenance());
+    return Handle<View<ELEMENT>>(newview.get(), bh.provenance());
   }
 
   // Free functions to retrieve a collection from the Event.
   // Will throw an exception if the collection is not available.
 
-  template <typename T>
-  T const& get(Event const& event, InputTag const& tag) noexcept(false) {
+  template <typename T> T const& get(Event const& event, InputTag const& tag) noexcept(false) {
     Handle<T> handle;
     event.getByLabel(tag, handle);
     // throw if the handle is not valid
-    return * handle.product();
+    return *handle.product();
   }
 
-  template <typename T>
-  T const& get(Event const& event, EDGetToken const& token) noexcept(false) {
+  template <typename T> T const& get(Event const& event, EDGetToken const& token) noexcept(false) {
     Handle<T> handle;
     event.getByToken(token, handle);
     // throw if the handle is not valid
-    return * handle.product();
+    return *handle.product();
   }
 
-  template <typename T>
-  T const& get(Event const& event, EDGetTokenT<T> const& token) noexcept(false) {
+  template <typename T> T const& get(Event const& event, EDGetTokenT<T> const& token) noexcept(false) {
     return event.get(token);
   }
 
-}
+}  // namespace edm
 
-#endif // FWCore_Framework_Event_h
+#endif  // FWCore_Framework_Event_h

--- a/FWCore/Framework/interface/EventForOutput.h
+++ b/FWCore/Framework/interface/EventForOutput.h
@@ -49,32 +49,24 @@ namespace edm {
 
   class EventForOutput : public OccurrenceForOutput {
   public:
-    EventForOutput(EventPrincipal const& ep, ModuleDescription const& md,
-          ModuleCallingContext const*);
+    EventForOutput(EventPrincipal const& ep, ModuleDescription const& md, ModuleCallingContext const*);
     ~EventForOutput() override;
-    
-    EventAuxiliary const& eventAuxiliary() const {return aux_;}
-    EventID const& id() const {return aux_.id();}
-    EventNumber_t event() const {return aux_.event();}
-    LuminosityBlockNumber_t luminosityBlock() const {return aux_.luminosityBlock();}
-    Timestamp const& time() const {return aux_.time();}
-    
+
+    EventAuxiliary const& eventAuxiliary() const { return aux_; }
+    EventID const& id() const { return aux_.id(); }
+    EventNumber_t event() const { return aux_.event(); }
+    LuminosityBlockNumber_t luminosityBlock() const { return aux_.luminosityBlock(); }
+    Timestamp const& time() const { return aux_.time(); }
+
     ///\return The id for the particular Stream processing the Event
-    StreamID streamID() const {
-      return streamID_;
-    }
+    StreamID streamID() const { return streamID_; }
 
-    LuminosityBlockForOutput const&
-    getLuminosityBlock() const {
-      return *luminosityBlock_;
-    }
+    LuminosityBlockForOutput const& getLuminosityBlock() const { return *luminosityBlock_; }
 
-    RunForOutput const&
-    getRun() const;
+    RunForOutput const& getRun() const;
 
-    RunNumber_t
-    run() const {return id().run();}
-    
+    RunNumber_t run() const { return id().run(); }
+
     BranchListIndexes const& branchListIndexes() const;
 
     EventSelectionIDVector const& eventSelectionIDs() const;
@@ -82,16 +74,14 @@ namespace edm {
     ProductProvenanceRetriever const* productProvenanceRetrieverPtr() const;
 
   private:
-    friend class edmtest::TestOutputModule; // For testing
+    friend class edmtest::TestOutputModule;  // For testing
 
-    EventPrincipal const&
-    eventPrincipal() const;
+    EventPrincipal const& eventPrincipal() const;
 
     EventAuxiliary const& aux_;
     std::shared_ptr<LuminosityBlockForOutput const> const luminosityBlock_;
 
     StreamID streamID_;
   };
-}
+}  // namespace edm
 #endif
-

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -51,18 +51,17 @@ namespace edm {
     typedef Base::ConstProductResolverPtr ConstProductResolverPtr;
     static int const invalidBunchXing = EventAuxiliary::invalidBunchXing;
     static int const invalidStoreNumber = EventAuxiliary::invalidStoreNumber;
-    EventPrincipal(
-        std::shared_ptr<ProductRegistry const> reg,
-        std::shared_ptr<BranchIDListHelper const> branchIDListHelper,
-        std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper,
-        ProcessConfiguration const& pc,
-        HistoryAppender* historyAppender,
-        unsigned int streamIndex = 0,
-        bool isForPrimaryProcess = true);
+    EventPrincipal(std::shared_ptr<ProductRegistry const> reg,
+                   std::shared_ptr<BranchIDListHelper const> branchIDListHelper,
+                   std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper,
+                   ProcessConfiguration const& pc,
+                   HistoryAppender* historyAppender,
+                   unsigned int streamIndex = 0,
+                   bool isForPrimaryProcess = true);
     ~EventPrincipal() override {}
 
     void fillEventPrincipal(EventAuxiliary const& aux,
-        ProcessHistoryRegistry const& processHistoryRegistry,
+                            ProcessHistoryRegistry const& processHistoryRegistry,
                             DelayedReader* reader = nullptr);
     void fillEventPrincipal(EventAuxiliary const& aux,
                             ProcessHistoryRegistry const& processHistoryRegistry,
@@ -77,97 +76,66 @@ namespace edm {
                             DelayedReader* reader = nullptr,
                             bool deepCopyRetriever = true);
 
-    
     void clearEventPrincipal();
 
-    LuminosityBlockPrincipal const& luminosityBlockPrincipal() const {
-      return *luminosityBlockPrincipal_;
-    }
+    LuminosityBlockPrincipal const& luminosityBlockPrincipal() const { return *luminosityBlockPrincipal_; }
 
-    LuminosityBlockPrincipal& luminosityBlockPrincipal() {
-      return *luminosityBlockPrincipal_;
-    }
+    LuminosityBlockPrincipal& luminosityBlockPrincipal() { return *luminosityBlockPrincipal_; }
 
-    bool luminosityBlockPrincipalPtrValid() const {
-      return luminosityBlockPrincipal_ != nullptr;
-    }
+    bool luminosityBlockPrincipalPtrValid() const { return luminosityBlockPrincipal_ != nullptr; }
 
     //does not share ownership
     void setLuminosityBlockPrincipal(LuminosityBlockPrincipal* lbp);
 
     void setRunAndLumiNumber(RunNumber_t run, LuminosityBlockNumber_t lumi);
 
-    EventID const& id() const {
-      return aux().id();
-    }
+    EventID const& id() const { return aux().id(); }
 
-    Timestamp const& time() const {
-      return aux().time();
-    }
+    Timestamp const& time() const { return aux().time(); }
 
-    bool isReal() const {
-      return aux().isRealData();
-    }
+    bool isReal() const { return aux().isRealData(); }
 
-    EventAuxiliary::ExperimentType ExperimentType() const {
-      return aux().experimentType();
-    }
+    EventAuxiliary::ExperimentType ExperimentType() const { return aux().experimentType(); }
 
-    int bunchCrossing() const {
-      return aux().bunchCrossing();
-    }
+    int bunchCrossing() const { return aux().bunchCrossing(); }
 
-    int storeNumber() const {
-      return aux().storeNumber();
-    }
+    int storeNumber() const { return aux().storeNumber(); }
 
-    EventAuxiliary const& aux() const {
-      return aux_;
-    }
+    EventAuxiliary const& aux() const { return aux_; }
 
-    StreamID streamID() const { return streamID_;}
+    StreamID streamID() const { return streamID_; }
 
-    LuminosityBlockNumber_t luminosityBlock() const {
-      return id().luminosityBlock();
-    }
+    LuminosityBlockNumber_t luminosityBlock() const { return id().luminosityBlock(); }
 
-    RunNumber_t run() const {
-      return id().run();
-    }
+    RunNumber_t run() const { return id().run(); }
 
     RunPrincipal const& runPrincipal() const;
 
-    ProductProvenanceRetriever const* productProvenanceRetrieverPtr() const {return provRetrieverPtr_.get();}
+    ProductProvenanceRetriever const* productProvenanceRetrieverPtr() const { return provRetrieverPtr_.get(); }
 
     EventSelectionIDVector const& eventSelectionIDs() const;
 
     BranchListIndexes const& branchListIndexes() const;
 
-    Provenance
-    getProvenance(ProductID const& pid, ModuleCallingContext const* mcc) const;
+    Provenance getProvenance(ProductID const& pid, ModuleCallingContext const* mcc) const;
 
-    BasicHandle
-    getByProductID(ProductID const& oid) const;
+    BasicHandle getByProductID(ProductID const& oid) const;
 
-    void put(
-        BranchDescription const& bd,
-        std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const& productProvenance) const;
-
-    void put(ProductResolverIndex index,
+    void put(BranchDescription const& bd,
              std::unique_ptr<WrapperBase> edp,
-             ParentageID productProvenance) const;
+             ProductProvenance const& productProvenance) const;
 
-    void putOnRead(
-        BranchDescription const& bd,
-        std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const* productProvenance) const;
+    void put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp, ParentageID productProvenance) const;
+
+    void putOnRead(BranchDescription const& bd,
+                   std::unique_ptr<WrapperBase> edp,
+                   ProductProvenance const* productProvenance) const;
 
     WrapperBase const* getIt(ProductID const& pid) const override;
     WrapperBase const* getThinnedProduct(ProductID const& pid, unsigned int& key) const override;
     void getThinnedProducts(ProductID const& pid,
-                                    std::vector<WrapperBase const*>& foundContainers,
-                                    std::vector<unsigned int>& keys) const override;
+                            std::vector<WrapperBase const*>& foundContainers,
+                            std::vector<unsigned int>& keys) const override;
 
     ProductID branchIDToProductID(BranchID const& bid) const;
 
@@ -178,18 +146,18 @@ namespace edm {
     using Base::getProvenance;
 
   private:
-
     BranchID pidToBid(ProductID const& pid) const;
 
     edm::ThinnedAssociation const* getThinnedAssociation(edm::BranchID const& branchID) const;
 
     unsigned int transitionIndex_() const override;
-    
-    std::shared_ptr<ProductProvenanceRetriever const> provRetrieverPtr() const {return get_underlying_safe(provRetrieverPtr_);}
-    std::shared_ptr<ProductProvenanceRetriever>& provRetrieverPtr() {return get_underlying_safe(provRetrieverPtr_);}
+
+    std::shared_ptr<ProductProvenanceRetriever const> provRetrieverPtr() const {
+      return get_underlying_safe(provRetrieverPtr_);
+    }
+    std::shared_ptr<ProductProvenanceRetriever>& provRetrieverPtr() { return get_underlying_safe(provRetrieverPtr_); }
 
   private:
-
     EventAuxiliary aux_;
 
     edm::propagate_const<LuminosityBlockPrincipal*> luminosityBlockPrincipal_;
@@ -205,16 +173,10 @@ namespace edm {
     BranchListIndexes branchListIndexes_;
 
     std::map<BranchListIndex, ProcessIndex> branchListIndexToProcessIndex_;
-    
-    StreamID streamID_;
 
+    StreamID streamID_;
   };
 
-  inline
-  bool
-  isSameEvent(EventPrincipal const& a, EventPrincipal const& b) {
-    return isSameEvent(a.aux(), b.aux());
-  }
-}
+  inline bool isSameEvent(EventPrincipal const& a, EventPrincipal const& b) { return isSameEvent(a.aux(), b.aux()); }
+}  // namespace edm
 #endif
-

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -54,15 +54,14 @@ namespace edm {
   class WaitingTaskHolder;
   class LuminosityBlockProcessingStatus;
   class IOVSyncValue;
-  
+
   namespace eventsetup {
     class EventSetupProvider;
     class EventSetupsController;
-  }
+  }  // namespace eventsetup
 
   class EventProcessor {
   public:
-
     // Status codes:
     //   0     successful completion
     //   1     exception of unknown type caught
@@ -71,8 +70,15 @@ namespace edm {
     //   4     input complete
     //   5     call timed out
     //   6     input count complete
-    enum StatusCode { epSuccess=0, epException=1, epOther=2, epSignal=3,
-      epInputComplete=4, epTimedOut=5, epCountComplete=6 };
+    enum StatusCode {
+      epSuccess = 0,
+      epException = 1,
+      epOther = 2,
+      epSignal = 3,
+      epInputComplete = 4,
+      epTimedOut = 5,
+      epCountComplete = 6
+    };
 
     // The input 'parameterSet' contains the entire contents of a  configuration file.
     // Also allows the attachement of pre-existing services specified  by 'token', and
@@ -97,8 +103,8 @@ namespace edm {
 
     ~EventProcessor();
 
-    EventProcessor(EventProcessor const&) = delete; // Disallow copying and moving
-    EventProcessor& operator=(EventProcessor const&) = delete; // Disallow copying and moving
+    EventProcessor(EventProcessor const&) = delete;             // Disallow copying and moving
+    EventProcessor& operator=(EventProcessor const&) = delete;  // Disallow copying and moving
 
     /**This should be called before the first call to 'run'
        If this is not called in time, it will automatically be called
@@ -124,8 +130,7 @@ namespace edm {
     /// *** passed to the caller. Do not call delete on these
     /// *** pointers!
 
-    std::vector<ModuleDescription const*>
-    getAllModuleDescriptions() const;
+    std::vector<ModuleDescription const*> getAllModuleDescriptions() const;
 
     ProcessConfiguration const& processConfiguration() const { return *processConfiguration_; }
 
@@ -185,11 +190,15 @@ namespace edm {
     // transition handling.
 
     InputSource::ItemType nextTransitionType();
-    InputSource::ItemType lastTransitionType() const { if(deferredExceptionPtrIsSet_) {return InputSource::IsStop;}
-                                                          return lastSourceTransition_;}
+    InputSource::ItemType lastTransitionType() const {
+      if (deferredExceptionPtrIsSet_) {
+        return InputSource::IsStop;
+      }
+      return lastSourceTransition_;
+    }
     std::pair<edm::ProcessHistoryID, edm::RunNumber_t> nextRunID();
     edm::LuminosityBlockNumber_t nextLuminosityBlockID();
-    
+
     void readFile();
     void closeInputFile(bool cleaningUpAfterException);
     void openOutputFiles();
@@ -206,32 +215,39 @@ namespace edm {
 
     void doErrorStuff();
 
-    void beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalBeginSucceeded,
+    void beginRun(ProcessHistoryID const& phid,
+                  RunNumber_t run,
+                  bool& globalBeginSucceeded,
                   bool& eventSetupForInstanceSucceeded);
     void endRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalBeginSucceeded, bool cleaningUpAfterException);
-    void endUnfinishedRun(ProcessHistoryID const& phid, RunNumber_t run,
-                          bool globalBeginSucceeded, bool cleaningUpAfterException,
+    void endUnfinishedRun(ProcessHistoryID const& phid,
+                          RunNumber_t run,
+                          bool globalBeginSucceeded,
+                          bool cleaningUpAfterException,
                           bool eventSetupForInstanceSucceeded);
 
     InputSource::ItemType processLumis(std::shared_ptr<void> const& iRunResource);
     void endUnfinishedLumi();
-    
+
     void beginLumiAsync(edm::IOVSyncValue const& iSyncValue,
                         std::shared_ptr<void> const& iRunResource,
                         edm::WaitingTaskHolder iHolder);
     void continueLumiAsync(edm::WaitingTaskHolder iHolder);
-    
+
     void globalEndLumiAsync(edm::WaitingTaskHolder iTask, std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus);
     void streamEndLumiAsync(edm::WaitingTaskHolder iTask,
                             unsigned int iStreamIndex,
                             std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus);
-    std::pair<ProcessHistoryID,RunNumber_t> readRun();
-    std::pair<ProcessHistoryID,RunNumber_t> readAndMergeRun();
+    std::pair<ProcessHistoryID, RunNumber_t> readRun();
+    std::pair<ProcessHistoryID, RunNumber_t> readAndMergeRun();
     void readLuminosityBlock(LuminosityBlockProcessingStatus&);
     int readAndMergeLumi(LuminosityBlockProcessingStatus&);
-    void writeRunAsync(WaitingTaskHolder, ProcessHistoryID const& phid, RunNumber_t run, MergeableRunProductMetadata const*);
+    void writeRunAsync(WaitingTaskHolder,
+                       ProcessHistoryID const& phid,
+                       RunNumber_t run,
+                       MergeableRunProductMetadata const*);
     void deleteRunFromCache(ProcessHistoryID const& phid, RunNumber_t run);
-    void writeLumiAsync(WaitingTaskHolder, std::shared_ptr<LuminosityBlockProcessingStatus> );
+    void writeLumiAsync(WaitingTaskHolder, std::shared_ptr<LuminosityBlockProcessingStatus>);
     void deleteLumiFromCache(LuminosityBlockProcessingStatus&);
 
     bool shouldWeStop() const;
@@ -247,41 +263,40 @@ namespace edm {
     //
     // Now private functions.
     // init() is used by only by constructors
-    void init(std::shared_ptr<ProcessDesc>& processDesc,
-              ServiceToken const& token,
-              serviceregistry::ServiceLegacy);
+    void init(std::shared_ptr<ProcessDesc>& processDesc, ServiceToken const& token, serviceregistry::ServiceLegacy);
 
-    bool readNextEventForStream(unsigned int iStreamIndex,
-                                LuminosityBlockProcessingStatus& iLumiStatus);
+    bool readNextEventForStream(unsigned int iStreamIndex, LuminosityBlockProcessingStatus& iLumiStatus);
 
-    void handleNextEventForStreamAsync(WaitingTaskHolder iTask,
-                                       unsigned int iStreamIndex);
+    void handleNextEventForStreamAsync(WaitingTaskHolder iTask, unsigned int iStreamIndex);
 
-    
     //read the next event using Stream iStreamIndex
     void readEvent(unsigned int iStreamIndex);
 
     //process the already read event using Stream iStreamIndex
-    void processEventAsync(WaitingTaskHolder iHolder,
-                           unsigned int iStreamIndex);
+    void processEventAsync(WaitingTaskHolder iHolder, unsigned int iStreamIndex);
 
-    void processEventAsyncImpl(WaitingTaskHolder iHolder,
-                               unsigned int iStreamIndex);
+    void processEventAsyncImpl(WaitingTaskHolder iHolder, unsigned int iStreamIndex);
 
     //returns true if an asynchronous stop was requested
     bool checkForAsyncStopRequest(StatusCode&);
-    
+
     void processEventWithLooper(EventPrincipal&);
 
-    std::shared_ptr<ProductRegistry const> preg() const {return get_underlying_safe(preg_);}
-    std::shared_ptr<ProductRegistry>& preg() {return get_underlying_safe(preg_);}
-    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return get_underlying_safe(branchIDListHelper_);}
-    std::shared_ptr<BranchIDListHelper>& branchIDListHelper() {return get_underlying_safe(branchIDListHelper_);}
-    std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {return get_underlying_safe(thinnedAssociationsHelper_);}
-    std::shared_ptr<ThinnedAssociationsHelper>& thinnedAssociationsHelper() {return get_underlying_safe(thinnedAssociationsHelper_);}
-    std::shared_ptr<EDLooperBase const> looper() const {return get_underlying_safe(looper_);}
-    std::shared_ptr<EDLooperBase>& looper() {return get_underlying_safe(looper_);}
-    
+    std::shared_ptr<ProductRegistry const> preg() const { return get_underlying_safe(preg_); }
+    std::shared_ptr<ProductRegistry>& preg() { return get_underlying_safe(preg_); }
+    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {
+      return get_underlying_safe(branchIDListHelper_);
+    }
+    std::shared_ptr<BranchIDListHelper>& branchIDListHelper() { return get_underlying_safe(branchIDListHelper_); }
+    std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {
+      return get_underlying_safe(thinnedAssociationsHelper_);
+    }
+    std::shared_ptr<ThinnedAssociationsHelper>& thinnedAssociationsHelper() {
+      return get_underlying_safe(thinnedAssociationsHelper_);
+    }
+    std::shared_ptr<EDLooperBase const> looper() const { return get_underlying_safe(looper_); }
+    std::shared_ptr<EDLooperBase>& looper() { return get_underlying_safe(looper_); }
+
     void warnAboutModulesRequiringLuminosityBLockSynchronization() const;
     //------------------------------------------------------------------
     //
@@ -290,27 +305,27 @@ namespace edm {
     // only during construction, and never again. If they aren't
     // really needed, we should remove them.
 
-    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
+    std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
     edm::propagate_const<std::shared_ptr<ProductRegistry>> preg_;
     edm::propagate_const<std::shared_ptr<BranchIDListHelper>> branchIDListHelper_;
     edm::propagate_const<std::shared_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
-    ServiceToken                                  serviceToken_;
+    ServiceToken serviceToken_;
     edm::propagate_const<std::unique_ptr<InputSource>> input_;
     InputSource::ItemType lastSourceTransition_;
     edm::propagate_const<std::unique_ptr<eventsetup::EventSetupsController>> espController_;
     edm::propagate_const<std::shared_ptr<eventsetup::EventSetupProvider>> esp_;
     edm::SerialTaskQueue iovQueue_;
-    std::unique_ptr<ExceptionToActionTable const>          act_table_;
-    std::shared_ptr<ProcessConfiguration const>       processConfiguration_;
-    ProcessContext                                processContext_;
-    PathsAndConsumesOfModules                     pathsAndConsumesOfModules_;
+    std::unique_ptr<ExceptionToActionTable const> act_table_;
+    std::shared_ptr<ProcessConfiguration const> processConfiguration_;
+    ProcessContext processContext_;
+    PathsAndConsumesOfModules pathsAndConsumesOfModules_;
     MergeableRunProductProcesses mergeableRunProductProcesses_;
     edm::propagate_const<std::unique_ptr<Schedule>> schedule_;
     std::vector<edm::SerialTaskQueue> streamQueues_;
     std::unique_ptr<edm::LimitedTaskQueue> lumiQueue_;
     std::vector<std::shared_ptr<LuminosityBlockProcessingStatus>> streamLumiStatus_;
-    std::atomic<unsigned int> streamLumiActive_{0}; //works as guard for streamLumiStatus
-    
+    std::atomic<unsigned int> streamLumiActive_{0};  //works as guard for streamLumiStatus
+
     std::vector<SubProcess> subProcesses_;
     edm::propagate_const<std::unique_ptr<HistoryAppender>> historyAppender_;
 
@@ -318,41 +333,37 @@ namespace edm {
     edm::propagate_const<std::shared_ptr<EDLooperBase>> looper_;
 
     //The atomic protects concurrent access of deferredExceptionPtr_
-    std::atomic<bool>                             deferredExceptionPtrIsSet_;
-    std::exception_ptr                            deferredExceptionPtr_;
-    
-    SharedResourcesAcquirer                       sourceResourcesAcquirer_;
-    std::shared_ptr<std::recursive_mutex>         sourceMutex_;
-    PrincipalCache                                principalCache_;
-    bool                                          beginJobCalled_;
-    bool                                          shouldWeStop_;
-    bool                                          fileModeNoMerge_;
-    std::string                                   exceptionMessageFiles_;
-    std::string                                   exceptionMessageRuns_;
-    std::string                                   exceptionMessageLumis_;
-    bool                                          forceLooperToEnd_;
-    bool                                          looperBeginJobRun_;
-    bool                                          forceESCacheClearOnNewRun_;
-    
-    PreallocationConfiguration                    preallocations_;
-    
-    bool                                          asyncStopRequestedWhileProcessingEvents_;
-    StatusCode                                    asyncStopStatusCodeFromProcessingEvents_;
-    bool firstEventInBlock_=true;
-    
-    typedef std::set<std::pair<std::string, std::string> > ExcludedData;
+    std::atomic<bool> deferredExceptionPtrIsSet_;
+    std::exception_ptr deferredExceptionPtr_;
+
+    SharedResourcesAcquirer sourceResourcesAcquirer_;
+    std::shared_ptr<std::recursive_mutex> sourceMutex_;
+    PrincipalCache principalCache_;
+    bool beginJobCalled_;
+    bool shouldWeStop_;
+    bool fileModeNoMerge_;
+    std::string exceptionMessageFiles_;
+    std::string exceptionMessageRuns_;
+    std::string exceptionMessageLumis_;
+    bool forceLooperToEnd_;
+    bool looperBeginJobRun_;
+    bool forceESCacheClearOnNewRun_;
+
+    PreallocationConfiguration preallocations_;
+
+    bool asyncStopRequestedWhileProcessingEvents_;
+    StatusCode asyncStopStatusCodeFromProcessingEvents_;
+    bool firstEventInBlock_ = true;
+
+    typedef std::set<std::pair<std::string, std::string>> ExcludedData;
     typedef std::map<std::string, ExcludedData> ExcludedDataMap;
-    ExcludedDataMap                               eventSetupDataToExcludeFromPrefetching_;
-    
+    ExcludedDataMap eventSetupDataToExcludeFromPrefetching_;
+
     bool printDependencies_ = false;
-  }; // class EventProcessor
+  };  // class EventProcessor
 
   //--------------------------------------------------------------------
 
-  inline
-  EventProcessor::StatusCode
-  EventProcessor::run() {
-    return runToCompletion();
-  }
-}
+  inline EventProcessor::StatusCode EventProcessor::run() { return runToCompletion(); }
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/EventSelector.h
+++ b/FWCore/Framework/interface/EventSelector.h
@@ -9,7 +9,7 @@
 // Change Log
 //
 // 1 - Mark Fischler Feb 6, 2008
-//	Internals for implementation of glob-style wildcard selection 
+//	Internals for implementation of glob-style wildcard selection
 //	In particular, !xyz* requires the vector nonveto_bits_
 //	nonveto_bits_ is designed to also accomodate an AND of triggers
 //      selection criterion, if that is wanted at some future date.
@@ -24,33 +24,23 @@
 #include <vector>
 #include <string>
 
-namespace edm
-{
+namespace edm {
   // possible return codes for the testSelectionOverlap
   // method defined below.
-  namespace evtSel
-  {
-    enum OverlapResult {InvalidSelection = 0,
-                        NoOverlap = 1,
-                        PartialOverlap = 2,
-                        ExactMatch = 3};
+  namespace evtSel {
+    enum OverlapResult { InvalidSelection = 0, NoOverlap = 1, PartialOverlap = 2, ExactMatch = 3 };
   }
 
   class ParameterSetDescription;
-  class EventSelector
-  {
+  class EventSelector {
   public:
-
     typedef std::vector<std::string> Strings;
 
-    EventSelector(Strings const& pathspecs,
-		  Strings const& names);
+    EventSelector(Strings const& pathspecs, Strings const& names);
 
-    explicit
-    EventSelector(Strings const& pathspecs);
+    explicit EventSelector(Strings const& pathspecs);
 
-    EventSelector(edm::ParameterSet const& pset,
-		  Strings const& pathNames);
+    EventSelector(edm::ParameterSet const& pset, Strings const& pathNames);
 
     bool wantAll() const { return accept_all_; }
     bool acceptEvent(TriggerResults const&);
@@ -58,25 +48,19 @@ namespace edm
 
     // 29-Jan-2008, KAB - added methods for testing and using
     // trigger selections (pathspecs).
-    static bool selectionIsValid(Strings const& pathspec,
-                                 Strings const& fullPathList);
-    static evtSel::OverlapResult
-      testSelectionOverlap(Strings const& pathspec1,
-                           Strings const& pathspec2,
-                           Strings const& fullPathList);
-    std::shared_ptr<TriggerResults>
-      maskTriggerResults(TriggerResults const& inputResults);
-    static std::vector<std::string>
-      getEventSelectionVString(edm::ParameterSet const& pset);
+    static bool selectionIsValid(Strings const& pathspec, Strings const& fullPathList);
+    static evtSel::OverlapResult testSelectionOverlap(Strings const& pathspec1,
+                                                      Strings const& pathspec2,
+                                                      Strings const& fullPathList);
+    std::shared_ptr<TriggerResults> maskTriggerResults(TriggerResults const& inputResults);
+    static std::vector<std::string> getEventSelectionVString(edm::ParameterSet const& pset);
 
     static void fillDescription(ParameterSetDescription& desc);
 
   private:
-
-    struct BitInfo
-    {
-      BitInfo(unsigned int pos, bool state):pos_(pos),accept_state_(state) { }
-      BitInfo():pos_(),accept_state_() { }
+    struct BitInfo {
+      BitInfo(unsigned int pos, bool state) : pos_(pos), accept_state_(state) {}
+      BitInfo() : pos_(), accept_state_() {}
 
       unsigned int pos_;
       bool accept_state_;
@@ -89,11 +73,11 @@ namespace edm
 
     typedef std::vector<BitInfo> Bits;
 
-    Bits absolute_acceptors_;					// change 3
-    Bits conditional_acceptors_;				// change 3
-    Bits exception_acceptors_;					// change 3
-    std::vector<Bits> all_must_fail_;				// change 1
-    std::vector<Bits> all_must_fail_noex_;			// change 3
+    Bits absolute_acceptors_;               // change 3
+    Bits conditional_acceptors_;            // change 3
+    Bits exception_acceptors_;              // change 3
+    std::vector<Bits> all_must_fail_;       // change 1
+    std::vector<Bits> all_must_fail_noex_;  // change 3
 
     ParameterSetID psetID_;
 
@@ -109,36 +93,23 @@ namespace edm
 
     bool acceptTriggerPath(HLTPathStatus const&, BitInfo const&) const;
 
-    bool acceptOneBit (Bits const & b, 
-    		       HLTGlobalStatus const & tr, 
-    		       hlt::HLTState const & s = hlt::Ready) const;
-    bool acceptAllBits (Bits const & b, 
-    		        HLTGlobalStatus const & tr) const;
+    bool acceptOneBit(Bits const& b, HLTGlobalStatus const& tr, hlt::HLTState const& s = hlt::Ready) const;
+    bool acceptAllBits(Bits const& b, HLTGlobalStatus const& tr) const;
 
-    bool containsExceptions(HLTGlobalStatus const & tr) const;
-    
-    bool selectionDecision(HLTGlobalStatus const & tr) const;
-    
+    bool containsExceptions(HLTGlobalStatus const& tr) const;
+
+    bool selectionDecision(HLTGlobalStatus const& tr) const;
+
     static std::string glob2reg(std::string const& s);
-    static std::vector< Strings::const_iterator > 
-      matching_triggers(Strings const& trigs, std::string const& s);
-      
-    static bool identical (std::vector<bool> const & a, 
-    			   std::vector<bool> const & b); 
-    static bool identical (EventSelector const & a, 
-    			   EventSelector const & b,
-			   unsigned int N); 
-    static std::vector<bool> expandDecisionList ( 
-    		Bits const & b,  
-		bool PassOrFail,
-		unsigned int n);
-    static bool overlapping ( std::vector<bool> const& a, 
-    			      std::vector<bool> const& b );
-    static bool subset  ( std::vector<bool> const& a, 
-    			  std::vector<bool> const& b );
-    static std::vector<bool> combine ( std::vector<bool> const& a, 
-    			               std::vector<bool> const& b );
+    static std::vector<Strings::const_iterator> matching_triggers(Strings const& trigs, std::string const& s);
+
+    static bool identical(std::vector<bool> const& a, std::vector<bool> const& b);
+    static bool identical(EventSelector const& a, EventSelector const& b, unsigned int N);
+    static std::vector<bool> expandDecisionList(Bits const& b, bool PassOrFail, unsigned int n);
+    static bool overlapping(std::vector<bool> const& a, std::vector<bool> const& b);
+    static bool subset(std::vector<bool> const& a, std::vector<bool> const& b);
+    static std::vector<bool> combine(std::vector<bool> const& a, std::vector<bool> const& b);
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -40,106 +40,88 @@
 // forward declarations
 
 namespace edm {
-   class ActivityRegistry;
-   class ESInputTag;
-   template <class T, class R>
-   class ESGetToken;
-   class PileUp;
+  class ActivityRegistry;
+  class ESInputTag;
+  template <class T, class R> class ESGetToken;
+  class PileUp;
 
-   namespace eventsetup {
-      class EventSetupProvider;
-      class EventSetupRecord;
-      class EventSetupRecordImpl;
-      class EventSetupKnownRecordsSupplier;
-   }
+  namespace eventsetup {
+    class EventSetupProvider;
+    class EventSetupRecord;
+    class EventSetupRecordImpl;
+    class EventSetupKnownRecordsSupplier;
+  }  // namespace eventsetup
 
-  class EventSetup
-  {
+  class EventSetup {
     ///Needed until a better solution can be found
     friend class edm::PileUp;
-    public:
 
-      explicit EventSetup(EventSetupImpl const& iSetup):
-      m_setup{iSetup} {}
-      EventSetup(EventSetup const&) = delete;
-      EventSetup& operator=(EventSetup const&) = delete;
+  public:
+    explicit EventSetup(EventSetupImpl const& iSetup) : m_setup{iSetup} {}
+    EventSetup(EventSetup const&) = delete;
+    EventSetup& operator=(EventSetup const&) = delete;
 
-      // ---------- const member functions ---------------------
-      /** returns the Record of type T.  If no such record available
+    // ---------- const member functions ---------------------
+    /** returns the Record of type T.  If no such record available
           a eventsetup::NoRecordException<T> is thrown */
-      template< typename T>
-         T get() const {
-           return m_setup.get<T>();
-         }
+    template <typename T> T get() const { return m_setup.get<T>(); }
 
-      /** returns the Record of type T.  If no such record available
+    /** returns the Record of type T.  If no such record available
        a null pointer is returned */
-      template< typename T>
-        std::optional<T> tryToGet() const {
-           return m_setup.tryToGet<T>();
-        }
+    template <typename T> std::optional<T> tryToGet() const { return m_setup.tryToGet<T>(); }
 
-      /** can directly access data if data_default_record_trait<> is defined for this data type **/
-      template< typename T>
-         bool getData(T& iHolder) const {
-            return getData(std::string{}, iHolder);
-         }
+    /** can directly access data if data_default_record_trait<> is defined for this data type **/
+    template <typename T> bool getData(T& iHolder) const { return getData(std::string{}, iHolder); }
 
-      template< typename T>
-         bool getData(const std::string& iLabel, T& iHolder) const {
-            auto const& rec = this->get<eventsetup::default_record_t<T>>();
-            return rec.get(iLabel, iHolder);
-         }
+    template <typename T> bool getData(const std::string& iLabel, T& iHolder) const {
+      auto const& rec = this->get<eventsetup::default_record_t<T>>();
+      return rec.get(iLabel, iHolder);
+    }
 
-      template< typename T>
-        bool getData(const ESInputTag& iTag, T& iHolder) const {
-           auto const& rec = this->get<eventsetup::default_record_t<T>>();
-           return rec.get(iTag, iHolder);
-        }
+    template <typename T> bool getData(const ESInputTag& iTag, T& iHolder) const {
+      auto const& rec = this->get<eventsetup::default_record_t<T>>();
+      return rec.get(iTag, iHolder);
+    }
 
-      template< typename T, typename R>
-        T const& getData(const ESGetToken<T, R>& iToken) const noexcept(false) {
-           return this->get<std::conditional_t<std::is_same_v<R, edm::DefaultRecord>,
-                                               eventsetup::default_record_t<ESHandle<T>>,
-                                               R>>().get(iToken);
-        }
-        template< typename T, typename R>
-        T const& getData(ESGetToken<T, R>& iToken) const noexcept(false) {
-           return this->getData( const_cast<const ESGetToken<T,R>&>(iToken));
-        }
+    template <typename T, typename R> T const& getData(const ESGetToken<T, R>& iToken) const noexcept(false) {
+      return this
+          ->get<std::conditional_t<std::is_same_v<R, edm::DefaultRecord>, eventsetup::default_record_t<ESHandle<T>>, R>>()
+          .get(iToken);
+    }
+    template <typename T, typename R> T const& getData(ESGetToken<T, R>& iToken) const noexcept(false) {
+      return this->getData(const_cast<const ESGetToken<T, R>&>(iToken));
+    }
 
-      template <typename T, typename R>
-       ESHandle<T> getHandle(const ESGetToken<T, R>& iToken) const {
-          if constexpr ( std::is_same_v<R, edm::DefaultRecord> ) {
-             auto const& rec = this->get<eventsetup::default_record_t<ESHandle<T>>>();
-             return rec.getHandle(iToken);
-          } else {
-             auto const& rec = this->get<R>();
-             return rec.getHandle(iToken);
-          }
+    template <typename T, typename R> ESHandle<T> getHandle(const ESGetToken<T, R>& iToken) const {
+      if constexpr (std::is_same_v<R, edm::DefaultRecord>) {
+        auto const& rec = this->get<eventsetup::default_record_t<ESHandle<T>>>();
+        return rec.getHandle(iToken);
+      } else {
+        auto const& rec = this->get<R>();
+        return rec.getHandle(iToken);
       }
+    }
 
-      std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey& iKey) const {
-         return m_setup.find(iKey);
-      }
+    std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey& iKey) const {
+      return m_setup.find(iKey);
+    }
 
-      ///clears the oToFill vector and then fills it with the keys for all available records
-      void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const {
-         m_setup.fillAvailableRecordKeys(oToFill);
-      }
-      ///returns true if the Record is provided by a Source or a Producer
-      /// a value of true does not mean this EventSetup object holds such a record
-      bool recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& iKey) const {
-         return m_setup.recordIsProvidedByAModule(iKey);
-      }
-      // ---------- static member functions --------------------
-      
-    private:
-      edm::EventSetupImpl const& impl() const {return m_setup;}
+    ///clears the oToFill vector and then fills it with the keys for all available records
+    void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const {
+      m_setup.fillAvailableRecordKeys(oToFill);
+    }
+    ///returns true if the Record is provided by a Source or a Producer
+    /// a value of true does not mean this EventSetup object holds such a record
+    bool recordIsProvidedByAModule(eventsetup::EventSetupRecordKey const& iKey) const {
+      return m_setup.recordIsProvidedByAModule(iKey);
+    }
+    // ---------- static member functions --------------------
 
+  private:
+    edm::EventSetupImpl const& impl() const { return m_setup; }
 
-      // ---------- member data --------------------------------
-     edm::EventSetupImpl const& m_setup;
+    // ---------- member data --------------------------------
+    edm::EventSetupImpl const& m_setup;
   };
 
   // Free functions to retrieve an object from the EventSetup.
@@ -151,18 +133,20 @@ namespace edm {
     // throw if the record is not available
     setup.get<R>().get(handle);
     // throw if the handle is not valid
-    return * handle.product();
+    return *handle.product();
   }
 
-  template <typename T, typename R = typename eventsetup::data_default_record_trait<typename T::value_type>::type, typename L>
-  T const& get(EventSetup const& setup, L && label) {
+  template <typename T,
+            typename R = typename eventsetup::data_default_record_trait<typename T::value_type>::type,
+            typename L>
+  T const& get(EventSetup const& setup, L&& label) {
     ESHandle<T> handle;
     // throw if the record is not available
     setup.get<R>().get(std::forward(label), handle);
     // throw if the handle is not valid
-    return * handle.product();
+    return *handle.product();
   }
 
-}
+}  // namespace edm
 
-#endif // FWCore_Framework_EventSetup_h
+#endif  // FWCore_Framework_EventSetup_h

--- a/FWCore/Framework/interface/EventSetupImpl.h
+++ b/FWCore/Framework/interface/EventSetupImpl.h
@@ -39,128 +39,122 @@
 // forward declarations
 
 namespace edm {
-   class ActivityRegistry;
-   class ESInputTag;
-   template <class T>
-   class ESGetTokenT;
+  class ActivityRegistry;
+  class ESInputTag;
+  template <class T> class ESGetTokenT;
 
-   namespace eventsetup {
-      class EventSetupProvider;
-      class EventSetupRecord;
-      class EventSetupRecordImpl;
-      class EventSetupKnownRecordsSupplier;
-   }
+  namespace eventsetup {
+    class EventSetupProvider;
+    class EventSetupRecord;
+    class EventSetupRecordImpl;
+    class EventSetupKnownRecordsSupplier;
+  }  // namespace eventsetup
 
-  class EventSetupImpl
-  {
+  class EventSetupImpl {
     ///Only EventSetupProvider allowed to create a EventSetup
     friend class eventsetup::EventSetupProvider;
-    public:
-      ~EventSetupImpl();
 
-      EventSetupImpl(EventSetupImpl const&) = delete;
-      EventSetupImpl& operator=(EventSetupImpl const&) = delete;
+  public:
+    ~EventSetupImpl();
 
-      // ---------- const member functions ---------------------
-      /** returns the Record of type T.  If no such record available
+    EventSetupImpl(EventSetupImpl const&) = delete;
+    EventSetupImpl& operator=(EventSetupImpl const&) = delete;
+
+    // ---------- const member functions ---------------------
+    /** returns the Record of type T.  If no such record available
           a eventsetup::NoRecordException<T> is thrown */
-      template< typename T>
-         T get() const {
-           using namespace eventsetup;
-           using namespace eventsetup::heterocontainer;
-            //NOTE: this will catch the case where T does not inherit from EventSetupRecord
-            //  HOWEVER the error message under gcc 3.x is awful
-            static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>, "Trying to get a class that is not a Record from EventSetup");
+    template <typename T> T get() const {
+      using namespace eventsetup;
+      using namespace eventsetup::heterocontainer;
+      //NOTE: this will catch the case where T does not inherit from EventSetupRecord
+      //  HOWEVER the error message under gcc 3.x is awful
+      static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>,
+                    "Trying to get a class that is not a Record from EventSetup");
 
-           auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
-           if(nullptr == temp) {
-             throw eventsetup::NoRecordException<T>(recordDoesExist(*this, eventsetup::EventSetupRecordKey::makeKey<T>()));
-           }
-           T returnValue;
-           returnValue.setImpl(temp);
-           return returnValue;
-         }
+      auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey, T>::Type,
+                                         eventsetup::EventSetupRecordKey>());
+      if (nullptr == temp) {
+        throw eventsetup::NoRecordException<T>(recordDoesExist(*this, eventsetup::EventSetupRecordKey::makeKey<T>()));
+      }
+      T returnValue;
+      returnValue.setImpl(temp);
+      return returnValue;
+    }
 
-      /** returns the Record of type T.  If no such record available
+    /** returns the Record of type T.  If no such record available
        a null pointer is returned */
-      template< typename T>
-        std::optional<T> tryToGet() const {
-           using namespace eventsetup;
-           using namespace eventsetup::heterocontainer;
+    template <typename T> std::optional<T> tryToGet() const {
+      using namespace eventsetup;
+      using namespace eventsetup::heterocontainer;
 
-           //NOTE: this will catch the case where T does not inherit from EventSetupRecord
-           static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>,"Trying to get a class that is not a Record from EventSetup");
-           auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
-           if(temp != nullptr) {
-              T rec;
-              rec.setImpl(temp);
-              return rec;
-           }
-           return std::nullopt;
-        }
-
-      /** can directly access data if data_default_record_trait<> is defined for this data type **/
-      template< typename T>
-         bool getData(T& iHolder) const {
-            return getData(std::string{}, iHolder);
-         }
-
-      template< typename T>
-         bool getData(const std::string& iLabel, T& iHolder) const {
-            auto const& rec = this->get<eventsetup::default_record_t<T>>();
-            return rec.get(iLabel, iHolder);
-         }
-
-      template< typename T>
-        bool getData(const ESInputTag& iTag, T& iHolder) const {
-           auto const& rec = this->get<eventsetup::default_record_t<T>>();
-           return rec.get(iTag, iHolder);
-        }
-
-      template <typename T>
-      bool getData(const ESGetTokenT<T>& iToken, ESHandle<T>& iHolder) const {
-        return getData(iToken.m_tag, iHolder);
+      //NOTE: this will catch the case where T does not inherit from EventSetupRecord
+      static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>,
+                    "Trying to get a class that is not a Record from EventSetup");
+      auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey, T>::Type,
+                                         eventsetup::EventSetupRecordKey>());
+      if (temp != nullptr) {
+        T rec;
+        rec.setImpl(temp);
+        return rec;
       }
+      return std::nullopt;
+    }
 
-      std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey&) const;
+    /** can directly access data if data_default_record_trait<> is defined for this data type **/
+    template <typename T> bool getData(T& iHolder) const { return getData(std::string{}, iHolder); }
 
-      ///clears the oToFill vector and then fills it with the keys for all available records
-      void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const;
+    template <typename T> bool getData(const std::string& iLabel, T& iHolder) const {
+      auto const& rec = this->get<eventsetup::default_record_t<T>>();
+      return rec.get(iLabel, iHolder);
+    }
 
-      ///returns true if the Record is provided by a Source or a Producer
-      /// a value of true does not mean this EventSetup object holds such a record
-      bool recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& ) const;
-      // ---------- static member functions --------------------
+    template <typename T> bool getData(const ESInputTag& iTag, T& iHolder) const {
+      auto const& rec = this->get<eventsetup::default_record_t<T>>();
+      return rec.get(iTag, iHolder);
+    }
 
-      friend class eventsetup::EventSetupRecordImpl;
+    template <typename T> bool getData(const ESGetTokenT<T>& iToken, ESHandle<T>& iHolder) const {
+      return getData(iToken.m_tag, iHolder);
+    }
 
-    protected:
-      //Only called by EventSetupProvider
-      void setKnownRecordsSupplier(eventsetup::EventSetupKnownRecordsSupplier const* iSupplier) {
-        knownRecords_ = iSupplier;
-      }
+    std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey&) const;
 
-      void add(const eventsetup::EventSetupRecordImpl& iRecord);
+    ///clears the oToFill vector and then fills it with the keys for all available records
+    void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const;
 
-      void clear();
+    ///returns true if the Record is provided by a Source or a Producer
+    /// a value of true does not mean this EventSetup object holds such a record
+    bool recordIsProvidedByAModule(eventsetup::EventSetupRecordKey const&) const;
+    // ---------- static member functions --------------------
 
-    private:
-      EventSetupImpl(ActivityRegistry const*);
+    friend class eventsetup::EventSetupRecordImpl;
 
-      ActivityRegistry const* activityRegistry() const { return activityRegistry_; }
-      eventsetup::EventSetupRecordImpl const* findImpl(const eventsetup::EventSetupRecordKey&) const;
+  protected:
+    //Only called by EventSetupProvider
+    void setKnownRecordsSupplier(eventsetup::EventSetupKnownRecordsSupplier const* iSupplier) {
+      knownRecords_ = iSupplier;
+    }
 
-      void insert(const eventsetup::EventSetupRecordKey&,
-                  const eventsetup::EventSetupRecordImpl*);
+    void add(const eventsetup::EventSetupRecordImpl& iRecord);
 
-      // ---------- member data --------------------------------
+    void clear();
 
-      //NOTE: the records are not owned
-      std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecordImpl const *> recordMap_;
-      eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;
-      ActivityRegistry const* activityRegistry_;
+  private:
+    EventSetupImpl(ActivityRegistry const*);
+
+    ActivityRegistry const* activityRegistry() const { return activityRegistry_; }
+    eventsetup::EventSetupRecordImpl const* findImpl(const eventsetup::EventSetupRecordKey&) const;
+
+    void insert(const eventsetup::EventSetupRecordKey&, const eventsetup::EventSetupRecordImpl*);
+
+    // ---------- member data --------------------------------
+
+    //NOTE: the records are not owned
+    std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecordImpl const*> recordMap_;
+    eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;
+    ActivityRegistry const* activityRegistry_;
   };
 
-}
+}  // namespace edm
 
-#endif // FWCore_Framework_EventSetup_h
+#endif  // FWCore_Framework_EventSetup_h

--- a/FWCore/Framework/interface/EventSetupKnownRecordsSupplier.h
+++ b/FWCore/Framework/interface/EventSetupKnownRecordsSupplier.h
@@ -22,30 +22,26 @@
 
 // system include files
 
-
 // forward declarations
 namespace edm {
 
-   namespace eventsetup {
-      class EventSetupRecordKey;
+  namespace eventsetup {
+    class EventSetupRecordKey;
 
-class EventSetupKnownRecordsSupplier {
-
-   public:
-
+    class EventSetupKnownRecordsSupplier {
+    public:
       EventSetupKnownRecordsSupplier() = default;
       virtual ~EventSetupKnownRecordsSupplier() = default;
 
       // ---------- const member functions ---------------------
       virtual bool isKnown(EventSetupRecordKey const&) const = 0;
 
-   private:
+    private:
       EventSetupKnownRecordsSupplier(EventSetupKnownRecordsSupplier const&) = delete;
 
       EventSetupKnownRecordsSupplier const& operator=(EventSetupKnownRecordsSupplier const&) = delete;
+    };
 
-};
-
-   }
-}
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -30,27 +30,25 @@
 #include <string>
 #include <vector>
 
-
 // forward declarations
 namespace edm {
-   class ActivityRegistry;
-   class EventSetupRecordIntervalFinder;
-   class IOVSyncValue;
-   class ParameterSet;
+  class ActivityRegistry;
+  class EventSetupRecordIntervalFinder;
+  class IOVSyncValue;
+  class ParameterSet;
 
-   namespace eventsetup {
-      struct ComponentDescription;
-      class DataKey;
-      class DataProxyProvider;
-      class EventSetupRecordImpl;
-      class EventSetupRecordKey;
-      class EventSetupRecordProvider;
-      class EventSetupsController;
-      class ParameterSetIDHolder;
+  namespace eventsetup {
+    struct ComponentDescription;
+    class DataKey;
+    class DataProxyProvider;
+    class EventSetupRecordImpl;
+    class EventSetupRecordKey;
+    class EventSetupRecordProvider;
+    class EventSetupsController;
+    class ParameterSetIDHolder;
 
-class EventSetupProvider {
-
-   public:
+    class EventSetupProvider {
+    public:
       typedef std::string RecordName;
       typedef std::string DataType;
       typedef std::string DataLabel;
@@ -58,19 +56,21 @@ class EventSetupProvider {
       typedef std::multimap<RecordName, DataKeyInfo> RecordToDataMap;
       typedef std::map<ComponentDescription, RecordToDataMap> PreferredProviderInfo;
 
-      EventSetupProvider(ActivityRegistry*, unsigned subProcessIndex = 0U, PreferredProviderInfo const* iInfo = nullptr);
+      EventSetupProvider(ActivityRegistry*,
+                         unsigned subProcessIndex = 0U,
+                         PreferredProviderInfo const* iInfo = nullptr);
       virtual ~EventSetupProvider();
 
       // ---------- const member functions ---------------------
       std::set<ComponentDescription> proxyProviderDescriptions() const;
-      bool isWithinValidityInterval(IOVSyncValue const& ) const;
-  
+      bool isWithinValidityInterval(IOVSyncValue const&) const;
+
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
       EventSetupImpl const& eventSetupForInstance(IOVSyncValue const&);
 
-      EventSetupImpl const& eventSetup() const {return eventSetup_;}
+      EventSetupImpl const& eventSetup() const { return eventSetup_; }
 
       //called by specializations of EventSetupRecordProviders
       void addRecordToEventSetup(EventSetupRecordImpl& iRecord);
@@ -87,14 +87,15 @@ class EventSetupProvider {
       ///Used when testing that all code properly updates on IOV changes of all Records
       void forceCacheClear();
 
-      void checkESProducerSharing(EventSetupProvider & precedingESProvider,
-                                  std::set<ParameterSetIDHolder>& sharingCheckDone,
-                                  std::map<EventSetupRecordKey, std::vector<ComponentDescription const*> >& referencedESProducers,
-                                  EventSetupsController & esController);
+      void checkESProducerSharing(
+          EventSetupProvider& precedingESProvider,
+          std::set<ParameterSetIDHolder>& sharingCheckDone,
+          std::map<EventSetupRecordKey, std::vector<ComponentDescription const*> >& referencedESProducers,
+          EventSetupsController& esController);
 
-      bool doRecordsMatch(EventSetupProvider & precedingESProvider,
+      bool doRecordsMatch(EventSetupProvider& precedingESProvider,
                           EventSetupRecordKey const& eventSetupRecordKey,
-                          std::map<EventSetupRecordKey, bool> & allComponentsMatch,
+                          std::map<EventSetupRecordKey, bool>& allComponentsMatch,
                           EventSetupsController const& esController);
 
       void fillReferencedDataKeys(EventSetupRecordKey const& eventSetupRecordKey);
@@ -107,14 +108,13 @@ class EventSetupProvider {
 
       static void logInfoWhenSharing(ParameterSet const& iConfiguration);
 
-   protected:
-
+    protected:
       void insert(std::unique_ptr<EventSetupRecordProvider> iRecordProvider);
 
-   private:
-      EventSetupProvider(EventSetupProvider const&) = delete; // stop default
+    private:
+      EventSetupProvider(EventSetupProvider const&) = delete;  // stop default
 
-      EventSetupProvider const& operator=(EventSetupProvider const&) = delete; // stop default
+      EventSetupProvider const& operator=(EventSetupProvider const&) = delete;  // stop default
 
       void insert(EventSetupRecordKey const&, std::unique_ptr<EventSetupRecordProvider>);
 
@@ -131,13 +131,15 @@ class EventSetupProvider {
       std::unique_ptr<PreferredProviderInfo> preferredProviderInfo_;
       std::unique_ptr<std::vector<std::shared_ptr<EventSetupRecordIntervalFinder> > > finders_;
       std::unique_ptr<std::vector<std::shared_ptr<DataProxyProvider> > > dataProviders_;
-      std::unique_ptr<std::map<EventSetupRecordKey, std::map<DataKey, ComponentDescription const*> > > referencedDataKeys_;
-      std::unique_ptr<std::map<EventSetupRecordKey, std::vector<std::shared_ptr<EventSetupRecordIntervalFinder> > > > recordToFinders_;
+      std::unique_ptr<std::map<EventSetupRecordKey, std::map<DataKey, ComponentDescription const*> > >
+          referencedDataKeys_;
+      std::unique_ptr<std::map<EventSetupRecordKey, std::vector<std::shared_ptr<EventSetupRecordIntervalFinder> > > >
+          recordToFinders_;
       std::unique_ptr<std::map<ParameterSetIDHolder, std::set<EventSetupRecordKey> > > psetIDToRecordKey_;
       std::unique_ptr<std::map<EventSetupRecordKey, std::map<DataKey, ComponentDescription> > > recordToPreferred_;
       std::unique_ptr<std::set<EventSetupRecordKey> > recordsWithALooperProxy_;
-};
+    };
 
-   }
-}
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/EventSetupProviderMaker.h
+++ b/FWCore/Framework/interface/EventSetupProviderMaker.h
@@ -12,16 +12,13 @@ namespace edm {
     class EventSetupProvider;
     class EventSetupsController;
 
-    std::unique_ptr<EventSetupProvider>
-    makeEventSetupProvider(ParameterSet const& params, unsigned subProcessIndex, ActivityRegistry*);
+    std::unique_ptr<EventSetupProvider> makeEventSetupProvider(ParameterSet const& params,
+                                                               unsigned subProcessIndex,
+                                                               ActivityRegistry*);
 
-    void
-    fillEventSetupProvider(EventSetupsController& esController,
-                           EventSetupProvider& cp,
-                           ParameterSet& params);
+    void fillEventSetupProvider(EventSetupsController& esController, EventSetupProvider& cp, ParameterSet& params);
 
-    void
-    validateEventSetupParameters(ParameterSet& pset);
-  }
-}
+    void validateEventSetupParameters(ParameterSet& pset);
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -47,7 +47,6 @@ using the 'setEventSetup' and 'clearEventSetup' functions.
 // Created:     Fri Mar 25 14:38:35 EST 2005
 //
 
-
 // user include files
 #include "FWCore/Framework/interface/FunctorESHandleExceptionFactory.h"
 #include "FWCore/Framework/interface/DataKey.h"
@@ -67,103 +66,94 @@ using the 'setEventSetup' and 'clearEventSetup' functions.
 
 // forward declarations
 namespace cms {
-   class Exception;
+  class Exception;
 }
 
 class testEventsetup;
 class testEventsetupRecord;
 
 namespace edm {
-   template<typename T>
-   class ESHandle;
-   class ESHandleExceptionFactory;
-   class ESInputTag;
-   class EventSetupImpl;
+  template <typename T> class ESHandle;
+  class ESHandleExceptionFactory;
+  class ESInputTag;
+  class EventSetupImpl;
 
-   namespace eventsetup {
-      struct ComponentDescription;
-      class DataProxy;
-      class EventSetupRecordKey;
+  namespace eventsetup {
+    struct ComponentDescription;
+    class DataProxy;
+    class EventSetupRecordKey;
 
-      class EventSetupRecord {
+    class EventSetupRecord {
+      friend class ::testEventsetup;
+      friend class ::testEventsetupRecord;
 
-        friend class ::testEventsetup;
-        friend class ::testEventsetupRecord;
-      public:
-         EventSetupRecord();
-         EventSetupRecord(EventSetupRecord&&) = default;
-         EventSetupRecord& operator=(EventSetupRecord&&) = default;
+    public:
+      EventSetupRecord();
+      EventSetupRecord(EventSetupRecord&&) = default;
+      EventSetupRecord& operator=(EventSetupRecord&&) = default;
 
-         EventSetupRecord(EventSetupRecord const&) = default;
-         EventSetupRecord& operator=(EventSetupRecord const&) = default;
-         virtual ~EventSetupRecord();
+      EventSetupRecord(EventSetupRecord const&) = default;
+      EventSetupRecord& operator=(EventSetupRecord const&) = default;
+      virtual ~EventSetupRecord();
 
-         // ---------- const member functions ---------------------
-         ValidityInterval const& validityInterval() const {
-            return impl_->validityInterval();
-         }
+      // ---------- const member functions ---------------------
+      ValidityInterval const& validityInterval() const { return impl_->validityInterval(); }
 
-        void setImpl( EventSetupRecordImpl const* iImpl ) { impl_ = iImpl; }
+      void setImpl(EventSetupRecordImpl const* iImpl) { impl_ = iImpl; }
 
-         template<typename HolderT>
-         bool get(HolderT& iHolder) const {
-            return get("", iHolder);
-         }
+      template <typename HolderT> bool get(HolderT& iHolder) const { return get("", iHolder); }
 
-         template<typename HolderT>
-         bool get(char const* iName, HolderT& iHolder) const {
-            typename HolderT::value_type const* value = nullptr;
-            ComponentDescription const* desc = nullptr;
-            std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
-            impl_->getImplementation(value, iName, desc, iHolder.transientAccessOnly, whyFailedFactory);
+      template <typename HolderT> bool get(char const* iName, HolderT& iHolder) const {
+        typename HolderT::value_type const* value = nullptr;
+        ComponentDescription const* desc = nullptr;
+        std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
+        impl_->getImplementation(value, iName, desc, iHolder.transientAccessOnly, whyFailedFactory);
 
-            if(value) {
-              iHolder = HolderT(value, desc);
-              return true;
-            } else {
-              iHolder = HolderT(std::move(whyFailedFactory));
-              return false;
-            }
-         }
-         template<typename HolderT>
-         bool get(std::string const& iName, HolderT& iHolder) const {
-           return get(iName.c_str(), iHolder);
-         }
+        if (value) {
+          iHolder = HolderT(value, desc);
+          return true;
+        } else {
+          iHolder = HolderT(std::move(whyFailedFactory));
+          return false;
+        }
+      }
+      template <typename HolderT> bool get(std::string const& iName, HolderT& iHolder) const {
+        return get(iName.c_str(), iHolder);
+      }
 
-         template<typename HolderT>
-         bool get(ESInputTag const& iTag, HolderT& iHolder) const {
-            typename HolderT::value_type const* value = nullptr;
-            ComponentDescription const* desc = nullptr;
-            std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
-            impl_->getImplementation(value, iTag.data().c_str(), desc, iHolder.transientAccessOnly, whyFailedFactory);
+      template <typename HolderT> bool get(ESInputTag const& iTag, HolderT& iHolder) const {
+        typename HolderT::value_type const* value = nullptr;
+        ComponentDescription const* desc = nullptr;
+        std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
+        impl_->getImplementation(value, iTag.data().c_str(), desc, iHolder.transientAccessOnly, whyFailedFactory);
 
-            if(value) {
-              validate(desc, iTag);
-              iHolder = HolderT(value, desc);
-              return true;
-            } else {
-              iHolder = HolderT(std::move(whyFailedFactory));
-              return false;
-            }
-         }
+        if (value) {
+          validate(desc, iTag);
+          iHolder = HolderT(value, desc);
+          return true;
+        } else {
+          iHolder = HolderT(std::move(whyFailedFactory));
+          return false;
+        }
+      }
 
-         ///returns false if no data available for key
-         bool doGet(DataKey const& aKey, bool aGetTransiently = false) const;
+      ///returns false if no data available for key
+      bool doGet(DataKey const& aKey, bool aGetTransiently = false) const;
 
-         /**returns true only if someone has already requested data for this key
+      /**returns true only if someone has already requested data for this key
           and the data was retrieved
           */
-         bool wasGotten(DataKey const& aKey) const;
+      bool wasGotten(DataKey const& aKey) const;
 
-         /**returns the ComponentDescription for the module which creates the data or 0
+      /**returns the ComponentDescription for the module which creates the data or 0
           if no module has been registered for the data. This does not cause the data to
           actually be constructed.
           */
-         ComponentDescription const* providerDescription(DataKey const& aKey) const;
+      ComponentDescription const* providerDescription(DataKey const& aKey) const;
 
-         virtual EventSetupRecordKey key() const = 0;
+      virtual EventSetupRecordKey key() const = 0;
 
-         /**If you are caching data from the Record, you should also keep
+      /**If you are caching data from the Record, you should also keep
           this number.  If this number changes then you know that
           the data you have cached is invalid. This is NOT true if
           if the validityInterval() hasn't changed since it is possible that
@@ -173,57 +163,50 @@ namespace edm {
           The value of '0' will never be returned so you can use that to
           denote that you have not yet checked the value.
           */
-         unsigned long long cacheIdentifier() const {
-            return impl_->cacheIdentifier();
-         }
+      unsigned long long cacheIdentifier() const { return impl_->cacheIdentifier(); }
 
-         ///clears the oToFill vector and then fills it with the keys for all registered data keys
-         void fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const {
-           impl_->fillRegisteredDataKeys(oToFill);
-         }
-      protected:
+      ///clears the oToFill vector and then fills it with the keys for all registered data keys
+      void fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const { impl_->fillRegisteredDataKeys(oToFill); }
 
-         template<typename T, typename R>
-         ESHandle<T> getHandleImpl(ESGetToken<T,R> const& iToken) const {
-           ESHandle<T> h;
-           (void) get(iToken.m_tag, h);
-           return h;
-         }
-        
+    protected:
+      template <typename T, typename R> ESHandle<T> getHandleImpl(ESGetToken<T, R> const& iToken) const {
+        ESHandle<T> h;
+        (void)get(iToken.m_tag, h);
+        return h;
+      }
 
-         DataProxy const* find(DataKey const& aKey) const ;
+      DataProxy const* find(DataKey const& aKey) const;
 
-         EventSetupImpl const& eventSetup() const {
-            return impl_->eventSetup();
-         }
+      EventSetupImpl const& eventSetup() const { return impl_->eventSetup(); }
 
-         void validate(ComponentDescription const*, ESInputTag const&) const;
+      void validate(ComponentDescription const*, ESInputTag const&) const;
 
-         void addTraceInfoToCmsException(cms::Exception& iException, char const* iName, ComponentDescription const*, DataKey const&) const;
-         void changeStdExceptionToCmsException(char const* iExceptionWhatMessage, char const* iName, ComponentDescription const*, DataKey const&) const;
+      void addTraceInfoToCmsException(cms::Exception& iException,
+                                      char const* iName,
+                                      ComponentDescription const*,
+                                      DataKey const&) const;
+      void changeStdExceptionToCmsException(char const* iExceptionWhatMessage,
+                                            char const* iName,
+                                            ComponentDescription const*,
+                                            DataKey const&) const;
 
-        EventSetupRecordImpl const* impl() const { return impl_;}
-      private:
+      EventSetupRecordImpl const* impl() const { return impl_; }
 
-         void const* getFromProxy(DataKey const& iKey ,
-                                  ComponentDescription const*& iDesc,
-                                  bool iTransientAccessOnly) const;
+    private:
+      void const* getFromProxy(DataKey const& iKey,
+                               ComponentDescription const*& iDesc,
+                               bool iTransientAccessOnly) const;
 
+      // ---------- member data --------------------------------
+      EventSetupRecordImpl const* impl_ = nullptr;
+    };
 
-         // ---------- member data --------------------------------
-         EventSetupRecordImpl const* impl_ = nullptr;
-      };
+    class EventSetupRecordGeneric : public EventSetupRecord {
+    public:
+      EventSetupRecordGeneric(EventSetupRecordImpl const* iImpl) { setImpl(iImpl); }
 
-     class EventSetupRecordGeneric : public EventSetupRecord {
-     public:
-       EventSetupRecordGeneric(EventSetupRecordImpl const* iImpl) {
-         setImpl(iImpl);
-       }
-
-       EventSetupRecordKey key() const final {
-         return impl()->key();
-       }
-     };
-   }
-}
+      EventSetupRecordKey key() const final { return impl()->key(); }
+    };
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -47,7 +47,6 @@ using the 'setEventSetup' and 'clearEventSetup' functions.
 // Created:     Fri Mar 25 14:38:35 EST 2005
 //
 
-
 // user include files
 #include "FWCore/Framework/interface/FunctorESHandleExceptionFactory.h"
 #include "FWCore/Framework/interface/DataKey.h"
@@ -67,47 +66,44 @@ using the 'setEventSetup' and 'clearEventSetup' functions.
 
 // forward declarations
 namespace cms {
-   class Exception;
+  class Exception;
 }
 
 namespace edm {
-   class ESHandleExceptionFactory;
-   class ESInputTag;
-   class EventSetupImpl;
+  class ESHandleExceptionFactory;
+  class ESInputTag;
+  class EventSetupImpl;
 
-   namespace eventsetup {
-      struct ComponentDescription;
-      class DataProxy;
+  namespace eventsetup {
+    struct ComponentDescription;
+    class DataProxy;
 
-      class EventSetupRecordImpl {
+    class EventSetupRecordImpl {
+      friend class EventSetupRecord;
 
-        friend class EventSetupRecord;
+    public:
+      EventSetupRecordImpl(const EventSetupRecordKey& iKey);
 
-      public:
-         EventSetupRecordImpl(const EventSetupRecordKey& iKey);
+      // ---------- const member functions ---------------------
+      ValidityInterval const& validityInterval() const { return validity_; }
 
-         // ---------- const member functions ---------------------
-         ValidityInterval const& validityInterval() const {
-            return validity_;
-         }
+      ///returns false if no data available for key
+      bool doGet(DataKey const& aKey, bool aGetTransiently = false) const;
 
-         ///returns false if no data available for key
-         bool doGet(DataKey const& aKey, bool aGetTransiently = false) const;
-
-         /**returns true only if someone has already requested data for this key
+      /**returns true only if someone has already requested data for this key
           and the data was retrieved
           */
-         bool wasGotten(DataKey const& aKey) const;
+      bool wasGotten(DataKey const& aKey) const;
 
-         /**returns the ComponentDescription for the module which creates the data or 0
+      /**returns the ComponentDescription for the module which creates the data or 0
           if no module has been registered for the data. This does not cause the data to
           actually be constructed.
           */
-         ComponentDescription const* providerDescription(DataKey const& aKey) const;
+      ComponentDescription const* providerDescription(DataKey const& aKey) const;
 
-         EventSetupRecordKey const& key() const { return key_; }
+      EventSetupRecordKey const& key() const { return key_; }
 
-         /**If you are caching data from the Record, you should also keep
+      /**If you are caching data from the Record, you should also keep
           this number.  If this number changes then you know that
           the data you have cached is invalid. This is NOT true if
           if the validityInterval() hasn't changed since it is possible that
@@ -117,83 +113,82 @@ namespace edm {
           The value of '0' will never be returned so you can use that to
           denote that you have not yet checked the value.
           */
-         unsigned long long cacheIdentifier() const {
-            return cacheIdentifier_;
-         }
+      unsigned long long cacheIdentifier() const { return cacheIdentifier_; }
 
-         ///clears the oToFill vector and then fills it with the keys for all registered data keys
-         void fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const;
-         // ---------- static member functions --------------------
+      ///clears the oToFill vector and then fills it with the keys for all registered data keys
+      void fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const;
+      // ---------- static member functions --------------------
 
-         // ---------- member functions ---------------------------
+      // ---------- member functions ---------------------------
 
-         // The following member functions should only be used by EventSetupRecordProvider
-         bool add(DataKey const& iKey ,
-                  DataProxy const* iProxy) ;
-         void clearProxies();
-         void cacheReset() ;
-         /// returns 'true' if a transient request has occurred since the last call to transientReset.
-         bool transientReset() ;
+      // The following member functions should only be used by EventSetupRecordProvider
+      bool add(DataKey const& iKey, DataProxy const* iProxy);
+      void clearProxies();
+      void cacheReset();
+      /// returns 'true' if a transient request has occurred since the last call to transientReset.
+      bool transientReset();
 
-         void set(ValidityInterval const&);
-         void setEventSetup(EventSetupImpl const* iEventSetup) {eventSetup_ = iEventSetup; }
+      void set(ValidityInterval const&);
+      void setEventSetup(EventSetupImpl const* iEventSetup) { eventSetup_ = iEventSetup; }
 
-         void getESProducers(std::vector<ComponentDescription const*>& esproducers);
-         void fillReferencedDataKeys(std::map<DataKey, ComponentDescription const*>& referencedDataKeys);
+      void getESProducers(std::vector<ComponentDescription const*>& esproducers);
+      void fillReferencedDataKeys(std::map<DataKey, ComponentDescription const*>& referencedDataKeys);
 
       //protected:
 
-         DataProxy const* find(DataKey const& aKey) const ;
+      DataProxy const* find(DataKey const& aKey) const;
 
-        EventSetupImpl const& eventSetup() const {
-          return *eventSetup_;
+      EventSetupImpl const& eventSetup() const { return *eventSetup_; }
+
+      void validate(ComponentDescription const*, ESInputTag const&) const;
+
+      void addTraceInfoToCmsException(cms::Exception& iException,
+                                      char const* iName,
+                                      ComponentDescription const*,
+                                      DataKey const&) const;
+      void changeStdExceptionToCmsException(char const* iExceptionWhatMessage,
+                                            char const* iName,
+                                            ComponentDescription const*,
+                                            DataKey const&) const;
+
+      void transientAccessRequested() const { transientAccessRequested_ = true; }
+
+    private:
+      EventSetupRecordImpl(EventSetupRecordImpl const&) = delete;
+
+      EventSetupRecordImpl const& operator=(EventSetupRecordImpl const&) = delete;
+
+      void const* getFromProxy(DataKey const& iKey,
+                               ComponentDescription const*& iDesc,
+                               bool iTransientAccessOnly) const;
+
+      template <typename DataT>
+      void getImplementation(DataT const*& iData,
+                             char const* iName,
+                             ComponentDescription const*& iDesc,
+                             bool iTransientAccessOnly,
+                             std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory) const {
+        DataKey dataKey(DataKey::makeTypeTag<DataT>(), iName, DataKey::kDoNotCopyMemory);
+
+        void const* pValue = this->getFromProxy(dataKey, iDesc, iTransientAccessOnly);
+        if (nullptr == pValue) {
+          whyFailedFactory = makeESHandleExceptionFactory([=] {
+            NoProxyException<DataT> ex(this->key(), dataKey);
+            return std::make_exception_ptr(ex);
+          });
         }
+        iData = reinterpret_cast<DataT const*>(pValue);
+      }
 
-         void validate(ComponentDescription const*, ESInputTag const&) const;
-
-         void addTraceInfoToCmsException(cms::Exception& iException, char const* iName, ComponentDescription const*, DataKey const&) const;
-         void changeStdExceptionToCmsException(char const* iExceptionWhatMessage, char const* iName, ComponentDescription const*, DataKey const&) const;
-
-         void transientAccessRequested() const { transientAccessRequested_ = true;}
-      private:
-         EventSetupRecordImpl(EventSetupRecordImpl const&) = delete;
-
-         EventSetupRecordImpl const& operator=(EventSetupRecordImpl const&) = delete;
-
-         void const* getFromProxy(DataKey const& iKey ,
-                                  ComponentDescription const*& iDesc,
-                                  bool iTransientAccessOnly) const;
-
-         template <typename DataT>
-         void getImplementation(DataT const*& iData ,
-                                char const* iName,
-                                ComponentDescription const*& iDesc,
-                                bool iTransientAccessOnly,
-                                std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory) const {
-            DataKey dataKey(DataKey::makeTypeTag<DataT>(),
-                            iName,
-                            DataKey::kDoNotCopyMemory);
-
-            void const* pValue = this->getFromProxy(dataKey, iDesc, iTransientAccessOnly);
-            if(nullptr == pValue) {
-              whyFailedFactory =
-                makeESHandleExceptionFactory([=] {
-                    NoProxyException<DataT> ex(this->key(), dataKey);
-                    return std::make_exception_ptr(ex);
-                });
-            }
-            iData = reinterpret_cast<DataT const*> (pValue);
-         }
-
-         // ---------- member data --------------------------------
-         ValidityInterval validity_;
-         EventSetupRecordKey key_;
-         std::vector<DataKey> keysForProxies_;
-         std::vector<DataProxy const*> proxies_;
-         EventSetupImpl const* eventSetup_;
-         unsigned long long cacheIdentifier_;
-         mutable std::atomic<bool> transientAccessRequested_;
-      };
-   }
-}
+      // ---------- member data --------------------------------
+      ValidityInterval validity_;
+      EventSetupRecordKey key_;
+      std::vector<DataKey> keysForProxies_;
+      std::vector<DataProxy const*> proxies_;
+      EventSetupImpl const* eventSetup_;
+      unsigned long long cacheIdentifier_;
+      mutable std::atomic<bool> transientAccessRequested_;
+    };
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/EventSetupRecordImplementation.h
+++ b/FWCore/Framework/interface/EventSetupRecordImplementation.h
@@ -32,66 +32,57 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
-      struct ComponentDescription;
+  namespace eventsetup {
+    struct ComponentDescription;
 
-      template<typename T>
-      class EventSetupRecordImplementation : public EventSetupRecord {
+    template <typename T> class EventSetupRecordImplementation : public EventSetupRecord {
+    public:
+      //virtual ~EventSetupRecordImplementation();
 
-      public:
-         //virtual ~EventSetupRecordImplementation();
+      // ---------- const member functions ---------------------
+      EventSetupRecordKey key() const override { return EventSetupRecordKey::makeKey<T>(); }
 
-         // ---------- const member functions ---------------------
-         EventSetupRecordKey key() const override {
-            return EventSetupRecordKey::makeKey<T>();
-         }
+      template <typename PRODUCT> ESHandle<PRODUCT> getHandle(ESGetToken<PRODUCT, T> const& iToken) const {
+        return getHandleImpl(iToken);
+      }
 
-         template<typename PRODUCT>
-         ESHandle<PRODUCT> getHandle(ESGetToken<PRODUCT,T> const& iToken) const {
-           return getHandleImpl(iToken);
-         }
+      template <typename PRODUCT>
+      ESHandle<PRODUCT> getHandle(ESGetToken<PRODUCT, edm::DefaultRecord> const& iToken) const {
+        static_assert(std::is_same_v<T, eventsetup::default_record_t<ESHandle<PRODUCT>>>,
+                      "The Record being used to retrieve the product is not the default record for the product type");
+        return getHandleImpl(iToken);
+      }
 
-         template<typename PRODUCT>
-         ESHandle<PRODUCT> getHandle(ESGetToken<PRODUCT,edm::DefaultRecord> const& iToken) const {
-           static_assert(std::is_same_v<T, eventsetup::default_record_t<ESHandle<PRODUCT>>>, "The Record being used to retrieve the product is not the default record for the product type");
-           return getHandleImpl(iToken);
-         }
+      using EventSetupRecord::get;
 
-         using EventSetupRecord::get;
-        
-         template<typename PRODUCT>
-         PRODUCT const& get(ESGetToken<PRODUCT,T> const& iToken) const {
-           return *getHandleImpl(iToken);
-         }
-        template<typename PRODUCT>
-        PRODUCT const& get(ESGetToken<PRODUCT,T>& iToken) const {
-          return *getHandleImpl(const_cast<const ESGetToken<PRODUCT,T>&>(iToken));
-        }
+      template <typename PRODUCT> PRODUCT const& get(ESGetToken<PRODUCT, T> const& iToken) const {
+        return *getHandleImpl(iToken);
+      }
+      template <typename PRODUCT> PRODUCT const& get(ESGetToken<PRODUCT, T>& iToken) const {
+        return *getHandleImpl(const_cast<const ESGetToken<PRODUCT, T>&>(iToken));
+      }
 
-         template<typename PRODUCT>
-         PRODUCT const& get(ESGetToken<PRODUCT,edm::DefaultRecord> const& iToken) const {
-           static_assert(std::is_same_v<T, eventsetup::default_record_t<ESHandle<PRODUCT>>>, "The Record being used to retrieve the product is not the default record for the product type");
-           return *getHandleImpl(iToken);
-         }
-        template<typename PRODUCT>
-        PRODUCT const& get(ESGetToken<PRODUCT,edm::DefaultRecord>& iToken) const {
-          return get(const_cast<const ESGetToken<PRODUCT,edm::DefaultRecord>&>(iToken) );
-        }
+      template <typename PRODUCT> PRODUCT const& get(ESGetToken<PRODUCT, edm::DefaultRecord> const& iToken) const {
+        static_assert(std::is_same_v<T, eventsetup::default_record_t<ESHandle<PRODUCT>>>,
+                      "The Record being used to retrieve the product is not the default record for the product type");
+        return *getHandleImpl(iToken);
+      }
+      template <typename PRODUCT> PRODUCT const& get(ESGetToken<PRODUCT, edm::DefaultRecord>& iToken) const {
+        return get(const_cast<const ESGetToken<PRODUCT, edm::DefaultRecord>&>(iToken));
+      }
 
-         // ---------- static member functions --------------------
-         static EventSetupRecordKey keyForClass()  {
-            return EventSetupRecordKey::makeKey<T>();
-         }
+      // ---------- static member functions --------------------
+      static EventSetupRecordKey keyForClass() { return EventSetupRecordKey::makeKey<T>(); }
 
-         // ---------- member functions ---------------------------
+      // ---------- member functions ---------------------------
 
-      protected:
-         EventSetupRecordImplementation() {}
+    protected:
+      EventSetupRecordImplementation() {}
 
-      private:
-         // ---------- member data --------------------------------
-      };
-   }
-}
+    private:
+      // ---------- member data --------------------------------
+    };
+  }  // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/EventSetupRecordIntervalFinder.h
+++ b/FWCore/Framework/interface/EventSetupRecordIntervalFinder.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     EventSetupRecordIntervalFinder
-// 
+//
 /**\class EventSetupRecordIntervalFinder EventSetupRecordIntervalFinder.h FWCore/Framework/interface/EventSetupRecordIntervalFinder.h
 
  Description: <one line class summary>
@@ -30,54 +30,45 @@
 // forward declarations
 namespace edm {
 
-class EventSetupRecordIntervalFinder
-{
+  class EventSetupRecordIntervalFinder {
+  public:
+    EventSetupRecordIntervalFinder() : intervals_() {}
+    virtual ~EventSetupRecordIntervalFinder() noexcept(false);
 
-   public:
-      EventSetupRecordIntervalFinder() : intervals_() {}
-      virtual ~EventSetupRecordIntervalFinder() noexcept(false);
+    // ---------- const member functions ---------------------
+    std::set<eventsetup::EventSetupRecordKey> findingForRecords() const;
 
-      // ---------- const member functions ---------------------
-      std::set<eventsetup::EventSetupRecordKey> findingForRecords() const ;
-   
-      const eventsetup::ComponentDescription& descriptionForFinder() const { return description_;}
-      // ---------- static member functions --------------------
+    const eventsetup::ComponentDescription& descriptionForFinder() const { return description_; }
+    // ---------- static member functions --------------------
 
-      // ---------- member functions ---------------------------
-      /**returns the 'default constructed' ValidityInterval if no valid interval.
+    // ---------- member functions ---------------------------
+    /**returns the 'default constructed' ValidityInterval if no valid interval.
        If upperbound is not known, it should be set to IOVSyncValue::invalidIOVSyncValue()
       */
-      const ValidityInterval& findIntervalFor(const eventsetup::EventSetupRecordKey&,
-                                            const IOVSyncValue&);
-   
-      void setDescriptionForFinder(const eventsetup::ComponentDescription& iDescription) {
-        description_ = iDescription;
-      }
-   protected:
-      virtual void setIntervalFor(const eventsetup::EventSetupRecordKey&,
-                                   const IOVSyncValue& , 
-                                   ValidityInterval&) = 0;
+    const ValidityInterval& findIntervalFor(const eventsetup::EventSetupRecordKey&, const IOVSyncValue&);
 
-      template< class T>
-         void findingRecord() {
-            findingRecordWithKey(eventsetup::EventSetupRecordKey::makeKey<T>());
-         }
-      
-      void findingRecordWithKey(const eventsetup::EventSetupRecordKey&);
-      
-private:
-      EventSetupRecordIntervalFinder(const EventSetupRecordIntervalFinder&) = delete; // stop default
+    void setDescriptionForFinder(const eventsetup::ComponentDescription& iDescription) { description_ = iDescription; }
 
-      const EventSetupRecordIntervalFinder& operator=(const EventSetupRecordIntervalFinder&) = delete; // stop default
+  protected:
+    virtual void setIntervalFor(const eventsetup::EventSetupRecordKey&, const IOVSyncValue&, ValidityInterval&) = 0;
 
-      /** override this method if you need to delay setting what records you will be using until after all modules are loaded*/
-      virtual void delaySettingRecords();
-      // ---------- member data --------------------------------
-      typedef  std::map<eventsetup::EventSetupRecordKey,ValidityInterval> Intervals;
-      Intervals intervals_;
+    template <class T> void findingRecord() { findingRecordWithKey(eventsetup::EventSetupRecordKey::makeKey<T>()); }
 
-      eventsetup::ComponentDescription description_;
-};
+    void findingRecordWithKey(const eventsetup::EventSetupRecordKey&);
 
-}
+  private:
+    EventSetupRecordIntervalFinder(const EventSetupRecordIntervalFinder&) = delete;  // stop default
+
+    const EventSetupRecordIntervalFinder& operator=(const EventSetupRecordIntervalFinder&) = delete;  // stop default
+
+    /** override this method if you need to delay setting what records you will be using until after all modules are loaded*/
+    virtual void delaySettingRecords();
+    // ---------- member data --------------------------------
+    typedef std::map<eventsetup::EventSetupRecordKey, ValidityInterval> Intervals;
+    Intervals intervals_;
+
+    eventsetup::ComponentDescription description_;
+  };
+
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/EventSetupRecordKey.h
+++ b/FWCore/Framework/interface/EventSetupRecordKey.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     EventSetupRecordKey
-// 
+//
 /**\class EventSetupRecordKey EventSetupRecordKey.h FWCore/Framework/interface/EventSetupRecordKey.h
 
  Description: Key used to lookup a EventSetupRecord within the EventSetup
@@ -26,48 +26,39 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
-class EventSetupRecordKey
-{
+  namespace eventsetup {
+    class EventSetupRecordKey {
+    public:
+      typedef heterocontainer::HCTypeTag TypeTag;
 
-   public:
-   typedef heterocontainer::HCTypeTag TypeTag;
-      
       EventSetupRecordKey();
-      EventSetupRecordKey(const TypeTag& iType) :
-         type_(iType) {}
+      EventSetupRecordKey(const TypeTag& iType) : type_(iType) {}
 
       //virtual ~EventSetupRecordKey();
 
       // ---------- const member functions ---------------------
-      const TypeTag& type() const { return type_;}
-      
-      bool operator<(const EventSetupRecordKey& iRHS) const {
-         return type_ < iRHS.type_;
-      }
-      bool operator==(const EventSetupRecordKey& iRHS) const {
-         return type_ == iRHS.type_;
-      }
-      
+      const TypeTag& type() const { return type_; }
+
+      bool operator<(const EventSetupRecordKey& iRHS) const { return type_ < iRHS.type_; }
+      bool operator==(const EventSetupRecordKey& iRHS) const { return type_ == iRHS.type_; }
+
       const char* name() const { return type().name(); }
       // ---------- static member functions --------------------
-      template<class T>
-         static EventSetupRecordKey makeKey() {
-            return eventsetup::heterocontainer::makeKey<T,EventSetupRecordKey>();
-         }
-      
+      template <class T> static EventSetupRecordKey makeKey() {
+        return eventsetup::heterocontainer::makeKey<T, EventSetupRecordKey>();
+      }
+
       // ---------- member functions ---------------------------
 
-   private:
+    private:
       //EventSetupRecordKey(const EventSetupRecordKey&); // allow default
 
       //const EventSetupRecordKey& operator=(const EventSetupRecordKey&); // allow default
 
       // ---------- member data --------------------------------
       TypeTag type_;
-         
-};
-   }
-}
+    };
+  }  // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/EventSetupRecordProvider.h
+++ b/FWCore/Framework/interface/EventSetupRecordProvider.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     EventSetupRecordProvider
-// 
+//
 /**\class EventSetupRecordProvider EventSetupRecordProvider.h FWCore/Framework/interface/EventSetupRecordProvider.h
 
  Description: Coordinates all EventSetupDataProviders with the same 'interval of validity'
@@ -33,87 +33,85 @@
 
 // forward declarations
 namespace edm {
-   class EventSetupRecordIntervalFinder;
+  class EventSetupRecordIntervalFinder;
 
-   namespace eventsetup {
-      struct ComponentDescription;
-      class DataKey;
-      class DataProxyProvider;
-      class EventSetupProvider;
-      class EventSetupRecordImpl;
-      class ParameterSetIDHolder;
-      
-class EventSetupRecordProvider {
+  namespace eventsetup {
+    struct ComponentDescription;
+    class DataKey;
+    class DataProxyProvider;
+    class EventSetupProvider;
+    class EventSetupRecordImpl;
+    class ParameterSetIDHolder;
 
-   public:
+    class EventSetupRecordProvider {
+    public:
       typedef std::map<DataKey, ComponentDescription> DataToPreferredProviderMap;
-   
+
       EventSetupRecordProvider(EventSetupRecordKey const& iKey);
 
       // ---------- const member functions ---------------------
 
-      ValidityInterval const& validityInterval() const {
-         return validityInterval_;
-      }
-      EventSetupRecordKey const& key() const { return key_; }      
+      ValidityInterval const& validityInterval() const { return validityInterval_; }
+      EventSetupRecordKey const& key() const { return key_; }
 
-      EventSetupRecordImpl const& record() const {return record_;}
-      EventSetupRecordImpl& record() { return record_;}
+      EventSetupRecordImpl const& record() const { return record_; }
+      EventSetupRecordImpl& record() { return record_; }
 
       ///Returns the list of Records the provided Record depends on (usually none)
       std::set<EventSetupRecordKey> dependentRecords() const;
-      
+
       ///return information on which DataProxyProviders are supplying information
       std::set<ComponentDescription> proxyProviderDescriptions() const;
-  
+
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
 
       ///returns the first matching DataProxyProvider or a 'null' if not found
       std::shared_ptr<DataProxyProvider> proxyProvider(ComponentDescription const&);
-  
+
       ///returns the first matching DataProxyProvider or a 'null' if not found
       std::shared_ptr<DataProxyProvider> proxyProvider(ParameterSetIDHolder const&);
-  
 
       void resetProxyProvider(ParameterSetIDHolder const&, std::shared_ptr<DataProxyProvider> const&);
 
       void addRecordTo(EventSetupProvider&);
-      void addRecordToIfValid(EventSetupProvider&, IOVSyncValue const&) ;
+      void addRecordToIfValid(EventSetupProvider&, IOVSyncValue const&);
 
       void add(std::shared_ptr<DataProxyProvider>);
       ///For now, only use one finder
       void addFinder(std::shared_ptr<EventSetupRecordIntervalFinder>);
       void setValidityInterval(ValidityInterval const&);
-      
+
       ///sets interval to this time and returns true if have a valid interval for time
       bool setValidityIntervalFor(IOVSyncValue const&);
 
       ///If the provided Record depends on other Records, here are the dependent Providers
-      void setDependentProviders(std::vector<std::shared_ptr<EventSetupRecordProvider> >const&);
+      void setDependentProviders(std::vector<std::shared_ptr<EventSetupRecordProvider>> const&);
 
       /**In the case of a conflict, sets what Provider to call.  This must be called after
          all providers have been added.  An empty map is acceptable. */
       void usePreferred(DataToPreferredProviderMap const&);
-      
+
       ///This will clear the cache's of all the Proxies so that next time they are called they will run
       void resetProxies();
-      
-      std::shared_ptr<EventSetupRecordIntervalFinder const> finder() const {return get_underlying_safe(finder_);}
-      std::shared_ptr<EventSetupRecordIntervalFinder>& finder() {return get_underlying_safe(finder_);}
 
-      void getReferencedESProducers(std::map<EventSetupRecordKey, std::vector<ComponentDescription const*> >& referencedESProducers);
+      std::shared_ptr<EventSetupRecordIntervalFinder const> finder() const { return get_underlying_safe(finder_); }
+      std::shared_ptr<EventSetupRecordIntervalFinder>& finder() { return get_underlying_safe(finder_); }
+
+      void getReferencedESProducers(
+          std::map<EventSetupRecordKey, std::vector<ComponentDescription const*>>& referencedESProducers);
 
       void fillReferencedDataKeys(std::map<DataKey, ComponentDescription const*>& referencedDataKeys);
 
       void resetRecordToProxyPointers(DataToPreferredProviderMap const& iMap);
 
-   protected:
+    protected:
       void addProxiesToRecordHelper(edm::propagate_const<std::shared_ptr<DataProxyProvider>>& dpp,
-                              DataToPreferredProviderMap const& mp) {addProxiesToRecord(get_underlying_safe(dpp), mp);}
-      void addProxiesToRecord(std::shared_ptr<DataProxyProvider>,
-                              DataToPreferredProviderMap const&);
+                                    DataToPreferredProviderMap const& mp) {
+        addProxiesToRecord(get_underlying_safe(dpp), mp);
+      }
+      void addProxiesToRecord(std::shared_ptr<DataProxyProvider>, DataToPreferredProviderMap const&);
       void cacheReset();
 
       std::shared_ptr<EventSetupRecordIntervalFinder> swapFinder(std::shared_ptr<EventSetupRecordIntervalFinder> iNew) {
@@ -121,10 +119,10 @@ class EventSetupRecordProvider {
         return iNew;
       }
 
-   private:
-      EventSetupRecordProvider(EventSetupRecordProvider const&) = delete; // stop default
+    private:
+      EventSetupRecordProvider(EventSetupRecordProvider const&) = delete;  // stop default
 
-      EventSetupRecordProvider const& operator=(EventSetupRecordProvider const&) = delete; // stop default
+      EventSetupRecordProvider const& operator=(EventSetupRecordProvider const&) = delete;  // stop default
 
       void resetTransients();
       bool checkResetTransients();
@@ -134,10 +132,11 @@ class EventSetupRecordProvider {
       ValidityInterval validityInterval_;
       edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>> finder_;
       std::vector<edm::propagate_const<std::shared_ptr<DataProxyProvider>>> providers_;
-      std::unique_ptr<std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>> multipleFinders_;
+      std::unique_ptr<std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>>
+          multipleFinders_;
       bool lastSyncWasBeginOfRun_;
-};
-   }
-}
+    };
+  }  // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ExceptionActions.h
+++ b/FWCore/Framework/interface/ExceptionActions.h
@@ -8,16 +8,10 @@
 
 namespace edm {
   namespace exception_actions {
-    enum ActionCodes {
-      IgnoreCompletely=0,
-      Rethrow,
-      SkipEvent,
-      FailPath,
-      LastCode
-    };
+    enum ActionCodes { IgnoreCompletely = 0, Rethrow, SkipEvent, FailPath, LastCode };
 
     const char* actionName(ActionCodes code);
-  }
+  }  // namespace exception_actions
 
   class ExceptionToActionTable {
   public:
@@ -34,5 +28,5 @@ namespace edm {
     void addDefaults();
     ActionMap map_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ExceptionHelpers.h
+++ b/FWCore/Framework/interface/ExceptionHelpers.h
@@ -43,26 +43,20 @@
 
 namespace edm {
 
-  void addContextAndPrintException(char const* context,
-                                   cms::Exception& ex,
-                                   bool disablePrint);
+  void addContextAndPrintException(char const* context, cms::Exception& ex, bool disablePrint);
 
   template <typename TReturn>
-  TReturn callWithTryCatchAndPrint(std::function<TReturn (void)> iFunc,
+  TReturn callWithTryCatchAndPrint(std::function<TReturn(void)> iFunc,
                                    char const* context = nullptr,
                                    bool disablePrint = false) {
-
     try {
-      return convertException::wrap([iFunc]() {
-        return iFunc();
-      });
-    }
-    catch(cms::Exception& ex) {
+      return convertException::wrap([iFunc]() { return iFunc(); });
+    } catch (cms::Exception& ex) {
       addContextAndPrintException(context, ex, disablePrint);
       throw;
     }
     return TReturn();
   }
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/FileBlock.h
+++ b/FWCore/Framework/interface/FileBlock.h
@@ -20,8 +20,7 @@ namespace edm {
   class FileBlock {
   public:
     // bit mask for reasons fast cloning can be disabled or not applicable
-    enum
-    WhyNotFastClonable {
+    enum WhyNotFastClonable {
       CanFastClone = 0x0,
 
       // For entire job
@@ -55,63 +54,67 @@ namespace edm {
       BranchMismatch = (SplitLevelMismatch << 1)
     };
 
-    FileBlock() :
-      fileFormatVersion_(),
-      tree_(nullptr), metaTree_(nullptr),
-      lumiTree_(nullptr), lumiMetaTree_(nullptr),
-      runTree_(nullptr), runMetaTree_(nullptr),
-      whyNotFastClonable_(NoRootInputSource),
-      hasNewlyDroppedBranch_(),
-      fileName_(),
-      branchListIndexesUnchanged_(false),
-      modifiedIDs_(false),
-      branchChildren_(new BranchChildren) {}
+    FileBlock()
+        : fileFormatVersion_(),
+          tree_(nullptr),
+          metaTree_(nullptr),
+          lumiTree_(nullptr),
+          lumiMetaTree_(nullptr),
+          runTree_(nullptr),
+          runMetaTree_(nullptr),
+          whyNotFastClonable_(NoRootInputSource),
+          hasNewlyDroppedBranch_(),
+          fileName_(),
+          branchListIndexesUnchanged_(false),
+          modifiedIDs_(false),
+          branchChildren_(new BranchChildren) {}
 
     FileBlock(FileFormatVersion const& version,
-              TTree const* ev, TTree const* meta,
-              TTree const* lumi, TTree const* lumiMeta,
-              TTree const* run, TTree const* runMeta,
+              TTree const* ev,
+              TTree const* meta,
+              TTree const* lumi,
+              TTree const* lumiMeta,
+              TTree const* run,
+              TTree const* runMeta,
               int whyNotFastClonable,
               std::array<bool, NumBranchTypes> const& hasNewlyDroppedBranch,
               std::string const& fileName,
               bool branchListIndexesUnchanged,
               bool modifiedIDs,
-              std::shared_ptr<BranchChildren const> branchChildren) :
-      fileFormatVersion_(version),
-      tree_(const_cast<TTree*>(ev)),
-      metaTree_(const_cast<TTree*>(meta)),
-      lumiTree_(const_cast<TTree*>(lumi)),
-      lumiMetaTree_(const_cast<TTree*>(lumiMeta)),
-      runTree_(const_cast<TTree*>(run)),
-      runMetaTree_(const_cast<TTree*>(runMeta)),
-      whyNotFastClonable_(whyNotFastClonable),
-      hasNewlyDroppedBranch_(hasNewlyDroppedBranch),
-      fileName_(fileName),
-      branchListIndexesUnchanged_(branchListIndexesUnchanged),
-      modifiedIDs_(modifiedIDs),
-      branchChildren_(branchChildren) {}
+              std::shared_ptr<BranchChildren const> branchChildren)
+        : fileFormatVersion_(version),
+          tree_(const_cast<TTree*>(ev)),
+          metaTree_(const_cast<TTree*>(meta)),
+          lumiTree_(const_cast<TTree*>(lumi)),
+          lumiMetaTree_(const_cast<TTree*>(lumiMeta)),
+          runTree_(const_cast<TTree*>(run)),
+          runMetaTree_(const_cast<TTree*>(runMeta)),
+          whyNotFastClonable_(whyNotFastClonable),
+          hasNewlyDroppedBranch_(hasNewlyDroppedBranch),
+          fileName_(fileName),
+          branchListIndexesUnchanged_(branchListIndexesUnchanged),
+          modifiedIDs_(modifiedIDs),
+          branchChildren_(branchChildren) {}
 
     ~FileBlock() {}
 
-    FileFormatVersion const& fileFormatVersion() const {return fileFormatVersion_;}
-    TTree* tree() const {return tree_;}
-    TTree* metaTree() const {return metaTree_;}
-    TTree* lumiTree() const {return lumiTree_;}
-    TTree* lumiMetaTree() const {return lumiMetaTree_;}
-    TTree* runTree() const {return runTree_;}
-    TTree* runMetaTree() const {return runMetaTree_;}
+    FileFormatVersion const& fileFormatVersion() const { return fileFormatVersion_; }
+    TTree* tree() const { return tree_; }
+    TTree* metaTree() const { return metaTree_; }
+    TTree* lumiTree() const { return lumiTree_; }
+    TTree* lumiMetaTree() const { return lumiMetaTree_; }
+    TTree* runTree() const { return runTree_; }
+    TTree* runMetaTree() const { return runMetaTree_; }
 
-    int whyNotFastClonable() const {return whyNotFastClonable_;}
-    std::array<bool, NumBranchTypes> const& hasNewlyDroppedBranch() const {return hasNewlyDroppedBranch_;}
-    std::string const& fileName() const {return fileName_;}
-    bool branchListIndexesUnchanged() const {return branchListIndexesUnchanged_;}
-    bool modifiedIDs() const {return modifiedIDs_;}
+    int whyNotFastClonable() const { return whyNotFastClonable_; }
+    std::array<bool, NumBranchTypes> const& hasNewlyDroppedBranch() const { return hasNewlyDroppedBranch_; }
+    std::string const& fileName() const { return fileName_; }
+    bool branchListIndexesUnchanged() const { return branchListIndexesUnchanged_; }
+    bool modifiedIDs() const { return modifiedIDs_; }
 
-    void setNotFastClonable(WhyNotFastClonable const& why) {
-      whyNotFastClonable_ |= why;
-    }
+    void setNotFastClonable(WhyNotFastClonable const& why) { whyNotFastClonable_ |= why; }
     BranchChildren const& branchChildren() const { return *branchChildren_; }
-    void close () {runMetaTree_ = lumiMetaTree_ = metaTree_ = runTree_ = lumiTree_ = tree_ = nullptr;}
+    void close() { runMetaTree_ = lumiMetaTree_ = metaTree_ = runTree_ = lumiTree_ = tree_ = nullptr; }
 
   private:
     FileFormatVersion fileFormatVersion_;
@@ -129,5 +132,5 @@ namespace edm {
     bool modifiedIDs_;
     std::shared_ptr<BranchChildren const> branchChildren_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/Frameworkfwd.h
+++ b/FWCore/Framework/interface/Frameworkfwd.h
@@ -48,6 +48,6 @@ namespace edm {
   struct TriggerReport;
   template <typename T> class View;
   template <typename T> class WorkerT;
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/FunctorESHandleExceptionFactory.h
+++ b/FWCore/Framework/interface/FunctorESHandleExceptionFactory.h
@@ -26,22 +26,18 @@
 
 namespace edm {
 
-  template<typename T>
-  class FunctorESHandleExceptionFactory : public ESHandleExceptionFactory {
-
+  template <typename T> class FunctorESHandleExceptionFactory : public ESHandleExceptionFactory {
   public:
     FunctorESHandleExceptionFactory(T&& iFunctor) : m_functor(std::move(iFunctor)) {}
 
-    std::exception_ptr make() const override {
-      return m_functor();
-    }
+    std::exception_ptr make() const override { return m_functor(); }
+
   private:
     T m_functor;
   };
 
-  template<typename T>
-  std::shared_ptr<ESHandleExceptionFactory> makeESHandleExceptionFactory(T&& iFunctor) {
+  template <typename T> std::shared_ptr<ESHandleExceptionFactory> makeESHandleExceptionFactory(T&& iFunctor) {
     return std::make_shared<FunctorESHandleExceptionFactory<T>>(std::move(iFunctor));
   }
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/GenericHandle.h
+++ b/FWCore/Framework/interface/GenericHandle.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     GenericHandle
-// 
+//
 /**\class GenericHandle GenericHandle.h FWCore/Framework/interface/GenericHandle.h
 
  Description: Allows interaction with data in the Event without actually using the C++ class
@@ -36,116 +36,97 @@
 
 // forward declarations
 namespace edm {
-   ///This class is just a 'tag' used to allow a specialization of edm::Handle
-struct GenericObject {
-};
+  ///This class is just a 'tag' used to allow a specialization of edm::Handle
+  struct GenericObject {};
 
-template<>
-class Handle<GenericObject> {
-public:
+  template <> class Handle<GenericObject> {
+  public:
     ///Throws exception if iName is not a known C++ class type
-    Handle(std::string const& iName) : 
-       type_(TypeWithDict::byName(iName)), prod_(), prov_(nullptr) {
-          if(!bool(type_)) {
-             Exception::throwThis(errors::NotFound,
-             "Handle<GenericObject> told to use uknown type '",
-             iName.c_str(),
-             "'.\n Please check spelling or that a module uses this type in the job.");
-           }
-        }
-   
-   ///Throws exception if iType is invalid
-   Handle(TypeWithDict const& iType) :
-      type_(iType), prod_(), prov_(nullptr) {
-         if(!bool(iType)) {
-            Exception::throwThis(errors::NotFound, "Handle<GenericObject> given an invalid type");
-         }
+    Handle(std::string const& iName) : type_(TypeWithDict::byName(iName)), prod_(), prov_(nullptr) {
+      if (!bool(type_)) {
+        Exception::throwThis(errors::NotFound, "Handle<GenericObject> told to use uknown type '", iName.c_str(),
+                             "'.\n Please check spelling or that a module uses this type in the job.");
       }
-   
-   Handle(Handle<GenericObject> const& h):
-   type_(h.type_),
-   prod_(h.prod_),
-   prov_(h.prov_),
-   whyFailedFactory_(h.whyFailedFactory_) {
-   }
-   
-   Handle(ObjectWithDict const& prod, Provenance const* prov, ProductID const&):
-   type_(prod.typeOf()),
-   prod_(prod),
-   prov_(prov) { 
+    }
+
+    ///Throws exception if iType is invalid
+    Handle(TypeWithDict const& iType) : type_(iType), prod_(), prov_(nullptr) {
+      if (!bool(iType)) {
+        Exception::throwThis(errors::NotFound, "Handle<GenericObject> given an invalid type");
+      }
+    }
+
+    Handle(Handle<GenericObject> const& h)
+        : type_(h.type_), prod_(h.prod_), prov_(h.prov_), whyFailedFactory_(h.whyFailedFactory_) {}
+
+    Handle(ObjectWithDict const& prod, Provenance const* prov, ProductID const&)
+        : type_(prod.typeOf()), prod_(prod), prov_(prov) {
       assert(prod_);
       assert(prov_);
-   }
-   
-      //~Handle();
-      
-   void swap(Handle<GenericObject>& other) {
+    }
+
+    //~Handle();
+
+    void swap(Handle<GenericObject>& other) {
       // use unqualified swap for user defined classes
       using std::swap;
       swap(type_, other.type_);
       std::swap(prod_, other.prod_);
       swap(prov_, other.prov_);
       swap(whyFailedFactory_, other.whyFailedFactory_);
-   }
-   
-   
-   Handle<GenericObject>& operator=(Handle<GenericObject> const& rhs) {
+    }
+
+    Handle<GenericObject>& operator=(Handle<GenericObject> const& rhs) {
       Handle<GenericObject> temp(rhs);
       this->swap(temp);
       return *this;
-   }
-   
-   bool isValid() const {
-      return prod_ && nullptr!= prov_;
-   }
+    }
 
-   bool failedToGet() const {
-     return bool(whyFailedFactory_);
-   }
-   ObjectWithDict const* product() const { 
-     if(this->failedToGet()) {
-       whyFailedFactory_->make()->raise();
-     } 
-     return &prod_;
-   }
-   ObjectWithDict const* operator->() const {return this->product();}
-   ObjectWithDict const& operator*() const {return *(this->product());}
-   
-   TypeWithDict const& type() const {return type_;}
-   Provenance const* provenance() const {return prov_;}
-   
-   ProductID id() const {return prov_->productID();}
+    bool isValid() const { return prod_ && nullptr != prov_; }
 
-   void clear() { prov_ = nullptr; whyFailedFactory_=nullptr;}
-      
-  void setWhyFailedFactory(std::shared_ptr<HandleExceptionFactory> const& iWhyFailed) {
-    whyFailedFactory_=iWhyFailed;
-  }
-private:
-   TypeWithDict type_;
-   ObjectWithDict prod_;
-   Provenance const* prov_;    
-  std::shared_ptr<HandleExceptionFactory> whyFailedFactory_;
+    bool failedToGet() const { return bool(whyFailedFactory_); }
+    ObjectWithDict const* product() const {
+      if (this->failedToGet()) {
+        whyFailedFactory_->make()->raise();
+      }
+      return &prod_;
+    }
+    ObjectWithDict const* operator->() const { return this->product(); }
+    ObjectWithDict const& operator*() const { return *(this->product()); }
 
-};
+    TypeWithDict const& type() const { return type_; }
+    Provenance const* provenance() const { return prov_; }
 
-typedef Handle<GenericObject> GenericHandle;
+    ProductID id() const { return prov_->productID(); }
 
-///specialize this function for GenericHandle
-void convert_handle(BasicHandle && orig,
-                    Handle<GenericObject>& result);
+    void clear() {
+      prov_ = nullptr;
+      whyFailedFactory_ = nullptr;
+    }
 
+    void setWhyFailedFactory(std::shared_ptr<HandleExceptionFactory> const& iWhyFailed) {
+      whyFailedFactory_ = iWhyFailed;
+    }
 
-///Specialize the Event's getByLabel method to work with a Handle<GenericObject>
-template<>
-bool
-edm::Event::getByLabel<GenericObject>(std::string const& label,
-                                      std::string const& productInstanceName,
-                                      Handle<GenericObject>& result) const;
+  private:
+    TypeWithDict type_;
+    ObjectWithDict prod_;
+    Provenance const* prov_;
+    std::shared_ptr<HandleExceptionFactory> whyFailedFactory_;
+  };
 
-template <>
-bool
-edm::Event::getByLabel(edm::InputTag const& tag, Handle<GenericObject>& result) const;
+  typedef Handle<GenericObject> GenericHandle;
 
-}
+  ///specialize this function for GenericHandle
+  void convert_handle(BasicHandle&& orig, Handle<GenericObject>& result);
+
+  ///Specialize the Event's getByLabel method to work with a Handle<GenericObject>
+  template <>
+  bool edm::Event::getByLabel<GenericObject>(std::string const& label,
+                                             std::string const& productInstanceName,
+                                             Handle<GenericObject>& result) const;
+
+  template <> bool edm::Event::getByLabel(edm::InputTag const& tag, Handle<GenericObject>& result) const;
+
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/GetterOfProducts.h
+++ b/FWCore/Framework/interface/GetterOfProducts.h
@@ -117,79 +117,74 @@ There are some variants for special cases
 
 namespace edm {
 
-   template <typename T>
-   class GetterOfProducts {
-   public:
+  template <typename T> class GetterOfProducts {
+  public:
+    GetterOfProducts() : branchType_(edm::InEvent) {}
 
-      GetterOfProducts() : branchType_(edm::InEvent) { }
+    template <typename U, typename M>
+    GetterOfProducts(U const& match, M* module, edm::BranchType branchType = edm::InEvent)
+        : matcher_(WillGetIfMatch<T>(match, module)),
+          tokens_(new std::vector<edm::EDGetTokenT<T>>),
+          branchType_(branchType) {}
 
-      template <typename U, typename M>
-      GetterOfProducts(U const& match, M* module, edm::BranchType branchType = edm::InEvent) : 
-        matcher_(WillGetIfMatch<T>(match, module)),
-        tokens_(new std::vector<edm::EDGetTokenT<T>>),
-        branchType_(branchType) {
+    void operator()(edm::BranchDescription const& branchDescription) {
+      if (branchDescription.dropped())
+        return;
+      if (branchDescription.branchType() == branchType_ &&
+          branchDescription.unwrappedTypeID() == edm::TypeID(typeid(T))) {
+        auto const& token = matcher_(branchDescription);
+        if (not token.isUninitialized()) {
+          tokens_->push_back(token);
+        }
       }
+    }
 
-      void operator()(edm::BranchDescription const& branchDescription) {
-
-         if (branchDescription.dropped()) return;
-         if (branchDescription.branchType() == branchType_ &&
-             branchDescription.unwrappedTypeID() == edm::TypeID(typeid(T))) {
-
-            auto const& token =matcher_(branchDescription);
-            if (not token.isUninitialized()) {
-               tokens_->push_back(token);
-           }
-         }
+    void fillHandles(edm::Event const& event, std::vector<edm::Handle<T>>& handles) const {
+      handles.clear();
+      if (branchType_ == edm::InEvent) {
+        handles.reserve(tokens_->size());
+        edm::Handle<T> handle;
+        for (auto const& token : *tokens_) {
+          if (auto handle = event.getHandle(token)) {
+            handles.push_back(handle);
+          }
+        }
       }
+    }
 
-      void fillHandles(edm::Event const& event, std::vector<edm::Handle<T> >& handles) const {
-         handles.clear();
-         if(branchType_ == edm::InEvent) {
-            handles.reserve(tokens_->size());
-            edm::Handle<T> handle;
-            for (auto const& token : *tokens_) {
-               if (auto handle = event.getHandle(token)) {
-                  handles.push_back(handle);
-               }
-            }
-         }
+    void fillHandles(edm::LuminosityBlock const& lumi, std::vector<edm::Handle<T>>& handles) const {
+      handles.clear();
+      if (branchType_ == edm::InLumi) {
+        handles.reserve(tokens_->size());
+        for (auto const& token : *tokens_) {
+          if (auto handle = lumi.getHandle(token)) {
+            handles.push_back(handle);
+          }
+        }
       }
+    }
 
-      void fillHandles(edm::LuminosityBlock const& lumi, std::vector<edm::Handle<T> >& handles) const {
-         handles.clear();
-         if(branchType_ == edm::InLumi ) {
-            handles.reserve(tokens_->size());
-            for (auto const& token : *tokens_) {
-               if (auto handle = lumi.getHandle(token)) {
-                  handles.push_back(handle);
-               }
-            }
-         }
+    void fillHandles(edm::Run const& run, std::vector<edm::Handle<T>>& handles) const {
+      handles.clear();
+      if (branchType_ == edm::InRun) {
+        handles.reserve(tokens_->size());
+        for (auto const& token : *tokens_) {
+          if (auto handle = run.getHandle(token)) {
+            handles.push_back(handle);
+          }
+        }
       }
+    }
 
-      void fillHandles(edm::Run const& run, std::vector<edm::Handle<T> >& handles) const {
-         handles.clear();
-         if(branchType_ == edm::InRun) {
-            handles.reserve(tokens_->size());
-            for (auto const& token : *tokens_) {
-               if (auto handle = run.getHandle(token)) {
-                  handles.push_back(handle);
-               }
-            }
-         }
-      }
+    std::vector<edm::EDGetTokenT<T>> const& tokens() const { return *tokens_; }
+    edm::BranchType branchType() const { return branchType_; }
 
-      std::vector<edm::EDGetTokenT<T>> const& tokens() const { return *tokens_; }
-      edm::BranchType branchType() const { return branchType_; }
-
-   private:
-
-      std::function<EDGetTokenT<T> (BranchDescription const&)> matcher_;
-      // A shared pointer is needed because objects of this type get assigned
-      // to std::function's and we want the copies in those to share the same vector.
-      std::shared_ptr<std::vector<edm::EDGetTokenT<T>> > tokens_;
-      edm::BranchType branchType_;
-   };
-}
+  private:
+    std::function<EDGetTokenT<T>(BranchDescription const&)> matcher_;
+    // A shared pointer is needed because objects of this type get assigned
+    // to std::function's and we want the copies in those to share the same vector.
+    std::shared_ptr<std::vector<edm::EDGetTokenT<T>>> tokens_;
+    edm::BranchType branchType_;
+  };
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/HCMethods.h
+++ b/FWCore/Framework/interface/HCMethods.h
@@ -4,8 +4,8 @@
 //
 // Package:     HeteroContainer
 // Module:      HCMethods
-// 
-// Description: Templated methods to be used to 'construct' a 
+//
+// Description: Templated methods to be used to 'construct' a
 //              heterogenous container
 //
 // Usage:
@@ -24,56 +24,46 @@
 namespace edm {
   namespace eventsetup {
     namespace heterocontainer {
-      template< class Type, class Key, class IdTag >
-      inline Key makeKey(const IdTag& iIdTag) {
-	HCTypeTag typeTag = HCTypeTag::make<Type>();
-	return Key(typeTag, iIdTag);
+      template <class Type, class Key, class IdTag> inline Key makeKey(const IdTag& iIdTag) {
+        HCTypeTag typeTag = HCTypeTag::make<Type>();
+        return Key(typeTag, iIdTag);
       }
-      
-      template< class Type, class Key>
-      inline Key makeKey() {
-	HCTypeTag typeTag = HCTypeTag::make<Type>();
-	return Key(typeTag);
+
+      template <class Type, class Key> inline Key makeKey() {
+        HCTypeTag typeTag = HCTypeTag::make<Type>();
+        return Key(typeTag);
       }
-      
+
       //NOTE: the following functions use this struct to determine
       //  how to find the 'Type' (what is returned from the Storage)
-      //  when given only an ItemType (what is stored in Storage). 
+      //  when given only an ItemType (what is stored in Storage).
       //  This allows the Storage to be composed of proxies instead of
       //  the 'Type' themselves
-      template<class Key, class ItemType> struct type_from_itemtype {
-	typedef typename std::remove_const<ItemType>::type Type;
+      template <class Key, class ItemType> struct type_from_itemtype {
+        typedef typename std::remove_const<ItemType>::type Type;
       };
 
-      template<class Key, class ItemType, class Storage, class IdTag >
+      template <class Key, class ItemType, class Storage, class IdTag>
       inline bool insert(Storage& iStorage, ItemType* iItem, const IdTag& iIdTag) {
-	return iStorage.insert(makeKey< typename type_from_itemtype<Key, ItemType>::Type, 
-			       Key>(iIdTag) , iItem);
+        return iStorage.insert(makeKey<typename type_from_itemtype<Key, ItemType>::Type, Key>(iIdTag), iItem);
       }
-      
-      template<  class Key, class ItemType, class Storage>
-      inline bool insert(Storage& iStorage, ItemType* iItem) {
-	return iStorage.insert(makeKey<ItemType,
-			       Key>() , iItem);
-         }
-      
-      
-      template< class Key, class ItemType, class Storage, class IdTag >
+
+      template <class Key, class ItemType, class Storage> inline bool insert(Storage& iStorage, ItemType* iItem) {
+        return iStorage.insert(makeKey<ItemType, Key>(), iItem);
+      }
+
+      template <class Key, class ItemType, class Storage, class IdTag>
       inline ItemType* find(const Storage& iStorage, const IdTag& iIdTag) {
-	//The cast should be safe since the Key tells us the type
-	return static_cast<ItemType*>(iStorage.find(
-						    makeKey<typename type_from_itemtype<Key,
-						    ItemType>::Type,Key>(iIdTag)));
+        //The cast should be safe since the Key tells us the type
+        return static_cast<ItemType*>(
+            iStorage.find(makeKey<typename type_from_itemtype<Key, ItemType>::Type, Key>(iIdTag)));
       }
-      
-      template< class Key, class ItemType, class Storage>
-      inline ItemType* find(const Storage& iStorage) {
-	//The cast should be safe since the Key tells us the type
-	return static_cast<ItemType*>( iStorage.find(
-						     makeKey<typename type_from_itemtype<Key,
-						     ItemType>::Type,Key>()));
-         }
-    }
-  }
-}
+
+      template <class Key, class ItemType, class Storage> inline ItemType* find(const Storage& iStorage) {
+        //The cast should be safe since the Key tells us the type
+        return static_cast<ItemType*>(iStorage.find(makeKey<typename type_from_itemtype<Key, ItemType>::Type, Key>()));
+      }
+    }  // namespace heterocontainer
+  }    // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/HCTypeTag.h
+++ b/FWCore/Framework/interface/HCTypeTag.h
@@ -37,7 +37,6 @@ namespace edm {
 
       class HCTypeTag : public TypeIDBase {
       public:
-
         HCTypeTag() = default;
 
         // ---------- member functions ---------------------------
@@ -50,25 +49,22 @@ namespace edm {
         static HCTypeTag findType(char const* iTypeName);
         static HCTypeTag findType(std::string const& iTypeName);
 
-        template <typename T>
-        static HCTypeTag make() {
-          return HCTypeTag(typelookup::classTypeInfo<T>(),typelookup::className<T>());
+        template <typename T> static HCTypeTag make() {
+          return HCTypeTag(typelookup::classTypeInfo<T>(), typelookup::className<T>());
         }
 
       protected:
         // ---------- protected member functions -----------------
-        HCTypeTag(std::type_info const& iValue, char const* iName) :
-          TypeIDBase(iValue), m_name(iName) {}
+        HCTypeTag(std::type_info const& iValue, char const* iName) : TypeIDBase(iValue), m_name(iName) {}
 
-        HCTypeTag(TypeIDBase const& iValue, const char* iName) :
-          TypeIDBase(iValue), m_name(iName) {}
+        HCTypeTag(TypeIDBase const& iValue, const char* iName) : TypeIDBase(iValue), m_name(iName) {}
 
       private:
         char const* m_name{""};
       };
-    }
-  }
-}
+    }  // namespace heterocontainer
+  }    // namespace eventsetup
+}  // namespace edm
 #define HCTYPETAG_HELPER_METHODS(_dataclass_) TYPELOOKUP_METHODS(_dataclass_)
 
 #define DEFINE_HCTYPETAG_REGISTRATION(type) DEFINE_TYPELOOKUP_REGISTRATION(type)

--- a/FWCore/Framework/interface/HistoryAppender.h
+++ b/FWCore/Framework/interface/HistoryAppender.h
@@ -13,16 +13,14 @@ namespace edm {
 
   class HistoryAppender {
   public:
-
     HistoryAppender();
 
     // Used to append the current process to the process history
     // when necessary. Optimized to cache the results so it
     // does not need to repeat the same calculations many times.
-    std::shared_ptr<ProcessHistory const>
-    appendToProcessHistory(ProcessHistoryID const& inputPHID,
-                           ProcessHistory const* inputProcessHistory,
-                           ProcessConfiguration const& pc);
+    std::shared_ptr<ProcessHistory const> appendToProcessHistory(ProcessHistoryID const& inputPHID,
+                                                                 ProcessHistory const* inputProcessHistory,
+                                                                 ProcessConfiguration const& pc);
 
   private:
     HistoryAppender(HistoryAppender const&) = delete;
@@ -30,11 +28,10 @@ namespace edm {
 
     // Throws if the new process name is already in the process
     // process history
-    void checkProcessHistory(ProcessHistory const& ph,
-                             ProcessConfiguration const& pc) const;
+    void checkProcessHistory(ProcessHistory const& ph, ProcessConfiguration const& pc) const;
 
     ProcessHistoryID m_cachedInputPHID;
     std::shared_ptr<ProcessHistory const> m_cachedHistory;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/IOVSyncValue.h
+++ b/FWCore/Framework/interface/IOVSyncValue.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     IOVSyncValue
-// 
+//
 /**\class IOVSyncValue IOVSyncValue.h FWCore/Framework/interface/IOVSyncValue.h
 
  Description: Provides the information needed to synchronize the EventSetup IOV with an Event
@@ -28,94 +28,80 @@
 // forward declarations
 
 namespace edm {
-class IOVSyncValue
-{
+  class IOVSyncValue {
+  public:
+    IOVSyncValue();
+    //virtual ~IOVSyncValue();
+    explicit IOVSyncValue(const EventID& iID);
+    explicit IOVSyncValue(const Timestamp& iTime);
+    IOVSyncValue(const EventID& iID, const Timestamp& iTime);
 
-   public:
-      IOVSyncValue();
-      //virtual ~IOVSyncValue();
-      explicit IOVSyncValue(const EventID& iID);
-      explicit IOVSyncValue(const Timestamp& iTime);
-      IOVSyncValue(const EventID& iID, const Timestamp& iTime);
+    // ---------- const member functions ---------------------
+    const EventID& eventID() const { return eventID_; }
+    LuminosityBlockNumber_t luminosityBlockNumber() const { return eventID_.luminosityBlock(); }
+    const Timestamp& time() const { return time_; }
 
-      // ---------- const member functions ---------------------
-      const EventID& eventID() const { return eventID_;}
-      LuminosityBlockNumber_t luminosityBlockNumber() const { return eventID_.luminosityBlock();}
-      const Timestamp& time() const {return time_; }
-      
-      bool operator==(const IOVSyncValue& iRHS) const {
-	 return comparable(iRHS) && doOp<std::equal_to>(iRHS);
-      }
-      bool operator!=(const IOVSyncValue& iRHS) const {
-	return (!comparable(iRHS)) || doOp<std::not_equal_to>(iRHS);
-      }
-      
-      bool operator<(const IOVSyncValue& iRHS) const {
-         return doOp<std::less>(iRHS);
-      }
-      bool operator<=(const IOVSyncValue& iRHS) const {
-         return doOp<std::less_equal>(iRHS);
-      }
-      bool operator>(const IOVSyncValue& iRHS) const {
-         return doOp<std::greater>(iRHS);
-      }
-      bool operator>=(const IOVSyncValue& iRHS) const {
-         return doOp<std::greater_equal>(iRHS);
-      }
-      
-      /** returns true if comparison operations are possible. Comparisons only fail if
+    bool operator==(const IOVSyncValue& iRHS) const { return comparable(iRHS) && doOp<std::equal_to>(iRHS); }
+    bool operator!=(const IOVSyncValue& iRHS) const { return (!comparable(iRHS)) || doOp<std::not_equal_to>(iRHS); }
+
+    bool operator<(const IOVSyncValue& iRHS) const { return doOp<std::less>(iRHS); }
+    bool operator<=(const IOVSyncValue& iRHS) const { return doOp<std::less_equal>(iRHS); }
+    bool operator>(const IOVSyncValue& iRHS) const { return doOp<std::greater>(iRHS); }
+    bool operator>=(const IOVSyncValue& iRHS) const { return doOp<std::greater_equal>(iRHS); }
+
+    /** returns true if comparison operations are possible. Comparisons only fail if
 	  a time only value is compared to a run/lumi/event only value.
        */
-      bool comparable(const IOVSyncValue& iOther) const {
-	return (haveID_==iOther.haveID_) || (haveTime_==iOther.haveTime_);
+    bool comparable(const IOVSyncValue& iOther) const {
+      return (haveID_ == iOther.haveID_) || (haveTime_ == iOther.haveTime_);
+    }
+
+    // ---------- static member functions --------------------
+    static const IOVSyncValue& invalidIOVSyncValue();
+    static const IOVSyncValue& endOfTime();
+    static const IOVSyncValue& beginOfTime();
+
+    // ---------- member functions ---------------------------
+
+  private:
+    //IOVSyncValue(const IOVSyncValue&); // stop default
+
+    //const IOVSyncValue& operator=(const IOVSyncValue&); // stop default
+    void throwInvalidComparison() const;
+    template <template <typename> class Op> bool doOp(const IOVSyncValue& iRHS) const {
+      bool returnValue = false;
+      if (haveID_ && iRHS.haveID_) {
+        if (luminosityBlockNumber() == 0 || iRHS.luminosityBlockNumber() == 0 ||
+            luminosityBlockNumber() == iRHS.luminosityBlockNumber()) {
+          Op<EventID> op;
+          returnValue = op(eventID_, iRHS.eventID_);
+        } else {
+          if (iRHS.eventID_.run() == eventID_.run()) {
+            Op<LuminosityBlockNumber_t> op;
+            returnValue = op(luminosityBlockNumber(), iRHS.luminosityBlockNumber());
+          } else {
+            Op<RunNumber_t> op;
+            returnValue = op(eventID_.run(), iRHS.eventID_.run());
+          }
+        }
+
+      } else if (haveTime_ && iRHS.haveTime_) {
+        Op<Timestamp> op;
+        returnValue = op(time_, iRHS.time_);
+      } else {
+        //error
+        throwInvalidComparison();
       }
+      return returnValue;
+    }
 
-      // ---------- static member functions --------------------
-      static const IOVSyncValue& invalidIOVSyncValue();
-      static const IOVSyncValue& endOfTime();
-      static const IOVSyncValue& beginOfTime();
+    // ---------- member data --------------------------------
+    EventID eventID_;
+    Timestamp time_;
+    bool haveID_;
+    bool haveTime_;
+  };
 
-      // ---------- member functions ---------------------------
-
-   private:
-      //IOVSyncValue(const IOVSyncValue&); // stop default
-
-      //const IOVSyncValue& operator=(const IOVSyncValue&); // stop default
-      void throwInvalidComparison() const;
-      template< template <typename> class Op >
-         bool doOp(const IOVSyncValue& iRHS) const {
-            bool returnValue = false;
-            if(haveID_ && iRHS.haveID_) {
-               if(luminosityBlockNumber()==0 || iRHS.luminosityBlockNumber()==0 || luminosityBlockNumber()==iRHS.luminosityBlockNumber()) {
-                  Op<EventID> op;
-                  returnValue = op(eventID_, iRHS.eventID_);
-               } else {
-                  if(iRHS.eventID_.run() == eventID_.run()) {
-                     Op<LuminosityBlockNumber_t> op;
-                     returnValue = op(luminosityBlockNumber(), iRHS.luminosityBlockNumber());
-                  } else {
-                     Op<RunNumber_t> op;
-                     returnValue = op(eventID_.run(), iRHS.eventID_.run());
-                  }
-               }
-
-            } else if (haveTime_ && iRHS.haveTime_) {
-               Op<Timestamp> op;
-               returnValue = op(time_, iRHS.time_);
-            } else {
-               //error
- 	       throwInvalidComparison();
-            }
-            return returnValue;
-         }
-         
-      // ---------- member data --------------------------------
-      EventID eventID_;
-      Timestamp time_;
-      bool haveID_;
-      bool haveTime_;
-};
-
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -75,22 +75,9 @@ namespace edm {
 
   class InputSource {
   public:
-    enum ItemType {
-      IsInvalid,
-      IsStop,
-      IsFile,
-      IsRun,
-      IsLumi,
-      IsEvent,
-      IsRepeat,
-      IsSynchronize
-    };
+    enum ItemType { IsInvalid, IsStop, IsFile, IsRun, IsLumi, IsEvent, IsRepeat, IsSynchronize };
 
-    enum ProcessingMode {
-      Runs,
-      RunsAndLumis,
-      RunsLumisAndEvents
-    };
+    enum ProcessingMode { Runs, RunsAndLumis, RunsLumisAndEvents };
 
     /// Constructor
     explicit InputSource(ParameterSet const&, InputSourceDescription const&);
@@ -98,22 +85,22 @@ namespace edm {
     /// Destructor
     virtual ~InputSource() noexcept(false);
 
-    InputSource(InputSource const&) = delete; // Disallow copying and moving
-    InputSource& operator=(InputSource const&) = delete; // Disallow copying and moving
+    InputSource(InputSource const&) = delete;             // Disallow copying and moving
+    InputSource& operator=(InputSource const&) = delete;  // Disallow copying and moving
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
     static const std::string& baseType();
     static void fillDescription(ParameterSetDescription& desc);
-    static void prevalidate(ConfigurationDescriptions& );
+    static void prevalidate(ConfigurationDescriptions&);
 
     /// Advances the source to the next item
     ItemType nextItemType();
 
     /// Read next event
-    void readEvent(EventPrincipal& ep, StreamContext &);
+    void readEvent(EventPrincipal& ep, StreamContext&);
 
     /// Read a specific event
-    bool readEvent(EventPrincipal& ep, EventID const&, StreamContext &);
+    bool readEvent(EventPrincipal& ep, EventID const&, StreamContext&);
 
     /// Read next luminosity block Auxilary
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary();
@@ -149,10 +136,10 @@ namespace edm {
     void rewind();
 
     /// Set the run number
-    void setRunNumber(RunNumber_t r) {setRun(r);}
+    void setRunNumber(RunNumber_t r) { setRun(r); }
 
     /// Set the luminosity block ID
-    void setLuminosityBlockNumber_t(LuminosityBlockNumber_t lb) {setLumi(lb);}
+    void setLuminosityBlockNumber_t(LuminosityBlockNumber_t lb) { setLumi(lb); }
 
     /// issue an event report
     void issueReports(EventID const& eventID, StreamID streamID);
@@ -161,54 +148,60 @@ namespace edm {
     virtual void registerProducts();
 
     /// Accessors for product registry
-    std::shared_ptr<ProductRegistry const> productRegistry() const {return get_underlying_safe(productRegistry_);}
-    std::shared_ptr<ProductRegistry>& productRegistry() {return get_underlying_safe(productRegistry_);}
+    std::shared_ptr<ProductRegistry const> productRegistry() const { return get_underlying_safe(productRegistry_); }
+    std::shared_ptr<ProductRegistry>& productRegistry() { return get_underlying_safe(productRegistry_); }
 
     /// Accessors for process history registry.
-    ProcessHistoryRegistry const& processHistoryRegistry() const {return *processHistoryRegistry_;}
-    ProcessHistoryRegistry& processHistoryRegistry() {return *processHistoryRegistry_;}
+    ProcessHistoryRegistry const& processHistoryRegistry() const { return *processHistoryRegistry_; }
+    ProcessHistoryRegistry& processHistoryRegistry() { return *processHistoryRegistry_; }
 
     /// Accessors for branchIDListHelper
-    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return get_underlying_safe(branchIDListHelper_);}
-    std::shared_ptr<BranchIDListHelper>& branchIDListHelper() {return get_underlying_safe(branchIDListHelper_);}
+    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {
+      return get_underlying_safe(branchIDListHelper_);
+    }
+    std::shared_ptr<BranchIDListHelper>& branchIDListHelper() { return get_underlying_safe(branchIDListHelper_); }
 
     /// Accessors for thinnedAssociationsHelper
-    std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {return get_underlying_safe(thinnedAssociationsHelper_);}
-    std::shared_ptr<ThinnedAssociationsHelper>& thinnedAssociationsHelper() {return get_underlying_safe(thinnedAssociationsHelper_);}
+    std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {
+      return get_underlying_safe(thinnedAssociationsHelper_);
+    }
+    std::shared_ptr<ThinnedAssociationsHelper>& thinnedAssociationsHelper() {
+      return get_underlying_safe(thinnedAssociationsHelper_);
+    }
 
     /// Reset the remaining number of events/lumis to the maximum number.
     void repeat() {
       remainingEvents_ = maxEvents_;
       remainingLumis_ = maxLumis_;
     }
-    
+
     /// Returns nullptr if no resource shared between the Source and a DelayedReader
-    std::pair<SharedResourcesAcquirer*,std::recursive_mutex*> resourceSharedWithDelayedReader();
+    std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> resourceSharedWithDelayedReader();
 
     /// Accessor for maximum number of events to be read.
     /// -1 is used for unlimited.
-    int maxEvents() const {return maxEvents_;}
+    int maxEvents() const { return maxEvents_; }
 
     /// Accessor for remaining number of events to be read.
     /// -1 is used for unlimited.
-    int remainingEvents() const {return remainingEvents_;}
+    int remainingEvents() const { return remainingEvents_; }
 
     /// Accessor for maximum number of lumis to be read.
     /// -1 is used for unlimited.
-    int maxLuminosityBlocks() const {return maxLumis_;}
+    int maxLuminosityBlocks() const { return maxLumis_; }
 
     /// Accessor for remaining number of lumis to be read.
     /// -1 is used for unlimited.
-    int remainingLuminosityBlocks() const {return remainingLumis_;}
+    int remainingLuminosityBlocks() const { return remainingLumis_; }
 
     /// Accessor for 'module' description.
-    ModuleDescription const& moduleDescription() const {return moduleDescription_;}
+    ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
     /// Accessor for Process Configuration
-    ProcessConfiguration const& processConfiguration() const {return moduleDescription().processConfiguration();}
+    ProcessConfiguration const& processConfiguration() const { return moduleDescription().processConfiguration(); }
 
     /// Accessor for global process identifier
-    std::string const& processGUID() const {return processGUID_;}
+    std::string const& processGUID() const { return processGUID_; }
 
     /// Called by framework at beginning of job
     void doBeginJob();
@@ -223,12 +216,12 @@ namespace edm {
     virtual void doBeginRun(RunPrincipal& rp, ProcessContext const*);
 
     /// Accessor for the current time, as seen by the input source
-    Timestamp const& timestamp() const {return time_;}
+    Timestamp const& timestamp() const { return time_; }
 
     /// Accessor for the reduced process history ID of the current run.
     /// This is the ID of the input process history which does not include
     /// the current process.
-    ProcessHistoryID const&  reducedProcessHistoryID() const;
+    ProcessHistoryID const& reducedProcessHistoryID() const;
 
     /// Accessor for current run number
     RunNumber_t run() const;
@@ -237,16 +230,16 @@ namespace edm {
     LuminosityBlockNumber_t luminosityBlock() const;
 
     /// RunsLumisAndEvents (default), RunsAndLumis, or Runs.
-    ProcessingMode processingMode() const {return processingMode_;}
+    ProcessingMode processingMode() const { return processingMode_; }
 
     /// Accessor for Activity Registry
-    std::shared_ptr<ActivityRegistry> actReg() const {return actReg_;}
+    std::shared_ptr<ActivityRegistry> actReg() const { return actReg_; }
 
     /// Called by the framework to merge or insert run in principal cache.
-    std::shared_ptr<RunAuxiliary> runAuxiliary() const {return runAuxiliary_;}
+    std::shared_ptr<RunAuxiliary> runAuxiliary() const { return runAuxiliary_; }
 
     /// Called by the framework to merge or insert lumi in principal cache.
-    std::shared_ptr<LuminosityBlockAuxiliary> luminosityBlockAuxiliary() const {return lumiAuxiliary_;}
+    std::shared_ptr<LuminosityBlockAuxiliary> luminosityBlockAuxiliary() const { return lumiAuxiliary_; }
 
     bool randomAccess() const;
     ProcessingController::ForwardState forwardState() const;
@@ -254,15 +247,15 @@ namespace edm {
 
     class EventSourceSentry {
     public:
-      EventSourceSentry(InputSource const& source, StreamContext & sc);
+      EventSourceSentry(InputSource const& source, StreamContext& sc);
       ~EventSourceSentry();
 
-      EventSourceSentry(EventSourceSentry const&) = delete; // Disallow copying and moving
-      EventSourceSentry& operator=(EventSourceSentry const&) = delete; // Disallow copying and moving
+      EventSourceSentry(EventSourceSentry const&) = delete;             // Disallow copying and moving
+      EventSourceSentry& operator=(EventSourceSentry const&) = delete;  // Disallow copying and moving
 
     private:
       InputSource const& source_;
-      StreamContext & sc_;
+      StreamContext& sc_;
     };
 
     class LumiSourceSentry {
@@ -270,8 +263,8 @@ namespace edm {
       LumiSourceSentry(InputSource const& source, LuminosityBlockIndex id);
       ~LumiSourceSentry();
 
-      LumiSourceSentry(LumiSourceSentry const&) = delete; // Disallow copying and moving
-      LumiSourceSentry& operator=(LumiSourceSentry const&) = delete; // Disallow copying and moving
+      LumiSourceSentry(LumiSourceSentry const&) = delete;             // Disallow copying and moving
+      LumiSourceSentry& operator=(LumiSourceSentry const&) = delete;  // Disallow copying and moving
 
     private:
       InputSource const& source_;
@@ -283,8 +276,8 @@ namespace edm {
       RunSourceSentry(InputSource const& source, RunIndex id);
       ~RunSourceSentry();
 
-      RunSourceSentry(RunSourceSentry const&) = delete; // Disallow copying and moving
-      RunSourceSentry& operator=(RunSourceSentry const&) = delete; // Disallow copying and moving
+      RunSourceSentry(RunSourceSentry const&) = delete;             // Disallow copying and moving
+      RunSourceSentry& operator=(RunSourceSentry const&) = delete;  // Disallow copying and moving
 
     private:
       InputSource const& source_;
@@ -297,8 +290,8 @@ namespace edm {
       explicit FileOpenSentry(InputSource const& source, std::string const& lfn, bool usedFallback);
       ~FileOpenSentry();
 
-      FileOpenSentry(FileOpenSentry const&) = delete; // Disallow copying and moving
-      FileOpenSentry& operator=(FileOpenSentry const&) = delete; // Disallow copying and moving
+      FileOpenSentry(FileOpenSentry const&) = delete;             // Disallow copying and moving
+      FileOpenSentry& operator=(FileOpenSentry const&) = delete;  // Disallow copying and moving
 
     private:
       Sig& post_;
@@ -312,8 +305,8 @@ namespace edm {
       explicit FileCloseSentry(InputSource const& source, std::string const& lfn, bool usedFallback);
       ~FileCloseSentry();
 
-      FileCloseSentry(FileCloseSentry const&) = delete; // Disallow copying and moving
-      FileCloseSentry& operator=(FileCloseSentry const&) = delete; // Disallow copying and moving
+      FileCloseSentry(FileCloseSentry const&) = delete;             // Disallow copying and moving
+      FileCloseSentry& operator=(FileCloseSentry const&) = delete;  // Disallow copying and moving
 
     private:
       Sig& post_;
@@ -323,17 +316,16 @@ namespace edm {
 
     signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> preEventReadFromSourceSignal_;
     signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> postEventReadFromSourceSignal_;
-    
 
   protected:
     virtual void skip(int offset);
 
     /// To set the current time, as seen by the input source
-    void setTimestamp(Timestamp const& theTime) {time_ = theTime;}
+    void setTimestamp(Timestamp const& theTime) { time_ = theTime; }
 
-    ProductRegistry& productRegistryUpdate() {return *productRegistry_;}
-    ProcessHistoryRegistry& processHistoryRegistryForUpdate() {return *processHistoryRegistry_;}
-    ItemType state() const{return state_;}
+    ProductRegistry& productRegistryUpdate() { return *productRegistry_; }
+    ProcessHistoryRegistry& processHistoryRegistryForUpdate() { return *processHistoryRegistry_; }
+    ItemType state() const { return state_; }
     void setRunAuxiliary(RunAuxiliary* rp) {
       runAuxiliary_.reset(rp);
       newRun_ = newLumi_ = true;
@@ -355,32 +347,38 @@ namespace edm {
       resetRunAuxiliary();
       state_ = IsInvalid;
     }
-    bool newRun() const {return newRun_;}
-    void setNewRun() {newRun_ = true;}
-    void resetNewRun() {newRun_ = false;}
-    bool newLumi() const {return newLumi_;}
-    void setNewLumi() {newLumi_ = true;}
-    void resetNewLumi() {newLumi_ = false;}
-    bool eventCached() const {return eventCached_;}
+    bool newRun() const { return newRun_; }
+    void setNewRun() { newRun_ = true; }
+    void resetNewRun() { newRun_ = false; }
+    bool newLumi() const { return newLumi_; }
+    void setNewLumi() { newLumi_ = true; }
+    void resetNewLumi() { newLumi_ = false; }
+    bool eventCached() const { return eventCached_; }
     /// Called by the framework to merge or ached() const {return eventCached_;}
-    void setEventCached() {eventCached_ = true;}
-    void resetEventCached() {eventCached_ = false;}
+    void setEventCached() { eventCached_ = true; }
+    void resetEventCached() { eventCached_ = false; }
 
     ///Called by inheriting classes when running multicore when the receiver has told them to
     /// skip some events.
     void decreaseRemainingEventsBy(int iSkipped);
 
   private:
-    bool eventLimitReached() const {return remainingEvents_ == 0;}
+    bool eventLimitReached() const { return remainingEvents_ == 0; }
     bool lumiLimitReached() const {
-      if (remainingLumis_ == 0) {return true;}
-      if (maxSecondsUntilRampdown_ <= 0) {return false;}
+      if (remainingLumis_ == 0) {
+        return true;
+      }
+      if (maxSecondsUntilRampdown_ <= 0) {
+        return false;
+      }
       auto end = std::chrono::steady_clock::now();
       auto elapsed = end - processingStart_;
-      if (std::chrono::duration_cast<std::chrono::seconds>(elapsed).count() > maxSecondsUntilRampdown_) {return true;}
+      if (std::chrono::duration_cast<std::chrono::seconds>(elapsed).count() > maxSecondsUntilRampdown_) {
+        return true;
+      }
       return false;
     }
-    bool limitReached() const {return eventLimitReached() || lumiLimitReached();}
+    bool limitReached() const { return eventLimitReached() || lumiLimitReached(); }
     virtual ItemType getNextItemType() = 0;
     ItemType nextItemType_();
     virtual std::shared_ptr<RunAuxiliary> readRunAuxiliary_() = 0;
@@ -397,15 +395,14 @@ namespace edm {
     virtual void rewind_();
     virtual void beginJob();
     virtual void endJob();
-    virtual std::pair<SharedResourcesAcquirer*,std::recursive_mutex*> resourceSharedWithDelayedReader_();
+    virtual std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> resourceSharedWithDelayedReader_();
 
     virtual bool randomAccess_() const;
     virtual ProcessingController::ForwardState forwardState_() const;
     virtual ProcessingController::ReverseState reverseState_() const;
 
   private:
-
-    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
+    std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
     int maxEvents_;
     int remainingEvents_;
     int maxLumis_;
@@ -426,11 +423,11 @@ namespace edm {
     bool eventCached_;
     mutable ItemType state_;
     mutable std::shared_ptr<RunAuxiliary> runAuxiliary_;
-    mutable std::shared_ptr<LuminosityBlockAuxiliary>  lumiAuxiliary_;
+    mutable std::shared_ptr<LuminosityBlockAuxiliary> lumiAuxiliary_;
     std::string statusFileName_;
 
     unsigned int numberOfEventsBeforeBigSkip_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/InputSourceDescription.h
+++ b/FWCore/Framework/interface/InputSourceDescription.h
@@ -18,14 +18,13 @@ namespace edm {
   class ThinnedAssociationsHelper;
 
   struct InputSourceDescription {
-    InputSourceDescription() :
-      moduleDescription_(),
-      productRegistry_(nullptr),
-      actReg_(),
-      maxEvents_(-1),
-      maxLumis_(-1),
-      allocations_(nullptr) {
-    }
+    InputSourceDescription()
+        : moduleDescription_(),
+          productRegistry_(nullptr),
+          actReg_(),
+          maxEvents_(-1),
+          maxLumis_(-1),
+          allocations_(nullptr) {}
 
     InputSourceDescription(ModuleDescription const& md,
                            std::shared_ptr<ProductRegistry> preg,
@@ -35,28 +34,27 @@ namespace edm {
                            int maxEvents,
                            int maxLumis,
                            int maxSecondsUntilRampdown,
-                           PreallocationConfiguration const& allocations) :
-      moduleDescription_(md),
-      productRegistry_(preg),
-      branchIDListHelper_(branchIDListHelper),
-      thinnedAssociationsHelper_(thinnedAssociationsHelper),
-      actReg_(areg),
-      maxEvents_(maxEvents),
-      maxLumis_(maxLumis),
-      maxSecondsUntilRampdown_(maxSecondsUntilRampdown),
-      allocations_(&allocations) {
-   }
+                           PreallocationConfiguration const& allocations)
+        : moduleDescription_(md),
+          productRegistry_(preg),
+          branchIDListHelper_(branchIDListHelper),
+          thinnedAssociationsHelper_(thinnedAssociationsHelper),
+          actReg_(areg),
+          maxEvents_(maxEvents),
+          maxLumis_(maxLumis),
+          maxSecondsUntilRampdown_(maxSecondsUntilRampdown),
+          allocations_(&allocations) {}
 
     ModuleDescription moduleDescription_;
     std::shared_ptr<ProductRegistry> productRegistry_;
     std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
     std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
-    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
+    std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
     int maxEvents_;
     int maxLumis_;
     int maxSecondsUntilRampdown_;
     PreallocationConfiguration const* allocations_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/InputSourceMacros.h
+++ b/FWCore/Framework/interface/InputSourceMacros.h
@@ -5,7 +5,8 @@
 #include "FWCore/Framework/interface/InputSource.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescriptionFillerPluginFactory.h"
 
-#define DEFINE_FWK_INPUT_SOURCE(type) \
-  DEFINE_EDM_PLUGIN (edm::InputSourcePluginFactory,type,#type); DEFINE_FWK_PSET_DESC_FILLER(type)
+#define DEFINE_FWK_INPUT_SOURCE(type)                            \
+  DEFINE_EDM_PLUGIN(edm::InputSourcePluginFactory, type, #type); \
+  DEFINE_FWK_PSET_DESC_FILLER(type)
 
 #endif

--- a/FWCore/Framework/interface/InputTagMatch.h
+++ b/FWCore/Framework/interface/InputTagMatch.h
@@ -17,32 +17,32 @@ See comments in the file GetterOfProducts.h for a description.
 
 namespace edm {
 
-   class InputTagMatch {
-   public:
+  class InputTagMatch {
+  public:
+    InputTagMatch(edm::InputTag const& inputTag) : inputTag_(inputTag) {}
 
-      InputTagMatch(edm::InputTag const& inputTag) : inputTag_(inputTag) { }
-
-      bool operator()(edm::BranchDescription const& branchDescription) {
-         bool result(true);
-         bool match(false);
-         if (!inputTag_.label().empty()) {
-           match = true;
-           result = (result && branchDescription.moduleLabel() == inputTag_.label());
-         }
-         if (!inputTag_.instance().empty()) {
-           match = true;
-           result = (result && branchDescription.productInstanceName() == inputTag_.instance());
-         }
-         if (!inputTag_.process().empty()) {
-           match = true;
-           result = (result && branchDescription.processName() == inputTag_.process());
-         }
-         if (match) return result;
-         return false;
+    bool operator()(edm::BranchDescription const& branchDescription) {
+      bool result(true);
+      bool match(false);
+      if (!inputTag_.label().empty()) {
+        match = true;
+        result = (result && branchDescription.moduleLabel() == inputTag_.label());
       }
+      if (!inputTag_.instance().empty()) {
+        match = true;
+        result = (result && branchDescription.productInstanceName() == inputTag_.instance());
+      }
+      if (!inputTag_.process().empty()) {
+        match = true;
+        result = (result && branchDescription.processName() == inputTag_.process());
+      }
+      if (match)
+        return result;
+      return false;
+    }
 
-   private:
-      edm::InputTag inputTag_;
-   };
-}
+  private:
+    edm::InputTag inputTag_;
+  };
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/LooperFactory.h
+++ b/FWCore/Framework/interface/LooperFactory.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     LooperFactory
-// 
+//
 /**\class LooperFactory LooperFactory.h FWCore/Framework/interface/LooperFactory.h
 
  Description: PluginManager factory for creating EDLoopers
@@ -28,89 +28,82 @@
 
 // forward declarations
 namespace edm {
-   class EDLooperBase;
-   class EventSetupRecordIntervalFinder;
-   class ParameterSet;
+  class EDLooperBase;
+  class EventSetupRecordIntervalFinder;
+  class ParameterSet;
 
-   namespace eventsetup {
+  namespace eventsetup {
 
-      class DataProxyProvider;
-      class EventSetupsController;
+    class DataProxyProvider;
+    class EventSetupsController;
 
-      namespace looper {
-      template<class T>
-         void addProviderTo(EventSetupProvider& iProvider, std::shared_ptr<T> iComponent, const DataProxyProvider*) 
-      {
-            std::shared_ptr<DataProxyProvider> pProvider(iComponent);
-            ComponentDescription description = pProvider->description();
-            description.isSource_=true;
-            description.isLooper_=true;
-	    if(description.label_ =="@main_looper") {
-	       //remove the 'hidden' label so that es_prefer statements will work
-	       description.label_ ="";
-	    }
-            pProvider->setDescription(description);
-            iProvider.add(pProvider);
+    namespace looper {
+      template <class T>
+      void addProviderTo(EventSetupProvider& iProvider, std::shared_ptr<T> iComponent, const DataProxyProvider*) {
+        std::shared_ptr<DataProxyProvider> pProvider(iComponent);
+        ComponentDescription description = pProvider->description();
+        description.isSource_ = true;
+        description.isLooper_ = true;
+        if (description.label_ == "@main_looper") {
+          //remove the 'hidden' label so that es_prefer statements will work
+          description.label_ = "";
+        }
+        pProvider->setDescription(description);
+        iProvider.add(pProvider);
       }
-      template<class T>
-         void addProviderTo(EventSetupProvider& /* iProvider */, std::shared_ptr<T> /*iComponent*/, const void*) 
-      {
-            //do nothing
+      template <class T>
+      void addProviderTo(EventSetupProvider& /* iProvider */, std::shared_ptr<T> /*iComponent*/, const void*) {
+        //do nothing
       }
 
-      template<class T>
-        void addFinderTo(EventSetupProvider& iProvider, std::shared_ptr<T> iComponent, const EventSetupRecordIntervalFinder*) 
-      {
-          std::shared_ptr<EventSetupRecordIntervalFinder> pFinder(iComponent);
+      template <class T>
+      void addFinderTo(EventSetupProvider& iProvider,
+                       std::shared_ptr<T> iComponent,
+                       const EventSetupRecordIntervalFinder*) {
+        std::shared_ptr<EventSetupRecordIntervalFinder> pFinder(iComponent);
 
-          ComponentDescription description = pFinder->descriptionForFinder();
-          description.isSource_=true;
-          description.isLooper_=true;
-          if(description.label_ =="@main_looper") {
-            //remove the 'hidden' label so that es_prefer statements will work
-            description.label_ ="";
-          }
-          pFinder->setDescriptionForFinder(description);
-          
-          iProvider.add(pFinder);
-      }
-      template<class T>
-        void addFinderTo(EventSetupProvider& /* iProvider */, std::shared_ptr<T> /*iComponent*/, const void*) 
-      {
-          //do nothing
-      }
-      }
-      struct LooperMakerTraits {
-         typedef EDLooperBase base_type;
-         static std::string name();
-         template<class T>
-         static void addTo(EventSetupProvider& iProvider,
-                           std::shared_ptr<T> iComponent,
-                           ParameterSet const&,
-                           bool)
-            {
-               //a looper does not always have to be a provider or a finder
-               looper::addProviderTo(iProvider, iComponent, static_cast<const T*>(nullptr));
-               looper::addFinderTo(iProvider, iComponent, static_cast<const T*>(nullptr));
-            }
+        ComponentDescription description = pFinder->descriptionForFinder();
+        description.isSource_ = true;
+        description.isLooper_ = true;
+        if (description.label_ == "@main_looper") {
+          //remove the 'hidden' label so that es_prefer statements will work
+          description.label_ = "";
+        }
+        pFinder->setDescriptionForFinder(description);
 
-         static void replaceExisting(EventSetupProvider& iProvider, std::shared_ptr<EDLooperBase> iComponent); 
+        iProvider.add(pFinder);
+      }
+      template <class T>
+      void addFinderTo(EventSetupProvider& /* iProvider */, std::shared_ptr<T> /*iComponent*/, const void*) {
+        //do nothing
+      }
+    }  // namespace looper
+    struct LooperMakerTraits {
+      typedef EDLooperBase base_type;
+      static std::string name();
+      template <class T>
+      static void addTo(EventSetupProvider& iProvider, std::shared_ptr<T> iComponent, ParameterSet const&, bool) {
+        //a looper does not always have to be a provider or a finder
+        looper::addProviderTo(iProvider, iComponent, static_cast<const T*>(nullptr));
+        looper::addFinderTo(iProvider, iComponent, static_cast<const T*>(nullptr));
+      }
 
-         static std::shared_ptr<base_type> getComponentAndRegisterProcess(EventSetupsController& esController,
-                                                                            ParameterSet const& iConfiguration);               
-         static void putComponent(EventSetupsController& esController,
-                                  ParameterSet const& iConfiguration,
-                                  std::shared_ptr<base_type> const& component);
-      };
-      template< class TType>
-         struct LooperMaker : public ComponentMaker<edm::eventsetup::LooperMakerTraits,TType> {};
-      typedef  ComponentFactory<LooperMakerTraits> LooperFactory ;
-      
-      typedef edmplugin::PluginFactory<edm::eventsetup::ComponentMakerBase<LooperMakerTraits>* ()> LooperPluginFactory;
-   }
-}
+      static void replaceExisting(EventSetupProvider& iProvider, std::shared_ptr<EDLooperBase> iComponent);
+
+      static std::shared_ptr<base_type> getComponentAndRegisterProcess(EventSetupsController& esController,
+                                                                       ParameterSet const& iConfiguration);
+      static void putComponent(EventSetupsController& esController,
+                               ParameterSet const& iConfiguration,
+                               std::shared_ptr<base_type> const& component);
+    };
+    template <class TType> struct LooperMaker : public ComponentMaker<edm::eventsetup::LooperMakerTraits, TType> {};
+    typedef ComponentFactory<LooperMakerTraits> LooperFactory;
+
+    typedef edmplugin::PluginFactory<edm::eventsetup::ComponentMakerBase<LooperMakerTraits>*()> LooperPluginFactory;
+  }  // namespace eventsetup
+}  // namespace edm
 
 #define DEFINE_FWK_LOOPER(type) \
-DEFINE_EDM_PLUGIN (edm::eventsetup::LooperPluginFactory,edm::eventsetup::LooperMaker<type>,#type)
+  DEFINE_EDM_PLUGIN(edm::eventsetup::LooperPluginFactory, edm::eventsetup::LooperMaker<type>, #type)
 
 #endif

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -40,18 +40,19 @@ namespace edm {
   class SharedResourcesAcquirer;
 
   namespace stream {
-    template< typename T> class ProducingModuleAdaptorBase;
+    template <typename T> class ProducingModuleAdaptorBase;
   }
-
 
   class LuminosityBlock : public LuminosityBlockBase {
   public:
-    LuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleDescription const& md,
-                    ModuleCallingContext const*, bool isAtEnd);
+    LuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                    ModuleDescription const& md,
+                    ModuleCallingContext const*,
+                    bool isAtEnd);
     ~LuminosityBlock() override;
 
     // AUX functions are defined in LuminosityBlockBase
-    LuminosityBlockAuxiliary const& luminosityBlockAuxiliary() const override {return aux_;}
+    LuminosityBlockAuxiliary const& luminosityBlockAuxiliary() const override { return aux_; }
 
     /**\return Reusable index which can be used to separate data for different simultaneous LuminosityBlocks.
      */
@@ -64,117 +65,79 @@ namespace edm {
      denote that you have not yet checked the value.
      */
     typedef unsigned long CacheIdentifier_t;
-    CacheIdentifier_t
-    cacheIdentifier() const;
+    CacheIdentifier_t cacheIdentifier() const;
 
     //Used in conjunction with EDGetToken
     void setConsumer(EDConsumerBase const* iConsumer);
 
-    void setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer);
+    void setSharedResourcesAcquirer(SharedResourcesAcquirer* iResourceAcquirer);
 
     void setProducer(ProducerBase const* iProducer);
 
-    template <typename PROD>
-    bool
-    getByLabel(std::string const& label, Handle<PROD>& result) const;
+    template <typename PROD> bool getByLabel(std::string const& label, Handle<PROD>& result) const;
 
     template <typename PROD>
-    bool
-    getByLabel(std::string const& label,
-               std::string const& productInstanceName,
-               Handle<PROD>& result) const;
+    bool getByLabel(std::string const& label, std::string const& productInstanceName, Handle<PROD>& result) const;
 
     /// same as above, but using the InputTag class
-    template <typename PROD>
-    bool
-    getByLabel(InputTag const& tag, Handle<PROD>& result) const;
+    template <typename PROD> bool getByLabel(InputTag const& tag, Handle<PROD>& result) const;
 
-    template<typename PROD>
-    bool
-    getByToken(EDGetToken token, Handle<PROD>& result) const;
+    template <typename PROD> bool getByToken(EDGetToken token, Handle<PROD>& result) const;
 
-    template<typename PROD>
-    bool
-    getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
+    template <typename PROD> bool getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
 
-    template<typename PROD>
-    Handle<PROD>
-    getHandle(EDGetTokenT<PROD> token) const;
+    template <typename PROD> Handle<PROD> getHandle(EDGetTokenT<PROD> token) const;
 
-    template<typename PROD>
-    PROD const&
-    get(EDGetTokenT<PROD> token) const noexcept(false);
+    template <typename PROD> PROD const& get(EDGetTokenT<PROD> token) const noexcept(false);
 
+    template <typename PROD> void getManyByType(std::vector<Handle<PROD>>& results) const;
 
-    template <typename PROD>
-    void
-    getManyByType(std::vector<Handle<PROD> >& results) const;
-
-    Run const&
-    getRun() const {
-      return *run_;
-    }
+    Run const& getRun() const { return *run_; }
 
     ///Put a new product.
-    template <typename PROD>
-    void
-    put(std::unique_ptr<PROD> product) {put<PROD>(std::move(product), std::string());}
+    template <typename PROD> void put(std::unique_ptr<PROD> product) { put<PROD>(std::move(product), std::string()); }
 
     ///Put a new product with a 'product instance name'
-    template <typename PROD>
-    void
-    put(std::unique_ptr<PROD> product, std::string const& productInstanceName);
+    template <typename PROD> void put(std::unique_ptr<PROD> product, std::string const& productInstanceName);
 
-    template<typename PROD>
-    void
-    put(EDPutToken token, std::unique_ptr<PROD> product);
-    
-    template<typename PROD>
-    void
-    put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product);
+    template <typename PROD> void put(EDPutToken token, std::unique_ptr<PROD> product);
+
+    template <typename PROD> void put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product);
 
     ///puts a new product
-    template<typename PROD, typename... Args>
-    void
-    emplace(EDPutTokenT<PROD> token, Args&&... args);
-    
-    template<typename PROD, typename... Args>
-    void
-    emplace(EDPutToken token, Args&&... args);
+    template <typename PROD, typename... Args> void emplace(EDPutTokenT<PROD> token, Args&&... args);
 
-    Provenance
-    getProvenance(BranchID const& theID) const;
+    template <typename PROD, typename... Args> void emplace(EDPutToken token, Args&&... args);
 
-    void
-    getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
+    Provenance getProvenance(BranchID const& theID) const;
+
+    void getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
 
     ProcessHistoryID const& processHistoryID() const;
 
-    ProcessHistory const&
-    processHistory() const;
+    ProcessHistory const& processHistory() const;
 
     ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
 
-    void labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const { provRecorder_.labelsForToken(iToken, oLabels); }
+    void labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const {
+      provRecorder_.labelsForToken(iToken, oLabels);
+    }
 
   private:
-    LuminosityBlockPrincipal const&
-    luminosityBlockPrincipal() const;
+    LuminosityBlockPrincipal const& luminosityBlockPrincipal() const;
 
     // Override version from LuminosityBlockBase class
-    BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const override;
+    BasicHandle getByLabelImpl(std::type_info const& iWrapperType,
+                               std::type_info const& iProductType,
+                               InputTag const& iTag) const override;
 
-    template<typename PROD>
-    void
-    putImpl(EDPutToken::value_type token, std::unique_ptr<PROD> product);
+    template <typename PROD> void putImpl(EDPutToken::value_type token, std::unique_ptr<PROD> product);
 
-    template<typename PROD, typename... Args>
-    void
-    emplaceImpl(EDPutToken::value_type token, Args&&... args);
+    template <typename PROD, typename... Args> void emplaceImpl(EDPutToken::value_type token, Args&&... args);
 
     typedef std::vector<edm::propagate_const<std::unique_ptr<WrapperBase>>> ProductPtrVec;
-    ProductPtrVec& putProducts() {return putProducts_;}
-    ProductPtrVec const& putProducts() const {return putProducts_;}
+    ProductPtrVec& putProducts() { return putProducts_; }
+    ProductPtrVec const& putProducts() const { return putProducts_; }
 
     // commit_() is called to complete the transaction represented by
     // this PrincipalGetAdapter. The friendships required seems gross, but any
@@ -182,8 +145,7 @@ namespace edm {
     // public interface is asking for trouble
     friend class RawInputSource;
     friend class ProducerBase;
-    template<typename T> friend class stream::ProducingModuleAdaptorBase;
-
+    template <typename T> friend class stream::ProducingModuleAdaptorBase;
 
     void commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut);
 
@@ -196,121 +158,104 @@ namespace edm {
     static const std::string emptyString_;
   };
 
-  template <typename PROD>
-  void
-  LuminosityBlock::putImpl(EDPutToken::value_type index,std::unique_ptr<PROD> product) {
+  template <typename PROD> void LuminosityBlock::putImpl(EDPutToken::value_type index, std::unique_ptr<PROD> product) {
     // The following will call post_insert if T has such a function,
     // and do nothing if T has no such function.
-    std::conditional_t<detail::has_postinsert<PROD>::value,
-    DoPostInsert<PROD>,
-    DoNotPostInsert<PROD>> maybe_inserter;
+    std::conditional_t<detail::has_postinsert<PROD>::value, DoPostInsert<PROD>, DoNotPostInsert<PROD>> maybe_inserter;
     maybe_inserter(product.get());
-    
+
     assert(index < putProducts().size());
-    
-    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(std::move(product)));
-    putProducts()[index]=std::move(wp);
+
+    std::unique_ptr<Wrapper<PROD>> wp(new Wrapper<PROD>(std::move(product)));
+    putProducts()[index] = std::move(wp);
   }
 
   template <typename PROD>
-  void
-  LuminosityBlock::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
-    if(UNLIKELY(product.get() == nullptr)) {                // null pointer is illegal
+  void LuminosityBlock::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
+    if (UNLIKELY(product.get() == nullptr)) {  // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID, productInstanceName);
     }
-    auto index =
-    provRecorder_.getPutTokenIndex(TypeID(*product), productInstanceName);
+    auto index = provRecorder_.getPutTokenIndex(TypeID(*product), productInstanceName);
     putImpl(index, std::move(product));
   }
 
-  template<typename PROD>
-  void
-  LuminosityBlock::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
-    if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
+  template <typename PROD> void LuminosityBlock::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
+    if (UNLIKELY(product.get() == 0)) {  // null pointer is illegal
       TypeID typeID(typeid(PROD));
-      principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID, provRecorder_.productInstanceLabel(token));
+      principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID,
+                                                            provRecorder_.productInstanceLabel(token));
     }
-    if(UNLIKELY(token.isUninitialized())) {
+    if (UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("LuminosityBlock", typeid(PROD));
     }
-    putImpl(token.index(),std::move(product));
-  }
-  
-  template<typename PROD>
-  void
-  LuminosityBlock::put(EDPutToken token, std::unique_ptr<PROD> product) {
-    if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
-      TypeID typeID(typeid(PROD));
-      principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID, provRecorder_.productInstanceLabel(token));
-    }
-    if(UNLIKELY(token.isUninitialized())) {
-      principal_get_adapter_detail::throwOnPutOfUninitializedToken("LuminosityBlock", typeid(PROD));
-    }
-    if(UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
-      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
-    }
-    
-    putImpl(token.index(),std::move(product));
+    putImpl(token.index(), std::move(product));
   }
 
-  template<typename PROD, typename... Args>
-  void
-  LuminosityBlock::emplace(EDPutTokenT<PROD> token, Args&&... args) {
-    if(UNLIKELY(token.isUninitialized())) {
+  template <typename PROD> void LuminosityBlock::put(EDPutToken token, std::unique_ptr<PROD> product) {
+    if (UNLIKELY(product.get() == 0)) {  // null pointer is illegal
+      TypeID typeID(typeid(PROD));
+      principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID,
+                                                            provRecorder_.productInstanceLabel(token));
+    }
+    if (UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("LuminosityBlock", typeid(PROD));
     }
-    emplaceImpl<PROD>(token.index(),std::forward<Args>(args)...);
+    if (UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD),
+                                                          provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    }
+
+    putImpl(token.index(), std::move(product));
   }
-  
-  template<typename PROD, typename... Args>
-  void
-  LuminosityBlock::emplace(EDPutToken token, Args&&... args) {
-    if(UNLIKELY(token.isUninitialized())) {
+
+  template <typename PROD, typename... Args> void LuminosityBlock::emplace(EDPutTokenT<PROD> token, Args&&... args) {
+    if (UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("LuminosityBlock", typeid(PROD));
     }
-    if(UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
-      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
-    }
-    
-    emplaceImpl(token.index(),std::forward<Args>(args)...);
+    emplaceImpl<PROD>(token.index(), std::forward<Args>(args)...);
   }
-  
-  template<typename PROD, typename... Args>
-  void
-  LuminosityBlock::emplaceImpl(EDPutToken::value_type index, Args&&... args) {
-    
+
+  template <typename PROD, typename... Args> void LuminosityBlock::emplace(EDPutToken token, Args&&... args) {
+    if (UNLIKELY(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("LuminosityBlock", typeid(PROD));
+    }
+    if (UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD),
+                                                          provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    }
+
+    emplaceImpl(token.index(), std::forward<Args>(args)...);
+  }
+
+  template <typename PROD, typename... Args>
+  void LuminosityBlock::emplaceImpl(EDPutToken::value_type index, Args&&... args) {
     assert(index < putProducts().size());
-    
-    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(WrapperBase::Emplace{},
-                                                         std::forward<Args>(args)...));
-    
+
+    std::unique_ptr<Wrapper<PROD>> wp(new Wrapper<PROD>(WrapperBase::Emplace{}, std::forward<Args>(args)...));
+
     // The following will call post_insert if T has such a function,
     // and do nothing if T has no such function.
-    std::conditional_t<detail::has_postinsert<PROD>::value,
-    DoPostInsert<PROD>,
-    DoNotPostInsert<PROD>> maybe_inserter;
+    std::conditional_t<detail::has_postinsert<PROD>::value, DoPostInsert<PROD>, DoNotPostInsert<PROD>> maybe_inserter;
     maybe_inserter(&(wp->bareProduct()));
-    
-    putProducts()[index]=std::move(wp);
+
+    putProducts()[index] = std::move(wp);
   }
 
-  template<typename PROD>
-  bool
-  LuminosityBlock::getByLabel(std::string const& label, Handle<PROD>& result) const {
+  template <typename PROD> bool LuminosityBlock::getByLabel(std::string const& label, Handle<PROD>& result) const {
     return getByLabel(label, emptyString_, result);
   }
 
-  template<typename PROD>
-  bool
-  LuminosityBlock::getByLabel(std::string const& label,
-                  std::string const& productInstanceName,
-                  Handle<PROD>& result) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD>
+  bool LuminosityBlock::getByLabel(std::string const& label,
+                                   std::string const& productInstanceName,
+                                   Handle<PROD>& result) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), label, productInstanceName);
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_,
+                                               moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
@@ -319,10 +264,8 @@ namespace edm {
   }
 
   /// same as above, but using the InputTag class
-  template<typename PROD>
-  bool
-  LuminosityBlock::getByLabel(InputTag const& tag, Handle<PROD>& result) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD> bool LuminosityBlock::getByLabel(InputTag const& tag, Handle<PROD>& result) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), tag.label(), tag.instance());
     }
     result.clear();
@@ -334,14 +277,12 @@ namespace edm {
     return true;
   }
 
-  template<typename PROD>
-  bool
-  LuminosityBlock::getByToken(EDGetToken token, Handle<PROD>& result) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD> bool LuminosityBlock::getByToken(EDGetToken token, Handle<PROD>& result) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
@@ -349,14 +290,12 @@ namespace edm {
     return true;
   }
 
-  template<typename PROD>
-  bool
-  LuminosityBlock::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD> bool LuminosityBlock::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
@@ -364,30 +303,26 @@ namespace edm {
     return true;
   }
 
-  template<typename PROD>
-  Handle<PROD>
-  LuminosityBlock::getHandle(EDGetTokenT<PROD> token) const {
-    if UNLIKELY(!provRecorder_.checkIfComplete<PROD>()) {
-      principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
-    }
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+  template <typename PROD> Handle<PROD> LuminosityBlock::getHandle(EDGetTokenT<PROD> token) const {
+    if
+      UNLIKELY(!provRecorder_.checkIfComplete<PROD>()) {
+        principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
+      }
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     return convert_handle<PROD>(std::move(bh));
   }
 
-  template<typename PROD>
-  PROD const&
-  LuminosityBlock::get(EDGetTokenT<PROD> token) const noexcept(false) {
-    if UNLIKELY(!provRecorder_.checkIfComplete<PROD>()) {
-      principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
-    }
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+  template <typename PROD> PROD const& LuminosityBlock::get(EDGetTokenT<PROD> token) const noexcept(false) {
+    if
+      UNLIKELY(!provRecorder_.checkIfComplete<PROD>()) {
+        principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
+      }
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     return *convert_handle<PROD>(std::move(bh));
   }
 
-  template<typename PROD>
-  void
-  LuminosityBlock::getManyByType(std::vector<Handle<PROD> >& results) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD> void LuminosityBlock::getManyByType(std::vector<Handle<PROD>>& results) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)));
     }
     return provRecorder_.getManyByType(results, moduleCallingContext_);
@@ -396,30 +331,27 @@ namespace edm {
   // Free functions to retrieve a collection from the LuminosityBlock.
   // Will throw an exception if the collection is not available.
 
-  template <typename T>
-  T const& get(LuminosityBlock const& event, InputTag const& tag) {
+  template <typename T> T const& get(LuminosityBlock const& event, InputTag const& tag) {
     Handle<T> handle;
     event.getByLabel(tag, handle);
     // throw if the handle is not valid
-    return * handle.product();
+    return *handle.product();
   }
 
-  template <typename T>
-  T const& get(LuminosityBlock const& event, EDGetToken const& token) {
+  template <typename T> T const& get(LuminosityBlock const& event, EDGetToken const& token) {
     Handle<T> handle;
     event.getByToken(token, handle);
     // throw if the handle is not valid
-    return * handle.product();
+    return *handle.product();
   }
 
-  template <typename T>
-  T const& get(LuminosityBlock const& event, EDGetTokenT<T> const& token) {
+  template <typename T> T const& get(LuminosityBlock const& event, EDGetTokenT<T> const& token) {
     Handle<T> handle;
     event.getByToken(token, handle);
     // throw if the handle is not valid
-    return * handle.product();
+    return *handle.product();
   }
 
-}
+}  // namespace edm
 
-#endif // FWCore_Framework_LuminosityBlock_h
+#endif  // FWCore_Framework_LuminosityBlock_h

--- a/FWCore/Framework/interface/LuminosityBlockForOutput.h
+++ b/FWCore/Framework/interface/LuminosityBlockForOutput.h
@@ -36,38 +36,36 @@ namespace edmtest {
 
 namespace edm {
   class ModuleCallingContext;
-  
+
   class LuminosityBlockForOutput : public OccurrenceForOutput {
   public:
-    LuminosityBlockForOutput(LuminosityBlockPrincipal const& lbp, ModuleDescription const& md,
-                    ModuleCallingContext const*, bool isAtEnd);
+    LuminosityBlockForOutput(LuminosityBlockPrincipal const& lbp,
+                             ModuleDescription const& md,
+                             ModuleCallingContext const*,
+                             bool isAtEnd);
     ~LuminosityBlockForOutput() override;
 
-    LuminosityBlockAuxiliary const& luminosityBlockAuxiliary() const {return aux_;}
-    LuminosityBlockID const& id() const {return aux_.id();}
-    LuminosityBlockNumber_t luminosityBlock() const {return aux_.luminosityBlock();}
-    RunNumber_t run() const {return aux_.run();}
-    Timestamp const& beginTime() const {return aux_.beginTime();}
-    Timestamp const& endTime() const {return aux_.endTime();}
+    LuminosityBlockAuxiliary const& luminosityBlockAuxiliary() const { return aux_; }
+    LuminosityBlockID const& id() const { return aux_.id(); }
+    LuminosityBlockNumber_t luminosityBlock() const { return aux_.luminosityBlock(); }
+    RunNumber_t run() const { return aux_.run(); }
+    Timestamp const& beginTime() const { return aux_.beginTime(); }
+    Timestamp const& endTime() const { return aux_.endTime(); }
 
     /**\return Reusable index which can be used to separate data for different simultaneous LuminosityBlocks.
      */
     LuminosityBlockIndex index() const;
 
-    RunForOutput const&
-    getRun() const {
-      return *run_;
-    }
+    RunForOutput const& getRun() const { return *run_; }
 
   private:
-    friend class edmtest::TestOutputModule; // For testing
+    friend class edmtest::TestOutputModule;  // For testing
 
-    LuminosityBlockPrincipal const&
-    luminosityBlockPrincipal() const;
+    LuminosityBlockPrincipal const& luminosityBlockPrincipal() const;
 
     LuminosityBlockAuxiliary const& aux_;
     std::shared_ptr<RunForOutput const> const run_;
   };
 
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -12,7 +12,6 @@ is the DataBlock.
 
 ----------------------------------------------------------------------*/
 
-
 #include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
 #include "DataFormats/Provenance/interface/RunID.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
@@ -34,75 +33,47 @@ namespace edm {
   public:
     typedef LuminosityBlockAuxiliary Auxiliary;
     typedef Principal Base;
-    LuminosityBlockPrincipal(
-        std::shared_ptr<ProductRegistry const> reg,
-        ProcessConfiguration const& pc,
-        HistoryAppender* historyAppender,
-        unsigned int index,
-        bool isForPrimaryProcess=true);
+    LuminosityBlockPrincipal(std::shared_ptr<ProductRegistry const> reg,
+                             ProcessConfiguration const& pc,
+                             HistoryAppender* historyAppender,
+                             unsigned int index,
+                             bool isForPrimaryProcess = true);
 
     ~LuminosityBlockPrincipal() override {}
 
-    void fillLuminosityBlockPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader = nullptr);
+    void fillLuminosityBlockPrincipal(ProcessHistoryRegistry const& processHistoryRegistry,
+                                      DelayedReader* reader = nullptr);
 
-    RunPrincipal const& runPrincipal() const {
-      return *runPrincipal_;
-    }
+    RunPrincipal const& runPrincipal() const { return *runPrincipal_; }
 
-    RunPrincipal& runPrincipal() {
-      return *runPrincipal_;
-    }
+    RunPrincipal& runPrincipal() { return *runPrincipal_; }
 
-    void setRunPrincipal(std::shared_ptr<RunPrincipal> rp) {
-      runPrincipal_ = rp;
-    }
+    void setRunPrincipal(std::shared_ptr<RunPrincipal> rp) { runPrincipal_ = rp; }
 
-    LuminosityBlockIndex index() const {
-      return index_;
-    }
-    
-    LuminosityBlockID id() const {
-      return aux().id();
-    }
+    LuminosityBlockIndex index() const { return index_; }
 
-    Timestamp const& beginTime() const {
-      return aux().beginTime();
-    }
+    LuminosityBlockID id() const { return aux().id(); }
 
-    Timestamp const& endTime() const {
-      return aux().endTime();
-    }
+    Timestamp const& beginTime() const { return aux().beginTime(); }
 
-    void setEndTime(Timestamp const& time) {
-      aux_.setEndTime(time);
-    }
+    Timestamp const& endTime() const { return aux().endTime(); }
 
-    LuminosityBlockNumber_t luminosityBlock() const {
-      return aux().luminosityBlock();
-    }
+    void setEndTime(Timestamp const& time) { aux_.setEndTime(time); }
 
-    void setAux( LuminosityBlockAuxiliary iAux) { aux_ = std::move(iAux);}
-    LuminosityBlockAuxiliary const& aux() const {
-      return aux_;
-    }
+    LuminosityBlockNumber_t luminosityBlock() const { return aux().luminosityBlock(); }
 
-    RunNumber_t run() const {
-      return aux().run();
-    }
+    void setAux(LuminosityBlockAuxiliary iAux) { aux_ = std::move(iAux); }
+    LuminosityBlockAuxiliary const& aux() const { return aux_; }
 
-    void mergeAuxiliary(LuminosityBlockAuxiliary const& aux) {
-      return aux_.mergeAuxiliary(aux);
-    }
+    RunNumber_t run() const { return aux().run(); }
 
-    void put(
-        BranchDescription const& bd,
-        std::unique_ptr<WrapperBase> edp) const;
+    void mergeAuxiliary(LuminosityBlockAuxiliary const& aux) { return aux_.mergeAuxiliary(aux); }
 
-    void put(ProductResolverIndex index,
-             std::unique_ptr<WrapperBase> edp) const;
+    void put(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
+
+    void put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const;
 
   private:
-
     unsigned int transitionIndex_() const override;
 
     edm::propagate_const<std::shared_ptr<RunPrincipal>> runPrincipal_;
@@ -111,6 +82,5 @@ namespace edm {
 
     LuminosityBlockIndex index_;
   };
-}
+}  // namespace edm
 #endif
-

--- a/FWCore/Framework/interface/MakeDataException.h
+++ b/FWCore/Framework/interface/MakeDataException.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     MakeDataException
-// 
+//
 /**\class MakeDataException MakeDataException.h FWCore/Framework/interface/MakeDataException.h
 
 Description: An exception that is thrown whenever a Proxy had a problem with
@@ -40,32 +40,29 @@ if(outOfBoundsValue) {
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
+  namespace eventsetup {
 
-class MakeDataException : public cms::Exception
-{
-   public:
-      MakeDataException(const EventSetupRecordKey&, const DataKey&);  
+    class MakeDataException : public cms::Exception {
+    public:
+      MakeDataException(const EventSetupRecordKey&, const DataKey&);
       ~MakeDataException() noexcept override {}
 
       // ---------- const member functions ---------------------
-      const char* myMessage() const noexcept {
-         return message_.c_str();
-      }
-   
-      // ---------- static member functions --------------------
-      static std::string standardMessage(const EventSetupRecordKey&, const DataKey&); 
-   // ---------- member functions ---------------------------
+      const char* myMessage() const noexcept { return message_.c_str(); }
 
-   private:
+      // ---------- static member functions --------------------
+      static std::string standardMessage(const EventSetupRecordKey&, const DataKey&);
+      // ---------- member functions ---------------------------
+
+    private:
       //MakeDataException(const MakeDataException&); // stop default
 
       //const MakeDataException& operator=(const MakeDataException&); // stop default
 
       // ---------- member data --------------------------------
       std::string message_;
-};
+    };
 
-   }
-}
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/MakerMacros.h
+++ b/FWCore/Framework/interface/MakerMacros.h
@@ -13,7 +13,7 @@
 // implementation file only.
 #include "FWCore/Framework/src/WorkerT.h"
 
-
-#define DEFINE_FWK_MODULE(type) \
-  DEFINE_EDM_PLUGIN (edm::MakerPluginFactory,edm::WorkerMaker<type>,#type); DEFINE_FWK_PSET_DESC_FILLER(type)
+#define DEFINE_FWK_MODULE(type)                                              \
+  DEFINE_EDM_PLUGIN(edm::MakerPluginFactory, edm::WorkerMaker<type>, #type); \
+  DEFINE_FWK_PSET_DESC_FILLER(type)
 #endif

--- a/FWCore/Framework/interface/MergeableRunProductMetadata.h
+++ b/FWCore/Framework/interface/MergeableRunProductMetadata.h
@@ -51,7 +51,6 @@ namespace edm {
 
   class MergeableRunProductMetadata : public MergeableRunProductMetadataBase {
   public:
-
     enum MergeDecision { MERGE, REPLACE, IGNORE };
 
     MergeableRunProductMetadata(MergeableRunProductProcesses const&);
@@ -65,10 +64,9 @@ namespace edm {
     // should be called before the run products themselves are read
     // because it sets the decision whether to merge, replace, or ignore
     // run products as they read.
-    void readRun(
-      long long inputRunEntry,
-      StoredMergeableRunProductMetadata const& inputStoredMergeableRunProductMetadata,
-      IndexIntoFileItrHolder const& inputIndexIntoFileItr);
+    void readRun(long long inputRunEntry,
+                 StoredMergeableRunProductMetadata const& inputStoredMergeableRunProductMetadata,
+                 IndexIntoFileItrHolder const& inputIndexIntoFileItr);
 
     // Called to record which lumis were processed by the current run
     void writeLumi(LuminosityBlockNumber_t lumi);
@@ -92,7 +90,6 @@ namespace edm {
 
     class MetadataForProcess {
     public:
-
       MetadataForProcess() = default;
 
       std::vector<LuminosityBlockNumber_t>& lumis() { return lumis_; }
@@ -113,7 +110,6 @@ namespace edm {
       void reset();
 
     private:
-
       std::vector<LuminosityBlockNumber_t> lumis_;
       MergeDecision mergeDecision_ = MERGE;
       bool valid_ = true;
@@ -124,19 +120,15 @@ namespace edm {
     MetadataForProcess const* metadataForOneProcess(std::string const& processName) const;
 
     // The next few functions are only intended to be used in tests.
-    std::vector<MetadataForProcess> const&
-    metadataForProcesses() const { return metadataForProcesses_; }
+    std::vector<MetadataForProcess> const& metadataForProcesses() const { return metadataForProcesses_; }
 
-    std::vector<LuminosityBlockNumber_t> const &
-    lumisFromIndexIntoFile() const { return lumisFromIndexIntoFile_; }
+    std::vector<LuminosityBlockNumber_t> const& lumisFromIndexIntoFile() const { return lumisFromIndexIntoFile_; }
 
     bool gotLumisFromIndexIntoFile() const { return gotLumisFromIndexIntoFile_; }
 
-    tbb::concurrent_vector<LuminosityBlockNumber_t> const&
-    lumisProcessed() const { return lumisProcessed_; }
+    tbb::concurrent_vector<LuminosityBlockNumber_t> const& lumisProcessed() const { return lumisProcessed_; }
 
   private:
-
     void mergeLumisFromIndexIntoFile();
 
     bool addProcess(StoredMergeableRunProductMetadata& storedMetadata,
@@ -158,5 +150,5 @@ namespace edm {
 
     tbb::concurrent_vector<LuminosityBlockNumber_t> lumisProcessed_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/MergeableRunProductProcesses.h
+++ b/FWCore/Framework/interface/MergeableRunProductProcesses.h
@@ -10,31 +10,25 @@ namespace edm {
 
   class MergeableRunProductProcesses {
   public:
-
     MergeableRunProductProcesses();
 
     std::vector<std::string> const& processesWithMergeableRunProducts() const {
       return processesWithMergeableRunProducts_;
     }
 
-    std::string const& getProcessName(unsigned int index) const {
-      return processesWithMergeableRunProducts_[index];
-    }
+    std::string const& getProcessName(unsigned int index) const { return processesWithMergeableRunProducts_[index]; }
 
-    std::vector<std::string>::size_type size() const {
-      return processesWithMergeableRunProducts_.size();
-    }
+    std::vector<std::string>::size_type size() const { return processesWithMergeableRunProducts_.size(); }
 
     // Called once in a job right after the ProductRegistry is frozen.
     // After that the names stored in this class are never modified.
     void setProcessesWithMergeableRunProducts(ProductRegistry const& productRegistry);
 
   private:
-
     // Holds the process names for processes that created mergeable
     // run products that are in the input of the current job.
     // Note this does not include the current process.
     std::vector<std::string> processesWithMergeableRunProducts_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ModuleChanger.h
+++ b/FWCore/Framework/interface/ModuleChanger.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ModuleChanger
-// 
+//
 /**\class ModuleChanger ModuleChanger.h FWCore/Framework/interface/ModuleChanger.h
 
  Description: Handles modifying a module after the job has started
@@ -28,32 +28,30 @@
 // forward declarations
 
 namespace edm {
-   class ParameterSet;
-   class Schedule;
-   class ProductRegistry;
+  class ParameterSet;
+  class Schedule;
+  class ProductRegistry;
 
-   class ModuleChanger {
+  class ModuleChanger {
+  public:
+    ModuleChanger(Schedule*, ProductRegistry const* iReg);
+    virtual ~ModuleChanger();
 
-   public:
-      ModuleChanger(Schedule*, ProductRegistry const* iReg);
-      virtual ~ModuleChanger();
+    // ---------- const member functions ---------------------
 
-      // ---------- const member functions ---------------------
+    // ---------- static member functions --------------------
 
-      // ---------- static member functions --------------------
+    // ---------- member functions ---------------------------
+    bool changeModule(const std::string& iLabel, const ParameterSet& iPSet);
 
-      // ---------- member functions ---------------------------
-      bool changeModule(const std::string& iLabel,
-                        const ParameterSet& iPSet);
+  private:
+    ModuleChanger(const ModuleChanger&) = delete;  // stop default
 
-   private:
-      ModuleChanger(const ModuleChanger&) = delete; // stop default
+    const ModuleChanger& operator=(const ModuleChanger&) = delete;  // stop default
 
-      const ModuleChanger& operator=(const ModuleChanger&) = delete; // stop default
-
-      // ---------- member data --------------------------------
-      edm::propagate_const<Schedule*> schedule_;
-      ProductRegistry const* registry_;
-   };
-}
+    // ---------- member data --------------------------------
+    edm::propagate_const<Schedule*> schedule_;
+    ProductRegistry const* registry_;
+  };
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ModuleContextSentry.h
+++ b/FWCore/Framework/interface/ModuleContextSentry.h
@@ -10,9 +10,8 @@ namespace edm {
 
   class ModuleContextSentry {
   public:
-    ModuleContextSentry(ModuleCallingContext* moduleCallingContext,
-                        ParentContext const& parentContext) :
-      moduleCallingContext_(moduleCallingContext) {
+    ModuleContextSentry(ModuleCallingContext* moduleCallingContext, ParentContext const& parentContext)
+        : moduleCallingContext_(moduleCallingContext) {
       moduleCallingContext_->setContext(ModuleCallingContext::State::kRunning, parentContext,
                                         CurrentModuleOnThread::getCurrentModuleOnThread());
       CurrentModuleOnThread::setCurrentModuleOnThread(moduleCallingContext_);
@@ -21,8 +20,9 @@ namespace edm {
       CurrentModuleOnThread::setCurrentModuleOnThread(moduleCallingContext_->previousModuleOnThread());
       moduleCallingContext_->setContext(ModuleCallingContext::State::kInvalid, ParentContext(), nullptr);
     }
+
   private:
     edm::propagate_const<ModuleCallingContext*> moduleCallingContext_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ModuleFactory.h
+++ b/FWCore/Framework/interface/ModuleFactory.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ModuleFactory
-// 
+//
 /**\class ModuleFactory ModuleFactory.h FWCore/Framework/interface/ModuleFactory.h
 
  Description: Factory which is dynamically loadable and used to create an eventstore module
@@ -28,38 +28,36 @@
 
 // forward declarations
 namespace edm {
-   class ParameterSet;
+  class ParameterSet;
 
-   namespace eventsetup {
-      class DataProxyProvider;
-      class EventSetupsController;
+  namespace eventsetup {
+    class DataProxyProvider;
+    class EventSetupsController;
 
-      struct ModuleMakerTraits {
-         typedef DataProxyProvider base_type;
-        
-         static std::string name();
-         static void addTo(EventSetupProvider& iProvider,
-                           std::shared_ptr<DataProxyProvider> iComponent,
-                           ParameterSet const&,
-                           bool);
-         static void replaceExisting(EventSetupProvider& iProvider, std::shared_ptr<DataProxyProvider> iComponent); 
-         static std::shared_ptr<base_type> getComponentAndRegisterProcess(EventSetupsController& esController,
-                                                                            ParameterSet const& iConfiguration);
-         static void putComponent(EventSetupsController& esController,
-                                  ParameterSet const& iConfiguration,
-                                  std::shared_ptr<base_type> const& component);
-      };
-      template< class TType>
-         struct ModuleMaker : public ComponentMaker<edm::eventsetup::ModuleMakerTraits,TType> {};
-      
-      typedef  ComponentFactory<ModuleMakerTraits> ModuleFactory ;
-      typedef edmplugin::PluginFactory<edm::eventsetup::ComponentMakerBase<ModuleMakerTraits>* ()> ModulePluginFactory;
-   }
-}
+    struct ModuleMakerTraits {
+      typedef DataProxyProvider base_type;
 
-#define DEFINE_FWK_EVENTSETUP_MODULE(type) \
-DEFINE_EDM_PLUGIN (edm::eventsetup::ModulePluginFactory,edm::eventsetup::ModuleMaker<type>,#type); \
-DEFINE_DESC_FILLER_FOR_ESPRODUCERS(type)
+      static std::string name();
+      static void addTo(EventSetupProvider& iProvider,
+                        std::shared_ptr<DataProxyProvider> iComponent,
+                        ParameterSet const&,
+                        bool);
+      static void replaceExisting(EventSetupProvider& iProvider, std::shared_ptr<DataProxyProvider> iComponent);
+      static std::shared_ptr<base_type> getComponentAndRegisterProcess(EventSetupsController& esController,
+                                                                       ParameterSet const& iConfiguration);
+      static void putComponent(EventSetupsController& esController,
+                               ParameterSet const& iConfiguration,
+                               std::shared_ptr<base_type> const& component);
+    };
+    template <class TType> struct ModuleMaker : public ComponentMaker<edm::eventsetup::ModuleMakerTraits, TType> {};
+
+    typedef ComponentFactory<ModuleMakerTraits> ModuleFactory;
+    typedef edmplugin::PluginFactory<edm::eventsetup::ComponentMakerBase<ModuleMakerTraits>*()> ModulePluginFactory;
+  }  // namespace eventsetup
+}  // namespace edm
+
+#define DEFINE_FWK_EVENTSETUP_MODULE(type)                                                            \
+  DEFINE_EDM_PLUGIN(edm::eventsetup::ModulePluginFactory, edm::eventsetup::ModuleMaker<type>, #type); \
+  DEFINE_DESC_FILLER_FOR_ESPRODUCERS(type)
 
 #endif
-

--- a/FWCore/Framework/interface/ModuleLabelMatch.h
+++ b/FWCore/Framework/interface/ModuleLabelMatch.h
@@ -16,17 +16,16 @@ See comments in the file GetterOfProducts.h for a description.
 
 namespace edm {
 
-   class ModuleLabelMatch {
-   public:
+  class ModuleLabelMatch {
+  public:
+    ModuleLabelMatch(std::string const& moduleLabel) : moduleLabel_(moduleLabel) {}
 
-      ModuleLabelMatch(std::string const& moduleLabel) : moduleLabel_(moduleLabel) { }
+    bool operator()(edm::BranchDescription const& branchDescription) {
+      return branchDescription.moduleLabel() == moduleLabel_;
+    }
 
-      bool operator()(edm::BranchDescription const& branchDescription) {
-         return branchDescription.moduleLabel() == moduleLabel_;
-      }
-
-   private:
-      std::string moduleLabel_;
-   };
-}
+  private:
+    std::string moduleLabel_;
+  };
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/NoDataException.h
+++ b/FWCore/Framework/interface/NoDataException.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Module:      NoDataException
-// 
+//
 /**\class NoDataException NoDataException.h Exception/interface/NoDataException.h
 
  Description: An exception that is thrown whenever data was not available
@@ -73,58 +73,52 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
+  namespace eventsetup {
 
-class NoDataExceptionBase : public cms::Exception
-{
-public:
-  NoDataExceptionBase(const EventSetupRecordKey& iRecordKey,
-                        const DataKey& iDataKey,
-                        const char* category_name = "NoDataException") ;
-  ~NoDataExceptionBase() noexcept override;
-  const DataKey& dataKey() const;
-protected:
-  static std::string providerButNoDataMessage(const EventSetupRecordKey& iKey);
-  static std::string noProxyMessage();
-  void constructMessage(const char* iClassName, const std::string& iExtraInfo);
-private:
-  void beginDataTypeMessage(std::string&) const;
-  void endDataTypeMessage(std::string&) const;
-  
-  // ---------- Constructors and destructor ----------------
-  //NoDataExceptionBase(const NoDataExceptionBase&) ; //allow default
-  //const NoDataExceptionBase& operator=(const NoDataExceptionBase&); // allow default
+    class NoDataExceptionBase : public cms::Exception {
+    public:
+      NoDataExceptionBase(const EventSetupRecordKey& iRecordKey,
+                          const DataKey& iDataKey,
+                          const char* category_name = "NoDataException");
+      ~NoDataExceptionBase() noexcept override;
+      const DataKey& dataKey() const;
 
-  // ---------- data members -------------------------------
-  EventSetupRecordKey record_;
-  DataKey dataKey_;
-};
+    protected:
+      static std::string providerButNoDataMessage(const EventSetupRecordKey& iKey);
+      static std::string noProxyMessage();
+      void constructMessage(const char* iClassName, const std::string& iExtraInfo);
 
-template <class T>
- class NoDataException : public NoDataExceptionBase 
-{
-public:
-  NoDataException(const EventSetupRecordKey& iRecordKey,
-                  const DataKey& iDataKey,
-                  const char* category_name = "NoDataException") :
-  NoDataExceptionBase(iRecordKey, iDataKey, category_name)
-  {
-    constructMessage(heterocontainer::className<T>(),
-                     providerButNoDataMessage(iRecordKey));
-  }
+    private:
+      void beginDataTypeMessage(std::string&) const;
+      void endDataTypeMessage(std::string&) const;
 
-  NoDataException(const EventSetupRecordKey& iRecordKey,
-                  const DataKey& iDataKey,
-                  const char* category_name ,
-                  const std::string& iExtraInfo ) :
-  NoDataExceptionBase(iRecordKey, iDataKey, category_name)  
-  {
-    constructMessage(heterocontainer::className<T>(),
-                     iExtraInfo);
-  }
+      // ---------- Constructors and destructor ----------------
+      //NoDataExceptionBase(const NoDataExceptionBase&) ; //allow default
+      //const NoDataExceptionBase& operator=(const NoDataExceptionBase&); // allow default
 
-};
+      // ---------- data members -------------------------------
+      EventSetupRecordKey record_;
+      DataKey dataKey_;
+    };
 
-   }
-}
+    template <class T> class NoDataException : public NoDataExceptionBase {
+    public:
+      NoDataException(const EventSetupRecordKey& iRecordKey,
+                      const DataKey& iDataKey,
+                      const char* category_name = "NoDataException")
+          : NoDataExceptionBase(iRecordKey, iDataKey, category_name) {
+        constructMessage(heterocontainer::className<T>(), providerButNoDataMessage(iRecordKey));
+      }
+
+      NoDataException(const EventSetupRecordKey& iRecordKey,
+                      const DataKey& iDataKey,
+                      const char* category_name,
+                      const std::string& iExtraInfo)
+          : NoDataExceptionBase(iRecordKey, iDataKey, category_name) {
+        constructMessage(heterocontainer::className<T>(), iExtraInfo);
+      }
+    };
+
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/NoProxyException.h
+++ b/FWCore/Framework/interface/NoProxyException.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Module:      NoProxyException
-// 
+//
 /**\class NoProxyException NoProxyException.h FWCore/Framework/interface/NoProxyException.h
 
  Description: An exception that is thrown whenever proxy was not available
@@ -26,25 +26,20 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
-template <class T>
-class NoProxyException : public NoDataException<T>
-{
+  namespace eventsetup {
+    template <class T> class NoProxyException : public NoDataException<T> {
       // ---------- friend classes and functions ---------------
 
-   public:
+    public:
       // ---------- constants, enums and typedefs --------------
 
       // ---------- Constructors and destructor ----------------
-      NoProxyException(const EventSetupRecordKey& iKey,
-			  const DataKey& iDataKey) :
-       NoDataException<T>(iKey, iDataKey,"NoProxyException",NoDataExceptionBase::noProxyMessage()) 
-       {
-       }
+      NoProxyException(const EventSetupRecordKey& iKey, const DataKey& iDataKey)
+          : NoDataException<T>(iKey, iDataKey, "NoProxyException", NoDataExceptionBase::noProxyMessage()) {}
 
       // ---------- member functions ---------------------------
 
-   private:
+    private:
       // ---------- const member functions ---------------------
 
       // ---------- static member functions --------------------
@@ -54,10 +49,10 @@ class NoProxyException : public NoDataException<T>
 
       //const NoProxyException& operator=(const NoProxyException&); // allow default
 
-      // ---------- data members -------------------------------      
-};
-   }
-}
+      // ---------- data members -------------------------------
+    };
+  }  // namespace eventsetup
+}  // namespace edm
 // inline function definitions
 
 #endif

--- a/FWCore/Framework/interface/NoRecordException.h
+++ b/FWCore/Framework/interface/NoRecordException.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Module:      NoRecordException
-// 
+//
 /**\class NoRecordException NoRecordException.h Framework/interface/NoRecordException.h
 
  Description: An exception that is thrown whenever a EventSetup is asked to retrieve
@@ -35,24 +35,20 @@
 
 // forward declarations
 namespace edm {
-   class IOVSyncValue;
-   class EventSetupImpl;
-   namespace eventsetup {
-      class EventSetupRecordKey;
-      void no_record_exception_message_builder(cms::Exception&,const char*, bool iKnownRecord);
-     bool recordDoesExist( edm::EventSetupImpl const& , edm::eventsetup::EventSetupRecordKey const&);
+  class IOVSyncValue;
+  class EventSetupImpl;
+  namespace eventsetup {
+    class EventSetupRecordKey;
+    void no_record_exception_message_builder(cms::Exception&, const char*, bool iKnownRecord);
+    bool recordDoesExist(edm::EventSetupImpl const&, edm::eventsetup::EventSetupRecordKey const&);
 
-//NOTE: when EDM gets own exception hierarchy, will need to change inheritance
-template <class T>
-class NoRecordException : public cms::Exception
-{
- public:
-  // ---------- Constructors and destructor ----------------
-  explicit NoRecordException(bool iKnownRecord )
-  :cms::Exception("NoRecord")
-  {
-    no_record_exception_message_builder(*this,heterocontainer::className<T>(), iKnownRecord);
-  }
+    //NOTE: when EDM gets own exception hierarchy, will need to change inheritance
+    template <class T> class NoRecordException : public cms::Exception {
+    public:
+      // ---------- Constructors and destructor ----------------
+      explicit NoRecordException(bool iKnownRecord) : cms::Exception("NoRecord") {
+        no_record_exception_message_builder(*this, heterocontainer::className<T>(), iKnownRecord);
+      }
 
       ~NoRecordException() noexcept override {}
 
@@ -61,8 +57,8 @@ class NoRecordException : public cms::Exception
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
-   
-   private:
+
+    private:
       // ---------- Constructors and destructor ----------------
       //NoRecordException(const NoRecordException&); // stop default
 
@@ -70,9 +66,9 @@ class NoRecordException : public cms::Exception
       //const NoRecordException& operator=(const NoRecordException&); // stop default
 
       // ---------- data members -------------------------------
-};
+    };
 
-// inline function definitions
-   }
-}
+    // inline function definitions
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/OccurrenceForOutput.h
+++ b/FWCore/Framework/interface/OccurrenceForOutput.h
@@ -44,8 +44,7 @@ namespace edm {
 
   class OccurrenceForOutput {
   public:
-    OccurrenceForOutput(Principal const& ep, ModuleDescription const& md,
-          ModuleCallingContext const*, bool isAtEnd);
+    OccurrenceForOutput(Principal const& ep, ModuleDescription const& md, ModuleCallingContext const*, bool isAtEnd);
     virtual ~OccurrenceForOutput();
 
     //Used in conjunction with EDGetToken
@@ -53,41 +52,29 @@ namespace edm {
 
     ProcessHistoryID const& processHistoryID() const;
 
-    BasicHandle
-    getByToken(EDGetToken token, TypeID const& typeID) const;
+    BasicHandle getByToken(EDGetToken token, TypeID const& typeID) const;
 
-    template<typename PROD>
-    bool
-    getByToken(EDGetToken token, Handle<PROD>& result) const;
+    template <typename PROD> bool getByToken(EDGetToken token, Handle<PROD>& result) const;
 
-    template<typename PROD>
-    bool
-    getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
+    template <typename PROD> bool getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
 
-    template<typename PROD>
-    Handle<PROD>
-    getHandle(EDGetTokenT<PROD> token) const;
+    template <typename PROD> Handle<PROD> getHandle(EDGetTokenT<PROD> token) const;
 
-    Provenance
-    getProvenance(BranchID const& theID) const;
+    Provenance getProvenance(BranchID const& theID) const;
 
-    void
-    getAllProvenance(std::vector<Provenance const*>& provenances) const;
+    void getAllProvenance(std::vector<Provenance const*>& provenances) const;
 
-    void
-    getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
+    void getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
 
-    virtual ProcessHistory const&
-    processHistory() const;
+    virtual ProcessHistory const& processHistory() const;
 
     size_t size() const;
 
   protected:
-    Principal const&
-    principal() const;
+    Principal const& principal() const;
 
   private:
-    friend class edmtest::TestOutputModule; // For testing
+    friend class edmtest::TestOutputModule;  // For testing
     ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
 
     PrincipalGetAdapter provRecorder_;
@@ -95,13 +82,11 @@ namespace edm {
     ModuleCallingContext const* moduleCallingContext_;
   };
 
-  template<typename PROD>
-  bool
-  OccurrenceForOutput::getByToken(EDGetToken token, Handle<PROD>& result) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD> bool OccurrenceForOutput::getByToken(EDGetToken token, Handle<PROD>& result) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("RunOrLumi", TypeID(typeid(PROD)), token);
     }
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
@@ -109,13 +94,11 @@ namespace edm {
     return true;
   }
 
-  template<typename PROD>
-  bool
-  OccurrenceForOutput::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD> bool OccurrenceForOutput::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("RunOrLumi", TypeID(typeid(PROD)), token);
     }
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
@@ -123,16 +106,13 @@ namespace edm {
     return true;
   }
 
-  template<typename PROD>
-  Handle<PROD>
-  OccurrenceForOutput::getHandle(EDGetTokenT<PROD> token) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD> Handle<PROD> OccurrenceForOutput::getHandle(EDGetTokenT<PROD> token) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("RunOrLumi", TypeID(typeid(PROD)), token);
     }
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     return convert_handle<PROD>(std::move(bh));  // throws on conversion error
   }
 
-}
+}  // namespace edm
 #endif
-

--- a/FWCore/Framework/interface/OccurrenceTraits.h
+++ b/FWCore/Framework/interface/OccurrenceTraits.h
@@ -21,7 +21,7 @@ OccurrenceTraits:
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 
-#include<string>
+#include <string>
 
 namespace edm {
 
@@ -29,8 +29,7 @@ namespace edm {
 
   template <typename T, BranchActionType B> class OccurrenceTraits;
 
-  template <>
-  class OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> {
+  template <> class OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> {
   public:
     typedef EventPrincipal MyPrincipal;
     typedef StreamContext Context;
@@ -44,26 +43,23 @@ namespace edm {
       streamContext.setTimestamp(principal.time());
     }
 
-    static void preScheduleSignal(ActivityRegistry *a, StreamContext const* streamContext) {
+    static void preScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
       a->preEventSignal_(*streamContext);
     }
-    static void postScheduleSignal(ActivityRegistry *a, StreamContext const* streamContext) {
+    static void postScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
       a->postEventSignal_(*streamContext);
     }
-    static void prePathSignal(ActivityRegistry *a, PathContext const* pathContext) {
+    static void prePathSignal(ActivityRegistry* a, PathContext const* pathContext) {
       a->prePathEventSignal_(*pathContext->streamContext(), *pathContext);
     }
-    static void postPathSignal(ActivityRegistry *a, HLTPathStatus const& status, PathContext const* pathContext) {
+    static void postPathSignal(ActivityRegistry* a, HLTPathStatus const& status, PathContext const* pathContext) {
       a->postPathEventSignal_(*pathContext->streamContext(), *pathContext, status);
     }
-    
-    static const char* transitionName() {
-      return "Event";
-    }
+
+    static const char* transitionName() { return "Event"; }
   };
 
-  template <>
-  class OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> {
+  template <> class OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> {
   public:
     typedef RunPrincipal MyPrincipal;
     typedef GlobalContext Context;
@@ -72,37 +68,33 @@ namespace edm {
     static bool constexpr isEvent_ = false;
 
     static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
-      return GlobalContext(GlobalContext::Transition::kBeginRun,
-                           LuminosityBlockID(principal.run(), 0),
-                           principal.index(),
-                           LuminosityBlockIndex::invalidLuminosityBlockIndex(),
-                           principal.beginTime(),
-                           processContext);
+      return GlobalContext(GlobalContext::Transition::kBeginRun, LuminosityBlockID(principal.run(), 0),
+                           principal.index(), LuminosityBlockIndex::invalidLuminosityBlockIndex(),
+                           principal.beginTime(), processContext);
     }
 
-    static void preScheduleSignal(ActivityRegistry *a, GlobalContext const* globalContext) {
+    static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
       a->preGlobalBeginRunSignal_(*globalContext);
     }
-    static void postScheduleSignal(ActivityRegistry *a, GlobalContext const* globalContext) {
+    static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
       a->postGlobalBeginRunSignal_(*globalContext);
     }
-    static void prePathSignal(ActivityRegistry *, PathContext const* ) {
-    }
-    static void postPathSignal(ActivityRegistry *, HLTPathStatus const& , PathContext const* ) {
-    }
-    static void preModuleSignal(ActivityRegistry *a, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void prePathSignal(ActivityRegistry*, PathContext const*) {}
+    static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
+    static void preModuleSignal(ActivityRegistry* a,
+                                GlobalContext const* globalContext,
+                                ModuleCallingContext const* moduleCallingContext) {
       a->preModuleGlobalBeginRunSignal_(*globalContext, *moduleCallingContext);
     }
-    static void postModuleSignal(ActivityRegistry *a, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void postModuleSignal(ActivityRegistry* a,
+                                 GlobalContext const* globalContext,
+                                 ModuleCallingContext const* moduleCallingContext) {
       a->postModuleGlobalBeginRunSignal_(*globalContext, *moduleCallingContext);
     }
-    static const char* transitionName() {
-      return "global begin Run";
-    }
+    static const char* transitionName() { return "global begin Run"; }
   };
 
-  template <>
-  class OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> {
+  template <> class OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> {
   public:
     typedef RunPrincipal MyPrincipal;
     typedef StreamContext Context;
@@ -118,29 +110,28 @@ namespace edm {
       streamContext.setTimestamp(principal.beginTime());
     }
 
-    static void preScheduleSignal(ActivityRegistry *a, StreamContext const* streamContext) {
+    static void preScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
       a->preStreamBeginRunSignal_(*streamContext);
     }
-    static void postScheduleSignal(ActivityRegistry *a, StreamContext const* streamContext) {
+    static void postScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
       a->postStreamBeginRunSignal_(*streamContext);
     }
-    static void prePathSignal(ActivityRegistry *, PathContext const* ) {
-    }
-    static void postPathSignal(ActivityRegistry *, HLTPathStatus const& , PathContext const*) {
-    }
-    static void preModuleSignal(ActivityRegistry *a, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void prePathSignal(ActivityRegistry*, PathContext const*) {}
+    static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
+    static void preModuleSignal(ActivityRegistry* a,
+                                StreamContext const* streamContext,
+                                ModuleCallingContext const* moduleCallingContext) {
       a->preModuleStreamBeginRunSignal_(*streamContext, *moduleCallingContext);
     }
-    static void postModuleSignal(ActivityRegistry *a, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void postModuleSignal(ActivityRegistry* a,
+                                 StreamContext const* streamContext,
+                                 ModuleCallingContext const* moduleCallingContext) {
       a->postModuleStreamBeginRunSignal_(*streamContext, *moduleCallingContext);
     }
-    static const char* transitionName() {
-      return "stream begin Run";
-    }
+    static const char* transitionName() { return "stream begin Run"; }
   };
 
-  template <>
-  class OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> {
+  template <> class OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> {
   public:
     typedef RunPrincipal MyPrincipal;
     typedef StreamContext Context;
@@ -156,29 +147,28 @@ namespace edm {
       streamContext.setTimestamp(principal.endTime());
     }
 
-    static void preScheduleSignal(ActivityRegistry *a, StreamContext const* streamContext) {
+    static void preScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
       a->preStreamEndRunSignal_(*streamContext);
     }
-    static void postScheduleSignal(ActivityRegistry *a, StreamContext const* streamContext) {
+    static void postScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
       a->postStreamEndRunSignal_(*streamContext);
     }
-    static void prePathSignal(ActivityRegistry *, PathContext const* ) {
-    }
-    static void postPathSignal(ActivityRegistry *, HLTPathStatus const& , PathContext const* ) {
-    }
-    static void preModuleSignal(ActivityRegistry *a, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void prePathSignal(ActivityRegistry*, PathContext const*) {}
+    static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
+    static void preModuleSignal(ActivityRegistry* a,
+                                StreamContext const* streamContext,
+                                ModuleCallingContext const* moduleCallingContext) {
       a->preModuleStreamEndRunSignal_(*streamContext, *moduleCallingContext);
     }
-    static void postModuleSignal(ActivityRegistry *a, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void postModuleSignal(ActivityRegistry* a,
+                                 StreamContext const* streamContext,
+                                 ModuleCallingContext const* moduleCallingContext) {
       a->postModuleStreamEndRunSignal_(*streamContext, *moduleCallingContext);
     }
-    static const char* transitionName() {
-      return "stream end Run";
-    }
+    static const char* transitionName() { return "stream end Run"; }
   };
 
-  template <>
-  class OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> {
+  template <> class OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> {
   public:
     typedef RunPrincipal MyPrincipal;
     typedef GlobalContext Context;
@@ -187,37 +177,32 @@ namespace edm {
     static bool constexpr isEvent_ = false;
 
     static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
-      return GlobalContext(GlobalContext::Transition::kEndRun,
-                           LuminosityBlockID(principal.run(), 0),
-                           principal.index(),
-                           LuminosityBlockIndex::invalidLuminosityBlockIndex(),
-                           principal.endTime(),
-                           processContext);
+      return GlobalContext(GlobalContext::Transition::kEndRun, LuminosityBlockID(principal.run(), 0), principal.index(),
+                           LuminosityBlockIndex::invalidLuminosityBlockIndex(), principal.endTime(), processContext);
     }
 
-    static void preScheduleSignal(ActivityRegistry *a, GlobalContext const* globalContext) {
+    static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
       a->preGlobalEndRunSignal_(*globalContext);
     }
-    static void postScheduleSignal(ActivityRegistry *a, GlobalContext const* globalContext) {
+    static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
       a->postGlobalEndRunSignal_(*globalContext);
     }
-    static void prePathSignal(ActivityRegistry *, PathContext const*) {
-    }
-    static void postPathSignal(ActivityRegistry *, HLTPathStatus const& , PathContext const* ) {
-    }
-    static void preModuleSignal(ActivityRegistry *a, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void prePathSignal(ActivityRegistry*, PathContext const*) {}
+    static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
+    static void preModuleSignal(ActivityRegistry* a,
+                                GlobalContext const* globalContext,
+                                ModuleCallingContext const* moduleCallingContext) {
       a->preModuleGlobalEndRunSignal_(*globalContext, *moduleCallingContext);
     }
-    static void postModuleSignal(ActivityRegistry *a, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void postModuleSignal(ActivityRegistry* a,
+                                 GlobalContext const* globalContext,
+                                 ModuleCallingContext const* moduleCallingContext) {
       a->postModuleGlobalEndRunSignal_(*globalContext, *moduleCallingContext);
     }
-    static const char* transitionName() {
-      return "global end Run";
-    }
+    static const char* transitionName() { return "global end Run"; }
   };
 
-  template <>
-  class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> {
+  template <> class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> {
   public:
     typedef LuminosityBlockPrincipal MyPrincipal;
     typedef GlobalContext Context;
@@ -226,37 +211,32 @@ namespace edm {
     static bool constexpr isEvent_ = false;
 
     static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
-      return GlobalContext(GlobalContext::Transition::kBeginLuminosityBlock,
-                           principal.id(),
-                           principal.runPrincipal().index(),
-                           principal.index(),
-                           principal.beginTime(),
-                           processContext);
+      return GlobalContext(GlobalContext::Transition::kBeginLuminosityBlock, principal.id(),
+                           principal.runPrincipal().index(), principal.index(), principal.beginTime(), processContext);
     }
 
-    static void preScheduleSignal(ActivityRegistry *a, GlobalContext const* globalContext) {
+    static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
       a->preGlobalBeginLumiSignal_(*globalContext);
     }
-    static void postScheduleSignal(ActivityRegistry *a, GlobalContext const* globalContext) {
+    static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
       a->postGlobalBeginLumiSignal_(*globalContext);
     }
-    static void prePathSignal(ActivityRegistry *, PathContext const*) {
-    }
-    static void postPathSignal(ActivityRegistry *, HLTPathStatus const&, PathContext const*) {
-    }
-    static void preModuleSignal(ActivityRegistry *a, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void prePathSignal(ActivityRegistry*, PathContext const*) {}
+    static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
+    static void preModuleSignal(ActivityRegistry* a,
+                                GlobalContext const* globalContext,
+                                ModuleCallingContext const* moduleCallingContext) {
       a->preModuleGlobalBeginLumiSignal_(*globalContext, *moduleCallingContext);
     }
-    static void postModuleSignal(ActivityRegistry *a, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void postModuleSignal(ActivityRegistry* a,
+                                 GlobalContext const* globalContext,
+                                 ModuleCallingContext const* moduleCallingContext) {
       a->postModuleGlobalBeginLumiSignal_(*globalContext, *moduleCallingContext);
     }
-    static const char* transitionName() {
-      return "global begin LuminosityBlock";
-    }
+    static const char* transitionName() { return "global begin LuminosityBlock"; }
   };
 
-  template <>
-  class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> {
+  template <> class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> {
   public:
     typedef LuminosityBlockPrincipal MyPrincipal;
     typedef StreamContext Context;
@@ -272,29 +252,28 @@ namespace edm {
       streamContext.setTimestamp(principal.beginTime());
     }
 
-    static void preScheduleSignal(ActivityRegistry *a, StreamContext const* streamContext) {
+    static void preScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
       a->preStreamBeginLumiSignal_(*streamContext);
     }
-    static void postScheduleSignal(ActivityRegistry *a, StreamContext const* streamContext) {
+    static void postScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
       a->postStreamBeginLumiSignal_(*streamContext);
     }
-    static void prePathSignal(ActivityRegistry *, PathContext const*) {
-    }
-    static void postPathSignal(ActivityRegistry *, HLTPathStatus const&, PathContext const*) {
-    }
-    static void preModuleSignal(ActivityRegistry *a, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void prePathSignal(ActivityRegistry*, PathContext const*) {}
+    static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
+    static void preModuleSignal(ActivityRegistry* a,
+                                StreamContext const* streamContext,
+                                ModuleCallingContext const* moduleCallingContext) {
       a->preModuleStreamBeginLumiSignal_(*streamContext, *moduleCallingContext);
     }
-    static void postModuleSignal(ActivityRegistry *a, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void postModuleSignal(ActivityRegistry* a,
+                                 StreamContext const* streamContext,
+                                 ModuleCallingContext const* moduleCallingContext) {
       a->postModuleStreamBeginLumiSignal_(*streamContext, *moduleCallingContext);
     }
-    static const char* transitionName() {
-      return "stream begin LuminosityBlock";
-    }
+    static const char* transitionName() { return "stream begin LuminosityBlock"; }
   };
 
-  template <>
-  class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> {
+  template <> class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> {
   public:
     typedef LuminosityBlockPrincipal MyPrincipal;
     typedef StreamContext Context;
@@ -312,29 +291,28 @@ namespace edm {
       streamContext.setTimestamp(principal.endTime());
     }
 
-    static void preScheduleSignal(ActivityRegistry *a, StreamContext const* streamContext) {
+    static void preScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
       a->preStreamEndLumiSignal_(*streamContext);
     }
-    static void postScheduleSignal(ActivityRegistry *a, StreamContext const* streamContext) {
+    static void postScheduleSignal(ActivityRegistry* a, StreamContext const* streamContext) {
       a->postStreamEndLumiSignal_(*streamContext);
     }
-    static void prePathSignal(ActivityRegistry *, PathContext const* ) {
-    }
-    static void postPathSignal(ActivityRegistry *, HLTPathStatus const&, PathContext const*) {
-    }
-    static void preModuleSignal(ActivityRegistry *a, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void prePathSignal(ActivityRegistry*, PathContext const*) {}
+    static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
+    static void preModuleSignal(ActivityRegistry* a,
+                                StreamContext const* streamContext,
+                                ModuleCallingContext const* moduleCallingContext) {
       a->preModuleStreamEndLumiSignal_(*streamContext, *moduleCallingContext);
     }
-    static void postModuleSignal(ActivityRegistry *a, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void postModuleSignal(ActivityRegistry* a,
+                                 StreamContext const* streamContext,
+                                 ModuleCallingContext const* moduleCallingContext) {
       a->postModuleStreamEndLumiSignal_(*streamContext, *moduleCallingContext);
     }
-    static const char* transitionName() {
-      return "end stream LuminosityBlock";
-    }
+    static const char* transitionName() { return "end stream LuminosityBlock"; }
   };
 
-  template <>
-  class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> {
+  template <> class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> {
   public:
     typedef LuminosityBlockPrincipal MyPrincipal;
     typedef GlobalContext Context;
@@ -343,33 +321,29 @@ namespace edm {
     static bool constexpr isEvent_ = false;
 
     static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
-      return GlobalContext(GlobalContext::Transition::kEndLuminosityBlock,
-                           principal.id(),
-                           principal.runPrincipal().index(),
-                           principal.index(),
-                           principal.beginTime(),
-                           processContext);
+      return GlobalContext(GlobalContext::Transition::kEndLuminosityBlock, principal.id(),
+                           principal.runPrincipal().index(), principal.index(), principal.beginTime(), processContext);
     }
 
-    static void preScheduleSignal(ActivityRegistry *a, GlobalContext const* globalContext) {
+    static void preScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
       a->preGlobalEndLumiSignal_(*globalContext);
     }
-    static void postScheduleSignal(ActivityRegistry *a, GlobalContext const* globalContext) {
+    static void postScheduleSignal(ActivityRegistry* a, GlobalContext const* globalContext) {
       a->postGlobalEndLumiSignal_(*globalContext);
     }
-    static void prePathSignal(ActivityRegistry *, PathContext const*) {
-    }
-    static void postPathSignal(ActivityRegistry *, HLTPathStatus const& , PathContext const* ) {
-    }
-    static void preModuleSignal(ActivityRegistry *a, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void prePathSignal(ActivityRegistry*, PathContext const*) {}
+    static void postPathSignal(ActivityRegistry*, HLTPathStatus const&, PathContext const*) {}
+    static void preModuleSignal(ActivityRegistry* a,
+                                GlobalContext const* globalContext,
+                                ModuleCallingContext const* moduleCallingContext) {
       a->preModuleGlobalEndLumiSignal_(*globalContext, *moduleCallingContext);
     }
-    static void postModuleSignal(ActivityRegistry *a, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
+    static void postModuleSignal(ActivityRegistry* a,
+                                 GlobalContext const* globalContext,
+                                 ModuleCallingContext const* moduleCallingContext) {
       a->postModuleGlobalEndLumiSignal_(*globalContext, *moduleCallingContext);
     }
-    static const char* transitionName() {
-      return "end global LuminosityBlock";
-    }
+    static const char* transitionName() { return "end global LuminosityBlock"; }
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -45,7 +45,7 @@ namespace edm {
   class WaitingTask;
 
   namespace maker {
-    template<typename T> class ModuleHolderT;
+    template <typename T> class ModuleHolderT;
   }
 
   typedef detail::TriggerResultsBasedEventSelector::handle_t Trig;
@@ -60,48 +60,47 @@ namespace edm {
     explicit OutputModule(ParameterSet const& pset);
     ~OutputModule() override;
 
-    OutputModule(OutputModule const&) = delete; // Disallow copying and moving
-    OutputModule& operator=(OutputModule const&) = delete; // Disallow copying and moving
+    OutputModule(OutputModule const&) = delete;             // Disallow copying and moving
+    OutputModule& operator=(OutputModule const&) = delete;  // Disallow copying and moving
 
     /// Accessor for maximum number of events to be written.
     /// -1 is used for unlimited.
-    int maxEvents() const {return maxEvents_;}
+    int maxEvents() const { return maxEvents_; }
 
     /// Accessor for remaining number of events to be written.
     /// -1 is used for unlimited.
-    int remainingEvents() const {return remainingEvents_;}
+    int remainingEvents() const { return remainingEvents_; }
 
     bool selected(BranchDescription const& desc) const;
 
     void selectProducts(ProductRegistry const& preg, ThinnedAssociationsHelper const&);
-    std::string const& processName() const {return process_name_;}
-    SelectedProductsForBranchType const& keptProducts() const {return keptProducts_;}
-    std::array<bool, NumBranchTypes> const& hasNewlyDroppedBranch() const {return hasNewlyDroppedBranch_;}
+    std::string const& processName() const { return process_name_; }
+    SelectedProductsForBranchType const& keptProducts() const { return keptProducts_; }
+    std::array<bool, NumBranchTypes> const& hasNewlyDroppedBranch() const { return hasNewlyDroppedBranch_; }
 
-    static void fillDescription(ParameterSetDescription & desc, std::vector<std::string> const& iDefaultOutputCommands = ProductSelectorRules::defaultSelectionStrings());
+    static void fillDescription(
+        ParameterSetDescription& desc,
+        std::vector<std::string> const& iDefaultOutputCommands = ProductSelectorRules::defaultSelectionStrings());
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
     static const std::string& baseType();
-    static void prevalidate(ConfigurationDescriptions& );
+    static void prevalidate(ConfigurationDescriptions&);
 
-    static bool wantsGlobalRuns() {return true;}
-    static bool wantsGlobalLuminosityBlocks() {return true;}
-    static bool wantsStreamRuns() {return false;}
-    static bool wantsStreamLuminosityBlocks() {return false;};
+    static bool wantsGlobalRuns() { return true; }
+    static bool wantsGlobalLuminosityBlocks() { return true; }
+    static bool wantsStreamRuns() { return false; }
+    static bool wantsStreamLuminosityBlocks() { return false; };
 
-    SerialTaskQueue* globalRunsQueue() { return &runQueue_;}
-    SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_;}
-    SharedResourcesAcquirer& sharedResourcesAcquirer() {
-      return resourceAcquirer_;
-    }
+    SerialTaskQueue* globalRunsQueue() { return &runQueue_; }
+    SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_; }
+    SharedResourcesAcquirer& sharedResourcesAcquirer() { return resourceAcquirer_; }
 
-    bool wantAllEvents() const {return wantAllEvents_;}
+    bool wantAllEvents() const { return wantAllEvents_; }
 
     BranchIDLists const* branchIDLists();
 
     ThinnedAssociationsHelper const* thinnedAssociationsHelper() const;
 
   protected:
-
     // This function is needed for compatibility with older code. We
     // need to clean up the use of EventForOutputand EventPrincipal, to avoid
     // creation of multiple EventForOutputobjects when handling a single
@@ -109,8 +108,7 @@ namespace edm {
     Trig getTriggerResults(EDGetTokenT<TriggerResults> const& token, EventForOutput const& e) const;
 
     ModuleDescription const& description() const;
-    ModuleDescription const& moduleDescription() const { return moduleDescription_;
-    }
+    ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
     ParameterSetID selectorConfig() const { return selector_config_id_; }
 
@@ -118,23 +116,27 @@ namespace edm {
 
     void doBeginJob();
     void doEndJob();
-    bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
+    bool doEvent(EventPrincipal const& ep,
+                 EventSetupImpl const& c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     //Needed by WorkerT but not supported
-    void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+    void preActionBeforeRunEventAsync(WaitingTask* iTask,
+                                      ModuleCallingContext const& iModuleCallingContext,
+                                      Principal const& iPrincipal) const {}
 
-    bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c,
-                    ModuleCallingContext const* mcc);
-    bool doEndRun(RunPrincipal const& rp, EventSetupImpl const& c,
-                  ModuleCallingContext const* mcc);
-    bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
+    bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    bool doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                EventSetupImpl const& c,
                                 ModuleCallingContext const* mcc);
-    bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
+    bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                              EventSetupImpl const& c,
                               ModuleCallingContext const* mcc);
 
-    void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
-                               bool anyProductProduced);
+    void setEventSelectionInfo(
+        std::map<std::string, std::vector<std::pair<std::string, int>>> const& outputModulePathPositions,
+        bool anyProductProduced);
 
     void configure(OutputModuleDescription const& desc);
 
@@ -143,7 +145,6 @@ namespace edm {
     }
 
   private:
-
     int maxEvents_;
     std::atomic<int> remainingEvents_;
 
@@ -198,11 +199,10 @@ namespace edm {
     void doOpenFile(FileBlock const& fb);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
-    void doRegisterThinnedAssociations(ProductRegistry const&,
-                                       ThinnedAssociationsHelper&) { }
+    void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
-    std::string workerType() const {return "WorkerT<OutputModule>";}
-    
+    std::string workerType() const { return "WorkerT<OutputModule>"; }
+
     /// Tell the OutputModule that is must end the current file.
     void doCloseFile();
 
@@ -211,22 +211,22 @@ namespace edm {
     virtual void reallyCloseFile();
 
     void registerProductsAndCallbacks(OutputModule const*, ProductRegistry const*) {}
-    
+
     bool needToRunSelection() const;
     std::vector<ProductResolverIndexAndSkipBit> productsUsedBySelection() const;
     bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
 
     /// Ask the OutputModule if we should end the current file.
-    virtual bool shouldWeCloseFile() const {return false;}
+    virtual bool shouldWeCloseFile() const { return false; }
 
     virtual void write(EventForOutput const&) = 0;
-    virtual void beginJob(){}
-    virtual void endJob(){}
-    virtual void beginRun(RunForOutput const&){}
-    virtual void endRun(RunForOutput const&){}
+    virtual void beginJob() {}
+    virtual void endJob() {}
+    virtual void beginRun(RunForOutput const&) {}
+    virtual void endRun(RunForOutput const&) {}
     virtual void writeRun(RunForOutput const&) = 0;
-    virtual void beginLuminosityBlock(LuminosityBlockForOutput const&){}
-    virtual void endLuminosityBlock(LuminosityBlockForOutput const&){}
+    virtual void beginLuminosityBlock(LuminosityBlockForOutput const&) {}
+    virtual void endLuminosityBlock(LuminosityBlockForOutput const&) {}
     virtual void writeLuminosityBlock(LuminosityBlockForOutput const&) = 0;
     virtual void openFile(FileBlock const&) {}
     virtual void respondToOpenInputFile(FileBlock const&) {}
@@ -243,11 +243,9 @@ namespace edm {
                         std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
                         std::set<BranchID>& keptProductsInEvent);
 
-    void setModuleDescription(ModuleDescription const& md) {
-      moduleDescription_ = md;
-    }
+    void setModuleDescription(ModuleDescription const& md) { moduleDescription_ = md; }
 
-    bool limitReached() const {return remainingEvents_ == 0;}
+    bool limitReached() const { return remainingEvents_ == 0; }
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/OutputModuleDescription.h
+++ b/FWCore/Framework/interface/OutputModuleDescription.h
@@ -18,15 +18,14 @@ namespace edm {
     //OutputModuleDescription() : maxEvents_(-1) {}
     explicit OutputModuleDescription(BranchIDLists const& branchIDLists,
                                      int maxEvents = -1,
-                                     SubProcessParentageHelper const* subProcessParentageHelper = nullptr) :
-      branchIDLists_(&branchIDLists),
-      maxEvents_(maxEvents),
-      subProcessParentageHelper_(subProcessParentageHelper)
-    {}
+                                     SubProcessParentageHelper const* subProcessParentageHelper = nullptr)
+        : branchIDLists_(&branchIDLists),
+          maxEvents_(maxEvents),
+          subProcessParentageHelper_(subProcessParentageHelper) {}
     BranchIDLists const* branchIDLists_;
     int maxEvents_;
     SubProcessParentageHelper const* subProcessParentageHelper_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ParameterSetIDHolder.h
+++ b/FWCore/Framework/interface/ParameterSetIDHolder.h
@@ -7,16 +7,17 @@
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 
 namespace edm {
-   namespace eventsetup {
+  namespace eventsetup {
 
-      class ParameterSetIDHolder {
-      public:
-         ParameterSetIDHolder(ParameterSetID const& psetID) : psetID_(psetID) { }
-         ParameterSetID const& psetID() const { return psetID_; }
-         bool operator<(ParameterSetIDHolder const& other) const { return psetID() < other.psetID(); }
-         bool operator==(ParameterSetIDHolder const& other) const { return psetID() == other.psetID(); }
-      private:
-         ParameterSetID psetID_;
-      };
-   }
-}
+    class ParameterSetIDHolder {
+    public:
+      ParameterSetIDHolder(ParameterSetID const& psetID) : psetID_(psetID) {}
+      ParameterSetID const& psetID() const { return psetID_; }
+      bool operator<(ParameterSetIDHolder const& other) const { return psetID() < other.psetID(); }
+      bool operator==(ParameterSetIDHolder const& other) const { return psetID() == other.psetID(); }
+
+    private:
+      ParameterSetID psetID_;
+    };
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/interface/PathsAndConsumesOfModules.h
+++ b/FWCore/Framework/interface/PathsAndConsumesOfModules.h
@@ -28,13 +28,11 @@ namespace edm {
 
   class PathsAndConsumesOfModules : public PathsAndConsumesOfModulesBase {
   public:
-
     ~PathsAndConsumesOfModules() override;
 
     void initialize(Schedule const*, std::shared_ptr<ProductRegistry const>);
 
   private:
-
     std::vector<std::string> const& doPaths() const override { return paths_; }
     std::vector<std::string> const& doEndPaths() const override { return endPaths_; }
 
@@ -43,7 +41,8 @@ namespace edm {
 
     std::vector<ModuleDescription const*> const& doModulesOnPath(unsigned int pathIndex) const override;
     std::vector<ModuleDescription const*> const& doModulesOnEndPath(unsigned int endPathIndex) const override;
-    std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedBy(unsigned int moduleID) const override;
+    std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedBy(
+        unsigned int moduleID) const override;
 
     std::vector<ConsumesInfo> doConsumesInfo(unsigned int moduleID) const override;
 
@@ -68,9 +67,7 @@ namespace edm {
     Schedule const* schedule_;
     std::shared_ptr<ProductRegistry const> preg_;
   };
-  
-  void
-  checkForModuleDependencyCorrectness(edm::PathsAndConsumesOfModulesBase const& iPnC,
-                                      bool iPrintDependencies);
-}
+
+  void checkForModuleDependencyCorrectness(edm::PathsAndConsumesOfModulesBase const& iPnC, bool iPrintDependencies);
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -52,12 +52,12 @@ namespace edm {
   class UnscheduledConfigurator;
 
   struct FilledProductPtr {
-    bool operator()(propagate_const<std::shared_ptr<ProductResolverBase>> const& iObj) { return bool(iObj);}
+    bool operator()(propagate_const<std::shared_ptr<ProductResolverBase>> const& iObj) { return bool(iObj); }
   };
 
   class Principal : public EDProductGetter {
   public:
-    typedef std::vector<propagate_const<std::shared_ptr<ProductResolverBase>> > ProductResolverCollection;
+    typedef std::vector<propagate_const<std::shared_ptr<ProductResolverBase>>> ProductResolverCollection;
     typedef boost::filter_iterator<FilledProductPtr, ProductResolverCollection::const_iterator> const_iterator;
     typedef boost::filter_iterator<FilledProductPtr, ProductResolverCollection::iterator> iterator;
     typedef ProcessHistory::const_iterator ProcessNameConstIterator;
@@ -84,12 +84,12 @@ namespace edm {
     void fillPrincipal(ProcessHistoryID const& hist, ProcessHistoryRegistry const& phr, DelayedReader* reader);
 
     void clearPrincipal();
-    
+
     void setupUnscheduled(UnscheduledConfigurator const&);
-  
+
     void deleteProduct(BranchID const& id) const;
-    
-    EDProductGetter const* prodGetter() const {return this;}
+
+    EDProductGetter const* prodGetter() const { return this; }
 
     // Return a BasicHandle to the product which:
     //   1. matches the given label, instance, and process
@@ -101,22 +101,22 @@ namespace edm {
     //      c.  typeID is the same as or a public base of
     //      this value_type,
 
-    BasicHandle  getByLabel(KindOfType kindOfType,
-                            TypeID const& typeID,
-                            InputTag const& inputTag,
-                            EDConsumerBase const* consumes,
-                            SharedResourcesAcquirer* sra,
-                            ModuleCallingContext const* mcc) const;
+    BasicHandle getByLabel(KindOfType kindOfType,
+                           TypeID const& typeID,
+                           InputTag const& inputTag,
+                           EDConsumerBase const* consumes,
+                           SharedResourcesAcquirer* sra,
+                           ModuleCallingContext const* mcc) const;
 
-    BasicHandle  getByLabel(KindOfType kindOfType,
-                            TypeID const& typeID,
-                            std::string const& label,
-                            std::string const& instance,
-                            std::string const& process,
-                            EDConsumerBase const* consumes,
-                            SharedResourcesAcquirer* sra,
-                            ModuleCallingContext const* mcc) const;
-    
+    BasicHandle getByLabel(KindOfType kindOfType,
+                           TypeID const& typeID,
+                           std::string const& label,
+                           std::string const& instance,
+                           std::string const& process,
+                           EDConsumerBase const* consumes,
+                           SharedResourcesAcquirer* sra,
+                           ModuleCallingContext const* mcc) const;
+
     BasicHandle getByToken(KindOfType kindOfType,
                            TypeID const& typeID,
                            ProductResolverIndex index,
@@ -137,63 +137,67 @@ namespace edm {
                        SharedResourcesAcquirer* sra,
                        ModuleCallingContext const* mcc) const;
 
-    ProcessHistory const& processHistory() const {
-      return *processHistoryPtr_;
-    }
+    ProcessHistory const& processHistory() const { return *processHistoryPtr_; }
 
-    ProcessHistoryID const& processHistoryID() const {
-      return processHistoryID_;
-    }
+    ProcessHistoryID const& processHistoryID() const { return processHistoryID_; }
 
-    ProcessConfiguration const& processConfiguration() const {return *processConfiguration_;}
+    ProcessConfiguration const& processConfiguration() const { return *processConfiguration_; }
 
-    ProductRegistry const& productRegistry() const {return *preg_;}
+    ProductRegistry const& productRegistry() const { return *preg_; }
 
-    ProductResolverIndexHelper const& productLookup() const {return *productLookup_;}
+    ProductResolverIndexHelper const& productLookup() const { return *productLookup_; }
 
     // merge Principals containing different products.
     void recombine(Principal& other, std::vector<BranchID> const& bids);
 
     ProductResolverBase* getModifiableProductResolver(BranchID const& oid) {
-      return const_cast<ProductResolverBase*>( const_cast<const Principal*>(this)->getProductResolver(oid));
+      return const_cast<ProductResolverBase*>(const_cast<const Principal*>(this)->getProductResolver(oid));
     }
 
     size_t size() const;
 
     // These iterators skip over any null shared pointers
-    const_iterator begin() const {return boost::make_filter_iterator<FilledProductPtr>(productResolvers_.begin(), productResolvers_.end());}
-    const_iterator end() const {return  boost::make_filter_iterator<FilledProductPtr>(productResolvers_.end(), productResolvers_.end());}
+    const_iterator begin() const {
+      return boost::make_filter_iterator<FilledProductPtr>(productResolvers_.begin(), productResolvers_.end());
+    }
+    const_iterator end() const {
+      return boost::make_filter_iterator<FilledProductPtr>(productResolvers_.end(), productResolvers_.end());
+    }
 
-    iterator begin() {return boost::make_filter_iterator<FilledProductPtr>(productResolvers_.begin(), productResolvers_.end());}
-    iterator end() {return  boost::make_filter_iterator<FilledProductPtr>(productResolvers_.end(), productResolvers_.end());}
+    iterator begin() {
+      return boost::make_filter_iterator<FilledProductPtr>(productResolvers_.begin(), productResolvers_.end());
+    }
+    iterator end() {
+      return boost::make_filter_iterator<FilledProductPtr>(productResolvers_.end(), productResolvers_.end());
+    }
 
-    Provenance getProvenance(BranchID const& bid,
-                             ModuleCallingContext const* mcc) const;
+    Provenance getProvenance(BranchID const& bid, ModuleCallingContext const* mcc) const;
 
     void getAllProvenance(std::vector<Provenance const*>& provenances) const;
 
     void getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
 
-    BranchType const& branchType() const {return branchType_;}
-    
+    BranchType const& branchType() const { return branchType_; }
+
     //This will never return 0 so you can use 0 to mean unset
     typedef unsigned long CacheIdentifier_t;
-    CacheIdentifier_t cacheIdentifier() const {return cacheIdentifier_;}
+    CacheIdentifier_t cacheIdentifier() const { return cacheIdentifier_; }
 
-    DelayedReader* reader() const {return reader_;}
+    DelayedReader* reader() const { return reader_; }
 
     ConstProductResolverPtr getProductResolver(BranchID const& oid) const;
 
-    ProductData const* findProductByTag(TypeID const& typeID, InputTag const& tag, ModuleCallingContext const* mcc) const;
+    ProductData const* findProductByTag(TypeID const& typeID,
+                                        InputTag const& tag,
+                                        ModuleCallingContext const* mcc) const;
 
     void readAllFromSourceAndMergeImmediately(MergeableRunProductMetadata const* mergeableRunProductMetadata = nullptr);
-    
+
     std::vector<unsigned int> const& lookupProcessOrder() const { return lookupProcessOrder_; }
 
     ConstProductResolverPtr getProductResolverByIndex(ProductResolverIndex const& oid) const;
 
   protected:
-
     // ----- Add a new ProductResolver
     // *this takes ownership of the ProductResolver, which in turn owns its
     // data.
@@ -203,18 +207,16 @@ namespace edm {
     ProductResolverBase const* getExistingProduct(BranchID const& branchID) const;
     ProductResolverBase const* getExistingProduct(ProductResolverBase const& phb) const;
 
-    void putOrMerge(BranchDescription const& bd, std::unique_ptr<WrapperBase>  edp) const;
-    
+    void putOrMerge(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
+
     //F must take an argument of type ProductResolverBase*
-    template <typename F>
-    void applyToResolvers( F iFunc) {
-      for(auto& resolver: productResolvers_) {
+    template <typename F> void applyToResolvers(F iFunc) {
+      for (auto& resolver : productResolvers_) {
         iFunc(resolver.get());
       }
     }
-    
-  private:
 
+  private:
     void addScheduledProduct(std::shared_ptr<BranchDescription const> bd);
     void addSourceProduct(std::shared_ptr<BranchDescription const> bd);
     void addInputProduct(std::shared_ptr<BranchDescription const> bd);
@@ -223,13 +225,12 @@ namespace edm {
     void addSwitchProducerProduct(std::shared_ptr<BranchDescription const> bd);
     void addSwitchAliasProduct(std::shared_ptr<BranchDescription const> bd);
     void addParentProcessProduct(std::shared_ptr<BranchDescription const> bd);
-    
 
     WrapperBase const* getIt(ProductID const&) const override;
     WrapperBase const* getThinnedProduct(ProductID const&, unsigned int&) const override;
     void getThinnedProducts(ProductID const&,
-                                    std::vector<WrapperBase const*>&,
-                                    std::vector<unsigned int>&) const override;
+                            std::vector<WrapperBase const*>&,
+                            std::vector<unsigned int>&) const override;
 
     void findProducts(std::vector<ProductResolverBase const*> const& holders,
                       TypeID const& typeID,
@@ -254,7 +255,7 @@ namespace edm {
                                           ModuleCallingContext const* mcc) const;
 
     void putOrMerge(std::unique_ptr<WrapperBase> prod, ProductResolverBase const* productResolver) const;
-    
+
     std::shared_ptr<ProcessHistory const> processHistoryPtr_;
 
     ProcessHistoryID processHistoryID_;
@@ -263,7 +264,7 @@ namespace edm {
     ProcessConfiguration const* processConfiguration_;
 
     // A vector of product holders.
-    ProductResolverCollection productResolvers_; // products and provenances are persistent
+    ProductResolverCollection productResolvers_;  // products and provenances are persistent
 
     // Pointer to the product registry. There is one entry in the registry
     // for each EDProduct in the event.
@@ -283,24 +284,24 @@ namespace edm {
     // input ProcessHistory, the following pointer should be null.
     // The Principal does not own this object.
     edm::propagate_const<HistoryAppender*> historyAppender_;
-    
+
     CacheIdentifier_t cacheIdentifier_;
   };
 
   template <typename PROD>
-  inline
-  std::shared_ptr<Wrapper<PROD> const>
-    getProductByTag(Principal const& ep, InputTag const& tag, ModuleCallingContext const* mcc) {
+  inline std::shared_ptr<Wrapper<PROD> const> getProductByTag(Principal const& ep,
+                                                              InputTag const& tag,
+                                                              ModuleCallingContext const* mcc) {
     TypeID tid = TypeID(typeid(PROD));
     ProductData const* result = ep.findProductByTag(tid, tag, mcc);
-    if(result == nullptr) {
-      return std::shared_ptr<Wrapper<PROD> const>(); 
+    if (result == nullptr) {
+      return std::shared_ptr<Wrapper<PROD> const>();
     }
 
-    if(!(result->wrapper()->dynamicTypeInfo() == typeid(PROD))) {
+    if (!(result->wrapper()->dynamicTypeInfo() == typeid(PROD))) {
       handleimpl::throwConvertTypeError(typeid(PROD), result->wrapper()->dynamicTypeInfo());
     }
     return std::static_pointer_cast<Wrapper<PROD> const>(result->sharedConstWrapper());
   }
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -5,7 +5,7 @@
 //
 
 // Class  :     PrincipalGetAdapter
-// 
+//
 /**\class PrincipalGetAdapter PrincipalGetAdapter.h FWCore/Framework/interface/PrincipalGetAdapter.h
 
 Description: This is the implementation for accessing EDProducts and 
@@ -108,7 +108,6 @@ edm::Ref<AppleCollection> ref(refApples, index);
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/Transition.h"
 
-
 namespace edm {
 
   class ModuleCallingContext;
@@ -116,81 +115,65 @@ namespace edm {
   class ProducerBase;
 
   namespace principal_get_adapter_detail {
-    void
-    throwOnPutOfNullProduct(char const* principalType, TypeID const& productType, std::string const& productInstanceName);
-    void
-    throwOnPutOfUninitializedToken(char const* principalType, std::type_info const& productType);
-    void
-    throwOnPutOfWrongType(std::type_info const& wrongType, TypeID const& rightType);
-    void
-    throwOnPrematureRead(char const* principalType, TypeID const& productType, std::string const& moduleLabel, std::string const& productInstanceName);
-    void
-    throwOnPrematureRead(char const* principalType, TypeID const& productType);
+    void throwOnPutOfNullProduct(char const* principalType,
+                                 TypeID const& productType,
+                                 std::string const& productInstanceName);
+    void throwOnPutOfUninitializedToken(char const* principalType, std::type_info const& productType);
+    void throwOnPutOfWrongType(std::type_info const& wrongType, TypeID const& rightType);
+    void throwOnPrematureRead(char const* principalType,
+                              TypeID const& productType,
+                              std::string const& moduleLabel,
+                              std::string const& productInstanceName);
+    void throwOnPrematureRead(char const* principalType, TypeID const& productType);
 
-    void
-    throwOnPrematureRead(char const* principalType, TypeID const& productType, EDGetToken);
+    void throwOnPrematureRead(char const* principalType, TypeID const& productType, EDGetToken);
 
-  }
+  }  // namespace principal_get_adapter_detail
   class PrincipalGetAdapter {
   public:
-    PrincipalGetAdapter(Principal const& pcpl,
-		 ModuleDescription const& md, bool isComplete);
+    PrincipalGetAdapter(Principal const& pcpl, ModuleDescription const& md, bool isComplete);
 
     ~PrincipalGetAdapter();
 
-    PrincipalGetAdapter(PrincipalGetAdapter const&) = delete; // Disallow copying and moving
-    PrincipalGetAdapter& operator=(PrincipalGetAdapter const&) = delete; // Disallow copying and moving
+    PrincipalGetAdapter(PrincipalGetAdapter const&) = delete;             // Disallow copying and moving
+    PrincipalGetAdapter& operator=(PrincipalGetAdapter const&) = delete;  // Disallow copying and moving
 
     //size_t size() const;
-    
-    void setConsumer(EDConsumerBase const* iConsumer) {
-      consumer_ = iConsumer;
-    }
-    
-    void setSharedResourcesAcquirer(SharedResourcesAcquirer* iSra) {
-      resourcesAcquirer_ = iSra;
-    }
 
-    void setProducer(ProducerBase const* iProd) {
-      prodBase_ = iProd;
-    }
+    void setConsumer(EDConsumerBase const* iConsumer) { consumer_ = iConsumer; }
 
-    size_t numberOfProductsConsumed() const ;
-    
-    bool isComplete() const { return isComplete_;}
+    void setSharedResourcesAcquirer(SharedResourcesAcquirer* iSra) { resourcesAcquirer_ = iSra; }
 
-    template <typename PROD>
-    bool 
-    checkIfComplete() const;
-    
+    void setProducer(ProducerBase const* iProd) { prodBase_ = iProd; }
+
+    size_t numberOfProductsConsumed() const;
+
+    bool isComplete() const { return isComplete_; }
+
+    template <typename PROD> bool checkIfComplete() const;
+
     Transition transition() const;
 
     template <typename PROD>
-    void 
-    getManyByType(std::vector<Handle<PROD> >& results, ModuleCallingContext const* mcc) const;
+    void getManyByType(std::vector<Handle<PROD> >& results, ModuleCallingContext const* mcc) const;
 
-    ProcessHistory const&
-    processHistory() const;
+    ProcessHistory const& processHistory() const;
 
-    Principal const& principal() const {return principal_;}
+    Principal const& principal() const { return principal_; }
 
-    BranchDescription const&
-    getBranchDescription(TypeID const& type, std::string const& productInstanceName) const;
+    BranchDescription const& getBranchDescription(TypeID const& type, std::string const& productInstanceName) const;
 
-    EDPutToken::value_type
-    getPutTokenIndex(TypeID const& type, std::string const& productInstanceName) const;
+    EDPutToken::value_type getPutTokenIndex(TypeID const& type, std::string const& productInstanceName) const;
 
     TypeID const& getTypeIDForPutTokenIndex(EDPutToken::value_type index) const;
     std::string const& productInstanceLabel(EDPutToken) const;
-    typedef std::vector<BasicHandle>  BasicHandleVec;
+    typedef std::vector<BasicHandle> BasicHandleVec;
 
-    BranchDescription const&
-    getBranchDescription(unsigned int iPutTokenIndex) const;
+    BranchDescription const& getBranchDescription(unsigned int iPutTokenIndex) const;
     ProductID const& getProductID(unsigned int iPutTokenIndex) const;
-    
-    std::vector<edm::ProductResolverIndex> const&
-    putTokenIndexToProductResolverIndex() const ;
-    
+
+    std::vector<edm::ProductResolverIndex> const& putTokenIndexToProductResolverIndex() const;
+
     //uses the EDPutToken index
     std::vector<bool> const& recordProvenanceList() const;
     //------------------------------------------------------------
@@ -200,37 +183,30 @@ namespace edm {
     // The following 'get' functions serve to isolate the PrincipalGetAdapter class
     // from the Principal class.
 
-    BasicHandle 
-    getByLabel_(TypeID const& tid, InputTag const& tag,
-                ModuleCallingContext const* mcc) const;
+    BasicHandle getByLabel_(TypeID const& tid, InputTag const& tag, ModuleCallingContext const* mcc) const;
 
-    BasicHandle 
-    getByLabel_(TypeID const& tid,
-                std::string const& label,
-                std::string const& instance,
-                std::string const& process,
-                ModuleCallingContext const* mcc) const;
+    BasicHandle getByLabel_(TypeID const& tid,
+                            std::string const& label,
+                            std::string const& instance,
+                            std::string const& process,
+                            ModuleCallingContext const* mcc) const;
 
-    BasicHandle
-    getByToken_(TypeID const& id, KindOfType kindOfType, EDGetToken token,
-                ModuleCallingContext const* mcc) const;
+    BasicHandle getByToken_(TypeID const& id,
+                            KindOfType kindOfType,
+                            EDGetToken token,
+                            ModuleCallingContext const* mcc) const;
 
-    BasicHandle
-    getMatchingSequenceByLabel_(TypeID const& typeID,
-                                InputTag const& tag,
-                                ModuleCallingContext const* mcc) const;
+    BasicHandle getMatchingSequenceByLabel_(TypeID const& typeID,
+                                            InputTag const& tag,
+                                            ModuleCallingContext const* mcc) const;
 
-    BasicHandle
-    getMatchingSequenceByLabel_(TypeID const& typeID,
-                                std::string const& label,
-                                std::string const& instance,
-                                std::string const& process,
-                                ModuleCallingContext const* mcc) const;
-    
-    void 
-    getManyByType_(TypeID const& tid, 
-		   BasicHandleVec& results,
-                   ModuleCallingContext const* mcc) const;
+    BasicHandle getMatchingSequenceByLabel_(TypeID const& typeID,
+                                            std::string const& label,
+                                            std::string const& instance,
+                                            std::string const& process,
+                                            ModuleCallingContext const* mcc) const;
+
+    void getManyByType_(TypeID const& tid, BasicHandleVec& results, ModuleCallingContext const* mcc) const;
 
     // Also isolates the PrincipalGetAdapter class
     // from the Principal class.
@@ -242,15 +218,12 @@ namespace edm {
     // Is this an Event, a LuminosityBlock, or a Run.
     BranchType const& branchType() const;
 
-    BasicHandle
-    makeFailToGetException(KindOfType,TypeID const&,EDGetToken) const;
+    BasicHandle makeFailToGetException(KindOfType, TypeID const&, EDGetToken) const;
 
-    void
-    throwAmbiguousException(TypeID const& productType, EDGetToken token) const;
+    void throwAmbiguousException(TypeID const& productType, EDGetToken token) const;
 
-    void
-    throwUnregisteredPutException(TypeID const& type,
-                                  std::string const& productInstanceLabel) const;
+    void throwUnregisteredPutException(TypeID const& type, std::string const& productInstanceLabel) const;
+
   private:
     //------------------------------------------------------------
     // Data members
@@ -263,21 +236,17 @@ namespace edm {
     // Each PrincipalGetAdapter must have a description of the module executing the
     // "transaction" which the PrincipalGetAdapter represents.
     ModuleDescription const& md_;
-    
+
     EDConsumerBase const* consumer_;
-    SharedResourcesAcquirer* resourcesAcquirer_; // We do not use propagate_const because the acquirer is itself mutable.
+    SharedResourcesAcquirer* resourcesAcquirer_;  // We do not use propagate_const because the acquirer is itself mutable.
     ProducerBase const* prodBase_ = nullptr;
     bool isComplete_;
   };
 
-  template <typename PROD>
-  inline
-  std::ostream& 
-  operator<<(std::ostream& os, Handle<PROD> const& h) {
+  template <typename PROD> inline std::ostream& operator<<(std::ostream& os, Handle<PROD> const& h) {
     os << h.product() << " " << h.provenance() << " " << h.id();
     return os;
   }
-
 
   //------------------------------------------------------------
   // Metafunction support for compile-time selection of code used in
@@ -294,23 +263,21 @@ namespace edm {
   // no such member function.
 
   namespace detail {
-    using no_tag = std::false_type; // type indicating FALSE
-    using yes_tag = std::true_type; // type indicating TRUE
+    using no_tag = std::false_type;  // type indicating FALSE
+    using yes_tag = std::true_type;  // type indicating TRUE
 
     // Definitions forthe following struct and function templates are
     // not needed; we only require the declarations.
-    template <typename T, void (T::*)()>  struct postinsert_function;
-    template <typename T> no_tag  has_postinsert_helper(...);
-    template <typename T> yes_tag has_postinsert_helper(postinsert_function<T, &T::post_insert> * p);
+    template <typename T, void (T::*)()> struct postinsert_function;
+    template <typename T> no_tag has_postinsert_helper(...);
+    template <typename T> yes_tag has_postinsert_helper(postinsert_function<T, &T::post_insert>* p);
 
-
-    template<typename T>
-    struct has_postinsert {
+    template <typename T> struct has_postinsert {
       static constexpr bool value = std::is_same<decltype(has_postinsert_helper<T>(nullptr)), yes_tag>::value &&
-	!std::is_base_of<DoNotSortUponInsertion, T>::value;
+                                    !std::is_base_of<DoNotSortUponInsertion, T>::value;
     };
 
-  }
+  }  // namespace detail
 
   //------------------------------------------------------------
 
@@ -318,35 +285,28 @@ namespace edm {
   // control of a metafunction if, to either call the given object's
   // post_insert function (if it has one), or to do nothing (if it
   // does not have a post_insert function).
-  template <typename T>
-  struct DoPostInsert {
+  template <typename T> struct DoPostInsert {
     void operator()(T* p) const { p->post_insert(); }
   };
 
-  template <typename T>
-  struct DoNotPostInsert {
-    void operator()(T*) const { }
+  template <typename T> struct DoNotPostInsert {
+    void operator()(T*) const {}
   };
 
   // Implementation of  PrincipalGetAdapter  member templates. See  PrincipalGetAdapter.cc for the
   // implementation of non-template members.
   //
 
-  template <typename PROD>
-  inline
-  bool 
-  PrincipalGetAdapter::checkIfComplete() const { 
+  template <typename PROD> inline bool PrincipalGetAdapter::checkIfComplete() const {
     return isComplete() || !detail::has_mergeProduct_function<PROD>::value;
   }
 
   template <typename PROD>
-  inline
-  void 
-  PrincipalGetAdapter::getManyByType(std::vector<Handle<PROD> >& results,
-                                     ModuleCallingContext const* mcc) const { 
+  inline void PrincipalGetAdapter::getManyByType(std::vector<Handle<PROD> >& results,
+                                                 ModuleCallingContext const* mcc) const {
     BasicHandleVec bhv;
     this->getManyByType_(TypeID(typeid(PROD)), bhv, mcc);
-    
+
     // Go through the returned handles; for each element,
     //   1. create a Handle<PROD> and
     //
@@ -370,5 +330,5 @@ namespace edm {
     }
     results.swap(products);
   }
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ProcessMatch.h
+++ b/FWCore/Framework/interface/ProcessMatch.h
@@ -16,17 +16,16 @@ See comments in the file GetterOfProducts.h for a description.
 
 namespace edm {
 
-   class ProcessMatch {
-   public:
+  class ProcessMatch {
+  public:
+    ProcessMatch(std::string const& processName) : processName_(processName) {}
 
-      ProcessMatch(std::string const& processName) : processName_(processName) { }
+    bool operator()(edm::BranchDescription const& branchDescription) {
+      return branchDescription.processName() == processName_ || processName_ == "*";
+    }
 
-      bool operator()(edm::BranchDescription const& branchDescription) {
-         return branchDescription.processName() == processName_ || processName_ == "*";
-      }
-
-   private:
-      std::string processName_;
-   };
-}
+  private:
+    std::string processName_;
+  };
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ProcessingController.h
+++ b/FWCore/Framework/interface/ProcessingController.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ProcessingController
-// 
+//
 /**\class ProcessingController ProcessingController.h FWCore/Framework/interface/ProcessingController.h
 
  Description: Interface used by an EDLooper to specify what event we should process next
@@ -25,83 +25,78 @@
 
 // forward declarations
 namespace edm {
-   
-   class ProcessingController {
-      
-   public:
-      enum ForwardState {
-         kEventsAheadInFile,
-         kNextFileExists, // but no events ahead in this file
-         kAtLastEvent,
-         kUnknownForward // returned by a source which is not random accessible
-      };
 
-      enum ReverseState {
-         kEventsBackwardsInFile,
-         kPreviousFileExists, // but no events backwards in this file
-         kAtFirstEvent,
-         kUnknownReverse // returned by a source which is not random accessible
-      };
+  class ProcessingController {
+  public:
+    enum ForwardState {
+      kEventsAheadInFile,
+      kNextFileExists,  // but no events ahead in this file
+      kAtLastEvent,
+      kUnknownForward  // returned by a source which is not random accessible
+    };
 
-      ProcessingController(ForwardState forwardState, ReverseState reverseState, bool iCanRandomAccess);
-      //virtual ~ProcessingController();
-      
-      // ---------- const member functions ---------------------
+    enum ReverseState {
+      kEventsBackwardsInFile,
+      kPreviousFileExists,  // but no events backwards in this file
+      kAtFirstEvent,
+      kUnknownReverse  // returned by a source which is not random accessible
+    };
 
-      ///Returns the present state of processing
-      ForwardState forwardState() const;
-      ReverseState reverseState() const;
+    ProcessingController(ForwardState forwardState, ReverseState reverseState, bool iCanRandomAccess);
+    //virtual ~ProcessingController();
 
-      ///Returns 'true' if the job's source can randomly access
-      bool canRandomAccess() const;
+    // ---------- const member functions ---------------------
 
-      enum Transition {
-         kToNextEvent,
-         kToPreviousEvent,
-         kToSpecifiedEvent
-      };
-      
-      Transition requestedTransition() const;
-      
-      ///If 'setTransitionToEvent was called this returns the value passed,
-      /// else it returns an invalid EventID
-      edm::EventID specifiedEventTransition() const;
+    ///Returns the present state of processing
+    ForwardState forwardState() const;
+    ReverseState reverseState() const;
 
-      bool lastOperationSucceeded() const;
+    ///Returns 'true' if the job's source can randomly access
+    bool canRandomAccess() const;
 
-      // ---------- static member functions --------------------
-      
-      // ---------- member functions ---------------------------
-      
-      /** Tells the framework that we should go onto the next event in the sequence.
+    enum Transition { kToNextEvent, kToPreviousEvent, kToSpecifiedEvent };
+
+    Transition requestedTransition() const;
+
+    ///If 'setTransitionToEvent was called this returns the value passed,
+    /// else it returns an invalid EventID
+    edm::EventID specifiedEventTransition() const;
+
+    bool lastOperationSucceeded() const;
+
+    // ---------- static member functions --------------------
+
+    // ---------- member functions ---------------------------
+
+    /** Tells the framework that we should go onto the next event in the sequence.
        If there is no next event the job will drop out of the event loop.
        */
-      void setTransitionToNextEvent();
-      
-      /** Tells the framework we should backup and run the previous event seen in the sequence.
+    void setTransitionToNextEvent();
+
+    /** Tells the framework we should backup and run the previous event seen in the sequence.
        If you are already at the first event the job will drop out of the event loop
        */
-      void setTransitionToPreviousEvent();
-      
-      /** Tells the framework that the next event to processes should be iID.
+    void setTransitionToPreviousEvent();
+
+    /** Tells the framework that the next event to processes should be iID.
        If event iID can not be found in the source, the job will drop out of the event loop.
        */
-      void setTransitionToEvent( edm::EventID const& iID);
+    void setTransitionToEvent(edm::EventID const& iID);
 
-      void setLastOperationSucceeded(bool value);
+    void setLastOperationSucceeded(bool value);
 
-   private:
-      ProcessingController(const ProcessingController&) = delete; // stop default
-      
-      const ProcessingController& operator=(const ProcessingController&) = delete; // stop default
-      
-      // ---------- member data --------------------------------
-      ForwardState forwardState_;
-      ReverseState reverseState_;
-      Transition transition_;
-      EventID specifiedEvent_;
-      bool canRandomAccess_;
-      bool lastOperationSucceeded_;
-   };
-}
+  private:
+    ProcessingController(const ProcessingController&) = delete;  // stop default
+
+    const ProcessingController& operator=(const ProcessingController&) = delete;  // stop default
+
+    // ---------- member data --------------------------------
+    ForwardState forwardState_;
+    ReverseState reverseState_;
+    Transition transition_;
+    EventID specifiedEvent_;
+    bool canRandomAccess_;
+    bool lastOperationSucceeded_;
+  };
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -24,73 +24,65 @@ namespace edm {
   class Event;
   class LuminosityBlock;
   class Run;
-  
+
   class EDProducer;
   class EDFilter;
   namespace one {
     class EDProducerBase;
     class EDFilterBase;
-  }
+  }  // namespace one
   namespace global {
     class EDProducerBase;
     class EDFilterBase;
-  }
+  }  // namespace global
   namespace limited {
     class EDProducerBase;
     class EDFilterBase;
-  }
+  }  // namespace limited
   namespace stream {
-    template<typename T> class ProducingModuleAdaptorBase;
+    template <typename T> class ProducingModuleAdaptorBase;
   }
-  
-  namespace producerbasehelper{
-    template<typename P> struct PrincipalTraits;
-    template<> struct PrincipalTraits<Run> {
-      static constexpr int kBranchType = InRun;
-    };
-    template<> struct PrincipalTraits<LuminosityBlock> {
-      static constexpr int kBranchType = InLumi;
-    };
-    template<> struct PrincipalTraits<Event> {
-      static constexpr int kBranchType = InEvent;
-    };
-  }
-  
+
+  namespace producerbasehelper {
+    template <typename P> struct PrincipalTraits;
+    template <> struct PrincipalTraits<Run> { static constexpr int kBranchType = InRun; };
+    template <> struct PrincipalTraits<LuminosityBlock> { static constexpr int kBranchType = InLumi; };
+    template <> struct PrincipalTraits<Event> { static constexpr int kBranchType = InEvent; };
+  }  // namespace producerbasehelper
+
   class ProducerBase : private ProductRegistryHelper {
   public:
     typedef ProductRegistryHelper::TypeLabelList TypeLabelList;
-    ProducerBase ();
+    ProducerBase();
     ~ProducerBase() noexcept(false) override;
- 
+
     /// used by the fwk to register list of products
     std::function<void(BranchDescription const&)> registrationCallback() const;
 
-    void registerProducts(ProducerBase*,
-			ProductRegistry*,
-			ModuleDescription const&);
+    void registerProducts(ProducerBase*, ProductRegistry*, ModuleDescription const&);
 
     using ProductRegistryHelper::produces;
-    using ProductRegistryHelper::typeLabelList;
     using ProductRegistryHelper::recordProvenanceList;
+    using ProductRegistryHelper::typeLabelList;
 
     void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
-       callWhenNewProductsRegistered_ = func;
+      callWhenNewProductsRegistered_ = func;
     }
-    
-    using ModuleToResolverIndicies = std::unordered_multimap<std::string,
-    std::tuple<edm::TypeID const*, const char*, edm::ProductResolverIndex>>;
+
+    using ModuleToResolverIndicies =
+        std::unordered_multimap<std::string, std::tuple<edm::TypeID const*, const char*, edm::ProductResolverIndex>>;
     void resolvePutIndicies(BranchType iBranchType,
                             ModuleToResolverIndicies const& iIndicies,
                             std::string const& moduleLabel);
-    
+
     std::vector<edm::ProductResolverIndex> const& indiciesForPutProducts(BranchType iBranchType) const {
       return putIndicies_[iBranchType];
     }
-    
-    std::vector<edm::ProductResolverIndex> const&
-    putTokenIndexToProductResolverIndex() const {
+
+    std::vector<edm::ProductResolverIndex> const& putTokenIndexToProductResolverIndex() const {
       return putTokenToResolverIndex_;
     }
+
   private:
     friend class EDProducer;
     friend class EDFilter;
@@ -101,15 +93,13 @@ namespace edm {
     friend class limited::EDProducerBase;
     friend class limited::EDFilterBase;
     friend class PuttableSourceBase;
-    template<typename T> friend class stream::ProducingModuleAdaptorBase;
-    
-    template< typename P>
-    void commit_(P& iPrincipal) {
+    template <typename T> friend class stream::ProducingModuleAdaptorBase;
+
+    template <typename P> void commit_(P& iPrincipal) {
       iPrincipal.commit_(putIndicies_[producerbasehelper::PrincipalTraits<P>::kBranchType]);
     }
 
-    template< typename P, typename I>
-    void commit_(P& iPrincipal, I* iID) {
+    template <typename P, typename I> void commit_(P& iPrincipal, I* iID) {
       iPrincipal.commit_(putIndicies_[producerbasehelper::PrincipalTraits<P>::kBranchType], iID);
     }
 
@@ -117,5 +107,5 @@ namespace edm {
     std::array<std::vector<edm::ProductResolverIndex>, edm::NumBranchTypes> putIndicies_;
     std::vector<edm::ProductResolverIndex> putTokenToResolverIndex_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ProductDeletedException.h
+++ b/FWCore/Framework/interface/ProductDeletedException.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ProductDeletedException
-// 
+//
 /**\class ProductDeletedException ProductDeletedException.h FWCore/Framework/interface/ProductDeletedException.h
 
  Description: Exception thrown if attempt to get data that has been deleted
@@ -26,25 +26,23 @@
 // forward declarations
 namespace edm {
   class ProductDeletedException : public cms::Exception {
-    
   public:
     ProductDeletedException();
     //virtual ~ProductDeletedException();
-    
+
     // ---------- const member functions ---------------------
-    
+
     // ---------- static member functions --------------------
-    
+
     // ---------- member functions ---------------------------
-    
+
   private:
     //ProductDeletedException(const ProductDeletedException&); // stop default
-    
+
     //const ProductDeletedException& operator=(const ProductDeletedException&); // stop default
-    
+
     // ---------- member data --------------------------------
-    
   };
-  
-}
+
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -19,7 +19,7 @@ namespace edm {
   class ModuleDescription;
   class ProductRegistry;
   struct DoNotRecordParents;
-  
+
   class ProductRegistryHelper {
   public:
     virtual ~ProductRegistryHelper() noexcept(false);
@@ -27,21 +27,19 @@ namespace edm {
 
     // has_donotrecordparents<T>::value is true if we should not
     // record parentage for type T, and false otherwise.
-    template <typename T>
-    struct has_donotrecordparents {
-      static constexpr bool value =
-      std::is_base_of<DoNotRecordParents,T>::value;
+    template <typename T> struct has_donotrecordparents {
+      static constexpr bool value = std::is_base_of<DoNotRecordParents, T>::value;
     };
 
     struct TypeLabelItem {
       enum class AliasType { kBranchAlias, kSwitchAlias };
 
-      TypeLabelItem (Transition const& transition, TypeID const& tid, std::string pin) :
-	      transition_(transition),
-        typeID_(tid),
-        productInstanceName_(std::move(pin)),
-        branchAlias_(),
-        aliasType_(AliasType::kBranchAlias) {}
+      TypeLabelItem(Transition const& transition, TypeID const& tid, std::string pin)
+          : transition_(transition),
+            typeID_(tid),
+            productInstanceName_(std::move(pin)),
+            branchAlias_(),
+            aliasType_(AliasType::kBranchAlias) {}
       Transition transition_;
       TypeID typeID_;
       std::string productInstanceName_;
@@ -50,9 +48,8 @@ namespace edm {
     };
 
     struct BranchAliasSetter {
-      BranchAliasSetter(TypeLabelItem& iItem, EDPutToken iToken):
-      value_(iItem), token_(std::move(iToken)) {}
-      
+      BranchAliasSetter(TypeLabelItem& iItem, EDPutToken iToken) : value_(iItem), token_(std::move(iToken)) {}
+
       BranchAliasSetter& setBranchAlias(std::string alias) {
         value_.branchAlias_ = std::move(alias);
         return *this;
@@ -64,120 +61,109 @@ namespace edm {
       }
       TypeLabelItem& value_;
       EDPutToken token_;
-      
-      operator EDPutToken() { return token_;}
+
+      operator EDPutToken() { return token_; }
     };
 
-    template <typename T>
-    struct BranchAliasSetterT {
-      BranchAliasSetterT(TypeLabelItem& iItem, EDPutTokenT<T> iToken):
-      value_(iItem), token_(std::move(iToken)) {}
+    template <typename T> struct BranchAliasSetterT {
+      BranchAliasSetterT(TypeLabelItem& iItem, EDPutTokenT<T> iToken) : value_(iItem), token_(std::move(iToken)) {}
 
-      BranchAliasSetterT( BranchAliasSetter&& iS):
-      value_(iS.value_), token_(iS.token_.index()) {}
-      
+      BranchAliasSetterT(BranchAliasSetter&& iS) : value_(iS.value_), token_(iS.token_.index()) {}
+
       BranchAliasSetterT<T>& setBranchAlias(std::string alias) {
         value_.branchAlias_ = std::move(alias);
         return *this;
       }
       TypeLabelItem& value_;
       EDPutTokenT<T> token_;
-      
-      operator EDPutTokenT<T>() { return token_;}
+
+      operator EDPutTokenT<T>() { return token_; }
       operator EDPutToken() { return EDPutToken(token_.index()); }
     };
 
     typedef std::vector<TypeLabelItem> TypeLabelList;
 
-    /// used by the fwk to register the list of products of this module 
+    /// used by the fwk to register the list of products of this module
     TypeLabelList const& typeLabelList() const;
-    
-    std::vector<bool> const& recordProvenanceList() const { return recordProvenanceList_;}
 
-    static
-    void addToRegistry(TypeLabelList::const_iterator const& iBegin,
-                             TypeLabelList::const_iterator const& iEnd,
-                             ModuleDescription const& iDesc,
-                             ProductRegistry& iReg,
-                             ProductRegistryHelper* iProd,
-                             bool iIsListener=false);
+    std::vector<bool> const& recordProvenanceList() const { return recordProvenanceList_; }
 
-    /// declare what type of product will make and with which optional label 
+    static void addToRegistry(TypeLabelList::const_iterator const& iBegin,
+                              TypeLabelList::const_iterator const& iEnd,
+                              ModuleDescription const& iDesc,
+                              ProductRegistry& iReg,
+                              ProductRegistryHelper* iProd,
+                              bool iIsListener = false);
+
+    /// declare what type of product will make and with which optional label
     /** the statement
         \code
            produces<ProductType>("optlabel");
         \endcode
         should be added to the producer ctor for every product */
 
-
-    template <class ProductType> 
-    BranchAliasSetterT<ProductType> produces() {
+    template <class ProductType> BranchAliasSetterT<ProductType> produces() {
       return produces<ProductType, InEvent>(std::string());
     }
 
-    template <class ProductType> 
-    BranchAliasSetterT<ProductType> produces(std::string instanceName) {
-      return produces<ProductType, InEvent>( std::move(instanceName));
+    template <class ProductType> BranchAliasSetterT<ProductType> produces(std::string instanceName) {
+      return produces<ProductType, InEvent>(std::move(instanceName));
     }
 
-    template <typename ProductType, BranchType B> 
-    BranchAliasSetterT<ProductType> produces() {
+    template <typename ProductType, BranchType B> BranchAliasSetterT<ProductType> produces() {
       return produces<ProductType, B>(std::string());
     }
 
-    template <typename ProductType, BranchType B> 
-    BranchAliasSetterT<ProductType> produces(std::string instanceName) {
+    template <typename ProductType, BranchType B> BranchAliasSetterT<ProductType> produces(std::string instanceName) {
       TypeID tid(typeid(ProductType));
-      return BranchAliasSetterT<ProductType>{produces<B>(tid,std::move(instanceName),
-                                                         (not has_donotrecordparents<ProductType>::value) and B == InEvent)};
+      return BranchAliasSetterT<ProductType>{
+          produces<B>(tid, std::move(instanceName), (not has_donotrecordparents<ProductType>::value) and B == InEvent)};
     }
 
-    template <typename ProductType, Transition B>
-    BranchAliasSetterT<ProductType> produces() {
+    template <typename ProductType, Transition B> BranchAliasSetterT<ProductType> produces() {
       return produces<ProductType, B>(std::string());
     }
-    
-    template <typename ProductType, Transition B>
-    BranchAliasSetterT<ProductType> produces(std::string instanceName) {
+
+    template <typename ProductType, Transition B> BranchAliasSetterT<ProductType> produces(std::string instanceName) {
       TypeID tid(typeid(ProductType));
-      return BranchAliasSetterT<ProductType>{produces<B>(tid,std::move(instanceName),
-                                                         (not has_donotrecordparents<ProductType>::value) and B == Transition::Event)};
+      return BranchAliasSetterT<ProductType>{produces<B>(
+          tid, std::move(instanceName), (not has_donotrecordparents<ProductType>::value) and B == Transition::Event)};
     }
 
-   
-    BranchAliasSetter produces(const TypeID& id, std::string instanceName=std::string(), bool recordProvenance = true) {
-      return produces<Transition::Event>(id,std::move(instanceName),recordProvenance);
+    BranchAliasSetter produces(const TypeID& id,
+                               std::string instanceName = std::string(),
+                               bool recordProvenance = true) {
+      return produces<Transition::Event>(id, std::move(instanceName), recordProvenance);
     }
 
     template <BranchType B>
-    BranchAliasSetter produces(const TypeID& id, std::string instanceName=std::string(), bool recordProvenance = true) {
-      unsigned int index =typeLabelList_.size();
+    BranchAliasSetter produces(const TypeID& id,
+                               std::string instanceName = std::string(),
+                               bool recordProvenance = true) {
+      unsigned int index = typeLabelList_.size();
       typeLabelList_.emplace_back(convertToTransition(B), id, std::move(instanceName));
       recordProvenanceList_.push_back(recordProvenance and B == InEvent);
-      return BranchAliasSetter{typeLabelList_.back(),EDPutToken{static_cast<unsigned int>(index)}};
+      return BranchAliasSetter{typeLabelList_.back(), EDPutToken{static_cast<unsigned int>(index)}};
     }
     template <Transition B>
-    BranchAliasSetter produces(const TypeID& id, std::string instanceName=std::string(), bool recordProvenance = true) {
-      unsigned int index =typeLabelList_.size();
+    BranchAliasSetter produces(const TypeID& id,
+                               std::string instanceName = std::string(),
+                               bool recordProvenance = true) {
+      unsigned int index = typeLabelList_.size();
       typeLabelList_.emplace_back(B, id, std::move(instanceName));
       recordProvenanceList_.push_back(recordProvenance and B == Transition::Event);
-      return BranchAliasSetter{typeLabelList_.back(),EDPutToken{ index }};
+      return BranchAliasSetter{typeLabelList_.back(), EDPutToken{index}};
     }
 
-    virtual bool hasAbilityToProduceInRuns() const {
-      return false;
-    }
+    virtual bool hasAbilityToProduceInRuns() const { return false; }
 
-    virtual bool hasAbilityToProduceInLumis() const {
-      return false;
-    }
+    virtual bool hasAbilityToProduceInLumis() const { return false; }
 
   private:
     TypeLabelList typeLabelList_;
     std::vector<bool> recordProvenanceList_;
   };
 
-
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ProductResolverBase.h
+++ b/FWCore/Framework/interface/ProductResolverBase.h
@@ -33,36 +33,37 @@ namespace edm {
 
   class ProductResolverBase {
   public:
-
     class Resolution {
     public:
       static std::uintptr_t constexpr kAmbiguityValue = 0x1;
       static std::uintptr_t constexpr kAmbiguityMask = std::numeric_limits<std::uintptr_t>::max() ^ kAmbiguityValue;
-      explicit Resolution( ProductData const* iData):
-      m_data(iData) {}
-      
+      explicit Resolution(ProductData const* iData) : m_data(iData) {}
+
       bool isAmbiguous() const { return reinterpret_cast<std::uintptr_t>(m_data) == kAmbiguityValue; }
-      
-      ProductData const* data() const { return reinterpret_cast<ProductData const*>(kAmbiguityMask & reinterpret_cast<std::uintptr_t>(m_data)); }
-      
+
+      ProductData const* data() const {
+        return reinterpret_cast<ProductData const*>(kAmbiguityMask & reinterpret_cast<std::uintptr_t>(m_data));
+      }
+
       static Resolution makeAmbiguous() { return Resolution(reinterpret_cast<ProductData const*>(kAmbiguityValue)); }
+
     private:
       ProductData const* m_data;
     };
-    
+
     ProductResolverBase();
     virtual ~ProductResolverBase();
 
-    ProductResolverBase(ProductResolverBase const&) = delete; // Disallow copying and moving
-    ProductResolverBase& operator=(ProductResolverBase const&) = delete; // Disallow copying and moving
+    ProductResolverBase(ProductResolverBase const&) = delete;             // Disallow copying and moving
+    ProductResolverBase& operator=(ProductResolverBase const&) = delete;  // Disallow copying and moving
 
     Resolution resolveProduct(Principal const& principal,
                               bool skipCurrentProcess,
                               SharedResourcesAcquirer* sra,
                               ModuleCallingContext const* mcc) const {
-      return resolveProduct_( principal, skipCurrentProcess, sra, mcc);
+      return resolveProduct_(principal, skipCurrentProcess, sra, mcc);
     }
-    
+
     /** oDataFetchedIsValid is allowed to be nullptr in which case no value will be assigned
      */
     void prefetchAsync(WaitingTask* waitTask,
@@ -74,18 +75,17 @@ namespace edm {
       return prefetchAsync_(waitTask, principal, skipCurrentProcess, token, sra, mcc);
     }
 
-    void retrieveAndMerge(Principal const& principal, MergeableRunProductMetadata const* mergeableRunProductMetadata) const {
+    void retrieveAndMerge(Principal const& principal,
+                          MergeableRunProductMetadata const* mergeableRunProductMetadata) const {
       retrieveAndMerge_(principal, mergeableRunProductMetadata);
     }
     void resetProductData() { resetProductData_(false); }
 
-    void unsafe_deleteProduct() const {
-      const_cast<ProductResolverBase*>(this)->resetProductData_(true);
-    }
-    
+    void unsafe_deleteProduct() const { const_cast<ProductResolverBase*>(this)->resetProductData_(true); }
+
     // product is not available (dropped or never created)
-    bool productUnavailable() const {return productUnavailable_();}
-    
+    bool productUnavailable() const { return productUnavailable_(); }
+
     // returns true if resolveProduct was already called for this product
     bool productResolved() const { return productResolved_(); }
 
@@ -94,50 +94,58 @@ namespace edm {
 
     // Only returns true if the module is unscheduled and was not run
     //   all other cases return false
-    bool unscheduledWasNotRun() const {return unscheduledWasNotRun_();}
-    
+    bool unscheduledWasNotRun() const { return unscheduledWasNotRun_(); }
+
     // Product was deleted early in order to save memory
-    bool productWasDeleted() const {return productWasDeleted_();}
-    
-    bool productWasFetchedAndIsValid(bool iSkipCurrentProcess) const { return productWasFetchedAndIsValid_(iSkipCurrentProcess); }
+    bool productWasDeleted() const { return productWasDeleted_(); }
+
+    bool productWasFetchedAndIsValid(bool iSkipCurrentProcess) const {
+      return productWasFetchedAndIsValid_(iSkipCurrentProcess);
+    }
 
     // Retrieves pointer to the per event(lumi)(run) provenance.
     ProductProvenance const* productProvenancePtr() const { return productProvenancePtr_(); }
 
     // Retrieves a reference to the event independent provenance.
-    BranchDescription const& branchDescription() const {return branchDescription_();}
+    BranchDescription const& branchDescription() const { return branchDescription_(); }
 
     // Retrieves a reference to the event independent provenance.
-    bool singleProduct() const {return singleProduct_();}
+    bool singleProduct() const { return singleProduct_(); }
 
     // Sets the pointer to the event independent provenance.
-    void resetBranchDescription(std::shared_ptr<BranchDescription const> bd) {resetBranchDescription_(bd);}
+    void resetBranchDescription(std::shared_ptr<BranchDescription const> bd) { resetBranchDescription_(bd); }
 
     // Retrieves a reference to the module label.
-    std::string const& moduleLabel() const {return branchDescription().moduleLabel();}
+    std::string const& moduleLabel() const { return branchDescription().moduleLabel(); }
 
     // Same as moduleLabel except in the case of an AliasProductResolver, in which
     // case it resolves the module which actually produces the product and returns
     // its module label
-    std::string const& resolvedModuleLabel() const {return resolvedModuleLabel_();}
+    std::string const& resolvedModuleLabel() const { return resolvedModuleLabel_(); }
 
     // Retrieves a reference to the product instance name
-    std::string const& productInstanceName() const {return branchDescription().productInstanceName();}
+    std::string const& productInstanceName() const { return branchDescription().productInstanceName(); }
 
     // Retrieves a reference to the process name
-    std::string const& processName() const {return branchDescription().processName();}
+    std::string const& processName() const { return branchDescription().processName(); }
 
     // Retrieves pointer to a class containing both the event independent and the per even provenance.
     Provenance const* provenance() const;
 
     // Retrieves pointer to a class containing the event independent provenance.
-    StableProvenance const* stableProvenance() const {return &provenance()->stable();}
+    StableProvenance const* stableProvenance() const { return &provenance()->stable(); }
 
     // Initializes the event independent portion of the provenance, plus the process history ID, the product ID, and the provRetriever.
-    void setProvenance(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) { setProvenance_(provRetriever, ph, pid); }
+    void setProvenance(ProductProvenanceRetriever const* provRetriever,
+                       ProcessHistory const& ph,
+                       ProductID const& pid) {
+      setProvenance_(provRetriever, ph, pid);
+    }
 
     // Initializes the portion of the provenance related to mergeable run products.
-    void setMergeableRunProductMetadata(MergeableRunProductMetadata const* mrpm) { setMergeableRunProductMetadata_(mrpm); }
+    void setMergeableRunProductMetadata(MergeableRunProductMetadata const* mrpm) {
+      setMergeableRunProductMetadata_(mrpm);
+    }
 
     // Initializes the process history.
     void setProcessHistory(ProcessHistory const& ph) { setProcessHistory_(ph); }
@@ -151,18 +159,17 @@ namespace edm {
     TypeID productType() const;
 
     // Retrieves the product ID of the product.
-    ProductID const& productID() const {return provenance()->productID();}
+    ProductID const& productID() const { return provenance()->productID(); }
 
     // Puts the product into the ProductResolver.
-    void putProduct(std::unique_ptr<WrapperBase> edp) const {
-      putProduct_(std::move(edp));
-    }
+    void putProduct(std::unique_ptr<WrapperBase> edp) const { putProduct_(std::move(edp)); }
 
     // If the product already exists we merge, else will put
-    void putOrMergeProduct(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const* mergeableRunProductMetadata = nullptr) const {
+    void putOrMergeProduct(std::unique_ptr<WrapperBase> edp,
+                           MergeableRunProductMetadata const* mergeableRunProductMetadata = nullptr) const {
       putOrMergeProduct_(std::move(edp), mergeableRunProductMetadata);
     }
-    
+
     virtual void connectTo(ProductResolverBase const&, Principal const*) = 0;
     virtual void setupUnscheduled(UnscheduledConfigurator const&);
 
@@ -177,9 +184,9 @@ namespace edm {
                                 ServiceToken const& token,
                                 SharedResourcesAcquirer* sra,
                                 ModuleCallingContext const* mcc) const = 0;
-    
-    virtual void retrieveAndMerge_(Principal const& principal, MergeableRunProductMetadata const* mergeableRunProductMetadata) const;
 
+    virtual void retrieveAndMerge_(Principal const& principal,
+                                   MergeableRunProductMetadata const* mergeableRunProductMetadata) const;
 
     virtual bool unscheduledWasNotRun_() const = 0;
     virtual bool productUnavailable_() const = 0;
@@ -188,12 +195,15 @@ namespace edm {
     virtual bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const = 0;
 
     virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const = 0;
-    virtual void putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const* mergeableRunProductMetadata) const = 0;
+    virtual void putOrMergeProduct_(std::unique_ptr<WrapperBase> edp,
+                                    MergeableRunProductMetadata const* mergeableRunProductMetadata) const = 0;
     virtual BranchDescription const& branchDescription_() const = 0;
     virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) = 0;
     virtual Provenance const* provenance_() const = 0;
     virtual std::string const& resolvedModuleLabel_() const = 0;
-    virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) = 0;
+    virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever,
+                                ProcessHistory const& ph,
+                                ProductID const& pid) = 0;
     virtual void setMergeableRunProductMetadata_(MergeableRunProductMetadata const*);
     virtual void setProcessHistory_(ProcessHistory const& ph) = 0;
     virtual ProductProvenance const* productProvenancePtr_() const = 0;
@@ -201,12 +211,10 @@ namespace edm {
     virtual bool singleProduct_() const = 0;
   };
 
-  inline
-  std::ostream&
-  operator<<(std::ostream& os, ProductResolverBase const& phb) {
+  inline std::ostream& operator<<(std::ostream& os, ProductResolverBase const& phb) {
     phb.write(os);
     return os;
   }
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h
+++ b/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     edm::ProductResolverIndexAndSkipBit
-// 
+//
 /**\class edm::ProductResolverIndexAndSkipBit
 
  Description:  This class holds a ProductIndexHolder and a boolean value
@@ -27,24 +27,20 @@ namespace edm {
 
   class ProductResolverIndexAndSkipBit {
   public:
-    ProductResolverIndexAndSkipBit(ProductResolverIndex productResolverIndex, bool skipCurrentProcess) :
-      value_(skipCurrentProcess ? s_skipMask | productResolverIndex :
-                                  ~s_skipMask & productResolverIndex) { }
-      ProductResolverIndex productResolverIndex() const {
-        bool specialIndexValue = (value_ & ProductResolverIndexValuesBit) != 0;
-        return specialIndexValue ? value_ | s_skipMask :
-                                   value_ & ~s_skipMask;
-      }
-      bool skipCurrentProcess() const { return (value_ & s_skipMask) != 0; }
+    ProductResolverIndexAndSkipBit(ProductResolverIndex productResolverIndex, bool skipCurrentProcess)
+        : value_(skipCurrentProcess ? s_skipMask | productResolverIndex : ~s_skipMask & productResolverIndex) {}
+    ProductResolverIndex productResolverIndex() const {
+      bool specialIndexValue = (value_ & ProductResolverIndexValuesBit) != 0;
+      return specialIndexValue ? value_ | s_skipMask : value_ & ~s_skipMask;
+    }
+    bool skipCurrentProcess() const { return (value_ & s_skipMask) != 0; }
 
-      bool operator==(ProductResolverIndexAndSkipBit const& r) {
-        return value_ == r.value_;
-      }
+    bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
 
   private:
-      static const unsigned int s_skipMask = 1U << 31;
+    static const unsigned int s_skipMask = 1U << 31;
 
-      unsigned int value_;
+    unsigned int value_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ProductSelector.h
+++ b/FWCore/Framework/interface/ProductSelector.h
@@ -28,15 +28,14 @@ namespace edm {
     ProductSelector();
 
     // N.B.: we assume there are not null pointers in the vector allBranches.
-    void initialize(ProductSelectorRules const& rules,
-		    std::vector<BranchDescription const*> const& branchDescriptions);
+    void initialize(ProductSelectorRules const& rules, std::vector<BranchDescription const*> const& branchDescriptions);
 
     bool selected(BranchDescription const& desc) const;
 
     // Printout intended for debugging purposes.
     void print(std::ostream& os) const;
 
-    bool initialized() const {return initialized_;}
+    bool initialized() const { return initialized_; }
 
     static void checkForDuplicateKeptBranch(BranchDescription const& desc,
                                             std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc);
@@ -46,7 +45,6 @@ namespace edm {
                                   std::map<BranchID::value_type, BranchID::value_type>& droppedBranchIDToKeptBranchID_);
 
   private:
-
     // We keep a sorted collection of branch names, indicating the
     // products which are to be selected.
 
@@ -60,11 +58,8 @@ namespace edm {
     bool initialized_;
   };
 
-  std::ostream&
-  operator<< (std::ostream& os, const ProductSelector& gs);
+  std::ostream& operator<<(std::ostream& os, const ProductSelector& gs);
 
-} // namespace edm
-
-
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ProductSelectorRules.h
+++ b/FWCore/Framework/interface/ProductSelectorRules.h
@@ -23,61 +23,64 @@ namespace edm {
 
   class ProductSelectorRules {
   public:
-    ProductSelectorRules(ParameterSet const& pset, std::string const& parameterName, std::string const& parameterOwnerName);
+    ProductSelectorRules(ParameterSet const& pset,
+                         std::string const& parameterName,
+                         std::string const& parameterOwnerName);
     //--------------------------------------------------
     // BranchSelectState is a struct which associates a BranchDescription
     // (*desc) with a bool indicating whether or not the branch with
     // that name is to be selected.  Note that desc may not be null.
     struct BranchSelectState {
       edm::BranchDescription const* desc;
-      bool                          selectMe;
-  
+      bool selectMe;
+
       // N.B.: We assume bd is not null.
-      explicit BranchSelectState (edm::BranchDescription const* bd) : 
-        desc(bd), 
-        selectMe(false)
-      { }
+      explicit BranchSelectState(edm::BranchDescription const* bd) : desc(bd), selectMe(false) {}
     };
-  
+
     void applyToAll(std::vector<BranchSelectState>& branchstates) const;
 
-    bool keepAll() const {return keepAll_;}
+    bool keepAll() const { return keepAll_; }
 
-    static void fillDescription(ParameterSetDescription& desc, char const* parameterName, std::vector<std::string> const& defaultStrings = defaultSelectionStrings());
+    static void fillDescription(ParameterSetDescription& desc,
+                                char const* parameterName,
+                                std::vector<std::string> const& defaultStrings = defaultSelectionStrings());
 
     static const std::vector<std::string>& defaultSelectionStrings();
+
   private:
     class Rule {
     public:
       Rule(std::string const& s, std::string const& parameterName, std::string const& owner);
-  
+
       // Apply the rule to all the given branch states. This may modify
       // the given branch states.
       void applyToAll(std::vector<BranchSelectState>& branchstates) const;
-  
+
       // Apply the rule to the given BranchDescription. The return value
       // is the value to which the 'select bit' should be set, according
       // to application of this rule.
       //bool applyToOne(BranchDescription const* branch) const;
-  
+
       // If this rule applies to the given BranchDescription, then
       // modify 'result' to match the rule's select flag. If the rule does
       // not apply, do not modify 'result'.
       void applyToOne(BranchDescription const* branch, bool& result) const;
-  
+
       // Return the answer to the question: "Does the rule apply to this
       // BranchDescription?"
       bool appliesTo(BranchDescription const* branch) const;
-  
+
     private:
       // selectflag_ carries the value to which we should set the 'select
       // bit' if this rule matches.
-      bool   selectflag_;
+      bool selectflag_;
       std::regex productType_;
       std::regex moduleLabel_;
       std::regex instanceName_;
       std::regex processName_;
     };
+
   private:
     std::vector<Rule> rules_;
     std::string parameterName_;
@@ -85,8 +88,6 @@ namespace edm {
     bool keepAll_;
   };
 
-} // namespace edm
-
-
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ProxyArgumentFactoryTemplate.h
+++ b/FWCore/Framework/interface/ProxyArgumentFactoryTemplate.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ProxyArgumentFactoryTemplate
-// 
+//
 /**\class ProxyArgumentFactoryTemplate ProxyArgumentFactoryTemplate.h FWCore/Framework/interface/ProxyArgumentFactoryTemplate.h
 
  Description: <one line class summary>
@@ -28,40 +28,35 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
-      
-template <class T, class ArgT>
-class ProxyArgumentFactoryTemplate : public ProxyFactoryBase
-{
+  namespace eventsetup {
 
-   public:
+    template <class T, class ArgT> class ProxyArgumentFactoryTemplate : public ProxyFactoryBase {
+    public:
       typedef typename T::record_type record_type;
 
       ProxyArgumentFactoryTemplate(ArgT iArg) : arg_(iArg) {}
       //virtual ~ProxyArgumentFactoryTemplate()
 
       // ---------- const member functions ---------------------
-      std::unique_ptr<DataProxy> makeProxy() const override {
-         return std::make_unique<T>(arg_);
-      }
-            
+      std::unique_ptr<DataProxy> makeProxy() const override { return std::make_unique<T>(arg_); }
+
       DataKey makeKey(const std::string& iName) const override {
-         return DataKey(DataKey::makeTypeTag< typename T::value_type>(),iName.c_str());
+        return DataKey(DataKey::makeTypeTag<typename T::value_type>(), iName.c_str());
       }
-      
+
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
 
-   private:
-      ProxyArgumentFactoryTemplate(const ProxyArgumentFactoryTemplate&) = delete; // stop default
+    private:
+      ProxyArgumentFactoryTemplate(const ProxyArgumentFactoryTemplate&) = delete;  // stop default
 
-      const ProxyArgumentFactoryTemplate& operator=(const ProxyArgumentFactoryTemplate&) = delete; // stop default
+      const ProxyArgumentFactoryTemplate& operator=(const ProxyArgumentFactoryTemplate&) = delete;  // stop default
 
       // ---------- member data --------------------------------
       mutable ArgT arg_;
-};
+    };
 
-   }
-}
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ProxyFactoryBase.h
+++ b/FWCore/Framework/interface/ProxyFactoryBase.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ProxyFactoryBase
-// 
+//
 /**\class ProxyFactoryBase ProxyFactoryBase.h FWCore/Framework/interface/ProxyFactoryBase.h
 
  Description: <one line class summary>
@@ -27,33 +27,30 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
-      class DataProxy;
-class ProxyFactoryBase
-{
-
-   public:
+  namespace eventsetup {
+    class DataProxy;
+    class ProxyFactoryBase {
+    public:
       ProxyFactoryBase() {}
       virtual ~ProxyFactoryBase() {}
 
       // ---------- const member functions ---------------------
       virtual std::unique_ptr<DataProxy> makeProxy() const = 0;
-      
+
       virtual DataKey makeKey(const std::string& iName) const = 0;
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
 
-   private:
-      ProxyFactoryBase(const ProxyFactoryBase&) = delete; // stop default
+    private:
+      ProxyFactoryBase(const ProxyFactoryBase&) = delete;  // stop default
 
-      const ProxyFactoryBase& operator=(const ProxyFactoryBase&) = delete; // stop default
+      const ProxyFactoryBase& operator=(const ProxyFactoryBase&) = delete;  // stop default
 
       // ---------- member data --------------------------------
+    };
 
-};
-
-   }
-}
+  }  // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ProxyFactoryTemplate.h
+++ b/FWCore/Framework/interface/ProxyFactoryTemplate.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ProxyFactoryTemplate
-// 
+//
 /**\class ProxyFactoryTemplate ProxyFactoryTemplate.h FWCore/Framework/interface/ProxyFactoryTemplate.h
 
  Description: <one line class summary>
@@ -28,42 +28,35 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
+  namespace eventsetup {
 
-template <class T>
-class ProxyFactoryTemplate : public ProxyFactoryBase
-{
-
-   public:
+    template <class T> class ProxyFactoryTemplate : public ProxyFactoryBase {
+    public:
       typedef typename T::record_type record_type;
-   
+
       ProxyFactoryTemplate() {}
       //virtual ~ProxyFactoryTemplate();
 
       // ---------- const member functions ---------------------
-      virtual std::unique_ptr<DataProxy> makeProxy() const {
-         return std::make_unique<T>();
-      }
-      
-      
+      virtual std::unique_ptr<DataProxy> makeProxy() const { return std::make_unique<T>(); }
+
       virtual DataKey makeKey(const std::string& iName) const {
-         return DataKey(DataKey::makeTypeTag< typename T::value_type>(),iName.c_str());
+        return DataKey(DataKey::makeTypeTag<typename T::value_type>(), iName.c_str());
       }
-      
+
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
 
-   private:
-      ProxyFactoryTemplate(const ProxyFactoryTemplate&); // stop default
+    private:
+      ProxyFactoryTemplate(const ProxyFactoryTemplate&);  // stop default
 
-      const ProxyFactoryTemplate& operator=(const ProxyFactoryTemplate&); // stop default
+      const ProxyFactoryTemplate& operator=(const ProxyFactoryTemplate&);  // stop default
 
       // ---------- member data --------------------------------
+    };
 
-};
-
-   }
-}
+  }  // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/RecordDependencyRegister.h
+++ b/FWCore/Framework/interface/RecordDependencyRegister.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     RecordDependencyRegister
-// 
+//
 /**\class RecordDependencyRegister RecordDependencyRegister.h "RecordDependencyRegister.h"
 
  Description: [one line class summary]
@@ -25,27 +25,22 @@
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/findDependentRecordsFor.h"
 
-
 // forward declarations
 
 namespace edm {
   namespace eventsetup {
-      using DepFunction = std::set<EventSetupRecordKey> (*)();
-      
-      std::set<EventSetupRecordKey> dependencies(EventSetupRecordKey const&);
-      
-      void addDependencyFunction(EventSetupRecordKey iKey, DepFunction iFunction);
-      
-    
-    template<typename T>
-    struct RecordDependencyRegister {
+    using DepFunction = std::set<EventSetupRecordKey> (*)();
+
+    std::set<EventSetupRecordKey> dependencies(EventSetupRecordKey const&);
+
+    void addDependencyFunction(EventSetupRecordKey iKey, DepFunction iFunction);
+
+    template <typename T> struct RecordDependencyRegister {
       RecordDependencyRegister() {
-        addDependencyFunction(EventSetupRecordKey::makeKey<T>(),
-                              &findDependentRecordsFor<T>);
+        addDependencyFunction(EventSetupRecordKey::makeKey<T>(), &findDependentRecordsFor<T>);
       }
     };
-  }
-}
-
+  }  // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -38,21 +38,18 @@ namespace edm {
   class SharedResourcesAcquirer;
 
   namespace stream {
-    template< typename T> class ProducingModuleAdaptorBase;
+    template <typename T> class ProducingModuleAdaptorBase;
   }
 
   class Run : public RunBase {
   public:
-    Run(RunPrincipal const& rp, ModuleDescription const& md,
-        ModuleCallingContext const*, bool isAtEnd);
+    Run(RunPrincipal const& rp, ModuleDescription const& md, ModuleCallingContext const*, bool isAtEnd);
     ~Run() override;
 
     //Used in conjunction with EDGetToken
-    void setConsumer(EDConsumerBase const* iConsumer) {
-      provRecorder_.setConsumer(iConsumer);
-    }
+    void setConsumer(EDConsumerBase const* iConsumer) { provRecorder_.setConsumer(iConsumer); }
 
-    void setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer) {
+    void setSharedResourcesAcquirer(SharedResourcesAcquirer* iResourceAcquirer) {
       provRecorder_.setSharedResourcesAcquirer(iResourceAcquirer);
     }
 
@@ -60,12 +57,12 @@ namespace edm {
 
     typedef PrincipalGetAdapter Base;
     // AUX functions are defined in RunBase
-    RunAuxiliary const& runAuxiliary() const override {return aux_;}
+    RunAuxiliary const& runAuxiliary() const override { return aux_; }
     // AUX functions.
-//     RunID const& id() const {return aux_.id();}
-//     RunNumber_t run() const {return aux_.run();}
-//     Timestamp const& beginTime() const {return aux_.beginTime();}
-//     Timestamp const& endTime() const {return aux_.endTime();}
+    //     RunID const& id() const {return aux_.id();}
+    //     RunNumber_t run() const {return aux_.run();}
+    //     Timestamp const& beginTime() const {return aux_.beginTime();}
+    //     Timestamp const& endTime() const {return aux_.endTime();}
 
     /**\return Reusable index which can be used to separate data for different simultaneous Runs.
      */
@@ -78,78 +75,44 @@ namespace edm {
      denote that you have not yet checked the value.
      */
     typedef unsigned long CacheIdentifier_t;
-    CacheIdentifier_t
-    cacheIdentifier() const;
+    CacheIdentifier_t cacheIdentifier() const;
 
-
-    template <typename PROD>
-    bool
-    getByLabel(std::string const& label, Handle<PROD>& result) const;
+    template <typename PROD> bool getByLabel(std::string const& label, Handle<PROD>& result) const;
 
     template <typename PROD>
-    bool
-    getByLabel(std::string const& label,
-               std::string const& productInstanceName,
-               Handle<PROD>& result) const;
+    bool getByLabel(std::string const& label, std::string const& productInstanceName, Handle<PROD>& result) const;
 
     /// same as above, but using the InputTag class
-    template <typename PROD>
-    bool
-    getByLabel(InputTag const& tag, Handle<PROD>& result) const;
+    template <typename PROD> bool getByLabel(InputTag const& tag, Handle<PROD>& result) const;
 
-    template<typename PROD>
-    bool
-    getByToken(EDGetToken token, Handle<PROD>& result) const;
+    template <typename PROD> bool getByToken(EDGetToken token, Handle<PROD>& result) const;
 
-    template<typename PROD>
-    bool
-    getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
+    template <typename PROD> bool getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
 
-    template<typename PROD>
-    Handle<PROD>
-    getHandle(EDGetTokenT<PROD> token) const;
-    
-    template<typename PROD>
-    PROD const&
-    get(EDGetTokenT<PROD> token) const noexcept(false);
-    
+    template <typename PROD> Handle<PROD> getHandle(EDGetTokenT<PROD> token) const;
 
-    template <typename PROD>
-    void
-    getManyByType(std::vector<Handle<PROD> >& results) const;
+    template <typename PROD> PROD const& get(EDGetTokenT<PROD> token) const noexcept(false);
+
+    template <typename PROD> void getManyByType(std::vector<Handle<PROD>>& results) const;
 
     ///Put a new product.
-    template <typename PROD>
-    void
-    put(std::unique_ptr<PROD> product) {put<PROD>(std::move(product), std::string());}
+    template <typename PROD> void put(std::unique_ptr<PROD> product) { put<PROD>(std::move(product), std::string()); }
 
     ///Put a new product with a 'product instance name'
-    template <typename PROD>
-    void
-    put(std::unique_ptr<PROD> product, std::string const& productInstanceName);
+    template <typename PROD> void put(std::unique_ptr<PROD> product, std::string const& productInstanceName);
 
-    template<typename PROD>
-    void
-    put(EDPutToken token, std::unique_ptr<PROD> product);
-    
-    template<typename PROD>
-    void
-    put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product);
+    template <typename PROD> void put(EDPutToken token, std::unique_ptr<PROD> product);
+
+    template <typename PROD> void put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product);
 
     ///puts a new product
-    template<typename PROD, typename... Args>
-    void
-    emplace(EDPutTokenT<PROD> token, Args&&... args);
-    
-    template<typename PROD, typename... Args>
-    void
-    emplace(EDPutToken token, Args&&... args);
+    template <typename PROD, typename... Args> void emplace(EDPutTokenT<PROD> token, Args&&... args);
 
-    Provenance
-    getProvenance(BranchID const& theID) const;
+    template <typename PROD, typename... Args> void emplace(EDPutToken token, Args&&... args);
 
-    void
-    getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
+    Provenance getProvenance(BranchID const& theID) const;
+
+    void getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
 
     // Return true if this Run has been subjected to a process with
     // the given processName, and false otherwise.
@@ -163,31 +126,29 @@ namespace edm {
 
     ProcessHistoryID const& processHistoryID() const;
 
-    ProcessHistory const&
-    processHistory() const;
+    ProcessHistory const& processHistory() const;
 
     ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
 
-    void labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const { provRecorder_.labelsForToken(iToken, oLabels); }
+    void labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const {
+      provRecorder_.labelsForToken(iToken, oLabels);
+    }
 
   private:
-    RunPrincipal const&
-    runPrincipal() const;
+    RunPrincipal const& runPrincipal() const;
 
     // Override version from RunBase class
-    BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const override;
+    BasicHandle getByLabelImpl(std::type_info const& iWrapperType,
+                               std::type_info const& iProductType,
+                               InputTag const& iTag) const override;
 
-    template<typename PROD>
-    void
-    putImpl(EDPutToken::value_type token, std::unique_ptr<PROD> product);
-    
-    template<typename PROD, typename... Args>
-    void
-    emplaceImpl(EDPutToken::value_type token, Args&&... args);
+    template <typename PROD> void putImpl(EDPutToken::value_type token, std::unique_ptr<PROD> product);
+
+    template <typename PROD, typename... Args> void emplaceImpl(EDPutToken::value_type token, Args&&... args);
 
     typedef std::vector<edm::propagate_const<std::unique_ptr<WrapperBase>>> ProductPtrVec;
-    ProductPtrVec& putProducts() {return putProducts_;}
-    ProductPtrVec const& putProducts() const {return putProducts_;}
+    ProductPtrVec& putProducts() { return putProducts_; }
+    ProductPtrVec const& putProducts() const { return putProducts_; }
 
     // commit_() is called to complete the transaction represented by
     // this PrincipalGetAdapter. The friendships required seems gross, but any
@@ -195,7 +156,7 @@ namespace edm {
     // public interface is asking for trouble
     friend class RawInputSource;
     friend class ProducerBase;
-    template<typename T> friend class stream::ProducingModuleAdaptorBase;
+    template <typename T> friend class stream::ProducingModuleAdaptorBase;
 
     void commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut);
 
@@ -203,127 +164,104 @@ namespace edm {
     ProductPtrVec putProducts_;
     RunAuxiliary const& aux_;
     ModuleCallingContext const* moduleCallingContext_;
-    SharedResourcesAcquirer* sharedResourcesAcquirer_; // We do not use propagate_const because the acquirer is itself mutable.
+    SharedResourcesAcquirer*
+        sharedResourcesAcquirer_;  // We do not use propagate_const because the acquirer is itself mutable.
 
     static const std::string emptyString_;
   };
 
-  template <typename PROD>
-  void
-  Run::putImpl(EDPutToken::value_type index,std::unique_ptr<PROD> product) {
+  template <typename PROD> void Run::putImpl(EDPutToken::value_type index, std::unique_ptr<PROD> product) {
     // The following will call post_insert if T has such a function,
     // and do nothing if T has no such function.
-    std::conditional_t<detail::has_postinsert<PROD>::value,
-    DoPostInsert<PROD>,
-    DoNotPostInsert<PROD>> maybe_inserter;
+    std::conditional_t<detail::has_postinsert<PROD>::value, DoPostInsert<PROD>, DoNotPostInsert<PROD>> maybe_inserter;
     maybe_inserter(product.get());
-    
+
     assert(index < putProducts().size());
-    
-    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(std::move(product)));
-    putProducts()[index]=std::move(wp);
+
+    std::unique_ptr<Wrapper<PROD>> wp(new Wrapper<PROD>(std::move(product)));
+    putProducts()[index] = std::move(wp);
   }
-  
-  template <typename PROD>
-  void
-  Run::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
-    if(UNLIKELY(product.get() == nullptr)) {                // null pointer is illegal
+
+  template <typename PROD> void Run::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
+    if (UNLIKELY(product.get() == nullptr)) {  // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Run", typeID, productInstanceName);
     }
-    auto index =
-    provRecorder_.getPutTokenIndex(TypeID(*product), productInstanceName);
+    auto index = provRecorder_.getPutTokenIndex(TypeID(*product), productInstanceName);
     putImpl(index, std::move(product));
   }
-  
-  template<typename PROD>
-  void
-  Run::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
-    if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
+
+  template <typename PROD> void Run::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
+    if (UNLIKELY(product.get() == 0)) {  // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Run", typeID, provRecorder_.productInstanceLabel(token));
     }
-    if(UNLIKELY(token.isUninitialized())) {
+    if (UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Run", typeid(PROD));
     }
-    putImpl(token.index(),std::move(product));
+    putImpl(token.index(), std::move(product));
   }
-  
-  template<typename PROD>
-  void
-  Run::put(EDPutToken token, std::unique_ptr<PROD> product) {
-    if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
+
+  template <typename PROD> void Run::put(EDPutToken token, std::unique_ptr<PROD> product) {
+    if (UNLIKELY(product.get() == 0)) {  // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Run", typeID, provRecorder_.productInstanceLabel(token));
     }
-    if(UNLIKELY(token.isUninitialized())) {
+    if (UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Run", typeid(PROD));
     }
-    if(UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
-      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    if (UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD),
+                                                          provRecorder_.getTypeIDForPutTokenIndex(token.index()));
     }
-    
-    putImpl(token.index(),std::move(product));
+
+    putImpl(token.index(), std::move(product));
   }
-  
-  template<typename PROD, typename... Args>
-  void
-  Run::emplace(EDPutTokenT<PROD> token, Args&&... args) {
-    if(UNLIKELY(token.isUninitialized())) {
+
+  template <typename PROD, typename... Args> void Run::emplace(EDPutTokenT<PROD> token, Args&&... args) {
+    if (UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Run", typeid(PROD));
     }
-    emplaceImpl<PROD>(token.index(),std::forward<Args>(args)...);
+    emplaceImpl<PROD>(token.index(), std::forward<Args>(args)...);
   }
-  
-  template<typename PROD, typename... Args>
-  void
-  Run::emplace(EDPutToken token, Args&&... args) {
-    if(UNLIKELY(token.isUninitialized())) {
+
+  template <typename PROD, typename... Args> void Run::emplace(EDPutToken token, Args&&... args) {
+    if (UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Run", typeid(PROD));
     }
-    if(UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
-      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    if (UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD),
+                                                          provRecorder_.getTypeIDForPutTokenIndex(token.index()));
     }
-    
-    emplaceImpl(token.index(),std::forward<Args>(args)...);
+
+    emplaceImpl(token.index(), std::forward<Args>(args)...);
   }
-  
-  template<typename PROD, typename... Args>
-  void
-  Run::emplaceImpl(EDPutToken::value_type index, Args&&... args) {
-    
+
+  template <typename PROD, typename... Args> void Run::emplaceImpl(EDPutToken::value_type index, Args&&... args) {
     assert(index < putProducts().size());
-    
-    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(WrapperBase::Emplace{},
-                                                         std::forward<Args>(args)...));
-    
+
+    std::unique_ptr<Wrapper<PROD>> wp(new Wrapper<PROD>(WrapperBase::Emplace{}, std::forward<Args>(args)...));
+
     // The following will call post_insert if T has such a function,
     // and do nothing if T has no such function.
-    std::conditional_t<detail::has_postinsert<PROD>::value,
-    DoPostInsert<PROD>,
-    DoNotPostInsert<PROD>> maybe_inserter;
+    std::conditional_t<detail::has_postinsert<PROD>::value, DoPostInsert<PROD>, DoNotPostInsert<PROD>> maybe_inserter;
     maybe_inserter(&(wp->bareProduct()));
-    
-    putProducts()[index]=std::move(wp);
+
+    putProducts()[index] = std::move(wp);
   }
 
-
-  template <typename PROD>
-  bool
-  Run::getByLabel(std::string const& label, Handle<PROD>& result) const {
+  template <typename PROD> bool Run::getByLabel(std::string const& label, Handle<PROD>& result) const {
     return getByLabel(label, emptyString_, result);
   }
 
   template <typename PROD>
-  bool
-  Run::getByLabel(std::string const& label,
-                  std::string const& productInstanceName,
-                  Handle<PROD>& result) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  bool Run::getByLabel(std::string const& label, std::string const& productInstanceName, Handle<PROD>& result) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)), label, productInstanceName);
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_,
+                                               moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
@@ -332,10 +270,8 @@ namespace edm {
   }
 
   /// same as above, but using the InputTag class
-  template <typename PROD>
-  bool
-  Run::getByLabel(InputTag const& tag, Handle<PROD>& result) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD> bool Run::getByLabel(InputTag const& tag, Handle<PROD>& result) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)), tag.label(), tag.instance());
     }
     result.clear();
@@ -347,14 +283,12 @@ namespace edm {
     return true;
   }
 
-  template<typename PROD>
-  bool
-  Run::getByToken(EDGetToken token, Handle<PROD>& result) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD> bool Run::getByToken(EDGetToken token, Handle<PROD>& result) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)), token);
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
@@ -362,14 +296,12 @@ namespace edm {
     return true;
   }
 
-  template<typename PROD>
-  bool
-  Run::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD> bool Run::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)), token);
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
@@ -377,30 +309,24 @@ namespace edm {
     return true;
   }
 
-  template<typename PROD>
-  Handle<PROD>
-  Run::getHandle(EDGetTokenT<PROD> token) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD> Handle<PROD> Run::getHandle(EDGetTokenT<PROD> token) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)), token);
     }
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     return convert_handle<PROD>(std::move(bh));
   }
 
-  template<typename PROD>
-  PROD const&
-  Run::get(EDGetTokenT<PROD> token) const noexcept(false) {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD> PROD const& Run::get(EDGetTokenT<PROD> token) const noexcept(false) {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)), token);
     }
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     return *convert_handle<PROD>(std::move(bh));
   }
 
-  template <typename PROD>
-  void
-  Run::getManyByType(std::vector<Handle<PROD> >& results) const {
-    if(!provRecorder_.checkIfComplete<PROD>()) {
+  template <typename PROD> void Run::getManyByType(std::vector<Handle<PROD>>& results) const {
+    if (!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)));
     }
     return provRecorder_.getManyByType(results, moduleCallingContext_);
@@ -409,30 +335,27 @@ namespace edm {
   // Free functions to retrieve a collection from the Run.
   // Will throw an exception if the collection is not available.
 
-  template <typename T>
-  T const& get(Run const& event, InputTag const& tag) {
+  template <typename T> T const& get(Run const& event, InputTag const& tag) {
     Handle<T> handle;
     event.getByLabel(tag, handle);
     // throw if the handle is not valid
-    return * handle.product();
+    return *handle.product();
   }
 
-  template <typename T>
-  T const& get(Run const& event, EDGetToken const& token) {
+  template <typename T> T const& get(Run const& event, EDGetToken const& token) {
     Handle<T> handle;
     event.getByToken(token, handle);
     // throw if the handle is not valid
-    return * handle.product();
+    return *handle.product();
   }
 
-  template <typename T>
-  T const& get(Run const& event, EDGetTokenT<T> const& token) {
+  template <typename T> T const& get(Run const& event, EDGetTokenT<T> const& token) {
     Handle<T> handle;
     event.getByToken(token, handle);
     // throw if the handle is not valid
-    return * handle.product();
+    return *handle.product();
   }
 
-}
+}  // namespace edm
 
-#endif // FWCore_Framework_Run_h
+#endif  // FWCore_Framework_Run_h

--- a/FWCore/Framework/interface/RunForOutput.h
+++ b/FWCore/Framework/interface/RunForOutput.h
@@ -35,26 +35,27 @@ namespace edmtest {
 namespace edm {
   class MergeableRunProductMetadata;
   class ModuleCallingContext;
-  
+
   class RunForOutput : public OccurrenceForOutput {
   public:
-    RunForOutput(RunPrincipal const& rp, ModuleDescription const& md,
-                 ModuleCallingContext const*, bool isAtEnd,
+    RunForOutput(RunPrincipal const& rp,
+                 ModuleDescription const& md,
+                 ModuleCallingContext const*,
+                 bool isAtEnd,
                  MergeableRunProductMetadata const* = nullptr);
     ~RunForOutput() override;
 
-    RunAuxiliary const& runAuxiliary() const {return aux_;}
-    RunID const& id() const {return aux_.id();}
-    RunNumber_t run() const {return aux_.run();}
-    Timestamp const& beginTime() const {return aux_.beginTime();}
-    Timestamp const& endTime() const {return aux_.endTime();}
+    RunAuxiliary const& runAuxiliary() const { return aux_; }
+    RunID const& id() const { return aux_.id(); }
+    RunNumber_t run() const { return aux_.run(); }
+    Timestamp const& beginTime() const { return aux_.beginTime(); }
+    Timestamp const& endTime() const { return aux_.endTime(); }
     MergeableRunProductMetadata const* mergeableRunProductMetadata() const { return mergeableRunProductMetadata_; }
 
   private:
-    friend class edmtest::TestOutputModule; // For testing
+    friend class edmtest::TestOutputModule;  // For testing
 
-    RunPrincipal const&
-    runPrincipal() const;
+    RunPrincipal const& runPrincipal() const;
 
     RunAuxiliary const& aux_;
 
@@ -62,5 +63,5 @@ namespace edm {
 
     static const std::string emptyString_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -35,14 +35,13 @@ namespace edm {
     typedef RunAuxiliary Auxiliary;
     typedef Principal Base;
 
-    RunPrincipal(
-        std::shared_ptr<RunAuxiliary> aux,
-        std::shared_ptr<ProductRegistry const> reg,
-        ProcessConfiguration const& pc,
-        HistoryAppender* historyAppender,
-        unsigned int iRunIndex,
-        bool isForPrimaryProcess=true,
-        MergeableRunProductProcesses const* mergeableRunProductProcesses = nullptr);
+    RunPrincipal(std::shared_ptr<RunAuxiliary> aux,
+                 std::shared_ptr<ProductRegistry const> reg,
+                 ProcessConfiguration const& pc,
+                 HistoryAppender* historyAppender,
+                 unsigned int iRunIndex,
+                 bool isForPrimaryProcess = true,
+                 MergeableRunProductProcesses const* mergeableRunProductProcesses = nullptr);
     ~RunPrincipal() override;
 
     void fillRunPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader = nullptr);
@@ -54,55 +53,33 @@ namespace edm {
      value will be reused once the processing of the previous Run 
      using that index has been completed.
      */
-    RunIndex index() const {
-      return index_;
-    }
-    
-    RunAuxiliary const& aux() const {
-      return *aux_;
-    }
+    RunIndex index() const { return index_; }
 
-    RunNumber_t run() const {
-      return aux().run();
-    }
-    
-    ProcessHistoryID const& reducedProcessHistoryID() const {
-      return m_reducedHistoryID;
-    }
+    RunAuxiliary const& aux() const { return *aux_; }
 
-    RunID const& id() const {
-      return aux().id();
-    }
+    RunNumber_t run() const { return aux().run(); }
 
-    Timestamp const& beginTime() const {
-      return aux().beginTime();
-    }
+    ProcessHistoryID const& reducedProcessHistoryID() const { return m_reducedHistoryID; }
 
-    Timestamp const& endTime() const {
-      return aux().endTime();
-    }
+    RunID const& id() const { return aux().id(); }
 
-    void setEndTime(Timestamp const& time) {
-      aux_->setEndTime(time);
-    }
+    Timestamp const& beginTime() const { return aux().beginTime(); }
 
-    void mergeAuxiliary(RunAuxiliary const& aux) {
-      return aux_->mergeAuxiliary(aux);
-    }
+    Timestamp const& endTime() const { return aux().endTime(); }
 
-    void put(
-        BranchDescription const& bd,
-        std::unique_ptr<WrapperBase> edp) const;
+    void setEndTime(Timestamp const& time) { aux_->setEndTime(time); }
 
-    void put(ProductResolverIndex index,
-             std::unique_ptr<WrapperBase> edp) const;
+    void mergeAuxiliary(RunAuxiliary const& aux) { return aux_->mergeAuxiliary(aux); }
 
-    MergeableRunProductMetadata* mergeableRunProductMetadata() {return mergeableRunProductMetadataPtr_.get();}
+    void put(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
+
+    void put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const;
+
+    MergeableRunProductMetadata* mergeableRunProductMetadata() { return mergeableRunProductMetadataPtr_.get(); }
 
     void preReadFile();
 
   private:
-
     unsigned int transitionIndex_() const override;
 
     edm::propagate_const<std::shared_ptr<RunAuxiliary>> aux_;
@@ -114,6 +91,5 @@ namespace edm {
     // per concurrent run. In all other cases, this should just be null.
     edm::propagate_const<std::unique_ptr<MergeableRunProductMetadata>> mergeableRunProductMetadataPtr_;
   };
-}
+}  // namespace edm
 #endif
-

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -115,7 +115,6 @@ namespace edm {
   class EndPathStatusInserter;
   class WaitingTaskHolder;
 
-  
   class Schedule {
   public:
     typedef std::vector<std::string> vstring;
@@ -159,8 +158,8 @@ namespace edm {
                                bool cleaningUpAfterException = false);
 
     void beginJob(ProductRegistry const&);
-    void endJob(ExceptionCollector & collector);
-    
+    void endJob(ExceptionCollector& collector);
+
     void beginStream(unsigned int);
     void endStream(unsigned int);
 
@@ -212,8 +211,7 @@ namespace edm {
     void endPaths(std::vector<std::string>& oLabelsToFill) const;
 
     ///adds to oLabelsToFill in execution order the labels of all modules in path iPathLabel
-    void modulesInPath(std::string const& iPathLabel,
-                       std::vector<std::string>& oLabelsToFill) const;
+    void modulesInPath(std::string const& iPathLabel, std::vector<std::string>& oLabelsToFill) const;
 
     ///adds the ModuleDescriptions into the vector for the modules scheduled in path iPathLabel
     ///hint is a performance optimization if you might know the position of the module in the path
@@ -228,8 +226,8 @@ namespace edm {
                                      unsigned int hint) const;
 
     void fillModuleAndConsumesInfo(std::vector<ModuleDescription const*>& allModuleDescriptions,
-                                   std::vector<std::pair<unsigned int, unsigned int> >& moduleIDToIndex,
-                                   std::vector<std::vector<ModuleDescription const*> >& modulesWhoseProductsAreConsumedBy,
+                                   std::vector<std::pair<unsigned int, unsigned int>>& moduleIDToIndex,
+                                   std::vector<std::vector<ModuleDescription const*>>& modulesWhoseProductsAreConsumedBy,
                                    ProductRegistry const& preg) const;
 
     /// Return the number of events this Schedule has tried to process
@@ -256,7 +254,7 @@ namespace edm {
     /// Return the trigger report information on paths,
     /// modules-in-path, modules-in-endpath, and modules.
     void getTriggerReport(TriggerReport& rep) const;
-    
+
     /// Return the trigger timing report information on paths,
     /// modules-in-path, modules-in-endpath, and modules.
     void getTriggerTimingReport(TriggerTimingReport& rep) const;
@@ -278,15 +276,16 @@ namespace edm {
     void convertCurrentProcessAlias(std::string const& processName);
 
   private:
-
     void limitOutput(ParameterSet const& proc_pset,
                      BranchIDLists const& branchIDLists,
                      SubProcessParentageHelper const* subProcessParentageHelper);
 
-    std::shared_ptr<TriggerResultInserter const> resultsInserter() const {return get_underlying_safe(resultsInserter_);}
-    std::shared_ptr<TriggerResultInserter>& resultsInserter() {return get_underlying_safe(resultsInserter_);}
-    std::shared_ptr<ModuleRegistry const> moduleRegistry() const {return get_underlying_safe(moduleRegistry_);}
-    std::shared_ptr<ModuleRegistry>& moduleRegistry() {return get_underlying_safe(moduleRegistry_);}
+    std::shared_ptr<TriggerResultInserter const> resultsInserter() const {
+      return get_underlying_safe(resultsInserter_);
+    }
+    std::shared_ptr<TriggerResultInserter>& resultsInserter() { return get_underlying_safe(resultsInserter_); }
+    std::shared_ptr<ModuleRegistry const> moduleRegistry() const { return get_underlying_safe(moduleRegistry_); }
+    std::shared_ptr<ModuleRegistry>& moduleRegistry() { return get_underlying_safe(moduleRegistry_); }
 
     edm::propagate_const<std::shared_ptr<TriggerResultInserter>> resultsInserter_;
     std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>> pathStatusInserters_;
@@ -296,8 +295,8 @@ namespace edm {
     //In the future, we will have one GlobalSchedule per simultaneous transition
     edm::propagate_const<std::unique_ptr<GlobalSchedule>> globalSchedule_;
 
-    AllOutputModuleCommunicators         all_output_communicators_;
-    PreallocationConfiguration           preallocConfig_;
+    AllOutputModuleCommunicators all_output_communicators_;
+    PreallocationConfiguration preallocConfig_;
 
     edm::propagate_const<std::unique_ptr<SystemTimeKeeper>> summaryTimeKeeper_;
 
@@ -305,10 +304,9 @@ namespace edm {
     std::vector<std::string> const* endPathNames_;
     bool wantSummary_;
 
-    volatile bool           endpathsAreActive_;
+    volatile bool endpathsAreActive_;
   };
 
-  
   template <typename T>
   void Schedule::processOneStreamAsync(WaitingTaskHolder iTaskHolder,
                                        unsigned int iStreamID,
@@ -316,19 +314,19 @@ namespace edm {
                                        EventSetupImpl const& es,
                                        ServiceToken const& token,
                                        bool cleaningUpAfterException) {
-    assert(iStreamID<streamSchedules_.size());
-    streamSchedules_[iStreamID]->processOneStreamAsync<T>(std::move(iTaskHolder),ep,es,token,cleaningUpAfterException);
+    assert(iStreamID < streamSchedules_.size());
+    streamSchedules_[iStreamID]->processOneStreamAsync<T>(std::move(iTaskHolder), ep, es, token,
+                                                          cleaningUpAfterException);
   }
 
   template <typename T>
-  void
-  Schedule::processOneGlobalAsync(WaitingTaskHolder iTaskHolder,
-                                  typename T::MyPrincipal& ep,
-                                  EventSetupImpl const& es,
-                                  ServiceToken const& token,
-                                  bool cleaningUpAfterException) {
-    globalSchedule_->processOneGlobalAsync<T>(iTaskHolder,ep,es,token,cleaningUpAfterException);
+  void Schedule::processOneGlobalAsync(WaitingTaskHolder iTaskHolder,
+                                       typename T::MyPrincipal& ep,
+                                       EventSetupImpl const& es,
+                                       ServiceToken const& token,
+                                       bool cleaningUpAfterException) {
+    globalSchedule_->processOneGlobalAsync<T>(iTaskHolder, ep, es, token, cleaningUpAfterException);
   }
 
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/ScheduleInfo.h
+++ b/FWCore/Framework/interface/ScheduleInfo.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ScheduleInfo
-// 
+//
 /**\class ScheduleInfo ScheduleInfo.h FWCore/Framework/interface/ScheduleInfo.h
 
  Description: Provides module and path information to EDLoopers
@@ -26,45 +26,42 @@
 
 // forward declarations
 namespace edm {
-   class ParameterSet;
-   class Schedule;
-   
-   class ScheduleInfo {
-      
-   public:
-      ScheduleInfo(const Schedule*);
-      virtual ~ScheduleInfo();
-      
-      // ---------- const member functions ---------------------
-      
-      ///adds to oLabelsToFill the labels for all modules used in the process
-      void availableModuleLabels(std::vector<std::string>& oLabelsToFill) const;
-      
-      /**returns a pointer to the parameters for the module with label iLabel, returns 0 if 
+  class ParameterSet;
+  class Schedule;
+
+  class ScheduleInfo {
+  public:
+    ScheduleInfo(const Schedule*);
+    virtual ~ScheduleInfo();
+
+    // ---------- const member functions ---------------------
+
+    ///adds to oLabelsToFill the labels for all modules used in the process
+    void availableModuleLabels(std::vector<std::string>& oLabelsToFill) const;
+
+    /**returns a pointer to the parameters for the module with label iLabel, returns 0 if 
        no module exists with that label.
        */
-      const edm::ParameterSet* parametersForModule(const std::string& iLabel) const;
-      
-      ///adds to oLabelsToFill the labels for all paths in the process
-      void availablePaths( std::vector<std::string>& oLabelsToFill) const;
-      
-      ///add to oLabelsToFill in execution order the labels of all modules in path iPathLabel
-      void modulesInPath(const std::string& iPathLabel,
-                         std::vector<std::string>& oLabelsToFill) const;
-      // ---------- static member functions --------------------      
-      
-      // ---------- member functions ---------------------------
-      
-   private:
-      //ScheduleInfo(const ScheduleInfo&); // stop default
-      
-      //const ScheduleInfo& operator=(const ScheduleInfo&); // stop default
-      
-      // ---------- member data --------------------------------
-      const Schedule* schedule_;
-      
-   };
+    const edm::ParameterSet* parametersForModule(const std::string& iLabel) const;
 
-}
+    ///adds to oLabelsToFill the labels for all paths in the process
+    void availablePaths(std::vector<std::string>& oLabelsToFill) const;
+
+    ///add to oLabelsToFill in execution order the labels of all modules in path iPathLabel
+    void modulesInPath(const std::string& iPathLabel, std::vector<std::string>& oLabelsToFill) const;
+    // ---------- static member functions --------------------
+
+    // ---------- member functions ---------------------------
+
+  private:
+    //ScheduleInfo(const ScheduleInfo&); // stop default
+
+    //const ScheduleInfo& operator=(const ScheduleInfo&); // stop default
+
+    // ---------- member data --------------------------------
+    const Schedule* schedule_;
+  };
+
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -30,42 +30,47 @@ namespace edm {
 
     ScheduleItems(ProductRegistry const& preg, SubProcess const& om);
 
-    ScheduleItems(ScheduleItems const&) = delete; // Disallow copying and moving
-    ScheduleItems& operator=(ScheduleItems const&) = delete; // Disallow copying and moving
+    ScheduleItems(ScheduleItems const&) = delete;             // Disallow copying and moving
+    ScheduleItems& operator=(ScheduleItems const&) = delete;  // Disallow copying and moving
 
-    ServiceToken
-    initServices(std::vector<ParameterSet>& servicePSets,
-                 ParameterSet& processPSet,
-                 ServiceToken const& iToken,
-                 serviceregistry::ServiceLegacy iLegacy,
-                 bool associate);
+    ServiceToken initServices(std::vector<ParameterSet>& servicePSets,
+                              ParameterSet& processPSet,
+                              ServiceToken const& iToken,
+                              serviceregistry::ServiceLegacy iLegacy,
+                              bool associate);
 
-    ServiceToken
-    addCPRandTNS(ParameterSet const& parameterSet, ServiceToken const& token);
+    ServiceToken addCPRandTNS(ParameterSet const& parameterSet, ServiceToken const& token);
 
-    std::shared_ptr<CommonParams>
-    initMisc(ParameterSet& parameterSet);
+    std::shared_ptr<CommonParams> initMisc(ParameterSet& parameterSet);
 
-    std::unique_ptr<Schedule>
-    initSchedule(ParameterSet& parameterSet,
-                 bool hasSubprocesses,
-                 PreallocationConfiguration const& iAllocConfig,
-                 ProcessContext const*);
+    std::unique_ptr<Schedule> initSchedule(ParameterSet& parameterSet,
+                                           bool hasSubprocesses,
+                                           PreallocationConfiguration const& iAllocConfig,
+                                           ProcessContext const*);
 
-    void
-    clear();
+    void clear();
 
-    std::shared_ptr<SignallingProductRegistry const> preg() const {return get_underlying_safe(preg_);}
-    std::shared_ptr<SignallingProductRegistry>& preg() {return get_underlying_safe(preg_);}
-    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return get_underlying_safe(branchIDListHelper_);}
-    std::shared_ptr<BranchIDListHelper>& branchIDListHelper() {return get_underlying_safe(branchIDListHelper_);}
-    std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {return get_underlying_safe(thinnedAssociationsHelper_);}
-    std::shared_ptr<ThinnedAssociationsHelper>& thinnedAssociationsHelper() {return get_underlying_safe(thinnedAssociationsHelper_);}
-    std::shared_ptr<SubProcessParentageHelper>& subProcessParentageHelper() {return get_underlying_safe(subProcessParentageHelper_);}
-    std::shared_ptr<ProcessConfiguration const> processConfiguration() const {return get_underlying_safe(processConfiguration_);}
-    std::shared_ptr<ProcessConfiguration>& processConfiguration() {return get_underlying_safe(processConfiguration_);}
+    std::shared_ptr<SignallingProductRegistry const> preg() const { return get_underlying_safe(preg_); }
+    std::shared_ptr<SignallingProductRegistry>& preg() { return get_underlying_safe(preg_); }
+    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {
+      return get_underlying_safe(branchIDListHelper_);
+    }
+    std::shared_ptr<BranchIDListHelper>& branchIDListHelper() { return get_underlying_safe(branchIDListHelper_); }
+    std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {
+      return get_underlying_safe(thinnedAssociationsHelper_);
+    }
+    std::shared_ptr<ThinnedAssociationsHelper>& thinnedAssociationsHelper() {
+      return get_underlying_safe(thinnedAssociationsHelper_);
+    }
+    std::shared_ptr<SubProcessParentageHelper>& subProcessParentageHelper() {
+      return get_underlying_safe(subProcessParentageHelper_);
+    }
+    std::shared_ptr<ProcessConfiguration const> processConfiguration() const {
+      return get_underlying_safe(processConfiguration_);
+    }
+    std::shared_ptr<ProcessConfiguration>& processConfiguration() { return get_underlying_safe(processConfiguration_); }
 
-    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
+    std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
     edm::propagate_const<std::shared_ptr<SignallingProductRegistry>> preg_;
     edm::propagate_const<std::shared_ptr<BranchIDListHelper>> branchIDListHelper_;
     edm::propagate_const<std::shared_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
@@ -73,5 +78,5 @@ namespace edm {
     std::unique_ptr<ExceptionToActionTable const> act_table_;
     edm::propagate_const<std::shared_ptr<ProcessConfiguration>> processConfiguration_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/SharedResourcesAcquirer.h
+++ b/FWCore/Framework/interface/SharedResourcesAcquirer.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     SharedResourcesAcquirer
-// 
+//
 /**\class SharedResourcesAcquirer SharedResourcesAcquirer.h "SharedResourcesAcquirer.h"
 
  Description: Handles acquiring and releasing a group of resources shared between modules
@@ -30,34 +30,32 @@ namespace edm {
   class SerialTaskQueueChain;
   class SerialTaskQueue;
 
-  class SharedResourcesAcquirer
-  {
+  class SharedResourcesAcquirer {
   public:
     friend class ::testSharedResourcesRegistry;
-    
+
     SharedResourcesAcquirer() = default;
-    explicit SharedResourcesAcquirer(std::vector<std::shared_ptr<SerialTaskQueue>>  iQueues):
-    m_queues(std::move(iQueues)){}
-    
+    explicit SharedResourcesAcquirer(std::vector<std::shared_ptr<SerialTaskQueue>> iQueues)
+        : m_queues(std::move(iQueues)) {}
+
     SharedResourcesAcquirer(SharedResourcesAcquirer&&) = default;
     SharedResourcesAcquirer(const SharedResourcesAcquirer&) = delete;
     SharedResourcesAcquirer& operator=(const SharedResourcesAcquirer&) = delete;
-    
+
     SharedResourcesAcquirer& operator=(SharedResourcesAcquirer&&) = default;
     ~SharedResourcesAcquirer() = default;
-    
+
     // ---------- member functions ---------------------------
-    
+
     ///The number returned may be less than the number of resources requested if a resource is only used by one module and therefore is not being shared.
-    size_t numberOfResources() const { return m_queues.numberOfQueues();}
-    
+    size_t numberOfResources() const { return m_queues.numberOfQueues(); }
+
     SerialTaskQueueChain& serialQueueChain() const { return m_queues; }
+
   private:
-    
     // ---------- member data --------------------------------
     mutable SerialTaskQueueChain m_queues;
   };
-}
-
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/SourceFactory.h
+++ b/FWCore/Framework/interface/SourceFactory.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     SourceFactory
-// 
+//
 /**\class SourceFactory SourceFactory.h FWCore/Framework/interface/SourceFactory.h
 
  Description: <one line class summary>
@@ -30,67 +30,65 @@
 // forward declarations
 
 namespace edm {
-   class EventSetupRecordIntervalFinder;
-   class ParameterSet;
+  class EventSetupRecordIntervalFinder;
+  class ParameterSet;
 
-   namespace eventsetup {
-      class DataProxyProvider;
-      class EventSetupsController;
-      
-      template<class T>
-         void addProviderTo(EventSetupProvider& iProvider, std::shared_ptr<T> iComponent, const DataProxyProvider*) 
-      {
-            std::shared_ptr<DataProxyProvider> pProvider(iComponent);
-            ComponentDescription description = pProvider->description();
-            description.isSource_=true;
-            pProvider->setDescription(description);
-            iProvider.add(pProvider);
+  namespace eventsetup {
+    class DataProxyProvider;
+    class EventSetupsController;
+
+    template <class T>
+    void addProviderTo(EventSetupProvider& iProvider, std::shared_ptr<T> iComponent, const DataProxyProvider*) {
+      std::shared_ptr<DataProxyProvider> pProvider(iComponent);
+      ComponentDescription description = pProvider->description();
+      description.isSource_ = true;
+      pProvider->setDescription(description);
+      iProvider.add(pProvider);
+    }
+    template <class T>
+    void addProviderTo(EventSetupProvider& /* iProvider */, std::shared_ptr<T> /*iComponent*/, const void*) {
+      //do nothing
+    }
+
+    struct SourceMakerTraits {
+      typedef EventSetupRecordIntervalFinder base_type;
+      static std::string name();
+      template <class T>
+      static void addTo(EventSetupProvider& iProvider,
+                        std::shared_ptr<T> iComponent,
+                        ParameterSet const& iConfiguration,
+                        bool matchesPreceding) {
+        if (matchesPreceding) {
+          logInfoWhenSharing(iConfiguration);
+        }
+        //a source does not always have to be a provider
+        addProviderTo(iProvider, iComponent, static_cast<const T*>(nullptr));
+        std::shared_ptr<EventSetupRecordIntervalFinder> pFinder(iComponent);
+        iProvider.add(pFinder);
       }
-      template<class T>
-         void addProviderTo(EventSetupProvider& /* iProvider */, std::shared_ptr<T> /*iComponent*/, const void*) 
-      {
-            //do nothing
-      }
-      
-      struct SourceMakerTraits {
-         typedef EventSetupRecordIntervalFinder base_type;
-         static std::string name();
-         template<class T>
-         static void addTo(EventSetupProvider& iProvider,
-                           std::shared_ptr<T> iComponent,
-                           ParameterSet const& iConfiguration,
-                           bool matchesPreceding)
-            {
-               if (matchesPreceding) {
-                  logInfoWhenSharing(iConfiguration);
-               }
-               //a source does not always have to be a provider
-               addProviderTo(iProvider, iComponent, static_cast<const T*>(nullptr));
-               std::shared_ptr<EventSetupRecordIntervalFinder> pFinder(iComponent);
-               iProvider.add(pFinder);
-            }
-         static void replaceExisting(EventSetupProvider& iProvider, std::shared_ptr<EventSetupRecordIntervalFinder> iComponent); 
-               
-         static std::shared_ptr<base_type> getComponentAndRegisterProcess(EventSetupsController& esController,
-                                                                            ParameterSet const& iConfiguration);
+      static void replaceExisting(EventSetupProvider& iProvider,
+                                  std::shared_ptr<EventSetupRecordIntervalFinder> iComponent);
 
-         static void putComponent(EventSetupsController& esController,
-                                  ParameterSet const& iConfiguration,
-                                  std::shared_ptr<base_type> const& component);
+      static std::shared_ptr<base_type> getComponentAndRegisterProcess(EventSetupsController& esController,
+                                                                       ParameterSet const& iConfiguration);
 
-         static void logInfoWhenSharing(ParameterSet const& iConfiguration);
-      };
+      static void putComponent(EventSetupsController& esController,
+                               ParameterSet const& iConfiguration,
+                               std::shared_ptr<base_type> const& component);
 
-      template< class TType>
-         struct SourceMaker : public ComponentMaker<edm::eventsetup::SourceMakerTraits,TType> {};
-      typedef  ComponentFactory<SourceMakerTraits> SourceFactory ;
-      
-      typedef edmplugin::PluginFactory<edm::eventsetup::ComponentMakerBase<edm::eventsetup::SourceMakerTraits>* ()> SourcePluginFactory;
-   }
-}
+      static void logInfoWhenSharing(ParameterSet const& iConfiguration);
+    };
 
-#define DEFINE_FWK_EVENTSETUP_SOURCE(type) \
-DEFINE_EDM_PLUGIN (edm::eventsetup::SourcePluginFactory,edm::eventsetup::SourceMaker<type>,#type); \
-DEFINE_DESC_FILLER_FOR_ESSOURCES(type)
+    template <class TType> struct SourceMaker : public ComponentMaker<edm::eventsetup::SourceMakerTraits, TType> {};
+    typedef ComponentFactory<SourceMakerTraits> SourceFactory;
+
+    typedef edmplugin::PluginFactory<edm::eventsetup::ComponentMakerBase<edm::eventsetup::SourceMakerTraits>*()>
+        SourcePluginFactory;
+  }  // namespace eventsetup
+}  // namespace edm
+
+#define DEFINE_FWK_EVENTSETUP_SOURCE(type)                                                            \
+  DEFINE_EDM_PLUGIN(edm::eventsetup::SourcePluginFactory, edm::eventsetup::SourceMaker<type>, #type); \
+  DEFINE_DESC_FILLER_FOR_ESSOURCES(type)
 
 #endif

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -58,32 +58,38 @@ namespace edm {
 
     ~SubProcess() override;
 
-    SubProcess(SubProcess const&) = delete; // Disallow copying
-    SubProcess& operator=(SubProcess const&) = delete; // Disallow copying
-    SubProcess(SubProcess&&) = default; // Allow Moving
-    SubProcess& operator=(SubProcess&&) = default; // Allow moving
+    SubProcess(SubProcess const&) = delete;             // Disallow copying
+    SubProcess& operator=(SubProcess const&) = delete;  // Disallow copying
+    SubProcess(SubProcess&&) = default;                 // Allow Moving
+    SubProcess& operator=(SubProcess&&) = default;      // Allow moving
 
     //From OutputModule
     void selectProducts(ProductRegistry const& preg,
                         ThinnedAssociationsHelper const& parentThinnedAssociationsHelper,
                         std::map<BranchID, bool>& keepAssociation);
 
-    SelectedProductsForBranchType const& keptProducts() const {return keptProducts_;}
+    SelectedProductsForBranchType const& keptProducts() const { return keptProducts_; }
 
     void doBeginJob();
     void doEndJob();
 
-    void doEventAsync(WaitingTaskHolder iHolder,
-                      EventPrincipal const& principal);
+    void doEventAsync(WaitingTaskHolder iHolder, EventPrincipal const& principal);
 
     void doBeginRunAsync(WaitingTaskHolder iHolder, RunPrincipal const& principal, IOVSyncValue const& ts);
 
-    void doEndRunAsync(WaitingTaskHolder iHolder, RunPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
+    void doEndRunAsync(WaitingTaskHolder iHolder,
+                       RunPrincipal const& principal,
+                       IOVSyncValue const& ts,
+                       bool cleaningUpAfterException);
 
-    void doBeginLuminosityBlockAsync(WaitingTaskHolder iHolder, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts);
+    void doBeginLuminosityBlockAsync(WaitingTaskHolder iHolder,
+                                     LuminosityBlockPrincipal const& principal,
+                                     IOVSyncValue const& ts);
 
-    void doEndLuminosityBlockAsync(WaitingTaskHolder iHolder, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
-
+    void doEndLuminosityBlockAsync(WaitingTaskHolder iHolder,
+                                   LuminosityBlockPrincipal const& principal,
+                                   IOVSyncValue const& ts,
+                                   bool cleaningUpAfterException);
 
     void doBeginStream(unsigned int);
     void doEndStream(unsigned int);
@@ -93,7 +99,8 @@ namespace edm {
                                IOVSyncValue const& ts);
 
     void doStreamEndRunAsync(WaitingTaskHolder iHolder,
-                             unsigned int iID, RunPrincipal const& principal,
+                             unsigned int iID,
+                             RunPrincipal const& principal,
                              IOVSyncValue const& ts,
                              bool cleaningUpAfterException);
 
@@ -108,14 +115,16 @@ namespace edm {
                                          IOVSyncValue const& ts,
                                          bool cleaningUpAfterException);
 
-
     // Write the luminosity block
     void writeLumiAsync(WaitingTaskHolder, LuminosityBlockPrincipal&);
 
     void deleteLumiFromCache(LuminosityBlockPrincipal&);
 
     // Write the run
-    void writeRunAsync(WaitingTaskHolder, ProcessHistoryID const& parentPhID, int runNumber, MergeableRunProductMetadata const*);
+    void writeRunAsync(WaitingTaskHolder,
+                       ProcessHistoryID const& parentPhID,
+                       int runNumber,
+                       MergeableRunProductMetadata const*);
 
     void deleteRunFromCache(ProcessHistoryID const& parentPhID, int runNumber);
 
@@ -148,11 +157,11 @@ namespace edm {
     // Call shouldWeCloseFile() on all OutputModules.
     bool shouldWeCloseOutput() const {
       ServiceRegistry::Operate operate(serviceToken_);
-      if(schedule_->shouldWeCloseOutput()) {
+      if (schedule_->shouldWeCloseOutput()) {
         return true;
       }
-      for(auto const& subProcess : subProcesses_) {
-        if(subProcess.shouldWeCloseOutput()) {
+      for (auto const& subProcess : subProcesses_) {
+        if (subProcess.shouldWeCloseOutput()) {
           return true;
         }
       }
@@ -169,9 +178,7 @@ namespace edm {
     /// Return the number of events this SubProcess has tried to process
     /// (inclues both successes and failures, including failures due
     /// to exceptions during processing).
-    int totalEvents() const {
-      return schedule_->totalEvents();
-    }
+    int totalEvents() const { return schedule_->totalEvents(); }
 
     /// Return the number of events which have been passed by one or more trigger paths.
     int totalEventsPassed() const {
@@ -191,7 +198,7 @@ namespace edm {
     void enableEndPaths(bool active) {
       ServiceRegistry::Operate operate(serviceToken_);
       schedule_->enableEndPaths(active);
-      for_all(subProcesses_, [active](auto& subProcess){ subProcess.enableEndPaths(active); });
+      for_all(subProcesses_, [active](auto& subProcess) { subProcess.enableEndPaths(active); });
     }
 
     /// Return true if end_paths are active, and false if they are inactive.
@@ -211,11 +218,11 @@ namespace edm {
     /// If there is a subprocess, get this information from the subprocess.
     bool terminate() const {
       ServiceRegistry::Operate operate(serviceToken_);
-      if(schedule_->terminate()) {
+      if (schedule_->terminate()) {
         return true;
       }
-      for(auto const& subProcess : subProcesses_) {
-        if(subProcess.terminate()) {
+      for (auto const& subProcess : subProcesses_) {
+        if (subProcess.terminate()) {
           return true;
         }
       }
@@ -226,7 +233,7 @@ namespace edm {
     void clearCounters() {
       ServiceRegistry::Operate operate(serviceToken_);
       schedule_->clearCounters();
-      for_all(subProcesses_, [](auto& subProcess){ subProcess.clearCounters(); });
+      for_all(subProcesses_, [](auto& subProcess) { subProcess.clearCounters(); });
     }
 
   private:
@@ -239,7 +246,8 @@ namespace edm {
     void endLuminosityBlock(LuminosityBlockPrincipal const& lb, IOVSyncValue const& ts, bool cleaningUpAfterException);
 
     void propagateProducts(BranchType type, Principal const& parentPrincipal, Principal& principal) const;
-    void fixBranchIDListsForEDAliases(std::map<BranchID::value_type, BranchID::value_type> const& droppedBranchIDToKeptBranchID);
+    void fixBranchIDListsForEDAliases(
+        std::map<BranchID::value_type, BranchID::value_type> const& droppedBranchIDToKeptBranchID);
     void keepThisBranch(BranchDescription const& desc,
                         std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
                         std::set<BranchID>& keptProductsInEvent);
@@ -248,34 +256,40 @@ namespace edm {
       return droppedBranchIDToKeptBranchID_;
     }
 
-    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return get_underlying_safe(branchIDListHelper_);}
-    std::shared_ptr<BranchIDListHelper>& branchIDListHelper() {return get_underlying_safe(branchIDListHelper_);}
-    std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {return get_underlying_safe(thinnedAssociationsHelper_);}
-    std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper() {return get_underlying_safe(thinnedAssociationsHelper_);}
+    std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {
+      return get_underlying_safe(branchIDListHelper_);
+    }
+    std::shared_ptr<BranchIDListHelper>& branchIDListHelper() { return get_underlying_safe(branchIDListHelper_); }
+    std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper() const {
+      return get_underlying_safe(thinnedAssociationsHelper_);
+    }
+    std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper() {
+      return get_underlying_safe(thinnedAssociationsHelper_);
+    }
 
-    std::shared_ptr<ActivityRegistry>             actReg_; // We do not use propagate_const because the registry itself is mutable.
-    ServiceToken                                  serviceToken_;
-    std::shared_ptr<ProductRegistry const>        parentPreg_;
-    std::shared_ptr<ProductRegistry const>        preg_;
+    std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
+    ServiceToken serviceToken_;
+    std::shared_ptr<ProductRegistry const> parentPreg_;
+    std::shared_ptr<ProductRegistry const> preg_;
     edm::propagate_const<std::shared_ptr<BranchIDListHelper>> branchIDListHelper_;
     edm::propagate_const<std::shared_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
     edm::propagate_const<std::shared_ptr<SubProcessParentageHelper>> subProcessParentageHelper_;
     std::unique_ptr<ExceptionToActionTable const> act_table_;
-    std::shared_ptr<ProcessConfiguration const>   processConfiguration_;
-    ProcessContext                                processContext_;
-    PathsAndConsumesOfModules                     pathsAndConsumesOfModules_;
+    std::shared_ptr<ProcessConfiguration const> processConfiguration_;
+    ProcessContext processContext_;
+    PathsAndConsumesOfModules pathsAndConsumesOfModules_;
     //We require 1 history for each Run, Lumi and Stream
     // The vectors first hold Stream info, then Lumi then Run
-    unsigned int                                  historyLumiOffset_;
-    unsigned int                                  historyRunOffset_;
-    std::vector<ProcessHistoryRegistry>           processHistoryRegistries_;
-    std::vector<HistoryAppender>                  historyAppenders_;
-    PrincipalCache                                principalCache_;
+    unsigned int historyLumiOffset_;
+    unsigned int historyRunOffset_;
+    std::vector<ProcessHistoryRegistry> processHistoryRegistries_;
+    std::vector<HistoryAppender> historyAppenders_;
+    PrincipalCache principalCache_;
     //vector index is principal lumi's index value
     std::vector<std::shared_ptr<LuminosityBlockPrincipal>> inUseLumiPrincipals_;
     edm::propagate_const<std::shared_ptr<eventsetup::EventSetupProvider>> esp_;
     edm::propagate_const<std::unique_ptr<Schedule>> schedule_;
-    std::map<ProcessHistoryID, ProcessHistoryID>  parentToChildPhID_;
+    std::map<ProcessHistoryID, ProcessHistoryID> parentToChildPhID_;
     std::vector<SubProcess> subProcesses_;
     edm::propagate_const<std::unique_ptr<ParameterSet>> processParameterSet_;
 
@@ -295,10 +309,9 @@ namespace edm {
     // needed because of possible EDAliases.
     // filled in only if key and value are different.
     std::map<BranchID::value_type, BranchID::value_type> droppedBranchIDToKeptBranchID_;
-
   };
 
   // free function
   std::vector<ParameterSet> popSubProcessVParameterSet(ParameterSet& parameterSet);
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/TriggerNamesService.h
+++ b/FWCore/Framework/interface/TriggerNamesService.h
@@ -39,10 +39,8 @@ namespace edm {
   class TriggerResults;
 
   namespace service {
-    class TriggerNamesService
-    {
+    class TriggerNamesService {
     public:
-
       typedef std::vector<std::string> Strings;
       typedef std::map<std::string, unsigned int> PosMap;
       typedef PosMap::size_type size_type;
@@ -55,8 +53,8 @@ namespace edm {
       // Return the number of trigger paths in the current process.
       size_type size() const { return trignames_.size(); }
       Strings const& getTrigPaths() const { return trignames_; }
-      std::string const&  getTrigPath(size_type const i) const { return trignames_.at(i);}
-      size_type  findTrigPath(std::string const& name) const { return find(trigpos_,name);}
+      std::string const& getTrigPath(size_type const i) const { return trignames_.at(i); }
+      size_type findTrigPath(std::string const& name) const { return find(trigpos_, name); }
 
       // Get the ordered vector of trigger names that corresponds to the bits
       // in the TriggerResults object.  Unlike the other functions in this class,
@@ -65,54 +63,45 @@ namespace edm {
       // works for modules in end paths, because the TriggerResults object is
       // not created until the normal paths complete execution.
       // Returns false if it fails to find the trigger path names.
-      bool getTrigPaths(TriggerResults const& triggerResults,
-                        Strings& trigPaths);
+      bool getTrigPaths(TriggerResults const& triggerResults, Strings& trigPaths);
 
       // This is the same as the previous function except the value returned in
       // the last argument indicates whether the results were retrieved from the
       // ParameterSet registry.  This will always be true except in old data where
       // the trigger names were stored inside of the TriggerResults object.
-      bool getTrigPaths(TriggerResults const& triggerResults,
-                        Strings& trigPaths,
-                        bool& fromPSetRegistry);
+      bool getTrigPaths(TriggerResults const& triggerResults, Strings& trigPaths, bool& fromPSetRegistry);
 
       Strings const& getEndPaths() const { return end_names_; }
-      std::string const&  getEndPath(size_type const i) const { return end_names_.at(i);}
-      size_type  findEndPath(std::string const& name) const { return find(end_pos_,name);}
+      std::string const& getEndPath(size_type const i) const { return end_names_.at(i); }
+      size_type findEndPath(std::string const& name) const { return find(end_pos_, name); }
 
-      Strings const& getTrigPathModules(std::string const& name) const {
-	return modulenames_.at(find(trigpos_,name));
+      Strings const& getTrigPathModules(std::string const& name) const { return modulenames_.at(find(trigpos_, name)); }
+      Strings const& getTrigPathModules(size_type const i) const { return modulenames_.at(i); }
+      std::string const& getTrigPathModule(std::string const& name, size_type const j) const {
+        return (modulenames_.at(find(trigpos_, name))).at(j);
       }
-      Strings const& getTrigPathModules(size_type const i) const {
-	return modulenames_.at(i);
-      }
-      std::string const&  getTrigPathModule (std::string const& name, size_type const j) const {
-	return (modulenames_.at(find(trigpos_,name))).at(j);
-      }
-      std::string const&  getTrigPathModule (size_type const i, size_type const j) const {
-	return (modulenames_.at(i)).at(j);
+      std::string const& getTrigPathModule(size_type const i, size_type const j) const {
+        return (modulenames_.at(i)).at(j);
       }
 
       Strings const& getEndPathModules(std::string const& name) const {
-	return end_modulenames_.at(find(end_pos_,name));
+        return end_modulenames_.at(find(end_pos_, name));
       }
-      Strings const& getEndPathModules(size_type const i) const {
-	return end_modulenames_.at(i);
+      Strings const& getEndPathModules(size_type const i) const { return end_modulenames_.at(i); }
+      std::string const& getEndPathModule(std::string const& name, size_type const j) const {
+        return (end_modulenames_.at(find(end_pos_, name))).at(j);
       }
-      std::string const&  getEndPathModule (std::string const& name, size_type const j) const {
-	return (end_modulenames_.at(find(end_pos_,name))).at(j);
-      }
-      std::string const&  getEndPathModule (size_type const i, size_type const j) const {
-	return (end_modulenames_.at(i)).at(j);
+      std::string const& getEndPathModule(size_type const i, size_type const j) const {
+        return (end_modulenames_.at(i)).at(j);
       }
 
-      size_type find (PosMap const& posmap, std::string const& name) const {
-	PosMap::const_iterator const pos(posmap.find(name));
+      size_type find(PosMap const& posmap, std::string const& name) const {
+        PosMap::const_iterator const pos(posmap.find(name));
         if (pos == posmap.end()) {
-	  return posmap.size();
-	} else {
+          return posmap.size();
+        } else {
           return pos->second;
-	}
+        }
       }
 
       std::string const& getProcessName() const { return process_name_; }
@@ -122,28 +111,27 @@ namespace edm {
       edm::ParameterSet const& getTriggerPSet() const { return trigger_pset_; }
 
     private:
-
       void loadPosMap(PosMap& posmap, Strings const& names) {
         size_type const n(names.size());
-	for (size_type i = 0; i != n; ++i) {
-	  posmap[names[i]] = i;
-	}
+        for (size_type i = 0; i != n; ++i) {
+          posmap[names[i]] = i;
+        }
       }
 
       edm::ParameterSet trigger_pset_;
 
       Strings trignames_;
-      PosMap  trigpos_;
+      PosMap trigpos_;
       Strings end_names_;
-      PosMap  end_pos_;
+      PosMap end_pos_;
 
-      std::vector<Strings> modulenames_;        // modules on trigger paths
-      std::vector<Strings> end_modulenames_;    // modules on endpaths
+      std::vector<Strings> modulenames_;      // modules on trigger paths
+      std::vector<Strings> end_modulenames_;  // modules on endpaths
 
       std::string process_name_;
       bool wantSummary_;
     };
-  }
-}
+  }  // namespace service
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/TriggerReport.h
+++ b/FWCore/Framework/interface/TriggerReport.h
@@ -15,15 +15,13 @@ creation.
 
 namespace edm {
 
-  struct EventSummary
-  {
+  struct EventSummary {
     int totalEvents = 0;
     int totalEventsPassed = 0;
     int totalEventsFailed = 0;
   };
 
-  struct ModuleInPathSummary
-  {
+  struct ModuleInPathSummary {
     int timesVisited = 0;
     int timesPassed = 0;
     int timesFailed = 0;
@@ -32,9 +30,7 @@ namespace edm {
     std::string moduleLabel;
   };
 
-
-  struct PathSummary
-  {
+  struct PathSummary {
     int bitPosition = 0;
     int timesRun = 0;
     int timesPassed = 0;
@@ -45,8 +41,7 @@ namespace edm {
     std::vector<ModuleInPathSummary> moduleInPathSummaries;
   };
 
-  struct WorkerSummary
-  {
+  struct WorkerSummary {
     int timesVisited = 0;
     int timesRun = 0;
     int timesPassed = 0;
@@ -56,18 +51,14 @@ namespace edm {
     std::string moduleLabel;
   };
 
-  inline
-  bool operator<(WorkerSummary const& a, WorkerSummary const& b) {
-    return a.moduleLabel < b.moduleLabel;
-  }
+  inline bool operator<(WorkerSummary const& a, WorkerSummary const& b) { return a.moduleLabel < b.moduleLabel; }
 
-  struct TriggerReport
-  {
-    EventSummary               eventSummary;
-    std::vector<PathSummary>   trigPathSummaries;
-    std::vector<PathSummary>   endPathSummaries;
+  struct TriggerReport {
+    EventSummary eventSummary;
+    std::vector<PathSummary> trigPathSummaries;
+    std::vector<PathSummary> endPathSummaries;
     std::vector<WorkerSummary> workerSummaries;
   };
 
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
+++ b/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
@@ -29,47 +29,40 @@ namespace edm {
 
     class NamedEventSelector {
     public:
-      NamedEventSelector(std::string const& n, EventSelector const& s, ConsumesCollector&& iC) :
-	inputTag_("TriggerResults", "", n),
-        token_(iC.consumes<TriggerResults>(inputTag_)),
-	eventSelector_(s)
-      { }
+      NamedEventSelector(std::string const& n, EventSelector const& s, ConsumesCollector&& iC)
+          : inputTag_("TriggerResults", "", n), token_(iC.consumes<TriggerResults>(inputTag_)), eventSelector_(s) {}
 
-      bool match(TriggerResults const& product) {
-	return eventSelector_.acceptEvent(product);
-      }
+      bool match(TriggerResults const& product) { return eventSelector_.acceptEvent(product); }
 
-      InputTag const& inputTag() const {
-        return inputTag_;
-      }
+      InputTag const& inputTag() const { return inputTag_; }
 
-      EDGetTokenT<TriggerResults> const& token() const {
-        return token_;
-      }
+      EDGetTokenT<TriggerResults> const& token() const { return token_; }
+
     private:
-      InputTag            inputTag_;
+      InputTag inputTag_;
       EDGetTokenT<TriggerResults> token_;
-      EventSelector       eventSelector_;
+      EventSelector eventSelector_;
     };
 
     class TriggerResultsBasedEventSelector {
     public:
       TriggerResultsBasedEventSelector();
-      typedef detail::handle_t                    handle_t;
-      typedef std::vector<NamedEventSelector>     selectors_t;
+      typedef detail::handle_t handle_t;
+      typedef std::vector<NamedEventSelector> selectors_t;
       typedef std::pair<std::string, std::string> parsed_path_spec_t;
 
       void setupDefault();
 
       void setup(std::vector<parsed_path_spec_t> const& path_specs,
-		 std::vector<std::string> const& triggernames,
+                 std::vector<std::string> const& triggernames,
                  std::string const& process_name,
                  ConsumesCollector&& iC);
 
       bool wantEvent(EventForOutput const& e);
 
-      unsigned int numberOfTokens() const { return selectors_.size();}
-      EDGetToken token(unsigned int index) const {return selectors_[index].token();}
+      unsigned int numberOfTokens() const { return selectors_.size(); }
+      EDGetToken token(unsigned int index) const { return selectors_[index].token(); }
+
     private:
       selectors_t selectors_;
       bool wantAllEvents_;
@@ -86,12 +79,13 @@ namespace edm {
     /** Takes the user specified SelectEvents PSet and creates a new one
      which conforms to the canonical format required for provenance
      */
-    ParameterSetID registerProperSelectionInfo(edm::ParameterSet const& iInitial,
-                                               std::string const& iLabel,
-                                               std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
-                                               bool anyProductProduced);
+    ParameterSetID registerProperSelectionInfo(
+        edm::ParameterSet const& iInitial,
+        std::string const& iLabel,
+        std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
+        bool anyProductProduced);
 
-  }
-}
+  }  // namespace detail
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/TriggerTimingReport.h
+++ b/FWCore/Framework/interface/TriggerTimingReport.h
@@ -14,54 +14,47 @@ reporting on the timing of the trigger.
 
 namespace edm {
 
-  struct EventTimingSummary
-  {
+  struct EventTimingSummary {
     int totalEvents = 0;
     double cpuTime = 0.;
-    double realTime =0.;
+    double realTime = 0.;
     double sumStreamRealTime = 0.;
   };
 
-  struct ModuleInPathTimingSummary
-  {
+  struct ModuleInPathTimingSummary {
     int timesVisited = 0;
-    double realTime =0.;
+    double realTime = 0.;
 
     std::string moduleLabel;
   };
 
-
-  struct PathTimingSummary
-  {
+  struct PathTimingSummary {
     int bitPosition = 0;
     int timesRun = 0;
-    double realTime =0.;
+    double realTime = 0.;
 
     std::string name;
     std::vector<ModuleInPathTimingSummary> moduleInPathSummaries;
   };
 
-  struct WorkerTimingSummary
-  {
+  struct WorkerTimingSummary {
     int timesVisited = 0;
     int timesRun = 0;
-    double realTime =0.;
+    double realTime = 0.;
 
     std::string moduleLabel;
   };
 
-  inline
-  bool operator<(WorkerTimingSummary const& a, WorkerTimingSummary const& b) {
+  inline bool operator<(WorkerTimingSummary const& a, WorkerTimingSummary const& b) {
     return a.moduleLabel < b.moduleLabel;
   }
 
-  struct TriggerTimingReport
-  {
-    EventTimingSummary               eventSummary;
-    std::vector<PathTimingSummary>   trigPathSummaries;
-    std::vector<PathTimingSummary>   endPathSummaries;
+  struct TriggerTimingReport {
+    EventTimingSummary eventSummary;
+    std::vector<PathTimingSummary> trigPathSummaries;
+    std::vector<PathTimingSummary> endPathSummaries;
     std::vector<WorkerTimingSummary> workerSummaries;
   };
 
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/UnknownModuleException.h
+++ b/FWCore/Framework/interface/UnknownModuleException.h
@@ -26,20 +26,17 @@ namespace edm {
   */
   class UnknownModuleException : public cms::Exception {
   public:
-
-    UnknownModuleException(const std::string & moduletype):
-      cms::Exception("UnknownModule")
-    {
-      (*this) << "Module " << moduletype << " was not registered \n"
-	"Perhaps your module type is misspelled or is not a "
-	"framework plugin \n"
-	"Try running EdmPluginDump to obtain a list "
-	"of available Plugins\n";
+    UnknownModuleException(const std::string& moduletype) : cms::Exception("UnknownModule") {
+      (*this) << "Module " << moduletype
+              << " was not registered \n"
+                 "Perhaps your module type is misspelled or is not a "
+                 "framework plugin \n"
+                 "Try running EdmPluginDump to obtain a list "
+                 "of available Plugins\n";
     }
-    ~UnknownModuleException() noexcept override{}
-  }; // UnknownModuleException
+    ~UnknownModuleException() noexcept override {}
+  };  // UnknownModuleException
 
-
-} // edm
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/UnscheduledCallProducer.h
+++ b/FWCore/Framework/interface/UnscheduledCallProducer.h
@@ -34,10 +34,9 @@ namespace edm {
 
   class UnscheduledCallProducer {
   public:
-    
     using worker_container = std::vector<Worker*>;
     using const_iterator = worker_container::const_iterator;
-    
+
     UnscheduledCallProducer(ActivityRegistry& iReg) : unscheduledWorkers_() {
       aux_.preModuleDelayedGetSignal_.connect(std::cref(iReg.preModuleEventDelayedGetSignal_));
       aux_.postModuleDelayedGetSignal_.connect(std::cref(iReg.postModuleEventDelayedGetSignal_));
@@ -49,24 +48,25 @@ namespace edm {
         accumulatorWorkers_.push_back(aWorker);
       }
     }
-    
-    void setEventSetup(EventSetupImpl const& iSetup) {
-      aux_.setEventSetup(&iSetup);
-    }
+
+    void setEventSetup(EventSetupImpl const& iSetup) { aux_.setEventSetup(&iSetup); }
 
     UnscheduledAuxiliary const& auxiliary() const { return aux_; }
 
     const_iterator begin() const { return unscheduledWorkers_.begin(); }
     const_iterator end() const { return unscheduledWorkers_.end(); }
-    
+
     template <typename T, typename U>
     void runNowAsync(WaitingTask* task,
-                     typename T::MyPrincipal& p, EventSetupImpl const& es,
-                     ServiceToken const& token, StreamID streamID,
-                     typename T::Context const* topContext, U const* context) const {
+                     typename T::MyPrincipal& p,
+                     EventSetupImpl const& es,
+                     ServiceToken const& token,
+                     StreamID streamID,
+                     typename T::Context const* topContext,
+                     U const* context) const {
       //do nothing for event since we will run when requested
-      if(!T::isEvent_) {
-        for(auto worker: unscheduledWorkers_) {
+      if (!T::isEvent_) {
+        for (auto worker : unscheduledWorkers_) {
           ParentContext parentContext(context);
 
           // We do not need to run prefetching here because this only handles
@@ -96,7 +96,7 @@ namespace edm {
     template <typename T, typename ID>
     void addContextToException(cms::Exception& ex, Worker const* worker, ID const& id) const {
       std::ostringstream ost;
-      ost << "Processing " << T::transitionName()<<" "<< id;
+      ost << "Processing " << T::transitionName() << " " << id;
       ex.addContext(ost.str());
     }
     worker_container unscheduledWorkers_;
@@ -104,7 +104,6 @@ namespace edm {
     UnscheduledAuxiliary aux_;
   };
 
-}
+}  // namespace edm
 
 #endif
-

--- a/FWCore/Framework/interface/ValidityInterval.h
+++ b/FWCore/Framework/interface/ValidityInterval.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ValidityInterval
-// 
+//
 /**\class ValidityInterval ValidityInterval.h FWCore/Framework/interface/ValidityInterval.h
 
  Description: <one line class summary>
@@ -25,49 +25,37 @@
 
 // forward declarations
 namespace edm {
-class ValidityInterval
-{
+  class ValidityInterval {
+  public:
+    ValidityInterval();
+    ValidityInterval(const IOVSyncValue& iFirst, const IOVSyncValue& iLast);
+    //virtual ~ValidityInterval();
 
-   public:
-      ValidityInterval();
-      ValidityInterval(const IOVSyncValue& iFirst,
-                       const IOVSyncValue& iLast);
-      //virtual ~ValidityInterval();
+    // ---------- const member functions ---------------------
+    bool validFor(const IOVSyncValue&) const;
 
-      // ---------- const member functions ---------------------
-      bool validFor(const IOVSyncValue&) const;
-      
-      const IOVSyncValue& first() const { return first_; }
-      const IOVSyncValue& last() const { return last_; }
-      
-      bool operator==(const ValidityInterval& iRHS) const {
-         return iRHS.first_ == first_ && 
-         iRHS.last_ == last_ ;
-      }
-      bool operator!=(const ValidityInterval& iRHS) const {
-         return ! (*this == iRHS);
-      }
-      
-      // ---------- static member functions --------------------
-      static const ValidityInterval& invalidInterval();
-      
-      // ---------- member functions ---------------------------
-      void setFirst(const IOVSyncValue& iTime) {
-         first_ = iTime;
-      }
-      void setLast(const IOVSyncValue& iTime) {
-         last_ = iTime;
-      }
-      
-   private:
-      //ValidityInterval(const ValidityInterval&); // stop default
+    const IOVSyncValue& first() const { return first_; }
+    const IOVSyncValue& last() const { return last_; }
 
-      //const ValidityInterval& operator=(const ValidityInterval&); // stop default
+    bool operator==(const ValidityInterval& iRHS) const { return iRHS.first_ == first_ && iRHS.last_ == last_; }
+    bool operator!=(const ValidityInterval& iRHS) const { return !(*this == iRHS); }
 
-      // ---------- member data --------------------------------
-      IOVSyncValue first_;
-      IOVSyncValue last_;
-};
+    // ---------- static member functions --------------------
+    static const ValidityInterval& invalidInterval();
 
-}
+    // ---------- member functions ---------------------------
+    void setFirst(const IOVSyncValue& iTime) { first_ = iTime; }
+    void setLast(const IOVSyncValue& iTime) { last_ = iTime; }
+
+  private:
+    //ValidityInterval(const ValidityInterval&); // stop default
+
+    //const ValidityInterval& operator=(const ValidityInterval&); // stop default
+
+    // ---------- member data --------------------------------
+    IOVSyncValue first_;
+    IOVSyncValue last_;
+  };
+
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/WillGetIfMatch.h
+++ b/FWCore/Framework/interface/WillGetIfMatch.h
@@ -18,36 +18,29 @@ See comments in the file GetterOfProducts.h.
 
 namespace edm {
 
-  template<typename T>
-  class WillGetIfMatch {
+  template <typename T> class WillGetIfMatch {
   public:
+    template <typename U> WillGetIfMatch(U const& match, EDConsumerBase* module) : match_(match), module_(module) {}
 
-    template <typename U>
-    WillGetIfMatch(U const& match, EDConsumerBase* module):
-      match_(match),
-      module_(module) {
-    }
-    
-    EDGetTokenT<T>  operator()(BranchDescription const& branchDescription) {
-      if (match_(branchDescription)){
+    EDGetTokenT<T> operator()(BranchDescription const& branchDescription) {
+      if (match_(branchDescription)) {
         auto transition = branchDescription.branchType();
-        edm::InputTag tag{branchDescription.moduleLabel(),
-                          branchDescription.productInstanceName(),
+        edm::InputTag tag{branchDescription.moduleLabel(), branchDescription.productInstanceName(),
                           branchDescription.processName()};
-        if(transition == edm::InEvent) {
+        if (transition == edm::InEvent) {
           return module_->template consumes<T>(tag);
-        } else if(transition == edm::InLumi) {
-          return module_->template consumes<T,edm::InLumi>(tag);
-        } else if(transition == edm::InRun) {
-          return module_->template consumes<T,edm::InRun>(tag);
+        } else if (transition == edm::InLumi) {
+          return module_->template consumes<T, edm::InLumi>(tag);
+        } else if (transition == edm::InRun) {
+          return module_->template consumes<T, edm::InRun>(tag);
         }
       }
       return EDGetTokenT<T>{};
     }
-    
+
   private:
     std::function<bool(BranchDescription const&)> match_;
     EDConsumerBase* module_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -27,7 +27,7 @@ namespace edm {
   class StreamContext;
   class ModuleRegistry;
   class PreallocationConfiguration;
-  
+
   class WorkerManager {
   public:
     typedef std::vector<Worker*> AllWorkers;
@@ -49,21 +49,20 @@ namespace edm {
     void setOnDemandProducts(ProductRegistry& pregistry, std::set<std::string> const& unscheduledLabels) const;
 
     template <typename T, typename U>
-      void processOneOccurrence(typename T::MyPrincipal& principal,
-                                EventSetupImpl const& eventSetup,
-                                StreamID streamID,
-                                typename T::Context const* topContext,
-                                U const* context,
-                                bool cleaningUpAfterException = false);
-    template <typename T, typename U>
-    void processOneOccurrenceAsync(
-                              WaitingTask* task,
-                              typename T::MyPrincipal& principal,
+    void processOneOccurrence(typename T::MyPrincipal& principal,
                               EventSetupImpl const& eventSetup,
-                              ServiceToken const& token,
                               StreamID streamID,
                               typename T::Context const* topContext,
-                              U const* context);
+                              U const* context,
+                              bool cleaningUpAfterException = false);
+    template <typename T, typename U>
+    void processOneOccurrenceAsync(WaitingTask* task,
+                                   typename T::MyPrincipal& principal,
+                                   EventSetupImpl const& eventSetup,
+                                   ServiceToken const& token,
+                                   StreamID streamID,
+                                   typename T::Context const* topContext,
+                                   U const* context);
 
     template <typename T>
     void processAccumulatorsAsync(WaitingTask* task,
@@ -82,12 +81,12 @@ namespace edm {
 
     void beginStream(StreamID iID, StreamContext& streamContext);
     void endStream(StreamID iID, StreamContext& streamContext);
-    
-    AllWorkers const& allWorkers() const {return allWorkers_;}
+
+    AllWorkers const& allWorkers() const { return allWorkers_; }
 
     void addToAllWorkers(Worker* w);
 
-    ExceptionToActionTable const&  actionTable() const {return *actionTable_;}
+    ExceptionToActionTable const& actionTable() const { return *actionTable_; }
 
     Worker* getWorker(ParameterSet& pset,
                       ProductRegistry& preg,
@@ -98,36 +97,34 @@ namespace edm {
     void resetAll();
 
   private:
-
-    WorkerRegistry      workerReg_;
-    ExceptionToActionTable const*  actionTable_;
-    AllWorkers          allWorkers_;
+    WorkerRegistry workerReg_;
+    ExceptionToActionTable const* actionTable_;
+    AllWorkers allWorkers_;
     UnscheduledCallProducer unscheduled_;
     void const* lastSetupEventPrincipal_;
   };
 
   template <typename T, typename U>
-  void
-    WorkerManager::processOneOccurrence(typename T::MyPrincipal& ep,
-                                        EventSetupImpl const& es,
-                                        StreamID streamID,
-                                        typename T::Context const* topContext,
-                                        U const* context,
-                                        bool cleaningUpAfterException) {
+  void WorkerManager::processOneOccurrence(typename T::MyPrincipal& ep,
+                                           EventSetupImpl const& es,
+                                           StreamID streamID,
+                                           typename T::Context const* topContext,
+                                           U const* context,
+                                           bool cleaningUpAfterException) {
     this->resetAll();
 
     auto waitTask = make_empty_waiting_task();
     waitTask->increment_ref_count();
-    processOneOccurrenceAsync<T,U>(waitTask.get(), ep, es, ServiceRegistry::instance().presentToken(), streamID, topContext, context);
+    processOneOccurrenceAsync<T, U>(waitTask.get(), ep, es, ServiceRegistry::instance().presentToken(), streamID,
+                                    topContext, context);
     waitTask->wait_for_all();
-    if(waitTask->exceptionPtr() != nullptr) {
-      try{ 
-      convertException::wrap([&]() {
-          std::rethrow_exception(* (waitTask->exceptionPtr()) );
-        });
-      } catch(cms::Exception& ex) {
+    if (waitTask->exceptionPtr() != nullptr) {
+      try {
+        convertException::wrap([&]() { std::rethrow_exception(*(waitTask->exceptionPtr())); });
+      } catch (cms::Exception& ex) {
         if (ex.context().empty()) {
-          addContextAndPrintException("Calling function WorkerManager::processOneOccurrence", ex, cleaningUpAfterException);
+          addContextAndPrintException("Calling function WorkerManager::processOneOccurrence", ex,
+                                      cleaningUpAfterException);
         } else {
           addContextAndPrintException("", ex, cleaningUpAfterException);
         }
@@ -137,29 +134,27 @@ namespace edm {
   }
 
   template <typename T, typename U>
-  void
-  WorkerManager::processOneOccurrenceAsync(WaitingTask* task,
-                                           typename T::MyPrincipal& ep,
-                                           EventSetupImpl const& es,
-                                           ServiceToken const& token,
-                                           StreamID streamID,
-                                           typename T::Context const* topContext,
-                                           U const* context) {
+  void WorkerManager::processOneOccurrenceAsync(WaitingTask* task,
+                                                typename T::MyPrincipal& ep,
+                                                EventSetupImpl const& es,
+                                                ServiceToken const& token,
+                                                StreamID streamID,
+                                                typename T::Context const* topContext,
+                                                U const* context) {
     //make sure the unscheduled items see this run or lumi transition
-    unscheduled_.runNowAsync<T,U>(task,ep, es, token, streamID, topContext, context);
+    unscheduled_.runNowAsync<T, U>(task, ep, es, token, streamID, topContext, context);
   }
 
   template <typename T>
-  void
-  WorkerManager::processAccumulatorsAsync(WaitingTask* task,
-                                          typename T::MyPrincipal const& ep,
-                                          EventSetupImpl const& es,
-                                          ServiceToken const& token,
-                                          StreamID streamID,
-                                          ParentContext const& parentContext,
-                                          typename T::Context const* context) {
+  void WorkerManager::processAccumulatorsAsync(WaitingTask* task,
+                                               typename T::MyPrincipal const& ep,
+                                               EventSetupImpl const& es,
+                                               ServiceToken const& token,
+                                               StreamID streamID,
+                                               ParentContext const& parentContext,
+                                               typename T::Context const* context) {
     unscheduled_.runAccumulatorsAsync<T>(task, ep, es, token, streamID, parentContext, context);
   }
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/data_default_record_trait.h
+++ b/FWCore/Framework/interface/data_default_record_trait.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     data_default_record_trait
-// 
+//
 /**\class data_default_record_trait data_default_record_trait.h FWCore/Framework/interface/data_default_record_trait.h
 
  Description: trait class that assigns a default EventSetup Record to a particular data type
@@ -42,34 +42,31 @@
 
 namespace edm {
 
-  template <typename T>
-  class ESHandle;
+  template <typename T> class ESHandle;
 
   // Special class to denote that the default record should be used.
   struct DefaultRecord {};
 
-   namespace eventsetup {
-      template< class T> struct MUST_GET_RECORD_FROM_EVENTSETUP_TO_GET_DATA;
-      
-      template<class DataT>
-         struct data_default_record_trait
-      {
-         //NOTE: by default, a data item does not have a default record
-         typedef MUST_GET_RECORD_FROM_EVENTSETUP_TO_GET_DATA<DataT> type;
-      };
+  namespace eventsetup {
+    template <class T> struct MUST_GET_RECORD_FROM_EVENTSETUP_TO_GET_DATA;
 
-    template <typename T>
-    struct default_record {
+    template <class DataT> struct data_default_record_trait {
+      //NOTE: by default, a data item does not have a default record
+      typedef MUST_GET_RECORD_FROM_EVENTSETUP_TO_GET_DATA<DataT> type;
+    };
+
+    template <typename T> struct default_record {
       using data_type = typename T::value_type;
       using RecordT = typename eventsetup::data_default_record_trait<data_type>::type;
     };
 
-    template <typename T>
-    using default_record_t = typename default_record<T>::RecordT;
-   }
-}
+    template <typename T> using default_record_t = typename default_record<T>::RecordT;
+  }  // namespace eventsetup
+}  // namespace edm
 
-#define EVENTSETUP_DATA_DEFAULT_RECORD(_data_, _record_) \
-  namespace edm::eventsetup { template<> struct data_default_record_trait<_data_>{ typedef _record_ type; }; }
+#define EVENTSETUP_DATA_DEFAULT_RECORD(_data_, _record_)                             \
+  namespace edm::eventsetup {                                                        \
+    template <> struct data_default_record_trait<_data_> { typedef _record_ type; }; \
+  }
 
 #endif

--- a/FWCore/Framework/interface/defaultCmsRunServices.h
+++ b/FWCore/Framework/interface/defaultCmsRunServices.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     defaultCmsRunServices
-// 
+//
 /**\class defaultCmsRunServices defaultCmsRunServices.h FWCore/Framework/interface/defaultCmsRunServices.h
 
  Description: Returns the names of the standard cmsRun default services
@@ -28,7 +28,7 @@
 // forward declarations
 
 namespace edm {
-   std::vector<std::string> defaultCmsRunServices();
+  std::vector<std::string> defaultCmsRunServices();
 }
 
 #endif

--- a/FWCore/Framework/interface/es_Label.h
+++ b/FWCore/Framework/interface/es_Label.h
@@ -32,8 +32,7 @@
 
 namespace edm::es {
 
-  template<typename T, int ILabel>
-  struct L {
+  template <typename T, int ILabel> struct L {
     using element_type = T;
 
     L() = default;
@@ -41,49 +40,40 @@ namespace edm::es {
     explicit L(std::unique_ptr<T> iP) : product_{std::move(iP)} {}
     explicit L(T* iP) : product_(iP) {}
 
-    T& operator*() { return *product_;}
+    T& operator*() { return *product_; }
     T* operator->() { return product_.get(); }
     mutable std::shared_ptr<T> product_{nullptr};
   };
 
-  template<int ILabel, typename T>
-  L<T,ILabel> l(std::shared_ptr<T>& iP) {
-    return L<T,ILabel>{iP};
-  }
+  template <int ILabel, typename T> L<T, ILabel> l(std::shared_ptr<T>& iP) { return L<T, ILabel>{iP}; }
 
   struct Label {
     Label() = default;
     Label(const char* iLabel) : default_{iLabel} {}
     Label(const std::string& iString) : default_{iString} {}
-    Label(const std::string& iString, unsigned int const iIndex) :
-      labels_(iIndex+1, def())
-    {
+    Label(const std::string& iString, unsigned int const iIndex) : labels_(iIndex + 1, def()) {
       labels_[iIndex] = iString;
     }
 
-    Label& operator()(const std::string& iString, unsigned int const iIndex)
-    {
+    Label& operator()(const std::string& iString, unsigned int const iIndex) {
       if (iIndex == labels_.size()) {
         labels_.push_back(iString);
-      } else if(iIndex > labels_.size()) {
-        std::vector<std::string> temp(iIndex+1,def());
+      } else if (iIndex > labels_.size()) {
+        std::vector<std::string> temp(iIndex + 1, def());
         copy_all(labels_, temp.begin());
         labels_.swap(temp);
       } else {
-        if( labels_[iIndex] != def() ) {
-          Exception e(errors::Configuration,"Duplicate Label");
-          e <<"The index "<<iIndex<<" was previously assigned the label \""
-            <<labels_[iIndex]<<"\" and then was later assigned \""
-            <<iString<<"\"";
+        if (labels_[iIndex] != def()) {
+          Exception e(errors::Configuration, "Duplicate Label");
+          e << "The index " << iIndex << " was previously assigned the label \"" << labels_[iIndex]
+            << "\" and then was later assigned \"" << iString << "\"";
           e.raise();
         }
         labels_[iIndex] = iString;
       }
       return *this;
     }
-    Label& operator()(int iIndex, const std::string& iString) {
-      return (*this)(iString, iIndex);
-    }
+    Label& operator()(int iIndex, const std::string& iString) { return (*this)(iString, iIndex); }
 
     static const std::string& def() {
       static const std::string s_def("\n\t");
@@ -94,12 +84,8 @@ namespace edm::es {
     std::string default_{};
   };
 
-  inline Label label(const std::string& iString, int iIndex) {
-    return Label(iString, iIndex);
-  }
-  inline Label label(int iIndex, const std::string& iString) {
-    return Label(iString, iIndex);
-  }
-}
+  inline Label label(const std::string& iString, int iIndex) { return Label(iString, iIndex); }
+  inline Label label(int iIndex, const std::string& iString) { return Label(iString, iIndex); }
+}  // namespace edm::es
 
 #endif

--- a/FWCore/Framework/interface/eventsetup_dependsOn.h
+++ b/FWCore/Framework/interface/eventsetup_dependsOn.h
@@ -5,7 +5,7 @@
 //
 // Package:     Framework
 // Class  :     eventsetup_dependsOn
-// 
+//
 /**\class eventsetup_dependsOn eventsetup_dependsOn.h FWCore/Framework/interface/eventsetup_dependsOn.h
 
  Description: function used to set what methods to call when a dependent Record changes
@@ -54,151 +54,150 @@
 
 // forward declarations
 
-
 namespace edm {
-   namespace eventsetup {
-      
-      //Simple functor that checks to see if a Record has changed since the last time it was called
-      // and if so, calls the appropriate member method.  Multiple callers can be chained together using the
-      // TCallerChain template argument.
-     template<class T, class TRecord, class TDependsOnRecord, class TCallerChain >
-	struct DependsOnCaller
-	{
-	DependsOnCaller(T* iCallee, void(T::* iMethod)(const TDependsOnRecord&) , const TCallerChain& iChain) : 
-	  callee_(iCallee), method_(iMethod), chain_(iChain),cacheID_(0){} 
-      
-	    void operator()(const TRecord& iRecord) {
-	    const TDependsOnRecord& record = iRecord.template getRecord<TDependsOnRecord>();
-	    if(record.cacheIdentifier() != cacheID_) {
-	      (callee_->*method_)(record);
-	      cacheID_=record.cacheIdentifier();
-	    }
-	    //call next 'functor' in our chain
-	    chain_(iRecord);
-	  }
-	private:
-	  T* callee_;
-	  void (T::*method_)(const TDependsOnRecord&);
-	  TCallerChain chain_;
-	  unsigned long long cacheID_;
-	};
+  namespace eventsetup {
 
-      //helper function to help create a DependsOnCaller
-      template<class T, class TRecord, class TDependsOnRecord, class TCallerChain >
-         DependsOnCaller<T,TRecord, TDependsOnRecord, TCallerChain>
-         createDependsOnCaller(T* iCallee, const TRecord*, void(T::*iMethod)(const TDependsOnRecord&), const TCallerChain& iChain) 
-      {
-            return DependsOnCaller<T,TRecord, TDependsOnRecord, TCallerChain>(iCallee, iMethod, iChain);
+    //Simple functor that checks to see if a Record has changed since the last time it was called
+    // and if so, calls the appropriate member method.  Multiple callers can be chained together using the
+    // TCallerChain template argument.
+    template <class T, class TRecord, class TDependsOnRecord, class TCallerChain> struct DependsOnCaller {
+      DependsOnCaller(T* iCallee, void (T::*iMethod)(const TDependsOnRecord&), const TCallerChain& iChain)
+          : callee_(iCallee), method_(iMethod), chain_(iChain), cacheID_(0) {}
+
+      void operator()(const TRecord& iRecord) {
+        const TDependsOnRecord& record = iRecord.template getRecord<TDependsOnRecord>();
+        if (record.cacheIdentifier() != cacheID_) {
+          (callee_->*method_)(record);
+          cacheID_ = record.cacheIdentifier();
+        }
+        //call next 'functor' in our chain
+        chain_(iRecord);
       }
-      
-      //A 'do nothing' functor that is used to terminate our chain of functors
-      template<class TRecord>
-         struct DependsOnDoNothingCaller { void operator()(const TRecord&) {} };
-      
-      //put implementation details used to get the dependsOn method to work into their own namespace
-      namespace depends_on {
-         //class to hold onto one member method pointer
-         template <class T, class TDependsOnRecord>
-         struct OneHolder {
-            typedef T Prod_t;
-            typedef TDependsOnRecord DependsOnRecord_t;
-            
-            OneHolder(void (T::*iHoldee)(const TDependsOnRecord&)) : holdee_(iHoldee) {}
-            void (T::*holdee_)(const TDependsOnRecord&);
-            
-         };
-         
-         //class to create a linked list of member method pointers
-         template <class T, class U>
-            struct TwoHolder {
-               typedef T T1_t;
-               typedef U T2_t;
-               TwoHolder(const T& i1, const U& i2) : h1_(i1), h2_(i2) {}
-               T h1_;
-               U h2_;
-            };
 
-         //allows one to create the linked list by applying operator & to member method pointers
-         template< class T, class U>
-            TwoHolder<T,U> operator&(const T& iT, const U& iU) {
-               return TwoHolder<T,U>(iT, iU);
-            }
-         
-         //HolderToCaller is used to state how a OneHolder or TwoHolder is converted into the appropriate 
-         // DependsOnCaller.  This class is needed to define the return value of the makeCaller function
-         template< class TRecord, class THolder>
-            struct HolderToCaller {
-            };
-         template< class TRecord, class T, class TDependsOnRecord >
-            struct HolderToCaller<TRecord, OneHolder<T, TDependsOnRecord> > {
-               typedef DependsOnCaller<T,TRecord, TDependsOnRecord, DependsOnDoNothingCaller<TRecord> > Caller_t;
-            };
-         template< class TRecord, class T, class T1, class T2>
-            struct HolderToCaller< TRecord, TwoHolder<T1, void (T::*)(const T2&) > > {
-               typedef DependsOnCaller<T, TRecord, T2 , typename HolderToCaller<TRecord,T1>::Caller_t > Caller_t;
-            };
+    private:
+      T* callee_;
+      void (T::*method_)(const TDependsOnRecord&);
+      TCallerChain chain_;
+      unsigned long long cacheID_;
+    };
 
-         //helper function to convert a OneHolder or TwoHolder into a DependsOnCaller.
-         template<class T, class TDependsOnRecord, class TRecord>
-            DependsOnCaller<T,TRecord, TDependsOnRecord, DependsOnDoNothingCaller<TRecord> >
-            makeCaller(T*iT, const TRecord* iRec, const OneHolder<T, TDependsOnRecord>& iHolder) {
-               return createDependsOnCaller(iT, iRec, iHolder.holdee_, DependsOnDoNothingCaller<TRecord>());
-            }
-         
-         template<class T, class T1, class T2, class TRecord>
-            DependsOnCaller<T,TRecord, T2, typename HolderToCaller<TRecord, T1>::Caller_t >
-            makeCaller(T*iT, const TRecord* iRec, const TwoHolder<T1, void (T::*)(const T2&)>& iHolder) {
-               return createDependsOnCaller(iT, iRec, iHolder.h2_, makeCaller(iT, iRec, iHolder.h1_));
-            }
+    //helper function to help create a DependsOnCaller
+    template <class T, class TRecord, class TDependsOnRecord, class TCallerChain>
+    DependsOnCaller<T, TRecord, TDependsOnRecord, TCallerChain> createDependsOnCaller(
+        T* iCallee, const TRecord*, void (T::*iMethod)(const TDependsOnRecord&), const TCallerChain& iChain) {
+      return DependsOnCaller<T, TRecord, TDependsOnRecord, TCallerChain>(iCallee, iMethod, iChain);
+    }
+
+    //A 'do nothing' functor that is used to terminate our chain of functors
+    template <class TRecord> struct DependsOnDoNothingCaller {
+      void operator()(const TRecord&) {}
+    };
+
+    //put implementation details used to get the dependsOn method to work into their own namespace
+    namespace depends_on {
+      //class to hold onto one member method pointer
+      template <class T, class TDependsOnRecord> struct OneHolder {
+        typedef T Prod_t;
+        typedef TDependsOnRecord DependsOnRecord_t;
+
+        OneHolder(void (T::*iHoldee)(const TDependsOnRecord&)) : holdee_(iHoldee) {}
+        void (T::*holdee_)(const TDependsOnRecord&);
+      };
+
+      //class to create a linked list of member method pointers
+      template <class T, class U> struct TwoHolder {
+        typedef T T1_t;
+        typedef U T2_t;
+        TwoHolder(const T& i1, const U& i2) : h1_(i1), h2_(i2) {}
+        T h1_;
+        U h2_;
+      };
+
+      //allows one to create the linked list by applying operator & to member method pointers
+      template <class T, class U> TwoHolder<T, U> operator&(const T& iT, const U& iU) {
+        return TwoHolder<T, U>(iT, iU);
       }
-      
-      //DecoratorFromArg is used to declare the return type of 'createDecoratorFrom' based on the arguments to the function.
-      template< typename T, typename TRecord, typename TArg>
-         struct DecoratorFromArg { typedef TArg Decorator_t; };
-      
-      template< typename T, typename TRecord, typename TDependsOnRecord>
-         struct DecoratorFromArg<T,TRecord, depends_on::OneHolder<T,TDependsOnRecord> > { 
-            typedef ESPreFunctorDecorator<TRecord,DependsOnCaller<T,TRecord, TDependsOnRecord, DependsOnDoNothingCaller<TRecord> > > Decorator_t; 
-         };
-      
-      
-      template< typename T, typename TRecord, typename TDependsOnRecord >
-         inline ESPreFunctorDecorator<TRecord,DependsOnCaller<T,TRecord, TDependsOnRecord, DependsOnDoNothingCaller<TRecord> > > 
-         createDecoratorFrom(T* iT, const TRecord*iRec, const depends_on::OneHolder<T,TDependsOnRecord>& iHolder) {
-            DependsOnDoNothingCaller<TRecord> tCaller;
-            ESPreFunctorDecorator<TRecord,DependsOnCaller<T,TRecord, TDependsOnRecord, DependsOnDoNothingCaller<TRecord> > >
-               temp(createDependsOnCaller(iT, iRec, iHolder.holdee_, tCaller));
-            return temp;
-         }
-      
-      template< typename T, typename TRecord, typename T1, typename T2>
-         struct DecoratorFromArg<T,TRecord, depends_on::TwoHolder<T1,T2> > { 
-            typedef ESPreFunctorDecorator<TRecord,typename depends_on::HolderToCaller<TRecord, depends_on::TwoHolder<T1, T2> >::Caller_t >
-            Decorator_t; 
-         };
-      template< typename T, typename TRecord, typename T1, typename T2>
-         inline ESPreFunctorDecorator<TRecord,typename depends_on::HolderToCaller<TRecord, depends_on::TwoHolder<T1, T2> >::Caller_t >
-         createDecoratorFrom(T* iT, const TRecord*iRec, const depends_on::TwoHolder<T1,T2>& iHolder) {
-            return ESPreFunctorDecorator<TRecord, typename depends_on::HolderToCaller<TRecord,depends_on::TwoHolder< T1, T2> >::Caller_t >
-            (createDependsOnCaller(iT, iRec, iHolder.h2_, makeCaller(iT, iRec, iHolder.h1_)));
-         }
-      
-      
-      //The actual dependsOn functions which users call
-      template <typename T, typename TDependsOnRecord>
-         depends_on::OneHolder<T,TDependsOnRecord> 
-         dependsOn(void(T::*iT)(const TDependsOnRecord&)) { return iT ; }
-      
-      template< typename T, typename T1, typename T2>
-         depends_on::TwoHolder<depends_on::OneHolder<T,T1>, T2> 
-         dependsOn(void (T::* iT1)(const T1&), T2 iT2) { return depends_on::OneHolder<T, T1>(iT1) & iT2; }
-      
-      template< typename T, typename T1, typename T2, typename T3>
-         depends_on::TwoHolder< depends_on::TwoHolder<depends_on::OneHolder<T,T1>, T2>, T3>
-         dependsOn(void(T::* iT1)(const T1&), T2 iT2, T3 iT3) { return depends_on::OneHolder<T,T1>(iT1) & iT2 & iT3; }
-      
 
-   }
-}
+      //HolderToCaller is used to state how a OneHolder or TwoHolder is converted into the appropriate
+      // DependsOnCaller.  This class is needed to define the return value of the makeCaller function
+      template <class TRecord, class THolder> struct HolderToCaller {};
+      template <class TRecord, class T, class TDependsOnRecord>
+      struct HolderToCaller<TRecord, OneHolder<T, TDependsOnRecord> > {
+        typedef DependsOnCaller<T, TRecord, TDependsOnRecord, DependsOnDoNothingCaller<TRecord> > Caller_t;
+      };
+      template <class TRecord, class T, class T1, class T2>
+      struct HolderToCaller<TRecord, TwoHolder<T1, void (T::*)(const T2&)> > {
+        typedef DependsOnCaller<T, TRecord, T2, typename HolderToCaller<TRecord, T1>::Caller_t> Caller_t;
+      };
+
+      //helper function to convert a OneHolder or TwoHolder into a DependsOnCaller.
+      template <class T, class TDependsOnRecord, class TRecord>
+      DependsOnCaller<T, TRecord, TDependsOnRecord, DependsOnDoNothingCaller<TRecord> > makeCaller(
+          T* iT, const TRecord* iRec, const OneHolder<T, TDependsOnRecord>& iHolder) {
+        return createDependsOnCaller(iT, iRec, iHolder.holdee_, DependsOnDoNothingCaller<TRecord>());
+      }
+
+      template <class T, class T1, class T2, class TRecord>
+      DependsOnCaller<T, TRecord, T2, typename HolderToCaller<TRecord, T1>::Caller_t> makeCaller(
+          T* iT, const TRecord* iRec, const TwoHolder<T1, void (T::*)(const T2&)>& iHolder) {
+        return createDependsOnCaller(iT, iRec, iHolder.h2_, makeCaller(iT, iRec, iHolder.h1_));
+      }
+    }  // namespace depends_on
+
+    //DecoratorFromArg is used to declare the return type of 'createDecoratorFrom' based on the arguments to the function.
+    template <typename T, typename TRecord, typename TArg> struct DecoratorFromArg { typedef TArg Decorator_t; };
+
+    template <typename T, typename TRecord, typename TDependsOnRecord>
+    struct DecoratorFromArg<T, TRecord, depends_on::OneHolder<T, TDependsOnRecord> > {
+      typedef ESPreFunctorDecorator<TRecord,
+                                    DependsOnCaller<T, TRecord, TDependsOnRecord, DependsOnDoNothingCaller<TRecord> > >
+          Decorator_t;
+    };
+
+    template <typename T, typename TRecord, typename TDependsOnRecord>
+    inline ESPreFunctorDecorator<TRecord,
+                                 DependsOnCaller<T, TRecord, TDependsOnRecord, DependsOnDoNothingCaller<TRecord> > >
+    createDecoratorFrom(T* iT, const TRecord* iRec, const depends_on::OneHolder<T, TDependsOnRecord>& iHolder) {
+      DependsOnDoNothingCaller<TRecord> tCaller;
+      ESPreFunctorDecorator<TRecord, DependsOnCaller<T, TRecord, TDependsOnRecord, DependsOnDoNothingCaller<TRecord> > >
+          temp(createDependsOnCaller(iT, iRec, iHolder.holdee_, tCaller));
+      return temp;
+    }
+
+    template <typename T, typename TRecord, typename T1, typename T2>
+    struct DecoratorFromArg<T, TRecord, depends_on::TwoHolder<T1, T2> > {
+      typedef ESPreFunctorDecorator<
+          TRecord,
+          typename depends_on::HolderToCaller<TRecord, depends_on::TwoHolder<T1, T2> >::Caller_t>
+          Decorator_t;
+    };
+    template <typename T, typename TRecord, typename T1, typename T2>
+    inline ESPreFunctorDecorator<TRecord,
+                                 typename depends_on::HolderToCaller<TRecord, depends_on::TwoHolder<T1, T2> >::Caller_t>
+    createDecoratorFrom(T* iT, const TRecord* iRec, const depends_on::TwoHolder<T1, T2>& iHolder) {
+      return ESPreFunctorDecorator<
+          TRecord, typename depends_on::HolderToCaller<TRecord, depends_on::TwoHolder<T1, T2> >::Caller_t>(
+          createDependsOnCaller(iT, iRec, iHolder.h2_, makeCaller(iT, iRec, iHolder.h1_)));
+    }
+
+    //The actual dependsOn functions which users call
+    template <typename T, typename TDependsOnRecord>
+    depends_on::OneHolder<T, TDependsOnRecord> dependsOn(void (T::*iT)(const TDependsOnRecord&)) {
+      return iT;
+    }
+
+    template <typename T, typename T1, typename T2>
+    depends_on::TwoHolder<depends_on::OneHolder<T, T1>, T2> dependsOn(void (T::*iT1)(const T1&), T2 iT2) {
+      return depends_on::OneHolder<T, T1>(iT1) & iT2;
+    }
+
+    template <typename T, typename T1, typename T2, typename T3>
+    depends_on::TwoHolder<depends_on::TwoHolder<depends_on::OneHolder<T, T1>, T2>, T3> dependsOn(
+        void (T::*iT1)(const T1&), T2 iT2, T3 iT3) {
+      return depends_on::OneHolder<T, T1>(iT1) & iT2 & iT3;
+    }
+
+  }  // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/eventsetuprecord_registration_macro.h
+++ b/FWCore/Framework/interface/eventsetuprecord_registration_macro.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     eventsetuprecord_registration_macro
-// 
+//
 /**\class eventsetuprecord_registration_macro eventsetuprecord_registration_macro.h FWCore/Framework/interface/eventsetuprecord_registration_macro.h
 
  Description: CPP macro used to register a new EventSetupRecord into the system
@@ -33,11 +33,11 @@ macro EVENTSETUP_RECORD_REG is used to create that code.
 
 #include "FWCore/Framework/interface/RecordDependencyRegister.h"
 
-#define EVENTSETUP_RECORD_NAME2(_a_, _b_) EVENTSETUP_RECORD_NAME2_HIDDEN(_a_,_b_)
-#define EVENTSETUP_RECORD_NAME2_HIDDEN(_a_,_b_) _a_ ## _b_
+#define EVENTSETUP_RECORD_NAME2(_a_, _b_) EVENTSETUP_RECORD_NAME2_HIDDEN(_a_, _b_)
+#define EVENTSETUP_RECORD_NAME2_HIDDEN(_a_, _b_) _a_##_b_
 
 #define EVENTSETUP_RECORD_REG(_recordclassname_) \
-TYPELOOKUP_DATA_REG(_recordclassname_); \
-static const edm::eventsetup::RecordDependencyRegister<_recordclassname_> EVENTSETUP_RECORD_NAME2(s_factory,__LINE__)
+  TYPELOOKUP_DATA_REG(_recordclassname_);        \
+  static const edm::eventsetup::RecordDependencyRegister<_recordclassname_> EVENTSETUP_RECORD_NAME2(s_factory, __LINE__)
 
 #endif

--- a/FWCore/Framework/interface/findDependentRecordsFor.h
+++ b/FWCore/Framework/interface/findDependentRecordsFor.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     findDependentRecordsFor
-// 
+//
 /**\function findDependentRecordsFor findDependentRecordsFor.h "findDependentRecordsFor.h"
 
  Description: [one line class summary]
@@ -32,50 +32,41 @@
 // forward declarations
 namespace edm {
   namespace eventsetup {
-    
+
     //If the types are the same, stop the recursion
-    template <typename T>
-    void addRecordToDependencies(const T*,
-                                 const T*,
-                                 std::set<EventSetupRecordKey>&) { }
-    
+    template <typename T> void addRecordToDependencies(const T*, const T*, std::set<EventSetupRecordKey>&) {}
+
     //Recursively desend container while adding first type's info to set
-    template< typename TFirst, typename TEnd>
-    void addRecordToDependencies(const TFirst*, const TEnd* iEnd,
-                                 std::set<EventSetupRecordKey>& oSet) {
+    template <typename TFirst, typename TEnd>
+    void addRecordToDependencies(const TFirst*, const TEnd* iEnd, std::set<EventSetupRecordKey>& oSet) {
       oSet.insert(EventSetupRecordKey::makeKey<typename boost::mpl::deref<TFirst>::type>());
-      const  typename boost::mpl::next< TFirst >::type * next(nullptr);
+      const typename boost::mpl::next<TFirst>::type* next(nullptr);
       addRecordToDependencies(next, iEnd, oSet);
     }
-    
+
     //Handle the case where a Record has dependencies
-    template <typename T>
-    struct FindDependenciesFromDependentRecord {
-      inline static void dependentRecords(std::set<EventSetupRecordKey>& oSet)  {
+    template <typename T> struct FindDependenciesFromDependentRecord {
+      inline static void dependentRecords(std::set<EventSetupRecordKey>& oSet) {
         typedef typename T::list_type list_type;
-        const  typename boost::mpl::begin<list_type>::type * begin(nullptr);
-        const  typename boost::mpl::end<list_type>::type * end(nullptr);
+        const typename boost::mpl::begin<list_type>::type* begin(nullptr);
+        const typename boost::mpl::end<list_type>::type* end(nullptr);
         addRecordToDependencies(begin, end, oSet);
       }
     };
-    
+
     //Handle the case where a Record has no dependencies
     struct NoDependenciesForRecord {
-      inline static void dependentRecords(std::set<EventSetupRecordKey>&)  {
-      }
+      inline static void dependentRecords(std::set<EventSetupRecordKey>&) {}
     };
-    
-    template <typename T>
-    std::set<EventSetupRecordKey>
-    findDependentRecordsFor() {
-      typedef typename boost::mpl::if_< typename std::is_base_of<edm::eventsetup::DependentRecordTag, T>::type,
-      FindDependenciesFromDependentRecord<T>,
-      NoDependenciesForRecord>::type DepFinder;
+
+    template <typename T> std::set<EventSetupRecordKey> findDependentRecordsFor() {
+      typedef typename boost::mpl::if_<typename std::is_base_of<edm::eventsetup::DependentRecordTag, T>::type,
+                                       FindDependenciesFromDependentRecord<T>, NoDependenciesForRecord>::type DepFinder;
       std::set<EventSetupRecordKey> returnValue;
       DepFinder::dependentRecords(returnValue);
       return returnValue;
     }
-  }
-}
+  }  // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/getAllTriggerNames.h
+++ b/FWCore/Framework/interface/getAllTriggerNames.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     getAllTriggerNames
-// 
+//
 /**\function getAllTriggerNames getAllTriggerNames.h "FWCore/Framework/interface/getAllTriggerNames.h"
 
  Description: Returns a list of all the trigger names in the current process

--- a/FWCore/Framework/interface/getProducerParameterSet.h
+++ b/FWCore/Framework/interface/getProducerParameterSet.h
@@ -26,7 +26,6 @@ namespace edm {
   class ParameterSet;
   class Provenance;
 
-  ParameterSet const*
-  getProducerParameterSet(Provenance const& provenance);
-}
+  ParameterSet const* getProducerParameterSet(Provenance const& provenance);
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/insertSelectedProcesses.h
+++ b/FWCore/Framework/interface/insertSelectedProcesses.h
@@ -8,7 +8,6 @@ namespace edm {
 
   class BranchDescription;
 
-  void insertSelectedProcesses(BranchDescription const& desc,
-                               std::set<std::string>& processes);
-}
+  void insertSelectedProcesses(BranchDescription const& desc, std::set<std::string>& processes);
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/makeRefToBaseProdFrom.h
+++ b/FWCore/Framework/interface/makeRefToBaseProdFrom.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     makeRefToBaseProdFrom
-// 
+//
 /**\class makeRefToBaseProdFrom makeRefToBaseProdFrom.h "FWCore/Framework/interface/makeRefToBaseProdFrom.h"
 
  Description: [one line class summary]
@@ -30,12 +30,11 @@
 // forward declarations
 
 namespace edm {
-  template<typename T>
-    RefToBaseProd<T> makeRefToBaseProdFrom(RefToBase<T> const& iRef, Event const& iEvent) {
+  template <typename T> RefToBaseProd<T> makeRefToBaseProdFrom(RefToBase<T> const& iRef, Event const& iEvent) {
     Handle<View<T>> view;
-    iEvent.get(iRef.id(),view);
+    iEvent.get(iRef.id(), view);
 
     return RefToBaseProd<T>(view);
   }
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/interface/moduleAbilities.h
+++ b/FWCore/Framework/interface/moduleAbilities.h
@@ -29,139 +29,123 @@
 namespace edm {
   namespace module {
     //Used in the case where ability is not available
-    struct Empty{};
-  }
+    struct Empty {};
+  }  // namespace module
 
-  template<typename T>
-  struct GlobalCache {
-    static constexpr module::Abilities kAbilities=module::Abilities::kGlobalCache;
+  template <typename T> struct GlobalCache {
+    static constexpr module::Abilities kAbilities = module::Abilities::kGlobalCache;
     typedef T Type;
   };
 
-  template<typename T>
-  struct StreamCache {
-    static constexpr module::Abilities kAbilities=module::Abilities::kStreamCache;
+  template <typename T> struct StreamCache {
+    static constexpr module::Abilities kAbilities = module::Abilities::kStreamCache;
     typedef T Type;
   };
 
-  template<typename T>
-  struct RunCache {
-    static constexpr module::Abilities kAbilities=module::Abilities::kRunCache;
+  template <typename T> struct RunCache {
+    static constexpr module::Abilities kAbilities = module::Abilities::kRunCache;
     typedef T Type;
   };
 
-  template<typename T>
-  struct LuminosityBlockCache {
-    static constexpr module::Abilities kAbilities=module::Abilities::kLuminosityBlockCache;
+  template <typename T> struct LuminosityBlockCache {
+    static constexpr module::Abilities kAbilities = module::Abilities::kLuminosityBlockCache;
     typedef T Type;
   };
 
-  template<typename T>
-  struct RunSummaryCache {
-    static constexpr module::Abilities kAbilities=module::Abilities::kRunSummaryCache;
+  template <typename T> struct RunSummaryCache {
+    static constexpr module::Abilities kAbilities = module::Abilities::kRunSummaryCache;
     typedef T Type;
   };
 
-  template<typename T>
-  struct LuminosityBlockSummaryCache {
-    static constexpr module::Abilities kAbilities=module::Abilities::kLuminosityBlockSummaryCache;
+  template <typename T> struct LuminosityBlockSummaryCache {
+    static constexpr module::Abilities kAbilities = module::Abilities::kLuminosityBlockSummaryCache;
     typedef T Type;
   };
 
   struct BeginRunProducer {
-    static constexpr module::Abilities kAbilities=module::Abilities::kBeginRunProducer;
+    static constexpr module::Abilities kAbilities = module::Abilities::kBeginRunProducer;
     typedef module::Empty Type;
   };
 
   struct EndRunProducer {
-    static constexpr module::Abilities kAbilities=module::Abilities::kEndRunProducer;
+    static constexpr module::Abilities kAbilities = module::Abilities::kEndRunProducer;
     typedef module::Empty Type;
   };
 
   struct BeginLuminosityBlockProducer {
-    static constexpr module::Abilities kAbilities=module::Abilities::kBeginLuminosityBlockProducer;
+    static constexpr module::Abilities kAbilities = module::Abilities::kBeginLuminosityBlockProducer;
     typedef module::Empty Type;
   };
 
   struct EndLuminosityBlockProducer {
-    static constexpr module::Abilities kAbilities=module::Abilities::kEndLuminosityBlockProducer;
+    static constexpr module::Abilities kAbilities = module::Abilities::kEndLuminosityBlockProducer;
     typedef module::Empty Type;
   };
 
   struct WatchInputFiles {
-    static constexpr module::Abilities kAbilities=module::Abilities::kWatchInputFiles;
+    static constexpr module::Abilities kAbilities = module::Abilities::kWatchInputFiles;
     typedef module::Empty Type;
   };
 
   struct ExternalWork {
-    static constexpr module::Abilities kAbilities=module::Abilities::kExternalWork;
+    static constexpr module::Abilities kAbilities = module::Abilities::kExternalWork;
     typedef module::Empty Type;
   };
 
   struct Accumulator {
-    static constexpr module::Abilities kAbilities=module::Abilities::kAccumulator;
+    static constexpr module::Abilities kAbilities = module::Abilities::kAccumulator;
     typedef module::Empty Type;
   };
 
   //Recursively checks VArgs template arguments looking for the ABILITY
-  template<module::Abilities ABILITY, typename... VArgs> struct CheckAbility;
+  template <module::Abilities ABILITY, typename... VArgs> struct CheckAbility;
 
-  template<module::Abilities ABILITY, typename T, typename... VArgs>
-  struct CheckAbility<ABILITY,T,VArgs...> {
-    static constexpr bool kHasIt = (T::kAbilities==ABILITY) | CheckAbility<ABILITY,VArgs...>::kHasIt;
-    typedef std::conditional_t<(T::kAbilities==ABILITY),
-                               typename T::Type,
-                               typename CheckAbility<ABILITY,VArgs...>::Type> Type;
+  template <module::Abilities ABILITY, typename T, typename... VArgs> struct CheckAbility<ABILITY, T, VArgs...> {
+    static constexpr bool kHasIt = (T::kAbilities == ABILITY) | CheckAbility<ABILITY, VArgs...>::kHasIt;
+    typedef std::
+        conditional_t<(T::kAbilities == ABILITY), typename T::Type, typename CheckAbility<ABILITY, VArgs...>::Type>
+            Type;
   };
 
   //End of the recursion
-  template<module::Abilities ABILITY>
-  struct CheckAbility<ABILITY> {
-    static constexpr bool kHasIt=false;
+  template <module::Abilities ABILITY> struct CheckAbility<ABILITY> {
+    static constexpr bool kHasIt = false;
     typedef edm::module::Empty Type;
   };
 
-  template<typename... VArgs>
-  struct WantsGlobalRunTransitions {
-    static constexpr bool value = CheckAbility<module::Abilities::kRunCache,VArgs...>::kHasIt or
-    CheckAbility<module::Abilities::kRunSummaryCache,VArgs...>::kHasIt or
-    CheckAbility<module::Abilities::kBeginRunProducer,VArgs...>::kHasIt or
-    CheckAbility<module::Abilities::kEndRunProducer, VArgs...>::kHasIt;
-  };
-  
-  template<typename... VArgs>
-  struct WantsGlobalLuminosityBlockTransitions {
-    static constexpr bool value = CheckAbility<module::Abilities::kLuminosityBlockCache,VArgs...>::kHasIt or
-    CheckAbility<module::Abilities::kLuminosityBlockSummaryCache,VArgs...>::kHasIt or
-    CheckAbility<module::Abilities::kBeginLuminosityBlockProducer,VArgs...>::kHasIt or
-    CheckAbility<module::Abilities::kEndLuminosityBlockProducer, VArgs...>::kHasIt;
+  template <typename... VArgs> struct WantsGlobalRunTransitions {
+    static constexpr bool value = CheckAbility<module::Abilities::kRunCache, VArgs...>::kHasIt or
+                                  CheckAbility<module::Abilities::kRunSummaryCache, VArgs...>::kHasIt or
+                                  CheckAbility<module::Abilities::kBeginRunProducer, VArgs...>::kHasIt or
+                                  CheckAbility<module::Abilities::kEndRunProducer, VArgs...>::kHasIt;
   };
 
-  template<typename... VArgs>
-  struct WantsStreamRunTransitions {
-    static constexpr bool value = CheckAbility<module::Abilities::kStreamCache,VArgs...>::kHasIt or
-    CheckAbility<module::Abilities::kRunSummaryCache,VArgs...>::kHasIt ;
-  };
-  
-  template<typename... VArgs>
-  struct WantsStreamLuminosityBlockTransitions {
-    static constexpr bool value = CheckAbility<module::Abilities::kStreamCache,VArgs...>::kHasIt or
-    CheckAbility<module::Abilities::kLuminosityBlockSummaryCache,VArgs...>::kHasIt;
+  template <typename... VArgs> struct WantsGlobalLuminosityBlockTransitions {
+    static constexpr bool value = CheckAbility<module::Abilities::kLuminosityBlockCache, VArgs...>::kHasIt or
+                                  CheckAbility<module::Abilities::kLuminosityBlockSummaryCache, VArgs...>::kHasIt or
+                                  CheckAbility<module::Abilities::kBeginLuminosityBlockProducer, VArgs...>::kHasIt or
+                                  CheckAbility<module::Abilities::kEndLuminosityBlockProducer, VArgs...>::kHasIt;
   };
 
-  template<typename... VArgs>
-  struct HasAbilityToProduceInRuns {
-    static constexpr bool value =
-      CheckAbility<module::Abilities::kBeginRunProducer,VArgs...>::kHasIt or
-      CheckAbility<module::Abilities::kEndRunProducer, VArgs...>::kHasIt;
+  template <typename... VArgs> struct WantsStreamRunTransitions {
+    static constexpr bool value = CheckAbility<module::Abilities::kStreamCache, VArgs...>::kHasIt or
+                                  CheckAbility<module::Abilities::kRunSummaryCache, VArgs...>::kHasIt;
   };
 
-  template<typename... VArgs>
-  struct HasAbilityToProduceInLumis {
-    static constexpr bool value =
-      CheckAbility<module::Abilities::kBeginLuminosityBlockProducer,VArgs...>::kHasIt or
-      CheckAbility<module::Abilities::kEndLuminosityBlockProducer, VArgs...>::kHasIt;
+  template <typename... VArgs> struct WantsStreamLuminosityBlockTransitions {
+    static constexpr bool value = CheckAbility<module::Abilities::kStreamCache, VArgs...>::kHasIt or
+                                  CheckAbility<module::Abilities::kLuminosityBlockSummaryCache, VArgs...>::kHasIt;
   };
-}
+
+  template <typename... VArgs> struct HasAbilityToProduceInRuns {
+    static constexpr bool value = CheckAbility<module::Abilities::kBeginRunProducer, VArgs...>::kHasIt or
+                                  CheckAbility<module::Abilities::kEndRunProducer, VArgs...>::kHasIt;
+  };
+
+  template <typename... VArgs> struct HasAbilityToProduceInLumis {
+    static constexpr bool value = CheckAbility<module::Abilities::kBeginLuminosityBlockProducer, VArgs...>::kHasIt or
+                                  CheckAbility<module::Abilities::kEndLuminosityBlockProducer, VArgs...>::kHasIt;
+  };
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/moduleAbilityEnums.h
+++ b/FWCore/Framework/interface/moduleAbilityEnums.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     ModuleAbilityEnums
-// 
+//
 /**\class ModuleAbilityEnums ModuleAbilityEnums.h "FWCore/Framework/interface/ModuleAbilityEnums.h"
 
  Description: Enums used internally by framework to determine abilities of a module
@@ -25,8 +25,8 @@
 // forward declarations
 namespace edm {
   namespace module {
-    typedef  unsigned char AbilitiesType;
-    
+    typedef unsigned char AbilitiesType;
+
     enum class Abilities {
       kGlobalCache,
       kStreamCache,
@@ -45,43 +45,45 @@ namespace edm {
       kExternalWork,
       kAccumulator
     };
-    
+
     namespace AbilityBits {
       enum Bits {
-        kGlobalCache=1,
-        kStreamCache=2,
-        kRunCache=4,
-        kLuminosityBlockCache=8,
-        kRunSummaryCache=16,
-        kLuminosityBlockSummaryCache=32,
-        kBeginRunProducer=64,
-        kEndRunProducer=128,
-        kOneSharedResources=256,
-        kOneWatchRuns=512,
-        kOneWatchLuminosityBlocks=1024,
-        kWatchInputFiles=2048
+        kGlobalCache = 1,
+        kStreamCache = 2,
+        kRunCache = 4,
+        kLuminosityBlockCache = 8,
+        kRunSummaryCache = 16,
+        kLuminosityBlockSummaryCache = 32,
+        kBeginRunProducer = 64,
+        kEndRunProducer = 128,
+        kOneSharedResources = 256,
+        kOneWatchRuns = 512,
+        kOneWatchLuminosityBlocks = 1024,
+        kWatchInputFiles = 2048
       };
     }
-    
+
     namespace AbilityToTransitions {
       enum Bits {
-        kBeginStream=AbilityBits::kStreamCache,
-        kEndStream=AbilityBits::kStreamCache,
-        
-        kGlobalBeginRun=AbilityBits::kRunCache|AbilityBits::kRunSummaryCache|AbilityBits::kOneWatchRuns,
-        kGlobalEndRun=AbilityBits::kRunCache|AbilityBits::kRunSummaryCache|AbilityBits::kEndRunProducer|AbilityBits::kOneWatchRuns,
-        kStreamBeginRun=AbilityBits::kStreamCache,
-        kStreamEndRun=AbilityBits::kStreamCache|AbilityBits::kRunSummaryCache,
-        
-        kGlobalBeginLuminosityBlock=AbilityBits::kLuminosityBlockCache|AbilityBits::kLuminosityBlockSummaryCache|AbilityBits::kOneWatchLuminosityBlocks,
-        kGlobalEndLuminosityBlock=AbilityBits::kLuminosityBlockCache|AbilityBits::kLuminosityBlockSummaryCache|AbilityBits::kOneWatchLuminosityBlocks,
-        kStreamBeginLuminosityBlock=AbilityBits::kStreamCache|AbilityBits::kLuminosityBlockSummaryCache,
-        kStreamEndLuminosityBlock=AbilityBits::kStreamCache|AbilityBits::kLuminosityBlockSummaryCache
-        
+        kBeginStream = AbilityBits::kStreamCache,
+        kEndStream = AbilityBits::kStreamCache,
+
+        kGlobalBeginRun = AbilityBits::kRunCache | AbilityBits::kRunSummaryCache | AbilityBits::kOneWatchRuns,
+        kGlobalEndRun = AbilityBits::kRunCache | AbilityBits::kRunSummaryCache | AbilityBits::kEndRunProducer |
+                        AbilityBits::kOneWatchRuns,
+        kStreamBeginRun = AbilityBits::kStreamCache,
+        kStreamEndRun = AbilityBits::kStreamCache | AbilityBits::kRunSummaryCache,
+
+        kGlobalBeginLuminosityBlock = AbilityBits::kLuminosityBlockCache | AbilityBits::kLuminosityBlockSummaryCache |
+                                      AbilityBits::kOneWatchLuminosityBlocks,
+        kGlobalEndLuminosityBlock = AbilityBits::kLuminosityBlockCache | AbilityBits::kLuminosityBlockSummaryCache |
+                                    AbilityBits::kOneWatchLuminosityBlocks,
+        kStreamBeginLuminosityBlock = AbilityBits::kStreamCache | AbilityBits::kLuminosityBlockSummaryCache,
+        kStreamEndLuminosityBlock = AbilityBits::kStreamCache | AbilityBits::kLuminosityBlockSummaryCache
+
       };
     }
-  }
-}
-
+  }  // namespace module
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/print_eventsetup_record_dependencies.h
+++ b/FWCore/Framework/interface/print_eventsetup_record_dependencies.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     print_eventsetup_record_dependencies
-// 
+//
 /**\class print_eventsetup_record_dependencies print_eventsetup_record_dependencies.h FWCore/Framework/interface/print_eventsetup_record_dependencies.h
 
  Description: <one line class summary>
@@ -32,53 +32,55 @@
 // forward declarations
 
 namespace edm {
-   namespace eventsetup {
-     struct DependentRecordTag;
-   }
-   template<typename RecordT>
-   void print_eventsetup_record_dependencies(std::ostream& oStream, std::string const& iIndent = std::string());
-   
-   template<typename T>
-   void print_eventsetup_record_dependencies(std::ostream&,
-                                             std::string,
-                                             T const*,
-                                             T const*) { }
+  namespace eventsetup {
+    struct DependentRecordTag;
+  }
+  template <typename RecordT>
+  void print_eventsetup_record_dependencies(std::ostream& oStream, std::string const& iIndent = std::string());
 
-   template<typename TFirst, typename TEnd>
-   void print_eventsetup_record_dependencies(std::ostream& oStream, 
-                                             std::string iIndent,
-                                             TFirst const*, TEnd const* iEnd) {
-      iIndent +=" ";
-      print_eventsetup_record_dependencies<typename boost::mpl::deref<TFirst>::type>(oStream,iIndent);
-      typename boost::mpl::next< TFirst >::type const* next(nullptr);
-      print_eventsetup_record_dependencies(oStream, iIndent, next, iEnd);
-   }
-   
-   namespace rec_dep {
-      boost::mpl::false_ inherits_from_DependentRecordTag(void const*) { return boost::mpl::false_();}
-      boost::mpl::true_ inherits_from_DependentRecordTag(edm::eventsetup::DependentRecordTag const*) { return boost::mpl::true_();}
-   }
+  template <typename T> void print_eventsetup_record_dependencies(std::ostream&, std::string, T const*, T const*) {}
 
-   template<typename RecordT>
-   void print_eventsetup_record_dependencies_recursive(std::ostream& oStream, std::string const& iIndent, boost::mpl::true_) {
-      typedef typename  RecordT::list_type list_type;
-      
-      typename boost::mpl::begin<list_type>::type const* begin(nullptr);
-      typename boost::mpl::end<list_type>::type const* end(nullptr);
-      print_eventsetup_record_dependencies(oStream, iIndent, begin, end);
-   }
+  template <typename TFirst, typename TEnd>
+  void print_eventsetup_record_dependencies(std::ostream& oStream,
+                                            std::string iIndent,
+                                            TFirst const*,
+                                            TEnd const* iEnd) {
+    iIndent += " ";
+    print_eventsetup_record_dependencies<typename boost::mpl::deref<TFirst>::type>(oStream, iIndent);
+    typename boost::mpl::next<TFirst>::type const* next(nullptr);
+    print_eventsetup_record_dependencies(oStream, iIndent, next, iEnd);
+  }
 
-   template<typename RecordT>
-   void print_eventsetup_record_dependencies_recursive(std::ostream&, std::string const&, boost::mpl::false_) {
-      return;
-   }
-   
-   template<typename RecordT>
-   void print_eventsetup_record_dependencies(std::ostream& oStream, std::string const& iIndent) {
-      oStream<<iIndent<<edm::eventsetup::EventSetupRecordKey::makeKey<RecordT>().name()<<std::endl;
-      
-      print_eventsetup_record_dependencies_recursive<RecordT>(oStream, iIndent, rec_dep::inherits_from_DependentRecordTag(static_cast<RecordT const*>(nullptr)));
-   }
-}
+  namespace rec_dep {
+    boost::mpl::false_ inherits_from_DependentRecordTag(void const*) { return boost::mpl::false_(); }
+    boost::mpl::true_ inherits_from_DependentRecordTag(edm::eventsetup::DependentRecordTag const*) {
+      return boost::mpl::true_();
+    }
+  }  // namespace rec_dep
+
+  template <typename RecordT>
+  void print_eventsetup_record_dependencies_recursive(std::ostream& oStream,
+                                                      std::string const& iIndent,
+                                                      boost::mpl::true_) {
+    typedef typename RecordT::list_type list_type;
+
+    typename boost::mpl::begin<list_type>::type const* begin(nullptr);
+    typename boost::mpl::end<list_type>::type const* end(nullptr);
+    print_eventsetup_record_dependencies(oStream, iIndent, begin, end);
+  }
+
+  template <typename RecordT>
+  void print_eventsetup_record_dependencies_recursive(std::ostream&, std::string const&, boost::mpl::false_) {
+    return;
+  }
+
+  template <typename RecordT>
+  void print_eventsetup_record_dependencies(std::ostream& oStream, std::string const& iIndent) {
+    oStream << iIndent << edm::eventsetup::EventSetupRecordKey::makeKey<RecordT>().name() << std::endl;
+
+    print_eventsetup_record_dependencies_recursive<RecordT>(
+        oStream, iIndent, rec_dep::inherits_from_DependentRecordTag(static_cast<RecordT const*>(nullptr)));
+  }
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/produce_helpers.h
+++ b/FWCore/Framework/interface/produce_helpers.h
@@ -25,93 +25,83 @@
 
 namespace edm::eventsetup {
 
-  namespace produce { struct Null;}
-
-  template<typename FromT, typename ToT> void moveFromTo(FromT& iFrom,
-                                                         ToT& iTo) {
-    iTo = std::move(iFrom);
+  namespace produce {
+    struct Null;
   }
 
-  template<typename FromT, typename ToT> void moveFromTo(std::unique_ptr<FromT>& iFrom, ToT& iTo) {
+  template <typename FromT, typename ToT> void moveFromTo(FromT& iFrom, ToT& iTo) { iTo = std::move(iFrom); }
+
+  template <typename FromT, typename ToT> void moveFromTo(std::unique_ptr<FromT>& iFrom, ToT& iTo) {
     iTo = std::move(iFrom);
   }
-  template<typename FromT, typename ToT> void moveFromTo(std::optional<FromT>& iFrom, ToT& iTo) {
+  template <typename FromT, typename ToT> void moveFromTo(std::optional<FromT>& iFrom, ToT& iTo) {
     iTo = std::move(iFrom.value());
   }
 
   namespace produce {
     struct Null {};
     template <typename T> struct EndList {
-      static_assert((not std::is_pointer_v<T>), "use std::shared_ptr or std::unique_ptr to hold EventSetup data products, do not use bare pointers");
+      static_assert(
+          (not std::is_pointer_v<T>),
+          "use std::shared_ptr or std::unique_ptr to hold EventSetup data products, do not use bare pointers");
       using tail_type = T;
       using head_type = Null;
     };
-    template <typename T> struct product_traits {
-      using type = T;
-    };
-    template< typename T> struct product_traits<T*> {
-      using type = EndList<T*>;
-    };
-    template< typename T> struct product_traits<std::unique_ptr<T>> {
-      using type = EndList<std::unique_ptr<T>>;
-    };
-    template< typename T> struct product_traits<std::shared_ptr<T>> {
-      using type = EndList<std::shared_ptr<T>>;
-    };
-    template< typename T> struct product_traits<std::optional<T>> {
-      using type = EndList<std::optional<T>>;
-    };
+    template <typename T> struct product_traits { using type = T; };
+    template <typename T> struct product_traits<T*> { using type = EndList<T*>; };
+    template <typename T> struct product_traits<std::unique_ptr<T>> { using type = EndList<std::unique_ptr<T>>; };
+    template <typename T> struct product_traits<std::shared_ptr<T>> { using type = EndList<std::shared_ptr<T>>; };
+    template <typename T> struct product_traits<std::optional<T>> { using type = EndList<std::optional<T>>; };
 
-    template<typename T> struct size {
+    template <typename T> struct size {
       using type = typename product_traits<T>::type;
-      constexpr static int value = size< typename type::head_type >::value + 1;
+      constexpr static int value = size<typename type::head_type>::value + 1;
     };
-    template<> struct size<Null> {
-      constexpr static int value = 0;
-    };
+    template <> struct size<Null> { constexpr static int value = 0; };
 
-    template<typename T> struct smart_pointer_traits {
+    template <typename T> struct smart_pointer_traits {
       using type = typename T::element_type;
-      static auto getPointer(T& iPtr)-> decltype(&*iPtr) { return &*iPtr;}
+      static auto getPointer(T& iPtr) -> decltype(&*iPtr) { return &*iPtr; }
     };
 
-    template<typename T> struct smart_pointer_traits<std::unique_ptr<const T>> {
+    template <typename T> struct smart_pointer_traits<std::unique_ptr<const T>> {
       using type = T;
-      static auto getPointer(std::unique_ptr<const T>& iPtr)-> decltype(&*iPtr) { return &*iPtr;}
+      static auto getPointer(std::unique_ptr<const T>& iPtr) -> decltype(&*iPtr) { return &*iPtr; }
     };
 
-    template<typename T> struct smart_pointer_traits<std::shared_ptr<const T>> {
+    template <typename T> struct smart_pointer_traits<std::shared_ptr<const T>> {
       using type = T;
-      static auto getPointer(std::shared_ptr<const T>& iPtr)-> decltype(&*iPtr) { return &*iPtr;}
+      static auto getPointer(std::shared_ptr<const T>& iPtr) -> decltype(&*iPtr) { return &*iPtr; }
     };
 
-    template<typename T> struct smart_pointer_traits<std::optional<T>> {
+    template <typename T> struct smart_pointer_traits<std::optional<T>> {
       using type = T;
       static T* getPointer(std::optional<T>& iPtr) {
-        if(iPtr.has_value()) { return &*iPtr;}
+        if (iPtr.has_value()) {
+          return &*iPtr;
+        }
         return nullptr;
       }
     };
 
-    template<typename T, typename FindT> struct find_index {
+    template <typename T, typename FindT> struct find_index {
       using container_type = typename product_traits<T>::type;
-      template<typename HeadT, typename TailT>
-      constexpr static int findIndexOf() {
-        if constexpr(not std::is_same_v<TailT,FindT>) {
-            using container_type= typename product_traits<HeadT>::type;
-            return findIndexOf<typename container_type::head_type,
-                               typename container_type::tail_type>()+1;
-          } else {
+      template <typename HeadT, typename TailT> constexpr static int findIndexOf() {
+        if constexpr (not std::is_same_v<TailT, FindT>) {
+          using container_type = typename product_traits<HeadT>::type;
+          return findIndexOf<typename container_type::head_type, typename container_type::tail_type>() + 1;
+        } else {
           return 0;
         }
       }
-      constexpr static int value = findIndexOf<typename container_type::head_type, typename container_type::tail_type>();
+      constexpr static int value =
+          findIndexOf<typename container_type::head_type, typename container_type::tail_type>();
     };
     namespace test {
-      template<typename T> const char* name(const T*);
+      template <typename T> const char* name(const T*);
     }
 
-  }
-}
+  }  // namespace produce
+}  // namespace edm::eventsetup
 
 #endif

--- a/FWCore/Framework/src/Breakpoints.cc
+++ b/FWCore/Framework/src/Breakpoints.cc
@@ -11,9 +11,7 @@
 */
 
 namespace bk {
-  void
-  beginJob() {}
+  void beginJob() {}
 
-  void
-  beginRuns() {}
-}
+  void beginRuns() {}
+}  // namespace bk

--- a/FWCore/Framework/src/Breakpoints.h
+++ b/FWCore/Framework/src/Breakpoints.h
@@ -12,11 +12,9 @@
 */
 
 namespace bk {
-  void
-  beginJob();
+  void beginJob();
 
-  void
-  beginRuns();
-}
+  void beginRuns();
+}  // namespace bk
 
 #endif

--- a/FWCore/Framework/src/ComponentMaker.cc
+++ b/FWCore/Framework/src/ComponentMaker.cc
@@ -6,16 +6,14 @@
 namespace edm {
   namespace eventsetup {
 
-ComponentDescription 
-ComponentMakerBaseHelper::createComponentDescription(ParameterSet const& iConfiguration) const
-{
-  ComponentDescription description;
-  description.type_  = iConfiguration.getParameter<std::string>("@module_type");
-  description.label_ = iConfiguration.getParameter<std::string>("@module_label");
+    ComponentDescription ComponentMakerBaseHelper::createComponentDescription(ParameterSet const& iConfiguration) const {
+      ComponentDescription description;
+      description.type_ = iConfiguration.getParameter<std::string>("@module_type");
+      description.label_ = iConfiguration.getParameter<std::string>("@module_label");
 
-  description.pid_            = iConfiguration.id();
-  return description;
-}
+      description.pid_ = iConfiguration.id();
+      return description;
+    }
 
-} // namespace eventsetup
-} // namespace edm
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/DataKey.cc
+++ b/FWCore/Framework/src/DataKey.cc
@@ -17,105 +17,90 @@
 // user include files
 #include "FWCore/Framework/interface/DataKey.h"
 
-
 //
 // constants, enums and typedefs
 //
 
 namespace {
-constexpr char kBlank[] = {'\0'};
+  constexpr char kBlank[] = {'\0'};
 }
 
 namespace edm::eventsetup {
 
-DataKey::DataKey() = default;
+  DataKey::DataKey() = default;
 
-DataKey& DataKey::operator=(const DataKey& rhs)
-{
-   //An exception safe implementation is
-   DataKey temp(rhs);
-   swap(temp);
+  DataKey& DataKey::operator=(const DataKey& rhs) {
+    //An exception safe implementation is
+    DataKey temp(rhs);
+    swap(temp);
 
-   return *this;
-}
+    return *this;
+  }
 
-//
-// member functions
-//
-void
-DataKey::swap(DataKey& iOther)
-{
-   std::swap(ownMemory_, iOther.ownMemory_);
-   // unqualified swap is used for user defined classes.
-   // The using directive is needed so that std::swap will be used if there is no other matching swap.
-   using std::swap;
-   swap(type_, iOther.type_);
-   swap(name_, iOther.name_);
-}
+  //
+  // member functions
+  //
+  void DataKey::swap(DataKey& iOther) {
+    std::swap(ownMemory_, iOther.ownMemory_);
+    // unqualified swap is used for user defined classes.
+    // The using directive is needed so that std::swap will be used if there is no other matching swap.
+    using std::swap;
+    swap(type_, iOther.type_);
+    swap(name_, iOther.name_);
+  }
 
-      namespace {
-         //used for exception safety
-         class ArrayHolder {
-         public:
-            ArrayHolder() = default;
+  namespace {
+    //used for exception safety
+    class ArrayHolder {
+    public:
+      ArrayHolder() = default;
 
-            void swap(ArrayHolder& iOther) {
-               const char* t = iOther.ptr_;
-               iOther.ptr_ = ptr_;
-               ptr_ = t;
-            }
-            ArrayHolder(const char* iPtr): ptr_(iPtr) {}
-            ~ArrayHolder() { delete [] ptr_; }
-            void release() { ptr_=nullptr;}
-         private:
-            const char* ptr_{nullptr};
-         };
+      void swap(ArrayHolder& iOther) {
+        const char* t = iOther.ptr_;
+        iOther.ptr_ = ptr_;
+        ptr_ = t;
       }
+      ArrayHolder(const char* iPtr) : ptr_(iPtr) {}
+      ~ArrayHolder() { delete[] ptr_; }
+      void release() { ptr_ = nullptr; }
 
-void
-DataKey::makeCopyOfMemory()
-{
-   //empty string is the most common case, so handle it special
+    private:
+      const char* ptr_{nullptr};
+    };
+  }  // namespace
 
-   char* pName = const_cast<char*>(kBlank);
-   //NOTE: if in the future additional tags are added then
-   // I should make sure that pName gets deleted in the case
-   // where an exception is thrown
-   ArrayHolder pNameHolder;
-   if(kBlank[0] != name().value()[0]) {
+  void DataKey::makeCopyOfMemory() {
+    //empty string is the most common case, so handle it special
+
+    char* pName = const_cast<char*>(kBlank);
+    //NOTE: if in the future additional tags are added then
+    // I should make sure that pName gets deleted in the case
+    // where an exception is thrown
+    ArrayHolder pNameHolder;
+    if (kBlank[0] != name().value()[0]) {
       size_t const nBytes = std::strlen(name().value()) + 1;
       pName = new char[nBytes];
       ArrayHolder t(pName);
       pNameHolder.swap(t);
       std::strncpy(pName, name().value(), nBytes);
-   }
-   name_ = NameTag(pName);
-   ownMemory_ = true;
-   pNameHolder.release();
-}
+    }
+    name_ = NameTag(pName);
+    ownMemory_ = true;
+    pNameHolder.release();
+  }
 
-void
-DataKey::deleteMemory()
-{
-   if(kBlank[0] != name().value()[0]) {
-      delete [] const_cast<char*>(name().value());
-   }
-}
+  void DataKey::deleteMemory() {
+    if (kBlank[0] != name().value()[0]) {
+      delete[] const_cast<char*>(name().value());
+    }
+  }
 
-//
-// const member functions
-//
-bool
-DataKey::operator==(const DataKey& iRHS) const
-{
-   return ((type_ == iRHS.type_) &&
-            (name_ == iRHS.name_));
-}
+  //
+  // const member functions
+  //
+  bool DataKey::operator==(const DataKey& iRHS) const { return ((type_ == iRHS.type_) && (name_ == iRHS.name_)); }
 
-bool
-DataKey::operator<(const DataKey& iRHS) const
-{
-   return (type_ < iRHS.type_) ||
-   ((type_ == iRHS.type_) && (name_ < iRHS.name_));
-}
-}
+  bool DataKey::operator<(const DataKey& iRHS) const {
+    return (type_ < iRHS.type_) || ((type_ == iRHS.type_) && (name_ < iRHS.name_));
+  }
+}  // namespace edm::eventsetup

--- a/FWCore/Framework/src/DataKeyTags.cc
+++ b/FWCore/Framework/src/DataKeyTags.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     DataKeyTags
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -16,52 +16,43 @@
 // user include files
 #include "FWCore/Framework/interface/DataKeyTags.h"
 
-
 //
 // constants, enums and typedefs
 //
 namespace edm {
-   namespace eventsetup {
-//
-// static data member definitions
-//
+  namespace eventsetup {
+    //
+    // static data member definitions
+    //
 
-//
-// constructors and destructor
+    //
+    // constructors and destructor
 
-//
-// assignment operators
-//
-// const DataKeyTags& DataKeyTags::operator=(const DataKeyTags& rhs)
-// {
-//   //An exception safe implementation is
-//   DataKeyTags temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+    //
+    // assignment operators
+    //
+    // const DataKeyTags& DataKeyTags::operator=(const DataKeyTags& rhs)
+    // {
+    //   //An exception safe implementation is
+    //   DataKeyTags temp(rhs);
+    //   swap(rhs);
+    //
+    //   return *this;
+    // }
 
-//
-// member functions
-//
+    //
+    // member functions
+    //
 
-//
-// const member functions
-//
-bool
-SimpleStringTag::operator==(const SimpleStringTag& iRHS) const
-{
-   return (0 == std::strcmp(tag_, iRHS.tag_));
-}
+    //
+    // const member functions
+    //
+    bool SimpleStringTag::operator==(const SimpleStringTag& iRHS) const { return (0 == std::strcmp(tag_, iRHS.tag_)); }
 
-bool
-SimpleStringTag::operator<(const SimpleStringTag& iRHS) const
-{
-   return (0 > std::strcmp(tag_, iRHS.tag_));
-}
+    bool SimpleStringTag::operator<(const SimpleStringTag& iRHS) const { return (0 > std::strcmp(tag_, iRHS.tag_)); }
 
-//
-// static member functions
-//
-   }
-}
+    //
+    // static member functions
+    //
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/DataProxy.cc
+++ b/FWCore/Framework/src/DataProxy.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     DataProxy
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -24,145 +24,136 @@
 // constants, enums and typedefs
 //
 namespace edm {
-   namespace eventsetup {
-     static std::recursive_mutex s_esGlobalMutex;
-//
-// static data member definitions
-//
-static
-const ComponentDescription*
-dummyDescription()
-{
-   static ComponentDescription s_desc;
-   return &s_desc;
-}     
-//
-// constructors and destructor
-//
-DataProxy::DataProxy() :
-   cache_(nullptr),
-   cacheIsValid_(false),
-   nonTransientAccessRequested_(false),
-   description_(dummyDescription())
-{
-}
+  namespace eventsetup {
+    static std::recursive_mutex s_esGlobalMutex;
+    //
+    // static data member definitions
+    //
+    static const ComponentDescription* dummyDescription() {
+      static ComponentDescription s_desc;
+      return &s_desc;
+    }
+    //
+    // constructors and destructor
+    //
+    DataProxy::DataProxy()
+        : cache_(nullptr),
+          cacheIsValid_(false),
+          nonTransientAccessRequested_(false),
+          description_(dummyDescription()) {}
 
-// DataProxy::DataProxy(const DataProxy& rhs)
-// {
-//    // do actual copying here;
-// }
+    // DataProxy::DataProxy(const DataProxy& rhs)
+    // {
+    //    // do actual copying here;
+    // }
 
-DataProxy::~DataProxy()
-{
-}
+    DataProxy::~DataProxy() {}
 
-//
-// assignment operators
-//
-// const DataProxy& DataProxy::operator=(const DataProxy& rhs)
-// {
-//   //An exception safe implementation is
-//   DataProxy temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+    //
+    // assignment operators
+    //
+    // const DataProxy& DataProxy::operator=(const DataProxy& rhs)
+    // {
+    //   //An exception safe implementation is
+    //   DataProxy temp(rhs);
+    //   swap(rhs);
+    //
+    //   return *this;
+    // }
 
-//
-// member functions
-//
-void DataProxy::clearCacheIsValid() {
-   cacheIsValid_.store(false, std::memory_order_release);
-   nonTransientAccessRequested_.store(false, std::memory_order_release);
-   cache_ = nullptr;
-}
-      
-void 
-DataProxy::resetIfTransient() {
-   if (!nonTransientAccessRequested_.load(std::memory_order_acquire)) {
-      clearCacheIsValid();
-      invalidateTransientCache();
-   }
-}
+    //
+    // member functions
+    //
+    void DataProxy::clearCacheIsValid() {
+      cacheIsValid_.store(false, std::memory_order_release);
+      nonTransientAccessRequested_.store(false, std::memory_order_release);
+      cache_ = nullptr;
+    }
 
-void 
-DataProxy::invalidateTransientCache() {
-   invalidateCache();
-}
-//
-// const member functions
-//
-namespace  {
-   void throwMakeException(const EventSetupRecordImpl& iRecord,
-                           const DataKey& iKey)  {
-      throw MakeDataException(iRecord.key(),iKey);
-   }
-
-   class ESSignalSentry {
-   public:
-      ESSignalSentry(const EventSetupRecordImpl& iRecord,
-                     const DataKey& iKey,
-                     ComponentDescription const* componentDescription,
-                     ActivityRegistry const* activityRegistry) :
-         eventSetupRecord_(iRecord),
-         dataKey_(iKey),
-         componentDescription_(componentDescription),
-         calledPostLock_(false),
-         activityRegistry_(activityRegistry) {
-
-         activityRegistry->preLockEventSetupGetSignal_(componentDescription_, eventSetupRecord_.key(), dataKey_);
+    void DataProxy::resetIfTransient() {
+      if (!nonTransientAccessRequested_.load(std::memory_order_acquire)) {
+        clearCacheIsValid();
+        invalidateTransientCache();
       }
-      void sendPostLockSignal() {
-         calledPostLock_ = true;
-         activityRegistry_->postLockEventSetupGetSignal_(componentDescription_, eventSetupRecord_.key(), dataKey_);
+    }
+
+    void DataProxy::invalidateTransientCache() { invalidateCache(); }
+    //
+    // const member functions
+    //
+    namespace {
+      void throwMakeException(const EventSetupRecordImpl& iRecord, const DataKey& iKey) {
+        throw MakeDataException(iRecord.key(), iKey);
       }
-      ~ESSignalSentry() noexcept(false) {
-         if (!calledPostLock_) {
+
+      class ESSignalSentry {
+      public:
+        ESSignalSentry(const EventSetupRecordImpl& iRecord,
+                       const DataKey& iKey,
+                       ComponentDescription const* componentDescription,
+                       ActivityRegistry const* activityRegistry)
+            : eventSetupRecord_(iRecord),
+              dataKey_(iKey),
+              componentDescription_(componentDescription),
+              calledPostLock_(false),
+              activityRegistry_(activityRegistry) {
+          activityRegistry->preLockEventSetupGetSignal_(componentDescription_, eventSetupRecord_.key(), dataKey_);
+        }
+        void sendPostLockSignal() {
+          calledPostLock_ = true;
+          activityRegistry_->postLockEventSetupGetSignal_(componentDescription_, eventSetupRecord_.key(), dataKey_);
+        }
+        ~ESSignalSentry() noexcept(false) {
+          if (!calledPostLock_) {
             activityRegistry_->postLockEventSetupGetSignal_(componentDescription_, eventSetupRecord_.key(), dataKey_);
-         }
-         activityRegistry_->postEventSetupGetSignal_(componentDescription_, eventSetupRecord_.key(), dataKey_);
+          }
+          activityRegistry_->postEventSetupGetSignal_(componentDescription_, eventSetupRecord_.key(), dataKey_);
+        }
+
+      private:
+        EventSetupRecordImpl const& eventSetupRecord_;
+        DataKey const& dataKey_;
+        ComponentDescription const* componentDescription_;
+        bool calledPostLock_;
+        ActivityRegistry const* activityRegistry_;
+      };
+    }  // namespace
+
+    const void* DataProxy::get(const EventSetupRecordImpl& iRecord,
+                               const DataKey& iKey,
+                               bool iTransiently,
+                               ActivityRegistry const* activityRegistry) const {
+      if (!cacheIsValid()) {
+        ESSignalSentry signalSentry(iRecord, iKey, providerDescription(), activityRegistry);
+        std::lock_guard<std::recursive_mutex> guard(s_esGlobalMutex);
+        signalSentry.sendPostLockSignal();
+        if (!cacheIsValid()) {
+          cache_ = const_cast<DataProxy*>(this)->getImpl(iRecord, iKey);
+          cacheIsValid_.store(true, std::memory_order_release);
+        }
       }
-   private:
-      EventSetupRecordImpl const& eventSetupRecord_;
-      DataKey const& dataKey_;
-      ComponentDescription const* componentDescription_;
-      bool calledPostLock_;
-      ActivityRegistry const* activityRegistry_;
-   };
-}
-
-const void* 
-DataProxy::get(const EventSetupRecordImpl& iRecord, const DataKey& iKey, bool iTransiently, ActivityRegistry const* activityRegistry) const
-{
-   if(!cacheIsValid()) {
-      ESSignalSentry signalSentry(iRecord, iKey, providerDescription(), activityRegistry);
-      std::lock_guard<std::recursive_mutex> guard(s_esGlobalMutex);
-      signalSentry.sendPostLockSignal();
-      if(!cacheIsValid()) {
-         cache_ = const_cast<DataProxy*>(this)->getImpl(iRecord, iKey);
-         cacheIsValid_.store(true,std::memory_order_release);
+      //We need to set the AccessType for each request so this can't be called in the if block above.
+      //This also must be before the cache_ check since we want to setCacheIsValid before a possible
+      // exception throw. If we don't, 'getImpl' will be called again on a second request for the data.
+      if (!iTransiently) {
+        nonTransientAccessRequested_.store(true, std::memory_order_release);
       }
-   }
-   //We need to set the AccessType for each request so this can't be called in the if block above.
-   //This also must be before the cache_ check since we want to setCacheIsValid before a possible
-   // exception throw. If we don't, 'getImpl' will be called again on a second request for the data.
-   if(!iTransiently) {
-      nonTransientAccessRequested_.store(true, std::memory_order_release);
-   }
 
-   if(nullptr == cache_) {
-      throwMakeException(iRecord, iKey);
-   }
-   return cache_;
-}
+      if (nullptr == cache_) {
+        throwMakeException(iRecord, iKey);
+      }
+      return cache_;
+    }
 
-void DataProxy::doGet(const EventSetupRecordImpl& iRecord, const DataKey& iKey, bool iTransiently, ActivityRegistry const* activityRegistry) const {
-   get(iRecord, iKey, iTransiently, activityRegistry);
-}
-      
-      
-//
-// static member functions
-//
-   }
-}
+    void DataProxy::doGet(const EventSetupRecordImpl& iRecord,
+                          const DataKey& iKey,
+                          bool iTransiently,
+                          ActivityRegistry const* activityRegistry) const {
+      get(iRecord, iKey, iTransiently, activityRegistry);
+    }
+
+    //
+    // static member functions
+    //
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/DataProxyProvider.cc
+++ b/FWCore/Framework/src/DataProxyProvider.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     DataProxyProvider
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -21,172 +21,137 @@
 #include <cassert>
 
 namespace edm {
-   namespace eventsetup {
-//
-// constants, enums and typedefs
-//
+  namespace eventsetup {
+    //
+    // constants, enums and typedefs
+    //
 
-//
-// static data member definitions
-//
+    //
+    // static data member definitions
+    //
 
-//
-// constructors and destructor
-//
-DataProxyProvider::DataProxyProvider() : recordProxies_(), description_()
-{
-}
+    //
+    // constructors and destructor
+    //
+    DataProxyProvider::DataProxyProvider() : recordProxies_(), description_() {}
 
-// DataProxyProvider::DataProxyProvider(const DataProxyProvider& rhs)
-// {
-//    // do actual copying here;
-// }
+    // DataProxyProvider::DataProxyProvider(const DataProxyProvider& rhs)
+    // {
+    //    // do actual copying here;
+    // }
 
-DataProxyProvider::~DataProxyProvider() noexcept(false)
-{
-}
+    DataProxyProvider::~DataProxyProvider() noexcept(false) {}
 
-//
-// assignment operators
-//
-// const DataProxyProvider& DataProxyProvider::operator=(const DataProxyProvider& rhs)
-// {
-//   //An exception safe implementation is
-//   DataProxyProvider temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+    //
+    // assignment operators
+    //
+    // const DataProxyProvider& DataProxyProvider::operator=(const DataProxyProvider& rhs)
+    // {
+    //   //An exception safe implementation is
+    //   DataProxyProvider temp(rhs);
+    //   swap(rhs);
+    //
+    //   return *this;
+    // }
 
-//
-// member functions
-//
-void 
-DataProxyProvider::usingRecordWithKey(const EventSetupRecordKey& iKey)
-{
-   recordProxies_[iKey];
-   //keys_.push_back(iKey);
-}
+    //
+    // member functions
+    //
+    void DataProxyProvider::usingRecordWithKey(const EventSetupRecordKey& iKey) {
+      recordProxies_[iKey];
+      //keys_.push_back(iKey);
+    }
 
-void 
-DataProxyProvider::invalidateProxies(const EventSetupRecordKey& iRecordKey) 
-{
-   KeyedProxies& proxyList((*(recordProxies_.find(iRecordKey))).second) ;
-   KeyedProxies::iterator finished(proxyList.end()) ;
-   for (KeyedProxies::iterator keyedProxy(proxyList.begin()) ;
-         keyedProxy != finished ;
-         ++keyedProxy) {
-      (*((*keyedProxy).second)).invalidate() ;
-   }
-   
-}
+    void DataProxyProvider::invalidateProxies(const EventSetupRecordKey& iRecordKey) {
+      KeyedProxies& proxyList((*(recordProxies_.find(iRecordKey))).second);
+      KeyedProxies::iterator finished(proxyList.end());
+      for (KeyedProxies::iterator keyedProxy(proxyList.begin()); keyedProxy != finished; ++keyedProxy) {
+        (*((*keyedProxy).second)).invalidate();
+      }
+    }
 
-void 
-DataProxyProvider::resetProxies(const EventSetupRecordKey& iRecordKey)
-{
-  invalidateProxies(iRecordKey);
-}
-      
-void 
-DataProxyProvider::resetProxiesIfTransient(const EventSetupRecordKey& iRecordKey) 
-{
-   KeyedProxies& proxyList((*(recordProxies_.find(iRecordKey))).second) ;
-   KeyedProxies::iterator finished(proxyList.end()) ;
-   for (KeyedProxies::iterator keyedProxy(proxyList.begin()) ;
-        keyedProxy != finished ;
-        ++keyedProxy) {
-      (*((*keyedProxy).second)).resetIfTransient() ;
-   }
-   
-}
-      
-void
-DataProxyProvider::setAppendToDataLabel(const edm::ParameterSet& iToAppend)
-{
-  std::string oldValue( appendToDataLabel_);
-  //this can only be changed once and the default value is the empty string
-  assert(oldValue.empty());
-  
-  const std::string kParamName("appendToDataLabel");
-  if(iToAppend.exists(kParamName) ) {    
-    appendToDataLabel_ = iToAppend.getParameter<std::string>(kParamName);
-  }
-}
-//
-// const member functions
-//
-bool 
-DataProxyProvider::isUsingRecord(const EventSetupRecordKey& iKey) const
-{
-   return recordProxies_.end() != recordProxies_.find(iKey);
-}
+    void DataProxyProvider::resetProxies(const EventSetupRecordKey& iRecordKey) { invalidateProxies(iRecordKey); }
 
-std::set<EventSetupRecordKey> 
-DataProxyProvider::usingRecords() const
-{
-   std::set<EventSetupRecordKey> returnValue;
-   for(RecordProxies::const_iterator itRecProxies = recordProxies_.begin(),
-        itRecProxiesEnd = recordProxies_.end();
-        itRecProxies != itRecProxiesEnd;
-        ++itRecProxies) {
-      returnValue.insert(returnValue.end(), itRecProxies->first);
-   }
-   //copy_all(keys_, std::inserter(returnValue, returnValue.end()));
-   return returnValue;
-}   
+    void DataProxyProvider::resetProxiesIfTransient(const EventSetupRecordKey& iRecordKey) {
+      KeyedProxies& proxyList((*(recordProxies_.find(iRecordKey))).second);
+      KeyedProxies::iterator finished(proxyList.end());
+      for (KeyedProxies::iterator keyedProxy(proxyList.begin()); keyedProxy != finished; ++keyedProxy) {
+        (*((*keyedProxy).second)).resetIfTransient();
+      }
+    }
 
-const DataProxyProvider::KeyedProxies& 
-DataProxyProvider::keyedProxies(const EventSetupRecordKey& iRecordKey) const
-{
-   RecordProxies::const_iterator itFind = recordProxies_.find(iRecordKey);
-   assert(itFind != recordProxies_.end());
-   
-   if(itFind->second.empty()) {
-      //delayed registration
-      KeyedProxies& proxies = const_cast<KeyedProxies&>(itFind->second);
-      const_cast<DataProxyProvider*>(this)->registerProxies(iRecordKey,
-                                                            proxies);
+    void DataProxyProvider::setAppendToDataLabel(const edm::ParameterSet& iToAppend) {
+      std::string oldValue(appendToDataLabel_);
+      //this can only be changed once and the default value is the empty string
+      assert(oldValue.empty());
 
-      bool mustChangeLabels = (!appendToDataLabel_.empty());
-      for(KeyedProxies::iterator itProxy = proxies.begin(), itProxyEnd = proxies.end();
-          itProxy != itProxyEnd;
-          ++itProxy) {
-        itProxy->second->setProviderDescription(&description());
-        if( mustChangeLabels ) {
-          //Using swap is fine since
-          // 1) the data structure is not a map and so we have not sorted on the keys
-          // 2) this is the first time filling this so no outside agency has yet seen
-          //   the label and therefore can not be dependent upon its value
-          std::string temp(std::string(itProxy->first.name().value())+appendToDataLabel_);
-          DataKey newKey(itProxy->first.type(),temp.c_str());
-          swap(itProxy->first,newKey);
+      const std::string kParamName("appendToDataLabel");
+      if (iToAppend.exists(kParamName)) {
+        appendToDataLabel_ = iToAppend.getParameter<std::string>(kParamName);
+      }
+    }
+    //
+    // const member functions
+    //
+    bool DataProxyProvider::isUsingRecord(const EventSetupRecordKey& iKey) const {
+      return recordProxies_.end() != recordProxies_.find(iKey);
+    }
+
+    std::set<EventSetupRecordKey> DataProxyProvider::usingRecords() const {
+      std::set<EventSetupRecordKey> returnValue;
+      for (RecordProxies::const_iterator itRecProxies = recordProxies_.begin(), itRecProxiesEnd = recordProxies_.end();
+           itRecProxies != itRecProxiesEnd; ++itRecProxies) {
+        returnValue.insert(returnValue.end(), itRecProxies->first);
+      }
+      //copy_all(keys_, std::inserter(returnValue, returnValue.end()));
+      return returnValue;
+    }
+
+    const DataProxyProvider::KeyedProxies& DataProxyProvider::keyedProxies(const EventSetupRecordKey& iRecordKey) const {
+      RecordProxies::const_iterator itFind = recordProxies_.find(iRecordKey);
+      assert(itFind != recordProxies_.end());
+
+      if (itFind->second.empty()) {
+        //delayed registration
+        KeyedProxies& proxies = const_cast<KeyedProxies&>(itFind->second);
+        const_cast<DataProxyProvider*>(this)->registerProxies(iRecordKey, proxies);
+
+        bool mustChangeLabels = (!appendToDataLabel_.empty());
+        for (KeyedProxies::iterator itProxy = proxies.begin(), itProxyEnd = proxies.end(); itProxy != itProxyEnd;
+             ++itProxy) {
+          itProxy->second->setProviderDescription(&description());
+          if (mustChangeLabels) {
+            //Using swap is fine since
+            // 1) the data structure is not a map and so we have not sorted on the keys
+            // 2) this is the first time filling this so no outside agency has yet seen
+            //   the label and therefore can not be dependent upon its value
+            std::string temp(std::string(itProxy->first.name().value()) + appendToDataLabel_);
+            DataKey newKey(itProxy->first.type(), temp.c_str());
+            swap(itProxy->first, newKey);
+          }
         }
       }
-   }
-   
-   return itFind->second;
-}
 
-//
-// static member functions
-//
-static const std::string kAppendToDataLabel("appendToDataLabel");
+      return itFind->second;
+    }
 
-void
-DataProxyProvider::prevalidate(ConfigurationDescriptions& iDesc)
-{
-   if(iDesc.defaultDescription()) {
-     if (iDesc.defaultDescription()->isLabelUnused(kAppendToDataLabel)) {
-       iDesc.defaultDescription()->add<std::string>(kAppendToDataLabel, std::string(""));
-     }
-   }
-   for(auto& v: iDesc) {
-     if (v.second.isLabelUnused(kAppendToDataLabel)) {
-       v.second.add<std::string>(kAppendToDataLabel, std::string(""));
-     }
-   }
-}
+    //
+    // static member functions
+    //
+    static const std::string kAppendToDataLabel("appendToDataLabel");
 
-   }
-}
+    void DataProxyProvider::prevalidate(ConfigurationDescriptions& iDesc) {
+      if (iDesc.defaultDescription()) {
+        if (iDesc.defaultDescription()->isLabelUnused(kAppendToDataLabel)) {
+          iDesc.defaultDescription()->add<std::string>(kAppendToDataLabel, std::string(""));
+        }
+      }
+      for (auto& v : iDesc) {
+        if (v.second.isLabelUnused(kAppendToDataLabel)) {
+          v.second.add<std::string>(kAppendToDataLabel, std::string(""));
+        }
+      }
+    }
 
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/DelayedReader.cc
+++ b/FWCore/Framework/src/DelayedReader.cc
@@ -11,24 +11,21 @@
 
 ----------------------------------------------------------------------*/
 
-
 namespace edm {
   DelayedReader::~DelayedReader() {}
 
-  std::unique_ptr<WrapperBase>
-  DelayedReader::getProduct(BranchID const& k,
-                            EDProductGetter const* ep,
-                            ModuleCallingContext const* mcc) {
-
+  std::unique_ptr<WrapperBase> DelayedReader::getProduct(BranchID const& k,
+                                                         EDProductGetter const* ep,
+                                                         ModuleCallingContext const* mcc) {
     auto preSignal = preEventReadFromSourceSignal();
-    if(mcc and preSignal) {
-      preSignal->emit(*(mcc->getStreamContext()),*mcc);
+    if (mcc and preSignal) {
+      preSignal->emit(*(mcc->getStreamContext()), *mcc);
     }
     auto postSignal = postEventReadFromSourceSignal();
-    
-    auto sentryCall = [&postSignal]( ModuleCallingContext const* iContext) {
-      if(postSignal) {
-        postSignal->emit(*(iContext->getStreamContext()),*iContext);
+
+    auto sentryCall = [&postSignal](ModuleCallingContext const* iContext) {
+      if (postSignal) {
+        postSignal->emit(*(iContext->getStreamContext()), *iContext);
       }
     };
     std::unique_ptr<ModuleCallingContext const, decltype(sentryCall)> sentry(mcc, sentryCall);
@@ -36,8 +33,7 @@ namespace edm {
     return getProduct_(k, ep);
   }
 
-  std::pair<SharedResourcesAcquirer*, std::recursive_mutex*>
-  DelayedReader::sharedResources_() const {
+  std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> DelayedReader::sharedResources_() const {
     return std::pair<SharedResourcesAcquirer*, std::recursive_mutex*>(nullptr, nullptr);
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/DependentRecordIntervalFinder.cc
+++ b/FWCore/Framework/src/DependentRecordIntervalFinder.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     DependentRecordIntervalFinder
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -21,192 +21,181 @@
 // constants, enums and typedefs
 //
 namespace edm {
-   namespace eventsetup {
-//
-// static data member definitions
-//
+  namespace eventsetup {
+    //
+    // static data member definitions
+    //
 
-//
-// constructors and destructor
-//
-DependentRecordIntervalFinder::DependentRecordIntervalFinder(const EventSetupRecordKey& iKey) :
-  providers_()
-{
-   findingRecordWithKey(iKey);
-}
+    //
+    // constructors and destructor
+    //
+    DependentRecordIntervalFinder::DependentRecordIntervalFinder(const EventSetupRecordKey& iKey) : providers_() {
+      findingRecordWithKey(iKey);
+    }
 
-// DependentRecordIntervalFinder::DependentRecordIntervalFinder(const DependentRecordIntervalFinder& rhs)
-// {
-//    // do actual copying here;
-// }
+    // DependentRecordIntervalFinder::DependentRecordIntervalFinder(const DependentRecordIntervalFinder& rhs)
+    // {
+    //    // do actual copying here;
+    // }
 
-DependentRecordIntervalFinder::~DependentRecordIntervalFinder()
-{
-}
+    DependentRecordIntervalFinder::~DependentRecordIntervalFinder() {}
 
-//
-// assignment operators
-//
-// const DependentRecordIntervalFinder& DependentRecordIntervalFinder::operator=(const DependentRecordIntervalFinder& rhs)
-// {
-//   //An exception safe implementation is
-//   DependentRecordIntervalFinder temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+    //
+    // assignment operators
+    //
+    // const DependentRecordIntervalFinder& DependentRecordIntervalFinder::operator=(const DependentRecordIntervalFinder& rhs)
+    // {
+    //   //An exception safe implementation is
+    //   DependentRecordIntervalFinder temp(rhs);
+    //   swap(rhs);
+    //
+    //   return *this;
+    // }
 
-//
-// member functions
-//
-void 
-DependentRecordIntervalFinder::addProviderWeAreDependentOn(std::shared_ptr<EventSetupRecordProvider> iProvider)
-{
-   providers_.push_back(iProvider);
-}
+    //
+    // member functions
+    //
+    void DependentRecordIntervalFinder::addProviderWeAreDependentOn(
+        std::shared_ptr<EventSetupRecordProvider> iProvider) {
+      providers_.push_back(iProvider);
+    }
 
-void 
-DependentRecordIntervalFinder::setAlternateFinder(std::shared_ptr<EventSetupRecordIntervalFinder> iOther)
-{
-  alternate_ = iOther;
-}
+    void DependentRecordIntervalFinder::setAlternateFinder(std::shared_ptr<EventSetupRecordIntervalFinder> iOther) {
+      alternate_ = iOther;
+    }
 
-void 
-DependentRecordIntervalFinder::setIntervalFor(const EventSetupRecordKey& iKey,
-                                               const IOVSyncValue& iTime, 
-                                               ValidityInterval& oInterval)
-{
-   //NOTE: oInterval is the last value that was used so if nothing changed do not modify oInterval
-   
-   //I am assuming that an invalidTime is always less then the first valid time
-   assert(IOVSyncValue::invalidIOVSyncValue() < IOVSyncValue::beginOfTime());
-   if(providers_.empty() && alternate_.get() == nullptr ) {
-      oInterval = ValidityInterval::invalidInterval();
-      return;
-   }
-   bool haveAValidDependentRecord = false;
-   bool allRecordsValid = true;
-   ValidityInterval newInterval(IOVSyncValue::beginOfTime(), IOVSyncValue::endOfTime());
-   
-   if (alternate_.get() != nullptr) {
-     ValidityInterval test = alternate_->findIntervalFor(iKey, iTime);
-     if ( test != ValidityInterval::invalidInterval() ) {
-       haveAValidDependentRecord =true;
-       newInterval = test;
-     }
-   }
-   bool intervalsWereComparible = true;
-   for(Providers::iterator itProvider = providers_.begin(), itProviderEnd = providers_.end();
-       itProvider != itProviderEnd;
-       ++itProvider) {
-      if((*itProvider)->setValidityIntervalFor(iTime)) {
-         haveAValidDependentRecord=true;
-         ValidityInterval providerInterval = (*itProvider)->validityInterval();
-	 if( (!newInterval.first().comparable(providerInterval.first())) ||
-	     (!newInterval.last().comparable(providerInterval.last()))) {
-	   intervalsWereComparible=false;
-	   break;
-	 }
-         if(newInterval.first() < providerInterval.first()) {
-            newInterval.setFirst(providerInterval.first());
-         }
-         if(newInterval.last() > providerInterval.last()) {
-            newInterval.setLast(providerInterval.last());
-         }
-      } else {
-	allRecordsValid = false;
+    void DependentRecordIntervalFinder::setIntervalFor(const EventSetupRecordKey& iKey,
+                                                       const IOVSyncValue& iTime,
+                                                       ValidityInterval& oInterval) {
+      //NOTE: oInterval is the last value that was used so if nothing changed do not modify oInterval
+
+      //I am assuming that an invalidTime is always less then the first valid time
+      assert(IOVSyncValue::invalidIOVSyncValue() < IOVSyncValue::beginOfTime());
+      if (providers_.empty() && alternate_.get() == nullptr) {
+        oInterval = ValidityInterval::invalidInterval();
+        return;
       }
-   }
-   if(intervalsWereComparible) {
-     if(!haveAValidDependentRecord) {
-       //If no Finder has no valid time, then this record is also invalid for this time
-       newInterval = ValidityInterval::invalidInterval();
-     }
-     if(!allRecordsValid) {
-       //since some of the dependent providers do not have a valid IOV for this syncvalue
-       // we do not know what the true end IOV is.  Therefore we must make it open ended
-       // so that we can check each time to see if those providers become valid.
-       newInterval.setLast(IOVSyncValue::invalidIOVSyncValue());
-     }
-     oInterval = newInterval;
-     return;
-   }
-   //handle the case where some providers use time and others use run/lumi/event
-   // in this case all we can do is find an IOV which changed since last time
-   // and use its start time to do the synching and use an 'invalid' end time
-   // so the system always checks back to see if something has changed
-   if (previousIOVs_.empty()) {
-      std::vector<ValidityInterval> tmp(providers_.size(),ValidityInterval());
-      previousIOVs_.swap(tmp);
-   }
+      bool haveAValidDependentRecord = false;
+      bool allRecordsValid = true;
+      ValidityInterval newInterval(IOVSyncValue::beginOfTime(), IOVSyncValue::endOfTime());
 
-   //I'm using an heuristic to pick a reasonable starting point for the IOV. The idea is to
-   // assume that lumi sections are 23 seconds long and therefore if we take a difference between
-   // iTime and the beginning of a changed IOV we can pick the changed IOV with the start time 
-   // closest to iTime. This doesn't have to be perfect, we just want to reduce the dependency
-   // on provider order to make the jobs more deterministic
-   
-   bool hadChangedIOV = false;
-   //both start at the smallest value
-   EventID closestID;
-   Timestamp closestTimeStamp(0);
-   std::vector<ValidityInterval>::iterator itIOVs = previousIOVs_.begin();
-   for(Providers::iterator itProvider = providers_.begin(), itProviderEnd = providers_.end();
-       itProvider != itProviderEnd;
-       ++itProvider, ++itIOVs) {
-      if((*itProvider)->setValidityIntervalFor(iTime)) {
-         ValidityInterval providerInterval = (*itProvider)->validityInterval();
-	 if(*itIOVs != providerInterval) {
+      if (alternate_.get() != nullptr) {
+        ValidityInterval test = alternate_->findIntervalFor(iKey, iTime);
+        if (test != ValidityInterval::invalidInterval()) {
+          haveAValidDependentRecord = true;
+          newInterval = test;
+        }
+      }
+      bool intervalsWereComparible = true;
+      for (Providers::iterator itProvider = providers_.begin(), itProviderEnd = providers_.end();
+           itProvider != itProviderEnd; ++itProvider) {
+        if ((*itProvider)->setValidityIntervalFor(iTime)) {
+          haveAValidDependentRecord = true;
+          ValidityInterval providerInterval = (*itProvider)->validityInterval();
+          if ((!newInterval.first().comparable(providerInterval.first())) ||
+              (!newInterval.last().comparable(providerInterval.last()))) {
+            intervalsWereComparible = false;
+            break;
+          }
+          if (newInterval.first() < providerInterval.first()) {
+            newInterval.setFirst(providerInterval.first());
+          }
+          if (newInterval.last() > providerInterval.last()) {
+            newInterval.setLast(providerInterval.last());
+          }
+        } else {
+          allRecordsValid = false;
+        }
+      }
+      if (intervalsWereComparible) {
+        if (!haveAValidDependentRecord) {
+          //If no Finder has no valid time, then this record is also invalid for this time
+          newInterval = ValidityInterval::invalidInterval();
+        }
+        if (!allRecordsValid) {
+          //since some of the dependent providers do not have a valid IOV for this syncvalue
+          // we do not know what the true end IOV is.  Therefore we must make it open ended
+          // so that we can check each time to see if those providers become valid.
+          newInterval.setLast(IOVSyncValue::invalidIOVSyncValue());
+        }
+        oInterval = newInterval;
+        return;
+      }
+      //handle the case where some providers use time and others use run/lumi/event
+      // in this case all we can do is find an IOV which changed since last time
+      // and use its start time to do the synching and use an 'invalid' end time
+      // so the system always checks back to see if something has changed
+      if (previousIOVs_.empty()) {
+        std::vector<ValidityInterval> tmp(providers_.size(), ValidityInterval());
+        previousIOVs_.swap(tmp);
+      }
+
+      //I'm using an heuristic to pick a reasonable starting point for the IOV. The idea is to
+      // assume that lumi sections are 23 seconds long and therefore if we take a difference between
+      // iTime and the beginning of a changed IOV we can pick the changed IOV with the start time
+      // closest to iTime. This doesn't have to be perfect, we just want to reduce the dependency
+      // on provider order to make the jobs more deterministic
+
+      bool hadChangedIOV = false;
+      //both start at the smallest value
+      EventID closestID;
+      Timestamp closestTimeStamp(0);
+      std::vector<ValidityInterval>::iterator itIOVs = previousIOVs_.begin();
+      for (Providers::iterator itProvider = providers_.begin(), itProviderEnd = providers_.end();
+           itProvider != itProviderEnd; ++itProvider, ++itIOVs) {
+        if ((*itProvider)->setValidityIntervalFor(iTime)) {
+          ValidityInterval providerInterval = (*itProvider)->validityInterval();
+          if (*itIOVs != providerInterval) {
             hadChangedIOV = true;
-            if(providerInterval.first().time().value() == 0) {
-               //this is a run/lumi based one
-               if( closestID < providerInterval.first().eventID()) {
-                  closestID = providerInterval.first().eventID();
-               }
+            if (providerInterval.first().time().value() == 0) {
+              //this is a run/lumi based one
+              if (closestID < providerInterval.first().eventID()) {
+                closestID = providerInterval.first().eventID();
+              }
             } else {
-               if(closestTimeStamp < providerInterval.first().time()) {
-                  closestTimeStamp = providerInterval.first().time();
-               }
+              if (closestTimeStamp < providerInterval.first().time()) {
+                closestTimeStamp = providerInterval.first().time();
+              }
             }
             *itIOVs = providerInterval;
-         }
+          }
+        }
       }
-   }
-   if(hadChangedIOV) {
-      if(closestID.run() !=0) {
-         if(closestTimeStamp.value() == 0) {
+      if (hadChangedIOV) {
+        if (closestID.run() != 0) {
+          if (closestTimeStamp.value() == 0) {
             //no time
             oInterval = ValidityInterval(IOVSyncValue(closestID), IOVSyncValue::invalidIOVSyncValue());
-         } else {
-            if(closestID.run() == iTime.eventID().run()) {
-               //can compare time to lumi
-               const unsigned long long kLumiTimeLength = 23;
-               
-               if( (iTime.eventID().luminosityBlock() - closestID.luminosityBlock())*kLumiTimeLength < 
-                  iTime.time().unixTime() - closestTimeStamp.unixTime() ) {
-                  //closestID was closer
-                  oInterval = ValidityInterval(IOVSyncValue(closestID), IOVSyncValue::invalidIOVSyncValue());
-               } else {
-                  oInterval = ValidityInterval(IOVSyncValue(closestTimeStamp), IOVSyncValue::invalidIOVSyncValue());
-               }
+          } else {
+            if (closestID.run() == iTime.eventID().run()) {
+              //can compare time to lumi
+              const unsigned long long kLumiTimeLength = 23;
+
+              if ((iTime.eventID().luminosityBlock() - closestID.luminosityBlock()) * kLumiTimeLength <
+                  iTime.time().unixTime() - closestTimeStamp.unixTime()) {
+                //closestID was closer
+                oInterval = ValidityInterval(IOVSyncValue(closestID), IOVSyncValue::invalidIOVSyncValue());
+              } else {
+                oInterval = ValidityInterval(IOVSyncValue(closestTimeStamp), IOVSyncValue::invalidIOVSyncValue());
+              }
             } else {
-               //since we don't know how to change run # into time we can't compare
-               // so if we have a time just use it
-               oInterval = ValidityInterval(IOVSyncValue(closestTimeStamp), IOVSyncValue::invalidIOVSyncValue());
+              //since we don't know how to change run # into time we can't compare
+              // so if we have a time just use it
+              oInterval = ValidityInterval(IOVSyncValue(closestTimeStamp), IOVSyncValue::invalidIOVSyncValue());
             }
-         }
-      } else {
-         oInterval = ValidityInterval( IOVSyncValue(closestTimeStamp), IOVSyncValue::invalidIOVSyncValue());
+          }
+        } else {
+          oInterval = ValidityInterval(IOVSyncValue(closestTimeStamp), IOVSyncValue::invalidIOVSyncValue());
+        }
       }
-   }
-}
+    }
 
-//
-// const member functions
-//
+    //
+    // const member functions
+    //
 
-//
-// static member functions
-//
-   }
-}
+    //
+    // static member functions
+    //
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/EDAnalyzer.cc
+++ b/FWCore/Framework/src/EDAnalyzer.cc
@@ -22,122 +22,94 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 namespace edm {
-  EDAnalyzer::~EDAnalyzer() {
-  }
+  EDAnalyzer::~EDAnalyzer() {}
   EDAnalyzer::EDAnalyzer() : moduleDescription_() {
-    SharedResourcesRegistry::instance()->registerSharedResource(
-                                                                SharedResourcesRegistry::kLegacyModuleResourceName);
+    SharedResourcesRegistry::instance()->registerSharedResource(SharedResourcesRegistry::kLegacyModuleResourceName);
   }
 
-
-  bool
-  EDAnalyzer::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
-                      ActivityRegistry* act,
-                      ModuleCallingContext const* mcc) {
+  bool EDAnalyzer::doEvent(EventPrincipal const& ep,
+                           EventSetupImpl const& ci,
+                           ActivityRegistry* act,
+                           ModuleCallingContext const* mcc) {
     Event e(ep, moduleDescription_, mcc);
     e.setConsumer(this);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
-    EventSignalsSentry sentry(act,mcc);
+    EventSignalsSentry sentry(act, mcc);
     const EventSetup c{ci};
     this->analyze(e, c);
     return true;
   }
 
-  void
-  EDAnalyzer::doBeginJob() {
+  void EDAnalyzer::doBeginJob() {
     std::vector<std::string> res = {SharedResourcesRegistry::kLegacyModuleResourceName};
     resourceAcquirer_ = SharedResourcesRegistry::instance()->createAcquirer(res);
 
     this->beginJob();
   }
 
-  void 
-  EDAnalyzer::doEndJob() {
-    this->endJob();
-  }
+  void EDAnalyzer::doEndJob() { this->endJob(); }
 
-  bool
-  EDAnalyzer::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci,
-                         ModuleCallingContext const* mcc) {
-    Run r(rp, moduleDescription_, mcc,false);
+  bool EDAnalyzer::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
+    Run r(rp, moduleDescription_, mcc, false);
     r.setConsumer(this);
     const EventSetup c{ci};
     this->beginRun(r, c);
     return true;
   }
 
-  bool
-  EDAnalyzer::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci,
-                       ModuleCallingContext const* mcc) {
-    Run r(rp, moduleDescription_, mcc,true);
+  bool EDAnalyzer::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
+    Run r(rp, moduleDescription_, mcc, true);
     r.setConsumer(this);
     const EventSetup c{ci};
     this->endRun(r, c);
     return true;
   }
 
-  bool
-  EDAnalyzer::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
-                                     ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(lbp, moduleDescription_, mcc,false);
+  bool EDAnalyzer::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                          EventSetupImpl const& ci,
+                                          ModuleCallingContext const* mcc) {
+    LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
     lb.setConsumer(this);
     const EventSetup c{ci};
     this->beginLuminosityBlock(lb, c);
     return true;
   }
 
-  bool
-  EDAnalyzer::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
-                                   ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(lbp, moduleDescription_, mcc,true);
+  bool EDAnalyzer::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                        EventSetupImpl const& ci,
+                                        ModuleCallingContext const* mcc) {
+    LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
     lb.setConsumer(this);
     const EventSetup c{ci};
     this->endLuminosityBlock(lb, c);
     return true;
   }
 
-  void
-  EDAnalyzer::doRespondToOpenInputFile(FileBlock const& fb) {
-    respondToOpenInputFile(fb);
-  }
+  void EDAnalyzer::doRespondToOpenInputFile(FileBlock const& fb) { respondToOpenInputFile(fb); }
 
-  void
-  EDAnalyzer::doRespondToCloseInputFile(FileBlock const& fb) {
-    respondToCloseInputFile(fb);
-  }
+  void EDAnalyzer::doRespondToCloseInputFile(FileBlock const& fb) { respondToCloseInputFile(fb); }
 
-  void
-  EDAnalyzer::callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
+  void EDAnalyzer::callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
     callWhenNewProductsRegistered_ = func;
   }
 
-  void
-  EDAnalyzer::fillDescriptions(ConfigurationDescriptions& descriptions) {
+  void EDAnalyzer::fillDescriptions(ConfigurationDescriptions& descriptions) {
     ParameterSetDescription desc;
     desc.setUnknown();
     descriptions.addDefault(desc);
   }
-  
-  void
-  EDAnalyzer::prevalidate(ConfigurationDescriptions& iConfig) {
-    edmodule_mightGet_config(iConfig);
-  }
 
-  void
-  EDAnalyzer::registerProductsAndCallbacks(EDAnalyzer const*, ProductRegistry* reg) {
+  void EDAnalyzer::prevalidate(ConfigurationDescriptions& iConfig) { edmodule_mightGet_config(iConfig); }
 
+  void EDAnalyzer::registerProductsAndCallbacks(EDAnalyzer const*, ProductRegistry* reg) {
     if (callWhenNewProductsRegistered_) {
+      reg->callForEachBranch(callWhenNewProductsRegistered_);
 
-       reg->callForEachBranch(callWhenNewProductsRegistered_);
-
-       Service<ConstProductRegistry> regService;
-       regService->watchProductAdditions(callWhenNewProductsRegistered_);
+      Service<ConstProductRegistry> regService;
+      regService->watchProductAdditions(callWhenNewProductsRegistered_);
     }
   }
 
   static const std::string kBaseType("EDAnalyzer");
-  const std::string&
-  EDAnalyzer::baseType() {
-    return kBaseType;
-  }
-}
+  const std::string& EDAnalyzer::baseType() { return kBaseType; }
+}  // namespace edm

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -2,7 +2,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     EDConsumerBase
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -49,9 +49,7 @@ using namespace edm;
 //    // do actual copying here;
 // }
 
-EDConsumerBase::~EDConsumerBase() noexcept(false)
-{
-}
+EDConsumerBase::~EDConsumerBase() noexcept(false) {}
 
 //
 // assignment operators
@@ -68,57 +66,52 @@ EDConsumerBase::~EDConsumerBase() noexcept(false)
 //
 // member functions
 //
-ConsumesCollector
-EDConsumerBase::consumesCollector() {
+ConsumesCollector EDConsumerBase::consumesCollector() {
   ConsumesCollector c{this};
   return c;
 }
 
 static const edm::InputTag kWasEmpty("@EmptyLabel@");
 
-edm::InputTag const&
-EDConsumerBase::checkIfEmpty(edm::InputTag const& iTag) {
+edm::InputTag const& EDConsumerBase::checkIfEmpty(edm::InputTag const& iTag) {
   if (iTag.label().empty()) {
     return kWasEmpty;
   }
   return iTag;
 }
 
-unsigned int
-EDConsumerBase::recordConsumes(BranchType iBranch, TypeToGet const& iType, edm::InputTag const& iTag, bool iAlwaysGets) {
-
-  if(frozen_) {
+unsigned int EDConsumerBase::recordConsumes(BranchType iBranch,
+                                            TypeToGet const& iType,
+                                            edm::InputTag const& iTag,
+                                            bool iAlwaysGets) {
+  if (frozen_) {
     throwConsumesCallAfterFrozen(iType, iTag);
   }
 
-  unsigned int index =m_tokenInfo.size();
+  unsigned int index = m_tokenInfo.size();
 
   bool skipCurrentProcess = iTag.willSkipCurrentProcess();
 
   const size_t labelSize = iTag.label().size();
   const size_t productInstanceSize = iTag.instance().size();
   unsigned int labelStart = m_tokenLabels.size();
-  unsigned short delta1 = labelSize+1;
-  unsigned short delta2 = labelSize+2+productInstanceSize;
+  unsigned short delta1 = labelSize + 1;
+  unsigned short delta2 = labelSize + 2 + productInstanceSize;
   m_tokenInfo.emplace_back(TokenLookupInfo{iType.type(), ProductResolverIndexInvalid, skipCurrentProcess, iBranch},
-                           iAlwaysGets,
-                           LabelPlacement{labelStart,delta1,delta2},
-                           iType.kind());
+                           iAlwaysGets, LabelPlacement{labelStart, delta1, delta2}, iType.kind());
 
-  const size_t additionalSize =
-      skipCurrentProcess ?
-      labelSize+productInstanceSize+3 :
-      labelSize+productInstanceSize+iTag.process().size()+3;
+  const size_t additionalSize = skipCurrentProcess ? labelSize + productInstanceSize + 3
+                                                   : labelSize + productInstanceSize + iTag.process().size() + 3;
 
-  m_tokenLabels.reserve(m_tokenLabels.size()+additionalSize);
+  m_tokenLabels.reserve(m_tokenLabels.size() + additionalSize);
   {
-    const std::string& m =iTag.label();
-    m_tokenLabels.insert(m_tokenLabels.end(),m.begin(),m.end());
+    const std::string& m = iTag.label();
+    m_tokenLabels.insert(m_tokenLabels.end(), m.begin(), m.end());
     m_tokenLabels.push_back('\0');
   }
   {
-    const std::string& m =iTag.instance();
-    m_tokenLabels.insert(m_tokenLabels.end(),m.begin(),m.end());
+    const std::string& m = iTag.instance();
+    m_tokenLabels.insert(m_tokenLabels.end(), m.begin(), m.end());
     m_tokenLabels.push_back('\0');
   }
   {
@@ -127,7 +120,7 @@ EDConsumerBase::recordConsumes(BranchType iBranch, TypeToGet const& iType, edm::
       containsCurrentProcessAlias_ = true;
     }
     if (!skipCurrentProcess) {
-      m_tokenLabels.insert(m_tokenLabels.end(),m.begin(),m.end());
+      m_tokenLabels.insert(m_tokenLabels.end(), m.begin(), m.end());
       m_tokenLabels.push_back('\0');
     } else {
       m_tokenLabels.push_back('\0');
@@ -136,55 +129,49 @@ EDConsumerBase::recordConsumes(BranchType iBranch, TypeToGet const& iType, edm::
   return index;
 }
 
-void
-EDConsumerBase::updateLookup(BranchType iBranchType,
-                             ProductResolverIndexHelper const& iHelper,
-                             bool iPrefetchMayGet)
-{
+void EDConsumerBase::updateLookup(BranchType iBranchType,
+                                  ProductResolverIndexHelper const& iHelper,
+                                  bool iPrefetchMayGet) {
   frozen_ = true;
   assert(!containsCurrentProcessAlias_);
   {
     auto itKind = m_tokenInfo.begin<kKind>();
     auto itLabels = m_tokenInfo.begin<kLabels>();
-    for(auto itInfo = m_tokenInfo.begin<kLookupInfo>(),itEnd = m_tokenInfo.end<kLookupInfo>();
-        itInfo != itEnd; ++itInfo,++itKind,++itLabels) {
-      if(itInfo->m_branchType == iBranchType) {
+    for (auto itInfo = m_tokenInfo.begin<kLookupInfo>(), itEnd = m_tokenInfo.end<kLookupInfo>(); itInfo != itEnd;
+         ++itInfo, ++itKind, ++itLabels) {
+      if (itInfo->m_branchType == iBranchType) {
         const unsigned int labelStart = itLabels->m_startOfModuleLabel;
         const char* moduleLabel = &(m_tokenLabels[labelStart]);
-        itInfo->m_index = ProductResolverIndexAndSkipBit(iHelper.index(*itKind,
-                                                                     itInfo->m_type,
-                                                                     moduleLabel,
-                                                                     moduleLabel+itLabels->m_deltaToProductInstance,
-                                                                     moduleLabel+itLabels->m_deltaToProcessName),
-                                                       itInfo->m_index.skipCurrentProcess());
+        itInfo->m_index = ProductResolverIndexAndSkipBit(
+            iHelper.index(*itKind, itInfo->m_type, moduleLabel, moduleLabel + itLabels->m_deltaToProductInstance,
+                          moduleLabel + itLabels->m_deltaToProcessName),
+            itInfo->m_index.skipCurrentProcess());
       }
     }
   }
 
   //now add resolved requests to get many to the end of our list
   // a get many will have an empty module label
-  for(size_t i=0, iEnd = m_tokenInfo.size(); i!=iEnd;++i) {
+  for (size_t i = 0, iEnd = m_tokenInfo.size(); i != iEnd; ++i) {
     //need to copy since pointer could be invalidated by emplace_back
     auto const info = m_tokenInfo.get<kLookupInfo>(i);
-    if(info.m_branchType == iBranchType &&
-       info.m_index.productResolverIndex() == ProductResolverIndexInvalid &&
-       m_tokenLabels[m_tokenInfo.get<kLabels>(i).m_startOfModuleLabel]=='\0') {
+    if (info.m_branchType == iBranchType && info.m_index.productResolverIndex() == ProductResolverIndexInvalid &&
+        m_tokenLabels[m_tokenInfo.get<kLabels>(i).m_startOfModuleLabel] == '\0') {
       //find all matching types
-      const auto kind=m_tokenInfo.get<kKind>(i);
-      auto matches = iHelper.relatedIndexes(kind,info.m_type);
+      const auto kind = m_tokenInfo.get<kKind>(i);
+      auto matches = iHelper.relatedIndexes(kind, info.m_type);
 
       //NOTE: This could be changed to contain the true labels for what is being
       // requested but for now I want to remember these are part of a get many
-      const LabelPlacement labels= m_tokenInfo.get<kLabels>(i);
+      const LabelPlacement labels = m_tokenInfo.get<kLabels>(i);
       bool alwaysGet = m_tokenInfo.get<kAlwaysGets>(i);
-      for(unsigned int j=0;j!=matches.numberOfMatches();++j) {
+      for (unsigned int j = 0; j != matches.numberOfMatches(); ++j) {
         //only keep the ones that are for a specific data item and not a collection
-        if(matches.isFullyResolved(j)) {
-          auto index =matches.index(j);
-          m_tokenInfo.emplace_back(TokenLookupInfo{info.m_type, index, info.m_index.skipCurrentProcess(), info.m_branchType},
-                                   alwaysGet,
-                                   labels,
-                                   kind);
+        if (matches.isFullyResolved(j)) {
+          auto index = matches.index(j);
+          m_tokenInfo.emplace_back(
+              TokenLookupInfo{info.m_type, index, info.m_index.skipCurrentProcess(), info.m_branchType}, alwaysGet,
+              labels, kind);
         }
       }
     }
@@ -192,7 +179,7 @@ EDConsumerBase::updateLookup(BranchType iBranchType,
   m_tokenInfo.shrink_to_fit();
 
   itemsToGet(iBranchType, itemsToGetFromBranch_[iBranchType]);
-  if(iPrefetchMayGet) {
+  if (iPrefetchMayGet) {
     itemsMayGet(iBranchType, itemsToGetFromBranch_[iBranchType]);
   }
 }
@@ -200,11 +187,11 @@ EDConsumerBase::updateLookup(BranchType iBranchType,
 //
 // const member functions
 //
-ProductResolverIndexAndSkipBit
-EDConsumerBase::indexFrom(EDGetToken iToken, BranchType iBranch, TypeID const& iType) const
-{
-  if(UNLIKELY(iToken.index()>=m_tokenInfo.size())) {
-    throwBadToken(iType,iToken);
+ProductResolverIndexAndSkipBit EDConsumerBase::indexFrom(EDGetToken iToken,
+                                                         BranchType iBranch,
+                                                         TypeID const& iType) const {
+  if (UNLIKELY(iToken.index() >= m_tokenInfo.size())) {
+    throwBadToken(iType, iToken);
   }
   const auto& info = m_tokenInfo.get<kLookupInfo>(iToken.index());
   if (LIKELY(iBranch == info.m_branchType)) {
@@ -214,45 +201,39 @@ EDConsumerBase::indexFrom(EDGetToken iToken, BranchType iBranch, TypeID const& i
       throwTypeMismatch(iType, iToken);
     }
   } else {
-    throwBranchMismatch(iBranch,iToken);
+    throwBranchMismatch(iBranch, iToken);
   }
   return ProductResolverIndexAndSkipBit(edm::ProductResolverIndexInvalid, false);
 }
 
-ProductResolverIndexAndSkipBit
-EDConsumerBase::uncheckedIndexFrom(EDGetToken iToken) const {
+ProductResolverIndexAndSkipBit EDConsumerBase::uncheckedIndexFrom(EDGetToken iToken) const {
   return m_tokenInfo.get<kLookupInfo>(iToken.index()).m_index;
 }
 
-
-void
-EDConsumerBase::itemsToGet(BranchType iBranch, std::vector<ProductResolverIndexAndSkipBit>& oIndices) const
-{
+void EDConsumerBase::itemsToGet(BranchType iBranch, std::vector<ProductResolverIndexAndSkipBit>& oIndices) const {
   //how many are we adding?
-  unsigned int count=0;
+  unsigned int count = 0;
   {
     auto itAlwaysGet = m_tokenInfo.begin<kAlwaysGets>();
-    for(auto it = m_tokenInfo.begin<kLookupInfo>(),
-        itEnd = m_tokenInfo.end<kLookupInfo>();
-        it != itEnd; ++it,++itAlwaysGet) {
-      if(iBranch==it->m_branchType) {
+    for (auto it = m_tokenInfo.begin<kLookupInfo>(), itEnd = m_tokenInfo.end<kLookupInfo>(); it != itEnd;
+         ++it, ++itAlwaysGet) {
+      if (iBranch == it->m_branchType) {
         if (it->m_index.productResolverIndex() != ProductResolverIndexInvalid) {
-          if(*itAlwaysGet) {
+          if (*itAlwaysGet) {
             ++count;
           }
         }
       }
     }
   }
-  oIndices.reserve(oIndices.size()+count);
+  oIndices.reserve(oIndices.size() + count);
   {
     auto itAlwaysGet = m_tokenInfo.begin<kAlwaysGets>();
-    for(auto it = m_tokenInfo.begin<kLookupInfo>(),
-        itEnd = m_tokenInfo.end<kLookupInfo>();
-        it != itEnd; ++it,++itAlwaysGet) {
-      if(iBranch==it->m_branchType) {
+    for (auto it = m_tokenInfo.begin<kLookupInfo>(), itEnd = m_tokenInfo.end<kLookupInfo>(); it != itEnd;
+         ++it, ++itAlwaysGet) {
+      if (iBranch == it->m_branchType) {
         if (it->m_index.productResolverIndex() != ProductResolverIndexInvalid) {
-          if(*itAlwaysGet) {
+          if (*itAlwaysGet) {
             oIndices.push_back(it->m_index);
           }
         }
@@ -261,34 +242,30 @@ EDConsumerBase::itemsToGet(BranchType iBranch, std::vector<ProductResolverIndexA
   }
 }
 
-void
-EDConsumerBase::itemsMayGet(BranchType iBranch, std::vector<ProductResolverIndexAndSkipBit>& oIndices) const
-{
+void EDConsumerBase::itemsMayGet(BranchType iBranch, std::vector<ProductResolverIndexAndSkipBit>& oIndices) const {
   //how many are we adding?
-  unsigned int count=0;
+  unsigned int count = 0;
   {
     auto itAlwaysGet = m_tokenInfo.begin<kAlwaysGets>();
-    for(auto it = m_tokenInfo.begin<kLookupInfo>(),
-        itEnd = m_tokenInfo.end<kLookupInfo>();
-        it != itEnd; ++it,++itAlwaysGet) {
-      if(iBranch==it->m_branchType) {
+    for (auto it = m_tokenInfo.begin<kLookupInfo>(), itEnd = m_tokenInfo.end<kLookupInfo>(); it != itEnd;
+         ++it, ++itAlwaysGet) {
+      if (iBranch == it->m_branchType) {
         if (it->m_index.productResolverIndex() != ProductResolverIndexInvalid) {
-          if(not *itAlwaysGet) {
+          if (not*itAlwaysGet) {
             ++count;
           }
         }
       }
     }
   }
-  oIndices.reserve(oIndices.size()+count);
+  oIndices.reserve(oIndices.size() + count);
   {
     auto itAlwaysGet = m_tokenInfo.begin<kAlwaysGets>();
-    for(auto it = m_tokenInfo.begin<kLookupInfo>(),
-        itEnd = m_tokenInfo.end<kLookupInfo>();
-        it != itEnd; ++it,++itAlwaysGet) {
-      if(iBranch==it->m_branchType) {
+    for (auto it = m_tokenInfo.begin<kLookupInfo>(), itEnd = m_tokenInfo.end<kLookupInfo>(); it != itEnd;
+         ++it, ++itAlwaysGet) {
+      if (iBranch == it->m_branchType) {
         if (it->m_index.productResolverIndex() != ProductResolverIndexInvalid) {
-          if(not *itAlwaysGet) {
+          if (not*itAlwaysGet) {
             oIndices.push_back(it->m_index);
           }
         }
@@ -297,71 +274,65 @@ EDConsumerBase::itemsMayGet(BranchType iBranch, std::vector<ProductResolverIndex
   }
 }
 
-void
-EDConsumerBase::labelsForToken(EDGetToken iToken, Labels& oLabels) const
-{
+void EDConsumerBase::labelsForToken(EDGetToken iToken, Labels& oLabels) const {
   unsigned int index = iToken.index();
   auto labels = m_tokenInfo.get<kLabels>(index);
   unsigned int start = labels.m_startOfModuleLabel;
   oLabels.module = &(m_tokenLabels[start]);
-  oLabels.productInstance = oLabels.module+labels.m_deltaToProductInstance;
-  oLabels.process = oLabels.module+labels.m_deltaToProcessName;
+  oLabels.productInstance = oLabels.module + labels.m_deltaToProductInstance;
+  oLabels.process = oLabels.module + labels.m_deltaToProcessName;
 }
 
-bool
-EDConsumerBase::registeredToConsume(ProductResolverIndex iIndex, bool skipCurrentProcess, BranchType iBranch) const
-{
-  for(auto it = m_tokenInfo.begin<kLookupInfo>(),
-      itEnd = m_tokenInfo.end<kLookupInfo>();
-      it != itEnd; ++it) {
-    if(it->m_index.productResolverIndex() == iIndex and
-       it->m_index.skipCurrentProcess() == skipCurrentProcess and
-       it->m_branchType == iBranch) {
+bool EDConsumerBase::registeredToConsume(ProductResolverIndex iIndex,
+                                         bool skipCurrentProcess,
+                                         BranchType iBranch) const {
+  for (auto it = m_tokenInfo.begin<kLookupInfo>(), itEnd = m_tokenInfo.end<kLookupInfo>(); it != itEnd; ++it) {
+    if (it->m_index.productResolverIndex() == iIndex and it->m_index.skipCurrentProcess() == skipCurrentProcess and
+        it->m_branchType == iBranch) {
       return true;
     }
   }
   return false;
 }
 
-bool
-EDConsumerBase::registeredToConsumeMany(TypeID const& iType, BranchType iBranch) const
-{
-  for(auto it = m_tokenInfo.begin<kLookupInfo>(),
-      itEnd = m_tokenInfo.end<kLookupInfo>();
-      it != itEnd; ++it) {
+bool EDConsumerBase::registeredToConsumeMany(TypeID const& iType, BranchType iBranch) const {
+  for (auto it = m_tokenInfo.begin<kLookupInfo>(), itEnd = m_tokenInfo.end<kLookupInfo>(); it != itEnd; ++it) {
     //consumesMany entries do not have their index resolved
-    if(it->m_index.productResolverIndex() == ProductResolverIndexInvalid and
-       it->m_type == iType and
-       it->m_branchType == iBranch) {
+    if (it->m_index.productResolverIndex() == ProductResolverIndexInvalid and it->m_type == iType and
+        it->m_branchType == iBranch) {
       return true;
     }
   }
   return false;
-  
 }
 
-
-void
-EDConsumerBase::throwTypeMismatch(edm::TypeID const& iType, EDGetToken iToken) const
-{
-  throw cms::Exception("TypeMismatch")<<"A get using a EDGetToken used the C++ type '"<<iType.className()<<"' but the consumes call was for type '"<<m_tokenInfo.get<kLookupInfo>(iToken.index()).m_type.className()<<"'.\n Please modify either the consumes or get call so the types match.";
+void EDConsumerBase::throwTypeMismatch(edm::TypeID const& iType, EDGetToken iToken) const {
+  throw cms::Exception("TypeMismatch") << "A get using a EDGetToken used the C++ type '" << iType.className()
+                                       << "' but the consumes call was for type '"
+                                       << m_tokenInfo.get<kLookupInfo>(iToken.index()).m_type.className()
+                                       << "'.\n Please modify either the consumes or get call so the types match.";
 }
-void
-EDConsumerBase::throwBranchMismatch(BranchType iBranch, EDGetToken iToken) const {
-  throw cms::Exception("BranchTypeMismatch")<<"A get using a EDGetToken was done in "<<BranchTypeToString(iBranch)<<" but the consumes call was for "<<BranchTypeToString(m_tokenInfo.get<kLookupInfo>(iToken.index()).m_branchType)<<".\n Please modify the consumes call to use the correct branch type.";
+void EDConsumerBase::throwBranchMismatch(BranchType iBranch, EDGetToken iToken) const {
+  throw cms::Exception("BranchTypeMismatch")
+      << "A get using a EDGetToken was done in " << BranchTypeToString(iBranch) << " but the consumes call was for "
+      << BranchTypeToString(m_tokenInfo.get<kLookupInfo>(iToken.index()).m_branchType)
+      << ".\n Please modify the consumes call to use the correct branch type.";
 }
 
-void
-EDConsumerBase::throwBadToken(edm::TypeID const& iType, EDGetToken iToken) const
-{
-  if(iToken.isUninitialized()) {
-    throw cms::Exception("BadToken")<<"A get using a EDGetToken with the C++ type '"<<iType.className()<<"' was made using an uninitialized token.\n Please check that the variable is being initialized from a 'consumes' call.";
+void EDConsumerBase::throwBadToken(edm::TypeID const& iType, EDGetToken iToken) const {
+  if (iToken.isUninitialized()) {
+    throw cms::Exception("BadToken") << "A get using a EDGetToken with the C++ type '" << iType.className()
+                                     << "' was made using an uninitialized token.\n Please check that the variable is "
+                                        "being initialized from a 'consumes' call.";
   }
-  throw cms::Exception("BadToken")<<"A get using a EDGetToken with the C++ type '"<<iType.className()<<"' was made using a token with a value "<<iToken.index()<<" which is beyond the range used by this module.\n Please check that the variable is being initialized from a 'consumes' call from this module.\n You can not share EDGetToken values between modules.";
+  throw cms::Exception("BadToken")
+      << "A get using a EDGetToken with the C++ type '" << iType.className() << "' was made using a token with a value "
+      << iToken.index()
+      << " which is beyond the range used by this module.\n Please check that the variable is being initialized from a "
+         "'consumes' call from this module.\n You can not share EDGetToken values between modules.";
 }
 
-void
-EDConsumerBase::throwConsumesCallAfterFrozen(TypeToGet const& typeToGet, InputTag const& inputTag) const {
+void EDConsumerBase::throwConsumesCallAfterFrozen(TypeToGet const& typeToGet, InputTag const& inputTag) const {
   throw cms::Exception("LogicError") << "A module declared it consumes a product after its constructor.\n"
                                      << "This must be done in the contructor\n"
                                      << "The product type was: " << typeToGet.type() << "\n"
@@ -370,24 +341,21 @@ EDConsumerBase::throwConsumesCallAfterFrozen(TypeToGet const& typeToGet, InputTa
 
 namespace {
   struct CharStarComp {
-    bool operator()(const char* iLHS, const char* iRHS) const {
-      return strcmp(iLHS,iRHS) < 0;
-    }
+    bool operator()(const char* iLHS, const char* iRHS) const { return strcmp(iLHS, iRHS) < 0; }
   };
-}
+}  // namespace
 
 namespace {
-  void
-  insertFoundModuleLabel(const char* consumedModuleLabel,
-                         std::vector<ModuleDescription const*>& modules,
-                         std::set<std::string>& alreadyFound,
-                         std::map<std::string, ModuleDescription const*> const& labelsToDesc,
-                         ProductRegistry const& preg) {
+  void insertFoundModuleLabel(const char* consumedModuleLabel,
+                              std::vector<ModuleDescription const*>& modules,
+                              std::set<std::string>& alreadyFound,
+                              std::map<std::string, ModuleDescription const*> const& labelsToDesc,
+                              ProductRegistry const& preg) {
     // Convert from label string to module description, eliminate duplicates,
     // then insert into the vector of modules
     auto it = labelsToDesc.find(consumedModuleLabel);
-    if(it != labelsToDesc.end()) {
-      if(alreadyFound.insert(consumedModuleLabel).second) {
+    if (it != labelsToDesc.end()) {
+      if (alreadyFound.insert(consumedModuleLabel).second) {
         modules.push_back(it->second);
       }
       return;
@@ -396,12 +364,11 @@ namespace {
     std::vector<std::pair<std::string, std::string> > const& aliasToOriginal = preg.aliasToOriginal();
     std::pair<std::string, std::string> target(consumedModuleLabel, std::string());
     auto iter = std::lower_bound(aliasToOriginal.begin(), aliasToOriginal.end(), target);
-    if(iter != aliasToOriginal.end() && iter->first == consumedModuleLabel) {
-
+    if (iter != aliasToOriginal.end() && iter->first == consumedModuleLabel) {
       std::string const& originalModuleLabel = iter->second;
       auto iter2 = labelsToDesc.find(originalModuleLabel);
-      if(iter2 != labelsToDesc.end()) {
-        if(alreadyFound.insert(originalModuleLabel).second) {
+      if (iter2 != labelsToDesc.end()) {
+        if (alreadyFound.insert(originalModuleLabel).second) {
           modules.push_back(iter2->second);
         }
         return;
@@ -410,63 +377,53 @@ namespace {
     // Ignore the source products, we are only interested in module products.
     // As far as I know, it should never be anything else so throw if something
     // unknown gets passed in.
-    if(std::string(consumedModuleLabel) != "source") {
+    if (std::string(consumedModuleLabel) != "source") {
       throw cms::Exception("EDConsumerBase", "insertFoundModuleLabel")
-        << "Couldn't find ModuleDescription for the consumed module label: "
-        << std::string(consumedModuleLabel) << "\n";
+          << "Couldn't find ModuleDescription for the consumed module label: " << std::string(consumedModuleLabel)
+          << "\n";
     }
   }
-}
+}  // namespace
 
-void
-EDConsumerBase::modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
-                                                ProductRegistry const& preg,
-                                                std::map<std::string, ModuleDescription const*> const& labelsToDesc,
-                                                std::string const& processName) const {
-
+void EDConsumerBase::modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
+                                                     ProductRegistry const& preg,
+                                                     std::map<std::string, ModuleDescription const*> const& labelsToDesc,
+                                                     std::string const& processName) const {
   ProductResolverIndexHelper const& iHelper = *preg.productLookup(InEvent);
 
   std::set<std::string> alreadyFound;
 
   auto itKind = m_tokenInfo.begin<kKind>();
   auto itLabels = m_tokenInfo.begin<kLabels>();
-  for(auto itInfo = m_tokenInfo.begin<kLookupInfo>(),itEnd = m_tokenInfo.end<kLookupInfo>();
-      itInfo != itEnd; ++itInfo,++itKind,++itLabels) {
-
-    if(itInfo->m_branchType == InEvent and
-       (not itInfo->m_index.skipCurrentProcess())) {
-
+  for (auto itInfo = m_tokenInfo.begin<kLookupInfo>(), itEnd = m_tokenInfo.end<kLookupInfo>(); itInfo != itEnd;
+       ++itInfo, ++itKind, ++itLabels) {
+    if (itInfo->m_branchType == InEvent and (not itInfo->m_index.skipCurrentProcess())) {
       const unsigned int labelStart = itLabels->m_startOfModuleLabel;
       const char* consumedModuleLabel = &(m_tokenLabels[labelStart]);
-      const char* consumedProcessName = consumedModuleLabel+itLabels->m_deltaToProcessName;
+      const char* consumedProcessName = consumedModuleLabel + itLabels->m_deltaToProcessName;
 
-      if(*consumedModuleLabel != '\0') { // not a consumesMany
-        if(*consumedProcessName != '\0') { // process name is specified in consumes call
+      if (*consumedModuleLabel != '\0') {    // not a consumesMany
+        if (*consumedProcessName != '\0') {  // process name is specified in consumes call
           if (processName == consumedProcessName &&
-              iHelper.index(*itKind,
-                            itInfo->m_type,
-                            consumedModuleLabel,
-                            consumedModuleLabel+itLabels->m_deltaToProductInstance,
-                            consumedModuleLabel+itLabels->m_deltaToProcessName) != ProductResolverIndexInvalid) {
+              iHelper.index(*itKind, itInfo->m_type, consumedModuleLabel,
+                            consumedModuleLabel + itLabels->m_deltaToProductInstance,
+                            consumedModuleLabel + itLabels->m_deltaToProcessName) != ProductResolverIndexInvalid) {
             insertFoundModuleLabel(consumedModuleLabel, modules, alreadyFound, labelsToDesc, preg);
           }
-        } else { // process name was empty
-          auto matches = iHelper.relatedIndexes(*itKind,
-                                                itInfo->m_type,
-                                                consumedModuleLabel,
-                                                consumedModuleLabel+itLabels->m_deltaToProductInstance);
-          for(unsigned int j = 0; j < matches.numberOfMatches(); ++j) {
-            if(processName == matches.processName(j)) {
+        } else {  // process name was empty
+          auto matches = iHelper.relatedIndexes(*itKind, itInfo->m_type, consumedModuleLabel,
+                                                consumedModuleLabel + itLabels->m_deltaToProductInstance);
+          for (unsigned int j = 0; j < matches.numberOfMatches(); ++j) {
+            if (processName == matches.processName(j)) {
               insertFoundModuleLabel(consumedModuleLabel, modules, alreadyFound, labelsToDesc, preg);
             }
           }
         }
-      // consumesMany case
-      } else if(itInfo->m_index.productResolverIndex() == ProductResolverIndexInvalid) {
-        auto matches = iHelper.relatedIndexes(*itKind,
-                                              itInfo->m_type);
-        for(unsigned int j = 0; j < matches.numberOfMatches(); ++j) {
-          if(processName == matches.processName(j)) {
+        // consumesMany case
+      } else if (itInfo->m_index.productResolverIndex() == ProductResolverIndexInvalid) {
+        auto matches = iHelper.relatedIndexes(*itKind, itInfo->m_type);
+        for (unsigned int j = 0; j < matches.numberOfMatches(); ++j) {
+          if (processName == matches.processName(j)) {
             insertFoundModuleLabel(matches.moduleLabel(j), modules, alreadyFound, labelsToDesc, preg);
           }
         }
@@ -475,9 +432,7 @@ EDConsumerBase::modulesWhoseProductsAreConsumed(std::vector<ModuleDescription co
   }
 }
 
-void
-EDConsumerBase::convertCurrentProcessAlias(std::string const& processName) {
-
+void EDConsumerBase::convertCurrentProcessAlias(std::string const& processName) {
   frozen_ = true;
 
   if (containsCurrentProcessAlias_) {
@@ -488,8 +443,7 @@ EDConsumerBase::convertCurrentProcessAlias(std::string const& processName) {
     // first calculate the size of the new vector and reserve memory for it
     std::vector<char>::size_type newSize = 0;
     std::string newProcessName;
-    for(auto iter = m_tokenInfo.begin<kLabels>(), itEnd = m_tokenInfo.end<kLabels>();
-        iter != itEnd; ++iter) {
+    for (auto iter = m_tokenInfo.begin<kLabels>(), itEnd = m_tokenInfo.end<kLabels>(); iter != itEnd; ++iter) {
       newProcessName = &m_tokenLabels[iter->m_startOfModuleLabel + iter->m_deltaToProcessName];
       if (newProcessName == InputTag::kCurrentProcess) {
         newProcessName = processName;
@@ -499,9 +453,7 @@ EDConsumerBase::convertCurrentProcessAlias(std::string const& processName) {
     newTokenLabels.reserve(newSize);
 
     unsigned int newStartOfModuleLabel = 0;
-    for(auto iter = m_tokenInfo.begin<kLabels>(), itEnd = m_tokenInfo.end<kLabels>();
-        iter != itEnd; ++iter) {
-
+    for (auto iter = m_tokenInfo.begin<kLabels>(), itEnd = m_tokenInfo.end<kLabels>(); iter != itEnd; ++iter) {
       unsigned int startOfModuleLabel = iter->m_startOfModuleLabel;
       unsigned short deltaToProcessName = iter->m_deltaToProcessName;
 
@@ -515,8 +467,7 @@ EDConsumerBase::convertCurrentProcessAlias(std::string const& processName) {
       newStartOfModuleLabel += (deltaToProcessName + newProcessName.size() + 1);
 
       // Copy in both the module label and instance, they are the same
-      newTokenLabels.insert(newTokenLabels.end(),
-                            m_tokenLabels.begin() + startOfModuleLabel,
+      newTokenLabels.insert(newTokenLabels.end(), m_tokenLabels.begin() + startOfModuleLabel,
                             m_tokenLabels.begin() + (startOfModuleLabel + deltaToProcessName));
 
       newTokenLabels.insert(newTokenLabels.end(), newProcessName.begin(), newProcessName.end());
@@ -526,9 +477,7 @@ EDConsumerBase::convertCurrentProcessAlias(std::string const& processName) {
   }
 }
 
-std::vector<ConsumesInfo>
-EDConsumerBase::consumesInfo() const {
-
+std::vector<ConsumesInfo> EDConsumerBase::consumesInfo() const {
   // Use this to eliminate duplicate entries related
   // to consumesMany items where only the type was specified
   // and the there are multiple matches. In these cases the
@@ -539,30 +488,23 @@ EDConsumerBase::consumesInfo() const {
   auto itAlways = m_tokenInfo.begin<kAlwaysGets>();
   auto itKind = m_tokenInfo.begin<kKind>();
   auto itLabels = m_tokenInfo.begin<kLabels>();
-  for(auto itInfo = m_tokenInfo.begin<kLookupInfo>(),itEnd = m_tokenInfo.end<kLookupInfo>();
-      itInfo != itEnd; ++itInfo,++itKind,++itLabels, ++itAlways) {
-
+  for (auto itInfo = m_tokenInfo.begin<kLookupInfo>(), itEnd = m_tokenInfo.end<kLookupInfo>(); itInfo != itEnd;
+       ++itInfo, ++itKind, ++itLabels, ++itAlways) {
     const unsigned int labelStart = itLabels->m_startOfModuleLabel;
     const char* consumedModuleLabel = &(m_tokenLabels[labelStart]);
-    const char* consumedInstance = consumedModuleLabel+itLabels->m_deltaToProductInstance;
-    const char* consumedProcessName = consumedModuleLabel+itLabels->m_deltaToProcessName;
+    const char* consumedInstance = consumedModuleLabel + itLabels->m_deltaToProductInstance;
+    const char* consumedProcessName = consumedModuleLabel + itLabels->m_deltaToProcessName;
 
     // consumesMany case
-    if(*consumedModuleLabel == '\0') {
-      if(!alreadySeenTypes.insert(itInfo->m_type).second) {
+    if (*consumedModuleLabel == '\0') {
+      if (!alreadySeenTypes.insert(itInfo->m_type).second) {
         continue;
       }
     }
 
     // Just copy the information into the ConsumesInfo data structure
-    result.emplace_back(itInfo->m_type,
-                        consumedModuleLabel,
-                        consumedInstance,
-                        consumedProcessName,
-                        itInfo->m_branchType,
-                        *itKind,
-                        *itAlways,
-                        itInfo->m_index.skipCurrentProcess());
+    result.emplace_back(itInfo->m_type, consumedModuleLabel, consumedInstance, consumedProcessName,
+                        itInfo->m_branchType, *itKind, *itAlways, itInfo->m_index.skipCurrentProcess());
   }
   return result;
 }

--- a/FWCore/Framework/src/EDFilter.cc
+++ b/FWCore/Framework/src/EDFilter.cc
@@ -17,112 +17,88 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 namespace edm {
-  
-  EDFilter::EDFilter() : ProducerBase() , moduleDescription_(),
-  previousParentage_(), previousParentageId_() {
-    SharedResourcesRegistry::instance()->registerSharedResource(
-                                                                SharedResourcesRegistry::kLegacyModuleResourceName);
+
+  EDFilter::EDFilter() : ProducerBase(), moduleDescription_(), previousParentage_(), previousParentageId_() {
+    SharedResourcesRegistry::instance()->registerSharedResource(SharedResourcesRegistry::kLegacyModuleResourceName);
   }
 
-  EDFilter::~EDFilter() {
-  }
+  EDFilter::~EDFilter() {}
 
-  bool
-  EDFilter::doEvent(EventPrincipal const& ep, EventSetupImpl const& c,
-                    ActivityRegistry* act,
-                    ModuleCallingContext const* mcc) {
+  bool EDFilter::doEvent(EventPrincipal const& ep,
+                         EventSetupImpl const& c,
+                         ActivityRegistry* act,
+                         ModuleCallingContext const* mcc) {
     bool rc = false;
     Event e(ep, moduleDescription_, mcc);
     e.setConsumer(this);
-    e.setProducer(this,&previousParentage_);
+    e.setProducer(this, &previousParentage_);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
-    EventSignalsSentry sentry(act,mcc);
+    EventSignalsSentry sentry(act, mcc);
     rc = this->filter(e, EventSetup{c});
     commit_(e, &previousParentageId_);
     return rc;
   }
 
-  void 
-  EDFilter::doBeginJob() {
+  void EDFilter::doBeginJob() {
     std::vector<std::string> res = {SharedResourcesRegistry::kLegacyModuleResourceName};
     resourceAcquirer_ = SharedResourcesRegistry::instance()->createAcquirer(res);
 
     this->beginJob();
   }
-   
-  void EDFilter::doEndJob() { 
-    this->endJob();
-  }
 
-  void
-  EDFilter::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c,
-                       ModuleCallingContext const* mcc) {
-    Run r(rp, moduleDescription_, mcc,false);
+  void EDFilter::doEndJob() { this->endJob(); }
+
+  void EDFilter::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
+    Run r(rp, moduleDescription_, mcc, false);
     r.setConsumer(this);
-    Run const& cnstR=r;
+    Run const& cnstR = r;
     this->beginRun(cnstR, EventSetup{c});
     commit_(r);
     return;
   }
 
-  void
-  EDFilter::doEndRun(RunPrincipal const& rp, EventSetupImpl const& c,
-                     ModuleCallingContext const* mcc) {
-    Run r(rp, moduleDescription_, mcc,true);
+  void EDFilter::doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
+    Run r(rp, moduleDescription_, mcc, true);
     r.setConsumer(this);
-    Run const& cnstR=r;
+    Run const& cnstR = r;
     this->endRun(cnstR, EventSetup{c});
     commit_(r);
     return;
   }
 
-  void
-  EDFilter::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
-                                   ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(lbp, moduleDescription_, mcc,false);
+  void EDFilter::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                        EventSetupImpl const& c,
+                                        ModuleCallingContext const* mcc) {
+    LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
     this->beginLuminosityBlock(cnstLb, EventSetup{c});
     commit_(lb);
   }
 
-  void
-  EDFilter::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
-                                 ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(lbp, moduleDescription_, mcc,true);
+  void EDFilter::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                      EventSetupImpl const& c,
+                                      ModuleCallingContext const* mcc) {
+    LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
     this->endLuminosityBlock(cnstLb, EventSetup{c});
     commit_(lb);
-    return ;
+    return;
   }
 
-  void
-  EDFilter::doRespondToOpenInputFile(FileBlock const& fb) {
-    respondToOpenInputFile(fb);
-  }
+  void EDFilter::doRespondToOpenInputFile(FileBlock const& fb) { respondToOpenInputFile(fb); }
 
-  void
-  EDFilter::doRespondToCloseInputFile(FileBlock const& fb) {
-    respondToCloseInputFile(fb);
-  }
+  void EDFilter::doRespondToCloseInputFile(FileBlock const& fb) { respondToCloseInputFile(fb); }
 
-  void
-  EDFilter::fillDescriptions(ConfigurationDescriptions& descriptions) {
+  void EDFilter::fillDescriptions(ConfigurationDescriptions& descriptions) {
     ParameterSetDescription desc;
     desc.setUnknown();
     descriptions.addDefault(desc);
   }
 
-  void
-  EDFilter::prevalidate(ConfigurationDescriptions& iConfig) {
-    edmodule_mightGet_config(iConfig);
-  }
-  
+  void EDFilter::prevalidate(ConfigurationDescriptions& iConfig) { edmodule_mightGet_config(iConfig); }
 
   static const std::string kBaseType("EDFilter");
-  const std::string&
-  EDFilter::baseType() {
-    return kBaseType;
-  }
-}
+  const std::string& EDFilter::baseType() { return kBaseType; }
+}  // namespace edm

--- a/FWCore/Framework/src/EDLooper.cc
+++ b/FWCore/Framework/src/EDLooper.cc
@@ -2,18 +2,17 @@
 //
 // Package:     <package>
 // Module:      EDLooper
-// 
+//
 // Author:      Valentin Kuznetsov
 // Created:     Wed Jul  5 11:44:26 EDT 2006
 
 #include "FWCore/Framework/interface/EDLooper.h"
 namespace edm {
 
-  EDLooper::EDLooper() : EDLooperBase(){ }
-  EDLooper::~EDLooper() { }
+  EDLooper::EDLooper() : EDLooperBase() {}
+  EDLooper::~EDLooper() {}
 
-  EDLooperBase::Status 
-  EDLooper::duringLoop(Event const& iEvent, EventSetup const& iEventSetup, ProcessingController&) {
+  EDLooperBase::Status EDLooper::duringLoop(Event const& iEvent, EventSetup const& iEventSetup, ProcessingController&) {
     return duringLoop(iEvent, iEventSetup);
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/EDLooperBase.cc
+++ b/FWCore/Framework/src/EDLooperBase.cc
@@ -2,7 +2,7 @@
 //
 // Package:     <package>
 // Module:      EDLooperBase
-// 
+//
 // Author:      Valentin Kuznetsov
 // Created:     Wed Jul  5 11:44:26 EDT 2006
 
@@ -29,21 +29,20 @@
 
 namespace edm {
 
-  EDLooperBase::EDLooperBase() : iCounter_(0), act_table_(nullptr), moduleChanger_(nullptr),
-                                 moduleDescription_("Looper", "looper"),
-                                 moduleCallingContext_(&moduleDescription_)
- { }
-  EDLooperBase::~EDLooperBase() noexcept(false) { }
+  EDLooperBase::EDLooperBase()
+      : iCounter_(0),
+        act_table_(nullptr),
+        moduleChanger_(nullptr),
+        moduleDescription_("Looper", "looper"),
+        moduleCallingContext_(&moduleDescription_) {}
+  EDLooperBase::~EDLooperBase() noexcept(false) {}
 
-  void
-  EDLooperBase::doStartingNewLoop() {
-    startingNewLoop(iCounter_);
-  }
+  void EDLooperBase::doStartingNewLoop() { startingNewLoop(iCounter_); }
 
-  EDLooperBase::Status
-  EDLooperBase::doDuringLoop(edm::EventPrincipal& eventPrincipal, const edm::EventSetupImpl& esi,
-                             edm::ProcessingController& ioController, StreamContext* streamContext) {
-
+  EDLooperBase::Status EDLooperBase::doDuringLoop(edm::EventPrincipal& eventPrincipal,
+                                                  const edm::EventSetupImpl& esi,
+                                                  edm::ProcessingController& ioController,
+                                                  StreamContext* streamContext) {
     streamContext->setTransition(StreamContext::Transition::kEvent);
     streamContext->setEventID(eventPrincipal.id());
     streamContext->setRunIndex(eventPrincipal.luminosityBlockPrincipal().runPrincipal().index());
@@ -57,124 +56,94 @@ namespace edm {
     try {
       const EventSetup es{esi};
       status = duringLoop(event, es, ioController);
-    }
-    catch(cms::Exception& e) {
+    } catch (cms::Exception& e) {
       e.addContext("Calling the 'duringLoop' method of a looper");
       exception_actions::ActionCodes action = (act_table_->find(e.category()));
       if (action != exception_actions::Rethrow) {
         edm::printCmsExceptionWarning("SkipEvent", e);
-      }
-      else {
+      } else {
         throw;
       }
     }
     return status;
   }
 
-  EDLooperBase::Status
-  EDLooperBase::doEndOfLoop(const edm::EventSetupImpl& esi) {
+  EDLooperBase::Status EDLooperBase::doEndOfLoop(const edm::EventSetupImpl& esi) {
     const EventSetup es{esi};
     return endOfLoop(es, iCounter_);
   }
 
-  void
-  EDLooperBase::prepareForNextLoop(eventsetup::EventSetupProvider* esp) {
+  void EDLooperBase::prepareForNextLoop(eventsetup::EventSetupProvider* esp) {
     ++iCounter_;
 
     std::set<edm::eventsetup::EventSetupRecordKey> const& keys = modifyingRecords();
     for_all(keys,
-      std::bind(&eventsetup::EventSetupProvider::resetRecordPlusDependentRecords,
-                  esp, std::placeholders::_1));
+            std::bind(&eventsetup::EventSetupProvider::resetRecordPlusDependentRecords, esp, std::placeholders::_1));
   }
 
-  void EDLooperBase::beginOfJob(const edm::EventSetupImpl& iImpl) { beginOfJob(EventSetup{iImpl});}
-  void EDLooperBase::beginOfJob(const edm::EventSetup&) { beginOfJob();}
-  void EDLooperBase::beginOfJob() { }
+  void EDLooperBase::beginOfJob(const edm::EventSetupImpl& iImpl) { beginOfJob(EventSetup{iImpl}); }
+  void EDLooperBase::beginOfJob(const edm::EventSetup&) { beginOfJob(); }
+  void EDLooperBase::beginOfJob() {}
 
-  void EDLooperBase::endOfJob() { }
+  void EDLooperBase::endOfJob() {}
 
   void EDLooperBase::doBeginRun(RunPrincipal& iRP, EventSetupImpl const& iES, ProcessContext* processContext) {
-        GlobalContext globalContext(GlobalContext::Transition::kBeginRun,
-                                    LuminosityBlockID(iRP.run(), 0),
-                                    iRP.index(),
-                                    LuminosityBlockIndex::invalidLuminosityBlockIndex(),
-                                    iRP.beginTime(),
-                                    processContext);
-        ParentContext parentContext(&globalContext);
-        ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
-        Run run(iRP, moduleDescription_, &moduleCallingContext_, false);
-        const EventSetup es{iES};
-        beginRun(run,es);
+    GlobalContext globalContext(GlobalContext::Transition::kBeginRun, LuminosityBlockID(iRP.run(), 0), iRP.index(),
+                                LuminosityBlockIndex::invalidLuminosityBlockIndex(), iRP.beginTime(), processContext);
+    ParentContext parentContext(&globalContext);
+    ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
+    Run run(iRP, moduleDescription_, &moduleCallingContext_, false);
+    const EventSetup es{iES};
+    beginRun(run, es);
   }
 
-  void EDLooperBase::doEndRun(RunPrincipal& iRP, EventSetupImpl const& iES, ProcessContext* processContext){
-        GlobalContext globalContext(GlobalContext::Transition::kEndRun,
-                                    LuminosityBlockID(iRP.run(), 0),
-                                    iRP.index(),
-                                    LuminosityBlockIndex::invalidLuminosityBlockIndex(),
-                                    iRP.endTime(),
-                                    processContext);
-        ParentContext parentContext(&globalContext);
-        ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
-        Run run(iRP, moduleDescription_, &moduleCallingContext_,true);
-        const EventSetup es{iES};
-        endRun(run,es);
+  void EDLooperBase::doEndRun(RunPrincipal& iRP, EventSetupImpl const& iES, ProcessContext* processContext) {
+    GlobalContext globalContext(GlobalContext::Transition::kEndRun, LuminosityBlockID(iRP.run(), 0), iRP.index(),
+                                LuminosityBlockIndex::invalidLuminosityBlockIndex(), iRP.endTime(), processContext);
+    ParentContext parentContext(&globalContext);
+    ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
+    Run run(iRP, moduleDescription_, &moduleCallingContext_, true);
+    const EventSetup es{iES};
+    endRun(run, es);
   }
-  void EDLooperBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& iLB, EventSetupImpl const& iES, ProcessContext* processContext){
-    GlobalContext globalContext(GlobalContext::Transition::kBeginLuminosityBlock,
-                                iLB.id(),
-                                iLB.runPrincipal().index(),
-                                iLB.index(),
-                                iLB.beginTime(),
-                                processContext);
+  void EDLooperBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& iLB,
+                                            EventSetupImpl const& iES,
+                                            ProcessContext* processContext) {
+    GlobalContext globalContext(GlobalContext::Transition::kBeginLuminosityBlock, iLB.id(), iLB.runPrincipal().index(),
+                                iLB.index(), iLB.beginTime(), processContext);
     ParentContext parentContext(&globalContext);
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     LuminosityBlock luminosityBlock(iLB, moduleDescription_, &moduleCallingContext_, false);
     const EventSetup es{iES};
-    beginLuminosityBlock(luminosityBlock,es);
+    beginLuminosityBlock(luminosityBlock, es);
   }
-  void EDLooperBase::doEndLuminosityBlock(LuminosityBlockPrincipal& iLB, EventSetupImpl const& iES, ProcessContext* processContext){
-    GlobalContext globalContext(GlobalContext::Transition::kEndLuminosityBlock,
-                                iLB.id(),
-                                iLB.runPrincipal().index(),
-                                iLB.index(),
-                                iLB.beginTime(),
-                                processContext);
+  void EDLooperBase::doEndLuminosityBlock(LuminosityBlockPrincipal& iLB,
+                                          EventSetupImpl const& iES,
+                                          ProcessContext* processContext) {
+    GlobalContext globalContext(GlobalContext::Transition::kEndLuminosityBlock, iLB.id(), iLB.runPrincipal().index(),
+                                iLB.index(), iLB.beginTime(), processContext);
     ParentContext parentContext(&globalContext);
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     LuminosityBlock luminosityBlock(iLB, moduleDescription_, &moduleCallingContext_, true);
     const EventSetup es{iES};
-    endLuminosityBlock(luminosityBlock,es);
+    endLuminosityBlock(luminosityBlock, es);
   }
 
-  void EDLooperBase::beginRun(Run const&, EventSetup const&){}
-  void EDLooperBase::endRun(Run const&, EventSetup const&){}
-  void EDLooperBase::beginLuminosityBlock(LuminosityBlock const&, EventSetup const&){}
-  void EDLooperBase::endLuminosityBlock(LuminosityBlock const&, EventSetup const&){}
+  void EDLooperBase::beginRun(Run const&, EventSetup const&) {}
+  void EDLooperBase::endRun(Run const&, EventSetup const&) {}
+  void EDLooperBase::beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) {}
+  void EDLooperBase::endLuminosityBlock(LuminosityBlock const&, EventSetup const&) {}
 
-  void EDLooperBase::attachTo(ActivityRegistry&){}
-   
+  void EDLooperBase::attachTo(ActivityRegistry&) {}
 
-  std::set<eventsetup::EventSetupRecordKey> 
-  EDLooperBase::modifyingRecords() const
-  {
-    return std::set<eventsetup::EventSetupRecordKey> ();
-  }
-   
-  void 
-  EDLooperBase::copyInfo(const ScheduleInfo& iInfo){
-    scheduleInfo_ = std::make_unique<ScheduleInfo>(iInfo);
-  }
-  void 
-  EDLooperBase::setModuleChanger(ModuleChanger* iChanger) {
-    moduleChanger_ = iChanger;
+  std::set<eventsetup::EventSetupRecordKey> EDLooperBase::modifyingRecords() const {
+    return std::set<eventsetup::EventSetupRecordKey>();
   }
 
-  ModuleChanger* EDLooperBase::moduleChanger() {
-    return moduleChanger_;
-  }
-  const ScheduleInfo* EDLooperBase::scheduleInfo() const {
-    return scheduleInfo_.get();
-  }
-  
-}
+  void EDLooperBase::copyInfo(const ScheduleInfo& iInfo) { scheduleInfo_ = std::make_unique<ScheduleInfo>(iInfo); }
+  void EDLooperBase::setModuleChanger(ModuleChanger* iChanger) { moduleChanger_ = iChanger; }
+
+  ModuleChanger* EDLooperBase::moduleChanger() { return moduleChanger_; }
+  const ScheduleInfo* EDLooperBase::scheduleInfo() const { return scheduleInfo_.get(); }
+
+}  // namespace edm

--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -17,47 +17,36 @@
 #include "SharedResourcesRegistry.h"
 
 namespace edm {
-  EDProducer::EDProducer() :
-      ProducerBase(),
-      moduleDescription_(),
-      previousParentage_(),
-      previousParentageId_() {
-        SharedResourcesRegistry::instance()->registerSharedResource(
-                                                                    SharedResourcesRegistry::kLegacyModuleResourceName);
-      }
+  EDProducer::EDProducer() : ProducerBase(), moduleDescription_(), previousParentage_(), previousParentageId_() {
+    SharedResourcesRegistry::instance()->registerSharedResource(SharedResourcesRegistry::kLegacyModuleResourceName);
+  }
 
-  EDProducer::~EDProducer() { }
+  EDProducer::~EDProducer() {}
 
-  bool
-  EDProducer::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
-                      ActivityRegistry* act,
-                      ModuleCallingContext const* mcc) {
+  bool EDProducer::doEvent(EventPrincipal const& ep,
+                           EventSetupImpl const& ci,
+                           ActivityRegistry* act,
+                           ModuleCallingContext const* mcc) {
     Event e(ep, moduleDescription_, mcc);
     e.setConsumer(this);
     e.setProducer(this, &previousParentage_);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
-    EventSignalsSentry sentry(act,mcc);
+    EventSignalsSentry sentry(act, mcc);
     const EventSetup c{ci};
     this->produce(e, c);
     commit_(e, &previousParentageId_);
     return true;
   }
 
-  void 
-  EDProducer::doBeginJob() {
+  void EDProducer::doBeginJob() {
     std::vector<std::string> res = {SharedResourcesRegistry::kLegacyModuleResourceName};
     resourceAcquirer_ = SharedResourcesRegistry::instance()->createAcquirer(res);
     this->beginJob();
   }
-  
-  void 
-  EDProducer::doEndJob() {
-    this->endJob();
-  }
 
-  void
-  EDProducer::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci,
-                         ModuleCallingContext const* mcc) {
+  void EDProducer::doEndJob() { this->endJob(); }
+
+  void EDProducer::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
     Run r(rp, moduleDescription_, mcc, false);
     r.setConsumer(this);
     Run const& cnstR = r;
@@ -66,10 +55,8 @@ namespace edm {
     commit_(r);
   }
 
-  void
-  EDProducer::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci,
-                       ModuleCallingContext const* mcc) {
-    Run r(rp, moduleDescription_, mcc,true);
+  void EDProducer::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
+    Run r(rp, moduleDescription_, mcc, true);
     r.setConsumer(this);
     Run const& cnstR = r;
     const EventSetup c{ci};
@@ -77,10 +64,10 @@ namespace edm {
     commit_(r);
   }
 
-  void
-  EDProducer::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
-                                     ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(lbp, moduleDescription_, mcc,false);
+  void EDProducer::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                          EventSetupImpl const& ci,
+                                          ModuleCallingContext const* mcc) {
+    LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
     const EventSetup c{ci};
@@ -88,10 +75,10 @@ namespace edm {
     commit_(lb);
   }
 
-  void
-  EDProducer::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
-                                   ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(lbp, moduleDescription_, mcc,true);
+  void EDProducer::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                        EventSetupImpl const& ci,
+                                        ModuleCallingContext const* mcc) {
+    LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
     lb.setConsumer(this);
     const EventSetup c{ci};
     LuminosityBlock const& cnstLb = lb;
@@ -99,32 +86,19 @@ namespace edm {
     commit_(lb);
   }
 
-  void
-  EDProducer::doRespondToOpenInputFile(FileBlock const& fb) {
-    respondToOpenInputFile(fb);
-  }
+  void EDProducer::doRespondToOpenInputFile(FileBlock const& fb) { respondToOpenInputFile(fb); }
 
-  void
-  EDProducer::doRespondToCloseInputFile(FileBlock const& fb) {
-    respondToCloseInputFile(fb);
-  }
+  void EDProducer::doRespondToCloseInputFile(FileBlock const& fb) { respondToCloseInputFile(fb); }
 
-  void
-  EDProducer::fillDescriptions(ConfigurationDescriptions& descriptions) {
+  void EDProducer::fillDescriptions(ConfigurationDescriptions& descriptions) {
     ParameterSetDescription desc;
     desc.setUnknown();
     descriptions.addDefault(desc);
   }
-  
-  void
-  EDProducer::prevalidate(ConfigurationDescriptions& iConfig) {
-    edmodule_mightGet_config(iConfig);
-  }
-  
+
+  void EDProducer::prevalidate(ConfigurationDescriptions& iConfig) { edmodule_mightGet_config(iConfig); }
+
   static const std::string kBaseType("EDProducer");
-  
-  const std::string&
-  EDProducer::baseType() {
-    return kBaseType;
-  }
-}
+
+  const std::string& EDProducer::baseType() { return kBaseType; }
+}  // namespace edm

--- a/FWCore/Framework/src/ESHandle.cc
+++ b/FWCore/Framework/src/ESHandle.cc
@@ -6,11 +6,10 @@
 
 namespace edm {
 
-  eventsetup::ComponentDescription const*
-  ESHandleBase::description() const {
-    if(!description_) {
-      throw edm::Exception(edm::errors::InvalidReference,"NullPointer");
+  eventsetup::ComponentDescription const* ESHandleBase::description() const {
+    if (!description_) {
+      throw edm::Exception(edm::errors::InvalidReference, "NullPointer");
     }
     return description_;
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/ESHandleExceptionFactory.cc
+++ b/FWCore/Framework/src/ESHandleExceptionFactory.cc
@@ -8,10 +8,6 @@
 
 #include "FWCore/Framework/interface/ESHandleExceptionFactory.h"
 
-edm::ESHandleExceptionFactory::ESHandleExceptionFactory()
-{
-}
+edm::ESHandleExceptionFactory::ESHandleExceptionFactory() {}
 
-edm::ESHandleExceptionFactory::~ESHandleExceptionFactory()
-{
-}
+edm::ESHandleExceptionFactory::~ESHandleExceptionFactory() {}

--- a/FWCore/Framework/src/ESProducer.cc
+++ b/FWCore/Framework/src/ESProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     ESProducer
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -15,52 +15,47 @@
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"
 
-
 //
 // constants, enums and typedefs
 //
 namespace edm {
-//
-// static data member definitions
-//
+  //
+  // static data member definitions
+  //
 
-//
-// constructors and destructor
-//
-ESProducer::ESProducer()
-{
-}
+  //
+  // constructors and destructor
+  //
+  ESProducer::ESProducer() {}
 
-// ESProducer::ESProducer(const ESProducer& rhs)
-// {
-//    // do actual copying here;
-// }
+  // ESProducer::ESProducer(const ESProducer& rhs)
+  // {
+  //    // do actual copying here;
+  // }
 
-ESProducer::~ESProducer() noexcept(false)
-{
-}
+  ESProducer::~ESProducer() noexcept(false) {}
 
-//
-// assignment operators
-//
-// const ESProducer& ESProducer::operator=(const ESProducer& rhs)
-// {
-//   //An exception safe implementation is
-//   ESProducer temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+  //
+  // assignment operators
+  //
+  // const ESProducer& ESProducer::operator=(const ESProducer& rhs)
+  // {
+  //   //An exception safe implementation is
+  //   ESProducer temp(rhs);
+  //   swap(rhs);
+  //
+  //   return *this;
+  // }
 
-//
-// member functions
-//
+  //
+  // member functions
+  //
 
-//
-// const member functions
-//
+  //
+  // const member functions
+  //
 
-//
-// static member functions
-//
-}
+  //
+  // static member functions
+  //
+}  // namespace edm

--- a/FWCore/Framework/src/ESProducerLooper.cc
+++ b/FWCore/Framework/src/ESProducerLooper.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     ESProducerLooper
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -28,9 +28,7 @@ using namespace edm::eventsetup;
 //
 // constructors and destructor
 //
-ESProducerLooper::ESProducerLooper()
-{
-}
+ESProducerLooper::ESProducerLooper() {}
 
 // ESProducerLooper::ESProducerLooper(const ESProducerLooper& rhs)
 // {
@@ -56,29 +54,22 @@ ESProducerLooper::~ESProducerLooper()
 //
 // member functions
 //
-void 
-ESProducerLooper::setIntervalFor(const EventSetupRecordKey&,
-                                 const IOVSyncValue&, 
-                                 ValidityInterval& oInterval)
-{
+void ESProducerLooper::setIntervalFor(const EventSetupRecordKey&, const IOVSyncValue&, ValidityInterval& oInterval) {
   //since non of the dependent records are valid, I will create one that is valid
   // at the beginning of time BUT must also be checked every request
   //oInterval = ValidityInterval(IOVSyncValue::beginOfTime(),
   //                             IOVSyncValue::invalidIOVSyncValue());
- //   }
+  //   }
   //} else {
-    //Give one valid for all time
-    oInterval = ValidityInterval(IOVSyncValue::beginOfTime(),
-                                 IOVSyncValue::endOfTime());
+  //Give one valid for all time
+  oInterval = ValidityInterval(IOVSyncValue::beginOfTime(), IOVSyncValue::endOfTime());
   //}
 }
 
 //use this to 'snoop' on what records are being used by the Producer
-void 
-ESProducerLooper::registerFactoryWithKey(const eventsetup::EventSetupRecordKey& iRecord ,
-                                         std::unique_ptr<eventsetup::ProxyFactoryBase> iFactory,
-                                         const std::string& iLabel )
-{
+void ESProducerLooper::registerFactoryWithKey(const eventsetup::EventSetupRecordKey& iRecord,
+                                              std::unique_ptr<eventsetup::ProxyFactoryBase> iFactory,
+                                              const std::string& iLabel) {
   findingRecordWithKey(iRecord);
   ESProxyFactoryProducer::registerFactoryWithKey(iRecord, std::move(iFactory), iLabel);
 }
@@ -86,10 +77,7 @@ ESProducerLooper::registerFactoryWithKey(const eventsetup::EventSetupRecordKey& 
 //
 // const member functions
 //
-std::set<eventsetup::EventSetupRecordKey>
-ESProducerLooper::modifyingRecords() const {
-  return findingForRecords();
-}
+std::set<eventsetup::EventSetupRecordKey> ESProducerLooper::modifyingRecords() const { return findingForRecords(); }
 //
 // static member functions
 //

--- a/FWCore/Framework/src/ESProxyFactoryProducer.cc
+++ b/FWCore/Framework/src/ESProxyFactoryProducer.cc
@@ -27,103 +27,86 @@
 using namespace edm::eventsetup;
 namespace edm {
 
-      typedef std::multimap< EventSetupRecordKey, FactoryInfo > Record2Factories;
+  typedef std::multimap<EventSetupRecordKey, FactoryInfo> Record2Factories;
 
-//
-// static data member definitions
-//
+  //
+  // static data member definitions
+  //
 
-//
-// constructors and destructor
-//
-ESProxyFactoryProducer::ESProxyFactoryProducer() : record2Factories_()
-{
-}
+  //
+  // constructors and destructor
+  //
+  ESProxyFactoryProducer::ESProxyFactoryProducer() : record2Factories_() {}
 
-// ESProxyFactoryProducer::ESProxyFactoryProducer(const ESProxyFactoryProducer& rhs)
-// {
-//    // do actual copying here;
-// }
+  // ESProxyFactoryProducer::ESProxyFactoryProducer(const ESProxyFactoryProducer& rhs)
+  // {
+  //    // do actual copying here;
+  // }
 
-ESProxyFactoryProducer::~ESProxyFactoryProducer() noexcept(false)
-{
-}
+  ESProxyFactoryProducer::~ESProxyFactoryProducer() noexcept(false) {}
 
-//
-// assignment operators
-//
-// const ESProxyFactoryProducer& ESProxyFactoryProducer::operator=(const ESProxyFactoryProducer& rhs)
-// {
-//   //An exception safe implementation is
-//   ESProxyFactoryProducer temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+  //
+  // assignment operators
+  //
+  // const ESProxyFactoryProducer& ESProxyFactoryProducer::operator=(const ESProxyFactoryProducer& rhs)
+  // {
+  //   //An exception safe implementation is
+  //   ESProxyFactoryProducer temp(rhs);
+  //   swap(rhs);
+  //
+  //   return *this;
+  // }
 
-//
-// member functions
-//
-void
-ESProxyFactoryProducer::registerProxies(const EventSetupRecordKey& iRecord,
-                                       KeyedProxies& iProxies)
-{
-   typedef Record2Factories::iterator Iterator;
-   std::pair< Iterator, Iterator > range = record2Factories_.equal_range(iRecord);
-   for(Iterator it = range.first; it != range.second; ++it) {
-
+  //
+  // member functions
+  //
+  void ESProxyFactoryProducer::registerProxies(const EventSetupRecordKey& iRecord, KeyedProxies& iProxies) {
+    typedef Record2Factories::iterator Iterator;
+    std::pair<Iterator, Iterator> range = record2Factories_.equal_range(iRecord);
+    for (Iterator it = range.first; it != range.second; ++it) {
       std::shared_ptr<DataProxy> proxy(it->second.factory_->makeProxy().release());
-      if(nullptr != proxy.get()) {
-         iProxies.push_back(KeyedProxies::value_type((*it).second.key_,
-                                         proxy));
+      if (nullptr != proxy.get()) {
+        iProxies.push_back(KeyedProxies::value_type((*it).second.key_, proxy));
       }
-   }
-}
+    }
+  }
 
-void
-ESProxyFactoryProducer::registerFactoryWithKey(const EventSetupRecordKey& iRecord ,
-                                             std::unique_ptr<ProxyFactoryBase> iFactory,
-                                             const std::string& iLabel )
-{
-   if(nullptr == iFactory.get()) {
+  void ESProxyFactoryProducer::registerFactoryWithKey(const EventSetupRecordKey& iRecord,
+                                                      std::unique_ptr<ProxyFactoryBase> iFactory,
+                                                      const std::string& iLabel) {
+    if (nullptr == iFactory.get()) {
       assert(false && "Factor pointer was null");
       ::exit(1);
-   }
+    }
 
-   usingRecordWithKey(iRecord);
+    usingRecordWithKey(iRecord);
 
-   std::shared_ptr<ProxyFactoryBase> temp(iFactory.release());
-   FactoryInfo info(temp->makeKey(iLabel),
-                    temp);
+    std::shared_ptr<ProxyFactoryBase> temp(iFactory.release());
+    FactoryInfo info(temp->makeKey(iLabel), temp);
 
-   //has this already been registered?
-   std::pair<Record2Factories::const_iterator,Record2Factories::const_iterator> range =
-      record2Factories_.equal_range(iRecord);
-   if(range.second != std::find_if(range.first,range.second,
-                                   [&info](const auto& r2f) {
-                                     return r2f.second.key_ == info.key_;
-                                   }
-                                   ) ) {
-      throw cms::Exception("IdenticalProducts")<<"Producer has been asked to produce "<<info.key_.type().name()
-      <<" \""<<info.key_.name().value()<<"\" multiple times.\n Please modify the code.";
-   }
+    //has this already been registered?
+    std::pair<Record2Factories::const_iterator, Record2Factories::const_iterator> range =
+        record2Factories_.equal_range(iRecord);
+    if (range.second !=
+        std::find_if(range.first, range.second, [&info](const auto& r2f) { return r2f.second.key_ == info.key_; })) {
+      throw cms::Exception("IdenticalProducts")
+          << "Producer has been asked to produce " << info.key_.type().name() << " \"" << info.key_.name().value()
+          << "\" multiple times.\n Please modify the code.";
+    }
 
-   record2Factories_.insert(Record2Factories::value_type(iRecord,
-                                                         std::move(info)));
-}
+    record2Factories_.insert(Record2Factories::value_type(iRecord, std::move(info)));
+  }
 
-void
-ESProxyFactoryProducer::newInterval(const EventSetupRecordKey& iRecordType,
-                                   const ValidityInterval& /*iInterval*/)
-{
-   invalidateProxies(iRecordType);
-}
+  void ESProxyFactoryProducer::newInterval(const EventSetupRecordKey& iRecordType,
+                                           const ValidityInterval& /*iInterval*/) {
+    invalidateProxies(iRecordType);
+  }
 
-//
-// const member functions
-//
+  //
+  // const member functions
+  //
 
-//
-// static member functions
-//
-}
+  //
+  // static member functions
+  //
+}  // namespace edm

--- a/FWCore/Framework/src/ESValidHandle.cc
+++ b/FWCore/Framework/src/ESValidHandle.cc
@@ -2,10 +2,9 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 namespace edm::esvhhelper {
-  void
-  throwIfNotValid(const void* iProduct) noexcept(false) {
-    if(nullptr == iProduct) {
-      throw cms::Exception("Invalid Product")<<"Attempted to fill a edm::ESValidHandle with an invalid product";
+  void throwIfNotValid(const void* iProduct) noexcept(false) {
+    if (nullptr == iProduct) {
+      throw cms::Exception("Invalid Product") << "Attempted to fill a edm::ESValidHandle with an invalid product";
     }
   }
-}
+}  // namespace edm::esvhhelper

--- a/FWCore/Framework/src/EarlyDeleteHelper.cc
+++ b/FWCore/Framework/src/EarlyDeleteHelper.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     EarlyDeleteHelper
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -32,24 +32,19 @@ using namespace edm;
 //
 EarlyDeleteHelper::EarlyDeleteHelper(unsigned int* iBeginIndexItr,
                                      unsigned int* iEndIndexItr,
-                                     std::vector<BranchToCount>* iBranchCounts):
-pBeginIndex_(iBeginIndexItr),
-pEndIndex_(iEndIndexItr),
-pBranchCounts_(iBranchCounts),
-pathsLeftToComplete_(0),
-nPathsOn_(0)
-{
-}
+                                     std::vector<BranchToCount>* iBranchCounts)
+    : pBeginIndex_(iBeginIndexItr),
+      pEndIndex_(iEndIndexItr),
+      pBranchCounts_(iBranchCounts),
+      pathsLeftToComplete_(0),
+      nPathsOn_(0) {}
 
-EarlyDeleteHelper::EarlyDeleteHelper(const EarlyDeleteHelper& rhs):
-pBeginIndex_(rhs.pBeginIndex_),
-pEndIndex_(rhs.pEndIndex_),
-pBranchCounts_(rhs.pBranchCounts_),
-pathsLeftToComplete_(rhs.pathsLeftToComplete_.load()),
-nPathsOn_(rhs.nPathsOn_)
-{
-  
-}
+EarlyDeleteHelper::EarlyDeleteHelper(const EarlyDeleteHelper& rhs)
+    : pBeginIndex_(rhs.pBeginIndex_),
+      pEndIndex_(rhs.pEndIndex_),
+      pBranchCounts_(rhs.pBranchCounts_),
+      pathsLeftToComplete_(rhs.pathsLeftToComplete_.load()),
+      nPathsOn_(rhs.nPathsOn_) {}
 
 //EarlyDeleteHelper::~EarlyDeleteHelper()
 //{
@@ -70,26 +65,24 @@ nPathsOn_(rhs.nPathsOn_)
 //
 // member functions
 //
-void 
-EarlyDeleteHelper::moduleRan(EventPrincipal const& iEvent) {
-  pathsLeftToComplete_=0;
-  for(auto it = pBeginIndex_; it != pEndIndex_;++it) {
+void EarlyDeleteHelper::moduleRan(EventPrincipal const& iEvent) {
+  pathsLeftToComplete_ = 0;
+  for (auto it = pBeginIndex_; it != pEndIndex_; ++it) {
     auto& count = (*pBranchCounts_)[*it];
-    assert(count.count>0);
+    assert(count.count > 0);
     auto value = --(count.count);
-    if(value==0) {
+    if (value == 0) {
       iEvent.deleteProduct(count.branch);
     }
   }
 }
 
-void 
-EarlyDeleteHelper::pathFinished(EventPrincipal const& iEvent) {
+void EarlyDeleteHelper::pathFinished(EventPrincipal const& iEvent) {
   unsigned int value = pathsLeftToComplete_;
-  while(value > 0) {
-    if( pathsLeftToComplete_.compare_exchange_strong(value, value-1)) {
+  while (value > 0) {
+    if (pathsLeftToComplete_.compare_exchange_strong(value, value - 1)) {
       //we were the thread that changed the value
-      if( value == 1) {
+      if (value == 1) {
         //we can never reach this module now so declare it as run
         moduleRan(iEvent);
       }
@@ -98,16 +91,14 @@ EarlyDeleteHelper::pathFinished(EventPrincipal const& iEvent) {
   }
 }
 
-void
-EarlyDeleteHelper::appendIndex(unsigned int iIndex) {
-  *pEndIndex_=iIndex;
+void EarlyDeleteHelper::appendIndex(unsigned int iIndex) {
+  *pEndIndex_ = iIndex;
   ++pEndIndex_;
 }
 
-void
-EarlyDeleteHelper::shiftIndexPointers(unsigned int iShift) {
-  pEndIndex_ -=iShift;
-  pBeginIndex_ -=iShift;
+void EarlyDeleteHelper::shiftIndexPointers(unsigned int iShift) {
+  pEndIndex_ -= iShift;
+  pBeginIndex_ -= iShift;
 }
 
 //

--- a/FWCore/Framework/src/EarlyDeleteHelper.h
+++ b/FWCore/Framework/src/EarlyDeleteHelper.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     EarlyDeleteHelper
-// 
+//
 /**\class EarlyDeleteHelper EarlyDeleteHelper.h FWCore/Framework/interface/EarlyDeleteHelper.h
 
  Description: [one line class summary]
@@ -27,57 +27,48 @@
 // forward declarations
 namespace edm {
   class EventPrincipal;
-  
+
   struct BranchToCount {
     edm::BranchID const branch;
     std::atomic<unsigned int> count;
-    
-    BranchToCount(edm::BranchID id, unsigned int count):
-    branch(id),
-    count(count) {}
-    
-    BranchToCount(BranchToCount const& iOther):
-    branch(iOther.branch),
-    count(iOther.count.load()) {}
+
+    BranchToCount(edm::BranchID id, unsigned int count) : branch(id), count(count) {}
+
+    BranchToCount(BranchToCount const& iOther) : branch(iOther.branch), count(iOther.count.load()) {}
   };
-  
-  class EarlyDeleteHelper
-  {
-    
+
+  class EarlyDeleteHelper {
   public:
     EarlyDeleteHelper(unsigned int* iBeginIndexItr,
                       unsigned int* iEndIndexItr,
                       std::vector<BranchToCount>* iBranchCounts);
     EarlyDeleteHelper(const EarlyDeleteHelper&);
-        EarlyDeleteHelper& operator=(const EarlyDeleteHelper&) = default;
+    EarlyDeleteHelper& operator=(const EarlyDeleteHelper&) = default;
     //virtual ~EarlyDeleteHelper();
-    
+
     // ---------- const member functions ---------------------
-    
+
     // ---------- static member functions --------------------
-    
+
     // ---------- member functions ---------------------------
-    void reset() {pathsLeftToComplete_ = nPathsOn_;}
+    void reset() { pathsLeftToComplete_ = nPathsOn_; }
     void moduleRan(EventPrincipal const&);
     void pathFinished(EventPrincipal const&);
-    void addedToPath() { ++nPathsOn_;}
+    void addedToPath() { ++nPathsOn_; }
     void appendIndex(unsigned int index);
     void shiftIndexPointers(unsigned int iShift);
-    
-    unsigned int* begin() { return pBeginIndex_;}
-    unsigned int* end() { return pEndIndex_;}
-    
+
+    unsigned int* begin() { return pBeginIndex_; }
+    unsigned int* end() { return pEndIndex_; }
+
   private:
-    
     // ---------- member data --------------------------------
     unsigned int* pBeginIndex_;
     unsigned int* pEndIndex_;
     std::vector<BranchToCount>* pBranchCounts_;
     std::atomic<unsigned int> pathsLeftToComplete_;
     unsigned int nPathsOn_;
-    
   };
-}
-
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/EndPathStatusInserter.cc
+++ b/FWCore/Framework/src/EndPathStatusInserter.cc
@@ -6,17 +6,11 @@
 
 #include <memory>
 
-namespace edm
-{
-  EndPathStatusInserter::EndPathStatusInserter(unsigned int):
-  token_{produces<EndPathStatus>()}
-  {
-  }
+namespace edm {
+  EndPathStatusInserter::EndPathStatusInserter(unsigned int) : token_{produces<EndPathStatus>()} {}
 
-  void
-  EndPathStatusInserter::produce(StreamID, edm::Event& event, edm::EventSetup const&) const
-  {
+  void EndPathStatusInserter::produce(StreamID, edm::Event& event, edm::EventSetup const&) const {
     //Puts a default constructed EndPathStatus
     event.emplace(token_);
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/EndPathStatusInserter.h
+++ b/FWCore/Framework/src/EndPathStatusInserter.h
@@ -13,12 +13,12 @@ namespace edm {
 
   class EndPathStatusInserter : public global::EDProducer<> {
   public:
-
     explicit EndPathStatusInserter(unsigned int numberOfStreams);
 
     void produce(StreamID, Event&, EventSetup const&) const final;
+
   private:
     EDPutTokenT<EndPathStatus> token_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -19,65 +19,57 @@ namespace edm {
 
   std::string const Event::emptyString_;
 
-  Event::Event(EventPrincipal const& ep, ModuleDescription const& md, ModuleCallingContext const* moduleCallingContext) :
-      provRecorder_(ep, md, true /*always at end*/),
-      aux_(ep.aux()),
-      luminosityBlock_(ep.luminosityBlockPrincipalPtrValid() ? new LuminosityBlock(ep.luminosityBlockPrincipal(), md, moduleCallingContext,false) : nullptr),
-      gotBranchIDs_(),
-      gotViews_(),
-      streamID_(ep.streamID()),
-      moduleCallingContext_(moduleCallingContext)
-  {
-  }
+  Event::Event(EventPrincipal const& ep, ModuleDescription const& md, ModuleCallingContext const* moduleCallingContext)
+      : provRecorder_(ep, md, true /*always at end*/),
+        aux_(ep.aux()),
+        luminosityBlock_(ep.luminosityBlockPrincipalPtrValid()
+                             ? new LuminosityBlock(ep.luminosityBlockPrincipal(), md, moduleCallingContext, false)
+                             : nullptr),
+        gotBranchIDs_(),
+        gotViews_(),
+        streamID_(ep.streamID()),
+        moduleCallingContext_(moduleCallingContext) {}
 
-  Event::~Event() {
-  }
+  Event::~Event() {}
 
-  Event::CacheIdentifier_t
-  Event::cacheIdentifier() const {
-    return eventPrincipal().cacheIdentifier();
-  }
+  Event::CacheIdentifier_t Event::cacheIdentifier() const { return eventPrincipal().cacheIdentifier(); }
 
-  void
-  Event::setConsumer(EDConsumerBase const* iConsumer) {
+  void Event::setConsumer(EDConsumerBase const* iConsumer) {
     provRecorder_.setConsumer(iConsumer);
     gotBranchIDs_.reserve(provRecorder_.numberOfProductsConsumed());
     const_cast<LuminosityBlock*>(luminosityBlock_.get())->setConsumer(iConsumer);
   }
-  
-  void
-  Event::setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer) {
+
+  void Event::setSharedResourcesAcquirer(SharedResourcesAcquirer* iResourceAcquirer) {
     provRecorder_.setSharedResourcesAcquirer(iResourceAcquirer);
     const_cast<LuminosityBlock*>(luminosityBlock_.get())->setSharedResourcesAcquirer(iResourceAcquirer);
   }
 
-  void
-  Event::setProducerCommon(ProducerBase const* iProd,
-                           std::vector<BranchID>* previousParentage) {
-
+  void Event::setProducerCommon(ProducerBase const* iProd, std::vector<BranchID>* previousParentage) {
     provRecorder_.setProducer(iProd);
     //set appropriate size
-    putProducts_.resize(
-                        provRecorder_.putTokenIndexToProductResolverIndex().size());
-    previousBranchIDs_ =previousParentage;
+    putProducts_.resize(provRecorder_.putTokenIndexToProductResolverIndex().size());
+    previousBranchIDs_ = previousParentage;
   }
 
-  void
-  Event::setProducer(ProducerBase const* iProd,
-                     std::vector<BranchID>* previousParentage,
-                     std::vector<BranchID>* gotBranchIDsFromAcquire) {
+  void Event::setProducer(ProducerBase const* iProd,
+                          std::vector<BranchID>* previousParentage,
+                          std::vector<BranchID>* gotBranchIDsFromAcquire) {
     setProducerCommon(iProd, previousParentage);
-    if(previousParentage) {
+    if (previousParentage) {
       //are we supposed to record parentage for at least one item?
       bool record_parents = false;
-      for( auto v: provRecorder_.recordProvenanceList()) {
-        if (v) { record_parents = true; break;}
+      for (auto v : provRecorder_.recordProvenanceList()) {
+        if (v) {
+          record_parents = true;
+          break;
+        }
       }
-      if(not record_parents) {
+      if (not record_parents) {
         previousBranchIDs_ = nullptr;
         return;
       }
-      gotBranchIDsFromPrevious_.resize(previousParentage->size(),false);
+      gotBranchIDsFromPrevious_.resize(previousParentage->size(), false);
       if (gotBranchIDsFromAcquire) {
         for (auto const& branchID : *gotBranchIDsFromAcquire) {
           addToGotBranchIDs(branchID);
@@ -86,113 +78,86 @@ namespace edm {
     }
   }
 
-  void
-  Event::setProducerForAcquire(ProducerBase const* iProd,
-                               std::vector<BranchID>* previousParentage,
-                               std::vector<BranchID>& gotBranchIDsFromAcquire) {
+  void Event::setProducerForAcquire(ProducerBase const* iProd,
+                                    std::vector<BranchID>* previousParentage,
+                                    std::vector<BranchID>& gotBranchIDsFromAcquire) {
     setProducerCommon(iProd, previousParentage);
     gotBranchIDsFromAcquire_ = &gotBranchIDsFromAcquire;
     gotBranchIDsFromAcquire_->clear();
   }
 
-  EventPrincipal const&
-  Event::eventPrincipal() const {
+  EventPrincipal const& Event::eventPrincipal() const {
     return dynamic_cast<EventPrincipal const&>(provRecorder_.principal());
   }
 
-  EDProductGetter const&
-  Event::productGetter() const {
-    return provRecorder_.principal();
-  }
+  EDProductGetter const& Event::productGetter() const { return provRecorder_.principal(); }
 
-  ProductID
-  Event::makeProductID(BranchDescription const& desc) const {
+  ProductID Event::makeProductID(BranchDescription const& desc) const {
     return eventPrincipal().branchIDToProductID(desc.originalBranchID());
   }
 
-  Run const&
-  Event::getRun() const {
-    return getLuminosityBlock().getRun();
-  }
+  Run const& Event::getRun() const { return getLuminosityBlock().getRun(); }
 
-  EventSelectionIDVector const&
-  Event::eventSelectionIDs() const {
-    return eventPrincipal().eventSelectionIDs();
-  }
+  EventSelectionIDVector const& Event::eventSelectionIDs() const { return eventPrincipal().eventSelectionIDs(); }
 
-  ProcessHistoryID const&
-  Event::processHistoryID() const {
-    return eventPrincipal().processHistoryID();
-  }
+  ProcessHistoryID const& Event::processHistoryID() const { return eventPrincipal().processHistoryID(); }
 
-  Provenance
-  Event::getProvenance(BranchID const& bid) const {
+  Provenance Event::getProvenance(BranchID const& bid) const {
     return provRecorder_.principal().getProvenance(bid, moduleCallingContext_);
   }
 
-  Provenance
-  Event::getProvenance(ProductID const& pid) const {
+  Provenance Event::getProvenance(ProductID const& pid) const {
     return eventPrincipal().getProvenance(pid, moduleCallingContext_);
   }
 
-  void
-  Event::getAllProvenance(std::vector<Provenance const*>& provenances) const {
+  void Event::getAllProvenance(std::vector<Provenance const*>& provenances) const {
     provRecorder_.principal().getAllProvenance(provenances);
   }
 
-  void
-  Event::getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const {
+  void Event::getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const {
     provRecorder_.principal().getAllStableProvenance(provenances);
   }
 
-  bool
-  Event::getProcessParameterSet(std::string const& processName,
-                                ParameterSet& ps) const {
+  bool Event::getProcessParameterSet(std::string const& processName, ParameterSet& ps) const {
     ProcessConfiguration config;
     bool process_found = processHistory().getConfigurationForProcess(processName, config);
-    if(process_found) {
+    if (process_found) {
       pset::Registry::instance()->getMapped(config.parameterSetID(), ps);
       assert(!ps.empty());
     }
     return process_found;
   }
 
-  edm::ParameterSet const*
-  Event::parameterSet(edm::ParameterSetID const& psID) const{
+  edm::ParameterSet const* Event::parameterSet(edm::ParameterSetID const& psID) const {
     return parameterSetForID_(psID);
   }
-  
-  BasicHandle
-  Event::getByProductID_(ProductID const& oid) const {
-    return eventPrincipal().getByProductID(oid);
-  }
 
-  void
-  Event::commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut, ParentageID* previousParentageId) {
+  BasicHandle Event::getByProductID_(ProductID const& oid) const { return eventPrincipal().getByProductID(oid); }
+
+  void Event::commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut, ParentageID* previousParentageId) {
     size_t nPut = 0;
-    for(auto const& p: putProducts()) {
-      if(p) {
+    for (auto const& p : putProducts()) {
+      if (p) {
         ++nPut;
       }
     }
-    if(nPut > 0) {
+    if (nPut > 0) {
       commit_aux(putProducts(), previousParentageId);
     }
     auto sz = iShouldPut.size();
-    if(sz !=0 and sz != nPut) {
+    if (sz != 0 and sz != nPut) {
       //some were missed
       auto& p = provRecorder_.principal();
-      for(auto index: iShouldPut){
+      for (auto index : iShouldPut) {
         auto resolver = p.getProductResolverByIndex(index);
-        if(not resolver->productResolved()) {
+        if (not resolver->productResolved()) {
           resolver->putProduct(std::unique_ptr<WrapperBase>());
         }
       }
     }
   }
 
-  void
-  Event::commit_aux(Event::ProductPtrVec& products, ParentageID* previousParentageId) {
+  void Event::commit_aux(Event::ProductPtrVec& products, ParentageID* previousParentageId) {
     // fill in guts of provenance here
     auto& ep = eventPrincipal();
 
@@ -200,46 +165,44 @@ namespace edm {
     // avoid constantly recalculating the ParentageID which is a time consuming operation
     ParentageID const* presentParentageId;
 
-    if(previousBranchIDs_) {
+    if (previousBranchIDs_) {
       bool sameAsPrevious = gotBranchIDs_.empty();
-      if(sameAsPrevious) {
-        for(auto i: gotBranchIDsFromPrevious_) {
-          if(not i) {
+      if (sameAsPrevious) {
+        for (auto i : gotBranchIDsFromPrevious_) {
+          if (not i) {
             sameAsPrevious = false;
             break;
           }
         }
       }
-      if( not sameAsPrevious) {
-        std::vector<BranchID> gotBranchIDVector{gotBranchIDs_.begin(),
-          gotBranchIDs_.end()};
+      if (not sameAsPrevious) {
+        std::vector<BranchID> gotBranchIDVector{gotBranchIDs_.begin(), gotBranchIDs_.end()};
         //add items in common from previous
         auto n = gotBranchIDsFromPrevious_.size();
-        for(size_t i =0;  i < n;++i) {
-          if(gotBranchIDsFromPrevious_[i]) {
+        for (size_t i = 0; i < n; ++i) {
+          if (gotBranchIDsFromPrevious_[i]) {
             gotBranchIDVector.push_back((*previousBranchIDs_)[i]);
           }
         }
-        std::sort(gotBranchIDVector.begin(),gotBranchIDVector.end());
+        std::sort(gotBranchIDVector.begin(), gotBranchIDVector.end());
         previousBranchIDs_->assign(gotBranchIDVector.begin(), gotBranchIDVector.end());
-        
+
         Parentage p;
         p.setParents(std::move(gotBranchIDVector));
         *previousParentageId = p.id();
         ParentageRegistry::instance()->insertMapped(p);
-
       }
-      presentParentageId =previousParentageId;
+      presentParentageId = previousParentageId;
     } else {
       presentParentageId = &s_emptyParentage;
     }
 
     auto const& recordProv = provRecorder_.recordProvenanceList();
-    for(unsigned int i = 0; i< products.size();++i) {
+    for (unsigned int i = 0; i < products.size(); ++i) {
       auto& p = get_underlying_safe(products[i]);
       if (p) {
-        if(recordProv[i]) {
-          ep.put(provRecorder_.putTokenIndexToProductResolverIndex()[i],  std::move(p), *presentParentageId);
+        if (recordProv[i]) {
+          ep.put(provRecorder_.putTokenIndexToProductResolverIndex()[i], std::move(p), *presentParentageId);
         } else {
           ep.put(provRecorder_.putTokenIndexToProductResolverIndex()[i], std::move(p), s_emptyParentage);
         }
@@ -250,16 +213,12 @@ namespace edm {
     products.clear();
   }
 
-  void
-  Event::addToGotBranchIDs(Provenance const& prov) const {
-    addToGotBranchIDs(prov.originalBranchID());
-  }
+  void Event::addToGotBranchIDs(Provenance const& prov) const { addToGotBranchIDs(prov.originalBranchID()); }
 
-  void
-  Event::addToGotBranchIDs(BranchID const& branchID) const {
-    if(previousBranchIDs_) {
+  void Event::addToGotBranchIDs(BranchID const& branchID) const {
+    if (previousBranchIDs_) {
       auto range = std::equal_range(previousBranchIDs_->begin(), previousBranchIDs_->end(), branchID);
-      if(range.first ==range.second) {
+      if (range.first == range.second) {
         gotBranchIDs_.insert(branchID.id());
       } else {
         gotBranchIDsFromPrevious_[range.first - previousBranchIDs_->begin()] = true;
@@ -269,48 +228,42 @@ namespace edm {
     }
   }
 
-  ProcessHistory const&
-  Event::processHistory() const {
-    return provRecorder_.processHistory();
+  ProcessHistory const& Event::processHistory() const { return provRecorder_.processHistory(); }
+
+  size_t Event::size() const {
+    return std::count_if(putProducts().begin(), putProducts().end(), [](auto const& i) { return bool(i); }) +
+           provRecorder_.principal().size();
   }
 
-  size_t
-  Event::size() const {
-    return std::count_if(putProducts().begin(),putProducts().end(),[](auto const& i) {return bool(i);}) + provRecorder_.principal().size();
-  }
-
-  BasicHandle
-  Event::getByLabelImpl(std::type_info const&, std::type_info const& iProductType, const InputTag& iTag) const {
+  BasicHandle Event::getByLabelImpl(std::type_info const&,
+                                    std::type_info const& iProductType,
+                                    const InputTag& iTag) const {
     BasicHandle h = provRecorder_.getByLabel_(TypeID(iProductType), iTag, moduleCallingContext_);
-    if(h.isValid()) {
+    if (h.isValid()) {
       addToGotBranchIDs(*(h.provenance()));
     }
     return h;
   }
 
-  BasicHandle
-  Event::getImpl(std::type_info const&, ProductID const& pid) const {
+  BasicHandle Event::getImpl(std::type_info const&, ProductID const& pid) const {
     BasicHandle h = this->getByProductID_(pid);
-    if(h.isValid()) {
+    if (h.isValid()) {
       addToGotBranchIDs(*(h.provenance()));
     }
     return h;
   }
 
-  TriggerNames const&
-  Event::triggerNames(edm::TriggerResults const& triggerResults) const {
+  TriggerNames const& Event::triggerNames(edm::TriggerResults const& triggerResults) const {
     edm::TriggerNames const* names = triggerNames_(triggerResults);
-    if(names != nullptr) return *names;
+    if (names != nullptr)
+      return *names;
 
-    throw cms::Exception("TriggerNamesNotFound")
-      << "TriggerNames not found in ParameterSet registry";
+    throw cms::Exception("TriggerNamesNotFound") << "TriggerNames not found in ParameterSet registry";
     return *names;
   }
 
-  TriggerResultsByName
-  Event::triggerResultsByName(edm::TriggerResults const& triggerResults) const {
-
+  TriggerResultsByName Event::triggerResultsByName(edm::TriggerResults const& triggerResults) const {
     edm::TriggerNames const* names = triggerNames_(triggerResults);
     return TriggerResultsByName(&triggerResults, names);
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/EventAcquireSignalsSentry.h
+++ b/FWCore/Framework/src/EventAcquireSignalsSentry.h
@@ -27,23 +27,19 @@
 // forward declarations
 namespace edm {
   class EventAcquireSignalsSentry {
-
   public:
-    EventAcquireSignalsSentry(ActivityRegistry* iReg,
-                       ModuleCallingContext const * iContext) :
-      m_reg(iReg),
-      m_context(iContext)
-    { iReg->preModuleEventAcquireSignal_( *(iContext->getStreamContext()), *iContext);}
-
-    ~EventAcquireSignalsSentry() {
-      m_reg->postModuleEventAcquireSignal_( *(m_context->getStreamContext()), *m_context);
+    EventAcquireSignalsSentry(ActivityRegistry* iReg, ModuleCallingContext const* iContext)
+        : m_reg(iReg), m_context(iContext) {
+      iReg->preModuleEventAcquireSignal_(*(iContext->getStreamContext()), *iContext);
     }
+
+    ~EventAcquireSignalsSentry() { m_reg->postModuleEventAcquireSignal_(*(m_context->getStreamContext()), *m_context); }
 
   private:
     // ---------- member data --------------------------------
-    ActivityRegistry* m_reg; // We do not use propagate_const because the registry itself is mutable.
+    ActivityRegistry* m_reg;  // We do not use propagate_const because the registry itself is mutable.
     ModuleCallingContext const* m_context;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/EventForOutput.cc
+++ b/FWCore/Framework/src/EventForOutput.cc
@@ -11,40 +11,33 @@
 
 namespace edm {
 
-  EventForOutput::EventForOutput(EventPrincipal const& ep, ModuleDescription const& md, ModuleCallingContext const* moduleCallingContext) :
-      OccurrenceForOutput(ep, md, moduleCallingContext, true /*always at end*/),
-      aux_(ep.aux()),
-      luminosityBlock_(ep.luminosityBlockPrincipalPtrValid() ? new LuminosityBlockForOutput(ep.luminosityBlockPrincipal(), md, moduleCallingContext,false /*not at end*/) : nullptr),
-      streamID_(ep.streamID())
-  {
-  }
+  EventForOutput::EventForOutput(EventPrincipal const& ep,
+                                 ModuleDescription const& md,
+                                 ModuleCallingContext const* moduleCallingContext)
+      : OccurrenceForOutput(ep, md, moduleCallingContext, true /*always at end*/),
+        aux_(ep.aux()),
+        luminosityBlock_(ep.luminosityBlockPrincipalPtrValid()
+                             ? new LuminosityBlockForOutput(
+                                   ep.luminosityBlockPrincipal(), md, moduleCallingContext, false /*not at end*/)
+                             : nullptr),
+        streamID_(ep.streamID()) {}
 
-  EventForOutput::~EventForOutput() {
-  }
+  EventForOutput::~EventForOutput() {}
 
-  EventPrincipal const&
-  EventForOutput::eventPrincipal() const {
+  EventPrincipal const& EventForOutput::eventPrincipal() const {
     return dynamic_cast<EventPrincipal const&>(principal());
   }
 
-  RunForOutput const&
-  EventForOutput::getRun() const {
-    return getLuminosityBlock().getRun();
-  }
+  RunForOutput const& EventForOutput::getRun() const { return getLuminosityBlock().getRun(); }
 
-  EventSelectionIDVector const&
-  EventForOutput::eventSelectionIDs() const {
+  EventSelectionIDVector const& EventForOutput::eventSelectionIDs() const {
     return eventPrincipal().eventSelectionIDs();
   }
 
-  ProductProvenanceRetriever const*
-  EventForOutput::productProvenanceRetrieverPtr() const {
-   return eventPrincipal().productProvenanceRetrieverPtr();
+  ProductProvenanceRetriever const* EventForOutput::productProvenanceRetrieverPtr() const {
+    return eventPrincipal().productProvenanceRetrieverPtr();
   }
 
-  BranchListIndexes const&
-  EventForOutput::branchListIndexes() const {
-    return eventPrincipal().branchListIndexes();
-  }
+  BranchListIndexes const& EventForOutput::branchListIndexes() const { return eventPrincipal().branchListIndexes(); }
 
-}
+}  // namespace edm

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -27,29 +27,27 @@
 #include <memory>
 
 namespace edm {
-  EventPrincipal::EventPrincipal(
-        std::shared_ptr<ProductRegistry const> reg,
-        std::shared_ptr<BranchIDListHelper const> branchIDListHelper,
-        std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper,
-        ProcessConfiguration const& pc,
-        HistoryAppender* historyAppender,
-        unsigned int streamIndex,
-        bool isForPrimaryProcess) :
-    Base(reg, reg->productLookup(InEvent), pc, InEvent, historyAppender,isForPrimaryProcess),
-          aux_(),
-          luminosityBlockPrincipal_(nullptr),
-          provRetrieverPtr_(new ProductProvenanceRetriever(streamIndex)),
-          eventSelectionIDs_(),
-          branchIDListHelper_(branchIDListHelper),
-          thinnedAssociationsHelper_(thinnedAssociationsHelper),
-          branchListIndexes_(),
-          branchListIndexToProcessIndex_(),
-          streamID_(streamIndex) {
+  EventPrincipal::EventPrincipal(std::shared_ptr<ProductRegistry const> reg,
+                                 std::shared_ptr<BranchIDListHelper const> branchIDListHelper,
+                                 std::shared_ptr<ThinnedAssociationsHelper const> thinnedAssociationsHelper,
+                                 ProcessConfiguration const& pc,
+                                 HistoryAppender* historyAppender,
+                                 unsigned int streamIndex,
+                                 bool isForPrimaryProcess)
+      : Base(reg, reg->productLookup(InEvent), pc, InEvent, historyAppender, isForPrimaryProcess),
+        aux_(),
+        luminosityBlockPrincipal_(nullptr),
+        provRetrieverPtr_(new ProductProvenanceRetriever(streamIndex)),
+        eventSelectionIDs_(),
+        branchIDListHelper_(branchIDListHelper),
+        thinnedAssociationsHelper_(thinnedAssociationsHelper),
+        branchListIndexes_(),
+        branchListIndexToProcessIndex_(),
+        streamID_(streamIndex) {
     assert(thinnedAssociationsHelper_);
   }
 
-  void
-  EventPrincipal::clearEventPrincipal() {
+  void EventPrincipal::clearEventPrincipal() {
     clearPrincipal();
     aux_ = EventAuxiliary();
     //do not clear luminosityBlockPrincipal_ since
@@ -58,14 +56,13 @@ namespace edm {
     branchListIndexToProcessIndex_.clear();
   }
 
-  void
-  EventPrincipal::fillEventPrincipal(EventAuxiliary const& aux,
-        ProcessHistoryRegistry const& processHistoryRegistry,
-        EventSelectionIDVector&& eventSelectionIDs,
-        BranchListIndexes&& branchListIndexes,
-        ProductProvenanceRetriever const& provRetriever,
-        DelayedReader* reader,
-        bool deepCopyRetriever) {
+  void EventPrincipal::fillEventPrincipal(EventAuxiliary const& aux,
+                                          ProcessHistoryRegistry const& processHistoryRegistry,
+                                          EventSelectionIDVector&& eventSelectionIDs,
+                                          BranchListIndexes&& branchListIndexes,
+                                          ProductProvenanceRetriever const& provRetriever,
+                                          DelayedReader* reader,
+                                          bool deepCopyRetriever) {
     eventSelectionIDs_ = eventSelectionIDs;
     if (deepCopyRetriever) {
       provRetrieverPtr_->deepCopy(provRetriever);
@@ -73,41 +70,39 @@ namespace edm {
       provRetrieverPtr_->mergeParentProcessRetriever(provRetriever);
     }
     branchListIndexes_ = branchListIndexes;
-    if(branchIDListHelper_->hasProducedProducts()) {
+    if (branchIDListHelper_->hasProducedProducts()) {
       // Add index into BranchIDListRegistry for products produced this process
       branchListIndexes_.push_back(branchIDListHelper_->producedBranchListIndex());
     }
-    fillEventPrincipal(aux,processHistoryRegistry,reader);
+    fillEventPrincipal(aux, processHistoryRegistry, reader);
   }
 
-  void
-  EventPrincipal::fillEventPrincipal(EventAuxiliary const& aux,
-                                     ProcessHistoryRegistry const& processHistoryRegistry,
-                                     EventSelectionIDVector&& eventSelectionIDs,
-                                     BranchListIndexes&& branchListIndexes) {
+  void EventPrincipal::fillEventPrincipal(EventAuxiliary const& aux,
+                                          ProcessHistoryRegistry const& processHistoryRegistry,
+                                          EventSelectionIDVector&& eventSelectionIDs,
+                                          BranchListIndexes&& branchListIndexes) {
     eventSelectionIDs_ = eventSelectionIDs;
     branchListIndexes_ = branchListIndexes;
-    if(branchIDListHelper_->hasProducedProducts()) {
+    if (branchIDListHelper_->hasProducedProducts()) {
       // Add index into BranchIDListRegistry for products produced this process
       branchListIndexes_.push_back(branchIDListHelper_->producedBranchListIndex());
     }
-    fillEventPrincipal(aux,processHistoryRegistry,nullptr);
+    fillEventPrincipal(aux, processHistoryRegistry, nullptr);
   }
 
-  void
-  EventPrincipal::fillEventPrincipal(EventAuxiliary const& aux,
-                                     ProcessHistoryRegistry const& processHistoryRegistry,
-                                     DelayedReader* reader) {
-    if(aux.event() == invalidEventNumber) {
-      throw Exception(errors::LogicError)
-        << "EventPrincipal::fillEventPrincipal, Invalid event number provided in EventAuxiliary, It is illegal for the event number to be 0\n";
+  void EventPrincipal::fillEventPrincipal(EventAuxiliary const& aux,
+                                          ProcessHistoryRegistry const& processHistoryRegistry,
+                                          DelayedReader* reader) {
+    if (aux.event() == invalidEventNumber) {
+      throw Exception(errors::LogicError) << "EventPrincipal::fillEventPrincipal, Invalid event number provided in "
+                                             "EventAuxiliary, It is illegal for the event number to be 0\n";
     }
 
     fillPrincipal(aux.processHistoryID(), processHistoryRegistry, reader);
     aux_ = aux;
     aux_.setProcessHistoryID(processHistoryID());
-    
-    if(branchListIndexes_.empty() and branchIDListHelper_->hasProducedProducts()) {
+
+    if (branchListIndexes_.empty() and branchIDListHelper_->hasProducedProducts()) {
       // Add index into BranchIDListRegistry for products produced this process
       //  if it hasn't already been filled in by the other fillEventPrincipal or by an earlier call to this function
       branchListIndexes_.push_back(branchIDListHelper_->producedBranchListIndex());
@@ -115,56 +110,44 @@ namespace edm {
 
     // Fill in helper map for Branch to ProductID mapping
     ProcessIndex pix = 0;
-    for(auto const& blindex : branchListIndexes_) {
+    for (auto const& blindex : branchListIndexes_) {
       branchListIndexToProcessIndex_.insert(std::make_pair(blindex, pix));
       ++pix;
     }
 
     // Fill in the product ID's in the product holders.
-    for(auto& prod : *this) {
+    for (auto& prod : *this) {
       if (prod->singleProduct()) {
         // If an alias is in the same process as the original then isAlias will be true.
         //  Under that condition, we want the ProductID to be the same as the original.
         //  If not, then we've internally changed the original BranchID to the alias BranchID
         //  in the ProductID lookup so we need the alias BranchID.
-        auto const & bd =prod->branchDescription();
-        prod->setProvenance(productProvenanceRetrieverPtr(),
-                            processHistory(),
-                            branchIDToProductID(bd.isAlias()?bd.originalBranchID(): bd.branchID()));
+        auto const& bd = prod->branchDescription();
+        prod->setProvenance(productProvenanceRetrieverPtr(), processHistory(),
+                            branchIDToProductID(bd.isAlias() ? bd.originalBranchID() : bd.branchID()));
       }
     }
   }
 
-  void
-  EventPrincipal::setLuminosityBlockPrincipal(LuminosityBlockPrincipal* lbp) {
-    luminosityBlockPrincipal_ = lbp;
-  }
+  void EventPrincipal::setLuminosityBlockPrincipal(LuminosityBlockPrincipal* lbp) { luminosityBlockPrincipal_ = lbp; }
 
-  void 
-  EventPrincipal::setRunAndLumiNumber(RunNumber_t run, LuminosityBlockNumber_t lumi) {
+  void EventPrincipal::setRunAndLumiNumber(RunNumber_t run, LuminosityBlockNumber_t lumi) {
     assert(run == luminosityBlockPrincipal_->run());
     assert(lumi == luminosityBlockPrincipal_->luminosityBlock());
     EventNumber_t event = aux_.id().event();
     aux_.id() = EventID(run, lumi, event);
   }
 
-  RunPrincipal const&
-  EventPrincipal::runPrincipal() const {
-    return luminosityBlockPrincipal().runPrincipal();
-  }
+  RunPrincipal const& EventPrincipal::runPrincipal() const { return luminosityBlockPrincipal().runPrincipal(); }
 
-  void
-  EventPrincipal::put(
-        BranchDescription const& bd,
-        std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const& productProvenance) const {
-
+  void EventPrincipal::put(BranchDescription const& bd,
+                           std::unique_ptr<WrapperBase> edp,
+                           ProductProvenance const& productProvenance) const {
     // assert commented out for DaqSource.  When DaqSource no longer uses put(), the assert can be restored.
     //assert(produced());
-    if(edp.get() == nullptr) {
-      throw Exception(errors::InsertFailure, "Null Pointer")
-        << "put: Cannot put because ptr to product is null."
-        << "\n";
+    if (edp.get() == nullptr) {
+      throw Exception(errors::InsertFailure, "Null Pointer") << "put: Cannot put because ptr to product is null."
+                                                             << "\n";
     }
     productProvenanceRetrieverPtr()->insertIntoSet(productProvenance);
     auto phb = getExistingProduct(bd.branchID());
@@ -173,32 +156,24 @@ namespace edm {
     phb->putProduct(std::move(edp));
   }
 
-  void
-  EventPrincipal::put(
-             ProductResolverIndex index,
-             std::unique_ptr<WrapperBase> edp,
-             ParentageID parentage) const {
-    if(edp.get() == nullptr) {
-      throw Exception(errors::InsertFailure, "Null Pointer")
-      << "put: Cannot put because ptr to product is null."
-      << "\n";
+  void EventPrincipal::put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp, ParentageID parentage) const {
+    if (edp.get() == nullptr) {
+      throw Exception(errors::InsertFailure, "Null Pointer") << "put: Cannot put because ptr to product is null."
+                                                             << "\n";
     }
     auto phb = getProductResolverByIndex(index);
-    
-    productProvenanceRetrieverPtr()->insertIntoSet(ProductProvenance(phb->branchDescription().branchID(), std::move(parentage)));
+
+    productProvenanceRetrieverPtr()->insertIntoSet(
+        ProductProvenance(phb->branchDescription().branchID(), std::move(parentage)));
 
     assert(phb);
     // ProductResolver assumes ownership
     phb->putProduct(std::move(edp));
-
   }
 
-  void
-  EventPrincipal::putOnRead(
-        BranchDescription const& bd,
-        std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const* productProvenance) const {
-
+  void EventPrincipal::putOnRead(BranchDescription const& bd,
+                                 std::unique_ptr<WrapperBase> edp,
+                                 ProductProvenance const* productProvenance) const {
     assert(!bd.produced());
     if (productProvenance) {
       productProvenanceRetrieverPtr()->insertIntoSet(*productProvenance);
@@ -209,128 +184,112 @@ namespace edm {
     phb->putProduct(std::move(edp));
   }
 
-  BranchID
-  EventPrincipal::pidToBid(ProductID const& pid) const {
-    if(!pid.isValid()) {
-      throw Exception(errors::ProductNotFound, "InvalidID")
-        << "get by product ID: invalid ProductID supplied\n";
+  BranchID EventPrincipal::pidToBid(ProductID const& pid) const {
+    if (!pid.isValid()) {
+      throw Exception(errors::ProductNotFound, "InvalidID") << "get by product ID: invalid ProductID supplied\n";
     }
     return productIDToBranchID(pid, branchIDListHelper_->branchIDLists(), branchListIndexes_);
   }
 
-  ProductID
-  EventPrincipal::branchIDToProductID(BranchID const& bid) const {
-    if(!bid.isValid()) {
-      throw Exception(errors::NotFound, "InvalidID")
-        << "branchIDToProductID: invalid BranchID supplied\n";
+  ProductID EventPrincipal::branchIDToProductID(BranchID const& bid) const {
+    if (!bid.isValid()) {
+      throw Exception(errors::NotFound, "InvalidID") << "branchIDToProductID: invalid BranchID supplied\n";
     }
     typedef BranchIDListHelper::BranchIDToIndexMap BIDToIndexMap;
     typedef BIDToIndexMap::const_iterator Iter;
     typedef std::pair<Iter, Iter> IndexRange;
 
     IndexRange range = branchIDListHelper_->branchIDToIndexMap().equal_range(bid);
-    for(Iter it = range.first; it != range.second; ++it) {
+    for (Iter it = range.first; it != range.second; ++it) {
       BranchListIndex blix = it->second.first;
       std::map<BranchListIndex, ProcessIndex>::const_iterator i = branchListIndexToProcessIndex_.find(blix);
-      if(i != branchListIndexToProcessIndex_.end()) {
+      if (i != branchListIndexToProcessIndex_.end()) {
         ProductIndex productIndex = it->second.second;
         ProcessIndex processIndex = i->second;
-        return ProductID(processIndex+1, productIndex+1);
+        return ProductID(processIndex + 1, productIndex + 1);
       }
     }
     // cannot throw, because some products may legitimately not have product ID's (e.g. pile-up).
     return ProductID();
   }
 
-  unsigned int
-  EventPrincipal::transitionIndex_() const {
-    return streamID_.value();
+  unsigned int EventPrincipal::transitionIndex_() const { return streamID_.value(); }
+
+  static void throwProductDeletedException(ProductID const& pid,
+                                           edm::EventPrincipal::ConstProductResolverPtr const phb) {
+    ProductDeletedException exception;
+    exception << "get by product ID: The product with given id: " << pid << "\ntype: " << phb->productType()
+              << "\nproduct instance name: " << phb->productInstanceName() << "\nprocess name: " << phb->processName()
+              << "\nwas already deleted. This is a configuration error. Please change the configuration of the module "
+                 "which caused this exception to state it reads this data.";
+    throw exception;
   }
 
-  static void throwProductDeletedException(ProductID const& pid, edm::EventPrincipal::ConstProductResolverPtr const phb) {
-    ProductDeletedException exception;
-    exception<<"get by product ID: The product with given id: "<<pid
-    <<"\ntype: "<<phb->productType()
-    <<"\nproduct instance name: "<<phb->productInstanceName()
-    <<"\nprocess name: "<<phb->processName()
-    <<"\nwas already deleted. This is a configuration error. Please change the configuration of the module which caused this exception to state it reads this data.";
-    throw exception;    
-  }
-  
-  BasicHandle
-  EventPrincipal::getByProductID(ProductID const& pid) const {
+  BasicHandle EventPrincipal::getByProductID(ProductID const& pid) const {
     BranchID bid = pidToBid(pid);
     ConstProductResolverPtr const phb = getProductResolver(bid);
-    if(phb == nullptr) {
-      return BasicHandle(makeHandleExceptionFactory([pid]()->std::shared_ptr<cms::Exception> {
+    if (phb == nullptr) {
+      return BasicHandle(makeHandleExceptionFactory([pid]() -> std::shared_ptr<cms::Exception> {
         std::shared_ptr<cms::Exception> whyFailed(std::make_shared<Exception>(errors::ProductNotFound, "InvalidID"));
-        *whyFailed
-        << "get by product ID: no product with given id: " << pid << "\n";
+        *whyFailed << "get by product ID: no product with given id: " << pid << "\n";
         return whyFailed;
       }));
     }
 
     // Was this already deleted?
-    if(phb->productWasDeleted()) {
+    if (phb->productWasDeleted()) {
       throwProductDeletedException(pid, phb);
     }
     // Check for case where we tried on demand production and
     // it failed to produce the object
-    if(phb->unscheduledWasNotRun()) {
-      return BasicHandle(makeHandleExceptionFactory([pid]()->std::shared_ptr<cms::Exception> {
+    if (phb->unscheduledWasNotRun()) {
+      return BasicHandle(makeHandleExceptionFactory([pid]() -> std::shared_ptr<cms::Exception> {
         std::shared_ptr<cms::Exception> whyFailed(std::make_shared<Exception>(errors::ProductNotFound, "InvalidID"));
-        *whyFailed
-        << "get by ProductID: could not get product with id: " << pid << "\n"
-        << "Unscheduled execution not allowed to get via ProductID.\n";
+        *whyFailed << "get by ProductID: could not get product with id: " << pid << "\n"
+                   << "Unscheduled execution not allowed to get via ProductID.\n";
         return whyFailed;
       }));
     }
-    auto resolution = phb->resolveProduct(*this,false,nullptr,nullptr);
+    auto resolution = phb->resolveProduct(*this, false, nullptr, nullptr);
 
     auto data = resolution.data();
-    if(data) {
+    if (data) {
       return BasicHandle(data->wrapper(), &(data->provenance()));
     }
-    return BasicHandle(nullptr,nullptr);
+    return BasicHandle(nullptr, nullptr);
   }
 
-  WrapperBase const*
-  EventPrincipal::getIt(ProductID const& pid) const {
-    return getByProductID(pid).wrapper();
-  }
+  WrapperBase const* EventPrincipal::getIt(ProductID const& pid) const { return getByProductID(pid).wrapper(); }
 
-  WrapperBase const*
-  EventPrincipal::getThinnedProduct(ProductID const& pid, unsigned int& key) const {
-
+  WrapperBase const* EventPrincipal::getThinnedProduct(ProductID const& pid, unsigned int& key) const {
     BranchID parent = pidToBid(pid);
 
     // Loop over thinned containers which were made by selecting elements from the parent container
-    for(auto associatedBranches = thinnedAssociationsHelper_->parentBegin(parent),
-                           iEnd = thinnedAssociationsHelper_->parentEnd(parent);
-        associatedBranches != iEnd; ++associatedBranches) {
+    for (auto associatedBranches = thinnedAssociationsHelper_->parentBegin(parent),
+              iEnd = thinnedAssociationsHelper_->parentEnd(parent);
+         associatedBranches != iEnd; ++associatedBranches) {
+      ThinnedAssociation const* thinnedAssociation = getThinnedAssociation(associatedBranches->association());
+      if (thinnedAssociation == nullptr)
+        continue;
 
-      ThinnedAssociation const* thinnedAssociation =
-        getThinnedAssociation(associatedBranches->association());
-      if(thinnedAssociation == nullptr) continue;
-
-      if(associatedBranches->parent() != pidToBid(thinnedAssociation->parentCollectionID())) {
+      if (associatedBranches->parent() != pidToBid(thinnedAssociation->parentCollectionID())) {
         continue;
       }
 
       unsigned int thinnedIndex = 0;
       // Does this thinned container have the element referenced by key?
       // If yes, thinnedIndex is set to point to it in the thinned container
-      if(!thinnedAssociation->hasParentIndex(key, thinnedIndex)) {
+      if (!thinnedAssociation->hasParentIndex(key, thinnedIndex)) {
         continue;
       }
       // Get the thinned container and return a pointer if we can find it
       ProductID const& thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
       BasicHandle bhThinned = getByProductID(thinnedCollectionPID);
-      if(!bhThinned.isValid()) {
+      if (!bhThinned.isValid()) {
         // Thinned container is not found, try looking recursively in thinned containers
         // which were made by selecting elements from this thinned container.
         WrapperBase const* wrapperBase = getThinnedProduct(thinnedCollectionPID, thinnedIndex);
-        if(wrapperBase != nullptr) {
+        if (wrapperBase != nullptr) {
           key = thinnedIndex;
           return wrapperBase;
         } else {
@@ -343,23 +302,20 @@ namespace edm {
     return nullptr;
   }
 
-  void
-  EventPrincipal::getThinnedProducts(ProductID const& pid,
-                                     std::vector<WrapperBase const*>& foundContainers,
-                                     std::vector<unsigned int>& keys) const {
-
+  void EventPrincipal::getThinnedProducts(ProductID const& pid,
+                                          std::vector<WrapperBase const*>& foundContainers,
+                                          std::vector<unsigned int>& keys) const {
     BranchID parent = pidToBid(pid);
 
     // Loop over thinned containers which were made by selecting elements from the parent container
-    for(auto associatedBranches = thinnedAssociationsHelper_->parentBegin(parent),
-                           iEnd = thinnedAssociationsHelper_->parentEnd(parent);
-        associatedBranches != iEnd; ++associatedBranches) {
+    for (auto associatedBranches = thinnedAssociationsHelper_->parentBegin(parent),
+              iEnd = thinnedAssociationsHelper_->parentEnd(parent);
+         associatedBranches != iEnd; ++associatedBranches) {
+      ThinnedAssociation const* thinnedAssociation = getThinnedAssociation(associatedBranches->association());
+      if (thinnedAssociation == nullptr)
+        continue;
 
-      ThinnedAssociation const* thinnedAssociation =
-        getThinnedAssociation(associatedBranches->association());
-      if(thinnedAssociation == nullptr) continue;
-
-      if(associatedBranches->parent() != pidToBid(thinnedAssociation->parentCollectionID())) {
+      if (associatedBranches->parent() != pidToBid(thinnedAssociation->parentCollectionID())) {
         continue;
       }
 
@@ -367,37 +323,42 @@ namespace edm {
       unsigned int doNotLookForThisIndex = std::numeric_limits<unsigned int>::max();
       std::vector<unsigned int> thinnedIndexes(nKeys, doNotLookForThisIndex);
       bool hasAny = false;
-      for(unsigned k = 0; k < nKeys; ++k) {
+      for (unsigned k = 0; k < nKeys; ++k) {
         // Already found this one
-        if(foundContainers[k] != nullptr) continue;
+        if (foundContainers[k] != nullptr)
+          continue;
         // Already know this one is not in this thinned container
-        if(keys[k] == doNotLookForThisIndex) continue;
+        if (keys[k] == doNotLookForThisIndex)
+          continue;
         // Does the thinned container hold the entry of interest?
         // Modifies thinnedIndexes[k] only if it returns true and
         // sets it to the index in the thinned collection.
-        if(thinnedAssociation->hasParentIndex(keys[k], thinnedIndexes[k])) {
+        if (thinnedAssociation->hasParentIndex(keys[k], thinnedIndexes[k])) {
           hasAny = true;
         }
       }
-      if(!hasAny) {
+      if (!hasAny) {
         continue;
       }
       // Get the thinned container and set the pointers and indexes into
       // it (if we can find it)
       ProductID thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
       BasicHandle bhThinned = getByProductID(thinnedCollectionPID);
-      if(!bhThinned.isValid()) {
+      if (!bhThinned.isValid()) {
         // Thinned container is not found, try looking recursively in thinned containers
         // which were made by selecting elements from this thinned container.
         getThinnedProducts(thinnedCollectionPID, foundContainers, thinnedIndexes);
-        for(unsigned k = 0; k < nKeys; ++k) {
-          if(foundContainers[k] == nullptr) continue;
-          if(thinnedIndexes[k] == doNotLookForThisIndex) continue;
+        for (unsigned k = 0; k < nKeys; ++k) {
+          if (foundContainers[k] == nullptr)
+            continue;
+          if (thinnedIndexes[k] == doNotLookForThisIndex)
+            continue;
           keys[k] = thinnedIndexes[k];
         }
       } else {
-        for(unsigned k = 0; k < nKeys; ++k) {
-          if(thinnedIndexes[k] == doNotLookForThisIndex) continue;
+        for (unsigned k = 0; k < nKeys; ++k) {
+          if (thinnedIndexes[k] == doNotLookForThisIndex)
+            continue;
           keys[k] = thinnedIndexes[k];
           foundContainers[k] = bhThinned.wrapper();
         }
@@ -405,43 +366,34 @@ namespace edm {
     }
   }
 
-  Provenance
-  EventPrincipal::getProvenance(ProductID const& pid, ModuleCallingContext const* mcc) const {
+  Provenance EventPrincipal::getProvenance(ProductID const& pid, ModuleCallingContext const* mcc) const {
     BranchID bid = pidToBid(pid);
     return getProvenance(bid, mcc);
   }
 
-  EventSelectionIDVector const&
-  EventPrincipal::eventSelectionIDs() const {
-    return eventSelectionIDs_;
-  }
+  EventSelectionIDVector const& EventPrincipal::eventSelectionIDs() const { return eventSelectionIDs_; }
 
-  BranchListIndexes const&
-  EventPrincipal::branchListIndexes() const {
-    return branchListIndexes_;
-  }
+  BranchListIndexes const& EventPrincipal::branchListIndexes() const { return branchListIndexes_; }
 
-  edm::ThinnedAssociation const*
-  EventPrincipal::getThinnedAssociation(edm::BranchID const& branchID) const {
-
+  edm::ThinnedAssociation const* EventPrincipal::getThinnedAssociation(edm::BranchID const& branchID) const {
     ConstProductResolverPtr const phb = getProductResolver(branchID);
 
-    if(phb == nullptr) {
+    if (phb == nullptr) {
       throw Exception(errors::LogicError)
-        << "EventPrincipal::getThinnedAssociation, ThinnedAssociation ProductResolver cannot be found\n"
-        << "This should never happen. Contact a Framework developer";
+          << "EventPrincipal::getThinnedAssociation, ThinnedAssociation ProductResolver cannot be found\n"
+          << "This should never happen. Contact a Framework developer";
     }
-    ProductData const* productData = (phb->resolveProduct(*this,false,nullptr,nullptr)).data();
+    ProductData const* productData = (phb->resolveProduct(*this, false, nullptr, nullptr)).data();
     if (productData == nullptr) {
       return nullptr;
     }
     WrapperBase const* product = productData->wrapper();
-    if(!(typeid(edm::ThinnedAssociation) == product->dynamicTypeInfo())) {
+    if (!(typeid(edm::ThinnedAssociation) == product->dynamicTypeInfo())) {
       throw Exception(errors::LogicError)
-        << "EventPrincipal::getThinnedProduct, product has wrong type, not a ThinnedAssociation.\n";
+          << "EventPrincipal::getThinnedProduct, product has wrong type, not a ThinnedAssociation.\n";
     }
     Wrapper<ThinnedAssociation> const* wrapper = static_cast<Wrapper<ThinnedAssociation> const*>(product);
     return wrapper->product();
   }
 
-}
+}  // namespace edm

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -94,54 +94,48 @@ namespace {
   // calling completedSuccessfully().
   class SendSourceTerminationSignalIfException {
   public:
-    SendSourceTerminationSignalIfException(edm::ActivityRegistry* iReg):
-      reg_(iReg) {}
+    SendSourceTerminationSignalIfException(edm::ActivityRegistry* iReg) : reg_(iReg) {}
     ~SendSourceTerminationSignalIfException() {
-      if(reg_) {
+      if (reg_) {
         reg_->preSourceEarlyTerminationSignal_(edm::TerminationOrigin::ExceptionFromThisContext);
       }
     }
-    void completedSuccessfully() {
-      reg_ = nullptr;
-    }
+    void completedSuccessfully() { reg_ = nullptr; }
+
   private:
-    edm::ActivityRegistry* reg_; // We do not use propagate_const because the registry itself is mutable.
+    edm::ActivityRegistry* reg_;  // We do not use propagate_const because the registry itself is mutable.
   };
 
-}
+}  // namespace
 
 namespace edm {
 
   // ---------------------------------------------------------------
-  std::unique_ptr<InputSource>
-  makeInput(ParameterSet& params,
-            CommonParams const& common,
-            std::shared_ptr<ProductRegistry> preg,
-            std::shared_ptr<BranchIDListHelper> branchIDListHelper,
-            std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper,
-            std::shared_ptr<ActivityRegistry> areg,
-            std::shared_ptr<ProcessConfiguration const> processConfiguration,
-            PreallocationConfiguration const& allocations) {
+  std::unique_ptr<InputSource> makeInput(ParameterSet& params,
+                                         CommonParams const& common,
+                                         std::shared_ptr<ProductRegistry> preg,
+                                         std::shared_ptr<BranchIDListHelper> branchIDListHelper,
+                                         std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper,
+                                         std::shared_ptr<ActivityRegistry> areg,
+                                         std::shared_ptr<ProcessConfiguration const> processConfiguration,
+                                         PreallocationConfiguration const& allocations) {
     ParameterSet* main_input = params.getPSetForUpdate("@main_input");
-    if(main_input == nullptr) {
+    if (main_input == nullptr) {
       throw Exception(errors::Configuration)
-        << "There must be exactly one source in the configuration.\n"
-        << "It is missing (or there are sufficient syntax errors such that it is not recognized as the source)\n";
+          << "There must be exactly one source in the configuration.\n"
+          << "It is missing (or there are sufficient syntax errors such that it is not recognized as the source)\n";
     }
 
     std::string modtype(main_input->getParameter<std::string>("@module_type"));
 
     std::unique_ptr<ParameterSetDescriptionFillerBase> filler(
-                                                              ParameterSetDescriptionFillerPluginFactory::get()->create(modtype));
+        ParameterSetDescriptionFillerPluginFactory::get()->create(modtype));
     ConfigurationDescriptions descriptions(filler->baseType(), modtype);
     filler->fill(descriptions);
 
     try {
-      convertException::wrap([&]() {
-          descriptions.validate(*main_input, std::string("source"));
-        });
-    }
-    catch (cms::Exception & iException) {
+      convertException::wrap([&]() { descriptions.validate(*main_input, std::string("source")); });
+    } catch (cms::Exception& iException) {
       std::ostringstream ost;
       ost << "Validating configuration of input source of type " << modtype;
       iException.addContext(ost.str());
@@ -156,28 +150,23 @@ namespace edm {
     // There is no module label for the unnamed input source, so
     // just use "source".
     // Only the tracked parameters belong in the process configuration.
-    ModuleDescription md(main_input->id(),
-                         main_input->getParameter<std::string>("@module_type"),
-                         "source",
-                         processConfiguration.get(),
-                         ModuleDescription::getUniqueID());
+    ModuleDescription md(main_input->id(), main_input->getParameter<std::string>("@module_type"), "source",
+                         processConfiguration.get(), ModuleDescription::getUniqueID());
 
-    InputSourceDescription isdesc(md, preg, branchIDListHelper, thinnedAssociationsHelper, areg,
-                                  common.maxEventsInput_, common.maxLumisInput_,
-                                  common.maxSecondsUntilRampdown_, allocations);
+    InputSourceDescription isdesc(md, preg, branchIDListHelper, thinnedAssociationsHelper, areg, common.maxEventsInput_,
+                                  common.maxLumisInput_, common.maxSecondsUntilRampdown_, allocations);
 
     areg->preSourceConstructionSignal_(md);
     std::unique_ptr<InputSource> input;
     try {
       //even if we have an exception, send the signal
-      std::shared_ptr<int> sentry(nullptr,[areg,&md](void*){areg->postSourceConstructionSignal_(md);});
+      std::shared_ptr<int> sentry(nullptr, [areg, &md](void*) { areg->postSourceConstructionSignal_(md); });
       convertException::wrap([&]() {
-          input = std::unique_ptr<InputSource>(InputSourceFactory::get()->makeInputSource(*main_input, isdesc).release());
-          input->preEventReadFromSourceSignal_.connect(std::cref(areg->preEventReadFromSourceSignal_));
-          input->postEventReadFromSourceSignal_.connect(std::cref(areg->postEventReadFromSourceSignal_));
-        });
-    }
-    catch (cms::Exception& iException) {
+        input = std::unique_ptr<InputSource>(InputSourceFactory::get()->makeInputSource(*main_input, isdesc).release());
+        input->preEventReadFromSourceSignal_.connect(std::cref(areg->preEventReadFromSourceSignal_));
+        input->postEventReadFromSourceSignal_.connect(std::cref(areg->postEventReadFromSourceSignal_));
+      });
+    } catch (cms::Exception& iException) {
       std::ostringstream ost;
       ost << "Constructing input source of type " << modtype;
       iException.addContext(ost.str());
@@ -187,105 +176,99 @@ namespace edm {
   }
 
   // ---------------------------------------------------------------
-  std::shared_ptr<EDLooperBase>
-  fillLooper(eventsetup::EventSetupsController& esController,
-             eventsetup::EventSetupProvider& cp,
-             ParameterSet& params) {
+  std::shared_ptr<EDLooperBase> fillLooper(eventsetup::EventSetupsController& esController,
+                                           eventsetup::EventSetupProvider& cp,
+                                           ParameterSet& params) {
     std::shared_ptr<EDLooperBase> vLooper;
 
     std::vector<std::string> loopers = params.getParameter<std::vector<std::string> >("@all_loopers");
 
-    if(loopers.empty()) {
+    if (loopers.empty()) {
       return vLooper;
     }
 
     assert(1 == loopers.size());
 
-    for(std::vector<std::string>::iterator itName = loopers.begin(), itNameEnd = loopers.end();
-        itName != itNameEnd;
-        ++itName) {
-
+    for (std::vector<std::string>::iterator itName = loopers.begin(), itNameEnd = loopers.end(); itName != itNameEnd;
+         ++itName) {
       ParameterSet* providerPSet = params.getPSetForUpdate(*itName);
       providerPSet->registerIt();
-      vLooper = eventsetup::LooperFactory::get()->addTo(esController,
-                                                        cp,
-                                                        *providerPSet);
+      vLooper = eventsetup::LooperFactory::get()->addTo(esController, cp, *providerPSet);
     }
     return vLooper;
   }
 
   // ---------------------------------------------------------------
-  EventProcessor::EventProcessor(std::unique_ptr<ParameterSet> parameterSet,//std::string const& config,
+  EventProcessor::EventProcessor(std::unique_ptr<ParameterSet> parameterSet,  //std::string const& config,
                                  ServiceToken const& iToken,
                                  serviceregistry::ServiceLegacy iLegacy,
                                  std::vector<std::string> const& defaultServices,
-                                 std::vector<std::string> const& forcedServices) :
-    actReg_(),
-    preg_(),
-    branchIDListHelper_(),
-    serviceToken_(),
-    input_(),
-    espController_(new eventsetup::EventSetupsController),
-    esp_(),
-    act_table_(),
-    processConfiguration_(),
-    schedule_(),
-    subProcesses_(),
-    historyAppender_(new HistoryAppender),
-    fb_(),
-    looper_(),
-    deferredExceptionPtrIsSet_(false),
-    sourceResourcesAcquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first),
-    sourceMutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
-    principalCache_(),
-    beginJobCalled_(false),
-    shouldWeStop_(false),
-    fileModeNoMerge_(false),
-    exceptionMessageFiles_(),
-    exceptionMessageRuns_(),
-    exceptionMessageLumis_(),
-    forceLooperToEnd_(false),
-    looperBeginJobRun_(false),
-    forceESCacheClearOnNewRun_(false),
-    eventSetupDataToExcludeFromPrefetching_() {
+                                 std::vector<std::string> const& forcedServices)
+      : actReg_(),
+        preg_(),
+        branchIDListHelper_(),
+        serviceToken_(),
+        input_(),
+        espController_(new eventsetup::EventSetupsController),
+        esp_(),
+        act_table_(),
+        processConfiguration_(),
+        schedule_(),
+        subProcesses_(),
+        historyAppender_(new HistoryAppender),
+        fb_(),
+        looper_(),
+        deferredExceptionPtrIsSet_(false),
+        sourceResourcesAcquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first),
+        sourceMutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
+        principalCache_(),
+        beginJobCalled_(false),
+        shouldWeStop_(false),
+        fileModeNoMerge_(false),
+        exceptionMessageFiles_(),
+        exceptionMessageRuns_(),
+        exceptionMessageLumis_(),
+        forceLooperToEnd_(false),
+        looperBeginJobRun_(false),
+        forceESCacheClearOnNewRun_(false),
+        eventSetupDataToExcludeFromPrefetching_() {
     auto processDesc = std::make_shared<ProcessDesc>(std::move(parameterSet));
     processDesc->addServices(defaultServices, forcedServices);
     init(processDesc, iToken, iLegacy);
   }
 
-  EventProcessor::EventProcessor(std::unique_ptr<ParameterSet> parameterSet,//std::string const& config,
+  EventProcessor::EventProcessor(std::unique_ptr<ParameterSet> parameterSet,  //std::string const& config,
                                  std::vector<std::string> const& defaultServices,
-                                 std::vector<std::string> const& forcedServices) :
-    actReg_(),
-    preg_(),
-    branchIDListHelper_(),
-    serviceToken_(),
-    input_(),
-    espController_(new eventsetup::EventSetupsController),
-    esp_(),
-    act_table_(),
-    processConfiguration_(),
-    schedule_(),
-    subProcesses_(),
-    historyAppender_(new HistoryAppender),
-    fb_(),
-    looper_(),
-    deferredExceptionPtrIsSet_(false),
-    sourceResourcesAcquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first),
-    sourceMutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
-    principalCache_(),
-    beginJobCalled_(false),
-    shouldWeStop_(false),
-    fileModeNoMerge_(false),
-    exceptionMessageFiles_(),
-    exceptionMessageRuns_(),
-    exceptionMessageLumis_(),
-    forceLooperToEnd_(false),
-    looperBeginJobRun_(false),
-    forceESCacheClearOnNewRun_(false),
-    asyncStopRequestedWhileProcessingEvents_(false),
-    eventSetupDataToExcludeFromPrefetching_()
-  {
+                                 std::vector<std::string> const& forcedServices)
+      : actReg_(),
+        preg_(),
+        branchIDListHelper_(),
+        serviceToken_(),
+        input_(),
+        espController_(new eventsetup::EventSetupsController),
+        esp_(),
+        act_table_(),
+        processConfiguration_(),
+        schedule_(),
+        subProcesses_(),
+        historyAppender_(new HistoryAppender),
+        fb_(),
+        looper_(),
+        deferredExceptionPtrIsSet_(false),
+        sourceResourcesAcquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first),
+        sourceMutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
+        principalCache_(),
+        beginJobCalled_(false),
+        shouldWeStop_(false),
+        fileModeNoMerge_(false),
+        exceptionMessageFiles_(),
+        exceptionMessageRuns_(),
+        exceptionMessageLumis_(),
+        forceLooperToEnd_(false),
+        looperBeginJobRun_(false),
+        forceESCacheClearOnNewRun_(false),
+        asyncStopRequestedWhileProcessingEvents_(false),
+        eventSetupDataToExcludeFromPrefetching_() {
     auto processDesc = std::make_shared<ProcessDesc>(std::move(parameterSet));
     processDesc->addServices(defaultServices, forcedServices);
     init(processDesc, ServiceToken(), serviceregistry::kOverlapIsError);
@@ -293,45 +276,42 @@ namespace edm {
 
   EventProcessor::EventProcessor(std::shared_ptr<ProcessDesc> processDesc,
                                  ServiceToken const& token,
-                                 serviceregistry::ServiceLegacy legacy) :
-    actReg_(),
-    preg_(),
-    branchIDListHelper_(),
-    serviceToken_(),
-    input_(),
-    espController_(new eventsetup::EventSetupsController),
-    esp_(),
-    act_table_(),
-    processConfiguration_(),
-    schedule_(),
-    subProcesses_(),
-    historyAppender_(new HistoryAppender),
-    fb_(),
-    looper_(),
-    deferredExceptionPtrIsSet_(false),
-    sourceResourcesAcquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first),
-    sourceMutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
-    principalCache_(),
-    beginJobCalled_(false),
-    shouldWeStop_(false),
-    fileModeNoMerge_(false),
-    exceptionMessageFiles_(),
-    exceptionMessageRuns_(),
-    exceptionMessageLumis_(),
-    forceLooperToEnd_(false),
-    looperBeginJobRun_(false),
-    forceESCacheClearOnNewRun_(false),
-    asyncStopRequestedWhileProcessingEvents_(false),
-    eventSetupDataToExcludeFromPrefetching_()
-  {
+                                 serviceregistry::ServiceLegacy legacy)
+      : actReg_(),
+        preg_(),
+        branchIDListHelper_(),
+        serviceToken_(),
+        input_(),
+        espController_(new eventsetup::EventSetupsController),
+        esp_(),
+        act_table_(),
+        processConfiguration_(),
+        schedule_(),
+        subProcesses_(),
+        historyAppender_(new HistoryAppender),
+        fb_(),
+        looper_(),
+        deferredExceptionPtrIsSet_(false),
+        sourceResourcesAcquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first),
+        sourceMutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
+        principalCache_(),
+        beginJobCalled_(false),
+        shouldWeStop_(false),
+        fileModeNoMerge_(false),
+        exceptionMessageFiles_(),
+        exceptionMessageRuns_(),
+        exceptionMessageLumis_(),
+        forceLooperToEnd_(false),
+        looperBeginJobRun_(false),
+        forceESCacheClearOnNewRun_(false),
+        asyncStopRequestedWhileProcessingEvents_(false),
+        eventSetupDataToExcludeFromPrefetching_() {
     init(processDesc, token, legacy);
   }
 
-  void
-  EventProcessor::init(std::shared_ptr<ProcessDesc>& processDesc,
-                       ServiceToken const& iToken,
-                       serviceregistry::ServiceLegacy iLegacy) {
-
+  void EventProcessor::init(std::shared_ptr<ProcessDesc>& processDesc,
+                            ServiceToken const& iToken,
+                            serviceregistry::ServiceLegacy iLegacy) {
     //std::cerr << processDesc->dump() << std::endl;
 
     // register the empty parentage vector , once and for all
@@ -355,9 +335,9 @@ namespace edm {
     ParameterSet const& optionsPset(parameterSet->getUntrackedParameterSet("options"));
     auto const& fileMode = optionsPset.getUntrackedParameter<std::string>("fileMode");
     if (fileMode != "NOMERGE" and fileMode != "FULLMERGE") {
-        throw Exception(errors::Configuration, "Illegal fileMode parameter value: ")
-        << fileMode << ".\n"
-        << "Legal values are 'NOMERGE' and 'FULLMERGE'.\n";
+      throw Exception(errors::Configuration, "Illegal fileMode parameter value: ")
+          << fileMode << ".\n"
+          << "Legal values are 'NOMERGE' and 'FULLMERGE'.\n";
     } else {
       fileModeNoMerge_ = (fileMode == "NOMERGE");
     }
@@ -375,14 +355,15 @@ namespace edm {
       nStreams = nThreads;
     }
     if (nThreads > 1 or nStreams > 1) {
-      edm::LogInfo("ThreadStreamSetup") <<"setting # threads "<<nThreads<<"\nsetting # streams "<<nStreams;
+      edm::LogInfo("ThreadStreamSetup") << "setting # threads " << nThreads << "\nsetting # streams " << nStreams;
     }
     unsigned int nConcurrentRuns = optionsPset.getUntrackedParameter<unsigned int>("numberOfConcurrentRuns");
     if (nConcurrentRuns != 1) {
       throw Exception(errors::Configuration, "Illegal value nConcurrentRuns : ")
-        << "Although the plan is to change this in the future, currently nConcurrentRuns must always be 1.\n";
+          << "Although the plan is to change this in the future, currently nConcurrentRuns must always be 1.\n";
     }
-    unsigned int nConcurrentLumis = optionsPset.getUntrackedParameter<unsigned int>("numberOfConcurrentLuminosityBlocks");
+    unsigned int nConcurrentLumis =
+        optionsPset.getUntrackedParameter<unsigned int>("numberOfConcurrentLuminosityBlocks");
     if (nConcurrentLumis == 0) {
       nConcurrentLumis = nConcurrentRuns;
     }
@@ -401,7 +382,7 @@ namespace edm {
     */
     IllegalParameters::setThrowAnException(optionsPset.getUntrackedParameter<bool>("throwIfIllegalParameter"));
 
-    printDependencies_ =  optionsPset.getUntrackedParameter<bool>("printDependencies");
+    printDependencies_ = optionsPset.getUntrackedParameter<bool>("printDependencies");
 
     // Now do general initialization
     ScheduleItems items;
@@ -414,7 +395,7 @@ namespace edm {
     //make the services available
     ServiceRegistry::Operate operate(serviceToken_);
 
-    if(nStreams>1) {
+    if (nStreams > 1) {
       edm::Service<RootHandlers> handler;
       handler->willBeUsingThreads();
     }
@@ -427,34 +408,28 @@ namespace edm {
 
     // initialize the looper, if any
     looper_ = fillLooper(*espController_, *esp_, *parameterSet);
-    if(looper_) {
+    if (looper_) {
       looper_->setActionTable(items.act_table_.get());
       looper_->attachTo(*items.actReg_);
 
       //For now loopers make us run only 1 transition at a time
-      nStreams=1;
-      nConcurrentLumis=1;
-      nConcurrentRuns=1;
+      nStreams = 1;
+      nConcurrentLumis = 1;
+      nConcurrentRuns = 1;
     }
 
-    preallocations_ = PreallocationConfiguration{nThreads,nStreams,nConcurrentLumis,nConcurrentRuns};
+    preallocations_ = PreallocationConfiguration{nThreads, nStreams, nConcurrentLumis, nConcurrentRuns};
 
     lumiQueue_ = std::make_unique<LimitedTaskQueue>(nConcurrentLumis);
     streamQueues_.resize(nStreams);
     streamLumiStatus_.resize(nStreams);
-    
+
     // initialize the input source
-    input_ = makeInput(*parameterSet,
-                       *common,
-                       items.preg(),
-                       items.branchIDListHelper(),
-                       items.thinnedAssociationsHelper(),
-                       items.actReg_,
-                       items.processConfiguration(),
-                       preallocations_);
+    input_ = makeInput(*parameterSet, *common, items.preg(), items.branchIDListHelper(),
+                       items.thinnedAssociationsHelper(), items.actReg_, items.processConfiguration(), preallocations_);
 
     // intialize the Schedule
-    schedule_ = items.initSchedule(*parameterSet,hasSubProcesses,preallocations_,&processContext_);
+    schedule_ = items.initSchedule(*parameterSet, hasSubProcesses, preallocations_, &processContext_);
 
     // set the data members
     act_table_ = std::move(items.act_table_);
@@ -470,34 +445,25 @@ namespace edm {
     FDEBUG(2) << parameterSet << std::endl;
 
     principalCache_.setNumberOfConcurrentPrincipals(preallocations_);
-    for(unsigned int index = 0; index<preallocations_.numberOfStreams(); ++index ) {
+    for (unsigned int index = 0; index < preallocations_.numberOfStreams(); ++index) {
       // Reusable event principal
-      auto ep = std::make_shared<EventPrincipal>(preg(), branchIDListHelper(),
-                                                 thinnedAssociationsHelper(), *processConfiguration_, historyAppender_.get(), index);
+      auto ep = std::make_shared<EventPrincipal>(preg(), branchIDListHelper(), thinnedAssociationsHelper(),
+                                                 *processConfiguration_, historyAppender_.get(), index);
       principalCache_.insert(std::move(ep));
     }
-    
-    for(unsigned int index =0; index < preallocations_.numberOfLuminosityBlocks(); ++index) {
-      auto lp = std::make_unique<LuminosityBlockPrincipal>(preg(), *processConfiguration_,
-                                                           historyAppender_.get(), index);
+
+    for (unsigned int index = 0; index < preallocations_.numberOfLuminosityBlocks(); ++index) {
+      auto lp =
+          std::make_unique<LuminosityBlockPrincipal>(preg(), *processConfiguration_, historyAppender_.get(), index);
       principalCache_.insert(std::move(lp));
     }
 
     // fill the subprocesses, if there are any
     subProcesses_.reserve(subProcessVParameterSet.size());
-    for(auto& subProcessPSet : subProcessVParameterSet) {
-      subProcesses_.emplace_back(subProcessPSet,
-                                 *parameterSet,
-                                 preg(),
-                                 branchIDListHelper(),
-                                 *thinnedAssociationsHelper_,
-                                 SubProcessParentageHelper(),
-                                 *espController_,
-                                 *actReg_,
-                                 token,
-                                 serviceregistry::kConfigurationOverrides,
-                                 preallocations_,
-                                 &processContext_);
+    for (auto& subProcessPSet : subProcessVParameterSet) {
+      subProcesses_.emplace_back(subProcessPSet, *parameterSet, preg(), branchIDListHelper(),
+                                 *thinnedAssociationsHelper_, SubProcessParentageHelper(), *espController_, *actReg_,
+                                 token, serviceregistry::kConfigurationOverrides, preallocations_, &processContext_);
     }
   }
 
@@ -519,20 +485,18 @@ namespace edm {
     ParentageRegistry::instance()->clear();
   }
 
-  void
-  EventProcessor::beginJob() {
-    if(beginJobCalled_) return;
-    beginJobCalled_=true;
+  void EventProcessor::beginJob() {
+    if (beginJobCalled_)
+      return;
+    beginJobCalled_ = true;
     bk::beginJob();
 
     // StateSentry toerror(this); // should we add this ?
     //make the services available
     ServiceRegistry::Operate operate(serviceToken_);
 
-    service::SystemBounds bounds(preallocations_.numberOfStreams(),
-                                 preallocations_.numberOfLuminosityBlocks(),
-                                 preallocations_.numberOfRuns(),
-                                 preallocations_.numberOfThreads());
+    service::SystemBounds bounds(preallocations_.numberOfStreams(), preallocations_.numberOfLuminosityBlocks(),
+                                 preallocations_.numberOfRuns(), preallocations_.numberOfThreads());
     actReg_->preallocateSignal_(bounds);
     schedule_->convertCurrentProcessAlias(processConfiguration_->processName());
     pathsAndConsumesOfModules_.initialize(schedule_.get(), preg());
@@ -541,7 +505,7 @@ namespace edm {
     checkForModuleDependencyCorrectness(pathsAndConsumesOfModules_, printDependencies_);
     actReg_->preBeginJobSignal_(pathsAndConsumesOfModules_, processContext_);
 
-    if(preallocations_.numberOfLuminosityBlocks() > 1) {
+    if (preallocations_.numberOfLuminosityBlocks() > 1) {
       warnAboutModulesRequiringLuminosityBLockSynchronization();
     }
     //NOTE:  This implementation assumes 'Job' means one call
@@ -559,137 +523,107 @@ namespace edm {
     //   looper_->beginOfJob(es);
     //}
     try {
-      convertException::wrap([&]() {
-          input_->doBeginJob();
-        });
-    }
-    catch(cms::Exception& ex) {
+      convertException::wrap([&]() { input_->doBeginJob(); });
+    } catch (cms::Exception& ex) {
       ex.addContext("Calling beginJob for the source");
       throw;
     }
     schedule_->beginJob(*preg_);
     // toerror.succeeded(); // should we add this?
-    for_all(subProcesses_, [](auto& subProcess){ subProcess.doBeginJob(); });
+    for_all(subProcesses_, [](auto& subProcess) { subProcess.doBeginJob(); });
     actReg_->postBeginJobSignal_();
 
-    for(unsigned int i=0; i<preallocations_.numberOfStreams();++i) {
+    for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
       schedule_->beginStream(i);
-      for_all(subProcesses_, [i](auto& subProcess){ subProcess.doBeginStream(i); });
+      for_all(subProcesses_, [i](auto& subProcess) { subProcess.doBeginStream(i); });
     }
   }
 
-  void
-  EventProcessor::endJob() {
+  void EventProcessor::endJob() {
     // Collects exceptions, so we don't throw before all operations are performed.
-    ExceptionCollector c("Multiple exceptions were thrown while executing endJob. An exception message follows for each.\n");
+    ExceptionCollector c(
+        "Multiple exceptions were thrown while executing endJob. An exception message follows for each.\n");
 
     //make the services available
     ServiceRegistry::Operate operate(serviceToken_);
 
     //NOTE: this really should go elsewhere in the future
-    for(unsigned int i=0; i<preallocations_.numberOfStreams();++i) {
-      c.call([this,i](){this->schedule_->endStream(i);});
-      for(auto& subProcess : subProcesses_) {
-        c.call([&subProcess,i](){ subProcess.doEndStream(i); } );
+    for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
+      c.call([this, i]() { this->schedule_->endStream(i); });
+      for (auto& subProcess : subProcesses_) {
+        c.call([&subProcess, i]() { subProcess.doEndStream(i); });
       }
     }
     auto actReg = actReg_.get();
-    c.call([actReg](){actReg->preEndJobSignal_();});
+    c.call([actReg]() { actReg->preEndJobSignal_(); });
     schedule_->endJob(c);
-    for(auto& subProcess : subProcesses_) {
+    for (auto& subProcess : subProcesses_) {
       c.call(std::bind(&SubProcess::doEndJob, &subProcess));
     }
     c.call(std::bind(&InputSource::doEndJob, input_.get()));
-    if(looper_) {
+    if (looper_) {
       c.call(std::bind(&EDLooperBase::endOfJob, looper()));
     }
-    c.call([actReg](){actReg->postEndJobSignal_();});
-    if(c.hasThrown()) {
+    c.call([actReg]() { actReg->postEndJobSignal_(); });
+    if (c.hasThrown()) {
       c.rethrow();
     }
   }
 
-  ServiceToken
-  EventProcessor::getToken() {
-    return serviceToken_;
-  }
+  ServiceToken EventProcessor::getToken() { return serviceToken_; }
 
-  std::vector<ModuleDescription const*>
-  EventProcessor::getAllModuleDescriptions() const {
+  std::vector<ModuleDescription const*> EventProcessor::getAllModuleDescriptions() const {
     return schedule_->getAllModuleDescriptions();
   }
 
-  int
-  EventProcessor::totalEvents() const {
-    return schedule_->totalEvents();
-  }
+  int EventProcessor::totalEvents() const { return schedule_->totalEvents(); }
 
-  int
-  EventProcessor::totalEventsPassed() const {
-    return schedule_->totalEventsPassed();
-  }
+  int EventProcessor::totalEventsPassed() const { return schedule_->totalEventsPassed(); }
 
-  int
-  EventProcessor::totalEventsFailed() const {
-    return schedule_->totalEventsFailed();
-  }
+  int EventProcessor::totalEventsFailed() const { return schedule_->totalEventsFailed(); }
 
-  void
-  EventProcessor::enableEndPaths(bool active) {
-    schedule_->enableEndPaths(active);
-  }
+  void EventProcessor::enableEndPaths(bool active) { schedule_->enableEndPaths(active); }
 
-  bool
-  EventProcessor::endPathsEnabled() const {
-    return schedule_->endPathsEnabled();
-  }
+  bool EventProcessor::endPathsEnabled() const { return schedule_->endPathsEnabled(); }
 
-  void
-  EventProcessor::getTriggerReport(TriggerReport& rep) const {
-    schedule_->getTriggerReport(rep);
-  }
+  void EventProcessor::getTriggerReport(TriggerReport& rep) const { schedule_->getTriggerReport(rep); }
 
-  void
-  EventProcessor::clearCounters() {
-    schedule_->clearCounters();
-  }
+  void EventProcessor::clearCounters() { schedule_->clearCounters(); }
 
   namespace {
 #include "TransitionProcessors.icc"
   }
 
-  bool
-  EventProcessor::checkForAsyncStopRequest(StatusCode& returnCode) {
+  bool EventProcessor::checkForAsyncStopRequest(StatusCode& returnCode) {
     bool returnValue = false;
 
     // Look for a shutdown signal
-    if(shutdown_flag.load(std::memory_order_acquire)) {
+    if (shutdown_flag.load(std::memory_order_acquire)) {
       returnValue = true;
       returnCode = epSignal;
     }
     return returnValue;
   }
 
-  InputSource::ItemType
-  EventProcessor::nextTransitionType() {
+  InputSource::ItemType EventProcessor::nextTransitionType() {
     if (deferredExceptionPtrIsSet_.load()) {
       lastSourceTransition_ = InputSource::IsStop;
       return InputSource::IsStop;
     }
-    
+
     SendSourceTerminationSignalIfException sentry(actReg_.get());
     InputSource::ItemType itemType;
     //For now, do nothing with InputSource::IsSynchronize
     do {
       itemType = input_->nextItemType();
-    } while( itemType == InputSource::IsSynchronize);
-    
+    } while (itemType == InputSource::IsSynchronize);
+
     lastSourceTransition_ = itemType;
     sentry.completedSuccessfully();
-    
-    StatusCode returnCode=epSuccess;
-    
-    if(checkForAsyncStopRequest(returnCode)) {
+
+    StatusCode returnCode = epSuccess;
+
+    if (checkForAsyncStopRequest(returnCode)) {
       actReg_->preSourceEarlyTerminationSignal_(TerminationOrigin::ExternalSignal);
       lastSourceTransition_ = InputSource::IsStop;
     }
@@ -697,63 +631,54 @@ namespace edm {
     return lastSourceTransition_;
   }
 
-  std::pair<edm::ProcessHistoryID, edm::RunNumber_t>
-  EventProcessor::nextRunID() {
+  std::pair<edm::ProcessHistoryID, edm::RunNumber_t> EventProcessor::nextRunID() {
     return std::make_pair(input_->reducedProcessHistoryID(), input_->run());
   }
-  
-  edm::LuminosityBlockNumber_t
-  EventProcessor::nextLuminosityBlockID() {
-    return input_->luminosityBlock();
-  }
 
-  EventProcessor::StatusCode
-  EventProcessor::runToCompletion() {
-    
-    StatusCode returnCode=epSuccess;
-    asyncStopStatusCodeFromProcessingEvents_=epSuccess;
+  edm::LuminosityBlockNumber_t EventProcessor::nextLuminosityBlockID() { return input_->luminosityBlock(); }
+
+  EventProcessor::StatusCode EventProcessor::runToCompletion() {
+    StatusCode returnCode = epSuccess;
+    asyncStopStatusCodeFromProcessingEvents_ = epSuccess;
     {
-      beginJob(); //make sure this was called
-      
+      beginJob();  //make sure this was called
+
       // make the services available
       ServiceRegistry::Operate operate(serviceToken_);
 
-      asyncStopRequestedWhileProcessingEvents_=false;
+      asyncStopRequestedWhileProcessingEvents_ = false;
       try {
         FilesProcessor fp(fileModeNoMerge_);
 
         convertException::wrap([&]() {
           bool firstTime = true;
           do {
-            if(not firstTime) {
+            if (not firstTime) {
               prepareForNextLoop();
               rewindInput();
             } else {
               firstTime = false;
             }
             startingNewLoop();
-            
+
             auto trans = fp.processFiles(*this);
-            
+
             fp.normalEnd();
-            
-            if(deferredExceptionPtrIsSet_.load()) {
+
+            if (deferredExceptionPtrIsSet_.load()) {
               std::rethrow_exception(deferredExceptionPtr_);
             }
-            if(trans != InputSource::IsStop) {
+            if (trans != InputSource::IsStop) {
               //problem with the source
               doErrorStuff();
-              
-              throw cms::Exception("BadTransition")
-              << "Unexpected transition change "
-              << trans;
 
+              throw cms::Exception("BadTransition") << "Unexpected transition change " << trans;
             }
-          } while(not endOfLoop());
-        }); // convertException::wrap
-        
-      } // Try block
-      catch (cms::Exception & e) {
+          } while (not endOfLoop());
+        });  // convertException::wrap
+
+      }  // Try block
+      catch (cms::Exception& e) {
         if (!exceptionMessageLumis_.empty()) {
           e.addAdditionalInfo(exceptionMessageLumis_);
           if (e.alreadyPrinted()) {
@@ -775,7 +700,7 @@ namespace edm {
         throw;
       }
     }
-    
+
     return returnCode;
   }
 
@@ -787,12 +712,11 @@ namespace edm {
     principalCache_.preReadFile();
 
     fb_ = input_->readFile();
-    if(size < preg_->size()) {
+    if (size < preg_->size()) {
       principalCache_.adjustIndexesAfterProductRegistryAddition();
     }
     principalCache_.adjustEventsToNewProductRegistry(preg());
-    if(preallocations_.numberOfStreams()>1 and
-        preallocations_.numberOfThreads()>1) {
+    if (preallocations_.numberOfStreams() > 1 and preallocations_.numberOfThreads() > 1) {
       fb_->setNotFastClonable(FileBlock::ParallelProcesses);
     }
     sentry.completedSuccessfully();
@@ -810,7 +734,7 @@ namespace edm {
   void EventProcessor::openOutputFiles() {
     if (fb_.get() != nullptr) {
       schedule_->openOutputFiles(*fb_);
-      for_all(subProcesses_, [this](auto& subProcess){ subProcess.openOutputFiles(*fb_); });
+      for_all(subProcesses_, [this](auto& subProcess) { subProcess.openOutputFiles(*fb_); });
     }
     FDEBUG(1) << "\topenOutputFiles\n";
   }
@@ -818,13 +742,14 @@ namespace edm {
   void EventProcessor::closeOutputFiles() {
     if (fb_.get() != nullptr) {
       schedule_->closeOutputFiles();
-      for_all(subProcesses_, [](auto& subProcess){ subProcess.closeOutputFiles(); });
+      for_all(subProcesses_, [](auto& subProcess) { subProcess.closeOutputFiles(); });
     }
     FDEBUG(1) << "\tcloseOutputFiles\n";
   }
 
   void EventProcessor::respondToOpenInputFile() {
-    for_all(subProcesses_, [this](auto& subProcess){ subProcess.updateBranchIDListHelper(branchIDListHelper_->branchIDLists()); } );
+    for_all(subProcesses_,
+            [this](auto& subProcess) { subProcess.updateBranchIDListHelper(branchIDListHelper_->branchIDLists()); });
     if (fb_.get() != nullptr) {
       schedule_->respondToOpenInputFile(*fb_);
       for_all(subProcesses_, [this](auto& subProcess) { subProcess.respondToOpenInputFile(*fb_); });
@@ -835,7 +760,7 @@ namespace edm {
   void EventProcessor::respondToCloseInputFile() {
     if (fb_.get() != nullptr) {
       schedule_->respondToCloseInputFile(*fb_);
-      for_all(subProcesses_, [this](auto& subProcess){ subProcess.respondToCloseInputFile(*fb_); });
+      for_all(subProcesses_, [this](auto& subProcess) { subProcess.respondToCloseInputFile(*fb_); });
     }
     FDEBUG(1) << "\trespondToCloseInputFile\n";
   }
@@ -844,20 +769,22 @@ namespace edm {
     shouldWeStop_ = false;
     //NOTE: for first loop, need to delay calling 'doStartingNewLoop'
     // until after we've called beginOfJob
-    if(looper_ && looperBeginJobRun_) {
+    if (looper_ && looperBeginJobRun_) {
       looper_->doStartingNewLoop();
     }
     FDEBUG(1) << "\tstartingNewLoop\n";
   }
 
   bool EventProcessor::endOfLoop() {
-    if(looper_) {
-      ModuleChanger changer(schedule_.get(),preg_.get());
+    if (looper_) {
+      ModuleChanger changer(schedule_.get(), preg_.get());
       looper_->setModuleChanger(&changer);
       EDLooperBase::Status status = looper_->doEndOfLoop(esp_->eventSetup());
       looper_->setModuleChanger(nullptr);
-      if(status != EDLooperBase::kContinue || forceLooperToEnd_) return true;
-      else return false;
+      if (status != EDLooperBase::kContinue || forceLooperToEnd_)
+        return true;
+      else
+        return false;
     }
     FDEBUG(1) << "\tendOfLoop\n";
     return true;
@@ -876,9 +803,9 @@ namespace edm {
 
   bool EventProcessor::shouldWeCloseOutput() const {
     FDEBUG(1) << "\tshouldWeCloseOutput\n";
-    if(!subProcesses_.empty()) {
-      for(auto const& subProcess : subProcesses_) {
-        if(subProcess.shouldWeCloseOutput()) {
+    if (!subProcesses_.empty()) {
+      for (auto const& subProcess : subProcesses_) {
+        if (subProcess.shouldWeCloseOutput()) {
           return true;
         }
       }
@@ -889,15 +816,16 @@ namespace edm {
 
   void EventProcessor::doErrorStuff() {
     FDEBUG(1) << "\tdoErrorStuff\n";
-    LogError("StateMachine")
-      << "The EventProcessor state machine encountered an unexpected event\n"
-      << "and went to the error state\n"
-      << "Will attempt to terminate processing normally\n"
-      << "(IF using the looper the next loop will be attempted)\n"
-      << "This likely indicates a bug in an input module or corrupted input or both\n";
+    LogError("StateMachine") << "The EventProcessor state machine encountered an unexpected event\n"
+                             << "and went to the error state\n"
+                             << "Will attempt to terminate processing normally\n"
+                             << "(IF using the looper the next loop will be attempted)\n"
+                             << "This likely indicates a bug in an input module or corrupted input or both\n";
   }
-  
-  void EventProcessor::beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalBeginSucceeded,
+
+  void EventProcessor::beginRun(ProcessHistoryID const& phid,
+                                RunNumber_t run,
+                                bool& globalBeginSucceeded,
                                 bool& eventSetupForInstanceSucceeded) {
     globalBeginSucceeded = false;
     RunPrincipal& runPrincipal = principalCache_.runPrincipal(phid, run);
@@ -908,9 +836,8 @@ namespace edm {
       sentry.completedSuccessfully();
     }
 
-    IOVSyncValue ts(EventID(runPrincipal.run(), 0, 0),
-                    runPrincipal.beginTime());
-    if(forceESCacheClearOnNewRun_){
+    IOVSyncValue ts(EventID(runPrincipal.run(), 0, 0), runPrincipal.beginTime());
+    if (forceESCacheClearOnNewRun_) {
       espController_->forceCacheClear();
     }
     {
@@ -920,7 +847,7 @@ namespace edm {
       sentry.completedSuccessfully();
     }
     auto const& es = esp_->eventSetup();
-    if(looper_ && looperBeginJobRun_== false) {
+    if (looper_ && looperBeginJobRun_ == false) {
       looper_->copyInfo(ScheduleInfo(schedule_.get()));
       looper_->beginOfJob(es);
       looperBeginJobRun_ = true;
@@ -930,58 +857,49 @@ namespace edm {
       typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> Traits;
       auto globalWaitTask = make_empty_waiting_task();
       globalWaitTask->increment_ref_count();
-      beginGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()),
-                                         *schedule_,
-                                         runPrincipal,
-                                         ts,
-                                         es,
-                                         serviceToken_,
-                                         subProcesses_);
+      beginGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()), *schedule_, runPrincipal, ts, es,
+                                         serviceToken_, subProcesses_);
       globalWaitTask->wait_for_all();
-      if(globalWaitTask->exceptionPtr() != nullptr) {
-        std::rethrow_exception(* (globalWaitTask->exceptionPtr()) );
+      if (globalWaitTask->exceptionPtr() != nullptr) {
+        std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
       }
     }
     globalBeginSucceeded = true;
     FDEBUG(1) << "\tbeginRun " << run << "\n";
-    if(looper_) {
+    if (looper_) {
       looper_->doBeginRun(runPrincipal, es, &processContext_);
     }
     {
       //To wait, the ref count has to be 1+#streams
       auto streamLoopWaitTask = make_empty_waiting_task();
       streamLoopWaitTask->increment_ref_count();
-      
+
       typedef OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> Traits;
-      
-      beginStreamsTransitionAsync<Traits>(streamLoopWaitTask.get(),
-                                         *schedule_,
-                                         preallocations_.numberOfStreams(),
-                                         runPrincipal,
-                                         ts,
-                                         es,
-                                         serviceToken_,
-                                         subProcesses_);
+
+      beginStreamsTransitionAsync<Traits>(streamLoopWaitTask.get(), *schedule_, preallocations_.numberOfStreams(),
+                                          runPrincipal, ts, es, serviceToken_, subProcesses_);
 
       streamLoopWaitTask->wait_for_all();
-      if(streamLoopWaitTask->exceptionPtr() != nullptr) {
-        std::rethrow_exception(* (streamLoopWaitTask->exceptionPtr()) );
+      if (streamLoopWaitTask->exceptionPtr() != nullptr) {
+        std::rethrow_exception(*(streamLoopWaitTask->exceptionPtr()));
       }
     }
     FDEBUG(1) << "\tstreamBeginRun " << run << "\n";
-    if(looper_) {
+    if (looper_) {
       //looper_->doStreamBeginRun(schedule_->streamID(),runPrincipal, es);
     }
   }
 
-  void EventProcessor::endUnfinishedRun(ProcessHistoryID const& phid, RunNumber_t run,
-                                        bool globalBeginSucceeded, bool cleaningUpAfterException,
+  void EventProcessor::endUnfinishedRun(ProcessHistoryID const& phid,
+                                        RunNumber_t run,
+                                        bool globalBeginSucceeded,
+                                        bool cleaningUpAfterException,
                                         bool eventSetupForInstanceSucceeded) {
     if (eventSetupForInstanceSucceeded) {
       //If we skip empty runs, this would be called conditionally
       endRun(phid, run, globalBeginSucceeded, cleaningUpAfterException);
-    
-      if(globalBeginSucceeded) {
+
+      if (globalBeginSucceeded) {
         auto t = edm::make_empty_waiting_task();
         t->increment_ref_count();
         RunPrincipal& runPrincipal = principalCache_.runPrincipal(phid, run);
@@ -990,7 +908,7 @@ namespace edm {
         writeRunAsync(edm::WaitingTaskHolder{t.get()}, phid, run, mergeableRunProductMetadata);
         t->wait_for_all();
         mergeableRunProductMetadata->postWriteRun();
-        if(t->exceptionPtr()) {
+        if (t->exceptionPtr()) {
           std::rethrow_exception(*t->exceptionPtr());
         }
       }
@@ -998,42 +916,40 @@ namespace edm {
     deleteRunFromCache(phid, run);
   }
 
-  void EventProcessor::endRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalBeginSucceeded, bool cleaningUpAfterException) {
+  void EventProcessor::endRun(ProcessHistoryID const& phid,
+                              RunNumber_t run,
+                              bool globalBeginSucceeded,
+                              bool cleaningUpAfterException) {
     RunPrincipal& runPrincipal = principalCache_.runPrincipal(phid, run);
     runPrincipal.setEndTime(input_->timestamp());
 
-    IOVSyncValue ts(EventID(runPrincipal.run(), LuminosityBlockID::maxLuminosityBlockNumber(), EventID::maxEventNumber()),
-                    runPrincipal.endTime());
+    IOVSyncValue ts(
+        EventID(runPrincipal.run(), LuminosityBlockID::maxLuminosityBlockNumber(), EventID::maxEventNumber()),
+        runPrincipal.endTime());
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
       espController_->eventSetupForInstance(ts);
       sentry.completedSuccessfully();
     }
     auto const& es = esp_->eventSetup();
-    if(globalBeginSucceeded){
+    if (globalBeginSucceeded) {
       //To wait, the ref count has to be 1+#streams
       auto streamLoopWaitTask = make_empty_waiting_task();
       streamLoopWaitTask->increment_ref_count();
-      
+
       typedef OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> Traits;
-      
-      endStreamsTransitionAsync<Traits>(WaitingTaskHolder(streamLoopWaitTask.get()),
-                                       *schedule_,
-                                       preallocations_.numberOfStreams(),
-                                       runPrincipal,
-                                       ts,
-                                       es,
-                                       serviceToken_,
-                                       subProcesses_,
-                                       cleaningUpAfterException);
-      
+
+      endStreamsTransitionAsync<Traits>(WaitingTaskHolder(streamLoopWaitTask.get()), *schedule_,
+                                        preallocations_.numberOfStreams(), runPrincipal, ts, es, serviceToken_,
+                                        subProcesses_, cleaningUpAfterException);
+
       streamLoopWaitTask->wait_for_all();
-      if(streamLoopWaitTask->exceptionPtr() != nullptr) {
-        std::rethrow_exception(* (streamLoopWaitTask->exceptionPtr()) );
+      if (streamLoopWaitTask->exceptionPtr() != nullptr) {
+        std::rethrow_exception(*(streamLoopWaitTask->exceptionPtr()));
       }
     }
     FDEBUG(1) << "\tstreamEndRun " << run << "\n";
-    if(looper_) {
+    if (looper_) {
       //looper_->doStreamEndRun(schedule_->streamID(),runPrincipal, es);
     }
     {
@@ -1041,60 +957,57 @@ namespace edm {
       globalWaitTask->increment_ref_count();
 
       typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Traits;
-      endGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()),
-                                       *schedule_,
-                                       runPrincipal,
-                                       ts,
-                                       es,
-                                       serviceToken_,
-                                       subProcesses_,
-                                       cleaningUpAfterException);
+      endGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()), *schedule_, runPrincipal, ts, es,
+                                       serviceToken_, subProcesses_, cleaningUpAfterException);
       globalWaitTask->wait_for_all();
-      if(globalWaitTask->exceptionPtr() != nullptr) {
-        std::rethrow_exception(* (globalWaitTask->exceptionPtr()) );
+      if (globalWaitTask->exceptionPtr() != nullptr) {
+        std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
       }
     }
     FDEBUG(1) << "\tendRun " << run << "\n";
-    if(looper_) {
+    if (looper_) {
       looper_->doEndRun(runPrincipal, es, &processContext_);
     }
   }
- 
-  InputSource::ItemType
-  EventProcessor::processLumis(std::shared_ptr<void> const& iRunResource) {
+
+  InputSource::ItemType EventProcessor::processLumis(std::shared_ptr<void> const& iRunResource) {
     auto waitTask = make_empty_waiting_task();
     waitTask->increment_ref_count();
-    
-    if(streamLumiActive_> 0) {
+
+    if (streamLumiActive_ > 0) {
       assert(streamLumiActive_ == preallocations_.numberOfStreams());
       continueLumiAsync(WaitingTaskHolder{waitTask.get()});
     } else {
       beginLumiAsync(IOVSyncValue(EventID(input_->run(), input_->luminosityBlock(), 0),
                                   input_->luminosityBlockAuxiliary()->beginTime()),
-                     iRunResource,
-                     WaitingTaskHolder{waitTask.get()});
+                     iRunResource, WaitingTaskHolder{waitTask.get()});
     }
     waitTask->wait_for_all();
-    
-    if(waitTask->exceptionPtr() != nullptr) {
-      std::rethrow_exception(* (waitTask->exceptionPtr()) );
+
+    if (waitTask->exceptionPtr() != nullptr) {
+      std::rethrow_exception(*(waitTask->exceptionPtr()));
     }
     return lastTransitionType();
   }
-  
-  void
-  EventProcessor::beginLumiAsync(IOVSyncValue const& iSync,
-                                 std::shared_ptr<void> const& iRunResource, edm::WaitingTaskHolder iHolder) {
-    if(iHolder.taskHasFailed()) { return; }
-    
-    auto status= std::make_shared<LuminosityBlockProcessingStatus>(this, preallocations_.numberOfStreams(), iRunResource) ;
+
+  void EventProcessor::beginLumiAsync(IOVSyncValue const& iSync,
+                                      std::shared_ptr<void> const& iRunResource,
+                                      edm::WaitingTaskHolder iHolder) {
+    if (iHolder.taskHasFailed()) {
+      return;
+    }
+
+    auto status =
+        std::make_shared<LuminosityBlockProcessingStatus>(this, preallocations_.numberOfStreams(), iRunResource);
 
     auto lumiWork = [this, iHolder, status](edm::LimitedTaskQueue::Resumer iResumer) mutable {
-      if(iHolder.taskHasFailed()) { return; }
+      if (iHolder.taskHasFailed()) {
+        return;
+      }
 
       status->setResumer(std::move(iResumer));
-      
-      sourceResourcesAcquirer_.serialQueueChain().push([this,iHolder,status]() mutable {
+
+      sourceResourcesAcquirer_.serialQueueChain().push([this, iHolder, status]() mutable {
         //make the services available
         ServiceRegistry::Operate operate(serviceToken_);
 
@@ -1110,92 +1023,84 @@ namespace edm {
           }
 
           Service<RandomNumberGenerator> rng;
-          if(rng.isAvailable()) {
+          if (rng.isAvailable()) {
             LuminosityBlock lb(lumiPrincipal, ModuleDescription(), nullptr, false);
             rng->preBeginLumi(lb);
           }
-          
+
           IOVSyncValue ts(EventID(lumiPrincipal.run(), lumiPrincipal.luminosityBlock(), 0), lumiPrincipal.beginTime());
 
           //Task to start the stream beginLumis
-          auto beginStreamsTask= make_waiting_task(tbb::task::allocate_root()
-                                                   ,[this, holder = iHolder, status, ts] (std::exception_ptr const* iPtr) mutable {
-            if (iPtr) {
-              holder.doneWaiting(*iPtr);
-            } else {
-
-              status->globalBeginDidSucceed();
-              auto const& es = esp_->eventSetup();
-              if(looper_) {
-                try {
-                  //make the services available
-                  ServiceRegistry::Operate operate(serviceToken_);
-                  looper_->doBeginLuminosityBlock(*(status->lumiPrincipal()), es, &processContext_);
-                }catch(...) {
-                  holder.doneWaiting(std::current_exception());
-                  return;
-                }
-              }
-              typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> Traits;
-              
-              for(unsigned int i=0; i<preallocations_.numberOfStreams();++i) {
-                streamQueues_[i].push([this,i,status,holder,ts,&es] () {
-                  streamQueues_[i].pause();
-                  
-                  auto eventTask = edm::make_waiting_task(tbb::task::allocate_root(),
-                                                          [this,i,h = holder](std::exception_ptr const* iPtr) mutable
-                  {
-                    if(iPtr) {
-                      h.doneWaiting(*iPtr);
-                    } else {
-                      handleNextEventForStreamAsync(std::move(h), i);
+          auto beginStreamsTask = make_waiting_task(
+              tbb::task::allocate_root(), [this, holder = iHolder, status, ts](std::exception_ptr const* iPtr) mutable {
+                if (iPtr) {
+                  holder.doneWaiting(*iPtr);
+                } else {
+                  status->globalBeginDidSucceed();
+                  auto const& es = esp_->eventSetup();
+                  if (looper_) {
+                    try {
+                      //make the services available
+                      ServiceRegistry::Operate operate(serviceToken_);
+                      looper_->doBeginLuminosityBlock(*(status->lumiPrincipal()), es, &processContext_);
+                    } catch (...) {
+                      holder.doneWaiting(std::current_exception());
+                      return;
                     }
-                  });
-                  auto& event = principalCache_.eventPrincipal(i);
-                  streamLumiStatus_[i] = status;
-                  ++streamLumiActive_;
-                  auto lp = status->lumiPrincipal();
-                  event.setLuminosityBlockPrincipal(lp.get());
-                  beginStreamTransitionAsync<Traits>(WaitingTaskHolder{eventTask},
-                                                     *schedule_,i,*lp,ts,es,
-                                                     serviceToken_,subProcesses_);
-                });
-              }
-            }
-          });
-          
+                  }
+                  typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> Traits;
+
+                  for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
+                    streamQueues_[i].push([this, i, status, holder, ts, &es]() {
+                      streamQueues_[i].pause();
+
+                      auto eventTask = edm::make_waiting_task(
+                          tbb::task::allocate_root(), [this, i, h = holder](std::exception_ptr const* iPtr) mutable {
+                            if (iPtr) {
+                              h.doneWaiting(*iPtr);
+                            } else {
+                              handleNextEventForStreamAsync(std::move(h), i);
+                            }
+                          });
+                      auto& event = principalCache_.eventPrincipal(i);
+                      streamLumiStatus_[i] = status;
+                      ++streamLumiActive_;
+                      auto lp = status->lumiPrincipal();
+                      event.setLuminosityBlockPrincipal(lp.get());
+                      beginStreamTransitionAsync<Traits>(WaitingTaskHolder{eventTask}, *schedule_, i, *lp, ts, es,
+                                                         serviceToken_, subProcesses_);
+                    });
+                  }
+                }
+              });
+
           //task to start the global begin lumi
           WaitingTaskHolder beginStreamsHolder{beginStreamsTask};
           auto const& es = esp_->eventSetup();
           {
             typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Traits;
-            beginGlobalTransitionAsync<Traits>(beginStreamsHolder,
-                                               *schedule_,
-                                               *(status->lumiPrincipal()),
-                                               ts,
-                                               es,
-                                               serviceToken_,
-                                               subProcesses_);
+            beginGlobalTransitionAsync<Traits>(beginStreamsHolder, *schedule_, *(status->lumiPrincipal()), ts, es,
+                                               serviceToken_, subProcesses_);
           }
-        } catch(...) {
+        } catch (...) {
           iHolder.doneWaiting(std::current_exception());
         }
       });
     };
-        
+
     //Safe to do check now since can not have multiple beginLumis at same time in this part of the code
     // because we do not attempt to read from the source again until we try to get the first event in a lumi
-    if(espController_->isWithinValidityInterval(iSync)) {
+    if (espController_->isWithinValidityInterval(iSync)) {
       iovQueue_.pause();
       lumiQueue_->pushAndPause(std::move(lumiWork));
     } else {
       //If EventSetup fails, need beginStreamsHolder in order to pass back exception
-      iovQueue_.push([this,iHolder,lumiWork,iSync]() mutable {
+      iovQueue_.push([this, iHolder, lumiWork, iSync]() mutable {
         try {
           SendSourceTerminationSignalIfException sentry(actReg_.get());
           espController_->eventSetupForInstance(iSync);
           sentry.completedSuccessfully();
-        } catch(...) {
+        } catch (...) {
           iHolder.doneWaiting(std::current_exception());
           return;
         }
@@ -1204,36 +1109,35 @@ namespace edm {
       });
     }
   }
-  
-  void
-  EventProcessor::continueLumiAsync(edm::WaitingTaskHolder iHolder) {
+
+  void EventProcessor::continueLumiAsync(edm::WaitingTaskHolder iHolder) {
     {
       //all streams are sharing the same status at the moment
-      auto status = streamLumiStatus_[0]; //read from streamLumiActive_ happened in calling routine
+      auto status = streamLumiStatus_[0];  //read from streamLumiActive_ happened in calling routine
       status->needToContinueLumi();
       status->startProcessingEvents();
     }
-    
-    unsigned int streamIndex = 0;
-    for(; streamIndex< preallocations_.numberOfStreams()-1; ++streamIndex) {
-      tbb::task::enqueue( *edm::make_functor_task(tbb::task::allocate_root(),
-                                              [this,streamIndex,h = iHolder](){
-        handleNextEventForStreamAsync(std::move(h), streamIndex);
-      }) );
 
+    unsigned int streamIndex = 0;
+    for (; streamIndex < preallocations_.numberOfStreams() - 1; ++streamIndex) {
+      tbb::task::enqueue(*edm::make_functor_task(tbb::task::allocate_root(), [this, streamIndex, h = iHolder]() {
+        handleNextEventForStreamAsync(std::move(h), streamIndex);
+      }));
     }
-    tbb::task::spawn( *edm::make_functor_task(tbb::task::allocate_root(),[this,streamIndex,h=std::move(iHolder)](){
-      handleNextEventForStreamAsync(std::move(h),streamIndex);
-    }) );
+    tbb::task::spawn(*edm::make_functor_task(tbb::task::allocate_root(), [this, streamIndex, h = std::move(iHolder)]() {
+      handleNextEventForStreamAsync(std::move(h), streamIndex);
+    }));
   }
 
-  void EventProcessor::globalEndLumiAsync(edm::WaitingTaskHolder iTask, std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus) {
+  void EventProcessor::globalEndLumiAsync(edm::WaitingTaskHolder iTask,
+                                          std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus) {
     //Need to be sure iTask is always destroyed after iLumiStatus since iLumiStatus can cause endRun to start.
-    auto t = edm::make_waiting_task(tbb::task::allocate_root(), [ items = std::make_pair(iLumiStatus,std::move(iTask)), this] (std::exception_ptr const* iPtr) mutable {
+    auto t = edm::make_waiting_task(tbb::task::allocate_root(), [items = std::make_pair(iLumiStatus, std::move(iTask)),
+                                                                 this](std::exception_ptr const* iPtr) mutable {
       std::exception_ptr ptr;
       //use an easier to remember variable name
       auto status = std::move(items.first);
-      if(iPtr) {
+      if (iPtr) {
         ptr = *iPtr;
         WaitingTaskHolder tmp(items.second);
         //set the exception early to prevent a beginLumi from running
@@ -1242,13 +1146,13 @@ namespace edm {
       } else {
         try {
           ServiceRegistry::Operate operate(serviceToken_);
-          if(looper_) {
+          if (looper_) {
             auto& lp = *(status->lumiPrincipal());
             auto const& es = esp_->eventSetup();
             looper_->doEndLuminosityBlock(lp, es, &processContext_);
           }
-        }catch(...) {
-          if(not ptr) {
+        } catch (...) {
+          if (not ptr) {
             ptr = std::current_exception();
           }
         }
@@ -1259,15 +1163,15 @@ namespace edm {
         //release our hold on the IOV
         iovQueue_.resume();
         status->resumeGlobalLumiQueue();
-      } catch(...) {
-        if( not ptr) {
+      } catch (...) {
+        if (not ptr) {
           ptr = std::current_exception();
         }
       }
       try {
         status.reset();
-      } catch(...) {
-        if( not ptr) {
+      } catch (...) {
+        if (not ptr) {
           ptr = std::current_exception();
         }
       }
@@ -1275,108 +1179,96 @@ namespace edm {
       items.second.doneWaiting(ptr);
     });
 
-    auto writeT = edm::make_waiting_task(tbb::task::allocate_root(), [this,status =iLumiStatus, task = WaitingTaskHolder(t)] (std::exception_ptr const* iExcept) mutable {
-      if(iExcept) {
-        task.doneWaiting(*iExcept);
-      } else {
-        //Only call writeLumi if beginLumi succeeded
-        if(status->didGlobalBeginSucceed()) {
-          writeLumiAsync(std::move(task),status);
-        }
-      }
-    });
+    auto writeT = edm::make_waiting_task(
+        tbb::task::allocate_root(),
+        [this, status = iLumiStatus, task = WaitingTaskHolder(t)](std::exception_ptr const* iExcept) mutable {
+          if (iExcept) {
+            task.doneWaiting(*iExcept);
+          } else {
+            //Only call writeLumi if beginLumi succeeded
+            if (status->didGlobalBeginSucceed()) {
+              writeLumiAsync(std::move(task), status);
+            }
+          }
+        });
     auto& lp = *(iLumiStatus->lumiPrincipal());
 
-    IOVSyncValue ts(EventID(lp.run(), lp.luminosityBlock(), EventID::maxEventNumber()),
-                    lp.beginTime());
-
+    IOVSyncValue ts(EventID(lp.run(), lp.luminosityBlock(), EventID::maxEventNumber()), lp.beginTime());
 
     typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Traits;
     auto const& es = esp_->eventSetup();
 
-    endGlobalTransitionAsync<Traits>(WaitingTaskHolder(writeT),
-                                     *schedule_,
-                                     lp,
-                                     ts,
-                                     es,
-                                     serviceToken_,
-                                     subProcesses_,
+    endGlobalTransitionAsync<Traits>(WaitingTaskHolder(writeT), *schedule_, lp, ts, es, serviceToken_, subProcesses_,
                                      iLumiStatus->cleaningUpAfterException());
   }
 
   void EventProcessor::streamEndLumiAsync(edm::WaitingTaskHolder iTask,
                                           unsigned int iStreamIndex,
                                           std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus) {
-    
-    auto t =edm::make_waiting_task(tbb::task::allocate_root(), [this, iStreamIndex, iTask](std::exception_ptr const* iPtr) mutable {
-      std::exception_ptr ptr;
-      if(iPtr) {
-        ptr = *iPtr;
-      }
-      auto status =streamLumiStatus_[iStreamIndex];
-      //reset status before releasing queue else get race condtion
-      streamLumiStatus_[iStreamIndex].reset();
-      --streamLumiActive_;
-      streamQueues_[iStreamIndex].resume();
-      
-      //are we the last one?
-      if( status->streamFinishedLumi()) {
-        globalEndLumiAsync(iTask, std::move(status));
-      }
-      iTask.doneWaiting(ptr);
-    });
-    
+    auto t = edm::make_waiting_task(tbb::task::allocate_root(),
+                                    [this, iStreamIndex, iTask](std::exception_ptr const* iPtr) mutable {
+                                      std::exception_ptr ptr;
+                                      if (iPtr) {
+                                        ptr = *iPtr;
+                                      }
+                                      auto status = streamLumiStatus_[iStreamIndex];
+                                      //reset status before releasing queue else get race condtion
+                                      streamLumiStatus_[iStreamIndex].reset();
+                                      --streamLumiActive_;
+                                      streamQueues_[iStreamIndex].resume();
+
+                                      //are we the last one?
+                                      if (status->streamFinishedLumi()) {
+                                        globalEndLumiAsync(iTask, std::move(status));
+                                      }
+                                      iTask.doneWaiting(ptr);
+                                    });
+
     edm::WaitingTaskHolder lumiDoneTask{t};
-    
+
     iLumiStatus->setEndTime();
-    
-    if(iLumiStatus->didGlobalBeginSucceed()) {
-      auto & lumiPrincipal = *iLumiStatus->lumiPrincipal();
+
+    if (iLumiStatus->didGlobalBeginSucceed()) {
+      auto& lumiPrincipal = *iLumiStatus->lumiPrincipal();
       IOVSyncValue ts(EventID(lumiPrincipal.run(), lumiPrincipal.luminosityBlock(), EventID::maxEventNumber()),
                       lumiPrincipal.endTime());
       auto const& es = esp_->eventSetup();
 
       bool cleaningUpAfterException = iLumiStatus->cleaningUpAfterException();
-      
-      using Traits =  OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd>;
-      endStreamTransitionAsync<Traits>(std::move(lumiDoneTask),
-                                       *schedule_,iStreamIndex,
-                                       lumiPrincipal,ts,es,
-                                       serviceToken_,
-                                       subProcesses_,cleaningUpAfterException);
+
+      using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd>;
+      endStreamTransitionAsync<Traits>(std::move(lumiDoneTask), *schedule_, iStreamIndex, lumiPrincipal, ts, es,
+                                       serviceToken_, subProcesses_, cleaningUpAfterException);
     }
   }
 
-  
   void EventProcessor::endUnfinishedLumi() {
-    if(streamLumiActive_.load() > 0) {
+    if (streamLumiActive_.load() > 0) {
       auto globalWaitTask = make_empty_waiting_task();
       globalWaitTask->increment_ref_count();
       {
         WaitingTaskHolder globalTaskHolder{globalWaitTask.get()};
-        for(unsigned int i=0; i< preallocations_.numberOfStreams(); ++i) {
-          if(streamLumiStatus_[i]) {
+        for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
+          if (streamLumiStatus_[i]) {
             streamEndLumiAsync(globalTaskHolder, i, streamLumiStatus_[i]);
           }
         }
       }
       globalWaitTask->wait_for_all();
-      if(globalWaitTask->exceptionPtr() != nullptr) {
-        std::rethrow_exception(* (globalWaitTask->exceptionPtr()) );
+      if (globalWaitTask->exceptionPtr() != nullptr) {
+        std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
       }
     }
   }
 
-  std::pair<ProcessHistoryID,RunNumber_t> EventProcessor::readRun() {
+  std::pair<ProcessHistoryID, RunNumber_t> EventProcessor::readRun() {
     if (principalCache_.hasRunPrincipal()) {
-      throw edm::Exception(edm::errors::LogicError)
-        << "EventProcessor::readRun\n"
-        << "Illegal attempt to insert run into cache\n"
-        << "Contact a Framework Developer\n";
+      throw edm::Exception(edm::errors::LogicError) << "EventProcessor::readRun\n"
+                                                    << "Illegal attempt to insert run into cache\n"
+                                                    << "Contact a Framework Developer\n";
     }
-    auto rp = std::make_shared<RunPrincipal>(input_->runAuxiliary(), preg(),
-                                             *processConfiguration_, historyAppender_.get(),
-                                             0, true, &mergeableRunProductProcesses_);
+    auto rp = std::make_shared<RunPrincipal>(input_->runAuxiliary(), preg(), *processConfiguration_,
+                                             historyAppender_.get(), 0, true, &mergeableRunProductProcesses_);
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
       input_->readRun(*rp, *historyAppender_);
@@ -1387,9 +1279,9 @@ namespace edm {
     return std::make_pair(rp->reducedProcessHistoryID(), input_->run());
   }
 
-  std::pair<ProcessHistoryID,RunNumber_t> EventProcessor::readAndMergeRun() {
+  std::pair<ProcessHistoryID, RunNumber_t> EventProcessor::readAndMergeRun() {
     principalCache_.merge(input_->runAuxiliary(), preg());
-    auto runPrincipal =principalCache_.runPrincipalPtr();
+    auto runPrincipal = principalCache_.runPrincipalPtr();
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
       input_->readAndMergeRun(*runPrincipal);
@@ -1401,11 +1293,10 @@ namespace edm {
 
   void EventProcessor::readLuminosityBlock(LuminosityBlockProcessingStatus& iStatus) {
     if (!principalCache_.hasRunPrincipal()) {
-      throw edm::Exception(edm::errors::LogicError)
-        << "EventProcessor::readLuminosityBlock\n"
-        << "Illegal attempt to insert lumi into cache\n"
-        << "Run is invalid\n"
-        << "Contact a Framework Developer\n";
+      throw edm::Exception(edm::errors::LogicError) << "EventProcessor::readLuminosityBlock\n"
+                                                    << "Illegal attempt to insert lumi into cache\n"
+                                                    << "Run is invalid\n"
+                                                    << "Contact a Framework Developer\n";
     }
     auto lbp = principalCache_.getAvailableLumiPrincipalPtr();
     assert(lbp);
@@ -1422,7 +1313,9 @@ namespace edm {
   int EventProcessor::readAndMergeLumi(LuminosityBlockProcessingStatus& iStatus) {
     auto& lumiPrincipal = *iStatus.lumiPrincipal();
     assert(lumiPrincipal.aux().sameIdentity(*input_->luminosityBlockAuxiliary()) or
-           input_->processHistoryRegistry().reducedProcessHistoryID(lumiPrincipal.aux().processHistoryID()) == input_->processHistoryRegistry().reducedProcessHistoryID(input_->luminosityBlockAuxiliary()->processHistoryID()));
+           input_->processHistoryRegistry().reducedProcessHistoryID(lumiPrincipal.aux().processHistoryID()) ==
+               input_->processHistoryRegistry().reducedProcessHistoryID(
+                   input_->luminosityBlockAuxiliary()->processHistoryID()));
     bool lumiOK = lumiPrincipal.adjustToNewProductRegistry(*preg());
     assert(lumiOK);
     lumiPrincipal.mergeAuxiliary(*input_->luminosityBlockAuxiliary());
@@ -1434,41 +1327,46 @@ namespace edm {
     return input_->luminosityBlock();
   }
 
-  void EventProcessor::writeRunAsync(WaitingTaskHolder task, ProcessHistoryID const& phid, RunNumber_t run,
+  void EventProcessor::writeRunAsync(WaitingTaskHolder task,
+                                     ProcessHistoryID const& phid,
+                                     RunNumber_t run,
                                      MergeableRunProductMetadata const* mergeableRunProductMetadata) {
-    auto subsT = edm::make_waiting_task(tbb::task::allocate_root(), [this,phid,run,task,mergeableRunProductMetadata]
-                                                                    (std::exception_ptr const* iExcept) mutable {
-      if(iExcept) {
-        task.doneWaiting(*iExcept);
-      } else {
-        ServiceRegistry::Operate op(serviceToken_);
-        for(auto&s : subProcesses_) {
-          s.writeRunAsync(task,phid,run,mergeableRunProductMetadata);
-        }
-      }
-    });
+    auto subsT = edm::make_waiting_task(
+        tbb::task::allocate_root(),
+        [this, phid, run, task, mergeableRunProductMetadata](std::exception_ptr const* iExcept) mutable {
+          if (iExcept) {
+            task.doneWaiting(*iExcept);
+          } else {
+            ServiceRegistry::Operate op(serviceToken_);
+            for (auto& s : subProcesses_) {
+              s.writeRunAsync(task, phid, run, mergeableRunProductMetadata);
+            }
+          }
+        });
     ServiceRegistry::Operate op(serviceToken_);
-    schedule_->writeRunAsync(WaitingTaskHolder(subsT), principalCache_.runPrincipal(phid, run),
-                             &processContext_, actReg_.get(), mergeableRunProductMetadata);
+    schedule_->writeRunAsync(WaitingTaskHolder(subsT), principalCache_.runPrincipal(phid, run), &processContext_,
+                             actReg_.get(), mergeableRunProductMetadata);
   }
 
   void EventProcessor::deleteRunFromCache(ProcessHistoryID const& phid, RunNumber_t run) {
     principalCache_.deleteRun(phid, run);
-    for_all(subProcesses_, [run,phid](auto& subProcess){ subProcess.deleteRunFromCache(phid, run); });
+    for_all(subProcesses_, [run, phid](auto& subProcess) { subProcess.deleteRunFromCache(phid, run); });
     FDEBUG(1) << "\tdeleteRunFromCache " << run << "\n";
   }
 
-  void EventProcessor::writeLumiAsync(WaitingTaskHolder task, std::shared_ptr<LuminosityBlockProcessingStatus> iStatus) {
-    auto subsT = edm::make_waiting_task(tbb::task::allocate_root(), [this,task, iStatus](std::exception_ptr const* iExcept) mutable {
-      if(iExcept) {
-        task.doneWaiting(*iExcept);
-      } else {
-        ServiceRegistry::Operate op(serviceToken_);
-        for(auto&s : subProcesses_) {
-          s.writeLumiAsync(task,*(iStatus->lumiPrincipal()));
-        }
-      }
-    });
+  void EventProcessor::writeLumiAsync(WaitingTaskHolder task,
+                                      std::shared_ptr<LuminosityBlockProcessingStatus> iStatus) {
+    auto subsT = edm::make_waiting_task(tbb::task::allocate_root(),
+                                        [this, task, iStatus](std::exception_ptr const* iExcept) mutable {
+                                          if (iExcept) {
+                                            task.doneWaiting(*iExcept);
+                                          } else {
+                                            ServiceRegistry::Operate op(serviceToken_);
+                                            for (auto& s : subProcesses_) {
+                                              s.writeLumiAsync(task, *(iStatus->lumiPrincipal()));
+                                            }
+                                          }
+                                        });
     ServiceRegistry::Operate op(serviceToken_);
 
     std::shared_ptr<LuminosityBlockPrincipal> const& lumiPrincipal = iStatus->lumiPrincipal();
@@ -1478,22 +1376,23 @@ namespace edm {
   }
 
   void EventProcessor::deleteLumiFromCache(LuminosityBlockProcessingStatus& iStatus) {
-    for(auto& s: subProcesses_) { s.deleteLumiFromCache(*iStatus.lumiPrincipal());}
+    for (auto& s : subProcesses_) {
+      s.deleteLumiFromCache(*iStatus.lumiPrincipal());
+    }
     iStatus.lumiPrincipal()->clearPrincipal();
     //FDEBUG(1) << "\tdeleteLumiFromCache " << run << "/" << lumi << "\n";
   }
 
-  bool EventProcessor::readNextEventForStream(unsigned int iStreamIndex,
-                                              LuminosityBlockProcessingStatus& iStatus) {
-    if(shouldWeStop()) {
+  bool EventProcessor::readNextEventForStream(unsigned int iStreamIndex, LuminosityBlockProcessingStatus& iStatus) {
+    if (shouldWeStop()) {
       return false;
     }
-    
-    if(deferredExceptionPtrIsSet_.load(std::memory_order_acquire)) {
+
+    if (deferredExceptionPtrIsSet_.load(std::memory_order_acquire)) {
       return false;
     }
-    
-    if(iStatus.wasEventProcessingStopped()) {
+
+    if (iStatus.wasEventProcessingStopped()) {
       return false;
     }
 
@@ -1503,87 +1402,84 @@ namespace edm {
       // of delayed provenance reading and reading data in response to
       // edm::Refs etc
       std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-      
-      auto itemType = iStatus.continuingLumi()? InputSource::IsLumi : nextTransitionType();
-      if(InputSource::IsLumi == itemType) {
+
+      auto itemType = iStatus.continuingLumi() ? InputSource::IsLumi : nextTransitionType();
+      if (InputSource::IsLumi == itemType) {
         iStatus.haveContinuedLumi();
-        while(itemType == InputSource::IsLumi and
-              iStatus.lumiPrincipal()->run() == input_->run() and
-              iStatus.lumiPrincipal()->luminosityBlock() == nextLuminosityBlockID()) {
+        while (itemType == InputSource::IsLumi and iStatus.lumiPrincipal()->run() == input_->run() and
+               iStatus.lumiPrincipal()->luminosityBlock() == nextLuminosityBlockID()) {
           readAndMergeLumi(iStatus);
           itemType = nextTransitionType();
         }
-        if(InputSource::IsLumi == itemType) {
+        if (InputSource::IsLumi == itemType) {
           iStatus.setNextSyncValue(IOVSyncValue(EventID(input_->run(), input_->luminosityBlock(), 0),
                                                 input_->luminosityBlockAuxiliary()->beginTime()));
         }
       }
-      if(InputSource::IsEvent != itemType) {
+      if (InputSource::IsEvent != itemType) {
         iStatus.stopProcessingEvents();
-        
+
         //IsFile may continue processing the lumi and
         // looper_ can cause the input source to declare a new IsRun which is actually
         // just a continuation of the previous run
-        if(InputSource::IsStop == itemType or
-           InputSource::IsLumi == itemType or
-           (InputSource::IsRun == itemType and iStatus.lumiPrincipal()->run() != input_->run())) {
+        if (InputSource::IsStop == itemType or InputSource::IsLumi == itemType or
+            (InputSource::IsRun == itemType and iStatus.lumiPrincipal()->run() != input_->run())) {
           iStatus.endLumi();
         }
         return false;
       }
       readEvent(iStreamIndex);
     } catch (...) {
-      bool expected =false;
-      if(deferredExceptionPtrIsSet_.compare_exchange_strong(expected,true)) {
+      bool expected = false;
+      if (deferredExceptionPtrIsSet_.compare_exchange_strong(expected, true)) {
         deferredExceptionPtr_ = std::current_exception();
       }
       return false;
     }
     return true;
   }
-  
-  void EventProcessor::handleNextEventForStreamAsync(WaitingTaskHolder iTask,
-                                                     unsigned int iStreamIndex)
-  {
-    sourceResourcesAcquirer_.serialQueueChain().push([this,iTask,iStreamIndex]() mutable {
-           ServiceRegistry::Operate operate(serviceToken_);
-           auto& status = streamLumiStatus_[iStreamIndex];
-           try {
-             if(readNextEventForStream(iStreamIndex, *status) ) {
-               auto recursionTask = make_waiting_task(tbb::task::allocate_root(), [this,iTask,iStreamIndex](std::exception_ptr const* iPtr) mutable {
-                 if(iPtr) {
-                   bool expected = false;
-                   if(deferredExceptionPtrIsSet_.compare_exchange_strong(expected,true)) {
-                     deferredExceptionPtr_ = *iPtr;
-                     iTask.doneWaiting(*iPtr);
-                   }
-                   //the stream will stop now
-                   return;
-                 }
-                 handleNextEventForStreamAsync(std::move(iTask), iStreamIndex);
-               });
 
-               processEventAsync( WaitingTaskHolder(recursionTask), iStreamIndex);
-             } else {
-               //the stream will stop now
-               if(status->isLumiEnding()) {
-                 if(lastTransitionType() == InputSource::IsLumi and not status->haveStartedNextLumi()) {
-                   status->startNextLumi();
-                   beginLumiAsync(status->nextSyncValue(), status->runResource(), iTask);
-                 }
-                 streamEndLumiAsync(std::move(iTask),iStreamIndex, status);
-               } else {
-                 iTask.doneWaiting(std::exception_ptr{});
-               }
-             }
-           } catch(...) {
-             bool expected = false;
-             if(deferredExceptionPtrIsSet_.compare_exchange_strong(expected,true)) {
-               auto e =std::current_exception();
-               deferredExceptionPtr_ = e;
-               iTask.doneWaiting(e);
-             }
-           }
+  void EventProcessor::handleNextEventForStreamAsync(WaitingTaskHolder iTask, unsigned int iStreamIndex) {
+    sourceResourcesAcquirer_.serialQueueChain().push([this, iTask, iStreamIndex]() mutable {
+      ServiceRegistry::Operate operate(serviceToken_);
+      auto& status = streamLumiStatus_[iStreamIndex];
+      try {
+        if (readNextEventForStream(iStreamIndex, *status)) {
+          auto recursionTask = make_waiting_task(
+              tbb::task::allocate_root(), [this, iTask, iStreamIndex](std::exception_ptr const* iPtr) mutable {
+                if (iPtr) {
+                  bool expected = false;
+                  if (deferredExceptionPtrIsSet_.compare_exchange_strong(expected, true)) {
+                    deferredExceptionPtr_ = *iPtr;
+                    iTask.doneWaiting(*iPtr);
+                  }
+                  //the stream will stop now
+                  return;
+                }
+                handleNextEventForStreamAsync(std::move(iTask), iStreamIndex);
+              });
+
+          processEventAsync(WaitingTaskHolder(recursionTask), iStreamIndex);
+        } else {
+          //the stream will stop now
+          if (status->isLumiEnding()) {
+            if (lastTransitionType() == InputSource::IsLumi and not status->haveStartedNextLumi()) {
+              status->startNextLumi();
+              beginLumiAsync(status->nextSyncValue(), status->runResource(), iTask);
+            }
+            streamEndLumiAsync(std::move(iTask), iStreamIndex, status);
+          } else {
+            iTask.doneWaiting(std::exception_ptr{});
+          }
+        }
+      } catch (...) {
+        bool expected = false;
+        if (deferredExceptionPtrIsSet_.compare_exchange_strong(expected, true)) {
+          auto e = std::current_exception();
+          deferredExceptionPtr_ = e;
+          iTask.doneWaiting(e);
+        }
+      }
     });
   }
 
@@ -1594,79 +1490,66 @@ namespace edm {
 
     SendSourceTerminationSignalIfException sentry(actReg_.get());
     input_->readEvent(event, streamContext);
-    
+
     streamLumiStatus_[iStreamIndex]->updateLastTimestamp(input_->timestamp());
     sentry.completedSuccessfully();
 
     FDEBUG(1) << "\treadEvent\n";
   }
 
-  void EventProcessor::processEventAsync(WaitingTaskHolder iHolder,
-                                         unsigned int iStreamIndex) {
-    tbb::task::spawn( *make_functor_task( tbb::task::allocate_root(), [=]() {
-      processEventAsyncImpl(iHolder, iStreamIndex);
-    }) );
+  void EventProcessor::processEventAsync(WaitingTaskHolder iHolder, unsigned int iStreamIndex) {
+    tbb::task::spawn(
+        *make_functor_task(tbb::task::allocate_root(), [=]() { processEventAsyncImpl(iHolder, iStreamIndex); }));
   }
-  
-  void EventProcessor::processEventAsyncImpl(WaitingTaskHolder iHolder,
-                                         unsigned int iStreamIndex) {
+
+  void EventProcessor::processEventAsyncImpl(WaitingTaskHolder iHolder, unsigned int iStreamIndex) {
     auto pep = &(principalCache_.eventPrincipal(iStreamIndex));
 
     ServiceRegistry::Operate operate(serviceToken_);
     Service<RandomNumberGenerator> rng;
-    if(rng.isAvailable()) {
+    if (rng.isAvailable()) {
       Event ev(*pep, ModuleDescription(), nullptr);
       rng->postEventRead(ev);
     }
-    
-    WaitingTaskHolder finalizeEventTask( make_waiting_task(
-                    tbb::task::allocate_root(),
-                    [this,pep,iHolder](std::exception_ptr const* iPtr) mutable
-             {
 
-               //NOTE: If we have a looper we only have one Stream
-               if(looper_) {
-                 ServiceRegistry::Operate operate(serviceToken_);
-                 processEventWithLooper(*pep);
-               }
-               
-               FDEBUG(1) << "\tprocessEvent\n";
-               pep->clearEventPrincipal();
-               if(iPtr) {
-                 iHolder.doneWaiting(*iPtr);
-               } else {
-                 iHolder.doneWaiting(std::exception_ptr());
-               }
-             }
-                                                           )
-                                        );
+    WaitingTaskHolder finalizeEventTask(
+        make_waiting_task(tbb::task::allocate_root(), [this, pep, iHolder](std::exception_ptr const* iPtr) mutable {
+          //NOTE: If we have a looper we only have one Stream
+          if (looper_) {
+            ServiceRegistry::Operate operate(serviceToken_);
+            processEventWithLooper(*pep);
+          }
+
+          FDEBUG(1) << "\tprocessEvent\n";
+          pep->clearEventPrincipal();
+          if (iPtr) {
+            iHolder.doneWaiting(*iPtr);
+          } else {
+            iHolder.doneWaiting(std::exception_ptr());
+          }
+        }));
     WaitingTaskHolder afterProcessTask;
-    if(subProcesses_.empty()) {
+    if (subProcesses_.empty()) {
       afterProcessTask = std::move(finalizeEventTask);
     } else {
       //Need to run SubProcesses after schedule has finished
       // with the event
-      afterProcessTask = WaitingTaskHolder(
-                   make_waiting_task(tbb::task::allocate_root(),
-                                     [this,pep,finalizeEventTask] (std::exception_ptr const* iPtr) mutable
-      {
-         if(not iPtr) {
-           //when run with 1 thread, we want to the order to be what
-           // it was before. This requires reversing the order since
-           // tasks are run last one in first one out
-           for(auto& subProcess: boost::adaptors::reverse(subProcesses_)) {
-             subProcess.doEventAsync(finalizeEventTask,*pep);
-           }
-         } else {
-           finalizeEventTask.doneWaiting(*iPtr);
-         }
-       })
-                                           );
+      afterProcessTask = WaitingTaskHolder(make_waiting_task(
+          tbb::task::allocate_root(), [this, pep, finalizeEventTask](std::exception_ptr const* iPtr) mutable {
+            if (not iPtr) {
+              //when run with 1 thread, we want to the order to be what
+              // it was before. This requires reversing the order since
+              // tasks are run last one in first one out
+              for (auto& subProcess : boost::adaptors::reverse(subProcesses_)) {
+                subProcess.doEventAsync(finalizeEventTask, *pep);
+              }
+            } else {
+              finalizeEventTask.doneWaiting(*iPtr);
+            }
+          }));
     }
-    
-    schedule_->processOneEventAsync(std::move(afterProcessTask),
-                                    iStreamIndex,*pep, esp_->eventSetup(), serviceToken_);
 
+    schedule_->processOneEventAsync(std::move(afterProcessTask), iStreamIndex, *pep, esp_->eventSetup(), serviceToken_);
   }
 
   void EventProcessor::processEventWithLooper(EventPrincipal& iPrincipal) {
@@ -1674,36 +1557,35 @@ namespace edm {
     ProcessingController::ForwardState forwardState = input_->forwardState();
     ProcessingController::ReverseState reverseState = input_->reverseState();
     ProcessingController pc(forwardState, reverseState, randomAccess);
-    
+
     EDLooperBase::Status status = EDLooperBase::kContinue;
     do {
-      
       StreamContext streamContext(iPrincipal.streamID(), &processContext_);
       status = looper_->doDuringLoop(iPrincipal, esp_->eventSetup(), pc, &streamContext);
-      
+
       bool succeeded = true;
-      if(randomAccess) {
-        if(pc.requestedTransition() == ProcessingController::kToPreviousEvent) {
+      if (randomAccess) {
+        if (pc.requestedTransition() == ProcessingController::kToPreviousEvent) {
           input_->skipEvents(-2);
-        }
-        else if(pc.requestedTransition() == ProcessingController::kToSpecifiedEvent) {
+        } else if (pc.requestedTransition() == ProcessingController::kToSpecifiedEvent) {
           succeeded = input_->goToEvent(pc.specifiedEventTransition());
         }
       }
       pc.setLastOperationSucceeded(succeeded);
-    } while(!pc.lastOperationSucceeded());
-    if(status != EDLooperBase::kContinue) {
+    } while (!pc.lastOperationSucceeded());
+    if (status != EDLooperBase::kContinue) {
       shouldWeStop_ = true;
-      lastSourceTransition_=InputSource::IsStop;
+      lastSourceTransition_ = InputSource::IsStop;
     }
   }
 
   bool EventProcessor::shouldWeStop() const {
     FDEBUG(1) << "\tshouldWeStop\n";
-    if(shouldWeStop_) return true;
-    if(!subProcesses_.empty()) {
-      for(auto const& subProcess : subProcesses_) {
-        if(subProcess.terminate()) {
+    if (shouldWeStop_)
+      return true;
+    if (!subProcesses_.empty()) {
+      for (auto const& subProcess : subProcesses_) {
+        if (subProcess.terminate()) {
           return true;
         }
       }
@@ -1712,37 +1594,31 @@ namespace edm {
     return schedule_->terminate();
   }
 
-  void EventProcessor::setExceptionMessageFiles(std::string& message) {
-    exceptionMessageFiles_ = message;
-  }
+  void EventProcessor::setExceptionMessageFiles(std::string& message) { exceptionMessageFiles_ = message; }
 
-  void EventProcessor::setExceptionMessageRuns(std::string& message) {
-    exceptionMessageRuns_ = message;
-  }
+  void EventProcessor::setExceptionMessageRuns(std::string& message) { exceptionMessageRuns_ = message; }
 
-  void EventProcessor::setExceptionMessageLumis(std::string& message) {
-    exceptionMessageLumis_ = message;
-  }
+  void EventProcessor::setExceptionMessageLumis(std::string& message) { exceptionMessageLumis_ = message; }
 
   bool EventProcessor::setDeferredException(std::exception_ptr iException) {
-    bool expected =false;
-    if(deferredExceptionPtrIsSet_.compare_exchange_strong(expected,true)) {
+    bool expected = false;
+    if (deferredExceptionPtrIsSet_.compare_exchange_strong(expected, true)) {
       deferredExceptionPtr_ = iException;
       return true;
     }
     return false;
   }
-  
+
   void EventProcessor::warnAboutModulesRequiringLuminosityBLockSynchronization() const {
     std::unique_ptr<LogSystem> s;
-    for( auto worker: schedule_->allWorkers()) {
-      if( worker->wantsGlobalLuminosityBlocks() and worker->globalLuminosityBlocksQueue()) {
-        if(not s) {
+    for (auto worker : schedule_->allWorkers()) {
+      if (worker->wantsGlobalLuminosityBlocks() and worker->globalLuminosityBlocksQueue()) {
+        if (not s) {
           s = std::make_unique<LogSystem>("ModulesSynchingOnLumis");
-          (*s) <<"The following modules require synchronizing on LuminosityBlock boundaries:";
+          (*s) << "The following modules require synchronizing on LuminosityBlock boundaries:";
         }
-        (*s)<<"\n  "<<worker->description().moduleName()<<" "<<worker->description().moduleLabel();
+        (*s) << "\n  " << worker->description().moduleName() << " " << worker->description().moduleLabel();
       }
     }
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/EventSelector.cc
+++ b/FWCore/Framework/src/EventSelector.cc
@@ -31,7 +31,6 @@
 //                      EventSelector instance for each call (in static case)
 //
 
-
 #include "FWCore/Framework/interface/EventSelector.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
@@ -45,252 +44,233 @@
 #include <algorithm>
 #include <cassert>
 
-namespace edm
-{
+namespace edm {
   using Strings = EventSelector::Strings;
-  EventSelector::EventSelector(Strings const& pathspecs,
-			       Strings const& pathNames):
-    pathspecs_(initPathSpecs(pathspecs)),
-    results_from_current_process_(true),
-    accept_all_(initAcceptAll()),
-    absolute_acceptors_(),
-    conditional_acceptors_(),
-    exception_acceptors_(),
-    all_must_fail_(),
-    all_must_fail_noex_(),
-    psetID_(),
-    nPathNames_(0)
-  {
+  EventSelector::EventSelector(Strings const& pathspecs, Strings const& pathNames)
+      : pathspecs_(initPathSpecs(pathspecs)),
+        results_from_current_process_(true),
+        accept_all_(initAcceptAll()),
+        absolute_acceptors_(),
+        conditional_acceptors_(),
+        exception_acceptors_(),
+        all_must_fail_(),
+        all_must_fail_noex_(),
+        psetID_(),
+        nPathNames_(0) {
     initPathNames(pathNames);
   }
 
-  EventSelector::EventSelector(Strings const& pathspecs):
-    pathspecs_(initPathSpecs(pathspecs)),
-    results_from_current_process_(false),
-    accept_all_(initAcceptAll()),
-    absolute_acceptors_(),
-    conditional_acceptors_(),
-    exception_acceptors_(),
-    all_must_fail_(),
-    all_must_fail_noex_(),
-    psetID_(),
-    nPathNames_(0)
-  {
-  }
+  EventSelector::EventSelector(Strings const& pathspecs)
+      : pathspecs_(initPathSpecs(pathspecs)),
+        results_from_current_process_(false),
+        accept_all_(initAcceptAll()),
+        absolute_acceptors_(),
+        conditional_acceptors_(),
+        exception_acceptors_(),
+        all_must_fail_(),
+        all_must_fail_noex_(),
+        psetID_(),
+        nPathNames_(0) {}
 
-  EventSelector::EventSelector(ParameterSet const& config, Strings const& pathNames):
-    pathspecs_(config.empty() ? Strings() : initPathSpecs(config.getParameter<Strings>("SelectEvents"))),
-    results_from_current_process_(true),
-    accept_all_(initAcceptAll()),
-    absolute_acceptors_(),
-    conditional_acceptors_(),
-    exception_acceptors_(),
-    all_must_fail_(),
-    all_must_fail_noex_(),
-    psetID_(),
-    nPathNames_(0)
-  {
+  EventSelector::EventSelector(ParameterSet const& config, Strings const& pathNames)
+      : pathspecs_(config.empty() ? Strings() : initPathSpecs(config.getParameter<Strings>("SelectEvents"))),
+        results_from_current_process_(true),
+        accept_all_(initAcceptAll()),
+        absolute_acceptors_(),
+        conditional_acceptors_(),
+        exception_acceptors_(),
+        all_must_fail_(),
+        all_must_fail_noex_(),
+        psetID_(),
+        nPathNames_(0) {
     initPathNames(pathNames);
   }
 
-  Strings
-  EventSelector::initPathSpecs(Strings const& pathSpecs) {
+  Strings EventSelector::initPathSpecs(Strings const& pathSpecs) {
     Strings trimmedPathSpecs(pathSpecs);
-    for(auto& pathspecifier : trimmedPathSpecs) {
-      boost::erase_all(pathspecifier, " \t"); // whitespace eliminated
+    for (auto& pathspecifier : trimmedPathSpecs) {
+      boost::erase_all(pathspecifier, " \t");  // whitespace eliminated
     }
     // Return value optimization should avoid another copy;
     return trimmedPathSpecs;
   }
 
-  bool
-  EventSelector::initAcceptAll() {
+  bool EventSelector::initAcceptAll() {
     if (pathspecs_.empty()) {
       return true;
     }
     // The following are for the purpose of establishing accept_all_ by
     // virtue of an inclusive set of paths:
     bool unrestricted_star = false;
-    bool negated_star      = false;
-    bool exception_star    = false;
+    bool negated_star = false;
+    bool exception_star = false;
 
-    for(auto const& pathspecifier : pathspecs_) {
-      if (pathspecifier == "*")           unrestricted_star = true;
-      if (pathspecifier == "!*")          negated_star = true;
-      if (pathspecifier == "exception@*") exception_star = true;
+    for (auto const& pathspecifier : pathspecs_) {
+      if (pathspecifier == "*")
+        unrestricted_star = true;
+      if (pathspecifier == "!*")
+        negated_star = true;
+      if (pathspecifier == "exception@*")
+        exception_star = true;
     }
     return (unrestricted_star && negated_star && exception_star);
   }
 
-  void
-  EventSelector::initPathNames(Strings const& pathNames) {
-    if(accept_all_) {
+  void EventSelector::initPathNames(Strings const& pathNames) {
+    if (accept_all_) {
       return;
     }
     // std::cerr << "### init entered\n";
-    absolute_acceptors_.clear(),
-    conditional_acceptors_.clear(),
-    exception_acceptors_.clear(),
-    all_must_fail_.clear();
+    absolute_acceptors_.clear(), conditional_acceptors_.clear(), exception_acceptors_.clear(), all_must_fail_.clear();
     all_must_fail_noex_.clear();
     nPathNames_ = pathNames.size();
 
-    for(auto const& pathspecifier : pathspecs_) {
+    for (auto const& pathspecifier : pathspecs_) {
       std::string basePathSpec(pathspecifier);
       bool noex_demanded = false;
-      std::string::size_type
-	      and_noexception = pathspecifier.find("&noexception");
+      std::string::size_type and_noexception = pathspecifier.find("&noexception");
       if (and_noexception != std::string::npos) {
-	basePathSpec = pathspecifier.substr(0,and_noexception);
+        basePathSpec = pathspecifier.substr(0, and_noexception);
         noex_demanded = true;
       }
       std::string::size_type and_noex = pathspecifier.find("&noex");
       if (and_noex != std::string::npos) {
-	basePathSpec = pathspecifier.substr(0,and_noexception);
+        basePathSpec = pathspecifier.substr(0, and_noexception);
         noex_demanded = true;
       }
       and_noexception = basePathSpec.find("&noexception");
-      and_noex = basePathSpec.find("&noex");	
-      if (and_noexception != std::string::npos ||
-	   and_noex != std::string::npos)
-          throw edm::Exception(errors::Configuration)
-            << "EventSelector::init, An OutputModule is using SelectEvents\n"
-               "to request a trigger name, but specifying &noexceptions twice\n"
-            << "The improper trigger name is: " << pathspecifier << "\n";
+      and_noex = basePathSpec.find("&noex");
+      if (and_noexception != std::string::npos || and_noex != std::string::npos)
+        throw edm::Exception(errors::Configuration) << "EventSelector::init, An OutputModule is using SelectEvents\n"
+                                                       "to request a trigger name, but specifying &noexceptions twice\n"
+                                                    << "The improper trigger name is: " << pathspecifier << "\n";
 
       std::string realname(basePathSpec);
       bool negative_criterion = false;
       if (basePathSpec[0] == '!') {
-	negative_criterion = true;
-	realname = basePathSpec.substr(1,std::string::npos);
+        negative_criterion = true;
+        realname = basePathSpec.substr(1, std::string::npos);
       }
       bool exception_spec = false;
       if (realname.find("exception@") == 0) {
-	exception_spec = true;
-	realname = realname.substr(10, std::string::npos);
-	// strip off 10 chars, which is length of "exception@"
-      }	
-      if (negative_criterion &&  exception_spec)
-          throw edm::Exception(errors::Configuration)
-            << "EventSelector::init, An OutputModule is using SelectEvents\n"
-               "to request a trigger name starting with !exception@.\n"
-	       "This is not supported.\n"
-            << "The improper trigger name is: " << pathspecifier << "\n";
-      if (noex_demanded &&  exception_spec)
-          throw edm::Exception(errors::Configuration)
-            << "EventSelector::init, An OutputModule is using SelectEvents\n"
-               "to request a trigger name starting with exception@ "
-	       "and also demanding no &exceptions.\n"
-            << "The improper trigger name is: " << pathspecifier << "\n";
-
+        exception_spec = true;
+        realname = realname.substr(10, std::string::npos);
+        // strip off 10 chars, which is length of "exception@"
+      }
+      if (negative_criterion && exception_spec)
+        throw edm::Exception(errors::Configuration) << "EventSelector::init, An OutputModule is using SelectEvents\n"
+                                                       "to request a trigger name starting with !exception@.\n"
+                                                       "This is not supported.\n"
+                                                    << "The improper trigger name is: " << pathspecifier << "\n";
+      if (noex_demanded && exception_spec)
+        throw edm::Exception(errors::Configuration) << "EventSelector::init, An OutputModule is using SelectEvents\n"
+                                                       "to request a trigger name starting with exception@ "
+                                                       "and also demanding no &exceptions.\n"
+                                                    << "The improper trigger name is: " << pathspecifier << "\n";
 
       // instead of "see if the name can be found in the full list of paths"
-      // we want to find all paths that match this name.	
-      std::vector<Strings::const_iterator> matches =
-	      regexMatch(pathNames, realname);
+      // we want to find all paths that match this name.
+      std::vector<Strings::const_iterator> matches = regexMatch(pathNames, realname);
 
-      if (matches.empty() && !is_glob(realname))
-      {
-          throw edm::Exception(errors::Configuration)
-            << "EventSelector::init, An OutputModule is using SelectEvents\n"
-               "to request a trigger name that does not exist\n"
-            << "The unknown trigger name is: " << realname << "\n";
+      if (matches.empty() && !is_glob(realname)) {
+        throw edm::Exception(errors::Configuration) << "EventSelector::init, An OutputModule is using SelectEvents\n"
+                                                       "to request a trigger name that does not exist\n"
+                                                    << "The unknown trigger name is: " << realname << "\n";
       }
-      if (matches.empty() && is_glob(realname))
-      {
-          LogWarning("Configuration")
-            << "EventSelector::init, An OutputModule is using SelectEvents\n"
-               "to request a wildcarded trigger name that does not match any trigger \n"
-            << "The wildcarded trigger name is: " << realname << "\n";
+      if (matches.empty() && is_glob(realname)) {
+        LogWarning("Configuration") << "EventSelector::init, An OutputModule is using SelectEvents\n"
+                                       "to request a wildcarded trigger name that does not match any trigger \n"
+                                    << "The wildcarded trigger name is: " << realname << "\n";
       }
 
       if (!negative_criterion && !noex_demanded && !exception_spec) {
-	for (unsigned int t = 0; t != matches.size(); ++t) {
-	  BitInfo bi(distance(pathNames.begin(),matches[t]), true);
-	  absolute_acceptors_.push_back(bi);
-	}
+        for (unsigned int t = 0; t != matches.size(); ++t) {
+          BitInfo bi(distance(pathNames.begin(), matches[t]), true);
+          absolute_acceptors_.push_back(bi);
+        }
       } else if (!negative_criterion && noex_demanded) {
-	for (unsigned int t = 0; t != matches.size(); ++t) {
-	  BitInfo bi(distance(pathNames.begin(),matches[t]), true);
-	  conditional_acceptors_.push_back(bi);
-	}
+        for (unsigned int t = 0; t != matches.size(); ++t) {
+          BitInfo bi(distance(pathNames.begin(), matches[t]), true);
+          conditional_acceptors_.push_back(bi);
+        }
       } else if (exception_spec) {
-	for (unsigned int t = 0; t != matches.size(); ++t) {
-	  BitInfo bi(distance(pathNames.begin(),matches[t]), true);
-	  exception_acceptors_.push_back(bi);
-	}
+        for (unsigned int t = 0; t != matches.size(); ++t) {
+          BitInfo bi(distance(pathNames.begin(), matches[t]), true);
+          exception_acceptors_.push_back(bi);
+        }
       } else if (negative_criterion && !noex_demanded) {
-	if (matches.empty()) {
-            throw edm::Exception(errors::Configuration)
-            << "EventSelector::init, An OutputModule is using SelectEvents\n"
-               "to request all fails on a set of trigger names that do not exist\n"
-            << "The problematic name is: " << pathspecifier << "\n";
+        if (matches.empty()) {
+          throw edm::Exception(errors::Configuration)
+              << "EventSelector::init, An OutputModule is using SelectEvents\n"
+                 "to request all fails on a set of trigger names that do not exist\n"
+              << "The problematic name is: " << pathspecifier << "\n";
 
-	} else if (matches.size() == 1) {
-	  BitInfo bi(distance(pathNames.begin(),matches[0]), false);
-	  absolute_acceptors_.push_back(bi);
-	} else {
-	  Bits mustfail;
-	  for (unsigned int t = 0; t != matches.size(); ++t) {
-	    BitInfo bi(distance(pathNames.begin(),matches[t]), false);
-	    // We set this to false because that will demand bits are Fail.
-	    mustfail.push_back(bi);
-	  }
-	  all_must_fail_.push_back(mustfail);
-	} 	
+        } else if (matches.size() == 1) {
+          BitInfo bi(distance(pathNames.begin(), matches[0]), false);
+          absolute_acceptors_.push_back(bi);
+        } else {
+          Bits mustfail;
+          for (unsigned int t = 0; t != matches.size(); ++t) {
+            BitInfo bi(distance(pathNames.begin(), matches[t]), false);
+            // We set this to false because that will demand bits are Fail.
+            mustfail.push_back(bi);
+          }
+          all_must_fail_.push_back(mustfail);
+        }
       } else if (negative_criterion && noex_demanded) {
-	if (matches.empty()) {
-            throw edm::Exception(errors::Configuration)
-            << "EventSelector::init, An OutputModule is using SelectEvents\n"
-               "to request all fails on a set of trigger names that do not exist\n"
-            << "The problematic name is: " << pathspecifier << "\n";
+        if (matches.empty()) {
+          throw edm::Exception(errors::Configuration)
+              << "EventSelector::init, An OutputModule is using SelectEvents\n"
+                 "to request all fails on a set of trigger names that do not exist\n"
+              << "The problematic name is: " << pathspecifier << "\n";
 
-	} else if (matches.size() == 1) {
-	  BitInfo bi(distance(pathNames.begin(),matches[0]), false);
-	  conditional_acceptors_.push_back(bi);
-	} else {
-	  Bits mustfail;
-	  for (unsigned int t = 0; t != matches.size(); ++t) {
-	    BitInfo bi(distance(pathNames.begin(),matches[t]), false);
-	    mustfail.push_back(bi);
-	  }
-	  all_must_fail_noex_.push_back(mustfail);
-	}
+        } else if (matches.size() == 1) {
+          BitInfo bi(distance(pathNames.begin(), matches[0]), false);
+          conditional_acceptors_.push_back(bi);
+        } else {
+          Bits mustfail;
+          for (unsigned int t = 0; t != matches.size(); ++t) {
+            BitInfo bi(distance(pathNames.begin(), matches[t]), false);
+            mustfail.push_back(bi);
+          }
+          all_must_fail_noex_.push_back(mustfail);
+        }
       }
-    } // end of the for loop on pathspecs
+    }  // end of the for loop on pathspecs
 
     // std::cerr << "### init exited\n";
 
-  } // EventSelector::init
+  }  // EventSelector::init
 
   bool EventSelector::acceptEvent(TriggerResults const& tr) {
-    if (accept_all_) return true;
+    if (accept_all_)
+      return true;
 
     if (!results_from_current_process_) {
       // The path names for prior processes may be different in different runs.
       // Check for this, and modify the selector accordingly if necessary.
       if (!psetID_.isValid() || psetID_ != tr.parameterSetID()) {
-         Strings pathNames;
-         bool fromPSetRegistry = false;
-         Service<service::TriggerNamesService> tns;
-         if (tns->getTrigPaths(tr, pathNames, fromPSetRegistry)) {
-           initPathNames(pathNames);
-           if (fromPSetRegistry) {
-             psetID_ = tr.parameterSetID();
-           } else {
-             // This can only happen for very old data, when the path names were stored
-             // in TriggerResults itself, rather than in the parameter set registry.
-             psetID_.reset();
-           }
-         } else {
-           // This should never happen
-           throw edm::Exception(errors::Unknown)
-             << "EventSelector::acceptEvent cannot find the trigger names for\n"
-                "a process for which the configuration has requested that the\n"
-                "OutputModule use TriggerResults to select events from.  This should\n"
-                "be impossible, please send information to reproduce this problem to\n"
-                "the edm developers.\n"; 
-         }
+        Strings pathNames;
+        bool fromPSetRegistry = false;
+        Service<service::TriggerNamesService> tns;
+        if (tns->getTrigPaths(tr, pathNames, fromPSetRegistry)) {
+          initPathNames(pathNames);
+          if (fromPSetRegistry) {
+            psetID_ = tr.parameterSetID();
+          } else {
+            // This can only happen for very old data, when the path names were stored
+            // in TriggerResults itself, rather than in the parameter set registry.
+            psetID_.reset();
+          }
+        } else {
+          // This should never happen
+          throw edm::Exception(errors::Unknown)
+              << "EventSelector::acceptEvent cannot find the trigger names for\n"
+                 "a process for which the configuration has requested that the\n"
+                 "OutputModule use TriggerResults to select events from.  This should\n"
+                 "be impossible, please send information to reproduce this problem to\n"
+                 "the edm developers.\n";
+        }
       }
     }
 
@@ -299,31 +279,26 @@ namespace edm
 
     return selectionDecision(tr);
 
-  } // acceptEvent(TriggerResults const& tr)
+  }  // acceptEvent(TriggerResults const& tr)
 
-  bool
-  EventSelector::acceptEvent(unsigned char const* array_of_trigger_results,
-  			     int number_of_trigger_paths) const
-  {
-
+  bool EventSelector::acceptEvent(unsigned char const* array_of_trigger_results, int number_of_trigger_paths) const {
     // This should never occur unless someone uses this function in
     // an incorrect way ...
     if (!results_from_current_process_) {
-      throw edm::Exception(errors::Configuration)
-        << "\nEventSelector.cc::acceptEvent, you are attempting to\n"
-        << "use a bit array for trigger results instead of the\n"
-        << "TriggerResults object for a previous process.  This\n"
-        << "will not work and ought to be impossible\n";
+      throw edm::Exception(errors::Configuration) << "\nEventSelector.cc::acceptEvent, you are attempting to\n"
+                                                  << "use a bit array for trigger results instead of the\n"
+                                                  << "TriggerResults object for a previous process.  This\n"
+                                                  << "will not work and ought to be impossible\n";
     }
 
-    if (accept_all_) return true;
+    if (accept_all_)
+      return true;
 
     // Form HLTGlobalStatus object to represent the array_of_trigger_results
     HLTGlobalStatus tr(number_of_trigger_paths);
     int byteIndex = 0;
-    int subIndex  = 0;
-    for (int pathIndex = 0; pathIndex < number_of_trigger_paths; ++pathIndex)
-    {
+    int subIndex = 0;
+    for (int pathIndex = 0; pathIndex < number_of_trigger_paths; ++pathIndex) {
       int state = array_of_trigger_results[byteIndex] >> (subIndex * 2);
       state &= 0x3;
       HLTPathStatus pathStatus(static_cast<hlt::HLTState>(state));
@@ -340,32 +315,34 @@ namespace edm
 
     return selectionDecision(tr);
 
-  } // acceptEvent(array_of_trigger_results, number_of_trigger_paths)
+  }  // acceptEvent(array_of_trigger_results, number_of_trigger_paths)
 
-  bool
-  EventSelector::selectionDecision(HLTGlobalStatus const& tr) const
-  {
-    if (accept_all_) return true;
+  bool EventSelector::selectionDecision(HLTGlobalStatus const& tr) const {
+    if (accept_all_)
+      return true;
 
     bool exceptionPresent = false;
     bool exceptionsLookedFor = false;
 
-    if (acceptOneBit(absolute_acceptors_, tr)) return true;
+    if (acceptOneBit(absolute_acceptors_, tr))
+      return true;
     if (acceptOneBit(conditional_acceptors_, tr)) {
       exceptionPresent = containsExceptions(tr);
-      if (!exceptionPresent) return true;
+      if (!exceptionPresent)
+        return true;
       exceptionsLookedFor = true;
     }
-    if (acceptOneBit(exception_acceptors_, tr, hlt::Exception)) return true;
+    if (acceptOneBit(exception_acceptors_, tr, hlt::Exception))
+      return true;
 
-    for (auto const& bit : all_must_fail_)
-    {
-      if (acceptAllBits(bit, tr)) return true;
+    for (auto const& bit : all_must_fail_) {
+      if (acceptAllBits(bit, tr))
+        return true;
     }
-    for (auto const& bitn : all_must_fail_noex_)
-    {
+    for (auto const& bitn : all_must_fail_noex_) {
       if (acceptAllBits(bitn, tr)) {
-        if (!exceptionsLookedFor) exceptionPresent = containsExceptions(tr);
+        if (!exceptionsLookedFor)
+          exceptionPresent = containsExceptions(tr);
         return (!exceptionPresent);
       }
     }
@@ -377,46 +354,36 @@ namespace edm
 
   }  // selectionDecision()
 
-// Obsolete...
-  bool EventSelector::acceptTriggerPath(HLTPathStatus const& pathStatus,
-                                        BitInfo const& pathInfo) const
-  {
-    return (((pathStatus.state()==hlt::Pass) && (pathInfo.accept_state_)) ||
-            ((pathStatus.state()==hlt::Fail) && !(pathInfo.accept_state_)) ||
-            ((pathStatus.state()==hlt::Exception)));
+  // Obsolete...
+  bool EventSelector::acceptTriggerPath(HLTPathStatus const& pathStatus, BitInfo const& pathInfo) const {
+    return (((pathStatus.state() == hlt::Pass) && (pathInfo.accept_state_)) ||
+            ((pathStatus.state() == hlt::Fail) && !(pathInfo.accept_state_)) ||
+            ((pathStatus.state() == hlt::Exception)));
   }
 
   // Indicate if any bit in the trigger results matches the desired value
   // at that position, based on the Bits array.  If s is Exception, this
   // looks for a Exceptionmatch; otherwise, true-->Pass, false-->Fail.
-  bool
-  EventSelector::acceptOneBit(Bits const& b,
-    		       	       HLTGlobalStatus const& tr,
-    		               hlt::HLTState const& s) const
-  {
+  bool EventSelector::acceptOneBit(Bits const& b, HLTGlobalStatus const& tr, hlt::HLTState const& s) const {
     bool lookForException = (s == hlt::Exception);
-    for(auto const& bit : b) {
-      hlt::HLTState bstate =
-          lookForException ? hlt::Exception
-      			   : bit.accept_state_ ? hlt::Pass
-				               : hlt::Fail;
-      if (tr[bit.pos_].state() == bstate) return true;
+    for (auto const& bit : b) {
+      hlt::HLTState bstate = lookForException ? hlt::Exception : bit.accept_state_ ? hlt::Pass : hlt::Fail;
+      if (tr[bit.pos_].state() == bstate)
+        return true;
     }
     return false;
-  } // acceptOneBit			
+  }  // acceptOneBit
 
   // Indicate if *every* bit in the trigger results matches the desired value
   // at that position, based on the Bits array: true-->Pass, false-->Fail.
-  bool
-  EventSelector::acceptAllBits(Bits const& b,
-    		        	HLTGlobalStatus const& tr) const
-  {
-    for(auto const& bit : b) {
+  bool EventSelector::acceptAllBits(Bits const& b, HLTGlobalStatus const& tr) const {
+    for (auto const& bit : b) {
       hlt::HLTState bstate = bit.accept_state_ ? hlt::Pass : hlt::Fail;
-      if (tr[bit.pos_].state() != bstate) return false;
+      if (tr[bit.pos_].state() != bstate)
+        return false;
     }
     return true;
-  } // acceptAllBits			
+  }  // acceptAllBits
 
   /**
    * Tests if the specified trigger selection list (pathspecs) is valid
@@ -433,20 +400,16 @@ namespace edm
    * @param fullPathList The full list of path names (vector of string).
    * @return true if the selection list is valid, false otherwise.
    */
-  bool EventSelector::selectionIsValid(Strings const& pathspecs,
-                                       Strings const& fullPathList)
-  {
+  bool EventSelector::selectionIsValid(Strings const& pathspecs, Strings const& fullPathList) {
     // an empty selection list is not valid
     // (we default an empty "SelectEvents" parameter to {"*","!*"} in
     // the getEventSelectionVString method below to help avoid this)
-    if (pathspecs.empty())
-    {
+    if (pathspecs.empty()) {
       return false;
     }
 
     // loop over each element in the selection list
-    for (unsigned int idx = 0; idx < pathspecs.size(); idx++)
-    {
+    for (unsigned int idx = 0; idx < pathspecs.size(); idx++) {
       Strings workingList;
       workingList.push_back(pathspecs[idx]);
 
@@ -454,8 +417,7 @@ namespace edm
       // (and anywhere else) and mark those as failures.
       // The EventSelector constructor seems to do the work of
       // checking if the selection is outside the full trigger list.
-      try
-      {
+      try {
         // create an EventSelector instance for this selection
         EventSelector evtSelector(workingList, fullPathList);
 
@@ -466,16 +428,11 @@ namespace edm
 
         // loop over each path
         bool oneResultMatched = false;
-        for (unsigned int iPath = 0; iPath < fullPathCount; iPath++)
-        {
+        for (unsigned int iPath = 0; iPath < fullPathCount; iPath++) {
           // loop over the possible values for the path status
-          for (int iState = static_cast<int>(hlt::Pass);
-               iState <= static_cast<int>(hlt::Exception);
-               iState++)
-          {
+          for (int iState = static_cast<int>(hlt::Pass); iState <= static_cast<int>(hlt::Exception); iState++) {
             sampleResults[iPath] = HLTPathStatus(static_cast<hlt::HLTState>(iState), 0);
-            if (evtSelector.wantAll() || evtSelector.acceptEvent(sampleResults))
-            {
+            if (evtSelector.wantAll() || evtSelector.acceptEvent(sampleResults)) {
               oneResultMatched = true;
               break;
             }
@@ -483,31 +440,29 @@ namespace edm
             sampleResults.reset(iPath);
           }
 
-          if (oneResultMatched) break;
+          if (oneResultMatched)
+            break;
         }
 
-	// Finally, check in case the selection element was a wildcarded
-	// negative such as "!*":
-	
-        if (!oneResultMatched)  {
-	  for (unsigned int iPath = 0; iPath < fullPathCount; iPath++) {
+        // Finally, check in case the selection element was a wildcarded
+        // negative such as "!*":
+
+        if (!oneResultMatched) {
+          for (unsigned int iPath = 0; iPath < fullPathCount; iPath++) {
             sampleResults[iPath] = HLTPathStatus(hlt::Fail, 0);
           }
-	  if (evtSelector.acceptEvent(sampleResults)) {
-              oneResultMatched = true;
+          if (evtSelector.acceptEvent(sampleResults)) {
+            oneResultMatched = true;
           }
         }
-	
+
         // if none of the possible trigger results matched the
         // selection element, then we declare the whole selection
         // list invalid
-        if (!oneResultMatched)
-        {
+        if (!oneResultMatched) {
           return false;
         }
-      }
-      catch (edm::Exception const&)
-      {
+      } catch (edm::Exception const&) {
         return false;
       }
     }
@@ -516,7 +471,6 @@ namespace edm
     // to satisfy every selection element one way or another
     return true;
   }
-
 
   /**
    * Tests if the specified trigger selection lists (path specs) overlap,
@@ -528,24 +482,19 @@ namespace edm
    * @param fullPathList The full list of trigger names (vector of string).
    * @return OverlapResult which indicates the degree of overlap.
    */
-  evtSel::OverlapResult
-  EventSelector::testSelectionOverlap(Strings const& pathspec1,
-                                      Strings const& pathspec2,
-                                      Strings const& fullPathList)
-  {
+  evtSel::OverlapResult EventSelector::testSelectionOverlap(Strings const& pathspec1,
+                                                            Strings const& pathspec2,
+                                                            Strings const& fullPathList) {
     bool overlap = false;
 
     // first, test that the selection lists are valid
-    if (!selectionIsValid(pathspec1, fullPathList) ||
-        !selectionIsValid(pathspec2, fullPathList))
-    {
+    if (!selectionIsValid(pathspec1, fullPathList) || !selectionIsValid(pathspec2, fullPathList)) {
       return evtSel::InvalidSelection;
     }
 
     // catch exceptions from the EventSelector constructor
     // (and anywhere else) and mark those as failures
-    try
-    {
+    try {
       // create an EventSelector instance for each selection list
       EventSelector a(pathspec1, fullPathList);
       EventSelector b(pathspec2, fullPathList);
@@ -553,44 +502,32 @@ namespace edm
       unsigned int N = fullPathList.size();
 
       // create the expanded masks for the various decision lists in a and b
-      std::vector<bool>
-      	aPassAbs = expandDecisionList(a.absolute_acceptors_,true,N);
-      std::vector<bool>
-      	aPassCon = expandDecisionList(a.conditional_acceptors_,true,N);
-      std::vector<bool>
-      	aFailAbs = expandDecisionList(a.absolute_acceptors_,false,N);
-      std::vector<bool>
-      	aFailCon = expandDecisionList(a.conditional_acceptors_,false,N);
-      std::vector<bool>
-      	aExc = expandDecisionList(a.exception_acceptors_,true,N);
-      std::vector< std::vector<bool> > aMustFail;
+      std::vector<bool> aPassAbs = expandDecisionList(a.absolute_acceptors_, true, N);
+      std::vector<bool> aPassCon = expandDecisionList(a.conditional_acceptors_, true, N);
+      std::vector<bool> aFailAbs = expandDecisionList(a.absolute_acceptors_, false, N);
+      std::vector<bool> aFailCon = expandDecisionList(a.conditional_acceptors_, false, N);
+      std::vector<bool> aExc = expandDecisionList(a.exception_acceptors_, true, N);
+      std::vector<std::vector<bool> > aMustFail;
       for (unsigned int m = 0; m != a.all_must_fail_.size(); ++m) {
-        aMustFail.push_back(expandDecisionList(a.all_must_fail_[m],false,N));
+        aMustFail.push_back(expandDecisionList(a.all_must_fail_[m], false, N));
       }
-      std::vector< std::vector<bool> > aMustFailNoex;
+      std::vector<std::vector<bool> > aMustFailNoex;
       for (unsigned int m = 0; m != a.all_must_fail_noex_.size(); ++m) {
-        aMustFailNoex.push_back
-		(expandDecisionList(a.all_must_fail_noex_[m],false,N));
+        aMustFailNoex.push_back(expandDecisionList(a.all_must_fail_noex_[m], false, N));
       }
 
-      std::vector<bool>
-      	bPassAbs = expandDecisionList(b.absolute_acceptors_,true,N);
-      std::vector<bool>
-      	bPassCon = expandDecisionList(b.conditional_acceptors_,true,N);
-      std::vector<bool>
-      	bFailAbs = expandDecisionList(b.absolute_acceptors_,false,N);
-      std::vector<bool>
-      	bFailCon = expandDecisionList(b.conditional_acceptors_,false,N);
-      std::vector<bool>
-      	bExc = expandDecisionList(b.exception_acceptors_,true,N);
-      std::vector< std::vector<bool> > bMustFail;
+      std::vector<bool> bPassAbs = expandDecisionList(b.absolute_acceptors_, true, N);
+      std::vector<bool> bPassCon = expandDecisionList(b.conditional_acceptors_, true, N);
+      std::vector<bool> bFailAbs = expandDecisionList(b.absolute_acceptors_, false, N);
+      std::vector<bool> bFailCon = expandDecisionList(b.conditional_acceptors_, false, N);
+      std::vector<bool> bExc = expandDecisionList(b.exception_acceptors_, true, N);
+      std::vector<std::vector<bool> > bMustFail;
       for (unsigned int m = 0; m != b.all_must_fail_.size(); ++m) {
-        bMustFail.push_back(expandDecisionList(b.all_must_fail_[m],false,N));
+        bMustFail.push_back(expandDecisionList(b.all_must_fail_[m], false, N));
       }
-      std::vector< std::vector<bool> > bMustFailNoex;
+      std::vector<std::vector<bool> > bMustFailNoex;
       for (unsigned int m = 0; m != b.all_must_fail_noex_.size(); ++m) {
-        bMustFailNoex.push_back
-		(expandDecisionList(b.all_must_fail_noex_[m],false,N));
+        bMustFailNoex.push_back(expandDecisionList(b.all_must_fail_noex_[m], false, N));
       }
 
       std::vector<bool> aPass = combine(aPassAbs, aPassCon);
@@ -599,49 +536,53 @@ namespace edm
       std::vector<bool> bFail = combine(bFailAbs, bFailCon);
 
       // Check for overlap in the primary masks
-      overlap = overlapping(aPass, bPass) ||
-      		overlapping(aFail, bFail) ||
-     		overlapping(aExc, bExc);
-      if (overlap) return identical(a,b,N) ? evtSel::ExactMatch
-      					     : evtSel::PartialOverlap;
+      overlap = overlapping(aPass, bPass) || overlapping(aFail, bFail) || overlapping(aExc, bExc);
+      if (overlap)
+        return identical(a, b, N) ? evtSel::ExactMatch : evtSel::PartialOverlap;
 
       // Check for overlap of a primary fail mask with a must fail mask
       for (unsigned int f = 0; f != aMustFail.size(); ++f) {
         overlap = overlapping(aMustFail[f], bFail);
-	if (overlap) return evtSel::PartialOverlap;
-	for (unsigned int g = 0; g != bMustFail.size(); ++g) {
+        if (overlap)
+          return evtSel::PartialOverlap;
+        for (unsigned int g = 0; g != bMustFail.size(); ++g) {
           overlap = subset(aMustFail[f], bMustFail[g]);
-	  if (overlap) return evtSel::PartialOverlap;
-	}
-	for (unsigned int g = 0; g != bMustFailNoex.size(); ++g) {
+          if (overlap)
+            return evtSel::PartialOverlap;
+        }
+        for (unsigned int g = 0; g != bMustFailNoex.size(); ++g) {
           overlap = subset(aMustFail[f], bMustFailNoex[g]);
-	  if (overlap) return evtSel::PartialOverlap;
-	}
+          if (overlap)
+            return evtSel::PartialOverlap;
+        }
       }
       for (unsigned int f = 0; f != aMustFailNoex.size(); ++f) {
         overlap = overlapping(aMustFailNoex[f], bFail);
-	if (overlap) return evtSel::PartialOverlap;
-	for (unsigned int g = 0; g != bMustFail.size(); ++g) {
+        if (overlap)
+          return evtSel::PartialOverlap;
+        for (unsigned int g = 0; g != bMustFail.size(); ++g) {
           overlap = subset(aMustFailNoex[f], bMustFail[g]);
-	  if (overlap) return evtSel::PartialOverlap;
-	}
-	for (unsigned int g = 0; g != bMustFailNoex.size(); ++g) {
+          if (overlap)
+            return evtSel::PartialOverlap;
+        }
+        for (unsigned int g = 0; g != bMustFailNoex.size(); ++g) {
           overlap = subset(aMustFailNoex[f], bMustFailNoex[g]);
-	  if (overlap) return evtSel::PartialOverlap;
-	}
+          if (overlap)
+            return evtSel::PartialOverlap;
+        }
       }
       for (unsigned int g = 0; g != bMustFail.size(); ++g) {
         overlap = overlapping(bMustFail[g], aFail);
-	if (overlap) return evtSel::PartialOverlap;
+        if (overlap)
+          return evtSel::PartialOverlap;
       }
       for (unsigned int g = 0; g != bMustFailNoex.size(); ++g) {
         overlap = overlapping(bMustFail[g], aFail);
-	if (overlap) return evtSel::PartialOverlap;
+        if (overlap)
+          return evtSel::PartialOverlap;
       }
 
-    }
-    catch (edm::Exception const&)
-    {
+    } catch (edm::Exception const&) {
       return evtSel::InvalidSelection;
     }
 
@@ -649,7 +590,7 @@ namespace edm
 
     return evtSel::NoOverlap;
 
-  } // testSelectionOverlap
+  }  // testSelectionOverlap
 
 #ifdef REMOVE
   /**
@@ -662,15 +603,11 @@ namespace edm
    * @param fullPathList The full list of trigger names (vector of string).
    * @return OverlapResult which indicates the degree of overlap.
    */
-  evtSel::OverlapResult
-  EventSelector::testSelectionOverlap(Strings const& pathspec1,
-                                      Strings const& pathspec2,
-                                      Strings const& fullPathList)
-  {
+  evtSel::OverlapResult EventSelector::testSelectionOverlap(Strings const& pathspec1,
+                                                            Strings const& pathspec2,
+                                                            Strings const& fullPathList) {
     // first, test that the selection lists are valid
-    if (!selectionIsValid(pathspec1, fullPathList) ||
-        !selectionIsValid(pathspec2, fullPathList))
-    {
+    if (!selectionIsValid(pathspec1, fullPathList) || !selectionIsValid(pathspec2, fullPathList)) {
       return evtSel::InvalidSelection;
     }
 
@@ -680,8 +617,7 @@ namespace edm
 
     // catch exceptions from the EventSelector constructor
     // (and anywhere else) and mark those as failures
-    try
-    {
+    try {
       // create an EventSelector instance for each selection list
       EventSelector selector1(pathspec1, fullPathList);
       EventSelector selector2(pathspec2, fullPathList);
@@ -692,38 +628,31 @@ namespace edm
       TriggerResults sampleResults(hltGS, fullPathList);
 
       // loop over each path
-      for (unsigned int iPath = 0; iPath < fullPathCount; iPath++)
-      {
+      for (unsigned int iPath = 0; iPath < fullPathCount; iPath++) {
         // loop over the possible values for the path status
-        for (int iState = static_cast<int>(hlt::Pass);
-             iState <= static_cast<int>(hlt::Exception);
-             iState++)
-        {
-          sampleResults[iPath] =
-            HLTPathStatus(static_cast<hlt::HLTState>(iState), 0);
-          bool accept1 = selector1.wantAll() ||
-            selector1.acceptEvent(sampleResults);
-          bool accept2 = selector2.wantAll() ||
-            selector2.acceptEvent(sampleResults);
-          if (accept1 != accept2)
-          {
+        for (int iState = static_cast<int>(hlt::Pass); iState <= static_cast<int>(hlt::Exception); iState++) {
+          sampleResults[iPath] = HLTPathStatus(static_cast<hlt::HLTState>(iState), 0);
+          bool accept1 = selector1.wantAll() || selector1.acceptEvent(sampleResults);
+          bool accept2 = selector2.wantAll() || selector2.acceptEvent(sampleResults);
+          if (accept1 != accept2) {
             exactMatch = false;
           }
-          if (accept1 && accept2)
-          {
+          if (accept1 && accept2) {
             noOverlap = false;
           }
           sampleResults.reset(iPath);
         }
       }
-    }
-    catch (edm::Exception const& excpt)
-    {
+    } catch (edm::Exception const& excpt) {
       return evtSel::InvalidSelection;
     }
 
-    if (exactMatch) {return evtSel::ExactMatch;}
-    if (noOverlap) {return evtSel::NoOverlap;}
+    if (exactMatch) {
+      return evtSel::ExactMatch;
+    }
+    if (noOverlap) {
+      return evtSel::NoOverlap;
+    }
     return evtSel::PartialOverlap;
   }
 #endif
@@ -744,19 +673,15 @@ namespace edm
    *         if the trigger selection is invalid in the context of the
    *         full trigger list.
    */
-  std::shared_ptr<TriggerResults>
-  EventSelector::maskTriggerResults(TriggerResults const& inputResults)
-  {
+  std::shared_ptr<TriggerResults> EventSelector::maskTriggerResults(TriggerResults const& inputResults) {
     // fetch and validate the total number of paths
     unsigned int fullPathCount = nPathNames_;
     unsigned int N = fullPathCount;
-    if (fullPathCount != inputResults.size())
-    {
+    if (fullPathCount != inputResults.size()) {
       throw edm::Exception(errors::EventCorruption)
-        << "EventSelector::maskTriggerResults, the TriggerResults\n"
-        << "size (" << inputResults.size()
-        << ") does not match the number of paths in the\n"
-        << "full trigger list (" << fullPathCount << ").\n";
+          << "EventSelector::maskTriggerResults, the TriggerResults\n"
+          << "size (" << inputResults.size() << ") does not match the number of paths in the\n"
+          << "full trigger list (" << fullPathCount << ").\n";
     }
 
     // create a suitable global status object to work with, all in Ready state
@@ -764,67 +689,53 @@ namespace edm
 
     // Deal with must_fail acceptors that would cause selection
     for (unsigned int m = 0; m < this->all_must_fail_.size(); ++m) {
-      std::vector<bool>
-        f = expandDecisionList(this->all_must_fail_[m],false,N);
+      std::vector<bool> f = expandDecisionList(this->all_must_fail_[m], false, N);
       bool all_fail = true;
       for (unsigned int ipath = 0; ipath < N; ++ipath) {
-	if  ((f[ipath]) && (inputResults [ipath].state() != hlt::Fail)) {
-	  all_fail = false;
-	  break;
-	}
+        if ((f[ipath]) && (inputResults[ipath].state() != hlt::Fail)) {
+          all_fail = false;
+          break;
+        }
       }
       if (all_fail) {
-	for (unsigned int ipath = 0; ipath < N; ++ipath) {
-          if  (f[ipath]) {
-	    mask[ipath] = hlt::Fail;
-	  }
-	}
+        for (unsigned int ipath = 0; ipath < N; ++ipath) {
+          if (f[ipath]) {
+            mask[ipath] = hlt::Fail;
+          }
+        }
       }
     }
     for (unsigned int m = 0; m < this->all_must_fail_noex_.size(); ++m) {
-      std::vector<bool>
-        f = expandDecisionList(this->all_must_fail_noex_[m],false,N);
+      std::vector<bool> f = expandDecisionList(this->all_must_fail_noex_[m], false, N);
       bool all_fail = true;
       for (unsigned int ipath = 0; ipath < N; ++ipath) {
-	if ((f[ipath]) && (inputResults [ipath].state() != hlt::Fail)) {
-	  all_fail = false;
-	  break;
-	}
+        if ((f[ipath]) && (inputResults[ipath].state() != hlt::Fail)) {
+          all_fail = false;
+          break;
+        }
       }
       if (all_fail) {
-	for (unsigned int ipath = 0; ipath < N; ++ipath) {
-          if  (f[ipath]) {
-	    mask[ipath] = hlt::Fail;
-	  }
-	}
+        for (unsigned int ipath = 0; ipath < N; ++ipath) {
+          if (f[ipath]) {
+            mask[ipath] = hlt::Fail;
+          }
+        }
       }
-    } // factoring opportunity - work done for fail_noex_ is same as for fail_
+    }  // factoring opportunity - work done for fail_noex_ is same as for fail_
 
     // Deal with normal acceptors that would cause selection
-    std::vector<bool>
-      aPassAbs = expandDecisionList(this->absolute_acceptors_,true,N);
-    std::vector<bool>
-      aPassCon = expandDecisionList(this->conditional_acceptors_,true,N);
-    std::vector<bool>
-      aFailAbs = expandDecisionList(this->absolute_acceptors_,false,N);
-    std::vector<bool>
-      aFailCon = expandDecisionList(this->conditional_acceptors_,false,N);
-    std::vector<bool>
-      aExc = expandDecisionList(this->exception_acceptors_,true,N);
+    std::vector<bool> aPassAbs = expandDecisionList(this->absolute_acceptors_, true, N);
+    std::vector<bool> aPassCon = expandDecisionList(this->conditional_acceptors_, true, N);
+    std::vector<bool> aFailAbs = expandDecisionList(this->absolute_acceptors_, false, N);
+    std::vector<bool> aFailCon = expandDecisionList(this->conditional_acceptors_, false, N);
+    std::vector<bool> aExc = expandDecisionList(this->exception_acceptors_, true, N);
     for (unsigned int ipath = 0; ipath < N; ++ipath) {
-      hlt::HLTState s = inputResults [ipath].state();
-      if (((aPassAbs[ipath]) && (s == hlt::Pass))
-      		||
-	  ((aPassCon[ipath]) && (s == hlt::Pass))		
-      		||
-	  ((aFailAbs[ipath]) && (s == hlt::Fail))		
-      		||
-	  ((aFailCon[ipath]) && (s == hlt::Fail))
-	        ||
-	  ((aExc[ipath]) && (s == hlt::Exception)))
-      {
+      hlt::HLTState s = inputResults[ipath].state();
+      if (((aPassAbs[ipath]) && (s == hlt::Pass)) || ((aPassCon[ipath]) && (s == hlt::Pass)) ||
+          ((aFailAbs[ipath]) && (s == hlt::Fail)) || ((aFailCon[ipath]) && (s == hlt::Fail)) ||
+          ((aExc[ipath]) && (s == hlt::Exception))) {
         mask[ipath] = s;
-      }		
+      }
     }
 
     // Based on the global status for the mask, create and return a
@@ -832,10 +743,6 @@ namespace edm
     auto maskedResults = std::make_shared<TriggerResults>(mask, inputResults.parameterSetID());
     return maskedResults;
   }  // maskTriggerResults
-
-
-
-
 
 #ifdef REMOVE
   /**
@@ -856,27 +763,22 @@ namespace edm
    *         if the trigger selection is invalid in the context of the
    *         full trigger list.
    */
-  std::shared_ptr<TriggerResults>
-  EventSelector::maskTriggerResults(Strings const& pathspecs,
-                                    TriggerResults const& inputResults,
-                                    Strings const& fullPathList)
-  {
+  std::shared_ptr<TriggerResults> EventSelector::maskTriggerResults(Strings const& pathspecs,
+                                                                    TriggerResults const& inputResults,
+                                                                    Strings const& fullPathList) {
     // fetch and validate the total number of paths
     unsigned int fullPathCount = fullPathList.size();
-    if (fullPathCount != inputResults.size())
-    {
+    if (fullPathCount != inputResults.size()) {
       throw edm::Exception(errors::EventCorruption)
-        << "EventSelector::maskTriggerResults, the TriggerResults\n"
-        << "size (" << inputResults.size()
-        << ") does not match the number of paths in the\n"
-        << "full trigger list (" << fullPathCount << ").\n";
+          << "EventSelector::maskTriggerResults, the TriggerResults\n"
+          << "size (" << inputResults.size() << ") does not match the number of paths in the\n"
+          << "full trigger list (" << fullPathCount << ").\n";
     }
 
     // create a working copy of the TriggerResults object
     HLTGlobalStatus hltGS(fullPathCount);
     auto maskedResults = std::make_shared<TriggerResults>(hltGS, inputResults.parameterSetID());
-    for (unsigned int iPath = 0; iPath < fullPathCount; iPath++)
-    {
+    for (unsigned int iPath = 0; iPath < fullPathCount; iPath++) {
       (*maskedResults)[iPath] = inputResults[iPath];
     }
 
@@ -888,11 +790,9 @@ namespace edm
     TriggerResults sampleResults(hltGS2, fullPathList);
 
     // loop over each path and reset the path status if needed
-    for (unsigned int iPath = 0; iPath < fullPathCount; iPath++)
-    {
+    for (unsigned int iPath = 0; iPath < fullPathCount; iPath++) {
       sampleResults[iPath] = (*maskedResults)[iPath];
-      if (!selector.wantAll() && !selector.acceptEvent(sampleResults))
-      {
+      if (!selector.wantAll() && !selector.acceptEvent(sampleResults)) {
         maskedResults->reset(iPath);
       }
       sampleResults.reset(iPath);
@@ -909,9 +809,7 @@ namespace edm
    * @param pset The ParameterSet that contains the trigger selection.
    * @return the trigger selection list (vector of string).
    */
-  std::vector<std::string>
-  EventSelector::getEventSelectionVString(ParameterSet const& pset)
-  {
+  std::vector<std::string> EventSelector::getEventSelectionVString(ParameterSet const& pset) {
     // default the selection to everything (wildcard)
     Strings selection;
     selection.push_back("*");
@@ -920,11 +818,9 @@ namespace edm
 
     // the SelectEvents parameter is a ParameterSet within
     // a ParameterSet, so we have to pull it out twice
-    ParameterSet selectEventsParamSet =
-      pset.getUntrackedParameter("SelectEvents", ParameterSet());
+    ParameterSet selectEventsParamSet = pset.getUntrackedParameter("SelectEvents", ParameterSet());
     if (!selectEventsParamSet.empty()) {
-      Strings path_specs =
-        selectEventsParamSet.getParameter<Strings>("SelectEvents");
+      Strings path_specs = selectEventsParamSet.getParameter<Strings>("SelectEvents");
       if (!path_specs.empty()) {
         selection = path_specs;
       }
@@ -934,124 +830,117 @@ namespace edm
     return selection;
   }
 
-  bool EventSelector::containsExceptions(HLTGlobalStatus const& tr) const
-  {
+  bool EventSelector::containsExceptions(HLTGlobalStatus const& tr) const {
     unsigned int e = tr.size();
     for (unsigned int i = 0; i < e; ++i) {
-      if (tr[i].state() == hlt::Exception) return true;
+      if (tr[i].state() == hlt::Exception)
+        return true;
     }
     return false;
   }
 
   // The following routines are helpers for testSelectionOverlap
 
-  bool
-  EventSelector::identical(std::vector<bool> const& a,
-  			   std::vector<bool> const& b) {
-     unsigned int n = a.size();
-     if (n != b.size()) return false;
-     for (unsigned int i=0; i!=n; ++i) {
-       if (a[i] != b[i]) return false;
-     }
-     return true;
+  bool EventSelector::identical(std::vector<bool> const& a, std::vector<bool> const& b) {
+    unsigned int n = a.size();
+    if (n != b.size())
+      return false;
+    for (unsigned int i = 0; i != n; ++i) {
+      if (a[i] != b[i])
+        return false;
+    }
+    return true;
   }
 
-  bool
-  EventSelector::identical(EventSelector const& a,
-  			   EventSelector const& b,
-			   unsigned int N)
-  {
-        // create the expanded masks for the various decision lists in a and b
-    if (!identical(expandDecisionList(a.absolute_acceptors_,true,N),
-                   expandDecisionList(b.absolute_acceptors_,true,N)))
-		   return false;
-    if (!identical(expandDecisionList(a.conditional_acceptors_,true,N),
-                   expandDecisionList(b.conditional_acceptors_,true,N)))
-		   return false;
-    if (!identical(expandDecisionList(a.absolute_acceptors_,false,N),
-                   expandDecisionList(b.absolute_acceptors_,false,N)))
-		   return false;
-    if (!identical(expandDecisionList(a.conditional_acceptors_,false,N),
-                   expandDecisionList(b.conditional_acceptors_,false,N)))
-		   return false;
-    if (!identical(expandDecisionList(a.exception_acceptors_,true,N),
-                   expandDecisionList(b.exception_acceptors_,true,N)))
-		   return false;
-    if (a.all_must_fail_.size() != b.all_must_fail_.size()) return false;
+  bool EventSelector::identical(EventSelector const& a, EventSelector const& b, unsigned int N) {
+    // create the expanded masks for the various decision lists in a and b
+    if (!identical(expandDecisionList(a.absolute_acceptors_, true, N),
+                   expandDecisionList(b.absolute_acceptors_, true, N)))
+      return false;
+    if (!identical(expandDecisionList(a.conditional_acceptors_, true, N),
+                   expandDecisionList(b.conditional_acceptors_, true, N)))
+      return false;
+    if (!identical(expandDecisionList(a.absolute_acceptors_, false, N),
+                   expandDecisionList(b.absolute_acceptors_, false, N)))
+      return false;
+    if (!identical(expandDecisionList(a.conditional_acceptors_, false, N),
+                   expandDecisionList(b.conditional_acceptors_, false, N)))
+      return false;
+    if (!identical(expandDecisionList(a.exception_acceptors_, true, N),
+                   expandDecisionList(b.exception_acceptors_, true, N)))
+      return false;
+    if (a.all_must_fail_.size() != b.all_must_fail_.size())
+      return false;
 
-    std::vector< std::vector<bool> > aMustFail;
+    std::vector<std::vector<bool> > aMustFail;
     for (unsigned int m = 0; m != a.all_must_fail_.size(); ++m) {
-      aMustFail.push_back(expandDecisionList(a.all_must_fail_[m],false,N));
+      aMustFail.push_back(expandDecisionList(a.all_must_fail_[m], false, N));
     }
-    std::vector< std::vector<bool> > aMustFailNoex;
+    std::vector<std::vector<bool> > aMustFailNoex;
     for (unsigned int m = 0; m != a.all_must_fail_noex_.size(); ++m) {
-      aMustFailNoex.push_back
-	      (expandDecisionList(a.all_must_fail_noex_[m],false,N));
+      aMustFailNoex.push_back(expandDecisionList(a.all_must_fail_noex_[m], false, N));
     }
-    std::vector< std::vector<bool> > bMustFail;
+    std::vector<std::vector<bool> > bMustFail;
     for (unsigned int m = 0; m != b.all_must_fail_.size(); ++m) {
-      bMustFail.push_back(expandDecisionList(b.all_must_fail_[m],false,N));
+      bMustFail.push_back(expandDecisionList(b.all_must_fail_[m], false, N));
     }
-    std::vector< std::vector<bool> > bMustFailNoex;
+    std::vector<std::vector<bool> > bMustFailNoex;
     for (unsigned int m = 0; m != b.all_must_fail_noex_.size(); ++m) {
-      bMustFailNoex.push_back
-	      (expandDecisionList(b.all_must_fail_noex_[m],false,N));
+      bMustFailNoex.push_back(expandDecisionList(b.all_must_fail_noex_[m], false, N));
     }
 
     for (unsigned int m = 0; m != aMustFail.size(); ++m) {
       bool match = false;
       for (unsigned int k = 0; k != bMustFail.size(); ++k) {
-        if (identical(aMustFail[m],bMustFail[k])) {
+        if (identical(aMustFail[m], bMustFail[k])) {
           match = true;
-	  break;
-	}
+          break;
+        }
       }
-      if (!match) return false;
+      if (!match)
+        return false;
     }
     for (unsigned int m = 0; m != aMustFailNoex.size(); ++m) {
       bool match = false;
       for (unsigned int k = 0; k != bMustFailNoex.size(); ++k) {
-         if (identical(aMustFailNoex[m],bMustFailNoex[k])) {
+        if (identical(aMustFailNoex[m], bMustFailNoex[k])) {
           match = true;
-	  break;
-	}
+          break;
+        }
       }
-      if (!match) return false;
+      if (!match)
+        return false;
     }
 
     return true;
 
-  } // identical (EventSelector, EventSelector, N);
+  }  // identical (EventSelector, EventSelector, N);
 
-  std::vector<bool>
-  EventSelector::expandDecisionList(Bits const& b,
-				      bool PassOrFail,
-				      unsigned int n)
-  {
+  std::vector<bool> EventSelector::expandDecisionList(Bits const& b, bool PassOrFail, unsigned int n) {
     std::vector<bool> x(n, false);
     for (unsigned int i = 0; i != b.size(); ++i) {
-      if (b[i].accept_state_ == PassOrFail) x[b[i].pos_] = true;
+      if (b[i].accept_state_ == PassOrFail)
+        x[b[i].pos_] = true;
     }
     return x;
-  } // expandDecisionList	
+  }  // expandDecisionList
 
   // Determines whether a and b share a true bit at any position
-  bool EventSelector::overlapping(std::vector<bool> const& a,
-    			             std::vector<bool> const& b)
-  {
-    if (a.size() != b.size()) return false;
+  bool EventSelector::overlapping(std::vector<bool> const& a, std::vector<bool> const& b) {
+    if (a.size() != b.size())
+      return false;
     for (unsigned int i = 0; i != a.size(); ++i) {
-      if (a[i] && b[i]) return true;
+      if (a[i] && b[i])
+        return true;
     }
     return false;
-  } // overlapping
+  }  // overlapping
 
   // determines whether the true bits of a are a non-empty subset of those of b,
   // or vice-versa.  The subset need not be proper.
-  bool EventSelector::subset(std::vector<bool> const& a,
-    			       std::vector<bool> const& b)
-  {
-    if (a.size() != b.size()) return false;
+  bool EventSelector::subset(std::vector<bool> const& a, std::vector<bool> const& b) {
+    if (a.size() != b.size())
+      return false;
     // First test whether a is a non-empty subset of b
     bool aPresent = false;
     bool aSubset = true;
@@ -1059,13 +948,15 @@ namespace edm
       if (a[i]) {
         aPresent = true;
         if (!b[i]) {
-	  aSubset = false;
-	  break;
-	}
+          aSubset = false;
+          break;
+        }
       }
     }
-    if (!aPresent) return false;
-    if (aSubset) return true;
+    if (!aPresent)
+      return false;
+    if (aSubset)
+      return true;
 
     // Now test whether b is a non-empty subset of a
     bool bPresent = false;
@@ -1074,36 +965,34 @@ namespace edm
       if (b[i]) {
         bPresent = true;
         if (!a[i]) {
-	  bSubset = false;
-	  break;
-	}
+          bSubset = false;
+          break;
+        }
       }
     }
-    if (!bPresent) return false;
-    if (bSubset) return true;
+    if (!bPresent)
+      return false;
+    if (bSubset)
+      return true;
 
     return false;
-  } // subset
+  }  // subset
 
   // Creates a vector of bits which is the OR of a and b
-  std::vector<bool>
-  EventSelector::combine(std::vector<bool> const& a,
-    			  std::vector<bool> const& b)
-  {
+  std::vector<bool> EventSelector::combine(std::vector<bool> const& a, std::vector<bool> const& b) {
     assert(a.size() == b.size());
     std::vector<bool> x(a.size());
     for (unsigned int i = 0; i != a.size(); ++i) {
       x[i] = a[i] || b[i];
-    } // a really sharp compiler will optimize the hell out of this,
-      // exploiting word-size OR operations.
+    }  // a really sharp compiler will optimize the hell out of this,
+    // exploiting word-size OR operations.
     return x;
-  } // combine			   			
+  }  // combine
 
-  void
-  EventSelector::fillDescription(ParameterSetDescription& desc) {
+  void EventSelector::fillDescription(ParameterSetDescription& desc) {
     ParameterSetDescription selector;
     selector.addOptional<std::vector<std::string> >("SelectEvents");
     desc.addUntracked<ParameterSetDescription>("SelectEvents", selector);
   }
 
-}
+}  // namespace edm

--- a/FWCore/Framework/src/EventSetup.cc
+++ b/FWCore/Framework/src/EventSetup.cc
@@ -20,43 +20,43 @@
 #include "FWCore/Framework/interface/EventSetupKnownRecordsSupplier.h"
 
 namespace edm {
-//
-// constants, enums and typedefs
-//
+  //
+  // constants, enums and typedefs
+  //
 
-//
-// static data member definitions
-//
+  //
+  // static data member definitions
+  //
 
-//
-// constructors and destructor
-//
+  //
+  // constructors and destructor
+  //
 
-// EventSetup::EventSetup(EventSetup const& rhs)
-// {
-//    // do actual copying here;
-// }
+  // EventSetup::EventSetup(EventSetup const& rhs)
+  // {
+  //    // do actual copying here;
+  // }
 
-//
-// assignment operators
-//
-// EventSetup const& EventSetup::operator=(EventSetup const& rhs)
-// {
-//   //An exception safe implementation is
-//   EventSetup temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+  //
+  // assignment operators
+  //
+  // EventSetup const& EventSetup::operator=(EventSetup const& rhs)
+  // {
+  //   //An exception safe implementation is
+  //   EventSetup temp(rhs);
+  //   swap(rhs);
+  //
+  //   return *this;
+  // }
 
-//
-// member functions
-//
-//
-// const member functions
-//
+  //
+  // member functions
+  //
+  //
+  // const member functions
+  //
 
-//
-// static member functions
-//
-}
+  //
+  // static member functions
+  //
+}  // namespace edm

--- a/FWCore/Framework/src/EventSetupImpl.cc
+++ b/FWCore/Framework/src/EventSetupImpl.cc
@@ -20,110 +20,88 @@
 #include "FWCore/Framework/interface/EventSetupKnownRecordsSupplier.h"
 
 namespace edm {
-//
-// constants, enums and typedefs
-//
+  //
+  // constants, enums and typedefs
+  //
 
-//
-// static data member definitions
-//
+  //
+  // static data member definitions
+  //
 
-//
-// constructors and destructor
-//
-EventSetupImpl::EventSetupImpl(ActivityRegistry const* activityRegistry) :
-   recordMap_(),
-   activityRegistry_(activityRegistry)
+  //
+  // constructors and destructor
+  //
+  EventSetupImpl::EventSetupImpl(ActivityRegistry const* activityRegistry)
+      : recordMap_(),
+        activityRegistry_(activityRegistry)
 
-{
-}
+  {}
 
-// EventSetupImpl::EventSetupImpl(EventSetupImpl const& rhs)
-// {
-//    // do actual copying here;
-// }
+  // EventSetupImpl::EventSetupImpl(EventSetupImpl const& rhs)
+  // {
+  //    // do actual copying here;
+  // }
 
-EventSetupImpl::~EventSetupImpl()
-{
-}
+  EventSetupImpl::~EventSetupImpl() {}
 
-//
-// assignment operators
-//
-// EventSetupImpl const& EventSetupImpl::operator=(EventSetupImpl const& rhs)
-// {
-//   //An exception safe implementation is
-//   EventSetupImpl temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+  //
+  // assignment operators
+  //
+  // EventSetupImpl const& EventSetupImpl::operator=(EventSetupImpl const& rhs)
+  // {
+  //   //An exception safe implementation is
+  //   EventSetupImpl temp(rhs);
+  //   swap(rhs);
+  //
+  //   return *this;
+  // }
 
-//
-// member functions
-//
-void
-EventSetupImpl::insert(const eventsetup::EventSetupRecordKey& iKey,
-                const eventsetup::EventSetupRecordImpl* iRecord)
-{
-   recordMap_[iKey]= iRecord;
-}
-
-void
-EventSetupImpl::clear()
-{
-   recordMap_.clear();
-}
-
-void
-EventSetupImpl::add(const eventsetup::EventSetupRecordImpl& iRecord)
-{
-   insert(iRecord.key(), &iRecord);
-}
-
-//
-// const member functions
-//
-std::optional<eventsetup::EventSetupRecordGeneric>
-EventSetupImpl::find(const eventsetup::EventSetupRecordKey& iKey) const
-{
-   auto itFind = recordMap_.find(iKey);
-   if(itFind == recordMap_.end()) {
-     return std::nullopt;
-   }
-  return eventsetup::EventSetupRecordGeneric(itFind->second);
-}
-
-eventsetup::EventSetupRecordImpl const*
-EventSetupImpl::findImpl(const eventsetup::EventSetupRecordKey& iKey) const
-{
-  auto itFind = recordMap_.find(iKey);
-  if(itFind == recordMap_.end()) {
-    return nullptr;
+  //
+  // member functions
+  //
+  void EventSetupImpl::insert(const eventsetup::EventSetupRecordKey& iKey,
+                              const eventsetup::EventSetupRecordImpl* iRecord) {
+    recordMap_[iKey] = iRecord;
   }
-  return itFind->second;
-}
 
-void
-EventSetupImpl::fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const
-{
-  oToFill.clear();
-  oToFill.reserve(recordMap_.size());
+  void EventSetupImpl::clear() { recordMap_.clear(); }
 
-  for(auto it = recordMap_.begin(), itEnd=recordMap_.end();
-      it != itEnd;
-      ++it) {
-    oToFill.push_back(it->first);
+  void EventSetupImpl::add(const eventsetup::EventSetupRecordImpl& iRecord) { insert(iRecord.key(), &iRecord); }
+
+  //
+  // const member functions
+  //
+  std::optional<eventsetup::EventSetupRecordGeneric> EventSetupImpl::find(
+      const eventsetup::EventSetupRecordKey& iKey) const {
+    auto itFind = recordMap_.find(iKey);
+    if (itFind == recordMap_.end()) {
+      return std::nullopt;
+    }
+    return eventsetup::EventSetupRecordGeneric(itFind->second);
   }
-}
 
-bool
-EventSetupImpl::recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& iKey) const
-{
-  return knownRecords_->isKnown(iKey);
-}
+  eventsetup::EventSetupRecordImpl const* EventSetupImpl::findImpl(const eventsetup::EventSetupRecordKey& iKey) const {
+    auto itFind = recordMap_.find(iKey);
+    if (itFind == recordMap_.end()) {
+      return nullptr;
+    }
+    return itFind->second;
+  }
 
-//
-// static member functions
-//
-}
+  void EventSetupImpl::fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const {
+    oToFill.clear();
+    oToFill.reserve(recordMap_.size());
+
+    for (auto it = recordMap_.begin(), itEnd = recordMap_.end(); it != itEnd; ++it) {
+      oToFill.push_back(it->first);
+    }
+  }
+
+  bool EventSetupImpl::recordIsProvidedByAModule(eventsetup::EventSetupRecordKey const& iKey) const {
+    return knownRecords_->isKnown(iKey);
+  }
+
+  //
+  // static member functions
+  //
+}  // namespace edm

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Module:      EventSetupProvider
-// 
+//
 // Description: <one line class summary>
 //
 // Implementation:
@@ -29,785 +29,712 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
-
 namespace edm {
-   namespace eventsetup {
+  namespace eventsetup {
 
-     namespace {
-       class KnownRecordsSupplierImpl : public EventSetupKnownRecordsSupplier {
-       public:
-         using Map = std::map<EventSetupRecordKey, std::shared_ptr<EventSetupRecordProvider> >;
-         
-         explicit KnownRecordsSupplierImpl( Map const& iMap) : map_(iMap) {}
-         
-         bool isKnown(EventSetupRecordKey const& iKey) const override {
-           return map_.find(iKey) != map_.end();
-         }
-         
-       private:
-         Map map_;
-       };
-     }
+    namespace {
+      class KnownRecordsSupplierImpl : public EventSetupKnownRecordsSupplier {
+      public:
+        using Map = std::map<EventSetupRecordKey, std::shared_ptr<EventSetupRecordProvider> >;
 
-//
-// constants, enums and typedefs
-//
+        explicit KnownRecordsSupplierImpl(Map const& iMap) : map_(iMap) {}
 
-//
-// static data member definitions
-//
+        bool isKnown(EventSetupRecordKey const& iKey) const override { return map_.find(iKey) != map_.end(); }
 
-//
-// constructors and destructor
-//
-EventSetupProvider::EventSetupProvider(ActivityRegistry* activityRegistry,
-                                       unsigned subProcessIndex,
-                                       const PreferredProviderInfo* iInfo) :
-eventSetup_(activityRegistry),
-providers_(),
-knownRecordsSupplier_( std::make_unique<KnownRecordsSupplierImpl>(providers_)),
-mustFinishConfiguration_(true),
-subProcessIndex_(subProcessIndex),
-preferredProviderInfo_((nullptr!=iInfo) ? (new PreferredProviderInfo(*iInfo)): nullptr),
-finders_(new std::vector<std::shared_ptr<EventSetupRecordIntervalFinder> >() ),
-dataProviders_(new std::vector<std::shared_ptr<DataProxyProvider> >() ),
-referencedDataKeys_(new std::map<EventSetupRecordKey, std::map<DataKey, ComponentDescription const*> >),
-recordToFinders_(new std::map<EventSetupRecordKey, std::vector<std::shared_ptr<EventSetupRecordIntervalFinder> > >),
-psetIDToRecordKey_(new std::map<ParameterSetIDHolder, std::set<EventSetupRecordKey> >),
-recordToPreferred_(new std::map<EventSetupRecordKey, std::map<DataKey, ComponentDescription> >),
-recordsWithALooperProxy_(new std::set<EventSetupRecordKey>)
-{
-  eventSetup_.setKnownRecordsSupplier(knownRecordsSupplier_.get());
-}
+      private:
+        Map map_;
+      };
+    }  // namespace
 
-// EventSetupProvider::EventSetupProvider(const EventSetupProvider& rhs)
-// {
-//    // do actual copying here;
-// }
+    //
+    // constants, enums and typedefs
+    //
 
-EventSetupProvider::~EventSetupProvider()
-{
-  forceCacheClear();
-}
+    //
+    // static data member definitions
+    //
 
-//
-// assignment operators
-//
-// const EventSetupProvider& EventSetupProvider::operator=(const EventSetupProvider& rhs)
-// {
-//   //An exception safe implementation is
-//   EventSetupProvider temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+    //
+    // constructors and destructor
+    //
+    EventSetupProvider::EventSetupProvider(ActivityRegistry* activityRegistry,
+                                           unsigned subProcessIndex,
+                                           const PreferredProviderInfo* iInfo)
+        : eventSetup_(activityRegistry),
+          providers_(),
+          knownRecordsSupplier_(std::make_unique<KnownRecordsSupplierImpl>(providers_)),
+          mustFinishConfiguration_(true),
+          subProcessIndex_(subProcessIndex),
+          preferredProviderInfo_((nullptr != iInfo) ? (new PreferredProviderInfo(*iInfo)) : nullptr),
+          finders_(new std::vector<std::shared_ptr<EventSetupRecordIntervalFinder> >()),
+          dataProviders_(new std::vector<std::shared_ptr<DataProxyProvider> >()),
+          referencedDataKeys_(new std::map<EventSetupRecordKey, std::map<DataKey, ComponentDescription const*> >),
+          recordToFinders_(
+              new std::map<EventSetupRecordKey, std::vector<std::shared_ptr<EventSetupRecordIntervalFinder> > >),
+          psetIDToRecordKey_(new std::map<ParameterSetIDHolder, std::set<EventSetupRecordKey> >),
+          recordToPreferred_(new std::map<EventSetupRecordKey, std::map<DataKey, ComponentDescription> >),
+          recordsWithALooperProxy_(new std::set<EventSetupRecordKey>) {
+      eventSetup_.setKnownRecordsSupplier(knownRecordsSupplier_.get());
+    }
 
-//
-// member functions
-//
-void 
-EventSetupProvider::insert(const EventSetupRecordKey& iKey, std::unique_ptr<EventSetupRecordProvider> iProvider)
-{
-   std::shared_ptr<EventSetupRecordProvider> temp(iProvider.release());
-   providers_[iKey] = temp;
-   //temp->addRecordTo(*this);
-}
+    // EventSetupProvider::EventSetupProvider(const EventSetupProvider& rhs)
+    // {
+    //    // do actual copying here;
+    // }
 
-void 
-EventSetupProvider::add(std::shared_ptr<DataProxyProvider> iProvider)
-{
-   assert(iProvider.get() != nullptr);
-   dataProviders_->push_back(iProvider);
-}
+    EventSetupProvider::~EventSetupProvider() { forceCacheClear(); }
 
-void 
-EventSetupProvider::replaceExisting(std::shared_ptr<DataProxyProvider> dataProxyProvider)
-{
-   ParameterSetIDHolder psetID(dataProxyProvider->description().pid_);
-   std::set<EventSetupRecordKey> const& keysForPSetID = (*psetIDToRecordKey_)[psetID];
-   for (auto const& key : keysForPSetID) {
-      std::shared_ptr<EventSetupRecordProvider> const& recordProvider = providers_[key];
-      recordProvider->resetProxyProvider(psetID, dataProxyProvider);
-   }
-}
+    //
+    // assignment operators
+    //
+    // const EventSetupProvider& EventSetupProvider::operator=(const EventSetupProvider& rhs)
+    // {
+    //   //An exception safe implementation is
+    //   EventSetupProvider temp(rhs);
+    //   swap(rhs);
+    //
+    //   return *this;
+    // }
 
-void 
-EventSetupProvider::add(std::shared_ptr<EventSetupRecordIntervalFinder> iFinder)
-{
-   assert(iFinder.get() != nullptr);
-   finders_->push_back(iFinder);
-}
+    //
+    // member functions
+    //
+    void EventSetupProvider::insert(const EventSetupRecordKey& iKey,
+                                    std::unique_ptr<EventSetupRecordProvider> iProvider) {
+      std::shared_ptr<EventSetupRecordProvider> temp(iProvider.release());
+      providers_[iKey] = temp;
+      //temp->addRecordTo(*this);
+    }
 
-typedef std::map<EventSetupRecordKey, std::shared_ptr<EventSetupRecordProvider> > Providers;
-typedef std::map<EventSetupRecordKey, EventSetupRecordProvider::DataToPreferredProviderMap> RecordToPreferred;
-///find everything made by a DataProxyProvider and add it to the 'preferred' list
-static
-void 
-preferEverything(const ComponentDescription& iComponent,
-                 const Providers& iProviders,
-                 RecordToPreferred& iReturnValue)
-{
-   //need to get our hands on the actual DataProxyProvider
-   bool foundProxyProvider = false;
-   for(Providers::const_iterator itProvider = iProviders.begin(), itProviderEnd = iProviders.end();
-       itProvider!= itProviderEnd;
-       ++itProvider) {
-      std::set<ComponentDescription> components = itProvider->second->proxyProviderDescriptions();
-      if(components.find(iComponent)!= components.end()) {
-         std::shared_ptr<DataProxyProvider> proxyProv = 
-         itProvider->second->proxyProvider(*(components.find(iComponent)));
-         assert(proxyProv.get());
-         
-         std::set<EventSetupRecordKey> records = proxyProv->usingRecords();
-         for(std::set<EventSetupRecordKey>::iterator itRecord = records.begin(),
-             itRecordEnd = records.end();
-             itRecord != itRecordEnd;
-             ++itRecord){
-            const DataProxyProvider::KeyedProxies& keyedProxies = proxyProv->keyedProxies(*itRecord);
-            if(!keyedProxies.empty()){
-               //add them to our output
-               EventSetupRecordProvider::DataToPreferredProviderMap& dataToProviderMap =
-               iReturnValue[*itRecord];
-               
-               for(DataProxyProvider::KeyedProxies::const_iterator itProxy = keyedProxies.begin(),
-	           itProxyEnd = keyedProxies.end();
-                   itProxy != itProxyEnd;
-                   ++itProxy) {
-                  EventSetupRecordProvider::DataToPreferredProviderMap::iterator itFind =
-                  dataToProviderMap.find(itProxy->first);
-                  if(itFind != dataToProviderMap.end()){
-                     throw cms::Exception("ESPreferConflict") <<"Two providers have been set to be preferred for\n"
-                     <<itProxy->first.type().name()<<" \""<<itProxy->first.name().value()<<"\""
-                     <<"\n the providers are "
-                     <<"\n 1) type="<<itFind->second.type_<<" label=\""<<itFind->second.label_<<"\""
-                     <<"\n 2) type="<<iComponent.type_<<" label=\""<<iComponent.label_<<"\""
-                     <<"\nPlease modify configuration so only one is preferred";
-                  }
-                  dataToProviderMap.insert(std::make_pair(itProxy->first,iComponent));
-               }
-            }
-         }
-         foundProxyProvider=true;
-         break;
+    void EventSetupProvider::add(std::shared_ptr<DataProxyProvider> iProvider) {
+      assert(iProvider.get() != nullptr);
+      dataProviders_->push_back(iProvider);
+    }
+
+    void EventSetupProvider::replaceExisting(std::shared_ptr<DataProxyProvider> dataProxyProvider) {
+      ParameterSetIDHolder psetID(dataProxyProvider->description().pid_);
+      std::set<EventSetupRecordKey> const& keysForPSetID = (*psetIDToRecordKey_)[psetID];
+      for (auto const& key : keysForPSetID) {
+        std::shared_ptr<EventSetupRecordProvider> const& recordProvider = providers_[key];
+        recordProvider->resetProxyProvider(psetID, dataProxyProvider);
       }
-   }
-   if(!foundProxyProvider) {
-      throw cms::Exception("ESPreferNoProvider")<<"Could not make type=\""<<iComponent.type_
-      <<"\" label=\""<<iComponent.label_<<"\" a preferred Provider."<<
-      "\n  Please check spelling of name, or that it was loaded into the job.";
-   }
-}
-static
-RecordToPreferred determinePreferred(const EventSetupProvider::PreferredProviderInfo* iInfo, 
-                                     const Providers& iProviders)
-{
-   using namespace edm::eventsetup;
-   RecordToPreferred returnValue;
-   if(nullptr != iInfo){
-      for(EventSetupProvider::PreferredProviderInfo::const_iterator itInfo = iInfo->begin(),
-          itInfoEnd = iInfo->end();
-          itInfo != itInfoEnd;
-          ++itInfo) {
-         if(itInfo->second.empty()) {
+    }
+
+    void EventSetupProvider::add(std::shared_ptr<EventSetupRecordIntervalFinder> iFinder) {
+      assert(iFinder.get() != nullptr);
+      finders_->push_back(iFinder);
+    }
+
+    typedef std::map<EventSetupRecordKey, std::shared_ptr<EventSetupRecordProvider> > Providers;
+    typedef std::map<EventSetupRecordKey, EventSetupRecordProvider::DataToPreferredProviderMap> RecordToPreferred;
+    ///find everything made by a DataProxyProvider and add it to the 'preferred' list
+    static void preferEverything(const ComponentDescription& iComponent,
+                                 const Providers& iProviders,
+                                 RecordToPreferred& iReturnValue) {
+      //need to get our hands on the actual DataProxyProvider
+      bool foundProxyProvider = false;
+      for (Providers::const_iterator itProvider = iProviders.begin(), itProviderEnd = iProviders.end();
+           itProvider != itProviderEnd; ++itProvider) {
+        std::set<ComponentDescription> components = itProvider->second->proxyProviderDescriptions();
+        if (components.find(iComponent) != components.end()) {
+          std::shared_ptr<DataProxyProvider> proxyProv =
+              itProvider->second->proxyProvider(*(components.find(iComponent)));
+          assert(proxyProv.get());
+
+          std::set<EventSetupRecordKey> records = proxyProv->usingRecords();
+          for (std::set<EventSetupRecordKey>::iterator itRecord = records.begin(), itRecordEnd = records.end();
+               itRecord != itRecordEnd; ++itRecord) {
+            const DataProxyProvider::KeyedProxies& keyedProxies = proxyProv->keyedProxies(*itRecord);
+            if (!keyedProxies.empty()) {
+              //add them to our output
+              EventSetupRecordProvider::DataToPreferredProviderMap& dataToProviderMap = iReturnValue[*itRecord];
+
+              for (DataProxyProvider::KeyedProxies::const_iterator itProxy = keyedProxies.begin(),
+                                                                   itProxyEnd = keyedProxies.end();
+                   itProxy != itProxyEnd; ++itProxy) {
+                EventSetupRecordProvider::DataToPreferredProviderMap::iterator itFind =
+                    dataToProviderMap.find(itProxy->first);
+                if (itFind != dataToProviderMap.end()) {
+                  throw cms::Exception("ESPreferConflict")
+                      << "Two providers have been set to be preferred for\n"
+                      << itProxy->first.type().name() << " \"" << itProxy->first.name().value() << "\""
+                      << "\n the providers are "
+                      << "\n 1) type=" << itFind->second.type_ << " label=\"" << itFind->second.label_ << "\""
+                      << "\n 2) type=" << iComponent.type_ << " label=\"" << iComponent.label_ << "\""
+                      << "\nPlease modify configuration so only one is preferred";
+                }
+                dataToProviderMap.insert(std::make_pair(itProxy->first, iComponent));
+              }
+            }
+          }
+          foundProxyProvider = true;
+          break;
+        }
+      }
+      if (!foundProxyProvider) {
+        throw cms::Exception("ESPreferNoProvider")
+            << "Could not make type=\"" << iComponent.type_ << "\" label=\"" << iComponent.label_
+            << "\" a preferred Provider."
+            << "\n  Please check spelling of name, or that it was loaded into the job.";
+      }
+    }
+    static RecordToPreferred determinePreferred(const EventSetupProvider::PreferredProviderInfo* iInfo,
+                                                const Providers& iProviders) {
+      using namespace edm::eventsetup;
+      RecordToPreferred returnValue;
+      if (nullptr != iInfo) {
+        for (EventSetupProvider::PreferredProviderInfo::const_iterator itInfo = iInfo->begin(),
+                                                                       itInfoEnd = iInfo->end();
+             itInfo != itInfoEnd; ++itInfo) {
+          if (itInfo->second.empty()) {
             //want everything
             preferEverything(itInfo->first, iProviders, returnValue);
-         } else {
-            for(EventSetupProvider::RecordToDataMap::const_iterator itRecData = itInfo->second.begin(),
-	        itRecDataEnd = itInfo->second.end();
-                itRecData != itRecDataEnd;
-                ++itRecData) {
-               std::string recordName= itRecData->first;
-               EventSetupRecordKey recordKey(eventsetup::EventSetupRecordKey::TypeTag::findType(recordName));
-               if(recordKey.type() == eventsetup::EventSetupRecordKey::TypeTag()) {
-                  throw cms::Exception("ESPreferUnknownRecord") <<"Unknown record \""<<recordName
-                  <<"\" used in es_prefer statement for type="
-                  <<itInfo->first.type_<<" label=\""<<itInfo->first.label_
-                  <<"\"\n Please check spelling.";
-                  //record not found
-               }
-               //See if the ProxyProvider provides something for this Record
-               Providers::const_iterator itRecordProvider = iProviders.find(recordKey);
-               assert(itRecordProvider != iProviders.end());
-               
-               std::set<ComponentDescription> components = itRecordProvider->second->proxyProviderDescriptions();
-               std::set<ComponentDescription>::iterator itProxyProv = components.find(itInfo->first);
-               if(itProxyProv == components.end()){
-                  throw cms::Exception("ESPreferWrongRecord")<<"The type="<<itInfo->first.type_<<" label=\""<<
-                  itInfo->first.label_<<"\" does not provide data for the Record "<<recordName;
-               }
-               //Does it data type exist?
-               eventsetup::TypeTag datumType = eventsetup::TypeTag::findType(itRecData->second.first);
-               if(datumType == eventsetup::TypeTag()) {
-                  //not found
-                  throw cms::Exception("ESPreferWrongDataType")<<"The es_prefer statement for type="<<itInfo->first.type_<<" label=\""<<
-                  itInfo->first.label_<<"\" has the unknown data type \""<<itRecData->second.first<<"\""
-                  <<"\n Please check spelling";
-               }
-               eventsetup::DataKey datumKey(datumType, itRecData->second.second.c_str());
-               
-               //Does the proxyprovider make this?
-               std::shared_ptr<DataProxyProvider> proxyProv = 
-                  itRecordProvider->second->proxyProvider(*itProxyProv);
-               const DataProxyProvider::KeyedProxies& keyedProxies = proxyProv->keyedProxies(recordKey);
-               if(std::find_if(keyedProxies.begin(), keyedProxies.end(),
-                               [&datumKey](auto const& kp) { return kp.first == datumKey;}) ==
-                   keyedProxies.end()){
-                  throw cms::Exception("ESPreferWrongData")<<"The es_prefer statement for type="<<itInfo->first.type_<<" label=\""<<
-                  itInfo->first.label_<<"\" specifies the data item \n"
-                  <<"  type=\""<<itRecData->second.first<<"\" label=\""<<itRecData->second.second<<"\""
-                  <<"  which is not provided.  Please check spelling.";
-               }
-               
-               EventSetupRecordProvider::DataToPreferredProviderMap& dataToProviderMap
-                  =returnValue[recordKey];
-               //has another provider already been specified?
-               if(dataToProviderMap.end() != dataToProviderMap.find(datumKey)) {
-                  EventSetupRecordProvider::DataToPreferredProviderMap::iterator itFind =
-                  dataToProviderMap.find(datumKey);
-                  throw cms::Exception("ESPreferConflict") <<"Two providers have been set to be preferred for\n"
-                  <<datumKey.type().name()<<" \""<<datumKey.name().value()<<"\""
-                  <<"\n the providers are "
-                  <<"\n 1) type="<<itFind->second.type_<<" label=\""<<itFind->second.label_<<"\""
-                  <<"\n 2) type="<<itProxyProv->type_<<" label=\""<<itProxyProv->label_<<"\""
-                  <<"\nPlease modify configuration so only one is preferred";
-               }
-               dataToProviderMap.insert(std::make_pair(datumKey,*itProxyProv));
+          } else {
+            for (EventSetupProvider::RecordToDataMap::const_iterator itRecData = itInfo->second.begin(),
+                                                                     itRecDataEnd = itInfo->second.end();
+                 itRecData != itRecDataEnd; ++itRecData) {
+              std::string recordName = itRecData->first;
+              EventSetupRecordKey recordKey(eventsetup::EventSetupRecordKey::TypeTag::findType(recordName));
+              if (recordKey.type() == eventsetup::EventSetupRecordKey::TypeTag()) {
+                throw cms::Exception("ESPreferUnknownRecord")
+                    << "Unknown record \"" << recordName
+                    << "\" used in es_prefer statement for type=" << itInfo->first.type_ << " label=\""
+                    << itInfo->first.label_ << "\"\n Please check spelling.";
+                //record not found
+              }
+              //See if the ProxyProvider provides something for this Record
+              Providers::const_iterator itRecordProvider = iProviders.find(recordKey);
+              assert(itRecordProvider != iProviders.end());
+
+              std::set<ComponentDescription> components = itRecordProvider->second->proxyProviderDescriptions();
+              std::set<ComponentDescription>::iterator itProxyProv = components.find(itInfo->first);
+              if (itProxyProv == components.end()) {
+                throw cms::Exception("ESPreferWrongRecord")
+                    << "The type=" << itInfo->first.type_ << " label=\"" << itInfo->first.label_
+                    << "\" does not provide data for the Record " << recordName;
+              }
+              //Does it data type exist?
+              eventsetup::TypeTag datumType = eventsetup::TypeTag::findType(itRecData->second.first);
+              if (datumType == eventsetup::TypeTag()) {
+                //not found
+                throw cms::Exception("ESPreferWrongDataType")
+                    << "The es_prefer statement for type=" << itInfo->first.type_ << " label=\"" << itInfo->first.label_
+                    << "\" has the unknown data type \"" << itRecData->second.first << "\""
+                    << "\n Please check spelling";
+              }
+              eventsetup::DataKey datumKey(datumType, itRecData->second.second.c_str());
+
+              //Does the proxyprovider make this?
+              std::shared_ptr<DataProxyProvider> proxyProv = itRecordProvider->second->proxyProvider(*itProxyProv);
+              const DataProxyProvider::KeyedProxies& keyedProxies = proxyProv->keyedProxies(recordKey);
+              if (std::find_if(keyedProxies.begin(), keyedProxies.end(),
+                               [&datumKey](auto const& kp) { return kp.first == datumKey; }) == keyedProxies.end()) {
+                throw cms::Exception("ESPreferWrongData")
+                    << "The es_prefer statement for type=" << itInfo->first.type_ << " label=\"" << itInfo->first.label_
+                    << "\" specifies the data item \n"
+                    << "  type=\"" << itRecData->second.first << "\" label=\"" << itRecData->second.second << "\""
+                    << "  which is not provided.  Please check spelling.";
+              }
+
+              EventSetupRecordProvider::DataToPreferredProviderMap& dataToProviderMap = returnValue[recordKey];
+              //has another provider already been specified?
+              if (dataToProviderMap.end() != dataToProviderMap.find(datumKey)) {
+                EventSetupRecordProvider::DataToPreferredProviderMap::iterator itFind =
+                    dataToProviderMap.find(datumKey);
+                throw cms::Exception("ESPreferConflict")
+                    << "Two providers have been set to be preferred for\n"
+                    << datumKey.type().name() << " \"" << datumKey.name().value() << "\""
+                    << "\n the providers are "
+                    << "\n 1) type=" << itFind->second.type_ << " label=\"" << itFind->second.label_ << "\""
+                    << "\n 2) type=" << itProxyProv->type_ << " label=\"" << itProxyProv->label_ << "\""
+                    << "\nPlease modify configuration so only one is preferred";
+              }
+              dataToProviderMap.insert(std::make_pair(datumKey, *itProxyProv));
             }
-         }
+          }
+        }
       }
-   }
-   return returnValue;
-}
+      return returnValue;
+    }
 
-void
-EventSetupProvider::finishConfiguration()
-{   
-   //we delayed adding finders to the system till here so that everything would be loaded first
-   recordToFinders_->clear();
-   for(std::vector<std::shared_ptr<EventSetupRecordIntervalFinder> >::iterator itFinder=finders_->begin(),
-       itEnd = finders_->end();
-       itFinder != itEnd;
-       ++itFinder) {
-      typedef std::set<EventSetupRecordKey> Keys;
-      const Keys recordsUsing = (*itFinder)->findingForRecords();
-      
-      for(Keys::const_iterator itKey = recordsUsing.begin(), itKeyEnd = recordsUsing.end();
-          itKey != itKeyEnd;
-          ++itKey) {
-        (*recordToFinders_)[*itKey].push_back(*itFinder);
-         Providers::iterator itFound = providers_.find(*itKey);
-         if(providers_.end() == itFound) {
-            //create a provider for this record
-            insert(*itKey,
-                   std::make_unique<EventSetupRecordProvider>(*itKey) );
-            itFound = providers_.find(*itKey);
-         }
-         itFound->second->addFinder(*itFinder);
-      }      
-   }
-   //we've transfered our ownership so this is no longer needed
-   finders_.reset();
+    void EventSetupProvider::finishConfiguration() {
+      //we delayed adding finders to the system till here so that everything would be loaded first
+      recordToFinders_->clear();
+      for (std::vector<std::shared_ptr<EventSetupRecordIntervalFinder> >::iterator itFinder = finders_->begin(),
+                                                                                   itEnd = finders_->end();
+           itFinder != itEnd; ++itFinder) {
+        typedef std::set<EventSetupRecordKey> Keys;
+        const Keys recordsUsing = (*itFinder)->findingForRecords();
 
-   //Now handle providers since sources can also be finders and the sources can delay registering
-   // their Records and therefore could delay setting up their Proxies
-   psetIDToRecordKey_->clear();
-   typedef std::set<EventSetupRecordKey> Keys;
-   for(std::vector<std::shared_ptr<DataProxyProvider> >::iterator itProvider=dataProviders_->begin(),
-       itEnd = dataProviders_->end();
-       itProvider != itEnd;
-       ++itProvider) {
-      
-      ParameterSetIDHolder psetID((*itProvider)->description().pid_);
-
-      const Keys recordsUsing = (*itProvider)->usingRecords();
-      
-      for(Keys::const_iterator itKey = recordsUsing.begin(), itKeyEnd = recordsUsing.end();
-          itKey != itKeyEnd;
-          ++itKey) {
-
-         if ((*itProvider)->description().isLooper_) {
-            recordsWithALooperProxy_->insert(*itKey);
-         }
-
-         (*psetIDToRecordKey_)[psetID].insert(*itKey);
-
-         Providers::iterator itFound = providers_.find(*itKey);
-         if(providers_.end() == itFound) {
+        for (Keys::const_iterator itKey = recordsUsing.begin(), itKeyEnd = recordsUsing.end(); itKey != itKeyEnd;
+             ++itKey) {
+          (*recordToFinders_)[*itKey].push_back(*itFinder);
+          Providers::iterator itFound = providers_.find(*itKey);
+          if (providers_.end() == itFound) {
             //create a provider for this record
             insert(*itKey, std::make_unique<EventSetupRecordProvider>(*itKey));
             itFound = providers_.find(*itKey);
-         }
-         itFound->second->add(*itProvider);
+          }
+          itFound->second->addFinder(*itFinder);
+        }
       }
-   }
-   dataProviders_.reset();
-   
-   //used for the case where no preferred Providers have been specified for the Record
-   static const EventSetupRecordProvider::DataToPreferredProviderMap kEmptyMap;
-   
-   *recordToPreferred_ = determinePreferred(preferredProviderInfo_.get(),providers_);
-   //For each Provider, find all the Providers it depends on.  If a dependent Provider
-   // can not be found pass in an empty list
-   //CHANGE: now allow for missing Providers
-   for(Providers::iterator itProvider = providers_.begin(), itProviderEnd = providers_.end();
-        itProvider != itProviderEnd;
-        ++itProvider) {
-      const EventSetupRecordProvider::DataToPreferredProviderMap* preferredInfo = &kEmptyMap;
-      RecordToPreferred::const_iterator itRecordFound = recordToPreferred_->find(itProvider->first);
-      if(itRecordFound != recordToPreferred_->end()) {
-         preferredInfo = &(itRecordFound->second);
+      //we've transfered our ownership so this is no longer needed
+      finders_.reset();
+
+      //Now handle providers since sources can also be finders and the sources can delay registering
+      // their Records and therefore could delay setting up their Proxies
+      psetIDToRecordKey_->clear();
+      typedef std::set<EventSetupRecordKey> Keys;
+      for (std::vector<std::shared_ptr<DataProxyProvider> >::iterator itProvider = dataProviders_->begin(),
+                                                                      itEnd = dataProviders_->end();
+           itProvider != itEnd; ++itProvider) {
+        ParameterSetIDHolder psetID((*itProvider)->description().pid_);
+
+        const Keys recordsUsing = (*itProvider)->usingRecords();
+
+        for (Keys::const_iterator itKey = recordsUsing.begin(), itKeyEnd = recordsUsing.end(); itKey != itKeyEnd;
+             ++itKey) {
+          if ((*itProvider)->description().isLooper_) {
+            recordsWithALooperProxy_->insert(*itKey);
+          }
+
+          (*psetIDToRecordKey_)[psetID].insert(*itKey);
+
+          Providers::iterator itFound = providers_.find(*itKey);
+          if (providers_.end() == itFound) {
+            //create a provider for this record
+            insert(*itKey, std::make_unique<EventSetupRecordProvider>(*itKey));
+            itFound = providers_.find(*itKey);
+          }
+          itFound->second->add(*itProvider);
+        }
       }
-      //Give it our list of preferred 
-      itProvider->second->usePreferred(*preferredInfo);
-      
-      std::set<EventSetupRecordKey> records = itProvider->second->dependentRecords();
-      if(!records.empty()) {
-         std::string missingRecords;
-         std::vector<std::shared_ptr<EventSetupRecordProvider> > depProviders;
-         depProviders.reserve(records.size());
-         bool foundAllProviders = true;
-         for(std::set<EventSetupRecordKey>::iterator itRecord = records.begin(),
-              itRecordEnd = records.end();
-              itRecord != itRecordEnd;
-              ++itRecord) {
+      dataProviders_.reset();
+
+      //used for the case where no preferred Providers have been specified for the Record
+      static const EventSetupRecordProvider::DataToPreferredProviderMap kEmptyMap;
+
+      *recordToPreferred_ = determinePreferred(preferredProviderInfo_.get(), providers_);
+      //For each Provider, find all the Providers it depends on.  If a dependent Provider
+      // can not be found pass in an empty list
+      //CHANGE: now allow for missing Providers
+      for (Providers::iterator itProvider = providers_.begin(), itProviderEnd = providers_.end();
+           itProvider != itProviderEnd; ++itProvider) {
+        const EventSetupRecordProvider::DataToPreferredProviderMap* preferredInfo = &kEmptyMap;
+        RecordToPreferred::const_iterator itRecordFound = recordToPreferred_->find(itProvider->first);
+        if (itRecordFound != recordToPreferred_->end()) {
+          preferredInfo = &(itRecordFound->second);
+        }
+        //Give it our list of preferred
+        itProvider->second->usePreferred(*preferredInfo);
+
+        std::set<EventSetupRecordKey> records = itProvider->second->dependentRecords();
+        if (!records.empty()) {
+          std::string missingRecords;
+          std::vector<std::shared_ptr<EventSetupRecordProvider> > depProviders;
+          depProviders.reserve(records.size());
+          bool foundAllProviders = true;
+          for (std::set<EventSetupRecordKey>::iterator itRecord = records.begin(), itRecordEnd = records.end();
+               itRecord != itRecordEnd; ++itRecord) {
             Providers::iterator itFound = providers_.find(*itRecord);
-            if(itFound == providers_.end()) {
-               foundAllProviders = false;
-               if(missingRecords.empty()) {
-                 missingRecords = itRecord->name();
-               } else {
-                 missingRecords += ", ";
-                 missingRecords += itRecord->name();
-               }
-               //break;
+            if (itFound == providers_.end()) {
+              foundAllProviders = false;
+              if (missingRecords.empty()) {
+                missingRecords = itRecord->name();
+              } else {
+                missingRecords += ", ";
+                missingRecords += itRecord->name();
+              }
+              //break;
             } else {
-               depProviders.push_back(itFound->second);
+              depProviders.push_back(itFound->second);
             }
-         }
-         
-         if(!foundAllProviders) {
-            edm::LogInfo("EventSetupDependency")<<"The EventSetup record "<<itProvider->second->key().name()
-            <<" depends on at least one Record \n ("<<missingRecords<<") which is not present in the job."
-           "\n This may lead to an exception begin thrown during event processing.\n If no exception occurs during the job than it is usually safe to ignore this message.";
+          }
+
+          if (!foundAllProviders) {
+            edm::LogInfo("EventSetupDependency")
+                << "The EventSetup record " << itProvider->second->key().name()
+                << " depends on at least one Record \n (" << missingRecords
+                << ") which is not present in the job."
+                   "\n This may lead to an exception begin thrown during event processing.\n If no exception occurs "
+                   "during the job than it is usually safe to ignore this message.";
 
             //depProviders.clear();
-           //NOTE: should provide a warning
-         }
-          
-         itProvider->second->setDependentProviders(depProviders);
-      }
-   }
-   mustFinishConfiguration_ = false;
-}
+            //NOTE: should provide a warning
+          }
 
-typedef std::map<EventSetupRecordKey, std::shared_ptr<EventSetupRecordProvider> > Providers;
-typedef Providers::iterator Itr;
-static
-void
-findDependents(const EventSetupRecordKey& iKey,
-               Itr itBegin,
-               Itr itEnd,
-               std::vector<std::shared_ptr<EventSetupRecordProvider> >& oDependents)
-{
-  
-  for(Itr it = itBegin; it != itEnd; ++it) {
-    //does it depend on the record in question?
-    const std::set<EventSetupRecordKey>& deps = it->second->dependentRecords();
-    if(deps.end() != deps.find(iKey)) {
-      oDependents.push_back(it->second);
-      //now see who is dependent on this record since they will be indirectly dependent on iKey
-      findDependents(it->first, itBegin, itEnd, oDependents);
+          itProvider->second->setDependentProviders(depProviders);
+        }
+      }
+      mustFinishConfiguration_ = false;
     }
-  }
-}
-               
-void 
-EventSetupProvider::resetRecordPlusDependentRecords(const EventSetupRecordKey& iKey)
-{
-  Providers::iterator itFind = providers_.find(iKey);
-  if(itFind == providers_.end()) {
-    return;
-  }
 
-  
-  std::vector<std::shared_ptr<EventSetupRecordProvider> > dependents;
-  findDependents(iKey, providers_.begin(), providers_.end(), dependents);
-
-  dependents.erase(std::unique(dependents.begin(),dependents.end()), dependents.end());
-  
-  itFind->second->resetProxies();
-  for(auto& d: dependents) {
-    d->resetProxies();
-  }
-}
-
-void 
-EventSetupProvider::forceCacheClear()
-{
-   for(Providers::iterator it=providers_.begin(), itEnd = providers_.end();
-       it != itEnd;
-       ++it) {
-      it->second->resetProxies();
-   }
-}
-
-void
-EventSetupProvider::checkESProducerSharing(EventSetupProvider& precedingESProvider,
-                                           std::set<ParameterSetIDHolder>& sharingCheckDone,
-                                           std::map<EventSetupRecordKey, std::vector<ComponentDescription const*> >& referencedESProducers,
-                                           EventSetupsController& esController) {
-
-   edm::LogVerbatim("EventSetupSharing") << "EventSetupProvider::checkESProducerSharing: Checking processes with SubProcess Indexes "
-                                         << subProcessIndex() << " and " << precedingESProvider.subProcessIndex();
-
-   if (referencedESProducers.empty()) {
-      for (auto const& recordProvider : providers_) {
-         recordProvider.second->getReferencedESProducers(referencedESProducers);
+    typedef std::map<EventSetupRecordKey, std::shared_ptr<EventSetupRecordProvider> > Providers;
+    typedef Providers::iterator Itr;
+    static void findDependents(const EventSetupRecordKey& iKey,
+                               Itr itBegin,
+                               Itr itEnd,
+                               std::vector<std::shared_ptr<EventSetupRecordProvider> >& oDependents) {
+      for (Itr it = itBegin; it != itEnd; ++it) {
+        //does it depend on the record in question?
+        const std::set<EventSetupRecordKey>& deps = it->second->dependentRecords();
+        if (deps.end() != deps.find(iKey)) {
+          oDependents.push_back(it->second);
+          //now see who is dependent on this record since they will be indirectly dependent on iKey
+          findDependents(it->first, itBegin, itEnd, oDependents);
+        }
       }
-   }
+    }
 
-   // This records whether the configurations of all the DataProxyProviders
-   // and finders matches for a particular pair of processes and
-   // a particular record and also the records it depends on.
-   std::map<EventSetupRecordKey, bool> allComponentsMatch;
+    void EventSetupProvider::resetRecordPlusDependentRecords(const EventSetupRecordKey& iKey) {
+      Providers::iterator itFind = providers_.find(iKey);
+      if (itFind == providers_.end()) {
+        return;
+      }
 
-   std::map<ParameterSetID, bool> candidateNotRejectedYet;
+      std::vector<std::shared_ptr<EventSetupRecordProvider> > dependents;
+      findDependents(iKey, providers_.begin(), providers_.end(), dependents);
 
-   // Loop over all the ESProducers which have a DataProxy
-   // referenced by any EventSetupRecord in this EventSetupProvider
-   for (auto const& iRecord : referencedESProducers) {
-      for (auto const& iComponent : iRecord.second) {
+      dependents.erase(std::unique(dependents.begin(), dependents.end()), dependents.end());
 
-         ParameterSetID const& psetID = iComponent->pid_;
-         ParameterSetIDHolder psetIDHolder(psetID);
-         if (sharingCheckDone.find(psetIDHolder) != sharingCheckDone.end()) continue;
+      itFind->second->resetProxies();
+      for (auto& d : dependents) {
+        d->resetProxies();
+      }
+    }
 
-         bool firstProcessWithThisPSet = false;
-         bool precedingHasMatchingPSet = false;
+    void EventSetupProvider::forceCacheClear() {
+      for (Providers::iterator it = providers_.begin(), itEnd = providers_.end(); it != itEnd; ++it) {
+        it->second->resetProxies();
+      }
+    }
 
-         esController.lookForMatches(psetID,
-                                     subProcessIndex_,
-                                     precedingESProvider.subProcessIndex_,
-                                     firstProcessWithThisPSet,
-                                     precedingHasMatchingPSet);
+    void EventSetupProvider::checkESProducerSharing(
+        EventSetupProvider& precedingESProvider,
+        std::set<ParameterSetIDHolder>& sharingCheckDone,
+        std::map<EventSetupRecordKey, std::vector<ComponentDescription const*> >& referencedESProducers,
+        EventSetupsController& esController) {
+      edm::LogVerbatim("EventSetupSharing")
+          << "EventSetupProvider::checkESProducerSharing: Checking processes with SubProcess Indexes "
+          << subProcessIndex() << " and " << precedingESProvider.subProcessIndex();
 
-         if (firstProcessWithThisPSet) {
+      if (referencedESProducers.empty()) {
+        for (auto const& recordProvider : providers_) {
+          recordProvider.second->getReferencedESProducers(referencedESProducers);
+        }
+      }
+
+      // This records whether the configurations of all the DataProxyProviders
+      // and finders matches for a particular pair of processes and
+      // a particular record and also the records it depends on.
+      std::map<EventSetupRecordKey, bool> allComponentsMatch;
+
+      std::map<ParameterSetID, bool> candidateNotRejectedYet;
+
+      // Loop over all the ESProducers which have a DataProxy
+      // referenced by any EventSetupRecord in this EventSetupProvider
+      for (auto const& iRecord : referencedESProducers) {
+        for (auto const& iComponent : iRecord.second) {
+          ParameterSetID const& psetID = iComponent->pid_;
+          ParameterSetIDHolder psetIDHolder(psetID);
+          if (sharingCheckDone.find(psetIDHolder) != sharingCheckDone.end())
+            continue;
+
+          bool firstProcessWithThisPSet = false;
+          bool precedingHasMatchingPSet = false;
+
+          esController.lookForMatches(psetID, subProcessIndex_, precedingESProvider.subProcessIndex_,
+                                      firstProcessWithThisPSet, precedingHasMatchingPSet);
+
+          if (firstProcessWithThisPSet) {
             sharingCheckDone.insert(psetIDHolder);
             allComponentsMatch[iRecord.first] = false;
             continue;
-         }
+          }
 
-         if (!precedingHasMatchingPSet) {
+          if (!precedingHasMatchingPSet) {
             allComponentsMatch[iRecord.first] = false;
             continue;
-         }
+          }
 
-         // An ESProducer that survives to this point is a candidate.
-         // It was shared with some other process in the first pass where
-         // ESProducers were constructed and one of three possibilities exists:
-         //    1) It should not have been shared and a new ESProducer needs
-         //    to be created and the proper pointers set.
-         //    2) It should have been shared with a different preceding process
-         //    in which case some pointers need to be modified.
-         //    3) It was originally shared which the correct prior process
-         //    in which case nothing needs to be done, but we do need to
-         //    do some work to verify that.
-         // Make an entry in a map for each of these ESProducers. We
-         // will set the value to false if and when we determine
-         // the ESProducer cannot be shared between this pair of processes. 
-         auto iCandidateNotRejectedYet = candidateNotRejectedYet.find(psetID);
-         if (iCandidateNotRejectedYet == candidateNotRejectedYet.end()) {
+          // An ESProducer that survives to this point is a candidate.
+          // It was shared with some other process in the first pass where
+          // ESProducers were constructed and one of three possibilities exists:
+          //    1) It should not have been shared and a new ESProducer needs
+          //    to be created and the proper pointers set.
+          //    2) It should have been shared with a different preceding process
+          //    in which case some pointers need to be modified.
+          //    3) It was originally shared which the correct prior process
+          //    in which case nothing needs to be done, but we do need to
+          //    do some work to verify that.
+          // Make an entry in a map for each of these ESProducers. We
+          // will set the value to false if and when we determine
+          // the ESProducer cannot be shared between this pair of processes.
+          auto iCandidateNotRejectedYet = candidateNotRejectedYet.find(psetID);
+          if (iCandidateNotRejectedYet == candidateNotRejectedYet.end()) {
             candidateNotRejectedYet[psetID] = true;
             iCandidateNotRejectedYet = candidateNotRejectedYet.find(psetID);
-         }
+          }
 
-         // At this point we know that the two processes both
-         // have an ESProducer matching the type and label in
-         // iComponent and also with exactly the same configuration.
-         // And there was not an earlier preceding process
-         // where the same instance of the ESProducer could
-         // have been shared.  And this ESProducer was referenced
-         // by the later process's EventSetupRecord (prefered or
-         // or just the only thing that could have made the data).
-         // To determine if sharing is allowed, now we need to
-         // check if all the DataProxyProviders and all the
-         // finders are the same for this record and also for
-         // all records this record depends on. And even
-         // if this is true, we have to wait until the loop
-         // ends because some other DataProxy associated with
-         // the ESProducer could write to a different record where
-         // the same determination will need to be repeated. Only if
-         // all of the the DataProxy's can be shared, can the ESProducer
-         // instance be shared across processes.
+          // At this point we know that the two processes both
+          // have an ESProducer matching the type and label in
+          // iComponent and also with exactly the same configuration.
+          // And there was not an earlier preceding process
+          // where the same instance of the ESProducer could
+          // have been shared.  And this ESProducer was referenced
+          // by the later process's EventSetupRecord (prefered or
+          // or just the only thing that could have made the data).
+          // To determine if sharing is allowed, now we need to
+          // check if all the DataProxyProviders and all the
+          // finders are the same for this record and also for
+          // all records this record depends on. And even
+          // if this is true, we have to wait until the loop
+          // ends because some other DataProxy associated with
+          // the ESProducer could write to a different record where
+          // the same determination will need to be repeated. Only if
+          // all of the the DataProxy's can be shared, can the ESProducer
+          // instance be shared across processes.
 
-         if (iCandidateNotRejectedYet->second == true) {
-
+          if (iCandidateNotRejectedYet->second == true) {
             auto iAllComponentsMatch = allComponentsMatch.find(iRecord.first);
             if (iAllComponentsMatch == allComponentsMatch.end()) {
-
-               // We do not know the value in AllComponents yet and
-               // we need it now so we have to do the difficult calculation
-               // now.
-               bool match = doRecordsMatch(precedingESProvider,
-                                           iRecord.first,
-                                           allComponentsMatch,
-                                           esController);
-               allComponentsMatch[iRecord.first] = match;
-               iAllComponentsMatch = allComponentsMatch.find(iRecord.first);            
+              // We do not know the value in AllComponents yet and
+              // we need it now so we have to do the difficult calculation
+              // now.
+              bool match = doRecordsMatch(precedingESProvider, iRecord.first, allComponentsMatch, esController);
+              allComponentsMatch[iRecord.first] = match;
+              iAllComponentsMatch = allComponentsMatch.find(iRecord.first);
             }
             if (!iAllComponentsMatch->second) {
               iCandidateNotRejectedYet->second = false;
             }
-         }
-      }  // end loop over components used by record
-   } // end loop over records
+          }
+        }  // end loop over components used by record
+      }    // end loop over records
 
-   // Loop over candidates
-   for (auto const& candidate : candidateNotRejectedYet) {
-      ParameterSetID const& psetID = candidate.first;
-      bool canBeShared = candidate.second;
-      if (canBeShared) {
-         ParameterSet const& pset = *esController.getESProducerPSet(psetID, subProcessIndex_);
-         logInfoWhenSharing(pset);
-         ParameterSetIDHolder psetIDHolder(psetID);
-         sharingCheckDone.insert(psetIDHolder);
-         if (esController.isFirstMatch(psetID,
-                                       subProcessIndex_,
-                                       precedingESProvider.subProcessIndex_)) {
+      // Loop over candidates
+      for (auto const& candidate : candidateNotRejectedYet) {
+        ParameterSetID const& psetID = candidate.first;
+        bool canBeShared = candidate.second;
+        if (canBeShared) {
+          ParameterSet const& pset = *esController.getESProducerPSet(psetID, subProcessIndex_);
+          logInfoWhenSharing(pset);
+          ParameterSetIDHolder psetIDHolder(psetID);
+          sharingCheckDone.insert(psetIDHolder);
+          if (esController.isFirstMatch(psetID, subProcessIndex_, precedingESProvider.subProcessIndex_)) {
             continue;  // Proper sharing was already done. Nothing more to do.
-         }
+          }
 
-         // Need to reset the pointer from the EventSetupRecordProvider to the
-         // the DataProxyProvider so these two processes share an ESProducer.
+          // Need to reset the pointer from the EventSetupRecordProvider to the
+          // the DataProxyProvider so these two processes share an ESProducer.
 
-         std::shared_ptr<DataProxyProvider> dataProxyProvider;
-         std::set<EventSetupRecordKey> const& keysForPSetID1 = (*precedingESProvider.psetIDToRecordKey_)[psetIDHolder];
-         for (auto const& key : keysForPSetID1) {
+          std::shared_ptr<DataProxyProvider> dataProxyProvider;
+          std::set<EventSetupRecordKey> const& keysForPSetID1 = (*precedingESProvider.psetIDToRecordKey_)[psetIDHolder];
+          for (auto const& key : keysForPSetID1) {
             std::shared_ptr<EventSetupRecordProvider> const& recordProvider = precedingESProvider.providers_[key];
             dataProxyProvider = recordProvider->proxyProvider(psetIDHolder);
             assert(dataProxyProvider);
             break;
-         }
+          }
 
-         std::set<EventSetupRecordKey> const& keysForPSetID2 = (*psetIDToRecordKey_)[psetIDHolder];
-         for (auto const& key : keysForPSetID2) {
+          std::set<EventSetupRecordKey> const& keysForPSetID2 = (*psetIDToRecordKey_)[psetIDHolder];
+          for (auto const& key : keysForPSetID2) {
             std::shared_ptr<EventSetupRecordProvider> const& recordProvider = providers_[key];
             recordProvider->resetProxyProvider(psetIDHolder, dataProxyProvider);
-         }
-      } else {
-         if (esController.isLastMatch(psetID,
-                                      subProcessIndex_,
-                                      precedingESProvider.subProcessIndex_)) {
-            
-
+          }
+        } else {
+          if (esController.isLastMatch(psetID, subProcessIndex_, precedingESProvider.subProcessIndex_)) {
             ParameterSet const& pset = *esController.getESProducerPSet(psetID, subProcessIndex_);
-            ModuleFactory::get()->addTo(esController,
-                                        *this,
-                                        pset,
-                                        true);
-
-         }
+            ModuleFactory::get()->addTo(esController, *this, pset, true);
+          }
+        }
       }
-   }
-}
-
-bool
-EventSetupProvider::doRecordsMatch(EventSetupProvider & precedingESProvider,
-                                   EventSetupRecordKey const& eventSetupRecordKey,
-                                   std::map<EventSetupRecordKey, bool> & allComponentsMatch,
-                                   EventSetupsController const& esController) {
-   // first check if this record matches. If not just return false
-
-   // then find the directly dependent records and iterate over them
-   // recursively call this function on them. If they return false
-   // set allComponentsMatch to false for them and return false.
-   // if they all return true then set allComponents to true
-   // and return true.
-
-   if (precedingESProvider.recordsWithALooperProxy_->find(eventSetupRecordKey) != precedingESProvider.recordsWithALooperProxy_->end()) {
-      return false;
-   }
-
-   if ((*recordToFinders_)[eventSetupRecordKey].size() != (*precedingESProvider.recordToFinders_)[eventSetupRecordKey].size()) {
-      return false;
-   }
-
-   for (auto const& finder : (*recordToFinders_)[eventSetupRecordKey]) {
-      ParameterSetID const& psetID = finder->descriptionForFinder().pid_;
-      bool itMatches = esController.isMatchingESSource(psetID,
-                                                       subProcessIndex_,
-                                                       precedingESProvider.subProcessIndex_);
-      if (!itMatches) {
-         return false;
-      }
-   }
-
-   fillReferencedDataKeys(eventSetupRecordKey);
-   precedingESProvider.fillReferencedDataKeys(eventSetupRecordKey);
-
-   std::map<DataKey, ComponentDescription const*> const& dataItems = (*referencedDataKeys_)[eventSetupRecordKey];
-
-   std::map<DataKey, ComponentDescription const*> const& precedingDataItems = (*precedingESProvider.referencedDataKeys_)[eventSetupRecordKey];
-
-   if (dataItems.size() != precedingDataItems.size()) {
-      return false;
-   }
-
-   for (auto const& dataItem : dataItems) {
-      auto precedingDataItem = precedingDataItems.find(dataItem.first);
-      if (precedingDataItem == precedingDataItems.end()) {
-         return false;
-      }
-      if (dataItem.second->pid_ != precedingDataItem->second->pid_) {
-         return false;
-      }
-      // Check that the configurations match exactly for the ESProducers
-      // (We already checked the ESSources above and there should not be
-      // any loopers)
-      if (!dataItem.second->isSource_ && !dataItem.second->isLooper_) {
-         bool itMatches = esController.isMatchingESProducer(dataItem.second->pid_,
-                                                            subProcessIndex_,
-                                                            precedingESProvider.subProcessIndex_);
-         if (!itMatches) {
-            return false;
-         }
-      }
-   }
-   Providers::iterator itFound = providers_.find(eventSetupRecordKey);
-   if (itFound != providers_.end()) {
-      std::set<EventSetupRecordKey> dependentRecords = itFound->second->dependentRecords();
-      for (auto const& dependentRecord : dependentRecords) {
-         auto iter = allComponentsMatch.find(dependentRecord);
-         if (iter != allComponentsMatch.end()) {
-            if (iter->second) {
-               continue;
-            } else {
-               return false;
-            }
-         }
-         bool match = doRecordsMatch(precedingESProvider,
-                                     dependentRecord,
-                                     allComponentsMatch,
-                                     esController);            
-         allComponentsMatch[dependentRecord] = match;
-         if (!match) return false;
-      }
-   }
-   return true;
-}
-
-void
-EventSetupProvider::fillReferencedDataKeys(EventSetupRecordKey const& eventSetupRecordKey) {
-
-   if (referencedDataKeys_->find(eventSetupRecordKey) != referencedDataKeys_->end()) return;
-
-   auto recordProvider = providers_.find(eventSetupRecordKey);
-   if (recordProvider == providers_.end()) {
-      (*referencedDataKeys_)[eventSetupRecordKey];
-      return;
-   }
-   if (recordProvider->second) {
-      recordProvider->second->fillReferencedDataKeys((*referencedDataKeys_)[eventSetupRecordKey]);
-   }
-}
-
-void
-EventSetupProvider::resetRecordToProxyPointers() {
-   for (auto const& recordProvider : providers_) {
-      static const EventSetupRecordProvider::DataToPreferredProviderMap kEmptyMap;
-      const EventSetupRecordProvider::DataToPreferredProviderMap* preferredInfo = &kEmptyMap;
-      RecordToPreferred::const_iterator itRecordFound = recordToPreferred_->find(recordProvider.first);
-      if(itRecordFound != recordToPreferred_->end()) {
-         preferredInfo = &(itRecordFound->second);
-      }
-      recordProvider.second->resetRecordToProxyPointers(*preferredInfo);
-   }
-}
-
-void
-EventSetupProvider::clearInitializationData() {
-   preferredProviderInfo_.reset();
-   referencedDataKeys_.reset();
-   recordToFinders_.reset();
-   psetIDToRecordKey_.reset();
-   recordToPreferred_.reset();
-   recordsWithALooperProxy_.reset();
-}
-
-void
-EventSetupProvider::addRecordToEventSetup(EventSetupRecordImpl& iRecord) {
-   iRecord.setEventSetup(&eventSetup_);
-   eventSetup_.add(iRecord);
-}
-     
-void
-EventSetupProvider::insert(std::unique_ptr<EventSetupRecordProvider> iRecordProvider) {
-   auto key =iRecordProvider->key();
-   insert( key, std::move(iRecordProvider));
-}
-
-//
-// const member functions
-//
-EventSetupImpl const&
-EventSetupProvider::eventSetupForInstance(const IOVSyncValue& iValue)
-{
-   eventSetup_.clear();
-
-   // In a cmsRun job this does nothing because the EventSetupsController
-   // will have already called finishConfiguration, but some tests will
-   // call finishConfiguration here.
-   if(mustFinishConfiguration_) {
-      finishConfiguration();
-   }
-
-   for(Providers::iterator itProvider = providers_.begin(), itProviderEnd = providers_.end();
-        itProvider != itProviderEnd;
-        ++itProvider) {
-      itProvider->second->addRecordToIfValid(*this, iValue);
-   }   
-   return eventSetup_;
-}
-
-std::set<ComponentDescription>
-EventSetupProvider::proxyProviderDescriptions() const
-{
-   typedef std::set<ComponentDescription> Set;
-   Set descriptions;
-
-   for(auto const& p: providers_) {
-     auto const& d = p.second->proxyProviderDescriptions();
-     descriptions.insert(d.begin(),d.end());
-   }
-   if(dataProviders_.get()) {
-     for(auto const& p: *dataProviders_) {
-       descriptions.insert(p->description());
-     }
-   }
-                       
-   return descriptions;
-}
-
-bool
-EventSetupProvider::isWithinValidityInterval(IOVSyncValue const& iSync) const {
-  for( auto const& provider: providers_) {
-    auto const& iov =provider.second->validityInterval();
-    if( (iov != ValidityInterval::invalidInterval()) and
-        (not provider.second->validityInterval().validFor(iSync)) ) {
-      return false;
     }
-  }
-  return true;
-}
-//
-// static member functions
-//
-void EventSetupProvider::logInfoWhenSharing(ParameterSet const& iConfiguration) {
 
-   std::string edmtype = iConfiguration.getParameter<std::string>("@module_edm_type");
-   std::string modtype = iConfiguration.getParameter<std::string>("@module_type");
-   std::string label = iConfiguration.getParameter<std::string>("@module_label");
-   edm::LogVerbatim("EventSetupSharing") << "Sharing " << edmtype << ": class=" << modtype << " label='" << label << "'";
-}
-   }
-}
+    bool EventSetupProvider::doRecordsMatch(EventSetupProvider& precedingESProvider,
+                                            EventSetupRecordKey const& eventSetupRecordKey,
+                                            std::map<EventSetupRecordKey, bool>& allComponentsMatch,
+                                            EventSetupsController const& esController) {
+      // first check if this record matches. If not just return false
+
+      // then find the directly dependent records and iterate over them
+      // recursively call this function on them. If they return false
+      // set allComponentsMatch to false for them and return false.
+      // if they all return true then set allComponents to true
+      // and return true.
+
+      if (precedingESProvider.recordsWithALooperProxy_->find(eventSetupRecordKey) !=
+          precedingESProvider.recordsWithALooperProxy_->end()) {
+        return false;
+      }
+
+      if ((*recordToFinders_)[eventSetupRecordKey].size() !=
+          (*precedingESProvider.recordToFinders_)[eventSetupRecordKey].size()) {
+        return false;
+      }
+
+      for (auto const& finder : (*recordToFinders_)[eventSetupRecordKey]) {
+        ParameterSetID const& psetID = finder->descriptionForFinder().pid_;
+        bool itMatches =
+            esController.isMatchingESSource(psetID, subProcessIndex_, precedingESProvider.subProcessIndex_);
+        if (!itMatches) {
+          return false;
+        }
+      }
+
+      fillReferencedDataKeys(eventSetupRecordKey);
+      precedingESProvider.fillReferencedDataKeys(eventSetupRecordKey);
+
+      std::map<DataKey, ComponentDescription const*> const& dataItems = (*referencedDataKeys_)[eventSetupRecordKey];
+
+      std::map<DataKey, ComponentDescription const*> const& precedingDataItems =
+          (*precedingESProvider.referencedDataKeys_)[eventSetupRecordKey];
+
+      if (dataItems.size() != precedingDataItems.size()) {
+        return false;
+      }
+
+      for (auto const& dataItem : dataItems) {
+        auto precedingDataItem = precedingDataItems.find(dataItem.first);
+        if (precedingDataItem == precedingDataItems.end()) {
+          return false;
+        }
+        if (dataItem.second->pid_ != precedingDataItem->second->pid_) {
+          return false;
+        }
+        // Check that the configurations match exactly for the ESProducers
+        // (We already checked the ESSources above and there should not be
+        // any loopers)
+        if (!dataItem.second->isSource_ && !dataItem.second->isLooper_) {
+          bool itMatches = esController.isMatchingESProducer(dataItem.second->pid_, subProcessIndex_,
+                                                             precedingESProvider.subProcessIndex_);
+          if (!itMatches) {
+            return false;
+          }
+        }
+      }
+      Providers::iterator itFound = providers_.find(eventSetupRecordKey);
+      if (itFound != providers_.end()) {
+        std::set<EventSetupRecordKey> dependentRecords = itFound->second->dependentRecords();
+        for (auto const& dependentRecord : dependentRecords) {
+          auto iter = allComponentsMatch.find(dependentRecord);
+          if (iter != allComponentsMatch.end()) {
+            if (iter->second) {
+              continue;
+            } else {
+              return false;
+            }
+          }
+          bool match = doRecordsMatch(precedingESProvider, dependentRecord, allComponentsMatch, esController);
+          allComponentsMatch[dependentRecord] = match;
+          if (!match)
+            return false;
+        }
+      }
+      return true;
+    }
+
+    void EventSetupProvider::fillReferencedDataKeys(EventSetupRecordKey const& eventSetupRecordKey) {
+      if (referencedDataKeys_->find(eventSetupRecordKey) != referencedDataKeys_->end())
+        return;
+
+      auto recordProvider = providers_.find(eventSetupRecordKey);
+      if (recordProvider == providers_.end()) {
+        (*referencedDataKeys_)[eventSetupRecordKey];
+        return;
+      }
+      if (recordProvider->second) {
+        recordProvider->second->fillReferencedDataKeys((*referencedDataKeys_)[eventSetupRecordKey]);
+      }
+    }
+
+    void EventSetupProvider::resetRecordToProxyPointers() {
+      for (auto const& recordProvider : providers_) {
+        static const EventSetupRecordProvider::DataToPreferredProviderMap kEmptyMap;
+        const EventSetupRecordProvider::DataToPreferredProviderMap* preferredInfo = &kEmptyMap;
+        RecordToPreferred::const_iterator itRecordFound = recordToPreferred_->find(recordProvider.first);
+        if (itRecordFound != recordToPreferred_->end()) {
+          preferredInfo = &(itRecordFound->second);
+        }
+        recordProvider.second->resetRecordToProxyPointers(*preferredInfo);
+      }
+    }
+
+    void EventSetupProvider::clearInitializationData() {
+      preferredProviderInfo_.reset();
+      referencedDataKeys_.reset();
+      recordToFinders_.reset();
+      psetIDToRecordKey_.reset();
+      recordToPreferred_.reset();
+      recordsWithALooperProxy_.reset();
+    }
+
+    void EventSetupProvider::addRecordToEventSetup(EventSetupRecordImpl& iRecord) {
+      iRecord.setEventSetup(&eventSetup_);
+      eventSetup_.add(iRecord);
+    }
+
+    void EventSetupProvider::insert(std::unique_ptr<EventSetupRecordProvider> iRecordProvider) {
+      auto key = iRecordProvider->key();
+      insert(key, std::move(iRecordProvider));
+    }
+
+    //
+    // const member functions
+    //
+    EventSetupImpl const& EventSetupProvider::eventSetupForInstance(const IOVSyncValue& iValue) {
+      eventSetup_.clear();
+
+      // In a cmsRun job this does nothing because the EventSetupsController
+      // will have already called finishConfiguration, but some tests will
+      // call finishConfiguration here.
+      if (mustFinishConfiguration_) {
+        finishConfiguration();
+      }
+
+      for (Providers::iterator itProvider = providers_.begin(), itProviderEnd = providers_.end();
+           itProvider != itProviderEnd; ++itProvider) {
+        itProvider->second->addRecordToIfValid(*this, iValue);
+      }
+      return eventSetup_;
+    }
+
+    std::set<ComponentDescription> EventSetupProvider::proxyProviderDescriptions() const {
+      typedef std::set<ComponentDescription> Set;
+      Set descriptions;
+
+      for (auto const& p : providers_) {
+        auto const& d = p.second->proxyProviderDescriptions();
+        descriptions.insert(d.begin(), d.end());
+      }
+      if (dataProviders_.get()) {
+        for (auto const& p : *dataProviders_) {
+          descriptions.insert(p->description());
+        }
+      }
+
+      return descriptions;
+    }
+
+    bool EventSetupProvider::isWithinValidityInterval(IOVSyncValue const& iSync) const {
+      for (auto const& provider : providers_) {
+        auto const& iov = provider.second->validityInterval();
+        if ((iov != ValidityInterval::invalidInterval()) and
+            (not provider.second->validityInterval().validFor(iSync))) {
+          return false;
+        }
+      }
+      return true;
+    }
+    //
+    // static member functions
+    //
+    void EventSetupProvider::logInfoWhenSharing(ParameterSet const& iConfiguration) {
+      std::string edmtype = iConfiguration.getParameter<std::string>("@module_edm_type");
+      std::string modtype = iConfiguration.getParameter<std::string>("@module_type");
+      std::string label = iConfiguration.getParameter<std::string>("@module_label");
+      edm::LogVerbatim("EventSetupSharing")
+          << "Sharing " << edmtype << ": class=" << modtype << " label='" << label << "'";
+    }
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/EventSetupProviderMaker.cc
+++ b/FWCore/Framework/src/EventSetupProviderMaker.cc
@@ -21,13 +21,13 @@
 
 namespace edm {
   namespace eventsetup {
-  // ---------------------------------------------------------------
-    std::unique_ptr<EventSetupProvider>
-    makeEventSetupProvider(ParameterSet const& params, unsigned subProcessIndex, ActivityRegistry* activityRegistry) {
-      std::vector<std::string> prefers =
-        params.getParameter<std::vector<std::string> >("@all_esprefers");
+    // ---------------------------------------------------------------
+    std::unique_ptr<EventSetupProvider> makeEventSetupProvider(ParameterSet const& params,
+                                                               unsigned subProcessIndex,
+                                                               ActivityRegistry* activityRegistry) {
+      std::vector<std::string> prefers = params.getParameter<std::vector<std::string> >("@all_esprefers");
 
-      if(prefers.empty()) {
+      if (prefers.empty()) {
         return std::make_unique<EventSetupProvider>(activityRegistry, subProcessIndex);
       }
 
@@ -39,102 +39,78 @@ namespace edm {
       //preferInfo[ComponentDescription("DummyProxyProvider", "", false)]=
       //      recordToData;
 
-      for(std::vector<std::string>::iterator itName = prefers.begin(), itNameEnd = prefers.end();
-          itName != itNameEnd;
-          ++itName) {
+      for (std::vector<std::string>::iterator itName = prefers.begin(), itNameEnd = prefers.end(); itName != itNameEnd;
+           ++itName) {
         recordToData.clear();
         ParameterSet const& preferPSet = params.getParameterSet(*itName);
         std::vector<std::string> recordNames = preferPSet.getParameterNames();
-        for(std::vector<std::string>::iterator itRecordName = recordNames.begin(),
-            itRecordNameEnd = recordNames.end();
-            itRecordName != itRecordNameEnd;
-            ++itRecordName) {
-
-          if((*itRecordName)[0] == '@') {
+        for (std::vector<std::string>::iterator itRecordName = recordNames.begin(), itRecordNameEnd = recordNames.end();
+             itRecordName != itRecordNameEnd; ++itRecordName) {
+          if ((*itRecordName)[0] == '@') {
             //this is a 'hidden parameter' so skip it
             continue;
           }
 
           //this should be a record name with its info
           try {
-            std::vector<std::string> dataInfo =
-              preferPSet.getParameter<std::vector<std::string> >(*itRecordName);
+            std::vector<std::string> dataInfo = preferPSet.getParameter<std::vector<std::string> >(*itRecordName);
 
-            if(dataInfo.empty()) {
+            if (dataInfo.empty()) {
               //FUTURE: empty should just mean all data
               throw Exception(errors::Configuration)
-                << "The record named "
-                << *itRecordName << " specifies no data items";
+                  << "The record named " << *itRecordName << " specifies no data items";
             }
             //FUTURE: 'any' should be a special name
-            for(std::vector<std::string>::iterator itDatum = dataInfo.begin(),
-                itDatumEnd = dataInfo.end();
-                itDatum != itDatumEnd;
-                ++itDatum){
+            for (std::vector<std::string>::iterator itDatum = dataInfo.begin(), itDatumEnd = dataInfo.end();
+                 itDatum != itDatumEnd; ++itDatum) {
               std::string datumName(*itDatum, 0, itDatum->find_first_of("/"));
               std::string labelName;
 
-              if(itDatum->size() != datumName.size()) {
+              if (itDatum->size() != datumName.size()) {
                 labelName = std::string(*itDatum, datumName.size() + 1);
               }
-              recordToData.insert(std::make_pair(std::string(*itRecordName),
-                                                 std::make_pair(datumName,
-                                                                labelName)));
+              recordToData.insert(std::make_pair(std::string(*itRecordName), std::make_pair(datumName, labelName)));
             }
-          } catch(cms::Exception const& iException) {
+          } catch (cms::Exception const& iException) {
             cms::Exception theError("ESPreferConfigurationError");
             theError << "While parsing the es_prefer statement for type="
-                     << preferPSet.getParameter<std::string>("@module_type")
-                     << " label=\""
-                     << preferPSet.getParameter<std::string>("@module_label")
-                     << "\" an error occurred.";
+                     << preferPSet.getParameter<std::string>("@module_type") << " label=\""
+                     << preferPSet.getParameter<std::string>("@module_label") << "\" an error occurred.";
             theError.append(iException);
             throw theError;
           }
         }
         preferInfo[ComponentDescription(preferPSet.getParameter<std::string>("@module_type"),
-                                        preferPSet.getParameter<std::string>("@module_label"),
-                                        false)] = recordToData;
+                                        preferPSet.getParameter<std::string>("@module_label"), false)] = recordToData;
       }
       return std::make_unique<EventSetupProvider>(activityRegistry, subProcessIndex, &preferInfo);
     }
 
     // ---------------------------------------------------------------
-    void
-    fillEventSetupProvider(EventSetupsController& esController,
-                           EventSetupProvider& cp,
-                           ParameterSet& params) {
-      std::vector<std::string> providers =
-        params.getParameter<std::vector<std::string> >("@all_esmodules");
+    void fillEventSetupProvider(EventSetupsController& esController, EventSetupProvider& cp, ParameterSet& params) {
+      std::vector<std::string> providers = params.getParameter<std::vector<std::string> >("@all_esmodules");
 
-      for(std::vector<std::string>::iterator itName = providers.begin(), itNameEnd = providers.end();
-          itName != itNameEnd;
-          ++itName) {
+      for (std::vector<std::string>::iterator itName = providers.begin(), itNameEnd = providers.end();
+           itName != itNameEnd; ++itName) {
         ParameterSet* providerPSet = params.getPSetForUpdate(*itName);
         validateEventSetupParameters(*providerPSet);
         providerPSet->registerIt();
-        ModuleFactory::get()->addTo(esController,
-                                    cp,
-                                    *providerPSet);
+        ModuleFactory::get()->addTo(esController, cp, *providerPSet);
       }
 
-      std::vector<std::string> sources =
-        params.getParameter<std::vector<std::string> >("@all_essources");
+      std::vector<std::string> sources = params.getParameter<std::vector<std::string> >("@all_essources");
 
-      for(std::vector<std::string>::iterator itName = sources.begin(), itNameEnd = sources.end();
-          itName != itNameEnd;
-          ++itName) {
+      for (std::vector<std::string>::iterator itName = sources.begin(), itNameEnd = sources.end(); itName != itNameEnd;
+           ++itName) {
         ParameterSet* providerPSet = params.getPSetForUpdate(*itName);
         validateEventSetupParameters(*providerPSet);
         providerPSet->registerIt();
-        SourceFactory::get()->addTo(esController,
-                                    cp,
-                                    *providerPSet);
+        SourceFactory::get()->addTo(esController, cp, *providerPSet);
       }
     }
 
     // ---------------------------------------------------------------
-    void validateEventSetupParameters(ParameterSet & pset) {
+    void validateEventSetupParameters(ParameterSet& pset) {
       std::string modtype;
       std::string moduleLabel;
       modtype = pset.getParameter<std::string>("@module_type");
@@ -149,21 +125,18 @@ namespace edm {
       }
 
       std::unique_ptr<ParameterSetDescriptionFillerBase> filler(
-        ParameterSetDescriptionFillerPluginFactory::get()->create(modtype));
+          ParameterSetDescriptionFillerPluginFactory::get()->create(modtype));
       ConfigurationDescriptions descriptions(filler->baseType(), modtype);
       filler->fill(descriptions);
       try {
-        edm::convertException::wrap([&]() {
-          descriptions.validate(pset, moduleLabel);
-        });
-      }
-      catch (cms::Exception & iException) {
+        edm::convertException::wrap([&]() { descriptions.validate(pset, moduleLabel); });
+      } catch (cms::Exception& iException) {
         std::ostringstream ost;
-        ost << "Validating configuration of ESProducer or ESSource of type " << modtype
-            << " with label: '" << moduleLabel << "'";
+        ost << "Validating configuration of ESProducer or ESSource of type " << modtype << " with label: '"
+            << moduleLabel << "'";
         iException.addContext(ost.str());
         throw;
       }
     }
-  }
-}
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/EventSetupRecord.cc
+++ b/FWCore/Framework/src/EventSetupRecord.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     EventSetupRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -26,103 +26,89 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 namespace edm {
-   namespace eventsetup {
-//
-// constants, enums and typedefs
-//
-      typedef std::map< DataKey , const DataProxy* > Proxies;
-//
-// static data member definitions
-//
+  namespace eventsetup {
+    //
+    // constants, enums and typedefs
+    //
+    typedef std::map<DataKey, const DataProxy*> Proxies;
+    //
+    // static data member definitions
+    //
 
-//
-// constructors and destructor
-//
-EventSetupRecord::EventSetupRecord()
-{
-}
+    //
+    // constructors and destructor
+    //
+    EventSetupRecord::EventSetupRecord() {}
 
-// EventSetupRecord::EventSetupRecord(const EventSetupRecord& rhs)
-// {
-//    // do actual copying here;
-// }
+    // EventSetupRecord::EventSetupRecord(const EventSetupRecord& rhs)
+    // {
+    //    // do actual copying here;
+    // }
 
-EventSetupRecord::~EventSetupRecord()
-{
-}
+    EventSetupRecord::~EventSetupRecord() {}
 
-//
-// assignment operators
-//
-// const EventSetupRecord& EventSetupRecord::operator=(const EventSetupRecord& rhs)
-// {
-//   //An exception safe implementation is
-//   EventSetupRecord temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+    //
+    // assignment operators
+    //
+    // const EventSetupRecord& EventSetupRecord::operator=(const EventSetupRecord& rhs)
+    // {
+    //   //An exception safe implementation is
+    //   EventSetupRecord temp(rhs);
+    //   swap(rhs);
+    //
+    //   return *this;
+    // }
 
-//
-// member functions
-//
-//
-// const member functions
-//
-      
-bool
-EventSetupRecord::doGet(const DataKey& aKey, bool aGetTransiently) const {
-  return impl_->doGet(aKey,aGetTransiently);
-}
+    //
+    // member functions
+    //
+    //
+    // const member functions
+    //
 
-bool 
-EventSetupRecord::wasGotten(const DataKey& aKey) const {
-  return impl_->wasGotten(aKey);
-}
+    bool EventSetupRecord::doGet(const DataKey& aKey, bool aGetTransiently) const {
+      return impl_->doGet(aKey, aGetTransiently);
+    }
 
-edm::eventsetup::ComponentDescription const* 
-EventSetupRecord::providerDescription(const DataKey& aKey) const {
-  return impl_->providerDescription(aKey);
-}
+    bool EventSetupRecord::wasGotten(const DataKey& aKey) const { return impl_->wasGotten(aKey); }
 
-void 
-EventSetupRecord::validate(const ComponentDescription* iDesc, const ESInputTag& iTag) const
-{
-   if(iDesc && !iTag.module().empty()) {
-      bool matched = false;
-      if(iDesc->label_.empty()) {
-         matched = iDesc->type_ == iTag.module();
-      } else {
-         matched = iDesc->label_ == iTag.module();
+    edm::eventsetup::ComponentDescription const* EventSetupRecord::providerDescription(const DataKey& aKey) const {
+      return impl_->providerDescription(aKey);
+    }
+
+    void EventSetupRecord::validate(const ComponentDescription* iDesc, const ESInputTag& iTag) const {
+      if (iDesc && !iTag.module().empty()) {
+        bool matched = false;
+        if (iDesc->label_.empty()) {
+          matched = iDesc->type_ == iTag.module();
+        } else {
+          matched = iDesc->label_ == iTag.module();
+        }
+        if (!matched) {
+          throw cms::Exception("EventSetupWrongModule")
+              << "EventSetup data was retrieved using an ESInputTag with the values\n"
+              << "  moduleLabel = '" << iTag.module() << "'\n"
+              << "  dataLabel = '" << iTag.data() << "'\n"
+              << "but the data matching the C++ class type and dataLabel comes from module type=" << iDesc->type_
+              << " label='" << iDesc->label_ << "'.\n Please either change the ESInputTag's 'module' label to be "
+              << (iDesc->label_.empty() ? iDesc->type_ : iDesc->label_) << "\n or add the EventSetup module "
+              << iTag.module() << " to the configuration.";
+        }
       }
-      if(!matched) {
-         throw cms::Exception("EventSetupWrongModule") <<"EventSetup data was retrieved using an ESInputTag with the values\n"
-         <<"  moduleLabel = '"<<iTag.module()<<"'\n"
-         <<"  dataLabel = '"<<iTag.data()<<"'\n"
-         <<"but the data matching the C++ class type and dataLabel comes from module type="<<iDesc->type_<<" label='"<<iDesc->label_
-         <<"'.\n Please either change the ESInputTag's 'module' label to be "<<( iDesc->label_.empty()? iDesc->type_:iDesc->label_)
-         <<"\n or add the EventSetup module "<<iTag.module()<<" to the configuration.";
-      }
-   }
-}
+    }
 
-void 
-EventSetupRecord::addTraceInfoToCmsException(cms::Exception& iException, const char* iName, const ComponentDescription* iDescription, const DataKey& iKey) const
-{
-   std::ostringstream ost;
-   ost << "Using EventSetup component "
-       << iDescription->type_
-       << "/'" << iDescription->label_
-       << "' to make data "
-       << iKey.type().name() << "/'"
-       << iName
-       << "' in record "
-       << this->key().type().name();
-   iException.addContext(ost.str());
-}         
+    void EventSetupRecord::addTraceInfoToCmsException(cms::Exception& iException,
+                                                      const char* iName,
+                                                      const ComponentDescription* iDescription,
+                                                      const DataKey& iKey) const {
+      std::ostringstream ost;
+      ost << "Using EventSetup component " << iDescription->type_ << "/'" << iDescription->label_ << "' to make data "
+          << iKey.type().name() << "/'" << iName << "' in record " << this->key().type().name();
+      iException.addContext(ost.str());
+    }
 
-//
-// static member functions
-//
-   }
-}
+    //
+    // static member functions
+    //
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/EventSetupRecordImpl.cc
+++ b/FWCore/Framework/src/EventSetupRecordImpl.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     EventSetupRecordImpl
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -26,259 +26,226 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 namespace edm {
-   namespace eventsetup {
-//
-// constants, enums and typedefs
-//
-      typedef std::map< DataKey , const DataProxy* > Proxies;
-//
-// static data member definitions
-//
+  namespace eventsetup {
+    //
+    // constants, enums and typedefs
+    //
+    typedef std::map<DataKey, const DataProxy*> Proxies;
+    //
+    // static data member definitions
+    //
 
-//
-// constructors and destructor
-//
-EventSetupRecordImpl::EventSetupRecordImpl(EventSetupRecordKey const& iKey) :
-validity_(),
-key_(iKey),
-proxies_(),
-eventSetup_(nullptr),
-cacheIdentifier_(1), //start with 1 since 0 means we haven't checked yet
-transientAccessRequested_(false)
-{
-}
+    //
+    // constructors and destructor
+    //
+    EventSetupRecordImpl::EventSetupRecordImpl(EventSetupRecordKey const& iKey)
+        : validity_(),
+          key_(iKey),
+          proxies_(),
+          eventSetup_(nullptr),
+          cacheIdentifier_(1),  //start with 1 since 0 means we haven't checked yet
+          transientAccessRequested_(false) {}
 
-//
-// member functions
-//
-void
-EventSetupRecordImpl::set(const ValidityInterval& iInterval)
-{
-   validity_ = iInterval;
-}
+    //
+    // member functions
+    //
+    void EventSetupRecordImpl::set(const ValidityInterval& iInterval) { validity_ = iInterval; }
 
-void
-EventSetupRecordImpl::getESProducers(std::vector<ComponentDescription const*>& esproducers) {
-   esproducers.clear();
-   esproducers.reserve(proxies_.size());
-   for (auto const& iData : proxies_) {
-      ComponentDescription const* componentDescription = iData->providerDescription();
-      if (!componentDescription->isLooper_ && !componentDescription->isSource_) {
-         esproducers.push_back(componentDescription);
+    void EventSetupRecordImpl::getESProducers(std::vector<ComponentDescription const*>& esproducers) {
+      esproducers.clear();
+      esproducers.reserve(proxies_.size());
+      for (auto const& iData : proxies_) {
+        ComponentDescription const* componentDescription = iData->providerDescription();
+        if (!componentDescription->isLooper_ && !componentDescription->isSource_) {
+          esproducers.push_back(componentDescription);
+        }
       }
-   }
-}
+    }
 
-void
-EventSetupRecordImpl::fillReferencedDataKeys(std::map<DataKey, ComponentDescription const*>& referencedDataKeys) {
-   referencedDataKeys.clear();
-   auto itProxies = proxies_.begin();
-   for (auto const& iData : keysForProxies_) {
-      referencedDataKeys.emplace(iData, (*itProxies)->providerDescription());
-      ++itProxies;
-   }
-}
+    void EventSetupRecordImpl::fillReferencedDataKeys(
+        std::map<DataKey, ComponentDescription const*>& referencedDataKeys) {
+      referencedDataKeys.clear();
+      auto itProxies = proxies_.begin();
+      for (auto const& iData : keysForProxies_) {
+        referencedDataKeys.emplace(iData, (*itProxies)->providerDescription());
+        ++itProxies;
+      }
+    }
 
-bool 
-EventSetupRecordImpl::add(const DataKey& iKey ,
-                    const DataProxy* iProxy)
-{
-   //
-   const DataProxy* proxy = find(iKey);
-   if (nullptr != proxy) {
+    bool EventSetupRecordImpl::add(const DataKey& iKey, const DataProxy* iProxy) {
       //
-      // we already know the field exist, so do not need to check against end()
-      //
-      
-      // POLICY: If a Producer and a Source both claim to deliver the same data, the
-      //  Producer 'trumps' the Source. If two modules of the same type claim to deliver the
-      //  same data, this is an error unless the configuration specifically states which one
-      //  is to be chosen.  A Looper trumps both a Producer and a Source.
+      const DataProxy* proxy = find(iKey);
+      if (nullptr != proxy) {
+        //
+        // we already know the field exist, so do not need to check against end()
+        //
 
-      assert(proxy->providerDescription());
-      assert(iProxy->providerDescription());
-      if(iProxy->providerDescription()->isLooper_) {
-        proxies_[std::distance(keysForProxies_.begin(),
-                               std::lower_bound(keysForProxies_.begin(),
-                                                keysForProxies_.end(),
-                                                iKey))] = iProxy;
-         return true;
-      }
-	 
-      if(proxy->providerDescription()->isSource_ == iProxy->providerDescription()->isSource_) {
-         //should lookup to see if there is a specified 'chosen' one and only if not, throw the exception
-         throw cms::Exception("EventSetupConflict") <<"two EventSetup "<< 
-         (proxy->providerDescription()->isSource_? "Sources":"Producers")
-         <<" want to deliver type=\""<< iKey.type().name() <<"\" label=\""<<iKey.name().value()<<"\"\n"
-         <<" from record "<<key().type().name() <<". The two providers are \n"
-         <<"1) type=\""<<proxy->providerDescription()->type_<<"\" label=\""<<proxy->providerDescription()->label_<<"\"\n"
-         <<"2) type=\""<<iProxy->providerDescription()->type_<<"\" label=\""<<iProxy->providerDescription()->label_<<"\"\n"
-         <<"Please either\n   remove one of these "<<(proxy->providerDescription()->isSource_?"Sources":"Producers")
-         <<"\n   or find a way of configuring one of them so it does not deliver this data"
-         <<"\n   or use an es_prefer statement in the configuration to choose one.";
-      } else if(proxy->providerDescription()->isSource_) {
-        proxies_[std::distance(keysForProxies_.begin(),
-                               std::lower_bound(keysForProxies_.begin(),
-                                                keysForProxies_.end(),
-                                                iKey) )] = iProxy;
+        // POLICY: If a Producer and a Source both claim to deliver the same data, the
+        //  Producer 'trumps' the Source. If two modules of the same type claim to deliver the
+        //  same data, this is an error unless the configuration specifically states which one
+        //  is to be chosen.  A Looper trumps both a Producer and a Source.
+
+        assert(proxy->providerDescription());
+        assert(iProxy->providerDescription());
+        if (iProxy->providerDescription()->isLooper_) {
+          proxies_[std::distance(keysForProxies_.begin(),
+                                 std::lower_bound(keysForProxies_.begin(), keysForProxies_.end(), iKey))] = iProxy;
+          return true;
+        }
+
+        if (proxy->providerDescription()->isSource_ == iProxy->providerDescription()->isSource_) {
+          //should lookup to see if there is a specified 'chosen' one and only if not, throw the exception
+          throw cms::Exception("EventSetupConflict")
+              << "two EventSetup " << (proxy->providerDescription()->isSource_ ? "Sources" : "Producers")
+              << " want to deliver type=\"" << iKey.type().name() << "\" label=\"" << iKey.name().value() << "\"\n"
+              << " from record " << key().type().name() << ". The two providers are \n"
+              << "1) type=\"" << proxy->providerDescription()->type_ << "\" label=\""
+              << proxy->providerDescription()->label_ << "\"\n"
+              << "2) type=\"" << iProxy->providerDescription()->type_ << "\" label=\""
+              << iProxy->providerDescription()->label_ << "\"\n"
+              << "Please either\n   remove one of these "
+              << (proxy->providerDescription()->isSource_ ? "Sources" : "Producers")
+              << "\n   or find a way of configuring one of them so it does not deliver this data"
+              << "\n   or use an es_prefer statement in the configuration to choose one.";
+        } else if (proxy->providerDescription()->isSource_) {
+          proxies_[std::distance(keysForProxies_.begin(),
+                                 std::lower_bound(keysForProxies_.begin(), keysForProxies_.end(), iKey))] = iProxy;
+        } else {
+          return false;
+        }
       } else {
-         return false;
+        auto lb = std::lower_bound(keysForProxies_.begin(), keysForProxies_.end(), iKey);
+        auto index = std::distance(keysForProxies_.begin(), lb);
+        keysForProxies_.insert(lb, iKey);
+        proxies_.insert(proxies_.begin() + index, iProxy);
       }
-   }
-   else {
-      auto lb = std::lower_bound(keysForProxies_.begin(),keysForProxies_.end(), iKey);
-      auto index = std::distance(keysForProxies_.begin(), lb);
-      keysForProxies_.insert(lb, iKey);
-      proxies_.insert(proxies_.begin()+index, iProxy);
-   }
-   return true ;
-}
+      return true;
+    }
 
-void 
-EventSetupRecordImpl::clearProxies()
-{
-   keysForProxies_.clear();
-   proxies_.clear();
-}
+    void EventSetupRecordImpl::clearProxies() {
+      keysForProxies_.clear();
+      proxies_.clear();
+    }
 
-void 
-EventSetupRecordImpl::cacheReset()
-{
-   transientAccessRequested_ = false;
-   ++cacheIdentifier_;
-}
+    void EventSetupRecordImpl::cacheReset() {
+      transientAccessRequested_ = false;
+      ++cacheIdentifier_;
+    }
 
-bool
-EventSetupRecordImpl::transientReset()
-{
-   bool returnValue = transientAccessRequested_;
-   transientAccessRequested_=false;
-   return returnValue;
-}
-      
-//
-// const member functions
-//
-      
-const void* 
-EventSetupRecordImpl::getFromProxy(DataKey const & iKey ,
-                               const ComponentDescription*& iDesc,
-                               bool iTransientAccessOnly) const
-{
-   if(iTransientAccessOnly) { this->transientAccessRequested(); }
+    bool EventSetupRecordImpl::transientReset() {
+      bool returnValue = transientAccessRequested_;
+      transientAccessRequested_ = false;
+      return returnValue;
+    }
 
-   const DataProxy* proxy = this->find(iKey);
-   
-   const void* hold = nullptr;
-   
-   if(nullptr!=proxy) {
-      try {
-        convertException::wrap([&]() {
-            hold = proxy->get(*this, iKey,iTransientAccessOnly, eventSetup_->activityRegistry());
-            iDesc = proxy->providerDescription(); 
-        });
+    //
+    // const member functions
+    //
+
+    const void* EventSetupRecordImpl::getFromProxy(DataKey const& iKey,
+                                                   const ComponentDescription*& iDesc,
+                                                   bool iTransientAccessOnly) const {
+      if (iTransientAccessOnly) {
+        this->transientAccessRequested();
       }
-      catch(cms::Exception& e) {
-         addTraceInfoToCmsException(e,iKey.name().value(),proxy->providerDescription(), iKey);
-         //NOTE: the above function can't do the 'throw' since it causes the C++ class type
-         // of the throw to be changed, a 'rethrow' does not have that problem
-         throw;
+
+      const DataProxy* proxy = this->find(iKey);
+
+      const void* hold = nullptr;
+
+      if (nullptr != proxy) {
+        try {
+          convertException::wrap([&]() {
+            hold = proxy->get(*this, iKey, iTransientAccessOnly, eventSetup_->activityRegistry());
+            iDesc = proxy->providerDescription();
+          });
+        } catch (cms::Exception& e) {
+          addTraceInfoToCmsException(e, iKey.name().value(), proxy->providerDescription(), iKey);
+          //NOTE: the above function can't do the 'throw' since it causes the C++ class type
+          // of the throw to be changed, a 'rethrow' does not have that problem
+          throw;
+        }
       }
-   }
-   return hold;   
-}
-      
-const DataProxy* 
-EventSetupRecordImpl::find(const DataKey& iKey) const
-{
-   auto lb = std::lower_bound(keysForProxies_.begin(),keysForProxies_.end(), iKey);
-   if( (lb == keysForProxies_.end()) or (*lb != iKey)) {
-     return nullptr;
-   }
-   return proxies_[std::distance(keysForProxies_.begin(), lb)];
-}
-      
-bool 
-EventSetupRecordImpl::doGet(const DataKey& aKey, bool aGetTransiently) const {
-   const DataProxy* proxy = find(aKey);
-   if(nullptr != proxy) {
-      try {
-         convertException::wrap([&]() {
-            proxy->doGet(*this, aKey, aGetTransiently, eventSetup_->activityRegistry());
-         });
+      return hold;
+    }
+
+    const DataProxy* EventSetupRecordImpl::find(const DataKey& iKey) const {
+      auto lb = std::lower_bound(keysForProxies_.begin(), keysForProxies_.end(), iKey);
+      if ((lb == keysForProxies_.end()) or (*lb != iKey)) {
+        return nullptr;
       }
-      catch( cms::Exception& e) {
-         addTraceInfoToCmsException(e,aKey.name().value(),proxy->providerDescription(), aKey);
-         //NOTE: the above function can't do the 'throw' since it causes the C++ class type
-         // of the throw to be changed, a 'rethrow' does not have that problem
-         throw;
+      return proxies_[std::distance(keysForProxies_.begin(), lb)];
+    }
+
+    bool EventSetupRecordImpl::doGet(const DataKey& aKey, bool aGetTransiently) const {
+      const DataProxy* proxy = find(aKey);
+      if (nullptr != proxy) {
+        try {
+          convertException::wrap(
+              [&]() { proxy->doGet(*this, aKey, aGetTransiently, eventSetup_->activityRegistry()); });
+        } catch (cms::Exception& e) {
+          addTraceInfoToCmsException(e, aKey.name().value(), proxy->providerDescription(), aKey);
+          //NOTE: the above function can't do the 'throw' since it causes the C++ class type
+          // of the throw to be changed, a 'rethrow' does not have that problem
+          throw;
+        }
       }
-   }
-   return nullptr != proxy;
-}
+      return nullptr != proxy;
+    }
 
-bool 
-EventSetupRecordImpl::wasGotten(const DataKey& aKey) const {
-   const DataProxy* proxy = find(aKey);
-   if(nullptr != proxy) {
-      return proxy->cacheIsValid();
-   }
-   return false;
-}
-
-edm::eventsetup::ComponentDescription const* 
-EventSetupRecordImpl::providerDescription(const DataKey& aKey) const {
-   const DataProxy* proxy = find(aKey);
-   if(nullptr != proxy) {
-      return proxy->providerDescription();
-   }
-   return nullptr;
-}
-
-void 
-EventSetupRecordImpl::fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const
-{
-  oToFill = keysForProxies_;
-}
-
-void 
-EventSetupRecordImpl::validate(const ComponentDescription* iDesc, const ESInputTag& iTag) const
-{
-   if(iDesc && !iTag.module().empty()) {
-      bool matched = false;
-      if(iDesc->label_.empty()) {
-         matched = iDesc->type_ == iTag.module();
-      } else {
-         matched = iDesc->label_ == iTag.module();
+    bool EventSetupRecordImpl::wasGotten(const DataKey& aKey) const {
+      const DataProxy* proxy = find(aKey);
+      if (nullptr != proxy) {
+        return proxy->cacheIsValid();
       }
-      if(!matched) {
-         throw cms::Exception("EventSetupWrongModule") <<"EventSetup data was retrieved using an ESInputTag with the values\n"
-         <<"  moduleLabel = '"<<iTag.module()<<"'\n"
-         <<"  dataLabel = '"<<iTag.data()<<"'\n"
-         <<"but the data matching the C++ class type and dataLabel comes from module type="<<iDesc->type_<<" label='"<<iDesc->label_
-         <<"'.\n Please either change the ESInputTag's 'module' label to be "<<( iDesc->label_.empty()? iDesc->type_:iDesc->label_)
-         <<"\n or add the EventSetup module "<<iTag.module()<<" to the configuration.";
+      return false;
+    }
+
+    edm::eventsetup::ComponentDescription const* EventSetupRecordImpl::providerDescription(const DataKey& aKey) const {
+      const DataProxy* proxy = find(aKey);
+      if (nullptr != proxy) {
+        return proxy->providerDescription();
       }
-   }
-}
+      return nullptr;
+    }
 
-void 
-EventSetupRecordImpl::addTraceInfoToCmsException(cms::Exception& iException, const char* iName, const ComponentDescription* iDescription, const DataKey& iKey) const
-{
-   std::ostringstream ost;
-   ost << "Using EventSetup component "
-       << iDescription->type_
-       << "/'" << iDescription->label_
-       << "' to make data "
-       << iKey.type().name() << "/'"
-       << iName
-       << "' in record "
-       << this->key().type().name();
-   iException.addContext(ost.str());
-}         
+    void EventSetupRecordImpl::fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const {
+      oToFill = keysForProxies_;
+    }
 
-//
-// static member functions
-//
-   }
-}
+    void EventSetupRecordImpl::validate(const ComponentDescription* iDesc, const ESInputTag& iTag) const {
+      if (iDesc && !iTag.module().empty()) {
+        bool matched = false;
+        if (iDesc->label_.empty()) {
+          matched = iDesc->type_ == iTag.module();
+        } else {
+          matched = iDesc->label_ == iTag.module();
+        }
+        if (!matched) {
+          throw cms::Exception("EventSetupWrongModule")
+              << "EventSetup data was retrieved using an ESInputTag with the values\n"
+              << "  moduleLabel = '" << iTag.module() << "'\n"
+              << "  dataLabel = '" << iTag.data() << "'\n"
+              << "but the data matching the C++ class type and dataLabel comes from module type=" << iDesc->type_
+              << " label='" << iDesc->label_ << "'.\n Please either change the ESInputTag's 'module' label to be "
+              << (iDesc->label_.empty() ? iDesc->type_ : iDesc->label_) << "\n or add the EventSetup module "
+              << iTag.module() << " to the configuration.";
+        }
+      }
+    }
+
+    void EventSetupRecordImpl::addTraceInfoToCmsException(cms::Exception& iException,
+                                                          const char* iName,
+                                                          const ComponentDescription* iDescription,
+                                                          const DataKey& iKey) const {
+      std::ostringstream ost;
+      ost << "Using EventSetup component " << iDescription->type_ << "/'" << iDescription->label_ << "' to make data "
+          << iKey.type().name() << "/'" << iName << "' in record " << this->key().type().name();
+      iException.addContext(ost.str());
+    }
+
+    //
+    // static member functions
+    //
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/EventSetupRecordIntervalFinder.cc
+++ b/FWCore/Framework/src/EventSetupRecordIntervalFinder.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     EventSetupRecordIntervalFinder
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -21,85 +21,74 @@
 //
 using namespace edm::eventsetup;
 namespace edm {
-//
-// static data member definitions
-//
+  //
+  // static data member definitions
+  //
 
-//
-// constructors and destructor
-//
-//EventSetupRecordIntervalFinder::EventSetupRecordIntervalFinder()
-//{
-//}
+  //
+  // constructors and destructor
+  //
+  //EventSetupRecordIntervalFinder::EventSetupRecordIntervalFinder()
+  //{
+  //}
 
-// EventSetupRecordIntervalFinder::EventSetupRecordIntervalFinder(const EventSetupRecordIntervalFinder& rhs)
-// {
-//    // do actual copying here;
-// }
+  // EventSetupRecordIntervalFinder::EventSetupRecordIntervalFinder(const EventSetupRecordIntervalFinder& rhs)
+  // {
+  //    // do actual copying here;
+  // }
 
-EventSetupRecordIntervalFinder::~EventSetupRecordIntervalFinder() noexcept(false)
-{
-}
+  EventSetupRecordIntervalFinder::~EventSetupRecordIntervalFinder() noexcept(false) {}
 
-//
-// assignment operators
-//
-// const EventSetupRecordIntervalFinder& EventSetupRecordIntervalFinder::operator=(const EventSetupRecordIntervalFinder& rhs)
-// {
-//   //An exception safe implementation is
-//   EventSetupRecordIntervalFinder temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+  //
+  // assignment operators
+  //
+  // const EventSetupRecordIntervalFinder& EventSetupRecordIntervalFinder::operator=(const EventSetupRecordIntervalFinder& rhs)
+  // {
+  //   //An exception safe implementation is
+  //   EventSetupRecordIntervalFinder temp(rhs);
+  //   swap(rhs);
+  //
+  //   return *this;
+  // }
 
-//
-// member functions
-//
-const ValidityInterval& 
-EventSetupRecordIntervalFinder::findIntervalFor(const EventSetupRecordKey& iKey,
-                                              const IOVSyncValue& iInstance)
-{
-   Intervals::iterator itFound = intervals_.find(iKey);
-   assert(itFound != intervals_.end()) ;
-   if(! itFound->second.validFor(iInstance)) {
+  //
+  // member functions
+  //
+  const ValidityInterval& EventSetupRecordIntervalFinder::findIntervalFor(const EventSetupRecordKey& iKey,
+                                                                          const IOVSyncValue& iInstance) {
+    Intervals::iterator itFound = intervals_.find(iKey);
+    assert(itFound != intervals_.end());
+    if (!itFound->second.validFor(iInstance)) {
       setIntervalFor(iKey, iInstance, itFound->second);
-   }
-   return itFound->second;
-}
+    }
+    return itFound->second;
+  }
 
-void 
-EventSetupRecordIntervalFinder::findingRecordWithKey(const EventSetupRecordKey& iKey) {
-   intervals_.insert(Intervals::value_type(iKey, ValidityInterval()));
-}
+  void EventSetupRecordIntervalFinder::findingRecordWithKey(const EventSetupRecordKey& iKey) {
+    intervals_.insert(Intervals::value_type(iKey, ValidityInterval()));
+  }
 
-void 
-EventSetupRecordIntervalFinder::delaySettingRecords()
-{
-}
+  void EventSetupRecordIntervalFinder::delaySettingRecords() {}
 
-//
-// const member functions
-//
-std::set<EventSetupRecordKey> 
-EventSetupRecordIntervalFinder::findingForRecords() const
-{
-   if(intervals_.empty()) {
+  //
+  // const member functions
+  //
+  std::set<EventSetupRecordKey> EventSetupRecordIntervalFinder::findingForRecords() const {
+    if (intervals_.empty()) {
       //we are delaying our reading
       const_cast<EventSetupRecordIntervalFinder*>(this)->delaySettingRecords();
-   }
-   
-   std::set<EventSetupRecordKey> returnValue;
-   
-   for(Intervals::const_iterator itEntry = intervals_.begin(), itEntryEnd = intervals_.end();
-       itEntry != itEntryEnd;
-       ++itEntry) {
-      returnValue.insert(returnValue.end(), itEntry->first);
-   }
-   return returnValue;
-}
+    }
 
-//
-// static member functions
-//
-}
+    std::set<EventSetupRecordKey> returnValue;
+
+    for (Intervals::const_iterator itEntry = intervals_.begin(), itEntryEnd = intervals_.end(); itEntry != itEntryEnd;
+         ++itEntry) {
+      returnValue.insert(returnValue.end(), itEntry->first);
+    }
+    return returnValue;
+  }
+
+  //
+  // static member functions
+  //
+}  // namespace edm

--- a/FWCore/Framework/src/EventSetupRecordKey.cc
+++ b/FWCore/Framework/src/EventSetupRecordKey.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     EventSetupRecordKey
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -15,55 +15,52 @@
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 
-
 //
 // constants, enums and typedefs
 //
 
 namespace edm {
-   namespace eventsetup {
-//
-// static data member definitions
-//
+  namespace eventsetup {
+    //
+    // static data member definitions
+    //
 
-//
-// constructors and destructor
-//
-EventSetupRecordKey::EventSetupRecordKey() : type_()
-{
-}
+    //
+    // constructors and destructor
+    //
+    EventSetupRecordKey::EventSetupRecordKey() : type_() {}
 
-// EventSetupRecordKey::EventSetupRecordKey(const EventSetupRecordKey& rhs)
-// {
-//    // do actual copying here;
-// }
+    // EventSetupRecordKey::EventSetupRecordKey(const EventSetupRecordKey& rhs)
+    // {
+    //    // do actual copying here;
+    // }
 
-//EventSetupRecordKey::~EventSetupRecordKey()
-//{
-//}
+    //EventSetupRecordKey::~EventSetupRecordKey()
+    //{
+    //}
 
-//
-// assignment operators
-//
-// const EventSetupRecordKey& EventSetupRecordKey::operator=(const EventSetupRecordKey& rhs)
-// {
-//   //An exception safe implementation is
-//   EventSetupRecordKey temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+    //
+    // assignment operators
+    //
+    // const EventSetupRecordKey& EventSetupRecordKey::operator=(const EventSetupRecordKey& rhs)
+    // {
+    //   //An exception safe implementation is
+    //   EventSetupRecordKey temp(rhs);
+    //   swap(rhs);
+    //
+    //   return *this;
+    // }
 
-//
-// member functions
-//
+    //
+    // member functions
+    //
 
-//
-// const member functions
-//
+    //
+    // const member functions
+    //
 
-//
-// static member functions
-//
-   }
-}
+    //
+    // static member functions
+    //
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     EventSetupRecordProvider
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -28,294 +28,252 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "make_shared_noexcept_false.h"
 
-
-
-
 //
 // constants, enums and typedefs
 //
 
 namespace edm {
-   namespace eventsetup {
-//
-// static data member definitions
-//
+  namespace eventsetup {
+    //
+    // static data member definitions
+    //
 
-//
-// constructors and destructor
-//
-EventSetupRecordProvider::EventSetupRecordProvider(const EventSetupRecordKey& iKey) :
-    record_(iKey),
-    key_(iKey),
-    validityInterval_(), finder_(), providers_(),
-    multipleFinders_(new std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>()),
-    lastSyncWasBeginOfRun_(true)
-{
-}
+    //
+    // constructors and destructor
+    //
+    EventSetupRecordProvider::EventSetupRecordProvider(const EventSetupRecordKey& iKey)
+        : record_(iKey),
+          key_(iKey),
+          validityInterval_(),
+          finder_(),
+          providers_(),
+          multipleFinders_(new std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>()),
+          lastSyncWasBeginOfRun_(true) {}
 
-// EventSetupRecordProvider::EventSetupRecordProvider(const EventSetupRecordProvider& rhs)
-// {
-//    // do actual copying here;
-// }
+    // EventSetupRecordProvider::EventSetupRecordProvider(const EventSetupRecordProvider& rhs)
+    // {
+    //    // do actual copying here;
+    // }
 
-//
-// assignment operators
-//
-// const EventSetupRecordProvider& EventSetupRecordProvider::operator=(const EventSetupRecordProvider& rhs)
-// {
-//   //An exception safe implementation is
-//   EventSetupRecordProvider temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+    //
+    // assignment operators
+    //
+    // const EventSetupRecordProvider& EventSetupRecordProvider::operator=(const EventSetupRecordProvider& rhs)
+    // {
+    //   //An exception safe implementation is
+    //   EventSetupRecordProvider temp(rhs);
+    //   swap(rhs);
+    //
+    //   return *this;
+    // }
 
-//
-// member functions
-//
-void 
-EventSetupRecordProvider::add(std::shared_ptr<DataProxyProvider> iProvider)
-{
-   assert(iProvider->isUsingRecord(key_));
-   edm::propagate_const<std::shared_ptr<DataProxyProvider>> pProvider(iProvider);
-   assert(!search_all(providers_, pProvider));
-   providers_.emplace_back(iProvider);
-}
+    //
+    // member functions
+    //
+    void EventSetupRecordProvider::add(std::shared_ptr<DataProxyProvider> iProvider) {
+      assert(iProvider->isUsingRecord(key_));
+      edm::propagate_const<std::shared_ptr<DataProxyProvider>> pProvider(iProvider);
+      assert(!search_all(providers_, pProvider));
+      providers_.emplace_back(iProvider);
+    }
 
-void 
-EventSetupRecordProvider::addFinder(std::shared_ptr<EventSetupRecordIntervalFinder> iFinder)
-{
-   auto oldFinder = finder();
-   finder_ = iFinder;
-   if (nullptr != multipleFinders_.get()) {
-     multipleFinders_->emplace_back(iFinder);
-   } else {
-     //dependent records set there finders after the multipleFinders_ has been released
-     // but they also have never had a finder set
-     if(nullptr != oldFinder.get()) {
-       cms::Exception("EventSetupMultipleSources")<<"An additional source has been added to the Record "
-       <<key_.name()<<"'\n"
-       <<"after all the other sources have been dealt with.  This is a logic error, please send email to the framework group.";
-     }
-   }
-}
-void
-EventSetupRecordProvider::setValidityInterval(const ValidityInterval& iInterval)
-{
-   validityInterval_ = iInterval;
-}
+    void EventSetupRecordProvider::addFinder(std::shared_ptr<EventSetupRecordIntervalFinder> iFinder) {
+      auto oldFinder = finder();
+      finder_ = iFinder;
+      if (nullptr != multipleFinders_.get()) {
+        multipleFinders_->emplace_back(iFinder);
+      } else {
+        //dependent records set there finders after the multipleFinders_ has been released
+        // but they also have never had a finder set
+        if (nullptr != oldFinder.get()) {
+          cms::Exception("EventSetupMultipleSources")
+              << "An additional source has been added to the Record " << key_.name() << "'\n"
+              << "after all the other sources have been dealt with.  This is a logic error, please send email to the "
+                 "framework group.";
+        }
+      }
+    }
+    void EventSetupRecordProvider::setValidityInterval(const ValidityInterval& iInterval) {
+      validityInterval_ = iInterval;
+    }
 
-void 
-EventSetupRecordProvider::setDependentProviders(const std::vector< std::shared_ptr<EventSetupRecordProvider> >& iProviders)
-{
-   using std::placeholders::_1;
-   std::shared_ptr<DependentRecordIntervalFinder> newFinder = make_shared_noexcept_false<DependentRecordIntervalFinder>(key());
+    void EventSetupRecordProvider::setDependentProviders(
+        const std::vector<std::shared_ptr<EventSetupRecordProvider>>& iProviders) {
+      using std::placeholders::_1;
+      std::shared_ptr<DependentRecordIntervalFinder> newFinder =
+          make_shared_noexcept_false<DependentRecordIntervalFinder>(key());
 
-   std::shared_ptr<EventSetupRecordIntervalFinder> old = swapFinder(newFinder);
+      std::shared_ptr<EventSetupRecordIntervalFinder> old = swapFinder(newFinder);
 
-   for(auto const& p: iProviders) { newFinder->addProviderWeAreDependentOn(p); };
-   //if a finder was already set, add it as a depedency.  This is done to ensure that the IOVs properly change even if the
-   // old finder does not update each time a dependent record does change
-   if(old.get() != nullptr) {
-      newFinder->setAlternateFinder(old);
-   }
-}
-void 
-EventSetupRecordProvider::usePreferred(const DataToPreferredProviderMap& iMap)
-{
-  using std::placeholders::_1;
-  for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecordHelper,this,_1,iMap));
-  if (1 < multipleFinders_->size()) {
-     std::shared_ptr<IntersectingIOVRecordIntervalFinder> intFinder = make_shared_noexcept_false<IntersectingIOVRecordIntervalFinder>(key_);
-     intFinder->swapFinders(*multipleFinders_);
-     finder_ = intFinder;
-  }
-  //now we get rid of the temporary
-  multipleFinders_.reset(nullptr);
-}
+      for (auto const& p : iProviders) {
+        newFinder->addProviderWeAreDependentOn(p);
+      };
+      //if a finder was already set, add it as a depedency.  This is done to ensure that the IOVs properly change even if the
+      // old finder does not update each time a dependent record does change
+      if (old.get() != nullptr) {
+        newFinder->setAlternateFinder(old);
+      }
+    }
+    void EventSetupRecordProvider::usePreferred(const DataToPreferredProviderMap& iMap) {
+      using std::placeholders::_1;
+      for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecordHelper, this, _1, iMap));
+      if (1 < multipleFinders_->size()) {
+        std::shared_ptr<IntersectingIOVRecordIntervalFinder> intFinder =
+            make_shared_noexcept_false<IntersectingIOVRecordIntervalFinder>(key_);
+        intFinder->swapFinders(*multipleFinders_);
+        finder_ = intFinder;
+      }
+      //now we get rid of the temporary
+      multipleFinders_.reset(nullptr);
+    }
 
-void 
-EventSetupRecordProvider::addProxiesToRecord(std::shared_ptr<DataProxyProvider> iProvider,
-                                const EventSetupRecordProvider::DataToPreferredProviderMap& iMap) {
-   typedef DataProxyProvider::KeyedProxies ProxyList ;
-   typedef EventSetupRecordProvider::DataToPreferredProviderMap PreferredMap;
-   
-   const ProxyList& keyedProxies(iProvider->keyedProxies(this->key())) ;
-   ProxyList::const_iterator finishedProxyList(keyedProxies.end()) ;
-   for (ProxyList::const_iterator keyedProxy(keyedProxies.begin()) ;
-        keyedProxy != finishedProxyList ;
-        ++keyedProxy) {
-      PreferredMap::const_iterator itFound = iMap.find(keyedProxy->first);
-      if(iMap.end() != itFound) {
-         if( itFound->second.type_ != keyedProxy->second->providerDescription()->type_ ||
-            itFound->second.label_ != keyedProxy->second->providerDescription()->label_ ) {
+    void EventSetupRecordProvider::addProxiesToRecord(std::shared_ptr<DataProxyProvider> iProvider,
+                                                      const EventSetupRecordProvider::DataToPreferredProviderMap& iMap) {
+      typedef DataProxyProvider::KeyedProxies ProxyList;
+      typedef EventSetupRecordProvider::DataToPreferredProviderMap PreferredMap;
+
+      const ProxyList& keyedProxies(iProvider->keyedProxies(this->key()));
+      ProxyList::const_iterator finishedProxyList(keyedProxies.end());
+      for (ProxyList::const_iterator keyedProxy(keyedProxies.begin()); keyedProxy != finishedProxyList; ++keyedProxy) {
+        PreferredMap::const_iterator itFound = iMap.find(keyedProxy->first);
+        if (iMap.end() != itFound) {
+          if (itFound->second.type_ != keyedProxy->second->providerDescription()->type_ ||
+              itFound->second.label_ != keyedProxy->second->providerDescription()->label_) {
             //this is not the preferred provider
             continue;
-         }
+          }
+        }
+        record_.add((*keyedProxy).first, (*keyedProxy).second.get());
       }
-      record_.add((*keyedProxy).first , (*keyedProxy).second.get()) ;
-   }
-}
-      
-void 
-EventSetupRecordProvider::addRecordTo(EventSetupProvider& iEventSetupProvider) {
-   record_.set(this->validityInterval());
-   iEventSetupProvider.addRecordToEventSetup(record_);
-}
-      
-//
-// const member functions
-//
-void 
-EventSetupRecordProvider::resetTransients()
-{
+    }
 
-   using std::placeholders::_1;
-   if(checkResetTransients())  {
-      for_all(providers_, std::bind(&DataProxyProvider::resetProxiesIfTransient,_1,key_)); 
-   }
-}
+    void EventSetupRecordProvider::addRecordTo(EventSetupProvider& iEventSetupProvider) {
+      record_.set(this->validityInterval());
+      iEventSetupProvider.addRecordToEventSetup(record_);
+    }
 
-      
-void 
-EventSetupRecordProvider::addRecordToIfValid(EventSetupProvider& iEventSetupProvider,
-                                          const IOVSyncValue& iTime)
-{
-   if(setValidityIntervalFor(iTime)) {
-      addRecordTo(iEventSetupProvider);
-   } 
-}
+    //
+    // const member functions
+    //
+    void EventSetupRecordProvider::resetTransients() {
+      using std::placeholders::_1;
+      if (checkResetTransients()) {
+        for_all(providers_, std::bind(&DataProxyProvider::resetProxiesIfTransient, _1, key_));
+      }
+    }
 
-bool 
-EventSetupRecordProvider::setValidityIntervalFor(const IOVSyncValue& iTime)
-{
-   //we want to wait until after the first event of a new run before
-   // we reset any transients just in case some modules get their data at beginRun or beginLumi
-   // and others wait till the first event
-   if(!lastSyncWasBeginOfRun_) {
-      resetTransients();
-   }
-   lastSyncWasBeginOfRun_=iTime.eventID().event() == 0;
-   
-   if(validityInterval_.validFor(iTime)) {
-      return true;
-   }
-   bool returnValue = false;
-   //need to see if we get a new interval
-   if(nullptr != finder_.get()) {
-      IOVSyncValue oldFirst(validityInterval_.first());
-      
-      validityInterval_ = finder_->findIntervalFor(key_, iTime);
-      //are we in a valid range?
-      if(validityInterval_.first() != IOVSyncValue::invalidIOVSyncValue()) {
-         returnValue = true;
-         //did we actually change?
-         if(oldFirst != validityInterval_.first()) {
+    void EventSetupRecordProvider::addRecordToIfValid(EventSetupProvider& iEventSetupProvider,
+                                                      const IOVSyncValue& iTime) {
+      if (setValidityIntervalFor(iTime)) {
+        addRecordTo(iEventSetupProvider);
+      }
+    }
+
+    bool EventSetupRecordProvider::setValidityIntervalFor(const IOVSyncValue& iTime) {
+      //we want to wait until after the first event of a new run before
+      // we reset any transients just in case some modules get their data at beginRun or beginLumi
+      // and others wait till the first event
+      if (!lastSyncWasBeginOfRun_) {
+        resetTransients();
+      }
+      lastSyncWasBeginOfRun_ = iTime.eventID().event() == 0;
+
+      if (validityInterval_.validFor(iTime)) {
+        return true;
+      }
+      bool returnValue = false;
+      //need to see if we get a new interval
+      if (nullptr != finder_.get()) {
+        IOVSyncValue oldFirst(validityInterval_.first());
+
+        validityInterval_ = finder_->findIntervalFor(key_, iTime);
+        //are we in a valid range?
+        if (validityInterval_.first() != IOVSyncValue::invalidIOVSyncValue()) {
+          returnValue = true;
+          //did we actually change?
+          if (oldFirst != validityInterval_.first()) {
             //tell all Providers to update
-            for(auto& provider : providers_) {
-               provider->newInterval(key_, validityInterval_);
+            for (auto& provider : providers_) {
+              provider->newInterval(key_, validityInterval_);
             }
             cacheReset();
-         }
+          }
+        }
       }
-   }
-   return returnValue;
-}
+      return returnValue;
+    }
 
-void 
-EventSetupRecordProvider::resetProxies()
-{
-   using std::placeholders::_1;
-   cacheReset();
-   for_all(providers_, std::bind(&DataProxyProvider::resetProxies,_1,key_));
-   //some proxies only clear if they were accessed transiently,
-   // since resetProxies resets that flag, calling resetTransients
-   // will force a clear
-   for_all(providers_, std::bind(&DataProxyProvider::resetProxiesIfTransient,_1,key_)); 
+    void EventSetupRecordProvider::resetProxies() {
+      using std::placeholders::_1;
+      cacheReset();
+      for_all(providers_, std::bind(&DataProxyProvider::resetProxies, _1, key_));
+      //some proxies only clear if they were accessed transiently,
+      // since resetProxies resets that flag, calling resetTransients
+      // will force a clear
+      for_all(providers_, std::bind(&DataProxyProvider::resetProxiesIfTransient, _1, key_));
+    }
 
-}
+    void EventSetupRecordProvider::getReferencedESProducers(
+        std::map<EventSetupRecordKey, std::vector<ComponentDescription const*>>& referencedESProducers) {
+      record().getESProducers(referencedESProducers[key_]);
+    }
 
-void
-EventSetupRecordProvider::getReferencedESProducers(std::map<EventSetupRecordKey, std::vector<ComponentDescription const*> >& referencedESProducers) {
-   record().getESProducers(referencedESProducers[key_]);
-}
+    void EventSetupRecordProvider::fillReferencedDataKeys(
+        std::map<DataKey, ComponentDescription const*>& referencedDataKeys) {
+      record().fillReferencedDataKeys(referencedDataKeys);
+    }
 
-void
-EventSetupRecordProvider::fillReferencedDataKeys(std::map<DataKey, ComponentDescription const*>& referencedDataKeys) {
-   record().fillReferencedDataKeys(referencedDataKeys);
-}
+    void EventSetupRecordProvider::resetRecordToProxyPointers(DataToPreferredProviderMap const& iMap) {
+      using std::placeholders::_1;
+      record().clearProxies();
+      for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecordHelper, this, _1, iMap));
+    }
 
-void
-EventSetupRecordProvider::resetRecordToProxyPointers(DataToPreferredProviderMap const& iMap) {
-   using std::placeholders::_1;
-   record().clearProxies();
-   for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecordHelper, this, _1, iMap));
-}
+    void EventSetupRecordProvider::cacheReset() { record().cacheReset(); }
 
-void 
-EventSetupRecordProvider::cacheReset()
-{
-   record().cacheReset();
-}
+    bool EventSetupRecordProvider::checkResetTransients() { return record().transientReset(); }
 
-bool 
-EventSetupRecordProvider::checkResetTransients() 
-{
-   return record().transientReset();
-}
-      
+    std::set<EventSetupRecordKey> EventSetupRecordProvider::dependentRecords() const { return dependencies(key()); }
 
-std::set<EventSetupRecordKey> 
-EventSetupRecordProvider::dependentRecords() const
-{
-  return dependencies(key());
-}
+    std::set<ComponentDescription> EventSetupRecordProvider::proxyProviderDescriptions() const {
+      using std::placeholders::_1;
+      std::set<ComponentDescription> descriptions;
+      std::transform(providers_.begin(), providers_.end(), std::inserter(descriptions, descriptions.end()),
+                     std::bind(&DataProxyProvider::description, _1));
+      return descriptions;
+    }
 
-std::set<ComponentDescription> 
-EventSetupRecordProvider::proxyProviderDescriptions() const
-{
-   using std::placeholders::_1;
-   std::set<ComponentDescription> descriptions;
-   std::transform(providers_.begin(), providers_.end(),
-                  std::inserter(descriptions,descriptions.end()),
-                  std::bind(&DataProxyProvider::description,_1));
-   return descriptions;
-}
+    std::shared_ptr<DataProxyProvider> EventSetupRecordProvider::proxyProvider(ComponentDescription const& iDesc) {
+      using std::placeholders::_1;
+      auto itFound = std::find_if(
+          providers_.begin(), providers_.end(),
+          std::bind(std::equal_to<ComponentDescription>(), iDesc, std::bind(&DataProxyProvider::description, _1)));
+      if (itFound == providers_.end()) {
+        return std::shared_ptr<DataProxyProvider>();
+      }
+      return get_underlying_safe(*itFound);
+    }
 
-std::shared_ptr<DataProxyProvider> 
-EventSetupRecordProvider::proxyProvider(ComponentDescription const& iDesc) {
-   using std::placeholders::_1;
-   auto itFound = std::find_if(providers_.begin(),providers_.end(),
-                std::bind(std::equal_to<ComponentDescription>(), 
-                            iDesc, 
-                            std::bind(&DataProxyProvider::description,_1)));
-   if(itFound == providers_.end()){
+    std::shared_ptr<DataProxyProvider> EventSetupRecordProvider::proxyProvider(ParameterSetIDHolder const& psetID) {
+      for (auto& dataProxyProvider : providers_) {
+        if (dataProxyProvider->description().pid_ == psetID.psetID()) {
+          return get_underlying_safe(dataProxyProvider);
+        }
+      }
       return std::shared_ptr<DataProxyProvider>();
-   }
-   return get_underlying_safe(*itFound);
-}
+    }
 
-std::shared_ptr<DataProxyProvider> 
-EventSetupRecordProvider::proxyProvider(ParameterSetIDHolder const& psetID) {
-   for (auto& dataProxyProvider : providers_) {
-      if (dataProxyProvider->description().pid_ == psetID.psetID()) {
-         return get_underlying_safe(dataProxyProvider);
+    void EventSetupRecordProvider::resetProxyProvider(
+        ParameterSetIDHolder const& psetID, std::shared_ptr<DataProxyProvider> const& sharedDataProxyProvider) {
+      for (auto& dataProxyProvider : providers_) {
+        if (dataProxyProvider->description().pid_ == psetID.psetID()) {
+          dataProxyProvider = sharedDataProxyProvider;
+        }
       }
-   }
-   return std::shared_ptr<DataProxyProvider>();
-}
+    }
 
-void
-EventSetupRecordProvider::resetProxyProvider(ParameterSetIDHolder const& psetID, std::shared_ptr<DataProxyProvider> const& sharedDataProxyProvider) {
-   for (auto& dataProxyProvider : providers_) {
-      if (dataProxyProvider->description().pid_ == psetID.psetID()) {
-         dataProxyProvider = sharedDataProxyProvider;
-      }
-   }
-}
-
-//
-// static member functions
-//
-   }
-}
+    //
+    // static member functions
+    //
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     EventSetupsController
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -25,38 +25,34 @@
 namespace edm {
   namespace eventsetup {
 
-    EventSetupsController::EventSetupsController() : mustFinishConfiguration_(true) {
-    }
+    EventSetupsController::EventSetupsController() : mustFinishConfiguration_(true) {}
 
-    std::shared_ptr<EventSetupProvider>
-    EventSetupsController::makeProvider(ParameterSet& iPSet, ActivityRegistry* activityRegistry) {
-
+    std::shared_ptr<EventSetupProvider> EventSetupsController::makeProvider(ParameterSet& iPSet,
+                                                                            ActivityRegistry* activityRegistry) {
       // Makes an EventSetupProvider
       // Also parses the prefer information from ParameterSets and puts
       // it in a map that is stored in the EventSetupProvider
-      std::shared_ptr<EventSetupProvider> returnValue(makeEventSetupProvider(iPSet, providers_.size(), activityRegistry) );
+      std::shared_ptr<EventSetupProvider> returnValue(
+          makeEventSetupProvider(iPSet, providers_.size(), activityRegistry));
 
       // Construct the ESProducers and ESSources
       // shared_ptrs to them are temporarily stored in this
       // EventSetupsController and in the EventSetupProvider
       fillEventSetupProvider(*this, *returnValue, iPSet);
-   
+
       providers_.push_back(returnValue);
       return returnValue;
     }
 
-    void
-    EventSetupsController::eventSetupForInstance(IOVSyncValue const& syncValue) {
-
+    void EventSetupsController::eventSetupForInstance(IOVSyncValue const& syncValue) {
       if (mustFinishConfiguration_) {
-        std::for_each(providers_.begin(), providers_.end(), [](std::shared_ptr<EventSetupProvider> const& esp) {
-          esp->finishConfiguration();
-        });
+        std::for_each(providers_.begin(), providers_.end(),
+                      [](std::shared_ptr<EventSetupProvider> const& esp) { esp->finishConfiguration(); });
         // When the ESSources and ESProducers were constructed a first pass was
         // done which attempts to get component sharing between SubProcesses
         // correct, but in this pass only the configuration of the components
         // being shared are compared. This is not good enough for ESProducers.
-        // In the following function, all the other components that contribute 
+        // In the following function, all the other components that contribute
         // to the same record and also the records that record depends on are
         // also checked. The component sharing is appropriately fixed as necessary.
         checkESProducerSharing();
@@ -69,25 +65,22 @@ namespace edm {
       });
     }
 
-    void
-    EventSetupsController::forceCacheClear() const {
-      std::for_each(providers_.begin(), providers_.end(), [](std::shared_ptr<EventSetupProvider> const& esp) {
-        esp->forceCacheClear();
-      });
+    void EventSetupsController::forceCacheClear() const {
+      std::for_each(providers_.begin(), providers_.end(),
+                    [](std::shared_ptr<EventSetupProvider> const& esp) { esp->forceCacheClear(); });
     }
 
-    bool
-    EventSetupsController::isWithinValidityInterval(IOVSyncValue const& syncValue) const {
-      for(auto const& provider: providers_) {
-        if( not provider->isWithinValidityInterval(syncValue)) {
+    bool EventSetupsController::isWithinValidityInterval(IOVSyncValue const& syncValue) const {
+      for (auto const& provider : providers_) {
+        if (not provider->isWithinValidityInterval(syncValue)) {
           return false;
         }
       }
       return true;
     }
-    
-    std::shared_ptr<DataProxyProvider>
-    EventSetupsController::getESProducerAndRegisterProcess(ParameterSet const& pset, unsigned subProcessIndex) {
+
+    std::shared_ptr<DataProxyProvider> EventSetupsController::getESProducerAndRegisterProcess(
+        ParameterSet const& pset, unsigned subProcessIndex) {
       // Try to find a DataProxyProvider with a matching ParameterSet
       auto elements = esproducers_.equal_range(pset.id());
       for (auto it = elements.first; it != elements.second; ++it) {
@@ -103,16 +96,17 @@ namespace edm {
       return std::shared_ptr<DataProxyProvider>();
     }
 
-    void
-    EventSetupsController::putESProducer(ParameterSet const& pset, std::shared_ptr<DataProxyProvider> const& component, unsigned subProcessIndex) {
-      auto newElement = esproducers_.insert(std::pair<ParameterSetID, ESProducerInfo>(pset.id(), 
-                                                                                      ESProducerInfo(&pset, component)));
+    void EventSetupsController::putESProducer(ParameterSet const& pset,
+                                              std::shared_ptr<DataProxyProvider> const& component,
+                                              unsigned subProcessIndex) {
+      auto newElement =
+          esproducers_.insert(std::pair<ParameterSetID, ESProducerInfo>(pset.id(), ESProducerInfo(&pset, component)));
       // Register processes with an exact match
       newElement->second.subProcessIndexes().push_back(subProcessIndex);
     }
 
-    std::shared_ptr<EventSetupRecordIntervalFinder>
-    EventSetupsController::getESSourceAndRegisterProcess(ParameterSet const& pset, unsigned subProcessIndex) {
+    std::shared_ptr<EventSetupRecordIntervalFinder> EventSetupsController::getESSourceAndRegisterProcess(
+        ParameterSet const& pset, unsigned subProcessIndex) {
       // Try to find a EventSetupRecordIntervalFinder with a matching ParameterSet
       auto elements = essources_.equal_range(pset.id());
       for (auto it = elements.first; it != elements.second; ++it) {
@@ -128,30 +122,27 @@ namespace edm {
       return std::shared_ptr<EventSetupRecordIntervalFinder>();
     }
 
-    void
-    EventSetupsController::putESSource(ParameterSet const& pset, std::shared_ptr<EventSetupRecordIntervalFinder> const& component, unsigned subProcessIndex) {
-      auto newElement = essources_.insert(std::pair<ParameterSetID, ESSourceInfo>(pset.id(), 
-                                                                                  ESSourceInfo(&pset, component)));
+    void EventSetupsController::putESSource(ParameterSet const& pset,
+                                            std::shared_ptr<EventSetupRecordIntervalFinder> const& component,
+                                            unsigned subProcessIndex) {
+      auto newElement =
+          essources_.insert(std::pair<ParameterSetID, ESSourceInfo>(pset.id(), ESSourceInfo(&pset, component)));
       // Register processes with an exact match
       newElement->second.subProcessIndexes().push_back(subProcessIndex);
     }
 
-    void
-    EventSetupsController::clearComponents() {
+    void EventSetupsController::clearComponents() {
       esproducers_.clear();
       essources_.clear();
     }
 
-    void
-    EventSetupsController::lookForMatches(ParameterSetID const& psetID,
-                                          unsigned subProcessIndex,
-                                          unsigned precedingProcessIndex,
-                                          bool& firstProcessWithThisPSet,
-                                          bool& precedingHasMatchingPSet) const {
-
+    void EventSetupsController::lookForMatches(ParameterSetID const& psetID,
+                                               unsigned subProcessIndex,
+                                               unsigned precedingProcessIndex,
+                                               bool& firstProcessWithThisPSet,
+                                               bool& precedingHasMatchingPSet) const {
       auto elements = esproducers_.equal_range(psetID);
       for (auto it = elements.first; it != elements.second; ++it) {
-
         std::vector<unsigned> const& subProcessIndexes = it->second.subProcessIndexes();
 
         auto iFound = std::find(subProcessIndexes.begin(), subProcessIndexes.end(), subProcessIndex);
@@ -161,7 +152,7 @@ namespace edm {
 
         if (iFound == subProcessIndexes.begin()) {
           firstProcessWithThisPSet = true;
-          precedingHasMatchingPSet = false;      
+          precedingHasMatchingPSet = false;
         } else {
           auto iFoundPreceding = std::find(subProcessIndexes.begin(), iFound, precedingProcessIndex);
           if (iFoundPreceding == iFound) {
@@ -169,25 +160,21 @@ namespace edm {
             precedingHasMatchingPSet = false;
           } else {
             firstProcessWithThisPSet = false;
-            precedingHasMatchingPSet = true;    
+            precedingHasMatchingPSet = true;
           }
         }
         return;
       }
-      throw edm::Exception(edm::errors::LogicError)
-        << "EventSetupsController::lookForMatches\n"
-        << "Subprocess index not found. This should never happen\n"
-        << "Please report this to a Framework Developer\n";   
+      throw edm::Exception(edm::errors::LogicError) << "EventSetupsController::lookForMatches\n"
+                                                    << "Subprocess index not found. This should never happen\n"
+                                                    << "Please report this to a Framework Developer\n";
     }
 
-    bool
-    EventSetupsController::isFirstMatch(ParameterSetID const& psetID,
-                                        unsigned subProcessIndex,
-                                        unsigned precedingProcessIndex) const {
-
+    bool EventSetupsController::isFirstMatch(ParameterSetID const& psetID,
+                                             unsigned subProcessIndex,
+                                             unsigned precedingProcessIndex) const {
       auto elements = esproducers_.equal_range(psetID);
       for (auto it = elements.first; it != elements.second; ++it) {
-
         std::vector<unsigned> const& subProcessIndexes = it->second.subProcessIndexes();
 
         auto iFound = std::find(subProcessIndexes.begin(), subProcessIndexes.end(), subProcessIndex);
@@ -202,21 +189,17 @@ namespace edm {
           return iFoundPreceding == subProcessIndexes.begin();
         }
       }
-      throw edm::Exception(edm::errors::LogicError)
-        << "EventSetupsController::isFirstMatch\n"
-        << "Subprocess index not found. This should never happen\n"
-        << "Please report this to a Framework Developer\n";
+      throw edm::Exception(edm::errors::LogicError) << "EventSetupsController::isFirstMatch\n"
+                                                    << "Subprocess index not found. This should never happen\n"
+                                                    << "Please report this to a Framework Developer\n";
       return false;
     }
 
-    bool
-    EventSetupsController::isLastMatch(ParameterSetID const& psetID,
-                                       unsigned subProcessIndex,
-                                       unsigned precedingProcessIndex) const {
-
+    bool EventSetupsController::isLastMatch(ParameterSetID const& psetID,
+                                            unsigned subProcessIndex,
+                                            unsigned precedingProcessIndex) const {
       auto elements = esproducers_.equal_range(psetID);
       for (auto it = elements.first; it != elements.second; ++it) {
-
         std::vector<unsigned> const& subProcessIndexes = it->second.subProcessIndexes();
 
         auto iFound = std::find(subProcessIndexes.begin(), subProcessIndexes.end(), subProcessIndex);
@@ -231,20 +214,17 @@ namespace edm {
           return (++iFoundPreceding) == iFound;
         }
       }
-      throw edm::Exception(edm::errors::LogicError)
-        << "EventSetupsController::isLastMatch\n"
-        << "Subprocess index not found. This should never happen\n"
-        << "Please report this to a Framework Developer\n";
+      throw edm::Exception(edm::errors::LogicError) << "EventSetupsController::isLastMatch\n"
+                                                    << "Subprocess index not found. This should never happen\n"
+                                                    << "Please report this to a Framework Developer\n";
       return false;
     }
 
-    bool
-    EventSetupsController::isMatchingESSource(ParameterSetID const& psetID,
-                                              unsigned subProcessIndex,
-                                              unsigned precedingProcessIndex) const {
+    bool EventSetupsController::isMatchingESSource(ParameterSetID const& psetID,
+                                                   unsigned subProcessIndex,
+                                                   unsigned precedingProcessIndex) const {
       auto elements = essources_.equal_range(psetID);
       for (auto it = elements.first; it != elements.second; ++it) {
-
         std::vector<unsigned> const& subProcessIndexes = it->second.subProcessIndexes();
 
         auto iFound = std::find(subProcessIndexes.begin(), subProcessIndexes.end(), subProcessIndex);
@@ -256,23 +236,20 @@ namespace edm {
         if (iFoundPreceding == iFound) {
           return false;
         } else {
-          return true;    
+          return true;
         }
       }
-      throw edm::Exception(edm::errors::LogicError)
-        << "EventSetupsController::lookForMatchingESSource\n"
-        << "Subprocess index not found. This should never happen\n"
-        << "Please report this to a Framework Developer\n";
+      throw edm::Exception(edm::errors::LogicError) << "EventSetupsController::lookForMatchingESSource\n"
+                                                    << "Subprocess index not found. This should never happen\n"
+                                                    << "Please report this to a Framework Developer\n";
       return false;
     }
 
-    bool
-    EventSetupsController::isMatchingESProducer(ParameterSetID const& psetID,
-                                                unsigned subProcessIndex,
-                                                unsigned precedingProcessIndex) const {
+    bool EventSetupsController::isMatchingESProducer(ParameterSetID const& psetID,
+                                                     unsigned subProcessIndex,
+                                                     unsigned precedingProcessIndex) const {
       auto elements = esproducers_.equal_range(psetID);
       for (auto it = elements.first; it != elements.second; ++it) {
-
         std::vector<unsigned> const& subProcessIndexes = it->second.subProcessIndexes();
 
         auto iFound = std::find(subProcessIndexes.begin(), subProcessIndexes.end(), subProcessIndex);
@@ -284,23 +261,19 @@ namespace edm {
         if (iFoundPreceding == iFound) {
           return false;
         } else {
-          return true;    
+          return true;
         }
       }
-      throw edm::Exception(edm::errors::LogicError)
-        << "EventSetupsController::lookForMatchingESSource\n"
-        << "Subprocess index not found. This should never happen\n"
-        << "Please report this to a Framework Developer\n";
+      throw edm::Exception(edm::errors::LogicError) << "EventSetupsController::lookForMatchingESSource\n"
+                                                    << "Subprocess index not found. This should never happen\n"
+                                                    << "Please report this to a Framework Developer\n";
       return false;
     }
 
-    ParameterSet const*
-    EventSetupsController::getESProducerPSet(ParameterSetID const& psetID,
-                                             unsigned subProcessIndex) const {
-   
+    ParameterSet const* EventSetupsController::getESProducerPSet(ParameterSetID const& psetID,
+                                                                 unsigned subProcessIndex) const {
       auto elements = esproducers_.equal_range(psetID);
       for (auto it = elements.first; it != elements.second; ++it) {
-
         std::vector<unsigned> const& subProcessIndexes = it->second.subProcessIndexes();
 
         auto iFound = std::find(subProcessIndexes.begin(), subProcessIndexes.end(), subProcessIndex);
@@ -309,22 +282,19 @@ namespace edm {
         }
         return it->second.pset();
       }
-      throw edm::Exception(edm::errors::LogicError)
-        << "EventSetupsController::getESProducerPSet\n"
-        << "Subprocess index not found. This should never happen\n"
-        << "Please report this to a Framework Developer\n";
+      throw edm::Exception(edm::errors::LogicError) << "EventSetupsController::getESProducerPSet\n"
+                                                    << "Subprocess index not found. This should never happen\n"
+                                                    << "Please report this to a Framework Developer\n";
       return nullptr;
     }
 
-    void
-    EventSetupsController::checkESProducerSharing() {
-
+    void EventSetupsController::checkESProducerSharing() {
       // Loop over SubProcesses, skip the top level process.
       auto esProvider = providers_.begin();
       auto esProviderEnd = providers_.end();
-      if (esProvider != esProviderEnd) ++esProvider;
-      for ( ; esProvider != esProviderEnd; ++esProvider) {
-
+      if (esProvider != esProviderEnd)
+        ++esProvider;
+      for (; esProvider != esProviderEnd; ++esProvider) {
         // An element is added to this set for each ESProducer
         // when we have determined which preceding process
         // this process can share that ESProducer with or
@@ -345,19 +315,16 @@ namespace edm {
         // EventSetupProviders from the preceding processes (the first
         // preceding process will be the top level process and the others
         // SubProcess's)
-        for (auto precedingESProvider = providers_.begin();
-             precedingESProvider != esProvider;
-             ++precedingESProvider) {
-
+        for (auto precedingESProvider = providers_.begin(); precedingESProvider != esProvider; ++precedingESProvider) {
           (*esProvider)->checkESProducerSharing(**precedingESProvider, sharingCheckDone, referencedESProducers, *this);
         }
 
         (*esProvider)->resetRecordToProxyPointers();
       }
       esProvider = providers_.begin();
-      for ( ; esProvider != esProviderEnd; ++esProvider) {
+      for (; esProvider != esProviderEnd; ++esProvider) {
         (*esProvider)->clearInitializationData();
       }
     }
-  }
-}
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/EventSetupsController.h
+++ b/FWCore/Framework/src/EventSetupsController.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     EventSetupsController
-// 
+//
 /** \class edm::eventsetup::EventSetupsController
 
  Description: Manages a group of EventSetups which can share components
@@ -26,131 +26,129 @@
 
 namespace edm {
 
-   class ActivityRegistry;
-   class EventSetupRecordIntervalFinder;
-   class ParameterSet;
-   class IOVSyncValue;
-   
-   namespace eventsetup {
+  class ActivityRegistry;
+  class EventSetupRecordIntervalFinder;
+  class ParameterSet;
+  class IOVSyncValue;
 
-      class DataProxyProvider;
-      class EventSetupProvider;
+  namespace eventsetup {
 
-      class ESProducerInfo {
-      public:
-         ESProducerInfo(ParameterSet const* ps,
-                        std::shared_ptr<DataProxyProvider> const& pr) : 
-            pset_(ps), provider_(pr), subProcessIndexes_() { }
+    class DataProxyProvider;
+    class EventSetupProvider;
 
-         ParameterSet const* pset() const { return pset_; }
-         std::shared_ptr<DataProxyProvider> const& provider() const { return provider_; }
-         std::vector<unsigned>& subProcessIndexes() { return subProcessIndexes_; }
-         std::vector<unsigned> const& subProcessIndexes() const { return subProcessIndexes_; }
+    class ESProducerInfo {
+    public:
+      ESProducerInfo(ParameterSet const* ps, std::shared_ptr<DataProxyProvider> const& pr)
+          : pset_(ps), provider_(pr), subProcessIndexes_() {}
 
-      private:
-         ParameterSet const* pset_;
-         std::shared_ptr<DataProxyProvider> provider_;
-         std::vector<unsigned> subProcessIndexes_;
-      };
+      ParameterSet const* pset() const { return pset_; }
+      std::shared_ptr<DataProxyProvider> const& provider() const { return provider_; }
+      std::vector<unsigned>& subProcessIndexes() { return subProcessIndexes_; }
+      std::vector<unsigned> const& subProcessIndexes() const { return subProcessIndexes_; }
 
-      class ESSourceInfo {
-      public:
-         ESSourceInfo(ParameterSet const* ps,
-                      std::shared_ptr<EventSetupRecordIntervalFinder> const& fi) :
-            pset_(ps), finder_(fi), subProcessIndexes_() { }
+    private:
+      ParameterSet const* pset_;
+      std::shared_ptr<DataProxyProvider> provider_;
+      std::vector<unsigned> subProcessIndexes_;
+    };
 
-         ParameterSet const* pset() const { return pset_; }
-         std::shared_ptr<EventSetupRecordIntervalFinder> const& finder() const { return finder_; }
-         std::vector<unsigned>& subProcessIndexes() { return subProcessIndexes_; }
-         std::vector<unsigned> const& subProcessIndexes() const { return subProcessIndexes_; }
+    class ESSourceInfo {
+    public:
+      ESSourceInfo(ParameterSet const* ps, std::shared_ptr<EventSetupRecordIntervalFinder> const& fi)
+          : pset_(ps), finder_(fi), subProcessIndexes_() {}
 
-      private:
-         ParameterSet const* pset_;
-         std::shared_ptr<EventSetupRecordIntervalFinder> finder_;
-         std::vector<unsigned> subProcessIndexes_;
-      };
+      ParameterSet const* pset() const { return pset_; }
+      std::shared_ptr<EventSetupRecordIntervalFinder> const& finder() const { return finder_; }
+      std::vector<unsigned>& subProcessIndexes() { return subProcessIndexes_; }
+      std::vector<unsigned> const& subProcessIndexes() const { return subProcessIndexes_; }
 
-      class EventSetupsController {
-         
-      public:
-         EventSetupsController();
+    private:
+      ParameterSet const* pset_;
+      std::shared_ptr<EventSetupRecordIntervalFinder> finder_;
+      std::vector<unsigned> subProcessIndexes_;
+    };
 
-         std::shared_ptr<EventSetupProvider> makeProvider(ParameterSet&, ActivityRegistry*);
+    class EventSetupsController {
+    public:
+      EventSetupsController();
 
-         void eventSetupForInstance(IOVSyncValue const& syncValue);
+      std::shared_ptr<EventSetupProvider> makeProvider(ParameterSet&, ActivityRegistry*);
 
-         bool isWithinValidityInterval(IOVSyncValue const& syncValue) const;
-        
-         void forceCacheClear() const;
+      void eventSetupForInstance(IOVSyncValue const& syncValue);
 
-         std::shared_ptr<DataProxyProvider> getESProducerAndRegisterProcess(ParameterSet const& pset, unsigned subProcessIndex);
-         void putESProducer(ParameterSet const& pset, std::shared_ptr<DataProxyProvider> const& component, unsigned subProcessIndex);
+      bool isWithinValidityInterval(IOVSyncValue const& syncValue) const;
 
-         std::shared_ptr<EventSetupRecordIntervalFinder> getESSourceAndRegisterProcess(ParameterSet const& pset, unsigned subProcessIndex);
-         void putESSource(ParameterSet const& pset, std::shared_ptr<EventSetupRecordIntervalFinder> const& component, unsigned subProcessIndex);
+      void forceCacheClear() const;
 
-         void clearComponents();
+      std::shared_ptr<DataProxyProvider> getESProducerAndRegisterProcess(ParameterSet const& pset,
+                                                                         unsigned subProcessIndex);
+      void putESProducer(ParameterSet const& pset,
+                         std::shared_ptr<DataProxyProvider> const& component,
+                         unsigned subProcessIndex);
 
-         unsigned indexOfNextProcess() const { return providers_.size(); }
+      std::shared_ptr<EventSetupRecordIntervalFinder> getESSourceAndRegisterProcess(ParameterSet const& pset,
+                                                                                    unsigned subProcessIndex);
+      void putESSource(ParameterSet const& pset,
+                       std::shared_ptr<EventSetupRecordIntervalFinder> const& component,
+                       unsigned subProcessIndex);
 
-         void lookForMatches(ParameterSetID const& psetID,
-                             unsigned subProcessIndex,
-                             unsigned precedingProcessIndex,
-                             bool& firstProcessWithThisPSet,
-                             bool& precedingHasMatchingPSet) const;
+      void clearComponents();
 
-         bool isFirstMatch(ParameterSetID const& psetID,
-                           unsigned subProcessIndex,
-                           unsigned precedingProcessIndex) const;
+      unsigned indexOfNextProcess() const { return providers_.size(); }
 
-         bool isLastMatch(ParameterSetID const& psetID,
+      void lookForMatches(ParameterSetID const& psetID,
                           unsigned subProcessIndex,
-                          unsigned precedingProcessIndex) const;
+                          unsigned precedingProcessIndex,
+                          bool& firstProcessWithThisPSet,
+                          bool& precedingHasMatchingPSet) const;
 
-         bool isMatchingESSource(ParameterSetID const& psetID,
-                                 unsigned subProcessIndex,
-                                 unsigned precedingProcessIndex) const;
+      bool isFirstMatch(ParameterSetID const& psetID, unsigned subProcessIndex, unsigned precedingProcessIndex) const;
 
-         bool isMatchingESProducer(ParameterSetID const& psetID,
-                                   unsigned subProcessIndex,
-                                   unsigned precedingProcessIndex) const;
+      bool isLastMatch(ParameterSetID const& psetID, unsigned subProcessIndex, unsigned precedingProcessIndex) const;
 
-         ParameterSet const* getESProducerPSet(ParameterSetID const& psetID,
-                                               unsigned subProcessIndex) const;
+      bool isMatchingESSource(ParameterSetID const& psetID,
+                              unsigned subProcessIndex,
+                              unsigned precedingProcessIndex) const;
 
-         std::vector<std::shared_ptr<EventSetupProvider> > const& providers() const { return providers_; }
+      bool isMatchingESProducer(ParameterSetID const& psetID,
+                                unsigned subProcessIndex,
+                                unsigned precedingProcessIndex) const;
 
-         std::multimap<ParameterSetID, ESProducerInfo> const& esproducers() const { return esproducers_; }
+      ParameterSet const* getESProducerPSet(ParameterSetID const& psetID, unsigned subProcessIndex) const;
 
-         std::multimap<ParameterSetID, ESSourceInfo> const& essources() const { return essources_; }
+      std::vector<std::shared_ptr<EventSetupProvider> > const& providers() const { return providers_; }
 
-         bool mustFinishConfiguration() const { return mustFinishConfiguration_; }
+      std::multimap<ParameterSetID, ESProducerInfo> const& esproducers() const { return esproducers_; }
 
-      private:
-         EventSetupsController(EventSetupsController const&) = delete; // stop default
-         
-         EventSetupsController const& operator=(EventSetupsController const&) = delete; // stop default
+      std::multimap<ParameterSetID, ESSourceInfo> const& essources() const { return essources_; }
 
-         void checkESProducerSharing();
-         
-         // ---------- member data --------------------------------
-         std::vector<std::shared_ptr<EventSetupProvider> > providers_;
+      bool mustFinishConfiguration() const { return mustFinishConfiguration_; }
 
-         // The following two multimaps have one entry for each unique
-         // ParameterSet. The ESProducerInfo or ESSourceInfo object
-         // contains a list of the processes that use that ParameterSet
-         // (0 for the top level process, then the SubProcesses are
-         // identified by counting their execution order starting at 1).
-         // There can be multiple entries for a single ParameterSetID because
-         // of a difference in untracked parameters. These are only
-         // used during initialization.  The Info objects also contain
-         // a pointer to the full validated ParameterSet and a shared_ptr
-         // to the component.
-         std::multimap<ParameterSetID, ESProducerInfo> esproducers_;
-         std::multimap<ParameterSetID, ESSourceInfo> essources_;
+    private:
+      EventSetupsController(EventSetupsController const&) = delete;  // stop default
 
-         bool mustFinishConfiguration_;
-      };
-   }
-}
+      EventSetupsController const& operator=(EventSetupsController const&) = delete;  // stop default
+
+      void checkESProducerSharing();
+
+      // ---------- member data --------------------------------
+      std::vector<std::shared_ptr<EventSetupProvider> > providers_;
+
+      // The following two multimaps have one entry for each unique
+      // ParameterSet. The ESProducerInfo or ESSourceInfo object
+      // contains a list of the processes that use that ParameterSet
+      // (0 for the top level process, then the SubProcesses are
+      // identified by counting their execution order starting at 1).
+      // There can be multiple entries for a single ParameterSetID because
+      // of a difference in untracked parameters. These are only
+      // used during initialization.  The Info objects also contain
+      // a pointer to the full validated ParameterSet and a shared_ptr
+      // to the component.
+      std::multimap<ParameterSetID, ESProducerInfo> esproducers_;
+      std::multimap<ParameterSetID, ESSourceInfo> essources_;
+
+      bool mustFinishConfiguration_;
+    };
+  }  // namespace eventsetup
+}  // namespace edm
 #endif

--- a/FWCore/Framework/src/EventSignalsSentry.h
+++ b/FWCore/Framework/src/EventSignalsSentry.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     EventSignalsSentry
-// 
+//
 /**\class edm::EventSignalsSentry EventSignalsSentry.h "EventSignalsSentry.h"
 
  Description: Guarantees that the pre/post module Event signals are sent
@@ -27,23 +27,19 @@
 // forward declarations
 namespace edm {
   class EventSignalsSentry {
-
   public:
-    EventSignalsSentry(ActivityRegistry* iReg,
-                       ModuleCallingContext const * iContext) :
-      m_reg(iReg),
-      m_context(iContext)
-    { iReg->preModuleEventSignal_( *(iContext->getStreamContext()), *iContext);}
-    
-    ~EventSignalsSentry() {
-      m_reg->postModuleEventSignal_( *(m_context->getStreamContext()), *m_context);
+    EventSignalsSentry(ActivityRegistry* iReg, ModuleCallingContext const* iContext)
+        : m_reg(iReg), m_context(iContext) {
+      iReg->preModuleEventSignal_(*(iContext->getStreamContext()), *iContext);
     }
-    
+
+    ~EventSignalsSentry() { m_reg->postModuleEventSignal_(*(m_context->getStreamContext()), *m_context); }
+
   private:
     // ---------- member data --------------------------------
-    ActivityRegistry* m_reg; // We do not use propagate_const because the registry itself is mutable.
+    ActivityRegistry* m_reg;  // We do not use propagate_const because the registry itself is mutable.
     ModuleCallingContext const* m_context;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/ExceptionActions.cc
+++ b/FWCore/Framework/src/ExceptionActions.cc
@@ -10,32 +10,30 @@ namespace edm {
   namespace exception_actions {
     namespace {
       struct ActionNames {
-	ActionNames():table_(LastCode + 1) {
-	  table_[IgnoreCompletely] = "IgnoreCompletely";
-	  table_[Rethrow] = "Rethrow";
-	  table_[SkipEvent] = "SkipEvent";
-	  table_[FailPath] = "FailPath";
-	}
+        ActionNames() : table_(LastCode + 1) {
+          table_[IgnoreCompletely] = "IgnoreCompletely";
+          table_[Rethrow] = "Rethrow";
+          table_[SkipEvent] = "SkipEvent";
+          table_[FailPath] = "FailPath";
+        }
 
-	typedef std::vector<char const*> Table;
-	Table table_;
-      };      
-    }
+        typedef std::vector<char const*> Table;
+        Table table_;
+      };
+    }  // namespace
 
     char const* actionName(ActionCodes code) {
       static ActionNames tab;
-      return static_cast<unsigned int>(code) < tab.table_.size() ?  tab.table_[code] : "UnknownAction";
+      return static_cast<unsigned int>(code) < tab.table_.size() ? tab.table_[code] : "UnknownAction";
     }
-  }
+  }  // namespace exception_actions
 
-  ExceptionToActionTable::ExceptionToActionTable() : map_() {
-    addDefaults();
-  }
+  ExceptionToActionTable::ExceptionToActionTable() : map_() { addDefaults(); }
 
   namespace {
     inline void install(exception_actions::ActionCodes code,
-			ExceptionToActionTable::ActionMap& out,
-			ParameterSet const& pset) {
+                        ExceptionToActionTable::ActionMap& out,
+                        ParameterSet const& pset) {
       typedef std::vector<std::string> vstring;
 
       // we cannot have parameters in the main process section so look
@@ -46,16 +44,15 @@ namespace edm {
       // exception type should be used so the catch can be more
       // specific.
 
-//	cerr << pset.toString() << std::endl;
+      //	cerr << pset.toString() << std::endl;
 
       ParameterSet const& opts = pset.getUntrackedParameterSet("options");
       //cerr << "looking for " << actionName(code) << std::endl;
-      for(auto const& v: opts.getUntrackedParameter<std::vector<std::string>>(actionName(code))) {
+      for (auto const& v : opts.getUntrackedParameter<std::vector<std::string>>(actionName(code))) {
         out[v] = code;
       }
-
-    }  
-  }
+    }
+  }  // namespace
 
   ExceptionToActionTable::ExceptionToActionTable(ParameterSet const& pset) : map_() {
     addDefaults();
@@ -70,17 +67,16 @@ namespace edm {
     // populate defaults that are not 'Rethrow'
     // (There are none as of CMSSW_3_4_X.)
     // 'Rethrow' is the default default.
-    if(2 <= debugit()) {
-	ActionMap::const_iterator ib(map_.begin()),ie(map_.end());
-	for(;ib != ie; ++ib) {
-	  std::cerr << ib->first << ',' << ib->second << '\n';
-	}
-	std::cerr << std::endl;
+    if (2 <= debugit()) {
+      ActionMap::const_iterator ib(map_.begin()), ie(map_.end());
+      for (; ib != ie; ++ib) {
+        std::cerr << ib->first << ',' << ib->second << '\n';
+      }
+      std::cerr << std::endl;
     }
   }
 
-  ExceptionToActionTable::~ExceptionToActionTable() {
-  }
+  ExceptionToActionTable::~ExceptionToActionTable() {}
 
   void ExceptionToActionTable::add(std::string const& category, exception_actions::ActionCodes code) {
     map_[category] = code;
@@ -91,4 +87,4 @@ namespace edm {
     return i != map_.end() ? i->second : exception_actions::Rethrow;
   }
 
-}
+}  // namespace edm

--- a/FWCore/Framework/src/ExceptionHelpers.cc
+++ b/FWCore/Framework/src/ExceptionHelpers.cc
@@ -8,23 +8,19 @@
 
 namespace edm {
 
-  void
-  addContextAndPrintException(char const* context,
-                              cms::Exception& ex,
-                              bool disablePrint) {
+  void addContextAndPrintException(char const* context, cms::Exception& ex, bool disablePrint) {
     if (context != nullptr && strlen(context) != 0U) {
       ex.addContext(context);
     }
     if (!disablePrint) {
       Service<JobReport> jobReportSvc;
       if (jobReportSvc.isAvailable()) {
-        JobReport *jobRep = jobReportSvc.operator->();
+        JobReport* jobRep = jobReportSvc.operator->();
         edm::printCmsException(ex, jobRep, ex.returnCode());
-      }
-      else {
+      } else {
         edm::printCmsException(ex);
       }
       ex.setAlreadyPrinted(true);
     }
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/Factory.cc
+++ b/FWCore/Framework/src/Factory.cc
@@ -6,81 +6,67 @@
 
 #include <iostream>
 
-EDM_REGISTER_PLUGINFACTORY(edm::MakerPluginFactory,"CMS EDM Framework Module");
+EDM_REGISTER_PLUGINFACTORY(edm::MakerPluginFactory, "CMS EDM Framework Module");
 namespace edm {
 
-  static void cleanup(const Factory::MakerMap::value_type& v)
-  {
-    delete v.second.get();
-  }
+  static void cleanup(const Factory::MakerMap::value_type& v) { delete v.second.get(); }
 
   Factory const Factory::singleInstance_;
-  
-  Factory::~Factory()
-  {
-    for_all(makers_, cleanup);
-  }
 
-  Factory::Factory(): makers_()
+  Factory::~Factory() { for_all(makers_, cleanup); }
 
-  {
-  }
+  Factory::Factory()
+      : makers_()
 
-  Factory const* Factory::get()
-  {
-    return &singleInstance_;
-  }
+  {}
 
-  Maker* Factory::findMaker(const MakeModuleParams& p) const
-  {
+  Factory const* Factory::get() { return &singleInstance_; }
+
+  Maker* Factory::findMaker(const MakeModuleParams& p) const {
     std::string modtype = p.pset_->getParameter<std::string>("@module_type");
     FDEBUG(1) << "Factory: module_type = " << modtype << std::endl;
     MakerMap::iterator it = makers_.find(modtype);
-    
-    if(it == makers_.end())
-    {
+
+    if (it == makers_.end()) {
       std::unique_ptr<Maker> wm(MakerPluginFactory::get()->create(modtype));
-      
-      if(wm.get()==nullptr)
-        throw edm::Exception(errors::Configuration,"UnknownModule")
-        << "Module " << modtype
-        << " with version " << p.processConfiguration_->releaseVersion()
-        << " was not registered.\n"
-        << "Perhaps your module type is misspelled or is not a "
-        << "framework plugin.\n"
-        << "Try running EdmPluginDump to obtain a list of "
-        << "available Plugins.";
-      
+
+      if (wm.get() == nullptr)
+        throw edm::Exception(errors::Configuration, "UnknownModule")
+            << "Module " << modtype << " with version " << p.processConfiguration_->releaseVersion()
+            << " was not registered.\n"
+            << "Perhaps your module type is misspelled or is not a "
+            << "framework plugin.\n"
+            << "Try running EdmPluginDump to obtain a list of "
+            << "available Plugins.";
+
       FDEBUG(1) << "Factory:  created worker of type " << modtype << std::endl;
-      
-      std::pair<MakerMap::iterator,bool> ret =
-      makers_.insert(std::pair<std::string,Maker*>(modtype,wm.get()));
-      
+
+      std::pair<MakerMap::iterator, bool> ret = makers_.insert(std::pair<std::string, Maker*>(modtype, wm.get()));
+
       //	if(ret.second==false)
       //	  throw runtime_error("Worker Factory map insert failed");
-      
+
       it = ret.first;
       wm.release();
     }
     return it->second;
   }
-  
-  std::shared_ptr<maker::ModuleHolder> Factory::makeModule(const MakeModuleParams& p,
-                                            signalslot::Signal<void(const ModuleDescription&)>& pre,
-                                            signalslot::Signal<void(const ModuleDescription&)>& post) const
-  {
+
+  std::shared_ptr<maker::ModuleHolder> Factory::makeModule(
+      const MakeModuleParams& p,
+      signalslot::Signal<void(const ModuleDescription&)>& pre,
+      signalslot::Signal<void(const ModuleDescription&)>& post) const {
     auto maker = findMaker(p);
-    auto mod(maker->makeModule(p,pre,post));
+    auto mod(maker->makeModule(p, pre, post));
     return mod;
   }
 
-  std::shared_ptr<maker::ModuleHolder> Factory::makeReplacementModule(const edm::ParameterSet& p) const
-  {
+  std::shared_ptr<maker::ModuleHolder> Factory::makeReplacementModule(const edm::ParameterSet& p) const {
     std::string modtype = p.getParameter<std::string>("@module_type");
     MakerMap::iterator it = makers_.find(modtype);
-    if(it != makers_.end()) {
+    if (it != makers_.end()) {
       return it->second->makeReplacementModule(p);
     }
     return std::shared_ptr<maker::ModuleHolder>{};
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/Factory.h
+++ b/FWCore/Framework/src/Factory.h
@@ -13,10 +13,9 @@
 #include "FWCore/Utilities/interface/propagate_const.h"
 
 namespace edm {
-  typedef edmplugin::PluginFactory<Maker* ()> MakerPluginFactory;
-  
-  class Factory  
-  {
+  typedef edmplugin::PluginFactory<Maker*()> MakerPluginFactory;
+
+  class Factory {
   public:
     typedef std::map<std::string, edm::propagate_const<Maker*>> MakerMap;
 
@@ -30,7 +29,6 @@ namespace edm {
 
     std::shared_ptr<maker::ModuleHolder> makeReplacementModule(const edm::ParameterSet&) const;
 
-
   private:
     Factory();
     Maker* findMaker(const MakeModuleParams& p) const;
@@ -38,5 +36,5 @@ namespace edm {
     mutable MakerMap makers_;
   };
 
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/src/GenericHandle.cc
+++ b/FWCore/Framework/src/GenericHandle.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     GenericHandle
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -16,67 +16,61 @@
 #include "FWCore/Framework/interface/GenericHandle.h"
 
 namespace edm {
-void convert_handle(BasicHandle && orig,
-                    Handle<GenericObject>& result)
-{
-  if(orig.failedToGet()) {
-    result.setWhyFailedFactory(orig.whyFailedFactory());
-    return;
-  }
-  WrapperBase const* originalWrap = orig.wrapper();
-  if(originalWrap == nullptr) {
-    throw Exception(errors::InvalidReference,"NullPointer")
-      << "edm::BasicHandle has null pointer to Wrapper";
-  }
-  
-  ObjectWithDict wrap(originalWrap->wrappedTypeInfo(), const_cast<WrapperBase*>(originalWrap));
-  assert(bool(wrap));
-  
-  ObjectWithDict product(wrap.get("obj"));
-  if(!product){
-    throw Exception(errors::LogicError)<<"GenericObject could not find 'obj' member";
-  }
-  if(product.typeOf() != result.type()) {
-    throw Exception(errors::LogicError) << "GenericObject asked for " << result.type().name()
-      << " but was given a " << product.typeOf().name();
-  }
-  
-  Handle<GenericObject> h(product, orig.provenance(), orig.id());
-  h.swap(result);
-}
+  void convert_handle(BasicHandle&& orig, Handle<GenericObject>& result) {
+    if (orig.failedToGet()) {
+      result.setWhyFailedFactory(orig.whyFailedFactory());
+      return;
+    }
+    WrapperBase const* originalWrap = orig.wrapper();
+    if (originalWrap == nullptr) {
+      throw Exception(errors::InvalidReference, "NullPointer") << "edm::BasicHandle has null pointer to Wrapper";
+    }
 
-///Specialize the getByLabel method to work with a Handle<GenericObject>
-template<>
-bool
-edm::Event::getByLabel<GenericObject>(std::string const& label,
-                                      std::string const& productInstanceName,
-                                      Handle<GenericObject>& result) const
-{
-  BasicHandle bh = provRecorder_.getByLabel_(TypeID(result.type().typeInfo()), label, productInstanceName, std::string(), moduleCallingContext_);
-  convert_handle(std::move(bh), result);  // throws on conversion error
-  if(!result.failedToGet()) {
-    addToGotBranchIDs(*bh.provenance());
-    return true;
-  }
-  return false;
-}
+    ObjectWithDict wrap(originalWrap->wrappedTypeInfo(), const_cast<WrapperBase*>(originalWrap));
+    assert(bool(wrap));
 
-template<>
-bool
-edm::Event::getByLabel<GenericObject>(edm::InputTag const& tag,
-                                             Handle<GenericObject>& result) const
-{
-  if (tag.process().empty()) {
-    return this->getByLabel(tag.label(), tag.instance(), result);
-  } else {
-    BasicHandle bh = provRecorder_.getByLabel_(TypeID(result.type().typeInfo()), tag.label(), tag.instance(),tag.process(), moduleCallingContext_);
+    ObjectWithDict product(wrap.get("obj"));
+    if (!product) {
+      throw Exception(errors::LogicError) << "GenericObject could not find 'obj' member";
+    }
+    if (product.typeOf() != result.type()) {
+      throw Exception(errors::LogicError)
+          << "GenericObject asked for " << result.type().name() << " but was given a " << product.typeOf().name();
+    }
+
+    Handle<GenericObject> h(product, orig.provenance(), orig.id());
+    h.swap(result);
+  }
+
+  ///Specialize the getByLabel method to work with a Handle<GenericObject>
+  template <>
+  bool edm::Event::getByLabel<GenericObject>(std::string const& label,
+                                             std::string const& productInstanceName,
+                                             Handle<GenericObject>& result) const {
+    BasicHandle bh = provRecorder_.getByLabel_(TypeID(result.type().typeInfo()), label, productInstanceName,
+                                               std::string(), moduleCallingContext_);
     convert_handle(std::move(bh), result);  // throws on conversion error
-    if(!result.failedToGet()) {
+    if (!result.failedToGet()) {
       addToGotBranchIDs(*bh.provenance());
       return true;
     }
+    return false;
   }
-  return false;
-}
 
-}
+  template <>
+  bool edm::Event::getByLabel<GenericObject>(edm::InputTag const& tag, Handle<GenericObject>& result) const {
+    if (tag.process().empty()) {
+      return this->getByLabel(tag.label(), tag.instance(), result);
+    } else {
+      BasicHandle bh = provRecorder_.getByLabel_(TypeID(result.type().typeInfo()), tag.label(), tag.instance(),
+                                                 tag.process(), moduleCallingContext_);
+      convert_handle(std::move(bh), result);  // throws on conversion error
+      if (!result.failedToGet()) {
+        addToGotBranchIDs(*bh.provenance());
+        return true;
+      }
+    }
+    return false;
+  }
+
+}  // namespace edm

--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -12,7 +12,6 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
@@ -20,89 +19,82 @@
 #include <map>
 
 namespace edm {
-  GlobalSchedule::GlobalSchedule(std::shared_ptr<TriggerResultInserter> inserter,
-                                 std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
-                                 std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
-                                 std::shared_ptr<ModuleRegistry> modReg,
-                                 std::vector<std::string> const& iModulesToUse,
-                                 ParameterSet& proc_pset,
-                                 ProductRegistry& pregistry,
-                                 PreallocationConfiguration const& prealloc,
-                                 ExceptionToActionTable const& actions,
-                                 std::shared_ptr<ActivityRegistry> areg,
-                                 std::shared_ptr<ProcessConfiguration> processConfiguration,
-                                 ProcessContext const* processContext) :
-    actReg_(areg),
-    processContext_(processContext)
-  {
+  GlobalSchedule::GlobalSchedule(
+      std::shared_ptr<TriggerResultInserter> inserter,
+      std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
+      std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
+      std::shared_ptr<ModuleRegistry> modReg,
+      std::vector<std::string> const& iModulesToUse,
+      ParameterSet& proc_pset,
+      ProductRegistry& pregistry,
+      PreallocationConfiguration const& prealloc,
+      ExceptionToActionTable const& actions,
+      std::shared_ptr<ActivityRegistry> areg,
+      std::shared_ptr<ProcessConfiguration> processConfiguration,
+      ProcessContext const* processContext)
+      : actReg_(areg), processContext_(processContext) {
     workerManagers_.reserve(prealloc.numberOfLuminosityBlocks());
-    for(unsigned int i = 0; i<prealloc.numberOfLuminosityBlocks(); ++i) {
-      workerManagers_.emplace_back(modReg,areg,actions);
+    for (unsigned int i = 0; i < prealloc.numberOfLuminosityBlocks(); ++i) {
+      workerManagers_.emplace_back(modReg, areg, actions);
     }
     for (auto const& moduleLabel : iModulesToUse) {
       bool isTracked;
       ParameterSet* modpset = proc_pset.getPSetForUpdate(moduleLabel, isTracked);
-      if (modpset != nullptr) { // It will be null for PathStatusInserters, it should
-                                // be impossible to be null for anything else
+      if (modpset != nullptr) {  // It will be null for PathStatusInserters, it should
+                                 // be impossible to be null for anything else
         assert(isTracked);
 
         //side effect keeps this module around
-        for(auto& wm: workerManagers_) {
-          wm.addToAllWorkers(wm.getWorker(*modpset, pregistry, &prealloc,processConfiguration, moduleLabel));
+        for (auto& wm : workerManagers_) {
+          wm.addToAllWorkers(wm.getWorker(*modpset, pregistry, &prealloc, processConfiguration, moduleLabel));
         }
       }
     }
-    if(inserter) {
+    if (inserter) {
       inserter->doPreallocate(prealloc);
-      for(auto& wm: workerManagers_) {
-        auto results_inserter = WorkerPtr(new edm::WorkerT<TriggerResultInserter::ModuleType>(inserter, inserter->moduleDescription(), &actions)); // propagate_const<T> has no reset() function
+      for (auto& wm : workerManagers_) {
+        auto results_inserter = WorkerPtr(new edm::WorkerT<TriggerResultInserter::ModuleType>(
+            inserter, inserter->moduleDescription(), &actions));  // propagate_const<T> has no reset() function
         results_inserter->setActivityRegistry(actReg_);
         wm.addToAllWorkers(results_inserter.get());
         extraWorkers_.emplace_back(std::move(results_inserter));
       }
     }
 
-    for(auto & pathStatusInserter : pathStatusInserters) {
+    for (auto& pathStatusInserter : pathStatusInserters) {
       std::shared_ptr<PathStatusInserter> inserterPtr = get_underlying(pathStatusInserter);
       inserterPtr->doPreallocate(prealloc);
-      
-      for(auto& wm: workerManagers_) {
-        WorkerPtr workerPtr(new edm::WorkerT<PathStatusInserter::ModuleType>(inserterPtr,
-                                                                             inserterPtr->moduleDescription(),
-                                                                             &actions));
+
+      for (auto& wm : workerManagers_) {
+        WorkerPtr workerPtr(
+            new edm::WorkerT<PathStatusInserter::ModuleType>(inserterPtr, inserterPtr->moduleDescription(), &actions));
         workerPtr->setActivityRegistry(actReg_);
         wm.addToAllWorkers(workerPtr.get());
         extraWorkers_.emplace_back(std::move(workerPtr));
       }
     }
 
-    for(auto & endPathStatusInserter : endPathStatusInserters) {
+    for (auto& endPathStatusInserter : endPathStatusInserters) {
       std::shared_ptr<EndPathStatusInserter> inserterPtr = get_underlying(endPathStatusInserter);
       inserterPtr->doPreallocate(prealloc);
-      for(auto& wm: workerManagers_) {
-        WorkerPtr workerPtr(new edm::WorkerT<EndPathStatusInserter::ModuleType>(inserterPtr,
-                                                                                inserterPtr->moduleDescription(),
-                                                                                &actions));
+      for (auto& wm : workerManagers_) {
+        WorkerPtr workerPtr(new edm::WorkerT<EndPathStatusInserter::ModuleType>(
+            inserterPtr, inserterPtr->moduleDescription(), &actions));
         workerPtr->setActivityRegistry(actReg_);
         wm.addToAllWorkers(workerPtr.get());
         extraWorkers_.emplace_back(std::move(workerPtr));
       }
     }
 
-  } // GlobalSchedule::GlobalSchedule
+  }  // GlobalSchedule::GlobalSchedule
 
-  void GlobalSchedule::endJob(ExceptionCollector & collector) {
-    workerManagers_[0].endJob(collector);
-  }
+  void GlobalSchedule::endJob(ExceptionCollector& collector) { workerManagers_[0].endJob(collector); }
 
-  void GlobalSchedule::beginJob(ProductRegistry const& iRegistry) {
-    workerManagers_[0].beginJob(iRegistry);
-  }
-  
-  void GlobalSchedule::replaceModule(maker::ModuleHolder* iMod,
-                                     std::string const& iLabel) {
+  void GlobalSchedule::beginJob(ProductRegistry const& iRegistry) { workerManagers_[0].beginJob(iRegistry); }
+
+  void GlobalSchedule::replaceModule(maker::ModuleHolder* iMod, std::string const& iLabel) {
     Worker* found = nullptr;
-    for(auto& wm: workerManagers_) {
+    for (auto& wm : workerManagers_) {
       for (auto const& worker : wm.allWorkers()) {
         if (worker->description().moduleLabel() == iLabel) {
           found = worker;
@@ -112,14 +104,13 @@ namespace edm {
       if (nullptr == found) {
         return;
       }
-      
+
       iMod->replaceModuleFor(found);
       found->beginJob();
     }
   }
 
-  std::vector<ModuleDescription const*>
-  GlobalSchedule::getAllModuleDescriptions() const {
+  std::vector<ModuleDescription const*> GlobalSchedule::getAllModuleDescriptions() const {
     std::vector<ModuleDescription const*> result;
     result.reserve(allWorkers().size());
 
@@ -129,4 +120,4 @@ namespace edm {
     }
     return result;
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -30,37 +30,36 @@
 #include <sstream>
 #include "boost/range/adaptor/reversed.hpp"
 
-
 namespace edm {
 
   namespace {
-    template <typename T>
-    class GlobalScheduleSignalSentry {
+    template <typename T> class GlobalScheduleSignalSentry {
     public:
-      GlobalScheduleSignalSentry(ActivityRegistry* a, typename T::Context const* context) :
-        a_(a), context_(context),
-        allowThrow_(false) {
-        if (a_) T::preScheduleSignal(a_, context_);
+      GlobalScheduleSignalSentry(ActivityRegistry* a, typename T::Context const* context)
+          : a_(a), context_(context), allowThrow_(false) {
+        if (a_)
+          T::preScheduleSignal(a_, context_);
       }
       ~GlobalScheduleSignalSentry() noexcept(false) {
         try {
-          if (a_) T::postScheduleSignal(a_, context_);
-        } catch(...) {
-          if(allowThrow_) {throw;}
+          if (a_)
+            T::postScheduleSignal(a_, context_);
+        } catch (...) {
+          if (allowThrow_) {
+            throw;
+          }
         }
       }
 
-      void allowThrow() {
-        allowThrow_ = true;
-      }
+      void allowThrow() { allowThrow_ = true; }
 
     private:
       // We own none of these resources.
-      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
+      ActivityRegistry* a_;  // We do not use propagate_const because the registry itself is mutable.
       typename T::Context const* context_;
       bool allowThrow_;
     };
-  }
+  }  // namespace
 
   class ActivityRegistry;
   class EventSetupImpl;
@@ -71,7 +70,7 @@ namespace edm {
   class TriggerResultInserter;
   class PathStatusInserter;
   class EndPathStatusInserter;
-  
+
   class GlobalSchedule {
   public:
     typedef std::vector<std::string> vstring;
@@ -101,8 +100,8 @@ namespace edm {
                                bool cleaningUpAfterException = false);
 
     void beginJob(ProductRegistry const&);
-    void endJob(ExceptionCollector & collector);
-    
+    void endJob(ExceptionCollector& collector);
+
     /// Return a vector allowing const access to all the
     /// ModuleDescriptions for this GlobalSchedule.
 
@@ -122,9 +121,7 @@ namespace edm {
     void replaceModule(maker::ModuleHolder* iMod, std::string const& iLabel);
 
     /// returns the collection of pointers to workers
-    AllWorkers const& allWorkers() const {
-      return workerManagers_[0].allWorkers();
-    }
+    AllWorkers const& allWorkers() const { return workerManagers_[0].allWorkers(); }
 
   private:
     //Sentry class to only send a signal if an
@@ -133,107 +130,99 @@ namespace edm {
     // calling completedSuccessfully().
     class SendTerminationSignalIfException {
     public:
-      SendTerminationSignalIfException(edm::ActivityRegistry* iReg, edm::GlobalContext const* iContext):
-      reg_(iReg),
-      context_(iContext){}
+      SendTerminationSignalIfException(edm::ActivityRegistry* iReg, edm::GlobalContext const* iContext)
+          : reg_(iReg), context_(iContext) {}
       ~SendTerminationSignalIfException() {
-        if(reg_) {
-          reg_->preGlobalEarlyTerminationSignal_(*context_,TerminationOrigin::ExceptionFromThisContext);
+        if (reg_) {
+          reg_->preGlobalEarlyTerminationSignal_(*context_, TerminationOrigin::ExceptionFromThisContext);
         }
       }
-      void completedSuccessfully() {
-        reg_ = nullptr;
-      }
+      void completedSuccessfully() { reg_ = nullptr; }
+
     private:
-      edm::ActivityRegistry* reg_; // We do not use propagate_const because the registry itself is mutable.
+      edm::ActivityRegistry* reg_;  // We do not use propagate_const because the registry itself is mutable.
       GlobalContext const* context_;
     };
 
     /// returns the action table
-    ExceptionToActionTable const& actionTable() const {
-      return workerManagers_[0].actionTable();
-    }
-    
-    std::vector<WorkerManager>            workerManagers_;
-    std::shared_ptr<ActivityRegistry>     actReg_; // We do not use propagate_const because the registry itself is mutable.
+    ExceptionToActionTable const& actionTable() const { return workerManagers_[0].actionTable(); }
+
+    std::vector<WorkerManager> workerManagers_;
+    std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
     std::vector<edm::propagate_const<WorkerPtr>> extraWorkers_;
-    ProcessContext const*                 processContext_;
+    ProcessContext const* processContext_;
   };
 
-
   template <typename T>
-  void
-  GlobalSchedule::processOneGlobalAsync(WaitingTaskHolder iHolder,
-                                        typename T::MyPrincipal& ep,
-                                        EventSetupImpl const& es,
-                                        ServiceToken const& token,
-                                        bool cleaningUpAfterException) {
+  void GlobalSchedule::processOneGlobalAsync(WaitingTaskHolder iHolder,
+                                             typename T::MyPrincipal& ep,
+                                             EventSetupImpl const& es,
+                                             ServiceToken const& token,
+                                             bool cleaningUpAfterException) {
     try {
       //need the doneTask to own the memory
       auto globalContext = std::make_shared<GlobalContext>(T::makeGlobalContext(ep, processContext_));
-      
-      if(actReg_) {
+
+      if (actReg_) {
         //Services may depend upon each other
         ServiceRegistry::Operate op(token);
         T::preScheduleSignal(actReg_.get(), globalContext.get());
       }
-      
-      auto doneTask = make_waiting_task(tbb::task::allocate_root(),
-                                        [this,iHolder, cleaningUpAfterException, globalContext, token](std::exception_ptr const* iPtr) mutable
-                                        {
-                                          std::exception_ptr excpt;
-                                          if(iPtr) {
-                                            excpt = *iPtr;
-                                            //add context information to the exception and print message
-                                            try {
-                                              convertException::wrap([&]() {
-                                                std::rethrow_exception(excpt);
-                                              });
-                                            } catch(cms::Exception& ex) {
-                                              //TODO: should add the transition type info
-                                              std::ostringstream ost;
-                                              if(ex.context().empty()) {
-                                                ost<<"Processing "<<T::transitionName()<<" ";
-                                              }
-                                              ServiceRegistry::Operate op(token);
-                                              addContextAndPrintException(ost.str().c_str(), ex, cleaningUpAfterException);
-                                              excpt = std::current_exception();
-                                            }
-                                            if(actReg_) {
-                                              ServiceRegistry::Operate op(token);
-                                              actReg_->preGlobalEarlyTerminationSignal_(*globalContext,TerminationOrigin::ExceptionFromThisContext);
-                                            }
-                                          }
-                                          if(actReg_) {
-                                            try {
-                                              ServiceRegistry::Operate op(token);
-                                              T::postScheduleSignal(actReg_.get(), globalContext.get());
-                                            } catch(...) {
-                                              if(not excpt) {
-                                                excpt = std::current_exception();
-                                              }
-                                            }
-                                          }
-                                          iHolder.doneWaiting(excpt);
-                                          
-                                        });
+
+      auto doneTask = make_waiting_task(
+          tbb::task::allocate_root(),
+          [this, iHolder, cleaningUpAfterException, globalContext, token](std::exception_ptr const* iPtr) mutable {
+            std::exception_ptr excpt;
+            if (iPtr) {
+              excpt = *iPtr;
+              //add context information to the exception and print message
+              try {
+                convertException::wrap([&]() { std::rethrow_exception(excpt); });
+              } catch (cms::Exception& ex) {
+                //TODO: should add the transition type info
+                std::ostringstream ost;
+                if (ex.context().empty()) {
+                  ost << "Processing " << T::transitionName() << " ";
+                }
+                ServiceRegistry::Operate op(token);
+                addContextAndPrintException(ost.str().c_str(), ex, cleaningUpAfterException);
+                excpt = std::current_exception();
+              }
+              if (actReg_) {
+                ServiceRegistry::Operate op(token);
+                actReg_->preGlobalEarlyTerminationSignal_(*globalContext, TerminationOrigin::ExceptionFromThisContext);
+              }
+            }
+            if (actReg_) {
+              try {
+                ServiceRegistry::Operate op(token);
+                T::postScheduleSignal(actReg_.get(), globalContext.get());
+              } catch (...) {
+                if (not excpt) {
+                  excpt = std::current_exception();
+                }
+              }
+            }
+            iHolder.doneWaiting(excpt);
+          });
       workerManagers_[ep.index()].resetAll();
-      
+
       ParentContext parentContext(globalContext.get());
       //make sure the ProductResolvers know about their
       // workers to allow proper data dependency handling
-      workerManagers_[ep.index()].setupOnDemandSystem(ep,es);
-      
+      workerManagers_[ep.index()].setupOnDemandSystem(ep, es);
+
       //make sure the task doesn't get run until all workers have beens started
       WaitingTaskHolder holdForLoop(doneTask);
       auto& aw = workerManagers_[ep.index()].allWorkers();
-      for(Worker* worker: boost::adaptors::reverse(aw) ) {
-        worker->doWorkAsync<T>(doneTask,ep,es,token, StreamID::invalidStreamID(),parentContext,globalContext.get());
+      for (Worker* worker : boost::adaptors::reverse(aw)) {
+        worker->doWorkAsync<T>(doneTask, ep, es, token, StreamID::invalidStreamID(), parentContext,
+                               globalContext.get());
       }
-    } catch(...) {
+    } catch (...) {
       iHolder.doneWaiting(std::current_exception());
     }
   }
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/HCTypeTag.cc
+++ b/FWCore/Framework/src/HCTypeTag.cc
@@ -4,7 +4,7 @@
 //
 // Package:     HeteroContainer
 // Module:      HCTypeTag
-// 
+//
 // Description: <one line class summary>
 //
 // Implementation:
@@ -67,73 +67,68 @@
 // constants, enums and typedefs
 //
 namespace edm {
-   namespace eventsetup {
-      namespace heterocontainer {
-         
-         //
-         // static data member definitions
-         //
-                  
-         //
-         // constructors and destructor
-         //
-         //HCTypeTag::HCTypeTag()
-         //{
-         //}
-         
-         // HCTypeTag::HCTypeTag(const HCTypeTag& rhs)
-         // {
-         //    // do actual copying here; if you implemented
-         //    // operator= correctly, you may be able to use just say      
-         //    *this = rhs;
-         // }
-         
-         //HCTypeTag::~HCTypeTag()
-         //{
-         //}
-         
-         //
-         // assignment operators
-         //
-         // const HCTypeTag& HCTypeTag::operator=(const HCTypeTag& rhs)
-         // {
-         //   if(this != &rhs) {
-         //      // do actual copying here, plus:
-         //      // "SuperClass"::operator=(rhs);
-         //   }
-         //
-         //   return *this;
-         // }
-         
-         //
-         // member functions
-         //
-         
-         //
-         // const member functions
-         //
-         
-         //
-         // static member functions
-         //
-         HCTypeTag
-         HCTypeTag::findType(const std::string& iTypeName) {
-            return HCTypeTag::findType(iTypeName.c_str());
-         }
-         
-         HCTypeTag
-         HCTypeTag::findType(const char* iTypeName)
-         {
-            std::pair<const char*,const std::type_info*> p = typelookup::findType(iTypeName);
-            
-            if(nullptr == p.second) {
-               return HCTypeTag();
-            }
-            //need to take name from the 'findType' since that address is guaranteed to be long lived
-            return HCTypeTag(*p.second, p.first);
-         }         
+  namespace eventsetup {
+    namespace heterocontainer {
+
+      //
+      // static data member definitions
+      //
+
+      //
+      // constructors and destructor
+      //
+      //HCTypeTag::HCTypeTag()
+      //{
+      //}
+
+      // HCTypeTag::HCTypeTag(const HCTypeTag& rhs)
+      // {
+      //    // do actual copying here; if you implemented
+      //    // operator= correctly, you may be able to use just say
+      //    *this = rhs;
+      // }
+
+      //HCTypeTag::~HCTypeTag()
+      //{
+      //}
+
+      //
+      // assignment operators
+      //
+      // const HCTypeTag& HCTypeTag::operator=(const HCTypeTag& rhs)
+      // {
+      //   if(this != &rhs) {
+      //      // do actual copying here, plus:
+      //      // "SuperClass"::operator=(rhs);
+      //   }
+      //
+      //   return *this;
+      // }
+
+      //
+      // member functions
+      //
+
+      //
+      // const member functions
+      //
+
+      //
+      // static member functions
+      //
+      HCTypeTag HCTypeTag::findType(const std::string& iTypeName) { return HCTypeTag::findType(iTypeName.c_str()); }
+
+      HCTypeTag HCTypeTag::findType(const char* iTypeName) {
+        std::pair<const char*, const std::type_info*> p = typelookup::findType(iTypeName);
+
+        if (nullptr == p.second) {
+          return HCTypeTag();
+        }
+        //need to take name from the 'findType' since that address is guaranteed to be long lived
+        return HCTypeTag(*p.second, p.first);
       }
-   }
-}
+    }  // namespace heterocontainer
+  }    // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/HistoryAppender.cc
+++ b/FWCore/Framework/src/HistoryAppender.cc
@@ -12,32 +12,27 @@ namespace {
     tmp.setProcessHistoryID();
     return tmp;
   }
-}
+}  // namespace
 static const edm::ProcessHistory s_emptyHistory = initializeEmpty();
 
 namespace edm {
 
-  HistoryAppender::HistoryAppender()
-  {
-  }
+  HistoryAppender::HistoryAppender() {}
 
-  std::shared_ptr<ProcessHistory const>
-  HistoryAppender::appendToProcessHistory(ProcessHistoryID const& inputPHID,
-                                          ProcessHistory const* iInputProcessHistory,
-                                          ProcessConfiguration const& pc)  {
+  std::shared_ptr<ProcessHistory const> HistoryAppender::appendToProcessHistory(
+      ProcessHistoryID const& inputPHID, ProcessHistory const* iInputProcessHistory, ProcessConfiguration const& pc) {
     assert((iInputProcessHistory) == nullptr or (inputPHID == iInputProcessHistory->id()));
-    if (m_cachedHistory.get() != nullptr and inputPHID==m_cachedInputPHID) {
+    if (m_cachedHistory.get() != nullptr and inputPHID == m_cachedInputPHID) {
       return m_cachedHistory;
     }
 
-    ProcessHistory const* inputProcessHistory = iInputProcessHistory? iInputProcessHistory : &s_emptyHistory;
+    ProcessHistory const* inputProcessHistory = iInputProcessHistory ? iInputProcessHistory : &s_emptyHistory;
 
     if (inputPHID.isValid()) {
       if (iInputProcessHistory == nullptr) {
-        throw Exception(errors::LogicError)
-          << "HistoryAppender::appendToProcessHistory\n"
-          << "Input ProcessHistory has valid ID but is nullptr\n"
-          << "Contact a Framework developer\n";
+        throw Exception(errors::LogicError) << "HistoryAppender::appendToProcessHistory\n"
+                                            << "Input ProcessHistory has valid ID but is nullptr\n"
+                                            << "Contact a Framework developer\n";
       }
     }
 
@@ -47,21 +42,19 @@ namespace edm {
     newProcessHistory->push_back(pc);
     //force it to create the ID
     newProcessHistory->setProcessHistoryID();
-    m_cachedInputPHID =inputPHID;
+    m_cachedInputPHID = inputPHID;
     m_cachedHistory = newProcessHistory;
     return m_cachedHistory;
   }
 
-  void
-  HistoryAppender::checkProcessHistory(ProcessHistory const& ph,
-                                       ProcessConfiguration const& pc) const {
+  void HistoryAppender::checkProcessHistory(ProcessHistory const& ph, ProcessConfiguration const& pc) const {
     std::string const& processName = pc.processName();
     for (auto const& process : ph) {
       if (processName == process.processName()) {
         throw edm::Exception(errors::Configuration, "Duplicate Process.")
-          << "The process name " << processName << " was already in the ProcessHistory.\n"
-          << "Please modify the configuration file to use a distinct process name.\n";
+            << "The process name " << processName << " was already in the ProcessHistory.\n"
+            << "Please modify the configuration file to use a distinct process name.\n";
       }
     }
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/IOVSyncValue.cc
+++ b/FWCore/Framework/src/IOVSyncValue.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     IOVSyncValue
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -22,86 +22,71 @@
 //
 namespace edm {
 
-//
-// static data member definitions
-//
+  //
+  // static data member definitions
+  //
 
+  //
+  // constructors and destructor
+  //
+  IOVSyncValue::IOVSyncValue() : eventID_(), time_(), haveID_(true), haveTime_(true) {}
 
-//
-// constructors and destructor
-//
-IOVSyncValue::IOVSyncValue(): eventID_(), time_(),
-haveID_(true), haveTime_(true)
-{
-}
+  IOVSyncValue::IOVSyncValue(const EventID& iID) : eventID_(iID), time_(), haveID_(true), haveTime_(false) {}
 
-IOVSyncValue::IOVSyncValue(const EventID& iID) : eventID_(iID), time_(),
-haveID_(true), haveTime_(false)
-{
-}
+  IOVSyncValue::IOVSyncValue(const Timestamp& iTime) : eventID_(), time_(iTime), haveID_(false), haveTime_(true) {}
 
-IOVSyncValue::IOVSyncValue(const Timestamp& iTime) : eventID_(), time_(iTime),
-haveID_(false), haveTime_(true)
-{
-}
+  IOVSyncValue::IOVSyncValue(const EventID& iID, const Timestamp& iTime)
+      : eventID_(iID), time_(iTime), haveID_(true), haveTime_(true) {}
 
-IOVSyncValue::IOVSyncValue(const EventID& iID, const Timestamp& iTime) :
-eventID_(iID), time_(iTime),
-haveID_(true), haveTime_(true)
-{
-}
+  // IOVSyncValue::IOVSyncValue(const IOVSyncValue& rhs)
+  // {
+  //    // do actual copying here;
+  // }
 
-// IOVSyncValue::IOVSyncValue(const IOVSyncValue& rhs)
-// {
-//    // do actual copying here;
-// }
+  //IOVSyncValue::~IOVSyncValue()
+  //{
+  //}
 
-//IOVSyncValue::~IOVSyncValue()
-//{
-//}
+  //
+  // assignment operators
+  //
+  // const IOVSyncValue& IOVSyncValue::operator=(const IOVSyncValue& rhs)
+  // {
+  //   //An exception safe implementation is
+  //   IOVSyncValue temp(rhs);
+  //   swap(rhs);
+  //
+  //   return *this;
+  // }
 
-//
-// assignment operators
-//
-// const IOVSyncValue& IOVSyncValue::operator=(const IOVSyncValue& rhs)
-// {
-//   //An exception safe implementation is
-//   IOVSyncValue temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+  //
+  // member functions
+  //
 
-//
-// member functions
-//
+  //
+  // const member functions
+  //
+  void IOVSyncValue::throwInvalidComparison() const {
+    throw cms::Exception("InvalidIOVSyncValueComparison")
+        << "Attempted to compare a time-only and a run/lumi/event-only IOVSyncValue. Please report this error to the "
+           "framework experts.";
+  }
 
-//
-// const member functions
-//
-void 
-IOVSyncValue::throwInvalidComparison() const {
-  throw cms::Exception("InvalidIOVSyncValueComparison")
-    <<"Attempted to compare a time-only and a run/lumi/event-only IOVSyncValue. Please report this error to the framework experts.";
-}
-
-//
-// static member functions
-//
-const IOVSyncValue&
-IOVSyncValue::invalidIOVSyncValue() {
-   static const IOVSyncValue s_invalid;
-   return s_invalid;
-}
-const IOVSyncValue&
-IOVSyncValue::endOfTime() {
-   static const IOVSyncValue s_endOfTime(EventID(0xFFFFFFFFUL, LuminosityBlockID::maxLuminosityBlockNumber(), EventID::maxEventNumber()),
-                                   Timestamp::endOfTime());
-   return s_endOfTime;
-}
-const IOVSyncValue&
-IOVSyncValue::beginOfTime() {
-   static const IOVSyncValue s_beginOfTime(EventID(1,0,0), Timestamp::beginOfTime());
-   return s_beginOfTime;
-}
-}
+  //
+  // static member functions
+  //
+  const IOVSyncValue& IOVSyncValue::invalidIOVSyncValue() {
+    static const IOVSyncValue s_invalid;
+    return s_invalid;
+  }
+  const IOVSyncValue& IOVSyncValue::endOfTime() {
+    static const IOVSyncValue s_endOfTime(
+        EventID(0xFFFFFFFFUL, LuminosityBlockID::maxLuminosityBlockNumber(), EventID::maxEventNumber()),
+        Timestamp::endOfTime());
+    return s_endOfTime;
+  }
+  const IOVSyncValue& IOVSyncValue::beginOfTime() {
+    static const IOVSyncValue s_beginOfTime(EventID(1, 0, 0), Timestamp::beginOfTime());
+    return s_beginOfTime;
+  }
+}  // namespace edm

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -27,46 +27,47 @@
 namespace edm {
 
   namespace {
-        std::string const& suffix(int count) {
-          static std::string const st("st");
-          static std::string const nd("nd");
-          static std::string const rd("rd");
-          static std::string const th("th");
-          // *0, *4 - *9 use "th".
-          int lastDigit = count % 10;
-          if(lastDigit >= 4 || lastDigit == 0) return th;
-          // *11, *12, or *13 use "th".
-          if(count % 100 - lastDigit == 10) return th;
-          return (lastDigit == 1 ? st : (lastDigit == 2 ? nd : rd));
-        }
-  }
+    std::string const& suffix(int count) {
+      static std::string const st("st");
+      static std::string const nd("nd");
+      static std::string const rd("rd");
+      static std::string const th("th");
+      // *0, *4 - *9 use "th".
+      int lastDigit = count % 10;
+      if (lastDigit >= 4 || lastDigit == 0)
+        return th;
+      // *11, *12, or *13 use "th".
+      if (count % 100 - lastDigit == 10)
+        return th;
+      return (lastDigit == 1 ? st : (lastDigit == 2 ? nd : rd));
+    }
+  }  // namespace
 
-  InputSource::InputSource(ParameterSet const& pset, InputSourceDescription const& desc) :
-      actReg_(desc.actReg_),
-      maxEvents_(desc.maxEvents_),
-      remainingEvents_(maxEvents_),
-      maxLumis_(desc.maxLumis_),
-      remainingLumis_(maxLumis_),
-      readCount_(0),
-      maxSecondsUntilRampdown_(desc.maxSecondsUntilRampdown_),
-      processingMode_(RunsLumisAndEvents),
-      moduleDescription_(desc.moduleDescription_),
-      productRegistry_(desc.productRegistry_),
-      processHistoryRegistry_(new ProcessHistoryRegistry),
-      branchIDListHelper_(desc.branchIDListHelper_),
-      thinnedAssociationsHelper_(desc.thinnedAssociationsHelper_),
-      processGUID_(createGlobalIdentifier()),
-      time_(),
-      newRun_(true),
-      newLumi_(true),
-      eventCached_(false),
-      state_(IsInvalid),
-      runAuxiliary_(),
-      lumiAuxiliary_(),
-      statusFileName_(),
-      numberOfEventsBeforeBigSkip_(0) {
-
-    if(pset.getUntrackedParameter<bool>("writeStatusFile", false)) {
+  InputSource::InputSource(ParameterSet const& pset, InputSourceDescription const& desc)
+      : actReg_(desc.actReg_),
+        maxEvents_(desc.maxEvents_),
+        remainingEvents_(maxEvents_),
+        maxLumis_(desc.maxLumis_),
+        remainingLumis_(maxLumis_),
+        readCount_(0),
+        maxSecondsUntilRampdown_(desc.maxSecondsUntilRampdown_),
+        processingMode_(RunsLumisAndEvents),
+        moduleDescription_(desc.moduleDescription_),
+        productRegistry_(desc.productRegistry_),
+        processHistoryRegistry_(new ProcessHistoryRegistry),
+        branchIDListHelper_(desc.branchIDListHelper_),
+        thinnedAssociationsHelper_(desc.thinnedAssociationsHelper_),
+        processGUID_(createGlobalIdentifier()),
+        time_(),
+        newRun_(true),
+        newLumi_(true),
+        eventCached_(false),
+        state_(IsInvalid),
+        runAuxiliary_(),
+        lumiAuxiliary_(),
+        statusFileName_(),
+        numberOfEventsBeforeBigSkip_(0) {
+    if (pset.getUntrackedParameter<bool>("writeStatusFile", false)) {
       std::ostringstream statusfilename;
       statusfilename << "source_" << getpid();
       statusFileName_ = statusfilename.str();
@@ -85,47 +86,41 @@ namespace edm {
     // input sources have defined descriptions, the defaults in the getUntrackedParameterSet function
     // calls can and should be deleted from the code.
     std::string processingMode = pset.getUntrackedParameter<std::string>("processingMode", defaultMode);
-    if(processingMode == runMode) {
+    if (processingMode == runMode) {
       processingMode_ = Runs;
-    } else if(processingMode == runLumiMode) {
+    } else if (processingMode == runLumiMode) {
       processingMode_ = RunsAndLumis;
-    } else if(processingMode != defaultMode) {
+    } else if (processingMode != defaultMode) {
       throw Exception(errors::Configuration)
-        << "InputSource::InputSource()\n"
-        << "The 'processingMode' parameter for sources has an illegal value '" << processingMode << "'\n"
-        << "Legal values are '" << defaultMode << "', '" << runLumiMode << "', or '" << runMode << "'.\n";
+          << "InputSource::InputSource()\n"
+          << "The 'processingMode' parameter for sources has an illegal value '" << processingMode << "'\n"
+          << "Legal values are '" << defaultMode << "', '" << runLumiMode << "', or '" << runMode << "'.\n";
     }
   }
 
   InputSource::~InputSource() noexcept(false) {}
 
-  void
-  InputSource::fillDescriptions(ConfigurationDescriptions& descriptions) {
+  void InputSource::fillDescriptions(ConfigurationDescriptions& descriptions) {
     ParameterSetDescription desc;
     desc.setUnknown();
     descriptions.addDefault(desc);
   }
 
-  void
-  InputSource::prevalidate(ConfigurationDescriptions& ) {
-  }
-  
+  void InputSource::prevalidate(ConfigurationDescriptions&) {}
 
   static std::string const kBaseType("Source");
 
-  std::string const&
-  InputSource::baseType() {
-    return kBaseType;
-  }
+  std::string const& InputSource::baseType() { return kBaseType; }
 
-  void
-  InputSource::fillDescription(ParameterSetDescription& desc) {
+  void InputSource::fillDescription(ParameterSetDescription& desc) {
     std::string defaultString("RunsLumisAndEvents");
-    desc.addUntracked<std::string>("processingMode", defaultString)->setComment(
-    "'RunsLumisAndEvents': process runs, lumis, and events.\n"
-    "'RunsAndLumis':       process runs and lumis (not events).\n"
-    "'Runs':               process runs (not lumis or events).");
-    desc.addUntracked<bool>("writeStatusFile", false)->setComment("Write a status file. Intended for use by workflow management.");
+    desc.addUntracked<std::string>("processingMode", defaultString)
+        ->setComment(
+            "'RunsLumisAndEvents': process runs, lumis, and events.\n"
+            "'RunsAndLumis':       process runs and lumis (not events).\n"
+            "'Runs':               process runs (not lumis or events).");
+    desc.addUntracked<bool>("writeStatusFile", false)
+        ->setComment("Write a status file. Intended for use by workflow management.");
   }
 
   // This next function is to guarantee that "runs only" mode does not return events or lumis,
@@ -136,36 +131,35 @@ namespace edm {
   // implement the skipping internally, so that the performance gain is realized.
   // If this is done for a source, the 'if' blocks in this function will never be entered
   // for that source.
-  InputSource::ItemType
-  InputSource::nextItemType_() {
-    ItemType itemType = callWithTryCatchAndPrint<ItemType>( [this](){ return getNextItemType(); }, "Calling InputSource::getNextItemType" );
+  InputSource::ItemType InputSource::nextItemType_() {
+    ItemType itemType = callWithTryCatchAndPrint<ItemType>([this]() { return getNextItemType(); },
+                                                           "Calling InputSource::getNextItemType");
 
-    if(itemType == IsEvent && processingMode() != RunsLumisAndEvents) {
+    if (itemType == IsEvent && processingMode() != RunsLumisAndEvents) {
       skipEvents(1);
       return nextItemType_();
     }
-    if(itemType == IsLumi && processingMode() == Runs) {
+    if (itemType == IsLumi && processingMode() == Runs) {
       // QQQ skipLuminosityBlock_();
       return nextItemType_();
     }
     return itemType;
   }
 
-  InputSource::ItemType
-  InputSource::nextItemType() {
+  InputSource::ItemType InputSource::nextItemType() {
     ItemType oldState = state_;
-    if(eventLimitReached()) {
+    if (eventLimitReached()) {
       // If the maximum event limit has been reached, stop.
       state_ = IsStop;
-    } else if(lumiLimitReached()) {
+    } else if (lumiLimitReached()) {
       // If the maximum lumi limit has been reached, stop
       // when reaching a new file, run, or lumi.
-      if(oldState == IsInvalid || oldState == IsFile || oldState == IsRun || processingMode() != RunsLumisAndEvents) {
+      if (oldState == IsInvalid || oldState == IsFile || oldState == IsRun || processingMode() != RunsLumisAndEvents) {
         state_ = IsStop;
       } else {
         ItemType newState = nextItemType_();
-        if(newState == IsEvent) {
-          assert (processingMode() == RunsLumisAndEvents);
+        if (newState == IsEvent) {
+          assert(processingMode() == RunsLumisAndEvents);
           state_ = IsEvent;
         } else {
           state_ = IsStop;
@@ -173,155 +167,134 @@ namespace edm {
       }
     } else {
       ItemType newState = nextItemType_();
-      if(newState == IsStop) {
+      if (newState == IsStop) {
         state_ = IsStop;
-      } else if(newState == IsSynchronize) {
+      } else if (newState == IsSynchronize) {
         state_ = IsSynchronize;
-      } else if(newState == IsFile || oldState == IsInvalid) {
+      } else if (newState == IsFile || oldState == IsInvalid) {
         state_ = IsFile;
-      } else if(newState == IsRun || oldState == IsFile) {
+      } else if (newState == IsRun || oldState == IsFile) {
         runAuxiliary_ = readRunAuxiliary();
         state_ = IsRun;
-      } else if(newState == IsLumi || oldState == IsRun) {
-        assert (processingMode() != Runs);
+      } else if (newState == IsLumi || oldState == IsRun) {
+        assert(processingMode() != Runs);
         lumiAuxiliary_ = readLuminosityBlockAuxiliary();
         state_ = IsLumi;
       } else {
-        assert (processingMode() == RunsLumisAndEvents);
+        assert(processingMode() == RunsLumisAndEvents);
         state_ = IsEvent;
       }
     }
-    if(state_ == IsStop) {
+    if (state_ == IsStop) {
       lumiAuxiliary_.reset();
       runAuxiliary_.reset();
     }
     return state_;
   }
 
-  std::shared_ptr<LuminosityBlockAuxiliary>
-  InputSource::readLuminosityBlockAuxiliary() {
-    return callWithTryCatchAndPrint<std::shared_ptr<LuminosityBlockAuxiliary> >( [this](){ return readLuminosityBlockAuxiliary_(); },
-                                                                                   "Calling InputSource::readLuminosityBlockAuxiliary_" );
+  std::shared_ptr<LuminosityBlockAuxiliary> InputSource::readLuminosityBlockAuxiliary() {
+    return callWithTryCatchAndPrint<std::shared_ptr<LuminosityBlockAuxiliary> >(
+        [this]() { return readLuminosityBlockAuxiliary_(); }, "Calling InputSource::readLuminosityBlockAuxiliary_");
   }
 
-  std::shared_ptr<RunAuxiliary>
-  InputSource::readRunAuxiliary() {
-    return callWithTryCatchAndPrint<std::shared_ptr<RunAuxiliary> >( [this](){ return readRunAuxiliary_(); },
-                                                                       "Calling InputSource::readRunAuxiliary_" );
+  std::shared_ptr<RunAuxiliary> InputSource::readRunAuxiliary() {
+    return callWithTryCatchAndPrint<std::shared_ptr<RunAuxiliary> >([this]() { return readRunAuxiliary_(); },
+                                                                    "Calling InputSource::readRunAuxiliary_");
   }
 
-  void
-  InputSource::doBeginJob() {
-    this->beginJob();
-  }
+  void InputSource::doBeginJob() { this->beginJob(); }
 
-  void
-  InputSource::doEndJob() {
-    endJob();
-  }
+  void InputSource::doEndJob() { endJob(); }
 
-  std::pair<SharedResourcesAcquirer*,std::recursive_mutex*>
-  InputSource::resourceSharedWithDelayedReader() {
+  std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> InputSource::resourceSharedWithDelayedReader() {
     return resourceSharedWithDelayedReader_();
   }
 
-  std::pair<SharedResourcesAcquirer*,std::recursive_mutex*>
-  InputSource::resourceSharedWithDelayedReader_() {
-    return std::pair<SharedResourcesAcquirer*,std::recursive_mutex*>(nullptr,nullptr);
+  std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> InputSource::resourceSharedWithDelayedReader_() {
+    return std::pair<SharedResourcesAcquirer*, std::recursive_mutex*>(nullptr, nullptr);
   }
 
-  void
-  InputSource::registerProducts() {
-  }
+  void InputSource::registerProducts() {}
 
   // Return a dummy file block.
-  std::unique_ptr<FileBlock>
-  InputSource::readFile() {
+  std::unique_ptr<FileBlock> InputSource::readFile() {
     assert(state_ == IsFile);
     assert(!limitReached());
-    return callWithTryCatchAndPrint<std::unique_ptr<FileBlock> >( [this](){ return readFile_(); },
-                                                                  "Calling InputSource::readFile_" );
+    return callWithTryCatchAndPrint<std::unique_ptr<FileBlock> >([this]() { return readFile_(); },
+                                                                 "Calling InputSource::readFile_");
   }
 
-  void
-  InputSource::closeFile(FileBlock* fb, bool cleaningUpAfterException) {
-    if(fb != nullptr) fb->close();
-    callWithTryCatchAndPrint<void>( [this](){ closeFile_(); },
-                                    "Calling InputSource::closeFile_",
-                                    cleaningUpAfterException );
+  void InputSource::closeFile(FileBlock* fb, bool cleaningUpAfterException) {
+    if (fb != nullptr)
+      fb->close();
+    callWithTryCatchAndPrint<void>([this]() { closeFile_(); }, "Calling InputSource::closeFile_",
+                                   cleaningUpAfterException);
     return;
   }
 
   // Return a dummy file block.
   // This function must be overridden for any input source that reads a file
   // containing Products.
-  std::unique_ptr<FileBlock>
-  InputSource::readFile_() {
-    return std::make_unique<FileBlock>();
-  }
+  std::unique_ptr<FileBlock> InputSource::readFile_() { return std::make_unique<FileBlock>(); }
 
-  void
-  InputSource::readRun(RunPrincipal& runPrincipal, HistoryAppender& ) {
+  void InputSource::readRun(RunPrincipal& runPrincipal, HistoryAppender&) {
     RunSourceSentry sentry(*this, runPrincipal.index());
-    callWithTryCatchAndPrint<void>( [this,&runPrincipal](){ readRun_(runPrincipal); }, "Calling InputSource::readRun_" );
+    callWithTryCatchAndPrint<void>([this, &runPrincipal]() { readRun_(runPrincipal); },
+                                   "Calling InputSource::readRun_");
   }
 
-  void
-  InputSource::readAndMergeRun(RunPrincipal& rp) {
+  void InputSource::readAndMergeRun(RunPrincipal& rp) {
     RunSourceSentry sentry(*this, rp.index());
-    callWithTryCatchAndPrint<void>( [this,&rp](){ readRun_(rp); }, "Calling InputSource::readRun_" );
+    callWithTryCatchAndPrint<void>([this, &rp]() { readRun_(rp); }, "Calling InputSource::readRun_");
   }
 
-  void
-  InputSource::readLuminosityBlock(LuminosityBlockPrincipal& lumiPrincipal, HistoryAppender& ) {
+  void InputSource::readLuminosityBlock(LuminosityBlockPrincipal& lumiPrincipal, HistoryAppender&) {
     LumiSourceSentry sentry(*this, lumiPrincipal.index());
-    callWithTryCatchAndPrint<void>( [this,&lumiPrincipal](){ readLuminosityBlock_(lumiPrincipal); }, "Calling InputSource::readLuminosityBlock_" );
-    if(remainingLumis_ > 0) {
+    callWithTryCatchAndPrint<void>([this, &lumiPrincipal]() { readLuminosityBlock_(lumiPrincipal); },
+                                   "Calling InputSource::readLuminosityBlock_");
+    if (remainingLumis_ > 0) {
       --remainingLumis_;
     }
   }
 
-  void
-  InputSource::readAndMergeLumi(LuminosityBlockPrincipal& lbp) {
+  void InputSource::readAndMergeLumi(LuminosityBlockPrincipal& lbp) {
     LumiSourceSentry sentry(*this, lbp.index());
-    callWithTryCatchAndPrint<void>( [this,&lbp](){ readLuminosityBlock_(lbp); }, "Calling InputSource::readLuminosityBlock_" );
-    if(remainingLumis_ > 0) {
+    callWithTryCatchAndPrint<void>([this, &lbp]() { readLuminosityBlock_(lbp); },
+                                   "Calling InputSource::readLuminosityBlock_");
+    if (remainingLumis_ > 0) {
       --remainingLumis_;
     }
   }
 
-  void
-  InputSource::readRun_(RunPrincipal& runPrincipal) {
+  void InputSource::readRun_(RunPrincipal& runPrincipal) {
     // Note: For the moment, we do not support saving and restoring the state of the
     // random number generator if random numbers are generated during processing of runs
     // (e.g. beginRun(), endRun())
     runPrincipal.fillRunPrincipal(processHistoryRegistry());
   }
 
-  void
-  InputSource::readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) {
+  void InputSource::readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) {
     lumiPrincipal.fillLuminosityBlockPrincipal(processHistoryRegistry());
   }
 
-  void
-  InputSource::readEvent(EventPrincipal& ep, StreamContext& streamContext) {
+  void InputSource::readEvent(EventPrincipal& ep, StreamContext& streamContext) {
     assert(state_ == IsEvent);
     assert(!eventLimitReached());
     {
       // block scope, in order to issue the PostSourceEvent signal before calling postRead and issueReports
       EventSourceSentry sentry(*this, streamContext);
 
-      callWithTryCatchAndPrint<void>( [this,&ep](){ readEvent_(ep); }, "Calling InputSource::readEvent_" );
+      callWithTryCatchAndPrint<void>([this, &ep]() { readEvent_(ep); }, "Calling InputSource::readEvent_");
     }
 
-    if(remainingEvents_ > 0) --remainingEvents_;
+    if (remainingEvents_ > 0)
+      --remainingEvents_;
     ++readCount_;
     setTimestamp(ep.time());
     issueReports(ep.id(), ep.streamID());
   }
 
-  bool
-  InputSource::readEvent(EventPrincipal& ep, EventID const& eventID, StreamContext& streamContext) {
+  bool InputSource::readEvent(EventPrincipal& ep, EventID const& eventID, StreamContext& streamContext) {
     bool result = false;
 
     if (not limitReached()) {
@@ -332,7 +305,8 @@ namespace edm {
       result = readIt(eventID, ep, streamContext);
 
       if (result) {
-        if(remainingEvents_ > 0) --remainingEvents_;
+        if (remainingEvents_ > 0)
+          --remainingEvents_;
         ++readCount_;
         issueReports(ep.id(), ep.streamID());
       }
@@ -340,37 +314,32 @@ namespace edm {
     return result;
   }
 
-  void
-  InputSource::skipEvents(int offset) {
-    callWithTryCatchAndPrint<void>( [this,&offset](){ skip(offset); }, "Calling InputSource::skip" );
+  void InputSource::skipEvents(int offset) {
+    callWithTryCatchAndPrint<void>([this, &offset]() { skip(offset); }, "Calling InputSource::skip");
   }
 
-  bool
-  InputSource::goToEvent(EventID const& eventID) {
-    return callWithTryCatchAndPrint<bool>( [this,&eventID](){ return goToEvent_(eventID); }, "Calling InputSource::goToEvent_" );
+  bool InputSource::goToEvent(EventID const& eventID) {
+    return callWithTryCatchAndPrint<bool>([this, &eventID]() { return goToEvent_(eventID); },
+                                          "Calling InputSource::goToEvent_");
   }
 
-  void
-  InputSource::rewind() {
+  void InputSource::rewind() {
     state_ = IsInvalid;
     remainingEvents_ = maxEvents_;
     setNewRun();
     setNewLumi();
     resetEventCached();
-    callWithTryCatchAndPrint<void>( [this](){ rewind_(); }, "Calling InputSource::rewind_" );
+    callWithTryCatchAndPrint<void>([this]() { rewind_(); }, "Calling InputSource::rewind_");
   }
 
-  void
-  InputSource::issueReports(EventID const& eventID, StreamID streamID) {
-    if(isInfoEnabled()) {
-      LogVerbatim("FwkReport") << "Begin processing the " << readCount_
-                               << suffix(readCount_) << " record. Run " << eventID.run()
-                               << ", Event " << eventID.event()
-                               << ", LumiSection " << eventID.luminosityBlock()
-                               << " on stream "<<streamID.value()
-                               << " at " << std::setprecision(3) << TimeOfDay();
+  void InputSource::issueReports(EventID const& eventID, StreamID streamID) {
+    if (isInfoEnabled()) {
+      LogVerbatim("FwkReport") << "Begin processing the " << readCount_ << suffix(readCount_) << " record. Run "
+                               << eventID.run() << ", Event " << eventID.event() << ", LumiSection "
+                               << eventID.luminosityBlock() << " on stream " << streamID.value() << " at "
+                               << std::setprecision(3) << TimeOfDay();
     }
-    if(!statusFileName_.empty()) {
+    if (!statusFileName_.empty()) {
       std::ofstream statusFile(statusFileName_.c_str());
       statusFile << eventID << " time: " << std::setprecision(3) << TimeOfDay() << '\n';
       statusFile.close();
@@ -379,188 +348,133 @@ namespace edm {
     // At some point we may want to initiate checkpointing here
   }
 
-  bool
-  InputSource::readIt(EventID const&, EventPrincipal&, StreamContext&) {
-    throw Exception(errors::LogicError)
-      << "InputSource::readIt()\n"
-      << "Random access is not implemented for this type of Input Source\n"
-      << "Contact a Framework Developer\n";
+  bool InputSource::readIt(EventID const&, EventPrincipal&, StreamContext&) {
+    throw Exception(errors::LogicError) << "InputSource::readIt()\n"
+                                        << "Random access is not implemented for this type of Input Source\n"
+                                        << "Contact a Framework Developer\n";
   }
 
-  void
-  InputSource::setRun(RunNumber_t) {
-    throw Exception(errors::LogicError)
-      << "InputSource::setRun()\n"
-      << "Run number cannot be modified for this type of Input Source\n"
-      << "Contact a Framework Developer\n";
+  void InputSource::setRun(RunNumber_t) {
+    throw Exception(errors::LogicError) << "InputSource::setRun()\n"
+                                        << "Run number cannot be modified for this type of Input Source\n"
+                                        << "Contact a Framework Developer\n";
   }
 
-  void
-  InputSource::setLumi(LuminosityBlockNumber_t) {
-    throw Exception(errors::LogicError)
-      << "InputSource::setLumi()\n"
-      << "Luminosity Block ID cannot be modified for this type of Input Source\n"
-      << "Contact a Framework Developer\n";
+  void InputSource::setLumi(LuminosityBlockNumber_t) {
+    throw Exception(errors::LogicError) << "InputSource::setLumi()\n"
+                                        << "Luminosity Block ID cannot be modified for this type of Input Source\n"
+                                        << "Contact a Framework Developer\n";
   }
 
-  void
-  InputSource::skip(int) {
-    throw Exception(errors::LogicError)
-      << "InputSource::skip()\n"
-      << "Random access are not implemented for this type of Input Source\n"
-      << "Contact a Framework Developer\n";
+  void InputSource::skip(int) {
+    throw Exception(errors::LogicError) << "InputSource::skip()\n"
+                                        << "Random access are not implemented for this type of Input Source\n"
+                                        << "Contact a Framework Developer\n";
   }
 
-  bool
-  InputSource::goToEvent_(EventID const&) {
-    throw Exception(errors::LogicError)
-      << "InputSource::goToEvent_()\n"
-      << "Random access is not implemented for this type of Input Source\n"
-      << "Contact a Framework Developer\n";
+  bool InputSource::goToEvent_(EventID const&) {
+    throw Exception(errors::LogicError) << "InputSource::goToEvent_()\n"
+                                        << "Random access is not implemented for this type of Input Source\n"
+                                        << "Contact a Framework Developer\n";
     return true;
   }
 
-  void
-  InputSource::rewind_() {
-    throw Exception(errors::LogicError)
-      << "InputSource::rewind()\n"
-      << "Random access are not implemented for this type of Input Source\n"
-      << "Contact a Framework Developer\n";
+  void InputSource::rewind_() {
+    throw Exception(errors::LogicError) << "InputSource::rewind()\n"
+                                        << "Random access are not implemented for this type of Input Source\n"
+                                        << "Contact a Framework Developer\n";
   }
 
-  void
-  InputSource::decreaseRemainingEventsBy(int iSkipped) {
-    if(-1 == remainingEvents_) {
+  void InputSource::decreaseRemainingEventsBy(int iSkipped) {
+    if (-1 == remainingEvents_) {
       return;
     }
-    if(iSkipped < remainingEvents_) {
+    if (iSkipped < remainingEvents_) {
       remainingEvents_ -= iSkipped;
     } else {
       remainingEvents_ = 0;
     }
   }
 
-  void
-  InputSource::doBeginRun(RunPrincipal& rp, ProcessContext const* ) {
+  void InputSource::doBeginRun(RunPrincipal& rp, ProcessContext const*) {}
+
+  void InputSource::doBeginLumi(LuminosityBlockPrincipal& lbp, ProcessContext const*) {}
+
+  bool InputSource::randomAccess() const {
+    return callWithTryCatchAndPrint<bool>([this]() { return randomAccess_(); }, "Calling InputSource::randomAccess_");
   }
 
-  void
-  InputSource::doBeginLumi(LuminosityBlockPrincipal& lbp, ProcessContext const* ) {
+  ProcessingController::ForwardState InputSource::forwardState() const {
+    return callWithTryCatchAndPrint<ProcessingController::ForwardState>([this]() { return forwardState_(); },
+                                                                        "Calling InputSource::forwardState_");
   }
 
-  bool
-  InputSource::randomAccess() const {
-    return callWithTryCatchAndPrint<bool>( [this](){ return randomAccess_(); },
-                                           "Calling InputSource::randomAccess_" );
+  ProcessingController::ReverseState InputSource::reverseState() const {
+    return callWithTryCatchAndPrint<ProcessingController::ReverseState>([this]() { return reverseState_(); },
+                                                                        "Calling InputSource::reverseState__");
   }
 
-  ProcessingController::ForwardState
-  InputSource::forwardState() const {
-    return callWithTryCatchAndPrint<ProcessingController::ForwardState>( [this](){ return forwardState_(); },
-                                                                         "Calling InputSource::forwardState_" );
-  }
+  void InputSource::beginJob() {}
 
-  ProcessingController::ReverseState
-  InputSource::reverseState() const {
-    return callWithTryCatchAndPrint<ProcessingController::ReverseState>( [this](){ return reverseState_(); },
-                                                                         "Calling InputSource::reverseState__" );
-  }
+  void InputSource::endJob() {}
 
-  void
-  InputSource::beginJob() {}
+  bool InputSource::randomAccess_() const { return false; }
 
-  void
-  InputSource::endJob() {}
-
-  bool
-  InputSource::randomAccess_() const {
-    return false;
-  }
-
-  ProcessingController::ForwardState
-  InputSource::forwardState_() const {
+  ProcessingController::ForwardState InputSource::forwardState_() const {
     return ProcessingController::kUnknownForward;
   }
 
-  ProcessingController::ReverseState
-  InputSource::reverseState_() const {
+  ProcessingController::ReverseState InputSource::reverseState_() const {
     return ProcessingController::kUnknownReverse;
   }
 
-  ProcessHistoryID const&
-  InputSource::reducedProcessHistoryID() const {
+  ProcessHistoryID const& InputSource::reducedProcessHistoryID() const {
     assert(runAuxiliary());
     return processHistoryRegistry_->reducedProcessHistoryID(runAuxiliary()->processHistoryID());
   }
 
-  RunNumber_t
-  InputSource::run() const {
+  RunNumber_t InputSource::run() const {
     assert(runAuxiliary());
     return runAuxiliary()->run();
   }
 
-  LuminosityBlockNumber_t
-  InputSource::luminosityBlock() const {
+  LuminosityBlockNumber_t InputSource::luminosityBlock() const {
     assert(luminosityBlockAuxiliary());
     return luminosityBlockAuxiliary()->luminosityBlock();
   }
 
-  InputSource::EventSourceSentry::EventSourceSentry(InputSource const& source, StreamContext & sc) :
-    source_(source),
-    sc_(sc)
-  {
+  InputSource::EventSourceSentry::EventSourceSentry(InputSource const& source, StreamContext& sc)
+      : source_(source), sc_(sc) {
     source.actReg()->preSourceSignal_(sc_.streamID());
   }
 
-  InputSource::EventSourceSentry::~EventSourceSentry() {
-    source_.actReg()->postSourceSignal_(sc_.streamID());
-  }
+  InputSource::EventSourceSentry::~EventSourceSentry() { source_.actReg()->postSourceSignal_(sc_.streamID()); }
 
-  InputSource::LumiSourceSentry::LumiSourceSentry(InputSource const& source, LuminosityBlockIndex index) :
-    source_(source),
-    index_(index)
-  {
+  InputSource::LumiSourceSentry::LumiSourceSentry(InputSource const& source, LuminosityBlockIndex index)
+      : source_(source), index_(index) {
     source_.actReg()->preSourceLumiSignal_(index_);
   }
 
-  InputSource::LumiSourceSentry::~LumiSourceSentry() {
-    source_.actReg()->postSourceLumiSignal_(index_);
-  }
+  InputSource::LumiSourceSentry::~LumiSourceSentry() { source_.actReg()->postSourceLumiSignal_(index_); }
 
-  InputSource::RunSourceSentry::RunSourceSentry(InputSource const& source, RunIndex index) :
-    source_(source),
-    index_(index)
-  {
+  InputSource::RunSourceSentry::RunSourceSentry(InputSource const& source, RunIndex index)
+      : source_(source), index_(index) {
     source_.actReg()->preSourceRunSignal_(index_);
   }
 
-  InputSource::RunSourceSentry::~RunSourceSentry() {
-    source_.actReg()->postSourceRunSignal_(index_);
+  InputSource::RunSourceSentry::~RunSourceSentry() { source_.actReg()->postSourceRunSignal_(index_); }
+
+  InputSource::FileOpenSentry::FileOpenSentry(InputSource const& source, std::string const& lfn, bool usedFallback)
+      : post_(source.actReg()->postOpenFileSignal_), lfn_(lfn), usedFallback_(usedFallback) {
+    source.actReg()->preOpenFileSignal_(lfn, usedFallback);
   }
 
-  InputSource::FileOpenSentry::FileOpenSentry(InputSource const& source,
-                                              std::string const& lfn,
-                                              bool usedFallback) :
-    post_(source.actReg()->postOpenFileSignal_),
-    lfn_(lfn),
-    usedFallback_(usedFallback) {
-     source.actReg()->preOpenFileSignal_(lfn, usedFallback);
-  }
+  InputSource::FileOpenSentry::~FileOpenSentry() { post_(lfn_, usedFallback_); }
 
-  InputSource::FileOpenSentry::~FileOpenSentry() {
-    post_(lfn_, usedFallback_);
-  }
-
-  InputSource::FileCloseSentry::FileCloseSentry(InputSource const& source,
-                                                std::string const& lfn,
-                                                bool usedFallback) :
-    post_(source.actReg()->postCloseFileSignal_),
-    lfn_(lfn),
-    usedFallback_(usedFallback) {
+  InputSource::FileCloseSentry::FileCloseSentry(InputSource const& source, std::string const& lfn, bool usedFallback)
+      : post_(source.actReg()->postCloseFileSignal_), lfn_(lfn), usedFallback_(usedFallback) {
     source.actReg()->preCloseFileSignal_(lfn, usedFallback);
   }
 
-  InputSource::FileCloseSentry::~FileCloseSentry() {
-    post_(lfn_, usedFallback_);
-  }
-}
+  InputSource::FileCloseSentry::~FileCloseSentry() { post_(lfn_, usedFallback_); }
+}  // namespace edm

--- a/FWCore/Framework/src/InputSourceFactory.cc
+++ b/FWCore/Framework/src/InputSourceFactory.cc
@@ -6,22 +6,16 @@
 
 #include <iostream>
 
-EDM_REGISTER_PLUGINFACTORY(edm::InputSourcePluginFactory,"CMS EDM Framework InputSource");
+EDM_REGISTER_PLUGINFACTORY(edm::InputSourcePluginFactory, "CMS EDM Framework InputSource");
 namespace edm {
 
+  InputSourceFactory::~InputSourceFactory() {}
 
-  InputSourceFactory::~InputSourceFactory()
-  {
-  }
-
-  InputSourceFactory::InputSourceFactory() 
-  {
-  }
+  InputSourceFactory::InputSourceFactory() {}
 
   InputSourceFactory const InputSourceFactory::singleInstance_;
 
-  InputSourceFactory const* InputSourceFactory::get()
-  {
+  InputSourceFactory const* InputSourceFactory::get() {
     // will not work with plugin factories
     //static InputSourceFactory f;
     //return &f;
@@ -29,31 +23,28 @@ namespace edm {
     return &singleInstance_;
   }
 
-  std::unique_ptr<InputSource>
-  InputSourceFactory::makeInputSource(ParameterSet const& conf,
-					InputSourceDescription const& desc) const
-    
+  std::unique_ptr<InputSource> InputSourceFactory::makeInputSource(ParameterSet const& conf,
+                                                                   InputSourceDescription const& desc) const
+
   {
     std::string modtype = conf.getParameter<std::string>("@module_type");
     FDEBUG(1) << "InputSourceFactory: module_type = " << modtype << std::endl;
-    std::unique_ptr<InputSource> wm = std::unique_ptr<InputSource>(InputSourcePluginFactory::get()->create(modtype,conf,desc));
-    
-    if(wm.get() == nullptr) {
-	throw edm::Exception(errors::Configuration,"NoSourceModule")
-	  << "InputSource Factory:\n"
-	  << "Cannot find source type from ParameterSet: "
-	  << modtype << "\n"
-	  << "Perhaps your source type is misspelled or is not an EDM Plugin?\n"
-	  << "Try running EdmPluginDump to obtain a list of available Plugins.";
+    std::unique_ptr<InputSource> wm =
+        std::unique_ptr<InputSource>(InputSourcePluginFactory::get()->create(modtype, conf, desc));
+
+    if (wm.get() == nullptr) {
+      throw edm::Exception(errors::Configuration, "NoSourceModule")
+          << "InputSource Factory:\n"
+          << "Cannot find source type from ParameterSet: " << modtype << "\n"
+          << "Perhaps your source type is misspelled or is not an EDM Plugin?\n"
+          << "Try running EdmPluginDump to obtain a list of available Plugins.";
     }
 
     wm->registerProducts();
 
-    FDEBUG(1) << "InputSourceFactory: created input source "
-	      << modtype
-	      << std::endl;
+    FDEBUG(1) << "InputSourceFactory: created input source " << modtype << std::endl;
 
     return wm;
   }
 
-}
+}  // namespace edm

--- a/FWCore/Framework/src/InputSourceFactory.h
+++ b/FWCore/Framework/src/InputSourceFactory.h
@@ -9,7 +9,7 @@
 
 namespace edm {
 
-  typedef InputSource* (ISFunc)(ParameterSet const&, InputSourceDescription const&);
+  typedef InputSource*(ISFunc)(ParameterSet const&, InputSourceDescription const&);
 
   typedef edmplugin::PluginFactory<ISFunc> InputSourcePluginFactory;
 
@@ -19,15 +19,12 @@ namespace edm {
 
     static InputSourceFactory const* get();
 
-    std::unique_ptr<InputSource>
-      makeInputSource(ParameterSet const&,
-		       InputSourceDescription const&) const;
-    
+    std::unique_ptr<InputSource> makeInputSource(ParameterSet const&, InputSourceDescription const&) const;
 
   private:
     InputSourceFactory();
     static InputSourceFactory const singleInstance_;
   };
 
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.cc
+++ b/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     IntersectingIOVRecordIntervalFinder
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -15,103 +15,97 @@
 // user include files
 #include "FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h"
 namespace edm {
-   namespace eventsetup {
+  namespace eventsetup {
 
-//
-// constants, enums and typedefs
-//
+    //
+    // constants, enums and typedefs
+    //
 
-//
-// static data member definitions
-//
+    //
+    // static data member definitions
+    //
 
-//
-// constructors and destructor
-//
-IntersectingIOVRecordIntervalFinder::IntersectingIOVRecordIntervalFinder(const EventSetupRecordKey& iKey)
-{
-   findingRecordWithKey(iKey);
-}
+    //
+    // constructors and destructor
+    //
+    IntersectingIOVRecordIntervalFinder::IntersectingIOVRecordIntervalFinder(const EventSetupRecordKey& iKey) {
+      findingRecordWithKey(iKey);
+    }
 
-// IntersectingIOVRecordIntervalFinder::IntersectingIOVRecordIntervalFinder(const IntersectingIOVRecordIntervalFinder& rhs)
-// {
-//    // do actual copying here;
-// }
+    // IntersectingIOVRecordIntervalFinder::IntersectingIOVRecordIntervalFinder(const IntersectingIOVRecordIntervalFinder& rhs)
+    // {
+    //    // do actual copying here;
+    // }
 
-IntersectingIOVRecordIntervalFinder::~IntersectingIOVRecordIntervalFinder()
-{
-}
+    IntersectingIOVRecordIntervalFinder::~IntersectingIOVRecordIntervalFinder() {}
 
-//
-// assignment operators
-//
-// const IntersectingIOVRecordIntervalFinder& IntersectingIOVRecordIntervalFinder::operator=(const IntersectingIOVRecordIntervalFinder& rhs)
-// {
-//   //An exception safe implementation is
-//   IntersectingIOVRecordIntervalFinder temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+    //
+    // assignment operators
+    //
+    // const IntersectingIOVRecordIntervalFinder& IntersectingIOVRecordIntervalFinder::operator=(const IntersectingIOVRecordIntervalFinder& rhs)
+    // {
+    //   //An exception safe implementation is
+    //   IntersectingIOVRecordIntervalFinder temp(rhs);
+    //   swap(rhs);
+    //
+    //   return *this;
+    // }
 
-//
-// member functions
-//
-void 
-IntersectingIOVRecordIntervalFinder::swapFinders(std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>& iFinders)
-{
-   finders_.swap(iFinders);
-}
+    //
+    // member functions
+    //
+    void IntersectingIOVRecordIntervalFinder::swapFinders(
+        std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>& iFinders) {
+      finders_.swap(iFinders);
+    }
 
-void 
-IntersectingIOVRecordIntervalFinder::setIntervalFor(const EventSetupRecordKey& iKey,
-                                                    const IOVSyncValue& iTime, 
-                                                    ValidityInterval& oInterval)
-{
-   if(finders_.empty()) {
-      oInterval = ValidityInterval::invalidInterval();
-      return;
-   }
-   
-   bool haveAValidRecord = false;
-   bool haveUnknownEnding = false;
-   ValidityInterval newInterval(IOVSyncValue::beginOfTime(), IOVSyncValue::endOfTime());
-
-   for(auto& finder : finders_) {
-      ValidityInterval test = finder->findIntervalFor(iKey, iTime);
-      if ( test != ValidityInterval::invalidInterval() ) {
-         haveAValidRecord =true;
-         if(newInterval.first() < test.first()) {
-            newInterval.setFirst(test.first());
-         }
-         if(newInterval.last() > test.last()) {
-            newInterval.setLast(test.last());
-         }
-         if(test.last() == IOVSyncValue::invalidIOVSyncValue()) {
-            haveUnknownEnding=true;
-         }
-      } else {
-         //if it is invalid then we must check on each new IOVSyncValue so that 
-         // we can find the time when it is valid
-         haveUnknownEnding=true;
+    void IntersectingIOVRecordIntervalFinder::setIntervalFor(const EventSetupRecordKey& iKey,
+                                                             const IOVSyncValue& iTime,
+                                                             ValidityInterval& oInterval) {
+      if (finders_.empty()) {
+        oInterval = ValidityInterval::invalidInterval();
+        return;
       }
-   }
-   
-   if(!haveAValidRecord) {
-      //If no Finder has a valid time, then this record is also invalid for this time
-      newInterval = ValidityInterval::invalidInterval();
-   } else if(haveUnknownEnding) {
-      newInterval.setLast(IOVSyncValue::invalidIOVSyncValue());
-   }
-   oInterval = newInterval;
-}
 
-//
-// const member functions
-//
+      bool haveAValidRecord = false;
+      bool haveUnknownEnding = false;
+      ValidityInterval newInterval(IOVSyncValue::beginOfTime(), IOVSyncValue::endOfTime());
 
-//
-// static member functions
-//
-   }
-}
+      for (auto& finder : finders_) {
+        ValidityInterval test = finder->findIntervalFor(iKey, iTime);
+        if (test != ValidityInterval::invalidInterval()) {
+          haveAValidRecord = true;
+          if (newInterval.first() < test.first()) {
+            newInterval.setFirst(test.first());
+          }
+          if (newInterval.last() > test.last()) {
+            newInterval.setLast(test.last());
+          }
+          if (test.last() == IOVSyncValue::invalidIOVSyncValue()) {
+            haveUnknownEnding = true;
+          }
+        } else {
+          //if it is invalid then we must check on each new IOVSyncValue so that
+          // we can find the time when it is valid
+          haveUnknownEnding = true;
+        }
+      }
+
+      if (!haveAValidRecord) {
+        //If no Finder has a valid time, then this record is also invalid for this time
+        newInterval = ValidityInterval::invalidInterval();
+      } else if (haveUnknownEnding) {
+        newInterval.setLast(IOVSyncValue::invalidIOVSyncValue());
+      }
+      oInterval = newInterval;
+    }
+
+    //
+    // const member functions
+    //
+
+    //
+    // static member functions
+    //
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h
+++ b/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     IntersectingIOVRecordIntervalFinder
-// 
+//
 /**\class IntersectingIOVRecordIntervalFinder IntersectingIOVRecordIntervalFinder.h FWCore/Framework/interface/IntersectingIOVRecordIntervalFinder.h
 
  Description: A RecordIntervalFinder which determines IOVs by taking the intersection of IOVs of other RecordIntervalFinders
@@ -28,34 +28,33 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
+  namespace eventsetup {
 
-      class IntersectingIOVRecordIntervalFinder : public EventSetupRecordIntervalFinder {
-         
-      public:
-         explicit IntersectingIOVRecordIntervalFinder(const EventSetupRecordKey&);
-         ~IntersectingIOVRecordIntervalFinder() override;
-         
-         // ---------- const member functions ---------------------
-         
-         // ---------- static member functions --------------------
-         
-         // ---------- member functions ---------------------------
-         void swapFinders(std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>&);
-      protected:
-         void setIntervalFor(const EventSetupRecordKey&,
-                                     const IOVSyncValue& , 
-                                     ValidityInterval&) override;
-         
-      private:
-         IntersectingIOVRecordIntervalFinder(const IntersectingIOVRecordIntervalFinder&) = delete; // stop default
-         
-         const IntersectingIOVRecordIntervalFinder& operator=(const IntersectingIOVRecordIntervalFinder&) = delete; // stop default
-         
-         // ---------- member data --------------------------------
-         std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>> finders_;
-      };
-   }
-}
+    class IntersectingIOVRecordIntervalFinder : public EventSetupRecordIntervalFinder {
+    public:
+      explicit IntersectingIOVRecordIntervalFinder(const EventSetupRecordKey&);
+      ~IntersectingIOVRecordIntervalFinder() override;
+
+      // ---------- const member functions ---------------------
+
+      // ---------- static member functions --------------------
+
+      // ---------- member functions ---------------------------
+      void swapFinders(std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>&);
+
+    protected:
+      void setIntervalFor(const EventSetupRecordKey&, const IOVSyncValue&, ValidityInterval&) override;
+
+    private:
+      IntersectingIOVRecordIntervalFinder(const IntersectingIOVRecordIntervalFinder&) = delete;  // stop default
+
+      const IntersectingIOVRecordIntervalFinder& operator=(const IntersectingIOVRecordIntervalFinder&) =
+          delete;  // stop default
+
+      // ---------- member data --------------------------------
+      std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>> finders_;
+    };
+  }  // namespace eventsetup
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/LooperFactory.cc
+++ b/FWCore/Framework/src/LooperFactory.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     LooperFactory
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -19,28 +19,24 @@
 // static member functions
 //
 namespace edm {
-   namespace eventsetup {
-      std::string LooperMakerTraits::name() { return "CMS EDM Framework EDLooper"; }
-      
-      void 
-      LooperMakerTraits::replaceExisting(EventSetupProvider&, std::shared_ptr<EDLooperBase>) {
-         throw edm::Exception(edm::errors::LogicError)
-            << "LooperMakerTraits::replaceExisting\n"
-            << "This function is not implemented and should never be called.\n"
-            << "Please report this to a Framework Developer\n";
-      }
+  namespace eventsetup {
+    std::string LooperMakerTraits::name() { return "CMS EDM Framework EDLooper"; }
 
-      std::shared_ptr<LooperMakerTraits::base_type>
-      LooperMakerTraits::getComponentAndRegisterProcess(EventSetupsController&,
-                                                        ParameterSet const&) {
-        return std::shared_ptr<LooperMakerTraits::base_type>();
-      }
+    void LooperMakerTraits::replaceExisting(EventSetupProvider&, std::shared_ptr<EDLooperBase>) {
+      throw edm::Exception(edm::errors::LogicError) << "LooperMakerTraits::replaceExisting\n"
+                                                    << "This function is not implemented and should never be called.\n"
+                                                    << "Please report this to a Framework Developer\n";
+    }
 
-      void LooperMakerTraits::putComponent(EventSetupsController&,
-                                           ParameterSet const&,
-                                           std::shared_ptr<base_type> const&) {
-      }
-   }
-}
+    std::shared_ptr<LooperMakerTraits::base_type> LooperMakerTraits::getComponentAndRegisterProcess(
+        EventSetupsController&, ParameterSet const&) {
+      return std::shared_ptr<LooperMakerTraits::base_type>();
+    }
+
+    void LooperMakerTraits::putComponent(EventSetupsController&,
+                                         ParameterSet const&,
+                                         std::shared_ptr<base_type> const&) {}
+  }  // namespace eventsetup
+}  // namespace edm
 
 COMPONENTFACTORY_GET(edm::eventsetup::LooperMakerTraits);

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -9,84 +9,72 @@ namespace edm {
 
   std::string const LuminosityBlock::emptyString_;
 
-  LuminosityBlock::LuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleDescription const& md,
-                                   ModuleCallingContext const* moduleCallingContext, bool isAtEnd) :
-        provRecorder_(lbp, md,isAtEnd),
+  LuminosityBlock::LuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                   ModuleDescription const& md,
+                                   ModuleCallingContext const* moduleCallingContext,
+                                   bool isAtEnd)
+      : provRecorder_(lbp, md, isAtEnd),
         aux_(lbp.aux()),
-        run_(new Run(lbp.runPrincipal(), md, moduleCallingContext,false)),
-        moduleCallingContext_(moduleCallingContext) {
+        run_(new Run(lbp.runPrincipal(), md, moduleCallingContext, false)),
+        moduleCallingContext_(moduleCallingContext) {}
+
+  LuminosityBlock::~LuminosityBlock() {}
+
+  LuminosityBlockIndex LuminosityBlock::index() const { return luminosityBlockPrincipal().index(); }
+
+  LuminosityBlock::CacheIdentifier_t LuminosityBlock::cacheIdentifier() const {
+    return luminosityBlockPrincipal().cacheIdentifier();
   }
 
-  LuminosityBlock::~LuminosityBlock() {
-  }
-
-  LuminosityBlockIndex
-  LuminosityBlock::index() const {
-    return luminosityBlockPrincipal().index();
-  }
-
-  LuminosityBlock::CacheIdentifier_t
-  LuminosityBlock::cacheIdentifier() const {return luminosityBlockPrincipal().cacheIdentifier();}
-
-  
-  void
-  LuminosityBlock::setConsumer(EDConsumerBase const* iConsumer) {
+  void LuminosityBlock::setConsumer(EDConsumerBase const* iConsumer) {
     provRecorder_.setConsumer(iConsumer);
-    if(run_) {
+    if (run_) {
       const_cast<Run*>(run_.get())->setConsumer(iConsumer);
     }
   }
-  
-  void
-  LuminosityBlock::setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer) {
+
+  void LuminosityBlock::setSharedResourcesAcquirer(SharedResourcesAcquirer* iResourceAcquirer) {
     provRecorder_.setSharedResourcesAcquirer(iResourceAcquirer);
     const_cast<Run*>(run_.get())->setSharedResourcesAcquirer(iResourceAcquirer);
   }
 
-  void
-  LuminosityBlock::setProducer(ProducerBase const* iProducer) {
+  void LuminosityBlock::setProducer(ProducerBase const* iProducer) {
     provRecorder_.setProducer(iProducer);
     //set appropriate size
-    putProducts_.resize(
-            provRecorder_.putTokenIndexToProductResolverIndex().size());
+    putProducts_.resize(provRecorder_.putTokenIndexToProductResolverIndex().size());
   }
 
-
-  LuminosityBlockPrincipal const&
-  LuminosityBlock::luminosityBlockPrincipal() const {
+  LuminosityBlockPrincipal const& LuminosityBlock::luminosityBlockPrincipal() const {
     return dynamic_cast<LuminosityBlockPrincipal const&>(provRecorder_.principal());
   }
 
-  Provenance
-  LuminosityBlock::getProvenance(BranchID const& bid) const {
+  Provenance LuminosityBlock::getProvenance(BranchID const& bid) const {
     return luminosityBlockPrincipal().getProvenance(bid, moduleCallingContext_);
   }
 
-  void
-  LuminosityBlock::getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const {
+  void LuminosityBlock::getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const {
     luminosityBlockPrincipal().getAllStableProvenance(provenances);
   }
 
-  void
-  LuminosityBlock::commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut) {
+  void LuminosityBlock::commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut) {
     LuminosityBlockPrincipal const& lbp = luminosityBlockPrincipal();
     size_t nPut = 0;
-    for(size_t i = 0; i < putProducts().size();++i) {
+    for (size_t i = 0; i < putProducts().size(); ++i) {
       auto& p = get_underlying_safe(putProducts()[i]);
-      if(p) {
-        lbp.put(provRecorder_.putTokenIndexToProductResolverIndex()[i],  std::move(p));
+      if (p) {
+        lbp.put(provRecorder_.putTokenIndexToProductResolverIndex()[i], std::move(p));
         ++nPut;
       }
     }
-    
+
     auto sz = iShouldPut.size();
-    if(sz !=0 and sz != nPut) {
+    if (sz != 0 and sz != nPut) {
       //some were missed
       auto& p = provRecorder_.principal();
-      for(auto index: iShouldPut){
+      for (auto index : iShouldPut) {
         auto resolver = p.getProductResolverByIndex(index);
-        if(not resolver->productResolved() and
-           isEndTransition(provRecorder_.transition()) == resolver->branchDescription().availableOnlyAtEndTransition()) {
+        if (not resolver->productResolved() and isEndTransition(provRecorder_.transition()) ==
+                                                    resolver->branchDescription().availableOnlyAtEndTransition()) {
           resolver->putProduct(std::unique_ptr<WrapperBase>());
         }
       }
@@ -96,19 +84,16 @@ namespace edm {
     putProducts().clear();
   }
 
-  ProcessHistoryID const&
-  LuminosityBlock::processHistoryID() const {
+  ProcessHistoryID const& LuminosityBlock::processHistoryID() const {
     return luminosityBlockPrincipal().processHistoryID();
   }
 
-  ProcessHistory const&
-  LuminosityBlock::processHistory() const {
-    return provRecorder_.processHistory();
-  }
+  ProcessHistory const& LuminosityBlock::processHistory() const { return provRecorder_.processHistory(); }
 
-  BasicHandle
-  LuminosityBlock::getByLabelImpl(std::type_info const&, std::type_info const& iProductType, const InputTag& iTag) const {
+  BasicHandle LuminosityBlock::getByLabelImpl(std::type_info const&,
+                                              std::type_info const& iProductType,
+                                              const InputTag& iTag) const {
     BasicHandle h = provRecorder_.getByLabel_(TypeID(iProductType), iTag, moduleCallingContext_);
     return h;
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/LuminosityBlockForOutput.cc
+++ b/FWCore/Framework/src/LuminosityBlockForOutput.cc
@@ -7,25 +7,22 @@
 
 namespace edm {
 
-  LuminosityBlockForOutput::LuminosityBlockForOutput(LuminosityBlockPrincipal const& lbp, ModuleDescription const& md,
-                                   ModuleCallingContext const* moduleCallingContext, bool isAtEnd) :
-        OccurrenceForOutput(lbp, md, moduleCallingContext, isAtEnd),
+  LuminosityBlockForOutput::LuminosityBlockForOutput(LuminosityBlockPrincipal const& lbp,
+                                                     ModuleDescription const& md,
+                                                     ModuleCallingContext const* moduleCallingContext,
+                                                     bool isAtEnd)
+      : OccurrenceForOutput(lbp, md, moduleCallingContext, isAtEnd),
         aux_(lbp.aux()),
-        run_(new RunForOutput(lbp.runPrincipal(), md, moduleCallingContext, false)) {
-  }
+        run_(new RunForOutput(lbp.runPrincipal(), md, moduleCallingContext, false)) {}
 
-  LuminosityBlockForOutput::~LuminosityBlockForOutput() {
-  }
+  LuminosityBlockForOutput::~LuminosityBlockForOutput() {}
 
-  LuminosityBlockPrincipal const&
-  LuminosityBlockForOutput::luminosityBlockPrincipal() const {
+  LuminosityBlockPrincipal const& LuminosityBlockForOutput::luminosityBlockPrincipal() const {
     return dynamic_cast<LuminosityBlockPrincipal const&>(principal());
   }
-  
+
   /**\return Reusable index which can be used to separate data for different simultaneous LuminosityBlocks.
    */
-  LuminosityBlockIndex LuminosityBlockForOutput::index() const {
-    return luminosityBlockPrincipal().index();
-  }
+  LuminosityBlockIndex LuminosityBlockForOutput::index() const { return luminosityBlockPrincipal().index(); }
 
-}
+}  // namespace edm

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -4,45 +4,33 @@
 
 namespace edm {
 
-  LuminosityBlockPrincipal::LuminosityBlockPrincipal(
-      std::shared_ptr<ProductRegistry const> reg,
-      ProcessConfiguration const& pc,
-      HistoryAppender* historyAppender,
-      unsigned int index,
-      bool isForPrimaryProcess) :
-    Base(reg, reg->productLookup(InLumi), pc, InLumi, historyAppender, isForPrimaryProcess),
+  LuminosityBlockPrincipal::LuminosityBlockPrincipal(std::shared_ptr<ProductRegistry const> reg,
+                                                     ProcessConfiguration const& pc,
+                                                     HistoryAppender* historyAppender,
+                                                     unsigned int index,
+                                                     bool isForPrimaryProcess)
+      : Base(reg, reg->productLookup(InLumi), pc, InLumi, historyAppender, isForPrimaryProcess),
         runPrincipal_(),
-        index_(index) {
-  }
+        index_(index) {}
 
-  void
-  LuminosityBlockPrincipal::fillLuminosityBlockPrincipal(
-      ProcessHistoryRegistry const& processHistoryRegistry,
-      DelayedReader* reader) {
+  void LuminosityBlockPrincipal::fillLuminosityBlockPrincipal(ProcessHistoryRegistry const& processHistoryRegistry,
+                                                              DelayedReader* reader) {
     fillPrincipal(aux_.processHistoryID(), processHistoryRegistry, reader);
 
-    for(auto& prod : *this) {
+    for (auto& prod : *this) {
       prod->setProcessHistory(processHistory());
     }
   }
 
-  void
-  LuminosityBlockPrincipal::put(
-        BranchDescription const& bd,
-        std::unique_ptr<WrapperBase> edp) const {
-    putOrMerge(bd,std::move(edp));
+  void LuminosityBlockPrincipal::put(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const {
+    putOrMerge(bd, std::move(edp));
   }
 
-  void
-  LuminosityBlockPrincipal::put(ProductResolverIndex index,
-                                std::unique_ptr<WrapperBase> edp) const {
+  void LuminosityBlockPrincipal::put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const {
     auto phb = getProductResolverByIndex(index);
     phb->putOrMergeProduct(std::move(edp));
   }
 
-  unsigned int
-  LuminosityBlockPrincipal::transitionIndex_() const {
-    return index().value();
-  }
+  unsigned int LuminosityBlockPrincipal::transitionIndex_() const { return index().value(); }
 
-}
+}  // namespace edm

--- a/FWCore/Framework/src/LuminosityBlockProcessingStatus.cc
+++ b/FWCore/Framework/src/LuminosityBlockProcessingStatus.cc
@@ -2,7 +2,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     LuminosityBlockProcessingStatus
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -18,16 +18,17 @@
 
 namespace edm {
   void LuminosityBlockProcessingStatus::setEndTime() {
-    if(2 != endTimeSetStatus_) {
+    if (2 != endTimeSetStatus_) {
       //not already set
       char expected = 0;
-      if(endTimeSetStatus_.compare_exchange_strong(expected,1)) {
+      if (endTimeSetStatus_.compare_exchange_strong(expected, 1)) {
         lumiPrincipal_->setEndTime(endTime_);
         endTimeSetStatus_.store(2);
       } else {
         //wait until time is set
-        while( 2 != endTimeSetStatus_.load()) {}
+        while (2 != endTimeSetStatus_.load()) {
+        }
       }
     }
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
+++ b/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     LuminosityBlockProcessingStatus
-// 
+//
 /**\class LuminosityBlockProcessingStatus LuminosityBlockProcessingStatus.h "LuminosityBlockProcessingStatus.h"
 
  Description: Keep status information about one LuminosityBlock transition
@@ -36,83 +36,77 @@ namespace edm {
   class LuminosityBlockProcessingStatus;
 #endif
 
-class LuminosityBlockProcessingStatus
-{
-
+  class LuminosityBlockProcessingStatus {
   public:
-  LuminosityBlockProcessingStatus(EventProcessor* iEP, unsigned int iNStreams, std::shared_ptr<void> iRunResource):
-  run_(std::move(iRunResource)) , eventProcessor_(iEP), nStreamsStillProcessingLumi_(iNStreams){}
+    LuminosityBlockProcessingStatus(EventProcessor* iEP, unsigned int iNStreams, std::shared_ptr<void> iRunResource)
+        : run_(std::move(iRunResource)), eventProcessor_(iEP), nStreamsStillProcessingLumi_(iNStreams) {}
 
-  std::shared_ptr<LuminosityBlockPrincipal>& lumiPrincipal() { return lumiPrincipal_;}
+    std::shared_ptr<LuminosityBlockPrincipal>& lumiPrincipal() { return lumiPrincipal_; }
 
-  void setResumer( LimitedTaskQueue::Resumer iResumer ) {
-    globalLumiQueueResumer_ = std::move(iResumer);
-  }
-  void resumeGlobalLumiQueue() {
-    //free lumi for next usage
-    lumiPrincipal_.reset();
-    globalLumiQueueResumer_.resume();
-  }
-  
-  bool streamFinishedLumi() {
-    return 0 == (--nStreamsStillProcessingLumi_);
-  }
-  
-  bool wasEventProcessingStopped() const { return stopProcessingEvents_;}
-  void stopProcessingEvents() { stopProcessingEvents_ = true;}
-  void startProcessingEvents() { stopProcessingEvents_ = false;}
-  
-  bool isLumiEnding() const {return lumiEnding_;}
-  void endLumi() { lumiEnding_ = true;}
-  
-  bool continuingLumi() const { return continuingLumi_;}
-  void haveContinuedLumi() { continuingLumi_ = false; }
-  void needToContinueLumi() { continuingLumi_ = true;}
+    void setResumer(LimitedTaskQueue::Resumer iResumer) { globalLumiQueueResumer_ = std::move(iResumer); }
+    void resumeGlobalLumiQueue() {
+      //free lumi for next usage
+      lumiPrincipal_.reset();
+      globalLumiQueueResumer_.resume();
+    }
 
-  bool haveStartedNextLumi() const { return startedNextLumi_;}
-  void startNextLumi() { startedNextLumi_ = true;}
-  
-  bool didGlobalBeginSucceed() const {return globalBeginSucceeded_;}
-  void globalBeginDidSucceed() { globalBeginSucceeded_ = true;}
+    bool streamFinishedLumi() { return 0 == (--nStreamsStillProcessingLumi_); }
 
-  void noExceptionHappened() { cleaningUpAfterException_ = false; }
-  bool cleaningUpAfterException() const { return cleaningUpAfterException_;}
+    bool wasEventProcessingStopped() const { return stopProcessingEvents_; }
+    void stopProcessingEvents() { stopProcessingEvents_ = true; }
+    void startProcessingEvents() { stopProcessingEvents_ = false; }
 
-  //These should only be called while in the InputSource's task queue
-  void updateLastTimestamp( edm::Timestamp const& iTime) {
-    if (iTime> endTime_) { endTime_ = iTime;}
-  }
-  edm::Timestamp const& lastTimestamp() const { return endTime_;}
-  
-  void setNextSyncValue(IOVSyncValue iValue) {
-    nextSyncValue_ = std::move(iValue);
-  }
-  
-  const IOVSyncValue nextSyncValue() const { return nextSyncValue_;}
-  
-  std::shared_ptr<void> const& runResource() const {return run_;}
-  
-  //Called once all events in Lumi have been processed
-  void setEndTime();
+    bool isLumiEnding() const { return lumiEnding_; }
+    void endLumi() { lumiEnding_ = true; }
+
+    bool continuingLumi() const { return continuingLumi_; }
+    void haveContinuedLumi() { continuingLumi_ = false; }
+    void needToContinueLumi() { continuingLumi_ = true; }
+
+    bool haveStartedNextLumi() const { return startedNextLumi_; }
+    void startNextLumi() { startedNextLumi_ = true; }
+
+    bool didGlobalBeginSucceed() const { return globalBeginSucceeded_; }
+    void globalBeginDidSucceed() { globalBeginSucceeded_ = true; }
+
+    void noExceptionHappened() { cleaningUpAfterException_ = false; }
+    bool cleaningUpAfterException() const { return cleaningUpAfterException_; }
+
+    //These should only be called while in the InputSource's task queue
+    void updateLastTimestamp(edm::Timestamp const& iTime) {
+      if (iTime > endTime_) {
+        endTime_ = iTime;
+      }
+    }
+    edm::Timestamp const& lastTimestamp() const { return endTime_; }
+
+    void setNextSyncValue(IOVSyncValue iValue) { nextSyncValue_ = std::move(iValue); }
+
+    const IOVSyncValue nextSyncValue() const { return nextSyncValue_; }
+
+    std::shared_ptr<void> const& runResource() const { return run_; }
+
+    //Called once all events in Lumi have been processed
+    void setEndTime();
+
   private:
-  // ---------- member data --------------------------------
-  std::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal_;
-  std::shared_ptr<void> run_;
-  LimitedTaskQueue::Resumer globalLumiQueueResumer_;
-  EventProcessor* eventProcessor_ = nullptr;
-  IOVSyncValue nextSyncValue_;
-  std::atomic<unsigned int> nStreamsStillProcessingLumi_{0}; //read/write as streams finish lumi so must be atomic
-  edm::Timestamp endTime_{};
-  std::atomic<char> endTimeSetStatus_{0};
-  bool stopProcessingEvents_{false}; //read/write in m_sourceQueue OR from main thread when no tasks running
-  bool lumiEnding_{false}; //read/write in m_sourceQueue NOTE: This is a useful cache instead of recalculating each call
-  bool continuingLumi_{false}; //read/write in m_sourceQueue OR from main thread when no tasks running
-  bool startedNextLumi_{false}; //read/write in m_sourceQueue
-  bool globalBeginSucceeded_{false};
-  bool cleaningUpAfterException_{true};
-
-
-};
-}
+    // ---------- member data --------------------------------
+    std::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal_;
+    std::shared_ptr<void> run_;
+    LimitedTaskQueue::Resumer globalLumiQueueResumer_;
+    EventProcessor* eventProcessor_ = nullptr;
+    IOVSyncValue nextSyncValue_;
+    std::atomic<unsigned int> nStreamsStillProcessingLumi_{0};  //read/write as streams finish lumi so must be atomic
+    edm::Timestamp endTime_{};
+    std::atomic<char> endTimeSetStatus_{0};
+    bool stopProcessingEvents_{false};  //read/write in m_sourceQueue OR from main thread when no tasks running
+    bool lumiEnding_{
+        false};  //read/write in m_sourceQueue NOTE: This is a useful cache instead of recalculating each call
+    bool continuingLumi_{false};   //read/write in m_sourceQueue OR from main thread when no tasks running
+    bool startedNextLumi_{false};  //read/write in m_sourceQueue
+    bool globalBeginSucceeded_{false};
+    bool cleaningUpAfterException_{true};
+  };
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/MakeDataException.cc
+++ b/FWCore/Framework/src/MakeDataException.cc
@@ -2,27 +2,19 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
+  namespace eventsetup {
 
-MakeDataException::MakeDataException( const EventSetupRecordKey& iRecordKey, const DataKey& iDataKey) : 
-cms::Exception("MakeDataException"),
-message_(standardMessage(iRecordKey,iDataKey))
-{
-  this->append(myMessage());
-}
+    MakeDataException::MakeDataException(const EventSetupRecordKey& iRecordKey, const DataKey& iDataKey)
+        : cms::Exception("MakeDataException"), message_(standardMessage(iRecordKey, iDataKey)) {
+      this->append(myMessage());
+    }
 
-      // ---------- static member functions --------------------
-std::string MakeDataException::standardMessage( const EventSetupRecordKey& iRecordKey, const DataKey& iDataKey) 
-{
- std::string returnValue = std::string("Error while making data \"") 
-   + iDataKey.type().name()
-   + "\" \""
-   + iDataKey.name().value()
-   + "\" in Record "
-   + iRecordKey.type().name();
-   return returnValue;
-}
-   
+    // ---------- static member functions --------------------
+    std::string MakeDataException::standardMessage(const EventSetupRecordKey& iRecordKey, const DataKey& iDataKey) {
+      std::string returnValue = std::string("Error while making data \"") + iDataKey.type().name() + "\" \"" +
+                                iDataKey.name().value() + "\" in Record " + iRecordKey.type().name();
+      return returnValue;
+    }
 
-   }
-}
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/MakeModuleHelper.h
+++ b/FWCore/Framework/src/MakeModuleHelper.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     MakeModuleHelper
-// 
+//
 /**\class edm::MakeModuleHelper MakeModuleHelper.h "MakeModuleHelper.h"
 
  Description: A template class which can be specialized to create a module from a user type
@@ -26,23 +26,18 @@
 namespace edm {
   class ParameterSet;
 
-  template<typename Base>
-  class MakeModuleHelper
-  {
-    
+  template <typename Base> class MakeModuleHelper {
   public:
     MakeModuleHelper() = delete;
-    MakeModuleHelper(const MakeModuleHelper&) = delete; // stop default
-    
-    const MakeModuleHelper& operator=(const MakeModuleHelper&) = delete; // stop default
+    MakeModuleHelper(const MakeModuleHelper&) = delete;  // stop default
 
-    template<typename T>
-    static std::unique_ptr<Base> makeModule(ParameterSet const& pset) {
+    const MakeModuleHelper& operator=(const MakeModuleHelper&) = delete;  // stop default
+
+    template <typename T> static std::unique_ptr<Base> makeModule(ParameterSet const& pset) {
       auto module = std::make_unique<T>(pset);
       return std::unique_ptr<Base>(module.release());
     }
   };
-}
-
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/MakeModuleParams.h
+++ b/FWCore/Framework/src/MakeModuleParams.h
@@ -19,24 +19,19 @@ namespace edm {
   class PreallocationConfiguration;
 
   struct MakeModuleParams {
-    MakeModuleParams() :
-      pset_(nullptr), reg_(nullptr), preallocate_(nullptr), processConfiguration_()
-      {}
+    MakeModuleParams() : pset_(nullptr), reg_(nullptr), preallocate_(nullptr), processConfiguration_() {}
 
     MakeModuleParams(ParameterSet* pset,
                      ProductRegistry& reg,
                      PreallocationConfiguration const* prealloc,
-                     std::shared_ptr<ProcessConfiguration const> processConfiguration) :
-      pset_(pset),
-      reg_(&reg),
-      preallocate_(prealloc),
-      processConfiguration_(processConfiguration) {}
+                     std::shared_ptr<ProcessConfiguration const> processConfiguration)
+        : pset_(pset), reg_(&reg), preallocate_(prealloc), processConfiguration_(processConfiguration) {}
 
     ParameterSet* pset_;
     ProductRegistry* reg_;
     PreallocationConfiguration const* preallocate_;
     std::shared_ptr<ProcessConfiguration const> processConfiguration_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/MergeableRunProductMetadata.cc
+++ b/FWCore/Framework/src/MergeableRunProductMetadata.cc
@@ -11,39 +11,29 @@
 
 namespace edm {
 
-  MergeableRunProductMetadata::
-  MergeableRunProductMetadata(MergeableRunProductProcesses const& mergeableRunProductProcesses) :
-    mergeableRunProductProcesses_(&mergeableRunProductProcesses),
-    metadataForProcesses_(mergeableRunProductProcesses.size()) {
-  }
+  MergeableRunProductMetadata::MergeableRunProductMetadata(
+      MergeableRunProductProcesses const& mergeableRunProductProcesses)
+      : mergeableRunProductProcesses_(&mergeableRunProductProcesses),
+        metadataForProcesses_(mergeableRunProductProcesses.size()) {}
 
-  MergeableRunProductMetadata::~MergeableRunProductMetadata() {
-  }
+  MergeableRunProductMetadata::~MergeableRunProductMetadata() {}
 
-  void MergeableRunProductMetadata::preReadFile() {
-    mergeLumisFromIndexIntoFile();
-  }
+  void MergeableRunProductMetadata::preReadFile() { mergeLumisFromIndexIntoFile(); }
 
   void MergeableRunProductMetadata::readRun(
-    long long inputRunEntry,
-    StoredMergeableRunProductMetadata const& inputStoredMergeableRunProductMetadata,
-    IndexIntoFileItrHolder const& inputIndexIntoFileItr) {
-
-    unsigned int processIndex {0};
-    for (auto & metadataForProcess : metadataForProcesses_) {
-
+      long long inputRunEntry,
+      StoredMergeableRunProductMetadata const& inputStoredMergeableRunProductMetadata,
+      IndexIntoFileItrHolder const& inputIndexIntoFileItr) {
+    unsigned int processIndex{0};
+    for (auto& metadataForProcess : metadataForProcesses_) {
       bool valid = true;
       std::vector<LuminosityBlockNumber_t>::const_iterator lumisInRunBeingReadBegin;
       std::vector<LuminosityBlockNumber_t>::const_iterator lumisInRunBeingReadEnd;
 
       std::string const& processName = mergeableRunProductProcesses_->processesWithMergeableRunProducts()[processIndex];
 
-      if (inputStoredMergeableRunProductMetadata.getLumiContent(inputRunEntry,
-                                                                processName,
-                                                                valid,
-                                                                lumisInRunBeingReadBegin,
-                                                                lumisInRunBeingReadEnd)) {
-
+      if (inputStoredMergeableRunProductMetadata.getLumiContent(inputRunEntry, processName, valid,
+                                                                lumisInRunBeingReadBegin, lumisInRunBeingReadEnd)) {
         // This is a reference to the container accumulating the luminosity
         // block numbers for the run entries read associated with the current
         // run being processed that correspond to the luminosity block content
@@ -62,7 +52,7 @@ namespace edm {
         std::vector<LuminosityBlockNumber_t>::const_iterator end1 = lumis.end();
         std::vector<LuminosityBlockNumber_t>::const_iterator end2 = lumisInRunBeingReadEnd;
         for (std::vector<LuminosityBlockNumber_t>::const_iterator iter1 = lumis.begin(),
-             iter2 = lumisInRunBeingReadBegin;
+                                                                  iter2 = lumisInRunBeingReadBegin;
              iter1 != end1 || iter2 != end2;) {
           if (iter1 == end1) {
             temp.push_back(*iter2);
@@ -111,7 +101,6 @@ namespace edm {
         }
 
       } else {
-
         metadataForProcess.setMergeDecision(MERGE);
         if (!valid) {
           metadataForProcess.setValid(false);
@@ -123,11 +112,10 @@ namespace edm {
         }
       }
       ++processIndex;
-    } // end of loop over processes
-  } // end of readRun function
+    }  // end of loop over processes
+  }    // end of readRun function
 
   void MergeableRunProductMetadata::writeLumi(LuminosityBlockNumber_t lumi) {
-
     if (metadataForProcesses_.empty()) {
       return;
     }
@@ -135,7 +123,6 @@ namespace edm {
   }
 
   void MergeableRunProductMetadata::preWriteRun() {
-
     if (metadataForProcesses_.empty()) {
       return;
     }
@@ -157,28 +144,22 @@ namespace edm {
     std::sort(lumisProcessed.begin(), lumisProcessed.end());
     auto uniqueEnd = std::unique(lumisProcessed.begin(), lumisProcessed.end());
 
-    for (auto & metadataForProcess : metadataForProcesses_) {
-
+    for (auto& metadataForProcess : metadataForProcesses_) {
       // Did we process all the lumis in this process that were processed
       // in the process that created the mergeable run products.
-      metadataForProcess.setAllLumisProcessed(
-        std::includes(lumisProcessed.begin(), uniqueEnd,
-                      metadataForProcess.lumis().begin(),
-                      metadataForProcess.lumis().end()));
+      metadataForProcess.setAllLumisProcessed(std::includes(
+          lumisProcessed.begin(), uniqueEnd, metadataForProcess.lumis().begin(), metadataForProcess.lumis().end()));
     }
   }
 
   void MergeableRunProductMetadata::postWriteRun() {
-
     lumisProcessed_.clear();
-    for (auto & metadataForProcess : metadataForProcesses_) {
+    for (auto& metadataForProcess : metadataForProcesses_) {
       metadataForProcess.reset();
     }
   }
 
-  void MergeableRunProductMetadata::
-  addEntryToStoredMetadata(StoredMergeableRunProductMetadata& storedMetadata) const {
-
+  void MergeableRunProductMetadata::addEntryToStoredMetadata(StoredMergeableRunProductMetadata& storedMetadata) const {
     if (metadataForProcesses_.empty()) {
       return;
     }
@@ -191,14 +172,10 @@ namespace edm {
     unsigned long long beginProcess = storedMetadata.singleRunEntryAndProcesses().size();
     unsigned long long endProcess = beginProcess;
 
-
     std::vector<std::string> const& processesWithMergeableRunProducts =
-      mergeableRunProductProcesses_->processesWithMergeableRunProducts();
+        mergeableRunProductProcesses_->processesWithMergeableRunProducts();
 
-    for (unsigned int storedProcessIndex = 0;
-         storedProcessIndex < storedProcesses.size();
-         ++storedProcessIndex) {
-
+    for (unsigned int storedProcessIndex = 0; storedProcessIndex < storedProcesses.size(); ++storedProcessIndex) {
       // Look for a matching process. It is intentional that no process
       // is added when there is no match. storedProcesses only contains
       // processes which created mergeable run products selected by the
@@ -207,21 +184,14 @@ namespace edm {
       // read from the input data files. Note storedProcesses may be
       // missing processes because the output module dropped products.
       // The other vector may be missing processes because of SubProcesses.
-      for (unsigned int transientProcessIndex = 0;
-           transientProcessIndex < processesWithMergeableRunProducts.size();
+      for (unsigned int transientProcessIndex = 0; transientProcessIndex < processesWithMergeableRunProducts.size();
            ++transientProcessIndex) {
-
         // This string comparison could be optimized away by storing an index mapping in
         // OutputModuleBase calculated once early in a job. (? Given how rare
         // mergeable run products are this optimization may not be worth doing)
-        if (processesWithMergeableRunProducts[transientProcessIndex] ==
-            storedProcesses[storedProcessIndex]) {
-
-          if (addProcess(storedMetadata,
-                         metadataForProcesses_.at(transientProcessIndex),
-                         storedProcessIndex,
-                         beginProcess,
-                         endProcess)) {
+        if (processesWithMergeableRunProducts[transientProcessIndex] == storedProcesses[storedProcessIndex]) {
+          if (addProcess(storedMetadata, metadataForProcesses_.at(transientProcessIndex), storedProcessIndex,
+                         beginProcess, endProcess)) {
             ++endProcess;
           }
           break;
@@ -231,15 +201,12 @@ namespace edm {
     storedMetadata.singleRunEntries().emplace_back(beginProcess, endProcess);
   }
 
-  bool MergeableRunProductMetadata::
-  addProcess(StoredMergeableRunProductMetadata& storedMetadata,
-             MetadataForProcess const& metadataForProcess,
-             unsigned int storedProcessIndex,
-             unsigned long long beginProcess,
-             unsigned long long endProcess) const {
-
-    if (metadataForProcess.valid() &&
-        metadataForProcess.allLumisProcessed()) {
+  bool MergeableRunProductMetadata::addProcess(StoredMergeableRunProductMetadata& storedMetadata,
+                                               MetadataForProcess const& metadataForProcess,
+                                               unsigned int storedProcessIndex,
+                                               unsigned long long beginProcess,
+                                               unsigned long long endProcess) const {
+    if (metadataForProcess.valid() && metadataForProcess.allLumisProcessed()) {
       return false;
     }
 
@@ -262,15 +229,12 @@ namespace edm {
       // the only thing that can happen is more lumi numbers appear
       // at steps where a run was only partially processed.
       bool found = false;
-      for (unsigned long long kProcess = beginProcess;
-           kProcess < endProcess;
-           ++kProcess) {
+      for (unsigned long long kProcess = beginProcess; kProcess < endProcess; ++kProcess) {
         StoredMergeableRunProductMetadata::SingleRunEntryAndProcess const& storedSingleRunEntryAndProcess =
-          storedMetadata.singleRunEntryAndProcesses().at(kProcess);
+            storedMetadata.singleRunEntryAndProcesses().at(kProcess);
 
         if (metadataForProcess.lumis().size() ==
             (storedSingleRunEntryAndProcess.endLumi() - storedSingleRunEntryAndProcess.beginLumi())) {
-
           iBeginLumi = storedSingleRunEntryAndProcess.beginLumi();
           iEndLumi = storedSingleRunEntryAndProcess.endLumi();
           found = true;
@@ -281,35 +245,28 @@ namespace edm {
         std::vector<LuminosityBlockNumber_t>& storedLumis = storedMetadata.lumis();
         std::vector<LuminosityBlockNumber_t> const& metdataLumis = metadataForProcess.lumis();
         iBeginLumi = storedLumis.size();
-        storedLumis.insert( storedLumis.end(), metdataLumis.begin(), metdataLumis.end() );
+        storedLumis.insert(storedLumis.end(), metdataLumis.begin(), metdataLumis.end());
         iEndLumi = storedLumis.size();
       }
     }
-    storedMetadata.singleRunEntryAndProcesses().emplace_back(iBeginLumi,
-                                                             iEndLumi,
-                                                             storedProcessIndex,
-                                                             metadataForProcess.valid(),
-                                                             metadataForProcess.allLumisProcessed());
+    storedMetadata.singleRunEntryAndProcesses().emplace_back(
+        iBeginLumi, iEndLumi, storedProcessIndex, metadataForProcess.valid(), metadataForProcess.allLumisProcessed());
     return true;
   }
 
-  MergeableRunProductMetadata::MergeDecision
-  MergeableRunProductMetadata::getMergeDecision(std::string const& processThatCreatedProduct) const {
-
+  MergeableRunProductMetadata::MergeDecision MergeableRunProductMetadata::getMergeDecision(
+      std::string const& processThatCreatedProduct) const {
     MetadataForProcess const* metadataForProcess = metadataForOneProcess(processThatCreatedProduct);
     if (metadataForProcess) {
       return metadataForProcess->mergeDecision();
     }
-    throw Exception(errors::LogicError)
-      << "MergeableRunProductMetadata::getMergeDecision could not find process.\n"
-      << "It should not be possible for this error to occur.\n"
-      << "Contact a Framework developer\n";
+    throw Exception(errors::LogicError) << "MergeableRunProductMetadata::getMergeDecision could not find process.\n"
+                                        << "It should not be possible for this error to occur.\n"
+                                        << "Contact a Framework developer\n";
     return MERGE;
   }
 
-  bool
-  MergeableRunProductMetadata::knownImproperlyMerged(std::string const& processThatCreatedProduct) const {
-
+  bool MergeableRunProductMetadata::knownImproperlyMerged(std::string const& processThatCreatedProduct) const {
     MetadataForProcess const* metadataForProcess = metadataForOneProcess(processThatCreatedProduct);
     if (metadataForProcess) {
       return !metadataForProcess->valid();
@@ -325,8 +282,8 @@ namespace edm {
     allLumisProcessed_ = false;
   }
 
-  MergeableRunProductMetadata::MetadataForProcess const*
-  MergeableRunProductMetadata::metadataForOneProcess(std::string const& processName) const {
+  MergeableRunProductMetadata::MetadataForProcess const* MergeableRunProductMetadata::metadataForOneProcess(
+      std::string const& processName) const {
     unsigned int processIndex = 0;
     for (auto const& metadataForProcess : metadataForProcesses_) {
       // This string comparison could be optimized away by storing an index in
@@ -340,8 +297,7 @@ namespace edm {
   }
 
   void MergeableRunProductMetadata::mergeLumisFromIndexIntoFile() {
-
-    for (auto & metadataForProcess : metadataForProcesses_) {
+    for (auto& metadataForProcess : metadataForProcesses_) {
       if (metadataForProcess.useIndexIntoFile()) {
         metadataForProcess.setUseIndexIntoFile(false);
 
@@ -350,7 +306,7 @@ namespace edm {
         std::vector<LuminosityBlockNumber_t>::const_iterator end1 = metadataForProcess.lumis().end();
         std::vector<LuminosityBlockNumber_t>::const_iterator end2 = lumisFromIndexIntoFile_.end();
         for (std::vector<LuminosityBlockNumber_t>::const_iterator iter1 = metadataForProcess.lumis().begin(),
-             iter2 = lumisFromIndexIntoFile_.begin();
+                                                                  iter2 = lumisFromIndexIntoFile_.begin();
              iter1 != end1 || iter2 != end2;) {
           if (iter1 == end1) {
             temp.push_back(*iter2);
@@ -379,4 +335,4 @@ namespace edm {
     lumisFromIndexIntoFile_.clear();
     gotLumisFromIndexIntoFile_ = false;
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/MergeableRunProductProcesses.cc
+++ b/FWCore/Framework/src/MergeableRunProductProcesses.cc
@@ -13,7 +13,7 @@
 
 namespace edm {
 
-  MergeableRunProductProcesses::MergeableRunProductProcesses() { }
+  MergeableRunProductProcesses::MergeableRunProductProcesses() {}
 
   void MergeableRunProductProcesses::setProcessesWithMergeableRunProducts(ProductRegistry const& productRegistry) {
     TClass* wrapperBaseTClass = TypeWithDict::byName("edm::WrapperBase").getClass();
@@ -32,4 +32,4 @@ namespace edm {
     }
     processesWithMergeableRunProducts_.assign(processSet.begin(), processSet.end());
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/MessageForParent.h
+++ b/FWCore/Framework/src/MessageForParent.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     MessageForParent
-// 
+//
 /**\class MessageForSource MessageForParent.h FWCore/Framework/interface/MessageForParent.h
 
  Description: Information passed from parent to source when doing multicore processing
@@ -27,35 +27,30 @@
 // forward declarations
 
 namespace edm {
-   namespace multicore {
-      class MessageForParent
-      {
-      public:
-         MessageForParent(): m_dummy(0) {}
-         
-         //virtual ~MessageForSource();
-         
-         // ---------- const member functions ---------------------
-         
-         // ---------- static member functions --------------------
-         static size_t sizeForBuffer() {
-           return sizeof(MessageForParent);
-         }
+  namespace multicore {
+    class MessageForParent {
+    public:
+      MessageForParent() : m_dummy(0) {}
 
-      public:
-         // ---------- member functions ---------------------------
-         
+      //virtual ~MessageForSource();
 
-         //MessageForSource(const MessageForSource&); // allow default
-         
-         //const MessageForSource& operator=(const MessageForSource&); // allow default
-         
-         // ---------- member data --------------------------------
-         int m_dummy;
+      // ---------- const member functions ---------------------
 
-      };
+      // ---------- static member functions --------------------
+      static size_t sizeForBuffer() { return sizeof(MessageForParent); }
 
-   }
-}
+    public:
+      // ---------- member functions ---------------------------
+
+      //MessageForSource(const MessageForSource&); // allow default
+
+      //const MessageForSource& operator=(const MessageForSource&); // allow default
+
+      // ---------- member data --------------------------------
+      int m_dummy;
+    };
+
+  }  // namespace multicore
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/MessageForSource.h
+++ b/FWCore/Framework/src/MessageForSource.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     MessageForSource
-// 
+//
 /**\class MessageForSource MessageForSource.h FWCore/Framework/interface/MessageForSource.h
 
  Description: Information passed from controller to source when doing multicore processing
@@ -31,37 +31,30 @@
 // forward declarations
 
 namespace edm {
-   namespace multicore {
-      class MessageForSource
-      {
-         
-      public:
-         MessageForSource():
-          startIndex(0),
-          nIndices(0) {}
-         
-         //virtual ~MessageForSource();
-         
-         // ---------- const member functions ---------------------
-         
-         // ---------- static member functions --------------------
-         static size_t sizeForBuffer() {
-            return sizeof(MessageForSource);
-         }
-         
-         // ---------- member functions ---------------------------
-         
-      public:
-         //MessageForSource(const MessageForSource&); // allow default
-         
-         //const MessageForSource& operator=(const MessageForSource&); // allow default
-         
-         // ---------- member data --------------------------------
-         unsigned long startIndex; //which event index to start processing for this 'block'
-         unsigned long nIndices; //number of consecutive indicies in the block
+  namespace multicore {
+    class MessageForSource {
+    public:
+      MessageForSource() : startIndex(0), nIndices(0) {}
 
-      };
-   }
-}
+      //virtual ~MessageForSource();
+
+      // ---------- const member functions ---------------------
+
+      // ---------- static member functions --------------------
+      static size_t sizeForBuffer() { return sizeof(MessageForSource); }
+
+      // ---------- member functions ---------------------------
+
+    public:
+      //MessageForSource(const MessageForSource&); // allow default
+
+      //const MessageForSource& operator=(const MessageForSource&); // allow default
+
+      // ---------- member data --------------------------------
+      unsigned long startIndex;  //which event index to start processing for this 'block'
+      unsigned long nIndices;    //number of consecutive indicies in the block
+    };
+  }  // namespace multicore
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/ModuleChanger.cc
+++ b/FWCore/Framework/src/ModuleChanger.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     ModuleChanger
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -28,20 +28,15 @@ using namespace edm;
 //
 // constructors and destructor
 //
-ModuleChanger::ModuleChanger(Schedule* iSchedule, ProductRegistry const* iRegistry):
-schedule_(iSchedule),
-registry_(iRegistry)
-{
-}
+ModuleChanger::ModuleChanger(Schedule* iSchedule, ProductRegistry const* iRegistry)
+    : schedule_(iSchedule), registry_(iRegistry) {}
 
 // ModuleChanger::ModuleChanger(const ModuleChanger& rhs)
 // {
 //    // do actual copying here;
 // }
 
-ModuleChanger::~ModuleChanger()
-{
-}
+ModuleChanger::~ModuleChanger() {}
 
 //
 // assignment operators
@@ -59,11 +54,8 @@ ModuleChanger::~ModuleChanger()
 // member functions
 //
 
-bool 
-ModuleChanger::changeModule(const std::string& iLabel,
-                            const ParameterSet& iPSet)
-{
-   return schedule_->changeModule(iLabel,iPSet, *registry_);
+bool ModuleChanger::changeModule(const std::string& iLabel, const ParameterSet& iPSet) {
+  return schedule_->changeModule(iLabel, iPSet, *registry_);
 }
 
 //

--- a/FWCore/Framework/src/ModuleFactory.cc
+++ b/FWCore/Framework/src/ModuleFactory.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     ModuleFactory
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -21,36 +21,34 @@
 // constants, enums and typedefs
 //
 namespace edm {
-   namespace eventsetup {
+  namespace eventsetup {
 
-//
-// static member functions
-//
-      std::string ModuleMakerTraits::name() { return "CMS EDM Framework ESModule"; }
-      void ModuleMakerTraits::addTo(EventSetupProvider& iProvider,
-                                    std::shared_ptr<DataProxyProvider> iComponent,
-                                    ParameterSet const&,
-                                    bool) 
-      {
-         iProvider.add(iComponent);
-      }
+    //
+    // static member functions
+    //
+    std::string ModuleMakerTraits::name() { return "CMS EDM Framework ESModule"; }
+    void ModuleMakerTraits::addTo(EventSetupProvider& iProvider,
+                                  std::shared_ptr<DataProxyProvider> iComponent,
+                                  ParameterSet const&,
+                                  bool) {
+      iProvider.add(iComponent);
+    }
 
-      void ModuleMakerTraits::replaceExisting(EventSetupProvider& iProvider, std::shared_ptr<DataProxyProvider> iComponent) 
-      {
-         iProvider.replaceExisting(iComponent);
-      }
+    void ModuleMakerTraits::replaceExisting(EventSetupProvider& iProvider,
+                                            std::shared_ptr<DataProxyProvider> iComponent) {
+      iProvider.replaceExisting(iComponent);
+    }
 
-      std::shared_ptr<ModuleMakerTraits::base_type>
-      ModuleMakerTraits::getComponentAndRegisterProcess(EventSetupsController& esController,
-                                                        ParameterSet const& iConfiguration) {
-         return esController.getESProducerAndRegisterProcess(iConfiguration, esController.indexOfNextProcess());
-      }
+    std::shared_ptr<ModuleMakerTraits::base_type> ModuleMakerTraits::getComponentAndRegisterProcess(
+        EventSetupsController& esController, ParameterSet const& iConfiguration) {
+      return esController.getESProducerAndRegisterProcess(iConfiguration, esController.indexOfNextProcess());
+    }
 
-      void ModuleMakerTraits::putComponent(EventSetupsController& esController,
-                                           ParameterSet const& iConfiguration,
-                                           std::shared_ptr<base_type> const& component) {
-         esController.putESProducer(iConfiguration, component, esController.indexOfNextProcess());
-      }
-   }
-}
+    void ModuleMakerTraits::putComponent(EventSetupsController& esController,
+                                         ParameterSet const& iConfiguration,
+                                         std::shared_ptr<base_type> const& component) {
+      esController.putESProducer(iConfiguration, component, esController.indexOfNextProcess());
+    }
+  }  // namespace eventsetup
+}  // namespace edm
 COMPONENTFACTORY_GET(edm::eventsetup::ModuleMakerTraits);

--- a/FWCore/Framework/src/ModuleHolder.cc
+++ b/FWCore/Framework/src/ModuleHolder.cc
@@ -2,7 +2,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     ModuleHolder
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -16,12 +16,10 @@
 #include "FWCore/Framework/src/ModuleHolder.h"
 #include "FWCore/Framework/src/WorkerMaker.h"
 
-
 namespace edm {
   namespace maker {
-    std::unique_ptr<Worker>
-    ModuleHolder::makeWorker(ExceptionToActionTable const* iActions) const {
-      return m_maker->makeWorker(iActions,this);
+    std::unique_ptr<Worker> ModuleHolder::makeWorker(ExceptionToActionTable const* iActions) const {
+      return m_maker->makeWorker(iActions, this);
     }
-  }
-}
+  }  // namespace maker
+}  // namespace edm

--- a/FWCore/Framework/src/ModuleHolder.h
+++ b/FWCore/Framework/src/ModuleHolder.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     ModuleHolder
-// 
+//
 /**\class edm::maker::ModuleHolder ModuleHolder.h "FWCore/Framework/src/ModuleHolder.h"
 
  Description: Base class used to own a module for the framework
@@ -36,56 +36,48 @@ namespace edm {
   namespace maker {
     class ModuleHolder {
     public:
-      ModuleHolder(Maker const* iMaker):
-      m_maker(iMaker){}
+      ModuleHolder(Maker const* iMaker) : m_maker(iMaker) {}
       virtual ~ModuleHolder() {}
       std::unique_ptr<Worker> makeWorker(ExceptionToActionTable const* actions) const;
-      
+
       virtual ModuleDescription const& moduleDescription() const = 0;
       virtual void setModuleDescription(ModuleDescription const& iDesc) = 0;
-      virtual void preallocate(PreallocationConfiguration const& ) = 0;
-      virtual void registerProductsAndCallbacks(ProductRegistry*)=0;
+      virtual void preallocate(PreallocationConfiguration const&) = 0;
+      virtual void registerProductsAndCallbacks(ProductRegistry*) = 0;
       virtual void replaceModuleFor(Worker*) const = 0;
 
       virtual std::unique_ptr<OutputModuleCommunicator> createOutputModuleCommunicator() = 0;
+
     protected:
       Maker const* m_maker;
     };
-    
-    template<typename T>
-    class ModuleHolderT : public ModuleHolder {
+
+    template <typename T> class ModuleHolderT : public ModuleHolder {
     public:
-      ModuleHolderT(std::shared_ptr<T> iModule, Maker const* iMaker) :ModuleHolder(iMaker), m_mod(iModule) {}
+      ModuleHolderT(std::shared_ptr<T> iModule, Maker const* iMaker) : ModuleHolder(iMaker), m_mod(iModule) {}
       ~ModuleHolderT() override {}
       std::shared_ptr<T> module() const { return m_mod; }
       void replaceModuleFor(Worker* iWorker) const override {
         auto w = dynamic_cast<WorkerT<T>*>(iWorker);
-        assert(nullptr!=w);
+        assert(nullptr != w);
         w->setModule(m_mod);
       }
-      ModuleDescription const& moduleDescription() const override {
-        return m_mod->moduleDescription();
-      }
-      void setModuleDescription(ModuleDescription const& iDesc) override {
-        m_mod->setModuleDescription(iDesc);
-      }
-      void preallocate(PreallocationConfiguration const& iPrealloc) override {
-        m_mod->doPreallocate(iPrealloc);
-      }
+      ModuleDescription const& moduleDescription() const override { return m_mod->moduleDescription(); }
+      void setModuleDescription(ModuleDescription const& iDesc) override { m_mod->setModuleDescription(iDesc); }
+      void preallocate(PreallocationConfiguration const& iPrealloc) override { m_mod->doPreallocate(iPrealloc); }
 
       void registerProductsAndCallbacks(ProductRegistry* iReg) override {
-        m_mod->registerProductsAndCallbacks(module().get(),iReg);
+        m_mod->registerProductsAndCallbacks(module().get(), iReg);
       }
-      
-      std::unique_ptr<OutputModuleCommunicator>
-      createOutputModuleCommunicator() override {
+
+      std::unique_ptr<OutputModuleCommunicator> createOutputModuleCommunicator() override {
         return std::move(OutputModuleCommunicatorT<T>::createIfNeeded(m_mod.get()));
       }
+
     private:
       std::shared_ptr<T> m_mod;
-
     };
-  }
-}
+  }  // namespace maker
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/ModuleRegistry.cc
+++ b/FWCore/Framework/src/ModuleRegistry.cc
@@ -2,7 +2,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     edm::ModuleRegistry
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -16,36 +16,32 @@
 #include "FWCore/Framework/src/ModuleRegistry.h"
 #include "FWCore/Framework/src/Factory.h"
 
-
 namespace edm {
-  std::shared_ptr<maker::ModuleHolder>
-  ModuleRegistry::getModule(MakeModuleParams const& p,
-                            std::string const& moduleLabel,
-                            signalslot::Signal<void(ModuleDescription const&)>& iPre,
-                            signalslot::Signal<void(ModuleDescription const&)>& iPost) {
+  std::shared_ptr<maker::ModuleHolder> ModuleRegistry::getModule(
+      MakeModuleParams const& p,
+      std::string const& moduleLabel,
+      signalslot::Signal<void(ModuleDescription const&)>& iPre,
+      signalslot::Signal<void(ModuleDescription const&)>& iPost) {
     auto modItr = labelToModule_.find(moduleLabel);
-    if(modItr == labelToModule_.end()) {
-      auto modPtr=
-      Factory::get()->makeModule(p,iPre,iPost);
-      
+    if (modItr == labelToModule_.end()) {
+      auto modPtr = Factory::get()->makeModule(p, iPre, iPost);
+
       // Transfer ownership of worker to the registry
       labelToModule_[moduleLabel] = modPtr;
       return modPtr;
     }
     return get_underlying_safe(modItr->second);
   }
-  
-  maker::ModuleHolder*
-  ModuleRegistry::replaceModule(std::string const& iModuleLabel,
-                                edm::ParameterSet const& iPSet,
-                                edm::PreallocationConfiguration const& iPrealloc) {
+
+  maker::ModuleHolder* ModuleRegistry::replaceModule(std::string const& iModuleLabel,
+                                                     edm::ParameterSet const& iPSet,
+                                                     edm::PreallocationConfiguration const& iPrealloc) {
     auto modItr = labelToModule_.find(iModuleLabel);
     if (modItr == labelToModule_.end()) {
       return nullptr;
     }
-    
-    auto modPtr=
-    Factory::get()->makeReplacementModule(iPSet);
+
+    auto modPtr = Factory::get()->makeReplacementModule(iPSet);
     modPtr->setModuleDescription(modItr->second->moduleDescription());
     modPtr->preallocate(iPrealloc);
 
@@ -53,4 +49,4 @@ namespace edm {
     modItr->second = modPtr;
     return modItr->second.get();
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/ModuleRegistry.h
+++ b/FWCore/Framework/src/ModuleRegistry.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     ModuleRegistry
-// 
+//
 /**\class edm::ModuleRegistry ModuleRegistry.h "FWCore/Framework/src/ModuleRegistry.h"
 
  Description: Constructs and owns framework modules
@@ -36,30 +36,28 @@ namespace edm {
   namespace maker {
     class ModuleHolder;
   }
-  
-  class ModuleRegistry
-  {
+
+  class ModuleRegistry {
   public:
     std::shared_ptr<maker::ModuleHolder> getModule(MakeModuleParams const& p,
                                                    std::string const& moduleLabel,
                                                    signalslot::Signal<void(ModuleDescription const&)>& iPre,
                                                    signalslot::Signal<void(ModuleDescription const&)>& iPost);
-    
+
     maker::ModuleHolder* replaceModule(std::string const& iModuleLabel,
                                        edm::ParameterSet const& iPSet,
                                        edm::PreallocationConfiguration const&);
-    
-    template <typename F>
-    void forAllModuleHolders(F iFunc) {
-      for(auto& labelMod: labelToModule_) {
+
+    template <typename F> void forAllModuleHolders(F iFunc) {
+      for (auto& labelMod : labelToModule_) {
         maker::ModuleHolder* t = labelMod.second.get();
         iFunc(t);
       }
     }
+
   private:
     std::map<std::string, edm::propagate_const<std::shared_ptr<maker::ModuleHolder>>> labelToModule_;
   };
-}
-
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/NoDataException.cc
+++ b/FWCore/Framework/src/NoDataException.cc
@@ -3,52 +3,45 @@
 namespace edm {
   namespace eventsetup {
 
-     NoDataExceptionBase::NoDataExceptionBase(const EventSetupRecordKey& iRecordKey,
-                                              const DataKey& iDataKey,
-                                              const char* category_name) :
-     cms::Exception(category_name),
-     record_(iRecordKey),
-     dataKey_(iDataKey)
-     {
-     }
-     
-     NoDataExceptionBase::~NoDataExceptionBase() noexcept {}
-     
-     const DataKey& NoDataExceptionBase::dataKey() const { return dataKey_; }
-     
-     std::string NoDataExceptionBase::providerButNoDataMessage(const EventSetupRecordKey& iKey) {
-        return std::string(" A provider for this data exists, but it's unable to deliver the data for this \"")
-        +iKey.name()
-        +"\" record.\n Perhaps no valid data exists for this IOV? Please check the data's interval of validity.\n";
-     }
-     
-     std::string NoDataExceptionBase::noProxyMessage() {
-        return std::string("Please add an ESSource or ESProducer to your job which can deliver this data.\n");
-     }
-     
-     void NoDataExceptionBase::beginDataTypeMessage(std::string& oString) const
-     {
-        oString+= std::string("No data of type \"");
-     }
-     
-     void NoDataExceptionBase::endDataTypeMessage(std::string& oString) const
-     {
-        oString += "\" with label \"";
-        oString += this->dataKey_.name().value();
-        oString += "\" in record \"";
-        oString += this->record_.name();
-        oString += "\"";
-     }
-     
-     void NoDataExceptionBase::constructMessage(const char* iClassName, const std::string& iExtraInfo)
-     {
-        std::string message;
-        beginDataTypeMessage(message);
-        message += iClassName;
-        endDataTypeMessage(message);
-        this->append(message+std::string("\n "));
-        this->append(iExtraInfo);
-     }
-     
-  }
-}
+    NoDataExceptionBase::NoDataExceptionBase(const EventSetupRecordKey& iRecordKey,
+                                             const DataKey& iDataKey,
+                                             const char* category_name)
+        : cms::Exception(category_name), record_(iRecordKey), dataKey_(iDataKey) {}
+
+    NoDataExceptionBase::~NoDataExceptionBase() noexcept {}
+
+    const DataKey& NoDataExceptionBase::dataKey() const { return dataKey_; }
+
+    std::string NoDataExceptionBase::providerButNoDataMessage(const EventSetupRecordKey& iKey) {
+      return std::string(" A provider for this data exists, but it's unable to deliver the data for this \"") +
+             iKey.name() +
+             "\" record.\n Perhaps no valid data exists for this IOV? Please check the data's interval of validity.\n";
+    }
+
+    std::string NoDataExceptionBase::noProxyMessage() {
+      return std::string("Please add an ESSource or ESProducer to your job which can deliver this data.\n");
+    }
+
+    void NoDataExceptionBase::beginDataTypeMessage(std::string& oString) const {
+      oString += std::string("No data of type \"");
+    }
+
+    void NoDataExceptionBase::endDataTypeMessage(std::string& oString) const {
+      oString += "\" with label \"";
+      oString += this->dataKey_.name().value();
+      oString += "\" in record \"";
+      oString += this->record_.name();
+      oString += "\"";
+    }
+
+    void NoDataExceptionBase::constructMessage(const char* iClassName, const std::string& iExtraInfo) {
+      std::string message;
+      beginDataTypeMessage(message);
+      message += iClassName;
+      endDataTypeMessage(message);
+      this->append(message + std::string("\n "));
+      this->append(iExtraInfo);
+    }
+
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/NoRecordException.cc
+++ b/FWCore/Framework/src/NoRecordException.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     NoRecordException
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -19,24 +19,21 @@
 #include "FWCore/Framework/interface/EventSetupImpl.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-bool
-edm::eventsetup::recordDoesExist( EventSetupImpl const& iES, EventSetupRecordKey const& iKey) {
+bool edm::eventsetup::recordDoesExist(EventSetupImpl const& iES, EventSetupRecordKey const& iKey) {
   return iES.recordIsProvidedByAModule(iKey);
 }
 
-
-void
-edm::eventsetup::no_record_exception_message_builder(cms::Exception& oException, const char* iName, bool iKnownRecord) {
-   oException
-   << "No \"" 
-   << iName
-   << "\" record found in the EventSetup.n";
-  if(iKnownRecord) {
-   oException<<"\n The Record is delivered by an ESSource or ESProducer but there is no valid IOV for the synchronizatio value.\n"
-    " Please check \n"
-    "   a) if the synchronization value is reasonable and report to the hypernews if it is not.\n"
-    "   b) else check that all ESSources have been properly configured. \n";
+void edm::eventsetup::no_record_exception_message_builder(cms::Exception& oException,
+                                                          const char* iName,
+                                                          bool iKnownRecord) {
+  oException << "No \"" << iName << "\" record found in the EventSetup.n";
+  if (iKnownRecord) {
+    oException << "\n The Record is delivered by an ESSource or ESProducer but there is no valid IOV for the "
+                  "synchronizatio value.\n"
+                  " Please check \n"
+                  "   a) if the synchronization value is reasonable and report to the hypernews if it is not.\n"
+                  "   b) else check that all ESSources have been properly configured. \n";
   } else {
-   oException <<"\n Please add an ESSource or ESProducer that delivers such a record.\n";
+    oException << "\n Please add an ESSource or ESProducer that delivers such a record.\n";
   }
 }

--- a/FWCore/Framework/src/OccurrenceForOutput.cc
+++ b/FWCore/Framework/src/OccurrenceForOutput.cc
@@ -12,65 +12,44 @@
 
 namespace edm {
 
-  OccurrenceForOutput::OccurrenceForOutput(Principal const& p, ModuleDescription const& md, ModuleCallingContext const* moduleCallingContext, bool isAtEnd) :
-      provRecorder_(p, md, isAtEnd),
-      moduleCallingContext_(moduleCallingContext)
-  {
-  }
+  OccurrenceForOutput::OccurrenceForOutput(Principal const& p,
+                                           ModuleDescription const& md,
+                                           ModuleCallingContext const* moduleCallingContext,
+                                           bool isAtEnd)
+      : provRecorder_(p, md, isAtEnd), moduleCallingContext_(moduleCallingContext) {}
 
-  OccurrenceForOutput::~OccurrenceForOutput() {
-  }
+  OccurrenceForOutput::~OccurrenceForOutput() {}
 
-  void
-  OccurrenceForOutput::setConsumer(EDConsumerBase const* iConsumer) {
-    provRecorder_.setConsumer(iConsumer);
-  }
+  void OccurrenceForOutput::setConsumer(EDConsumerBase const* iConsumer) { provRecorder_.setConsumer(iConsumer); }
 
-  Principal const&
-  OccurrenceForOutput::principal() const {
-    return provRecorder_.principal();
-  }
+  Principal const& OccurrenceForOutput::principal() const { return provRecorder_.principal(); }
 
-  ProcessHistoryID const&
-  OccurrenceForOutput::processHistoryID() const {
-    return principal().processHistoryID();
-  }
+  ProcessHistoryID const& OccurrenceForOutput::processHistoryID() const { return principal().processHistoryID(); }
 
-  Provenance
-  OccurrenceForOutput::getProvenance(BranchID const& bid) const {
+  Provenance OccurrenceForOutput::getProvenance(BranchID const& bid) const {
     return provRecorder_.principal().getProvenance(bid, moduleCallingContext_);
   }
 
-  void
-  OccurrenceForOutput::getAllProvenance(std::vector<Provenance const*>& provenances) const {
+  void OccurrenceForOutput::getAllProvenance(std::vector<Provenance const*>& provenances) const {
     provRecorder_.principal().getAllProvenance(provenances);
   }
 
-  void
-  OccurrenceForOutput::getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const {
+  void OccurrenceForOutput::getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const {
     provRecorder_.principal().getAllStableProvenance(provenances);
   }
 
-  ProcessHistory const&
-  OccurrenceForOutput::processHistory() const {
-    return provRecorder_.processHistory();
-  }
+  ProcessHistory const& OccurrenceForOutput::processHistory() const { return provRecorder_.processHistory(); }
 
-  size_t
-  OccurrenceForOutput::size() const {
-    return provRecorder_.principal().size();
-  }
+  size_t OccurrenceForOutput::size() const { return provRecorder_.principal().size(); }
 
-  BasicHandle
-  OccurrenceForOutput::getByToken(EDGetToken token, TypeID const& typeID) const {
+  BasicHandle OccurrenceForOutput::getByToken(EDGetToken token, TypeID const& typeID) const {
     auto result = provRecorder_.getByToken_(typeID, PRODUCT_TYPE, token, moduleCallingContext_);
     if (result.failedToGet()) {
       return result;
     }
-    if(!provRecorder_.isComplete() && result.wrapper()->isMergeable()) {
+    if (!provRecorder_.isComplete() && result.wrapper()->isMergeable()) {
       principal_get_adapter_detail::throwOnPrematureRead("RunOrLumi", typeID, token);
     }
     return result;
   }
-}
-
+}  // namespace edm

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -37,46 +37,39 @@
 namespace edm {
 
   // -------------------------------------------------------
-  OutputModule::OutputModule(ParameterSet const& pset) :
-    maxEvents_(-1),
-    remainingEvents_(maxEvents_),
-    keptProducts_(),
-    hasNewlyDroppedBranch_(),
-    process_name_(),
-    productSelectorRules_(pset, "outputCommands", "OutputModule"),
-    productSelector_(),
-    moduleDescription_(),
-    wantAllEvents_(false),
-    selectors_(),
-    selector_config_id_(),
-    droppedBranchIDToKeptBranchID_(),
-    branchIDLists_(new BranchIDLists),
-    origBranchIDLists_(nullptr),
-    thinnedAssociationsHelper_(new ThinnedAssociationsHelper) {
-
+  OutputModule::OutputModule(ParameterSet const& pset)
+      : maxEvents_(-1),
+        remainingEvents_(maxEvents_),
+        keptProducts_(),
+        hasNewlyDroppedBranch_(),
+        process_name_(),
+        productSelectorRules_(pset, "outputCommands", "OutputModule"),
+        productSelector_(),
+        moduleDescription_(),
+        wantAllEvents_(false),
+        selectors_(),
+        selector_config_id_(),
+        droppedBranchIDToKeptBranchID_(),
+        branchIDLists_(new BranchIDLists),
+        origBranchIDLists_(nullptr),
+        thinnedAssociationsHelper_(new ThinnedAssociationsHelper) {
     hasNewlyDroppedBranch_.fill(false);
 
     Service<service::TriggerNamesService> tns;
     process_name_ = tns->getProcessName();
 
-    selectEvents_ =
-      pset.getUntrackedParameterSet("SelectEvents", ParameterSet());
+    selectEvents_ = pset.getUntrackedParameterSet("SelectEvents", ParameterSet());
 
-    selectEvents_.registerIt(); // Just in case this PSet is not registered
+    selectEvents_.registerIt();  // Just in case this PSet is not registered
 
     selector_config_id_ = selectEvents_.id();
     selectors_.resize(1);
     //need to set wantAllEvents_ in constructor
     // we will make the remaining selectors once we know how many streams
-    wantAllEvents_ = detail::configureEventSelector(selectEvents_,
-                                                          process_name_,
-                                                          getAllTriggerNames(),
-                                                          selectors_[0],
-                                                          consumesCollector());
+    wantAllEvents_ = detail::configureEventSelector(selectEvents_, process_name_, getAllTriggerNames(), selectors_[0],
+                                                    consumesCollector());
 
-    SharedResourcesRegistry::instance()->registerSharedResource(
-                                                                SharedResourcesRegistry::kLegacyModuleResourceName);
-
+    SharedResourcesRegistry::instance()->registerSharedResource(SharedResourcesRegistry::kLegacyModuleResourceName);
   }
 
   void OutputModule::configure(OutputModuleDescription const& desc) {
@@ -86,7 +79,8 @@ namespace edm {
 
   void OutputModule::selectProducts(ProductRegistry const& preg,
                                     ThinnedAssociationsHelper const& thinnedAssociationsHelper) {
-    if(productSelector_.initialized()) return;
+    if (productSelector_.initialized())
+      return;
     productSelector_.initialize(productSelectorRules_, preg.allBranchDescriptions());
 
     // TODO: See if we can collapse keptProducts_ and productSelector_ into a
@@ -98,19 +92,18 @@ namespace edm {
     std::set<BranchID> keptProductsInEvent;
     std::set<std::string> processesWithSelectedMergeableRunProducts;
 
-    for(auto const& it : preg.productList()) {
+    for (auto const& it : preg.productList()) {
       BranchDescription const& desc = it.second;
-      if(desc.transient()) {
+      if (desc.transient()) {
         // if the class of the branch is marked transient, output nothing
-      } else if(!desc.present() && !desc.produced()) {
+      } else if (!desc.present() && !desc.produced()) {
         // else if the branch containing the product has been previously dropped,
         // output nothing
-      } else if(desc.unwrappedType() == typeid(ThinnedAssociation)) {
+      } else if (desc.unwrappedType() == typeid(ThinnedAssociation)) {
         associationDescriptions.push_back(&desc);
-      } else if(selected(desc)) {
+      } else if (selected(desc)) {
         keepThisBranch(desc, trueBranchIDToKeptBranchDesc, keptProductsInEvent);
-        insertSelectedProcesses(desc,
-                                processesWithSelectedMergeableRunProducts);
+        insertSelectedProcesses(desc, processesWithSelectedMergeableRunProducts);
       } else {
         // otherwise, output nothing,
         // and mark the fact that there is a newly dropped branch of this type.
@@ -120,12 +113,10 @@ namespace edm {
 
     setProcessesWithSelectedMergeableRunProducts(processesWithSelectedMergeableRunProducts);
 
-    thinnedAssociationsHelper.selectAssociationProducts(associationDescriptions,
-                                                        keptProductsInEvent,
-                                                        keepAssociation_);
+    thinnedAssociationsHelper.selectAssociationProducts(associationDescriptions, keptProductsInEvent, keepAssociation_);
 
-    for(auto association : associationDescriptions) {
-      if(keepAssociation_[association->branchID()]) {
+    for (auto association : associationDescriptions) {
+      if (keepAssociation_[association->branchID()]) {
         keepThisBranch(*association, trueBranchIDToKeptBranchDesc, keptProductsInEvent);
       } else {
         hasNewlyDroppedBranch_[association->branchType()] = true;
@@ -135,15 +126,14 @@ namespace edm {
     // Now fill in a mapping needed in the case that a branch was dropped while its EDAlias was kept.
     ProductSelector::fillDroppedToKept(preg, trueBranchIDToKeptBranchDesc, droppedBranchIDToKeptBranchID_);
 
-    thinnedAssociationsHelper_->updateFromParentProcess(thinnedAssociationsHelper, keepAssociation_, droppedBranchIDToKeptBranchID_);
+    thinnedAssociationsHelper_->updateFromParentProcess(thinnedAssociationsHelper, keepAssociation_,
+                                                        droppedBranchIDToKeptBranchID_);
   }
 
   void OutputModule::keepThisBranch(BranchDescription const& desc,
                                     std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
                                     std::set<BranchID>& keptProductsInEvent) {
-
-    ProductSelector::checkForDuplicateKeptBranch(desc,
-                                                 trueBranchIDToKeptBranchDesc);
+    ProductSelector::checkForDuplicateKeptBranch(desc, trueBranchIDToKeptBranchDesc);
 
     EDGetToken token;
 
@@ -154,63 +144,49 @@ namespace edm {
     }
 
     switch (desc.branchType()) {
-    case InEvent:
-      {
-        if(desc.produced()) {
+      case InEvent: {
+        if (desc.produced()) {
           keptProductsInEvent.insert(desc.originalBranchID());
         } else {
           keptProductsInEvent.insert(desc.branchID());
         }
-        token = consumes(TypeToGet{desc.unwrappedTypeID(),PRODUCT_TYPE},
-                     InputTag{desc.moduleLabel(),
-                     desc.productInstanceName(),
-                     desc.processName()});
+        token = consumes(TypeToGet{desc.unwrappedTypeID(), PRODUCT_TYPE},
+                         InputTag{desc.moduleLabel(), desc.productInstanceName(), desc.processName()});
         break;
       }
-    case InLumi:
-      {
-        token = consumes<InLumi>(TypeToGet{desc.unwrappedTypeID(),PRODUCT_TYPE},
-                                  InputTag(desc.moduleLabel(),
-                                  desc.productInstanceName(),
-                                  desc.processName()));
+      case InLumi: {
+        token = consumes<InLumi>(TypeToGet{desc.unwrappedTypeID(), PRODUCT_TYPE},
+                                 InputTag(desc.moduleLabel(), desc.productInstanceName(), desc.processName()));
         break;
       }
-    case InRun:
-      {
-        token = consumes<InRun>(TypeToGet{desc.unwrappedTypeID(),PRODUCT_TYPE},
-                                 InputTag(desc.moduleLabel(),
-                                 desc.productInstanceName(),
-                                 desc.processName()));
+      case InRun: {
+        token = consumes<InRun>(TypeToGet{desc.unwrappedTypeID(), PRODUCT_TYPE},
+                                InputTag(desc.moduleLabel(), desc.productInstanceName(), desc.processName()));
         break;
       }
-    default:
-      assert(false);
-      break;
+      default:
+        assert(false);
+        break;
     }
     // Now put it in the list of selected branches.
     keptProducts_[desc.branchType()].push_back(std::make_pair(&desc, token));
   }
 
-  OutputModule::~OutputModule() { }
+  OutputModule::~OutputModule() {}
 
   void OutputModule::doPreallocate(PreallocationConfiguration const& iPC) {
     auto nstreams = iPC.numberOfStreams();
     selectors_.resize(nstreams);
 
     bool seenFirst = false;
-    for(auto& s : selectors_) {
-      if(seenFirst) {
-        detail::configureEventSelector(selectEvents_,
-                                       process_name_,
-                                       getAllTriggerNames(),
-                                       s,
-                                       consumesCollector());
+    for (auto& s : selectors_) {
+      if (seenFirst) {
+        detail::configureEventSelector(selectEvents_, process_name_, getAllTriggerNames(), s, consumesCollector());
       }
       seenFirst = true;
     }
   }
 
-  
   void OutputModule::doBeginJob() {
     std::vector<std::string> res = {SharedResourcesRegistry::kLegacyModuleResourceName};
     resourceAcquirer_ = SharedResourcesRegistry::instance()->createAcquirer(res);
@@ -218,10 +194,7 @@ namespace edm {
     this->beginJob();
   }
 
-  void OutputModule::doEndJob() {
-    endJob();
-  }
-
+  void OutputModule::doEndJob() { endJob(); }
 
   Trig OutputModule::getTriggerResults(EDGetTokenT<TriggerResults> const& token, EventForOutput const& e) const {
     //This cast is safe since we only call const functions of the EventForOutputafter this point
@@ -229,162 +202,141 @@ namespace edm {
     e.getByToken<TriggerResults>(token, result);
     return result;
   }
-  
-  bool OutputModule::needToRunSelection() const {
-    return !wantAllEvents_;
-  }
-  
-  std::vector<ProductResolverIndexAndSkipBit>
-  OutputModule::productsUsedBySelection() const {
+
+  bool OutputModule::needToRunSelection() const { return !wantAllEvents_; }
+
+  std::vector<ProductResolverIndexAndSkipBit> OutputModule::productsUsedBySelection() const {
     std::vector<ProductResolverIndexAndSkipBit> returnValue;
     auto const& s = selectors_[0];
     auto const n = s.numberOfTokens();
     returnValue.reserve(n);
-    
-    for(unsigned int i=0; i< n;++i) {
+
+    for (unsigned int i = 0; i < n; ++i) {
       returnValue.emplace_back(uncheckedIndexFrom(s.token(i)));
     }
     return returnValue;
   }
 
   bool OutputModule::prePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) {
-    if(wantAllEvents_) return true;
+    if (wantAllEvents_)
+      return true;
     auto& s = selectors_[id.value()];
     EventForOutput e(ep, moduleDescription_, mcc);
     e.setConsumer(this);
     return s.wantEvent(e);
   }
 
-  bool
-  OutputModule::doEvent(EventPrincipal const& ep,
-                        EventSetupImpl const&,
-                        ActivityRegistry* act,
-                        ModuleCallingContext const* mcc) {
-
+  bool OutputModule::doEvent(EventPrincipal const& ep,
+                             EventSetupImpl const&,
+                             ActivityRegistry* act,
+                             ModuleCallingContext const* mcc) {
     FDEBUG(2) << "writeEvent called\n";
 
     {
       EventForOutput e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
-      EventSignalsSentry sentry(act,mcc);
+      EventSignalsSentry sentry(act, mcc);
       write(e);
     }
-    if(remainingEvents_ > 0) {
+    if (remainingEvents_ > 0) {
       --remainingEvents_;
     }
     return true;
   }
 
-//   bool OutputModule::wantEvent(EventForOutput const& ev)
-//   {
-//     getTriggerResults(ev);
-//     bool eventAccepted = false;
+  //   bool OutputModule::wantEvent(EventForOutput const& ev)
+  //   {
+  //     getTriggerResults(ev);
+  //     bool eventAccepted = false;
 
-//     typedef std::vector<NamedEventSelector>::const_iterator iter;
-//     for(iter i = selectResult_.begin(), e = selectResult_.end();
-//          !eventAccepted && i != e; ++i)
-//       {
-//         eventAccepted = i->acceptEvent(*prods_);
-//       }
+  //     typedef std::vector<NamedEventSelector>::const_iterator iter;
+  //     for(iter i = selectResult_.begin(), e = selectResult_.end();
+  //          !eventAccepted && i != e; ++i)
+  //       {
+  //         eventAccepted = i->acceptEvent(*prods_);
+  //       }
 
-//     FDEBUG(2) << "Accept event " << ep.id() << " " << eventAccepted << "\n";
-//     return eventAccepted;
-//   }
+  //     FDEBUG(2) << "Accept event " << ep.id() << " " << eventAccepted << "\n";
+  //     return eventAccepted;
+  //   }
 
-  bool
-  OutputModule::doBeginRun(RunPrincipal const& rp,
-                           EventSetupImpl const&,
-                           ModuleCallingContext const* mcc) {
+  bool OutputModule::doBeginRun(RunPrincipal const& rp, EventSetupImpl const&, ModuleCallingContext const* mcc) {
     FDEBUG(2) << "beginRun called\n";
-    RunForOutput r(rp, moduleDescription_, mcc,false);
+    RunForOutput r(rp, moduleDescription_, mcc, false);
     r.setConsumer(this);
     beginRun(r);
     return true;
   }
 
-  bool
-  OutputModule::doEndRun(RunPrincipal const& rp,
-                         EventSetupImpl const&,
-                         ModuleCallingContext const* mcc) {
+  bool OutputModule::doEndRun(RunPrincipal const& rp, EventSetupImpl const&, ModuleCallingContext const* mcc) {
     FDEBUG(2) << "endRun called\n";
-    RunForOutput r(rp, moduleDescription_, mcc,true);
+    RunForOutput r(rp, moduleDescription_, mcc, true);
     r.setConsumer(this);
     endRun(r);
     return true;
   }
 
-  void
-  OutputModule::doWriteRun(RunPrincipal const& rp,
-                           ModuleCallingContext const* mcc,
-                           MergeableRunProductMetadata const* mrpm) {
+  void OutputModule::doWriteRun(RunPrincipal const& rp,
+                                ModuleCallingContext const* mcc,
+                                MergeableRunProductMetadata const* mrpm) {
     FDEBUG(2) << "writeRun called\n";
-    RunForOutput r(rp, moduleDescription_, mcc,true, mrpm);
+    RunForOutput r(rp, moduleDescription_, mcc, true, mrpm);
     r.setConsumer(this);
     writeRun(r);
   }
 
-  bool
-  OutputModule::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                       EventSetupImpl const&,
-                                       ModuleCallingContext const* mcc) {
+  bool OutputModule::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                            EventSetupImpl const&,
+                                            ModuleCallingContext const* mcc) {
     FDEBUG(2) << "beginLuminosityBlock called\n";
-    LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc,false);
+    LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, false);
     lb.setConsumer(this);
     beginLuminosityBlock(lb);
     return true;
   }
 
-  bool
-  OutputModule::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                     EventSetupImpl const&,
-                                     ModuleCallingContext const* mcc) {
+  bool OutputModule::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                          EventSetupImpl const&,
+                                          ModuleCallingContext const* mcc) {
     FDEBUG(2) << "endLuminosityBlock called\n";
-    LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc,true);
+    LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, true);
     lb.setConsumer(this);
     endLuminosityBlock(lb);
     return true;
   }
 
-  void OutputModule::doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                            ModuleCallingContext const* mcc) {
+  void OutputModule::doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const* mcc) {
     FDEBUG(2) << "writeLuminosityBlock called\n";
-    LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc,true);
+    LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, true);
     lb.setConsumer(this);
     writeLuminosityBlock(lb);
   }
 
-  void OutputModule::doOpenFile(FileBlock const& fb) {
-    openFile(fb);
-  }
+  void OutputModule::doOpenFile(FileBlock const& fb) { openFile(fb); }
 
-  void OutputModule::doRespondToOpenInputFile(FileBlock const& fb) {
-    respondToOpenInputFile(fb);
-  }
+  void OutputModule::doRespondToOpenInputFile(FileBlock const& fb) { respondToOpenInputFile(fb); }
 
-  void OutputModule::doRespondToCloseInputFile(FileBlock const& fb) {
-    respondToCloseInputFile(fb);
-  }
+  void OutputModule::doRespondToCloseInputFile(FileBlock const& fb) { respondToCloseInputFile(fb); }
 
   void OutputModule::doCloseFile() {
-    if(isFileOpen()) {
+    if (isFileOpen()) {
       reallyCloseFile();
     }
   }
 
-  void OutputModule::reallyCloseFile() {
-  }
+  void OutputModule::reallyCloseFile() {}
 
-  BranchIDLists const*
-  OutputModule::branchIDLists() {
-    if(!droppedBranchIDToKeptBranchID_.empty()) {
+  BranchIDLists const* OutputModule::branchIDLists() {
+    if (!droppedBranchIDToKeptBranchID_.empty()) {
       // Make a private copy of the BranchIDLists.
       *branchIDLists_ = *origBranchIDLists_;
       // Check for branches dropped while an EDAlias was kept.
-      for(BranchIDList& branchIDList : *branchIDLists_) {
-        for(BranchID::value_type& branchID : branchIDList) {
+      for (BranchIDList& branchIDList : *branchIDLists_) {
+        for (BranchID::value_type& branchID : branchIDList) {
           // Replace BranchID of each dropped branch with that of the kept alias, so the alias branch will have the product ID of the original branch.
-          std::map<BranchID::value_type, BranchID::value_type>::const_iterator iter = droppedBranchIDToKeptBranchID_.find(branchID);
-          if(iter != droppedBranchIDToKeptBranchID_.end()) {
+          std::map<BranchID::value_type, BranchID::value_type>::const_iterator iter =
+              droppedBranchIDToKeptBranchID_.find(branchID);
+          if (iter != droppedBranchIDToKeptBranchID_.end()) {
             branchID = iter->second;
           }
         }
@@ -394,51 +346,36 @@ namespace edm {
     return origBranchIDLists_;
   }
 
-  ThinnedAssociationsHelper const*
-  OutputModule::thinnedAssociationsHelper() const {
+  ThinnedAssociationsHelper const* OutputModule::thinnedAssociationsHelper() const {
     return thinnedAssociationsHelper_.get();
   }
 
-  ModuleDescription const&
-  OutputModule::description() const {
-    return moduleDescription_;
-  }
+  ModuleDescription const& OutputModule::description() const { return moduleDescription_; }
 
-  bool
-  OutputModule::selected(BranchDescription const& desc) const {
-    return productSelector_.selected(desc);
-  }
+  bool OutputModule::selected(BranchDescription const& desc) const { return productSelector_.selected(desc); }
 
-  void
-  OutputModule::fillDescriptions(ConfigurationDescriptions& descriptions) {
+  void OutputModule::fillDescriptions(ConfigurationDescriptions& descriptions) {
     ParameterSetDescription desc;
     desc.setUnknown();
     descriptions.addDefault(desc);
   }
-  
-  void
-  OutputModule::fillDescription(ParameterSetDescription& desc, std::vector<std::string> const& defaultOutputCommands) {
-    ProductSelectorRules::fillDescription(desc, "outputCommands",defaultOutputCommands);
+
+  void OutputModule::fillDescription(ParameterSetDescription& desc,
+                                     std::vector<std::string> const& defaultOutputCommands) {
+    ProductSelectorRules::fillDescription(desc, "outputCommands", defaultOutputCommands);
     EventSelector::fillDescription(desc);
   }
-  
-  void
-  OutputModule::prevalidate(ConfigurationDescriptions& ) {
-  }
-  
+
+  void OutputModule::prevalidate(ConfigurationDescriptions&) {}
 
   static const std::string kBaseType("OutputModule");
-  const std::string&
-  OutputModule::baseType() {
-    return kBaseType;
+  const std::string& OutputModule::baseType() { return kBaseType; }
+
+  void OutputModule::setEventSelectionInfo(
+      std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
+      bool anyProductProduced) {
+    selector_config_id_ =
+        detail::registerProperSelectionInfo(getParameterSet(selector_config_id_), description().moduleLabel(),
+                                            outputModulePathPositions, anyProductProduced);
   }
-  
-  void
-  OutputModule::setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
-                                      bool anyProductProduced) {
-    selector_config_id_ = detail::registerProperSelectionInfo(getParameterSet(selector_config_id_),
-                                      description().moduleLabel(),
-                                                      outputModulePathPositions,
-                                                      anyProductProduced);
-  }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/OutputModuleCommunicator.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicator.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Package
 // Class  :     OutputModuleCommunicator
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -17,6 +17,4 @@
 
 using namespace edm;
 
-OutputModuleCommunicator::~OutputModuleCommunicator()
-{
-}
+OutputModuleCommunicator::~OutputModuleCommunicator() {}

--- a/FWCore/Framework/src/OutputModuleCommunicator.h
+++ b/FWCore/Framework/src/OutputModuleCommunicator.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     OutputModuleCommunicator
-// 
+//
 /**\class edm::OutputModuleCommunicator OutputModuleCommunicator.h "FWCore/Framework/interface/OutputModuleCommunicator.h"
 
  Description: Base class used by the framework to communicate with an OutputModule
@@ -36,56 +36,54 @@ namespace edm {
   class ThinnedAssociationsHelper;
   class WaitingTaskHolder;
 
-  class OutputModuleCommunicator
-  {
-    
+  class OutputModuleCommunicator {
   public:
     OutputModuleCommunicator() = default;
     virtual ~OutputModuleCommunicator();
-    
+
     virtual void closeFile() = 0;
-    
+
     ///\return true if output module wishes to close its file
     virtual bool shouldWeCloseFile() const = 0;
-    
+
     ///\return true if no event filtering is applied to OutputModule
     virtual bool wantAllEvents() const = 0;
-    
+
     virtual void openFile(FileBlock const& fb) = 0;
-    
+
     virtual void writeRunAsync(WaitingTaskHolder iTask,
                                RunPrincipal const& rp,
                                ProcessContext const*,
                                ActivityRegistry*,
                                MergeableRunProductMetadata const*) = 0;
-    
+
     virtual void writeLumiAsync(WaitingTaskHolder iTask,
                                 LuminosityBlockPrincipal const& lbp,
                                 ProcessContext const*,
                                 ActivityRegistry*) = 0;
-    
+
     ///\return true if OutputModule has reached its limit on maximum number of events it wants to see
     virtual bool limitReached() const = 0;
-    
+
     virtual void configure(OutputModuleDescription const& desc) = 0;
-    
+
     virtual SelectedProductsForBranchType const& keptProducts() const = 0;
-    
+
     virtual void selectProducts(ProductRegistry const& preg, ThinnedAssociationsHelper const&) = 0;
-    
-    virtual void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
-                                       bool anyProductProduced) = 0;
+
+    virtual void setEventSelectionInfo(
+        std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
+        bool anyProductProduced) = 0;
 
     virtual ModuleDescription const& description() const = 0;
-    
+
   private:
-    OutputModuleCommunicator(const OutputModuleCommunicator&) = delete; // stop default
-    
-    const OutputModuleCommunicator& operator=(const OutputModuleCommunicator&) = delete; // stop default
-    
+    OutputModuleCommunicator(const OutputModuleCommunicator&) = delete;  // stop default
+
+    const OutputModuleCommunicator& operator=(const OutputModuleCommunicator&) = delete;  // stop default
+
     // ---------- member data --------------------------------
-    
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.cc
@@ -23,63 +23,47 @@
 #include "FWCore/Framework/interface/limited/OutputModuleBase.h"
 
 namespace {
-  template <typename F>
-  void async( edm::OutputModule& iMod, F&& iFunc ) {
+  template <typename F> void async(edm::OutputModule& iMod, F&& iFunc) {
     iMod.sharedResourcesAcquirer().serialQueueChain().push(std::move(iFunc));
   }
-  
-  template <typename F>
-  void async( edm::one::OutputModuleBase& iMod, F&& iFunc ) {
+
+  template <typename F> void async(edm::one::OutputModuleBase& iMod, F&& iFunc) {
     iMod.sharedResourcesAcquirer().serialQueueChain().push(std::move(iFunc));
   }
-  
-  template <typename F>
-  void async( edm::limited::OutputModuleBase& iMod, F&& iFunc ) {
+
+  template <typename F> void async(edm::limited::OutputModuleBase& iMod, F&& iFunc) {
     iMod.queue().push(std::move(iFunc));
   }
-  
-  template <typename F>
-  void async( edm::global::OutputModuleBase&, F iFunc ) {
+
+  template <typename F> void async(edm::global::OutputModuleBase&, F iFunc) {
     auto t = edm::make_functor_task(tbb::task::allocate_root(), iFunc);
     tbb::task::spawn(*t);
   }
-}
+}  // namespace
 
 namespace edm {
 
-  template<typename T>
-  void
-  OutputModuleCommunicatorT<T>::closeFile() {
-    module().doCloseFile();
-  }
+  template <typename T> void OutputModuleCommunicatorT<T>::closeFile() { module().doCloseFile(); }
 
-  template<typename T>
-  bool
-  OutputModuleCommunicatorT<T>::shouldWeCloseFile() const {
+  template <typename T> bool OutputModuleCommunicatorT<T>::shouldWeCloseFile() const {
     return module().shouldWeCloseFile();
   }
 
-  template<typename T>
-  void
-  OutputModuleCommunicatorT<T>::openFile(edm::FileBlock const& fb) {
+  template <typename T> void OutputModuleCommunicatorT<T>::openFile(edm::FileBlock const& fb) {
     module().doOpenFile(fb);
   }
 
-  template<typename T>
-  void
-  OutputModuleCommunicatorT<T>::writeRunAsync(WaitingTaskHolder iTask,
-                                              edm::RunPrincipal const& rp,
-                                              ProcessContext const* processContext,
-                                              ActivityRegistry* activityRegistry,
-                                              MergeableRunProductMetadata const* mergeableRunProductMetadata) {
+  template <typename T>
+  void OutputModuleCommunicatorT<T>::writeRunAsync(WaitingTaskHolder iTask,
+                                                   edm::RunPrincipal const& rp,
+                                                   ProcessContext const* processContext,
+                                                   ActivityRegistry* activityRegistry,
+                                                   MergeableRunProductMetadata const* mergeableRunProductMetadata) {
     auto token = ServiceRegistry::instance().presentToken();
-    GlobalContext globalContext(GlobalContext::Transition::kWriteRun,
-                                LuminosityBlockID(rp.run(), 0),
-                                rp.index(),
-                                LuminosityBlockIndex::invalidLuminosityBlockIndex(),
-                                rp.endTime(),
-                                processContext);
-    auto t = [&mod = module(), &rp, globalContext, token, desc = &description(), activityRegistry, mergeableRunProductMetadata, iTask]() mutable {
+    GlobalContext globalContext(GlobalContext::Transition::kWriteRun, LuminosityBlockID(rp.run(), 0), rp.index(),
+                                LuminosityBlockIndex::invalidLuminosityBlockIndex(), rp.endTime(), processContext);
+    auto t = [& mod = module(), &rp, globalContext, token, desc = &description(), activityRegistry,
+              mergeableRunProductMetadata, iTask]() mutable {
       std::exception_ptr ex;
       try {
         ServiceRegistry::Operate op(token);
@@ -87,12 +71,11 @@ namespace edm {
         ModuleCallingContext mcc(desc);
         ModuleContextSentry moduleContextSentry(&mcc, parentContext);
         activityRegistry->preModuleWriteRunSignal_(globalContext, mcc);
-        auto sentry( make_sentry(activityRegistry,
-                               [&globalContext, &mcc](ActivityRegistry* activityRegistry) {
-                                 activityRegistry->postModuleWriteRunSignal_(globalContext, mcc);
-                               }));
+        auto sentry(make_sentry(activityRegistry, [&globalContext, &mcc](ActivityRegistry* activityRegistry) {
+          activityRegistry->postModuleWriteRunSignal_(globalContext, mcc);
+        }));
         mod.doWriteRun(rp, &mcc, mergeableRunProductMetadata);
-      } catch(...) {
+      } catch (...) {
         ex = std::current_exception();
       }
       iTask.doneWaiting(ex);
@@ -100,20 +83,15 @@ namespace edm {
     async(module(), std::move(t));
   }
 
-  template<typename T>
-  void
-  OutputModuleCommunicatorT<T>::writeLumiAsync(WaitingTaskHolder iTask,
-                                               edm::LuminosityBlockPrincipal const& lbp,
-                                               ProcessContext const* processContext,
-                                               ActivityRegistry* activityRegistry) {
+  template <typename T>
+  void OutputModuleCommunicatorT<T>::writeLumiAsync(WaitingTaskHolder iTask,
+                                                    edm::LuminosityBlockPrincipal const& lbp,
+                                                    ProcessContext const* processContext,
+                                                    ActivityRegistry* activityRegistry) {
     auto token = ServiceRegistry::instance().presentToken();
-    GlobalContext globalContext(GlobalContext::Transition::kWriteLuminosityBlock,
-                                lbp.id(),
-                                lbp.runPrincipal().index(),
-                                lbp.index(),
-                                lbp.beginTime(),
-                                processContext);
-    auto t=[&mod = module(), &lbp, activityRegistry, token, globalContext,desc = &description(),iTask]() mutable {
+    GlobalContext globalContext(GlobalContext::Transition::kWriteLuminosityBlock, lbp.id(), lbp.runPrincipal().index(),
+                                lbp.index(), lbp.beginTime(), processContext);
+    auto t = [& mod = module(), &lbp, activityRegistry, token, globalContext, desc = &description(), iTask]() mutable {
       std::exception_ptr ex;
       try {
         ServiceRegistry::Operate op(token);
@@ -122,12 +100,11 @@ namespace edm {
         ModuleCallingContext mcc(desc);
         ModuleContextSentry moduleContextSentry(&mcc, parentContext);
         activityRegistry->preModuleWriteLumiSignal_(globalContext, mcc);
-        auto sentry( make_sentry(activityRegistry,
-                               [&globalContext, &mcc](ActivityRegistry* activityRegistry) {
-                                 activityRegistry->postModuleWriteLumiSignal_(globalContext, mcc);
-                               }));
+        auto sentry(make_sentry(activityRegistry, [&globalContext, &mcc](ActivityRegistry* activityRegistry) {
+          activityRegistry->postModuleWriteLumiSignal_(globalContext, mcc);
+        }));
         mod.doWriteLuminosityBlock(lbp, &mcc);
-      } catch(...) {
+      } catch (...) {
         ex = std::current_exception();
       }
       iTask.doneWaiting(ex);
@@ -135,58 +112,57 @@ namespace edm {
     async(module(), std::move(t));
   }
 
-  template<typename T>
-  bool OutputModuleCommunicatorT<T>::wantAllEvents() const {return module().wantAllEvents();}
+  template <typename T> bool OutputModuleCommunicatorT<T>::wantAllEvents() const { return module().wantAllEvents(); }
 
-  template<typename T>
-  bool OutputModuleCommunicatorT<T>::limitReached() const {return module().limitReached();}
+  template <typename T> bool OutputModuleCommunicatorT<T>::limitReached() const { return module().limitReached(); }
 
-  template<typename T>
-  void OutputModuleCommunicatorT<T>::configure(OutputModuleDescription const& desc) {module().configure(desc);}
+  template <typename T> void OutputModuleCommunicatorT<T>::configure(OutputModuleDescription const& desc) {
+    module().configure(desc);
+  }
 
-  template<typename T>
-  edm::SelectedProductsForBranchType const& OutputModuleCommunicatorT<T>::keptProducts() const {
+  template <typename T> edm::SelectedProductsForBranchType const& OutputModuleCommunicatorT<T>::keptProducts() const {
     return module().keptProducts();
   }
 
-  template<typename T>
-  void OutputModuleCommunicatorT<T>::selectProducts(edm::ProductRegistry const& preg, ThinnedAssociationsHelper const& helper) {
+  template <typename T>
+  void OutputModuleCommunicatorT<T>::selectProducts(edm::ProductRegistry const& preg,
+                                                    ThinnedAssociationsHelper const& helper) {
     module().selectProducts(preg, helper);
   }
 
-  template<typename T>
-  void OutputModuleCommunicatorT<T>::setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
-                                                    bool anyProductProduced) {
+  template <typename T>
+  void OutputModuleCommunicatorT<T>::setEventSelectionInfo(
+      std::map<std::string, std::vector<std::pair<std::string, int>>> const& outputModulePathPositions,
+      bool anyProductProduced) {
     module().setEventSelectionInfo(outputModulePathPositions, anyProductProduced);
   }
 
-  template<typename T>
-  ModuleDescription const& OutputModuleCommunicatorT<T>::description() const {
+  template <typename T> ModuleDescription const& OutputModuleCommunicatorT<T>::description() const {
     return module().description();
   }
 
   namespace impl {
-    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(void *) {
+    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(void*) {
       return std::unique_ptr<edm::OutputModuleCommunicator>{};
     }
-    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::OutputModule * iMod){
+    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::OutputModule* iMod) {
       return std::make_unique<OutputModuleCommunicatorT<edm::OutputModule>>(iMod);
     }
-    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::global::OutputModuleBase * iMod){
+    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::global::OutputModuleBase* iMod) {
       return std::make_unique<OutputModuleCommunicatorT<edm::global::OutputModuleBase>>(iMod);
     }
-    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::one::OutputModuleBase * iMod){
+    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::one::OutputModuleBase* iMod) {
       return std::make_unique<OutputModuleCommunicatorT<edm::one::OutputModuleBase>>(iMod);
     }
-    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::limited::OutputModuleBase * iMod){
+    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::limited::OutputModuleBase* iMod) {
       return std::make_unique<OutputModuleCommunicatorT<edm::limited::OutputModuleBase>>(iMod);
     }
-  }
-}
+  }  // namespace impl
+}  // namespace edm
 
 namespace edm {
   template class OutputModuleCommunicatorT<OutputModule>;
   template class OutputModuleCommunicatorT<one::OutputModuleBase>;
   template class OutputModuleCommunicatorT<global::OutputModuleBase>;
   template class OutputModuleCommunicatorT<limited::OutputModuleBase>;
-}
+}  // namespace edm

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.h
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.h
@@ -22,52 +22,52 @@ namespace edm {
     class OutputModuleBase;
   }
   namespace impl {
-    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(void *);
-    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::OutputModule *);
-    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::one::OutputModuleBase *);
-    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::global::OutputModuleBase *);
-    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::limited::OutputModuleBase *);
-  }
-  
+    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(void*);
+    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::OutputModule*);
+    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::one::OutputModuleBase*);
+    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::global::OutputModuleBase*);
+    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::limited::OutputModuleBase*);
+  }  // namespace impl
+
   template <typename T>
-  
+
   class OutputModuleCommunicatorT : public edm::OutputModuleCommunicator {
   public:
-    OutputModuleCommunicatorT(T* iModule):
-    module_(iModule){}
+    OutputModuleCommunicatorT(T* iModule) : module_(iModule) {}
     void closeFile() override;
-    
+
     ///\return true if output module wishes to close its file
     bool shouldWeCloseFile() const override;
-    
+
     ///\return true if no event filtering is applied to OutputModule
     bool wantAllEvents() const override;
-    
+
     void openFile(edm::FileBlock const& fb) override;
-    
+
     void writeRunAsync(WaitingTaskHolder iTask,
                        edm::RunPrincipal const& rp,
                        ProcessContext const*,
                        ActivityRegistry*,
                        MergeableRunProductMetadata const*) override;
-    
+
     void writeLumiAsync(WaitingTaskHolder iTask,
                         edm::LuminosityBlockPrincipal const& lbp,
                         ProcessContext const*,
                         ActivityRegistry*) override;
-    
+
     ///\return true if OutputModule has reached its limit on maximum number of events it wants to see
     bool limitReached() const override;
-    
+
     void configure(edm::OutputModuleDescription const& desc) override;
-    
+
     edm::SelectedProductsForBranchType const& keptProducts() const override;
-    
+
     void selectProducts(edm::ProductRegistry const& preg, ThinnedAssociationsHelper const&) override;
-    
-    void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
-                                       bool anyProductProduced) override;
-    
+
+    void setEventSelectionInfo(
+        std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
+        bool anyProductProduced) override;
+
     ModuleDescription const& description() const override;
 
     static std::unique_ptr<edm::OutputModuleCommunicator> createIfNeeded(T* iMod) {
@@ -75,8 +75,8 @@ namespace edm {
     }
 
   private:
-    inline T& module() const { return *module_;}
+    inline T& module() const { return *module_; }
     T* module_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -12,116 +12,114 @@
 #include <algorithm>
 
 namespace edm {
-  Path::Path(int bitpos, std::string const& path_name,
+  Path::Path(int bitpos,
+             std::string const& path_name,
              WorkersInPath const& workers,
              TrigResPtr trptr,
              ExceptionToActionTable const& actions,
              std::shared_ptr<ActivityRegistry> areg,
              StreamContext const* streamContext,
              std::atomic<bool>* stopProcessingEvent,
-             PathContext::PathType pathType) :
-    timesRun_(),
-    timesPassed_(),
-    timesFailed_(),
-    timesExcept_(),
-    state_(hlt::Ready),
-    bitpos_(bitpos),
-    trptr_(trptr),
-    actReg_(areg),
-    act_table_(&actions),
-    workers_(workers),
-    pathContext_(path_name, streamContext, bitpos, pathType),
-    stopProcessingEvent_(stopProcessingEvent),
-    pathStatusInserter_(nullptr),
-    pathStatusInserterWorker_(nullptr) {
-
+             PathContext::PathType pathType)
+      : timesRun_(),
+        timesPassed_(),
+        timesFailed_(),
+        timesExcept_(),
+        state_(hlt::Ready),
+        bitpos_(bitpos),
+        trptr_(trptr),
+        actReg_(areg),
+        act_table_(&actions),
+        workers_(workers),
+        pathContext_(path_name, streamContext, bitpos, pathType),
+        stopProcessingEvent_(stopProcessingEvent),
+        pathStatusInserter_(nullptr),
+        pathStatusInserterWorker_(nullptr) {
     for (auto& workerInPath : workers_) {
       workerInPath.setPathContext(&pathContext_);
     }
   }
 
-  Path::Path(Path const& r) :
-    timesRun_(r.timesRun_),
-    timesPassed_(r.timesPassed_),
-    timesFailed_(r.timesFailed_),
-    timesExcept_(r.timesExcept_),
-    state_(r.state_),
-    bitpos_(r.bitpos_),
-    trptr_(r.trptr_),
-    actReg_(r.actReg_),
-    act_table_(r.act_table_),
-    workers_(r.workers_),
-    earlyDeleteHelpers_(r.earlyDeleteHelpers_),
-    pathContext_(r.pathContext_),
-    stopProcessingEvent_(r.stopProcessingEvent_),
-    pathStatusInserter_(r.pathStatusInserter_),
-    pathStatusInserterWorker_(r.pathStatusInserterWorker_) {
-
+  Path::Path(Path const& r)
+      : timesRun_(r.timesRun_),
+        timesPassed_(r.timesPassed_),
+        timesFailed_(r.timesFailed_),
+        timesExcept_(r.timesExcept_),
+        state_(r.state_),
+        bitpos_(r.bitpos_),
+        trptr_(r.trptr_),
+        actReg_(r.actReg_),
+        act_table_(r.act_table_),
+        workers_(r.workers_),
+        earlyDeleteHelpers_(r.earlyDeleteHelpers_),
+        pathContext_(r.pathContext_),
+        stopProcessingEvent_(r.stopProcessingEvent_),
+        pathStatusInserter_(r.pathStatusInserter_),
+        pathStatusInserterWorker_(r.pathStatusInserterWorker_) {
     for (auto& workerInPath : workers_) {
       workerInPath.setPathContext(&pathContext_);
     }
   }
 
-
-  bool
-  Path::handleWorkerFailure(cms::Exception & e,
-			    int nwrwue,
-                            bool isEvent,
-                            bool begin,
-                            BranchType branchType,
-                            ModuleDescription const& desc,
-                            std::string const& id) {
-    if(e.context().empty()) {
+  bool Path::handleWorkerFailure(cms::Exception& e,
+                                 int nwrwue,
+                                 bool isEvent,
+                                 bool begin,
+                                 BranchType branchType,
+                                 ModuleDescription const& desc,
+                                 std::string const& id) {
+    if (e.context().empty()) {
       exceptionContext(e, isEvent, begin, branchType, desc, id, pathContext_);
     }
     bool should_continue = true;
 
     // there is no support as of yet for specific paths having
     // different exception behavior
-    
+
     // If not processing an event, always rethrow.
     exception_actions::ActionCodes action = (isEvent ? act_table_->find(e.category()) : exception_actions::Rethrow);
-    switch(action) {
+    switch (action) {
       case exception_actions::FailPath: {
-	  should_continue = false;
-          edm::printCmsExceptionWarning("FailPath", e);
-	  break;
+        should_continue = false;
+        edm::printCmsExceptionWarning("FailPath", e);
+        break;
       }
       case exception_actions::SkipEvent: {
         //Need the other Paths to stop as soon as possible
-        if(stopProcessingEvent_) {
+        if (stopProcessingEvent_) {
           *stopProcessingEvent_ = true;
         }
       }
       default: {
-	  if (isEvent) ++timesExcept_;
-	  state_ = hlt::Exception;
-	  recordStatus(nwrwue, isEvent);
-	  if (action == exception_actions::Rethrow) {
-	    std::string pNF = Exception::codeToString(errors::ProductNotFound);
-            if (e.category() == pNF) {
-	      std::ostringstream ost;
-              ost <<  "If you wish to continue processing events after a " << pNF << " exception,\n" <<
-	      "add \"SkipEvent = cms.untracked.vstring('ProductNotFound')\" to the \"options\" PSet in the configuration.\n";
-              e.addAdditionalInfo(ost.str());
-            }
-	  }
-          //throw will copy which will slice the object
-          e.raise();
+        if (isEvent)
+          ++timesExcept_;
+        state_ = hlt::Exception;
+        recordStatus(nwrwue, isEvent);
+        if (action == exception_actions::Rethrow) {
+          std::string pNF = Exception::codeToString(errors::ProductNotFound);
+          if (e.category() == pNF) {
+            std::ostringstream ost;
+            ost << "If you wish to continue processing events after a " << pNF << " exception,\n"
+                << "add \"SkipEvent = cms.untracked.vstring('ProductNotFound')\" to the \"options\" PSet in the "
+                   "configuration.\n";
+            e.addAdditionalInfo(ost.str());
+          }
+        }
+        //throw will copy which will slice the object
+        e.raise();
       }
     }
 
     return should_continue;
   }
 
-  void
-  Path::exceptionContext(cms::Exception & ex,
-                         bool isEvent,
-                         bool begin,
-                         BranchType branchType,
-                         ModuleDescription const& desc,
-                         std::string const& id,
-                         PathContext const& pathContext) {
+  void Path::exceptionContext(cms::Exception& ex,
+                              bool isEvent,
+                              bool begin,
+                              BranchType branchType,
+                              ModuleDescription const& desc,
+                              std::string const& id,
+                              PathContext const& pathContext) {
     std::ostringstream ost;
     ost << "Running path '" << pathContext.pathName() << "'";
     ex.addContext(ost.str());
@@ -131,17 +129,13 @@ namespace edm {
     // added the necessary module context to the exception
     if (begin && branchType == InRun) {
       ost << "stream begin Run";
-    }
-    else if (begin && branchType == InLumi) {
+    } else if (begin && branchType == InLumi) {
       ost << "stream begin LuminosityBlock ";
-    }
-    else if (!begin && branchType == InLumi) {
+    } else if (!begin && branchType == InLumi) {
       ost << "stream end LuminosityBlock ";
-    }
-    else if (!begin && branchType == InRun) {
+    } else if (!begin && branchType == InRun) {
       ost << "stream end Run ";
-    }
-    else if (isEvent) {
+    } else if (isEvent) {
       // It should be impossible to get here ...
       ost << "Event ";
     }
@@ -149,93 +143,88 @@ namespace edm {
     ex.addContext(ost.str());
   }
 
-  void
-  Path::recordStatus(int nwrwue, bool isEvent) {
-    if(isEvent && trptr_) {
-      (*trptr_)[bitpos_]=HLTPathStatus(state_, nwrwue);    
+  void Path::recordStatus(int nwrwue, bool isEvent) {
+    if (isEvent && trptr_) {
+      (*trptr_)[bitpos_] = HLTPathStatus(state_, nwrwue);
     }
   }
 
-  void
-  Path::updateCounters(bool success, bool isEvent) {
+  void Path::updateCounters(bool success, bool isEvent) {
     if (success) {
-      if (isEvent) ++timesPassed_;
+      if (isEvent)
+        ++timesPassed_;
       state_ = hlt::Pass;
     } else {
-      if(isEvent) ++timesFailed_;
+      if (isEvent)
+        ++timesFailed_;
       state_ = hlt::Fail;
     }
   }
 
-  void
-  Path::clearCounters() {
+  void Path::clearCounters() {
     using std::placeholders::_1;
     timesRun_ = timesPassed_ = timesFailed_ = timesExcept_ = 0;
     for_all(workers_, std::bind(&WorkerInPath::clearCounters, _1));
   }
 
-  void 
-  Path::setEarlyDeleteHelpers(std::map<const Worker*,EarlyDeleteHelper*> const& iWorkerToDeleter) {
+  void Path::setEarlyDeleteHelpers(std::map<const Worker*, EarlyDeleteHelper*> const& iWorkerToDeleter) {
     //we use a temp so we can overset the size but then when moving to earlyDeleteHelpers we only
     // have to use the space necessary
     std::vector<EarlyDeleteHelper*> temp;
     temp.reserve(iWorkerToDeleter.size());
-    for(unsigned int index=0; index !=size();++index) {
+    for (unsigned int index = 0; index != size(); ++index) {
       auto found = iWorkerToDeleter.find(getWorker(index));
-      if(found != iWorkerToDeleter.end()) {
+      if (found != iWorkerToDeleter.end()) {
         temp.push_back(found->second);
         found->second->addedToPath();
       }
     }
-    std::vector<EarlyDeleteHelper*> tempCorrectSize(temp.begin(),temp.end());
+    std::vector<EarlyDeleteHelper*> tempCorrectSize(temp.begin(), temp.end());
     earlyDeleteHelpers_.swap(tempCorrectSize);
   }
 
-  void
-  Path::setPathStatusInserter(PathStatusInserter* pathStatusInserter,
-                              Worker* pathStatusInserterWorker) {
+  void Path::setPathStatusInserter(PathStatusInserter* pathStatusInserter, Worker* pathStatusInserterWorker) {
     pathStatusInserter_ = pathStatusInserter;
     pathStatusInserterWorker_ = pathStatusInserterWorker;
   }
 
-  void
-  Path::handleEarlyFinish(EventPrincipal const& iEvent) {
-    for(auto helper: earlyDeleteHelpers_) {
+  void Path::handleEarlyFinish(EventPrincipal const& iEvent) {
+    for (auto helper : earlyDeleteHelpers_) {
       helper->pathFinished(iEvent);
     }
   }
 
-  void
-  Path::processOneOccurrenceAsync(WaitingTask* iTask,
-                                  EventPrincipal const& iEP,
-                                  EventSetupImpl const& iES,
-                                  ServiceToken const& iToken,
-                                  StreamID const& iStreamID,
-                                  StreamContext const* iStreamContext) {
+  void Path::processOneOccurrenceAsync(WaitingTask* iTask,
+                                       EventPrincipal const& iEP,
+                                       EventSetupImpl const& iES,
+                                       ServiceToken const& iToken,
+                                       StreamID const& iStreamID,
+                                       StreamContext const* iStreamContext) {
     waitingTasks_.reset();
     ++timesRun_;
     waitingTasks_.add(iTask);
-    if(actReg_) {
+    if (actReg_) {
       ServiceRegistry::Operate guard(iToken);
       actReg_->prePathEventSignal_(*iStreamContext, pathContext_);
     }
     state_ = hlt::Ready;
-    
-    if(workers_.empty()) {
+
+    if (workers_.empty()) {
       ServiceRegistry::Operate guard(iToken);
       finished(-1, true, std::exception_ptr(), iStreamContext, iEP, iES, iStreamID);
       return;
     }
-    
-    runNextWorkerAsync(0,iEP,iES, iToken, iStreamID, iStreamContext);
+
+    runNextWorkerAsync(0, iEP, iES, iToken, iStreamID, iStreamContext);
   }
 
-  void
-  Path::workerFinished(std::exception_ptr const* iException,
-                       unsigned int iModuleIndex,
-                       EventPrincipal const& iEP, EventSetupImpl const& iES,
-                       ServiceToken const& iToken,
-                       StreamID const& iID, StreamContext const* iContext) {
+  void Path::workerFinished(std::exception_ptr const* iException,
+                            unsigned int iModuleIndex,
+                            EventPrincipal const& iEP,
+                            EventSetupImpl const& iES,
+                            ServiceToken const& iToken,
+                            StreamID const& iID,
+                            StreamContext const* iContext) {
     ServiceRegistry::Operate guard(iToken);
 
     //This call also allows the WorkerInPath to update statistics
@@ -243,22 +232,22 @@ namespace edm {
     auto& worker = workers_[iModuleIndex];
     bool shouldContinue = worker.checkResultsOfRunWorker(true);
     std::exception_ptr finalException;
-    if(iException) {
+    if (iException) {
       std::unique_ptr<cms::Exception> pEx;
       try {
         std::rethrow_exception(*iException);
-      } catch(cms::Exception& oldEx) {
+      } catch (cms::Exception& oldEx) {
         pEx = std::unique_ptr<cms::Exception>(oldEx.clone());
       }
       try {
         std::ostringstream ost;
         ost << iEP.id();
         shouldContinue = handleWorkerFailure(*pEx, iModuleIndex, /*isEvent*/ true, /*isBegin*/ true, InEvent,
-                                              worker.getWorker()->description(), ost.str());
+                                             worker.getWorker()->description(), ost.str());
         //If we didn't rethrow, then we effectively skipped
         worker.skipWorker(iEP);
         finalException = std::exception_ptr();
-      } catch(...) {
+      } catch (...) {
         shouldContinue = false;
         finalException = std::current_exception();
         //set the exception early to avoid case where another Path is waiting
@@ -268,78 +257,71 @@ namespace edm {
         waitingTasks_.presetTaskAsFailed(finalException);
       }
     }
-    if(stopProcessingEvent_ and *stopProcessingEvent_) {
+    if (stopProcessingEvent_ and *stopProcessingEvent_) {
       shouldContinue = false;
     }
-    auto const nextIndex = iModuleIndex +1;
+    auto const nextIndex = iModuleIndex + 1;
     if (shouldContinue and nextIndex < workers_.size()) {
       runNextWorkerAsync(nextIndex, iEP, iES, iToken, iID, iContext);
       return;
     }
-    
+
     if (not shouldContinue) {
       //we are leaving the path early
-      for(auto it = workers_.begin()+nextIndex, itEnd=workers_.end();
-          it != itEnd; ++it) {
+      for (auto it = workers_.begin() + nextIndex, itEnd = workers_.end(); it != itEnd; ++it) {
         it->skipWorker(iEP);
       }
       handleEarlyFinish(iEP);
     }
-    finished(iModuleIndex, shouldContinue, finalException, iContext, iEP, iES,iID);
+    finished(iModuleIndex, shouldContinue, finalException, iContext, iEP, iES, iID);
   }
-  
-  void
-  Path::finished(int iModuleIndex, bool iSucceeded, std::exception_ptr iException, StreamContext const* iContext,
-                 EventPrincipal const& iEP,
-                 EventSetupImpl const& iES,
-                 StreamID const& streamID) {
-    
-    if(not iException) {
+
+  void Path::finished(int iModuleIndex,
+                      bool iSucceeded,
+                      std::exception_ptr iException,
+                      StreamContext const* iContext,
+                      EventPrincipal const& iEP,
+                      EventSetupImpl const& iES,
+                      StreamID const& streamID) {
+    if (not iException) {
       updateCounters(iSucceeded, true);
       recordStatus(iModuleIndex, true);
     }
     try {
       HLTPathStatus status(state_, iModuleIndex);
 
-      if (pathStatusInserter_) { // pathStatusInserter is null for EndPaths
+      if (pathStatusInserter_) {  // pathStatusInserter is null for EndPaths
         pathStatusInserter_->setPathStatus(streamID, status);
       }
       std::exception_ptr jException =
-        pathStatusInserterWorker_->runModuleDirectly<OccurrenceTraits<EventPrincipal,
-                                                                      BranchActionStreamBegin>>(
-          iEP, iES, streamID, ParentContext(iContext), iContext
-        );
-      if(jException && not iException) {
+          pathStatusInserterWorker_->runModuleDirectly<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
+              iEP, iES, streamID, ParentContext(iContext), iContext);
+      if (jException && not iException) {
         iException = jException;
       }
       actReg_->postPathEventSignal_(*iContext, pathContext_, status);
-    } catch(...) {
-      if(not iException) {
+    } catch (...) {
+      if (not iException) {
         iException = std::current_exception();
       }
     }
     waitingTasks_.doneWaiting(iException);
   }
-  
-  void
-  Path::runNextWorkerAsync(unsigned int iNextModuleIndex,
-                           EventPrincipal const& iEP, EventSetupImpl const& iES,
-                           ServiceToken const& iToken,
-                           StreamID const& iID, StreamContext const* iContext) {
-    
-    auto nextTask = make_waiting_task( tbb::task::allocate_root(),
-                                      [this, iNextModuleIndex, &iEP,&iES, iID, iContext, token=iToken](std::exception_ptr const* iException)
-    {
-      this->workerFinished(iException, iNextModuleIndex, iEP,iES,token,iID,iContext);
-    });
-    
-    workers_[iNextModuleIndex].runWorkerAsync<
-    OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(nextTask,
-                                                                iEP,
-                                                                iES,
-                                                                iToken,
-                                                                iID,
-                                                                iContext);
+
+  void Path::runNextWorkerAsync(unsigned int iNextModuleIndex,
+                                EventPrincipal const& iEP,
+                                EventSetupImpl const& iES,
+                                ServiceToken const& iToken,
+                                StreamID const& iID,
+                                StreamContext const* iContext) {
+    auto nextTask = make_waiting_task(
+        tbb::task::allocate_root(),
+        [this, iNextModuleIndex, &iEP, &iES, iID, iContext, token = iToken](std::exception_ptr const* iException) {
+          this->workerFinished(iException, iNextModuleIndex, iEP, iES, token, iID, iContext);
+        });
+
+    workers_[iNextModuleIndex].runWorkerAsync<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
+        nextTask, iEP, iES, iToken, iID, iContext);
   }
 
-}
+}  // namespace edm

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -46,10 +46,11 @@ namespace edm {
     typedef hlt::HLTState State;
 
     typedef std::vector<WorkerInPath> WorkersInPath;
-    typedef WorkersInPath::size_type        size_type;
+    typedef WorkersInPath::size_type size_type;
     typedef std::shared_ptr<HLTGlobalStatus> TrigResPtr;
 
-    Path(int bitpos, std::string const& path_name,
+    Path(int bitpos,
+         std::string const& path_name,
          WorkersInPath const& workers,
          TrigResPtr trptr,
          ExceptionToActionTable const& actions,
@@ -63,14 +64,18 @@ namespace edm {
     template <typename T>
     void runAllModulesAsync(WaitingTask*,
                             typename T::MyPrincipal const&,
-                            EventSetupImpl  const&,
+                            EventSetupImpl const&,
                             ServiceToken const&,
                             StreamID const&,
                             typename T::Context const*);
 
-    void processOneOccurrenceAsync(WaitingTask*, EventPrincipal const&, EventSetupImpl const&,
-                                   ServiceToken const&, StreamID const&, StreamContext const*);
-    
+    void processOneOccurrenceAsync(WaitingTask*,
+                                   EventPrincipal const&,
+                                   EventSetupImpl const&,
+                                   ServiceToken const&,
+                                   StreamID const&,
+                                   StreamContext const*);
+
     int bitPosition() const { return bitpos_; }
     std::string const& name() const { return pathContext_.pathName(); }
 
@@ -85,21 +90,19 @@ namespace edm {
 
     size_type size() const { return workers_.size(); }
     int timesVisited(size_type i) const { return workers_.at(i).timesVisited(); }
-    int timesPassed (size_type i) const { return workers_.at(i).timesPassed() ; }
-    int timesFailed (size_type i) const { return workers_.at(i).timesFailed() ; }
-    int timesExcept (size_type i) const { return workers_.at(i).timesExcept() ; }
+    int timesPassed(size_type i) const { return workers_.at(i).timesPassed(); }
+    int timesFailed(size_type i) const { return workers_.at(i).timesFailed(); }
+    int timesExcept(size_type i) const { return workers_.at(i).timesExcept(); }
     Worker const* getWorker(size_type i) const { return workers_.at(i).getWorker(); }
-    
-    void setEarlyDeleteHelpers(std::map<const Worker*,EarlyDeleteHelper*> const&);
 
-    void setPathStatusInserter(PathStatusInserter* pathStatusInserter,
-                               Worker* pathStatusInserterWorker);
+    void setEarlyDeleteHelpers(std::map<const Worker*, EarlyDeleteHelper*> const&);
+
+    void setPathStatusInserter(PathStatusInserter* pathStatusInserter, Worker* pathStatusInserterWorker);
 
   private:
-
     // If you define this be careful about the pointer in the
     // PlaceInPathContext object in the contained WorkerInPath objects.
-    Path const& operator=(Path const&) = delete; // stop default
+    Path const& operator=(Path const&) = delete;  // stop default
 
     int timesRun_;
     int timesPassed_;
@@ -110,7 +113,7 @@ namespace edm {
 
     int bitpos_;
     TrigResPtr trptr_;
-    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
+    std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
     ExceptionToActionTable const* act_table_;
 
     WorkersInPath workers_;
@@ -125,14 +128,14 @@ namespace edm {
 
     // Helper functions
     // nwrwue = numWorkersRunWithoutUnhandledException (really!)
-    bool handleWorkerFailure(cms::Exception & e,
+    bool handleWorkerFailure(cms::Exception& e,
                              int nwrwue,
                              bool isEvent,
                              bool begin,
                              BranchType branchType,
                              ModuleDescription const&,
                              std::string const& id);
-    static void exceptionContext(cms::Exception & ex,
+    static void exceptionContext(cms::Exception& ex,
                                  bool isEvent,
                                  bool begin,
                                  BranchType branchType,
@@ -141,8 +144,10 @@ namespace edm {
                                  PathContext const&);
     void recordStatus(int nwrwue, bool isEvent);
     void updateCounters(bool succeed, bool isEvent);
-    
-    void finished(int iModuleIndex, bool iSucceeded, std::exception_ptr,
+
+    void finished(int iModuleIndex,
+                  bool iSucceeded,
+                  std::exception_ptr,
                   StreamContext const*,
                   EventPrincipal const& iEP,
                   EventSetupImpl const& iES,
@@ -151,55 +156,60 @@ namespace edm {
     void handleEarlyFinish(EventPrincipal const&);
     void handleEarlyFinish(RunPrincipal const&) {}
     void handleEarlyFinish(LuminosityBlockPrincipal const&) {}
-    
+
     //Handle asynchronous processing
     void workerFinished(std::exception_ptr const* iException,
                         unsigned int iModuleIndex,
-                        EventPrincipal const& iEP, EventSetupImpl const& iES,
+                        EventPrincipal const& iEP,
+                        EventSetupImpl const& iES,
                         ServiceToken const& iToken,
-                        StreamID const& iID, StreamContext const* iContext);
+                        StreamID const& iID,
+                        StreamContext const* iContext);
     void runNextWorkerAsync(unsigned int iNextModuleIndex,
-                            EventPrincipal const&, EventSetupImpl const&,
+                            EventPrincipal const&,
+                            EventSetupImpl const&,
                             ServiceToken const&,
-                            StreamID const&, StreamContext const*);
-
+                            StreamID const&,
+                            StreamContext const*);
   };
 
   namespace {
-    template <typename T>
-    class PathSignalSentry {
+    template <typename T> class PathSignalSentry {
     public:
-      PathSignalSentry(ActivityRegistry *a,
+      PathSignalSentry(ActivityRegistry* a,
                        int const& nwrwue,
                        hlt::HLTState const& state,
-                       PathContext const* pathContext) :
-        a_(a), nwrwue_(nwrwue), state_(state), pathContext_(pathContext) {
-        if (a_) T::prePathSignal(a_, pathContext_);
+                       PathContext const* pathContext)
+          : a_(a), nwrwue_(nwrwue), state_(state), pathContext_(pathContext) {
+        if (a_)
+          T::prePathSignal(a_, pathContext_);
       }
       ~PathSignalSentry() {
         HLTPathStatus status(state_, nwrwue_);
-        if(a_) T::postPathSignal(a_, status, pathContext_);
+        if (a_)
+          T::postPathSignal(a_, status, pathContext_);
       }
+
     private:
-      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
+      ActivityRegistry* a_;  // We do not use propagate_const because the registry itself is mutable.
       int const& nwrwue_;
       hlt::HLTState const& state_;
       PathContext const* pathContext_;
     };
-  }
+  }  // namespace
 
   template <typename T>
   void Path::runAllModulesAsync(WaitingTask* task,
                                 typename T::MyPrincipal const& p,
-                                EventSetupImpl  const& es,
+                                EventSetupImpl const& es,
                                 ServiceToken const& token,
                                 StreamID const& streamID,
                                 typename T::Context const* context) {
-    for(auto& worker: workers_) {
-      worker.runWorkerAsync<T>(task,p,es,token,streamID,context);
+    for (auto& worker : workers_) {
+      worker.runWorkerAsync<T>(task, p, es, token, streamID, context);
     }
   }
 
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/PathStatusInserter.cc
+++ b/FWCore/Framework/src/PathStatusInserter.cc
@@ -5,23 +5,15 @@
 
 #include <memory>
 
-namespace edm
-{
-  PathStatusInserter::PathStatusInserter(unsigned int numberOfStreams) :
-    hltPathStatus_(numberOfStreams),
-    token_{produces<HLTPathStatus>()}
-  {
-  }
+namespace edm {
+  PathStatusInserter::PathStatusInserter(unsigned int numberOfStreams)
+      : hltPathStatus_(numberOfStreams), token_{produces<HLTPathStatus>()} {}
 
-  void
-  PathStatusInserter::setPathStatus(StreamID const& streamID,
-                                    HLTPathStatus const& hltPathStatus) {
+  void PathStatusInserter::setPathStatus(StreamID const& streamID, HLTPathStatus const& hltPathStatus) {
     hltPathStatus_[streamID.value()] = hltPathStatus;
   }
 
-  void
-  PathStatusInserter::produce(StreamID streamID, edm::Event& event, edm::EventSetup const&) const
-  {
-    event.emplace(token_,hltPathStatus_[streamID.value()]);
+  void PathStatusInserter::produce(StreamID streamID, edm::Event& event, edm::EventSetup const&) const {
+    event.emplace(token_, hltPathStatus_[streamID.value()]);
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/PathStatusInserter.h
+++ b/FWCore/Framework/src/PathStatusInserter.h
@@ -14,7 +14,6 @@ namespace edm {
 
   class PathStatusInserter : public global::EDProducer<> {
   public:
-
     PathStatusInserter(unsigned int numberOfStreams);
 
     void setPathStatus(StreamID const&, HLTPathStatus const&);
@@ -22,9 +21,8 @@ namespace edm {
     void produce(StreamID, Event&, EventSetup const&) const final;
 
   private:
-
     std::vector<HLTPathStatus> hltPathStatus_;
     EDPutTokenT<HLTPathStatus> token_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -9,11 +9,9 @@
 #include <algorithm>
 namespace edm {
 
-  PathsAndConsumesOfModules::~PathsAndConsumesOfModules() {
-  }
+  PathsAndConsumesOfModules::~PathsAndConsumesOfModules() {}
 
   void PathsAndConsumesOfModules::initialize(Schedule const* schedule, std::shared_ptr<ProductRegistry const> preg) {
-
     schedule_ = schedule;
     preg_ = preg;
 
@@ -26,74 +24,68 @@ namespace edm {
     modulesOnPaths_.resize(paths_.size());
     unsigned int i = 0;
     unsigned int hint = 0;
-    for(auto const& path : paths_) {
+    for (auto const& path : paths_) {
       schedule->moduleDescriptionsInPath(path, modulesOnPaths_.at(i), hint);
-      if(!modulesOnPaths_.at(i).empty()) ++hint;
+      if (!modulesOnPaths_.at(i).empty())
+        ++hint;
       ++i;
     }
 
     modulesOnEndPaths_.resize(endPaths_.size());
     i = 0;
     hint = 0;
-    for(auto const& endpath : endPaths_) {
+    for (auto const& endpath : endPaths_) {
       schedule->moduleDescriptionsInEndPath(endpath, modulesOnEndPaths_.at(i), hint);
-      if(!modulesOnEndPaths_.at(i).empty()) ++hint;
+      if (!modulesOnEndPaths_.at(i).empty())
+        ++hint;
       ++i;
     }
 
-    schedule->fillModuleAndConsumesInfo(allModuleDescriptions_,
-                                        moduleIDToIndex_,
-                                        modulesWhoseProductsAreConsumedBy_,
+    schedule->fillModuleAndConsumesInfo(allModuleDescriptions_, moduleIDToIndex_, modulesWhoseProductsAreConsumedBy_,
                                         *preg);
   }
 
-  ModuleDescription const*
-  PathsAndConsumesOfModules::doModuleDescription(unsigned int moduleID) const {
+  ModuleDescription const* PathsAndConsumesOfModules::doModuleDescription(unsigned int moduleID) const {
     unsigned int dummy = 0;
     auto target = std::make_pair(moduleID, dummy);
-    std::vector<std::pair<unsigned int, unsigned int> >::const_iterator iter =
-      std::lower_bound(moduleIDToIndex_.begin(), moduleIDToIndex_.end(), target);
+    std::vector<std::pair<unsigned int, unsigned int>>::const_iterator iter =
+        std::lower_bound(moduleIDToIndex_.begin(), moduleIDToIndex_.end(), target);
     if (iter == moduleIDToIndex_.end() || iter->first != moduleID) {
-      throw Exception(errors::LogicError)
-        << "PathsAndConsumesOfModules::moduleDescription: Unknown moduleID\n";
+      throw Exception(errors::LogicError) << "PathsAndConsumesOfModules::moduleDescription: Unknown moduleID\n";
     }
     return allModuleDescriptions_.at(iter->second);
   }
 
-  std::vector<ModuleDescription const*> const&
-  PathsAndConsumesOfModules::doModulesOnPath(unsigned int pathIndex) const {
+  std::vector<ModuleDescription const*> const& PathsAndConsumesOfModules::doModulesOnPath(unsigned int pathIndex) const {
     return modulesOnPaths_.at(pathIndex);
   }
 
-  std::vector<ModuleDescription const*> const&
-  PathsAndConsumesOfModules::doModulesOnEndPath(unsigned int endPathIndex) const {
+  std::vector<ModuleDescription const*> const& PathsAndConsumesOfModules::doModulesOnEndPath(
+      unsigned int endPathIndex) const {
     return modulesOnEndPaths_.at(endPathIndex);
   }
 
-  std::vector<ModuleDescription const*> const&
-  PathsAndConsumesOfModules::doModulesWhoseProductsAreConsumedBy(unsigned int moduleID) const {
+  std::vector<ModuleDescription const*> const& PathsAndConsumesOfModules::doModulesWhoseProductsAreConsumedBy(
+      unsigned int moduleID) const {
     return modulesWhoseProductsAreConsumedBy_.at(moduleIndex(moduleID));
   }
 
-  std::vector<ConsumesInfo> 
-  PathsAndConsumesOfModules::doConsumesInfo(unsigned int moduleID) const {
+  std::vector<ConsumesInfo> PathsAndConsumesOfModules::doConsumesInfo(unsigned int moduleID) const {
     Worker const* worker = schedule_->allWorkers().at(moduleIndex(moduleID));
     return worker->consumesInfo();
   }
 
-  unsigned int
-  PathsAndConsumesOfModules::moduleIndex(unsigned int moduleID) const {
+  unsigned int PathsAndConsumesOfModules::moduleIndex(unsigned int moduleID) const {
     unsigned int dummy = 0;
     auto target = std::make_pair(moduleID, dummy);
-    std::vector<std::pair<unsigned int, unsigned int> >::const_iterator iter =
-      std::lower_bound(moduleIDToIndex_.begin(), moduleIDToIndex_.end(), target);
+    std::vector<std::pair<unsigned int, unsigned int>>::const_iterator iter =
+        std::lower_bound(moduleIDToIndex_.begin(), moduleIDToIndex_.end(), target);
     if (iter == moduleIDToIndex_.end() || iter->first != moduleID) {
-      throw Exception(errors::LogicError)
-        << "PathsAndConsumesOfModules::moduleIndex: Unknown moduleID\n";
+      throw Exception(errors::LogicError) << "PathsAndConsumesOfModules::moduleIndex: Unknown moduleID\n";
     }
     return iter->second;
   }
-  
+
   //====================================
   // checkForCorrectness algorithm
   //
@@ -134,10 +126,8 @@ namespace edm {
   //  Cycle: A consumes B, B consumes C, C consumes A
   //  Since this cycle has 0 path only edges it is unrunnable.
   //====================================
-  
 
-  void checkForModuleDependencyCorrectness(edm::PathsAndConsumesOfModulesBase const& iPnC,
-                                           bool iPrintDependencies) {
+  void checkForModuleDependencyCorrectness(edm::PathsAndConsumesOfModulesBase const& iPnC, bool iPrintDependencies) {
     using namespace edm::graph;
     //Need to lookup ids to names quickly
     std::unordered_map<unsigned int, std::string> moduleIndexToNames;
@@ -151,21 +141,19 @@ namespace edm {
     unsigned int kTriggerResultsIndex = kInvalidIndex;
     unsigned int largestIndex = 0;
     unsigned int kPathToTriggerResultsDependencyLastIndex = kInvalidIndex;
-    for(auto const& description: iPnC.allModules()) {
-      moduleIndexToNames.insert(std::make_pair(description->id(),
-                                               description->moduleLabel()));
-      if(kTriggerResults == description->moduleLabel()) {
+    for (auto const& description : iPnC.allModules()) {
+      moduleIndexToNames.insert(std::make_pair(description->id(), description->moduleLabel()));
+      if (kTriggerResults == description->moduleLabel()) {
         kTriggerResultsIndex = description->id();
       }
-      if(description->id() > largestIndex) {
+      if (description->id() > largestIndex) {
         largestIndex = description->id();
       }
-      if(description->moduleName() == kPathStatusInserter || description->moduleName() == kEndPathStatusInserter) {
+      if (description->moduleName() == kPathStatusInserter || description->moduleName() == kEndPathStatusInserter) {
         pathStatusInserterModuleLabelToModuleID[description->moduleLabel()] = description->id();
       }
     }
-    kPathToTriggerResultsDependencyLastIndex = largestIndex ;
-
+    kPathToTriggerResultsDependencyLastIndex = largestIndex;
 
     /*
     {
@@ -221,130 +209,130 @@ namespace edm {
 
     const std::string kPathEnded("@PathEnded");
     const std::string kEndPathStart("@EndPathStart");
-    
+
     //The finished processing depends on all paths and end paths
     const std::string kFinishedProcessing("@FinishedProcessing");
     const unsigned int kFinishedProcessingIndex{0};
-    moduleIndexToNames.insert(std::make_pair(kFinishedProcessingIndex,
-                                             kFinishedProcessing));
-
+    moduleIndexToNames.insert(std::make_pair(kFinishedProcessingIndex, kFinishedProcessing));
 
     pathNames.insert(pathNames.end(), iPnC.endPaths().begin(), iPnC.endPaths().end());
     std::vector<std::vector<unsigned int>> pathIndexToModuleIndexOrder(pathNames.size());
     {
-      
-      for(unsigned int pathIndex = 0; pathIndex != pathNames.size(); ++pathIndex) {
+      for (unsigned int pathIndex = 0; pathIndex != pathNames.size(); ++pathIndex) {
         std::set<unsigned int> alreadySeenIndex;
-        
+
         std::vector<ModuleDescription const*> const* moduleDescriptions;
-        if(pathIndex < kFirstEndPathIndex) {
-          moduleDescriptions= &(iPnC.modulesOnPath(pathIndex));
+        if (pathIndex < kFirstEndPathIndex) {
+          moduleDescriptions = &(iPnC.modulesOnPath(pathIndex));
         } else {
-          moduleDescriptions= &(iPnC.modulesOnEndPath(pathIndex-kFirstEndPathIndex));
+          moduleDescriptions = &(iPnC.modulesOnEndPath(pathIndex - kFirstEndPathIndex));
         }
         unsigned int lastModuleIndex = kInvalidIndex;
-        auto& pathOrder =pathIndexToModuleIndexOrder[pathIndex];
+        auto& pathOrder = pathIndexToModuleIndexOrder[pathIndex];
         pathOrder.reserve(moduleDescriptions->size() + 1);
-        for(auto const& description: *moduleDescriptions) {
+        for (auto const& description : *moduleDescriptions) {
           auto found = alreadySeenIndex.insert(description->id());
-          if(found.second) {
+          if (found.second) {
             //first time for this path
             unsigned int const moduleIndex = description->id();
             pathOrder.push_back(moduleIndex);
-            auto& paths =moduleIndexToPathIndex[moduleIndex];
+            auto& paths = moduleIndexToPathIndex[moduleIndex];
             paths.push_back(pathIndex);
-            if(lastModuleIndex  != kInvalidIndex ) {
-              edgeToPathMap[std::make_pair(moduleIndex,lastModuleIndex)].push_back(pathIndex);
+            if (lastModuleIndex != kInvalidIndex) {
+              edgeToPathMap[std::make_pair(moduleIndex, lastModuleIndex)].push_back(pathIndex);
             }
             lastModuleIndex = moduleIndex;
           }
         }
-        //Have TriggerResults depend on the end of all paths 
+        //Have TriggerResults depend on the end of all paths
         // Have all EndPaths depend on TriggerResults
         auto labelToID = pathStatusInserterModuleLabelToModuleID.find(pathNames[pathIndex]);
-        if(labelToID == pathStatusInserterModuleLabelToModuleID.end()) {
+        if (labelToID == pathStatusInserterModuleLabelToModuleID.end()) {
           // should never happen
           throw Exception(errors::LogicError)
-            << "PathsAndConsumesOfModules::moduleDescription:checkForModuleDependencyCorrectness Could not find PathStatusInserter\n";
+              << "PathsAndConsumesOfModules::moduleDescription:checkForModuleDependencyCorrectness Could not find "
+                 "PathStatusInserter\n";
         }
         unsigned int pathStatusInserterModuleID = labelToID->second;
-        if( pathIndex < kFirstEndPathIndex) {
-          if( (lastModuleIndex  != kInvalidIndex) ) {
+        if (pathIndex < kFirstEndPathIndex) {
+          if ((lastModuleIndex != kInvalidIndex)) {
             edgeToPathMap[std::make_pair(pathStatusInserterModuleID, lastModuleIndex)].push_back(pathIndex);
-            moduleIndexToNames.insert(std::make_pair(pathStatusInserterModuleID,
-                                                     kPathEnded));
+            moduleIndexToNames.insert(std::make_pair(pathStatusInserterModuleID, kPathEnded));
             if (kTriggerResultsIndex != kInvalidIndex) {
-              edgeToPathMap[std::make_pair(kTriggerResultsIndex, pathStatusInserterModuleID)].push_back(kDataDependencyIndex);
+              edgeToPathMap[std::make_pair(kTriggerResultsIndex, pathStatusInserterModuleID)].push_back(
+                  kDataDependencyIndex);
             }
             //Need to make dependency for finished process
-            edgeToPathMap[std::make_pair(kFinishedProcessingIndex, pathStatusInserterModuleID)].push_back(kDataDependencyIndex);
+            edgeToPathMap[std::make_pair(kFinishedProcessingIndex, pathStatusInserterModuleID)].push_back(
+                kDataDependencyIndex);
             pathOrder.push_back(pathStatusInserterModuleID);
           }
         } else {
-          if( (not moduleDescriptions->empty()) ) {
+          if ((not moduleDescriptions->empty())) {
             if (kTriggerResultsIndex != kInvalidIndex) {
               ++kPathToTriggerResultsDependencyLastIndex;
-              edgeToPathMap[std::make_pair(moduleDescriptions->front()->id(),kPathToTriggerResultsDependencyLastIndex)].push_back(pathIndex);
-              moduleIndexToNames.insert(std::make_pair(kPathToTriggerResultsDependencyLastIndex,
-                                                       kEndPathStart));
-              edgeToPathMap[std::make_pair(kPathToTriggerResultsDependencyLastIndex,kTriggerResultsIndex)].push_back(kDataDependencyIndex);
-              pathOrder.insert(pathOrder.begin(),kPathToTriggerResultsDependencyLastIndex);
+              edgeToPathMap[std::make_pair(moduleDescriptions->front()->id(), kPathToTriggerResultsDependencyLastIndex)]
+                  .push_back(pathIndex);
+              moduleIndexToNames.insert(std::make_pair(kPathToTriggerResultsDependencyLastIndex, kEndPathStart));
+              edgeToPathMap[std::make_pair(kPathToTriggerResultsDependencyLastIndex, kTriggerResultsIndex)].push_back(
+                  kDataDependencyIndex);
+              pathOrder.insert(pathOrder.begin(), kPathToTriggerResultsDependencyLastIndex);
             }
             //Need to make dependency for finished process
             ++kPathToTriggerResultsDependencyLastIndex;
             edgeToPathMap[std::make_pair(pathStatusInserterModuleID, lastModuleIndex)].push_back(pathIndex);
-            moduleIndexToNames.insert(std::make_pair(pathStatusInserterModuleID,
-                                                     kPathEnded));
-            edgeToPathMap[std::make_pair(kFinishedProcessingIndex, pathStatusInserterModuleID)].push_back(kDataDependencyIndex);
+            moduleIndexToNames.insert(std::make_pair(pathStatusInserterModuleID, kPathEnded));
+            edgeToPathMap[std::make_pair(kFinishedProcessingIndex, pathStatusInserterModuleID)].push_back(
+                kDataDependencyIndex);
             pathOrder.push_back(pathStatusInserterModuleID);
           }
         }
       }
     }
     {
-
       //determine the data dependencies
-      for(auto const& description: iPnC.allModules()) {
+      for (auto const& description : iPnC.allModules()) {
         unsigned int const moduleIndex = description->id();
         auto const& dependentModules = iPnC.modulesWhoseProductsAreConsumedBy(moduleIndex);
-        for(auto const& depDescription: dependentModules) {
-          if(iPrintDependencies) {
-            edm::LogAbsolute("ModuleDependency") << "ModuleDependency '" << description->moduleLabel() <<
-            "' depends on data products from module '" << depDescription->moduleLabel()<<"'";
+        for (auto const& depDescription : dependentModules) {
+          if (iPrintDependencies) {
+            edm::LogAbsolute("ModuleDependency")
+                << "ModuleDependency '" << description->moduleLabel() << "' depends on data products from module '"
+                << depDescription->moduleLabel() << "'";
           }
           //see if all paths containing this module also contain the dependent module earlier in the path
           // if it does, then treat this only as a path dependency and not a data dependency as this
           // simplifies the circular dependency checking logic
-          auto depID =depDescription->id();
+          auto depID = depDescription->id();
           auto itPathsFound = moduleIndexToPathIndex.find(moduleIndex);
           bool keepDataDependency = true;
-          auto itDepsPathsFound =moduleIndexToPathIndex.find(depID);
-          if(itPathsFound != moduleIndexToPathIndex.end() and itDepsPathsFound != moduleIndexToPathIndex.end()) {
+          auto itDepsPathsFound = moduleIndexToPathIndex.find(depID);
+          if (itPathsFound != moduleIndexToPathIndex.end() and itDepsPathsFound != moduleIndexToPathIndex.end()) {
             keepDataDependency = false;
-            for(auto const pathIndex: itPathsFound->second) {
-              for(auto idToCheck: pathIndexToModuleIndexOrder[pathIndex]) {
-                if(idToCheck == depID) {
+            for (auto const pathIndex : itPathsFound->second) {
+              for (auto idToCheck : pathIndexToModuleIndexOrder[pathIndex]) {
+                if (idToCheck == depID) {
                   //found dependent module first so check next path
                   break;
                 }
-                if(idToCheck == moduleIndex) {
+                if (idToCheck == moduleIndex) {
                   //did not find dependent module earlier on path so
                   // must keep data dependency
                   keepDataDependency = true;
                   break;
                 }
               }
-              if(keepDataDependency) {
+              if (keepDataDependency) {
                 break;
               }
             }
           }
-          if(keepDataDependency) {
+          if (keepDataDependency) {
             edgeToPathMap[std::make_pair(moduleIndex, depID)].push_back(kDataDependencyIndex);
           }
         }
       }
     }
-    graph::throwIfImproperDependencies(edgeToPathMap,pathIndexToModuleIndexOrder,pathNames,moduleIndexToNames);
+    graph::throwIfImproperDependencies(edgeToPathMap, pathIndexToModuleIndexOrder, pathNames, moduleIndexToNames);
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/PreallocationConfiguration.h
+++ b/FWCore/Framework/src/PreallocationConfiguration.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     PreallocationConfiguration
-// 
+//
 /**\class edm::PreallocationConfiguration PreallocationConfiguration.h "PreallocationConfiguration.h"
 
  Description: Holds number of simultaneous Streams, LuminosityBlocks and Runs the job will allow.
@@ -24,39 +24,29 @@
 
 // forward declarations
 namespace edm {
-  class PreallocationConfiguration
-  {
-    
+  class PreallocationConfiguration {
   public:
-    PreallocationConfiguration():
-    PreallocationConfiguration(1,1,1,1) {}
-    PreallocationConfiguration(unsigned int iNThreads,
-                               unsigned int iNStreams,
-                               unsigned int iNLumis,
-                               unsigned int iNRuns ):
-    m_nthreads(iNThreads),
-    m_nStreams(iNStreams),
-    m_nLumis(iNLumis),
-    m_nRuns(iNRuns) {}
-    
+    PreallocationConfiguration() : PreallocationConfiguration(1, 1, 1, 1) {}
+    PreallocationConfiguration(unsigned int iNThreads, unsigned int iNStreams, unsigned int iNLumis, unsigned int iNRuns)
+        : m_nthreads(iNThreads), m_nStreams(iNStreams), m_nLumis(iNLumis), m_nRuns(iNRuns) {}
+
     // ---------- const member functions ---------------------
-    unsigned int numberOfThreads() const {return m_nthreads;}
-    unsigned int numberOfStreams() const {return m_nStreams;}
-    unsigned int numberOfLuminosityBlocks() const {return m_nLumis;}
-    unsigned int numberOfRuns() const {return m_nRuns;}
-    
+    unsigned int numberOfThreads() const { return m_nthreads; }
+    unsigned int numberOfStreams() const { return m_nStreams; }
+    unsigned int numberOfLuminosityBlocks() const { return m_nLumis; }
+    unsigned int numberOfRuns() const { return m_nRuns; }
+
   private:
     //PreallocationConfiguration(const PreallocationConfiguration&) = delete; // stop default
-    
+
     //const PreallocationConfiguration& operator=(const PreallocationConfiguration&) = delete; // stop default
-    
+
     // ---------- member data --------------------------------
     unsigned int m_nthreads;
     unsigned int m_nStreams;
     unsigned int m_nLumis;
     unsigned int m_nRuns;
   };
-}
-
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -33,8 +33,8 @@ namespace edm {
 
   static ProcessHistory const s_emptyProcessHistory;
 
-  static
-  std::string appendCurrentProcessIfAlias(std::string const& processFromInputTag, std::string const& currentProcess) {
+  static std::string appendCurrentProcessIfAlias(std::string const& processFromInputTag,
+                                                 std::string const& currentProcess) {
     if (processFromInputTag == InputTag::kCurrentProcess) {
       std::string returnValue = processFromInputTag;
       returnValue += " (";
@@ -45,41 +45,49 @@ namespace edm {
     return processFromInputTag;
   }
 
-  static
-  void
-  throwProductNotFoundException(char const* where, errors::ErrorCodes error, BranchID const& bid) {
-    throw Exception(error, "InvalidID")
-      << "Principal::" << where << ": no product with given branch id: "<< bid << "\n";
+  static void throwProductNotFoundException(char const* where, errors::ErrorCodes error, BranchID const& bid) {
+    throw Exception(error, "InvalidID") << "Principal::" << where << ": no product with given branch id: " << bid
+                                        << "\n";
   }
 
-  static
-  std::shared_ptr<cms::Exception>
-  makeNotFoundException(char const* where, KindOfType kindOfType,
-                        TypeID const& productType, std::string const& label, std::string const& instance, std::string const& process) {
+  static std::shared_ptr<cms::Exception> makeNotFoundException(char const* where,
+                                                               KindOfType kindOfType,
+                                                               TypeID const& productType,
+                                                               std::string const& label,
+                                                               std::string const& instance,
+                                                               std::string const& process) {
     std::shared_ptr<cms::Exception> exception = std::make_shared<Exception>(errors::ProductNotFound);
     if (kindOfType == PRODUCT_TYPE) {
-      *exception << "Principal::" << where << ": Found zero products matching all criteria\nLooking for type: " << productType << "\n"
-                 << "Looking for module label: " << label << "\n" << "Looking for productInstanceName: " << instance << "\n"
+      *exception << "Principal::" << where
+                 << ": Found zero products matching all criteria\nLooking for type: " << productType << "\n"
+                 << "Looking for module label: " << label << "\n"
+                 << "Looking for productInstanceName: " << instance << "\n"
                  << (process.empty() ? "" : "Looking for process: ") << process << "\n";
     } else {
-      *exception << "Principal::" << where << ": Found zero products matching all criteria\nLooking for a container with elements of type: " << productType << "\n"
-                 << "Looking for module label: " << label << "\n" << "Looking for productInstanceName: " << instance << "\n"
+      *exception << "Principal::" << where
+                 << ": Found zero products matching all criteria\nLooking for a container with elements of type: "
+                 << productType << "\n"
+                 << "Looking for module label: " << label << "\n"
+                 << "Looking for productInstanceName: " << instance << "\n"
                  << (process.empty() ? "" : "Looking for process: ") << process << "\n";
     }
     return exception;
   }
 
-  static
-  void
-  throwAmbiguousException(const char* where, TypeID const& productType,std::string const& label, std::string const& instance, std::string const& process) {
+  static void throwAmbiguousException(const char* where,
+                                      TypeID const& productType,
+                                      std::string const& label,
+                                      std::string const& instance,
+                                      std::string const& process) {
     cms::Exception exception("AmbiguousProduct");
-    exception << "Principal::" << where << ": More than 1 product matches all criteria\nLooking for type: " << productType << "\n"
-    << "Looking for module label: " << label << "\n" << "Looking for productInstanceName: " << instance << "\n"
-    << (process.empty() ? "" : "Looking for process: ") << process << "\n"
-    << "This can only occur with get function calls using a Handle<View> argument.\n"
-    << "Try a get not using a View or change the instance name of one of the products";
+    exception << "Principal::" << where
+              << ": More than 1 product matches all criteria\nLooking for type: " << productType << "\n"
+              << "Looking for module label: " << label << "\n"
+              << "Looking for productInstanceName: " << instance << "\n"
+              << (process.empty() ? "" : "Looking for process: ") << process << "\n"
+              << "This can only occur with get function calls using a Handle<View> argument.\n"
+              << "Try a get not using a View or change the instance name of one of the products";
     throw exception;
-    
   }
 
   namespace {
@@ -89,7 +97,7 @@ namespace edm {
                 << " without a corresponding consumesMany being called for this module. \n";
       throw exception;
     }
-    
+
     void failedToRegisterConsumes(KindOfType kindOfType,
                                   TypeID const& productType,
                                   std::string const& moduleLabel,
@@ -99,38 +107,37 @@ namespace edm {
       exception << "::getByLabel without corresponding call to consumes or mayConsumes for this module.\n"
                 << (kindOfType == PRODUCT_TYPE ? "  type: " : " type: edm::View<") << productType
                 << (kindOfType == PRODUCT_TYPE ? "\n  module label: " : ">\n  module label: ") << moduleLabel
-                <<"\n  product instance name: '" << productInstanceName
-                <<"'\n  process name: '" << processName << "'\n";
+                << "\n  product instance name: '" << productInstanceName << "'\n  process name: '" << processName
+                << "'\n";
       throw exception;
     }
-}
+  }  // namespace
 
   //0 means unset
   static std::atomic<Principal::CacheIdentifier_t> s_nextIdentifier{1};
   static inline Principal::CacheIdentifier_t nextIdentifier() {
-    return s_nextIdentifier.fetch_add(1,std::memory_order_acq_rel);
+    return s_nextIdentifier.fetch_add(1, std::memory_order_acq_rel);
   }
-  
+
   Principal::Principal(std::shared_ptr<ProductRegistry const> reg,
                        std::shared_ptr<ProductResolverIndexHelper const> productLookup,
                        ProcessConfiguration const& pc,
                        BranchType bt,
                        HistoryAppender* historyAppender,
-                       bool isForPrimaryProcess) :
-    EDProductGetter(),
-    processHistoryPtr_(),
-    processHistoryID_(),
-    processHistoryIDBeforeConfig_(),
-    processConfiguration_(&pc),
-    productResolvers_(),
-    preg_(reg),
-    productLookup_(productLookup),
-    lookupProcessOrder_(productLookup->lookupProcessNames().size(), 0),
-    reader_(),
-    branchType_(bt),
-    historyAppender_(historyAppender),
-    cacheIdentifier_(nextIdentifier())
-  {
+                       bool isForPrimaryProcess)
+      : EDProductGetter(),
+        processHistoryPtr_(),
+        processHistoryID_(),
+        processHistoryIDBeforeConfig_(),
+        processConfiguration_(&pc),
+        productResolvers_(),
+        preg_(reg),
+        productLookup_(productLookup),
+        lookupProcessOrder_(productLookup->lookupProcessNames().size(), 0),
+        reader_(),
+        branchType_(bt),
+        historyAppender_(historyAppender),
+        cacheIdentifier_(nextIdentifier()) {
     productResolvers_.resize(reg->getNextIndexValue(bt));
     //Now that these have been set, we can create the list of Branches we need.
     std::string const source("source");
@@ -139,18 +146,18 @@ namespace edm {
     // So, the non-alias product holders must be created first.
     // Therefore, on this first pass, skip current EDAliases.
     bool hasAliases = false;
-    for(auto const& prod : prodsList) {
+    for (auto const& prod : prodsList) {
       BranchDescription const& bd = prod.second;
-      if(bd.branchType() == branchType_) {
-        if(isForPrimaryProcess or bd.processName() == pc.processName()) {
-          if(bd.isAnyAlias()) {
+      if (bd.branchType() == branchType_) {
+        if (isForPrimaryProcess or bd.processName() == pc.processName()) {
+          if (bd.isAnyAlias()) {
             hasAliases = true;
           } else {
             auto cbd = std::make_shared<BranchDescription const>(bd);
-            if(bd.produced()) {
-              if(bd.moduleLabel() == source) {
+            if (bd.produced()) {
+              if (bd.moduleLabel() == source) {
                 addSourceProduct(cbd);
-              } else if(bd.onDemand()) {
+              } else if (bd.onDemand()) {
                 assert(branchType_ == InEvent);
                 addUnscheduledProduct(cbd);
               } else {
@@ -162,32 +169,30 @@ namespace edm {
           }
         } else {
           //We are in a SubProcess and this branch is from the parent
-          auto cbd =std::make_shared<BranchDescription const>(bd);
+          auto cbd = std::make_shared<BranchDescription const>(bd);
           addParentProcessProduct(cbd);
         }
       }
     }
     // Now process any EDAliases
-    if(hasAliases) {
-      for(auto const& prod : prodsList) {
+    if (hasAliases) {
+      for (auto const& prod : prodsList) {
         BranchDescription const& bd = prod.second;
-        if(bd.isAnyAlias() && bd.branchType() == branchType_) {
+        if (bd.isAnyAlias() && bd.branchType() == branchType_) {
           auto cbd = std::make_shared<BranchDescription const>(bd);
-          if(bd.isSwitchAlias()) {
+          if (bd.isSwitchAlias()) {
             assert(branchType_ == InEvent);
             // Need different implementation for SwitchProducers not
             // in any Path (onDemand) and for those in a Path in order
             // to prevent the switch-aliased-for EDProducers from
             // being run when the SwitchProducer is in a Path after a
             // failing EDFilter.
-            if(bd.onDemand()) {
+            if (bd.onDemand()) {
               addSwitchAliasProduct(cbd);
-            }
-            else {
+            } else {
               addSwitchProducerProduct(cbd);
             }
-          }
-          else {
+          } else {
             addAliasedProduct(cbd);
           }
         }
@@ -207,36 +212,36 @@ namespace edm {
     std::vector<char> const& processNamesCharArray = productLookup_->processNames();
 
     unsigned int numberOfMatches = 0;
-    ProductResolverIndex lastMatchIndex =ProductResolverIndexInvalid;
+    ProductResolverIndex lastMatchIndex = ProductResolverIndexInvalid;
     if (!sortedTypeIDs.empty()) {
       ProductResolverIndex productResolverIndex = ProductResolverIndexInvalid;
-      for(unsigned int k = 0, kEnd = sortedTypeIDs.size(); k < kEnd; ++k) {
+      for (unsigned int k = 0, kEnd = sortedTypeIDs.size(); k < kEnd; ++k) {
         ProductResolverIndexHelper::Range const& range = ranges.at(k);
         for (unsigned int i = range.begin(); i < range.end(); ++i) {
           ProductResolverIndexHelper::IndexAndNames const& product = indexAndNames.at(i);
           if (product.startInProcessNames() == 0) {
             if (productResolverIndex != ProductResolverIndexInvalid) {
-              if ((numberOfMatches == 1) and
-                  (lastMatchIndex != ProductResolverIndexAmbiguous)) {
+              if ((numberOfMatches == 1) and (lastMatchIndex != ProductResolverIndexAmbiguous)) {
                 //only one choice so use a special resolver
-                productResolvers_.at(productResolverIndex) = std::make_shared<SingleChoiceNoProcessProductResolver>(lastMatchIndex);
+                productResolvers_.at(productResolverIndex) =
+                    std::make_shared<SingleChoiceNoProcessProductResolver>(lastMatchIndex);
               } else {
                 bool productMadeAtEnd = false;
                 //Need to know if the product from this processes is added at end of transition
-                for(unsigned int i=0; i< matchingHolders.size();++i) {
-                  if( (not ambiguous[i]) and
-                     ProductResolverIndexInvalid != matchingHolders[i] and
-                     productResolvers_[matchingHolders[i]]->branchDescription().availableOnlyAtEndTransition()) {
+                for (unsigned int i = 0; i < matchingHolders.size(); ++i) {
+                  if ((not ambiguous[i]) and ProductResolverIndexInvalid != matchingHolders[i] and
+                      productResolvers_[matchingHolders[i]]->branchDescription().availableOnlyAtEndTransition()) {
                     productMadeAtEnd = true;
                     break;
                   }
                 }
-                std::shared_ptr<ProductResolverBase> newHolder = std::make_shared<NoProcessProductResolver>(matchingHolders, ambiguous, productMadeAtEnd);
+                std::shared_ptr<ProductResolverBase> newHolder =
+                    std::make_shared<NoProcessProductResolver>(matchingHolders, ambiguous, productMadeAtEnd);
                 productResolvers_.at(productResolverIndex) = newHolder;
               }
               matchingHolders.assign(lookupProcessNames.size(), ProductResolverIndexInvalid);
               ambiguous.assign(lookupProcessNames.size(), false);
-              numberOfMatches= 0;
+              numberOfMatches = 0;
               lastMatchIndex = ProductResolverIndexInvalid;
             }
             productResolverIndex = product.index();
@@ -258,40 +263,36 @@ namespace edm {
         }
       }
       //Need to know if the product from this processes is added at end of transition
-      if ((numberOfMatches == 1) and
-          (lastMatchIndex != ProductResolverIndexAmbiguous)) {
+      if ((numberOfMatches == 1) and (lastMatchIndex != ProductResolverIndexAmbiguous)) {
         //only one choice so use a special resolver
-        productResolvers_.at(productResolverIndex) = std::make_shared<SingleChoiceNoProcessProductResolver>(lastMatchIndex);
+        productResolvers_.at(productResolverIndex) =
+            std::make_shared<SingleChoiceNoProcessProductResolver>(lastMatchIndex);
       } else {
         bool productMadeAtEnd = false;
-        for(unsigned int i=0; i< matchingHolders.size();++i) {
-          if( (not ambiguous[i]) and
-             ProductResolverIndexInvalid != matchingHolders[i] and
-             productResolvers_[matchingHolders[i]]->branchDescription().availableOnlyAtEndTransition()) {
+        for (unsigned int i = 0; i < matchingHolders.size(); ++i) {
+          if ((not ambiguous[i]) and ProductResolverIndexInvalid != matchingHolders[i] and
+              productResolvers_[matchingHolders[i]]->branchDescription().availableOnlyAtEndTransition()) {
             productMadeAtEnd = true;
             break;
           }
         }
-        std::shared_ptr<ProductResolverBase> newHolder = std::make_shared<NoProcessProductResolver>(matchingHolders, ambiguous, productMadeAtEnd);
+        std::shared_ptr<ProductResolverBase> newHolder =
+            std::make_shared<NoProcessProductResolver>(matchingHolders, ambiguous, productMadeAtEnd);
         productResolvers_.at(productResolverIndex) = newHolder;
       }
     }
   }
 
-  Principal::~Principal() {
-  }
+  Principal::~Principal() {}
 
   // Number of products in the Principal.
   // For products in an input file and not yet read in due to delayed read,
   // this routine assumes a real product is there.
-  size_t
-  Principal::size() const {
+  size_t Principal::size() const {
     size_t size = 0U;
-    for(auto const& prod : *this) {
-      if(prod->singleProduct() && // Not a NoProcessProductResolver
-         !prod->productUnavailable() &&
-         !prod->unscheduledWasNotRun() &&
-         !prod->branchDescription().dropped()) {
+    for (auto const& prod : *this) {
+      if (prod->singleProduct() &&  // Not a NoProcessProductResolver
+          !prod->productUnavailable() && !prod->unscheduledWasNotRun() && !prod->branchDescription().dropped()) {
         ++size;
       }
     }
@@ -299,16 +300,15 @@ namespace edm {
   }
 
   // adjust provenance for input products after new input file has been merged
-  bool
-  Principal::adjustToNewProductRegistry(ProductRegistry const& reg) {
+  bool Principal::adjustToNewProductRegistry(ProductRegistry const& reg) {
     ProductRegistry::ProductList const& prodsList = reg.productList();
-    for(auto const& prod : prodsList) {
+    for (auto const& prod : prodsList) {
       BranchDescription const& bd = prod.second;
-      if(!bd.produced() && (bd.branchType() == branchType_)) {
+      if (!bd.produced() && (bd.branchType() == branchType_)) {
         auto cbd = std::make_shared<BranchDescription const>(bd);
         auto phb = getExistingProduct(cbd->branchID());
-        if(phb == nullptr || phb->branchDescription().branchName() != cbd->branchName()) {
-            return false;
+        if (phb == nullptr || phb->branchDescription().branchName() != cbd->branchName()) {
+          return false;
         }
         phb->resetBranchDescription(cbd);
       }
@@ -316,122 +316,105 @@ namespace edm {
     return true;
   }
 
-  void
-  Principal::addScheduledProduct(std::shared_ptr<BranchDescription const> bd) {
+  void Principal::addScheduledProduct(std::shared_ptr<BranchDescription const> bd) {
     auto phb = std::make_unique<PuttableProductResolver>(std::move(bd));
     addProductOrThrow(std::move(phb));
   }
 
-  void
-  Principal::addSourceProduct(std::shared_ptr<BranchDescription const> bd) {
+  void Principal::addSourceProduct(std::shared_ptr<BranchDescription const> bd) {
     auto phb = std::make_unique<PuttableProductResolver>(std::move(bd));
     addProductOrThrow(std::move(phb));
   }
 
-  void
-  Principal::addInputProduct(std::shared_ptr<BranchDescription const> bd) {
+  void Principal::addInputProduct(std::shared_ptr<BranchDescription const> bd) {
     addProductOrThrow(std::make_unique<InputProductResolver>(std::move(bd)));
   }
 
-  void
-  Principal::addUnscheduledProduct(std::shared_ptr<BranchDescription const> bd) {
+  void Principal::addUnscheduledProduct(std::shared_ptr<BranchDescription const> bd) {
     addProductOrThrow(std::make_unique<UnscheduledProductResolver>(std::move(bd)));
   }
 
-  void
-  Principal::addAliasedProduct(std::shared_ptr<BranchDescription const> bd) {
+  void Principal::addAliasedProduct(std::shared_ptr<BranchDescription const> bd) {
     ProductResolverIndex index = preg_->indexFrom(bd->originalBranchID());
     assert(index != ProductResolverIndexInvalid);
 
-    addProductOrThrow(std::make_unique<AliasProductResolver>(std::move(bd), dynamic_cast<ProducedProductResolver&>(*productResolvers_[index])));
+    addProductOrThrow(std::make_unique<AliasProductResolver>(
+        std::move(bd), dynamic_cast<ProducedProductResolver&>(*productResolvers_[index])));
   }
 
-  void
-  Principal::addSwitchProducerProduct(std::shared_ptr<BranchDescription const> bd) {
+  void Principal::addSwitchProducerProduct(std::shared_ptr<BranchDescription const> bd) {
     ProductResolverIndex index = preg_->indexFrom(bd->switchAliasForBranchID());
     assert(index != ProductResolverIndexInvalid);
 
-    addProductOrThrow(std::make_unique<SwitchProducerProductResolver>(std::move(bd), dynamic_cast<ProducedProductResolver&>(*productResolvers_[index])));
+    addProductOrThrow(std::make_unique<SwitchProducerProductResolver>(
+        std::move(bd), dynamic_cast<ProducedProductResolver&>(*productResolvers_[index])));
   }
 
-  void
-  Principal::addSwitchAliasProduct(std::shared_ptr<BranchDescription const> bd) {
+  void Principal::addSwitchAliasProduct(std::shared_ptr<BranchDescription const> bd) {
     ProductResolverIndex index = preg_->indexFrom(bd->switchAliasForBranchID());
     assert(index != ProductResolverIndexInvalid);
 
-    addProductOrThrow(std::make_unique<SwitchAliasProductResolver>(std::move(bd), dynamic_cast<ProducedProductResolver&>(*productResolvers_[index])));
+    addProductOrThrow(std::make_unique<SwitchAliasProductResolver>(
+        std::move(bd), dynamic_cast<ProducedProductResolver&>(*productResolvers_[index])));
   }
 
-  void
-  Principal::addParentProcessProduct(std::shared_ptr<BranchDescription const> bd) {
+  void Principal::addParentProcessProduct(std::shared_ptr<BranchDescription const> bd) {
     addProductOrThrow(std::make_unique<ParentProcessProductResolver>(std::move(bd)));
   }
 
   // "Zero" the principal so it can be reused for another Event.
-  void
-  Principal::clearPrincipal() {
+  void Principal::clearPrincipal() {
     //We do not clear the product history information
     // because it rarely changes and recalculating takes
     // time.
     reader_ = nullptr;
-    for(auto& prod : *this) {
+    for (auto& prod : *this) {
       prod->resetProductData();
     }
   }
 
-  void
-  Principal::deleteProduct(BranchID const& id) const {
+  void Principal::deleteProduct(BranchID const& id) const {
     auto phb = getExistingProduct(id);
     assert(nullptr != phb);
     phb->unsafe_deleteProduct();
   }
-  
-  void
-  Principal::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
-    applyToResolvers([&iConfigure](ProductResolverBase* iResolver) {
-      iResolver->setupUnscheduled(iConfigure);
-    });
+
+  void Principal::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
+    applyToResolvers([&iConfigure](ProductResolverBase* iResolver) { iResolver->setupUnscheduled(iConfigure); });
   }
-  
 
   // Set the principal for the Event, Lumi, or Run.
-  void
-  Principal::fillPrincipal(ProcessHistoryID const& hist,
-                           ProcessHistoryRegistry const& processHistoryRegistry,
-                           DelayedReader* reader) {
+  void Principal::fillPrincipal(ProcessHistoryID const& hist,
+                                ProcessHistoryRegistry const& processHistoryRegistry,
+                                DelayedReader* reader) {
     //increment identifier here since clearPrincipal isn't called for Run/Lumi
-    cacheIdentifier_=nextIdentifier();
-    if(reader) {
+    cacheIdentifier_ = nextIdentifier();
+    if (reader) {
       reader_ = reader;
     }
 
     if (historyAppender_ && productRegistry().anyProductProduced()) {
-      if( (not processHistoryPtr_) || (processHistoryIDBeforeConfig_ != hist) ) {
-        processHistoryPtr_ =
-          historyAppender_->appendToProcessHistory(hist,
-                                                   processHistoryRegistry.  getMapped(hist),
-                                                   *processConfiguration_);
+      if ((not processHistoryPtr_) || (processHistoryIDBeforeConfig_ != hist)) {
+        processHistoryPtr_ = historyAppender_->appendToProcessHistory(hist, processHistoryRegistry.getMapped(hist),
+                                                                      *processConfiguration_);
         processHistoryID_ = processHistoryPtr_->id();
         processHistoryIDBeforeConfig_ = hist;
       }
-    }
-    else {
+    } else {
       std::shared_ptr<ProcessHistory const> inputProcessHistory;
-      if( (not processHistoryPtr_) || (processHistoryIDBeforeConfig_ != hist) ) {
+      if ((not processHistoryPtr_) || (processHistoryIDBeforeConfig_ != hist)) {
         if (hist.isValid()) {
           //does not own the pointer
-          auto noDel =[](void const*){};
-          inputProcessHistory =
-          std::shared_ptr<ProcessHistory const>(processHistoryRegistry.getMapped(hist),noDel);
+          auto noDel = [](void const*) {};
+          inputProcessHistory = std::shared_ptr<ProcessHistory const>(processHistoryRegistry.getMapped(hist), noDel);
           if (inputProcessHistory.get() == nullptr) {
-            throw Exception(errors::LogicError)
-              << "Principal::fillPrincipal\n"
-              << "Input ProcessHistory not found in registry\n"
-              << "Contact a Framework developer\n";
+            throw Exception(errors::LogicError) << "Principal::fillPrincipal\n"
+                                                << "Input ProcessHistory not found in registry\n"
+                                                << "Contact a Framework developer\n";
           }
         } else {
           //Since this is static we don't want it deleted
-          inputProcessHistory = std::shared_ptr<ProcessHistory const>(&s_emptyProcessHistory,[](void const*){});
+          inputProcessHistory = std::shared_ptr<ProcessHistory const>(&s_emptyProcessHistory, [](void const*) {});
           //no need to do any ordering since it is empty
           orderProcessHistoryID_ = hist;
         }
@@ -454,7 +437,8 @@ namespace edm {
       // The current process might be needed but not be in the process
       // history if all the products produced in the current process are
       // transient.
-      auto nameIter = std::find(lookupProcessNames.begin(), lookupProcessNames.end(), processConfiguration_->processName());
+      auto nameIter =
+          std::find(lookupProcessNames.begin(), lookupProcessNames.end(), processConfiguration_->processName());
       if (nameIter != lookupProcessNames.end()) {
         lookupProcessOrder_.at(k) = nameIter - lookupProcessNames.begin();
         ++k;
@@ -479,28 +463,27 @@ namespace edm {
     }
   }
 
-  ProductResolverBase*
-  Principal::getExistingProduct(BranchID const& branchID) {
-    return const_cast<ProductResolverBase*>( const_cast<const Principal*>(this)->getExistingProduct(branchID));
+  ProductResolverBase* Principal::getExistingProduct(BranchID const& branchID) {
+    return const_cast<ProductResolverBase*>(const_cast<const Principal*>(this)->getExistingProduct(branchID));
   }
 
-  ProductResolverBase const*
-  Principal::getExistingProduct(BranchID const& branchID) const {
+  ProductResolverBase const* Principal::getExistingProduct(BranchID const& branchID) const {
     ProductResolverIndex index = preg_->indexFrom(branchID);
     assert(index != ProductResolverIndexInvalid);
     return productResolvers_.at(index).get();
   }
 
-  ProductResolverBase const*
-  Principal::getExistingProduct(ProductResolverBase const& productResolver) const {
+  ProductResolverBase const* Principal::getExistingProduct(ProductResolverBase const& productResolver) const {
     auto phb = getExistingProduct(productResolver.branchDescription().branchID());
-    if(nullptr != phb && BranchKey(productResolver.branchDescription()) != BranchKey(phb->branchDescription())) {
+    if (nullptr != phb && BranchKey(productResolver.branchDescription()) != BranchKey(phb->branchDescription())) {
       BranchDescription const& newProduct = phb->branchDescription();
       BranchDescription const& existing = productResolver.branchDescription();
-      if(newProduct.branchName() != existing.branchName() && newProduct.branchID() == existing.branchID()) {
-        throw cms::Exception("HashCollision") << "Principal::getExistingProduct\n" <<
-          " Branch " << newProduct.branchName() << " has same branch ID as branch " << existing.branchName() << "\n" <<
-          "Workaround: change process name or product instance name of " << newProduct.branchName() << "\n";
+      if (newProduct.branchName() != existing.branchName() && newProduct.branchID() == existing.branchID()) {
+        throw cms::Exception("HashCollision")
+            << "Principal::getExistingProduct\n"
+            << " Branch " << newProduct.branchName() << " has same branch ID as branch " << existing.branchName()
+            << "\n"
+            << "Workaround: change process name or product instance name of " << newProduct.branchName() << "\n";
       } else {
         assert(nullptr == phb || BranchKey(productResolver.branchDescription()) == BranchKey(phb->branchDescription()));
       }
@@ -508,13 +491,12 @@ namespace edm {
     return phb;
   }
 
-  void
-  Principal::addProduct_(std::unique_ptr<ProductResolverBase> productResolver) {
+  void Principal::addProduct_(std::unique_ptr<ProductResolverBase> productResolver) {
     BranchDescription const& bd = productResolver->branchDescription();
-    assert (!bd.className().empty());
-    assert (!bd.friendlyClassName().empty());
-    assert (!bd.moduleLabel().empty());
-    assert (!bd.processName().empty());
+    assert(!bd.className().empty());
+    assert(!bd.friendlyClassName().empty());
+    assert(!bd.moduleLabel().empty());
+    assert(!bd.processName().empty());
     SharedProductPtr phb(productResolver.release());
 
     ProductResolverIndex index = preg_->indexFrom(bd.branchID());
@@ -522,96 +504,84 @@ namespace edm {
     productResolvers_[index] = phb;
   }
 
-  void
-  Principal::addProductOrThrow(std::unique_ptr<ProductResolverBase> productResolver) {
+  void Principal::addProductOrThrow(std::unique_ptr<ProductResolverBase> productResolver) {
     ProductResolverBase const* phb = getExistingProduct(*productResolver);
-    if(phb != nullptr) {
+    if (phb != nullptr) {
       BranchDescription const& bd = productResolver->branchDescription();
       throw Exception(errors::InsertFailure, "AlreadyPresent")
           << "addProductOrThrow: Problem found while adding product, "
-          << "product already exists for ("
-          << bd.friendlyClassName() << ","
-          << bd.moduleLabel() << ","
-          << bd.productInstanceName() << ","
-          << bd.processName()
-          << ")\n";
+          << "product already exists for (" << bd.friendlyClassName() << "," << bd.moduleLabel() << ","
+          << bd.productInstanceName() << "," << bd.processName() << ")\n";
     }
     addProduct_(std::move(productResolver));
   }
 
-  Principal::ConstProductResolverPtr
-  Principal::getProductResolver(BranchID const& bid) const {
+  Principal::ConstProductResolverPtr Principal::getProductResolver(BranchID const& bid) const {
     ProductResolverIndex index = preg_->indexFrom(bid);
-    if(index == ProductResolverIndexInvalid){
-       return ConstProductResolverPtr();
+    if (index == ProductResolverIndexInvalid) {
+      return ConstProductResolverPtr();
     }
     return getProductResolverByIndex(index);
   }
 
-  Principal::ConstProductResolverPtr
-  Principal::getProductResolverByIndex(ProductResolverIndex const& index) const {
-
+  Principal::ConstProductResolverPtr Principal::getProductResolverByIndex(ProductResolverIndex const& index) const {
     ConstProductResolverPtr const phb = productResolvers_[index].get();
     return phb;
   }
 
-  BasicHandle
-  Principal::getByLabel(KindOfType kindOfType,
-                        TypeID const& typeID,
-                        InputTag const& inputTag,
-                        EDConsumerBase const* consumer,
-                        SharedResourcesAcquirer* sra,
-                        ModuleCallingContext const* mcc) const {
-
+  BasicHandle Principal::getByLabel(KindOfType kindOfType,
+                                    TypeID const& typeID,
+                                    InputTag const& inputTag,
+                                    EDConsumerBase const* consumer,
+                                    SharedResourcesAcquirer* sra,
+                                    ModuleCallingContext const* mcc) const {
     ProductData const* result = findProductByLabel(kindOfType, typeID, inputTag, consumer, sra, mcc);
-    if(result == nullptr) {
-      return BasicHandle(makeHandleExceptionFactory([=]()->std::shared_ptr<cms::Exception> {
-        return makeNotFoundException("getByLabel", kindOfType, typeID, inputTag.label(), inputTag.instance(),
-                                     appendCurrentProcessIfAlias(inputTag.process(), processConfiguration_->processName()));
+    if (result == nullptr) {
+      return BasicHandle(makeHandleExceptionFactory([=]() -> std::shared_ptr<cms::Exception> {
+        return makeNotFoundException(
+            "getByLabel", kindOfType, typeID, inputTag.label(), inputTag.instance(),
+            appendCurrentProcessIfAlias(inputTag.process(), processConfiguration_->processName()));
       }));
     }
     return BasicHandle(result->wrapper(), &(result->provenance()));
   }
 
-  BasicHandle
-  Principal::getByLabel(KindOfType kindOfType,
-                        TypeID const& typeID,
-                        std::string const& label,
-                        std::string const& instance,
-                        std::string const& process,
-                        EDConsumerBase const* consumer,
-                        SharedResourcesAcquirer* sra,
-                        ModuleCallingContext const* mcc) const {
-
-    ProductData const* result = findProductByLabel(kindOfType, typeID, label, instance, process,consumer, sra, mcc);
-    if(result == nullptr) {
-      return BasicHandle(makeHandleExceptionFactory([=]()->std::shared_ptr<cms::Exception> {
+  BasicHandle Principal::getByLabel(KindOfType kindOfType,
+                                    TypeID const& typeID,
+                                    std::string const& label,
+                                    std::string const& instance,
+                                    std::string const& process,
+                                    EDConsumerBase const* consumer,
+                                    SharedResourcesAcquirer* sra,
+                                    ModuleCallingContext const* mcc) const {
+    ProductData const* result = findProductByLabel(kindOfType, typeID, label, instance, process, consumer, sra, mcc);
+    if (result == nullptr) {
+      return BasicHandle(makeHandleExceptionFactory([=]() -> std::shared_ptr<cms::Exception> {
         return makeNotFoundException("getByLabel", kindOfType, typeID, label, instance, process);
       }));
     }
     return BasicHandle(result->wrapper(), &(result->provenance()));
   }
 
-  BasicHandle
-  Principal::getByToken(KindOfType,
-                        TypeID const&,
-                        ProductResolverIndex index,
-                        bool skipCurrentProcess,
-                        bool& ambiguous,
-                        SharedResourcesAcquirer* sra,
-                        ModuleCallingContext const* mcc) const {
-    assert(index !=ProductResolverIndexInvalid);
+  BasicHandle Principal::getByToken(KindOfType,
+                                    TypeID const&,
+                                    ProductResolverIndex index,
+                                    bool skipCurrentProcess,
+                                    bool& ambiguous,
+                                    SharedResourcesAcquirer* sra,
+                                    ModuleCallingContext const* mcc) const {
+    assert(index != ProductResolverIndexInvalid);
     auto& productResolver = productResolvers_[index];
-    assert(nullptr!=productResolver.get());
+    assert(nullptr != productResolver.get());
     auto resolution = productResolver->resolveProduct(*this, skipCurrentProcess, sra, mcc);
-    if(resolution.isAmbiguous()) {
+    if (resolution.isAmbiguous()) {
       ambiguous = true;
       //The caller is looking explicitly for this case
       // and uses the extra data at the caller to setup the exception
       return BasicHandle::makeInvalid();
     }
     auto productData = resolution.data();
-    if(productData == nullptr) {
+    if (productData == nullptr) {
       //The caller is looking explicitly for this case
       // and uses the extra data at the caller to setup the exception
       return BasicHandle::makeInvalid();
@@ -619,33 +589,29 @@ namespace edm {
     return BasicHandle(productData->wrapper(), &(productData->provenance()));
   }
 
-  void
-  Principal::prefetchAsync(WaitingTask * task,
-                      ProductResolverIndex index,
-                      bool skipCurrentProcess,
-                      ServiceToken const& token,
-                      ModuleCallingContext const* mcc) const {
+  void Principal::prefetchAsync(WaitingTask* task,
+                                ProductResolverIndex index,
+                                bool skipCurrentProcess,
+                                ServiceToken const& token,
+                                ModuleCallingContext const* mcc) const {
     auto const& productResolver = productResolvers_.at(index);
-    assert(nullptr!=productResolver.get());
-    productResolver->prefetchAsync(task,*this, skipCurrentProcess,token, nullptr,mcc);
+    assert(nullptr != productResolver.get());
+    productResolver->prefetchAsync(task, *this, skipCurrentProcess, token, nullptr, mcc);
   }
 
-  void
-  Principal::getManyByType(TypeID const& typeID,
-                           BasicHandleVec& results,
-                           EDConsumerBase const* consumer,
-                           SharedResourcesAcquirer* sra,
-                           ModuleCallingContext const* mcc) const {
-
+  void Principal::getManyByType(TypeID const& typeID,
+                                BasicHandleVec& results,
+                                EDConsumerBase const* consumer,
+                                SharedResourcesAcquirer* sra,
+                                ModuleCallingContext const* mcc) const {
     assert(results.empty());
 
-    if(UNLIKELY(consumer and (not consumer->registeredToConsumeMany(typeID,branchType())))) {
+    if (UNLIKELY(consumer and (not consumer->registeredToConsumeMany(typeID, branchType())))) {
       failedToRegisterConsumesMany(typeID);
     }
 
     // This finds the indexes to all the ProductResolver's matching the type
-    ProductResolverIndexHelper::Matches matches =
-      productLookup().relatedIndexes(PRODUCT_TYPE, typeID);
+    ProductResolverIndexHelper::Matches matches = productLookup().relatedIndexes(PRODUCT_TYPE, typeID);
 
     if (matches.numberOfMatches() == 0) {
       return;
@@ -674,16 +640,15 @@ namespace edm {
     // a label and instance. We do not need these for getManyByType and
     // skip them. In addition to skipping them, we make use of the fact
     // that they mark the beginning of each subset of holders with the same
-    // label and instance. They tell us when to call findProducts. 
+    // label and instance. They tell us when to call findProducts.
 
     std::vector<ProductResolverBase const*> holders;
 
-    for(unsigned int i = 0; i < matches.numberOfMatches(); ++i) {
-
+    for (unsigned int i = 0; i < matches.numberOfMatches(); ++i) {
       ProductResolverIndex index = matches.index(i);
 
-      if(!matches.isFullyResolved(i)) {
-        if(!holders.empty()) {
+      if (!matches.isFullyResolved(i)) {
+        if (!holders.empty()) {
           // Process the ones with a particular module label and instance
           findProducts(holders, typeID, results, sra, mcc);
           holders.clear();
@@ -695,34 +660,29 @@ namespace edm {
       }
     }
     // Do not miss the last subset of products
-    if(!holders.empty()) {
+    if (!holders.empty()) {
       findProducts(holders, typeID, results, sra, mcc);
     }
     return;
   }
 
-  void
-  Principal::findProducts(std::vector<ProductResolverBase const*> const& holders,
-                          TypeID const&,
-                          BasicHandleVec& results,
-                          SharedResourcesAcquirer* sra,
-                          ModuleCallingContext const* mcc) const {
-
-    for (auto iter = processHistoryPtr_->rbegin(),
-              iEnd = processHistoryPtr_->rend();
-         iter != iEnd; ++iter) {
+  void Principal::findProducts(std::vector<ProductResolverBase const*> const& holders,
+                               TypeID const&,
+                               BasicHandleVec& results,
+                               SharedResourcesAcquirer* sra,
+                               ModuleCallingContext const* mcc) const {
+    for (auto iter = processHistoryPtr_->rbegin(), iEnd = processHistoryPtr_->rend(); iter != iEnd; ++iter) {
       std::string const& process = iter->processName();
       for (auto productResolver : holders) {
         BranchDescription const& bd = productResolver->branchDescription();
         if (process == bd.processName()) {
-
           // Ignore aliases to avoid matching the same product multiple times.
-          if(bd.isAnyAlias()) {
+          if (bd.isAnyAlias()) {
             continue;
           }
 
-          ProductData const* productData = productResolver->resolveProduct(*this,false, sra, mcc).data();
-          if(productData) {
+          ProductData const* productData = productResolver->resolveProduct(*this, false, sra, mcc).data();
+          if (productData) {
             // Skip product if not available.
             results.emplace_back(productData->wrapper(), &(productData->provenance()));
           }
@@ -731,20 +691,17 @@ namespace edm {
     }
   }
 
-  ProductData const*
-  Principal::findProductByLabel(KindOfType kindOfType,
-                                TypeID const& typeID,
-                                InputTag const& inputTag,
-                                EDConsumerBase const* consumer,
-                                SharedResourcesAcquirer* sra,
-                                ModuleCallingContext const* mcc) const {
-
+  ProductData const* Principal::findProductByLabel(KindOfType kindOfType,
+                                                   TypeID const& typeID,
+                                                   InputTag const& inputTag,
+                                                   EDConsumerBase const* consumer,
+                                                   SharedResourcesAcquirer* sra,
+                                                   ModuleCallingContext const* mcc) const {
     bool skipCurrentProcess = inputTag.willSkipCurrentProcess();
 
     ProductResolverIndex index = inputTag.indexFor(typeID, branchType(), &productRegistry());
 
     if (index == ProductResolverIndexInvalid) {
-
       char const* processName = inputTag.process().c_str();
       if (skipCurrentProcess) {
         processName = "\0";
@@ -752,13 +709,10 @@ namespace edm {
         processName = processConfiguration_->processName().c_str();
       }
 
-      index = productLookup().index(kindOfType,
-                                    typeID,
-                                    inputTag.label().c_str(),
-                                    inputTag.instance().c_str(),
-                                    processName);
+      index =
+          productLookup().index(kindOfType, typeID, inputTag.label().c_str(), inputTag.instance().c_str(), processName);
 
-      if(index == ProductResolverIndexAmbiguous) {
+      if (index == ProductResolverIndexAmbiguous) {
         throwAmbiguousException("findProductByLabel", typeID, inputTag.label(), inputTag.instance(),
                                 appendCurrentProcessIfAlias(inputTag.process(), processConfiguration_->processName()));
       } else if (index == ProductResolverIndexInvalid) {
@@ -766,79 +720,66 @@ namespace edm {
       }
       inputTag.tryToCacheIndex(index, typeID, branchType(), &productRegistry());
     }
-    if(UNLIKELY( consumer and (not consumer->registeredToConsume(index, skipCurrentProcess, branchType())))) {
-      failedToRegisterConsumes(kindOfType,typeID,inputTag.label(),inputTag.instance(),
+    if (UNLIKELY(consumer and (not consumer->registeredToConsume(index, skipCurrentProcess, branchType())))) {
+      failedToRegisterConsumes(kindOfType, typeID, inputTag.label(), inputTag.instance(),
                                appendCurrentProcessIfAlias(inputTag.process(), processConfiguration_->processName()));
     }
 
-    
     auto const& productResolver = productResolvers_[index];
 
     auto resolution = productResolver->resolveProduct(*this, skipCurrentProcess, sra, mcc);
-    if(resolution.isAmbiguous()) {
+    if (resolution.isAmbiguous()) {
       throwAmbiguousException("findProductByLabel", typeID, inputTag.label(), inputTag.instance(),
                               appendCurrentProcessIfAlias(inputTag.process(), processConfiguration_->processName()));
     }
     return resolution.data();
   }
 
-  ProductData const*
-  Principal::findProductByLabel(KindOfType kindOfType,
-                                TypeID const& typeID,
-                                std::string const& label,
-                                std::string const& instance,
-                                std::string const& process,
-                                EDConsumerBase const* consumer,
-                                SharedResourcesAcquirer* sra,
-                                ModuleCallingContext const* mcc) const {
+  ProductData const* Principal::findProductByLabel(KindOfType kindOfType,
+                                                   TypeID const& typeID,
+                                                   std::string const& label,
+                                                   std::string const& instance,
+                                                   std::string const& process,
+                                                   EDConsumerBase const* consumer,
+                                                   SharedResourcesAcquirer* sra,
+                                                   ModuleCallingContext const* mcc) const {
+    ProductResolverIndex index =
+        productLookup().index(kindOfType, typeID, label.c_str(), instance.c_str(), process.c_str());
 
-    ProductResolverIndex index = productLookup().index(kindOfType,
-                                                     typeID,
-                                                     label.c_str(),
-                                                     instance.c_str(),
-                                                     process.c_str());
-   
-    if(index == ProductResolverIndexAmbiguous) {
+    if (index == ProductResolverIndexAmbiguous) {
       throwAmbiguousException("findProductByLabel", typeID, label, instance, process);
     } else if (index == ProductResolverIndexInvalid) {
       return nullptr;
     }
-    
-    if(UNLIKELY( consumer and (not consumer->registeredToConsume(index, false, branchType())))) {
-      failedToRegisterConsumes(kindOfType,typeID,label,instance,process);
+
+    if (UNLIKELY(consumer and (not consumer->registeredToConsume(index, false, branchType())))) {
+      failedToRegisterConsumes(kindOfType, typeID, label, instance, process);
     }
-    
+
     auto const& productResolver = productResolvers_[index];
 
     auto resolution = productResolver->resolveProduct(*this, false, sra, mcc);
-    if(resolution.isAmbiguous()) {
+    if (resolution.isAmbiguous()) {
       throwAmbiguousException("findProductByLabel", typeID, label, instance, process);
     }
     return resolution.data();
   }
 
-  ProductData const*
-  Principal::findProductByTag(TypeID const& typeID, InputTag const& tag, ModuleCallingContext const* mcc) const {
-    ProductData const* productData =
-      findProductByLabel(PRODUCT_TYPE,
-                         typeID,
-                         tag,
-                         nullptr,
-                         nullptr,
-                         mcc);
+  ProductData const* Principal::findProductByTag(TypeID const& typeID,
+                                                 InputTag const& tag,
+                                                 ModuleCallingContext const* mcc) const {
+    ProductData const* productData = findProductByLabel(PRODUCT_TYPE, typeID, tag, nullptr, nullptr, mcc);
     return productData;
   }
 
-  Provenance
-  Principal::getProvenance(BranchID const& bid,
-                           ModuleCallingContext const* mcc) const {
+  Provenance Principal::getProvenance(BranchID const& bid, ModuleCallingContext const* mcc) const {
     ConstProductResolverPtr const phb = getProductResolver(bid);
-    if(phb == nullptr) {
+    if (phb == nullptr) {
       throwProductNotFoundException("getProvenance", errors::ProductNotFound, bid);
     }
 
-    if(phb->unscheduledWasNotRun()) {
-      if(not phb->resolveProduct(*this,false, nullptr, mcc).data() ) {
+    if (phb->unscheduledWasNotRun()) {
+      if (not phb->resolveProduct(*this, false, nullptr, mcc).data()) {
         throwProductNotFoundException("getProvenance(onDemand)", errors::ProductNotFound, bid);
       }
     }
@@ -848,15 +789,15 @@ namespace edm {
   // This one is mostly for test printout purposes
   // No attempt to trigger on demand execution
   // Skips provenance when the EDProduct is not there
-  void
-  Principal::getAllProvenance(std::vector<Provenance const*>& provenances) const {
+  void Principal::getAllProvenance(std::vector<Provenance const*>& provenances) const {
     provenances.clear();
-    for(auto const& productResolver : *this) {
-      if(productResolver->singleProduct() && productResolver->provenanceAvailable() && !productResolver->branchDescription().isAnyAlias()) {
+    for (auto const& productResolver : *this) {
+      if (productResolver->singleProduct() && productResolver->provenanceAvailable() &&
+          !productResolver->branchDescription().isAnyAlias()) {
         // We do not attempt to get the event/lumi/run status from the provenance,
         // because the per event provenance may have been dropped.
-        if(productResolver->provenance()->branchDescription().present()) {
-           provenances.push_back(productResolver->provenance());
+        if (productResolver->provenance()->branchDescription().present()) {
+          provenances.push_back(productResolver->provenance());
         }
       }
     }
@@ -865,60 +806,53 @@ namespace edm {
   // This one is also mostly for test printout purposes
   // No attempt to trigger on demand execution
   // Skips provenance for dropped branches.
-  void
-  Principal::getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const {
+  void Principal::getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const {
     provenances.clear();
-    for(auto const& productResolver : *this) {
-      if(productResolver->singleProduct() && !productResolver->branchDescription().isAnyAlias()) {
-        if(productResolver->stableProvenance()->branchDescription().present()) {
-           provenances.push_back(productResolver->stableProvenance());
+    for (auto const& productResolver : *this) {
+      if (productResolver->singleProduct() && !productResolver->branchDescription().isAnyAlias()) {
+        if (productResolver->stableProvenance()->branchDescription().present()) {
+          provenances.push_back(productResolver->stableProvenance());
         }
       }
     }
   }
- 
-  void
-  Principal::recombine(Principal& other, std::vector<BranchID> const& bids) {
-    for(auto& prod : bids) {
-      ProductResolverIndex index= preg_->indexFrom(prod);
-      assert(index!=ProductResolverIndexInvalid);
+
+  void Principal::recombine(Principal& other, std::vector<BranchID> const& bids) {
+    for (auto& prod : bids) {
+      ProductResolverIndex index = preg_->indexFrom(prod);
+      assert(index != ProductResolverIndexInvalid);
       ProductResolverIndex indexO = other.preg_->indexFrom(prod);
-      assert(indexO!=ProductResolverIndexInvalid);
+      assert(indexO != ProductResolverIndexInvalid);
       get_underlying_safe(productResolvers_[index]).swap(get_underlying_safe(other.productResolvers_[indexO]));
     }
     reader_->mergeReaders(other.reader());
   }
 
-  WrapperBase const*
-  Principal::getIt(ProductID const&) const {
+  WrapperBase const* Principal::getIt(ProductID const&) const {
     assert(false);
     return nullptr;
   }
 
-  WrapperBase const*
-  Principal::getThinnedProduct(ProductID const&, unsigned int&) const {
+  WrapperBase const* Principal::getThinnedProduct(ProductID const&, unsigned int&) const {
     assert(false);
     return nullptr;
   }
 
-  void
-  Principal::getThinnedProducts(ProductID const&,
-                                  std::vector<WrapperBase const*>&,
-                                  std::vector<unsigned int>&) const {
+  void Principal::getThinnedProducts(ProductID const&,
+                                     std::vector<WrapperBase const*>&,
+                                     std::vector<unsigned int>&) const {
     assert(false);
   }
 
-  void
-  Principal::putOrMerge(std::unique_ptr<WrapperBase> prod, ProductResolverBase const* phb) const {
+  void Principal::putOrMerge(std::unique_ptr<WrapperBase> prod, ProductResolverBase const* phb) const {
     phb->putOrMergeProduct(std::move(prod));
   }
 
-  void
-  Principal::putOrMerge(BranchDescription const& bd, std::unique_ptr<WrapperBase>  edp) const {
-    if(edp.get() == nullptr) {
-      throw edm::Exception(edm::errors::InsertFailure,"Null Pointer")
-      << "put: Cannot put because unique_ptr to product is null."
-      << "\n";
+  void Principal::putOrMerge(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const {
+    if (edp.get() == nullptr) {
+      throw edm::Exception(edm::errors::InsertFailure, "Null Pointer")
+          << "put: Cannot put because unique_ptr to product is null."
+          << "\n";
     }
     auto phb = getExistingProduct(bd.branchID());
     assert(phb);
@@ -926,17 +860,15 @@ namespace edm {
     putOrMerge(std::move(edp), phb);
   }
 
-
-  void
-  Principal::adjustIndexesAfterProductRegistryAddition() {
-    if(preg_->getNextIndexValue(branchType_) != productResolvers_.size()) {
+  void Principal::adjustIndexesAfterProductRegistryAddition() {
+    if (preg_->getNextIndexValue(branchType_) != productResolvers_.size()) {
       productResolvers_.resize(preg_->getNextIndexValue(branchType_));
-      for(auto const& prod : preg_->productList()) {
+      for (auto const& prod : preg_->productList()) {
         BranchDescription const& bd = prod.second;
-        if(bd.branchType() == branchType_) {
+        if (bd.branchType() == branchType_) {
           ProductResolverIndex index = preg_->indexFrom(bd.branchID());
           assert(index != ProductResolverIndexInvalid);
-          if(!productResolvers_[index]) {
+          if (!productResolvers_[index]) {
             // no product holder.  Must add one. The new entry must be an input product holder.
             assert(!bd.produced());
             auto cbd = std::make_shared<BranchDescription const>(bd);
@@ -947,13 +879,14 @@ namespace edm {
     }
     assert(preg_->getNextIndexValue(branchType_) == productResolvers_.size());
   }
-  
-  void
-  Principal::readAllFromSourceAndMergeImmediately(MergeableRunProductMetadata const* mergeableRunProductMetadata) {
-    if(not reader()) {return;}
-    
-    for(auto & prod : *this) {
+
+  void Principal::readAllFromSourceAndMergeImmediately(MergeableRunProductMetadata const* mergeableRunProductMetadata) {
+    if (not reader()) {
+      return;
+    }
+
+    for (auto& prod : *this) {
       prod->retrieveAndMerge(*this, mergeableRunProductMetadata);
     }
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/PrincipalCache.cc
+++ b/FWCore/Framework/src/PrincipalCache.cc
@@ -9,82 +9,69 @@
 
 namespace edm {
 
-  PrincipalCache::PrincipalCache() :
-    run_(0U),
-    lumi_(0U) {
-  }
+  PrincipalCache::PrincipalCache() : run_(0U), lumi_(0U) {}
 
-  PrincipalCache::~PrincipalCache() { }
+  PrincipalCache::~PrincipalCache() {}
 
-  
-  void PrincipalCache::setNumberOfConcurrentPrincipals(PreallocationConfiguration const& iConfig)
-  {
+  void PrincipalCache::setNumberOfConcurrentPrincipals(PreallocationConfiguration const& iConfig) {
     eventPrincipals_.resize(iConfig.numberOfStreams());
   }
 
-  RunPrincipal&
-  PrincipalCache::runPrincipal(ProcessHistoryID const& phid, RunNumber_t run) const {
-    if (phid != reducedInputProcessHistoryID_ ||
-        run != run_ ||
-        runPrincipal_.get() == nullptr) {
+  RunPrincipal& PrincipalCache::runPrincipal(ProcessHistoryID const& phid, RunNumber_t run) const {
+    if (phid != reducedInputProcessHistoryID_ || run != run_ || runPrincipal_.get() == nullptr) {
       throwRunMissing();
     }
     return *runPrincipal_.get();
   }
 
-  std::shared_ptr<RunPrincipal> const&
-  PrincipalCache::runPrincipalPtr(ProcessHistoryID const& phid, RunNumber_t run) const {
-    if (phid != reducedInputProcessHistoryID_ ||
-        run != run_ ||
-        runPrincipal_.get() == nullptr) {
+  std::shared_ptr<RunPrincipal> const& PrincipalCache::runPrincipalPtr(ProcessHistoryID const& phid,
+                                                                       RunNumber_t run) const {
+    if (phid != reducedInputProcessHistoryID_ || run != run_ || runPrincipal_.get() == nullptr) {
       throwRunMissing();
     }
     return runPrincipal_;
   }
 
-  RunPrincipal&
-  PrincipalCache::runPrincipal() const {
+  RunPrincipal& PrincipalCache::runPrincipal() const {
     if (runPrincipal_.get() == nullptr) {
       throwRunMissing();
     }
     return *runPrincipal_.get();
   }
 
-  std::shared_ptr<RunPrincipal> const&
-  PrincipalCache::runPrincipalPtr() const {
+  std::shared_ptr<RunPrincipal> const& PrincipalCache::runPrincipalPtr() const {
     if (runPrincipal_.get() == nullptr) {
       throwRunMissing();
     }
     return runPrincipal_;
   }
 
-  std::shared_ptr<LuminosityBlockPrincipal>
-  PrincipalCache::getAvailableLumiPrincipalPtr() { return lumiHolder_.tryToGet();}
+  std::shared_ptr<LuminosityBlockPrincipal> PrincipalCache::getAvailableLumiPrincipalPtr() {
+    return lumiHolder_.tryToGet();
+  }
 
   void PrincipalCache::merge(std::shared_ptr<RunAuxiliary> aux, std::shared_ptr<ProductRegistry const> reg) {
     if (runPrincipal_.get() == nullptr) {
-      throw edm::Exception(edm::errors::LogicError)
-        << "PrincipalCache::merge\n"
-        << "Illegal attempt to merge run into cache\n"
-        << "There is no run in cache to merge with\n"
-        << "Contact a Framework Developer\n";
+      throw edm::Exception(edm::errors::LogicError) << "PrincipalCache::merge\n"
+                                                    << "Illegal attempt to merge run into cache\n"
+                                                    << "There is no run in cache to merge with\n"
+                                                    << "Contact a Framework Developer\n";
     }
     if (inputProcessHistoryID_ != aux->processHistoryID()) {
       if (reducedInputProcessHistoryID_ != processHistoryRegistry_->reducedProcessHistoryID(aux->processHistoryID())) {
         throw edm::Exception(edm::errors::LogicError)
-          << "PrincipalCache::merge\n"
-          << "Illegal attempt to merge run into cache\n"
-          << "Reduced ProcessHistoryID inconsistent with the one already in cache\n"
-          << "Contact a Framework Developer\n";
+            << "PrincipalCache::merge\n"
+            << "Illegal attempt to merge run into cache\n"
+            << "Reduced ProcessHistoryID inconsistent with the one already in cache\n"
+            << "Contact a Framework Developer\n";
       }
       inputProcessHistoryID_ = aux->processHistoryID();
     }
     if (aux->run() != run_) {
-      throw edm::Exception(edm::errors::LogicError)
-        << "PrincipalCache::merge\n"
-        << "Illegal attempt to merge run into cache\n"
-        << "Run number inconsistent with run number already in cache\n"
-        << "Contact a Framework Developer\n";
+      throw edm::Exception(edm::errors::LogicError) << "PrincipalCache::merge\n"
+                                                    << "Illegal attempt to merge run into cache\n"
+                                                    << "Run number inconsistent with run number already in cache\n"
+                                                    << "Contact a Framework Developer\n";
     }
     bool runOK = runPrincipal_->adjustToNewProductRegistry(*reg);
     assert(runOK);
@@ -93,22 +80,19 @@ namespace edm {
 
   void PrincipalCache::insert(std::shared_ptr<RunPrincipal> rp) {
     if (runPrincipal_.get() != nullptr) {
-      throw edm::Exception(edm::errors::LogicError)
-        << "PrincipalCache::insert\n"
-        << "Illegal attempt to insert run into cache\n"
-        << "Contact a Framework Developer\n";
+      throw edm::Exception(edm::errors::LogicError) << "PrincipalCache::insert\n"
+                                                    << "Illegal attempt to insert run into cache\n"
+                                                    << "Contact a Framework Developer\n";
     }
     if (inputProcessHistoryID_ != rp->aux().processHistoryID()) {
       reducedInputProcessHistoryID_ = processHistoryRegistry_->reducedProcessHistoryID(rp->aux().processHistoryID());
       inputProcessHistoryID_ = rp->aux().processHistoryID();
     }
     run_ = rp->run();
-    runPrincipal_ = rp; 
+    runPrincipal_ = rp;
   }
 
-  void PrincipalCache::insert(std::unique_ptr<LuminosityBlockPrincipal> lbp) {
-    lumiHolder_.add(std::move(lbp));
-  }
+  void PrincipalCache::insert(std::unique_ptr<LuminosityBlockPrincipal> lbp) { lumiHolder_.add(std::move(lbp)); }
 
   void PrincipalCache::insert(std::shared_ptr<EventPrincipal> ep) {
     unsigned int iStreamIndex = ep->streamID().value();
@@ -118,25 +102,23 @@ namespace edm {
 
   void PrincipalCache::deleteRun(ProcessHistoryID const& phid, RunNumber_t run) {
     if (runPrincipal_.get() == nullptr) {
-      throw edm::Exception(edm::errors::LogicError)
-        << "PrincipalCache::deleteRun\n"
-        << "Illegal attempt to delete run from cache\n"
-        << "There is no run in cache to delete\n"
-        << "Contact a Framework Developer\n";
+      throw edm::Exception(edm::errors::LogicError) << "PrincipalCache::deleteRun\n"
+                                                    << "Illegal attempt to delete run from cache\n"
+                                                    << "There is no run in cache to delete\n"
+                                                    << "Contact a Framework Developer\n";
     }
-    if (reducedInputProcessHistoryID_ != phid ||
-        run != run_) {
+    if (reducedInputProcessHistoryID_ != phid || run != run_) {
       throw edm::Exception(edm::errors::LogicError)
-        << "PrincipalCache::deleteRun\n"
-        << "Illegal attempt to delete run from cache\n"
-        << "Run number or reduced ProcessHistoryID inconsistent with those in cache\n"
-        << "Contact a Framework Developer\n";
+          << "PrincipalCache::deleteRun\n"
+          << "Illegal attempt to delete run from cache\n"
+          << "Run number or reduced ProcessHistoryID inconsistent with those in cache\n"
+          << "Contact a Framework Developer\n";
     }
     runPrincipal_.reset();
   }
 
   void PrincipalCache::adjustEventsToNewProductRegistry(std::shared_ptr<ProductRegistry const> reg) {
-    for(auto &eventPrincipal : eventPrincipals_) {
+    for (auto& eventPrincipal : eventPrincipals_) {
       if (eventPrincipal) {
         eventPrincipal->adjustIndexesAfterProductRegistryAddition();
         bool eventOK = eventPrincipal->adjustToNewProductRegistry(*reg);
@@ -144,39 +126,35 @@ namespace edm {
       }
     }
   }
-  
+
   void PrincipalCache::adjustIndexesAfterProductRegistryAddition() {
     if (runPrincipal_) {
       runPrincipal_->adjustIndexesAfterProductRegistryAddition();
     }
     //Need to temporarily hold all the lumis to clear out the lumiHolder_
     std::vector<std::shared_ptr<LuminosityBlockPrincipal>> temp;
-    while(auto p = lumiHolder_.tryToGet()) {
+    while (auto p = lumiHolder_.tryToGet()) {
       p->adjustIndexesAfterProductRegistryAddition();
       temp.emplace_back(std::move(p));
     }
   }
 
-  void
-  PrincipalCache::preReadFile() {
+  void PrincipalCache::preReadFile() {
     if (runPrincipal_) {
       runPrincipal_->preReadFile();
     }
   }
 
-  void
-  PrincipalCache::throwRunMissing() const {
-    throw edm::Exception(edm::errors::LogicError)
-      << "PrincipalCache::runPrincipal\n"
-      << "Requested a run that is not in the cache (should never happen)\n"
-      << "Contact a Framework Developer\n";
+  void PrincipalCache::throwRunMissing() const {
+    throw edm::Exception(edm::errors::LogicError) << "PrincipalCache::runPrincipal\n"
+                                                  << "Requested a run that is not in the cache (should never happen)\n"
+                                                  << "Contact a Framework Developer\n";
   }
 
-  void
-  PrincipalCache::throwLumiMissing() const {
+  void PrincipalCache::throwLumiMissing() const {
     throw edm::Exception(edm::errors::LogicError)
-      << "PrincipalCache::lumiPrincipal or PrincipalCache::lumiPrincipalPtr\n"
-      << "Requested a luminosity block that is not in the cache (should never happen)\n"
-      << "Contact a Framework Developer\n";
+        << "PrincipalCache::lumiPrincipal or PrincipalCache::lumiPrincipalPtr\n"
+        << "Requested a luminosity block that is not in the cache (should never happen)\n"
+        << "Contact a Framework Developer\n";
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/PrincipalCache.h
+++ b/FWCore/Framework/src/PrincipalCache.h
@@ -46,7 +46,6 @@ namespace edm {
 
   class PrincipalCache {
   public:
-
     PrincipalCache();
     ~PrincipalCache();
     PrincipalCache(PrincipalCache&&) = default;
@@ -55,7 +54,7 @@ namespace edm {
     std::shared_ptr<RunPrincipal> const& runPrincipalPtr(ProcessHistoryID const& phid, RunNumber_t run) const;
     RunPrincipal& runPrincipal() const;
     std::shared_ptr<RunPrincipal> const& runPrincipalPtr() const;
-    bool hasRunPrincipal() const {return bool(runPrincipal_);}
+    bool hasRunPrincipal() const { return bool(runPrincipal_); }
 
     std::shared_ptr<LuminosityBlockPrincipal> getAvailableLumiPrincipalPtr();
 
@@ -74,12 +73,11 @@ namespace edm {
 
     void adjustIndexesAfterProductRegistryAddition();
 
-    void setProcessHistoryRegistry(ProcessHistoryRegistry const& phr) {processHistoryRegistry_ = &phr;}
+    void setProcessHistoryRegistry(ProcessHistoryRegistry const& phr) { processHistoryRegistry_ = &phr; }
 
     void preReadFile();
 
   private:
-
     void throwRunMissing() const;
     void throwLumiMissing() const;
 
@@ -89,8 +87,8 @@ namespace edm {
     edm::ReusableObjectHolder<LuminosityBlockPrincipal> lumiHolder_;
     std::vector<std::shared_ptr<EventPrincipal>> eventPrincipals_;
 
-    // This is just an accessor to the registry owned by the input source. 
-    ProcessHistoryRegistry const* processHistoryRegistry_; // We don't own this
+    // This is just an accessor to the registry owned by the input source.
+    ProcessHistoryRegistry const* processHistoryRegistry_;  // We don't own this
 
     // These are intentionally not cleared so that when inserting
     // the next principal the conversion from full ProcessHistoryID_
@@ -104,6 +102,6 @@ namespace edm {
     RunNumber_t run_;
     LuminosityBlockNumber_t lumi_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -19,319 +19,257 @@
 
 namespace edm {
 
-  PrincipalGetAdapter::PrincipalGetAdapter(Principal const& pcpl,
-	ModuleDescription const& md, bool isComplete)  :
-    //putProducts_(),
-    principal_(pcpl),
-    md_(md),
-    consumer_(nullptr),
-    resourcesAcquirer_(nullptr),
-    isComplete_(isComplete)
-  {
+  PrincipalGetAdapter::PrincipalGetAdapter(Principal const& pcpl, ModuleDescription const& md, bool isComplete)
+      :  //putProducts_(),
+        principal_(pcpl),
+        md_(md),
+        consumer_(nullptr),
+        resourcesAcquirer_(nullptr),
+        isComplete_(isComplete) {}
+
+  PrincipalGetAdapter::~PrincipalGetAdapter() {}
+
+  void principal_get_adapter_detail::throwOnPutOfNullProduct(char const* principalType,
+                                                             TypeID const& productType,
+                                                             std::string const& productInstanceName) {
+    throw Exception(errors::NullPointerError)
+        << principalType << "::put: A null unique_ptr was passed to 'put'.\n"
+        << "The pointer is of type " << productType << ".\nThe specified productInstanceName was '"
+        << productInstanceName << "'.\n";
   }
 
-  PrincipalGetAdapter::~PrincipalGetAdapter() {
-  }
-
-  void
-  principal_get_adapter_detail::throwOnPutOfNullProduct(
-	char const* principalType,
-	TypeID const& productType,
-	std::string const& productInstanceName) {
-      throw Exception(errors::NullPointerError)
-	<< principalType
-	<< "::put: A null unique_ptr was passed to 'put'.\n"
-	<< "The pointer is of type "
-	<< productType
-        << ".\nThe specified productInstanceName was '"
-	<< productInstanceName
-        << "'.\n";
-  }
-
-  void
-  principal_get_adapter_detail::throwOnPutOfUninitializedToken(char const* principalType, std::type_info const& type) {
+  void principal_get_adapter_detail::throwOnPutOfUninitializedToken(char const* principalType,
+                                                                    std::type_info const& type) {
     TypeID productType{type};
-    throw Exception(errors::LogicError)
-    << principalType
-    << "::put: An uninitialized EDPutToken was passed to 'put'.\n"
-    << "The pointer is of type "
-    << productType
-    << ".\n";
+    throw Exception(errors::LogicError) << principalType << "::put: An uninitialized EDPutToken was passed to 'put'.\n"
+                                        << "The pointer is of type " << productType << ".\n";
   }
 
-  void
-  principal_get_adapter_detail::throwOnPutOfWrongType(std::type_info const& wrongType, TypeID const& rightType) {
+  void principal_get_adapter_detail::throwOnPutOfWrongType(std::type_info const& wrongType, TypeID const& rightType) {
     TypeID wrongTypeID{wrongType};
-    throw Exception(errors::LogicError)
-    << "The registered type for an EDPutToken does not match the put type.\n"
-    << "The expected type "
-    << rightType
-    << "\nThe put type "
-    << wrongTypeID
-    << ".\n";
+    throw Exception(errors::LogicError) << "The registered type for an EDPutToken does not match the put type.\n"
+                                        << "The expected type " << rightType << "\nThe put type " << wrongTypeID
+                                        << ".\n";
   }
 
-  void
-  principal_get_adapter_detail::throwOnPrematureRead(
-	char const* principalType,
-	TypeID const& productType,
-	std::string const& moduleLabel,
-	std::string const& productInstanceName) {
-      //throw Exception(errors::LogicError)
-      LogWarning("LogicError")
-	<< "::getByLabel: An attempt was made to read a "
-	<< principalType
-        << " product before end"
-	<< principalType
-        << "() was called.\n"
-	<< "The product is of type '"
-	<< productType
-        << "'.\nThe specified ModuleLabel was '"
-	<< moduleLabel
-        << "'.\nThe specified productInstanceName was '"
-	<< productInstanceName
-        << "'.\n";
+  void principal_get_adapter_detail::throwOnPrematureRead(char const* principalType,
+                                                          TypeID const& productType,
+                                                          std::string const& moduleLabel,
+                                                          std::string const& productInstanceName) {
+    //throw Exception(errors::LogicError)
+    LogWarning("LogicError") << "::getByLabel: An attempt was made to read a " << principalType << " product before end"
+                             << principalType << "() was called.\n"
+                             << "The product is of type '" << productType << "'.\nThe specified ModuleLabel was '"
+                             << moduleLabel << "'.\nThe specified productInstanceName was '" << productInstanceName
+                             << "'.\n";
   }
 
-  void
-  principal_get_adapter_detail::throwOnPrematureRead(
-	char const* principalType,
-	TypeID const& productType) {
-      //throw Exception(errors::LogicError)
-      LogWarning("LogicError")
-	<< "::getManyByType: An attempt was made to read a "
-	<< principalType
-        << " product before end"
-	<< principalType
-        << "() was called.\n"
-	<< "The product is of type '"
-	<< productType
-        << "'.\n";
-  }
-  
-  void
-  principal_get_adapter_detail::throwOnPrematureRead(
-                                                     char const* principalType,
-                                                     TypeID const& productType,
-                                                     EDGetToken token) {
-    throw Exception(errors::LogicError)
-    << "::getByToken: An attempt was made to read a "
-    << principalType
-    << " product before end"
-    << principalType
-    << "() was called.\n"
-    << "The index of the token was "<<token.index()<<".\n";
-  }
-  
-  size_t
-  PrincipalGetAdapter::numberOfProductsConsumed() const {
-    return consumer_->itemsToGetFrom(InEvent).size();
+  void principal_get_adapter_detail::throwOnPrematureRead(char const* principalType, TypeID const& productType) {
+    //throw Exception(errors::LogicError)
+    LogWarning("LogicError") << "::getManyByType: An attempt was made to read a " << principalType
+                             << " product before end" << principalType << "() was called.\n"
+                             << "The product is of type '" << productType << "'.\n";
   }
 
-  void
-  PrincipalGetAdapter::labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const {
-    consumer_->labelsForToken(iToken,oLabels);
+  void principal_get_adapter_detail::throwOnPrematureRead(char const* principalType,
+                                                          TypeID const& productType,
+                                                          EDGetToken token) {
+    throw Exception(errors::LogicError) << "::getByToken: An attempt was made to read a " << principalType
+                                        << " product before end" << principalType << "() was called.\n"
+                                        << "The index of the token was " << token.index() << ".\n";
   }
 
-  BasicHandle
-  PrincipalGetAdapter::makeFailToGetException(KindOfType kindOfType,
-                                              TypeID const& productType,
-                                              EDGetToken token) const {
+  size_t PrincipalGetAdapter::numberOfProductsConsumed() const { return consumer_->itemsToGetFrom(InEvent).size(); }
+
+  void PrincipalGetAdapter::labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const {
+    consumer_->labelsForToken(iToken, oLabels);
+  }
+
+  BasicHandle PrincipalGetAdapter::makeFailToGetException(KindOfType kindOfType,
+                                                          TypeID const& productType,
+                                                          EDGetToken token) const {
     EDConsumerBase::Labels labels;
-    consumer_->labelsForToken(token,labels);
+    consumer_->labelsForToken(token, labels);
     //no need to copy memory since the exception will no occur after the
     // const char* have been deleted
-    return BasicHandle(makeHandleExceptionFactory([labels,kindOfType,productType]()->std::shared_ptr<cms::Exception> {
-      std::shared_ptr<cms::Exception> exception(std::make_shared<Exception>(errors::ProductNotFound));
-      if (kindOfType == PRODUCT_TYPE) {
-        *exception << "Principal::getByToken: Found zero products matching all criteria\nLooking for type: " << productType << "\n"
-        << "Looking for module label: " << labels.module << "\n" << "Looking for productInstanceName: " << labels.productInstance << "\n"
-        << (0==labels.process[0] ? "" : "Looking for process: ") << labels.process << "\n";
-      } else {
-        *exception << "Principal::getByToken: Found zero products matching all criteria\nLooking for a container with elements of type: " << productType << "\n"
-        << "Looking for module label: " << labels.module << "\n" << "Looking for productInstanceName: " << labels.productInstance << "\n"
-        << (0==labels.process[0] ? "" : "Looking for process: ") << labels.process << "\n";
-      }
-      return exception;
-    }));
+    return BasicHandle(
+        makeHandleExceptionFactory([labels, kindOfType, productType]() -> std::shared_ptr<cms::Exception> {
+          std::shared_ptr<cms::Exception> exception(std::make_shared<Exception>(errors::ProductNotFound));
+          if (kindOfType == PRODUCT_TYPE) {
+            *exception << "Principal::getByToken: Found zero products matching all criteria\nLooking for type: "
+                       << productType << "\n"
+                       << "Looking for module label: " << labels.module << "\n"
+                       << "Looking for productInstanceName: " << labels.productInstance << "\n"
+                       << (0 == labels.process[0] ? "" : "Looking for process: ") << labels.process << "\n";
+          } else {
+            *exception << "Principal::getByToken: Found zero products matching all criteria\nLooking for a container "
+                          "with elements of type: "
+                       << productType << "\n"
+                       << "Looking for module label: " << labels.module << "\n"
+                       << "Looking for productInstanceName: " << labels.productInstance << "\n"
+                       << (0 == labels.process[0] ? "" : "Looking for process: ") << labels.process << "\n";
+          }
+          return exception;
+        }));
   }
 
-  void
-  PrincipalGetAdapter::throwAmbiguousException(TypeID const& productType,
-                                               EDGetToken token) const {
+  void PrincipalGetAdapter::throwAmbiguousException(TypeID const& productType, EDGetToken token) const {
     EDConsumerBase::Labels labels;
-    consumer_->labelsForToken(token,labels);
+    consumer_->labelsForToken(token, labels);
     cms::Exception exception("AmbiguousProduct");
-    exception << "Principal::getByToken: More than 1 product matches all criteria\nLooking for a container with elements of type: " << productType << "\n"
-    << "Looking for module label: " << labels.module << "\n" << "Looking for productInstanceName: " << labels.productInstance << "\n"
-    << (0==labels.process[0] ? "" : "Looking for process: ") << labels.process << "\n"
-    << "This can only occur with get function calls using a Handle<View> argument.\n"
-    << "Try a get not using a View or change the instance name of one of the products";
-    throw exception;    
+    exception << "Principal::getByToken: More than 1 product matches all criteria\nLooking for a container with "
+                 "elements of type: "
+              << productType << "\n"
+              << "Looking for module label: " << labels.module << "\n"
+              << "Looking for productInstanceName: " << labels.productInstance << "\n"
+              << (0 == labels.process[0] ? "" : "Looking for process: ") << labels.process << "\n"
+              << "This can only occur with get function calls using a Handle<View> argument.\n"
+              << "Try a get not using a View or change the instance name of one of the products";
+    throw exception;
   }
 
-  BranchType const&
-  PrincipalGetAdapter::branchType() const {
-    return principal_.branchType();
-  }
+  BranchType const& PrincipalGetAdapter::branchType() const { return principal_.branchType(); }
 
-  BasicHandle
-  PrincipalGetAdapter::getByLabel_(TypeID const& typeID,
-                                   InputTag const& tag,
-                                   ModuleCallingContext const* mcc) const {
+  BasicHandle PrincipalGetAdapter::getByLabel_(TypeID const& typeID,
+                                               InputTag const& tag,
+                                               ModuleCallingContext const* mcc) const {
     return principal_.getByLabel(PRODUCT_TYPE, typeID, tag, consumer_, resourcesAcquirer_, mcc);
   }
 
-  BasicHandle
-  PrincipalGetAdapter::getByLabel_(TypeID const& typeID,
-                                   std::string const& label,
-  	                           std::string const& instance,
-  	                           std::string const& process,
-                                   ModuleCallingContext const* mcc) const {
+  BasicHandle PrincipalGetAdapter::getByLabel_(TypeID const& typeID,
+                                               std::string const& label,
+                                               std::string const& instance,
+                                               std::string const& process,
+                                               ModuleCallingContext const* mcc) const {
     return principal_.getByLabel(PRODUCT_TYPE, typeID, label, instance, process, consumer_, resourcesAcquirer_, mcc);
   }
-  
-  BasicHandle
-  PrincipalGetAdapter::getByToken_(TypeID const& id, KindOfType kindOfType, EDGetToken token,
-                                   ModuleCallingContext const* mcc) const {
-    ProductResolverIndexAndSkipBit indexAndBit = consumer_->indexFrom(token,branchType(),id);
+
+  BasicHandle PrincipalGetAdapter::getByToken_(TypeID const& id,
+                                               KindOfType kindOfType,
+                                               EDGetToken token,
+                                               ModuleCallingContext const* mcc) const {
+    ProductResolverIndexAndSkipBit indexAndBit = consumer_->indexFrom(token, branchType(), id);
     ProductResolverIndex index = indexAndBit.productResolverIndex();
     bool skipCurrentProcess = indexAndBit.skipCurrentProcess();
-    if( UNLIKELY(index == ProductResolverIndexInvalid)) {
-      return makeFailToGetException(kindOfType,id,token);
-    } else if( UNLIKELY(index == ProductResolverIndexAmbiguous)) {
+    if (UNLIKELY(index == ProductResolverIndexInvalid)) {
+      return makeFailToGetException(kindOfType, id, token);
+    } else if (UNLIKELY(index == ProductResolverIndexAmbiguous)) {
       // This deals with ambiguities where the process is specified
       throwAmbiguousException(id, token);
     }
     bool ambiguous = false;
-    BasicHandle h = principal_.getByToken(kindOfType, id, index, skipCurrentProcess, ambiguous, resourcesAcquirer_, mcc);
+    BasicHandle h =
+        principal_.getByToken(kindOfType, id, index, skipCurrentProcess, ambiguous, resourcesAcquirer_, mcc);
     if (ambiguous) {
       // This deals with ambiguities where the process is not specified
       throwAmbiguousException(id, token);
-    } else if(!h.isValid()) {
-      return makeFailToGetException(kindOfType,id,token);
+    } else if (!h.isValid()) {
+      return makeFailToGetException(kindOfType, id, token);
     }
     return h;
   }
 
-  BasicHandle
-  PrincipalGetAdapter::getMatchingSequenceByLabel_(TypeID const& typeID,
-                                                   InputTag const& tag,
-                                                   ModuleCallingContext const* mcc) const {
+  BasicHandle PrincipalGetAdapter::getMatchingSequenceByLabel_(TypeID const& typeID,
+                                                               InputTag const& tag,
+                                                               ModuleCallingContext const* mcc) const {
     return principal_.getByLabel(ELEMENT_TYPE, typeID, tag, consumer_, resourcesAcquirer_, mcc);
   }
 
-  BasicHandle
-  PrincipalGetAdapter::getMatchingSequenceByLabel_(TypeID const& typeID,
-                                                   std::string const& label,
-                                                   std::string const& instance,
-                                                   std::string const& process,
-                                                   ModuleCallingContext const* mcc) const {
-    auto h= principal_.getByLabel(ELEMENT_TYPE,
-                                  typeID,
-                                  label,
-                                  instance,
-                                  process,
-                                  consumer_,
-                                  resourcesAcquirer_,
-                                  mcc);
+  BasicHandle PrincipalGetAdapter::getMatchingSequenceByLabel_(TypeID const& typeID,
+                                                               std::string const& label,
+                                                               std::string const& instance,
+                                                               std::string const& process,
+                                                               ModuleCallingContext const* mcc) const {
+    auto h = principal_.getByLabel(ELEMENT_TYPE, typeID, label, instance, process, consumer_, resourcesAcquirer_, mcc);
     return h;
   }
 
-  void
-  PrincipalGetAdapter::getManyByType_(TypeID const& tid,
-                                      BasicHandleVec& results,
-                                      ModuleCallingContext const* mcc) const {
+  void PrincipalGetAdapter::getManyByType_(TypeID const& tid,
+                                           BasicHandleVec& results,
+                                           ModuleCallingContext const* mcc) const {
     principal_.getManyByType(tid, results, consumer_, resourcesAcquirer_, mcc);
   }
 
-  ProcessHistory const&
-  PrincipalGetAdapter::processHistory() const {
-    return principal_.processHistory();
-  }
+  ProcessHistory const& PrincipalGetAdapter::processHistory() const { return principal_.processHistory(); }
 
-  void
-  PrincipalGetAdapter::throwUnregisteredPutException(TypeID const& type,
-                                                     std::string const& productInstanceName) const {
+  void PrincipalGetAdapter::throwUnregisteredPutException(TypeID const& type,
+                                                          std::string const& productInstanceName) const {
     std::ostringstream str;
-    for(auto branchDescription: principal_.productRegistry().allBranchDescriptions()) {
-      if (branchDescription->moduleLabel() == md_.moduleLabel() and branchDescription->processName() == md_.processName()) {
-        str << *branchDescription<< "-----\n";
+    for (auto branchDescription : principal_.productRegistry().allBranchDescriptions()) {
+      if (branchDescription->moduleLabel() == md_.moduleLabel() and
+          branchDescription->processName() == md_.processName()) {
+        str << *branchDescription << "-----\n";
       }
     }
     throw edm::Exception(edm::errors::InsertFailure)
-    << "Illegal attempt to 'put' an unregistered product.\n"
-    << "No product is registered for\n"
-    << "  product friendly class name: '" << type.friendlyClassName() << "'\n"
-    << "  module label:                '" << md_.moduleLabel() << "'\n"
-    << "  product instance name:       '" << productInstanceName << "'\n"
-    << "  process name:                '" << md_.processName() << "'\n"
-    
-    << "The following data products are registered for production by "<<md_.moduleLabel()<<":\n"
-    << str.str()
-    << '\n'
-    << "To correct the problem:\n"
-    "   1) make sure the proper 'produce' call is being made in the module's constructor,\n"
-    "   2) if 'produce' exists and uses a product instance name make sure that same name is used during the 'put' call.";
+        << "Illegal attempt to 'put' an unregistered product.\n"
+        << "No product is registered for\n"
+        << "  product friendly class name: '" << type.friendlyClassName() << "'\n"
+        << "  module label:                '" << md_.moduleLabel() << "'\n"
+        << "  product instance name:       '" << productInstanceName << "'\n"
+        << "  process name:                '" << md_.processName() << "'\n"
+
+        << "The following data products are registered for production by " << md_.moduleLabel() << ":\n"
+        << str.str() << '\n'
+        << "To correct the problem:\n"
+           "   1) make sure the proper 'produce' call is being made in the module's constructor,\n"
+           "   2) if 'produce' exists and uses a product instance name make sure that same name is used during the "
+           "'put' call.";
   }
 
-  BranchDescription const&
-  PrincipalGetAdapter::getBranchDescription(TypeID const& type,
-                                            std::string const& productInstanceName) const {
+  BranchDescription const& PrincipalGetAdapter::getBranchDescription(TypeID const& type,
+                                                                     std::string const& productInstanceName) const {
     ProductResolverIndexHelper const& productResolverIndexHelper = principal_.productLookup();
-    ProductResolverIndex index = productResolverIndexHelper.index(PRODUCT_TYPE, type, md_.moduleLabel().c_str(),productInstanceName.c_str(), md_.processName().c_str());
-    if(UNLIKELY(index == ProductResolverIndexInvalid)) {
+    ProductResolverIndex index = productResolverIndexHelper.index(
+        PRODUCT_TYPE, type, md_.moduleLabel().c_str(), productInstanceName.c_str(), md_.processName().c_str());
+    if (UNLIKELY(index == ProductResolverIndexInvalid)) {
       throwUnregisteredPutException(type, productInstanceName);
     }
-    ProductResolverBase const*  phb = principal_.getProductResolverByIndex(index);
-    assert(phb != nullptr);
-    return phb->branchDescription();
-  }
-  
-  BranchDescription const&
-  PrincipalGetAdapter::getBranchDescription(unsigned int iPutTokenIndex) const {
-    auto index = prodBase_->putTokenIndexToProductResolverIndex()[iPutTokenIndex];
-    ProductResolverBase const*  phb = principal_.getProductResolverByIndex(index);
+    ProductResolverBase const* phb = principal_.getProductResolverByIndex(index);
     assert(phb != nullptr);
     return phb->branchDescription();
   }
 
-  ProductID const&
-  PrincipalGetAdapter::getProductID(unsigned int iPutTokenIndex) const {
+  BranchDescription const& PrincipalGetAdapter::getBranchDescription(unsigned int iPutTokenIndex) const {
     auto index = prodBase_->putTokenIndexToProductResolverIndex()[iPutTokenIndex];
-    ProductResolverBase const*  phb = principal_.getProductResolverByIndex(index);
+    ProductResolverBase const* phb = principal_.getProductResolverByIndex(index);
+    assert(phb != nullptr);
+    return phb->branchDescription();
+  }
+
+  ProductID const& PrincipalGetAdapter::getProductID(unsigned int iPutTokenIndex) const {
+    auto index = prodBase_->putTokenIndexToProductResolverIndex()[iPutTokenIndex];
+    ProductResolverBase const* phb = principal_.getProductResolverByIndex(index);
     assert(phb != nullptr);
     auto prov = phb->stableProvenance();
     assert(prov != nullptr);
     return prov->productID();
   }
 
-  Transition
-  PrincipalGetAdapter::transition() const {
-    if(LIKELY(principal().branchType() == InEvent)) {
+  Transition PrincipalGetAdapter::transition() const {
+    if (LIKELY(principal().branchType() == InEvent)) {
       return Transition::Event;
     }
-    if(principal().branchType() == InRun) {
-      if(isComplete()) {
+    if (principal().branchType() == InRun) {
+      if (isComplete()) {
         return Transition::EndRun;
       } else {
         return Transition::BeginRun;
       }
     }
-    if(isComplete()) {
+    if (isComplete()) {
       return Transition::EndLuminosityBlock;
     }
     return Transition::BeginLuminosityBlock;
     //Must be lumi
   }
 
-  EDPutToken::value_type
-  PrincipalGetAdapter::getPutTokenIndex(TypeID const& type, std::string const& productInstanceName) const {
+  EDPutToken::value_type PrincipalGetAdapter::getPutTokenIndex(TypeID const& type,
+                                                               std::string const& productInstanceName) const {
     auto tran = transition();
     size_t index = 0;
-    for(auto const& tl : prodBase_->typeLabelList()) {
-      if((tran == tl.transition_) and (type == tl.typeID_)
-         and (productInstanceName == tl.productInstanceName_)) {
+    for (auto const& tl : prodBase_->typeLabelList()) {
+      if ((tran == tl.transition_) and (type == tl.typeID_) and (productInstanceName == tl.productInstanceName_)) {
         return index;
       }
       ++index;
@@ -340,31 +278,21 @@ namespace edm {
     return std::numeric_limits<unsigned int>::max();
   }
 
-  
-  std::string const&
-  PrincipalGetAdapter::productInstanceLabel(EDPutToken iToken) const {
+  std::string const& PrincipalGetAdapter::productInstanceLabel(EDPutToken iToken) const {
     return prodBase_->typeLabelList()[iToken.index()].productInstanceName_;
   }
-  
-  TypeID const&
-  PrincipalGetAdapter::getTypeIDForPutTokenIndex(EDPutToken::value_type index) const {
+
+  TypeID const& PrincipalGetAdapter::getTypeIDForPutTokenIndex(EDPutToken::value_type index) const {
     return prodBase_->typeLabelList()[index].typeID_;
   }
 
-
-  std::vector<edm::ProductResolverIndex> const&
-  PrincipalGetAdapter::putTokenIndexToProductResolverIndex() const {
+  std::vector<edm::ProductResolverIndex> const& PrincipalGetAdapter::putTokenIndexToProductResolverIndex() const {
     return prodBase_->putTokenIndexToProductResolverIndex();
   }
 
-  std::vector<bool> const&
-  PrincipalGetAdapter::recordProvenanceList() const {
+  std::vector<bool> const& PrincipalGetAdapter::recordProvenanceList() const {
     return prodBase_->recordProvenanceList();
   }
 
-  
-  EDProductGetter const*
-  PrincipalGetAdapter::prodGetter() const{
-    return principal_.prodGetter();
-  }
-}
+  EDProductGetter const* PrincipalGetAdapter::prodGetter() const { return principal_.prodGetter(); }
+}  // namespace edm

--- a/FWCore/Framework/src/ProcessingController.cc
+++ b/FWCore/Framework/src/ProcessingController.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     ProcessingController
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -27,15 +27,13 @@ using namespace edm;
 //
 // constructors and destructor
 //
-ProcessingController::ProcessingController(ForwardState forwardState, ReverseState reverseState, bool iCanRandomAccess) :
-forwardState_(forwardState),
-reverseState_(reverseState),
-transition_(kToNextEvent),
-specifiedEvent_(),
-canRandomAccess_(iCanRandomAccess),
-lastOperationSucceeded_(true)
-{
-}
+ProcessingController::ProcessingController(ForwardState forwardState, ReverseState reverseState, bool iCanRandomAccess)
+    : forwardState_(forwardState),
+      reverseState_(reverseState),
+      transition_(kToNextEvent),
+      specifiedEvent_(),
+      canRandomAccess_(iCanRandomAccess),
+      lastOperationSucceeded_(true) {}
 
 // ProcessingController::ProcessingController(const ProcessingController& rhs)
 // {
@@ -61,67 +59,28 @@ lastOperationSucceeded_(true)
 //
 // member functions
 //
-void 
-ProcessingController::setTransitionToNextEvent()
-{
-   transition_ = kToNextEvent;
+void ProcessingController::setTransitionToNextEvent() { transition_ = kToNextEvent; }
+
+void ProcessingController::setTransitionToPreviousEvent() { transition_ = kToPreviousEvent; }
+
+void ProcessingController::setTransitionToEvent(edm::EventID const& iID) {
+  transition_ = kToSpecifiedEvent;
+  specifiedEvent_ = iID;
 }
 
-void 
-ProcessingController::setTransitionToPreviousEvent()
-{
-   transition_ = kToPreviousEvent;
-}
-
-void 
-ProcessingController::setTransitionToEvent( edm::EventID const& iID)
-{
-   transition_ = kToSpecifiedEvent;
-   specifiedEvent_ =iID;
-}
-
-void
-ProcessingController::setLastOperationSucceeded(bool value)
-{
-  lastOperationSucceeded_ = value;
-}
+void ProcessingController::setLastOperationSucceeded(bool value) { lastOperationSucceeded_ = value; }
 
 //
 // const member functions
 //
-ProcessingController::ForwardState 
-ProcessingController::forwardState() const
-{
-   return forwardState_;
-}
+ProcessingController::ForwardState ProcessingController::forwardState() const { return forwardState_; }
 
-ProcessingController::ReverseState 
-ProcessingController::reverseState() const
-{
-   return reverseState_;
-}
+ProcessingController::ReverseState ProcessingController::reverseState() const { return reverseState_; }
 
-bool 
-ProcessingController::canRandomAccess() const
-{
-   return canRandomAccess_;
-}
+bool ProcessingController::canRandomAccess() const { return canRandomAccess_; }
 
-ProcessingController::Transition 
-ProcessingController::requestedTransition() const
-{
-   return transition_;
-}
+ProcessingController::Transition ProcessingController::requestedTransition() const { return transition_; }
 
+edm::EventID ProcessingController::specifiedEventTransition() const { return specifiedEvent_; }
 
-edm::EventID 
-ProcessingController::specifiedEventTransition() const
-{
-   return specifiedEvent_;
-}
-
-bool
-ProcessingController::lastOperationSucceeded() const
-{
-  return lastOperationSucceeded_;
-}
+bool ProcessingController::lastOperationSucceeded() const { return lastOperationSucceeded_; }

--- a/FWCore/Framework/src/ProcessingTask.h
+++ b/FWCore/Framework/src/ProcessingTask.h
@@ -3,8 +3,7 @@
 
 #include <string>
 
-namespace edm
-{
+namespace edm {
   typedef std::string ProcessingTask;
 }
 

--- a/FWCore/Framework/src/ProducerBase.cc
+++ b/FWCore/Framework/src/ProducerBase.cc
@@ -13,91 +13,83 @@
 
 namespace edm {
   ProducerBase::ProducerBase() : ProductRegistryHelper(), callWhenNewProductsRegistered_() {}
-  ProducerBase::~ProducerBase() noexcept(false) { }
+  ProducerBase::~ProducerBase() noexcept(false) {}
 
-   std::function<void(BranchDescription const&)> ProducerBase::registrationCallback() const {
-      return callWhenNewProductsRegistered_;
-   }
-
-
-   namespace {
-     class CallbackWrapper {
-       public:  
-        CallbackWrapper(ProductRegistryHelper* iProd,
-                        std::function<void(BranchDescription const&)> iCallback,
-                        ProductRegistry* iReg,
-                        const ModuleDescription& iDesc):
-        prod_(iProd), callback_(iCallback), reg_(iReg), mdesc_(iDesc),
-        lastSize_(iProd->typeLabelList().size()) {}
-        
-        void operator()(BranchDescription const& iDesc) {
-           callback_(iDesc);
-           addToRegistry();
-        }
-        
-        void addToRegistry() {
-           ProducerBase::TypeLabelList const& plist = prod_->typeLabelList();
-           
-           if(lastSize_!=plist.size()){
-              ProducerBase::TypeLabelList::const_iterator pStart = plist.begin();
-              advance(pStart, lastSize_);
-              ProductRegistryHelper::addToRegistry(pStart, plist.end() ,mdesc_, *reg_, prod_);
-              lastSize_ = plist.size();
-           }
-        }
-
-      private:
-        ProductRegistryHelper* prod_;
-        std::function<void(BranchDescription const&)> callback_;
-        ProductRegistry* reg_;
-        ModuleDescription mdesc_;
-        unsigned int lastSize_;
-         
-     };
+  std::function<void(BranchDescription const&)> ProducerBase::registrationCallback() const {
+    return callWhenNewProductsRegistered_;
   }
 
+  namespace {
+    class CallbackWrapper {
+    public:
+      CallbackWrapper(ProductRegistryHelper* iProd,
+                      std::function<void(BranchDescription const&)> iCallback,
+                      ProductRegistry* iReg,
+                      const ModuleDescription& iDesc)
+          : prod_(iProd), callback_(iCallback), reg_(iReg), mdesc_(iDesc), lastSize_(iProd->typeLabelList().size()) {}
 
-  void ProducerBase::registerProducts(ProducerBase* producer,
-				ProductRegistry* iReg,
-				ModuleDescription const& md)
-  {
+      void operator()(BranchDescription const& iDesc) {
+        callback_(iDesc);
+        addToRegistry();
+      }
+
+      void addToRegistry() {
+        ProducerBase::TypeLabelList const& plist = prod_->typeLabelList();
+
+        if (lastSize_ != plist.size()) {
+          ProducerBase::TypeLabelList::const_iterator pStart = plist.begin();
+          advance(pStart, lastSize_);
+          ProductRegistryHelper::addToRegistry(pStart, plist.end(), mdesc_, *reg_, prod_);
+          lastSize_ = plist.size();
+        }
+      }
+
+    private:
+      ProductRegistryHelper* prod_;
+      std::function<void(BranchDescription const&)> callback_;
+      ProductRegistry* reg_;
+      ModuleDescription mdesc_;
+      unsigned int lastSize_;
+    };
+  }  // namespace
+
+  void ProducerBase::registerProducts(ProducerBase* producer, ProductRegistry* iReg, ModuleDescription const& md) {
     if (typeLabelList().empty() && !registrationCallback()) {
       return;
     }
     //If we have a callback, first tell the callback about all the entries already in the
-    // product registry, then add any items this producer wants to add to the registry 
+    // product registry, then add any items this producer wants to add to the registry
     // and only after that do we register the callback. This is done so the callback does not
     // get called for items registered by this producer (avoids circular reference problems)
     bool isListener = false;
-    if(registrationCallback()) {
-       isListener=true;
-       iReg->callForEachBranch(registrationCallback());
+    if (registrationCallback()) {
+      isListener = true;
+      iReg->callForEachBranch(registrationCallback());
     }
     TypeLabelList const& plist = typeLabelList();
 
     ProductRegistryHelper::addToRegistry(plist.begin(), plist.end(), md, *(iReg), this, isListener);
-    if(registrationCallback()) {
-       Service<ConstProductRegistry> regService;
-       regService->watchProductAdditions(CallbackWrapper(producer, registrationCallback(), iReg, md));
+    if (registrationCallback()) {
+      Service<ConstProductRegistry> regService;
+      regService->watchProductAdditions(CallbackWrapper(producer, registrationCallback(), iReg, md));
     }
   }
-  
+
   void ProducerBase::resolvePutIndicies(BranchType iBranchType,
-                          ModuleToResolverIndicies const& iIndicies,
-                          std::string const& moduleLabel) {
+                                        ModuleToResolverIndicies const& iIndicies,
+                                        std::string const& moduleLabel) {
     auto const& plist = typeLabelList();
-    if(putTokenToResolverIndex_.size() != plist.size()) {
-      putTokenToResolverIndex_.resize(plist.size(),std::numeric_limits<unsigned int>::max());
+    if (putTokenToResolverIndex_.size() != plist.size()) {
+      putTokenToResolverIndex_.resize(plist.size(), std::numeric_limits<unsigned int>::max());
     }
     auto range = iIndicies.equal_range(moduleLabel);
     putIndicies_[iBranchType].reserve(iIndicies.count(moduleLabel));
-    for(auto it = range.first; it != range.second;++it) {
+    for (auto it = range.first; it != range.second; ++it) {
       putIndicies_[iBranchType].push_back(std::get<2>(it->second));
       unsigned int i = 0;
-      for(auto const& tl: plist) {
-        if(convertToBranchType(tl.transition_) == iBranchType and
-           (tl.typeID_ == *std::get<0>(it->second)) and
-           (tl.productInstanceName_ == std::get<1>(it->second)) ) {
+      for (auto const& tl : plist) {
+        if (convertToBranchType(tl.transition_) == iBranchType and (tl.typeID_ == *std::get<0>(it->second)) and
+            (tl.productInstanceName_ == std::get<1>(it->second))) {
           putTokenToResolverIndex_[i] = std::get<2>(it->second);
           //NOTE: The ExternalLHEProducer puts the 'same' product in at
           // both beginRun and endRun. Therefore we can get multiple matches.
@@ -108,4 +100,4 @@ namespace edm {
       }
     }
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/ProductDeletedException.cc
+++ b/FWCore/Framework/src/ProductDeletedException.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     ProductDeletedException
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -14,7 +14,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/ProductDeletedException.h"
-
 
 using namespace edm;
 
@@ -29,7 +28,4 @@ using namespace edm;
 //
 // constructors and destructor
 //
-ProductDeletedException::ProductDeletedException():
-cms::Exception("ProductDeleted")
-{
-}
+ProductDeletedException::ProductDeletedException() : cms::Exception("ProductDeleted") {}

--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -15,42 +15,34 @@
 #include <typeindex>
 
 namespace edm {
-  ProductRegistryHelper::~ProductRegistryHelper() noexcept(false) { }
+  ProductRegistryHelper::~ProductRegistryHelper() noexcept(false) {}
 
-  ProductRegistryHelper::TypeLabelList const& ProductRegistryHelper::typeLabelList() const {
-    return typeLabelList_;
-  }
+  ProductRegistryHelper::TypeLabelList const& ProductRegistryHelper::typeLabelList() const { return typeLabelList_; }
 
   namespace {
-    void throwProducesWithoutAbility(const char* runOrLumi,
-                                     std::string const& productTypeName) {
-
+    void throwProducesWithoutAbility(const char* runOrLumi, std::string const& productTypeName) {
       throw edm::Exception(edm::errors::LogicError)
-        << "Module declares it can produce a product of type \'" << productTypeName
-        << "\'\nin a " << runOrLumi << ", but does not have the ability to produce in "
-        << runOrLumi << "s.\n"
-        << "You must add a template parameter of type Begin" << runOrLumi << "Producer\n"
-        << "or End" << runOrLumi << "Producer to the EDProducer or EDFilter base class\n"
-        << "of the module. Or you could remove the call to the function \'produces\'\n"
-        << "(Note legacy modules are not ever allowed to produce in Runs or Lumis)\n";
+          << "Module declares it can produce a product of type \'" << productTypeName << "\'\nin a " << runOrLumi
+          << ", but does not have the ability to produce in " << runOrLumi << "s.\n"
+          << "You must add a template parameter of type Begin" << runOrLumi << "Producer\n"
+          << "or End" << runOrLumi << "Producer to the EDProducer or EDFilter base class\n"
+          << "of the module. Or you could remove the call to the function \'produces\'\n"
+          << "(Note legacy modules are not ever allowed to produce in Runs or Lumis)\n";
     }
-  }
+  }  // namespace
 
-  void
-  ProductRegistryHelper::addToRegistry(TypeLabelList::const_iterator const& iBegin,
-                                       TypeLabelList::const_iterator const& iEnd,
-                                       ModuleDescription const& iDesc,
-                                       ProductRegistry& iReg,
-                                       ProductRegistryHelper* iProd,
-                                       bool iIsListener) {
-
+  void ProductRegistryHelper::addToRegistry(TypeLabelList::const_iterator const& iBegin,
+                                            TypeLabelList::const_iterator const& iEnd,
+                                            ModuleDescription const& iDesc,
+                                            ProductRegistry& iReg,
+                                            ProductRegistryHelper* iProd,
+                                            bool iIsListener) {
     std::vector<std::string> missingDictionaries;
     std::vector<std::string> producedTypes;
-    std::set<std::tuple<BranchType,std::type_index,std::string>> registeredProducts;
+    std::set<std::tuple<BranchType, std::type_index, std::string>> registeredProducts;
 
-    for(TypeLabelList::const_iterator p = iBegin; p != iEnd; ++p) {
-      if (p->transition_ == Transition::BeginRun ||
-          p->transition_ == Transition::EndRun) {
+    for (TypeLabelList::const_iterator p = iBegin; p != iEnd; ++p) {
+      if (p->transition_ == Transition::BeginRun || p->transition_ == Transition::EndRun) {
         if (not iProd->hasAbilityToProduceInRuns()) {
           throwProducesWithoutAbility("Run", p->typeID_.userClassName());
         }
@@ -66,9 +58,10 @@ namespace edm {
         continue;
       }
       auto branchType = convertToBranchType(p->transition_);
-      if(branchType != InEvent) {
-        std::tuple<BranchType, std::type_index, std::string> entry{ branchType,p->typeID_.typeInfo(),p->productInstanceName_};
-        if(registeredProducts.end() != registeredProducts.find(entry) ) {
+      if (branchType != InEvent) {
+        std::tuple<BranchType, std::type_index, std::string> entry{branchType, p->typeID_.typeInfo(),
+                                                                   p->productInstanceName_};
+        if (registeredProducts.end() != registeredProducts.find(entry)) {
           //ignore registration of items if in both begin and end transitions for now
           // This is to work around ExternalLHEProducer
           continue;
@@ -78,21 +71,14 @@ namespace edm {
       }
 
       TypeWithDict type(p->typeID_.typeInfo());
-      BranchDescription pdesc(branchType,
-                              iDesc.moduleLabel(),
-                              iDesc.processName(),
-                              p->typeID_.userClassName(),
-                              p->typeID_.friendlyClassName(),
-                              p->productInstanceName_,
-                              iDesc.moduleName(),
-                              iDesc.parameterSetID(),
-                              type,
-                              true,
-                              isEndTransition(p->transition_));
-      if(p->aliasType_ == TypeLabelItem::AliasType::kSwitchAlias) {
-        if(p->branchAlias_.empty()) {
-          throw edm::Exception(edm::errors::LogicError) << "Branch alias type has been set to SwitchAlias, but the alias content is empty.\n"
-                                                        << "Please report this error to the FWCore developers";
+      BranchDescription pdesc(branchType, iDesc.moduleLabel(), iDesc.processName(), p->typeID_.userClassName(),
+                              p->typeID_.friendlyClassName(), p->productInstanceName_, iDesc.moduleName(),
+                              iDesc.parameterSetID(), type, true, isEndTransition(p->transition_));
+      if (p->aliasType_ == TypeLabelItem::AliasType::kSwitchAlias) {
+        if (p->branchAlias_.empty()) {
+          throw edm::Exception(edm::errors::LogicError)
+              << "Branch alias type has been set to SwitchAlias, but the alias content is empty.\n"
+              << "Please report this error to the FWCore developers";
         }
         pdesc.setSwitchAliasModuleLabel(p->branchAlias_);
       }
@@ -113,7 +99,8 @@ namespace edm {
           continue;
         }
       }
-      if (!p->branchAlias_.empty()) pdesc.insertBranchAlias(p->branchAlias_);
+      if (!p->branchAlias_.empty())
+        pdesc.insertBranchAlias(p->branchAlias_);
       iReg.addProduct(pdesc, iIsListener);
     }
 
@@ -122,4 +109,4 @@ namespace edm {
       throwMissingDictionariesException(missingDictionaries, context, producedTypes);
     }
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/ProductResolverBase.cc
+++ b/FWCore/Framework/src/ProductResolverBase.cc
@@ -15,11 +15,10 @@ namespace edm {
 
   ProductResolverBase::~ProductResolverBase() {}
 
-  bool
-  ProductResolverBase::provenanceAvailable() const {
+  bool ProductResolverBase::provenanceAvailable() const {
     // If this product is from a the current process,
     // the provenance is available if and only if a product has been put.
-    if(branchDescription().produced()) {
+    if (branchDescription().produced()) {
       return productResolved();
     }
     // If this product is from a prior process, the provenance is available,
@@ -27,33 +26,20 @@ namespace edm {
     return true;
   }
 
-  TypeID
-  ProductResolverBase::productType() const {
-    return TypeID(branchDescription().wrappedTypeID());
-  }
+  TypeID ProductResolverBase::productType() const { return TypeID(branchDescription().wrappedTypeID()); }
 
-  Provenance const*
-  ProductResolverBase::provenance() const {
-    return provenance_();
-  }
+  Provenance const* ProductResolverBase::provenance() const { return provenance_(); }
 
-  void
-  ProductResolverBase::retrieveAndMerge_(Principal const&, MergeableRunProductMetadata const*) const {
-  }
+  void ProductResolverBase::retrieveAndMerge_(Principal const&, MergeableRunProductMetadata const*) const {}
 
-  void
-  ProductResolverBase::setMergeableRunProductMetadata_(MergeableRunProductMetadata const*) {
-  }
+  void ProductResolverBase::setMergeableRunProductMetadata_(MergeableRunProductMetadata const*) {}
 
-  void
-  ProductResolverBase::write(std::ostream& os) const {
+  void ProductResolverBase::write(std::ostream& os) const {
     // This is grossly inadequate. It is also not critical for the
     // first pass.
-    os << std::string("ProductResolver for product with ID: ")
-       << productID();
+    os << std::string("ProductResolver for product with ID: ") << productID();
   }
-  
-  void
-  ProductResolverBase::setupUnscheduled(UnscheduledConfigurator const&) {}
-  
-}
+
+  void ProductResolverBase::setupUnscheduled(UnscheduledConfigurator const&) {}
+
+}  // namespace edm

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -31,45 +31,42 @@ namespace edm {
   void DataManagingProductResolver::throwProductDeletedException() const {
     ProductDeletedException exception;
     exception << "ProductResolverBase::resolveProduct_: The product matching all criteria was already deleted\n"
-    << "Looking for type: " << branchDescription().unwrappedTypeID() << "\n"
-    << "Looking for module label: " << moduleLabel() << "\n"
-    << "Looking for productInstanceName: " << productInstanceName() << "\n"
-    << (processName().empty() ? "" : "Looking for process: ") << processName() << "\n"
-    << "This means there is a configuration error.\n"
-    << "The module which is asking for this data must be configured to state that it will read this data.";
+              << "Looking for type: " << branchDescription().unwrappedTypeID() << "\n"
+              << "Looking for module label: " << moduleLabel() << "\n"
+              << "Looking for productInstanceName: " << productInstanceName() << "\n"
+              << (processName().empty() ? "" : "Looking for process: ") << processName() << "\n"
+              << "This means there is a configuration error.\n"
+              << "The module which is asking for this data must be configured to state that it will read this data.";
     throw exception;
-    
   }
 
   //This is a templated function in order to avoid calling another virtual function
   template <bool callResolver, typename FUNC>
-  ProductResolverBase::Resolution
-  DataManagingProductResolver::resolveProductImpl(FUNC resolver) const {
-    
-    if(productWasDeleted()) {
+  ProductResolverBase::Resolution DataManagingProductResolver::resolveProductImpl(FUNC resolver) const {
+    if (productWasDeleted()) {
       throwProductDeletedException();
     }
     auto presentStatus = status();
-    
-    if(callResolver && presentStatus == ProductStatus::ResolveNotRun) {
+
+    if (callResolver && presentStatus == ProductStatus::ResolveNotRun) {
       //if resolver fails because of exception or not setting product
       // make sure the status goes to failed
       auto failedStatusSetter = [this](ProductStatus* presentStatus) {
-        if(this->status() == ProductStatus::ResolveNotRun) {
+        if (this->status() == ProductStatus::ResolveNotRun) {
           this->setFailedStatus();
         }
         *presentStatus = this->status();
       };
-      std::unique_ptr<ProductStatus, decltype(failedStatusSetter)> failedStatusGuard(&presentStatus, failedStatusSetter);
+      std::unique_ptr<ProductStatus, decltype(failedStatusSetter)> failedStatusGuard(&presentStatus,
+                                                                                     failedStatusSetter);
 
       //If successful, this will call setProduct
       resolver();
     }
-    
-    
+
     if (presentStatus == ProductStatus::ProductSet) {
       auto pd = &getProductData();
-      if(pd->wrapper()->isPresent()) {
+      if (pd->wrapper()->isPresent()) {
         return Resolution(pd);
       }
     }
@@ -77,9 +74,8 @@ namespace edm {
     return Resolution(nullptr);
   }
 
-  void
-  DataManagingProductResolver::mergeProduct(std::unique_ptr<WrapperBase> iFrom, MergeableRunProductMetadata const* mergeableRunProductMetadata) const {
-
+  void DataManagingProductResolver::mergeProduct(std::unique_ptr<WrapperBase> iFrom,
+                                                 MergeableRunProductMetadata const* mergeableRunProductMetadata) const {
     // if its not mergeable and the previous read failed, go ahead and use this one
     if (status() == ProductStatus::ResolveFailed) {
       setProduct(std::move(iFrom));
@@ -87,26 +83,30 @@ namespace edm {
     }
 
     assert(status() == ProductStatus::ProductSet);
-    if(not iFrom) { return;}
-    
+    if (not iFrom) {
+      return;
+    }
+
     checkType(*iFrom);
-    
-    auto original =getProductData().unsafe_wrapper();
+
+    auto original = getProductData().unsafe_wrapper();
     if (original->isMergeable()) {
       if (original->isPresent() != iFrom->isPresent()) {
         throw Exception(errors::MismatchedInputFiles)
-          << "Merge of Run or Lumi product failed for branch " << branchDescription().branchName() << "\n"
-          << "Was trying to merge objects where one product had been put in the input file and the other had not been." << "\n"
-          << "The solution is to drop the branch on input. Or better do not create inconsistent files\n"
-          << "that need to be merged in the first place.\n";
+            << "Merge of Run or Lumi product failed for branch " << branchDescription().branchName() << "\n"
+            << "Was trying to merge objects where one product had been put in the input file and the other had not "
+               "been."
+            << "\n"
+            << "The solution is to drop the branch on input. Or better do not create inconsistent files\n"
+            << "that need to be merged in the first place.\n";
       }
       if (original->isPresent()) {
-
         BranchDescription const& desc = branchDescription_();
         if (mergeableRunProductMetadata == nullptr || desc.branchType() != InRun) {
           original->mergeProduct(iFrom.get());
         } else {
-          MergeableRunProductMetadata::MergeDecision decision = mergeableRunProductMetadata->getMergeDecision(desc.processName());
+          MergeableRunProductMetadata::MergeDecision decision =
+              mergeableRunProductMetadata->getMergeDecision(desc.processName());
           if (decision == MergeableRunProductMetadata::MERGE) {
             original->mergeProduct(iFrom.get());
           } else if (decision == MergeableRunProductMetadata::REPLACE) {
@@ -123,18 +123,18 @@ namespace edm {
       }
       // If both have isPresent false, do nothing
 
-    } else if(original->hasIsProductEqual()) {
+    } else if (original->hasIsProductEqual()) {
       if (original->isPresent() && iFrom->isPresent()) {
-        if(!original->isProductEqual(iFrom.get())) {
+        if (!original->isProductEqual(iFrom.get())) {
           auto const& bd = branchDescription();
           edm::LogError("RunLumiMerging")
-            << "ProductResolver::mergeTheProduct\n"
-            << "Two run/lumi products for the same run/lumi which should be equal are not\n"
-            << "Using the first, ignoring the second\n"
-            << "className = " << bd.className() << "\n"
-            << "moduleLabel = " << bd.moduleLabel() << "\n"
-            << "instance = " << bd.productInstanceName() << "\n"
-            << "process = " << bd.processName() << "\n";
+              << "ProductResolver::mergeTheProduct\n"
+              << "Two run/lumi products for the same run/lumi which should be equal are not\n"
+              << "Using the first, ignoring the second\n"
+              << "className = " << bd.className() << "\n"
+              << "moduleLabel = " << bd.moduleLabel() << "\n"
+              << "instance = " << bd.productInstanceName() << "\n"
+              << "process = " << bd.processName() << "\n";
         }
       } else if (!original->isPresent() && iFrom->isPresent()) {
         setProduct(std::move(iFrom));
@@ -142,14 +142,13 @@ namespace edm {
       // if not iFrom->isPresent(), do nothing
     } else {
       auto const& bd = branchDescription();
-      edm::LogWarning("RunLumiMerging")
-        << "ProductResolver::mergeTheProduct\n"
-        << "Run/lumi product has neither a mergeProduct nor isProductEqual function\n"
-        << "Using the first, ignoring the second in merge\n"
-        << "className = " << bd.className() << "\n"
-        << "moduleLabel = " << bd.moduleLabel() << "\n"
-        << "instance = " << bd.productInstanceName() << "\n"
-        << "process = " << bd.processName() << "\n";
+      edm::LogWarning("RunLumiMerging") << "ProductResolver::mergeTheProduct\n"
+                                        << "Run/lumi product has neither a mergeProduct nor isProductEqual function\n"
+                                        << "Using the first, ignoring the second in merge\n"
+                                        << "className = " << bd.className() << "\n"
+                                        << "moduleLabel = " << bd.moduleLabel() << "\n"
+                                        << "instance = " << bd.productInstanceName() << "\n"
+                                        << "process = " << bd.processName() << "\n";
       if (!original->isPresent() && iFrom->isPresent()) {
         setProduct(std::move(iFrom));
       }
@@ -157,50 +156,46 @@ namespace edm {
     }
   }
 
-  ProductResolverBase::Resolution
-  InputProductResolver::resolveProduct_(Principal const& principal,
-                                        bool,
-                                        SharedResourcesAcquirer* ,
-                                        ModuleCallingContext const* mcc) const {
-    return resolveProductImpl<true>([this,&principal,mcc]() {
+  ProductResolverBase::Resolution InputProductResolver::resolveProduct_(Principal const& principal,
+                                                                        bool,
+                                                                        SharedResourcesAcquirer*,
+                                                                        ModuleCallingContext const* mcc) const {
+    return resolveProductImpl<true>([this, &principal, mcc]() {
       auto branchType = principal.branchType();
-      if(branchType != InEvent) {
+      if (branchType != InEvent) {
         //delayed get has not been allowed with Run or Lumis
         // The file may already be closed so the reader is invalid
         return;
       }
-      if(mcc and (branchType == InEvent) and aux_) {
-        aux_->preModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()),*mcc);
+      if (mcc and (branchType == InEvent) and aux_) {
+        aux_->preModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()), *mcc);
       }
 
-      auto sentry( make_sentry(mcc,
-                               [this, branchType](ModuleCallingContext const* iContext){
-                                 if(branchType == InEvent and aux_) {
-                                   aux_->postModuleDelayedGetSignal_.emit(*(iContext->getStreamContext()), *iContext); }
-                               }));
-
-      if(auto reader=principal.reader()) {
-        std::unique_lock<std::recursive_mutex> guard;
-        if(auto sr = reader->sharedResources().second) {
-          guard =std::unique_lock<std::recursive_mutex>(*sr);
+      auto sentry(make_sentry(mcc, [this, branchType](ModuleCallingContext const* iContext) {
+        if (branchType == InEvent and aux_) {
+          aux_->postModuleDelayedGetSignal_.emit(*(iContext->getStreamContext()), *iContext);
         }
-        if ( not productResolved()) {
+      }));
+
+      if (auto reader = principal.reader()) {
+        std::unique_lock<std::recursive_mutex> guard;
+        if (auto sr = reader->sharedResources().second) {
+          guard = std::unique_lock<std::recursive_mutex>(*sr);
+        }
+        if (not productResolved()) {
           //another thread could have beaten us here
-          putProduct( reader->getProduct(branchDescription().branchID(), &principal, mcc));
+          putProduct(reader->getProduct(branchDescription().branchID(), &principal, mcc));
         }
       }
     });
-                              
   }
 
-  void
-  InputProductResolver::retrieveAndMerge_(Principal const& principal, MergeableRunProductMetadata const* mergeableRunProductMetadata) const {
-
-    if(auto reader = principal.reader()) {
-
+  void InputProductResolver::retrieveAndMerge_(Principal const& principal,
+                                               MergeableRunProductMetadata const* mergeableRunProductMetadata) const {
+    if (auto reader = principal.reader()) {
       std::unique_lock<std::recursive_mutex> guard;
-      if(auto sr = reader->sharedResources().second) {
-        guard =std::unique_lock<std::recursive_mutex>(*sr);
+      if (auto sr = reader->sharedResources().second) {
+        guard = std::unique_lock<std::recursive_mutex>(*sr);
       }
 
       //Can't use resolveProductImpl since it first checks to see
@@ -210,39 +205,41 @@ namespace edm {
       if (edp.get() != nullptr) {
         if (edp->isMergeable() && branchDescription().branchType() == InRun && !edp->hasSwap()) {
           throw Exception(errors::LogicError)
-            << "Missing definition of member function swap for branch name " << branchDescription().branchName() << "\n"
-            << "Mergeable data types written to a Run must have the swap member function defined" << "\n";
+              << "Missing definition of member function swap for branch name " << branchDescription().branchName()
+              << "\n"
+              << "Mergeable data types written to a Run must have the swap member function defined"
+              << "\n";
         }
-        if (status() == defaultStatus() ||
-            status() == ProductStatus::ProductSet ||
+        if (status() == defaultStatus() || status() == ProductStatus::ProductSet ||
             (status() == ProductStatus::ResolveFailed && !branchDescription().isMergeable())) {
           putOrMergeProduct(std::move(edp), mergeableRunProductMetadata);
-        } else { // status() == ResolveFailed && branchDescription().isMergeable()
+        } else {  // status() == ResolveFailed && branchDescription().isMergeable()
           throw Exception(errors::MismatchedInputFiles)
-            << "Merge of Run or Lumi product failed for branch " << branchDescription().branchName() << "\n"
-            << "The product branch was dropped in the first run or lumi fragment and present in a later one" << "\n"
-            << "The solution is to drop the branch on input. Or better do not create inconsistent files\n"
-            << "that need to be merged in the first place.\n";
+              << "Merge of Run or Lumi product failed for branch " << branchDescription().branchName() << "\n"
+              << "The product branch was dropped in the first run or lumi fragment and present in a later one"
+              << "\n"
+              << "The solution is to drop the branch on input. Or better do not create inconsistent files\n"
+              << "that need to be merged in the first place.\n";
         }
       } else if (status() == defaultStatus()) {
         setFailedStatus();
-      } else if ( status() != ProductStatus::ResolveFailed && branchDescription().isMergeable()) {
+      } else if (status() != ProductStatus::ResolveFailed && branchDescription().isMergeable()) {
         throw Exception(errors::MismatchedInputFiles)
-          << "Merge of Run or Lumi product failed for branch " << branchDescription().branchName() << "\n"
-          << "The product branch was present in first run or lumi fragment and dropped in a later one" << "\n"
-          << "The solution is to drop the branch on input. Or better do not create inconsistent files\n"
-          << "that need to be merged in the first place.\n";
+            << "Merge of Run or Lumi product failed for branch " << branchDescription().branchName() << "\n"
+            << "The product branch was present in first run or lumi fragment and dropped in a later one"
+            << "\n"
+            << "The solution is to drop the branch on input. Or better do not create inconsistent files\n"
+            << "that need to be merged in the first place.\n";
       }
       // Do nothing in other case. status is ResolveFailed already or
       // it is not mergeable and the status is ProductSet
     }
   }
 
-  void
-  InputProductResolver::setMergeableRunProductMetadata_(MergeableRunProductMetadata const* mrpm) {
+  void InputProductResolver::setMergeableRunProductMetadata_(MergeableRunProductMetadata const* mrpm) {
     setMergeableRunProductMetadataInProductData(mrpm);
   }
-  
+
   void InputProductResolver::prefetchAsync_(WaitingTask* waitTask,
                                             Principal const& principal,
                                             bool skipCurrentProcess,
@@ -250,78 +247,70 @@ namespace edm {
                                             SharedResourcesAcquirer* sra,
                                             ModuleCallingContext const* mcc) const {
     m_waitingTasks.add(waitTask);
-    
+
     bool expected = false;
-    if( m_prefetchRequested.compare_exchange_strong(expected, true) ) {
-      
-      auto workToDo = [this, mcc, &principal, token] () {
+    if (m_prefetchRequested.compare_exchange_strong(expected, true)) {
+      auto workToDo = [this, mcc, &principal, token]() {
         //need to make sure Service system is activated on the reading thread
         ServiceRegistry::Operate guard(token);
         try {
-          resolveProductImpl<true>([this,&principal,mcc]() {
-            if(principal.branchType() != InEvent) { return; }
-            if(auto reader = principal.reader()) {
+          resolveProductImpl<true>([this, &principal, mcc]() {
+            if (principal.branchType() != InEvent) {
+              return;
+            }
+            if (auto reader = principal.reader()) {
               std::unique_lock<std::recursive_mutex> guard;
-              if(auto sr = reader->sharedResources().second) {
-                guard =std::unique_lock<std::recursive_mutex>(*sr);
+              if (auto sr = reader->sharedResources().second) {
+                guard = std::unique_lock<std::recursive_mutex>(*sr);
               }
-              if ( not productResolved()) {
+              if (not productResolved()) {
                 //another thread could have finished this while we were waiting
-                putProduct( reader->getProduct(branchDescription().branchID(), &principal, mcc));
+                putProduct(reader->getProduct(branchDescription().branchID(), &principal, mcc));
               }
             }
           });
-        } catch(...) {
+        } catch (...) {
           this->m_waitingTasks.doneWaiting(std::current_exception());
           return;
         }
         this->m_waitingTasks.doneWaiting(nullptr);
       };
-      
+
       SerialTaskQueueChain* queue = nullptr;
-      if(auto reader = principal.reader()) {
+      if (auto reader = principal.reader()) {
         if (auto shared_res = reader->sharedResources().first) {
           queue = &(shared_res->serialQueueChain());
         }
       }
-      if(queue) {
+      if (queue) {
         queue->push(workToDo);
       } else {
         //Have to create a new task
-        auto t = make_functor_task(tbb::task::allocate_root(),
-                                   workToDo);
+        auto t = make_functor_task(tbb::task::allocate_root(), workToDo);
         tbb::task::spawn(*t);
       }
     }
   }
 
-  void
-  InputProductResolver::resetProductData_(bool deleteEarly) {
+  void InputProductResolver::resetProductData_(bool deleteEarly) {
     m_prefetchRequested = false;
     m_waitingTasks.reset();
     DataManagingProductResolver::resetProductData_(deleteEarly);
   }
 
-  void
-  InputProductResolver::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
+  void InputProductResolver::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
     aux_ = iConfigure.auxiliary();
   }
 
-  
-  bool
-  InputProductResolver::isFromCurrentProcess() const {
-    return false;
-  }
+  bool InputProductResolver::isFromCurrentProcess() const { return false; }
 
-  
-  ProductResolverBase::Resolution
-  PuttableProductResolver::resolveProduct_(Principal const&,
-                                           bool skipCurrentProcess,
-                                           SharedResourcesAcquirer*,
-                                           ModuleCallingContext const*) const {
+  ProductResolverBase::Resolution PuttableProductResolver::resolveProduct_(Principal const&,
+                                                                           bool skipCurrentProcess,
+                                                                           SharedResourcesAcquirer*,
+                                                                           ModuleCallingContext const*) const {
     if (!skipCurrentProcess) {
       //'false' means never call the lambda function
-      return resolveProductImpl<false>([](){return;});
+      return resolveProductImpl<false>([]() { return; });
     }
     return Resolution(nullptr);
   }
@@ -332,220 +321,185 @@ namespace edm {
                                                ServiceToken const& token,
                                                SharedResourcesAcquirer* sra,
                                                ModuleCallingContext const* mcc) const {
-    if(not skipCurrentProcess) {
-      if(branchDescription().availableOnlyAtEndTransition() and mcc ) {
-        if( not mcc->parent().isAtEndTransition() ) {
+    if (not skipCurrentProcess) {
+      if (branchDescription().availableOnlyAtEndTransition() and mcc) {
+        if (not mcc->parent().isAtEndTransition()) {
           return;
         }
       }
       m_waitingTasks.add(waitTask);
-      
+
       bool expected = false;
-      if(worker_ and prefetchRequested_.compare_exchange_strong(expected,true)) {
+      if (worker_ and prefetchRequested_.compare_exchange_strong(expected, true)) {
         //using a waiting task to do a callback guarantees that
         // the m_waitingTasks list will be released from waiting even
         // if the module does not put this data product or the
         // module has an exception while running
-        
-        auto waiting = make_waiting_task(tbb::task::allocate_root(),
-                                         [this](std::exception_ptr const *  iException) {
-                                           if(nullptr != iException) {
-                                             m_waitingTasks.doneWaiting(*iException);
-                                           } else {
-                                             m_waitingTasks.doneWaiting(std::exception_ptr());
-                                           }
-                                         });
+
+        auto waiting = make_waiting_task(tbb::task::allocate_root(), [this](std::exception_ptr const* iException) {
+          if (nullptr != iException) {
+            m_waitingTasks.doneWaiting(*iException);
+          } else {
+            m_waitingTasks.doneWaiting(std::exception_ptr());
+          }
+        });
         worker_->callWhenDoneAsync(waiting);
       }
     }
   }
-  
-  void
-  PuttableProductResolver::putProduct_(std::unique_ptr<WrapperBase> edp) const {
+
+  void PuttableProductResolver::putProduct_(std::unique_ptr<WrapperBase> edp) const {
     ProducedProductResolver::putProduct_(std::move(edp));
     bool expected = false;
-    if(prefetchRequested_.compare_exchange_strong(expected,true)) {
+    if (prefetchRequested_.compare_exchange_strong(expected, true)) {
       m_waitingTasks.doneWaiting(std::exception_ptr());
     }
   }
 
-  
-  void
-  PuttableProductResolver::resetProductData_(bool deleteEarly) {
+  void PuttableProductResolver::resetProductData_(bool deleteEarly) {
     m_waitingTasks.reset();
     DataManagingProductResolver::resetProductData_(deleteEarly);
     prefetchRequested_ = false;
   }
 
-  void
-  PuttableProductResolver::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
+  void PuttableProductResolver::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
     worker_ = iConfigure.findWorker(branchDescription().moduleLabel());
   }
 
-  
-  void
-  UnscheduledProductResolver::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
+  void UnscheduledProductResolver::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
     aux_ = iConfigure.auxiliary();
     worker_ = iConfigure.findWorker(branchDescription().moduleLabel());
     assert(worker_ != nullptr);
-    
-  }  
-  
-  ProductResolverBase::Resolution
-  UnscheduledProductResolver::resolveProduct_(Principal const& principal,
-                                              bool skipCurrentProcess,
-                                              SharedResourcesAcquirer* sra,
-                                              ModuleCallingContext const* mcc) const {
+  }
+
+  ProductResolverBase::Resolution UnscheduledProductResolver::resolveProduct_(Principal const& principal,
+                                                                              bool skipCurrentProcess,
+                                                                              SharedResourcesAcquirer* sra,
+                                                                              ModuleCallingContext const* mcc) const {
     if (!skipCurrentProcess and worker_) {
-      return resolveProductImpl<true>(
-        [&principal,this,sra,mcc]() {
-          try {
-            auto const& event = static_cast<EventPrincipal const&>(principal);
-            ParentContext parentContext(mcc);
-            aux_->preModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()),*mcc);
+      return resolveProductImpl<true>([&principal, this, sra, mcc]() {
+        try {
+          auto const& event = static_cast<EventPrincipal const&>(principal);
+          ParentContext parentContext(mcc);
+          aux_->preModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()), *mcc);
 
-            auto workCall = [this,&event,&parentContext,mcc] () {
-              auto sentry( make_sentry(mcc,[this](ModuleCallingContext const* iContext){aux_->postModuleDelayedGetSignal_.emit(*(iContext->getStreamContext()), *iContext); }));
-              
-              worker_->doWork<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> >(
-                                           event,
-                                           *(aux_->eventSetup()),
-                                           event.streamID(),
-                                           parentContext,
-                                           mcc->getStreamContext());
-            };
-            
-            if (sra) {
-              assert(false);
-            } else {
-              workCall();
-            }
+          auto workCall = [this, &event, &parentContext, mcc]() {
+            auto sentry(make_sentry(mcc, [this](ModuleCallingContext const* iContext) {
+              aux_->postModuleDelayedGetSignal_.emit(*(iContext->getStreamContext()), *iContext);
+            }));
 
+            worker_->doWork<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> >(
+                event, *(aux_->eventSetup()), event.streamID(), parentContext, mcc->getStreamContext());
+          };
+
+          if (sra) {
+            assert(false);
+          } else {
+            workCall();
           }
-          catch (cms::Exception & ex) {
-            std::ostringstream ost;
-            ost << "Calling produce method for unscheduled module "
-            << worker_->description().moduleName() << "/'"
-            << worker_->description().moduleLabel() << "'";
-            ex.addContext(ost.str());
-            throw;
-          }
-        });
+
+        } catch (cms::Exception& ex) {
+          std::ostringstream ost;
+          ost << "Calling produce method for unscheduled module " << worker_->description().moduleName() << "/'"
+              << worker_->description().moduleLabel() << "'";
+          ex.addContext(ost.str());
+          throw;
+        }
+      });
     }
     return Resolution(nullptr);
   }
-  
-  void
-  UnscheduledProductResolver::prefetchAsync_(WaitingTask* waitTask,
-                                             Principal const& principal,
-                                             bool skipCurrentProcess,
-                                             ServiceToken const& token,
-                                             SharedResourcesAcquirer* sra,
-                                             ModuleCallingContext const* mcc) const
-  {
-    if(skipCurrentProcess) { return; }
+
+  void UnscheduledProductResolver::prefetchAsync_(WaitingTask* waitTask,
+                                                  Principal const& principal,
+                                                  bool skipCurrentProcess,
+                                                  ServiceToken const& token,
+                                                  SharedResourcesAcquirer* sra,
+                                                  ModuleCallingContext const* mcc) const {
+    if (skipCurrentProcess) {
+      return;
+    }
     waitingTasks_.add(waitTask);
     bool expected = false;
-    if(prefetchRequested_.compare_exchange_strong(expected, true)) {
-      
+    if (prefetchRequested_.compare_exchange_strong(expected, true)) {
       //Have to create a new task which will make sure the state for UnscheduledProductResolver
       // is properly set after the module has run
-      auto t = make_waiting_task(tbb::task::allocate_root(),
-                                 [this](std::exception_ptr const* iPtr)
-      {
+      auto t = make_waiting_task(tbb::task::allocate_root(), [this](std::exception_ptr const* iPtr) {
         //The exception is being rethrown because resolveProductImpl sets the ProductResolver to a failed
         // state for the case where an exception occurs during the call to the function.
         try {
           resolveProductImpl<true>([iPtr]() {
-            if ( iPtr) {
+            if (iPtr) {
               std::rethrow_exception(*iPtr);
             }
           });
-        } catch(...) {
+        } catch (...) {
           waitingTasks_.doneWaiting(std::current_exception());
           return;
         }
         waitingTasks_.doneWaiting(nullptr);
-      } );
+      });
       auto const& event = static_cast<EventPrincipal const&>(principal);
       ParentContext parentContext(mcc);
 
-      worker_->doWorkAsync<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> >(t,
-                                                                                       event,
-                                                                                       *(aux_->eventSetup()),
-                                                                                       token,
-                                                                                       event.streamID(),
-                                                                                       parentContext,
-                                                                                       mcc->getStreamContext());
+      worker_->doWorkAsync<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> >(
+          t, event, *(aux_->eventSetup()), token, event.streamID(), parentContext, mcc->getStreamContext());
     }
   }
-  
-  void
-  UnscheduledProductResolver::resetProductData_(bool deleteEarly) {
+
+  void UnscheduledProductResolver::resetProductData_(bool deleteEarly) {
     prefetchRequested_ = false;
     waitingTasks_.reset();
     DataManagingProductResolver::resetProductData_(deleteEarly);
   }
 
-
-  void
-  ProducedProductResolver::putProduct_(std::unique_ptr<WrapperBase> edp) const {
-    if(status() != defaultStatus()) {
+  void ProducedProductResolver::putProduct_(std::unique_ptr<WrapperBase> edp) const {
+    if (status() != defaultStatus()) {
       throw Exception(errors::InsertFailure)
           << "Attempt to insert more than one product on branch " << branchDescription().branchName() << "\n";
     }
-    
+
     setProduct(std::move(edp));  // ProductResolver takes ownership
   }
 
-  void
-  InputProductResolver::putProduct_(std::unique_ptr<WrapperBase> edp) const {
-    if ( not productResolved()) {
+  void InputProductResolver::putProduct_(std::unique_ptr<WrapperBase> edp) const {
+    if (not productResolved()) {
       //Another thread could have set this
       setProduct(std::move(edp));
     }
   }
-  
-  bool
-  ProducedProductResolver::isFromCurrentProcess() const {
-    return true;
-  }
-  
-  void
-  DataManagingProductResolver::connectTo(ProductResolverBase const& iOther, Principal const*) {
-    assert(false);
-  }
-  
-  void
-  DataManagingProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> prod, MergeableRunProductMetadata const* mergeableRunProductMetadata) const {
-    if(not prod) {return;}
-    if(status() == defaultStatus()) {
+
+  bool ProducedProductResolver::isFromCurrentProcess() const { return true; }
+
+  void DataManagingProductResolver::connectTo(ProductResolverBase const& iOther, Principal const*) { assert(false); }
+
+  void DataManagingProductResolver::putOrMergeProduct_(
+      std::unique_ptr<WrapperBase> prod, MergeableRunProductMetadata const* mergeableRunProductMetadata) const {
+    if (not prod) {
+      return;
+    }
+    if (status() == defaultStatus()) {
       //resolveProduct has not been called or it failed
       putProduct(std::move(prod));
     } else {
       mergeProduct(std::move(prod), mergeableRunProductMetadata);
     }
   }
-  
 
-  
-  void
-  DataManagingProductResolver::checkType(WrapperBase const& prod) const {
+  void DataManagingProductResolver::checkType(WrapperBase const& prod) const {
     // Check if the types match.
     TypeID typeID(prod.dynamicTypeInfo());
-    if(typeID !=TypeID{branchDescription().unwrappedType().unvalidatedTypeInfo()}) {
+    if (typeID != TypeID{branchDescription().unwrappedType().unvalidatedTypeInfo()}) {
       // Types do not match.
       throw Exception(errors::EventCorruption)
-      << "Product on branch " << branchDescription().branchName() << " is of wrong type.\n"
-      << "It is supposed to be of type " << branchDescription().className() << ".\n"
-      << "It is actually of type " << typeID.className() << ".\n";
+          << "Product on branch " << branchDescription().branchName() << " is of wrong type.\n"
+          << "It is supposed to be of type " << branchDescription().className() << ".\n"
+          << "It is actually of type " << typeID.className() << ".\n";
     }
   }
-  
 
-  void
-  DataManagingProductResolver::setProduct(std::unique_ptr<WrapperBase> edp) const {
-    if(edp) {
+  void DataManagingProductResolver::setProduct(std::unique_ptr<WrapperBase> edp) const {
+    if (edp) {
       checkType(*edp);
       productData_.unsafe_setWrapper(std::move(edp));
       theStatus_ = ProductStatus::ProductSet;
@@ -556,112 +510,97 @@ namespace edm {
   // This routine returns true if it is known that currently there is no real product.
   // If there is a real product, it returns false.
   // If it is not known if there is a real product, it returns false.
-  bool
-  DataManagingProductResolver::productUnavailable_() const {
+  bool DataManagingProductResolver::productUnavailable_() const {
     auto presentStatus = status();
-    if(presentStatus == ProductStatus::ProductSet) {
+    if (presentStatus == ProductStatus::ProductSet) {
       return !(getProductData().wrapper()->isPresent());
     }
     return presentStatus != ProductStatus::ResolveNotRun;
   }
-    
-  bool
-  DataManagingProductResolver::productResolved_() const {
+
+  bool DataManagingProductResolver::productResolved_() const {
     auto s = status();
-    return (s != defaultStatus() ) or (s == ProductStatus::ProductDeleted);
+    return (s != defaultStatus()) or (s == ProductStatus::ProductDeleted);
   }
 
-  
   // This routine returns true if the product was deleted early in order to save memory
-  bool
-  DataManagingProductResolver::productWasDeleted_() const {
-    return status() == ProductStatus::ProductDeleted;
-  }
-  
-  bool
-  DataManagingProductResolver::productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const {
-    if (iSkipCurrentProcess and isFromCurrentProcess() ) {
+  bool DataManagingProductResolver::productWasDeleted_() const { return status() == ProductStatus::ProductDeleted; }
+
+  bool DataManagingProductResolver::productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const {
+    if (iSkipCurrentProcess and isFromCurrentProcess()) {
       return false;
     }
     if (status() == ProductStatus::ProductSet) {
-      if(getProductData().wrapper()->isPresent()) {
+      if (getProductData().wrapper()->isPresent()) {
         return true;
       }
     }
     return false;
   }
 
-  
-  void DataManagingProductResolver::setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) {
-    productData_.setProvenance(provRetriever,ph,pid);
+  void DataManagingProductResolver::setProvenance_(ProductProvenanceRetriever const* provRetriever,
+                                                   ProcessHistory const& ph,
+                                                   ProductID const& pid) {
+    productData_.setProvenance(provRetriever, ph, pid);
   }
 
-  void DataManagingProductResolver::setMergeableRunProductMetadataInProductData(MergeableRunProductMetadata const* mrpm) {
+  void DataManagingProductResolver::setMergeableRunProductMetadataInProductData(
+      MergeableRunProductMetadata const* mrpm) {
     productData_.setMergeableRunProductMetadata(mrpm);
   }
 
-  void DataManagingProductResolver::setProcessHistory_(ProcessHistory const& ph) {
-    productData_.setProcessHistory(ph);
-  }
-  
+  void DataManagingProductResolver::setProcessHistory_(ProcessHistory const& ph) { productData_.setProcessHistory(ph); }
+
   ProductProvenance const* DataManagingProductResolver::productProvenancePtr_() const {
     return provenance()->productProvenance();
   }
-  
+
   void DataManagingProductResolver::resetProductData_(bool deleteEarly) {
-    if(theStatus_ == ProductStatus::ProductSet) {
+    if (theStatus_ == ProductStatus::ProductSet) {
       productData_.resetProductData();
     }
-    if(deleteEarly) {
+    if (deleteEarly) {
       theStatus_ = ProductStatus::ProductDeleted;
     } else {
       resetStatus();
     }
   }
-  
-  bool DataManagingProductResolver::singleProduct_() const {
-    return true;
+
+  bool DataManagingProductResolver::singleProduct_() const { return true; }
+
+  void AliasProductResolver::setProvenance_(ProductProvenanceRetriever const* provRetriever,
+                                            ProcessHistory const& ph,
+                                            ProductID const& pid) {
+    realProduct_.setProvenance(provRetriever, ph, pid);
   }
 
-  void AliasProductResolver::setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) {
-    realProduct_.setProvenance(provRetriever,ph,pid);
-  }
-
-  void AliasProductResolver::setProcessHistory_(ProcessHistory const& ph) {
-    realProduct_.setProcessHistory(ph);
-  }
+  void AliasProductResolver::setProcessHistory_(ProcessHistory const& ph) { realProduct_.setProcessHistory(ph); }
 
   ProductProvenance const* AliasProductResolver::productProvenancePtr_() const {
     return provenance()->productProvenance();
   }
 
-  void AliasProductResolver::resetProductData_(bool deleteEarly) {
-    realProduct_.resetProductData_(deleteEarly);
+  void AliasProductResolver::resetProductData_(bool deleteEarly) { realProduct_.resetProductData_(deleteEarly); }
+
+  bool AliasProductResolver::singleProduct_() const { return true; }
+
+  void AliasProductResolver::putProduct_(std::unique_ptr<WrapperBase>) const {
+    throw Exception(errors::LogicError)
+        << "AliasProductResolver::putProduct_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
-  bool AliasProductResolver::singleProduct_() const {
-    return true;
-  }
-  
-  void AliasProductResolver::putProduct_(std::unique_ptr<WrapperBase> ) const {
+  void AliasProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp,
+                                                MergeableRunProductMetadata const*) const {
     throw Exception(errors::LogicError)
-    << "AliasProductResolver::putProduct_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+        << "AliasProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata "
+           "const*) not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
-  
-  void AliasProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) const {
-    throw Exception(errors::LogicError)
-    << "AliasProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
-  }
-  
 
-  SwitchBaseProductResolver::SwitchBaseProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct):
-    realProduct_(realProduct),
-    productData_(std::move(bd)),
-    prefetchRequested_(false),
-    status_(defaultStatus_)
-  {
+  SwitchBaseProductResolver::SwitchBaseProductResolver(std::shared_ptr<BranchDescription const> bd,
+                                                       ProducedProductResolver& realProduct)
+      : realProduct_(realProduct), productData_(std::move(bd)), prefetchRequested_(false), status_(defaultStatus_) {
     // Parentage of this branch is always the same by construction, so we can compute the ID just "once" here.
     Parentage p;
     p.setParents(std::vector<BranchID>{realProduct.branchDescription().branchID()});
@@ -669,19 +608,18 @@ namespace edm {
     ParentageRegistry::instance()->insertMapped(p);
   }
 
-  void SwitchBaseProductResolver::connectTo(ProductResolverBase const& iOther, Principal const *iParentPrincipal) {
+  void SwitchBaseProductResolver::connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) {
     throw Exception(errors::LogicError)
-    << "SwitchBaseProductResolver::connectTo() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+        << "SwitchBaseProductResolver::connectTo() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
   void SwitchBaseProductResolver::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
     worker_ = iConfigure.findWorker(branchDescription().moduleLabel());
   }
 
-  ProductResolverBase::Resolution
-  SwitchBaseProductResolver::resolveProductImpl(Resolution res) const {
-    if(res.data() == nullptr)
+  ProductResolverBase::Resolution SwitchBaseProductResolver::resolveProductImpl(Resolution res) const {
+    if (res.data() == nullptr)
       return res;
     // Use the Wrapper of the pointed-to resolver, but the provenance of this resolver
     productData_.unsafe_setWrapper(res.data()->sharedConstWrapper());
@@ -697,135 +635,140 @@ namespace edm {
   }
 
   void SwitchBaseProductResolver::putProduct_(std::unique_ptr<WrapperBase> edp) const {
-    if(status_ != defaultStatus_) {
-      throw Exception(errors::InsertFailure) << "Attempt to insert more than one product for a branch " << branchDescription().branchName() << "This makes no sense for SwitchBaseProductResolver.\nContact a Framework developer";
+    if (status_ != defaultStatus_) {
+      throw Exception(errors::InsertFailure)
+          << "Attempt to insert more than one product for a branch " << branchDescription().branchName()
+          << "This makes no sense for SwitchBaseProductResolver.\nContact a Framework developer";
     }
     // Let's use ResolveFailed to signal that produce() was called, as
     // there is no real product in this resolver
     status_ = ProductStatus::ResolveFailed;
     bool expected = false;
-    if(prefetchRequested_.compare_exchange_strong(expected, true)) {
+    if (prefetchRequested_.compare_exchange_strong(expected, true)) {
       waitingTasks_.doneWaiting(std::exception_ptr());
     }
   }
 
-  void SwitchBaseProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) const {
+  void SwitchBaseProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp,
+                                                     MergeableRunProductMetadata const*) const {
     throw Exception(errors::LogicError)
-    << "SwitchBaseProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+        << "SwitchBaseProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, "
+           "MergeableRunProductMetadata const*) not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
-  void SwitchBaseProductResolver::setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) {
+  void SwitchBaseProductResolver::setProvenance_(ProductProvenanceRetriever const* provRetriever,
+                                                 ProcessHistory const& ph,
+                                                 ProductID const& pid) {
     // insertIntoSet is const, so let's exploit that to fake the getting of the "input" product
     provRetriever->insertIntoSet(ProductProvenance(branchDescription().branchID(), parentageID_));
-    productData_.setProvenance(provRetriever,ph,pid);
+    productData_.setProvenance(provRetriever, ph, pid);
   }
 
   void SwitchBaseProductResolver::resetProductData_(bool deleteEarly) {
     productData_.resetProductData();
     realProduct_.resetProductData_(deleteEarly);
-    if(not deleteEarly) {
+    if (not deleteEarly) {
       status_ = defaultStatus_;
     }
   }
 
-  ProductResolverBase::Resolution
-  SwitchProducerProductResolver::resolveProduct_(Principal const& principal,
-                                                bool skipCurrentProcess,
-                                                SharedResourcesAcquirer* sra,
-                                                ModuleCallingContext const* mcc) const {
-    if(status() == ProductStatus::ResolveFailed) {
+  ProductResolverBase::Resolution SwitchProducerProductResolver::resolveProduct_(Principal const& principal,
+                                                                                 bool skipCurrentProcess,
+                                                                                 SharedResourcesAcquirer* sra,
+                                                                                 ModuleCallingContext const* mcc) const {
+    if (status() == ProductStatus::ResolveFailed) {
       return resolveProductImpl(realProduct().resolveProduct(principal, skipCurrentProcess, sra, mcc));
     }
     return Resolution(nullptr);
   }
 
   void SwitchProducerProductResolver::prefetchAsync_(WaitingTask* waitTask,
-                                                    Principal const& principal,
-                                                    bool skipCurrentProcess,
-                                                    ServiceToken const& token,
-                                                    SharedResourcesAcquirer* sra,
-                                                    ModuleCallingContext const* mcc) const {
-    if(skipCurrentProcess) { return; }
-    if(branchDescription().availableOnlyAtEndTransition() and mcc and not mcc->parent().isAtEndTransition()) {
+                                                     Principal const& principal,
+                                                     bool skipCurrentProcess,
+                                                     ServiceToken const& token,
+                                                     SharedResourcesAcquirer* sra,
+                                                     ModuleCallingContext const* mcc) const {
+    if (skipCurrentProcess) {
+      return;
+    }
+    if (branchDescription().availableOnlyAtEndTransition() and mcc and not mcc->parent().isAtEndTransition()) {
       return;
     }
     waitingTasks().add(waitTask);
 
     bool expected = false;
-    if(prefetchRequested().compare_exchange_strong(expected, true)) {
+    if (prefetchRequested().compare_exchange_strong(expected, true)) {
       //using a waiting task to do a callback guarantees that
       // the waitingTasks() list will be released from waiting even
       // if the module does not put this data product or the
       // module has an exception while running
-      auto waiting = make_waiting_task(tbb::task::allocate_root(),
-                                       [this](std::exception_ptr const *iException) {
-                                         if(nullptr != iException) {
-                                           waitingTasks().doneWaiting(*iException);
-                                         }
-                                         else {
-                                           waitingTasks().doneWaiting(std::exception_ptr());
-                                         }
-                                       });
+      auto waiting = make_waiting_task(tbb::task::allocate_root(), [this](std::exception_ptr const* iException) {
+        if (nullptr != iException) {
+          waitingTasks().doneWaiting(*iException);
+        } else {
+          waitingTasks().doneWaiting(std::exception_ptr());
+        }
+      });
       worker()->callWhenDoneAsync(waiting);
     }
   }
 
   bool SwitchProducerProductResolver::productUnavailable_() const {
     // if produce() was run (ResolveFailed), ask from the real resolver
-    if(status() == ProductStatus::ResolveFailed) {
+    if (status() == ProductStatus::ResolveFailed) {
       return realProduct().productUnavailable();
     }
     return true;
   }
 
-  ProductResolverBase::Resolution
-  SwitchAliasProductResolver::resolveProduct_(Principal const& principal,
-                                              bool skipCurrentProcess,
-                                              SharedResourcesAcquirer* sra,
-                                              ModuleCallingContext const* mcc) const {
+  ProductResolverBase::Resolution SwitchAliasProductResolver::resolveProduct_(Principal const& principal,
+                                                                              bool skipCurrentProcess,
+                                                                              SharedResourcesAcquirer* sra,
+                                                                              ModuleCallingContext const* mcc) const {
     return resolveProductImpl(realProduct().resolveProduct(principal, skipCurrentProcess, sra, mcc));
   }
 
   void SwitchAliasProductResolver::prefetchAsync_(WaitingTask* waitTask,
-                                                    Principal const& principal,
-                                                    bool skipCurrentProcess,
-                                                    ServiceToken const& token,
-                                                    SharedResourcesAcquirer* sra,
-                                                    ModuleCallingContext const* mcc) const {
-    if(skipCurrentProcess) { return; }
+                                                  Principal const& principal,
+                                                  bool skipCurrentProcess,
+                                                  ServiceToken const& token,
+                                                  SharedResourcesAcquirer* sra,
+                                                  ModuleCallingContext const* mcc) const {
+    if (skipCurrentProcess) {
+      return;
+    }
     realProduct().prefetchAsync(waitTask, principal, skipCurrentProcess, token, sra, mcc);
   }
-  
-  
-  void ParentProcessProductResolver::setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) {
+
+  void ParentProcessProductResolver::setProvenance_(ProductProvenanceRetriever const* provRetriever,
+                                                    ProcessHistory const& ph,
+                                                    ProductID const& pid) {
     provRetriever_ = provRetriever;
   }
-  
-  void ParentProcessProductResolver::setProcessHistory_(ProcessHistory const& ph) {
-  }
-  
+
+  void ParentProcessProductResolver::setProcessHistory_(ProcessHistory const& ph) {}
+
   ProductProvenance const* ParentProcessProductResolver::productProvenancePtr_() const {
-    return provRetriever_? provRetriever_->branchIDToProvenance(bd_->originalBranchID()): nullptr;
-  }
-  
-  void ParentProcessProductResolver::resetProductData_(bool deleteEarly) {
-  }
-  
-  bool ParentProcessProductResolver::singleProduct_() const {
-    return true;
+    return provRetriever_ ? provRetriever_->branchIDToProvenance(bd_->originalBranchID()) : nullptr;
   }
 
-  void ParentProcessProductResolver::putProduct_(std::unique_ptr<WrapperBase> ) const {
+  void ParentProcessProductResolver::resetProductData_(bool deleteEarly) {}
+
+  bool ParentProcessProductResolver::singleProduct_() const { return true; }
+
+  void ParentProcessProductResolver::putProduct_(std::unique_ptr<WrapperBase>) const {
     throw Exception(errors::LogicError)
-    << "ParentProcessProductResolver::putProduct_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+        << "ParentProcessProductResolver::putProduct_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
-  
-  void ParentProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) const {
+
+  void ParentProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp,
+                                                        MergeableRunProductMetadata const*) const {
     throw Exception(errors::LogicError)
-    << "ParentProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+        << "ParentProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, "
+           "MergeableRunProductMetadata const*) not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
   void ParentProcessProductResolver::throwNullRealProduct() const {
@@ -845,119 +788,113 @@ namespace edm {
     // be addressed someday is how ProductResolvers for non-kept branches are
     // connected to earlier SubProcesses.
     throw Exception(errors::LogicError)
-      << "ParentProcessProductResolver::throwNullRealProduct RealProduct pointer not set in this context.\n"
-      << "Contact a Framework developer\n";
+        << "ParentProcessProductResolver::throwNullRealProduct RealProduct pointer not set in this context.\n"
+        << "Contact a Framework developer\n";
   }
 
-  NoProcessProductResolver::
-  NoProcessProductResolver(std::vector<ProductResolverIndex> const&  matchingHolders,
-                           std::vector<bool> const& ambiguous,
-                           bool madeAtEnd) :
-  matchingHolders_(matchingHolders),
-  ambiguous_(ambiguous),
-  lastCheckIndex_(ambiguous_.size() + kUnsetOffset),
-  lastSkipCurrentCheckIndex_(lastCheckIndex_.load()),
-  prefetchRequested_(false),
-  skippingPrefetchRequested_(false),
-  madeAtEnd_{madeAtEnd}
-  {
+  NoProcessProductResolver::NoProcessProductResolver(std::vector<ProductResolverIndex> const& matchingHolders,
+                                                     std::vector<bool> const& ambiguous,
+                                                     bool madeAtEnd)
+      : matchingHolders_(matchingHolders),
+        ambiguous_(ambiguous),
+        lastCheckIndex_(ambiguous_.size() + kUnsetOffset),
+        lastSkipCurrentCheckIndex_(lastCheckIndex_.load()),
+        prefetchRequested_(false),
+        skippingPrefetchRequested_(false),
+        madeAtEnd_{madeAtEnd} {
     assert(ambiguous_.size() == matchingHolders_.size());
   }
-  
-  ProductResolverBase::Resolution
-  NoProcessProductResolver::tryResolver(unsigned int index,
-                                        Principal const& principal,
-                                        bool skipCurrentProcess,
-                                        SharedResourcesAcquirer* sra,
-                                        ModuleCallingContext const* mcc) const {
+
+  ProductResolverBase::Resolution NoProcessProductResolver::tryResolver(unsigned int index,
+                                                                        Principal const& principal,
+                                                                        bool skipCurrentProcess,
+                                                                        SharedResourcesAcquirer* sra,
+                                                                        ModuleCallingContext const* mcc) const {
     ProductResolverBase const* productResolver = principal.getProductResolverByIndex(matchingHolders_[index]);
     return productResolver->resolveProduct(principal, skipCurrentProcess, sra, mcc);
   }
-  
-  
-  ProductResolverBase::Resolution
-  NoProcessProductResolver::resolveProduct_(Principal const& principal,
-                                            bool skipCurrentProcess,
-                                            SharedResourcesAcquirer* sra,
-                                            ModuleCallingContext const* mcc) const {
+
+  ProductResolverBase::Resolution NoProcessProductResolver::resolveProduct_(Principal const& principal,
+                                                                            bool skipCurrentProcess,
+                                                                            SharedResourcesAcquirer* sra,
+                                                                            ModuleCallingContext const* mcc) const {
     //See if we've already cached which Resolver we should call or if
     // we know it is ambiguous
     const unsigned int choiceSize = ambiguous_.size();
 
     //madeAtEnd_==true and not at end transition is the same as skipping the current process
-    if( (not skipCurrentProcess) and (madeAtEnd_ and mcc)) {
+    if ((not skipCurrentProcess) and (madeAtEnd_ and mcc)) {
       skipCurrentProcess = not mcc->parent().isAtEndTransition();
     }
 
-    unsigned int checkCacheIndex = skipCurrentProcess? lastSkipCurrentCheckIndex_.load() : lastCheckIndex_.load();
-    if( checkCacheIndex != choiceSize +kUnsetOffset) {
-      if (checkCacheIndex == choiceSize+kAmbiguousOffset) {
+    unsigned int checkCacheIndex = skipCurrentProcess ? lastSkipCurrentCheckIndex_.load() : lastCheckIndex_.load();
+    if (checkCacheIndex != choiceSize + kUnsetOffset) {
+      if (checkCacheIndex == choiceSize + kAmbiguousOffset) {
         return ProductResolverBase::Resolution::makeAmbiguous();
-      } else if(checkCacheIndex == choiceSize+kMissingOffset) {
+      } else if (checkCacheIndex == choiceSize + kMissingOffset) {
         return Resolution(nullptr);
       }
-      return tryResolver(checkCacheIndex, principal, skipCurrentProcess,
-                         sra,mcc);
+      return tryResolver(checkCacheIndex, principal, skipCurrentProcess, sra, mcc);
     }
 
-    std::atomic<unsigned int>& updateCacheIndex = skipCurrentProcess? lastSkipCurrentCheckIndex_ : lastCheckIndex_;
+    std::atomic<unsigned int>& updateCacheIndex = skipCurrentProcess ? lastSkipCurrentCheckIndex_ : lastCheckIndex_;
 
     std::vector<unsigned int> const& lookupProcessOrder = principal.lookupProcessOrder();
-    for(unsigned int k : lookupProcessOrder) {
+    for (unsigned int k : lookupProcessOrder) {
       assert(k < ambiguous_.size());
-      if(k == 0) break; // Done
-      if(ambiguous_[k]) {
+      if (k == 0)
+        break;  // Done
+      if (ambiguous_[k]) {
         updateCacheIndex = choiceSize + kAmbiguousOffset;
         return ProductResolverBase::Resolution::makeAmbiguous();
       }
       if (matchingHolders_[k] != ProductResolverIndexInvalid) {
-        auto resolution = tryResolver(k,principal, skipCurrentProcess, sra,mcc);
-        if(resolution.data() != nullptr) {
+        auto resolution = tryResolver(k, principal, skipCurrentProcess, sra, mcc);
+        if (resolution.data() != nullptr) {
           updateCacheIndex = k;
           return resolution;
         }
       }
     }
-    
+
     updateCacheIndex = choiceSize + kMissingOffset;
     return Resolution(nullptr);
   }
-  
-  void
-  NoProcessProductResolver::prefetchAsync_(WaitingTask* waitTask,
-                                           Principal const& principal,
-                                           bool skipCurrentProcess,
-                                           ServiceToken const& token,
-                                           SharedResourcesAcquirer* sra,
-                                           ModuleCallingContext const* mcc) const {
+
+  void NoProcessProductResolver::prefetchAsync_(WaitingTask* waitTask,
+                                                Principal const& principal,
+                                                bool skipCurrentProcess,
+                                                ServiceToken const& token,
+                                                SharedResourcesAcquirer* sra,
+                                                ModuleCallingContext const* mcc) const {
     bool timeToMakeAtEnd = true;
-    if(madeAtEnd_ and mcc) {
+    if (madeAtEnd_ and mcc) {
       timeToMakeAtEnd = mcc->parent().isAtEndTransition();
     }
 
     //If timeToMakeAtEnd is false, then it is equivalent to skipping the current process
-    if(not skipCurrentProcess and timeToMakeAtEnd) {
+    if (not skipCurrentProcess and timeToMakeAtEnd) {
       waitingTasks_.add(waitTask);
-      
+
       bool expected = false;
-      if( prefetchRequested_.compare_exchange_strong(expected,true)) {
+      if (prefetchRequested_.compare_exchange_strong(expected, true)) {
         //we are the first thread to request
         tryPrefetchResolverAsync(0, principal, false, sra, mcc, token);
       }
     } else {
       skippingWaitingTasks_.add(waitTask);
       bool expected = false;
-      if( skippingPrefetchRequested_.compare_exchange_strong(expected,true)) {
-      //we are the first thread to request
+      if (skippingPrefetchRequested_.compare_exchange_strong(expected, true)) {
+        //we are the first thread to request
         tryPrefetchResolverAsync(0, principal, true, sra, mcc, token);
       }
     }
   }
-  
-  void NoProcessProductResolver::setCache(bool iSkipCurrentProcess, 
-                                          ProductResolverIndex iIndex, 
+
+  void NoProcessProductResolver::setCache(bool iSkipCurrentProcess,
+                                          ProductResolverIndex iIndex,
                                           std::exception_ptr iExceptPtr) const {
-    if( not iSkipCurrentProcess) {
+    if (not iSkipCurrentProcess) {
       lastCheckIndex_ = iIndex;
       waitingTasks_.doneWaiting(iExceptPtr);
     } else {
@@ -969,39 +906,34 @@ namespace edm {
   namespace {
     class TryNextResolverWaitingTask : public edm::WaitingTask {
     public:
-      
       TryNextResolverWaitingTask(NoProcessProductResolver const* iResolver,
                                  unsigned int iResolverIndex,
                                  Principal const* iPrincipal,
                                  SharedResourcesAcquirer* iSRA,
                                  ModuleCallingContext const* iMCC,
                                  bool iSkipCurrentProcess,
-                                 ServiceToken iToken) :
-      resolver_(iResolver),
-      principal_(iPrincipal),
-      sra_(iSRA),
-      mcc_(iMCC),
-      serviceToken_(iToken),
-      index_(iResolverIndex),
-      skipCurrentProcess_(iSkipCurrentProcess){}
-      
+                                 ServiceToken iToken)
+          : resolver_(iResolver),
+            principal_(iPrincipal),
+            sra_(iSRA),
+            mcc_(iMCC),
+            serviceToken_(iToken),
+            index_(iResolverIndex),
+            skipCurrentProcess_(iSkipCurrentProcess) {}
+
       tbb::task* execute() override {
-        auto exceptPtr =exceptionPtr();
-        if(exceptPtr) {
+        auto exceptPtr = exceptionPtr();
+        if (exceptPtr) {
           resolver_->prefetchFailed(index_, *principal_, skipCurrentProcess_, *exceptPtr);
         } else {
-          if(not resolver_->dataValidFromResolver(index_, *principal_, skipCurrentProcess_)) {
-            resolver_->tryPrefetchResolverAsync(index_+1,
-                                                *principal_,
-                                                skipCurrentProcess_,
-                                                sra_,
-                                                mcc_,
+          if (not resolver_->dataValidFromResolver(index_, *principal_, skipCurrentProcess_)) {
+            resolver_->tryPrefetchResolverAsync(index_ + 1, *principal_, skipCurrentProcess_, sra_, mcc_,
                                                 serviceToken_);
           }
         }
         return nullptr;
       }
-      
+
     private:
       NoProcessProductResolver const* resolver_;
       Principal const* principal_;
@@ -1011,83 +943,66 @@ namespace edm {
       unsigned int index_;
       bool skipCurrentProcess_;
     };
-  }
+  }  // namespace
 
-  void
-  NoProcessProductResolver::prefetchFailed(unsigned int iProcessingIndex,
-                                           Principal const& principal,
-                                           bool iSkipCurrentProcess,
-                                           std::exception_ptr iExceptPtr) const {
+  void NoProcessProductResolver::prefetchFailed(unsigned int iProcessingIndex,
+                                                Principal const& principal,
+                                                bool iSkipCurrentProcess,
+                                                std::exception_ptr iExceptPtr) const {
     std::vector<unsigned int> const& lookupProcessOrder = principal.lookupProcessOrder();
     auto k = lookupProcessOrder[iProcessingIndex];
 
     setCache(iSkipCurrentProcess, k, iExceptPtr);
   }
 
-  
-  bool
-  NoProcessProductResolver::dataValidFromResolver(unsigned int iProcessingIndex,
-                                                  Principal const& principal,
-                                                  bool iSkipCurrentProcess) const {
+  bool NoProcessProductResolver::dataValidFromResolver(unsigned int iProcessingIndex,
+                                                       Principal const& principal,
+                                                       bool iSkipCurrentProcess) const {
     std::vector<unsigned int> const& lookupProcessOrder = principal.lookupProcessOrder();
     auto k = lookupProcessOrder[iProcessingIndex];
     ProductResolverBase const* productResolver = principal.getProductResolverByIndex(matchingHolders_[k]);
 
-    if(productResolver->productWasFetchedAndIsValid(iSkipCurrentProcess)) {
-
+    if (productResolver->productWasFetchedAndIsValid(iSkipCurrentProcess)) {
       setCache(iSkipCurrentProcess, k, nullptr);
       return true;
     }
     return false;
   }
 
-  
-  void
-  NoProcessProductResolver::tryPrefetchResolverAsync(unsigned int iProcessingIndex,
-                                                     Principal const& principal,
-                                                     bool skipCurrentProcess,
-                                                     SharedResourcesAcquirer* sra,
-                                                     ModuleCallingContext const* mcc,
-                                                     ServiceToken token) const {
+  void NoProcessProductResolver::tryPrefetchResolverAsync(unsigned int iProcessingIndex,
+                                                          Principal const& principal,
+                                                          bool skipCurrentProcess,
+                                                          SharedResourcesAcquirer* sra,
+                                                          ModuleCallingContext const* mcc,
+                                                          ServiceToken token) const {
     std::vector<unsigned int> const& lookupProcessOrder = principal.lookupProcessOrder();
     auto index = iProcessingIndex;
 
     const unsigned int choiceSize = ambiguous_.size();
     unsigned int newCacheIndex = choiceSize + kMissingOffset;
-    while(index < lookupProcessOrder.size()) {
+    while (index < lookupProcessOrder.size()) {
       auto k = lookupProcessOrder[index];
-      if(k==0) {
+      if (k == 0) {
         break;
       }
       assert(k < ambiguous_.size());
-      if(ambiguous_[k]) {
+      if (ambiguous_[k]) {
         newCacheIndex = choiceSize + kAmbiguousOffset;
         break;
       }
       if (matchingHolders_[k] != ProductResolverIndexInvalid) {
         //make new task
-        
-        auto task = new (tbb::task::allocate_root()) TryNextResolverWaitingTask(
-                                                                                this,
-                                                                                index,
-                                                                                &principal,
-                                                                                sra,
-                                                                                mcc,
-                                                                                skipCurrentProcess,
-                                                                                token
-                                                                                );
+
+        auto task = new (tbb::task::allocate_root())
+            TryNextResolverWaitingTask(this, index, &principal, sra, mcc, skipCurrentProcess, token);
         task->increment_ref_count();
         ProductResolverBase const* productResolver = principal.getProductResolverByIndex(matchingHolders_[k]);
 
         //Make sure the Services are available on this thread
         ServiceRegistry::Operate guard(token);
 
-        productResolver->prefetchAsync(task,
-                                       principal,
-                                       skipCurrentProcess,
-                                       token,
-                                       sra, mcc);
-        if(0 == task->decrement_ref_count()) {
+        productResolver->prefetchAsync(task, principal, skipCurrentProcess, token, sra, mcc);
+        if (0 == task->decrement_ref_count()) {
           tbb::task::spawn(*task);
         }
         return;
@@ -1097,18 +1012,16 @@ namespace edm {
     //data product unavailable
     setCache(skipCurrentProcess, newCacheIndex, nullptr);
   }
-  
-  void NoProcessProductResolver::setProvenance_(ProductProvenanceRetriever const* , ProcessHistory const& , ProductID const& ) {
-  }
 
-  void NoProcessProductResolver::setProcessHistory_(ProcessHistory const& ) {
-  }
+  void NoProcessProductResolver::setProvenance_(ProductProvenanceRetriever const*,
+                                                ProcessHistory const&,
+                                                ProductID const&) {}
 
-  ProductProvenance const* NoProcessProductResolver::productProvenancePtr_() const {
-    return nullptr;
-  }
+  void NoProcessProductResolver::setProcessHistory_(ProcessHistory const&) {}
 
-  inline unsigned int NoProcessProductResolver::unsetIndexValue() const { return ambiguous_.size()+kUnsetOffset; }
+  ProductProvenance const* NoProcessProductResolver::productProvenancePtr_() const { return nullptr; }
+
+  inline unsigned int NoProcessProductResolver::unsetIndexValue() const { return ambiguous_.size() + kUnsetOffset; }
 
   void NoProcessProductResolver::resetProductData_(bool) {
     const auto resetValue = unsetIndexValue();
@@ -1120,91 +1033,88 @@ namespace edm {
     skippingWaitingTasks_.reset();
   }
 
-  bool NoProcessProductResolver::singleProduct_() const {
-    return false;
-  }
+  bool NoProcessProductResolver::singleProduct_() const { return false; }
 
   bool NoProcessProductResolver::unscheduledWasNotRun_() const {
     throw Exception(errors::LogicError)
-      << "NoProcessProductResolver::unscheduledWasNotRun_() not implemented and should never be called.\n"
-      << "Contact a Framework developer\n";
+        << "NoProcessProductResolver::unscheduledWasNotRun_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
   bool NoProcessProductResolver::productUnavailable_() const {
     throw Exception(errors::LogicError)
-      << "NoProcessProductResolver::productUnavailable_() not implemented and should never be called.\n"
-      << "Contact a Framework developer\n";
+        << "NoProcessProductResolver::productUnavailable_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
   bool NoProcessProductResolver::productResolved_() const {
     throw Exception(errors::LogicError)
-    << "NoProcessProductResolver::productResolved_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+        << "NoProcessProductResolver::productResolved_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
   bool NoProcessProductResolver::productWasDeleted_() const {
     throw Exception(errors::LogicError)
-      << "NoProcessProductResolver::productWasDeleted_() not implemented and should never be called.\n"
-      << "Contact a Framework developer\n";
+        << "NoProcessProductResolver::productWasDeleted_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
   bool NoProcessProductResolver::productWasFetchedAndIsValid_(bool /*iSkipCurrentProcess*/) const {
     throw Exception(errors::LogicError)
-    << "NoProcessProductResolver::productWasFetchedAndIsValid_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+        << "NoProcessProductResolver::productWasFetchedAndIsValid_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
-  void NoProcessProductResolver::putProduct_(std::unique_ptr<WrapperBase> ) const {
+  void NoProcessProductResolver::putProduct_(std::unique_ptr<WrapperBase>) const {
     throw Exception(errors::LogicError)
-      << "NoProcessProductResolver::putProduct_() not implemented and should never be called.\n"
-      << "Contact a Framework developer\n";
+        << "NoProcessProductResolver::putProduct_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
-  void NoProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) const {
+  void NoProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp,
+                                                    MergeableRunProductMetadata const*) const {
     throw Exception(errors::LogicError)
-      << "NoProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) not implemented and should never be called.\n"
-      << "Contact a Framework developer\n";
+        << "NoProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata "
+           "const*) not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
   BranchDescription const& NoProcessProductResolver::branchDescription_() const {
     throw Exception(errors::LogicError)
-      << "NoProcessProductResolver::branchDescription_() not implemented and should never be called.\n"
-      << "Contact a Framework developer\n";
+        << "NoProcessProductResolver::branchDescription_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
   void NoProcessProductResolver::resetBranchDescription_(std::shared_ptr<BranchDescription const>) {
     throw Exception(errors::LogicError)
-      << "NoProcessProductResolver::resetBranchDescription_() not implemented and should never be called.\n"
-      << "Contact a Framework developer\n";
+        << "NoProcessProductResolver::resetBranchDescription_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
   Provenance const* NoProcessProductResolver::provenance_() const {
     throw Exception(errors::LogicError)
-    << "NoProcessProductResolver::provenance_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+        << "NoProcessProductResolver::provenance_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
   void NoProcessProductResolver::connectTo(ProductResolverBase const&, Principal const*) {
     throw Exception(errors::LogicError)
-    << "NoProcessProductResolver::connectTo() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
-    
+        << "NoProcessProductResolver::connectTo() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
-  
+
   //---- SingleChoiceNoProcessProductResolver ----------------
   ProductResolverBase::Resolution SingleChoiceNoProcessProductResolver::resolveProduct_(
-                                             Principal const& principal,
-                                             bool skipCurrentProcess,
-                                             SharedResourcesAcquirer* sra,
-                                             ModuleCallingContext const* mcc) const
-  {
+      Principal const& principal,
+      bool skipCurrentProcess,
+      SharedResourcesAcquirer* sra,
+      ModuleCallingContext const* mcc) const {
     //NOTE: Have to lookup the other ProductResolver each time rather than cache
     // it's pointer since it appears the pointer can change at some later stage
     return principal.getProductResolverByIndex(realResolverIndex_)
-      ->resolveProduct(principal,
-                       skipCurrentProcess, sra, mcc);
+        ->resolveProduct(principal, skipCurrentProcess, sra, mcc);
   }
-  
+
   void SingleChoiceNoProcessProductResolver::prefetchAsync_(WaitingTask* waitTask,
                                                             Principal const& principal,
                                                             bool skipCurrentProcess,
@@ -1212,93 +1122,87 @@ namespace edm {
                                                             SharedResourcesAcquirer* sra,
                                                             ModuleCallingContext const* mcc) const {
     principal.getProductResolverByIndex(realResolverIndex_)
-    ->prefetchAsync(waitTask,principal,
-                    skipCurrentProcess, token, sra, mcc);
+        ->prefetchAsync(waitTask, principal, skipCurrentProcess, token, sra, mcc);
   }
-  
-  void SingleChoiceNoProcessProductResolver::setProvenance_(ProductProvenanceRetriever const* , ProcessHistory const& , ProductID const& ) {
-  }
-  
-  void SingleChoiceNoProcessProductResolver::setProcessHistory_(ProcessHistory const& ) {
-  }
-  
-  ProductProvenance const* SingleChoiceNoProcessProductResolver::productProvenancePtr_() const {
-    return nullptr;
-  }
-  
-  void SingleChoiceNoProcessProductResolver::resetProductData_(bool) {
-  }
-  
-  bool SingleChoiceNoProcessProductResolver::singleProduct_() const {
-    return false;
-  }
-  
+
+  void SingleChoiceNoProcessProductResolver::setProvenance_(ProductProvenanceRetriever const*,
+                                                            ProcessHistory const&,
+                                                            ProductID const&) {}
+
+  void SingleChoiceNoProcessProductResolver::setProcessHistory_(ProcessHistory const&) {}
+
+  ProductProvenance const* SingleChoiceNoProcessProductResolver::productProvenancePtr_() const { return nullptr; }
+
+  void SingleChoiceNoProcessProductResolver::resetProductData_(bool) {}
+
+  bool SingleChoiceNoProcessProductResolver::singleProduct_() const { return false; }
+
   bool SingleChoiceNoProcessProductResolver::unscheduledWasNotRun_() const {
     throw Exception(errors::LogicError)
-    << "SingleChoiceNoProcessProductResolver::unscheduledWasNotRun_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+        << "SingleChoiceNoProcessProductResolver::unscheduledWasNotRun_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
-  
+
   bool SingleChoiceNoProcessProductResolver::productUnavailable_() const {
     throw Exception(errors::LogicError)
-    << "SingleChoiceNoProcessProductResolver::productUnavailable_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+        << "SingleChoiceNoProcessProductResolver::productUnavailable_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
-  
+
   bool SingleChoiceNoProcessProductResolver::productResolved_() const {
     throw Exception(errors::LogicError)
-    << "SingleChoiceNoProcessProductResolver::productResolved_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+        << "SingleChoiceNoProcessProductResolver::productResolved_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
-  
+
   bool SingleChoiceNoProcessProductResolver::productWasDeleted_() const {
     throw Exception(errors::LogicError)
-    << "SingleChoiceNoProcessProductResolver::productWasDeleted_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
-  }
-  
-  bool SingleChoiceNoProcessProductResolver::productWasFetchedAndIsValid_(bool /*iSkipCurrentProcess*/) const {
-    throw Exception(errors::LogicError)
-    << "SingleChoiceNoProcessProductResolver::productWasFetchedAndIsValid_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+        << "SingleChoiceNoProcessProductResolver::productWasDeleted_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
-  
-  void SingleChoiceNoProcessProductResolver::putProduct_(std::unique_ptr<WrapperBase> ) const {
-    throw Exception(errors::LogicError)
-    << "SingleChoiceNoProcessProductResolver::putProduct_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+  bool SingleChoiceNoProcessProductResolver::productWasFetchedAndIsValid_(bool /*iSkipCurrentProcess*/) const {
+    throw Exception(errors::LogicError) << "SingleChoiceNoProcessProductResolver::productWasFetchedAndIsValid_() not "
+                                           "implemented and should never be called.\n"
+                                        << "Contact a Framework developer\n";
   }
-  
-  void SingleChoiceNoProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) const {
+
+  void SingleChoiceNoProcessProductResolver::putProduct_(std::unique_ptr<WrapperBase>) const {
     throw Exception(errors::LogicError)
-    << "SingleChoiceNoProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
+        << "SingleChoiceNoProcessProductResolver::putProduct_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
-  
+
+  void SingleChoiceNoProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp,
+                                                                MergeableRunProductMetadata const*) const {
+    throw Exception(errors::LogicError)
+        << "SingleChoiceNoProcessProductResolver::putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, "
+           "MergeableRunProductMetadata const*) not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
+  }
+
   BranchDescription const& SingleChoiceNoProcessProductResolver::branchDescription_() const {
     throw Exception(errors::LogicError)
-    << "SingleChoiceNoProcessProductResolver::branchDescription_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
-  }
-  
-  void SingleChoiceNoProcessProductResolver::resetBranchDescription_(std::shared_ptr<BranchDescription const>) {
-    throw Exception(errors::LogicError)
-    << "SingleChoiceNoProcessProductResolver::resetBranchDescription_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
-  }
-  
-  Provenance const* SingleChoiceNoProcessProductResolver::provenance_() const {
-    throw Exception(errors::LogicError)
-    << "SingleChoiceNoProcessProductResolver::provenance_() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
-  }
-  
-  void SingleChoiceNoProcessProductResolver::connectTo(ProductResolverBase const&, Principal const*) {
-    throw Exception(errors::LogicError)
-    << "SingleChoiceNoProcessProductResolver::connectTo() not implemented and should never be called.\n"
-    << "Contact a Framework developer\n";
-    
+        << "SingleChoiceNoProcessProductResolver::branchDescription_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
   }
 
-}
+  void SingleChoiceNoProcessProductResolver::resetBranchDescription_(std::shared_ptr<BranchDescription const>) {
+    throw Exception(errors::LogicError) << "SingleChoiceNoProcessProductResolver::resetBranchDescription_() not "
+                                           "implemented and should never be called.\n"
+                                        << "Contact a Framework developer\n";
+  }
+
+  Provenance const* SingleChoiceNoProcessProductResolver::provenance_() const {
+    throw Exception(errors::LogicError)
+        << "SingleChoiceNoProcessProductResolver::provenance_() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
+  }
+
+  void SingleChoiceNoProcessProductResolver::connectTo(ProductResolverBase const&, Principal const*) {
+    throw Exception(errors::LogicError)
+        << "SingleChoiceNoProcessProductResolver::connectTo() not implemented and should never be called.\n"
+        << "Contact a Framework developer\n";
+  }
+
+}  // namespace edm

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -35,57 +35,52 @@ namespace edm {
 
   class DataManagingProductResolver : public ProductResolverBase {
   public:
-    enum class ProductStatus {
-      ProductSet,
-      NotPut,
-      ResolveFailed,
-      ResolveNotRun,
-      ProductDeleted
-    };
+    enum class ProductStatus { ProductSet, NotPut, ResolveFailed, ResolveNotRun, ProductDeleted };
 
-    DataManagingProductResolver(std::shared_ptr<BranchDescription const> bd,ProductStatus iDefaultStatus): ProductResolverBase(),
-    productData_(bd),
-    theStatus_(iDefaultStatus),
-    defaultStatus_(iDefaultStatus){}
+    DataManagingProductResolver(std::shared_ptr<BranchDescription const> bd, ProductStatus iDefaultStatus)
+        : ProductResolverBase(), productData_(bd), theStatus_(iDefaultStatus), defaultStatus_(iDefaultStatus) {}
 
     void connectTo(ProductResolverBase const&, Principal const*) final;
 
-    void resetStatus() {theStatus_ = defaultStatus_;}
+    void resetStatus() { theStatus_ = defaultStatus_; }
 
     //Give AliasProductResolver access
     void resetProductData_(bool deleteEarly) override;
 
   protected:
     void setProduct(std::unique_ptr<WrapperBase> edp) const;
-    ProductStatus status() const { return theStatus_;}
+    ProductStatus status() const { return theStatus_; }
     ProductStatus defaultStatus() const { return defaultStatus_; }
     void setFailedStatus() const { theStatus_ = ProductStatus::ResolveFailed; }
     //Handle the boilerplate code needed for resolveProduct_
-    template <bool callResolver, typename FUNC>
-    Resolution resolveProductImpl( FUNC resolver) const;
+    template <bool callResolver, typename FUNC> Resolution resolveProductImpl(FUNC resolver) const;
     void setMergeableRunProductMetadataInProductData(MergeableRunProductMetadata const*);
 
   private:
-
     void throwProductDeletedException() const;
     void checkType(WrapperBase const& prod) const;
-    ProductData const& getProductData() const {return productData_;}
+    ProductData const& getProductData() const { return productData_; }
     virtual bool isFromCurrentProcess() const = 0;
     // merges the product with the pre-existing product
     void mergeProduct(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) const;
 
-    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod, MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
+    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod,
+                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
     bool productUnavailable_() const final;
     bool productResolved_() const final;
     bool productWasDeleted_() const final;
-    bool productWasFetchedAndIsValid_( bool iSkipCurrentProcess) const final;
+    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final;
 
-    BranchDescription const& branchDescription_() const final {return *getProductData().branchDescription();}
-    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) final {productData_.resetBranchDescription(bd);}
-    Provenance const* provenance_() const final {return &productData_.provenance();}
+    BranchDescription const& branchDescription_() const final { return *getProductData().branchDescription(); }
+    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) final {
+      productData_.resetBranchDescription(bd);
+    }
+    Provenance const* provenance_() const final { return &productData_.provenance(); }
 
-    std::string const& resolvedModuleLabel_() const final {return moduleLabel();}
-    void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) final;
+    std::string const& resolvedModuleLabel_() const final { return moduleLabel(); }
+    void setProvenance_(ProductProvenanceRetriever const* provRetriever,
+                        ProcessHistory const& ph,
+                        ProductID const& pid) final;
     void setProcessHistory_(ProcessHistory const& ph) final;
     ProductProvenance const* productProvenancePtr_() const final;
     bool singleProduct_() const final;
@@ -96,74 +91,74 @@ namespace edm {
   };
 
   class InputProductResolver : public DataManagingProductResolver {
-    public:
-    explicit InputProductResolver(std::shared_ptr<BranchDescription const> bd) :
-      DataManagingProductResolver(bd, ProductStatus::ResolveNotRun),
-      m_prefetchRequested{ false },
-      aux_{nullptr} {}
+  public:
+    explicit InputProductResolver(std::shared_ptr<BranchDescription const> bd)
+        : DataManagingProductResolver(bd, ProductStatus::ResolveNotRun), m_prefetchRequested{false}, aux_{nullptr} {}
 
     void setupUnscheduled(UnscheduledConfigurator const&) final;
 
-    private:
-      bool isFromCurrentProcess() const final;
+  private:
+    bool isFromCurrentProcess() const final;
 
+    Resolution resolveProduct_(Principal const& principal,
+                               bool skipCurrentProcess,
+                               SharedResourcesAcquirer* sra,
+                               ModuleCallingContext const* mcc) const override;
+    void prefetchAsync_(WaitingTask* waitTask,
+                        Principal const& principal,
+                        bool skipCurrentProcess,
+                        ServiceToken const& token,
+                        SharedResourcesAcquirer* sra,
+                        ModuleCallingContext const* mcc) const override;
+    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
 
-      Resolution resolveProduct_(Principal const& principal,
-                                 bool skipCurrentProcess,
-                                 SharedResourcesAcquirer* sra,
-                                 ModuleCallingContext const* mcc) const override;
-     void prefetchAsync_(WaitingTask* waitTask,
-                         Principal const& principal,
-                         bool skipCurrentProcess,
-                         ServiceToken const& token,
-                         SharedResourcesAcquirer* sra,
-                         ModuleCallingContext const* mcc) const override;
-      void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+    void retrieveAndMerge_(Principal const& principal,
+                           MergeableRunProductMetadata const* mergeableRunProductMetadata) const override;
 
-      void retrieveAndMerge_(Principal const& principal, MergeableRunProductMetadata const* mergeableRunProductMetadata) const override;
+    void setMergeableRunProductMetadata_(MergeableRunProductMetadata const*) override;
 
-      void setMergeableRunProductMetadata_(MergeableRunProductMetadata const*) override;
+    bool unscheduledWasNotRun_() const final { return false; }
 
-      bool unscheduledWasNotRun_() const final {return false;}
+    void resetProductData_(bool deleteEarly) override;
 
-      void resetProductData_(bool deleteEarly) override;
-
-      mutable std::atomic<bool> m_prefetchRequested;
-      mutable WaitingTaskList m_waitingTasks;
-      UnscheduledAuxiliary const* aux_; //provides access to the delayedGet signals
-
-
+    mutable std::atomic<bool> m_prefetchRequested;
+    mutable WaitingTaskList m_waitingTasks;
+    UnscheduledAuxiliary const* aux_;  //provides access to the delayedGet signals
   };
 
   class ProducedProductResolver : public DataManagingProductResolver {
-    public:
-      ProducedProductResolver(std::shared_ptr<BranchDescription const> bd, ProductStatus iDefaultStatus) : DataManagingProductResolver(bd, iDefaultStatus) {assert(bd->produced());}
+  public:
+    ProducedProductResolver(std::shared_ptr<BranchDescription const> bd, ProductStatus iDefaultStatus)
+        : DataManagingProductResolver(bd, iDefaultStatus) {
+      assert(bd->produced());
+    }
 
-    protected:
-      void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-    private:
-      bool isFromCurrentProcess() const final;
+  protected:
+    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
 
+  private:
+    bool isFromCurrentProcess() const final;
   };
 
   class PuttableProductResolver : public ProducedProductResolver {
   public:
-    explicit PuttableProductResolver(std::shared_ptr<BranchDescription const> bd) : ProducedProductResolver(bd, ProductStatus::NotPut), worker_(nullptr), prefetchRequested_(false) {}
+    explicit PuttableProductResolver(std::shared_ptr<BranchDescription const> bd)
+        : ProducedProductResolver(bd, ProductStatus::NotPut), worker_(nullptr), prefetchRequested_(false) {}
 
     void setupUnscheduled(UnscheduledConfigurator const&) final;
 
   private:
     Resolution resolveProduct_(Principal const& principal,
-                                       bool skipCurrentProcess,
-                                       SharedResourcesAcquirer* sra,
-                                       ModuleCallingContext const* mcc) const override;
-     void prefetchAsync_(WaitingTask* waitTask,
-                                 Principal const& principal,
-                                 bool skipCurrentProcess,
-                         ServiceToken const& token,
-                                 SharedResourcesAcquirer* sra,
-                                 ModuleCallingContext const* mcc) const override;
-    bool unscheduledWasNotRun_() const override {return false;}
+                               bool skipCurrentProcess,
+                               SharedResourcesAcquirer* sra,
+                               ModuleCallingContext const* mcc) const override;
+    void prefetchAsync_(WaitingTask* waitTask,
+                        Principal const& principal,
+                        bool skipCurrentProcess,
+                        ServiceToken const& token,
+                        SharedResourcesAcquirer* sra,
+                        ModuleCallingContext const* mcc) const override;
+    bool unscheduledWasNotRun_() const override { return false; }
 
     void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
     void resetProductData_(bool deleteEarly) override;
@@ -171,120 +166,131 @@ namespace edm {
     mutable WaitingTaskList m_waitingTasks;
     Worker* worker_;
     mutable std::atomic<bool> prefetchRequested_;
-
   };
 
   class UnscheduledProductResolver : public ProducedProductResolver {
-    public:
-      explicit UnscheduledProductResolver(std::shared_ptr<BranchDescription const> bd) :
-       ProducedProductResolver(bd,ProductStatus::ResolveNotRun),
-       aux_(nullptr),
-       prefetchRequested_(false){}
+  public:
+    explicit UnscheduledProductResolver(std::shared_ptr<BranchDescription const> bd)
+        : ProducedProductResolver(bd, ProductStatus::ResolveNotRun), aux_(nullptr), prefetchRequested_(false) {}
 
-      void setupUnscheduled(UnscheduledConfigurator const&) final;
+    void setupUnscheduled(UnscheduledConfigurator const&) final;
 
-    private:
-      Resolution resolveProduct_(Principal const& principal,
-                                         bool skipCurrentProcess,
-                                         SharedResourcesAcquirer* sra,
-                                         ModuleCallingContext const* mcc) const override;
-       void prefetchAsync_(WaitingTask* waitTask,
-                           Principal const& principal,
-                           bool skipCurrentProcess,
-                           ServiceToken const& token,
-                           SharedResourcesAcquirer* sra,
-                           ModuleCallingContext const* mcc) const override;
-      bool unscheduledWasNotRun_() const override {return status() == ProductStatus::ResolveNotRun;}
+  private:
+    Resolution resolveProduct_(Principal const& principal,
+                               bool skipCurrentProcess,
+                               SharedResourcesAcquirer* sra,
+                               ModuleCallingContext const* mcc) const override;
+    void prefetchAsync_(WaitingTask* waitTask,
+                        Principal const& principal,
+                        bool skipCurrentProcess,
+                        ServiceToken const& token,
+                        SharedResourcesAcquirer* sra,
+                        ModuleCallingContext const* mcc) const override;
+    bool unscheduledWasNotRun_() const override { return status() == ProductStatus::ResolveNotRun; }
 
-      void resetProductData_(bool deleteEarly) override;
+    void resetProductData_(bool deleteEarly) override;
 
-      mutable WaitingTaskList waitingTasks_;
-      UnscheduledAuxiliary const* aux_;
-      Worker* worker_;
-      mutable std::atomic<bool> prefetchRequested_;
+    mutable WaitingTaskList waitingTasks_;
+    UnscheduledAuxiliary const* aux_;
+    Worker* worker_;
+    mutable std::atomic<bool> prefetchRequested_;
   };
 
   class AliasProductResolver : public ProductResolverBase {
-    public:
-      typedef ProducedProductResolver::ProductStatus ProductStatus;
-      explicit AliasProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct) : ProductResolverBase(), realProduct_(realProduct), bd_(bd) {}
+  public:
+    typedef ProducedProductResolver::ProductStatus ProductStatus;
+    explicit AliasProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct)
+        : ProductResolverBase(), realProduct_(realProduct), bd_(bd) {}
 
-      void connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) final {
-        realProduct_.connectTo(iOther, iParentPrincipal );
-      };
+    void connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) final {
+      realProduct_.connectTo(iOther, iParentPrincipal);
+    };
 
-    private:
-      Resolution resolveProduct_(Principal const& principal,
-                                 bool skipCurrentProcess,
-                                 SharedResourcesAcquirer* sra,
-                                 ModuleCallingContext const* mcc) const override {
-        return realProduct_.resolveProduct(principal, skipCurrentProcess, sra, mcc);}
-       void prefetchAsync_(WaitingTask* waitTask,
-                           Principal const& principal,
-                           bool skipCurrentProcess,
-                           ServiceToken const& token,
-                           SharedResourcesAcquirer* sra,
-                           ModuleCallingContext const* mcc) const override {
-        realProduct_.prefetchAsync(waitTask, principal, skipCurrentProcess, token, sra, mcc);
-      }
-      bool unscheduledWasNotRun_() const override {return realProduct_.unscheduledWasNotRun();}
-      bool productUnavailable_() const override {return realProduct_.productUnavailable();}
-      bool productResolved_() const final {
-          return realProduct_.productResolved(); }
-      bool productWasDeleted_() const override {return realProduct_.productWasDeleted();}
-      bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final {
-        return realProduct_.productWasFetchedAndIsValid(iSkipCurrentProcess);
-      }
+  private:
+    Resolution resolveProduct_(Principal const& principal,
+                               bool skipCurrentProcess,
+                               SharedResourcesAcquirer* sra,
+                               ModuleCallingContext const* mcc) const override {
+      return realProduct_.resolveProduct(principal, skipCurrentProcess, sra, mcc);
+    }
+    void prefetchAsync_(WaitingTask* waitTask,
+                        Principal const& principal,
+                        bool skipCurrentProcess,
+                        ServiceToken const& token,
+                        SharedResourcesAcquirer* sra,
+                        ModuleCallingContext const* mcc) const override {
+      realProduct_.prefetchAsync(waitTask, principal, skipCurrentProcess, token, sra, mcc);
+    }
+    bool unscheduledWasNotRun_() const override { return realProduct_.unscheduledWasNotRun(); }
+    bool productUnavailable_() const override { return realProduct_.productUnavailable(); }
+    bool productResolved_() const final { return realProduct_.productResolved(); }
+    bool productWasDeleted_() const override { return realProduct_.productWasDeleted(); }
+    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final {
+      return realProduct_.productWasFetchedAndIsValid(iSkipCurrentProcess);
+    }
 
-      void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-      void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod, MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
-      BranchDescription const& branchDescription_() const override {return *bd_;}
-      void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override {bd_ = bd;}
-      Provenance const* provenance_() const final { return realProduct_.provenance(); }
+    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod,
+                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
+    BranchDescription const& branchDescription_() const override { return *bd_; }
+    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override { bd_ = bd; }
+    Provenance const* provenance_() const final { return realProduct_.provenance(); }
 
-      std::string const& resolvedModuleLabel_() const override {return realProduct_.moduleLabel();}
-      void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
-      void setProcessHistory_(ProcessHistory const& ph) override;
-      ProductProvenance const* productProvenancePtr_() const override;
-      void resetProductData_(bool deleteEarly) override;
-      bool singleProduct_() const override;
+    std::string const& resolvedModuleLabel_() const override { return realProduct_.moduleLabel(); }
+    void setProvenance_(ProductProvenanceRetriever const* provRetriever,
+                        ProcessHistory const& ph,
+                        ProductID const& pid) override;
+    void setProcessHistory_(ProcessHistory const& ph) override;
+    ProductProvenance const* productProvenancePtr_() const override;
+    void resetProductData_(bool deleteEarly) override;
+    bool singleProduct_() const override;
 
-      ProducedProductResolver& realProduct_;
-      std::shared_ptr<BranchDescription const> bd_;
+    ProducedProductResolver& realProduct_;
+    std::shared_ptr<BranchDescription const> bd_;
   };
 
   // Switch is a mixture of DataManaging (for worker and provenance) and Alias (for product)
-  class SwitchBaseProductResolver: public ProductResolverBase {
+  class SwitchBaseProductResolver : public ProductResolverBase {
   public:
     using ProductStatus = DataManagingProductResolver::ProductStatus;
     SwitchBaseProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct);
 
-    void connectTo(ProductResolverBase const& iOther, Principal const *iParentPrincipal) final;
+    void connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) final;
     void setupUnscheduled(UnscheduledConfigurator const& iConfigure) final;
 
   protected:
     Resolution resolveProductImpl(Resolution) const;
-    WaitingTaskList& waitingTasks() const {return waitingTasks_;}
-    Worker *worker() const {return worker_;}
-    ProductStatus status() const {return status_;}
-    ProducedProductResolver const& realProduct() const {return realProduct_;}
-    std::atomic<bool>& prefetchRequested() const {return prefetchRequested_;}
-    
+    WaitingTaskList& waitingTasks() const { return waitingTasks_; }
+    Worker* worker() const { return worker_; }
+    ProductStatus status() const { return status_; }
+    ProducedProductResolver const& realProduct() const { return realProduct_; }
+    std::atomic<bool>& prefetchRequested() const { return prefetchRequested_; }
+
   private:
     bool productResolved_() const final;
     bool productWasDeleted_() const final { return realProduct_.productWasDeleted(); }
-    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final { return realProduct_.productWasFetchedAndIsValid(iSkipCurrentProcess); }
+    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final {
+      return realProduct_.productWasFetchedAndIsValid(iSkipCurrentProcess);
+    }
     void putProduct_(std::unique_ptr<WrapperBase> edp) const final;
-    void putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
-    BranchDescription const& branchDescription_() const final {return *productData_.branchDescription();;}
-    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) final {productData_.resetBranchDescription(bd);}
-    Provenance const* provenance_() const final {return &productData_.provenance();}
-    std::string const& resolvedModuleLabel_() const final {return moduleLabel();}
-    void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) final;
-    void setProcessHistory_(ProcessHistory const& ph) final {productData_.setProcessHistory(ph);}
-    ProductProvenance const* productProvenancePtr_() const final {return provenance()->productProvenance();}
+    void putOrMergeProduct_(std::unique_ptr<WrapperBase> edp,
+                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
+    BranchDescription const& branchDescription_() const final {
+      return *productData_.branchDescription();
+      ;
+    }
+    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) final {
+      productData_.resetBranchDescription(bd);
+    }
+    Provenance const* provenance_() const final { return &productData_.provenance(); }
+    std::string const& resolvedModuleLabel_() const final { return moduleLabel(); }
+    void setProvenance_(ProductProvenanceRetriever const* provRetriever,
+                        ProcessHistory const& ph,
+                        ProductID const& pid) final;
+    void setProcessHistory_(ProcessHistory const& ph) final { productData_.setProcessHistory(ph); }
+    ProductProvenance const* productProvenancePtr_() const final { return provenance()->productProvenance(); }
     void resetProductData_(bool deleteEarly) final;
-    bool singleProduct_() const final {return true;}
+    bool singleProduct_() const final { return true; }
 
     constexpr static const ProductStatus defaultStatus_ = ProductStatus::NotPut;
 
@@ -292,7 +298,7 @@ namespace edm {
     ProducedProductResolver& realProduct_;
     // for "product" view
     ProductData productData_;
-    Worker *worker_ = nullptr;
+    Worker* worker_ = nullptr;
     mutable WaitingTaskList waitingTasks_;
     mutable std::atomic<bool> prefetchRequested_;
     // for provenance
@@ -302,10 +308,11 @@ namespace edm {
   };
 
   // For the case when SwitchProducer is on a Path
-  class SwitchProducerProductResolver: public SwitchBaseProductResolver {
+  class SwitchProducerProductResolver : public SwitchBaseProductResolver {
   public:
-    SwitchProducerProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct):
-      SwitchBaseProductResolver(std::move(bd), realProduct) {}
+    SwitchProducerProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct)
+        : SwitchBaseProductResolver(std::move(bd), realProduct) {}
+
   private:
     Resolution resolveProduct_(Principal const& principal,
                                bool skipCurrentProcess,
@@ -322,10 +329,11 @@ namespace edm {
   };
 
   // For the case when SwitchProducer is not on any Path
-  class SwitchAliasProductResolver: public SwitchBaseProductResolver {
+  class SwitchAliasProductResolver : public SwitchBaseProductResolver {
   public:
-    SwitchAliasProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct):
-      SwitchBaseProductResolver(std::move(bd), realProduct) {}
+    SwitchAliasProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct)
+        : SwitchBaseProductResolver(std::move(bd), realProduct) {}
+
   private:
     Resolution resolveProduct_(Principal const& principal,
                                bool skipCurrentProcess,
@@ -337,14 +345,15 @@ namespace edm {
                         ServiceToken const& token,
                         SharedResourcesAcquirer* sra,
                         ModuleCallingContext const* mcc) const final;
-    bool unscheduledWasNotRun_() const final {return realProduct().unscheduledWasNotRun();}
-    bool productUnavailable_() const final {return realProduct().productUnavailable();}
+    bool unscheduledWasNotRun_() const final { return realProduct().unscheduledWasNotRun(); }
+    bool productUnavailable_() const final { return realProduct().productUnavailable(); }
   };
 
   class ParentProcessProductResolver : public ProductResolverBase {
   public:
     typedef ProducedProductResolver::ProductStatus ProductStatus;
-    explicit ParentProcessProductResolver(std::shared_ptr<BranchDescription const> bd) : ProductResolverBase(), realProduct_(nullptr), bd_(bd), provRetriever_(nullptr), parentPrincipal_(nullptr) {}
+    explicit ParentProcessProductResolver(std::shared_ptr<BranchDescription const> bd)
+        : ProductResolverBase(), realProduct_(nullptr), bd_(bd), provRetriever_(nullptr), parentPrincipal_(nullptr) {}
 
     void connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) final {
       realProduct_ = &iOther;
@@ -359,36 +368,39 @@ namespace edm {
       skipCurrentProcess = false;
       return realProduct_->resolveProduct(*parentPrincipal_, skipCurrentProcess, sra, mcc);
     }
-     void prefetchAsync_(WaitingTask* waitTask,
-                         Principal const& principal,
-                         bool skipCurrentProcess,
-                         ServiceToken const& token,
-                         SharedResourcesAcquirer* sra,
-                         ModuleCallingContext const* mcc) const override {
+    void prefetchAsync_(WaitingTask* waitTask,
+                        Principal const& principal,
+                        bool skipCurrentProcess,
+                        ServiceToken const& token,
+                        SharedResourcesAcquirer* sra,
+                        ModuleCallingContext const* mcc) const override {
       skipCurrentProcess = false;
-      realProduct_->prefetchAsync( waitTask, *parentPrincipal_, skipCurrentProcess, token, sra, mcc);
+      realProduct_->prefetchAsync(waitTask, *parentPrincipal_, skipCurrentProcess, token, sra, mcc);
     }
     bool unscheduledWasNotRun_() const override {
-      if (realProduct_) return realProduct_->unscheduledWasNotRun();
+      if (realProduct_)
+        return realProduct_->unscheduledWasNotRun();
       throwNullRealProduct();
       return false;
     }
-    bool productUnavailable_() const override {return realProduct_->productUnavailable();}
+    bool productUnavailable_() const override { return realProduct_->productUnavailable(); }
     bool productResolved_() const final { return realProduct_->productResolved(); }
-    bool productWasDeleted_() const override {return realProduct_->productWasDeleted();}
+    bool productWasDeleted_() const override { return realProduct_->productWasDeleted(); }
     bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override {
       iSkipCurrentProcess = false;
       return realProduct_->productWasFetchedAndIsValid(iSkipCurrentProcess);
     }
 
     void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod, MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
-    BranchDescription const& branchDescription_() const override {return *bd_;}
-    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override {bd_ = bd;}
-    Provenance const* provenance_() const final {return realProduct_->provenance();
-    }
-    std::string const& resolvedModuleLabel_() const override {return realProduct_->moduleLabel();}
-    void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
+    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod,
+                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
+    BranchDescription const& branchDescription_() const override { return *bd_; }
+    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override { bd_ = bd; }
+    Provenance const* provenance_() const final { return realProduct_->provenance(); }
+    std::string const& resolvedModuleLabel_() const override { return realProduct_->moduleLabel(); }
+    void setProvenance_(ProductProvenanceRetriever const* provRetriever,
+                        ProcessHistory const& ph,
+                        ProductID const& pid) override;
     void setProcessHistory_(ProcessHistory const& ph) override;
     ProductProvenance const* productProvenancePtr_() const override;
     void resetProductData_(bool deleteEarly) override;
@@ -402,12 +414,13 @@ namespace edm {
   };
 
   class NoProcessProductResolver : public ProductResolverBase {
-    public:
-      typedef ProducedProductResolver::ProductStatus ProductStatus;
-      NoProcessProductResolver(std::vector<ProductResolverIndex> const& matchingHolders,
-                             std::vector<bool> const& ambiguous, bool madeAtEnd);
+  public:
+    typedef ProducedProductResolver::ProductStatus ProductStatus;
+    NoProcessProductResolver(std::vector<ProductResolverIndex> const& matchingHolders,
+                             std::vector<bool> const& ambiguous,
+                             bool madeAtEnd);
 
-    void connectTo(ProductResolverBase const& iOther, Principal const*) final ;
+    void connectTo(ProductResolverBase const& iOther, Principal const*) final;
 
     void tryPrefetchResolverAsync(unsigned int iProcessingIndex,
                                   Principal const& principal,
@@ -424,75 +437,19 @@ namespace edm {
                         Principal const& principal,
                         bool iSkipCurrentProcess,
                         std::exception_ptr iExceptPtr) const;
-    private:
-      unsigned int unsetIndexValue() const;
-      Resolution resolveProduct_(Principal const& principal,
-                                 bool skipCurrentProcess,
-                                 SharedResourcesAcquirer* sra,
-                                 ModuleCallingContext const* mcc) const override;
-       void prefetchAsync_(WaitingTask* waitTask,
-                           Principal const& principal,
-                           bool skipCurrentProcess,
-                           ServiceToken const& token,
-                           SharedResourcesAcquirer* sra,
-                           ModuleCallingContext const* mcc) const override;
-      bool unscheduledWasNotRun_() const override;
-      bool productUnavailable_() const override;
-      bool productWasDeleted_() const override;
-      bool productResolved_() const final;
-      bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
-
-      void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-      void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod, MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
-      BranchDescription const& branchDescription_() const override;
-      void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
-      Provenance const* provenance_() const override;
-
-      std::string const& resolvedModuleLabel_() const override {return moduleLabel();}
-      void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
-      void setProcessHistory_(ProcessHistory const& ph) override;
-      ProductProvenance const* productProvenancePtr_() const override;
-      void resetProductData_(bool deleteEarly) override;
-      bool singleProduct_() const override;
-
-      Resolution tryResolver(unsigned int index,
-                             Principal const& principal,
-                             bool skipCurrentProcess,
-                             SharedResourcesAcquirer* sra,
-                             ModuleCallingContext const* mcc) const;
-
-      void setCache(bool skipCurrentProcess, ProductResolverIndex index, std::exception_ptr exceptionPtr) const;
-
-      std::vector<ProductResolverIndex> matchingHolders_;
-      std::vector<bool> ambiguous_;
-      mutable WaitingTaskList waitingTasks_;
-      mutable WaitingTaskList skippingWaitingTasks_;
-      mutable std::atomic<unsigned int> lastCheckIndex_;
-      mutable std::atomic<unsigned int> lastSkipCurrentCheckIndex_;
-      mutable std::atomic<bool> prefetchRequested_;
-      mutable std::atomic<bool> skippingPrefetchRequested_;
-      const bool madeAtEnd_;
-  };
-
-  class SingleChoiceNoProcessProductResolver : public ProductResolverBase {
-  public:
-    typedef ProducedProductResolver::ProductStatus ProductStatus;
-    SingleChoiceNoProcessProductResolver(ProductResolverIndex iChoice):
-    ProductResolverBase(), realResolverIndex_(iChoice) {}
-
-    void connectTo(ProductResolverBase const& iOther, Principal const*) final ;
 
   private:
+    unsigned int unsetIndexValue() const;
     Resolution resolveProduct_(Principal const& principal,
                                bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const override;
-     void prefetchAsync_(WaitingTask* waitTask,
-                         Principal const& principal,
-                         bool skipCurrentProcess,
-                         ServiceToken const& token,
-                         SharedResourcesAcquirer* sra,
-                         ModuleCallingContext const* mcc) const override;
+    void prefetchAsync_(WaitingTask* waitTask,
+                        Principal const& principal,
+                        bool skipCurrentProcess,
+                        ServiceToken const& token,
+                        SharedResourcesAcquirer* sra,
+                        ModuleCallingContext const* mcc) const override;
     bool unscheduledWasNotRun_() const override;
     bool productUnavailable_() const override;
     bool productWasDeleted_() const override;
@@ -500,13 +457,76 @@ namespace edm {
     bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
 
     void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod, MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
+    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod,
+                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
     BranchDescription const& branchDescription_() const override;
     void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
     Provenance const* provenance_() const override;
 
-    std::string const& resolvedModuleLabel_() const override {return moduleLabel();}
-    void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
+    std::string const& resolvedModuleLabel_() const override { return moduleLabel(); }
+    void setProvenance_(ProductProvenanceRetriever const* provRetriever,
+                        ProcessHistory const& ph,
+                        ProductID const& pid) override;
+    void setProcessHistory_(ProcessHistory const& ph) override;
+    ProductProvenance const* productProvenancePtr_() const override;
+    void resetProductData_(bool deleteEarly) override;
+    bool singleProduct_() const override;
+
+    Resolution tryResolver(unsigned int index,
+                           Principal const& principal,
+                           bool skipCurrentProcess,
+                           SharedResourcesAcquirer* sra,
+                           ModuleCallingContext const* mcc) const;
+
+    void setCache(bool skipCurrentProcess, ProductResolverIndex index, std::exception_ptr exceptionPtr) const;
+
+    std::vector<ProductResolverIndex> matchingHolders_;
+    std::vector<bool> ambiguous_;
+    mutable WaitingTaskList waitingTasks_;
+    mutable WaitingTaskList skippingWaitingTasks_;
+    mutable std::atomic<unsigned int> lastCheckIndex_;
+    mutable std::atomic<unsigned int> lastSkipCurrentCheckIndex_;
+    mutable std::atomic<bool> prefetchRequested_;
+    mutable std::atomic<bool> skippingPrefetchRequested_;
+    const bool madeAtEnd_;
+  };
+
+  class SingleChoiceNoProcessProductResolver : public ProductResolverBase {
+  public:
+    typedef ProducedProductResolver::ProductStatus ProductStatus;
+    SingleChoiceNoProcessProductResolver(ProductResolverIndex iChoice)
+        : ProductResolverBase(), realResolverIndex_(iChoice) {}
+
+    void connectTo(ProductResolverBase const& iOther, Principal const*) final;
+
+  private:
+    Resolution resolveProduct_(Principal const& principal,
+                               bool skipCurrentProcess,
+                               SharedResourcesAcquirer* sra,
+                               ModuleCallingContext const* mcc) const override;
+    void prefetchAsync_(WaitingTask* waitTask,
+                        Principal const& principal,
+                        bool skipCurrentProcess,
+                        ServiceToken const& token,
+                        SharedResourcesAcquirer* sra,
+                        ModuleCallingContext const* mcc) const override;
+    bool unscheduledWasNotRun_() const override;
+    bool productUnavailable_() const override;
+    bool productWasDeleted_() const override;
+    bool productResolved_() const final;
+    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
+
+    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod,
+                            MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
+    BranchDescription const& branchDescription_() const override;
+    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
+    Provenance const* provenance_() const override;
+
+    std::string const& resolvedModuleLabel_() const override { return moduleLabel(); }
+    void setProvenance_(ProductProvenanceRetriever const* provRetriever,
+                        ProcessHistory const& ph,
+                        ProductID const& pid) override;
     void setProcessHistory_(ProcessHistory const& ph) override;
     ProductProvenance const* productProvenancePtr_() const override;
     void resetProductData_(bool deleteEarly) override;
@@ -515,6 +535,6 @@ namespace edm {
     ProductResolverIndex realResolverIndex_;
   };
 
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/ProductSelector.cc
+++ b/FWCore/Framework/src/ProductSelector.cc
@@ -10,16 +10,14 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
-
 namespace edm {
-// The following typedef is used only in this implementation file, in
-// order to shorten several lines of code.
+  // The following typedef is used only in this implementation file, in
+  // order to shorten several lines of code.
   typedef std::vector<edm::BranchDescription const*> VCBDP;
 
   ProductSelector::ProductSelector() : productsToSelect_(), initialized_(false) {}
 
-  void
-  ProductSelector::initialize(ProductSelectorRules const& rules, VCBDP const& branchDescriptions) {
+  void ProductSelector::initialize(ProductSelectorRules const& rules, VCBDP const& branchDescriptions) {
     typedef ProductSelectorRules::BranchSelectState BranchSelectState;
 
     // Get a BranchSelectState for each branch, containing the branch
@@ -27,10 +25,11 @@ namespace edm {
     std::vector<BranchSelectState> branchstates;
     {
       branchstates.reserve(branchDescriptions.size());
-      
+
       VCBDP::const_iterator it = branchDescriptions.begin();
       VCBDP::const_iterator end = branchDescriptions.end();
-      for (; it != end; ++it) branchstates.emplace_back(*it);
+      for (; it != end; ++it)
+        branchstates.emplace_back(*it);
     }
 
     // Now  apply the rules to  the branchstates, in order.  Each rule
@@ -45,7 +44,8 @@ namespace edm {
       std::vector<BranchSelectState>::const_iterator it = branchstates.begin();
       std::vector<BranchSelectState>::const_iterator end = branchstates.end();
       for (; it != end; ++it) {
-	  if (it->selectMe) productsToSelect_.push_back(it->desc->branchName());
+        if (it->selectMe)
+          productsToSelect_.push_back(it->desc->branchName());
       }
       sort_all(productsToSelect_);
     }
@@ -54,58 +54,54 @@ namespace edm {
 
   bool ProductSelector::selected(BranchDescription const& desc) const {
     if (!initialized_) {
-      throw edm::Exception(edm::errors::LogicError)
-        << "ProductSelector::selected() called prematurely\n"
-        << "before the product registry has been frozen.\n";
+      throw edm::Exception(edm::errors::LogicError) << "ProductSelector::selected() called prematurely\n"
+                                                    << "before the product registry has been frozen.\n";
     }
     // We are to select this 'branch' if its name is one of the ones we
     // have been told to select.
     return binary_search_all(productsToSelect_, desc.branchName());
   }
 
-  void
-  ProductSelector::print(std::ostream& os) const {
-    os << "ProductSelector at: "
-       << static_cast<void const*>(this)
-       << " has "
-       << productsToSelect_.size()
-       << " products to select:\n";      
+  void ProductSelector::print(std::ostream& os) const {
+    os << "ProductSelector at: " << static_cast<void const*>(this) << " has " << productsToSelect_.size()
+       << " products to select:\n";
     copy_all(productsToSelect_, std::ostream_iterator<std::string>(os, "\n"));
   }
 
-  void
-  ProductSelector::checkForDuplicateKeptBranch(BranchDescription const& desc,
-                                               std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc) {
+  void ProductSelector::checkForDuplicateKeptBranch(
+      BranchDescription const& desc, std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc) {
     // Check if an equivalent branch has already been selected due to an EDAlias.
     // We only need the check for products produced in this process.
-    if(desc.produced()) {
+    if (desc.produced()) {
       BranchID const& trueBranchID = desc.originalBranchID();
-      std::map<BranchID, BranchDescription const*>::const_iterator iter = trueBranchIDToKeptBranchDesc.find(trueBranchID);
-      if(iter != trueBranchIDToKeptBranchDesc.end()) {
+      std::map<BranchID, BranchDescription const*>::const_iterator iter =
+          trueBranchIDToKeptBranchDesc.find(trueBranchID);
+      if (iter != trueBranchIDToKeptBranchDesc.end()) {
         throw edm::Exception(errors::Configuration, "Duplicate Output Selection")
-          << "Two (or more) equivalent branches have been selected for output.\n"
-          << "#1: " << BranchKey(desc) << "\n"
-          << "#2: " << BranchKey(*iter->second) << "\n"
-          << "Please drop at least one of them.\n";
+            << "Two (or more) equivalent branches have been selected for output.\n"
+            << "#1: " << BranchKey(desc) << "\n"
+            << "#2: " << BranchKey(*iter->second) << "\n"
+            << "Please drop at least one of them.\n";
       }
       trueBranchIDToKeptBranchDesc.insert(std::make_pair(trueBranchID, &desc));
     }
   }
 
   // Fills in a mapping needed in the case that a branch was dropped while its EDAlias was kept.
-  void
-  ProductSelector::fillDroppedToKept(ProductRegistry const& preg,
-                                     std::map<BranchID, BranchDescription const*> const& trueBranchIDToKeptBranchDesc,
-                                     std::map<BranchID::value_type, BranchID::value_type>& droppedBranchIDToKeptBranchID_) {
-    for(auto const& it : preg.productList()) {
+  void ProductSelector::fillDroppedToKept(
+      ProductRegistry const& preg,
+      std::map<BranchID, BranchDescription const*> const& trueBranchIDToKeptBranchDesc,
+      std::map<BranchID::value_type, BranchID::value_type>& droppedBranchIDToKeptBranchID_) {
+    for (auto const& it : preg.productList()) {
       BranchDescription const& desc = it.second;
-      if(!desc.produced() || desc.isAlias()) continue;
+      if (!desc.produced() || desc.isAlias())
+        continue;
       BranchID const& branchID = desc.branchID();
       std::map<BranchID, BranchDescription const*>::const_iterator iter = trueBranchIDToKeptBranchDesc.find(branchID);
-      if(iter != trueBranchIDToKeptBranchDesc.end()) {
+      if (iter != trueBranchIDToKeptBranchDesc.end()) {
         // This branch, produced in this process, or an alias of it, was persisted.
         BranchID const& keptBranchID = iter->second->branchID();
-        if(keptBranchID != branchID) {
+        if (keptBranchID != branchID) {
           // An EDAlias branch was persisted.
           droppedBranchIDToKeptBranchID_.insert(std::make_pair(branchID.id(), keptBranchID.id()));
         }
@@ -113,16 +109,13 @@ namespace edm {
     }
   }
 
-
   //--------------------------------------------------
   //
   // Associated free functions
   //
-  std::ostream&
-  operator<< (std::ostream& os, const ProductSelector& gs)
-  {
+  std::ostream& operator<<(std::ostream& os, const ProductSelector& gs) {
     gs.print(os);
     return os;
   }
-  
-}
+
+}  // namespace edm

--- a/FWCore/Framework/src/RecordDependencyRegister.cc
+++ b/FWCore/Framework/src/RecordDependencyRegister.cc
@@ -2,7 +2,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     RecordDependencyRegister
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -11,41 +11,34 @@
 //
 
 // system include files
- #include "tbb/concurrent_unordered_map.h"
+#include "tbb/concurrent_unordered_map.h"
 
 // user include files
 #include "FWCore/Framework/interface/RecordDependencyRegister.h"
 
 namespace edm {
   namespace eventsetup {
-namespace {
-  struct KeyHash {
-    std::size_t operator()(EventSetupRecordKey const& iKey) const {
-      return iKey.type().value().hash_code();
+    namespace {
+      struct KeyHash {
+        std::size_t operator()(EventSetupRecordKey const& iKey) const { return iKey.type().value().hash_code(); }
+      };
+
+      tbb::concurrent_unordered_map<EventSetupRecordKey, DepFunction, KeyHash>& getMap() {
+        static tbb::concurrent_unordered_map<EventSetupRecordKey, DepFunction, KeyHash> s_map;
+        return s_map;
+      }
+    }  // namespace
+
+    std::set<EventSetupRecordKey> dependencies(EventSetupRecordKey const& iKey) {
+      auto& map = getMap();
+      auto itFind = map.find(iKey);
+      if (itFind != map.end()) {
+        return itFind->second();
+      }
+      return std::set<EventSetupRecordKey>();
     }
-  };
-  
-  tbb::concurrent_unordered_map<EventSetupRecordKey, DepFunction, KeyHash>& getMap() {
-    static tbb::concurrent_unordered_map<EventSetupRecordKey, DepFunction, KeyHash> s_map;
-    return s_map;
-  }
-}
 
+    void addDependencyFunction(EventSetupRecordKey iKey, DepFunction iFunction) { getMap().emplace(iKey, iFunction); }
 
-std::set<EventSetupRecordKey> dependencies(EventSetupRecordKey const& iKey) {
-  auto& map = getMap();
-  auto itFind = map.find(iKey);
-  if(itFind != map.end()) {
-    return itFind->second();
-  }
-  return std::set<EventSetupRecordKey>();
-}
-
-void addDependencyFunction(EventSetupRecordKey iKey, DepFunction iFunction) {
-  getMap().emplace(iKey,iFunction);
-}
-
-    
-  }
-}
-
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/RunForOutput.cc
+++ b/FWCore/Framework/src/RunForOutput.cc
@@ -6,19 +6,16 @@
 
 namespace edm {
 
-  RunForOutput::RunForOutput(RunPrincipal const& rp, ModuleDescription const& md,
-                             ModuleCallingContext const* moduleCallingContext, bool isAtEnd,
-                             MergeableRunProductMetadata const* mrpm) :
-        OccurrenceForOutput(rp, md, moduleCallingContext, isAtEnd), 
+  RunForOutput::RunForOutput(RunPrincipal const& rp,
+                             ModuleDescription const& md,
+                             ModuleCallingContext const* moduleCallingContext,
+                             bool isAtEnd,
+                             MergeableRunProductMetadata const* mrpm)
+      : OccurrenceForOutput(rp, md, moduleCallingContext, isAtEnd),
         aux_(rp.aux()),
-        mergeableRunProductMetadata_(mrpm) {
-  }
+        mergeableRunProductMetadata_(mrpm) {}
 
-  RunForOutput::~RunForOutput() {
-  }
+  RunForOutput::~RunForOutput() {}
 
-  RunPrincipal const&
-  RunForOutput::runPrincipal() const {
-    return dynamic_cast<RunPrincipal const&>(principal());
-  }
-}
+  RunPrincipal const& RunForOutput::runPrincipal() const { return dynamic_cast<RunPrincipal const&>(principal()); }
+}  // namespace edm

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -6,59 +6,48 @@
 #include "FWCore/Framework/interface/MergeableRunProductMetadata.h"
 
 namespace edm {
-  RunPrincipal::RunPrincipal(
-    std::shared_ptr<RunAuxiliary> aux,
-    std::shared_ptr<ProductRegistry const> reg,
-    ProcessConfiguration const& pc,
-    HistoryAppender* historyAppender,
-    unsigned int iRunIndex,
-    bool isForPrimaryProcess,
-    MergeableRunProductProcesses const* mergeableRunProductProcesses) :
-    Base(reg, reg->productLookup(InRun), pc, InRun, historyAppender, isForPrimaryProcess),
-    aux_(aux), index_(iRunIndex) {
-
-    if (mergeableRunProductProcesses) { // primary RunPrincipals of EventProcessor
+  RunPrincipal::RunPrincipal(std::shared_ptr<RunAuxiliary> aux,
+                             std::shared_ptr<ProductRegistry const> reg,
+                             ProcessConfiguration const& pc,
+                             HistoryAppender* historyAppender,
+                             unsigned int iRunIndex,
+                             bool isForPrimaryProcess,
+                             MergeableRunProductProcesses const* mergeableRunProductProcesses)
+      : Base(reg, reg->productLookup(InRun), pc, InRun, historyAppender, isForPrimaryProcess),
+        aux_(aux),
+        index_(iRunIndex) {
+    if (mergeableRunProductProcesses) {  // primary RunPrincipals of EventProcessor
       mergeableRunProductMetadataPtr_ = (std::make_unique<MergeableRunProductMetadata>(*mergeableRunProductProcesses));
     }
   }
 
   RunPrincipal::~RunPrincipal() {}
 
-  void
-  RunPrincipal::fillRunPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader) {
+  void RunPrincipal::fillRunPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader) {
     m_reducedHistoryID = processHistoryRegistry.reducedProcessHistoryID(aux_->processHistoryID());
     fillPrincipal(aux_->processHistoryID(), processHistoryRegistry, reader);
 
-    for(auto& prod : *this) {
+    for (auto& prod : *this) {
       prod->setProcessHistory(processHistory());
       prod->setMergeableRunProductMetadata(mergeableRunProductMetadataPtr_.get());
     }
   }
 
-  void
-  RunPrincipal::put(
-        BranchDescription const& bd,
-        std::unique_ptr<WrapperBase>  edp) const {
-    putOrMerge(bd,std::move(edp));
+  void RunPrincipal::put(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const {
+    putOrMerge(bd, std::move(edp));
   }
 
-  void
-  RunPrincipal::put(ProductResolverIndex index,
-                    std::unique_ptr<WrapperBase> edp) const {
+  void RunPrincipal::put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const {
     auto phb = getProductResolverByIndex(index);
     phb->putOrMergeProduct(std::move(edp));
   }
-  
-  unsigned int
-  RunPrincipal::transitionIndex_() const {
-    return index().value();
-  }
 
-  void
-  RunPrincipal::preReadFile() {
+  unsigned int RunPrincipal::transitionIndex_() const { return index().value(); }
+
+  void RunPrincipal::preReadFile() {
     if (mergeableRunProductMetadataPtr_) {
       mergeableRunProductMetadataPtr_->preReadFile();
     }
   }
 
-}
+}  // namespace edm

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -33,8 +33,6 @@
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 
-
-
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
@@ -47,7 +45,6 @@
 #include <sstream>
 
 #include "make_shared_noexcept_false.h"
-
 
 namespace edm {
 
@@ -63,42 +60,37 @@ namespace edm {
     // Here we make the trigger results inserter directly.  This should
     // probably be a utility in the WorkerRegistry or elsewhere.
 
-    std::shared_ptr<TriggerResultInserter>
-    makeInserter(ParameterSet& proc_pset,
-                 PreallocationConfiguration const& iPrealloc,
-                 ProductRegistry& preg,
-                 ExceptionToActionTable const& actions,
-                 std::shared_ptr<ActivityRegistry> areg,
-                 std::shared_ptr<ProcessConfiguration> processConfiguration) {
-
+    std::shared_ptr<TriggerResultInserter> makeInserter(ParameterSet& proc_pset,
+                                                        PreallocationConfiguration const& iPrealloc,
+                                                        ProductRegistry& preg,
+                                                        ExceptionToActionTable const& actions,
+                                                        std::shared_ptr<ActivityRegistry> areg,
+                                                        std::shared_ptr<ProcessConfiguration> processConfiguration) {
       ParameterSet* trig_pset = proc_pset.getPSetForUpdate("@trigger_paths");
       trig_pset->registerIt();
 
       WorkerParams work_args(trig_pset, preg, &iPrealloc, processConfiguration, actions);
-      ModuleDescription md(trig_pset->id(),
-                           "TriggerResultInserter",
-                           "TriggerResults",
-                           processConfiguration.get(),
+      ModuleDescription md(trig_pset->id(), "TriggerResultInserter", "TriggerResults", processConfiguration.get(),
                            ModuleDescription::getUniqueID());
 
       areg->preModuleConstructionSignal_(md);
       bool postCalled = false;
       std::shared_ptr<TriggerResultInserter> returnValue;
       try {
-        maker::ModuleHolderT<TriggerResultInserter> holder(make_shared_noexcept_false<TriggerResultInserter>(*trig_pset, iPrealloc.numberOfStreams()),static_cast<Maker const*>(nullptr));
+        maker::ModuleHolderT<TriggerResultInserter> holder(
+            make_shared_noexcept_false<TriggerResultInserter>(*trig_pset, iPrealloc.numberOfStreams()),
+            static_cast<Maker const*>(nullptr));
         holder.setModuleDescription(md);
         holder.registerProductsAndCallbacks(&preg);
-        returnValue =holder.module();
+        returnValue = holder.module();
         postCalled = true;
         // if exception then post will be called in the catch block
         areg->postModuleConstructionSignal_(md);
-      }
-      catch (...) {
-        if(!postCalled) {
+      } catch (...) {
+        if (!postCalled) {
           try {
             areg->postModuleConstructionSignal_(md);
-          }
-          catch (...) {
+          } catch (...) {
             // If post throws an exception ignore it because we are already handling another exception
           }
         }
@@ -108,15 +100,13 @@ namespace edm {
     }
 
     template <typename T>
-    void
-    makePathStatusInserters(std::vector<edm::propagate_const<std::shared_ptr<T>>>& pathStatusInserters,
-                            std::vector<std::string> const& pathNames,
-                            PreallocationConfiguration const& iPrealloc,
-                            ProductRegistry& preg,
-                            std::shared_ptr<ActivityRegistry> areg,
-                            std::shared_ptr<ProcessConfiguration> processConfiguration,
-                            std::string const& moduleTypeName) {
-
+    void makePathStatusInserters(std::vector<edm::propagate_const<std::shared_ptr<T>>>& pathStatusInserters,
+                                 std::vector<std::string> const& pathNames,
+                                 PreallocationConfiguration const& iPrealloc,
+                                 ProductRegistry& preg,
+                                 std::shared_ptr<ActivityRegistry> areg,
+                                 std::shared_ptr<ProcessConfiguration> processConfiguration,
+                                 std::string const& moduleTypeName) {
       ParameterSet pset;
       pset.addParameter<std::string>("@module_type", moduleTypeName);
       pset.addParameter<std::string>("@module_edm_type", "EDProducer");
@@ -125,11 +115,7 @@ namespace edm {
       pathStatusInserters.reserve(pathNames.size());
 
       for (auto const& pathName : pathNames) {
-
-        ModuleDescription md(pset.id(),
-                             moduleTypeName,
-                             pathName,
-                             processConfiguration.get(),
+        ModuleDescription md(pset.id(), moduleTypeName, pathName, processConfiguration.get(),
                              ModuleDescription::getUniqueID());
 
         areg->preModuleConstructionSignal_(md);
@@ -144,13 +130,11 @@ namespace edm {
           postCalled = true;
           // if exception then post will be called in the catch block
           areg->postModuleConstructionSignal_(md);
-        }
-        catch (...) {
-          if(!postCalled) {
+        } catch (...) {
+          if (!postCalled) {
             try {
               areg->postModuleConstructionSignal_(md);
-            }
-            catch (...) {
+            } catch (...) {
               // If post throws an exception ignore it because we are already handling another exception
             }
           }
@@ -159,58 +143,60 @@ namespace edm {
       }
     }
 
-    void
-    checkAndInsertAlias(std::string const& friendlyClassName,
-                        std::string const& moduleLabel,
-                        std::string const& productInstanceName,
-                        std::string const& processName,
-                        std::string const& alias,
-                        std::string const& instanceAlias,
-                        ProductRegistry const& preg,
-                        std::multimap<BranchKey, BranchKey>& aliasMap,
-                        std::map<BranchKey, BranchKey>& aliasKeys) {
+    void checkAndInsertAlias(std::string const& friendlyClassName,
+                             std::string const& moduleLabel,
+                             std::string const& productInstanceName,
+                             std::string const& processName,
+                             std::string const& alias,
+                             std::string const& instanceAlias,
+                             ProductRegistry const& preg,
+                             std::multimap<BranchKey, BranchKey>& aliasMap,
+                             std::map<BranchKey, BranchKey>& aliasKeys) {
       std::string const star("*");
 
       BranchKey key(friendlyClassName, moduleLabel, productInstanceName, processName);
-      if(preg.productList().find(key) == preg.productList().end()) {
+      if (preg.productList().find(key) == preg.productList().end()) {
         // No product was found matching the alias.
         // We throw an exception only if a module with the specified module label was created in this process.
-        for(auto const& product : preg.productList()) {
-          if(moduleLabel == product.first.moduleLabel() && processName == product.first.processName()) {
+        for (auto const& product : preg.productList()) {
+          if (moduleLabel == product.first.moduleLabel() && processName == product.first.processName()) {
             throw Exception(errors::Configuration, "EDAlias does not match data\n")
-              << "There are no products of type '" << friendlyClassName << "'\n"
-              << "with module label '" << moduleLabel << "' and instance name '" << productInstanceName << "'.\n";
+                << "There are no products of type '" << friendlyClassName << "'\n"
+                << "with module label '" << moduleLabel << "' and instance name '" << productInstanceName << "'.\n";
           }
         }
       }
 
       std::string const& theInstanceAlias(instanceAlias == star ? productInstanceName : instanceAlias);
       BranchKey aliasKey(friendlyClassName, alias, theInstanceAlias, processName);
-      if(preg.productList().find(aliasKey) != preg.productList().end()) {
+      if (preg.productList().find(aliasKey) != preg.productList().end()) {
         throw Exception(errors::Configuration, "EDAlias conflicts with data\n")
-          << "A product of type '" << friendlyClassName << "'\n"
-          << "with module label '" << alias << "' and instance name '" << theInstanceAlias << "'\n"
-          << "already exists.\n";
+            << "A product of type '" << friendlyClassName << "'\n"
+            << "with module label '" << alias << "' and instance name '" << theInstanceAlias << "'\n"
+            << "already exists.\n";
       }
       auto iter = aliasKeys.find(aliasKey);
-      if(iter != aliasKeys.end()) {
+      if (iter != aliasKeys.end()) {
         // The alias matches a previous one.  If the same alias is used for different product, throw.
-        if(iter->second != key) {
+        if (iter->second != key) {
           throw Exception(errors::Configuration, "EDAlias conflict\n")
-            << "The module label alias '" << alias << "' and product instance alias '" << theInstanceAlias << "'\n"
-            << "are used for multiple products of type '" << friendlyClassName << "'\n"
-            << "One has module label '" << moduleLabel << "' and product instance name '" << productInstanceName << "',\n"
-            << "the other has module label '" << iter->second.moduleLabel() << "' and product instance name '" << iter->second.productInstanceName() << "'.\n";
+              << "The module label alias '" << alias << "' and product instance alias '" << theInstanceAlias << "'\n"
+              << "are used for multiple products of type '" << friendlyClassName << "'\n"
+              << "One has module label '" << moduleLabel << "' and product instance name '" << productInstanceName
+              << "',\n"
+              << "the other has module label '" << iter->second.moduleLabel() << "' and product instance name '"
+              << iter->second.productInstanceName() << "'.\n";
         }
       } else {
         auto prodIter = preg.productList().find(key);
-        if(prodIter != preg.productList().end()) {
+        if (prodIter != preg.productList().end()) {
           if (!prodIter->second.produced()) {
             throw Exception(errors::Configuration, "EDAlias\n")
-              << "The module label alias '" << alias << "' and product instance alias '" << theInstanceAlias << "'\n"
-              << "are used for a product of type '" << friendlyClassName << "'\n"
-              << "with module label '" << moduleLabel << "' and product instance name '" << productInstanceName << "',\n"
-              << "An EDAlias can only be used for products produced in the current process. This one is not.\n";
+                << "The module label alias '" << alias << "' and product instance alias '" << theInstanceAlias << "'\n"
+                << "are used for a product of type '" << friendlyClassName << "'\n"
+                << "with module label '" << moduleLabel << "' and product instance name '" << productInstanceName
+                << "',\n"
+                << "An EDAlias can only be used for products produced in the current process. This one is not.\n";
           }
           aliasMap.insert(std::make_pair(key, aliasKey));
           aliasKeys.insert(std::make_pair(aliasKey, key));
@@ -218,10 +204,9 @@ namespace edm {
       }
     }
 
-    void
-    processEDAliases(ParameterSet const& proc_pset, std::string const& processName, ProductRegistry& preg) {
-      std::vector<std::string> aliases = proc_pset.getParameter<std::vector<std::string> >("@all_aliases");
-      if(aliases.empty()) {
+    void processEDAliases(ParameterSet const& proc_pset, std::string const& processName, ProductRegistry& preg) {
+      std::vector<std::string> aliases = proc_pset.getParameter<std::vector<std::string>>("@all_aliases");
+      if (aliases.empty()) {
         return;
       }
       std::string const star("*");
@@ -233,58 +218,59 @@ namespace edm {
 
       std::multimap<BranchKey, BranchKey> aliasMap;
 
-      std::map<BranchKey, BranchKey> aliasKeys; // Used to search for duplicates or clashes.
+      std::map<BranchKey, BranchKey> aliasKeys;  // Used to search for duplicates or clashes.
 
       // Now, loop over the alias information and store it in aliasMap.
-      for(std::string const& alias : aliases) {
+      for (std::string const& alias : aliases) {
         ParameterSet const& aliasPSet = proc_pset.getParameterSet(alias);
         std::vector<std::string> vPSetNames = aliasPSet.getParameterNamesForType<VParameterSet>();
-        for(std::string const& moduleLabel : vPSetNames) {
+        for (std::string const& moduleLabel : vPSetNames) {
           VParameterSet vPSet = aliasPSet.getParameter<VParameterSet>(moduleLabel);
-          for(ParameterSet& pset : vPSet) {
+          for (ParameterSet& pset : vPSet) {
             desc.validate(pset);
             std::string friendlyClassName = pset.getParameter<std::string>("type");
             std::string productInstanceName = pset.getParameter<std::string>("fromProductInstance");
             std::string instanceAlias = pset.getParameter<std::string>("toProductInstance");
-            if(productInstanceName == star) {
+            if (productInstanceName == star) {
               bool match = false;
               BranchKey lowerBound(friendlyClassName, moduleLabel, empty, empty);
-              for(ProductRegistry::ProductList::const_iterator it = preg.productList().lower_bound(lowerBound);
-                  it != preg.productList().end() && it->first.friendlyClassName() == friendlyClassName && it->first.moduleLabel() == moduleLabel;
-                  ++it) {
-                if(it->first.processName() != processName) {
+              for (ProductRegistry::ProductList::const_iterator it = preg.productList().lower_bound(lowerBound);
+                   it != preg.productList().end() && it->first.friendlyClassName() == friendlyClassName &&
+                   it->first.moduleLabel() == moduleLabel;
+                   ++it) {
+                if (it->first.processName() != processName) {
                   continue;
                 }
                 match = true;
 
-                checkAndInsertAlias(friendlyClassName, moduleLabel, it->first.productInstanceName(), processName, alias, instanceAlias, preg, aliasMap, aliasKeys);
+                checkAndInsertAlias(friendlyClassName, moduleLabel, it->first.productInstanceName(), processName, alias,
+                                    instanceAlias, preg, aliasMap, aliasKeys);
               }
-              if(!match) {
+              if (!match) {
                 // No product was found matching the alias.
                 // We throw an exception only if a module with the specified module label was created in this process.
-                for(auto const& product : preg.productList()) {
-                  if(moduleLabel == product.first.moduleLabel() && processName == product.first.processName()) {
+                for (auto const& product : preg.productList()) {
+                  if (moduleLabel == product.first.moduleLabel() && processName == product.first.processName()) {
                     throw Exception(errors::Configuration, "EDAlias parameter set mismatch\n")
-                       << "There are no products of type '" << friendlyClassName << "'\n"
-                       << "with module label '" << moduleLabel << "'.\n";
+                        << "There are no products of type '" << friendlyClassName << "'\n"
+                        << "with module label '" << moduleLabel << "'.\n";
                   }
                 }
               }
             } else {
-              checkAndInsertAlias(friendlyClassName, moduleLabel, productInstanceName, processName, alias, instanceAlias, preg, aliasMap, aliasKeys);
+              checkAndInsertAlias(friendlyClassName, moduleLabel, productInstanceName, processName, alias,
+                                  instanceAlias, preg, aliasMap, aliasKeys);
             }
           }
         }
       }
 
-
       // Now add the new alias entries to the product registry.
-      for(auto const& aliasEntry : aliasMap) {
+      for (auto const& aliasEntry : aliasMap) {
         ProductRegistry::ProductList::const_iterator it = preg.productList().find(aliasEntry.first);
         assert(it != preg.productList().end());
         preg.addLabelAlias(it->second, aliasEntry.second.moduleLabel(), aliasEntry.second.productInstanceName());
       }
-
     }
 
     typedef std::vector<std::string> vstring;
@@ -292,72 +278,78 @@ namespace edm {
     void processSwitchProducers(ParameterSet const& proc_pset, std::string const& processName, ProductRegistry& preg) {
       // Update Switch BranchDescriptions for the chosen case
       struct BranchesCases {
-        BranchesCases(std::vector<std::string> cases): caseLabels{std::move(cases)} {}
+        BranchesCases(std::vector<std::string> cases) : caseLabels{std::move(cases)} {}
         std::vector<BranchKey> chosenBranches;
         std::vector<std::string> caseLabels;
       };
       std::map<std::string, BranchesCases> switchMap;
-      for(auto& prod: preg.productListUpdator()) {
-        if(prod.second.isSwitchAlias()) {
+      for (auto& prod : preg.productListUpdator()) {
+        if (prod.second.isSwitchAlias()) {
           auto it = switchMap.find(prod.second.moduleLabel());
-          if(it == switchMap.end())  {
+          if (it == switchMap.end()) {
             auto const& switchPSet = proc_pset.getParameter<edm::ParameterSet>(prod.second.moduleLabel());
-            auto inserted = switchMap.emplace(prod.second.moduleLabel(), switchPSet.getParameter<std::vector<std::string>>("@all_cases"));
+            auto inserted = switchMap.emplace(prod.second.moduleLabel(),
+                                              switchPSet.getParameter<std::vector<std::string>>("@all_cases"));
             assert(inserted.second);
             it = inserted.first;
           }
 
-          for(auto const& item: preg.productList()) {
-            if(item.second.branchType() == prod.second.branchType() and
-               item.second.unwrappedTypeID().typeInfo() == prod.second.unwrappedTypeID().typeInfo() and
-               item.first.moduleLabel() == prod.second.switchAliasModuleLabel() and
-               item.first.productInstanceName() == prod.second.productInstanceName()
-               ) {
-              if(item.first.processName() != processName) {
+          for (auto const& item : preg.productList()) {
+            if (item.second.branchType() == prod.second.branchType() and
+                item.second.unwrappedTypeID().typeInfo() == prod.second.unwrappedTypeID().typeInfo() and
+                item.first.moduleLabel() == prod.second.switchAliasModuleLabel() and
+                item.first.productInstanceName() == prod.second.productInstanceName()) {
+              if (item.first.processName() != processName) {
                 throw Exception(errors::LogicError)
-                  << "Encountered a BranchDescription that is aliased-for by SwitchProducer, and whose processName " << item.first.processName() << " differs from current process " << processName
-                  << ". Module label is " << item.first.moduleLabel() << ".\nPlease contact a framework developer.";
+                    << "Encountered a BranchDescription that is aliased-for by SwitchProducer, and whose processName "
+                    << item.first.processName() << " differs from current process " << processName
+                    << ". Module label is " << item.first.moduleLabel() << ".\nPlease contact a framework developer.";
               }
               prod.second.setSwitchAliasForBranch(item.second);
-              it->second.chosenBranches.push_back(prod.first); // with moduleLabel of the Switch
+              it->second.chosenBranches.push_back(prod.first);  // with moduleLabel of the Switch
             }
           }
         }
       }
-      if(switchMap.empty())
+      if (switchMap.empty())
         return;
 
-      for(auto& elem: switchMap) {
+      for (auto& elem : switchMap) {
         std::sort(elem.second.chosenBranches.begin(), elem.second.chosenBranches.end());
       }
 
       // Check that non-chosen cases declare exactly the same branches
       std::vector<bool> foundBranches;
-      for(auto const& switchItem: switchMap) {
+      for (auto const& switchItem : switchMap) {
         auto const& switchLabel = switchItem.first;
         auto const& chosenBranches = switchItem.second.chosenBranches;
         auto const& caseLabels = switchItem.second.caseLabels;
         foundBranches.resize(chosenBranches.size());
-        for(auto const& caseLabel: caseLabels) {
+        for (auto const& caseLabel : caseLabels) {
           std::fill(foundBranches.begin(), foundBranches.end(), false);
-          for(auto const& item: preg.productList()) {
-            if(item.first.moduleLabel() == caseLabel) {
-              auto range = std::equal_range(chosenBranches.begin(), chosenBranches.end(), BranchKey(item.first.friendlyClassName(),
-                                                                                                    switchLabel,
-                                                                                                    item.first.productInstanceName(),
-                                                                                                    item.first.processName()));
-              if(range.first == range.second) {
+          for (auto const& item : preg.productList()) {
+            if (item.first.moduleLabel() == caseLabel) {
+              auto range = std::equal_range(chosenBranches.begin(), chosenBranches.end(),
+                                            BranchKey(item.first.friendlyClassName(), switchLabel,
+                                                      item.first.productInstanceName(), item.first.processName()));
+              if (range.first == range.second) {
                 throw Exception(errors::Configuration)
-                  << "SwitchProducer " << switchLabel << " has a case " << caseLabel << " with a product " << item.first << " that is not produced by the chosen case " << proc_pset.getParameter<edm::ParameterSet>(switchLabel).getUntrackedParameter<std::string>("@chosen_case");
+                    << "SwitchProducer " << switchLabel << " has a case " << caseLabel << " with a product "
+                    << item.first << " that is not produced by the chosen case "
+                    << proc_pset.getParameter<edm::ParameterSet>(switchLabel)
+                           .getUntrackedParameter<std::string>("@chosen_case");
               }
               assert(std::distance(range.first, range.second) == 1);
               foundBranches[std::distance(chosenBranches.begin(), range.first)] = true;
 
               // Check that there are no BranchAliases for any of the cases
               auto const& bd = item.second;
-              if(not bd.branchAliases().empty()) {
-                auto ex = Exception(errors::UnimplementedFeature) << "SwitchProducer does not support ROOT branch aliases. Got the following ROOT branch aliases for SwitchProducer with label " << switchLabel << " for case " << caseLabel << ":";
-                for(auto const& item: bd.branchAliases()) {
+              if (not bd.branchAliases().empty()) {
+                auto ex = Exception(errors::UnimplementedFeature)
+                          << "SwitchProducer does not support ROOT branch aliases. Got the following ROOT branch "
+                             "aliases for SwitchProducer with label "
+                          << switchLabel << " for case " << caseLabel << ":";
+                for (auto const& item : bd.branchAliases()) {
                   ex << " " << item;
                 }
                 throw ex;
@@ -365,10 +357,13 @@ namespace edm {
             }
           }
 
-          for(size_t i=0; i<chosenBranches.size(); i++) {
-            if(not foundBranches[i]) {
+          for (size_t i = 0; i < chosenBranches.size(); i++) {
+            if (not foundBranches[i]) {
               throw Exception(errors::Configuration)
-                << "SwitchProducer " << switchLabel << " has a case " << caseLabel << " that does not produce a product " << chosenBranches[i] << " that is produced by the chosen case " << proc_pset.getParameter<edm::ParameterSet>(switchLabel).getUntrackedParameter<std::string>("@chosen_case");
+                  << "SwitchProducer " << switchLabel << " has a case " << caseLabel
+                  << " that does not produce a product " << chosenBranches[i] << " that is produced by the chosen case "
+                  << proc_pset.getParameter<edm::ParameterSet>(switchLabel)
+                         .getUntrackedParameter<std::string>("@chosen_case");
             }
           }
         }
@@ -379,7 +374,7 @@ namespace edm {
                             vstring const& end_path_name_list,
                             vstring& modulesInConfig,
                             std::set<std::string> const& usedModuleLabels,
-                            std::map<std::string, std::vector<std::pair<std::string, int> > >& outputModulePathPositions) {
+                            std::map<std::string, std::vector<std::pair<std::string, int>>>& outputModulePathPositions) {
       // Before calculating the ParameterSetID of the top level ParameterSet or
       // saving it in the registry drop from the top level ParameterSet all
       // OutputModules and EDAnalyzers not on trigger paths. If unscheduled
@@ -406,15 +401,15 @@ namespace edm {
       vstring scheduledPaths = proc_pset.getParameter<vstring>("@paths");
       std::set<std::string> modulesOnPaths;
       {
-        std::set<std::string> noEndPaths(scheduledPaths.begin(),scheduledPaths.end());
-        for(auto const& endPath: end_path_name_list) {
+        std::set<std::string> noEndPaths(scheduledPaths.begin(), scheduledPaths.end());
+        for (auto const& endPath : end_path_name_list) {
           noEndPaths.erase(endPath);
         }
         {
           vstring labels;
-          for(auto const& path: noEndPaths) {
+          for (auto const& path : noEndPaths) {
             labels = proc_pset.getParameter<vstring>(path);
-            modulesOnPaths.insert(labels.begin(),labels.end());
+            modulesOnPaths.insert(labels.begin(), labels.end());
           }
         }
       }
@@ -422,12 +417,11 @@ namespace edm {
       // the configuration but which are not being used by the system
       std::vector<std::string> labelsToBeDropped;
       labelsToBeDropped.reserve(modulesInConfigSet.size());
-      std::set_difference(modulesInConfigSet.begin(),modulesInConfigSet.end(),
-                          usedModuleLabels.begin(),usedModuleLabels.end(),
-                          std::back_inserter(labelsToBeDropped));
+      std::set_difference(modulesInConfigSet.begin(), modulesInConfigSet.end(), usedModuleLabels.begin(),
+                          usedModuleLabels.end(), std::back_inserter(labelsToBeDropped));
 
       const unsigned int sizeBeforeOutputModules = labelsToBeDropped.size();
-      for (auto const& modLabel: usedModuleLabels) {
+      for (auto const& modLabel : usedModuleLabels) {
         // Do nothing for modules that do not have a ParameterSet. Modules of type
         // PathStatusInserter and EndPathStatusInserter will not have a ParameterSet.
         if (proc_pset.existsAs<ParameterSet>(modLabel)) {
@@ -436,23 +430,24 @@ namespace edm {
             outputModuleLabels.push_back(modLabel);
             labelsToBeDropped.push_back(modLabel);
           }
-          if(edmType == edAnalyzer) {
-            if(modulesOnPaths.end()==modulesOnPaths.find(modLabel)) {
+          if (edmType == edAnalyzer) {
+            if (modulesOnPaths.end() == modulesOnPaths.find(modLabel)) {
               labelsToBeDropped.push_back(modLabel);
             }
           }
         }
       }
       //labelsToBeDropped must be sorted
-      std::inplace_merge(labelsToBeDropped.begin(),
-                         labelsToBeDropped.begin()+sizeBeforeOutputModules,
+      std::inplace_merge(labelsToBeDropped.begin(), labelsToBeDropped.begin() + sizeBeforeOutputModules,
                          labelsToBeDropped.end());
 
       // drop the parameter sets used to configure the modules
       for_all(labelsToBeDropped, std::bind(&ParameterSet::eraseOrSetUntrackedParameterSet, std::ref(proc_pset), _1));
 
       // drop the labels from @all_modules
-      vstring::iterator endAfterRemove = std::remove_if(modulesInConfig.begin(), modulesInConfig.end(), std::bind(binary_search_string, std::ref(labelsToBeDropped), _1));
+      vstring::iterator endAfterRemove =
+          std::remove_if(modulesInConfig.begin(), modulesInConfig.end(),
+                         std::bind(binary_search_string, std::ref(labelsToBeDropped), _1));
       modulesInConfig.erase(endAfterRemove, modulesInConfig.end());
       proc_pset.addParameter<vstring>(std::string("@all_modules"), modulesInConfig);
 
@@ -460,14 +455,12 @@ namespace edm {
       vstring endPathsToBeDropped;
       vstring labels;
       for (vstring::const_iterator iEndPath = end_path_name_list.begin(), endEndPath = end_path_name_list.end();
-           iEndPath != endEndPath;
-           ++iEndPath) {
+           iEndPath != endEndPath; ++iEndPath) {
         labels = proc_pset.getParameter<vstring>(*iEndPath);
         vstring::iterator iSave = labels.begin();
         vstring::iterator iBegin = labels.begin();
 
-        for (vstring::iterator iLabel = labels.begin(), iEnd = labels.end();
-             iLabel != iEnd; ++iLabel) {
+        for (vstring::iterator iLabel = labels.begin(), iEnd = labels.end(); iLabel != iEnd; ++iLabel) {
           if (binary_search_string(labelsToBeDropped, *iLabel)) {
             if (binary_search_string(outputModuleLabels, *iLabel)) {
               outputModulePathPositions[*iLabel].emplace_back(*iEndPath, iSave - iBegin);
@@ -491,23 +484,24 @@ namespace edm {
       sort_all(endPathsToBeDropped);
 
       // remove empty end paths from @paths
-      endAfterRemove = std::remove_if(scheduledPaths.begin(), scheduledPaths.end(), std::bind(binary_search_string, std::ref(endPathsToBeDropped), _1));
+      endAfterRemove = std::remove_if(scheduledPaths.begin(), scheduledPaths.end(),
+                                      std::bind(binary_search_string, std::ref(endPathsToBeDropped), _1));
       scheduledPaths.erase(endAfterRemove, scheduledPaths.end());
       proc_pset.addParameter<vstring>(std::string("@paths"), scheduledPaths);
 
       // remove empty end paths from @end_paths
       vstring scheduledEndPaths = proc_pset.getParameter<vstring>("@end_paths");
-      endAfterRemove = std::remove_if(scheduledEndPaths.begin(), scheduledEndPaths.end(), std::bind(binary_search_string, std::ref(endPathsToBeDropped), _1));
+      endAfterRemove = std::remove_if(scheduledEndPaths.begin(), scheduledEndPaths.end(),
+                                      std::bind(binary_search_string, std::ref(endPathsToBeDropped), _1));
       scheduledEndPaths.erase(endAfterRemove, scheduledEndPaths.end());
       proc_pset.addParameter<vstring>(std::string("@end_paths"), scheduledEndPaths);
-
     }
 
     class RngEDConsumer : public EDConsumerBase {
     public:
       explicit RngEDConsumer(std::set<TypeID>& typesConsumed) {
         Service<RandomNumberGenerator> rng;
-        if(rng.isAvailable()) {
+        if (rng.isAvailable()) {
           rng->consumes(consumesCollector());
           for (auto const& consumesInfo : this->consumesInfo()) {
             typesConsumed.emplace(consumesInfo.type());
@@ -515,7 +509,7 @@ namespace edm {
         }
       }
     };
-  }
+  }  // namespace
   // -----------------------------
 
   typedef std::vector<std::string> vstring;
@@ -533,47 +527,31 @@ namespace edm {
                      std::shared_ptr<ProcessConfiguration> processConfiguration,
                      bool hasSubprocesses,
                      PreallocationConfiguration const& prealloc,
-                     ProcessContext const* processContext) :
-  //Only create a resultsInserter if there is a trigger path
-  resultsInserter_{tns.getTrigPaths().empty()? std::shared_ptr<TriggerResultInserter>{} :makeInserter(proc_pset,prealloc,preg,actions,areg,processConfiguration)},
-    moduleRegistry_(new ModuleRegistry()),
-    all_output_communicators_(),
-    preallocConfig_(prealloc),
-    pathNames_(&tns.getTrigPaths()),
-    endPathNames_(&tns.getEndPaths()),
-    wantSummary_(tns.wantSummary()),
-    endpathsAreActive_(true)
-  {
-    makePathStatusInserters(pathStatusInserters_,
-                            *pathNames_,
-                            prealloc,
-                            preg,
-                            areg,
-                            processConfiguration,
+                     ProcessContext const* processContext)
+      :  //Only create a resultsInserter if there is a trigger path
+        resultsInserter_{tns.getTrigPaths().empty()
+                             ? std::shared_ptr<TriggerResultInserter>{}
+                             : makeInserter(proc_pset, prealloc, preg, actions, areg, processConfiguration)},
+        moduleRegistry_(new ModuleRegistry()),
+        all_output_communicators_(),
+        preallocConfig_(prealloc),
+        pathNames_(&tns.getTrigPaths()),
+        endPathNames_(&tns.getEndPaths()),
+        wantSummary_(tns.wantSummary()),
+        endpathsAreActive_(true) {
+    makePathStatusInserters(pathStatusInserters_, *pathNames_, prealloc, preg, areg, processConfiguration,
                             std::string("PathStatusInserter"));
 
-    makePathStatusInserters(endPathStatusInserters_,
-                            *endPathNames_,
-                            prealloc,
-                            preg,
-                            areg,
-                            processConfiguration,
+    makePathStatusInserters(endPathStatusInserters_, *endPathNames_, prealloc, preg, areg, processConfiguration,
                             std::string("EndPathStatusInserter"));
 
-    assert(0<prealloc.numberOfStreams());
+    assert(0 < prealloc.numberOfStreams());
     streamSchedules_.reserve(prealloc.numberOfStreams());
-    for(unsigned int i=0; i<prealloc.numberOfStreams();++i) {
+    for (unsigned int i = 0; i < prealloc.numberOfStreams(); ++i) {
       streamSchedules_.emplace_back(make_shared_noexcept_false<StreamSchedule>(
-        resultsInserter(),
-        pathStatusInserters_,
-        endPathStatusInserters_,
-        moduleRegistry(),
-        proc_pset,tns,prealloc,preg,
-        branchIDListHelper,actions,
-        areg,processConfiguration,
-        !hasSubprocesses,
-        StreamID{i},
-        processContext));
+          resultsInserter(), pathStatusInserters_, endPathStatusInserters_, moduleRegistry(), proc_pset, tns, prealloc,
+          preg, branchIDListHelper, actions, areg, processConfiguration, !hasSubprocesses, StreamID{i},
+          processContext));
     }
 
     //TriggerResults are injected automatically by StreamSchedules and are
@@ -581,45 +559,38 @@ namespace edm {
     const std::string kTriggerResults("TriggerResults");
     std::vector<std::string> modulesToUse;
     modulesToUse.reserve(streamSchedules_[0]->allWorkers().size());
-    for(auto const& worker : streamSchedules_[0]->allWorkers()) {
-      if(worker->description().moduleLabel() != kTriggerResults) {
+    for (auto const& worker : streamSchedules_[0]->allWorkers()) {
+      if (worker->description().moduleLabel() != kTriggerResults) {
         modulesToUse.push_back(worker->description().moduleLabel());
       }
     }
     //The unscheduled modules are at the end of the list, but we want them at the front
     unsigned int n = streamSchedules_[0]->numberOfUnscheduledModules();
-    if(n>0) {
+    if (n > 0) {
       std::vector<std::string> temp;
       temp.reserve(modulesToUse.size());
-      auto itBeginUnscheduled = modulesToUse.begin()+modulesToUse.size()-n;
-      std::copy(itBeginUnscheduled,modulesToUse.end(),
-                std::back_inserter(temp));
-      std::copy(modulesToUse.begin(),itBeginUnscheduled,std::back_inserter(temp));
+      auto itBeginUnscheduled = modulesToUse.begin() + modulesToUse.size() - n;
+      std::copy(itBeginUnscheduled, modulesToUse.end(), std::back_inserter(temp));
+      std::copy(modulesToUse.begin(), itBeginUnscheduled, std::back_inserter(temp));
       temp.swap(modulesToUse);
     }
 
     // propagate_const<T> has no reset() function
-    globalSchedule_ = std::make_unique<GlobalSchedule>(
-      resultsInserter(),
-      pathStatusInserters_,
-      endPathStatusInserters_,
-      moduleRegistry(),
-      modulesToUse,
-      proc_pset, preg, prealloc,
-      actions,areg,processConfiguration,processContext);
+    globalSchedule_ = std::make_unique<GlobalSchedule>(resultsInserter(), pathStatusInserters_, endPathStatusInserters_,
+                                                       moduleRegistry(), modulesToUse, proc_pset, preg, prealloc,
+                                                       actions, areg, processConfiguration, processContext);
 
     //TriggerResults is not in the top level ParameterSet so the call to
     // reduceParameterSet would fail to find it. Just remove it up front.
     std::set<std::string> usedModuleLabels;
-    for(auto const& worker: allWorkers()) {
-      if(worker->description().moduleLabel() != kTriggerResults) {
+    for (auto const& worker : allWorkers()) {
+      if (worker->description().moduleLabel() != kTriggerResults) {
         usedModuleLabels.insert(worker->description().moduleLabel());
       }
     }
-    std::vector<std::string> modulesInConfig(proc_pset.getParameter<std::vector<std::string> >("@all_modules"));
-    std::map<std::string, std::vector<std::pair<std::string, int> > > outputModulePathPositions;
-    reduceParameterSet(proc_pset, tns.getEndPaths(), modulesInConfig, usedModuleLabels,
-                       outputModulePathPositions);
+    std::vector<std::string> modulesInConfig(proc_pset.getParameter<std::vector<std::string>>("@all_modules"));
+    std::map<std::string, std::vector<std::pair<std::string, int>>> outputModulePathPositions;
+    reduceParameterSet(proc_pset, tns.getEndPaths(), modulesInConfig, usedModuleLabels, outputModulePathPositions);
     processEDAliases(proc_pset, processConfiguration->processName(), preg);
     processSwitchProducers(proc_pset, processConfiguration->processName(), preg);
     proc_pset.registerIt();
@@ -630,7 +601,7 @@ namespace edm {
     // modifications alter the number of workers at a later date.
     size_t all_workers_count = allWorkers().size();
 
-    moduleRegistry_->forAllModuleHolders([this](maker::ModuleHolder* iHolder){
+    moduleRegistry_->forAllModuleHolders([this](maker::ModuleHolder* iHolder) {
       auto comm = iHolder->createOutputModuleCommunicator();
       if (comm) {
         all_output_communicators_.emplace_back(std::shared_ptr<OutputModuleCommunicator>{comm.release()});
@@ -641,11 +612,11 @@ namespace edm {
 
     // Sanity check: make sure nobody has added a worker after we've
     // already relied on the WorkerManager being full.
-    assert (all_workers_count == allWorkers().size());
+    assert(all_workers_count == allWorkers().size());
 
     branchIDListHelper.updateFromRegistry(preg);
 
-    for(auto const& worker : streamSchedules_[0]->allWorkers()) {
+    for (auto const& worker : streamSchedules_[0]->allWorkers()) {
       worker->registerThinnedAssociations(preg, thinnedAssociationsHelper);
     }
     thinnedAssociationsHelper.sort();
@@ -656,7 +627,7 @@ namespace edm {
       c->selectProducts(preg, thinnedAssociationsHelper);
     }
 
-    for(auto & product : preg.productListUpdator()) {
+    for (auto& product : preg.productListUpdator()) {
       setIsMergeable(product.second);
     }
 
@@ -675,13 +646,11 @@ namespace edm {
         }
       }
       // The SubProcess class is not a module, yet it may consume.
-      if(hasSubprocesses) {
+      if (hasSubprocesses) {
         productTypesConsumed.emplace(typeid(TriggerResults));
       }
       // The RandomNumberGeneratorService is not a module, yet it consumes.
-      {
-         RngEDConsumer rngConsumer = RngEDConsumer(productTypesConsumed);
-      }
+      { RngEDConsumer rngConsumer = RngEDConsumer(productTypesConsumed); }
       preg.setFrozen(productTypesConsumed, elementTypesConsumed, processConfiguration->processName());
     }
 
@@ -689,23 +658,16 @@ namespace edm {
       c->setEventSelectionInfo(outputModulePathPositions, preg.anyProductProduced());
     }
 
-    if(wantSummary_) {
+    if (wantSummary_) {
       std::vector<const ModuleDescription*> modDesc;
       const auto& workers = allWorkers();
       modDesc.reserve(workers.size());
 
-      std::transform(workers.begin(),workers.end(),
-                     std::back_inserter(modDesc),
-                     [](const Worker* iWorker) -> const ModuleDescription* {
-                       return iWorker->descPtr();
-                     });
+      std::transform(workers.begin(), workers.end(), std::back_inserter(modDesc),
+                     [](const Worker* iWorker) -> const ModuleDescription* { return iWorker->descPtr(); });
 
       // propagate_const<T> has no reset() function
-      summaryTimeKeeper_ = std::make_unique<SystemTimeKeeper>(
-                                                    prealloc.numberOfStreams(),
-                                                    modDesc,
-                                                    tns,
-                                                    processContext);
+      summaryTimeKeeper_ = std::make_unique<SystemTimeKeeper>(prealloc.numberOfStreams(), modDesc, tns, processContext);
       auto timeKeeperPtr = summaryTimeKeeper_.get();
 
       areg->watchPreModuleEvent(timeKeeperPtr, &SystemTimeKeeper::startModuleEvent);
@@ -713,7 +675,7 @@ namespace edm {
       areg->watchPreModuleEventAcquire(timeKeeperPtr, &SystemTimeKeeper::restartModuleEvent);
       areg->watchPostModuleEventAcquire(timeKeeperPtr, &SystemTimeKeeper::stopModuleEvent);
       areg->watchPreModuleEventDelayedGet(timeKeeperPtr, &SystemTimeKeeper::pauseModuleEvent);
-      areg->watchPostModuleEventDelayedGet(timeKeeperPtr,&SystemTimeKeeper::restartModuleEvent);
+      areg->watchPostModuleEventDelayedGet(timeKeeperPtr, &SystemTimeKeeper::restartModuleEvent);
 
       areg->watchPreSourceEvent(timeKeeperPtr, &SystemTimeKeeper::startEvent);
       areg->watchPostEvent(timeKeeperPtr, &SystemTimeKeeper::stopEvent);
@@ -728,13 +690,11 @@ namespace edm {
       //});
     }
 
-  } // Schedule::Schedule
+  }  // Schedule::Schedule
 
-
-  void
-  Schedule::limitOutput(ParameterSet const& proc_pset,
-                        BranchIDLists const& branchIDLists,
-                        SubProcessParentageHelper const* subProcessParentageHelper) {
+  void Schedule::limitOutput(ParameterSet const& proc_pset,
+                             BranchIDLists const& branchIDLists,
+                             SubProcessParentageHelper const* subProcessParentageHelper) {
     std::string const output("output");
 
     ParameterSet const& maxEventsPSet = proc_pset.getUntrackedParameterSet("maxEvents");
@@ -754,8 +714,8 @@ namespace edm {
     }
 
     if (maxEventSpecs > 1) {
-      throw Exception(errors::Configuration) <<
-        "\nAt most, one form of 'output' may appear in the 'maxEvents' parameter set";
+      throw Exception(errors::Configuration)
+          << "\nAt most, one form of 'output' may appear in the 'maxEvents' parameter set";
     }
 
     for (auto& c : all_output_communicators_) {
@@ -765,8 +725,8 @@ namespace edm {
         try {
           desc.maxEvents_ = vMaxEventsOut->getUntrackedParameter<int>(moduleLabel);
         } catch (Exception const&) {
-          throw Exception(errors::Configuration) <<
-            "\nNo entry in 'maxEvents' for output module label '" << moduleLabel << "'.\n";
+          throw Exception(errors::Configuration)
+              << "\nNo entry in 'maxEvents' for output module label '" << moduleLabel << "'.\n";
         }
       }
       c->configure(desc);
@@ -783,19 +743,19 @@ namespace edm {
         return false;
       }
     }
-    LogInfo("SuccessfulTermination")
-      << "The job is terminating successfully because each output module\n"
-      << "has reached its configured limit.\n";
+    LogInfo("SuccessfulTermination") << "The job is terminating successfully because each output module\n"
+                                     << "has reached its configured limit.\n";
     return true;
   }
 
-  void Schedule::endJob(ExceptionCollector & collector) {
+  void Schedule::endJob(ExceptionCollector& collector) {
     globalSchedule_->endJob(collector);
     if (collector.hasThrown()) {
       return;
     }
 
-    if (wantSummary_ == false) return;
+    if (wantSummary_ == false)
+      return;
     {
       TriggerReport tr;
       getTriggerReport(tr);
@@ -803,41 +763,40 @@ namespace edm {
       // The trigger report (pass/fail etc.):
 
       LogVerbatim("FwkSummary") << "";
-      if(streamSchedules_[0]->context().processContext()->isSubProcess()) {
-        LogVerbatim("FwkSummary") << "TrigReport Process: "<<streamSchedules_[0]->context().processContext()->processName();
+      if (streamSchedules_[0]->context().processContext()->isSubProcess()) {
+        LogVerbatim("FwkSummary") << "TrigReport Process: "
+                                  << streamSchedules_[0]->context().processContext()->processName();
       }
-      LogVerbatim("FwkSummary") << "TrigReport " << "---------- Event  Summary ------------";
-      if(!tr.trigPathSummaries.empty()) {
+      LogVerbatim("FwkSummary") << "TrigReport "
+                                << "---------- Event  Summary ------------";
+      if (!tr.trigPathSummaries.empty()) {
         LogVerbatim("FwkSummary") << "TrigReport"
-        << " Events total = " << tr.eventSummary.totalEvents
-        << " passed = " << tr.eventSummary.totalEventsPassed
-        << " failed = " << tr.eventSummary.totalEventsFailed
-        << "";
+                                  << " Events total = " << tr.eventSummary.totalEvents
+                                  << " passed = " << tr.eventSummary.totalEventsPassed
+                                  << " failed = " << tr.eventSummary.totalEventsFailed << "";
       } else {
         LogVerbatim("FwkSummary") << "TrigReport"
-        << " Events total = " << tr.eventSummary.totalEvents
-        << " passed = " << tr.eventSummary.totalEvents
-        << " failed = 0";
+                                  << " Events total = " << tr.eventSummary.totalEvents
+                                  << " passed = " << tr.eventSummary.totalEvents << " failed = 0";
       }
 
       LogVerbatim("FwkSummary") << "";
-      LogVerbatim("FwkSummary") << "TrigReport " << "---------- Path   Summary ------------";
       LogVerbatim("FwkSummary") << "TrigReport "
-      << std::right << std::setw(10) << "Trig Bit#" << " "
-      << std::right << std::setw(10) << "Executed" << " "
-      << std::right << std::setw(10) << "Passed" << " "
-      << std::right << std::setw(10) << "Failed" << " "
-      << std::right << std::setw(10) << "Error" << " "
-      << "Name" << "";
-      for (auto const& p: tr.trigPathSummaries) {
-        LogVerbatim("FwkSummary") << "TrigReport "
-        << std::right << std::setw(5) << 1
-        << std::right << std::setw(5) << p.bitPosition << " "
-        << std::right << std::setw(10) << p.timesRun << " "
-        << std::right << std::setw(10) << p.timesPassed << " "
-        << std::right << std::setw(10) << p.timesFailed << " "
-        << std::right << std::setw(10) << p.timesExcept << " "
-        << p.name << "";
+                                << "---------- Path   Summary ------------";
+      LogVerbatim("FwkSummary") << "TrigReport " << std::right << std::setw(10) << "Trig Bit#"
+                                << " " << std::right << std::setw(10) << "Executed"
+                                << " " << std::right << std::setw(10) << "Passed"
+                                << " " << std::right << std::setw(10) << "Failed"
+                                << " " << std::right << std::setw(10) << "Error"
+                                << " "
+                                << "Name"
+                                << "";
+      for (auto const& p : tr.trigPathSummaries) {
+        LogVerbatim("FwkSummary") << "TrigReport " << std::right << std::setw(5) << 1 << std::right << std::setw(5)
+                                  << p.bitPosition << " " << std::right << std::setw(10) << p.timesRun << " "
+                                  << std::right << std::setw(10) << p.timesPassed << " " << std::right << std::setw(10)
+                                  << p.timesFailed << " " << std::right << std::setw(10) << p.timesExcept << " "
+                                  << p.name << "";
       }
 
       /*
@@ -858,92 +817,89 @@ namespace edm {
        */
 
       LogVerbatim("FwkSummary") << "";
-      LogVerbatim("FwkSummary") << "TrigReport " << "-------End-Path   Summary ------------";
       LogVerbatim("FwkSummary") << "TrigReport "
-      << std::right << std::setw(10) << "Trig Bit#" << " "
-      << std::right << std::setw(10) << "Executed" << " "
-      << std::right << std::setw(10) << "Passed" << " "
-      << std::right << std::setw(10) << "Failed" << " "
-      << std::right << std::setw(10) << "Error" << " "
-      << "Name" << "";
-      for (auto const& p: tr.endPathSummaries) {
-        LogVerbatim("FwkSummary") << "TrigReport "
-        << std::right << std::setw(5) << 0
-        << std::right << std::setw(5) << p.bitPosition << " "
-        << std::right << std::setw(10) << p.timesRun << " "
-        << std::right << std::setw(10) << p.timesPassed << " "
-        << std::right << std::setw(10) << p.timesFailed << " "
-        << std::right << std::setw(10) << p.timesExcept << " "
-        << p.name << "";
+                                << "-------End-Path   Summary ------------";
+      LogVerbatim("FwkSummary") << "TrigReport " << std::right << std::setw(10) << "Trig Bit#"
+                                << " " << std::right << std::setw(10) << "Executed"
+                                << " " << std::right << std::setw(10) << "Passed"
+                                << " " << std::right << std::setw(10) << "Failed"
+                                << " " << std::right << std::setw(10) << "Error"
+                                << " "
+                                << "Name"
+                                << "";
+      for (auto const& p : tr.endPathSummaries) {
+        LogVerbatim("FwkSummary") << "TrigReport " << std::right << std::setw(5) << 0 << std::right << std::setw(5)
+                                  << p.bitPosition << " " << std::right << std::setw(10) << p.timesRun << " "
+                                  << std::right << std::setw(10) << p.timesPassed << " " << std::right << std::setw(10)
+                                  << p.timesFailed << " " << std::right << std::setw(10) << p.timesExcept << " "
+                                  << p.name << "";
       }
 
-      for (auto const& p: tr.trigPathSummaries) {
+      for (auto const& p : tr.trigPathSummaries) {
         LogVerbatim("FwkSummary") << "";
-        LogVerbatim("FwkSummary") << "TrigReport " << "---------- Modules in Path: " << p.name << " ------------";
         LogVerbatim("FwkSummary") << "TrigReport "
-        << std::right << std::setw(10) << "Trig Bit#" << " "
-        << std::right << std::setw(10) << "Visited" << " "
-        << std::right << std::setw(10) << "Passed" << " "
-        << std::right << std::setw(10) << "Failed" << " "
-        << std::right << std::setw(10) << "Error" << " "
-        << "Name" << "";
+                                  << "---------- Modules in Path: " << p.name << " ------------";
+        LogVerbatim("FwkSummary") << "TrigReport " << std::right << std::setw(10) << "Trig Bit#"
+                                  << " " << std::right << std::setw(10) << "Visited"
+                                  << " " << std::right << std::setw(10) << "Passed"
+                                  << " " << std::right << std::setw(10) << "Failed"
+                                  << " " << std::right << std::setw(10) << "Error"
+                                  << " "
+                                  << "Name"
+                                  << "";
 
         unsigned int bitpos = 0;
-        for (auto const& mod: p.moduleInPathSummaries) {
-          LogVerbatim("FwkSummary") << "TrigReport "
-          << std::right << std::setw(5) << 1
-          << std::right << std::setw(5) << bitpos << " "
-          << std::right << std::setw(10) << mod.timesVisited << " "
-          << std::right << std::setw(10) << mod.timesPassed << " "
-          << std::right << std::setw(10) << mod.timesFailed << " "
-          << std::right << std::setw(10) << mod.timesExcept << " "
-          << mod.moduleLabel << "";
+        for (auto const& mod : p.moduleInPathSummaries) {
+          LogVerbatim("FwkSummary") << "TrigReport " << std::right << std::setw(5) << 1 << std::right << std::setw(5)
+                                    << bitpos << " " << std::right << std::setw(10) << mod.timesVisited << " "
+                                    << std::right << std::setw(10) << mod.timesPassed << " " << std::right
+                                    << std::setw(10) << mod.timesFailed << " " << std::right << std::setw(10)
+                                    << mod.timesExcept << " " << mod.moduleLabel << "";
           ++bitpos;
         }
       }
 
-      for (auto const& p: tr.endPathSummaries) {
+      for (auto const& p : tr.endPathSummaries) {
         LogVerbatim("FwkSummary") << "";
-        LogVerbatim("FwkSummary") << "TrigReport " << "------ Modules in End-Path: " << p.name << " ------------";
         LogVerbatim("FwkSummary") << "TrigReport "
-        << std::right << std::setw(10) << "Trig Bit#" << " "
-        << std::right << std::setw(10) << "Visited" << " "
-        << std::right << std::setw(10) << "Passed" << " "
-        << std::right << std::setw(10) << "Failed" << " "
-        << std::right << std::setw(10) << "Error" << " "
-        << "Name" << "";
+                                  << "------ Modules in End-Path: " << p.name << " ------------";
+        LogVerbatim("FwkSummary") << "TrigReport " << std::right << std::setw(10) << "Trig Bit#"
+                                  << " " << std::right << std::setw(10) << "Visited"
+                                  << " " << std::right << std::setw(10) << "Passed"
+                                  << " " << std::right << std::setw(10) << "Failed"
+                                  << " " << std::right << std::setw(10) << "Error"
+                                  << " "
+                                  << "Name"
+                                  << "";
 
-        unsigned int bitpos=0;
-        for (auto const& mod: p.moduleInPathSummaries) {
-          LogVerbatim("FwkSummary") << "TrigReport "
-          << std::right << std::setw(5) << 0
-          << std::right << std::setw(5) << bitpos << " "
-          << std::right << std::setw(10) << mod.timesVisited << " "
-          << std::right << std::setw(10) << mod.timesPassed << " "
-          << std::right << std::setw(10) << mod.timesFailed << " "
-          << std::right << std::setw(10) << mod.timesExcept << " "
-          << mod.moduleLabel << "";
+        unsigned int bitpos = 0;
+        for (auto const& mod : p.moduleInPathSummaries) {
+          LogVerbatim("FwkSummary") << "TrigReport " << std::right << std::setw(5) << 0 << std::right << std::setw(5)
+                                    << bitpos << " " << std::right << std::setw(10) << mod.timesVisited << " "
+                                    << std::right << std::setw(10) << mod.timesPassed << " " << std::right
+                                    << std::setw(10) << mod.timesFailed << " " << std::right << std::setw(10)
+                                    << mod.timesExcept << " " << mod.moduleLabel << "";
           ++bitpos;
         }
       }
 
       LogVerbatim("FwkSummary") << "";
-      LogVerbatim("FwkSummary") << "TrigReport " << "---------- Module Summary ------------";
       LogVerbatim("FwkSummary") << "TrigReport "
-      << std::right << std::setw(10) << "Visited" << " "
-      << std::right << std::setw(10) << "Executed" << " "
-      << std::right << std::setw(10) << "Passed" << " "
-      << std::right << std::setw(10) << "Failed" << " "
-      << std::right << std::setw(10) << "Error" << " "
-      << "Name" << "";
+                                << "---------- Module Summary ------------";
+      LogVerbatim("FwkSummary") << "TrigReport " << std::right << std::setw(10) << "Visited"
+                                << " " << std::right << std::setw(10) << "Executed"
+                                << " " << std::right << std::setw(10) << "Passed"
+                                << " " << std::right << std::setw(10) << "Failed"
+                                << " " << std::right << std::setw(10) << "Error"
+                                << " "
+                                << "Name"
+                                << "";
       for (auto const& worker : tr.workerSummaries) {
-        LogVerbatim("FwkSummary") << "TrigReport "
-        << std::right << std::setw(10) << worker.timesVisited << " "
-        << std::right << std::setw(10) << worker.timesRun << " "
-        << std::right << std::setw(10) << worker.timesPassed << " "
-        << std::right << std::setw(10) << worker.timesFailed << " "
-        << std::right << std::setw(10) << worker.timesExcept << " "
-        << worker.moduleLabel << "";
+        LogVerbatim("FwkSummary") << "TrigReport " << std::right << std::setw(10) << worker.timesVisited << " "
+                                  << std::right << std::setw(10) << worker.timesRun << " " << std::right
+                                  << std::setw(10) << worker.timesPassed << " " << std::right << std::setw(10)
+                                  << worker.timesFailed << " " << std::right << std::setw(10) << worker.timesExcept
+                                  << " " << worker.moduleLabel << "";
       }
       LogVerbatim("FwkSummary") << "";
     }
@@ -953,127 +909,123 @@ namespace edm {
 
     const int totalEvents = std::max(1, tr.eventSummary.totalEvents);
 
-    LogVerbatim("FwkSummary") << "TimeReport " << "---------- Event  Summary ---[sec]----";
-    LogVerbatim("FwkSummary") << "TimeReport"
-                              << std::setprecision(6) << std::fixed
-                              << "       event loop CPU/event = " << tr.eventSummary.cpuTime/totalEvents;
-    LogVerbatim("FwkSummary") << "TimeReport"
-                              << std::setprecision(6) << std::fixed
-                              << "      event loop Real/event = " << tr.eventSummary.realTime/totalEvents;
-    LogVerbatim("FwkSummary") << "TimeReport"
-                              << std::setprecision(6) << std::fixed
-                              << "     sum Streams Real/event = " << tr.eventSummary.sumStreamRealTime/totalEvents;
-    LogVerbatim("FwkSummary") << "TimeReport"
-                              << std::setprecision(6) << std::fixed
-                              << " efficiency CPU/Real/thread = " << tr.eventSummary.cpuTime/tr.eventSummary.realTime/preallocConfig_.numberOfThreads();
+    LogVerbatim("FwkSummary") << "TimeReport "
+                              << "---------- Event  Summary ---[sec]----";
+    LogVerbatim("FwkSummary") << "TimeReport" << std::setprecision(6) << std::fixed
+                              << "       event loop CPU/event = " << tr.eventSummary.cpuTime / totalEvents;
+    LogVerbatim("FwkSummary") << "TimeReport" << std::setprecision(6) << std::fixed
+                              << "      event loop Real/event = " << tr.eventSummary.realTime / totalEvents;
+    LogVerbatim("FwkSummary") << "TimeReport" << std::setprecision(6) << std::fixed
+                              << "     sum Streams Real/event = " << tr.eventSummary.sumStreamRealTime / totalEvents;
+    LogVerbatim("FwkSummary") << "TimeReport" << std::setprecision(6) << std::fixed << " efficiency CPU/Real/thread = "
+                              << tr.eventSummary.cpuTime / tr.eventSummary.realTime / preallocConfig_.numberOfThreads();
 
     constexpr int kColumn1Size = 10;
     constexpr int kColumn2Size = 12;
     constexpr int kColumn3Size = 12;
     LogVerbatim("FwkSummary") << "";
-    LogVerbatim("FwkSummary") << "TimeReport " << "---------- Path   Summary ---[Real sec]----";
     LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(kColumn1Size) << "per event"<<" "
-                              << std::right << std::setw(kColumn2Size) << "per exec"
+                              << "---------- Path   Summary ---[Real sec]----";
+    LogVerbatim("FwkSummary") << "TimeReport " << std::right << std::setw(kColumn1Size) << "per event"
+                              << " " << std::right << std::setw(kColumn2Size) << "per exec"
                               << "  Name";
-    for (auto const& p: tr.trigPathSummaries) {
+    for (auto const& p : tr.trigPathSummaries) {
       const int timesRun = std::max(1, p.timesRun);
-      LogVerbatim("FwkSummary") << "TimeReport "
-                                << std::setprecision(6) << std::fixed
-                                << std::right << std::setw(kColumn1Size) << p.realTime/totalEvents << " "
-                                << std::right << std::setw(kColumn2Size) << p.realTime/timesRun << "  "
-                                << p.name << "";
+      LogVerbatim("FwkSummary") << "TimeReport " << std::setprecision(6) << std::fixed << std::right
+                                << std::setw(kColumn1Size) << p.realTime / totalEvents << " " << std::right
+                                << std::setw(kColumn2Size) << p.realTime / timesRun << "  " << p.name << "";
     }
-    LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(kColumn1Size) << "per event"<<" "
-                              << std::right << std::setw(kColumn2Size) << "per exec"
-                              << "  Name" << "";
+    LogVerbatim("FwkSummary") << "TimeReport " << std::right << std::setw(kColumn1Size) << "per event"
+                              << " " << std::right << std::setw(kColumn2Size) << "per exec"
+                              << "  Name"
+                              << "";
 
     LogVerbatim("FwkSummary") << "";
-    LogVerbatim("FwkSummary") << "TimeReport " << "-------End-Path   Summary ---[Real sec]----";
     LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(kColumn1Size) << "per event" <<" "
-                              << std::right << std::setw(kColumn2Size) << "per exec"
-                              << "  Name" << "";
-    for (auto const& p: tr.endPathSummaries) {
+                              << "-------End-Path   Summary ---[Real sec]----";
+    LogVerbatim("FwkSummary") << "TimeReport " << std::right << std::setw(kColumn1Size) << "per event"
+                              << " " << std::right << std::setw(kColumn2Size) << "per exec"
+                              << "  Name"
+                              << "";
+    for (auto const& p : tr.endPathSummaries) {
       const int timesRun = std::max(1, p.timesRun);
 
-      LogVerbatim("FwkSummary") << "TimeReport "
-                                << std::setprecision(6) << std::fixed
-                                << std::right << std::setw(kColumn1Size) << p.realTime/totalEvents << " "
-                                << std::right << std::setw(kColumn2Size) << p.realTime/timesRun << "  "
-                                << p.name << "";
+      LogVerbatim("FwkSummary") << "TimeReport " << std::setprecision(6) << std::fixed << std::right
+                                << std::setw(kColumn1Size) << p.realTime / totalEvents << " " << std::right
+                                << std::setw(kColumn2Size) << p.realTime / timesRun << "  " << p.name << "";
     }
-    LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(kColumn1Size) << "per event" <<" "
-                              << std::right << std::setw(kColumn2Size) << "per exec"
-                              << "  Name" << "";
+    LogVerbatim("FwkSummary") << "TimeReport " << std::right << std::setw(kColumn1Size) << "per event"
+                              << " " << std::right << std::setw(kColumn2Size) << "per exec"
+                              << "  Name"
+                              << "";
 
-    for (auto const& p: tr.trigPathSummaries) {
+    for (auto const& p : tr.trigPathSummaries) {
       LogVerbatim("FwkSummary") << "";
-      LogVerbatim("FwkSummary") << "TimeReport " << "---------- Modules in Path: " << p.name << " ---[Real sec]----";
       LogVerbatim("FwkSummary") << "TimeReport "
-                                << std::right << std::setw(kColumn1Size) << "per event" <<" "
-                                << std::right << std::setw(kColumn2Size) << "per visit"
-                                << "  Name" << "";
-      for (auto const& mod: p.moduleInPathSummaries) {
-        LogVerbatim("FwkSummary") << "TimeReport "
-                                  << std::setprecision(6) << std::fixed
-                                  << std::right << std::setw(kColumn1Size) << mod.realTime/totalEvents << " "
-                                  << std::right << std::setw(kColumn2Size) << mod.realTime/std::max(1, mod.timesVisited) << "  "
+                                << "---------- Modules in Path: " << p.name << " ---[Real sec]----";
+      LogVerbatim("FwkSummary") << "TimeReport " << std::right << std::setw(kColumn1Size) << "per event"
+                                << " " << std::right << std::setw(kColumn2Size) << "per visit"
+                                << "  Name"
+                                << "";
+      for (auto const& mod : p.moduleInPathSummaries) {
+        LogVerbatim("FwkSummary") << "TimeReport " << std::setprecision(6) << std::fixed << std::right
+                                  << std::setw(kColumn1Size) << mod.realTime / totalEvents << " " << std::right
+                                  << std::setw(kColumn2Size) << mod.realTime / std::max(1, mod.timesVisited) << "  "
                                   << mod.moduleLabel << "";
       }
     }
-    if(not tr.trigPathSummaries.empty()) {
-      LogVerbatim("FwkSummary") << "TimeReport "
-                                << std::right << std::setw(kColumn1Size) << "per event" <<" "
-                                << std::right << std::setw(kColumn2Size) << "per visit"
-                                << "  Name" << "";
+    if (not tr.trigPathSummaries.empty()) {
+      LogVerbatim("FwkSummary") << "TimeReport " << std::right << std::setw(kColumn1Size) << "per event"
+                                << " " << std::right << std::setw(kColumn2Size) << "per visit"
+                                << "  Name"
+                                << "";
     }
-    for (auto const& p: tr.endPathSummaries) {
+    for (auto const& p : tr.endPathSummaries) {
       LogVerbatim("FwkSummary") << "";
-      LogVerbatim("FwkSummary") << "TimeReport " << "------ Modules in End-Path: " << p.name << " ---[Real sec]----";
       LogVerbatim("FwkSummary") << "TimeReport "
-                                << std::right << std::setw(kColumn1Size) << "per event" <<" "
-                                << std::right << std::setw(kColumn2Size) << "per visit"
-                                << "  Name" << "";
-      for (auto const& mod: p.moduleInPathSummaries) {
-        LogVerbatim("FwkSummary") << "TimeReport "
-                                  << std::setprecision(6) << std::fixed
-                                  << std::right << std::setw(kColumn1Size) << mod.realTime/totalEvents << " "
-                                  << std::right << std::setw(kColumn2Size) << mod.realTime/std::max(1, mod.timesVisited) << "  "
+                                << "------ Modules in End-Path: " << p.name << " ---[Real sec]----";
+      LogVerbatim("FwkSummary") << "TimeReport " << std::right << std::setw(kColumn1Size) << "per event"
+                                << " " << std::right << std::setw(kColumn2Size) << "per visit"
+                                << "  Name"
+                                << "";
+      for (auto const& mod : p.moduleInPathSummaries) {
+        LogVerbatim("FwkSummary") << "TimeReport " << std::setprecision(6) << std::fixed << std::right
+                                  << std::setw(kColumn1Size) << mod.realTime / totalEvents << " " << std::right
+                                  << std::setw(kColumn2Size) << mod.realTime / std::max(1, mod.timesVisited) << "  "
                                   << mod.moduleLabel << "";
       }
     }
-    if(not tr.endPathSummaries.empty()) {
-      LogVerbatim("FwkSummary") << "TimeReport "
-                                << std::right << std::setw(kColumn1Size) << "per event" <<" "
-                                << std::right << std::setw(kColumn2Size) << "per visit"
-                                << "  Name" << "";
+    if (not tr.endPathSummaries.empty()) {
+      LogVerbatim("FwkSummary") << "TimeReport " << std::right << std::setw(kColumn1Size) << "per event"
+                                << " " << std::right << std::setw(kColumn2Size) << "per visit"
+                                << "  Name"
+                                << "";
     }
     LogVerbatim("FwkSummary") << "";
-    LogVerbatim("FwkSummary") << "TimeReport " << "---------- Module Summary ---[Real sec]----";
     LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(kColumn1Size) << "per event" <<" "
-                              << std::right << std::setw(kColumn2Size) << "per exec" <<" "
-                              << std::right << std::setw(kColumn3Size) << "per visit"
-                              << "  Name" << "";
+                              << "---------- Module Summary ---[Real sec]----";
+    LogVerbatim("FwkSummary") << "TimeReport " << std::right << std::setw(kColumn1Size) << "per event"
+                              << " " << std::right << std::setw(kColumn2Size) << "per exec"
+                              << " " << std::right << std::setw(kColumn3Size) << "per visit"
+                              << "  Name"
+                              << "";
     for (auto const& worker : tr.workerSummaries) {
-      LogVerbatim("FwkSummary") << "TimeReport "
-                                << std::setprecision(6) << std::fixed
-                                << std::right << std::setw(kColumn1Size) << worker.realTime/totalEvents << " "
-                                << std::right << std::setw(kColumn2Size) << worker.realTime/std::max(1, worker.timesRun) << " "
-                                << std::right << std::setw(kColumn3Size) << worker.realTime/std::max(1, worker.timesVisited) << "  "
-                                << worker.moduleLabel << "";
+      LogVerbatim("FwkSummary") << "TimeReport " << std::setprecision(6) << std::fixed << std::right
+                                << std::setw(kColumn1Size) << worker.realTime / totalEvents << " " << std::right
+                                << std::setw(kColumn2Size) << worker.realTime / std::max(1, worker.timesRun) << " "
+                                << std::right << std::setw(kColumn3Size)
+                                << worker.realTime / std::max(1, worker.timesVisited) << "  " << worker.moduleLabel
+                                << "";
     }
-    LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(kColumn1Size) << "per event" <<" "
-                              << std::right << std::setw(kColumn2Size) << "per exec" <<" "
-                              << std::right << std::setw(kColumn3Size) << "per visit"
-                              << "  Name" << "";
+    LogVerbatim("FwkSummary") << "TimeReport " << std::right << std::setw(kColumn1Size) << "per event"
+                              << " " << std::right << std::setw(kColumn2Size) << "per exec"
+                              << " " << std::right << std::setw(kColumn3Size) << "per visit"
+                              << "  Name"
+                              << "";
 
     LogVerbatim("FwkSummary") << "";
-    LogVerbatim("FwkSummary") << "T---Report end!" << "";
+    LogVerbatim("FwkSummary") << "T---Report end!"
+                              << "";
     LogVerbatim("FwkSummary") << "";
   }
 
@@ -1092,7 +1044,7 @@ namespace edm {
                                ProcessContext const* processContext,
                                ActivityRegistry* activityRegistry,
                                MergeableRunProductMetadata const* mergeableRunProductMetadata) {
-    for(auto& c: all_output_communicators_) {
+    for (auto& c : all_output_communicators_) {
       c->writeRunAsync(task, rp, processContext, activityRegistry, mergeableRunProductMetadata);
     }
   }
@@ -1101,7 +1053,7 @@ namespace edm {
                                 LuminosityBlockPrincipal const& lbp,
                                 ProcessContext const* processContext,
                                 ActivityRegistry* activityRegistry) {
-    for(auto& c: all_output_communicators_) {
+    for (auto& c : all_output_communicators_) {
       c->writeLumiAsync(task, lbp, processContext, activityRegistry);
     }
   }
@@ -1109,9 +1061,9 @@ namespace edm {
   bool Schedule::shouldWeCloseOutput() const {
     using std::placeholders::_1;
     // Return true iff at least one output module returns true.
-    return (std::find_if (all_output_communicators_.begin(), all_output_communicators_.end(),
-                     std::bind(&OutputModuleCommunicator::shouldWeCloseFile, _1))
-                     != all_output_communicators_.end());
+    return (std::find_if(all_output_communicators_.begin(), all_output_communicators_.end(),
+                         std::bind(&OutputModuleCommunicator::shouldWeCloseFile, _1)) !=
+            all_output_communicators_.end());
   }
 
   void Schedule::respondToOpenInputFile(FileBlock const& fb) {
@@ -1124,32 +1076,28 @@ namespace edm {
     for_all(allWorkers(), std::bind(&Worker::respondToCloseInputFile, _1, std::cref(fb)));
   }
 
-  void Schedule::beginJob(ProductRegistry const& iRegistry) {
-    globalSchedule_->beginJob(iRegistry);
-  }
+  void Schedule::beginJob(ProductRegistry const& iRegistry) { globalSchedule_->beginJob(iRegistry); }
 
   void Schedule::beginStream(unsigned int iStreamID) {
-    assert(iStreamID<streamSchedules_.size());
+    assert(iStreamID < streamSchedules_.size());
     streamSchedules_[iStreamID]->beginStream();
   }
 
   void Schedule::endStream(unsigned int iStreamID) {
-    assert(iStreamID<streamSchedules_.size());
+    assert(iStreamID < streamSchedules_.size());
     streamSchedules_[iStreamID]->endStream();
   }
-  
+
   void Schedule::processOneEventAsync(WaitingTaskHolder iTask,
                                       unsigned int iStreamID,
                                       EventPrincipal& ep,
                                       EventSetupImpl const& es,
                                       ServiceToken const& token) {
-    assert(iStreamID<streamSchedules_.size());
-    streamSchedules_[iStreamID]->processOneEventAsync(std::move(iTask),ep,es,token,pathStatusInserters_);
+    assert(iStreamID < streamSchedules_.size());
+    streamSchedules_[iStreamID]->processOneEventAsync(std::move(iTask), ep, es, token, pathStatusInserters_);
   }
-  
-  bool Schedule::changeModule(std::string const& iLabel,
-                              ParameterSet const& iPSet,
-                              const ProductRegistry& iRegistry) {
+
+  bool Schedule::changeModule(std::string const& iLabel, ParameterSet const& iPSet, const ProductRegistry& iRegistry) {
     Worker* found = nullptr;
     for (auto const& worker : allWorkers()) {
       if (worker->description().moduleLabel() == iLabel) {
@@ -1161,12 +1109,12 @@ namespace edm {
       return false;
     }
 
-    auto newMod = moduleRegistry_->replaceModule(iLabel,iPSet,preallocConfig_);
+    auto newMod = moduleRegistry_->replaceModule(iLabel, iPSet, preallocConfig_);
 
-    globalSchedule_->replaceModule(newMod,iLabel);
+    globalSchedule_->replaceModule(newMod, iLabel);
 
-    for(auto& s: streamSchedules_) {
-      s->replaceModule(newMod,iLabel);
+    for (auto& s : streamSchedules_) {
+      s->replaceModule(newMod, iLabel);
     }
 
     {
@@ -1174,26 +1122,23 @@ namespace edm {
       auto const runLookup = iRegistry.productLookup(InRun);
       auto const lumiLookup = iRegistry.productLookup(InLumi);
       auto const eventLookup = iRegistry.productLookup(InEvent);
-      found->updateLookup(InRun,*runLookup);
-      found->updateLookup(InLumi,*lumiLookup);
-      found->updateLookup(InEvent,*eventLookup);
-      
+      found->updateLookup(InRun, *runLookup);
+      found->updateLookup(InLumi, *lumiLookup);
+      found->updateLookup(InEvent, *eventLookup);
+
       auto const& processName = newMod->moduleDescription().processName();
       auto const& runModuleToIndicies = runLookup->indiciesForModulesInProcess(processName);
       auto const& lumiModuleToIndicies = lumiLookup->indiciesForModulesInProcess(processName);
       auto const& eventModuleToIndicies = eventLookup->indiciesForModulesInProcess(processName);
-      found->resolvePutIndicies(InRun,runModuleToIndicies);
-      found->resolvePutIndicies(InLumi,lumiModuleToIndicies);
-      found->resolvePutIndicies(InEvent,eventModuleToIndicies);
-
-
+      found->resolvePutIndicies(InRun, runModuleToIndicies);
+      found->resolvePutIndicies(InLumi, lumiModuleToIndicies);
+      found->resolvePutIndicies(InEvent, eventModuleToIndicies);
     }
 
     return true;
   }
 
-  std::vector<ModuleDescription const*>
-  Schedule::getAllModuleDescriptions() const {
+  std::vector<ModuleDescription const*> Schedule::getAllModuleDescriptions() const {
     std::vector<ModuleDescription const*> result;
     result.reserve(allWorkers().size());
 
@@ -1204,10 +1149,7 @@ namespace edm {
     return result;
   }
 
-  Schedule::AllWorkers const&
-  Schedule::allWorkers() const {
-    return globalSchedule_->allWorkers();
-  }
+  Schedule::AllWorkers const& Schedule::allWorkers() const { return globalSchedule_->allWorkers(); }
 
   void Schedule::convertCurrentProcessAlias(std::string const& processName) {
     for (auto const& worker : allWorkers()) {
@@ -1215,47 +1157,35 @@ namespace edm {
     }
   }
 
-  void
-  Schedule::availablePaths(std::vector<std::string>& oLabelsToFill) const {
+  void Schedule::availablePaths(std::vector<std::string>& oLabelsToFill) const {
     streamSchedules_[0]->availablePaths(oLabelsToFill);
   }
 
-  void
-  Schedule::triggerPaths(std::vector<std::string>& oLabelsToFill) const {
-    oLabelsToFill = *pathNames_;
+  void Schedule::triggerPaths(std::vector<std::string>& oLabelsToFill) const { oLabelsToFill = *pathNames_; }
 
+  void Schedule::endPaths(std::vector<std::string>& oLabelsToFill) const { oLabelsToFill = *endPathNames_; }
+
+  void Schedule::modulesInPath(std::string const& iPathLabel, std::vector<std::string>& oLabelsToFill) const {
+    streamSchedules_[0]->modulesInPath(iPathLabel, oLabelsToFill);
   }
 
-  void
-  Schedule::endPaths(std::vector<std::string>& oLabelsToFill) const {
-    oLabelsToFill = *endPathNames_;
-  }
-
-  void
-  Schedule::modulesInPath(std::string const& iPathLabel,
-                          std::vector<std::string>& oLabelsToFill) const {
-    streamSchedules_[0]->modulesInPath(iPathLabel,oLabelsToFill);
-  }
-
-  void
-  Schedule::moduleDescriptionsInPath(std::string const& iPathLabel,
-                                     std::vector<ModuleDescription const*>& descriptions,
-                                     unsigned int hint) const {
+  void Schedule::moduleDescriptionsInPath(std::string const& iPathLabel,
+                                          std::vector<ModuleDescription const*>& descriptions,
+                                          unsigned int hint) const {
     streamSchedules_[0]->moduleDescriptionsInPath(iPathLabel, descriptions, hint);
   }
 
-  void
-  Schedule::moduleDescriptionsInEndPath(std::string const& iEndPathLabel,
-                                        std::vector<ModuleDescription const*>& descriptions,
-                                        unsigned int hint) const {
+  void Schedule::moduleDescriptionsInEndPath(std::string const& iEndPathLabel,
+                                             std::vector<ModuleDescription const*>& descriptions,
+                                             unsigned int hint) const {
     streamSchedules_[0]->moduleDescriptionsInEndPath(iEndPathLabel, descriptions, hint);
   }
 
-  void
-  Schedule::fillModuleAndConsumesInfo(std::vector<ModuleDescription const*>& allModuleDescriptions,
-                                      std::vector<std::pair<unsigned int, unsigned int> >& moduleIDToIndex,
-                                      std::vector<std::vector<ModuleDescription const*> >& modulesWhoseProductsAreConsumedBy,
-                                      ProductRegistry const& preg) const {
+  void Schedule::fillModuleAndConsumesInfo(
+      std::vector<ModuleDescription const*>& allModuleDescriptions,
+      std::vector<std::pair<unsigned int, unsigned int>>& moduleIDToIndex,
+      std::vector<std::vector<ModuleDescription const*>>& modulesWhoseProductsAreConsumedBy,
+      ProductRegistry const& preg) const {
     allModuleDescriptions.clear();
     moduleIDToIndex.clear();
     modulesWhoseProductsAreConsumedBy.clear();
@@ -1283,70 +1213,59 @@ namespace edm {
     }
   }
 
-  void
-  Schedule::enableEndPaths(bool active) {
+  void Schedule::enableEndPaths(bool active) {
     endpathsAreActive_ = active;
-    for(auto& s : streamSchedules_) {
+    for (auto& s : streamSchedules_) {
       s->enableEndPaths(active);
     }
   }
 
-  bool
-  Schedule::endPathsEnabled() const {
-    return endpathsAreActive_;
-  }
+  bool Schedule::endPathsEnabled() const { return endpathsAreActive_; }
 
-  void
-  Schedule::getTriggerReport(TriggerReport& rep) const {
+  void Schedule::getTriggerReport(TriggerReport& rep) const {
     rep.eventSummary.totalEvents = 0;
     rep.eventSummary.totalEventsPassed = 0;
     rep.eventSummary.totalEventsFailed = 0;
-    for(auto& s: streamSchedules_) {
+    for (auto& s : streamSchedules_) {
       s->getTriggerReport(rep);
     }
     sort_all(rep.workerSummaries);
   }
 
-  void
-  Schedule::getTriggerTimingReport(TriggerTimingReport& rep) const {
+  void Schedule::getTriggerTimingReport(TriggerTimingReport& rep) const {
     rep.eventSummary.totalEvents = 0;
     rep.eventSummary.cpuTime = 0.;
     rep.eventSummary.realTime = 0.;
     summaryTimeKeeper_->fillTriggerTimingReport(rep);
   }
 
-  int
-  Schedule::totalEvents() const {
+  int Schedule::totalEvents() const {
     int returnValue = 0;
-    for(auto& s: streamSchedules_) {
+    for (auto& s : streamSchedules_) {
       returnValue += s->totalEvents();
     }
     return returnValue;
   }
 
-  int
-  Schedule::totalEventsPassed() const {
+  int Schedule::totalEventsPassed() const {
     int returnValue = 0;
-    for(auto& s: streamSchedules_) {
+    for (auto& s : streamSchedules_) {
       returnValue += s->totalEventsPassed();
     }
     return returnValue;
   }
 
-  int
-  Schedule::totalEventsFailed() const {
+  int Schedule::totalEventsFailed() const {
     int returnValue = 0;
-    for(auto& s: streamSchedules_) {
+    for (auto& s : streamSchedules_) {
       returnValue += s->totalEventsFailed();
     }
     return returnValue;
   }
 
-
-  void
-  Schedule::clearCounters() {
-    for(auto& s: streamSchedules_) {
+  void Schedule::clearCounters() {
+    for (auto& s : streamSchedules_) {
       s->clearCounters();
     }
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/ScheduleInfo.cc
+++ b/FWCore/Framework/src/ScheduleInfo.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     ScheduleInfo
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -33,19 +33,14 @@ using namespace edm;
 //
 // constructors and destructor
 //
-ScheduleInfo::ScheduleInfo(const Schedule* iSchedule):
-schedule_(iSchedule)
-{
-}
+ScheduleInfo::ScheduleInfo(const Schedule* iSchedule) : schedule_(iSchedule) {}
 
 // ScheduleInfo::ScheduleInfo(const ScheduleInfo& rhs)
 // {
 //    // do actual copying here;
 // }
 
-ScheduleInfo::~ScheduleInfo()
-{
-}
+ScheduleInfo::~ScheduleInfo() {}
 
 //
 // assignment operators
@@ -66,46 +61,34 @@ ScheduleInfo::~ScheduleInfo()
 //
 // const member functions
 //
-void 
-ScheduleInfo::availableModuleLabels(std::vector<std::string>& oLabelsToFill) const
-{
-   using std::placeholders::_1;
-   std::vector<ModuleDescription const*> desc = schedule_->getAllModuleDescriptions();
-   
-   oLabelsToFill.reserve(oLabelsToFill.size()+desc.size());
-   std::transform(desc.begin(),desc.end(),
-                  std::back_inserter(oLabelsToFill),
-                  std::bind(&ModuleDescription::moduleLabel,_1));
+void ScheduleInfo::availableModuleLabels(std::vector<std::string>& oLabelsToFill) const {
+  using std::placeholders::_1;
+  std::vector<ModuleDescription const*> desc = schedule_->getAllModuleDescriptions();
+
+  oLabelsToFill.reserve(oLabelsToFill.size() + desc.size());
+  std::transform(desc.begin(), desc.end(), std::back_inserter(oLabelsToFill),
+                 std::bind(&ModuleDescription::moduleLabel, _1));
 }
 
-const ParameterSet*
-ScheduleInfo::parametersForModule(const std::string& iLabel) const 
-{
-   using std::placeholders::_1;
-   std::vector<ModuleDescription const*> desc = schedule_->getAllModuleDescriptions();
-   
-   std::vector<ModuleDescription const*>::iterator itFound = std::find_if(desc.begin(),
-                                                                          desc.end(),
-                                                                          std::bind(std::equal_to<std::string>(),
-                                                                                      iLabel,
-                                                                                      std::bind(&ModuleDescription::moduleLabel,_1)));
-   if (itFound == desc.end()) {
-      return nullptr;
-   }
-   return pset::Registry::instance()->getMapped((*itFound)->parameterSetID());
+const ParameterSet* ScheduleInfo::parametersForModule(const std::string& iLabel) const {
+  using std::placeholders::_1;
+  std::vector<ModuleDescription const*> desc = schedule_->getAllModuleDescriptions();
+
+  std::vector<ModuleDescription const*>::iterator itFound =
+      std::find_if(desc.begin(), desc.end(),
+                   std::bind(std::equal_to<std::string>(), iLabel, std::bind(&ModuleDescription::moduleLabel, _1)));
+  if (itFound == desc.end()) {
+    return nullptr;
+  }
+  return pset::Registry::instance()->getMapped((*itFound)->parameterSetID());
 }
 
-void 
-ScheduleInfo::availablePaths(std::vector<std::string>& oLabelsToFill) const
-{
-   schedule_->availablePaths(oLabelsToFill);
+void ScheduleInfo::availablePaths(std::vector<std::string>& oLabelsToFill) const {
+  schedule_->availablePaths(oLabelsToFill);
 }
 
-void 
-ScheduleInfo::modulesInPath(const std::string& iPathLabel,
-                            std::vector<std::string>& oLabelsToFill) const
-{
-   schedule_->modulesInPath(iPathLabel, oLabelsToFill);
+void ScheduleInfo::modulesInPath(const std::string& iPathLabel, std::vector<std::string>& oLabelsToFill) const {
+  schedule_->modulesInPath(iPathLabel, oLabelsToFill);
 }
 
 //

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -23,26 +23,24 @@
 #include <set>
 
 namespace edm {
-  ScheduleItems::ScheduleItems() :
-      actReg_(std::make_shared<ActivityRegistry>()),
-      preg_(std::make_shared<SignallingProductRegistry>()),
-      branchIDListHelper_(std::make_shared<BranchIDListHelper>()),
-      thinnedAssociationsHelper_(std::make_shared<ThinnedAssociationsHelper>()),
-      subProcessParentageHelper_(),
-      act_table_(),
-      processConfiguration_() {
-  }
+  ScheduleItems::ScheduleItems()
+      : actReg_(std::make_shared<ActivityRegistry>()),
+        preg_(std::make_shared<SignallingProductRegistry>()),
+        branchIDListHelper_(std::make_shared<BranchIDListHelper>()),
+        thinnedAssociationsHelper_(std::make_shared<ThinnedAssociationsHelper>()),
+        subProcessParentageHelper_(),
+        act_table_(),
+        processConfiguration_() {}
 
-  ScheduleItems::ScheduleItems(ProductRegistry const& preg, SubProcess const& om) :
-      actReg_(std::make_shared<ActivityRegistry>()),
-      preg_(std::make_shared<SignallingProductRegistry>(preg)),
-      branchIDListHelper_(std::make_shared<BranchIDListHelper>()),
-      thinnedAssociationsHelper_(std::make_shared<ThinnedAssociationsHelper>()),
-      subProcessParentageHelper_(std::make_shared<SubProcessParentageHelper>()),
-      act_table_(),
-      processConfiguration_() {
-
-    for(auto& item : preg_->productListUpdator()) {
+  ScheduleItems::ScheduleItems(ProductRegistry const& preg, SubProcess const& om)
+      : actReg_(std::make_shared<ActivityRegistry>()),
+        preg_(std::make_shared<SignallingProductRegistry>(preg)),
+        branchIDListHelper_(std::make_shared<BranchIDListHelper>()),
+        thinnedAssociationsHelper_(std::make_shared<ThinnedAssociationsHelper>()),
+        subProcessParentageHelper_(std::make_shared<SubProcessParentageHelper>()),
+        act_table_(),
+        processConfiguration_() {
+    for (auto& item : preg_->productListUpdator()) {
       BranchDescription& prod = item.second;
       prod.setOnDemand(false);
       prod.setProduced(false);
@@ -51,41 +49,39 @@ namespace edm {
     // Mark dropped branches as dropped in the product registry.
     std::set<BranchID> keptBranches;
     SelectedProducts const& keptVectorR = om.keptProducts()[InRun];
-    for(auto const& item : keptVectorR) {
+    for (auto const& item : keptVectorR) {
       BranchDescription const& desc = *item.first;
       keptBranches.insert(desc.branchID());
     }
     SelectedProducts const& keptVectorL = om.keptProducts()[InLumi];
-    for(auto const& item : keptVectorL) {
+    for (auto const& item : keptVectorL) {
       BranchDescription const& desc = *item.first;
       keptBranches.insert(desc.branchID());
     }
     SelectedProducts const& keptVectorE = om.keptProducts()[InEvent];
-    for(auto const& item : keptVectorE) {
+    for (auto const& item : keptVectorE) {
       BranchDescription const& desc = *item.first;
       keptBranches.insert(desc.branchID());
     }
-    for(auto& item : preg_->productListUpdator()) {
+    for (auto& item : preg_->productListUpdator()) {
       BranchDescription& prod = item.second;
-      if(keptBranches.find(prod.branchID()) == keptBranches.end()) {
+      if (keptBranches.find(prod.branchID()) == keptBranches.end()) {
         prod.setDropped(true);
       }
     }
   }
 
-  ServiceToken
-  ScheduleItems::initServices(std::vector<ParameterSet>& pServiceSets,
-                             ParameterSet& parameterSet,
-                             ServiceToken const& iToken,
-                             serviceregistry::ServiceLegacy iLegacy,
-                             bool associate) {
-
+  ServiceToken ScheduleItems::initServices(std::vector<ParameterSet>& pServiceSets,
+                                           ParameterSet& parameterSet,
+                                           ServiceToken const& iToken,
+                                           serviceregistry::ServiceLegacy iLegacy,
+                                           bool associate) {
     //create the services
     ServiceToken token(ServiceRegistry::createSet(pServiceSets, iToken, iLegacy, associate));
 
     //see if any of the Services have to have their PSets stored
-    for(auto const& item : pServiceSets) {
-      if(item.exists("@save_config")) {
+    for (auto const& item : pServiceSets) {
+      if (item.exists("@save_config")) {
         parameterSet.addParameter(item.getParameter<std::string>("@service_type"), item);
       }
     }
@@ -95,15 +91,11 @@ namespace edm {
     return token;
   }
 
-  ServiceToken
-  ScheduleItems::addCPRandTNS(ParameterSet const& parameterSet, ServiceToken const& token) {
-
+  ServiceToken ScheduleItems::addCPRandTNS(ParameterSet const& parameterSet, ServiceToken const& token) {
     //add the ProductRegistry as a service ONLY for the construction phase
     typedef serviceregistry::ServiceWrapper<ConstProductRegistry> w_CPR;
     auto reg = std::make_shared<w_CPR>(std::make_unique<ConstProductRegistry>(*preg_));
-    ServiceToken tempToken(ServiceRegistry::createContaining(reg,
-                                                             token,
-                                                             serviceregistry::kOverlapIsError));
+    ServiceToken tempToken(ServiceRegistry::createContaining(reg, token, serviceregistry::kOverlapIsError));
 
     // the next thing is ugly: pull out the trigger path pset and
     // create a service and extra token for it
@@ -113,48 +105,32 @@ namespace edm {
 
     auto tnsptr = std::make_shared<w_TNS>(std::make_unique<TNS>(parameterSet));
 
-    return ServiceRegistry::createContaining(tnsptr,
-                                             tempToken,
-                                             serviceregistry::kOverlapIsError);
+    return ServiceRegistry::createContaining(tnsptr, tempToken, serviceregistry::kOverlapIsError);
   }
 
-  std::shared_ptr<CommonParams>
-  ScheduleItems::initMisc(ParameterSet& parameterSet) {
+  std::shared_ptr<CommonParams> ScheduleItems::initMisc(ParameterSet& parameterSet) {
     act_table_.reset(new ExceptionToActionTable(parameterSet));
     std::string processName = parameterSet.getParameter<std::string>("@process_name");
-    processConfiguration_ = std::make_shared<ProcessConfiguration>(processName, getReleaseVersion(), getPassID()); // propagate_const<T> has no reset() function
+    processConfiguration_ = std::make_shared<ProcessConfiguration>(
+        processName, getReleaseVersion(), getPassID());  // propagate_const<T> has no reset() function
     auto common = std::make_shared<CommonParams>(
-                                parameterSet.getUntrackedParameterSet(
-                                   "maxEvents").getUntrackedParameter<int>("input"),
-                                parameterSet.getUntrackedParameterSet(
-                                   "maxLuminosityBlocks").getUntrackedParameter<int>("input"),
-                                parameterSet.getUntrackedParameterSet(
-                                   "maxSecondsUntilRampdown").getUntrackedParameter<int>("input"));
+        parameterSet.getUntrackedParameterSet("maxEvents").getUntrackedParameter<int>("input"),
+        parameterSet.getUntrackedParameterSet("maxLuminosityBlocks").getUntrackedParameter<int>("input"),
+        parameterSet.getUntrackedParameterSet("maxSecondsUntilRampdown").getUntrackedParameter<int>("input"));
     return common;
   }
 
-  std::unique_ptr<Schedule>
-  ScheduleItems::initSchedule(ParameterSet& parameterSet,
-                              bool hasSubprocesses,
-                              PreallocationConfiguration const& config,
-                              ProcessContext const* processContext) {
+  std::unique_ptr<Schedule> ScheduleItems::initSchedule(ParameterSet& parameterSet,
+                                                        bool hasSubprocesses,
+                                                        PreallocationConfiguration const& config,
+                                                        ProcessContext const* processContext) {
     return std::make_unique<Schedule>(
-                     parameterSet,
-                     ServiceRegistry::instance().get<service::TriggerNamesService>(),
-                     *preg_,
-                     *branchIDListHelper_,
-                     *thinnedAssociationsHelper_,
-                     subProcessParentageHelper_ ? subProcessParentageHelper_.get() : nullptr,
-                     *act_table_,
-                     actReg_,
-                     processConfiguration(),
-                     hasSubprocesses,
-                     config,
-                     processContext);
+        parameterSet, ServiceRegistry::instance().get<service::TriggerNamesService>(), *preg_, *branchIDListHelper_,
+        *thinnedAssociationsHelper_, subProcessParentageHelper_ ? subProcessParentageHelper_.get() : nullptr,
+        *act_table_, actReg_, processConfiguration(), hasSubprocesses, config, processContext);
   }
 
-  void
-  ScheduleItems::clear() {
+  void ScheduleItems::clear() {
     // propagate_const<T> has no reset() function
     actReg_ = nullptr;
     preg_ = nullptr;
@@ -162,4 +138,4 @@ namespace edm {
     thinnedAssociationsHelper_ = nullptr;
     processConfiguration_ = nullptr;
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/SharedResourcesRegistry.h
+++ b/FWCore/Framework/src/SharedResourcesRegistry.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     SharedResourcesRegistry
-// 
+//
 /**\class SharedResourcesRegistry SharedResourcesRegistry.h "SharedResourcesRegistry.h"
 
  Description: Manages the Acquirers used to take temporary control of a resource shared between modules
@@ -35,51 +35,51 @@ class testSharedResourcesRegistry;
 
 namespace edm {
   class SharedResourcesAcquirer;
-  
-  class SharedResourcesRegistry
-  {
-    
+
+  class SharedResourcesRegistry {
   public:
     //needed for testing
     friend class ::testSharedResourcesRegistry;
-    
+
     // ---------- const member functions ---------------------
     SharedResourcesAcquirer createAcquirer(std::vector<std::string> const&) const;
-    
+
     std::pair<SharedResourcesAcquirer, std::shared_ptr<std::recursive_mutex>> createAcquirerForSourceDelayedReader();
-    
+
     // ---------- static member functions --------------------
     static SharedResourcesRegistry* instance();
-    
+
     ///All legacy modules share this resource
     static const std::string kLegacyModuleResourceName;
-    
+
     // ---------- member functions ---------------------------
     ///A resource name must be registered before it can be used in the createAcquirer call
     void registerSharedResource(const std::string&);
 
 #ifdef SHAREDRESOURCETESTACCESSORS
     // The next function is intended to be used only in a unit test
-    std::map<std::string, std::pair<std::shared_ptr<SerialTaskQueue>,unsigned int>> const& resourceMap() const { return resourceMap_; }
+    std::map<std::string, std::pair<std::shared_ptr<SerialTaskQueue>, unsigned int>> const& resourceMap() const {
+      return resourceMap_;
+    }
 #endif
 
   private:
     SharedResourcesRegistry();
-    ~SharedResourcesRegistry()=default;
+    ~SharedResourcesRegistry() = default;
 
-    SharedResourcesRegistry(const SharedResourcesRegistry&) = delete; // stop default
-    
-    const SharedResourcesRegistry& operator=(const SharedResourcesRegistry&) = delete; // stop default
-    
+    SharedResourcesRegistry(const SharedResourcesRegistry&) = delete;  // stop default
+
+    const SharedResourcesRegistry& operator=(const SharedResourcesRegistry&) = delete;  // stop default
+
     // ---------- member data --------------------------------
-    std::map<std::string, std::pair<std::shared_ptr<SerialTaskQueue>,unsigned int>> resourceMap_;
-    
+    std::map<std::string, std::pair<std::shared_ptr<SerialTaskQueue>, unsigned int>> resourceMap_;
+
     edm::propagate_const<std::shared_ptr<std::recursive_mutex>> resourceForDelayedReader_;
-    
+
     edm::propagate_const<std::shared_ptr<SerialTaskQueue>> queueForDelayedReader_;
 
     unsigned int nLegacy_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/SignallingProductRegistry.cc
+++ b/FWCore/Framework/src/SignallingProductRegistry.cc
@@ -21,40 +21,37 @@ using namespace edm;
 // member functions
 //
 namespace {
-   struct StackGuard {
-      StackGuard(std::string const& iTypeName, std::map<std::string, unsigned int>& ioStack, bool iFromListener) :
-          numType_(++ioStack[iTypeName]), itr_(ioStack.find(iTypeName)), fromListener_(iFromListener) {
-        if(iFromListener) {++(itr_->second);}
+  struct StackGuard {
+    StackGuard(std::string const& iTypeName, std::map<std::string, unsigned int>& ioStack, bool iFromListener)
+        : numType_(++ioStack[iTypeName]), itr_(ioStack.find(iTypeName)), fromListener_(iFromListener) {
+      if (iFromListener) {
+        ++(itr_->second);
       }
+    }
 
-      ~StackGuard() {
-         --(itr_->second);
-         if(fromListener_) {
-            --(itr_->second);
-         }
+    ~StackGuard() {
+      --(itr_->second);
+      if (fromListener_) {
+        --(itr_->second);
       }
+    }
 
-      unsigned int numType_;
-      std::map<std::string, unsigned int>::iterator itr_;
-      bool fromListener_;
-   };
-}
+    unsigned int numType_;
+    std::map<std::string, unsigned int>::iterator itr_;
+    bool fromListener_;
+  };
+}  // namespace
 
 void SignallingProductRegistry::addCalled(BranchDescription const& iProd, bool iFromListener) {
-   StackGuard guard(iProd.className(), typeAddedStack_, iFromListener);
-   if(guard.numType_ > 2) {
-     throw cms::Exception("CircularReference")
-       << "Attempted to register the production of "
-       << iProd.className()
-       << " from module "
-       << iProd.moduleLabel()
-       << " with product instance \""
-       << iProd.productInstanceName()
-       << "\"\n"
-       << "However, this was in reaction to a registration of a production for the same type \n"
-       << "from another module who was also listening to product registrations.\n"
-       << "This can lead to circular Event::get* calls.\n"
-       << "Please reconfigure job so it does not contain both of the modules.";
-   }
-   productAddedSignal_(iProd);
+  StackGuard guard(iProd.className(), typeAddedStack_, iFromListener);
+  if (guard.numType_ > 2) {
+    throw cms::Exception("CircularReference")
+        << "Attempted to register the production of " << iProd.className() << " from module " << iProd.moduleLabel()
+        << " with product instance \"" << iProd.productInstanceName() << "\"\n"
+        << "However, this was in reaction to a registration of a production for the same type \n"
+        << "from another module who was also listening to product registrations.\n"
+        << "This can lead to circular Event::get* calls.\n"
+        << "Please reconfigure job so it does not contain both of the modules.";
+  }
+  productAddedSignal_(iProd);
 }

--- a/FWCore/Framework/src/SignallingProductRegistry.h
+++ b/FWCore/Framework/src/SignallingProductRegistry.h
@@ -29,21 +29,21 @@
 
 // forward declarations
 namespace edm {
-   class SignallingProductRegistry : public ProductRegistry {
+  class SignallingProductRegistry : public ProductRegistry {
+  public:
+    SignallingProductRegistry() : ProductRegistry(), productAddedSignal_(), typeAddedStack_() {}
+    explicit SignallingProductRegistry(ProductRegistry const& preg)
+        : ProductRegistry(preg.productList(), false), productAddedSignal_(), typeAddedStack_() {}
+    signalslot::Signal<void(BranchDescription const&)> productAddedSignal_;
 
-   public:
-      SignallingProductRegistry() : ProductRegistry(), productAddedSignal_(), typeAddedStack_() {}
-      explicit SignallingProductRegistry(ProductRegistry const& preg) : ProductRegistry(preg.productList(), false), productAddedSignal_(), typeAddedStack_() {}
-      signalslot::Signal<void(BranchDescription const&)> productAddedSignal_;
+    SignallingProductRegistry(SignallingProductRegistry const&) = delete;             // Disallow copying and moving
+    SignallingProductRegistry& operator=(SignallingProductRegistry const&) = delete;  // Disallow copying and moving
 
-      SignallingProductRegistry(SignallingProductRegistry const&) = delete; // Disallow copying and moving
-      SignallingProductRegistry& operator=(SignallingProductRegistry const&) = delete; // Disallow copying and moving
-
-   private:
-      void addCalled(BranchDescription const&, bool) override;
-      // ---------- member data --------------------------------
-      std::map<std::string, unsigned int> typeAddedStack_;
-   };
-}
+  private:
+    void addCalled(BranchDescription const&, bool) override;
+    // ---------- member data --------------------------------
+    std::map<std::string, unsigned int> typeAddedStack_;
+  };
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/SourceFactory.cc
+++ b/FWCore/Framework/src/SourceFactory.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     SourceFactory
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -23,38 +23,35 @@
 // static member functions
 //
 namespace edm {
-   namespace eventsetup {
+  namespace eventsetup {
 
-      std::string SourceMakerTraits::name() { return "CMS EDM Framework ESSource"; }
+    std::string SourceMakerTraits::name() { return "CMS EDM Framework ESSource"; }
 
-      void 
-      SourceMakerTraits::replaceExisting(EventSetupProvider&, std::shared_ptr<EventSetupRecordIntervalFinder> ) {
-         throw edm::Exception(edm::errors::LogicError)
-            << "SourceMakerTraits::replaceExisting\n"
-            << "This function is not implemented and should never be called.\n"
-            << "Please report this to a Framework Developer\n";
-      }
+    void SourceMakerTraits::replaceExisting(EventSetupProvider&, std::shared_ptr<EventSetupRecordIntervalFinder>) {
+      throw edm::Exception(edm::errors::LogicError) << "SourceMakerTraits::replaceExisting\n"
+                                                    << "This function is not implemented and should never be called.\n"
+                                                    << "Please report this to a Framework Developer\n";
+    }
 
-      std::shared_ptr<SourceMakerTraits::base_type>
-      SourceMakerTraits::getComponentAndRegisterProcess(EventSetupsController& esController,
-                                                        ParameterSet const& iConfiguration) {
-         return esController.getESSourceAndRegisterProcess(iConfiguration, esController.indexOfNextProcess());
-      }
+    std::shared_ptr<SourceMakerTraits::base_type> SourceMakerTraits::getComponentAndRegisterProcess(
+        EventSetupsController& esController, ParameterSet const& iConfiguration) {
+      return esController.getESSourceAndRegisterProcess(iConfiguration, esController.indexOfNextProcess());
+    }
 
-      void SourceMakerTraits::putComponent(EventSetupsController& esController,
-                                           ParameterSet const& iConfiguration,
-                                           std::shared_ptr<base_type> const& component) {
-         esController.putESSource(iConfiguration, component, esController.indexOfNextProcess());
-      }
+    void SourceMakerTraits::putComponent(EventSetupsController& esController,
+                                         ParameterSet const& iConfiguration,
+                                         std::shared_ptr<base_type> const& component) {
+      esController.putESSource(iConfiguration, component, esController.indexOfNextProcess());
+    }
 
-      void SourceMakerTraits::logInfoWhenSharing(ParameterSet const& iConfiguration) {
-
-         std::string edmtype = iConfiguration.getParameter<std::string>("@module_edm_type");
-         std::string modtype = iConfiguration.getParameter<std::string>("@module_type");
-         std::string label = iConfiguration.getParameter<std::string>("@module_label");
-         edm::LogVerbatim("EventSetupSharing") << "Sharing " << edmtype << ": class=" << modtype << " label='" << label << "'";
-      }
-   }
-}
+    void SourceMakerTraits::logInfoWhenSharing(ParameterSet const& iConfiguration) {
+      std::string edmtype = iConfiguration.getParameter<std::string>("@module_edm_type");
+      std::string modtype = iConfiguration.getParameter<std::string>("@module_type");
+      std::string label = iConfiguration.getParameter<std::string>("@module_label");
+      edm::LogVerbatim("EventSetupSharing")
+          << "Sharing " << edmtype << ": class=" << modtype << " label='" << label << "'";
+    }
+  }  // namespace eventsetup
+}  // namespace edm
 
 COMPONENTFACTORY_GET(edm::eventsetup::SourceMakerTraits);

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -45,10 +45,9 @@ namespace edm {
     // should take a const_reference to the 'input', and write to a
     // reference to the 'output'.
     template <typename InputIterator, typename ForwardIterator, typename Func>
-    void
-    transform_into(InputIterator begin, InputIterator end,
-                   ForwardIterator out, Func func) {
-      for (; begin != end; ++begin, ++out) func(*begin, *out);
+    void transform_into(InputIterator begin, InputIterator end, ForwardIterator out, Func func) {
+      for (; begin != end; ++begin, ++out)
+        func(*begin, *out);
     }
 
     // Function template that takes a sequence 'from', a sequence
@@ -56,10 +55,8 @@ namespace edm {
     // transform_into to fill the 'to' sequence with the values
     // calcuated by the callable object, taking care to fill the
     // outupt only if all calls succeed.
-    template <typename FROM, typename TO, typename FUNC>
-    void
-    fill_summary(FROM const& from, TO& to, FUNC func) {
-      if(to.size()!=from.size()) {
+    template <typename FROM, typename TO, typename FUNC> void fill_summary(FROM const& from, TO& to, FUNC func) {
+      if (to.size() != from.size()) {
         TO temp(from.size());
         transform_into(from.begin(), from.end(), temp.begin(), func);
         to.swap(temp);
@@ -73,60 +70,56 @@ namespace edm {
     // Here we make the trigger results inserter directly.  This should
     // probably be a utility in the WorkerRegistry or elsewhere.
 
-    StreamSchedule::WorkerPtr
-    makeInserter(ExceptionToActionTable const& actions,
-                 std::shared_ptr<ActivityRegistry> areg,
-                 std::shared_ptr<TriggerResultInserter> inserter) {
-      StreamSchedule::WorkerPtr ptr(new edm::WorkerT<TriggerResultInserter::ModuleType>(inserter, inserter->moduleDescription(), &actions));
+    StreamSchedule::WorkerPtr makeInserter(ExceptionToActionTable const& actions,
+                                           std::shared_ptr<ActivityRegistry> areg,
+                                           std::shared_ptr<TriggerResultInserter> inserter) {
+      StreamSchedule::WorkerPtr ptr(
+          new edm::WorkerT<TriggerResultInserter::ModuleType>(inserter, inserter->moduleDescription(), &actions));
       ptr->setActivityRegistry(areg);
       return ptr;
     }
 
-    void
-    initializeBranchToReadingWorker(ParameterSet const& opts,
-                                    ProductRegistry const& preg,
-                                    std::multimap<std::string,Worker*>& branchToReadingWorker)
-    {
+    void initializeBranchToReadingWorker(ParameterSet const& opts,
+                                         ProductRegistry const& preg,
+                                         std::multimap<std::string, Worker*>& branchToReadingWorker) {
       // See if any data has been marked to be deleted early (removing any duplicates)
       auto vBranchesToDeleteEarly = opts.getUntrackedParameter<std::vector<std::string>>("canDeleteEarly");
-      if(not vBranchesToDeleteEarly.empty()) {
-        std::sort(vBranchesToDeleteEarly.begin(),vBranchesToDeleteEarly.end(),std::less<std::string>());
-        vBranchesToDeleteEarly.erase(std::unique(vBranchesToDeleteEarly.begin(),vBranchesToDeleteEarly.end()),
+      if (not vBranchesToDeleteEarly.empty()) {
+        std::sort(vBranchesToDeleteEarly.begin(), vBranchesToDeleteEarly.end(), std::less<std::string>());
+        vBranchesToDeleteEarly.erase(std::unique(vBranchesToDeleteEarly.begin(), vBranchesToDeleteEarly.end()),
                                      vBranchesToDeleteEarly.end());
-        
+
         // Are the requested items in the product registry?
         auto allBranchNames = preg.allBranchNames();
         //the branch names all end with a period, which we do not want to compare with
-        for(auto & b:allBranchNames) {
-          b.resize(b.size()-1);
+        for (auto& b : allBranchNames) {
+          b.resize(b.size() - 1);
         }
-        std::sort(allBranchNames.begin(),allBranchNames.end(),std::less<std::string>());
+        std::sort(allBranchNames.begin(), allBranchNames.end(), std::less<std::string>());
         std::vector<std::string> temp;
-        temp.reserve(vBranchesToDeleteEarly.size());  
-        
-        std::set_intersection(vBranchesToDeleteEarly.begin(),vBranchesToDeleteEarly.end(),
-                              allBranchNames.begin(),allBranchNames.end(),
-                              std::back_inserter(temp));
+        temp.reserve(vBranchesToDeleteEarly.size());
+
+        std::set_intersection(vBranchesToDeleteEarly.begin(), vBranchesToDeleteEarly.end(), allBranchNames.begin(),
+                              allBranchNames.end(), std::back_inserter(temp));
         vBranchesToDeleteEarly.swap(temp);
-        if(temp.size() != vBranchesToDeleteEarly.size()) {
+        if (temp.size() != vBranchesToDeleteEarly.size()) {
           std::vector<std::string> missingProducts;
-          std::set_difference(temp.begin(),temp.end(),
-                              vBranchesToDeleteEarly.begin(),vBranchesToDeleteEarly.end(),
+          std::set_difference(temp.begin(), temp.end(), vBranchesToDeleteEarly.begin(), vBranchesToDeleteEarly.end(),
                               std::back_inserter(missingProducts));
           LogInfo l("MissingProductsForCanDeleteEarly");
-          l<<"The following products in the 'canDeleteEarly' list are not available in this job and will be ignored.";
-          for(auto const& n:missingProducts){
-            l<<"\n "<<n;
+          l << "The following products in the 'canDeleteEarly' list are not available in this job and will be ignored.";
+          for (auto const& n : missingProducts) {
+            l << "\n " << n;
           }
         }
         //set placeholder for the branch, we will remove the nullptr if a
         // module actually wants the branch.
-        for(auto const& branch:vBranchesToDeleteEarly) {
+        for (auto const& branch : vBranchesToDeleteEarly) {
           branchToReadingWorker.insert(std::make_pair(branch, static_cast<Worker*>(nullptr)));
         }
       }
     }
-  }
+  }  // namespace
 
   // -----------------------------
 
@@ -134,35 +127,35 @@ namespace edm {
 
   // -----------------------------
 
-  StreamSchedule::StreamSchedule(std::shared_ptr<TriggerResultInserter> inserter,
-                                 std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
-                                 std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
-                                 std::shared_ptr<ModuleRegistry> modReg,
-                                 ParameterSet& proc_pset,
-                                 service::TriggerNamesService const& tns,
-                                 PreallocationConfiguration const& prealloc,
-                                 ProductRegistry& preg,
-                                 BranchIDListHelper& branchIDListHelper,
-                                 ExceptionToActionTable const& actions,
-                                 std::shared_ptr<ActivityRegistry> areg,
-                                 std::shared_ptr<ProcessConfiguration> processConfiguration,
-                                 bool allowEarlyDelete,
-                                 StreamID streamID,
-                                 ProcessContext const* processContext) :
-    workerManager_(modReg,areg, actions),
-    actReg_(areg),
-    results_(new HLTGlobalStatus(tns.getTrigPaths().size())),
-    results_inserter_(),
-    trig_paths_(),
-    end_paths_(),
-    total_events_(),
-    total_passed_(),
-    number_of_unscheduled_modules_(0),
-    streamID_(streamID),
-    streamContext_(streamID_, processContext),
-    endpathsAreActive_(true),
-    skippingEvent_(false){
-
+  StreamSchedule::StreamSchedule(
+      std::shared_ptr<TriggerResultInserter> inserter,
+      std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
+      std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
+      std::shared_ptr<ModuleRegistry> modReg,
+      ParameterSet& proc_pset,
+      service::TriggerNamesService const& tns,
+      PreallocationConfiguration const& prealloc,
+      ProductRegistry& preg,
+      BranchIDListHelper& branchIDListHelper,
+      ExceptionToActionTable const& actions,
+      std::shared_ptr<ActivityRegistry> areg,
+      std::shared_ptr<ProcessConfiguration> processConfiguration,
+      bool allowEarlyDelete,
+      StreamID streamID,
+      ProcessContext const* processContext)
+      : workerManager_(modReg, areg, actions),
+        actReg_(areg),
+        results_(new HLTGlobalStatus(tns.getTrigPaths().size())),
+        results_inserter_(),
+        trig_paths_(),
+        end_paths_(),
+        total_events_(),
+        total_passed_(),
+        number_of_unscheduled_modules_(0),
+        streamID_(streamID),
+        streamContext_(streamID_, processContext),
+        endpathsAreActive_(true),
+        skippingEvent_(false) {
     ParameterSet const& opts = proc_pset.getUntrackedParameterSet("options", ParameterSet());
     bool hasPath = false;
     std::vector<std::string> const& pathNames = tns.getTrigPaths();
@@ -199,14 +192,13 @@ namespace edm {
     for (auto const& worker : allWorkers()) {
       usedWorkerLabels.insert(worker->description().moduleLabel());
     }
-    std::vector<std::string> modulesInConfig(proc_pset.getParameter<std::vector<std::string> >("@all_modules"));
+    std::vector<std::string> modulesInConfig(proc_pset.getParameter<std::vector<std::string>>("@all_modules"));
     std::set<std::string> modulesInConfigSet(modulesInConfig.begin(), modulesInConfig.end());
     std::vector<std::string> unusedLabels;
-    set_difference(modulesInConfigSet.begin(), modulesInConfigSet.end(),
-                   usedWorkerLabels.begin(), usedWorkerLabels.end(),
-                   back_inserter(unusedLabels));
+    set_difference(modulesInConfigSet.begin(), modulesInConfigSet.end(), usedWorkerLabels.begin(),
+                   usedWorkerLabels.end(), back_inserter(unusedLabels));
     std::set<std::string> unscheduledLabels;
-    std::vector<std::string>  shouldBeUsedLabels;
+    std::vector<std::string> shouldBeUsedLabels;
     if (!unusedLabels.empty()) {
       //Need to
       // 1) create worker
@@ -217,97 +209,94 @@ namespace edm {
         ParameterSet* modulePSet(proc_pset.getPSetForUpdate(label, isTracked));
         assert(isTracked);
         assert(modulePSet != nullptr);
-        workerManager_.addToUnscheduledWorkers(*modulePSet, preg, &prealloc, processConfiguration, label, unscheduledLabels, shouldBeUsedLabels);
+        workerManager_.addToUnscheduledWorkers(*modulePSet, preg, &prealloc, processConfiguration, label,
+                                               unscheduledLabels, shouldBeUsedLabels);
       }
       if (!shouldBeUsedLabels.empty()) {
         std::ostringstream unusedStream;
         unusedStream << "'" << shouldBeUsedLabels.front() << "'";
         for (std::vector<std::string>::iterator itLabel = shouldBeUsedLabels.begin() + 1,
-              itLabelEnd = shouldBeUsedLabels.end();
-            itLabel != itLabelEnd;
-            ++itLabel) {
+                                                itLabelEnd = shouldBeUsedLabels.end();
+             itLabel != itLabelEnd; ++itLabel) {
           unusedStream << ",'" << *itLabel << "'";
         }
-        LogInfo("path")
-          << "The following module labels are not assigned to any path:\n"
-          << unusedStream.str()
-          << "\n";
+        LogInfo("path") << "The following module labels are not assigned to any path:\n" << unusedStream.str() << "\n";
       }
     }
     if (!unscheduledLabels.empty()) {
-      number_of_unscheduled_modules_=unscheduledLabels.size();
+      number_of_unscheduled_modules_ = unscheduledLabels.size();
       workerManager_.setOnDemandProducts(preg, unscheduledLabels);
     }
 
+    initializeEarlyDelete(*modReg, opts, preg, allowEarlyDelete);
 
-    initializeEarlyDelete(*modReg, opts,preg,allowEarlyDelete);
-    
-  } // StreamSchedule::StreamSchedule
+  }  // StreamSchedule::StreamSchedule
 
-  
-  void StreamSchedule::initializeEarlyDelete(ModuleRegistry & modReg,
-                                             edm::ParameterSet const& opts, edm::ProductRegistry const& preg,
-                                       bool allowEarlyDelete) {
+  void StreamSchedule::initializeEarlyDelete(ModuleRegistry& modReg,
+                                             edm::ParameterSet const& opts,
+                                             edm::ProductRegistry const& preg,
+                                             bool allowEarlyDelete) {
     //for now, if have a subProcess, don't allow early delete
     // In the future we should use the SubProcess's 'keep list' to decide what can be kept
-    if(not allowEarlyDelete)  return;
+    if (not allowEarlyDelete)
+      return;
 
     //see if 'canDeleteEarly' was set and if so setup the list with those products actually
     // registered for this job
-    std::multimap<std::string,Worker*> branchToReadingWorker;
-    initializeBranchToReadingWorker(opts,preg,branchToReadingWorker);
-    
+    std::multimap<std::string, Worker*> branchToReadingWorker;
+    initializeBranchToReadingWorker(opts, preg, branchToReadingWorker);
+
     //If no delete early items have been specified we don't have to do anything
-    if(branchToReadingWorker.empty()) {
+    if (branchToReadingWorker.empty()) {
       return;
     }
     const std::vector<std::string> kEmpty;
-    std::map<Worker*,unsigned int> reserveSizeForWorker;
-    unsigned int upperLimitOnReadingWorker =0;
+    std::map<Worker*, unsigned int> reserveSizeForWorker;
+    unsigned int upperLimitOnReadingWorker = 0;
     unsigned int upperLimitOnIndicies = 0;
-    unsigned int nUniqueBranchesToDelete=branchToReadingWorker.size();
-    
+    unsigned int nUniqueBranchesToDelete = branchToReadingWorker.size();
+
     //talk with output modules first
-    modReg.forAllModuleHolders([&branchToReadingWorker,&nUniqueBranchesToDelete](maker::ModuleHolder* iHolder){
+    modReg.forAllModuleHolders([&branchToReadingWorker, &nUniqueBranchesToDelete](maker::ModuleHolder* iHolder) {
       auto comm = iHolder->createOutputModuleCommunicator();
       if (comm) {
-        if(!branchToReadingWorker.empty()) {
+        if (!branchToReadingWorker.empty()) {
           //If an OutputModule needs a product, we can't delete it early
           // so we should remove it from our list
           SelectedProductsForBranchType const& kept = comm->keptProducts();
-          for(auto const& item: kept[InEvent]) {
+          for (auto const& item : kept[InEvent]) {
             BranchDescription const& desc = *item.first;
             auto found = branchToReadingWorker.equal_range(desc.branchName());
-            if(found.first !=found.second) {
+            if (found.first != found.second) {
               --nUniqueBranchesToDelete;
-              branchToReadingWorker.erase(found.first,found.second);
+              branchToReadingWorker.erase(found.first, found.second);
             }
           }
         }
       }
     });
-    
-    if(branchToReadingWorker.empty()) {
+
+    if (branchToReadingWorker.empty()) {
       return;
     }
-    
-    for (auto w :allWorkers()) {
+
+    for (auto w : allWorkers()) {
       //determine if this module could read a branch we want to delete early
       auto pset = pset::Registry::instance()->getMapped(w->description().parameterSetID());
-      if(nullptr!=pset) {
-        auto branches = pset->getUntrackedParameter<std::vector<std::string>>("mightGet",kEmpty);
-        if(not branches.empty()) {
+      if (nullptr != pset) {
+        auto branches = pset->getUntrackedParameter<std::vector<std::string>>("mightGet", kEmpty);
+        if (not branches.empty()) {
           ++upperLimitOnReadingWorker;
         }
-        for(auto const& branch:branches){
+        for (auto const& branch : branches) {
           auto found = branchToReadingWorker.equal_range(branch);
-          if(found.first != found.second) {
+          if (found.first != found.second) {
             ++upperLimitOnIndicies;
             ++reserveSizeForWorker[w];
-            if(nullptr == found.first->second) {
+            if (nullptr == found.first->second) {
               found.first->second = w;
             } else {
-              branchToReadingWorker.insert(make_pair(found.first->first,w));
+              branchToReadingWorker.insert(make_pair(found.first->first, w));
             }
           }
         }
@@ -316,8 +305,8 @@ namespace edm {
     {
       auto it = branchToReadingWorker.begin();
       std::vector<std::string> unusedBranches;
-      while(it !=branchToReadingWorker.end()) {
-        if(it->second == nullptr) {
+      while (it != branchToReadingWorker.end()) {
+        if (it->second == nullptr) {
           unusedBranches.push_back(it->first);
           //erasing the object invalidates the iterator so must advance it first
           auto temp = it;
@@ -327,74 +316,72 @@ namespace edm {
           ++it;
         }
       }
-      if(not unusedBranches.empty()) {
+      if (not unusedBranches.empty()) {
         LogWarning l("UnusedProductsForCanDeleteEarly");
-        l<<"The following products in the 'canDeleteEarly' list are not used in this job and will be ignored.\n"
-        " If possible, remove the producer from the job or add the product to the producer's own 'mightGet' list.";
-        for(auto const& n:unusedBranches){
-          l<<"\n "<<n;
+        l << "The following products in the 'canDeleteEarly' list are not used in this job and will be ignored.\n"
+             " If possible, remove the producer from the job or add the product to the producer's own 'mightGet' list.";
+        for (auto const& n : unusedBranches) {
+          l << "\n " << n;
         }
       }
-    }  
-    if(!branchToReadingWorker.empty()) {
+    }
+    if (!branchToReadingWorker.empty()) {
       earlyDeleteHelpers_.reserve(upperLimitOnReadingWorker);
-      earlyDeleteHelperToBranchIndicies_.resize(upperLimitOnIndicies,0);
+      earlyDeleteHelperToBranchIndicies_.resize(upperLimitOnIndicies, 0);
       earlyDeleteBranchToCount_.reserve(nUniqueBranchesToDelete);
-      std::map<const Worker*,EarlyDeleteHelper*> alreadySeenWorkers;
+      std::map<const Worker*, EarlyDeleteHelper*> alreadySeenWorkers;
       std::string lastBranchName;
       size_t nextOpenIndex = 0;
       unsigned int* beginAddress = &(earlyDeleteHelperToBranchIndicies_.front());
-      for(auto& branchAndWorker:branchToReadingWorker) {
-        if(lastBranchName != branchAndWorker.first) {
+      for (auto& branchAndWorker : branchToReadingWorker) {
+        if (lastBranchName != branchAndWorker.first) {
           //have to put back the period we removed earlier in order to get the proper name
-          BranchID bid(branchAndWorker.first+".");
-          earlyDeleteBranchToCount_.emplace_back(bid,0U);
+          BranchID bid(branchAndWorker.first + ".");
+          earlyDeleteBranchToCount_.emplace_back(bid, 0U);
           lastBranchName = branchAndWorker.first;
         }
         auto found = alreadySeenWorkers.find(branchAndWorker.second);
-        if(alreadySeenWorkers.end() == found) {
+        if (alreadySeenWorkers.end() == found) {
           //NOTE: we will set aside enough space in earlyDeleteHelperToBranchIndicies_ to accommodate
           // all the branches that might be read by this worker. However, initially we will only tell the
           // EarlyDeleteHelper about the first one. As additional branches are added via 'appendIndex' the
           // EarlyDeleteHelper will automatically advance its internal end pointer.
           size_t index = nextOpenIndex;
           size_t nIndices = reserveSizeForWorker[branchAndWorker.second];
-          earlyDeleteHelperToBranchIndicies_[index]=earlyDeleteBranchToCount_.size()-1;
-          earlyDeleteHelpers_.emplace_back(beginAddress+index,
-                                           beginAddress+index+1,
-                                           &earlyDeleteBranchToCount_);
+          earlyDeleteHelperToBranchIndicies_[index] = earlyDeleteBranchToCount_.size() - 1;
+          earlyDeleteHelpers_.emplace_back(beginAddress + index, beginAddress + index + 1, &earlyDeleteBranchToCount_);
           branchAndWorker.second->setEarlyDeleteHelper(&(earlyDeleteHelpers_.back()));
-          alreadySeenWorkers.insert(std::make_pair(branchAndWorker.second,&(earlyDeleteHelpers_.back())));
-          nextOpenIndex +=nIndices;
+          alreadySeenWorkers.insert(std::make_pair(branchAndWorker.second, &(earlyDeleteHelpers_.back())));
+          nextOpenIndex += nIndices;
         } else {
-          found->second->appendIndex(earlyDeleteBranchToCount_.size()-1);
+          found->second->appendIndex(earlyDeleteBranchToCount_.size() - 1);
         }
       }
-      
+
       //Now we can compactify the earlyDeleteHelperToBranchIndicies_ since we may have over estimated the
       // space needed for each module
       auto itLast = earlyDeleteHelpers_.begin();
-      for(auto it = earlyDeleteHelpers_.begin()+1;it != earlyDeleteHelpers_.end();++it) {
-        if(itLast->end() != it->begin()) {
+      for (auto it = earlyDeleteHelpers_.begin() + 1; it != earlyDeleteHelpers_.end(); ++it) {
+        if (itLast->end() != it->begin()) {
           //figure the offset for next Worker since it hasn't been moved yet so it has the original address
-          unsigned int delta = it->begin()- itLast->end();
+          unsigned int delta = it->begin() - itLast->end();
           it->shiftIndexPointers(delta);
-          
-          earlyDeleteHelperToBranchIndicies_.erase(earlyDeleteHelperToBranchIndicies_.begin()+
-                                                   (itLast->end()-beginAddress),
-                                                   earlyDeleteHelperToBranchIndicies_.begin()+
-                                                   (it->begin()-beginAddress));
+
+          earlyDeleteHelperToBranchIndicies_.erase(
+              earlyDeleteHelperToBranchIndicies_.begin() + (itLast->end() - beginAddress),
+              earlyDeleteHelperToBranchIndicies_.begin() + (it->begin() - beginAddress));
         }
         itLast = it;
       }
-      earlyDeleteHelperToBranchIndicies_.erase(earlyDeleteHelperToBranchIndicies_.begin()+(itLast->end()-beginAddress),
-                                               earlyDeleteHelperToBranchIndicies_.end());
-      
+      earlyDeleteHelperToBranchIndicies_.erase(
+          earlyDeleteHelperToBranchIndicies_.begin() + (itLast->end() - beginAddress),
+          earlyDeleteHelperToBranchIndicies_.end());
+
       //now tell the paths about the deleters
-      for(auto& p : trig_paths_) {
+      for (auto& p : trig_paths_) {
         p.setEarlyDeleteHelpers(alreadySeenWorkers);
       }
-      for(auto& p : end_paths_) {
+      for (auto& p : end_paths_) {
         p.setEarlyDeleteHelpers(alreadySeenWorkers);
       }
       resetEarlyDelete();
@@ -414,13 +401,15 @@ namespace edm {
 
     unsigned int placeInPath = 0;
     for (auto const& name : modnames) {
-
       WorkerInPath::FilterAction filterAction = WorkerInPath::Normal;
-      if (name[0] == '!')       filterAction = WorkerInPath::Veto;
-      else if (name[0] == '-')  filterAction = WorkerInPath::Ignore;
+      if (name[0] == '!')
+        filterAction = WorkerInPath::Veto;
+      else if (name[0] == '-')
+        filterAction = WorkerInPath::Ignore;
 
       std::string moduleLabel = name;
-      if (filterAction != WorkerInPath::Normal) moduleLabel.erase(0, 1);
+      if (filterAction != WorkerInPath::Normal)
+        moduleLabel.erase(0, 1);
 
       bool isTracked;
       ParameterSet* modpset = proc_pset.getPSetForUpdate(moduleLabel, isTracked);
@@ -429,26 +418,26 @@ namespace edm {
         if (!search_all(endPathNames, pathName)) {
           pathType = std::string("path");
         }
-        throw Exception(errors::Configuration) <<
-          "The unknown module label \"" << moduleLabel <<
-          "\" appears in " << pathType << " \"" << pathName <<
-          "\"\n please check spelling or remove that label from the path.";
+        throw Exception(errors::Configuration)
+            << "The unknown module label \"" << moduleLabel << "\" appears in " << pathType << " \"" << pathName
+            << "\"\n please check spelling or remove that label from the path.";
       }
       assert(isTracked);
 
       Worker* worker = workerManager_.getWorker(*modpset, preg, prealloc, processConfiguration, moduleLabel);
-      if (ignoreFilters && filterAction != WorkerInPath::Ignore && worker->moduleType()==Worker::kFilter) {
+      if (ignoreFilters && filterAction != WorkerInPath::Ignore && worker->moduleType() == Worker::kFilter) {
         // We have a filter on an end path, and the filter is not explicitly ignored.
         // See if the filter is allowed.
         std::vector<std::string> allowed_filters = proc_pset.getUntrackedParameter<vstring>("@filters_on_endpaths");
         if (!search_all(allowed_filters, worker->description().moduleName())) {
           // Filter is not allowed. Ignore the result, and issue a warning.
           filterAction = WorkerInPath::Ignore;
-          LogWarning("FilterOnEndPath")
-            << "The EDFilter '" << worker->description().moduleName() << "' with module label '" << moduleLabel << "' appears on EndPath '" << pathName << "'.\n"
-            << "The return value of the filter will be ignored.\n"
-            << "To suppress this warning, either remove the filter from the endpath,\n"
-            << "or explicitly ignore it in the configuration by using cms.ignore().\n";
+          LogWarning("FilterOnEndPath") << "The EDFilter '" << worker->description().moduleName()
+                                        << "' with module label '" << moduleLabel << "' appears on EndPath '"
+                                        << pathName << "'.\n"
+                                        << "The return value of the filter will be ignored.\n"
+                                        << "To suppress this warning, either remove the filter from the endpath,\n"
+                                        << "or explicitly ignore it in the configuration by using cms.ignore().\n";
         }
       }
       tmpworkers.emplace_back(worker, filterAction, placeInPath);
@@ -462,14 +451,17 @@ namespace edm {
                                     ProductRegistry& preg,
                                     PreallocationConfiguration const* prealloc,
                                     std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                                    int bitpos, std::string const& name, TrigResPtr trptr,
+                                    int bitpos,
+                                    std::string const& name,
+                                    TrigResPtr trptr,
                                     std::vector<std::string> const& endPathNames) {
     PathWorkers tmpworkers;
     fillWorkers(proc_pset, preg, prealloc, processConfiguration, name, false, tmpworkers, endPathNames);
 
     // an empty path will cause an extra bit that is not used
     if (!tmpworkers.empty()) {
-      trig_paths_.emplace_back(bitpos, name, tmpworkers, trptr, actionTable(), actReg_, &streamContext_, &skippingEvent_, PathContext::PathType::kPath);
+      trig_paths_.emplace_back(bitpos, name, tmpworkers, trptr, actionTable(), actReg_, &streamContext_,
+                               &skippingEvent_, PathContext::PathType::kPath);
     } else {
       empty_trig_paths_.push_back(bitpos);
     }
@@ -482,14 +474,16 @@ namespace edm {
                                    ProductRegistry& preg,
                                    PreallocationConfiguration const* prealloc,
                                    std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                                   int bitpos, std::string const& name,
+                                   int bitpos,
+                                   std::string const& name,
                                    std::vector<std::string> const& endPathNames) {
     PathWorkers tmpworkers;
     fillWorkers(proc_pset, preg, prealloc, processConfiguration, name, true, tmpworkers, endPathNames);
 
     if (!tmpworkers.empty()) {
       //EndPaths are not supposed to stop if SkipEvent type exception happens
-      end_paths_.emplace_back(bitpos, name, tmpworkers, TrigResPtr(), actionTable(), actReg_, &streamContext_, nullptr, PathContext::PathType::kEndPath);
+      end_paths_.emplace_back(bitpos, name, tmpworkers, TrigResPtr(), actionTable(), actReg_, &streamContext_, nullptr,
+                              PathContext::PathType::kEndPath);
     } else {
       empty_end_paths_.push_back(bitpos);
     }
@@ -498,16 +492,11 @@ namespace edm {
     }
   }
 
-  void StreamSchedule::beginStream() {
-    workerManager_.beginStream(streamID_, streamContext_);
-  }
-  
-  void StreamSchedule::endStream() {
-    workerManager_.endStream(streamID_, streamContext_);
-  }
+  void StreamSchedule::beginStream() { workerManager_.beginStream(streamID_, streamContext_); }
 
-  void StreamSchedule::replaceModule(maker::ModuleHolder* iMod,
-                                    std::string const& iLabel) {
+  void StreamSchedule::endStream() { workerManager_.endStream(streamID_, streamContext_); }
+
+  void StreamSchedule::replaceModule(maker::ModuleHolder* iMod, std::string const& iLabel) {
     Worker* found = nullptr;
     for (auto const& worker : allWorkers()) {
       if (worker->description().moduleLabel() == iLabel) {
@@ -520,11 +509,10 @@ namespace edm {
     }
 
     iMod->replaceModuleFor(found);
-    found->beginStream(streamID_,streamContext_);
+    found->beginStream(streamID_, streamContext_);
   }
 
-  std::vector<ModuleDescription const*>
-  StreamSchedule::getAllModuleDescriptions() const {
+  std::vector<ModuleDescription const*> StreamSchedule::getAllModuleDescriptions() const {
     std::vector<ModuleDescription const*> result;
     result.reserve(allWorkers().size());
 
@@ -534,17 +522,18 @@ namespace edm {
     }
     return result;
   }
-  
-  void StreamSchedule::processOneEventAsync(WaitingTaskHolder iTask,
-                                            EventPrincipal& ep,
-                                            EventSetupImpl const& es,
-                                            ServiceToken const& serviceToken,
-                                            std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters) {
+
+  void StreamSchedule::processOneEventAsync(
+      WaitingTaskHolder iTask,
+      EventPrincipal& ep,
+      EventSetupImpl const& es,
+      ServiceToken const& serviceToken,
+      std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters) {
     try {
       this->resetAll();
 
       using Traits = OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>;
-      
+
       Traits::setStreamContext(streamContext_, ep);
       //a service may want to communicate with another service
       ServiceRegistry::Operate guard(serviceToken);
@@ -554,119 +543,114 @@ namespace edm {
       for (int empty_trig_path : empty_trig_paths_) {
         results_->at(empty_trig_path) = hltPathStatus;
         pathStatusInserters[empty_trig_path]->setPathStatus(streamID_, hltPathStatus);
-        std::exception_ptr except = pathStatusInserterWorkers_[empty_trig_path]->runModuleDirectly<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
-            ep, es, streamID_, ParentContext(&streamContext_), &streamContext_
-        );
+        std::exception_ptr except = pathStatusInserterWorkers_[empty_trig_path]
+                                        ->runModuleDirectly<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
+                                            ep, es, streamID_, ParentContext(&streamContext_), &streamContext_);
         if (except) {
           iTask.doneWaiting(except);
           return;
         }
       }
       for (int empty_end_path : empty_end_paths_) {
-        std::exception_ptr except = endPathStatusInserterWorkers_[empty_end_path]->runModuleDirectly<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
-            ep, es, streamID_, ParentContext(&streamContext_), &streamContext_
-        );
+        std::exception_ptr except = endPathStatusInserterWorkers_[empty_end_path]
+                                        ->runModuleDirectly<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
+                                            ep, es, streamID_, ParentContext(&streamContext_), &streamContext_);
         if (except) {
           iTask.doneWaiting(except);
           return;
         }
       }
-      
+
       // This call takes care of the unscheduled processing.
-      workerManager_.setupOnDemandSystem(ep,es);
-      
+      workerManager_.setupOnDemandSystem(ep, es);
+
       ++total_events_;
 
       //use to give priorities on an error to ones from Paths
       auto pathErrorHolder = std::make_unique<std::atomic<std::exception_ptr*>>(nullptr);
       auto pathErrorPtr = pathErrorHolder.get();
-      auto allPathsDone = make_waiting_task(tbb::task::allocate_root(),
-                                            [iTask,this,serviceToken,pathError=std::move(pathErrorHolder)](std::exception_ptr const* iPtr) mutable
-                                            {
-                                              ServiceRegistry::Operate operate(serviceToken);
-                                              
-                                              std::exception_ptr ptr;
-                                              if(pathError->load()) {
-                                                ptr = *pathError->load();
-                                                delete pathError->load();
-                                              } 
-                                              if( (not ptr) and iPtr) {
-                                                ptr = *iPtr;
-                                              }
-                                              iTask.doneWaiting(finishProcessOneEvent(ptr));
-                                            });
+      auto allPathsDone = make_waiting_task(
+          tbb::task::allocate_root(),
+          [iTask, this, serviceToken, pathError = std::move(pathErrorHolder)](std::exception_ptr const* iPtr) mutable {
+            ServiceRegistry::Operate operate(serviceToken);
+
+            std::exception_ptr ptr;
+            if (pathError->load()) {
+              ptr = *pathError->load();
+              delete pathError->load();
+            }
+            if ((not ptr) and iPtr) {
+              ptr = *iPtr;
+            }
+            iTask.doneWaiting(finishProcessOneEvent(ptr));
+          });
       //The holder guarantees that if the paths finish before the loop ends
       // that we do not start too soon. It also guarantees that the task will
       // run under that condition.
       WaitingTaskHolder allPathsHolder(allPathsDone);
 
-      auto pathsDone = make_waiting_task(tbb::task::allocate_root(),
-                                         [allPathsHolder,pathErrorPtr,&ep, &es, this,serviceToken](std::exception_ptr const* iPtr) mutable
-                                            {
-                                              ServiceRegistry::Operate operate(serviceToken);
+      auto pathsDone = make_waiting_task(
+          tbb::task::allocate_root(),
+          [allPathsHolder, pathErrorPtr, &ep, &es, this, serviceToken](std::exception_ptr const* iPtr) mutable {
+            ServiceRegistry::Operate operate(serviceToken);
 
-                                              if(iPtr) {
-                                                //this is used to prioritize this error over one
-                                                // that happens in EndPath or Accumulate
-                                                pathErrorPtr->store( new std::exception_ptr(*iPtr) );
-                                              }
-                                              finishedPaths(*pathErrorPtr, std::move(allPathsHolder), ep, es);
-                                            });
-      
+            if (iPtr) {
+              //this is used to prioritize this error over one
+              // that happens in EndPath or Accumulate
+              pathErrorPtr->store(new std::exception_ptr(*iPtr));
+            }
+            finishedPaths(*pathErrorPtr, std::move(allPathsHolder), ep, es);
+          });
+
       //The holder guarantees that if the paths finish before the loop ends
       // that we do not start too soon. It also guarantees that the task will
       // run under that condition.
       WaitingTaskHolder taskHolder(pathsDone);
 
       //start end paths first so on single threaded the paths will run first
-      for(auto it = end_paths_.rbegin(), itEnd = end_paths_.rend();
-          it != itEnd; ++it) {
-        it->processOneOccurrenceAsync(allPathsDone,ep, es, serviceToken, streamID_, &streamContext_);
+      for (auto it = end_paths_.rbegin(), itEnd = end_paths_.rend(); it != itEnd; ++it) {
+        it->processOneOccurrenceAsync(allPathsDone, ep, es, serviceToken, streamID_, &streamContext_);
       }
 
-      for(auto it = trig_paths_.rbegin(), itEnd = trig_paths_.rend();
-          it != itEnd; ++ it) {
-        it->processOneOccurrenceAsync(pathsDone,ep, es, serviceToken, streamID_, &streamContext_);
+      for (auto it = trig_paths_.rbegin(), itEnd = trig_paths_.rend(); it != itEnd; ++it) {
+        it->processOneOccurrenceAsync(pathsDone, ep, es, serviceToken, streamID_, &streamContext_);
       }
 
       ParentContext parentContext(&streamContext_);
       workerManager_.processAccumulatorsAsync<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
-        allPathsDone, ep, es, serviceToken, streamID_, parentContext, &streamContext_);
-    }catch (...) {
+          allPathsDone, ep, es, serviceToken, streamID_, parentContext, &streamContext_);
+    } catch (...) {
       iTask.doneWaiting(std::current_exception());
     }
   }
-  
-  void
-  StreamSchedule::finishedPaths(std::atomic<std::exception_ptr*>& iExcept, WaitingTaskHolder iWait, EventPrincipal& ep,
-                                EventSetupImpl const& es) {
-    
-    if(iExcept) {
+
+  void StreamSchedule::finishedPaths(std::atomic<std::exception_ptr*>& iExcept,
+                                     WaitingTaskHolder iWait,
+                                     EventPrincipal& ep,
+                                     EventSetupImpl const& es) {
+    if (iExcept) {
       try {
         std::rethrow_exception(*(iExcept.load()));
-      }
-      catch(cms::Exception& e) {
+      } catch (cms::Exception& e) {
         exception_actions::ActionCodes action = actionTable().find(e.category());
-        assert (action != exception_actions::IgnoreCompletely);
-        assert (action != exception_actions::FailPath);
+        assert(action != exception_actions::IgnoreCompletely);
+        assert(action != exception_actions::FailPath);
         if (action == exception_actions::SkipEvent) {
           edm::printCmsExceptionWarning("SkipEvent", e);
           *(iExcept.load()) = std::exception_ptr();
         } else {
           *(iExcept.load()) = std::current_exception();
         }
-      }
-      catch(...) {
+      } catch (...) {
         *(iExcept.load()) = std::current_exception();
       }
     }
 
-    
-    if((not iExcept) and results_->accept()) {
+    if ((not iExcept) and results_->accept()) {
       ++total_passed_;
     }
 
-    if(nullptr != results_inserter_.get()) {
+    if (nullptr != results_inserter_.get()) {
       try {
         //Even if there was an exception, we need to allow results inserter
         // to run since some module may be waiting on its results.
@@ -674,42 +658,36 @@ namespace edm {
         using Traits = OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>;
 
         results_inserter_->doWork<Traits>(ep, es, streamID_, parentContext, &streamContext_);
-      }
-      catch (cms::Exception & ex) {
+      } catch (cms::Exception& ex) {
         if (not iExcept) {
-          if(ex.context().empty()) {
+          if (ex.context().empty()) {
             std::ostringstream ost;
             ost << "Processing Event " << ep.id();
             ex.addContext(ost.str());
           }
-          iExcept.store( new std::exception_ptr(std::current_exception()));
+          iExcept.store(new std::exception_ptr(std::current_exception()));
         }
-      }
-      catch(...) {
+      } catch (...) {
         if (not iExcept) {
           iExcept.store(new std::exception_ptr(std::current_exception()));
         }
       }
     }
     std::exception_ptr ptr;
-    if(iExcept) {
+    if (iExcept) {
       ptr = *iExcept.load();
     }
     iWait.doneWaiting(ptr);
   }
 
-  
-  std::exception_ptr
-  StreamSchedule::finishProcessOneEvent(std::exception_ptr iExcept) {
+  std::exception_ptr StreamSchedule::finishProcessOneEvent(std::exception_ptr iExcept) {
     using Traits = OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>;
 
-    if(iExcept) {
+    if (iExcept) {
       //add context information to the exception and print message
       try {
-        convertException::wrap([&]() {
-          std::rethrow_exception(iExcept);
-        });
-      } catch(cms::Exception& ex) {
+        convertException::wrap([&]() { std::rethrow_exception(iExcept); });
+      } catch (cms::Exception& ex) {
         bool const cleaningUpAfterException = false;
         if (ex.context().empty()) {
           addContextAndPrintException("Calling function StreamSchedule::processOneEvent", ex, cleaningUpAfterException);
@@ -719,42 +697,34 @@ namespace edm {
         iExcept = std::current_exception();
       }
 
-      actReg_->preStreamEarlyTerminationSignal_(streamContext_,TerminationOrigin::ExceptionFromThisContext);
+      actReg_->preStreamEarlyTerminationSignal_(streamContext_, TerminationOrigin::ExceptionFromThisContext);
     }
-    
+
     try {
       Traits::postScheduleSignal(actReg_.get(), &streamContext_);
-    } catch(...) {
-      if(not iExcept) {
+    } catch (...) {
+      if (not iExcept) {
         iExcept = std::current_exception();
       }
     }
-    if(not iExcept ) {
+    if (not iExcept) {
       resetEarlyDelete();
     }
-    
+
     return iExcept;
   }
 
-  void
-  StreamSchedule::availablePaths(std::vector<std::string>& oLabelsToFill) const {
+  void StreamSchedule::availablePaths(std::vector<std::string>& oLabelsToFill) const {
     oLabelsToFill.reserve(trig_paths_.size());
-    std::transform(trig_paths_.begin(),
-                   trig_paths_.end(),
-                   std::back_inserter(oLabelsToFill),
+    std::transform(trig_paths_.begin(), trig_paths_.end(), std::back_inserter(oLabelsToFill),
                    std::bind(&Path::name, std::placeholders::_1));
   }
 
-  void
-  StreamSchedule::modulesInPath(std::string const& iPathLabel,
-                          std::vector<std::string>& oLabelsToFill) const {
-    TrigPaths::const_iterator itFound =
-    std::find_if (trig_paths_.begin(),
-                 trig_paths_.end(),
-                 std::bind(std::equal_to<std::string>(),
-                             iPathLabel,
-                             std::bind(&Path::name, std::placeholders::_1)));
-    if (itFound!=trig_paths_.end()) {
+  void StreamSchedule::modulesInPath(std::string const& iPathLabel, std::vector<std::string>& oLabelsToFill) const {
+    TrigPaths::const_iterator itFound = std::find_if(
+        trig_paths_.begin(), trig_paths_.end(),
+        std::bind(std::equal_to<std::string>(), iPathLabel, std::bind(&Path::name, std::placeholders::_1)));
+    if (itFound != trig_paths_.end()) {
       oLabelsToFill.reserve(itFound->size());
       for (size_t i = 0; i < itFound->size(); ++i) {
         oLabelsToFill.push_back(itFound->getWorker(i)->description().moduleLabel());
@@ -762,26 +732,25 @@ namespace edm {
     }
   }
 
-  void
-  StreamSchedule::moduleDescriptionsInPath(std::string const& iPathLabel,
-                                           std::vector<ModuleDescription const*>& descriptions,
-                                           unsigned int hint) const {
+  void StreamSchedule::moduleDescriptionsInPath(std::string const& iPathLabel,
+                                                std::vector<ModuleDescription const*>& descriptions,
+                                                unsigned int hint) const {
     descriptions.clear();
     bool found = false;
     TrigPaths::const_iterator itFound;
 
-    if(hint < trig_paths_.size()) {
+    if (hint < trig_paths_.size()) {
       itFound = trig_paths_.begin() + hint;
-      if(itFound->name() == iPathLabel) found = true;
+      if (itFound->name() == iPathLabel)
+        found = true;
     }
-    if(!found) {
+    if (!found) {
       // if the hint did not work, do it the slow way
-      itFound = std::find_if (trig_paths_.begin(),
-                              trig_paths_.end(),
-                              std::bind(std::equal_to<std::string>(),
-                                        iPathLabel,
-                                        std::bind(&Path::name, std::placeholders::_1)));
-      if (itFound != trig_paths_.end()) found = true;
+      itFound = std::find_if(
+          trig_paths_.begin(), trig_paths_.end(),
+          std::bind(std::equal_to<std::string>(), iPathLabel, std::bind(&Path::name, std::placeholders::_1)));
+      if (itFound != trig_paths_.end())
+        found = true;
     }
     if (found) {
       descriptions.reserve(itFound->size());
@@ -791,26 +760,25 @@ namespace edm {
     }
   }
 
-  void
-  StreamSchedule::moduleDescriptionsInEndPath(std::string const& iEndPathLabel,
-                                              std::vector<ModuleDescription const*>& descriptions,
-                                              unsigned int hint) const {
+  void StreamSchedule::moduleDescriptionsInEndPath(std::string const& iEndPathLabel,
+                                                   std::vector<ModuleDescription const*>& descriptions,
+                                                   unsigned int hint) const {
     descriptions.clear();
     bool found = false;
     TrigPaths::const_iterator itFound;
 
-    if(hint < end_paths_.size()) {
+    if (hint < end_paths_.size()) {
       itFound = end_paths_.begin() + hint;
-      if(itFound->name() == iEndPathLabel) found = true;
+      if (itFound->name() == iEndPathLabel)
+        found = true;
     }
-    if(!found) {
+    if (!found) {
       // if the hint did not work, do it the slow way
-      itFound = std::find_if (end_paths_.begin(),
-                              end_paths_.end(),
-                              std::bind(std::equal_to<std::string>(),
-                                        iEndPathLabel,
-                                        std::bind(&Path::name, std::placeholders::_1)));
-      if (itFound != end_paths_.end()) found = true;
+      itFound = std::find_if(
+          end_paths_.begin(), end_paths_.end(),
+          std::bind(std::equal_to<std::string>(), iEndPathLabel, std::bind(&Path::name, std::placeholders::_1)));
+      if (itFound != end_paths_.end())
+        found = true;
     }
     if (found) {
       descriptions.reserve(itFound->size());
@@ -820,38 +788,28 @@ namespace edm {
     }
   }
 
-  void
-  StreamSchedule::enableEndPaths(bool active) {
-    endpathsAreActive_ = active;
-  }
+  void StreamSchedule::enableEndPaths(bool active) { endpathsAreActive_ = active; }
 
-  bool
-  StreamSchedule::endPathsEnabled() const {
-    return endpathsAreActive_;
-  }
+  bool StreamSchedule::endPathsEnabled() const { return endpathsAreActive_; }
 
-  static void
-  fillModuleInPathSummary(Path const& path,
-                          size_t which,
-                          ModuleInPathSummary& sum) {
+  static void fillModuleInPathSummary(Path const& path, size_t which, ModuleInPathSummary& sum) {
     sum.timesVisited += path.timesVisited(which);
-    sum.timesPassed  += path.timesPassed(which);
-    sum.timesFailed  += path.timesFailed(which);
-    sum.timesExcept  += path.timesExcept(which);
-    sum.moduleLabel  = path.getWorker(which)->description().moduleLabel();
+    sum.timesPassed += path.timesPassed(which);
+    sum.timesFailed += path.timesFailed(which);
+    sum.timesExcept += path.timesExcept(which);
+    sum.moduleLabel = path.getWorker(which)->description().moduleLabel();
   }
 
-  static void
-  fillPathSummary(Path const& path, PathSummary& sum) {
-    sum.name        = path.name();
+  static void fillPathSummary(Path const& path, PathSummary& sum) {
+    sum.name = path.name();
     sum.bitPosition = path.bitPosition();
-    sum.timesRun    += path.timesRun();
+    sum.timesRun += path.timesRun();
     sum.timesPassed += path.timesPassed();
     sum.timesFailed += path.timesFailed();
     sum.timesExcept += path.timesExcept();
-    
+
     Path::size_type sz = path.size();
-    if(sum.moduleInPathSummaries.empty()) {
+    if (sum.moduleInPathSummaries.empty()) {
       std::vector<ModuleInPathSummary> temp(sz);
       for (size_t i = 0; i != sz; ++i) {
         fillModuleInPathSummary(path, i, temp[i]);
@@ -865,34 +823,28 @@ namespace edm {
     }
   }
 
-  static void
-  fillWorkerSummaryAux(Worker const& w, WorkerSummary& sum) {
+  static void fillWorkerSummaryAux(Worker const& w, WorkerSummary& sum) {
     sum.timesVisited += w.timesVisited();
-    sum.timesRun     += w.timesRun();
-    sum.timesPassed  += w.timesPassed();
-    sum.timesFailed  += w.timesFailed();
-    sum.timesExcept  += w.timesExcept();
-    sum.moduleLabel  = w.description().moduleLabel();
+    sum.timesRun += w.timesRun();
+    sum.timesPassed += w.timesPassed();
+    sum.timesFailed += w.timesFailed();
+    sum.timesExcept += w.timesExcept();
+    sum.moduleLabel = w.description().moduleLabel();
   }
 
-  static void
-  fillWorkerSummary(Worker const* pw, WorkerSummary& sum) {
-    fillWorkerSummaryAux(*pw, sum);
-  }
+  static void fillWorkerSummary(Worker const* pw, WorkerSummary& sum) { fillWorkerSummaryAux(*pw, sum); }
 
-  void
-  StreamSchedule::getTriggerReport(TriggerReport& rep) const {
+  void StreamSchedule::getTriggerReport(TriggerReport& rep) const {
     rep.eventSummary.totalEvents += totalEvents();
     rep.eventSummary.totalEventsPassed += totalEventsPassed();
     rep.eventSummary.totalEventsFailed += totalEventsFailed();
 
-    fill_summary(trig_paths_,  rep.trigPathSummaries, &fillPathSummary);
-    fill_summary(end_paths_,   rep.endPathSummaries,  &fillPathSummary);
-    fill_summary(allWorkers(), rep.workerSummaries,   &fillWorkerSummary);
+    fill_summary(trig_paths_, rep.trigPathSummaries, &fillPathSummary);
+    fill_summary(end_paths_, rep.endPathSummaries, &fillPathSummary);
+    fill_summary(allWorkers(), rep.workerSummaries, &fillWorkerSummary);
   }
 
-  void
-  StreamSchedule::clearCounters() {
+  void StreamSchedule::clearCounters() {
     using std::placeholders::_1;
     total_events_ = total_passed_ = 0;
     for_all(trig_paths_, std::bind(&Path::clearCounters, _1));
@@ -900,46 +852,38 @@ namespace edm {
     for_all(allWorkers(), std::bind(&Worker::clearCounters, _1));
   }
 
-  void
-  StreamSchedule::resetAll() {
+  void StreamSchedule::resetAll() {
     skippingEvent_ = false;
     results_->reset();
   }
 
-  void
-  StreamSchedule::addToAllWorkers(Worker* w) {
-    workerManager_.addToAllWorkers(w);
-  }
+  void StreamSchedule::addToAllWorkers(Worker* w) { workerManager_.addToAllWorkers(w); }
 
-  void 
-  StreamSchedule::resetEarlyDelete() {
+  void StreamSchedule::resetEarlyDelete() {
     //must be sure we have cleared the count first
-    for(auto& count:earlyDeleteBranchToCount_) {
+    for (auto& count : earlyDeleteBranchToCount_) {
       count.count = 0;
     }
     //now reset based on how many helpers use that branch
-    for(auto& index: earlyDeleteHelperToBranchIndicies_) {
+    for (auto& index : earlyDeleteHelperToBranchIndicies_) {
       ++(earlyDeleteBranchToCount_[index].count);
     }
-    for(auto& helper: earlyDeleteHelpers_) {
+    for (auto& helper : earlyDeleteHelpers_) {
       helper.reset();
     }
   }
 
-  void
-  StreamSchedule::makePathStatusInserters(
+  void StreamSchedule::makePathStatusInserters(
       std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
       std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
       ExceptionToActionTable const& actions) {
-
     int bitpos = 0;
     unsigned int indexEmpty = 0;
     unsigned int indexOfPath = 0;
-    for(auto & pathStatusInserter : pathStatusInserters) {
+    for (auto& pathStatusInserter : pathStatusInserters) {
       std::shared_ptr<PathStatusInserter> inserterPtr = get_underlying(pathStatusInserter);
-      WorkerPtr workerPtr(new edm::WorkerT<PathStatusInserter::ModuleType>(inserterPtr,
-                                                                           inserterPtr->moduleDescription(),
-                                                                           &actions));
+      WorkerPtr workerPtr(
+          new edm::WorkerT<PathStatusInserter::ModuleType>(inserterPtr, inserterPtr->moduleDescription(), &actions));
       pathStatusInserterWorkers_.emplace_back(workerPtr);
       workerPtr->setActivityRegistry(actReg_);
       addToAllWorkers(workerPtr.get());
@@ -950,8 +894,7 @@ namespace edm {
       if (indexEmpty < empty_trig_paths_.size() && bitpos == empty_trig_paths_.at(indexEmpty)) {
         ++indexEmpty;
       } else {
-        trig_paths_.at(indexOfPath).setPathStatusInserter(inserterPtr.get(),
-                                                          workerPtr.get());
+        trig_paths_.at(indexOfPath).setPathStatusInserter(inserterPtr.get(), workerPtr.get());
         ++indexOfPath;
       }
       ++bitpos;
@@ -960,11 +903,10 @@ namespace edm {
     bitpos = 0;
     indexEmpty = 0;
     indexOfPath = 0;
-    for(auto & endPathStatusInserter : endPathStatusInserters) {
+    for (auto& endPathStatusInserter : endPathStatusInserters) {
       std::shared_ptr<EndPathStatusInserter> inserterPtr = get_underlying(endPathStatusInserter);
-      WorkerPtr workerPtr(new edm::WorkerT<EndPathStatusInserter::ModuleType>(inserterPtr,
-                                                                              inserterPtr->moduleDescription(),
-                                                                              &actions));
+      WorkerPtr workerPtr(
+          new edm::WorkerT<EndPathStatusInserter::ModuleType>(inserterPtr, inserterPtr->moduleDescription(), &actions));
       endPathStatusInserterWorkers_.emplace_back(workerPtr);
       workerPtr->setActivityRegistry(actReg_);
       addToAllWorkers(workerPtr.get());
@@ -975,11 +917,10 @@ namespace edm {
       if (indexEmpty < empty_end_paths_.size() && bitpos == empty_end_paths_.at(indexEmpty)) {
         ++indexEmpty;
       } else {
-        end_paths_.at(indexOfPath).setPathStatusInserter(nullptr,
-                                                         workerPtr.get());
+        end_paths_.at(indexOfPath).setPathStatusInserter(nullptr, workerPtr.get());
         ++indexOfPath;
       }
       ++bitpos;
     }
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -117,33 +117,35 @@ namespace edm {
   }
 
   namespace {
-    template <typename T>
-    class StreamScheduleSignalSentry {
+    template <typename T> class StreamScheduleSignalSentry {
     public:
-      StreamScheduleSignalSentry(ActivityRegistry* a, typename T::Context const* context) :
-        a_(a), context_(context), allowThrow_(false) {
-        if (a_) T::preScheduleSignal(a_, context_);
+      StreamScheduleSignalSentry(ActivityRegistry* a, typename T::Context const* context)
+          : a_(a), context_(context), allowThrow_(false) {
+        if (a_)
+          T::preScheduleSignal(a_, context_);
       }
       ~StreamScheduleSignalSentry() noexcept(false) {
         try {
-          if (a_) { T::postScheduleSignal(a_, context_); }
-        } catch(...) {
-          if(allowThrow_) {throw;}
+          if (a_) {
+            T::postScheduleSignal(a_, context_);
+          }
+        } catch (...) {
+          if (allowThrow_) {
+            throw;
+          }
         }
       }
-      
-      void allowThrow() {
-        allowThrow_ = true;
-      }
+
+      void allowThrow() { allowThrow_ = true; }
 
     private:
       // We own none of these resources.
-      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
+      ActivityRegistry* a_;  // We do not use propagate_const because the registry itself is mutable.
       typename T::Context const* context_;
       bool allowThrow_;
     };
-  }
-  
+  }  // namespace
+
   class StreamSchedule {
   public:
     typedef std::vector<std::string> vstring;
@@ -173,14 +175,15 @@ namespace edm {
                    bool allowEarlyDelete,
                    StreamID streamID,
                    ProcessContext const* processContext);
-    
+
     StreamSchedule(StreamSchedule const&) = delete;
 
-    void processOneEventAsync(WaitingTaskHolder iTask,
-                              EventPrincipal& ep,
-                              EventSetupImpl const& es,
-                              ServiceToken const& token,
-                              std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters);
+    void processOneEventAsync(
+        WaitingTaskHolder iTask,
+        EventPrincipal& ep,
+        EventSetupImpl const& es,
+        ServiceToken const& token,
+        std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters);
 
     template <typename T>
     void processOneStreamAsync(WaitingTaskHolder iTask,
@@ -193,7 +196,7 @@ namespace edm {
     void endStream();
 
     StreamID streamID() const { return streamID_; }
-    
+
     /// Return a vector allowing const access to all the
     /// ModuleDescriptions for this StreamSchedule.
 
@@ -206,8 +209,7 @@ namespace edm {
     void availablePaths(std::vector<std::string>& oLabelsToFill) const;
 
     ///adds to oLabelsToFill in execution order the labels of all modules in path iPathLabel
-    void modulesInPath(std::string const& iPathLabel,
-                       std::vector<std::string>& oLabelsToFill) const;
+    void modulesInPath(std::string const& iPathLabel, std::vector<std::string>& oLabelsToFill) const;
 
     void moduleDescriptionsInPath(std::string const& iPathLabel,
                                   std::vector<ModuleDescription const*>& descriptions,
@@ -220,21 +222,15 @@ namespace edm {
     /// Return the number of events this StreamSchedule has tried to process
     /// (inclues both successes and failures, including failures due
     /// to exceptions during processing).
-    int totalEvents() const {
-      return total_events_;
-    }
+    int totalEvents() const { return total_events_; }
 
     /// Return the number of events which have been passed by one or
     /// more trigger paths.
-    int totalEventsPassed() const {
-      return total_passed_;
-    }
+    int totalEventsPassed() const { return total_passed_; }
 
     /// Return the number of events that have not passed any trigger.
     /// (N.B. totalEventsFailed() + totalEventsPassed() == totalEvents()
-    int totalEventsFailed() const {
-      return totalEvents() - totalEventsPassed();
-    }
+    int totalEventsFailed() const { return totalEvents() - totalEventsPassed(); }
 
     /// Turn end_paths "off" if "active" is false;
     /// turn end_paths "on" if "active" is true.
@@ -255,15 +251,12 @@ namespace edm {
     void replaceModule(maker::ModuleHolder* iMod, std::string const& iLabel);
 
     /// returns the collection of pointers to workers
-    AllWorkers const& allWorkers() const {
-      return workerManager_.allWorkers();
-    }
-    
-    unsigned int numberOfUnscheduledModules() const {
-      return number_of_unscheduled_modules_;
-    }
-    
-    StreamContext const& context() const { return streamContext_;}
+    AllWorkers const& allWorkers() const { return workerManager_.allWorkers(); }
+
+    unsigned int numberOfUnscheduledModules() const { return number_of_unscheduled_modules_; }
+
+    StreamContext const& context() const { return streamContext_; }
+
   private:
     //Sentry class to only send a signal if an
     // exception occurs. An exception is identified
@@ -271,84 +264,86 @@ namespace edm {
     // calling completedSuccessfully().
     class SendTerminationSignalIfException {
     public:
-      SendTerminationSignalIfException(edm::ActivityRegistry* iReg, edm::StreamContext const* iContext):
-      reg_(iReg),
-      context_(iContext){}
+      SendTerminationSignalIfException(edm::ActivityRegistry* iReg, edm::StreamContext const* iContext)
+          : reg_(iReg), context_(iContext) {}
       ~SendTerminationSignalIfException() {
-        if(reg_) {
-          reg_->preStreamEarlyTerminationSignal_(*context_,TerminationOrigin::ExceptionFromThisContext);
+        if (reg_) {
+          reg_->preStreamEarlyTerminationSignal_(*context_, TerminationOrigin::ExceptionFromThisContext);
         }
       }
-      void completedSuccessfully() {
-        reg_ = nullptr;
-      }
+      void completedSuccessfully() { reg_ = nullptr; }
+
     private:
-      edm::ActivityRegistry* reg_; // We do not use propagate_const because the registry itself is mutable.
+      edm::ActivityRegistry* reg_;  // We do not use propagate_const because the registry itself is mutable.
       StreamContext const* context_;
     };
 
     /// returns the action table
-    ExceptionToActionTable const& actionTable() const {
-      return workerManager_.actionTable();
-    }
-    
+    ExceptionToActionTable const& actionTable() const { return workerManager_.actionTable(); }
 
     void resetAll();
 
-    void finishedPaths(std::atomic<std::exception_ptr*>&, WaitingTaskHolder,
-                       EventPrincipal& ep, EventSetupImpl const& es);
+    void finishedPaths(std::atomic<std::exception_ptr*>&,
+                       WaitingTaskHolder,
+                       EventPrincipal& ep,
+                       EventSetupImpl const& es);
     std::exception_ptr finishProcessOneEvent(std::exception_ptr);
-    
+
     void reportSkipped(EventPrincipal const& ep) const;
 
     void fillWorkers(ParameterSet& proc_pset,
                      ProductRegistry& preg,
                      PreallocationConfiguration const* prealloc,
                      std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                     std::string const& name, bool ignoreFilters, PathWorkers& out,
+                     std::string const& name,
+                     bool ignoreFilters,
+                     PathWorkers& out,
                      std::vector<std::string> const& endPathNames);
     void fillTrigPath(ParameterSet& proc_pset,
                       ProductRegistry& preg,
                       PreallocationConfiguration const* prealloc,
                       std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                      int bitpos, std::string const& name, TrigResPtr,
+                      int bitpos,
+                      std::string const& name,
+                      TrigResPtr,
                       std::vector<std::string> const& endPathNames);
     void fillEndPath(ParameterSet& proc_pset,
                      ProductRegistry& preg,
                      PreallocationConfiguration const* prealloc,
                      std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                     int bitpos, std::string const& name,
+                     int bitpos,
+                     std::string const& name,
                      std::vector<std::string> const& endPathNames);
 
     void addToAllWorkers(Worker* w);
-    
+
     void resetEarlyDelete();
-    void initializeEarlyDelete(ModuleRegistry & modReg,
+    void initializeEarlyDelete(ModuleRegistry& modReg,
                                edm::ParameterSet const& opts,
-                               edm::ProductRegistry const& preg, 
+                               edm::ProductRegistry const& preg,
                                bool allowEarlyDelete);
 
-    TrigResConstPtr results() const {return get_underlying_safe(results_);}
-    TrigResPtr& results() {return get_underlying_safe(results_);}
+    TrigResConstPtr results() const { return get_underlying_safe(results_); }
+    TrigResPtr& results() { return get_underlying_safe(results_); }
 
     void makePathStatusInserters(
-      std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
-      std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
-      ExceptionToActionTable const& actions);
+        std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
+        std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
+        ExceptionToActionTable const& actions);
 
-    WorkerManager            workerManager_;
-    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
-    
+    WorkerManager workerManager_;
+    std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
+
     edm::propagate_const<TrigResPtr> results_;
 
     edm::propagate_const<WorkerPtr> results_inserter_;
     std::vector<edm::propagate_const<WorkerPtr>> pathStatusInserterWorkers_;
     std::vector<edm::propagate_const<WorkerPtr>> endPathStatusInserterWorkers_;
 
-    TrigPaths                trig_paths_;
-    TrigPaths                end_paths_;
-    std::vector<int>         empty_trig_paths_;
-    std::vector<int>         empty_end_paths_;
+    TrigPaths trig_paths_;
+    TrigPaths end_paths_;
+    std::vector<int> empty_trig_paths_;
+    std::vector<int> empty_end_paths_;
 
     //For each branch that has been marked for early deletion
     // keep track of how many modules are left that read this data but have
@@ -358,26 +353,24 @@ namespace edm {
     // but putting it into one vector makes for better allocation as well as
     // faster iteration when used to reset the earlyDeleteBranchToCount_
     // Each EarlyDeleteHelper hold a begin and end range into this vector. The values
-    // of this vector correspond to indexes into earlyDeleteBranchToCount_ so 
+    // of this vector correspond to indexes into earlyDeleteBranchToCount_ so
     // tell which EarlyDeleteHelper is associated with which BranchIDs.
     std::vector<unsigned int> earlyDeleteHelperToBranchIndicies_;
     //There is one EarlyDeleteHelper per Module which are reading data that
     // has been marked for early deletion
     std::vector<EarlyDeleteHelper> earlyDeleteHelpers_;
 
-    int                            total_events_;
-    int                            total_passed_;
-    unsigned int                   number_of_unscheduled_modules_;
-    
-    StreamID                streamID_;
-    StreamContext           streamContext_;
-    volatile bool           endpathsAreActive_;
-    std::atomic<bool>       skippingEvent_;
+    int total_events_;
+    int total_passed_;
+    unsigned int number_of_unscheduled_modules_;
+
+    StreamID streamID_;
+    StreamContext streamContext_;
+    volatile bool endpathsAreActive_;
+    std::atomic<bool> skippingEvent_;
   };
 
-  void
-  inline
-  StreamSchedule::reportSkipped(EventPrincipal const& ep) const {
+  void inline StreamSchedule::reportSkipped(EventPrincipal const& ep) const {
     Service<JobReport> reportSvc;
     reportSvc->reportSkippedEvent(ep.id().run(), ep.id().event());
   }
@@ -391,76 +384,72 @@ namespace edm {
     T::setStreamContext(streamContext_, ep);
 
     auto id = ep.id();
-    auto doneTask = make_waiting_task(tbb::task::allocate_root(),
-                                      [this,iHolder, id,cleaningUpAfterException,token](std::exception_ptr const* iPtr) mutable
-    {
+    auto doneTask = make_waiting_task(tbb::task::allocate_root(), [this, iHolder, id, cleaningUpAfterException,
+                                                                   token](std::exception_ptr const* iPtr) mutable {
       std::exception_ptr excpt;
-      if(iPtr) {
+      if (iPtr) {
         excpt = *iPtr;
         //add context information to the exception and print message
         try {
-          convertException::wrap([&]() {
-            std::rethrow_exception(excpt);
-          });
-        } catch(cms::Exception& ex) {
+          convertException::wrap([&]() { std::rethrow_exception(excpt); });
+        } catch (cms::Exception& ex) {
           //TODO: should add the transition type info
           std::ostringstream ost;
-          if(ex.context().empty()) {
-            ost<<"Processing "<<T::transitionName()<<" "<<id;
+          if (ex.context().empty()) {
+            ost << "Processing " << T::transitionName() << " " << id;
           }
           ServiceRegistry::Operate op(token);
           addContextAndPrintException(ost.str().c_str(), ex, cleaningUpAfterException);
           excpt = std::current_exception();
         }
-        
+
         ServiceRegistry::Operate op(token);
-        actReg_->preStreamEarlyTerminationSignal_(streamContext_,TerminationOrigin::ExceptionFromThisContext);
+        actReg_->preStreamEarlyTerminationSignal_(streamContext_, TerminationOrigin::ExceptionFromThisContext);
       }
-      
+
       try {
         ServiceRegistry::Operate op(token);
         T::postScheduleSignal(actReg_.get(), &streamContext_);
-      } catch(...) {
-        if(not excpt) {
+      } catch (...) {
+        if (not excpt) {
           excpt = std::current_exception();
         }
       }
       iHolder.doneWaiting(excpt);
-      
     });
-    
-    auto task = make_functor_task(tbb::task::allocate_root(), [this,doneTask, h =WaitingTaskHolder(doneTask) ,&ep,&es,token] () mutable {
+
+    auto task = make_functor_task(tbb::task::allocate_root(), [this, doneTask, h = WaitingTaskHolder(doneTask), &ep,
+                                                               &es, token]() mutable {
       ServiceRegistry::Operate op(token);
       try {
         T::preScheduleSignal(actReg_.get(), &streamContext_);
 
         workerManager_.resetAll();
-      }catch(...) {
+      } catch (...) {
         h.doneWaiting(std::current_exception());
         return;
       }
 
-      for(auto& p : end_paths_) {
+      for (auto& p : end_paths_) {
         p.runAllModulesAsync<T>(doneTask, ep, es, token, streamID_, &streamContext_);
       }
 
-      for(auto& p : trig_paths_) {
+      for (auto& p : trig_paths_) {
         p.runAllModulesAsync<T>(doneTask, ep, es, token, streamID_, &streamContext_);
       }
-      
-      workerManager_.processOneOccurrenceAsync<T>(doneTask,
-                                                  ep, es, token, streamID_, &streamContext_, &streamContext_);
+
+      workerManager_.processOneOccurrenceAsync<T>(doneTask, ep, es, token, streamID_, &streamContext_, &streamContext_);
     });
-    
-    if(streamID_.value() == 0) {
+
+    if (streamID_.value() == 0) {
       //Enqueueing will start another thread if there is only
       // one thread in the job. Having stream == 0 use spawn
       // avoids starting up another thread when there is only one stream.
-      tbb::task::spawn( *task);
+      tbb::task::spawn(*task);
     } else {
-      tbb::task::enqueue( *task);
+      tbb::task::enqueue(*task);
     }
   }
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -53,44 +53,37 @@ namespace edm {
                          ServiceToken const& token,
                          serviceregistry::ServiceLegacy iLegacy,
                          PreallocationConfiguration const& preallocConfig,
-                         ProcessContext const* parentProcessContext) :
-    EDConsumerBase(),
-    serviceToken_(),
-    parentPreg_(parentProductRegistry),
-    preg_(),
-    branchIDListHelper_(),
-    act_table_(),
-    processConfiguration_(),
-    historyLumiOffset_(preallocConfig.numberOfStreams()),
-    historyRunOffset_(historyLumiOffset_+preallocConfig.numberOfLuminosityBlocks()),
-    processHistoryRegistries_(historyRunOffset_+ preallocConfig.numberOfRuns()),
-    historyAppenders_(historyRunOffset_+preallocConfig.numberOfRuns()),
-    principalCache_(),
-    esp_(),
-    schedule_(),
-    parentToChildPhID_(),
-    subProcesses_(),
-    processParameterSet_(),
-    productSelectorRules_(parameterSet, "outputCommands", "OutputModule"),
-    productSelector_(),
-    wantAllEvents_(true) {
-
+                         ProcessContext const* parentProcessContext)
+      : EDConsumerBase(),
+        serviceToken_(),
+        parentPreg_(parentProductRegistry),
+        preg_(),
+        branchIDListHelper_(),
+        act_table_(),
+        processConfiguration_(),
+        historyLumiOffset_(preallocConfig.numberOfStreams()),
+        historyRunOffset_(historyLumiOffset_ + preallocConfig.numberOfLuminosityBlocks()),
+        processHistoryRegistries_(historyRunOffset_ + preallocConfig.numberOfRuns()),
+        historyAppenders_(historyRunOffset_ + preallocConfig.numberOfRuns()),
+        principalCache_(),
+        esp_(),
+        schedule_(),
+        parentToChildPhID_(),
+        subProcesses_(),
+        processParameterSet_(),
+        productSelectorRules_(parameterSet, "outputCommands", "OutputModule"),
+        productSelector_(),
+        wantAllEvents_(true) {
     //Setup the event selection
     Service<service::TriggerNamesService> tns;
 
-    ParameterSet selectevents =
-      parameterSet.getUntrackedParameterSet("SelectEvents", ParameterSet());
+    ParameterSet selectevents = parameterSet.getUntrackedParameterSet("SelectEvents", ParameterSet());
 
-    selectevents.registerIt(); // Just in case this PSet is not registered
-    wantAllEvents_ = detail::configureEventSelector(selectevents,
-                                                    tns->getProcessName(),
-                                                    getAllTriggerNames(),
-                                                    selectors_,
-                                                    consumesCollector());
-    std::map<std::string, std::vector<std::pair<std::string, int> > > outputModulePathPositions;
-    selector_config_id_ = detail::registerProperSelectionInfo(selectevents,
-                                                              "",
-                                                              outputModulePathPositions,
+    selectevents.registerIt();  // Just in case this PSet is not registered
+    wantAllEvents_ = detail::configureEventSelector(selectevents, tns->getProcessName(), getAllTriggerNames(),
+                                                    selectors_, consumesCollector());
+    std::map<std::string, std::vector<std::pair<std::string, int>>> outputModulePathPositions;
+    selector_config_id_ = detail::registerProperSelectionInfo(selectevents, "", outputModulePathPositions,
                                                               parentProductRegistry->anyProductProduced());
 
     std::map<BranchID, bool> keepAssociation;
@@ -100,22 +93,25 @@ namespace edm {
     std::string const maxLumis("maxLuminosityBlocks");
 
     // propagate_const<T> has no reset() function
-    processParameterSet_ = std::unique_ptr<ParameterSet>(parameterSet.popParameterSet(std::string("process")).release());
+    processParameterSet_ =
+        std::unique_ptr<ParameterSet>(parameterSet.popParameterSet(std::string("process")).release());
 
     // if this process has a maxEvents or maxLuminosityBlocks parameter set, remove them.
-    if(processParameterSet_->exists(maxEvents)) {
+    if (processParameterSet_->exists(maxEvents)) {
       processParameterSet_->popParameterSet(maxEvents);
     }
-    if(processParameterSet_->exists(maxLumis)) {
+    if (processParameterSet_->exists(maxLumis)) {
       processParameterSet_->popParameterSet(maxLumis);
     }
 
     // if the top level process has a maxEvents or maxLuminosityBlocks parameter set, add them to this process.
-    if(topLevelParameterSet.exists(maxEvents)) {
-      processParameterSet_->addUntrackedParameter<ParameterSet>(maxEvents, topLevelParameterSet.getUntrackedParameterSet(maxEvents));
+    if (topLevelParameterSet.exists(maxEvents)) {
+      processParameterSet_->addUntrackedParameter<ParameterSet>(
+          maxEvents, topLevelParameterSet.getUntrackedParameterSet(maxEvents));
     }
-    if(topLevelParameterSet.exists(maxLumis)) {
-      processParameterSet_->addUntrackedParameter<ParameterSet>(maxLumis, topLevelParameterSet.getUntrackedParameterSet(maxLumis));
+    if (topLevelParameterSet.exists(maxLumis)) {
+      processParameterSet_->addUntrackedParameter<ParameterSet>(
+          maxLumis, topLevelParameterSet.getUntrackedParameterSet(maxLumis));
     }
 
     // If there are subprocesses, pop the subprocess parameter sets out of the process parameter set
@@ -140,7 +136,6 @@ namespace edm {
     parentActReg.connectToSubProcess(*items.actReg_);
     serviceToken_ = items.addCPRandTNS(*processParameterSet_, newToken);
 
-
     //make the services available
     ServiceRegistry::Operate operate(serviceToken_);
 
@@ -154,10 +149,11 @@ namespace edm {
     updateBranchIDListHelper(parentBranchIDListHelper->branchIDLists());
 
     thinnedAssociationsHelper_ = items.thinnedAssociationsHelper();
-    thinnedAssociationsHelper_->updateFromParentProcess(parentThinnedAssociationsHelper, keepAssociation, droppedBranchIDToKeptBranchID_);
+    thinnedAssociationsHelper_->updateFromParentProcess(parentThinnedAssociationsHelper, keepAssociation,
+                                                        droppedBranchIDToKeptBranchID_);
 
     // intialize the Schedule
-    schedule_ = items.initSchedule(*processParameterSet_,hasSubProcesses,preallocConfig,&processContext_);
+    schedule_ = items.initSchedule(*processParameterSet_, hasSubProcesses, preallocConfig, &processContext_);
 
     // set the items
     act_table_ = std::move(items.act_table_);
@@ -171,68 +167,47 @@ namespace edm {
     // another thread. We really need to change how this is done in the PrincipalCache.
     principalCache_.setProcessHistoryRegistry(processHistoryRegistries_[historyRunOffset_]);
 
-
     processConfiguration_ = items.processConfiguration();
     processContext_.setProcessConfiguration(processConfiguration_.get());
     processContext_.setParentProcessContext(parentProcessContext);
 
     principalCache_.setNumberOfConcurrentPrincipals(preallocConfig);
-    for(unsigned int index = 0; index < preallocConfig.numberOfStreams(); ++index) {
-      auto ep = std::make_shared<EventPrincipal>(preg_,
-                                                 branchIDListHelper(),
-                                                 thinnedAssociationsHelper(),
-                                                 *processConfiguration_,
-                                                 &(historyAppenders_[index]),
-                                                 index,
+    for (unsigned int index = 0; index < preallocConfig.numberOfStreams(); ++index) {
+      auto ep = std::make_shared<EventPrincipal>(preg_, branchIDListHelper(), thinnedAssociationsHelper(),
+                                                 *processConfiguration_, &(historyAppenders_[index]), index,
                                                  false /*not primary process*/);
       principalCache_.insert(ep);
     }
-    for(unsigned int index = 0; index < preallocConfig.numberOfLuminosityBlocks(); ++ index) {
-      auto lbpp = std::make_unique<LuminosityBlockPrincipal>(preg_, *processConfiguration_, &(historyAppenders_[historyLumiOffset_+index]),index,false);
+    for (unsigned int index = 0; index < preallocConfig.numberOfLuminosityBlocks(); ++index) {
+      auto lbpp = std::make_unique<LuminosityBlockPrincipal>(
+          preg_, *processConfiguration_, &(historyAppenders_[historyLumiOffset_ + index]), index, false);
       principalCache_.insert(std::move(lbpp));
     }
-      
+
     inUseLumiPrincipals_.resize(preallocConfig.numberOfLuminosityBlocks());
 
     subProcesses_.reserve(subProcessVParameterSet.size());
-    for(auto& subProcessPSet : subProcessVParameterSet) {
-      subProcesses_.emplace_back(subProcessPSet,
-                                 topLevelParameterSet,
-                                 preg_,
-                                 branchIDListHelper(),
-                                 *thinnedAssociationsHelper_,
-                                 *subProcessParentageHelper_,
-                                 esController,
-                                 *items.actReg_,
-                                 newToken,
-                                 iLegacy,
-                                 preallocConfig,
-                                 &processContext_);
+    for (auto& subProcessPSet : subProcessVParameterSet) {
+      subProcesses_.emplace_back(subProcessPSet, topLevelParameterSet, preg_, branchIDListHelper(),
+                                 *thinnedAssociationsHelper_, *subProcessParentageHelper_, esController, *items.actReg_,
+                                 newToken, iLegacy, preallocConfig, &processContext_);
     }
   }
 
   SubProcess::~SubProcess() {}
 
-  void
-  SubProcess::doBeginJob() {
-    this->beginJob();
-  }
+  void SubProcess::doBeginJob() { this->beginJob(); }
 
-  void
-  SubProcess::doEndJob() {
-    endJob();
-  }
+  void SubProcess::doEndJob() { endJob(); }
 
-
-  void
-  SubProcess::beginJob() {
+  void SubProcess::beginJob() {
     // If event selection is being used, the SubProcess class reads TriggerResults
     // object(s) in the parent process from the event. This next call is needed for
     // getByToken to work properly. Normally, this is done by the worker, but since
     // a SubProcess is not a module, it has no worker.
-    updateLookup(InEvent, *parentPreg_->productLookup(InEvent),false);
+    updateLookup(InEvent, *parentPreg_->productLookup(InEvent), false);
 
-    if(!droppedBranchIDToKeptBranchID().empty()) {
+    if (!droppedBranchIDToKeptBranchID().empty()) {
       fixBranchIDListsForEDAliases(droppedBranchIDToKeptBranchID());
     }
     ServiceRegistry::Operate operate(serviceToken_);
@@ -242,27 +217,27 @@ namespace edm {
     checkForModuleDependencyCorrectness(pathsAndConsumesOfModules_, false);
     actReg_->preBeginJobSignal_(pathsAndConsumesOfModules_, processContext_);
     schedule_->beginJob(*preg_);
-    for_all(subProcesses_, [](auto& subProcess){ subProcess.doBeginJob(); });
+    for_all(subProcesses_, [](auto& subProcess) { subProcess.doBeginJob(); });
   }
 
-  void
-  SubProcess::endJob() {
+  void SubProcess::endJob() {
     ServiceRegistry::Operate operate(serviceToken_);
-    ExceptionCollector c("Multiple exceptions were thrown while executing endJob. An exception message follows for each.");
+    ExceptionCollector c(
+        "Multiple exceptions were thrown while executing endJob. An exception message follows for each.");
     schedule_->endJob(c);
-    for(auto& subProcess : subProcesses_) {
-      c.call([&subProcess](){ subProcess.doEndJob();});
+    for (auto& subProcess : subProcesses_) {
+      c.call([&subProcess]() { subProcess.doEndJob(); });
     }
-    if(c.hasThrown()) {
+    if (c.hasThrown()) {
       c.rethrow();
     }
   }
 
-  void
-  SubProcess::selectProducts(ProductRegistry const& preg,
-                             ThinnedAssociationsHelper const& parentThinnedAssociationsHelper,
-                             std::map<BranchID, bool>& keepAssociation) {
-    if(productSelector_.initialized()) return;
+  void SubProcess::selectProducts(ProductRegistry const& preg,
+                                  ThinnedAssociationsHelper const& parentThinnedAssociationsHelper,
+                                  std::map<BranchID, bool>& keepAssociation) {
+    if (productSelector_.initialized())
+      return;
     productSelector_.initialize(productSelectorRules_, preg.allBranchDescriptions());
 
     // TODO: See if we can collapse keptProducts_ and productSelector_ into a
@@ -273,26 +248,25 @@ namespace edm {
     std::vector<BranchDescription const*> associationDescriptions;
     std::set<BranchID> keptProductsInEvent;
 
-    for(auto const& it : preg.productList()) {
+    for (auto const& it : preg.productList()) {
       BranchDescription const& desc = it.second;
-      if(desc.transient()) {
+      if (desc.transient()) {
         // if the class of the branch is marked transient, output nothing
-      } else if(!desc.present() && !desc.produced()) {
+      } else if (!desc.present() && !desc.produced()) {
         // else if the branch containing the product has been previously dropped,
         // output nothing
-      } else if(desc.unwrappedType() == typeid(ThinnedAssociation)) {
+      } else if (desc.unwrappedType() == typeid(ThinnedAssociation)) {
         associationDescriptions.push_back(&desc);
-      } else if(productSelector_.selected(desc)) {
+      } else if (productSelector_.selected(desc)) {
         keepThisBranch(desc, trueBranchIDToKeptBranchDesc, keptProductsInEvent);
       }
     }
 
-    parentThinnedAssociationsHelper.selectAssociationProducts(associationDescriptions,
-                                                              keptProductsInEvent,
+    parentThinnedAssociationsHelper.selectAssociationProducts(associationDescriptions, keptProductsInEvent,
                                                               keepAssociation);
 
-    for(auto association : associationDescriptions) {
-      if(keepAssociation[association->branchID()]) {
+    for (auto association : associationDescriptions) {
+      if (keepAssociation[association->branchID()]) {
         keepThisBranch(*association, trueBranchIDToKeptBranchDesc, keptProductsInEvent);
       }
     }
@@ -304,206 +278,185 @@ namespace edm {
   void SubProcess::keepThisBranch(BranchDescription const& desc,
                                   std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
                                   std::set<BranchID>& keptProductsInEvent) {
+    ProductSelector::checkForDuplicateKeptBranch(desc, trueBranchIDToKeptBranchDesc);
 
-    ProductSelector::checkForDuplicateKeptBranch(desc,
-                                                 trueBranchIDToKeptBranchDesc);
-
-    if(desc.branchType() == InEvent) {
-      if(desc.produced()) {
+    if (desc.branchType() == InEvent) {
+      if (desc.produced()) {
         keptProductsInEvent.insert(desc.originalBranchID());
       } else {
         keptProductsInEvent.insert(desc.branchID());
       }
     }
-    EDGetToken token = consumes(TypeToGet{desc.unwrappedTypeID(),PRODUCT_TYPE},
-                                InputTag{desc.moduleLabel(),
-                                    desc.productInstanceName(),
-                                    desc.processName()});
+    EDGetToken token = consumes(TypeToGet{desc.unwrappedTypeID(), PRODUCT_TYPE},
+                                InputTag{desc.moduleLabel(), desc.productInstanceName(), desc.processName()});
 
     // Now put it in the list of selected branches.
     keptProducts_[desc.branchType()].push_back(std::make_pair(&desc, token));
   }
 
-  void
-  SubProcess::fixBranchIDListsForEDAliases(std::map<BranchID::value_type, BranchID::value_type> const& droppedBranchIDToKeptBranchID) {
+  void SubProcess::fixBranchIDListsForEDAliases(
+      std::map<BranchID::value_type, BranchID::value_type> const& droppedBranchIDToKeptBranchID) {
     // Check for branches dropped while an EDAlias was kept.
     // Replace BranchID of each dropped branch with that of the kept alias.
-    for(BranchIDList& branchIDList : branchIDListHelper_->mutableBranchIDLists()) {
-      for(BranchID::value_type& branchID : branchIDList) {
-        std::map<BranchID::value_type, BranchID::value_type>::const_iterator iter = droppedBranchIDToKeptBranchID.find(branchID);
-        if(iter != droppedBranchIDToKeptBranchID.end()) {
+    for (BranchIDList& branchIDList : branchIDListHelper_->mutableBranchIDLists()) {
+      for (BranchID::value_type& branchID : branchIDList) {
+        std::map<BranchID::value_type, BranchID::value_type>::const_iterator iter =
+            droppedBranchIDToKeptBranchID.find(branchID);
+        if (iter != droppedBranchIDToKeptBranchID.end()) {
           branchID = iter->second;
         }
       }
     }
-    for_all(subProcesses_, [&droppedBranchIDToKeptBranchID](auto& subProcess){ subProcess.fixBranchIDListsForEDAliases(droppedBranchIDToKeptBranchID); });
+    for_all(subProcesses_, [&droppedBranchIDToKeptBranchID](auto& subProcess) {
+      subProcess.fixBranchIDListsForEDAliases(droppedBranchIDToKeptBranchID);
+    });
   }
 
-  void
-  SubProcess::doEventAsync(WaitingTaskHolder iHolder,
-                           EventPrincipal const& ep) {
+  void SubProcess::doEventAsync(WaitingTaskHolder iHolder, EventPrincipal const& ep) {
     ServiceRegistry::Operate operate(serviceToken_);
     /* BEGIN relevant bits from OutputModule::doEvent */
-    if(!wantAllEvents_) {
+    if (!wantAllEvents_) {
       EventForOutput e(ep, ModuleDescription(), nullptr);
       e.setConsumer(this);
-      if(!selectors_.wantEvent(e)) {
+      if (!selectors_.wantEvent(e)) {
         return;
       }
     }
-    processAsync(std::move(iHolder),ep);
+    processAsync(std::move(iHolder), ep);
     /* END relevant bits from OutputModule::doEvent */
   }
 
-  void
-  SubProcess::processAsync(WaitingTaskHolder iHolder,
-                           EventPrincipal const& principal) {
+  void SubProcess::processAsync(WaitingTaskHolder iHolder, EventPrincipal const& principal) {
     EventAuxiliary aux(principal.aux());
     aux.setProcessHistoryID(principal.processHistoryID());
-    
+
     EventSelectionIDVector esids{principal.eventSelectionIDs()};
     if (principal.productRegistry().anyProductProduced() || !wantAllEvents_) {
       esids.push_back(selector_config_id_);
     }
-    
+
     EventPrincipal& ep = principalCache_.eventPrincipal(principal.streamID().value());
-    auto & processHistoryRegistry = processHistoryRegistries_[principal.streamID().value()];
+    auto& processHistoryRegistry = processHistoryRegistries_[principal.streamID().value()];
     processHistoryRegistry.registerProcessHistory(principal.processHistory());
     BranchListIndexes bli(principal.branchListIndexes());
     branchIDListHelper_->fixBranchListIndexes(bli);
     bool deepCopyRetriever = false;
-    ep.fillEventPrincipal(aux,
-                          processHistoryRegistry,
-                          std::move(esids),
-                          std::move(bli),
-                          *(principal.productProvenanceRetrieverPtr()),//NOTE: this transfers the per product provenance
-                          principal.reader(),
-                          deepCopyRetriever);
+    ep.fillEventPrincipal(
+        aux, processHistoryRegistry, std::move(esids), std::move(bli),
+        *(principal.productProvenanceRetrieverPtr()),  //NOTE: this transfers the per product provenance
+        principal.reader(), deepCopyRetriever);
     ep.setLuminosityBlockPrincipal(inUseLumiPrincipals_[principal.luminosityBlockPrincipal().index()].get());
     propagateProducts(InEvent, principal, ep);
-    
-    WaitingTaskHolder finalizeEventTask( make_waiting_task(tbb::task::allocate_root(),
-                                                           [&ep,iHolder](std::exception_ptr const* iPtr) mutable
-      {
-        ep.clearEventPrincipal();
-        if(iPtr) {
-          iHolder.doneWaiting(*iPtr);
-        } else {
-          iHolder.doneWaiting(std::exception_ptr());
-        }
-      }
-                                                           )
-                                        );
+
+    WaitingTaskHolder finalizeEventTask(
+        make_waiting_task(tbb::task::allocate_root(), [&ep, iHolder](std::exception_ptr const* iPtr) mutable {
+          ep.clearEventPrincipal();
+          if (iPtr) {
+            iHolder.doneWaiting(*iPtr);
+          } else {
+            iHolder.doneWaiting(std::exception_ptr());
+          }
+        }));
     WaitingTaskHolder afterProcessTask;
-    if(subProcesses_.empty()) {
+    if (subProcesses_.empty()) {
       afterProcessTask = std::move(finalizeEventTask);
     } else {
-      afterProcessTask = WaitingTaskHolder(
-                                           make_waiting_task(tbb::task::allocate_root(),
-                                                             [this,&ep,finalizeEventTask] (std::exception_ptr const* iPtr) mutable{
-        if(not iPtr) {
-          for(auto& subProcess: boost::adaptors::reverse(subProcesses_)) {
-            subProcess.doEventAsync(finalizeEventTask,ep);
-          }
-        } else {
-          finalizeEventTask.doneWaiting(*iPtr);
-        }
-      })
-                                           );
+      afterProcessTask = WaitingTaskHolder(make_waiting_task(
+          tbb::task::allocate_root(), [this, &ep, finalizeEventTask](std::exception_ptr const* iPtr) mutable {
+            if (not iPtr) {
+              for (auto& subProcess : boost::adaptors::reverse(subProcesses_)) {
+                subProcess.doEventAsync(finalizeEventTask, ep);
+              }
+            } else {
+              finalizeEventTask.doneWaiting(*iPtr);
+            }
+          }));
     }
-    
-    schedule_->processOneEventAsync(std::move(afterProcessTask),
-                                    ep.streamID().value(),ep, esp_->eventSetup(),serviceToken_);
+
+    schedule_->processOneEventAsync(std::move(afterProcessTask), ep.streamID().value(), ep, esp_->eventSetup(),
+                                    serviceToken_);
   }
 
-  void
-  SubProcess::doBeginRunAsync(WaitingTaskHolder iHolder, RunPrincipal const& principal, IOVSyncValue const& ts) {
+  void SubProcess::doBeginRunAsync(WaitingTaskHolder iHolder, RunPrincipal const& principal, IOVSyncValue const& ts) {
     ServiceRegistry::Operate operate(serviceToken_);
 
     auto aux = std::make_shared<RunAuxiliary>(principal.aux());
     aux->setProcessHistoryID(principal.processHistoryID());
-    auto rpp = std::make_shared<RunPrincipal>(aux, preg_, *processConfiguration_, &(historyAppenders_[historyRunOffset_+principal.index()]),principal.index(),false);
-    auto & processHistoryRegistry = processHistoryRegistries_[historyRunOffset_+principal.index()];
+    auto rpp = std::make_shared<RunPrincipal>(aux, preg_, *processConfiguration_,
+                                              &(historyAppenders_[historyRunOffset_ + principal.index()]),
+                                              principal.index(), false);
+    auto& processHistoryRegistry = processHistoryRegistries_[historyRunOffset_ + principal.index()];
     processHistoryRegistry.registerProcessHistory(principal.processHistory());
     rpp->fillRunPrincipal(processHistoryRegistry, principal.reader());
     principalCache_.insert(rpp);
-    
+
     ProcessHistoryID const& parentInputReducedPHID = principal.reducedProcessHistoryID();
-    ProcessHistoryID const& inputReducedPHID       = rpp->reducedProcessHistoryID();
-    
-    parentToChildPhID_.insert(std::make_pair(parentInputReducedPHID,inputReducedPHID));
-    
+    ProcessHistoryID const& inputReducedPHID = rpp->reducedProcessHistoryID();
+
+    parentToChildPhID_.insert(std::make_pair(parentInputReducedPHID, inputReducedPHID));
+
     RunPrincipal& rp = *principalCache_.runPrincipalPtr();
     propagateProducts(InRun, principal, rp);
     typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> Traits;
-    beginGlobalTransitionAsync<Traits>(std::move(iHolder),
-                                       *schedule_,
-                                       rp,
-                                       ts,
-                                       esp_->eventSetup(),
-                                       serviceToken_,
+    beginGlobalTransitionAsync<Traits>(std::move(iHolder), *schedule_, rp, ts, esp_->eventSetup(), serviceToken_,
                                        subProcesses_);
   }
 
-  
-  void
-  SubProcess::doEndRunAsync(WaitingTaskHolder iHolder,
-                            RunPrincipal const& principal,
-                            IOVSyncValue const& ts,
-                            bool cleaningUpAfterException) {
+  void SubProcess::doEndRunAsync(WaitingTaskHolder iHolder,
+                                 RunPrincipal const& principal,
+                                 IOVSyncValue const& ts,
+                                 bool cleaningUpAfterException) {
     RunPrincipal& rp = *principalCache_.runPrincipalPtr();
     propagateProducts(InRun, principal, rp);
     typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Traits;
-    endGlobalTransitionAsync<Traits>(std::move(iHolder),
-                                     *schedule_,
-                                     rp,
-                                     ts,
-                                     esp_->eventSetup(),
-                                     serviceToken_,
-                                     subProcesses_,
-                                     cleaningUpAfterException);
+    endGlobalTransitionAsync<Traits>(std::move(iHolder), *schedule_, rp, ts, esp_->eventSetup(), serviceToken_,
+                                     subProcesses_, cleaningUpAfterException);
   }
 
-  void
-  SubProcess::writeRunAsync(edm::WaitingTaskHolder task, ProcessHistoryID const& parentPhID, int runNumber,
-                            MergeableRunProductMetadata const* mergeableRunProductMetadata) {
+  void SubProcess::writeRunAsync(edm::WaitingTaskHolder task,
+                                 ProcessHistoryID const& parentPhID,
+                                 int runNumber,
+                                 MergeableRunProductMetadata const* mergeableRunProductMetadata) {
     ServiceRegistry::Operate operate(serviceToken_);
     std::map<ProcessHistoryID, ProcessHistoryID>::const_iterator it = parentToChildPhID_.find(parentPhID);
     assert(it != parentToChildPhID_.end());
     auto const& childPhID = it->second;
-    
-    auto subTasks = edm::make_waiting_task(tbb::task::allocate_root(), [this,childPhID,runNumber, task, mergeableRunProductMetadata](std::exception_ptr const* iExcept) mutable {
-      if( iExcept) {
-        task.doneWaiting(*iExcept);
-      } else {
-        ServiceRegistry::Operate operate(serviceToken_);
-        for(auto& s: subProcesses_) {
-          s.writeRunAsync(task, childPhID, runNumber, mergeableRunProductMetadata);
-        }
-      }
-    });
-    schedule_->writeRunAsync(WaitingTaskHolder(subTasks),principalCache_.runPrincipal(childPhID, runNumber),
+
+    auto subTasks = edm::make_waiting_task(
+        tbb::task::allocate_root(),
+        [this, childPhID, runNumber, task, mergeableRunProductMetadata](std::exception_ptr const* iExcept) mutable {
+          if (iExcept) {
+            task.doneWaiting(*iExcept);
+          } else {
+            ServiceRegistry::Operate operate(serviceToken_);
+            for (auto& s : subProcesses_) {
+              s.writeRunAsync(task, childPhID, runNumber, mergeableRunProductMetadata);
+            }
+          }
+        });
+    schedule_->writeRunAsync(WaitingTaskHolder(subTasks), principalCache_.runPrincipal(childPhID, runNumber),
                              &processContext_, actReg_.get(), mergeableRunProductMetadata);
   }
 
-  void
-  SubProcess::deleteRunFromCache(ProcessHistoryID const& parentPhID, int runNumber) {
+  void SubProcess::deleteRunFromCache(ProcessHistoryID const& parentPhID, int runNumber) {
     std::map<ProcessHistoryID, ProcessHistoryID>::const_iterator it = parentToChildPhID_.find(parentPhID);
     assert(it != parentToChildPhID_.end());
     auto const& childPhID = it->second;
     principalCache_.deleteRun(childPhID, runNumber);
-    for_all(subProcesses_, [&childPhID, runNumber](auto& subProcess){ subProcess.deleteRunFromCache(childPhID, runNumber); });
+    for_all(subProcesses_,
+            [&childPhID, runNumber](auto& subProcess) { subProcess.deleteRunFromCache(childPhID, runNumber); });
   }
 
-  void
-  SubProcess::doBeginLuminosityBlockAsync(WaitingTaskHolder iHolder, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts) {
+  void SubProcess::doBeginLuminosityBlockAsync(WaitingTaskHolder iHolder,
+                                               LuminosityBlockPrincipal const& principal,
+                                               IOVSyncValue const& ts) {
     ServiceRegistry::Operate operate(serviceToken_);
 
     auto aux = principal.aux();
     aux.setProcessHistoryID(principal.processHistoryID());
     auto lbpp = principalCache_.getAvailableLumiPrincipalPtr();
     lbpp->setAux(aux);
-    auto & processHistoryRegistry = processHistoryRegistries_[historyLumiOffset_+lbpp->index()];
+    auto& processHistoryRegistry = processHistoryRegistries_[historyLumiOffset_ + lbpp->index()];
     inUseLumiPrincipals_[principal.index()] = lbpp;
     processHistoryRegistry.registerProcessHistory(principal.processHistory());
     lbpp->fillLuminosityBlockPrincipal(processHistoryRegistry, principal.reader());
@@ -511,155 +464,115 @@ namespace edm {
     LuminosityBlockPrincipal& lbp = *lbpp;
     propagateProducts(InLumi, principal, lbp);
     typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Traits;
-    beginGlobalTransitionAsync<Traits>(std::move(iHolder),
-                                       *schedule_,
-                                       lbp,
-                                       ts,
-                                       esp_->eventSetup(),
-                                       serviceToken_,
+    beginGlobalTransitionAsync<Traits>(std::move(iHolder), *schedule_, lbp, ts, esp_->eventSetup(), serviceToken_,
                                        subProcesses_);
   }
 
-  void
-  SubProcess::doEndLuminosityBlockAsync(WaitingTaskHolder iHolder,LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException) {
-    
+  void SubProcess::doEndLuminosityBlockAsync(WaitingTaskHolder iHolder,
+                                             LuminosityBlockPrincipal const& principal,
+                                             IOVSyncValue const& ts,
+                                             bool cleaningUpAfterException) {
     LuminosityBlockPrincipal& lbp = *inUseLumiPrincipals_[principal.index()];
     propagateProducts(InLumi, principal, lbp);
     typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Traits;
-    endGlobalTransitionAsync<Traits>(std::move(iHolder),
-                                     *schedule_,
-                                     lbp,
-                                     ts,
-                                     esp_->eventSetup(),
-                                     serviceToken_,
-                                     subProcesses_,
-                                     cleaningUpAfterException);
+    endGlobalTransitionAsync<Traits>(std::move(iHolder), *schedule_, lbp, ts, esp_->eventSetup(), serviceToken_,
+                                     subProcesses_, cleaningUpAfterException);
   }
 
-  
-  void
-  SubProcess::writeLumiAsync(WaitingTaskHolder task, LuminosityBlockPrincipal& principal) {
+  void SubProcess::writeLumiAsync(WaitingTaskHolder task, LuminosityBlockPrincipal& principal) {
     ServiceRegistry::Operate operate(serviceToken_);
 
-    auto l =inUseLumiPrincipals_[principal.index()];
-    auto subTasks = edm::make_waiting_task(tbb::task::allocate_root(), [this,l, task](std::exception_ptr const* iExcept) mutable {
-      if( iExcept) {
-        task.doneWaiting(*iExcept);
-      } else {
-        ServiceRegistry::Operate operate(serviceToken_);
-        for(auto& s: subProcesses_) {
-          s.writeLumiAsync(task, *l);
-        }
-      }
-    });
-    schedule_->writeLumiAsync(WaitingTaskHolder(subTasks),*l, &processContext_, actReg_.get());
+    auto l = inUseLumiPrincipals_[principal.index()];
+    auto subTasks =
+        edm::make_waiting_task(tbb::task::allocate_root(), [this, l, task](std::exception_ptr const* iExcept) mutable {
+          if (iExcept) {
+            task.doneWaiting(*iExcept);
+          } else {
+            ServiceRegistry::Operate operate(serviceToken_);
+            for (auto& s : subProcesses_) {
+              s.writeLumiAsync(task, *l);
+            }
+          }
+        });
+    schedule_->writeLumiAsync(WaitingTaskHolder(subTasks), *l, &processContext_, actReg_.get());
   }
 
-  void
-  SubProcess::deleteLumiFromCache(LuminosityBlockPrincipal& principal) {
+  void SubProcess::deleteLumiFromCache(LuminosityBlockPrincipal& principal) {
     //release from list but stay around till end of routine
     auto lb = std::move(inUseLumiPrincipals_[principal.index()]);
-    for(auto& s: subProcesses_) {
+    for (auto& s : subProcesses_) {
       s.deleteLumiFromCache(*lb);
     }
     lb->clearPrincipal();
   }
 
-  void
-  SubProcess::doBeginStream(unsigned int iID) {
+  void SubProcess::doBeginStream(unsigned int iID) {
     ServiceRegistry::Operate operate(serviceToken_);
     schedule_->beginStream(iID);
-    for_all(subProcesses_, [iID](auto& subProcess){ subProcess.doBeginStream(iID); });
+    for_all(subProcesses_, [iID](auto& subProcess) { subProcess.doBeginStream(iID); });
   }
 
-  void
-  SubProcess::doEndStream(unsigned int iID) {
+  void SubProcess::doEndStream(unsigned int iID) {
     ServiceRegistry::Operate operate(serviceToken_);
     schedule_->endStream(iID);
-    for_all(subProcesses_, [iID](auto& subProcess){ subProcess.doEndStream(iID); });
+    for_all(subProcesses_, [iID](auto& subProcess) { subProcess.doEndStream(iID); });
   }
 
-  void
-  SubProcess::doStreamBeginRunAsync(WaitingTaskHolder iHolder,
-                                    unsigned int id, RunPrincipal const& principal, IOVSyncValue const& ts) {
+  void SubProcess::doStreamBeginRunAsync(WaitingTaskHolder iHolder,
+                                         unsigned int id,
+                                         RunPrincipal const& principal,
+                                         IOVSyncValue const& ts) {
     typedef OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> Traits;
 
     RunPrincipal& rp = *principalCache_.runPrincipalPtr();
 
-    beginStreamTransitionAsync<Traits>(std::move(iHolder),
-                                       *schedule_,
-                                       id,
-                                       rp,
-                                       ts,
-                                       esp_->eventSetup(),
-                                       serviceToken_,
+    beginStreamTransitionAsync<Traits>(std::move(iHolder), *schedule_, id, rp, ts, esp_->eventSetup(), serviceToken_,
                                        subProcesses_);
-    
   }
 
-  
-  void
-  SubProcess::doStreamEndRunAsync(WaitingTaskHolder iHolder,
-                                  unsigned int id, RunPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException) {
+  void SubProcess::doStreamEndRunAsync(WaitingTaskHolder iHolder,
+                                       unsigned int id,
+                                       RunPrincipal const& principal,
+                                       IOVSyncValue const& ts,
+                                       bool cleaningUpAfterException) {
     RunPrincipal& rp = *principalCache_.runPrincipalPtr();
     typedef OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> Traits;
-    
-    endStreamTransitionAsync<Traits>(std::move(iHolder),
-                                      *schedule_,
-                                       id,
-                                       rp,
-                                       ts,
-                                       esp_->eventSetup(),
-                                       serviceToken_,
-                                       subProcesses_,
-                                     cleaningUpAfterException);
+
+    endStreamTransitionAsync<Traits>(std::move(iHolder), *schedule_, id, rp, ts, esp_->eventSetup(), serviceToken_,
+                                     subProcesses_, cleaningUpAfterException);
   }
 
-  void
-  SubProcess::doStreamBeginLuminosityBlockAsync(WaitingTaskHolder iHolder,
-                                                unsigned int id, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts) {
+  void SubProcess::doStreamBeginLuminosityBlockAsync(WaitingTaskHolder iHolder,
+                                                     unsigned int id,
+                                                     LuminosityBlockPrincipal const& principal,
+                                                     IOVSyncValue const& ts) {
     typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> Traits;
-    
+
     LuminosityBlockPrincipal& lbp = *inUseLumiPrincipals_[principal.index()];
-    
-    beginStreamTransitionAsync<Traits>(std::move(iHolder),
-                                       *schedule_,
-                                       id,
-                                       lbp,
-                                       ts,
-                                       esp_->eventSetup(),
-                                       serviceToken_,
+
+    beginStreamTransitionAsync<Traits>(std::move(iHolder), *schedule_, id, lbp, ts, esp_->eventSetup(), serviceToken_,
                                        subProcesses_);
   }
 
-  
-  
-  void
-  SubProcess::doStreamEndLuminosityBlockAsync(WaitingTaskHolder iHolder,
-                                              unsigned int id, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException) {
+  void SubProcess::doStreamEndLuminosityBlockAsync(WaitingTaskHolder iHolder,
+                                                   unsigned int id,
+                                                   LuminosityBlockPrincipal const& principal,
+                                                   IOVSyncValue const& ts,
+                                                   bool cleaningUpAfterException) {
     LuminosityBlockPrincipal& lbp = *inUseLumiPrincipals_[principal.index()];
     typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> Traits;
-    endStreamTransitionAsync<Traits>(std::move(iHolder),
-                                       *schedule_,
-                                       id,
-                                       lbp,
-                                       ts,
-                                       esp_->eventSetup(),
-                                       serviceToken_,
-                                       subProcesses_,
-                                       cleaningUpAfterException);
+    endStreamTransitionAsync<Traits>(std::move(iHolder), *schedule_, id, lbp, ts, esp_->eventSetup(), serviceToken_,
+                                     subProcesses_, cleaningUpAfterException);
   }
 
-
-  void
-  SubProcess::propagateProducts(BranchType type, Principal const& parentPrincipal, Principal& principal) const {
+  void SubProcess::propagateProducts(BranchType type, Principal const& parentPrincipal, Principal& principal) const {
     SelectedProducts const& keptVector = keptProducts()[type];
-    for(auto const& item : keptVector) {
+    for (auto const& item : keptVector) {
       BranchDescription const& desc = *item.first;
       ProductResolverBase const* parentProductResolver = parentPrincipal.getProductResolver(desc.branchID());
-      if(parentProductResolver != nullptr) {
+      if (parentProductResolver != nullptr) {
         ProductResolverBase* productResolver = principal.getModifiableProductResolver(desc.branchID());
-        if(productResolver != nullptr) {
+        if (productResolver != nullptr) {
           //Propagate the per event(run)(lumi) data for this product to the subprocess.
           //First, the product itself.
           productResolver->connectTo(*parentProductResolver, &parentPrincipal);
@@ -670,24 +583,24 @@ namespace edm {
 
   void SubProcess::updateBranchIDListHelper(BranchIDLists const& branchIDLists) {
     branchIDListHelper_->updateFromParent(branchIDLists);
-    for_all(subProcesses_, [this](auto& subProcess){ subProcess.updateBranchIDListHelper(branchIDListHelper_->branchIDLists()); });
+    for_all(subProcesses_,
+            [this](auto& subProcess) { subProcess.updateBranchIDListHelper(branchIDListHelper_->branchIDLists()); });
   }
 
   // Call respondToOpenInputFile() on all Modules
-  void
-  SubProcess::respondToOpenInputFile(FileBlock const& fb) {
+  void SubProcess::respondToOpenInputFile(FileBlock const& fb) {
     ServiceRegistry::Operate operate(serviceToken_);
     schedule_->respondToOpenInputFile(fb);
-    for_all(subProcesses_, [&fb](auto& subProcess){ subProcess.respondToOpenInputFile(fb); });
+    for_all(subProcesses_, [&fb](auto& subProcess) { subProcess.respondToOpenInputFile(fb); });
   }
 
   // free function
-  std::vector<ParameterSet>
-  popSubProcessVParameterSet(ParameterSet& parameterSet) {
-    std::vector<std::string> subProcesses = parameterSet.getUntrackedParameter<std::vector<std::string>>("@all_subprocesses");
-    if(!subProcesses.empty()) {
+  std::vector<ParameterSet> popSubProcessVParameterSet(ParameterSet& parameterSet) {
+    std::vector<std::string> subProcesses =
+        parameterSet.getUntrackedParameter<std::vector<std::string>>("@all_subprocesses");
+    if (!subProcesses.empty()) {
       return parameterSet.popVParameterSet("subProcesses");
     }
     return {};
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/SystemTimeKeeper.cc
+++ b/FWCore/Framework/src/SystemTimeKeeper.cc
@@ -2,7 +2,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     SystemTimeKeeper
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -41,85 +41,74 @@ using namespace edm;
 SystemTimeKeeper::SystemTimeKeeper(unsigned int iNumStreams,
                                    std::vector<const ModuleDescription*> const& iModules,
                                    service::TriggerNamesService const& iNamesService,
-                                   ProcessContext const* iProcessContext):
-m_streamEventTimer(iNumStreams),
-m_streamPathTiming(iNumStreams),
-m_modules(iModules),
-m_processContext(iProcessContext),
-m_minModuleID(0),
-m_numberOfEvents(0)
-{
-  std::sort(m_modules.begin(),m_modules.end(),
-            [] (const ModuleDescription* iLHS,
-                      const ModuleDescription* iRHS) -> bool {
-              return iLHS->id() < iRHS->id();
-            });
-  if(not m_modules.empty()) {
+                                   ProcessContext const* iProcessContext)
+    : m_streamEventTimer(iNumStreams),
+      m_streamPathTiming(iNumStreams),
+      m_modules(iModules),
+      m_processContext(iProcessContext),
+      m_minModuleID(0),
+      m_numberOfEvents(0) {
+  std::sort(
+      m_modules.begin(), m_modules.end(),
+      [](const ModuleDescription* iLHS, const ModuleDescription* iRHS) -> bool { return iLHS->id() < iRHS->id(); });
+  if (not m_modules.empty()) {
     m_minModuleID = m_modules.front()->id();
     unsigned int numModuleSlots = m_modules.back()->id() - m_minModuleID + 1;
     m_streamModuleTiming.resize(iNumStreams);
-    for(auto& stream: m_streamModuleTiming) {
+    for (auto& stream : m_streamModuleTiming) {
       stream.resize(numModuleSlots);
     }
   }
-  
-  
+
   std::vector<unsigned int> numModulesInPath;
   std::vector<unsigned int> numModulesInEndPath;
-  
+
   const unsigned int numPaths = iNamesService.getTrigPaths().size();
   const unsigned int numEndPaths = iNamesService.getEndPaths().size();
-  m_pathNames.reserve(numPaths+numEndPaths);
-  std::copy(iNamesService.getTrigPaths().begin(),
-            iNamesService.getTrigPaths().end(),
-            std::back_inserter(m_pathNames));
-  std::copy(iNamesService.getEndPaths().begin(),
-            iNamesService.getEndPaths().end(),
-            std::back_inserter(m_pathNames));
-  
+  m_pathNames.reserve(numPaths + numEndPaths);
+  std::copy(iNamesService.getTrigPaths().begin(), iNamesService.getTrigPaths().end(), std::back_inserter(m_pathNames));
+  std::copy(iNamesService.getEndPaths().begin(), iNamesService.getEndPaths().end(), std::back_inserter(m_pathNames));
+
   numModulesInPath.reserve(numPaths);
   numModulesInEndPath.reserve(numEndPaths);
-  
-  m_modulesOnPaths.reserve(numPaths+numEndPaths);
-  
-  for(unsigned int i =0; i<numPaths;++i) {
+
+  m_modulesOnPaths.reserve(numPaths + numEndPaths);
+
+  for (unsigned int i = 0; i < numPaths; ++i) {
     numModulesInPath.push_back(iNamesService.getTrigPathModules(i).size());
     m_modulesOnPaths.push_back(iNamesService.getTrigPathModules(i));
   }
-  for(unsigned int i =0; i<numEndPaths;++i) {
+  for (unsigned int i = 0; i < numEndPaths; ++i) {
     numModulesInEndPath.push_back(iNamesService.getEndPathModules(i).size());
     m_modulesOnPaths.push_back(iNamesService.getEndPathModules(i));
   }
-  
-  m_endPathOffset =numModulesInPath.size();
 
-  for( auto& stream: m_streamPathTiming) {
+  m_endPathOffset = numModulesInPath.size();
+
+  for (auto& stream : m_streamPathTiming) {
     unsigned int index = 0;
-    stream.resize(numModulesInPath.size()+numModulesInEndPath.size());
-    for(unsigned int numMods : numModulesInPath) {
+    stream.resize(numModulesInPath.size() + numModulesInEndPath.size());
+    for (unsigned int numMods : numModulesInPath) {
       stream[index].m_moduleTiming.resize(numMods);
       ++index;
     }
-    for(unsigned int numMods : numModulesInEndPath) {
+    for (unsigned int numMods : numModulesInEndPath) {
       stream[index].m_moduleTiming.resize(numMods);
       ++index;
     }
-    
   }
 }
 
 //
 // member functions
 //
-SystemTimeKeeper::PathTiming&
-SystemTimeKeeper::pathTiming(StreamContext const& iStream,
-                             PathContext const& iPath) {
+SystemTimeKeeper::PathTiming& SystemTimeKeeper::pathTiming(StreamContext const& iStream, PathContext const& iPath) {
   unsigned int offset = 0;
-  if(iPath.isEndPath()) {
+  if (iPath.isEndPath()) {
     offset = m_endPathOffset;
   }
-  assert(iPath.pathID()+offset < m_streamPathTiming[iStream.streamID().value()].size());
-  return m_streamPathTiming[iStream.streamID().value()][iPath.pathID()+offset];
+  assert(iPath.pathID() + offset < m_streamPathTiming[iStream.streamID().value()].size());
+  return m_streamPathTiming[iStream.streamID().value()][iPath.pathID() + offset];
 }
 
 //NOTE: Have to check bounds rather than ProcessContext on the
@@ -127,137 +116,108 @@ SystemTimeKeeper::pathTiming(StreamContext const& iStream,
 // SubProcess which requested an usncheduled execution of a
 // module in a parent process. In that case the ProcessContext
 // is for the SubProcess but the module is is for the parent process.
-inline bool
-SystemTimeKeeper::checkBounds(unsigned int id) const {
-  return id >= m_minModuleID and id <m_streamModuleTiming.front().size()+ m_minModuleID;
+inline bool SystemTimeKeeper::checkBounds(unsigned int id) const {
+  return id >= m_minModuleID and id < m_streamModuleTiming.front().size() + m_minModuleID;
 }
 
-
-
-void
-SystemTimeKeeper::startEvent(StreamID iID) {
+void SystemTimeKeeper::startEvent(StreamID iID) {
   m_numberOfEvents++;
   m_streamEventTimer[iID.value()].start();
 }
 
-void
-SystemTimeKeeper::stopEvent(StreamContext const& iContext) {
+void SystemTimeKeeper::stopEvent(StreamContext const& iContext) {
   m_streamEventTimer[iContext.streamID().value()].stop();
 }
 
-void
-SystemTimeKeeper::startPath(StreamContext const& iStream,
-                            PathContext const& iPath) {
-  if(m_processContext == iStream.processContext()) {
-    auto& timing = pathTiming(iStream,iPath);
+void SystemTimeKeeper::startPath(StreamContext const& iStream, PathContext const& iPath) {
+  if (m_processContext == iStream.processContext()) {
+    auto& timing = pathTiming(iStream, iPath);
     timing.m_timer.start();
   }
 }
 
-void
-SystemTimeKeeper::stopPath(StreamContext const& iStream,
-                           PathContext const& iPath,
-                           HLTPathStatus const& iStatus) {
-  if(m_processContext == iStream.processContext()) {
-
-    auto& timing = pathTiming(iStream,iPath);
+void SystemTimeKeeper::stopPath(StreamContext const& iStream, PathContext const& iPath, HLTPathStatus const& iStatus) {
+  if (m_processContext == iStream.processContext()) {
+    auto& timing = pathTiming(iStream, iPath);
     timing.m_timer.stop();
-    
+
     //mark all modules up to and including the decision module as being visited
     auto& modsOnPath = timing.m_moduleTiming;
-    for(unsigned int i = 0; i< iStatus.index()+1;++i) {
+    for (unsigned int i = 0; i < iStatus.index() + 1; ++i) {
       ++modsOnPath[i].m_timesVisited;
     }
   }
 }
 
-
-void
-SystemTimeKeeper::startModuleEvent(StreamContext const& iStream, ModuleCallingContext const& iModule) {
-  if(checkBounds(iModule.moduleDescription()->id())) {
-    auto& mod =
-    m_streamModuleTiming[iStream.streamID().value()][iModule.moduleDescription()->id()-m_minModuleID];
+void SystemTimeKeeper::startModuleEvent(StreamContext const& iStream, ModuleCallingContext const& iModule) {
+  if (checkBounds(iModule.moduleDescription()->id())) {
+    auto& mod = m_streamModuleTiming[iStream.streamID().value()][iModule.moduleDescription()->id() - m_minModuleID];
     mod.m_timer.start();
     ++(mod.m_timesRun);
   }
 }
-void SystemTimeKeeper::stopModuleEvent(StreamContext const& iStream,
-                                       ModuleCallingContext const& iModule) {
-  if(checkBounds(iModule.moduleDescription()->id())) {
-    auto& mod =
-    m_streamModuleTiming[iStream.streamID().value()][iModule.moduleDescription()->id()-m_minModuleID];
+void SystemTimeKeeper::stopModuleEvent(StreamContext const& iStream, ModuleCallingContext const& iModule) {
+  if (checkBounds(iModule.moduleDescription()->id())) {
+    auto& mod = m_streamModuleTiming[iStream.streamID().value()][iModule.moduleDescription()->id() - m_minModuleID];
     auto times = mod.m_timer.stop();
-    
-    if(iModule.type() == ParentContext::Type::kPlaceInPath ) {
+
+    if (iModule.type() == ParentContext::Type::kPlaceInPath) {
       auto place = iModule.placeInPathContext();
-      
-      auto& modTiming = pathTiming(iStream,*(place->pathContext())).m_moduleTiming[place->placeInPath()];
+
+      auto& modTiming = pathTiming(iStream, *(place->pathContext())).m_moduleTiming[place->placeInPath()];
       modTiming.m_realTime += times;
     }
   }
 }
-void SystemTimeKeeper::pauseModuleEvent(StreamContext const& iStream,
-                                        ModuleCallingContext const& iModule) {
-  if(checkBounds(iModule.moduleDescription()->id())) {
-    auto& mod =
-    m_streamModuleTiming[iStream.streamID().value()][iModule.moduleDescription()->id()-m_minModuleID];
+void SystemTimeKeeper::pauseModuleEvent(StreamContext const& iStream, ModuleCallingContext const& iModule) {
+  if (checkBounds(iModule.moduleDescription()->id())) {
+    auto& mod = m_streamModuleTiming[iStream.streamID().value()][iModule.moduleDescription()->id() - m_minModuleID];
     auto times = mod.m_timer.stop();
-    
-    if(iModule.type() == ParentContext::Type::kPlaceInPath ) {
+
+    if (iModule.type() == ParentContext::Type::kPlaceInPath) {
       auto place = iModule.placeInPathContext();
-      
-      auto& modTiming = pathTiming(iStream,*(place->pathContext())).m_moduleTiming[place->placeInPath()];
+
+      auto& modTiming = pathTiming(iStream, *(place->pathContext())).m_moduleTiming[place->placeInPath()];
       modTiming.m_realTime += times;
     }
   }
 }
-void
-SystemTimeKeeper::restartModuleEvent(StreamContext const& iStream,
-                                     ModuleCallingContext const& iModule) {
-  if(checkBounds(iModule.moduleDescription()->id())) {
-    auto& mod =
-    m_streamModuleTiming[iStream.streamID().value()][iModule.moduleDescription()->id()-m_minModuleID];
+void SystemTimeKeeper::restartModuleEvent(StreamContext const& iStream, ModuleCallingContext const& iModule) {
+  if (checkBounds(iModule.moduleDescription()->id())) {
+    auto& mod = m_streamModuleTiming[iStream.streamID().value()][iModule.moduleDescription()->id() - m_minModuleID];
     mod.m_timer.start();
   }
 }
 
-void
-SystemTimeKeeper::startProcessingLoop() {
-  m_processingLoopTimer.start();
-}
+void SystemTimeKeeper::startProcessingLoop() { m_processingLoopTimer.start(); }
 
-void
-SystemTimeKeeper::stopProcessingLoop() {
-  m_processingLoopTimer.stop();
-}
+void SystemTimeKeeper::stopProcessingLoop() { m_processingLoopTimer.stop(); }
 
+static void fillPathSummary(unsigned int iStartIndex,
+                            unsigned int iEndIndex,
+                            std::vector<std::string> const& iPathNames,
+                            std::vector<std::vector<std::string>> const& iModulesOnPaths,
+                            std::vector<std::vector<SystemTimeKeeper::PathTiming>> const& iPathTimings,
+                            std::vector<PathTimingSummary>& iSummary) {
+  iSummary.resize(iEndIndex - iStartIndex);
 
-static void
-fillPathSummary(unsigned int iStartIndex,
-                unsigned int iEndIndex,
-                std::vector<std::string> const& iPathNames,
-                std::vector<std::vector<std::string>> const& iModulesOnPaths,
-                std::vector<std::vector<SystemTimeKeeper::PathTiming>> const& iPathTimings,
-                std::vector<PathTimingSummary>& iSummary) {
-  iSummary.resize(iEndIndex-iStartIndex);
-
-  for(auto const& stream: iPathTimings) {
+  for (auto const& stream : iPathTimings) {
     auto it = iSummary.begin();
-    for(unsigned int index = iStartIndex; index < iEndIndex; ++index, ++it) {
+    for (unsigned int index = iStartIndex; index < iEndIndex; ++index, ++it) {
       auto const& pathTiming = stream[index];
       it->name = iPathNames[index];
-      it->bitPosition = index-iStartIndex;
-      if(not pathTiming.m_moduleTiming.empty()) {
+      it->bitPosition = index - iStartIndex;
+      if (not pathTiming.m_moduleTiming.empty()) {
         it->timesRun += pathTiming.m_moduleTiming[0].m_timesVisited;
       }
       it->realTime += pathTiming.m_timer.realTime();
-      if(it->moduleInPathSummaries.empty()) {
+      if (it->moduleInPathSummaries.empty()) {
         it->moduleInPathSummaries.resize(pathTiming.m_moduleTiming.size());
       }
-      for(unsigned int modIndex=0; modIndex < pathTiming.m_moduleTiming.size(); ++modIndex) {
-        auto const& modTiming =pathTiming.m_moduleTiming[modIndex];
-        auto& modSummary =it->moduleInPathSummaries[modIndex];
-        if(modSummary.moduleLabel.empty()) {
+      for (unsigned int modIndex = 0; modIndex < pathTiming.m_moduleTiming.size(); ++modIndex) {
+        auto const& modTiming = pathTiming.m_moduleTiming[modIndex];
+        auto& modSummary = it->moduleInPathSummaries[modIndex];
+        if (modSummary.moduleLabel.empty()) {
           modSummary.moduleLabel = iModulesOnPaths[index][modIndex];
         }
         modSummary.timesVisited += modTiming.m_timesVisited;
@@ -267,30 +227,29 @@ fillPathSummary(unsigned int iStartIndex,
   }
 }
 
-void
-SystemTimeKeeper::fillTriggerTimingReport(TriggerTimingReport& rep) const {
+void SystemTimeKeeper::fillTriggerTimingReport(TriggerTimingReport& rep) const {
   {
     rep.eventSummary.totalEvents = m_numberOfEvents;
     double sumEventTime = 0.;
-    for(auto const& stream: m_streamEventTimer) {
+    for (auto const& stream : m_streamEventTimer) {
       sumEventTime += stream.realTime();
     }
     rep.eventSummary.realTime = m_processingLoopTimer.realTime();
     rep.eventSummary.cpuTime = m_processingLoopTimer.cpuTime();
     rep.eventSummary.sumStreamRealTime = sumEventTime;
   }
-  
+
   //Per module summary
   {
     auto& summary = rep.workerSummaries;
     summary.resize(m_modules.size());
     //Figure out how often a module was visited
-    std::map<std::string,unsigned int> visited;
-    for(auto const& stream: m_streamPathTiming) {
+    std::map<std::string, unsigned int> visited;
+    for (auto const& stream : m_streamPathTiming) {
       unsigned int pathIndex = 0;
-      for(auto const& path: stream) {
+      for (auto const& path : stream) {
         unsigned int modIndex = 0;
-        for(auto const& mod: path.m_moduleTiming) {
+        for (auto const& mod : path.m_moduleTiming) {
           visited[m_modulesOnPaths[pathIndex][modIndex]] += mod.m_timesVisited;
           ++modIndex;
         }
@@ -298,34 +257,34 @@ SystemTimeKeeper::fillTriggerTimingReport(TriggerTimingReport& rep) const {
       }
     }
 
-    unsigned int modIndex=0;
-    for(auto const& mod: m_modules) {
+    unsigned int modIndex = 0;
+    for (auto const& mod : m_modules) {
       auto& outMod = summary[modIndex];
       outMod.moduleLabel = mod->moduleLabel();
       outMod.realTime = 0.;
-      
-      auto moduleId =mod->id()-m_minModuleID;
-      for(auto const& stream: m_streamModuleTiming) {
+
+      auto moduleId = mod->id() - m_minModuleID;
+      for (auto const& stream : m_streamModuleTiming) {
         auto const& timing = stream[moduleId];
         outMod.realTime += timing.m_timer.realTime();
         outMod.timesRun += timing.m_timesRun;
       }
       outMod.timesVisited = visited[mod->moduleLabel()];
-      if(0 == outMod.timesVisited) {
+      if (0 == outMod.timesVisited) {
         outMod.timesVisited = outMod.timesRun;
       }
       ++modIndex;
     }
   }
   sort_all(rep.workerSummaries);
-  
+
   //Per path summary
   {
     fillPathSummary(0, m_endPathOffset, m_pathNames, m_modulesOnPaths, m_streamPathTiming, rep.trigPathSummaries);
-    fillPathSummary(m_endPathOffset, m_streamPathTiming[0].size(), m_pathNames, m_modulesOnPaths, m_streamPathTiming, rep.endPathSummaries);
+    fillPathSummary(m_endPathOffset, m_streamPathTiming[0].size(), m_pathNames, m_modulesOnPaths, m_streamPathTiming,
+                    rep.endPathSummaries);
   }
 }
-
 
 //
 // const member functions

--- a/FWCore/Framework/src/SystemTimeKeeper.h
+++ b/FWCore/Framework/src/SystemTimeKeeper.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     SystemTimeKeeper
-// 
+//
 /**\class SystemTimeKeeper SystemTimeKeeper.h "SystemTimeKeeper.h"
 
  Description: Runs timers for system components
@@ -42,35 +42,33 @@ namespace edm {
   namespace service {
     class TriggerNamesService;
   }
-  
-  class SystemTimeKeeper
-  {
-    
+
+  class SystemTimeKeeper {
   public:
     SystemTimeKeeper(unsigned int iNumStreams,
                      std::vector<const ModuleDescription*> const& iModules,
                      service::TriggerNamesService const& iNameService,
                      ProcessContext const* iProcessContext);
-    
+
     // ---------- const member functions ---------------------
-    
+
     // ---------- static member functions --------------------
-    
+
     // ---------- member functions ---------------------------
     void startProcessingLoop();
     void stopProcessingLoop();
-    
+
     void startEvent(StreamID);
     void stopEvent(StreamContext const&);
-    
+
     void startPath(StreamContext const&, PathContext const&);
     void stopPath(StreamContext const&, PathContext const&, HLTPathStatus const&);
-    
+
     void startModuleEvent(StreamContext const&, ModuleCallingContext const&);
     void stopModuleEvent(StreamContext const&, ModuleCallingContext const&);
     void pauseModuleEvent(StreamContext const&, ModuleCallingContext const&);
     void restartModuleEvent(StreamContext const&, ModuleCallingContext const&);
-    
+
     struct ModuleInPathTiming {
       double m_realTime = 0.;
       unsigned int m_timesVisited = 0;
@@ -82,38 +80,37 @@ namespace edm {
 
     struct ModuleTiming {
       WallclockTimer m_timer;
-      unsigned int m_timesRun =0;
+      unsigned int m_timesRun = 0;
     };
 
     void fillTriggerTimingReport(TriggerTimingReport& rep) const;
+
   private:
-    SystemTimeKeeper(const SystemTimeKeeper&) = delete; // stop default
-    
-    const SystemTimeKeeper& operator=(const SystemTimeKeeper&) = delete; // stop default
-    
+    SystemTimeKeeper(const SystemTimeKeeper&) = delete;  // stop default
+
+    const SystemTimeKeeper& operator=(const SystemTimeKeeper&) = delete;  // stop default
+
     PathTiming& pathTiming(StreamContext const&, PathContext const&);
     bool checkBounds(unsigned int id) const;
-    
+
     // ---------- member data --------------------------------
     std::vector<WallclockTimer> m_streamEventTimer;
-    
+
     std::vector<std::vector<PathTiming>> m_streamPathTiming;
-    
+
     std::vector<std::vector<ModuleTiming>> m_streamModuleTiming;
-    
-    std::vector<const ModuleDescription*>  m_modules;
+
+    std::vector<const ModuleDescription*> m_modules;
     std::vector<std::string> m_pathNames;
     std::vector<std::vector<std::string>> m_modulesOnPaths;
 
     CPUTimer m_processingLoopTimer;
     ProcessContext const* m_processContext;
-    
+
     unsigned int m_minModuleID;
     unsigned int m_endPathOffset;
     std::atomic<unsigned int> m_numberOfEvents;
-
   };
-}
-
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/TriggerNamesService.cc
+++ b/FWCore/Framework/src/TriggerNamesService.cc
@@ -12,66 +12,58 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
-
 namespace edm {
   namespace service {
 
     TriggerNamesService::TriggerNamesService(const ParameterSet& pset) {
-
-      trigger_pset_ = 
-	pset.getParameterSet("@trigger_paths");
+      trigger_pset_ = pset.getParameterSet("@trigger_paths");
 
       trignames_ = trigger_pset_.getParameter<Strings>("@trigger_paths");
       end_names_ = pset.getParameter<Strings>("@end_paths");
 
       ParameterSet defopts;
-      ParameterSet const& opts = 
-	pset.getUntrackedParameterSet("options", defopts);
-      wantSummary_ =
-	opts.getUntrackedParameter("wantSummary", false);
+      ParameterSet const& opts = pset.getUntrackedParameterSet("options", defopts);
+      wantSummary_ = opts.getUntrackedParameter("wantSummary", false);
 
       process_name_ = pset.getParameter<std::string>("@process_name");
 
-      loadPosMap(trigpos_,trignames_);
-      loadPosMap(end_pos_,end_names_);
+      loadPosMap(trigpos_, trignames_);
+      loadPosMap(end_pos_, end_names_);
 
       const unsigned int n(trignames_.size());
-      for(unsigned int i = 0; i != n; ++i) {
+      for (unsigned int i = 0; i != n; ++i) {
         modulenames_.push_back(pset.getParameter<Strings>(trignames_[i]));
       }
-      for(unsigned int i = 0; i != end_names_.size(); ++i) {
+      for (unsigned int i = 0; i != end_names_.size(); ++i) {
         end_modulenames_.push_back(pset.getParameter<Strings>(end_names_[i]));
       }
     }
 
-    bool
-    TriggerNamesService::getTrigPaths(TriggerResults const& triggerResults,
-                                      Strings& trigPaths,
-                                      bool& fromPSetRegistry) {
-
+    bool TriggerNamesService::getTrigPaths(TriggerResults const& triggerResults,
+                                           Strings& trigPaths,
+                                           bool& fromPSetRegistry) {
       // Get the parameter set containing the trigger names from the parameter set registry
       // using the ID from TriggerResults as the key used to find it.
       ParameterSet const* pset = nullptr;
       pset::Registry const* psetRegistry = pset::Registry::instance();
       if (nullptr != (pset = psetRegistry->getMapped(triggerResults.parameterSetID()))) {
-
         // Check to make sure the parameter set contains
         // a Strings parameter named "trigger_paths".
         // We do not want to throw an exception if it is not there
         // for reasons of backward compatibility
         Strings const& psetNames = pset->getParameterNamesForType<Strings>();
         std::string name("@trigger_paths");
-	if (search_all(psetNames, name)) {
+        if (search_all(psetNames, name)) {
           // It is there, get it
           trigPaths = pset->getParameter<Strings>("@trigger_paths");
 
           // This should never happen
           if (trigPaths.size() != triggerResults.size()) {
             throw edm::Exception(edm::errors::Unknown)
-              << "TriggerNamesService::getTrigPaths, Trigger names vector and\n"
-                 "TriggerResults are different sizes.  This should be impossible,\n"
-                 "please send information to reproduce this problem to\n"
-                 "the edm developers.\n";
+                << "TriggerNamesService::getTrigPaths, Trigger names vector and\n"
+                   "TriggerResults are different sizes.  This should be impossible,\n"
+                   "please send information to reproduce this problem to\n"
+                   "the edm developers.\n";
           }
 
           fromPSetRegistry = true;
@@ -92,11 +84,9 @@ namespace edm {
       return false;
     }
 
-    bool
-    TriggerNamesService::getTrigPaths(TriggerResults const& triggerResults,
-                                      Strings& trigPaths) {
+    bool TriggerNamesService::getTrigPaths(TriggerResults const& triggerResults, Strings& trigPaths) {
       bool dummy;
       return getTrigPaths(triggerResults, trigPaths, dummy);
     }
-  }
-}
+  }  // namespace service
+}  // namespace edm

--- a/FWCore/Framework/src/TriggerResultInserter.cc
+++ b/FWCore/Framework/src/TriggerResultInserter.cc
@@ -6,22 +6,15 @@
 
 #include <memory>
 
-namespace edm
-{
-  TriggerResultInserter::TriggerResultInserter(const ParameterSet& pset, unsigned int iNStreams) :
-  resultsPerStream_(iNStreams),
-  pset_id_(pset.id()),
-  token_{produces<TriggerResults>()}
-  {
+namespace edm {
+  TriggerResultInserter::TriggerResultInserter(const ParameterSet& pset, unsigned int iNStreams)
+      : resultsPerStream_(iNStreams), pset_id_(pset.id()), token_{produces<TriggerResults>()} {}
+
+  void TriggerResultInserter::setTrigResultForStream(unsigned int iStreamIndex, const TrigResPtr& trptr) {
+    resultsPerStream_[iStreamIndex] = trptr;
   }
 
-  void
-  TriggerResultInserter::setTrigResultForStream(unsigned int iStreamIndex, const TrigResPtr& trptr) {
-    resultsPerStream_[iStreamIndex] =trptr;
+  void TriggerResultInserter::produce(StreamID id, edm::Event& e, edm::EventSetup const&) const {
+    e.emplace(token_, *resultsPerStream_[id.value()], pset_id_);
   }
-
-  void TriggerResultInserter::produce(StreamID id, edm::Event& e, edm::EventSetup const&) const
-  {
-    e.emplace(token_,*resultsPerStream_[id.value()], pset_id_);
-  }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/TriggerResultInserter.h
+++ b/FWCore/Framework/src/TriggerResultInserter.h
@@ -20,18 +20,15 @@
 
 #include <memory>
 
-namespace edm
-{
+namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
   class HLTGlobalStatus;
   class TriggerResults;
 
-  class TriggerResultInserter : public edm::global::EDProducer<>
-  {
+  class TriggerResultInserter : public edm::global::EDProducer<> {
   public:
-
     typedef std::shared_ptr<HLTGlobalStatus> TrigResPtr;
 
     // standard constructor not supported for this module
@@ -40,8 +37,7 @@ namespace edm
     // the pset needed here is the one that defines the trigger path names
     TriggerResultInserter(edm::ParameterSet const& ps, unsigned int iNStreams);
 
-    void setTrigResultForStream(unsigned int iStreamIndex,
-                                const TrigResPtr& trptr);
+    void setTrigResultForStream(unsigned int iStreamIndex, const TrigResPtr& trptr);
     void produce(StreamID id, edm::Event& e, edm::EventSetup const& c) const final;
 
   private:
@@ -50,5 +46,5 @@ namespace edm
     ParameterSetID pset_id_;
     EDPutTokenT<TriggerResults> token_;
   };
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
+++ b/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
@@ -28,18 +28,16 @@ namespace {
   // optional), return a parsed_path_spec_t containing "a" and "b".
 
   typedef std::pair<std::string, std::string> parsed_path_spec_t;
-  void parse_path_spec(std::string const& path_spec,
-                       parsed_path_spec_t& output) {
+  void parse_path_spec(std::string const& path_spec, parsed_path_spec_t& output) {
     std::string trimmed_path_spec(path_spec);
     remove_whitespace(trimmed_path_spec);
 
     std::string::size_type colon = trimmed_path_spec.find(":");
-    if(colon == std::string::npos) {
+    if (colon == std::string::npos) {
       output.first = trimmed_path_spec;
     } else {
-      output.first  = trimmed_path_spec.substr(0, colon);
-      output.second = trimmed_path_spec.substr(colon + 1,
-                                               trimmed_path_spec.size());
+      output.first = trimmed_path_spec.substr(0, colon);
+      output.second = trimmed_path_spec.substr(colon + 1, trimmed_path_spec.size());
     }
   }
 
@@ -52,34 +50,32 @@ namespace {
     paths.push_back("eee:  p4  ");
 
     std::vector<parsed_path_spec_t> parsed(paths.size());
-    for(size_t i = 0; i < paths.size(); ++i) {
+    for (size_t i = 0; i < paths.size(); ++i) {
       parse_path_spec(paths[i], parsed[i]);
     }
 
-    assert(parsed[0].first  == "a");
+    assert(parsed[0].first == "a");
     assert(parsed[0].second == "p1");
-    assert(parsed[1].first  == "b");
+    assert(parsed[1].first == "b");
     assert(parsed[1].second == "p2");
-    assert(parsed[2].first  == "c");
+    assert(parsed[2].first == "c");
     assert(parsed[2].second == "");
-    assert(parsed[3].first  == "ddd");
+    assert(parsed[3].first == "ddd");
     assert(parsed[3].second == "p3");
-    assert(parsed[4].first  == "eee");
+    assert(parsed[4].first == "eee");
     assert(parsed[4].second == "p4");
   }
-}
+}  // namespace
 
-namespace edm
-{
+namespace edm {
   namespace test {
     void run_all_output_module_tests() {
       test_remove_whitespace();
       test_parse_path_spec();
     }
-  }
+  }  // namespace test
 
-  namespace detail
-  {
+  namespace detail {
 
     bool configureEventSelector(edm::ParameterSet const& iPSet,
                                 std::string const& iProcessName,
@@ -90,15 +86,14 @@ namespace edm
       // all events, or one which contains a vstrig 'SelectEvents' that
       // is empty, we are to write all events. We have no need for any
       // EventSelectors.
-      if(iPSet.empty()) {
+      if (iPSet.empty()) {
         oSelector.setupDefault();
         return true;
       }
 
-      std::vector<std::string> path_specs =
-      iPSet.getParameter<std::vector<std::string> >("SelectEvents");
+      std::vector<std::string> path_specs = iPSet.getParameter<std::vector<std::string> >("SelectEvents");
 
-      if(path_specs.empty()) {
+      if (path_specs.empty()) {
         oSelector.setupDefault();
         return true;
       }
@@ -106,7 +101,7 @@ namespace edm
       // If we get here, we have the possibility of having to deal with
       // path_specs that look at more than one process.
       std::vector<parsed_path_spec_t> parsed_paths(path_specs.size());
-      for(size_t i = 0; i < path_specs.size(); ++i) {
+      for (size_t i = 0; i < path_specs.size(); ++i) {
         parse_path_spec(path_specs[i], parsed_paths[i]);
       }
       oSelector.setup(parsed_paths, iAllTriggerNames, iProcessName, std::move(iC));
@@ -116,21 +111,14 @@ namespace edm
 
     // typedef detail::NamedEventSelector NES;
 
-    TriggerResultsBasedEventSelector::TriggerResultsBasedEventSelector() :
-      selectors_(),
-      wantAllEvents_(false)
-    { }
+    TriggerResultsBasedEventSelector::TriggerResultsBasedEventSelector() : selectors_(), wantAllEvents_(false) {}
 
-    void
-    TriggerResultsBasedEventSelector::setupDefault() {
-      wantAllEvents_ = true;
-    }
+    void TriggerResultsBasedEventSelector::setupDefault() { wantAllEvents_ = true; }
 
-    void
-    TriggerResultsBasedEventSelector::setup(std::vector<parsed_path_spec_t> const& path_specs,
-                          std::vector<std::string> const& triggernames,
-                          std::string const& process_name,
-                          ConsumesCollector&& iC) {
+    void TriggerResultsBasedEventSelector::setup(std::vector<parsed_path_spec_t> const& path_specs,
+                                                 std::vector<std::string> const& triggernames,
+                                                 std::string const& process_name,
+                                                 ConsumesCollector&& iC) {
       // paths_for_process maps each PROCESS names to a sequence of
       // PATH names
       std::map<std::string, std::vector<std::string> > paths_for_process;
@@ -138,8 +126,7 @@ namespace edm
         // Default to current process if none specified
         if (path_spec.second == "") {
           paths_for_process[process_name].push_back(path_spec.first);
-        }
-        else {
+        } else {
           paths_for_process[path_spec.second].push_back(path_spec.first);
         }
       }
@@ -158,27 +145,26 @@ namespace edm
       }
     }
 
-    bool
-    TriggerResultsBasedEventSelector::wantEvent(EventForOutput const& ev) {
-      if(wantAllEvents_) {
+    bool TriggerResultsBasedEventSelector::wantEvent(EventForOutput const& ev) {
+      if (wantAllEvents_) {
         return true;
       }
-      for(auto& selector : selectors_) {
+      for (auto& selector : selectors_) {
         Handle<TriggerResults> handle;
         ev.getByToken<TriggerResults>(selector.token(), handle);
         bool match = selector.match(*handle);
-        if(match) {
+        if (match) {
           return true;
         }
       }
       return false;
     }
 
-    ParameterSetID
-    registerProperSelectionInfo(edm::ParameterSet const& iInitial,
-                                std::string const& iLabel,
-                                std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
-                                bool anyProductProduced) {
+    ParameterSetID registerProperSelectionInfo(
+        edm::ParameterSet const& iInitial,
+        std::string const& iLabel,
+        std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
+        bool anyProductProduced) {
       ParameterSet selectEventsInfo;
       selectEventsInfo.copyForModify(iInitial);
       selectEventsInfo.addParameter<bool>("InProcessHistory", anyProductProduced);
@@ -188,9 +174,10 @@ namespace edm
       // The label will be empty if and only if this is a SubProcess
       // SubProcess's do not appear on any end path
       if (!iLabel.empty()) {
-        std::map<std::string, std::vector<std::pair<std::string, int> > >::const_iterator iter = outputModulePathPositions.find(iLabel);
+        std::map<std::string, std::vector<std::pair<std::string, int> > >::const_iterator iter =
+            outputModulePathPositions.find(iLabel);
         assert(iter != outputModulePathPositions.end());
-        for(auto const& item : iter->second) {
+        for (auto const& item : iter->second) {
           endPaths.push_back(item.first);
           endPathPositions.push_back(item.second);
         }
@@ -205,5 +192,5 @@ namespace edm
       return selectEventsInfo.id();
     }
 
-  } // namespace detail
-} // namespace edm
+  }  // namespace detail
+}  // namespace edm

--- a/FWCore/Framework/src/UnscheduledAuxiliary.cc
+++ b/FWCore/Framework/src/UnscheduledAuxiliary.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Subsystem/Package
 // Class  :     UnscheduledAuxiliary
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -15,7 +15,6 @@
 // user include files
 #include "UnscheduledAuxiliary.h"
 
-
 //
 // constants, enums and typedefs
 //
@@ -27,7 +26,6 @@
 //
 // constructors and destructor
 //
-
 
 //
 // member functions

--- a/FWCore/Framework/src/UnscheduledAuxiliary.h
+++ b/FWCore/Framework/src/UnscheduledAuxiliary.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     UnscheduledAuxiliary
-// 
+//
 /**\class UnscheduledAuxiliary UnscheduledAuxiliary.h "UnscheduledAuxiliary.h"
 
  Description: Holds auxiliary information needed for unscheduled calls to EDProducers
@@ -29,32 +29,26 @@ namespace edm {
   class EventSetupImpl;
   class ModuleCallingContext;
   class StreamContext;
-  
-  class UnscheduledAuxiliary
-  {
 
+  class UnscheduledAuxiliary {
   public:
-    UnscheduledAuxiliary(): m_eventSetup(nullptr) {}
+    UnscheduledAuxiliary() : m_eventSetup(nullptr) {}
 
     // ---------- const member functions ---------------------
-    EventSetupImpl const* eventSetup() const { return m_eventSetup;}
-    
+    EventSetupImpl const* eventSetup() const { return m_eventSetup; }
+
     // ---------- static member functions --------------------
 
     // ---------- member functions ---------------------------
-    void setEventSetup( EventSetupImpl const* iSetup) {
-      m_eventSetup = iSetup;
-    }
+    void setEventSetup(EventSetupImpl const* iSetup) { m_eventSetup = iSetup; }
 
     signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> preModuleDelayedGetSignal_;
     signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> postModuleDelayedGetSignal_;
+
   private:
-
     // ---------- member data --------------------------------
-    EventSetupImpl const * m_eventSetup;
-
+    EventSetupImpl const* m_eventSetup;
   };
-}
-
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/UnscheduledConfigurator.h
+++ b/FWCore/Framework/src/UnscheduledConfigurator.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     UnscheduledConfigurator
-// 
+//
 /**\class UnscheduledConfigurator UnscheduledConfigurator.h "UnscheduledConfigurator.h"
 
  Description: [one line class summary]
@@ -28,41 +28,35 @@
 namespace edm {
   class Worker;
   class UnscheduledAuxiliary;
-  
-  class UnscheduledConfigurator
-  {
-   public:
-      template<typename IT>
-      UnscheduledConfigurator(IT iBegin,
-                              IT iEnd,
-                              UnscheduledAuxiliary const* iAux):
-    m_aux(iAux) {
-      for(auto it = iBegin; it != iEnd; ++it) {
-        m_labelToWorker.emplace((*it)->description().moduleLabel(),*it);
+
+  class UnscheduledConfigurator {
+  public:
+    template <typename IT> UnscheduledConfigurator(IT iBegin, IT iEnd, UnscheduledAuxiliary const* iAux) : m_aux(iAux) {
+      for (auto it = iBegin; it != iEnd; ++it) {
+        m_labelToWorker.emplace((*it)->description().moduleLabel(), *it);
       }
     }
 
     // ---------- const member functions ---------------------
     Worker* findWorker(std::string const& iLabel) const {
       auto itFound = m_labelToWorker.find(iLabel);
-      if(itFound != m_labelToWorker.end()) {
+      if (itFound != m_labelToWorker.end()) {
         return itFound->second;
       }
       return nullptr;
     }
 
     UnscheduledAuxiliary const* auxiliary() const { return m_aux; }
-   private:
-      UnscheduledConfigurator(const UnscheduledConfigurator&) = delete; // stop default
 
-  const UnscheduledConfigurator& operator=(const UnscheduledConfigurator&) = delete; // stop default
+  private:
+    UnscheduledConfigurator(const UnscheduledConfigurator&) = delete;  // stop default
 
-      // ---------- member data --------------------------------
+    const UnscheduledConfigurator& operator=(const UnscheduledConfigurator&) = delete;  // stop default
+
+    // ---------- member data --------------------------------
     std::unordered_map<std::string, Worker*> m_labelToWorker;
     UnscheduledAuxiliary const* m_aux;
-    
   };
-}
-
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/ValidityInterval.cc
+++ b/FWCore/Framework/src/ValidityInterval.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     ValidityInterval
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -16,71 +16,61 @@
 #include "FWCore/Framework/interface/ValidityInterval.h"
 
 namespace edm {
-//
-// constants, enums and typedefs
-//
+  //
+  // constants, enums and typedefs
+  //
 
-//
-// static data member definitions
-//
+  //
+  // static data member definitions
+  //
 
-//
-// constructors and destructor
-//
-   ValidityInterval::ValidityInterval() :
-   first_(IOVSyncValue::invalidIOVSyncValue()),
-   last_(IOVSyncValue::invalidIOVSyncValue())
-{
-}
+  //
+  // constructors and destructor
+  //
+  ValidityInterval::ValidityInterval()
+      : first_(IOVSyncValue::invalidIOVSyncValue()), last_(IOVSyncValue::invalidIOVSyncValue()) {}
 
-ValidityInterval::ValidityInterval(const IOVSyncValue& iFirst,
-                                   const IOVSyncValue& iLast) :
-first_(iFirst), last_(iLast)
-{
-}
+  ValidityInterval::ValidityInterval(const IOVSyncValue& iFirst, const IOVSyncValue& iLast)
+      : first_(iFirst), last_(iLast) {}
 
-// ValidityInterval::ValidityInterval(const ValidityInterval& rhs)
-// {
-//    // do actual copying here;
-// }
+  // ValidityInterval::ValidityInterval(const ValidityInterval& rhs)
+  // {
+  //    // do actual copying here;
+  // }
 
-//ValidityInterval::~ValidityInterval()
-//{
-//}
+  //ValidityInterval::~ValidityInterval()
+  //{
+  //}
 
-//
-// assignment operators
-//
-// const ValidityInterval& ValidityInterval::operator=(const ValidityInterval& rhs)
-// {
-//   //An exception safe implementation is
-//   ValidityInterval temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+  //
+  // assignment operators
+  //
+  // const ValidityInterval& ValidityInterval::operator=(const ValidityInterval& rhs)
+  // {
+  //   //An exception safe implementation is
+  //   ValidityInterval temp(rhs);
+  //   swap(rhs);
+  //
+  //   return *this;
+  // }
 
-//
-// member functions
-//
+  //
+  // member functions
+  //
 
-//
-// const member functions
-//
-bool
-ValidityInterval::validFor(const IOVSyncValue& iInstance) const
-{
-   return first_ <= iInstance && iInstance <= last_;
-}
-   
-//
-// static member functions
-//
-const ValidityInterval& 
-ValidityInterval::invalidInterval()
-{
-   static const ValidityInterval s_invalid;
-   return s_invalid;
-}
+  //
+  // const member functions
+  //
+  bool ValidityInterval::validFor(const IOVSyncValue& iInstance) const {
+    return first_ <= iInstance && iInstance <= last_;
+  }
 
-}
+  //
+  // static member functions
+  //
+  const ValidityInterval& ValidityInterval::invalidInterval() {
+    static const ValidityInterval s_invalid;
+    return s_invalid;
+  }
+
+}  // namespace edm

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -11,110 +11,108 @@
 namespace edm {
   namespace {
     class ModuleBeginJobSignalSentry {
-public:
-      ModuleBeginJobSignalSentry(ActivityRegistry* a, ModuleDescription const& md):a_(a), md_(&md) {
-        if(a_) a_->preModuleBeginJobSignal_(*md_);
+    public:
+      ModuleBeginJobSignalSentry(ActivityRegistry* a, ModuleDescription const& md) : a_(a), md_(&md) {
+        if (a_)
+          a_->preModuleBeginJobSignal_(*md_);
       }
       ~ModuleBeginJobSignalSentry() {
-        if(a_) a_->postModuleBeginJobSignal_(*md_);
+        if (a_)
+          a_->postModuleBeginJobSignal_(*md_);
       }
-private:
-      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
+
+    private:
+      ActivityRegistry* a_;  // We do not use propagate_const because the registry itself is mutable.
       ModuleDescription const* md_;
     };
 
     class ModuleEndJobSignalSentry {
-public:
-      ModuleEndJobSignalSentry(ActivityRegistry* a, ModuleDescription const& md):a_(a), md_(&md) {
-        if(a_) a_->preModuleEndJobSignal_(*md_);
+    public:
+      ModuleEndJobSignalSentry(ActivityRegistry* a, ModuleDescription const& md) : a_(a), md_(&md) {
+        if (a_)
+          a_->preModuleEndJobSignal_(*md_);
       }
       ~ModuleEndJobSignalSentry() {
-        if(a_) a_->postModuleEndJobSignal_(*md_);
+        if (a_)
+          a_->postModuleEndJobSignal_(*md_);
       }
-private:
-      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
+
+    private:
+      ActivityRegistry* a_;  // We do not use propagate_const because the registry itself is mutable.
       ModuleDescription const* md_;
     };
 
     class ModuleBeginStreamSignalSentry {
     public:
-      ModuleBeginStreamSignalSentry(ActivityRegistry* a,
-                                    StreamContext const& sc,
-                                    ModuleCallingContext const& mcc) : a_(a), sc_(sc), mcc_(mcc) {
-        if(a_) a_->preModuleBeginStreamSignal_(sc_, mcc_);
+      ModuleBeginStreamSignalSentry(ActivityRegistry* a, StreamContext const& sc, ModuleCallingContext const& mcc)
+          : a_(a), sc_(sc), mcc_(mcc) {
+        if (a_)
+          a_->preModuleBeginStreamSignal_(sc_, mcc_);
       }
       ~ModuleBeginStreamSignalSentry() {
-        if(a_) a_->postModuleBeginStreamSignal_(sc_, mcc_);
+        if (a_)
+          a_->postModuleBeginStreamSignal_(sc_, mcc_);
       }
+
     private:
-      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
+      ActivityRegistry* a_;  // We do not use propagate_const because the registry itself is mutable.
       StreamContext const& sc_;
       ModuleCallingContext const& mcc_;
     };
 
     class ModuleEndStreamSignalSentry {
     public:
-      ModuleEndStreamSignalSentry(ActivityRegistry* a,
-                                  StreamContext const& sc,
-                                  ModuleCallingContext const& mcc) : a_(a), sc_(sc), mcc_(mcc) {
-        if(a_) a_->preModuleEndStreamSignal_(sc_, mcc_);
+      ModuleEndStreamSignalSentry(ActivityRegistry* a, StreamContext const& sc, ModuleCallingContext const& mcc)
+          : a_(a), sc_(sc), mcc_(mcc) {
+        if (a_)
+          a_->preModuleEndStreamSignal_(sc_, mcc_);
       }
       ~ModuleEndStreamSignalSentry() {
-        if(a_) a_->postModuleEndStreamSignal_(sc_, mcc_);
+        if (a_)
+          a_->postModuleEndStreamSignal_(sc_, mcc_);
       }
+
     private:
-      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
+      ActivityRegistry* a_;  // We do not use propagate_const because the registry itself is mutable.
       StreamContext const& sc_;
       ModuleCallingContext const& mcc_;
     };
 
-  }
+  }  // namespace
 
-  Worker::Worker(ModuleDescription const& iMD, 
-		 ExceptionToActionTable const* iActions) :
-    timesRun_(0),
-    timesVisited_(0),
-    timesPassed_(0),
-    timesFailed_(0),
-    timesExcept_(0),
-    state_(Ready),
-    numberOfPathsOn_(0),
-    numberOfPathsLeftToRun_(0),
-    moduleCallingContext_(&iMD),
-    actions_(iActions),
-    cached_exception_(),
-    actReg_(),
-    earlyDeleteHelper_(nullptr),
-    workStarted_(false),
-    ranAcquireWithoutException_(false)
-  {
-  }
+  Worker::Worker(ModuleDescription const& iMD, ExceptionToActionTable const* iActions)
+      : timesRun_(0),
+        timesVisited_(0),
+        timesPassed_(0),
+        timesFailed_(0),
+        timesExcept_(0),
+        state_(Ready),
+        numberOfPathsOn_(0),
+        numberOfPathsLeftToRun_(0),
+        moduleCallingContext_(&iMD),
+        actions_(iActions),
+        cached_exception_(),
+        actReg_(),
+        earlyDeleteHelper_(nullptr),
+        workStarted_(false),
+        ranAcquireWithoutException_(false) {}
 
-  Worker::~Worker() {
-  }
+  Worker::~Worker() {}
 
-  void Worker::setActivityRegistry(std::shared_ptr<ActivityRegistry> areg) {
-    actReg_ = areg;
-  }
+  void Worker::setActivityRegistry(std::shared_ptr<ActivityRegistry> areg) { actReg_ = areg; }
 
-  
-  void Worker::exceptionContext(
-                        cms::Exception& ex,
-                        ModuleCallingContext const* mcc) {
-    
+  void Worker::exceptionContext(cms::Exception& ex, ModuleCallingContext const* mcc) {
     ModuleCallingContext const* imcc = mcc;
-    while( (imcc->type() == ParentContext::Type::kModule) or
-          (imcc->type()  == ParentContext::Type::kInternal) ) {
+    while ((imcc->type() == ParentContext::Type::kModule) or (imcc->type() == ParentContext::Type::kInternal)) {
       std::ostringstream iost;
-      if( imcc->state() == ModuleCallingContext::State::kPrefetching ) {
+      if (imcc->state() == ModuleCallingContext::State::kPrefetching) {
         iost << "Prefetching for module ";
       } else {
         iost << "Calling method for module ";
       }
-      iost << imcc->moduleDescription()->moduleName() << "/'"
-      << imcc->moduleDescription()->moduleLabel() << "'";
+      iost << imcc->moduleDescription()->moduleName() << "/'" << imcc->moduleDescription()->moduleLabel() << "'";
 
-      if(imcc->type() == ParentContext::Type::kInternal) {
+      if (imcc->type() == ParentContext::Type::kInternal) {
         iost << " (probably inside some kind of mixing module)";
         imcc = imcc->internalContext()->moduleCallingContext();
       } else {
@@ -123,34 +121,33 @@ private:
       ex.addContext(iost.str());
     }
     std::ostringstream ost;
-    if( imcc->state() == ModuleCallingContext::State::kPrefetching ) {
+    if (imcc->state() == ModuleCallingContext::State::kPrefetching) {
       ost << "Prefetching for module ";
     } else {
       ost << "Calling method for module ";
     }
-    ost << imcc->moduleDescription()->moduleName() << "/'"
-    << imcc->moduleDescription()->moduleLabel() << "'";
+    ost << imcc->moduleDescription()->moduleName() << "/'" << imcc->moduleDescription()->moduleLabel() << "'";
     ex.addContext(ost.str());
-    
+
     if (imcc->type() == ParentContext::Type::kPlaceInPath) {
       ost.str("");
       ost << "Running path '";
       ost << imcc->placeInPathContext()->pathContext()->pathName() << "'";
       ex.addContext(ost.str());
-      auto streamContext =imcc->placeInPathContext()->pathContext()->streamContext();
-      if(streamContext) {
+      auto streamContext = imcc->placeInPathContext()->pathContext()->streamContext();
+      if (streamContext) {
         ost.str("");
-        edm::exceptionContext(ost,*streamContext);
+        edm::exceptionContext(ost, *streamContext);
         ex.addContext(ost.str());
       }
     } else {
       if (imcc->type() == ParentContext::Type::kStream) {
         ost.str("");
-        edm::exceptionContext(ost, *(imcc->streamContext()) );
+        edm::exceptionContext(ost, *(imcc->streamContext()));
         ex.addContext(ost.str());
-      } else if(imcc->type() == ParentContext::Type::kGlobal) {
+      } else if (imcc->type() == ParentContext::Type::kGlobal) {
         ost.str("");
-        edm::exceptionContext(ost, *(imcc->globalContext()) );
+        edm::exceptionContext(ost, *(imcc->globalContext()));
         ex.addContext(ost.str());
       }
     }
@@ -160,42 +157,38 @@ private:
                                       ParentContext const& parentContext,
                                       bool isEvent,
                                       TransitionIDValueBase const& iID) const {
-    
     // NOTE: the warning printed as a result of ignoring or failing
     // a module will only be printed during the full true processing
     // pass of this module
-    
+
     // Get the action corresponding to this exception.  However, if processing
     // something other than an event (e.g. run, lumi) always rethrow.
-    if(not isEvent) {
+    if (not isEvent) {
       return true;
     }
     try {
-      convertException::wrap([&]() {
-        std::rethrow_exception(iPtr);
-      });
-    } catch(cms::Exception &ex) {
+      convertException::wrap([&]() { std::rethrow_exception(iPtr); });
+    } catch (cms::Exception& ex) {
       exception_actions::ActionCodes action = actions_->find(ex.category());
-    
-      if(action == exception_actions::Rethrow) {
+
+      if (action == exception_actions::Rethrow) {
         return true;
       }
-    
-      ModuleCallingContext tempContext(&description(),ModuleCallingContext::State::kInvalid, parentContext, nullptr);
-      
+
+      ModuleCallingContext tempContext(&description(), ModuleCallingContext::State::kInvalid, parentContext, nullptr);
+
       // If we are processing an endpath and the module was scheduled, treat SkipEvent or FailPath
       // as IgnoreCompletely, so any subsequent OutputModules are still run.
       // For unscheduled modules only treat FailPath as IgnoreCompletely but still allow SkipEvent to throw
       ModuleCallingContext const* top_mcc = tempContext.getTopModuleCallingContext();
-      if(top_mcc->type() == ParentContext::Type::kPlaceInPath &&
-         top_mcc->placeInPathContext()->pathContext()->isEndPath()) {
-        
+      if (top_mcc->type() == ParentContext::Type::kPlaceInPath &&
+          top_mcc->placeInPathContext()->pathContext()->isEndPath()) {
         if ((action == exception_actions::SkipEvent && tempContext.type() == ParentContext::Type::kPlaceInPath) ||
             action == exception_actions::FailPath) {
           action = exception_actions::IgnoreCompletely;
         }
       }
-      if(action == exception_actions::IgnoreCompletely) {
+      if (action == exception_actions::IgnoreCompletely) {
         edm::printCmsExceptionWarning("IgnoreCompletely", ex);
         return false;
       }
@@ -203,85 +196,85 @@ private:
     return true;
   }
 
-  
-  void Worker::prefetchAsync(WaitingTask* iTask, ServiceToken const& token, ParentContext const& parentContext, Principal const& iPrincipal) {
+  void Worker::prefetchAsync(WaitingTask* iTask,
+                             ServiceToken const& token,
+                             ParentContext const& parentContext,
+                             Principal const& iPrincipal) {
     // Prefetch products the module declares it consumes (not including the products it maybe consumes)
     std::vector<ProductResolverIndexAndSkipBit> const& items = itemsToGetFrom(iPrincipal.branchType());
 
-    moduleCallingContext_.setContext(ModuleCallingContext::State::kPrefetching,parentContext,nullptr);
-    
-    if(iPrincipal.branchType()==InEvent) {
-      actReg_->preModuleEventPrefetchingSignal_.emit(*moduleCallingContext_.getStreamContext(),moduleCallingContext_);
+    moduleCallingContext_.setContext(ModuleCallingContext::State::kPrefetching, parentContext, nullptr);
+
+    if (iPrincipal.branchType() == InEvent) {
+      actReg_->preModuleEventPrefetchingSignal_.emit(*moduleCallingContext_.getStreamContext(), moduleCallingContext_);
     }
 
     //Need to be sure the ref count isn't set to 0 immediately
     iTask->increment_ref_count();
-    for(auto const& item : items) {
+    for (auto const& item : items) {
       ProductResolverIndex productResolverIndex = item.productResolverIndex();
       bool skipCurrentProcess = item.skipCurrentProcess();
-      if(productResolverIndex != ProductResolverIndexAmbiguous) {
-        iPrincipal.prefetchAsync(iTask,productResolverIndex, skipCurrentProcess, token, &moduleCallingContext_);
+      if (productResolverIndex != ProductResolverIndexAmbiguous) {
+        iPrincipal.prefetchAsync(iTask, productResolverIndex, skipCurrentProcess, token, &moduleCallingContext_);
       }
     }
-    
-    if(iPrincipal.branchType()==InEvent) {
-      preActionBeforeRunEventAsync(iTask,moduleCallingContext_,iPrincipal);
+
+    if (iPrincipal.branchType() == InEvent) {
+      preActionBeforeRunEventAsync(iTask, moduleCallingContext_, iPrincipal);
     }
-    
-    if(0 == iTask->decrement_ref_count()) {
+
+    if (0 == iTask->decrement_ref_count()) {
       //if everything finishes before we leave this routine, we need to launch the task
       tbb::task::spawn(*iTask);
     }
   }
-  
+
   void Worker::prePrefetchSelectionAsync(WaitingTask* successTask,
                                          ServiceToken const& token,
-                                 StreamID id,
-                                 EventPrincipal const* iPrincipal) {
+                                         StreamID id,
+                                         EventPrincipal const* iPrincipal) {
     successTask->increment_ref_count();
 
-    auto choiceTask = edm::make_waiting_task(tbb::task::allocate_root(),
-     [id,successTask,iPrincipal,this,token](std::exception_ptr const*) {
-       ServiceRegistry::Operate guard(token);
-       try {
-         if( not implDoPrePrefetchSelection(id,*iPrincipal,&moduleCallingContext_) ) {
-           timesRun_.fetch_add(1,std::memory_order_relaxed);
-           setPassed<true>();
-           waitingTasks_.doneWaiting(nullptr);
-           //TBB requires that destroyed tasks have count 0
-           if ( 0 == successTask->decrement_ref_count() ) {
-             tbb::task::destroy(*successTask);
-           }
-           return;
-         }
-       } catch(...) {}
-       if(0 == successTask->decrement_ref_count()) {
-         tbb::task::spawn(*successTask);
-       }
-     });
-    
+    auto choiceTask = edm::make_waiting_task(
+        tbb::task::allocate_root(), [id, successTask, iPrincipal, this, token](std::exception_ptr const*) {
+          ServiceRegistry::Operate guard(token);
+          try {
+            if (not implDoPrePrefetchSelection(id, *iPrincipal, &moduleCallingContext_)) {
+              timesRun_.fetch_add(1, std::memory_order_relaxed);
+              setPassed<true>();
+              waitingTasks_.doneWaiting(nullptr);
+              //TBB requires that destroyed tasks have count 0
+              if (0 == successTask->decrement_ref_count()) {
+                tbb::task::destroy(*successTask);
+              }
+              return;
+            }
+          } catch (...) {
+          }
+          if (0 == successTask->decrement_ref_count()) {
+            tbb::task::spawn(*successTask);
+          }
+        });
+
     WaitingTaskHolder choiceHolder{choiceTask};
 
     std::vector<ProductResolverIndexAndSkipBit> items;
     itemsToGetForSelection(items);
-    
-    for(auto const& item : items) {
+
+    for (auto const& item : items) {
       ProductResolverIndex productResolverIndex = item.productResolverIndex();
       bool skipCurrentProcess = item.skipCurrentProcess();
-      if(productResolverIndex != ProductResolverIndexAmbiguous) {
-        iPrincipal->prefetchAsync(choiceTask,productResolverIndex, skipCurrentProcess, token, &moduleCallingContext_);
+      if (productResolverIndex != ProductResolverIndexAmbiguous) {
+        iPrincipal->prefetchAsync(choiceTask, productResolverIndex, skipCurrentProcess, token, &moduleCallingContext_);
       }
     }
     choiceHolder.doneWaiting(std::exception_ptr{});
   }
 
-  
-  void Worker::setEarlyDeleteHelper(EarlyDeleteHelper* iHelper) {
-    earlyDeleteHelper_=iHelper;
-  }
-  
+  void Worker::setEarlyDeleteHelper(EarlyDeleteHelper* iHelper) { earlyDeleteHelper_ = iHelper; }
+
   void Worker::resetModuleDescription(ModuleDescription const* iDesc) {
-    ModuleCallingContext temp(iDesc,moduleCallingContext_.state(),moduleCallingContext_.parent(),
+    ModuleCallingContext temp(iDesc, moduleCallingContext_.state(), moduleCallingContext_.parent(),
                               moduleCallingContext_.previousModuleOnThread());
     moduleCallingContext_ = temp;
   }
@@ -292,8 +285,7 @@ private:
         ModuleBeginJobSignalSentry cpp(actReg_.get(), description());
         implBeginJob();
       });
-    }
-    catch(cms::Exception& ex) {
+    } catch (cms::Exception& ex) {
       state_ = Exception;
       std::ostringstream ost;
       ost << "Calling beginJob for module " << description().moduleName() << "/'" << description().moduleLabel() << "'";
@@ -301,15 +293,14 @@ private:
       throw;
     }
   }
-  
+
   void Worker::endJob() {
     try {
       convertException::wrap([&]() {
         ModuleEndJobSignalSentry cpp(actReg_.get(), description());
         implEndJob();
       });
-    }
-    catch(cms::Exception& ex) {
+    } catch (cms::Exception& ex) {
       state_ = Exception;
       std::ostringstream ost;
       ost << "Calling endJob for module " << description().moduleName() << "/'" << description().moduleLabel() << "'";
@@ -332,16 +323,16 @@ private:
         ModuleBeginStreamSignalSentry beginSentry(actReg_.get(), streamContext, moduleCallingContext_);
         implBeginStream(id);
       });
-    }
-    catch(cms::Exception& ex) {
+    } catch (cms::Exception& ex) {
       state_ = Exception;
       std::ostringstream ost;
-      ost << "Calling beginStream for module " << description().moduleName() << "/'" << description().moduleLabel() << "'";
+      ost << "Calling beginStream for module " << description().moduleName() << "/'" << description().moduleLabel()
+          << "'";
       ex.addContext(ost.str());
       throw;
     }
   }
-  
+
   void Worker::endStream(StreamID id, StreamContext& streamContext) {
     try {
       convertException::wrap([&]() {
@@ -356,24 +347,24 @@ private:
         ModuleEndStreamSignalSentry endSentry(actReg_.get(), streamContext, moduleCallingContext_);
         implEndStream(id);
       });
-    }
-    catch(cms::Exception& ex) {
+    } catch (cms::Exception& ex) {
       state_ = Exception;
       std::ostringstream ost;
-      ost << "Calling endStream for module " << description().moduleName() << "/'" << description().moduleLabel() << "'";
+      ost << "Calling endStream for module " << description().moduleName() << "/'" << description().moduleLabel()
+          << "'";
       ex.addContext(ost.str());
       throw;
     }
   }
-  
+
   void Worker::skipOnPath() {
-    if( 0 == --numberOfPathsLeftToRun_) {
+    if (0 == --numberOfPathsLeftToRun_) {
       waitingTasks_.doneWaiting(cached_exception_);
     }
   }
 
   void Worker::postDoEvent(EventPrincipal const& iEvent) {
-    if(earlyDeleteHelper_) {
+    if (earlyDeleteHelper_) {
       earlyDeleteHelper_->moduleRan(iEvent);
     }
   }
@@ -382,18 +373,14 @@ private:
                           EventSetupImpl const& es,
                           ParentContext const& parentContext,
                           WaitingTaskWithArenaHolder& holder) {
-
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     try {
-      convertException::wrap([&]()
-      {
-        this->implDoAcquire(ep, es, &moduleCallingContext_, holder);
-      });
-    } catch(cms::Exception& ex) {
+      convertException::wrap([&]() { this->implDoAcquire(ep, es, &moduleCallingContext_, holder); });
+    } catch (cms::Exception& ex) {
       exceptionContext(ex, &moduleCallingContext_);
       TransitionIDValue<EventPrincipal> idValue(ep);
-      if(shouldRethrowException(std::current_exception(), parentContext, true, idValue)) {
-        timesRun_.fetch_add(1,std::memory_order_relaxed);
+      if (shouldRethrowException(std::current_exception(), parentContext, true, idValue)) {
+        timesRun_.fetch_add(1, std::memory_order_relaxed);
         throw;
       }
     }
@@ -406,18 +393,18 @@ private:
                                             WaitingTaskWithArenaHolder holder) {
     ranAcquireWithoutException_ = false;
     std::exception_ptr exceptionPtr;
-    if(iEPtr) {
+    if (iEPtr) {
       assert(*iEPtr);
       TransitionIDValue<EventPrincipal> idValue(ep);
-      if(shouldRethrowException(*iEPtr, parentContext, true, idValue)) {
+      if (shouldRethrowException(*iEPtr, parentContext, true, idValue)) {
         exceptionPtr = *iEPtr;
       }
-      moduleCallingContext_.setContext(ModuleCallingContext::State::kInvalid,ParentContext(),nullptr);
+      moduleCallingContext_.setContext(ModuleCallingContext::State::kInvalid, ParentContext(), nullptr);
     } else {
       try {
         runAcquire(ep, es, parentContext, holder);
         ranAcquireWithoutException_ = true;
-      } catch(...) {
+      } catch (...) {
         exceptionPtr = std::current_exception();
       }
     }
@@ -429,10 +416,8 @@ private:
                                                          ParentContext const& parentContext) {
     if (ranAcquireWithoutException_) {
       try {
-        convertException::wrap([iEPtr]() {
-          std::rethrow_exception(*iEPtr);
-        });
-      } catch(cms::Exception &ex) {
+        convertException::wrap([iEPtr]() { std::rethrow_exception(*iEPtr); });
+      } catch (cms::Exception& ex) {
         ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
         exceptionContext(ex, &moduleCallingContext_);
         return std::current_exception();
@@ -441,28 +426,21 @@ private:
     return *iEPtr;
   }
 
-  Worker::HandleExternalWorkExceptionTask::
-  HandleExternalWorkExceptionTask(Worker* worker,
-                                  WaitingTask* runModuleTask,
-                                  ParentContext const& parentContext) :
-    m_worker(worker),
-    m_runModuleTask(runModuleTask),
-    m_parentContext(parentContext) {
-  }
+  Worker::HandleExternalWorkExceptionTask::HandleExternalWorkExceptionTask(Worker* worker,
+                                                                           WaitingTask* runModuleTask,
+                                                                           ParentContext const& parentContext)
+      : m_worker(worker), m_runModuleTask(runModuleTask), m_parentContext(parentContext) {}
 
-  tbb::task*
-  Worker::HandleExternalWorkExceptionTask::execute() {
-
+  tbb::task* Worker::HandleExternalWorkExceptionTask::execute() {
     auto excptr = exceptionPtr();
     if (excptr) {
       // increment the ref count so the holder will not spawn it
       m_runModuleTask->set_ref_count(1);
       WaitingTaskHolder holder(m_runModuleTask);
-      holder.doneWaiting(m_worker->handleExternalWorkException(excptr,
-                                                               m_parentContext));
+      holder.doneWaiting(m_worker->handleExternalWorkException(excptr, m_parentContext));
     }
     m_runModuleTask->set_ref_count(0);
     // Depend on TBB Scheduler Bypass to run the next task
     return m_runModuleTask;
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -73,76 +73,72 @@ namespace edm {
   class ThinnedAssociationsHelper;
 
   namespace workerhelper {
-    template< typename O> class CallImpl;
+    template <typename O> class CallImpl;
   }
 
   class Worker {
   public:
     enum State { Ready, Pass, Fail, Exception };
-    enum Types { kAnalyzer, kFilter, kProducer, kOutputModule};
+    enum Types { kAnalyzer, kFilter, kProducer, kOutputModule };
     struct TaskQueueAdaptor {
       SerialTaskQueueChain* serial_ = nullptr;
       LimitedTaskQueue* limited_ = nullptr;
-      
+
       TaskQueueAdaptor() = default;
-      TaskQueueAdaptor(SerialTaskQueueChain* iChain): serial_(iChain) {}
-      TaskQueueAdaptor(LimitedTaskQueue* iLimited): limited_(iLimited) {}
-      
+      TaskQueueAdaptor(SerialTaskQueueChain* iChain) : serial_(iChain) {}
+      TaskQueueAdaptor(LimitedTaskQueue* iLimited) : limited_(iLimited) {}
+
       operator bool() { return serial_ != nullptr or limited_ != nullptr; }
-      
-      template <class F>
-      void push(F&& iF) {
-        if(serial_) {
+
+      template <class F> void push(F&& iF) {
+        if (serial_) {
           serial_->push(iF);
         } else {
           limited_->push(iF);
         }
       }
-      template <class F>
-      void pushAndWait(F&& iF) {
-        if(serial_) {
+      template <class F> void pushAndWait(F&& iF) {
+        if (serial_) {
           serial_->pushAndWait(iF);
         } else {
           limited_->pushAndWait(iF);
         }
       }
-      
     };
 
     Worker(ModuleDescription const& iMD, ExceptionToActionTable const* iActions);
     virtual ~Worker();
 
-    Worker(Worker const&) = delete; // Disallow copying and moving
-    Worker& operator=(Worker const&) = delete; // Disallow copying and moving
+    Worker(Worker const&) = delete;             // Disallow copying and moving
+    Worker& operator=(Worker const&) = delete;  // Disallow copying and moving
 
     virtual bool wantsGlobalRuns() const = 0;
     virtual bool wantsGlobalLuminosityBlocks() const = 0;
     virtual bool wantsStreamRuns() const = 0;
     virtual bool wantsStreamLuminosityBlocks() const = 0;
-    
+
     virtual SerialTaskQueue* globalRunsQueue() = 0;
     virtual SerialTaskQueue* globalLuminosityBlocksQueue() = 0;
 
     template <typename T>
-    bool doWork(typename T::MyPrincipal const&, EventSetupImpl const& c,
+    bool doWork(typename T::MyPrincipal const&,
+                EventSetupImpl const& c,
                 StreamID stream,
                 ParentContext const& parentContext,
                 typename T::Context const* context);
-    
-    void prePrefetchSelectionAsync(WaitingTask* task,
-                                   ServiceToken const&,
-                                      StreamID stream,
-                                      EventPrincipal const*);
 
-    void prePrefetchSelectionAsync(WaitingTask* task,
-                                   ServiceToken const&,
-                                   StreamID stream,
-                                   void const*) {assert(false);}
+    void prePrefetchSelectionAsync(WaitingTask* task, ServiceToken const&, StreamID stream, EventPrincipal const*);
+
+    void prePrefetchSelectionAsync(WaitingTask* task, ServiceToken const&, StreamID stream, void const*) {
+      assert(false);
+    }
 
     template <typename T>
     void doWorkAsync(WaitingTask* task,
-                     typename T::MyPrincipal const&, EventSetupImpl const& c,
-                     ServiceToken const& token, StreamID stream,
+                     typename T::MyPrincipal const&,
+                     EventSetupImpl const& c,
+                     ServiceToken const& token,
+                     StreamID stream,
                      ParentContext const& parentContext,
                      typename T::Context const* context);
 
@@ -162,18 +158,18 @@ namespace edm {
                                          ParentContext const& parentContext,
                                          typename T::Context const* context);
 
-    void callWhenDoneAsync(WaitingTask* task) {
-      waitingTasks_.add(task);
-    }
+    void callWhenDoneAsync(WaitingTask* task) { waitingTasks_.add(task); }
     void skipOnPath();
-    void beginJob() ;
+    void beginJob();
     void endJob();
     void beginStream(StreamID id, StreamContext& streamContext);
     void endStream(StreamID id, StreamContext& streamContext);
-    void respondToOpenInputFile(FileBlock const& fb) {implRespondToOpenInputFile(fb);}
-    void respondToCloseInputFile(FileBlock const& fb) {implRespondToCloseInputFile(fb);}
+    void respondToOpenInputFile(FileBlock const& fb) { implRespondToOpenInputFile(fb); }
+    void respondToCloseInputFile(FileBlock const& fb) { implRespondToCloseInputFile(fb); }
 
-    void registerThinnedAssociations(ProductRegistry const& registry, ThinnedAssociationsHelper& helper) { implRegisterThinnedAssociations(registry, helper); }
+    void registerThinnedAssociations(ProductRegistry const& registry, ThinnedAssociationsHelper& helper) {
+      implRegisterThinnedAssociations(registry, helper);
+    }
 
     void reset() {
       cached_exception_ = std::exception_ptr();
@@ -185,8 +181,8 @@ namespace edm {
 
     void postDoEvent(EventPrincipal const&);
 
-    ModuleDescription const& description() const {return *(moduleCallingContext_.moduleDescription());}
-    ModuleDescription const* descPtr() const {return moduleCallingContext_.moduleDescription(); }
+    ModuleDescription const& description() const { return *(moduleCallingContext_.moduleDescription()); }
+    ModuleDescription const* descPtr() const { return moduleCallingContext_.moduleDescription(); }
     ///The signals are required to live longer than the last call to 'doWork'
     /// this was done to improve performance based on profiling
     void setActivityRegistry(std::shared_ptr<ActivityRegistry> areg);
@@ -194,32 +190,32 @@ namespace edm {
     void setEarlyDeleteHelper(EarlyDeleteHelper* iHelper);
 
     //Used to make EDGetToken work
-    virtual void updateLookup(BranchType iBranchType,
-                      ProductResolverIndexHelper const&) = 0;
-    virtual void resolvePutIndicies(BranchType iBranchType,
-                                    std::unordered_multimap<std::string, std::tuple<TypeID const*, const char*, edm::ProductResolverIndex>> const& iIndicies) = 0;
+    virtual void updateLookup(BranchType iBranchType, ProductResolverIndexHelper const&) = 0;
+    virtual void resolvePutIndicies(
+        BranchType iBranchType,
+        std::unordered_multimap<std::string, std::tuple<TypeID const*, const char*, edm::ProductResolverIndex>> const&
+            iIndicies) = 0;
 
-    virtual void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
-                                                 ProductRegistry const& preg,
-                                                 std::map<std::string, ModuleDescription const*> const& labelsToDesc) const = 0;
+    virtual void modulesWhoseProductsAreConsumed(
+        std::vector<ModuleDescription const*>& modules,
+        ProductRegistry const& preg,
+        std::map<std::string, ModuleDescription const*> const& labelsToDesc) const = 0;
 
     virtual void convertCurrentProcessAlias(std::string const& processName) = 0;
 
     virtual std::vector<ConsumesInfo> consumesInfo() const = 0;
 
-    virtual Types moduleType() const =0;
+    virtual Types moduleType() const = 0;
 
     void clearCounters() {
-      timesRun_.store(0,std::memory_order_release);
-      timesVisited_.store(0,std::memory_order_release);
-      timesPassed_.store(0,std::memory_order_release);
-      timesFailed_.store(0,std::memory_order_release);
-      timesExcept_.store(0,std::memory_order_release);
+      timesRun_.store(0, std::memory_order_release);
+      timesVisited_.store(0, std::memory_order_release);
+      timesPassed_.store(0, std::memory_order_release);
+      timesFailed_.store(0, std::memory_order_release);
+      timesExcept_.store(0, std::memory_order_release);
     }
 
-    void addedToPath() {
-      ++numberOfPathsOn_;
-    }
+    void addedToPath() { ++numberOfPathsOn_; }
     //NOTE: calling state() is done to force synchronization across threads
     int timesRun() const { return timesRun_.load(std::memory_order_acquire); }
     int timesVisited() const { return timesVisited_.load(std::memory_order_acquire); }
@@ -228,41 +224,47 @@ namespace edm {
     int timesExcept() const { return timesExcept_.load(std::memory_order_acquire); }
     State state() const { return state_; }
 
-    int timesPass() const { return timesPassed(); } // for backward compatibility only - to be removed soon
+    int timesPass() const { return timesPassed(); }  // for backward compatibility only - to be removed soon
 
     virtual bool hasAccumulator() const = 0;
 
   protected:
-    template<typename O> friend class workerhelper::CallImpl;
+    template <typename O> friend class workerhelper::CallImpl;
     virtual std::string workerType() const = 0;
-    virtual bool implDo(EventPrincipal const&, EventSetupImpl const& c,
-                        ModuleCallingContext const* mcc) = 0;
+    virtual bool implDo(EventPrincipal const&, EventSetupImpl const& c, ModuleCallingContext const* mcc) = 0;
 
     virtual void itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>&) const = 0;
     virtual bool implNeedToRunSelection() const = 0;
 
-    virtual void implDoAcquire(EventPrincipal const&, EventSetupImpl const& c,
+    virtual void implDoAcquire(EventPrincipal const&,
+                               EventSetupImpl const& c,
                                ModuleCallingContext const* mcc,
                                WaitingTaskWithArenaHolder& holder) = 0;
 
-    virtual bool implDoPrePrefetchSelection(StreamID id,
-                                            EventPrincipal const& ep,
-                                            ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoBegin(RunPrincipal const& rp, EventSetupImpl const& c,
-                             ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetupImpl const& c,
+    virtual bool implDoPrePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) = 0;
+    virtual bool implDoBegin(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) = 0;
+    virtual bool implDoStreamBegin(StreamID id,
+                                   RunPrincipal const& rp,
+                                   EventSetupImpl const& c,
                                    ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetupImpl const& c,
+    virtual bool implDoStreamEnd(StreamID id,
+                                 RunPrincipal const& rp,
+                                 EventSetupImpl const& c,
                                  ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoEnd(RunPrincipal const& rp, EventSetupImpl const& c,
-                           ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
+    virtual bool implDoEnd(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) = 0;
+    virtual bool implDoBegin(LuminosityBlockPrincipal const& lbp,
+                             EventSetupImpl const& c,
                              ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
+    virtual bool implDoStreamBegin(StreamID id,
+                                   LuminosityBlockPrincipal const& lbp,
+                                   EventSetupImpl const& c,
                                    ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
+    virtual bool implDoStreamEnd(StreamID id,
+                                 LuminosityBlockPrincipal const& lbp,
+                                 EventSetupImpl const& c,
                                  ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
+    virtual bool implDoEnd(LuminosityBlockPrincipal const& lbp,
+                           EventSetupImpl const& c,
                            ModuleCallingContext const* mcc) = 0;
     virtual void implBeginJob() = 0;
     virtual void implEndJob() = 0;
@@ -274,33 +276,33 @@ namespace edm {
     ActivityRegistry* activityRegistry() { return actReg_.get(); }
 
   private:
-    
     template <typename T>
-    bool runModule(typename T::MyPrincipal const&, EventSetupImpl const& c,
-                StreamID stream,
-                ParentContext const& parentContext,
-                typename T::Context const* context);
+    bool runModule(typename T::MyPrincipal const&,
+                   EventSetupImpl const& c,
+                   StreamID stream,
+                   ParentContext const& parentContext,
+                   typename T::Context const* context);
 
     virtual void itemsToGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const = 0;
     virtual void itemsMayGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const = 0;
 
     virtual std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFrom(BranchType) const = 0;
 
-
     virtual std::vector<ProductResolverIndex> const& itemsShouldPutInEvent() const = 0;
 
-    virtual void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& moduleCallingContext, Principal const& iPrincipal) const = 0;
-    
+    virtual void preActionBeforeRunEventAsync(WaitingTask* iTask,
+                                              ModuleCallingContext const& moduleCallingContext,
+                                              Principal const& iPrincipal) const = 0;
+
     virtual void implRespondToOpenInputFile(FileBlock const& fb) = 0;
     virtual void implRespondToCloseInputFile(FileBlock const& fb) = 0;
 
     virtual void implRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) = 0;
-    
+
     virtual TaskQueueAdaptor serializeRunModule() = 0;
-    
-    static void exceptionContext(cms::Exception& ex,
-                                 ModuleCallingContext const* mcc);
-    
+
+    static void exceptionContext(cms::Exception& ex, ModuleCallingContext const* mcc);
+
     /*This base class is used to hide the differences between the ID used
      for Event, LuminosityBlock and Run. Using the base class allows us
      to only convert the ID to string form if it is actually needed in
@@ -311,67 +313,60 @@ namespace edm {
       virtual std::string value() const = 0;
       virtual ~TransitionIDValueBase() {}
     };
-    
-    template< typename T>
-    class TransitionIDValue : public TransitionIDValueBase {
+
+    template <typename T> class TransitionIDValue : public TransitionIDValueBase {
     public:
-      TransitionIDValue(T const& iP): p_(iP) {}
+      TransitionIDValue(T const& iP) : p_(iP) {}
       std::string value() const override {
         std::ostringstream iost;
-        iost<<p_.id();
+        iost << p_.id();
         return iost.str();
       }
-      private:
-        T const& p_;
-        
+
+    private:
+      T const& p_;
     };
-    
+
     bool shouldRethrowException(std::exception_ptr iPtr,
                                 ParentContext const& parentContext,
                                 bool isEvent,
                                 TransitionIDValueBase const& iID) const;
 
-    template<bool IS_EVENT>
-    bool setPassed() {
-      if(IS_EVENT) {
-        timesPassed_.fetch_add(1,std::memory_order_relaxed);
+    template <bool IS_EVENT> bool setPassed() {
+      if (IS_EVENT) {
+        timesPassed_.fetch_add(1, std::memory_order_relaxed);
       }
       state_ = Pass;
       return true;
     }
 
-    template<bool IS_EVENT>
-    bool setFailed() {
-      if(IS_EVENT) {
-        timesFailed_.fetch_add(1,std::memory_order_relaxed);
+    template <bool IS_EVENT> bool setFailed() {
+      if (IS_EVENT) {
+        timesFailed_.fetch_add(1, std::memory_order_relaxed);
       }
       state_ = Fail;
       return false;
     }
 
-    template<bool IS_EVENT>
-    std::exception_ptr setException(std::exception_ptr iException) {
+    template <bool IS_EVENT> std::exception_ptr setException(std::exception_ptr iException) {
       if (IS_EVENT) {
-        timesExcept_.fetch_add(1,std::memory_order_relaxed);
+        timesExcept_.fetch_add(1, std::memory_order_relaxed);
       }
-      cached_exception_ = iException; // propagate_const<T> has no reset() function
+      cached_exception_ = iException;  // propagate_const<T> has no reset() function
       state_ = Exception;
       return cached_exception_;
     }
-        
-    void prefetchAsync(WaitingTask*,
-                       ServiceToken const&,
-                       ParentContext const& parentContext,
-                       Principal const& );
-        
+
+    void prefetchAsync(WaitingTask*, ServiceToken const&, ParentContext const& parentContext, Principal const&);
+
     void emitPostModuleEventPrefetchingSignal() {
-      actReg_->postModuleEventPrefetchingSignal_.emit(*moduleCallingContext_.getStreamContext(),moduleCallingContext_);
+      actReg_->postModuleEventPrefetchingSignal_.emit(*moduleCallingContext_.getStreamContext(), moduleCallingContext_);
     }
 
     virtual bool hasAcquire() const = 0;
 
-    template<typename T>
-    std::exception_ptr runModuleAfterAsyncPrefetch(std::exception_ptr const * iEPtr,
+    template <typename T>
+    std::exception_ptr runModuleAfterAsyncPrefetch(std::exception_ptr const* iEPtr,
                                                    typename T::MyPrincipal const& ep,
                                                    EventSetupImpl const& es,
                                                    StreamID streamID,
@@ -389,11 +384,9 @@ namespace edm {
                                       ParentContext const& parentContext,
                                       WaitingTaskWithArenaHolder holder);
 
-    std::exception_ptr handleExternalWorkException(std::exception_ptr const* iEPtr,
-                                                   ParentContext const& parentContext);
+    std::exception_ptr handleExternalWorkException(std::exception_ptr const* iEPtr, ParentContext const& parentContext);
 
-    template< typename T>
-    class RunModuleTask : public WaitingTask {
+    template <typename T> class RunModuleTask : public WaitingTask {
     public:
       RunModuleTask(Worker* worker,
                     typename T::MyPrincipal const& ep,
@@ -401,23 +394,27 @@ namespace edm {
                     ServiceToken const& token,
                     StreamID streamID,
                     ParentContext const& parentContext,
-                    typename T::Context const* context):
-      m_worker(worker),
-      m_principal(ep),
-      m_es(es),
-      m_streamID(streamID),
-      m_parentContext(parentContext),
-      m_context(context),
-      m_serviceToken(token) {}
-      
+                    typename T::Context const* context)
+          : m_worker(worker),
+            m_principal(ep),
+            m_es(es),
+            m_streamID(streamID),
+            m_parentContext(parentContext),
+            m_context(context),
+            m_serviceToken(token) {}
+
       struct EnableQueueGuard {
         SerialTaskQueue* queue_;
-        EnableQueueGuard(SerialTaskQueue* iQueue): queue_{iQueue} {}
+        EnableQueueGuard(SerialTaskQueue* iQueue) : queue_{iQueue} {}
         EnableQueueGuard(EnableQueueGuard const&) = delete;
         EnableQueueGuard& operator=(EnableQueueGuard const&) = delete;
         EnableQueueGuard& operator=(EnableQueueGuard&&) = delete;
-        EnableQueueGuard(EnableQueueGuard&& iGuard): queue_{iGuard.queue_} {iGuard.queue_ = nullptr;}
-        ~EnableQueueGuard() { if(queue_) {queue_->resume();} }
+        EnableQueueGuard(EnableQueueGuard&& iGuard) : queue_{iGuard.queue_} { iGuard.queue_ = nullptr; }
+        ~EnableQueueGuard() {
+          if (queue_) {
+            queue_->resume();
+          }
+        }
       };
 
       tbb::task* execute() override {
@@ -428,64 +425,52 @@ namespace edm {
         // to hold the exception_ptr
         std::exception_ptr temp_excptr;
         auto excptr = exceptionPtr();
-        if(T::isEvent_ && !m_worker->hasAcquire()) {
+        if (T::isEvent_ && !m_worker->hasAcquire()) {
           try {
             //pre was called in prefetchAsync
             m_worker->emitPostModuleEventPrefetchingSignal();
-          }catch(...) {
+          } catch (...) {
             temp_excptr = std::current_exception();
-            if(not excptr) {
+            if (not excptr) {
               excptr = &temp_excptr;
             }
           }
         }
 
-        if( not excptr) {
-          if(auto queue = m_worker->serializeRunModule()) {
-            auto const & principal = m_principal;
+        if (not excptr) {
+          if (auto queue = m_worker->serializeRunModule()) {
+            auto const& principal = m_principal;
             auto& es = m_es;
-            auto f = [worker = m_worker, &principal,
-                      &es, streamID = m_streamID,
-                      parentContext = m_parentContext,
-                      sContext = m_context, serviceToken = m_serviceToken]()
-            {
+            auto f = [worker = m_worker, &principal, &es, streamID = m_streamID, parentContext = m_parentContext,
+                      sContext = m_context, serviceToken = m_serviceToken]() {
               //Need to make the services available
               ServiceRegistry::Operate guard(serviceToken);
-              
+
               //If needed, we pause the queue in begin transition and resume it
               // at the end transition. This guarantees that the module
               // only processes one transition at a time
-              EnableQueueGuard enableQueueGuard{ workerhelper::CallImpl<T>::enableGlobalQueue(worker)};
+              EnableQueueGuard enableQueueGuard{workerhelper::CallImpl<T>::enableGlobalQueue(worker)};
               std::exception_ptr* ptr = nullptr;
-              worker->template runModuleAfterAsyncPrefetch<T>(ptr,
-                                                     principal,
-                                                     es,
-                                                     streamID,
-                                                     parentContext,
-                                                     sContext);
+              worker->template runModuleAfterAsyncPrefetch<T>(ptr, principal, es, streamID, parentContext, sContext);
             };
             //keep another global transition from running if necessary
             auto gQueue = workerhelper::CallImpl<T>::pauseGlobalQueue(m_worker);
-            if(gQueue) {
-              gQueue->push( [queue,gQueue, f]() mutable {
+            if (gQueue) {
+              gQueue->push([queue, gQueue, f]() mutable {
                 gQueue->pause();
-                queue.push(std::move(f));} );
+                queue.push(std::move(f));
+              });
             } else {
-              queue.push( std::move(f) );
+              queue.push(std::move(f));
             }
             return nullptr;
           }
         }
 
-        m_worker->runModuleAfterAsyncPrefetch<T>(excptr,
-                                                 m_principal,
-                                                 m_es,
-                                                 m_streamID,
-                                                 m_parentContext,
-                                                 m_context);
+        m_worker->runModuleAfterAsyncPrefetch<T>(excptr, m_principal, m_es, m_streamID, m_parentContext, m_context);
         return nullptr;
       }
-      
+
     private:
       Worker* m_worker;
       typename T::MyPrincipal const& m_principal;
@@ -500,8 +485,7 @@ namespace edm {
     // it as a template so all cases will compile.
     // DUMMY exists to work around the C++ Standard prohibition on
     // fully specializing templates nested in other classes.
-    template <typename T, typename DUMMY = void>
-    class AcquireTask : public WaitingTask {
+    template <typename T, typename DUMMY = void> class AcquireTask : public WaitingTask {
     public:
       AcquireTask(Worker* worker,
                   typename T::MyPrincipal const& ep,
@@ -520,13 +504,13 @@ namespace edm {
                   EventSetupImpl const& es,
                   ServiceToken const& token,
                   ParentContext const& parentContext,
-                  WaitingTaskWithArenaHolder holder):
-      m_worker(worker),
-      m_principal(ep),
-      m_es(es),
-      m_parentContext(parentContext),
-        m_holder(std::move(holder)),
-      m_serviceToken(token) {}
+                  WaitingTaskWithArenaHolder holder)
+          : m_worker(worker),
+            m_principal(ep),
+            m_es(es),
+            m_parentContext(parentContext),
+            m_holder(std::move(holder)),
+            m_serviceToken(token) {}
 
       tbb::task* execute() override {
         //Need to make the services available early so other services can see them
@@ -539,40 +523,30 @@ namespace edm {
         try {
           //pre was called in prefetchAsync
           m_worker->emitPostModuleEventPrefetchingSignal();
-        } catch(...) {
+        } catch (...) {
           temp_excptr = std::current_exception();
-          if(not excptr) {
+          if (not excptr) {
             excptr = &temp_excptr;
           }
         }
 
-        if( not excptr) {
-          if(auto queue = m_worker->serializeRunModule()) {
-            auto const & principal = m_principal;
+        if (not excptr) {
+          if (auto queue = m_worker->serializeRunModule()) {
+            auto const& principal = m_principal;
             auto& es = m_es;
-            queue.push( [worker = m_worker, &principal,
-                         &es, parentContext = m_parentContext,
-                         serviceToken = m_serviceToken, holder = m_holder]()
-            {
+            queue.push([worker = m_worker, &principal, &es, parentContext = m_parentContext,
+                        serviceToken = m_serviceToken, holder = m_holder]() {
               //Need to make the services available
               ServiceRegistry::Operate guard(serviceToken);
 
               std::exception_ptr* ptr = nullptr;
-              worker->runAcquireAfterAsyncPrefetch(ptr,
-                                                   principal,
-                                                   es,
-                                                   parentContext,
-                                                   holder);
+              worker->runAcquireAfterAsyncPrefetch(ptr, principal, es, parentContext, holder);
             });
             return nullptr;
           }
         }
 
-        m_worker->runAcquireAfterAsyncPrefetch(excptr,
-                                               m_principal,
-                                               m_es,
-                                               m_parentContext,
-                                               std::move(m_holder));
+        m_worker->runAcquireAfterAsyncPrefetch(excptr, m_principal, m_es, m_parentContext, std::move(m_holder));
         return nullptr;
       }
 
@@ -590,10 +564,7 @@ namespace edm {
     // exception to a CMS exception and adding context to the exception.
     class HandleExternalWorkExceptionTask : public WaitingTask {
     public:
-
-      HandleExternalWorkExceptionTask(Worker* worker,
-                                      WaitingTask* runModuleTask,
-                                      ParentContext const& parentContext);
+      HandleExternalWorkExceptionTask(Worker* worker, WaitingTask* runModuleTask, ParentContext const& parentContext);
 
       tbb::task* execute() override;
 
@@ -611,242 +582,213 @@ namespace edm {
     std::atomic<State> state_;
     int numberOfPathsOn_;
     std::atomic<int> numberOfPathsLeftToRun_;
-        
+
     ModuleCallingContext moduleCallingContext_;
 
-    ExceptionToActionTable const* actions_; // memory assumed to be managed elsewhere
-    CMS_THREAD_GUARD(state_) std::exception_ptr cached_exception_; // if state is 'exception'
+    ExceptionToActionTable const* actions_;                         // memory assumed to be managed elsewhere
+    CMS_THREAD_GUARD(state_) std::exception_ptr cached_exception_;  // if state is 'exception'
 
-    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
+    std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
 
     edm::propagate_const<EarlyDeleteHelper*> earlyDeleteHelper_;
-    
+
     edm::WaitingTaskList waitingTasks_;
     std::atomic<bool> workStarted_;
     bool ranAcquireWithoutException_;
   };
 
   namespace {
-    template <typename T>
-    class ModuleSignalSentry {
+    template <typename T> class ModuleSignalSentry {
     public:
-      ModuleSignalSentry(ActivityRegistry *a,
+      ModuleSignalSentry(ActivityRegistry* a,
                          typename T::Context const* context,
-                         ModuleCallingContext const* moduleCallingContext) :
-        a_(a), context_(context), moduleCallingContext_(moduleCallingContext) {
-
-	if(a_) T::preModuleSignal(a_, context, moduleCallingContext_);
+                         ModuleCallingContext const* moduleCallingContext)
+          : a_(a), context_(context), moduleCallingContext_(moduleCallingContext) {
+        if (a_)
+          T::preModuleSignal(a_, context, moduleCallingContext_);
       }
 
       ~ModuleSignalSentry() {
-	if(a_) T::postModuleSignal(a_, context_, moduleCallingContext_);
+        if (a_)
+          T::postModuleSignal(a_, context_, moduleCallingContext_);
       }
 
     private:
-      ActivityRegistry* a_; // We do not use propagate_const because the registry itself is mutable.
+      ActivityRegistry* a_;  // We do not use propagate_const because the registry itself is mutable.
       typename T::Context const* context_;
       ModuleCallingContext const* moduleCallingContext_;
     };
 
-  }
+  }  // namespace
 
   namespace workerhelper {
-    template<>
-    class CallImpl<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>> {
+    template <> class CallImpl<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>> {
     public:
       typedef OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> Arg;
-      static bool call(Worker* iWorker, StreamID,
-                       EventPrincipal const& ep, EventSetupImpl const& es,
+      static bool call(Worker* iWorker,
+                       StreamID,
+                       EventPrincipal const& ep,
+                       EventSetupImpl const& es,
                        ActivityRegistry* /* actReg */,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* /* context*/) {
         //Signal sentry is handled by the module
-        return iWorker->implDo(ep,es, mcc);
+        return iWorker->implDo(ep, es, mcc);
       }
-      static bool wantsTransition(Worker const* iWorker) {
-        return true;
-      }      
-      static bool needToRunSelection( Worker const* iWorker) {
-        return iWorker->implNeedToRunSelection();
-      }
-      
-      static SerialTaskQueue* pauseGlobalQueue(Worker*) { return nullptr;}
-      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr;}
+      static bool wantsTransition(Worker const* iWorker) { return true; }
+      static bool needToRunSelection(Worker const* iWorker) { return iWorker->implNeedToRunSelection(); }
+
+      static SerialTaskQueue* pauseGlobalQueue(Worker*) { return nullptr; }
+      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr; }
     };
 
-    template<>
-    class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin>>{
+    template <> class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin>> {
     public:
       typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> Arg;
-      static bool call(Worker* iWorker,StreamID,
-                       RunPrincipal const& ep, EventSetupImpl const& es,
+      static bool call(Worker* iWorker,
+                       StreamID,
+                       RunPrincipal const& ep,
+                       EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoBegin(ep,es, mcc);
+        return iWorker->implDoBegin(ep, es, mcc);
       }
-      static bool wantsTransition(Worker const* iWorker) {
-        return iWorker->wantsGlobalRuns();
-      }
-      static bool needToRunSelection( Worker const* iWorker) {
-        return false;
-      }
-      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return iWorker->globalRunsQueue();}
-      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr;}
-
+      static bool wantsTransition(Worker const* iWorker) { return iWorker->wantsGlobalRuns(); }
+      static bool needToRunSelection(Worker const* iWorker) { return false; }
+      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return iWorker->globalRunsQueue(); }
+      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr; }
     };
-    template<>
-    class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionStreamBegin>>{
+    template <> class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionStreamBegin>> {
     public:
       typedef OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> Arg;
-      static bool call(Worker* iWorker,StreamID id,
-                       RunPrincipal const & ep, EventSetupImpl const& es,
+      static bool call(Worker* iWorker,
+                       StreamID id,
+                       RunPrincipal const& ep,
+                       EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoStreamBegin(id,ep,es, mcc);
+        return iWorker->implDoStreamBegin(id, ep, es, mcc);
       }
-      static bool wantsTransition(Worker const* iWorker) {
-        return iWorker->wantsStreamRuns();
-      }
-      static bool needToRunSelection( Worker const* iWorker) {
-        return false;
-      }
-      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr;}
-      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr;}
-
+      static bool wantsTransition(Worker const* iWorker) { return iWorker->wantsStreamRuns(); }
+      static bool needToRunSelection(Worker const* iWorker) { return false; }
+      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr; }
+      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr; }
     };
-    template<>
-    class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd>>{
+    template <> class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd>> {
     public:
       typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Arg;
-      static bool call(Worker* iWorker,StreamID,
-                       RunPrincipal const& ep, EventSetupImpl const& es,
+      static bool call(Worker* iWorker,
+                       StreamID,
+                       RunPrincipal const& ep,
+                       EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoEnd(ep,es, mcc);
+        return iWorker->implDoEnd(ep, es, mcc);
       }
-      static bool wantsTransition(Worker const* iWorker) {
-        return iWorker->wantsGlobalRuns();
-      }
-      static bool needToRunSelection( Worker const* iWorker) {
-        return false;
-      }
-      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr;}
-      static SerialTaskQueue* enableGlobalQueue(Worker* iWorker) { return iWorker->globalRunsQueue();}
+      static bool wantsTransition(Worker const* iWorker) { return iWorker->wantsGlobalRuns(); }
+      static bool needToRunSelection(Worker const* iWorker) { return false; }
+      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr; }
+      static SerialTaskQueue* enableGlobalQueue(Worker* iWorker) { return iWorker->globalRunsQueue(); }
     };
-    template<>
-    class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionStreamEnd>>{
+    template <> class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionStreamEnd>> {
     public:
       typedef OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> Arg;
-      static bool call(Worker* iWorker,StreamID id,
-                       RunPrincipal const& ep, EventSetupImpl const& es,
+      static bool call(Worker* iWorker,
+                       StreamID id,
+                       RunPrincipal const& ep,
+                       EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoStreamEnd(id,ep,es, mcc);
+        return iWorker->implDoStreamEnd(id, ep, es, mcc);
       }
-      static bool wantsTransition(Worker const* iWorker) {
-        return iWorker->wantsStreamRuns();
-      }
-      static bool needToRunSelection( Worker const* iWorker) {
-        return false;
-      }
-      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr;}
-      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr;}
+      static bool wantsTransition(Worker const* iWorker) { return iWorker->wantsStreamRuns(); }
+      static bool needToRunSelection(Worker const* iWorker) { return false; }
+      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr; }
+      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr; }
     };
 
-    template<>
-    class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin>>{
+    template <> class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin>> {
     public:
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Arg;
-      static bool call(Worker* iWorker,StreamID,
-                       LuminosityBlockPrincipal const& ep, EventSetupImpl const& es,
+      static bool call(Worker* iWorker,
+                       StreamID,
+                       LuminosityBlockPrincipal const& ep,
+                       EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoBegin(ep,es, mcc);
+        return iWorker->implDoBegin(ep, es, mcc);
       }
-      static bool wantsTransition(Worker const* iWorker) {
-        return iWorker->wantsGlobalLuminosityBlocks();
-      }
-      static bool needToRunSelection( Worker const* iWorker) {
-        return false;
-      }
-      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return iWorker->globalLuminosityBlocksQueue();}
-      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr;}
+      static bool wantsTransition(Worker const* iWorker) { return iWorker->wantsGlobalLuminosityBlocks(); }
+      static bool needToRunSelection(Worker const* iWorker) { return false; }
+      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return iWorker->globalLuminosityBlocksQueue(); }
+      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr; }
     };
-    template<>
-    class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin>>{
+    template <> class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin>> {
     public:
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> Arg;
-      static bool call(Worker* iWorker,StreamID id,
-                       LuminosityBlockPrincipal const& ep, EventSetupImpl const& es,
+      static bool call(Worker* iWorker,
+                       StreamID id,
+                       LuminosityBlockPrincipal const& ep,
+                       EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoStreamBegin(id,ep,es, mcc);
+        return iWorker->implDoStreamBegin(id, ep, es, mcc);
       }
-      static bool wantsTransition(Worker const* iWorker) {
-        return iWorker->wantsStreamLuminosityBlocks();
-      }
-      static bool needToRunSelection( Worker const* iWorker) {
-        return false;
-      }
-      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr;}
-      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr;}
-};
+      static bool wantsTransition(Worker const* iWorker) { return iWorker->wantsStreamLuminosityBlocks(); }
+      static bool needToRunSelection(Worker const* iWorker) { return false; }
+      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr; }
+      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr; }
+    };
 
-    template<>
-    class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd>>{
+    template <> class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd>> {
     public:
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Arg;
-      static bool call(Worker* iWorker,StreamID,
-                       LuminosityBlockPrincipal const& ep, EventSetupImpl const& es,
+      static bool call(Worker* iWorker,
+                       StreamID,
+                       LuminosityBlockPrincipal const& ep,
+                       EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoEnd(ep,es, mcc);
+        return iWorker->implDoEnd(ep, es, mcc);
       }
-      static bool wantsTransition(Worker const* iWorker) {
-        return iWorker->wantsGlobalLuminosityBlocks();
-      }
-      static bool needToRunSelection( Worker const* iWorker) {
-        return false;
-      }
-      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr;}
-      static SerialTaskQueue* enableGlobalQueue(Worker* iWorker) { return iWorker->globalLuminosityBlocksQueue();}
+      static bool wantsTransition(Worker const* iWorker) { return iWorker->wantsGlobalLuminosityBlocks(); }
+      static bool needToRunSelection(Worker const* iWorker) { return false; }
+      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr; }
+      static SerialTaskQueue* enableGlobalQueue(Worker* iWorker) { return iWorker->globalLuminosityBlocksQueue(); }
     };
-    template<>
-    class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd>>{
+    template <> class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd>> {
     public:
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> Arg;
-      static bool call(Worker* iWorker,StreamID id,
-                       LuminosityBlockPrincipal const& ep, EventSetupImpl const& es,
+      static bool call(Worker* iWorker,
+                       StreamID id,
+                       LuminosityBlockPrincipal const& ep,
+                       EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoStreamEnd(id,ep,es, mcc);
+        return iWorker->implDoStreamEnd(id, ep, es, mcc);
       }
-      static bool wantsTransition(Worker const* iWorker) {
-        return iWorker->wantsStreamLuminosityBlocks();
-       }
-      static bool needToRunSelection( Worker const* iWorker) {
-        return false;
-      }
-      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr;}
-      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr;}
+      static bool wantsTransition(Worker const* iWorker) { return iWorker->wantsStreamLuminosityBlocks(); }
+      static bool needToRunSelection(Worker const* iWorker) { return false; }
+      static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr; }
+      static SerialTaskQueue* enableGlobalQueue(Worker*) { return nullptr; }
     };
-  }
+  }  // namespace workerhelper
 
   template <typename T>
   void Worker::doWorkAsync(WaitingTask* task,
@@ -861,33 +803,32 @@ namespace edm {
     }
 
     waitingTasks_.add(task);
-    if(T::isEvent_) {
-      timesVisited_.fetch_add(1,std::memory_order_relaxed);
+    if (T::isEvent_) {
+      timesVisited_.fetch_add(1, std::memory_order_relaxed);
     }
 
     bool expected = false;
-    if(workStarted_.compare_exchange_strong(expected,true)) {
-      moduleCallingContext_.setContext(ModuleCallingContext::State::kPrefetching,parentContext,nullptr);
+    if (workStarted_.compare_exchange_strong(expected, true)) {
+      moduleCallingContext_.setContext(ModuleCallingContext::State::kPrefetching, parentContext, nullptr);
 
       //if have TriggerResults based selection we want to reject the event before doing prefetching
-      if(workerhelper::CallImpl<T>::needToRunSelection(this)) {
+      if (workerhelper::CallImpl<T>::needToRunSelection(this)) {
         //We need to run the selection in a different task so that
         // we can prefetch the data needed for the selection
-        auto runTask = new (tbb::task::allocate_root()) RunModuleTask<T>(
-                                                                         this, ep,es,token,streamID,parentContext,context);
+        auto runTask =
+            new (tbb::task::allocate_root()) RunModuleTask<T>(this, ep, es, token, streamID, parentContext, context);
 
         //make sure the task is either run or destroyed
         struct DestroyTask {
-        DestroyTask(edm::WaitingTask* iTask):
-          m_task(iTask) {}
-          
+          DestroyTask(edm::WaitingTask* iTask) : m_task(iTask) {}
+
           ~DestroyTask() {
             auto p = m_task.load();
-            if(p) {
+            if (p) {
               tbb::task::destroy(*p);
             }
           }
-          
+
           edm::WaitingTask* release() {
             auto t = m_task.load();
             m_task.store(nullptr);
@@ -898,30 +839,27 @@ namespace edm {
         };
 
         auto ownRunTask = std::make_shared<DestroyTask>(runTask);
-        auto selectionTask = make_waiting_task(tbb::task::allocate_root(), [ownRunTask,parentContext,&ep,token, this] (std::exception_ptr const* ) mutable {
-          
+        auto selectionTask = make_waiting_task(tbb::task::allocate_root(), [ownRunTask, parentContext, &ep, token,
+                                                                            this](std::exception_ptr const*) mutable {
           ServiceRegistry::Operate guard(token);
           prefetchAsync(ownRunTask->release(), token, parentContext, ep);
         });
-        prePrefetchSelectionAsync(selectionTask,token,streamID, &ep);
+        prePrefetchSelectionAsync(selectionTask, token, streamID, &ep);
       } else {
-        WaitingTask* moduleTask = new (tbb::task::allocate_root()) RunModuleTask<T>(
-          this, ep, es, token, streamID, parentContext, context);
+        WaitingTask* moduleTask =
+            new (tbb::task::allocate_root()) RunModuleTask<T>(this, ep, es, token, streamID, parentContext, context);
         if (T::isEvent_ && hasAcquire()) {
           WaitingTaskWithArenaHolder runTaskHolder(
-            new (tbb::task::allocate_root())
-              HandleExternalWorkExceptionTask(this,
-                                              moduleTask,
-                                              parentContext));
-          moduleTask = new (tbb::task::allocate_root()) AcquireTask<T>(
-            this, ep, es, token, parentContext, std::move(runTaskHolder));
+              new (tbb::task::allocate_root()) HandleExternalWorkExceptionTask(this, moduleTask, parentContext));
+          moduleTask = new (tbb::task::allocate_root())
+              AcquireTask<T>(this, ep, es, token, parentContext, std::move(runTaskHolder));
         }
         prefetchAsync(moduleTask, token, parentContext, ep);
       }
     }
   }
 
-  template<typename T>
+  template <typename T>
   std::exception_ptr Worker::runModuleAfterAsyncPrefetch(std::exception_ptr const* iEPtr,
                                                          typename T::MyPrincipal const& ep,
                                                          EventSetupImpl const& es,
@@ -929,20 +867,20 @@ namespace edm {
                                                          ParentContext const& parentContext,
                                                          typename T::Context const* context) {
     std::exception_ptr exceptionPtr;
-    if(iEPtr) {
+    if (iEPtr) {
       assert(*iEPtr);
       TransitionIDValue<typename T::MyPrincipal> idValue(ep);
-      if(shouldRethrowException(*iEPtr, parentContext, T::isEvent_, idValue)) {
+      if (shouldRethrowException(*iEPtr, parentContext, T::isEvent_, idValue)) {
         exceptionPtr = *iEPtr;
         setException<T::isEvent_>(exceptionPtr);
       } else {
         setPassed<T::isEvent_>();
       }
-      moduleCallingContext_.setContext(ModuleCallingContext::State::kInvalid,ParentContext(),nullptr);
+      moduleCallingContext_.setContext(ModuleCallingContext::State::kInvalid, ParentContext(), nullptr);
     } else {
       try {
-        runModule<T>(ep,es,streamID,parentContext,context);
-      } catch(...) {
+        runModule<T>(ep, es, streamID, parentContext, context);
+      } catch (...) {
         exceptionPtr = std::current_exception();
       }
     }
@@ -952,40 +890,34 @@ namespace edm {
 
   template <typename T>
   void Worker::doWorkNoPrefetchingAsync(WaitingTask* task,
-                           typename T::MyPrincipal const& principal,
-                           EventSetupImpl const& es,
-                           ServiceToken const& serviceToken,
-                           StreamID streamID,
-                           ParentContext const& parentContext,
-                           typename T::Context const* context) {
+                                        typename T::MyPrincipal const& principal,
+                                        EventSetupImpl const& es,
+                                        ServiceToken const& serviceToken,
+                                        StreamID streamID,
+                                        ParentContext const& parentContext,
+                                        typename T::Context const* context) {
     if (not workerhelper::CallImpl<T>::wantsTransition(this)) {
       return;
     }
     waitingTasks_.add(task);
     bool expected = false;
-    if(workStarted_.compare_exchange_strong(expected,true)) {
-      
-      auto toDo =[this, &principal, &es, streamID,parentContext,context, serviceToken]()
-      {
+    if (workStarted_.compare_exchange_strong(expected, true)) {
+      auto toDo = [this, &principal, &es, streamID, parentContext, context, serviceToken]() {
         std::exception_ptr exceptionPtr;
         try {
           //Need to make the services available
           ServiceRegistry::Operate guard(serviceToken);
-            
-          this->runModule<T>(principal,
-                               es,
-                               streamID,
-                               parentContext,
-                               context);
-        } catch( ... ) {
+
+          this->runModule<T>(principal, es, streamID, parentContext, context);
+        } catch (...) {
           exceptionPtr = std::current_exception();
         }
         this->waitingTasks_.doneWaiting(exceptionPtr);
       };
-      if(auto queue = this->serializeRunModule()) {
-        queue.push( toDo);
+      if (auto queue = this->serializeRunModule()) {
+        queue.push(toDo);
       } else {
-        auto task = make_functor_task( tbb::task::allocate_root(), toDo);
+        auto task = make_functor_task(tbb::task::allocate_root(), toDo);
         tbb::task::spawn(*task);
       }
     }
@@ -997,35 +929,40 @@ namespace edm {
                       StreamID streamID,
                       ParentContext const& parentContext,
                       typename T::Context const* context) {
-
     if (T::isEvent_) {
-      timesVisited_.fetch_add(1,std::memory_order_relaxed);
+      timesVisited_.fetch_add(1, std::memory_order_relaxed);
     }
     bool rc = false;
 
-    switch(state_) {
-      case Ready: break;
-      case Pass: return true;
-      case Fail: return false;
+    switch (state_) {
+      case Ready:
+        break;
+      case Pass:
+        return true;
+      case Fail:
+        return false;
       case Exception: {
         std::rethrow_exception(cached_exception_);
       }
     }
-    
+
     bool expected = false;
-    if(not workStarted_.compare_exchange_strong(expected, true) ) {
+    if (not workStarted_.compare_exchange_strong(expected, true)) {
       //another thread beat us here
       auto waitTask = edm::make_empty_waiting_task();
       waitTask->increment_ref_count();
-      
+
       waitingTasks_.add(waitTask.get());
-      
+
       waitTask->wait_for_all();
-      
-      switch(state_) {
-        case Ready: assert(false);
-        case Pass: return true;
-        case Fail: return false;
+
+      switch (state_) {
+        case Ready:
+          assert(false);
+        case Pass:
+          return true;
+        case Fail:
+          return false;
         case Exception: {
           std::rethrow_exception(cached_exception_);
         }
@@ -1033,23 +970,23 @@ namespace edm {
     }
 
     //Need the context to be set until after any exception is resolved
-    moduleCallingContext_.setContext(ModuleCallingContext::State::kPrefetching,parentContext,nullptr);
+    moduleCallingContext_.setContext(ModuleCallingContext::State::kPrefetching, parentContext, nullptr);
 
-    auto resetContext = [](ModuleCallingContext* iContext) {iContext->setContext(ModuleCallingContext::State::kInvalid,ParentContext(),nullptr); };
-    std::unique_ptr<ModuleCallingContext, decltype(resetContext)> prefetchSentry(&moduleCallingContext_,resetContext);
+    auto resetContext = [](ModuleCallingContext* iContext) {
+      iContext->setContext(ModuleCallingContext::State::kInvalid, ParentContext(), nullptr);
+    };
+    std::unique_ptr<ModuleCallingContext, decltype(resetContext)> prefetchSentry(&moduleCallingContext_, resetContext);
 
     if (T::isEvent_) {
       //if have TriggerResults based selection we want to reject the event before doing prefetching
-      if ( workerhelper::CallImpl<T>::needToRunSelection(this)) {
+      if (workerhelper::CallImpl<T>::needToRunSelection(this)) {
         auto waitTask = edm::make_empty_waiting_task();
         waitTask->set_ref_count(2);
-        prePrefetchSelectionAsync(waitTask.get(),
-                                  ServiceRegistry::instance().presentToken(),
-                                  streamID, &ep);
+        prePrefetchSelectionAsync(waitTask.get(), ServiceRegistry::instance().presentToken(), streamID, &ep);
         waitTask->decrement_ref_count();
         waitTask->wait_for_all();
-        
-        if(state() != Ready) {
+
+        if (state() != Ready) {
           //The selection must have rejected this event
           return true;
         }
@@ -1059,21 +996,19 @@ namespace edm {
         //Make sure signal is sent once the prefetching is done
         // [the 'pre' signal was sent in prefetchAsync]
         //The purpose of this block is to send the signal after wait_for_all
-        auto sentryFunc = [this](void*) {
-          emitPostModuleEventPrefetchingSignal();
-        };
-        std::unique_ptr<ActivityRegistry, decltype(sentryFunc)> signalSentry(actReg_.get(),sentryFunc);
-        
+        auto sentryFunc = [this](void*) { emitPostModuleEventPrefetchingSignal(); };
+        std::unique_ptr<ActivityRegistry, decltype(sentryFunc)> signalSentry(actReg_.get(), sentryFunc);
+
         //set count to 2 since wait_for_all requires value to not go to 0
         waitTask->set_ref_count(2);
-        
-        prefetchAsync(waitTask.get(),ServiceRegistry::instance().presentToken(), parentContext, ep);
+
+        prefetchAsync(waitTask.get(), ServiceRegistry::instance().presentToken(), parentContext, ep);
         waitTask->decrement_ref_count();
         waitTask->wait_for_all();
       }
-      if(waitTask->exceptionPtr() != nullptr) {
+      if (waitTask->exceptionPtr() != nullptr) {
         TransitionIDValue<typename T::MyPrincipal> idValue(ep);
-        if(shouldRethrowException(*waitTask->exceptionPtr(), parentContext, T::isEvent_, idValue)) {
+        if (shouldRethrowException(*waitTask->exceptionPtr(), parentContext, T::isEvent_, idValue)) {
           setException<T::isEvent_>(*waitTask->exceptionPtr());
           waitingTasks_.doneWaiting(cached_exception_);
           std::rethrow_exception(cached_exception_);
@@ -1084,66 +1019,64 @@ namespace edm {
         }
       }
     }
-    
+
     //successful prefetch so no reset necessary
     prefetchSentry.release();
-    if(auto queue = serializeRunModule()) {
+    if (auto queue = serializeRunModule()) {
       auto serviceToken = ServiceRegistry::instance().presentToken();
       queue.pushAndWait([&]() {
         //Need to make the services available
         ServiceRegistry::Operate guard(serviceToken);
         try {
-          rc = runModule<T>(ep,es,streamID,parentContext,context);
-        } catch(...) {
+          rc = runModule<T>(ep, es, streamID, parentContext, context);
+        } catch (...) {
         }
       });
     } else {
       try {
-        rc = runModule<T>(ep,es,streamID,parentContext,context);
-      } catch(...) {
+        rc = runModule<T>(ep, es, streamID, parentContext, context);
+      } catch (...) {
       }
     }
-    if(state_ == Exception) {
+    if (state_ == Exception) {
       waitingTasks_.doneWaiting(cached_exception_);
       std::rethrow_exception(cached_exception_);
     }
-    
+
     waitingTasks_.doneWaiting(nullptr);
     return rc;
   }
-  
-  
+
   template <typename T>
   bool Worker::runModule(typename T::MyPrincipal const& ep,
-                      EventSetupImpl const& es,
-                      StreamID streamID,
-                      ParentContext const& parentContext,
-                      typename T::Context const* context) {
+                         EventSetupImpl const& es,
+                         StreamID streamID,
+                         ParentContext const& parentContext,
+                         typename T::Context const* context) {
     //unscheduled producers should advance this
     //if (T::isEvent_) {
     //  ++timesVisited_;
     //}
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     if (T::isEvent_) {
-      timesRun_.fetch_add(1,std::memory_order_relaxed);
+      timesRun_.fetch_add(1, std::memory_order_relaxed);
     }
 
     bool rc = true;
     try {
-      convertException::wrap([&]()
-      {
-        rc = workerhelper::CallImpl<T>::call(this,streamID,ep,es, actReg_.get(), &moduleCallingContext_, context);
-        
+      convertException::wrap([&]() {
+        rc = workerhelper::CallImpl<T>::call(this, streamID, ep, es, actReg_.get(), &moduleCallingContext_, context);
+
         if (rc) {
           setPassed<T::isEvent_>();
         } else {
           setFailed<T::isEvent_>();
         }
       });
-    } catch(cms::Exception& ex) {
+    } catch (cms::Exception& ex) {
       exceptionContext(ex, &moduleCallingContext_);
       TransitionIDValue<typename T::MyPrincipal> idValue(ep);
-      if(shouldRethrowException(std::current_exception(), parentContext, T::isEvent_, idValue)) {
+      if (shouldRethrowException(std::current_exception(), parentContext, T::isEvent_, idValue)) {
         assert(not cached_exception_);
         setException<T::isEvent_>(std::current_exception());
         std::rethrow_exception(cached_exception_);
@@ -1151,7 +1084,7 @@ namespace edm {
         rc = setPassed<T::isEvent_>();
       }
     }
-    
+
     return rc;
   }
 
@@ -1161,10 +1094,9 @@ namespace edm {
                                                StreamID streamID,
                                                ParentContext const& parentContext,
                                                typename T::Context const* context) {
-
-    timesVisited_.fetch_add(1,std::memory_order_relaxed);
-    std::exception_ptr const* prefetchingException = nullptr; // null because there was no prefetching to do
+    timesVisited_.fetch_add(1, std::memory_order_relaxed);
+    std::exception_ptr const* prefetchingException = nullptr;  // null because there was no prefetching to do
     return runModuleAfterAsyncPrefetch<T>(prefetchingException, ep, es, streamID, parentContext, context);
   }
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/src/WorkerInPath.cc
+++ b/FWCore/Framework/src/WorkerInPath.cc
@@ -3,16 +3,15 @@
 #include "FWCore/Framework/src/WorkerInPath.h"
 
 namespace edm {
-  WorkerInPath::WorkerInPath(Worker* w, FilterAction theFilterAction, unsigned int placeInPath):
-    timesVisited_(),
-    timesPassed_(),
-    timesFailed_(),
-    timesExcept_(),
-    filterAction_(theFilterAction),
-    worker_(w),
-    placeInPathContext_(placeInPath)
-  {
+  WorkerInPath::WorkerInPath(Worker* w, FilterAction theFilterAction, unsigned int placeInPath)
+      : timesVisited_(),
+        timesPassed_(),
+        timesFailed_(),
+        timesExcept_(),
+        filterAction_(theFilterAction),
+        worker_(w),
+        placeInPathContext_(placeInPath) {
     w->addedToPath();
   }
 
-}
+}  // namespace edm

--- a/FWCore/Framework/src/WorkerMaker.cc
+++ b/FWCore/Framework/src/WorkerMaker.cc
@@ -11,60 +11,50 @@
 #include <sstream>
 #include <exception>
 namespace edm {
-  
-  Maker::~Maker() {
-  }
-  
-  ModuleDescription
-  Maker::createModuleDescription(MakeModuleParams const &p) const {
+
+  Maker::~Maker() {}
+
+  ModuleDescription Maker::createModuleDescription(MakeModuleParams const& p) const {
     ParameterSet const& conf = *p.pset_;
-    ModuleDescription md(conf.id(),
-                         conf.getParameter<std::string>("@module_type"),
-                         conf.getParameter<std::string>("@module_label"),
-                         p.processConfiguration_.get(),
+    ModuleDescription md(conf.id(), conf.getParameter<std::string>("@module_type"),
+                         conf.getParameter<std::string>("@module_label"), p.processConfiguration_.get(),
                          ModuleDescription::getUniqueID());
     return md;
   }
-  
-  void
-  Maker::throwValidationException(MakeModuleParams const& p,
-                                  cms::Exception & iException) const {
+
+  void Maker::throwValidationException(MakeModuleParams const& p, cms::Exception& iException) const {
     ParameterSet const& conf = *p.pset_;
     std::string moduleName = conf.getParameter<std::string>("@module_type");
     std::string moduleLabel = conf.getParameter<std::string>("@module_label");
-    
+
     std::ostringstream ost;
-    ost << "Validating configuration of module: class=" << moduleName
-    << " label='" << moduleLabel << "'";
+    ost << "Validating configuration of module: class=" << moduleName << " label='" << moduleLabel << "'";
     iException.addContext(ost.str());
     throw;
   }
-  
-  void
-  Maker::throwConfigurationException(ModuleDescription const& md,
-                                     cms::Exception & iException) const {
+
+  void Maker::throwConfigurationException(ModuleDescription const& md, cms::Exception& iException) const {
     std::ostringstream ost;
     ost << "Constructing module: class=" << md.moduleName() << " label='" << md.moduleLabel() << "'";
     iException.addContext(ost.str());
     throw;
   }
-  
-  void
-  Maker::validateEDMType(std::string const& edmType, MakeModuleParams const& p) const {
+
+  void Maker::validateEDMType(std::string const& edmType, MakeModuleParams const& p) const {
     std::string expected = p.pset_->getParameter<std::string>("@module_edm_type");
     if (edmType != expected) {
       throw Exception(errors::Configuration)
-      << "The base type in the python configuration is " << expected << ", but the base type\n"
-      << "for the module's C++ class is " << edmType << ". "
-      << "Please fix the configuration.\n"
-      << "It must use the same base type as the C++ class.\n";
+          << "The base type in the python configuration is " << expected << ", but the base type\n"
+          << "for the module's C++ class is " << edmType << ". "
+          << "Please fix the configuration.\n"
+          << "It must use the same base type as the C++ class.\n";
     }
   }
-  
-  std::shared_ptr<maker::ModuleHolder>
-  Maker::makeModule(MakeModuleParams const& p,
-                    signalslot::Signal<void(ModuleDescription const&)>& pre,
-                    signalslot::Signal<void(ModuleDescription const&)>& post) const {
+
+  std::shared_ptr<maker::ModuleHolder> Maker::makeModule(
+      MakeModuleParams const& p,
+      signalslot::Signal<void(ModuleDescription const&)>& pre,
+      signalslot::Signal<void(ModuleDescription const&)>& post) const {
     ConfigurationDescriptions descriptions(baseType(), p.pset_->getParameter<std::string>("@module_type"));
     fillDescriptions(descriptions);
     try {
@@ -72,8 +62,7 @@ namespace edm {
         descriptions.validate(*p.pset_, p.pset_->getParameter<std::string>("@module_label"));
         validateEDMType(baseType(), p);
       });
-    }
-    catch (cms::Exception & iException) {
+    } catch (cms::Exception& iException) {
       throwValidationException(p, iException);
     }
     p.pset_->registerIt();
@@ -83,8 +72,8 @@ namespace edm {
     //NOTE: a better implementation would be to change ParameterSet::registerIt
     // but that would require rebuilding much more code so will be done at
     // a later date.
-    edm::pset::Registry::instance()->insertMapped(*(p.pset_),true);
-    
+    edm::pset::Registry::instance()->insertMapped(*(p.pset_), true);
+
     ModuleDescription md = createModuleDescription(p);
     std::shared_ptr<maker::ModuleHolder> module;
     bool postCalled = false;
@@ -99,13 +88,11 @@ namespace edm {
         postCalled = true;
         post(md);
       });
-    }
-    catch(cms::Exception & iException){
-      if(!postCalled) {
+    } catch (cms::Exception& iException) {
+      if (!postCalled) {
         try {
           post(md);
-        }
-        catch (...) {
+        } catch (...) {
           // If post throws an exception ignore it because we are already handling another exception
         }
       }
@@ -113,12 +100,10 @@ namespace edm {
     }
     return module;
   }
-  
-  std::unique_ptr<Worker> 
-  Maker::makeWorker(ExceptionToActionTable const* actions,
-                    maker::ModuleHolder const* mod) const {
-    
-    return makeWorker(actions,mod->moduleDescription(),mod);
+
+  std::unique_ptr<Worker> Maker::makeWorker(ExceptionToActionTable const* actions,
+                                            maker::ModuleHolder const* mod) const {
+    return makeWorker(actions, mod->moduleDescription(), mod);
   }
-  
-} // end of edm::
+
+}  // namespace edm

--- a/FWCore/Framework/src/WorkerMaker.h
+++ b/FWCore/Framework/src/WorkerMaker.h
@@ -12,81 +12,76 @@
 
 #include "FWCore/Utilities/interface/Signal.h"
 
-
 namespace edm {
   class ConfigurationDescriptions;
   class ModuleDescription;
   class ParameterSet;
   class Maker;
   class ExceptionToActionTable;
-  
+
   class Maker {
   public:
     virtual ~Maker();
     std::shared_ptr<maker::ModuleHolder> makeModule(MakeModuleParams const&,
-                                       signalslot::Signal<void(ModuleDescription const&)>& iPre,
-                                       signalslot::Signal<void(ModuleDescription const&)>& iPost) const;
-    std::unique_ptr<Worker> makeWorker(ExceptionToActionTable const*,
-                                       maker::ModuleHolder const*) const;
+                                                    signalslot::Signal<void(ModuleDescription const&)>& iPre,
+                                                    signalslot::Signal<void(ModuleDescription const&)>& iPost) const;
+    std::unique_ptr<Worker> makeWorker(ExceptionToActionTable const*, maker::ModuleHolder const*) const;
 
-    std::shared_ptr<maker::ModuleHolder> makeReplacementModule(edm::ParameterSet const& p) const { return makeModule(p);}
-protected:
-      
+    std::shared_ptr<maker::ModuleHolder> makeReplacementModule(edm::ParameterSet const& p) const {
+      return makeModule(p);
+    }
+
+  protected:
     ModuleDescription createModuleDescription(MakeModuleParams const& p) const;
 
-    void throwConfigurationException(ModuleDescription const& md,
-                                     cms::Exception & iException) const;
+    void throwConfigurationException(ModuleDescription const& md, cms::Exception& iException) const;
 
-    void throwValidationException(MakeModuleParams const& p,
-				  cms::Exception & iException) const;
+    void throwValidationException(MakeModuleParams const& p, cms::Exception& iException) const;
 
     void validateEDMType(std::string const& edmType, MakeModuleParams const& p) const;
 
   private:
     virtual void fillDescriptions(ConfigurationDescriptions& iDesc) const = 0;
-    virtual std::shared_ptr<maker::ModuleHolder> makeModule(edm::ParameterSet const& p) const  = 0;
+    virtual std::shared_ptr<maker::ModuleHolder> makeModule(edm::ParameterSet const& p) const = 0;
     virtual std::unique_ptr<Worker> makeWorker(ExceptionToActionTable const* actions,
-                                             ModuleDescription const& md,
+                                               ModuleDescription const& md,
                                                maker::ModuleHolder const* mod) const = 0;
-    virtual const std::string& baseType() const =0;
+    virtual const std::string& baseType() const = 0;
   };
-  
-  
 
-  template <class T>
-  class WorkerMaker : public Maker {
+  template <class T> class WorkerMaker : public Maker {
   public:
     //typedef T worker_type;
     explicit WorkerMaker();
+
   private:
     void fillDescriptions(ConfigurationDescriptions& iDesc) const override;
-    std::unique_ptr<Worker> makeWorker(ExceptionToActionTable const* actions, ModuleDescription const& md, maker::ModuleHolder const* mod) const override;
+    std::unique_ptr<Worker> makeWorker(ExceptionToActionTable const* actions,
+                                       ModuleDescription const& md,
+                                       maker::ModuleHolder const* mod) const override;
     std::shared_ptr<maker::ModuleHolder> makeModule(edm::ParameterSet const& p) const override;
     const std::string& baseType() const override;
   };
 
-  template <class T>
-  WorkerMaker<T>::WorkerMaker() {
-  }
+  template <class T> WorkerMaker<T>::WorkerMaker() {}
 
-  template <class T>
-  void WorkerMaker<T>::fillDescriptions(ConfigurationDescriptions& iDesc) const {
+  template <class T> void WorkerMaker<T>::fillDescriptions(ConfigurationDescriptions& iDesc) const {
     T::fillDescriptions(iDesc);
     T::prevalidate(iDesc);
   }
 
-  template<class T>
-  std::shared_ptr<maker::ModuleHolder> WorkerMaker<T>::makeModule(edm::ParameterSet const& p) const
-  {
+  template <class T> std::shared_ptr<maker::ModuleHolder> WorkerMaker<T>::makeModule(edm::ParameterSet const& p) const {
     typedef T UserType;
     typedef typename UserType::ModuleType ModuleType;
     typedef MakeModuleHelper<ModuleType> MakerHelperType;
-    
-    return std::shared_ptr<maker::ModuleHolder>(std::make_shared<maker::ModuleHolderT<ModuleType> >(MakerHelperType::template makeModule<UserType>(p),this));
+
+    return std::shared_ptr<maker::ModuleHolder>(
+        std::make_shared<maker::ModuleHolderT<ModuleType> >(MakerHelperType::template makeModule<UserType>(p), this));
   }
-  
+
   template <class T>
-  std::unique_ptr<Worker> WorkerMaker<T>::makeWorker(ExceptionToActionTable const* actions, ModuleDescription const& md,
+  std::unique_ptr<Worker> WorkerMaker<T>::makeWorker(ExceptionToActionTable const* actions,
+                                                     ModuleDescription const& md,
                                                      maker::ModuleHolder const* mod) const {
     typedef T UserType;
     typedef typename UserType::ModuleType ModuleType;
@@ -95,13 +90,9 @@ protected:
     maker::ModuleHolderT<ModuleType> const* h = dynamic_cast<maker::ModuleHolderT<ModuleType> const*>(mod);
     return std::make_unique<WorkerType>(h->module(), md, actions);
   }
-  
 
-  template<class T>
-  const std::string& WorkerMaker<T>::baseType() const {
-    return T::baseType();
-  }
-  
-}
+  template <class T> const std::string& WorkerMaker<T>::baseType() const { return T::baseType(); }
+
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -14,32 +14,27 @@ static const std::string kProducerType("EDProducer");
 namespace edm {
   // -----------------------------
 
-  WorkerManager::WorkerManager(std::shared_ptr<ActivityRegistry> areg, ExceptionToActionTable const& actions) :
-    workerReg_(areg),
-    actionTable_(&actions),
-    allWorkers_(),
-    unscheduled_(*areg),
-    lastSetupEventPrincipal_(nullptr)
-  {
-
-  } // WorkerManager::WorkerManager
+  WorkerManager::WorkerManager(std::shared_ptr<ActivityRegistry> areg, ExceptionToActionTable const& actions)
+      : workerReg_(areg),
+        actionTable_(&actions),
+        allWorkers_(),
+        unscheduled_(*areg),
+        lastSetupEventPrincipal_(nullptr) {}  // WorkerManager::WorkerManager
 
   WorkerManager::WorkerManager(std::shared_ptr<ModuleRegistry> modReg,
                                std::shared_ptr<ActivityRegistry> areg,
-                               ExceptionToActionTable const& actions) :
-  workerReg_(areg,modReg),
-  actionTable_(&actions),
-  allWorkers_(),
-  unscheduled_(*areg),
-  lastSetupEventPrincipal_(nullptr)
-  {
-  } // WorkerManager::WorkerManager
+                               ExceptionToActionTable const& actions)
+      : workerReg_(areg, modReg),
+        actionTable_(&actions),
+        allWorkers_(),
+        unscheduled_(*areg),
+        lastSetupEventPrincipal_(nullptr) {}  // WorkerManager::WorkerManager
 
   Worker* WorkerManager::getWorker(ParameterSet& pset,
                                    ProductRegistry& preg,
                                    PreallocationConfiguration const* prealloc,
                                    std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                                   std::string const & label) {
+                                   std::string const& label) {
     WorkerParams params(&pset, preg, prealloc, processConfiguration, *actionTable_);
     return workerReg_.getWorker(params, label);
   }
@@ -55,7 +50,7 @@ namespace edm {
     // 1) create worker
     // 2) if it is a WorkerT<EDProducer>, add it to our list
     auto modType = pset.getParameter<std::string>("@module_edm_type");
-    if(modType == kProducerType || modType == kFilterType) {
+    if (modType == kProducerType || modType == kFilterType) {
       Worker* newWorker = getWorker(pset, preg, prealloc, processConfiguration, label);
       assert(newWorker->moduleType() == Worker::kProducer || newWorker->moduleType() == Worker::kFilter);
       unscheduledLabels.insert(label);
@@ -67,93 +62,82 @@ namespace edm {
     }
   }
 
-  void WorkerManager::setOnDemandProducts(ProductRegistry& pregistry, std::set<std::string> const& unscheduledLabels) const {
-    for(auto& prod : pregistry.productListUpdator()) {
-      if(prod.second.produced() &&
-          prod.second.branchType() == InEvent &&
+  void WorkerManager::setOnDemandProducts(ProductRegistry& pregistry,
+                                          std::set<std::string> const& unscheduledLabels) const {
+    for (auto& prod : pregistry.productListUpdator()) {
+      if (prod.second.produced() && prod.second.branchType() == InEvent &&
           unscheduledLabels.end() != unscheduledLabels.find(prod.second.moduleLabel())) {
         prod.second.setOnDemand(true);
       }
     }
   }
-  
+
   void WorkerManager::endJob() {
-    for(auto& worker : allWorkers_) {
+    for (auto& worker : allWorkers_) {
       worker->endJob();
     }
   }
 
   void WorkerManager::endJob(ExceptionCollector& collector) {
-    for(auto& worker : allWorkers_) {
+    for (auto& worker : allWorkers_) {
       try {
-        convertException::wrap([&]() {
-          worker->endJob();
-        });
-      }
-      catch (cms::Exception const& ex) {
+        convertException::wrap([&]() { worker->endJob(); });
+      } catch (cms::Exception const& ex) {
         collector.addException(ex);
       }
     }
   }
 
-
   void WorkerManager::beginJob(ProductRegistry const& iRegistry) {
     auto const runLookup = iRegistry.productLookup(InRun);
     auto const lumiLookup = iRegistry.productLookup(InLumi);
     auto const eventLookup = iRegistry.productLookup(InEvent);
-    if(!allWorkers_.empty()) {
+    if (!allWorkers_.empty()) {
       auto const& processName = allWorkers_[0]->description().processName();
       auto runModuleToIndicies = runLookup->indiciesForModulesInProcess(processName);
       auto lumiModuleToIndicies = lumiLookup->indiciesForModulesInProcess(processName);
       auto eventModuleToIndicies = eventLookup->indiciesForModulesInProcess(processName);
-      for(auto& worker : allWorkers_) {
-        worker->updateLookup(InRun,*runLookup);
-        worker->updateLookup(InLumi,*lumiLookup);
-        worker->updateLookup(InEvent,*eventLookup);
-        worker->resolvePutIndicies(InRun,runModuleToIndicies);
-        worker->resolvePutIndicies(InLumi,lumiModuleToIndicies);
-        worker->resolvePutIndicies(InEvent,eventModuleToIndicies);
+      for (auto& worker : allWorkers_) {
+        worker->updateLookup(InRun, *runLookup);
+        worker->updateLookup(InLumi, *lumiLookup);
+        worker->updateLookup(InEvent, *eventLookup);
+        worker->resolvePutIndicies(InRun, runModuleToIndicies);
+        worker->resolvePutIndicies(InLumi, lumiModuleToIndicies);
+        worker->resolvePutIndicies(InEvent, eventModuleToIndicies);
       }
-      
+
       for_all(allWorkers_, std::bind(&Worker::beginJob, std::placeholders::_1));
     }
   }
 
-  void
-  WorkerManager::beginStream(StreamID iID, StreamContext& streamContext) {
-    for(auto& worker: allWorkers_) {
+  void WorkerManager::beginStream(StreamID iID, StreamContext& streamContext) {
+    for (auto& worker : allWorkers_) {
       worker->beginStream(iID, streamContext);
     }
   }
 
-  void
-  WorkerManager::endStream(StreamID iID, StreamContext& streamContext) {
-    for(auto& worker: allWorkers_) {
+  void WorkerManager::endStream(StreamID iID, StreamContext& streamContext) {
+    for (auto& worker : allWorkers_) {
       worker->endStream(iID, streamContext);
     }
   }
 
-  void
-  WorkerManager::resetAll() {
-    for_all(allWorkers_, std::bind(&Worker::reset, std::placeholders::_1));
-  }
+  void WorkerManager::resetAll() { for_all(allWorkers_, std::bind(&Worker::reset, std::placeholders::_1)); }
 
-  void
-  WorkerManager::addToAllWorkers(Worker* w) {
-    if(!search_all(allWorkers_, w)) {
+  void WorkerManager::addToAllWorkers(Worker* w) {
+    if (!search_all(allWorkers_, w)) {
       allWorkers_.push_back(w);
     }
   }
 
-  void
-  WorkerManager::setupOnDemandSystem(Principal& ep, EventSetupImpl const& es) {
+  void WorkerManager::setupOnDemandSystem(Principal& ep, EventSetupImpl const& es) {
     this->resetAll();
     unscheduled_.setEventSetup(es);
-    if(&ep != lastSetupEventPrincipal_) {
-      UnscheduledConfigurator config( allWorkers_.begin(), allWorkers_.end(), &(unscheduled_.auxiliary()));
+    if (&ep != lastSetupEventPrincipal_) {
+      UnscheduledConfigurator config(allWorkers_.begin(), allWorkers_.end(), &(unscheduled_.auxiliary()));
       ep.setupUnscheduled(config);
       lastSetupEventPrincipal_ = &ep;
     }
   }
-  
-}
+
+}  // namespace edm

--- a/FWCore/Framework/src/WorkerParams.h
+++ b/FWCore/Framework/src/WorkerParams.h
@@ -20,20 +20,18 @@ namespace edm {
   class PreallocationConfiguration;
 
   struct WorkerParams {
-    WorkerParams() :
-      pset_(nullptr), reg_(nullptr), preallocate_(nullptr),processConfiguration_(), actions_(nullptr)
-      {}
+    WorkerParams() : pset_(nullptr), reg_(nullptr), preallocate_(nullptr), processConfiguration_(), actions_(nullptr) {}
 
     WorkerParams(ParameterSet* pset,
                  ProductRegistry& reg,
                  PreallocationConfiguration const* prealloc,
                  std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                 ExceptionToActionTable const& actions) :
-      pset_(pset),
-      reg_(&reg),
-      preallocate_(prealloc),
-      processConfiguration_(processConfiguration),
-      actions_(&actions) {}
+                 ExceptionToActionTable const& actions)
+        : pset_(pset),
+          reg_(&reg),
+          preallocate_(prealloc),
+          processConfiguration_(processConfiguration),
+          actions_(&actions) {}
 
     ParameterSet* pset_;
     ProductRegistry* reg_;
@@ -41,6 +39,6 @@ namespace edm {
     std::shared_ptr<ProcessConfiguration const> processConfiguration_;
     ExceptionToActionTable const* actions_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/WorkerRegistry.cc
+++ b/FWCore/Framework/src/WorkerRegistry.cc
@@ -14,47 +14,34 @@
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
 namespace edm {
-  
-  WorkerRegistry::WorkerRegistry(std::shared_ptr<ActivityRegistry> areg) :
-    modRegistry_(new ModuleRegistry),
-    m_workerMap(),
-    actReg_(areg)
-  {
-  }
-  
-  WorkerRegistry::WorkerRegistry(std::shared_ptr<ActivityRegistry> areg,
-                                 std::shared_ptr<ModuleRegistry> modReg):
-  modRegistry_(modReg),
-  m_workerMap(),
-  actReg_(areg)
-  {
-  }
 
-  WorkerRegistry:: ~WorkerRegistry() {
-  }
+  WorkerRegistry::WorkerRegistry(std::shared_ptr<ActivityRegistry> areg)
+      : modRegistry_(new ModuleRegistry), m_workerMap(), actReg_(areg) {}
 
-  void WorkerRegistry::clear() {
-    m_workerMap.clear();
-  }
+  WorkerRegistry::WorkerRegistry(std::shared_ptr<ActivityRegistry> areg, std::shared_ptr<ModuleRegistry> modReg)
+      : modRegistry_(modReg), m_workerMap(), actReg_(areg) {}
+
+  WorkerRegistry::~WorkerRegistry() {}
+
+  void WorkerRegistry::clear() { m_workerMap.clear(); }
 
   Worker* WorkerRegistry::getWorker(WorkerParams const& p, std::string const& moduleLabel) {
-
     WorkerMap::iterator workerIt = m_workerMap.find(moduleLabel);
-  
+
     // if the worker is not there, make it
-    if (workerIt == m_workerMap.end()){
-      MakeModuleParams mmp(p.pset_,*p.reg_,p.preallocate_,p.processConfiguration_);
-      auto modulePtr = modRegistry_->getModule(mmp,moduleLabel,
-                                               actReg_->preModuleConstructionSignal_,
+    if (workerIt == m_workerMap.end()) {
+      MakeModuleParams mmp(p.pset_, *p.reg_, p.preallocate_, p.processConfiguration_);
+      auto modulePtr = modRegistry_->getModule(mmp, moduleLabel, actReg_->preModuleConstructionSignal_,
                                                actReg_->postModuleConstructionSignal_);
-      auto workerPtr= modulePtr->makeWorker(p.actions_);
-    
+      auto workerPtr = modulePtr->makeWorker(p.actions_);
+
       workerPtr->setActivityRegistry(actReg_);
 
       // Transfer ownership of worker to the registry
-      m_workerMap[moduleLabel] = std::shared_ptr<Worker>(workerPtr.release()); // propagate_const<T> has no reset() function
-      return m_workerMap[moduleLabel].get(); 
-    } 
+      m_workerMap[moduleLabel] =
+          std::shared_ptr<Worker>(workerPtr.release());  // propagate_const<T> has no reset() function
+      return m_workerMap[moduleLabel].get();
+    }
     return (workerIt->second.get());
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/WorkerRegistry.h
+++ b/FWCore/Framework/src/WorkerRegistry.h
@@ -36,17 +36,14 @@ namespace edm {
   */
 
   class WorkerRegistry {
-
   public:
-
     explicit WorkerRegistry(std::shared_ptr<ActivityRegistry> areg);
-    WorkerRegistry(std::shared_ptr<ActivityRegistry> areg,
-                   std::shared_ptr<ModuleRegistry> iModReg);
+    WorkerRegistry(std::shared_ptr<ActivityRegistry> areg, std::shared_ptr<ModuleRegistry> iModReg);
     ~WorkerRegistry();
 
     WorkerRegistry(WorkerRegistry&&) = default;
-    WorkerRegistry(WorkerRegistry const&) = delete; // Disallow copying and moving
-    WorkerRegistry& operator=(WorkerRegistry const&) = delete; // Disallow copying and moving
+    WorkerRegistry(WorkerRegistry const&) = delete;             // Disallow copying and moving
+    WorkerRegistry& operator=(WorkerRegistry const&) = delete;  // Disallow copying and moving
 
     /// Retrieve the particular instance of the worker
     /** If the worker with that set of parameters does not exist,
@@ -54,21 +51,19 @@ namespace edm {
         @note Workers are owned by this class, do not delete them*/
     Worker* getWorker(WorkerParams const& p, std::string const& moduleLabel);
     void clear();
-    
+
   private:
     /// the container of workers
     typedef std::map<std::string, edm::propagate_const<std::shared_ptr<Worker>>> WorkerMap;
 
     edm::propagate_const<std::shared_ptr<ModuleRegistry>> modRegistry_;
-    
+
     /// internal map of registered workers (owned).
     WorkerMap m_workerMap;
-    std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
-     
-  }; // WorkerRegistry
+    std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
 
+  };  // WorkerRegistry
 
-} // edm
-
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -25,631 +25,442 @@
 
 #include <type_traits>
 
-namespace edm{
+namespace edm {
   namespace workerimpl {
-    template<typename T>
-    struct has_stream_functions {
-      static bool constexpr value = false;
-    };
+    template <typename T> struct has_stream_functions { static bool constexpr value = false; };
 
-    template<>
-    struct has_stream_functions<edm::global::EDProducerBase> {
-      static bool constexpr value = true;
-    };
+    template <> struct has_stream_functions<edm::global::EDProducerBase> { static bool constexpr value = true; };
 
-    template<>
-    struct has_stream_functions<edm::global::EDFilterBase> {
-      static bool constexpr value = true;
-    };
+    template <> struct has_stream_functions<edm::global::EDFilterBase> { static bool constexpr value = true; };
 
-    template<>
-    struct has_stream_functions<edm::global::EDAnalyzerBase> {
-      static bool constexpr value = true;
-    };
+    template <> struct has_stream_functions<edm::global::EDAnalyzerBase> { static bool constexpr value = true; };
 
-    template<>
-    struct has_stream_functions<edm::limited::EDProducerBase> {
-      static bool constexpr value = true;
-    };
-    
-    template<>
-    struct has_stream_functions<edm::limited::EDFilterBase> {
-      static bool constexpr value = true;
-    };
-    
-    template<>
-    struct has_stream_functions<edm::limited::EDAnalyzerBase> {
-      static bool constexpr value = true;
-    };
+    template <> struct has_stream_functions<edm::limited::EDProducerBase> { static bool constexpr value = true; };
 
-    template<>
-    struct has_stream_functions<edm::stream::EDProducerAdaptorBase> {
-      static bool constexpr value = true;
-    };
+    template <> struct has_stream_functions<edm::limited::EDFilterBase> { static bool constexpr value = true; };
 
-    template<>
-    struct has_stream_functions<edm::stream::EDFilterAdaptorBase> {
-      static bool constexpr value = true;
-    };
+    template <> struct has_stream_functions<edm::limited::EDAnalyzerBase> { static bool constexpr value = true; };
 
-    template<>
-    struct has_stream_functions<edm::stream::EDAnalyzerAdaptorBase> {
-      static bool constexpr value = true;
-    };
+    template <> struct has_stream_functions<edm::stream::EDProducerAdaptorBase> { static bool constexpr value = true; };
+
+    template <> struct has_stream_functions<edm::stream::EDFilterAdaptorBase> { static bool constexpr value = true; };
+
+    template <> struct has_stream_functions<edm::stream::EDAnalyzerAdaptorBase> { static bool constexpr value = true; };
 
     struct DoNothing {
-      template< typename... T>
-      inline void operator()(const T&...) {}
+      template <typename... T> inline void operator()(const T&...) {}
     };
 
-    template<typename T>
-    struct DoBeginStream {
-      inline void operator()(WorkerT<T>* iWorker, StreamID id) {
-        iWorker->callWorkerBeginStream(0,id);
+    template <typename T> struct DoBeginStream {
+      inline void operator()(WorkerT<T>* iWorker, StreamID id) { iWorker->callWorkerBeginStream(0, id); }
+    };
+
+    template <typename T> struct DoEndStream {
+      inline void operator()(WorkerT<T>* iWorker, StreamID id) { iWorker->callWorkerEndStream(0, id); }
+    };
+
+    template <typename T, typename P> struct DoStreamBeginTrans {
+      inline void operator()(
+          WorkerT<T>* iWorker, StreamID id, P const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
+        iWorker->callWorkerStreamBegin(0, id, rp, c, mcc);
       }
     };
 
-    template<typename T>
-    struct DoEndStream {
-      inline void operator()(WorkerT<T>* iWorker, StreamID id) {
-        iWorker->callWorkerEndStream(0,id);
+    template <typename T, typename P> struct DoStreamEndTrans {
+      inline void operator()(
+          WorkerT<T>* iWorker, StreamID id, P const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
+        iWorker->callWorkerStreamEnd(0, id, rp, c, mcc);
       }
     };
+  }  // namespace workerimpl
 
-    template<typename T, typename P>
-    struct DoStreamBeginTrans {
-      inline void operator() (WorkerT<T>* iWorker, StreamID id, P const& rp,
-                              EventSetupImpl const& c,
-                              ModuleCallingContext const* mcc) {
-        iWorker->callWorkerStreamBegin(0,id,rp,c, mcc);
-      }
-    };
-
-    template<typename T, typename P>
-    struct DoStreamEndTrans {
-      inline void operator() (WorkerT<T>* iWorker, StreamID id, P const& rp,
-                              EventSetupImpl const& c,
-                              ModuleCallingContext const* mcc) {
-        iWorker->callWorkerStreamEnd(0,id,rp,c, mcc);
-      }
-    };
-  }
-
-  template<typename T>
-  inline
-  WorkerT<T>::WorkerT(std::shared_ptr<T> ed, ModuleDescription const& md, ExceptionToActionTable const* actions) :
-    Worker(md, actions),
-    module_(ed) {
+  template <typename T>
+  inline WorkerT<T>::WorkerT(std::shared_ptr<T> ed, ModuleDescription const& md, ExceptionToActionTable const* actions)
+      : Worker(md, actions), module_(ed) {
     assert(module_ != nullptr);
   }
 
-  template<typename T>
-  WorkerT<T>::~WorkerT() {
-  }
+  template <typename T> WorkerT<T>::~WorkerT() {}
 
-  
-  template<typename T>
-  bool WorkerT<T>::wantsGlobalRuns() const {
-    return module_->wantsGlobalRuns();
-  }
-  
-  template<typename T>
-  bool WorkerT<T>::wantsGlobalLuminosityBlocks() const {
+  template <typename T> bool WorkerT<T>::wantsGlobalRuns() const { return module_->wantsGlobalRuns(); }
+
+  template <typename T> bool WorkerT<T>::wantsGlobalLuminosityBlocks() const {
     return module_->wantsGlobalLuminosityBlocks();
   }
 
-  template<typename T>
-  bool WorkerT<T>::wantsStreamRuns() const {
-    return module_->wantsStreamRuns();
-  }
-  
-  template<typename T>
-  bool WorkerT<T>::wantsStreamLuminosityBlocks() const {
+  template <typename T> bool WorkerT<T>::wantsStreamRuns() const { return module_->wantsStreamRuns(); }
+
+  template <typename T> bool WorkerT<T>::wantsStreamLuminosityBlocks() const {
     return module_->wantsStreamLuminosityBlocks();
   }
 
-  template<typename T>
-  SerialTaskQueue* WorkerT<T>::globalRunsQueue() {
-    return nullptr;
-  }
-  template<typename T>
-  SerialTaskQueue* WorkerT<T>::globalLuminosityBlocksQueue() {
-    return nullptr;
-  }
-  template<>
-  SerialTaskQueue* WorkerT<EDProducer>::globalRunsQueue() {
-    return module_->globalRunsQueue();
-  }
-  template<>
-  SerialTaskQueue* WorkerT<EDProducer>::globalLuminosityBlocksQueue() {
+  template <typename T> SerialTaskQueue* WorkerT<T>::globalRunsQueue() { return nullptr; }
+  template <typename T> SerialTaskQueue* WorkerT<T>::globalLuminosityBlocksQueue() { return nullptr; }
+  template <> SerialTaskQueue* WorkerT<EDProducer>::globalRunsQueue() { return module_->globalRunsQueue(); }
+  template <> SerialTaskQueue* WorkerT<EDProducer>::globalLuminosityBlocksQueue() {
     return module_->globalLuminosityBlocksQueue();
   }
-  template<>
-  SerialTaskQueue* WorkerT<EDFilter>::globalRunsQueue() {
-    return module_->globalRunsQueue();
-  }
-  template<>
-  SerialTaskQueue* WorkerT<EDFilter>::globalLuminosityBlocksQueue() {
+  template <> SerialTaskQueue* WorkerT<EDFilter>::globalRunsQueue() { return module_->globalRunsQueue(); }
+  template <> SerialTaskQueue* WorkerT<EDFilter>::globalLuminosityBlocksQueue() {
     return module_->globalLuminosityBlocksQueue();
   }
-  template<>
-  SerialTaskQueue* WorkerT<EDAnalyzer>::globalRunsQueue() {
-    return module_->globalRunsQueue();
-  }
-  template<>
-  SerialTaskQueue* WorkerT<EDAnalyzer>::globalLuminosityBlocksQueue() {
+  template <> SerialTaskQueue* WorkerT<EDAnalyzer>::globalRunsQueue() { return module_->globalRunsQueue(); }
+  template <> SerialTaskQueue* WorkerT<EDAnalyzer>::globalLuminosityBlocksQueue() {
     return module_->globalLuminosityBlocksQueue();
   }
-  template<>
-  SerialTaskQueue* WorkerT<OutputModule>::globalRunsQueue() {
-    return module_->globalRunsQueue();
-  }
-  template<>
-  SerialTaskQueue* WorkerT<OutputModule>::globalLuminosityBlocksQueue() {
+  template <> SerialTaskQueue* WorkerT<OutputModule>::globalRunsQueue() { return module_->globalRunsQueue(); }
+  template <> SerialTaskQueue* WorkerT<OutputModule>::globalLuminosityBlocksQueue() {
     return module_->globalLuminosityBlocksQueue();
   }
   //one
-  template<>
-  SerialTaskQueue* WorkerT<one::EDProducerBase>::globalRunsQueue() {
-    return module_->globalRunsQueue();
-  }
-  template<>
-  SerialTaskQueue* WorkerT<one::EDProducerBase>::globalLuminosityBlocksQueue() {
+  template <> SerialTaskQueue* WorkerT<one::EDProducerBase>::globalRunsQueue() { return module_->globalRunsQueue(); }
+  template <> SerialTaskQueue* WorkerT<one::EDProducerBase>::globalLuminosityBlocksQueue() {
     return module_->globalLuminosityBlocksQueue();
   }
-  template<>
-  SerialTaskQueue* WorkerT<one::EDFilterBase>::globalRunsQueue() {
-    return module_->globalRunsQueue();
-  }
-  template<>
-  SerialTaskQueue* WorkerT<one::EDFilterBase>::globalLuminosityBlocksQueue() {
+  template <> SerialTaskQueue* WorkerT<one::EDFilterBase>::globalRunsQueue() { return module_->globalRunsQueue(); }
+  template <> SerialTaskQueue* WorkerT<one::EDFilterBase>::globalLuminosityBlocksQueue() {
     return module_->globalLuminosityBlocksQueue();
   }
-  template<>
-  SerialTaskQueue* WorkerT<one::EDAnalyzerBase>::globalRunsQueue() {
-    return module_->globalRunsQueue();
-  }
-  template<>
-  SerialTaskQueue* WorkerT<one::EDAnalyzerBase>::globalLuminosityBlocksQueue() {
+  template <> SerialTaskQueue* WorkerT<one::EDAnalyzerBase>::globalRunsQueue() { return module_->globalRunsQueue(); }
+  template <> SerialTaskQueue* WorkerT<one::EDAnalyzerBase>::globalLuminosityBlocksQueue() {
     return module_->globalLuminosityBlocksQueue();
   }
-  template<>
-  SerialTaskQueue* WorkerT<one::OutputModuleBase>::globalRunsQueue() {
-    return module_->globalRunsQueue();
-  }
-  template<>
-  SerialTaskQueue* WorkerT<one::OutputModuleBase>::globalLuminosityBlocksQueue() {
+  template <> SerialTaskQueue* WorkerT<one::OutputModuleBase>::globalRunsQueue() { return module_->globalRunsQueue(); }
+  template <> SerialTaskQueue* WorkerT<one::OutputModuleBase>::globalLuminosityBlocksQueue() {
     return module_->globalLuminosityBlocksQueue();
   }
 
-  
-  template<typename T>
-  inline
-  bool
-  WorkerT<T>::implDo(EventPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
-    std::shared_ptr<Worker> sentry(this,[&ep](Worker* obj) {obj->postDoEvent(ep);});
+  template <typename T>
+  inline bool WorkerT<T>::implDo(EventPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
+    std::shared_ptr<Worker> sentry(this, [&ep](Worker* obj) { obj->postDoEvent(ep); });
     return module_->doEvent(ep, c, activityRegistry(), mcc);
   }
 
-  template<typename T>
-  inline
-  void
-  WorkerT<T>::implDoAcquire(EventPrincipal const&, EventSetupImpl const&,
-                            ModuleCallingContext const*,
-                            WaitingTaskWithArenaHolder&) {
-  }
+  template <typename T>
+  inline void WorkerT<T>::implDoAcquire(EventPrincipal const&,
+                                        EventSetupImpl const&,
+                                        ModuleCallingContext const*,
+                                        WaitingTaskWithArenaHolder&) {}
 
-  template<>
-  inline
-  void
-  WorkerT<global::EDProducerBase>::implDoAcquire(EventPrincipal const& ep, EventSetupImpl const& c,
-                                                 ModuleCallingContext const* mcc,
-                                                 WaitingTaskWithArenaHolder& holder) {
+  template <>
+  inline void WorkerT<global::EDProducerBase>::implDoAcquire(EventPrincipal const& ep,
+                                                             EventSetupImpl const& c,
+                                                             ModuleCallingContext const* mcc,
+                                                             WaitingTaskWithArenaHolder& holder) {
     module_->doAcquire(ep, c, activityRegistry(), mcc, holder);
   }
 
-  template<>
-  inline
-  void
-  WorkerT<global::EDFilterBase>::implDoAcquire(EventPrincipal const& ep, EventSetupImpl const& c,
-                                               ModuleCallingContext const* mcc,
-                                               WaitingTaskWithArenaHolder& holder) {
+  template <>
+  inline void WorkerT<global::EDFilterBase>::implDoAcquire(EventPrincipal const& ep,
+                                                           EventSetupImpl const& c,
+                                                           ModuleCallingContext const* mcc,
+                                                           WaitingTaskWithArenaHolder& holder) {
     module_->doAcquire(ep, c, activityRegistry(), mcc, holder);
   }
 
-  template<>
-  inline
-  void
-  WorkerT<stream::EDProducerAdaptorBase>::implDoAcquire(EventPrincipal const& ep, EventSetupImpl const& c,
-                                                        ModuleCallingContext const* mcc,
-                                                        WaitingTaskWithArenaHolder& holder) {
+  template <>
+  inline void WorkerT<stream::EDProducerAdaptorBase>::implDoAcquire(EventPrincipal const& ep,
+                                                                    EventSetupImpl const& c,
+                                                                    ModuleCallingContext const* mcc,
+                                                                    WaitingTaskWithArenaHolder& holder) {
     module_->doAcquire(ep, c, activityRegistry(), mcc, holder);
   }
 
-  template<>
-  inline
-  void
-  WorkerT<stream::EDFilterAdaptorBase>::implDoAcquire(EventPrincipal const& ep, EventSetupImpl const& c,
-                                                      ModuleCallingContext const* mcc,
-                                                      WaitingTaskWithArenaHolder& holder) {
+  template <>
+  inline void WorkerT<stream::EDFilterAdaptorBase>::implDoAcquire(EventPrincipal const& ep,
+                                                                  EventSetupImpl const& c,
+                                                                  ModuleCallingContext const* mcc,
+                                                                  WaitingTaskWithArenaHolder& holder) {
     module_->doAcquire(ep, c, activityRegistry(), mcc, holder);
   }
 
-  template<typename T>
-  inline
-  bool
-  WorkerT<T>::implNeedToRunSelection() const { return false;}
+  template <typename T> inline bool WorkerT<T>::implNeedToRunSelection() const { return false; }
 
-  template<typename T>
-  inline
-  bool
-  WorkerT<T>::implDoPrePrefetchSelection(StreamID id,
-                                         EventPrincipal const& ep,
-                                         ModuleCallingContext const* mcc) {
+  template <typename T>
+  inline bool WorkerT<T>::implDoPrePrefetchSelection(StreamID id,
+                                                     EventPrincipal const& ep,
+                                                     ModuleCallingContext const* mcc) {
     return true;
   }
-  template<typename T>
-  inline
-  void
-  WorkerT<T>::itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>&) const {}
+  template <typename T>
+  inline void WorkerT<T>::itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>&) const {}
 
-
-  template<>
-  inline
-  bool
-  WorkerT<OutputModule>::implNeedToRunSelection() const { return true;}
-  template<>
-  inline
-  bool
-  WorkerT<OutputModule>::implDoPrePrefetchSelection(StreamID id,
-                                                    EventPrincipal const& ep,
-                                                    ModuleCallingContext const* mcc) {
-    return module_->prePrefetchSelection(id,ep,mcc);
+  template <> inline bool WorkerT<OutputModule>::implNeedToRunSelection() const { return true; }
+  template <>
+  inline bool WorkerT<OutputModule>::implDoPrePrefetchSelection(StreamID id,
+                                                                EventPrincipal const& ep,
+                                                                ModuleCallingContext const* mcc) {
+    return module_->prePrefetchSelection(id, ep, mcc);
   }
-  template<>
-  inline
-  void
-  WorkerT<OutputModule>::itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>& iItems) const {
+  template <>
+  inline void WorkerT<OutputModule>::itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>& iItems) const {
     iItems = module_->productsUsedBySelection();
   }
 
-  template<>
-  inline
-  bool
-  WorkerT<edm::one::OutputModuleBase>::implNeedToRunSelection() const { return true;}
+  template <> inline bool WorkerT<edm::one::OutputModuleBase>::implNeedToRunSelection() const { return true; }
 
-  template<>
-  inline
-  bool
-  WorkerT<edm::one::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
-                                                                  EventPrincipal const& ep,
-                                                                  ModuleCallingContext const* mcc) {
-    return module_->prePrefetchSelection(id,ep,mcc);
+  template <>
+  inline bool WorkerT<edm::one::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
+                                                                              EventPrincipal const& ep,
+                                                                              ModuleCallingContext const* mcc) {
+    return module_->prePrefetchSelection(id, ep, mcc);
   }
-  template<>
-  inline
-  void
-  WorkerT<edm::one::OutputModuleBase>::itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>& iItems) const {
+  template <>
+  inline void WorkerT<edm::one::OutputModuleBase>::itemsToGetForSelection(
+      std::vector<ProductResolverIndexAndSkipBit>& iItems) const {
     iItems = module_->productsUsedBySelection();
   }
 
-  template<>
-  inline
-  bool
-  WorkerT<edm::global::OutputModuleBase>::implNeedToRunSelection() const { return true;}
-  template<>
-  inline
-  bool
-  WorkerT<edm::global::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
-                                                                     EventPrincipal const& ep,
-                                                                     ModuleCallingContext const* mcc) {
-    return module_->prePrefetchSelection(id,ep,mcc);
+  template <> inline bool WorkerT<edm::global::OutputModuleBase>::implNeedToRunSelection() const { return true; }
+  template <>
+  inline bool WorkerT<edm::global::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
+                                                                                 EventPrincipal const& ep,
+                                                                                 ModuleCallingContext const* mcc) {
+    return module_->prePrefetchSelection(id, ep, mcc);
   }
-  template<>
-  inline
-  void
-  WorkerT<edm::global::OutputModuleBase>::itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>& iItems) const {
+  template <>
+  inline void WorkerT<edm::global::OutputModuleBase>::itemsToGetForSelection(
+      std::vector<ProductResolverIndexAndSkipBit>& iItems) const {
     iItems = module_->productsUsedBySelection();
   }
 
-  template<>
-  inline
-  bool
-  WorkerT<edm::limited::OutputModuleBase>::implNeedToRunSelection() const { return true;}
-  template<>
-  inline
-  bool
-  WorkerT<edm::limited::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
-                                                                     EventPrincipal const& ep,
-                                                                     ModuleCallingContext const* mcc) {
-    return module_->prePrefetchSelection(id,ep,mcc);
+  template <> inline bool WorkerT<edm::limited::OutputModuleBase>::implNeedToRunSelection() const { return true; }
+  template <>
+  inline bool WorkerT<edm::limited::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
+                                                                                  EventPrincipal const& ep,
+                                                                                  ModuleCallingContext const* mcc) {
+    return module_->prePrefetchSelection(id, ep, mcc);
   }
-  template<>
-  inline
-  void
-  WorkerT<edm::limited::OutputModuleBase>::itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>& iItems) const {
+  template <>
+  inline void WorkerT<edm::limited::OutputModuleBase>::itemsToGetForSelection(
+      std::vector<ProductResolverIndexAndSkipBit>& iItems) const {
     iItems = module_->productsUsedBySelection();
   }
 
-  template<typename T>
-  inline
-  bool
-  WorkerT<T>::implDoBegin(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
+  template <typename T>
+  inline bool WorkerT<T>::implDoBegin(RunPrincipal const& rp,
+                                      EventSetupImpl const& c,
+                                      ModuleCallingContext const* mcc) {
     module_->doBeginRun(rp, c, mcc);
     return true;
   }
 
-  template<typename T>
-  template<typename D>
-  void
-  WorkerT<T>::callWorkerStreamBegin(D, StreamID id, RunPrincipal const& rp,
-                                    EventSetupImpl const& c,
-                                    ModuleCallingContext const* mcc) {
+  template <typename T>
+  template <typename D>
+  void WorkerT<T>::callWorkerStreamBegin(
+      D, StreamID id, RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
     module_->doStreamBeginRun(id, rp, c, mcc);
   }
 
-  template<typename T>
-  template<typename D>
-  void
-  WorkerT<T>::callWorkerStreamEnd(D, StreamID id, RunPrincipal const& rp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const* mcc) {
+  template <typename T>
+  template <typename D>
+  void WorkerT<T>::callWorkerStreamEnd(
+      D, StreamID id, RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
     module_->doStreamEndRun(id, rp, c, mcc);
   }
 
-
-  template<typename T>
-  inline
-  bool
-  WorkerT<T>::implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetupImpl const& c,
-                                ModuleCallingContext const* mcc) {
+  template <typename T>
+  inline bool WorkerT<T>::implDoStreamBegin(StreamID id,
+                                            RunPrincipal const& rp,
+                                            EventSetupImpl const& c,
+                                            ModuleCallingContext const* mcc) {
     std::conditional_t<workerimpl::has_stream_functions<T>::value,
-                       workerimpl::DoStreamBeginTrans<T,RunPrincipal const>,
-                       workerimpl::DoNothing> might_call;
-    might_call(this,id,rp,c, mcc);
+                       workerimpl::DoStreamBeginTrans<T, RunPrincipal const>, workerimpl::DoNothing>
+        might_call;
+    might_call(this, id, rp, c, mcc);
     return true;
   }
 
-  template<typename T>
-  inline
-  bool
-  WorkerT<T>::implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetupImpl const& c,
-                              ModuleCallingContext const* mcc) {
-    std::conditional_t<workerimpl::has_stream_functions<T>::value,
-                       workerimpl::DoStreamEndTrans<T,RunPrincipal const>,
-                       workerimpl::DoNothing> might_call;
-    might_call(this,id,rp,c, mcc);
+  template <typename T>
+  inline bool WorkerT<T>::implDoStreamEnd(StreamID id,
+                                          RunPrincipal const& rp,
+                                          EventSetupImpl const& c,
+                                          ModuleCallingContext const* mcc) {
+    std::conditional_t<workerimpl::has_stream_functions<T>::value, workerimpl::DoStreamEndTrans<T, RunPrincipal const>,
+                       workerimpl::DoNothing>
+        might_call;
+    might_call(this, id, rp, c, mcc);
     return true;
   }
 
-  template<typename T>
-  inline
-  bool
-  WorkerT<T>::implDoEnd(RunPrincipal const& rp, EventSetupImpl const& c,
-                        ModuleCallingContext const* mcc) {
+  template <typename T>
+  inline bool WorkerT<T>::implDoEnd(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
     module_->doEndRun(rp, c, mcc);
     return true;
   }
 
-  template<typename T>
-  inline
-  bool
-  WorkerT<T>::implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
-                          ModuleCallingContext const* mcc) {
+  template <typename T>
+  inline bool WorkerT<T>::implDoBegin(LuminosityBlockPrincipal const& lbp,
+                                      EventSetupImpl const& c,
+                                      ModuleCallingContext const* mcc) {
     module_->doBeginLuminosityBlock(lbp, c, mcc);
     return true;
   }
 
-  template<typename T>
-  template<typename D>
-  void
-  WorkerT<T>::callWorkerStreamBegin(D, StreamID id, LuminosityBlockPrincipal const& rp,
-                                    EventSetupImpl const& c,
-                                    ModuleCallingContext const* mcc) {
+  template <typename T>
+  template <typename D>
+  void WorkerT<T>::callWorkerStreamBegin(
+      D, StreamID id, LuminosityBlockPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
     module_->doStreamBeginLuminosityBlock(id, rp, c, mcc);
   }
 
-  template<typename T>
-  template<typename D>
-  void
-  WorkerT<T>::callWorkerStreamEnd(D, StreamID id, LuminosityBlockPrincipal const& rp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const* mcc) {
+  template <typename T>
+  template <typename D>
+  void WorkerT<T>::callWorkerStreamEnd(
+      D, StreamID id, LuminosityBlockPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
     module_->doStreamEndLuminosityBlock(id, rp, c, mcc);
   }
 
-
-  template<typename T>
-  inline
-  bool
-  WorkerT<T>::implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
-                                ModuleCallingContext const* mcc) {
+  template <typename T>
+  inline bool WorkerT<T>::implDoStreamBegin(StreamID id,
+                                            LuminosityBlockPrincipal const& lbp,
+                                            EventSetupImpl const& c,
+                                            ModuleCallingContext const* mcc) {
     std::conditional_t<workerimpl::has_stream_functions<T>::value,
-                       workerimpl::DoStreamBeginTrans<T,LuminosityBlockPrincipal>,
-                       workerimpl::DoNothing> might_call;
-    might_call(this,id,lbp,c, mcc);
+                       workerimpl::DoStreamBeginTrans<T, LuminosityBlockPrincipal>, workerimpl::DoNothing>
+        might_call;
+    might_call(this, id, lbp, c, mcc);
     return true;
   }
 
-  template<typename T>
-  inline
-  bool
-  WorkerT<T>::implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
-                              ModuleCallingContext const* mcc) {
+  template <typename T>
+  inline bool WorkerT<T>::implDoStreamEnd(StreamID id,
+                                          LuminosityBlockPrincipal const& lbp,
+                                          EventSetupImpl const& c,
+                                          ModuleCallingContext const* mcc) {
     std::conditional_t<workerimpl::has_stream_functions<T>::value,
-                       workerimpl::DoStreamEndTrans<T,LuminosityBlockPrincipal>,
-                       workerimpl::DoNothing> might_call;
-    might_call(this,id,lbp,c,mcc);
+                       workerimpl::DoStreamEndTrans<T, LuminosityBlockPrincipal>, workerimpl::DoNothing>
+        might_call;
+    might_call(this, id, lbp, c, mcc);
 
     return true;
   }
 
-  template<typename T>
-  inline
-  bool
-  WorkerT<T>::implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
-                        ModuleCallingContext const* mcc) {
+  template <typename T>
+  inline bool WorkerT<T>::implDoEnd(LuminosityBlockPrincipal const& lbp,
+                                    EventSetupImpl const& c,
+                                    ModuleCallingContext const* mcc) {
     module_->doEndLuminosityBlock(lbp, c, mcc);
     return true;
   }
 
-  template<typename T>
-  inline
-  std::string
-  WorkerT<T>::workerType() const {
-    return module_->workerType();
-  }
+  template <typename T> inline std::string WorkerT<T>::workerType() const { return module_->workerType(); }
 
-  template<typename T>
-  inline
-  void
-  WorkerT<T>::implBeginJob() {
-    module_->doBeginJob();
-  }
+  template <typename T> inline void WorkerT<T>::implBeginJob() { module_->doBeginJob(); }
 
-  template<typename T>
-  inline
-  void
-  WorkerT<T>::implEndJob() {
-    module_->doEndJob();
-  }
+  template <typename T> inline void WorkerT<T>::implEndJob() { module_->doEndJob(); }
 
-  template<typename T>
-  template<typename D>
-  void WorkerT<T>::callWorkerBeginStream(D, StreamID id) {
+  template <typename T> template <typename D> void WorkerT<T>::callWorkerBeginStream(D, StreamID id) {
     module_->doBeginStream(id);
   }
 
-  template<typename T>
-  inline
-  void
-  WorkerT<T>::implBeginStream(StreamID id) {
-    std::conditional_t<workerimpl::has_stream_functions<T>::value,
-                       workerimpl::DoBeginStream<T>,
-                       workerimpl::DoNothing> might_call;
-    might_call(this,id);
+  template <typename T> inline void WorkerT<T>::implBeginStream(StreamID id) {
+    std::conditional_t<workerimpl::has_stream_functions<T>::value, workerimpl::DoBeginStream<T>, workerimpl::DoNothing>
+        might_call;
+    might_call(this, id);
   }
 
-  template<typename T>
-  template<typename D>
-  void WorkerT<T>::callWorkerEndStream(D, StreamID id) {
+  template <typename T> template <typename D> void WorkerT<T>::callWorkerEndStream(D, StreamID id) {
     module_->doEndStream(id);
   }
 
-  template<typename T>
-  inline
-  void
-  WorkerT<T>::implEndStream(StreamID id) {
-    std::conditional_t<workerimpl::has_stream_functions<T>::value,
-                       workerimpl::DoEndStream<T>,
-                       workerimpl::DoNothing> might_call;
-    might_call(this,id);
+  template <typename T> inline void WorkerT<T>::implEndStream(StreamID id) {
+    std::conditional_t<workerimpl::has_stream_functions<T>::value, workerimpl::DoEndStream<T>, workerimpl::DoNothing>
+        might_call;
+    might_call(this, id);
   }
 
-  template<typename T>
-  inline
-  void
-  WorkerT<T>::implRespondToOpenInputFile(FileBlock const& fb) {
+  template <typename T> inline void WorkerT<T>::implRespondToOpenInputFile(FileBlock const& fb) {
     module_->doRespondToOpenInputFile(fb);
   }
 
-  template<typename T>
-  inline
-  void
-  WorkerT<T>::implRespondToCloseInputFile(FileBlock const& fb) {
+  template <typename T> inline void WorkerT<T>::implRespondToCloseInputFile(FileBlock const& fb) {
     module_->doRespondToCloseInputFile(fb);
   }
 
-  template<typename T>
-  inline
-  void
-  WorkerT<T>::implRegisterThinnedAssociations(ProductRegistry const& registry,
-                                              ThinnedAssociationsHelper& helper) {
+  template <typename T>
+  inline void WorkerT<T>::implRegisterThinnedAssociations(ProductRegistry const& registry,
+                                                          ThinnedAssociationsHelper& helper) {
     module_->doRegisterThinnedAssociations(registry, helper);
   }
 
-  template<typename T>
-  inline
-  Worker::TaskQueueAdaptor WorkerT<T>::serializeRunModule() {
+  template <typename T> inline Worker::TaskQueueAdaptor WorkerT<T>::serializeRunModule() {
     return Worker::TaskQueueAdaptor{};
   }
-  template<> Worker::TaskQueueAdaptor WorkerT<EDAnalyzer>::serializeRunModule() {
+  template <> Worker::TaskQueueAdaptor WorkerT<EDAnalyzer>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> Worker::TaskQueueAdaptor WorkerT<EDFilter>::serializeRunModule() {
+  template <> Worker::TaskQueueAdaptor WorkerT<EDFilter>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> Worker::TaskQueueAdaptor WorkerT<EDProducer>::serializeRunModule() {
+  template <> Worker::TaskQueueAdaptor WorkerT<EDProducer>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> Worker::TaskQueueAdaptor WorkerT<OutputModule>::serializeRunModule() {
+  template <> Worker::TaskQueueAdaptor WorkerT<OutputModule>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> Worker::TaskQueueAdaptor WorkerT<one::EDAnalyzerBase>::serializeRunModule() {
+  template <> Worker::TaskQueueAdaptor WorkerT<one::EDAnalyzerBase>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> Worker::TaskQueueAdaptor WorkerT<one::EDFilterBase>::serializeRunModule() {
+  template <> Worker::TaskQueueAdaptor WorkerT<one::EDFilterBase>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> Worker::TaskQueueAdaptor WorkerT<one::EDProducerBase>::serializeRunModule() {
+  template <> Worker::TaskQueueAdaptor WorkerT<one::EDProducerBase>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> Worker::TaskQueueAdaptor WorkerT<one::OutputModuleBase>::serializeRunModule() {
+  template <> Worker::TaskQueueAdaptor WorkerT<one::OutputModuleBase>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> Worker::TaskQueueAdaptor WorkerT<limited::EDAnalyzerBase>::serializeRunModule() {
+  template <> Worker::TaskQueueAdaptor WorkerT<limited::EDAnalyzerBase>::serializeRunModule() {
     return &(module_->queue());
   }
-  template<> Worker::TaskQueueAdaptor WorkerT<limited::EDFilterBase>::serializeRunModule() {
+  template <> Worker::TaskQueueAdaptor WorkerT<limited::EDFilterBase>::serializeRunModule() {
     return &(module_->queue());
   }
-  template<> Worker::TaskQueueAdaptor WorkerT<limited::EDProducerBase>::serializeRunModule() {
+  template <> Worker::TaskQueueAdaptor WorkerT<limited::EDProducerBase>::serializeRunModule() {
     return &(module_->queue());
   }
-  template<> Worker::TaskQueueAdaptor WorkerT<limited::OutputModuleBase>::serializeRunModule() {
+  template <> Worker::TaskQueueAdaptor WorkerT<limited::OutputModuleBase>::serializeRunModule() {
     return &(module_->queue());
   }
-
 
   namespace {
     template <typename T> bool mustPrefetchMayGet();
 
-    template<> bool mustPrefetchMayGet<EDAnalyzer>() { return true;}
-    template<> bool mustPrefetchMayGet<EDProducer>() { return true;}
-    template<> bool mustPrefetchMayGet<EDFilter>() { return true;}
-    template<> bool mustPrefetchMayGet<OutputModule>() { return true;}
+    template <> bool mustPrefetchMayGet<EDAnalyzer>() { return true; }
+    template <> bool mustPrefetchMayGet<EDProducer>() { return true; }
+    template <> bool mustPrefetchMayGet<EDFilter>() { return true; }
+    template <> bool mustPrefetchMayGet<OutputModule>() { return true; }
 
-    template<> bool mustPrefetchMayGet<edm::one::EDProducerBase>() { return true;}
-    template<> bool mustPrefetchMayGet<edm::one::EDFilterBase>() { return true;}
-    template<> bool mustPrefetchMayGet<edm::one::EDAnalyzerBase>() { return true;}
-    template<> bool mustPrefetchMayGet<edm::one::OutputModuleBase>() { return true;}
+    template <> bool mustPrefetchMayGet<edm::one::EDProducerBase>() { return true; }
+    template <> bool mustPrefetchMayGet<edm::one::EDFilterBase>() { return true; }
+    template <> bool mustPrefetchMayGet<edm::one::EDAnalyzerBase>() { return true; }
+    template <> bool mustPrefetchMayGet<edm::one::OutputModuleBase>() { return true; }
 
-    template<> bool mustPrefetchMayGet<edm::global::EDProducerBase>() { return true;}
-    template<> bool mustPrefetchMayGet<edm::global::EDFilterBase>() { return true;}
-    template<> bool mustPrefetchMayGet<edm::global::EDAnalyzerBase>() { return true;}
-    template<> bool mustPrefetchMayGet<edm::global::OutputModuleBase>() { return true;}
+    template <> bool mustPrefetchMayGet<edm::global::EDProducerBase>() { return true; }
+    template <> bool mustPrefetchMayGet<edm::global::EDFilterBase>() { return true; }
+    template <> bool mustPrefetchMayGet<edm::global::EDAnalyzerBase>() { return true; }
+    template <> bool mustPrefetchMayGet<edm::global::OutputModuleBase>() { return true; }
 
-    template<> bool mustPrefetchMayGet<edm::limited::EDProducerBase>() { return true;}
-    template<> bool mustPrefetchMayGet<edm::limited::EDFilterBase>() { return true;}
-    template<> bool mustPrefetchMayGet<edm::limited::EDAnalyzerBase>() { return true;}
-    template<> bool mustPrefetchMayGet<edm::limited::OutputModuleBase>() { return true;}
+    template <> bool mustPrefetchMayGet<edm::limited::EDProducerBase>() { return true; }
+    template <> bool mustPrefetchMayGet<edm::limited::EDFilterBase>() { return true; }
+    template <> bool mustPrefetchMayGet<edm::limited::EDAnalyzerBase>() { return true; }
+    template <> bool mustPrefetchMayGet<edm::limited::OutputModuleBase>() { return true; }
 
-    template<> bool mustPrefetchMayGet<edm::stream::EDProducerAdaptorBase>() { return true;}
-    template<> bool mustPrefetchMayGet<edm::stream::EDFilterAdaptorBase>() { return true;}
-    template<> bool mustPrefetchMayGet<edm::stream::EDAnalyzerAdaptorBase>() { return true;}
+    template <> bool mustPrefetchMayGet<edm::stream::EDProducerAdaptorBase>() { return true; }
+    template <> bool mustPrefetchMayGet<edm::stream::EDFilterAdaptorBase>() { return true; }
+    template <> bool mustPrefetchMayGet<edm::stream::EDAnalyzerAdaptorBase>() { return true; }
 
-  }
+  }  // namespace
 
-
-  template<typename T>
-  void WorkerT<T>::updateLookup(BranchType iBranchType,
-                                ProductResolverIndexHelper const& iHelper) {
-    module_->updateLookup(iBranchType,iHelper,mustPrefetchMayGet<T>());
+  template <typename T>
+  void WorkerT<T>::updateLookup(BranchType iBranchType, ProductResolverIndexHelper const& iHelper) {
+    module_->updateLookup(iBranchType, iHelper, mustPrefetchMayGet<T>());
   }
 
   namespace {
-    using ModuleToResolverIndicies = std::unordered_multimap<std::string,
-    std::tuple<edm::TypeID const*, const char*, edm::ProductResolverIndex>>;
+    using ModuleToResolverIndicies =
+        std::unordered_multimap<std::string, std::tuple<edm::TypeID const*, const char*, edm::ProductResolverIndex>>;
     void resolvePutIndiciesImpl(void*,
                                 BranchType iBranchType,
                                 ModuleToResolverIndicies const& iIndicies,
@@ -679,9 +490,7 @@ namespace edm{
 
     std::vector<ProductResolverIndex> s_emptyIndexList;
 
-    std::vector<ProductResolverIndex> const& itemsShouldPutInEventImpl(void const*) {
-      return s_emptyIndexList;
-    }
+    std::vector<ProductResolverIndex> const& itemsShouldPutInEventImpl(void const*) { return s_emptyIndexList; }
 
     std::vector<ProductResolverIndex> const& itemsShouldPutInEventImpl(ProducerBase const* iProd) {
       return iProd->indiciesForPutProducts(edm::InEvent);
@@ -695,65 +504,48 @@ namespace edm{
       return iProd->indiciesForPutProducts(edm::InEvent);
     }
 
+  }  // namespace
+
+  template <typename T>
+  void WorkerT<T>::resolvePutIndicies(
+      BranchType iBranchType,
+      std::unordered_multimap<std::string, std::tuple<TypeID const*, const char*, edm::ProductResolverIndex>> const&
+          iIndicies) {
+    resolvePutIndiciesImpl(&module(), iBranchType, iIndicies, description().moduleLabel());
   }
 
-  template<typename T>
-  void WorkerT<T>::resolvePutIndicies(BranchType iBranchType,
-                                      std::unordered_multimap<std::string,
-                                      std::tuple<TypeID const*, const char*, edm::ProductResolverIndex>> const& iIndicies) {
-    resolvePutIndiciesImpl(&module(), iBranchType,iIndicies, description().moduleLabel());
-  }
-
-
-  template<typename T>
-  std::vector<ProductResolverIndex> const&
-  WorkerT<T>::itemsShouldPutInEvent() const {
+  template <typename T> std::vector<ProductResolverIndex> const& WorkerT<T>::itemsShouldPutInEvent() const {
     return itemsShouldPutInEventImpl(&module());
   }
 
+  template <> Worker::Types WorkerT<EDAnalyzer>::moduleType() const { return Worker::kAnalyzer; }
+  template <> Worker::Types WorkerT<EDProducer>::moduleType() const { return Worker::kProducer; }
+  template <> Worker::Types WorkerT<EDFilter>::moduleType() const { return Worker::kFilter; }
+  template <> Worker::Types WorkerT<OutputModule>::moduleType() const { return Worker::kOutputModule; }
+  template <> Worker::Types WorkerT<edm::one::EDProducerBase>::moduleType() const { return Worker::kProducer; }
+  template <> Worker::Types WorkerT<edm::one::EDFilterBase>::moduleType() const { return Worker::kFilter; }
+  template <> Worker::Types WorkerT<edm::one::EDAnalyzerBase>::moduleType() const { return Worker::kAnalyzer; }
+  template <> Worker::Types WorkerT<edm::one::OutputModuleBase>::moduleType() const { return Worker::kOutputModule; }
 
-  template<>
-  Worker::Types WorkerT<EDAnalyzer>::moduleType() const { return Worker::kAnalyzer;}
-  template<>
-  Worker::Types WorkerT<EDProducer>::moduleType() const { return Worker::kProducer;}
-  template<>
-  Worker::Types WorkerT<EDFilter>::moduleType() const { return Worker::kFilter;}
-  template<>
-  Worker::Types WorkerT<OutputModule>::moduleType() const { return Worker::kOutputModule;}
-  template<>
-  Worker::Types WorkerT<edm::one::EDProducerBase>::moduleType() const { return Worker::kProducer;}
-  template<>
-  Worker::Types WorkerT<edm::one::EDFilterBase>::moduleType() const { return Worker::kFilter;}
-  template<>
-  Worker::Types WorkerT<edm::one::EDAnalyzerBase>::moduleType() const { return Worker::kAnalyzer;}
-  template<>
-  Worker::Types WorkerT<edm::one::OutputModuleBase>::moduleType() const { return Worker::kOutputModule;}
+  template <> Worker::Types WorkerT<edm::global::EDProducerBase>::moduleType() const { return Worker::kProducer; }
+  template <> Worker::Types WorkerT<edm::global::EDFilterBase>::moduleType() const { return Worker::kFilter; }
+  template <> Worker::Types WorkerT<edm::global::EDAnalyzerBase>::moduleType() const { return Worker::kAnalyzer; }
+  template <> Worker::Types WorkerT<edm::global::OutputModuleBase>::moduleType() const { return Worker::kOutputModule; }
 
-  template<>
-  Worker::Types WorkerT<edm::global::EDProducerBase>::moduleType() const { return Worker::kProducer;}
-  template<>
-  Worker::Types WorkerT<edm::global::EDFilterBase>::moduleType() const { return Worker::kFilter;}
-  template<>
-  Worker::Types WorkerT<edm::global::EDAnalyzerBase>::moduleType() const { return Worker::kAnalyzer;}
-  template<>
-  Worker::Types WorkerT<edm::global::OutputModuleBase>::moduleType() const { return Worker::kOutputModule;}
+  template <> Worker::Types WorkerT<edm::limited::EDProducerBase>::moduleType() const { return Worker::kProducer; }
+  template <> Worker::Types WorkerT<edm::limited::EDFilterBase>::moduleType() const { return Worker::kFilter; }
+  template <> Worker::Types WorkerT<edm::limited::EDAnalyzerBase>::moduleType() const { return Worker::kAnalyzer; }
+  template <> Worker::Types WorkerT<edm::limited::OutputModuleBase>::moduleType() const {
+    return Worker::kOutputModule;
+  }
 
-  template<>
-  Worker::Types WorkerT<edm::limited::EDProducerBase>::moduleType() const { return Worker::kProducer;}
-  template<>
-  Worker::Types WorkerT<edm::limited::EDFilterBase>::moduleType() const { return Worker::kFilter;}
-  template<>
-  Worker::Types WorkerT<edm::limited::EDAnalyzerBase>::moduleType() const { return Worker::kAnalyzer;}
-  template<>
-  Worker::Types WorkerT<edm::limited::OutputModuleBase>::moduleType() const { return Worker::kOutputModule;}
-
-
-  template<>
-  Worker::Types WorkerT<edm::stream::EDProducerAdaptorBase>::moduleType() const { return Worker::kProducer;}
-  template<>
-  Worker::Types WorkerT<edm::stream::EDFilterAdaptorBase>::moduleType() const { return Worker::kFilter;}
-  template<>
-  Worker::Types WorkerT<edm::stream::EDAnalyzerAdaptorBase>::moduleType() const { return Worker::kAnalyzer;}
+  template <> Worker::Types WorkerT<edm::stream::EDProducerAdaptorBase>::moduleType() const {
+    return Worker::kProducer;
+  }
+  template <> Worker::Types WorkerT<edm::stream::EDFilterAdaptorBase>::moduleType() const { return Worker::kFilter; }
+  template <> Worker::Types WorkerT<edm::stream::EDAnalyzerAdaptorBase>::moduleType() const {
+    return Worker::kAnalyzer;
+  }
 
   //Explicitly instantiate our needed templates to avoid having the compiler
   // instantiate them in all of our libraries
@@ -776,4 +568,4 @@ namespace edm{
   template class WorkerT<limited::EDFilterBase>;
   template class WorkerT<limited::EDAnalyzerBase>;
   template class WorkerT<limited::OutputModuleBase>;
-}
+}  // namespace edm

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -27,24 +27,21 @@ namespace edm {
   class ThinnedAssociationsHelper;
   class WaitingTaskWithArenaHolder;
 
-  template<typename T>
-  class WorkerT : public Worker {
+  template <typename T> class WorkerT : public Worker {
   public:
     typedef T ModuleType;
     typedef WorkerT<T> WorkerType;
-    WorkerT(std::shared_ptr<T>,
-            ModuleDescription const&,
-            ExceptionToActionTable const* actions);
+    WorkerT(std::shared_ptr<T>, ModuleDescription const&, ExceptionToActionTable const* actions);
 
     ~WorkerT() override;
 
-    void setModule( std::shared_ptr<T> iModule) {
+    void setModule(std::shared_ptr<T> iModule) {
       module_ = iModule;
       resetModuleDescription(&(module_->moduleDescription()));
     }
-    
+
     Types moduleType() const override;
-    
+
     bool wantsGlobalRuns() const final;
     bool wantsGlobalLuminosityBlocks() const final;
     bool wantsStreamRuns() const final;
@@ -53,67 +50,67 @@ namespace edm {
     SerialTaskQueue* globalRunsQueue() final;
     SerialTaskQueue* globalLuminosityBlocksQueue() final;
 
+    void updateLookup(BranchType iBranchType, ProductResolverIndexHelper const&) override;
+    void resolvePutIndicies(
+        BranchType iBranchType,
+        std::unordered_multimap<std::string, std::tuple<TypeID const*, const char*, edm::ProductResolverIndex>> const&
+            iIndicies) override;
 
-    void updateLookup(BranchType iBranchType,
-                              ProductResolverIndexHelper const&) override;
-    void resolvePutIndicies(BranchType iBranchType,
-                                    std::unordered_multimap<std::string, std::tuple<TypeID const*, const char*, edm::ProductResolverIndex>> const& iIndicies) override;
+    template <typename D> void callWorkerBeginStream(D, StreamID);
+    template <typename D> void callWorkerEndStream(D, StreamID);
+    template <typename D>
+    void callWorkerStreamBegin(
+        D, StreamID id, RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    template <typename D>
+    void callWorkerStreamEnd(
+        D, StreamID id, RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    template <typename D>
+    void callWorkerStreamBegin(
+        D, StreamID id, LuminosityBlockPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    template <typename D>
+    void callWorkerStreamEnd(
+        D, StreamID id, LuminosityBlockPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
 
-    template<typename D>
-    void callWorkerBeginStream(D, StreamID);
-    template<typename D>
-    void callWorkerEndStream(D, StreamID);
-    template<typename D>
-    void callWorkerStreamBegin(D, StreamID id, RunPrincipal const& rp,
-                               EventSetupImpl const& c,
-                               ModuleCallingContext const* mcc);
-    template<typename D>
-    void callWorkerStreamEnd(D, StreamID id, RunPrincipal const& rp,
-                             EventSetupImpl const& c,
-                             ModuleCallingContext const* mcc);
-    template<typename D>
-    void callWorkerStreamBegin(D, StreamID id, LuminosityBlockPrincipal const& rp,
-                               EventSetupImpl const& c,
-                               ModuleCallingContext const* mcc);
-    template<typename D>
-    void callWorkerStreamEnd(D, StreamID id, LuminosityBlockPrincipal const& rp,
-                             EventSetupImpl const& c,
-                             ModuleCallingContext const* mcc);
-    
   protected:
-    T& module() {return *module_;}
-    T const& module() const {return *module_;}
+    T& module() { return *module_; }
+    T const& module() const { return *module_; }
 
   private:
-    bool implDo(EventPrincipal const& ep, EventSetupImpl const& c,
-                        ModuleCallingContext const* mcc) override;
+    bool implDo(EventPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const* mcc) override;
 
     void itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>&) const final;
     bool implNeedToRunSelection() const final;
 
-    void implDoAcquire(EventPrincipal const& ep, EventSetupImpl const& c,
+    void implDoAcquire(EventPrincipal const& ep,
+                       EventSetupImpl const& c,
                        ModuleCallingContext const* mcc,
                        WaitingTaskWithArenaHolder& holder) final;
 
-    bool implDoPrePrefetchSelection(StreamID id,
-                                            EventPrincipal const& ep,
-                                            ModuleCallingContext const* mcc) override;
-    bool implDoBegin(RunPrincipal const& rp, EventSetupImpl const& c,
-                             ModuleCallingContext const* mcc) override;
-    bool implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetupImpl const& c,
-                                   ModuleCallingContext const* mcc) override;
-    bool implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetupImpl const& c,
-                                 ModuleCallingContext const* mcc) override;
-    bool implDoEnd(RunPrincipal const& rp, EventSetupImpl const& c,
+    bool implDoPrePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) override;
+    bool implDoBegin(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) override;
+    bool implDoStreamBegin(StreamID id,
+                           RunPrincipal const& rp,
+                           EventSetupImpl const& c,
                            ModuleCallingContext const* mcc) override;
-    bool implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
-                             ModuleCallingContext const* mcc) override;
-    bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
-                                   ModuleCallingContext const* mcc) override;
-    bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
-                                 ModuleCallingContext const* mcc) override;
-    bool implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
+    bool implDoStreamEnd(StreamID id,
+                         RunPrincipal const& rp,
+                         EventSetupImpl const& c,
+                         ModuleCallingContext const* mcc) override;
+    bool implDoEnd(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) override;
+    bool implDoBegin(LuminosityBlockPrincipal const& lbp,
+                     EventSetupImpl const& c,
+                     ModuleCallingContext const* mcc) override;
+    bool implDoStreamBegin(StreamID id,
+                           LuminosityBlockPrincipal const& lbp,
+                           EventSetupImpl const& c,
                            ModuleCallingContext const* mcc) override;
+    bool implDoStreamEnd(StreamID id,
+                         LuminosityBlockPrincipal const& lbp,
+                         EventSetupImpl const& c,
+                         ModuleCallingContext const* mcc) override;
+    bool implDoEnd(LuminosityBlockPrincipal const& lbp,
+                   EventSetupImpl const& c,
+                   ModuleCallingContext const* mcc) override;
     void implBeginJob() override;
     void implEndJob() override;
     void implBeginStream(StreamID) override;
@@ -124,10 +121,10 @@ namespace edm {
     std::string workerType() const override;
     TaskQueueAdaptor serializeRunModule() override;
 
-
-    void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
-                                                 ProductRegistry const& preg,
-                                                 std::map<std::string, ModuleDescription const*> const& labelsToDesc) const override {
+    void modulesWhoseProductsAreConsumed(
+        std::vector<ModuleDescription const*>& modules,
+        ProductRegistry const& preg,
+        std::map<std::string, ModuleDescription const*> const& labelsToDesc) const override {
       module_->modulesWhoseProductsAreConsumed(modules, preg, labelsToDesc, module_->moduleDescription().processName());
     }
 
@@ -135,9 +132,7 @@ namespace edm {
       module_->convertCurrentProcessAlias(processName);
     }
 
-    std::vector<ConsumesInfo> consumesInfo() const override {
-      return module_->consumesInfo();
-    }
+    std::vector<ConsumesInfo> consumesInfo() const override { return module_->consumesInfo(); }
 
     void itemsToGet(BranchType branchType, std::vector<ProductResolverIndexAndSkipBit>& indexes) const override {
       module_->itemsToGet(branchType, indexes);
@@ -147,25 +142,25 @@ namespace edm {
       module_->itemsMayGet(branchType, indexes);
     }
 
-    std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFrom(BranchType iType) const final { return module_->itemsToGetFrom(iType); }
-    
+    std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFrom(BranchType iType) const final {
+      return module_->itemsToGetFrom(iType);
+    }
+
     std::vector<ProductResolverIndex> const& itemsShouldPutInEvent() const override;
 
-    void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const override {
-      module_->preActionBeforeRunEventAsync(iTask,iModuleCallingContext,iPrincipal);
+    void preActionBeforeRunEventAsync(WaitingTask* iTask,
+                                      ModuleCallingContext const& iModuleCallingContext,
+                                      Principal const& iPrincipal) const override {
+      module_->preActionBeforeRunEventAsync(iTask, iModuleCallingContext, iPrincipal);
     }
 
-    bool hasAcquire() const override {
-      return module_->hasAcquire();
-    }
+    bool hasAcquire() const override { return module_->hasAcquire(); }
 
-    bool hasAccumulator() const override {
-      return module_->hasAccumulator();
-    }
+    bool hasAccumulator() const override { return module_->hasAccumulator(); }
 
     edm::propagate_const<std::shared_ptr<T>> module_;
   };
 
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/defaultCmsRunServices.cc
+++ b/FWCore/Framework/src/defaultCmsRunServices.cc
@@ -2,7 +2,7 @@
 //
 // Package:     FWCore/Framework
 // Function:    defaultCmsRunServices
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -16,17 +16,12 @@
 #include "FWCore/Framework/interface/defaultCmsRunServices.h"
 
 namespace edm {
-   std::vector<std::string> defaultCmsRunServices() {
-      std::vector<std::string> returnValue = {"MessageLogger",
-                                              "InitRootHandlers",
-                                              "UnixSignalService",
-                                              "AdaptorConfig",
-                                              "SiteLocalConfigService",
-                                              "StatisticsSenderService",
-                                              "CondorStatusService",
-                                              "XrdAdaptor::XrdStatisticsService"};
+  std::vector<std::string> defaultCmsRunServices() {
+    std::vector<std::string> returnValue = {
+        "MessageLogger",          "InitRootHandlers",        "UnixSignalService",   "AdaptorConfig",
+        "SiteLocalConfigService", "StatisticsSenderService", "CondorStatusService", "XrdAdaptor::XrdStatisticsService"};
 
-      return returnValue;
-   }
-   
-}
+    return returnValue;
+  }
+
+}  // namespace edm

--- a/FWCore/Framework/src/edmodule_mightGet_config.cc
+++ b/FWCore/Framework/src/edmodule_mightGet_config.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     edmodule_mightGet_config
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -17,7 +17,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 
-
 //
 // constants, enums and typedefs
 //
@@ -27,28 +26,26 @@
 //
 
 static const std::string kMightGet("mightGet");
-static const char* const kComment=
-"List contains the branch names for the EDProducts which might be requested by the module.\n"
-"The format for identifying the EDProduct is the same as the one used for OutputModules, "
-"except no wild cards are allowed. E.g.\n"
-"Foos_foomodule_whichFoo_RECO";
+static const char* const kComment =
+    "List contains the branch names for the EDProducts which might be requested by the module.\n"
+    "The format for identifying the EDProduct is the same as the one used for OutputModules, "
+    "except no wild cards are allowed. E.g.\n"
+    "Foos_foomodule_whichFoo_RECO";
 
 namespace edm {
   void edmodule_mightGet_config(ConfigurationDescriptions& iDesc) {
     //NOTE: by not giving a default, we are intentionally not having 'mightGet' added
     // to any cfi files. This was done intentionally to avoid problems with HLT. If requested,
     // the appropriate default would be an empty vector.
-    if(iDesc.defaultDescription()) {
+    if (iDesc.defaultDescription()) {
       if (iDesc.defaultDescription()->isLabelUnused(kMightGet)) {
-        iDesc.defaultDescription()->addOptionalUntracked<std::vector<std::string> >(kMightGet)
-        ->setComment(kComment);
+        iDesc.defaultDescription()->addOptionalUntracked<std::vector<std::string> >(kMightGet)->setComment(kComment);
       }
     }
-    for(auto& v: iDesc) {
+    for (auto& v : iDesc) {
       if (v.second.isLabelUnused(kMightGet)) {
         v.second.addOptionalUntracked<std::vector<std::string> >(kMightGet)->setComment(kComment);
       }
     }
-    
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/edmodule_mightGet_config.h
+++ b/FWCore/Framework/src/edmodule_mightGet_config.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     edmodule_mightGet_config
-// 
+//
 /**\class edmodule_mightGet_config edmodule_mightGet_config.h FWCore/Framework/interface/edmodule_mightGet_config.h
 
  Description: Injects 'mightGet' PSet into all ed module configurations
@@ -25,5 +25,5 @@
 namespace edm {
   class ConfigurationDescriptions;
   void edmodule_mightGet_config(ConfigurationDescriptions&);
-}
+}  // namespace edm
 #endif

--- a/FWCore/Framework/src/getAllTriggerNames.cc
+++ b/FWCore/Framework/src/getAllTriggerNames.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Package
 // Class  :     getAllTriggerNames
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -17,11 +17,10 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
 
-
 namespace edm {
-  
+
   std::vector<std::string> const& getAllTriggerNames() {
     Service<service::TriggerNamesService> tns;
     return tns->getTrigPaths();
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/getProducerParameterSet.cc
+++ b/FWCore/Framework/src/getProducerParameterSet.cc
@@ -13,11 +13,8 @@
 
 namespace edm {
 
-  ParameterSet const*
-  getProducerParameterSet(Provenance const& provenance) {
-
-    const std::shared_ptr<BranchDescription const>& branchDescription =
-      provenance.constBranchDescriptionPtr();
+  ParameterSet const* getProducerParameterSet(Provenance const& provenance) {
+    const std::shared_ptr<BranchDescription const>& branchDescription = provenance.constBranchDescriptionPtr();
 
     if (branchDescription) {
       std::string const& process = branchDescription->processName();
@@ -38,8 +35,7 @@ namespace edm {
       }
     }
     // This should never happen
-    throw cms::Exception("LogicError")
-      << "getProducerParameterSet failed";
+    throw cms::Exception("LogicError") << "getProducerParameterSet failed";
     return nullptr;
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/globalTransitionAsync.h
+++ b/FWCore/Framework/src/globalTransitionAsync.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Function:    globalTransitionAsync
-// 
+//
 /**\function globalTransitionAsync globalTransitionAsync.h "globalTransitionAsync.h"
 
  Description: Helper functions for handling asynchronous global transitions
@@ -33,90 +33,104 @@ namespace edm {
   class EventSetupImpl;
   class LuminosityBlockPrincipal;
   class RunPrincipal;
-  
+
   //This is code in common between beginStreamRun and beginGlobalLuminosityBlock
-  inline void subProcessDoGlobalBeginTransitionAsync(WaitingTaskHolder iHolder,SubProcess& iSubProcess, LuminosityBlockPrincipal& iPrincipal, IOVSyncValue const& iTS) {
-    iSubProcess.doBeginLuminosityBlockAsync(std::move(iHolder),iPrincipal, iTS);
+  inline void subProcessDoGlobalBeginTransitionAsync(WaitingTaskHolder iHolder,
+                                                     SubProcess& iSubProcess,
+                                                     LuminosityBlockPrincipal& iPrincipal,
+                                                     IOVSyncValue const& iTS) {
+    iSubProcess.doBeginLuminosityBlockAsync(std::move(iHolder), iPrincipal, iTS);
   }
-  
-  inline void subProcessDoGlobalBeginTransitionAsync(WaitingTaskHolder iHolder, SubProcess& iSubProcess, RunPrincipal& iPrincipal, IOVSyncValue const& iTS) {
-    iSubProcess.doBeginRunAsync(std::move(iHolder),iPrincipal, iTS);
+
+  inline void subProcessDoGlobalBeginTransitionAsync(WaitingTaskHolder iHolder,
+                                                     SubProcess& iSubProcess,
+                                                     RunPrincipal& iPrincipal,
+                                                     IOVSyncValue const& iTS) {
+    iSubProcess.doBeginRunAsync(std::move(iHolder), iPrincipal, iTS);
   }
-  
-  inline void subProcessDoGlobalEndTransitionAsync(WaitingTaskHolder iHolder, SubProcess& iSubProcess, LuminosityBlockPrincipal& iPrincipal, IOVSyncValue const& iTS, bool cleaningUpAfterException) {
-    iSubProcess.doEndLuminosityBlockAsync(std::move(iHolder),iPrincipal, iTS,cleaningUpAfterException);
+
+  inline void subProcessDoGlobalEndTransitionAsync(WaitingTaskHolder iHolder,
+                                                   SubProcess& iSubProcess,
+                                                   LuminosityBlockPrincipal& iPrincipal,
+                                                   IOVSyncValue const& iTS,
+                                                   bool cleaningUpAfterException) {
+    iSubProcess.doEndLuminosityBlockAsync(std::move(iHolder), iPrincipal, iTS, cleaningUpAfterException);
   }
-  
-  inline void subProcessDoGlobalEndTransitionAsync(WaitingTaskHolder iHolder, SubProcess& iSubProcess, RunPrincipal& iPrincipal, IOVSyncValue const& iTS, bool cleaningUpAfterException) {
+
+  inline void subProcessDoGlobalEndTransitionAsync(WaitingTaskHolder iHolder,
+                                                   SubProcess& iSubProcess,
+                                                   RunPrincipal& iPrincipal,
+                                                   IOVSyncValue const& iTS,
+                                                   bool cleaningUpAfterException) {
     iSubProcess.doEndRunAsync(std::move(iHolder), iPrincipal, iTS, cleaningUpAfterException);
   }
 
-  template<typename Traits, typename P, typename SC >
+  template <typename Traits, typename P, typename SC>
   void beginGlobalTransitionAsync(WaitingTaskHolder iWait,
                                   Schedule& iSchedule,
                                   P& iPrincipal,
-                                  IOVSyncValue const & iTS,
+                                  IOVSyncValue const& iTS,
                                   EventSetupImpl const& iES,
                                   ServiceToken const& token,
                                   SC& iSubProcesses) {
-
     //When we are done processing the global for this process,
     // we need to run the global for all SubProcesses
-    auto subs = make_waiting_task(tbb::task::allocate_root(), [&iSubProcesses, iWait,&iPrincipal,iTS](std::exception_ptr const* iPtr) mutable {
-      if(iPtr) {
-        auto excpt = *iPtr;
-        auto delayError = make_waiting_task(tbb::task::allocate_root(), [iWait,excpt](std::exception_ptr const* ) mutable {
-          iWait.doneWaiting(excpt);
+    auto subs = make_waiting_task(
+        tbb::task::allocate_root(), [&iSubProcesses, iWait, &iPrincipal, iTS](std::exception_ptr const* iPtr) mutable {
+          if (iPtr) {
+            auto excpt = *iPtr;
+            auto delayError =
+                make_waiting_task(tbb::task::allocate_root(),
+                                  [iWait, excpt](std::exception_ptr const*) mutable { iWait.doneWaiting(excpt); });
+            WaitingTaskHolder h(delayError);
+            for (auto& subProcess : iSubProcesses) {
+              subProcessDoGlobalBeginTransitionAsync(h, subProcess, iPrincipal, iTS);
+            }
+          } else {
+            for (auto& subProcess : iSubProcesses) {
+              subProcessDoGlobalBeginTransitionAsync(iWait, subProcess, iPrincipal, iTS);
+            }
+          }
         });
-        WaitingTaskHolder h(delayError);
-        for(auto& subProcess: iSubProcesses) {
-          subProcessDoGlobalBeginTransitionAsync(h,subProcess,iPrincipal, iTS);
-        }
-      } else {
-        for(auto& subProcess:iSubProcesses){
-          subProcessDoGlobalBeginTransitionAsync(iWait,subProcess,iPrincipal, iTS);
-        }
-      }
-    });
-    
+
     WaitingTaskHolder h(subs);
-    iSchedule.processOneGlobalAsync<Traits>(std::move(h),iPrincipal, iES,token);
+    iSchedule.processOneGlobalAsync<Traits>(std::move(h), iPrincipal, iES, token);
   }
 
-  
-  template<typename Traits, typename P, typename SC >
+  template <typename Traits, typename P, typename SC>
   void endGlobalTransitionAsync(WaitingTaskHolder iWait,
                                 Schedule& iSchedule,
                                 P& iPrincipal,
-                                IOVSyncValue const & iTS,
+                                IOVSyncValue const& iTS,
                                 EventSetupImpl const& iES,
                                 ServiceToken const& token,
                                 SC& iSubProcesses,
-                                bool cleaningUpAfterException)
-  {
+                                bool cleaningUpAfterException) {
     //When we are done processing the global for this process,
     // we need to run the global for all SubProcesses
-    auto subs = make_waiting_task(tbb::task::allocate_root(), [&iSubProcesses, iWait,&iPrincipal,iTS,cleaningUpAfterException](std::exception_ptr const* iPtr) mutable {
-      if(iPtr) {
-        auto excpt = *iPtr;
-        auto delayError = make_waiting_task(tbb::task::allocate_root(), [iWait,excpt](std::exception_ptr const* ) mutable {
-          iWait.doneWaiting(excpt);
+    auto subs = make_waiting_task(
+        tbb::task::allocate_root(),
+        [&iSubProcesses, iWait, &iPrincipal, iTS, cleaningUpAfterException](std::exception_ptr const* iPtr) mutable {
+          if (iPtr) {
+            auto excpt = *iPtr;
+            auto delayError =
+                make_waiting_task(tbb::task::allocate_root(),
+                                  [iWait, excpt](std::exception_ptr const*) mutable { iWait.doneWaiting(excpt); });
+            WaitingTaskHolder h(delayError);
+            for (auto& subProcess : iSubProcesses) {
+              subProcessDoGlobalEndTransitionAsync(h, subProcess, iPrincipal, iTS, cleaningUpAfterException);
+            }
+          } else {
+            for (auto& subProcess : iSubProcesses) {
+              subProcessDoGlobalEndTransitionAsync(iWait, subProcess, iPrincipal, iTS, cleaningUpAfterException);
+            }
+          }
         });
-        WaitingTaskHolder h(delayError);
-        for(auto& subProcess: iSubProcesses){
-          subProcessDoGlobalEndTransitionAsync(h,subProcess,iPrincipal, iTS,cleaningUpAfterException);
-        }
-      } else {
-        for(auto& subProcess: iSubProcesses){
-          subProcessDoGlobalEndTransitionAsync(iWait,subProcess,iPrincipal, iTS,cleaningUpAfterException);
-        }
-      }
-    });
-    
+
     WaitingTaskHolder h(subs);
-    iSchedule.processOneGlobalAsync<Traits>(std::move(h),iPrincipal, iES,token,cleaningUpAfterException);
+    iSchedule.processOneGlobalAsync<Traits>(std::move(h), iPrincipal, iES, token, cleaningUpAfterException);
   }
 
-};
+};  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/insertSelectedProcesses.cc
+++ b/FWCore/Framework/src/insertSelectedProcesses.cc
@@ -12,12 +12,9 @@
 
 namespace edm {
 
-  void insertSelectedProcesses(BranchDescription const& desc,
-                               std::set<std::string>& processes) {
-
+  void insertSelectedProcesses(BranchDescription const& desc, std::set<std::string>& processes) {
     // Select input processes in which mergeable run products were produced
     if (desc.branchType() == InRun && !desc.produced()) {
-
       // Determine if the product is "mergeable"
       TClass* tClass = desc.wrappedType().getClass();
       void* p = tClass->New();
@@ -30,4 +27,4 @@ namespace edm {
       }
     }
   }
-}
+}  // namespace edm

--- a/FWCore/Framework/src/make_shared_noexcept_false.h
+++ b/FWCore/Framework/src/make_shared_noexcept_false.h
@@ -2,15 +2,14 @@
 #define FWCore_Framework_make_shared_noexcept_false_h
 #include <memory>
 namespace edm {
-template<typename T, typename ... Args>
-std::shared_ptr<T> make_shared_noexcept_false(Args&& ... args) {
+  template <typename T, typename... Args> std::shared_ptr<T> make_shared_noexcept_false(Args&&... args) {
 #if defined(__APPLE__)
-// libc++ from Apple Clang does not allow non-default destructors 
-// in some cases the destructor uses noexcept(false).
-return std::shared_ptr<T>( new T(std::forward<Args>(args)... ));
+    // libc++ from Apple Clang does not allow non-default destructors
+    // in some cases the destructor uses noexcept(false).
+    return std::shared_ptr<T>(new T(std::forward<Args>(args)...));
 #else
-return std::make_shared<T>(std::forward<Args>(args)... );
+    return std::make_shared<T>(std::forward<Args>(args)...);
 #endif
-} 
-}
+  }
+}  // namespace edm
 #endif

--- a/FWCore/Framework/src/streamTransitionAsync.h
+++ b/FWCore/Framework/src/streamTransitionAsync.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Function:    streamTransitionAsync
-// 
+//
 /**\function streamTransitionAsync streamTransitionAsync.h "streamTransitionAsync.h"
 
  Description: Helper functions for handling asynchronous stream transitions
@@ -33,129 +33,145 @@ namespace edm {
   class EventSetupImpl;
   class LuminosityBlockPrincipal;
   class RunPrincipal;
-  
+
   //This is code in common between beginStreamRun and beginStreamLuminosityBlock
-  inline void subProcessDoStreamBeginTransitionAsync(WaitingTaskHolder iHolder,SubProcess& iSubProcess, unsigned int i, LuminosityBlockPrincipal& iPrincipal, IOVSyncValue const& iTS) {
-    iSubProcess.doStreamBeginLuminosityBlockAsync(std::move(iHolder),i,iPrincipal, iTS);
-  }
-  
-  inline void subProcessDoStreamBeginTransitionAsync(WaitingTaskHolder iHolder, SubProcess& iSubProcess, unsigned int i, RunPrincipal& iPrincipal, IOVSyncValue const& iTS) {
-    iSubProcess.doStreamBeginRunAsync(std::move(iHolder),i,iPrincipal, iTS);
-  }
-  
-  inline void subProcessDoStreamEndTransitionAsync(WaitingTaskHolder iHolder, SubProcess& iSubProcess, unsigned int i, LuminosityBlockPrincipal& iPrincipal, IOVSyncValue const& iTS, bool cleaningUpAfterException) {
-    iSubProcess.doStreamEndLuminosityBlockAsync(std::move(iHolder),i,iPrincipal, iTS,cleaningUpAfterException);
-  }
-  
-  inline void subProcessDoStreamEndTransitionAsync(WaitingTaskHolder iHolder, SubProcess& iSubProcess, unsigned int i, RunPrincipal& iPrincipal, IOVSyncValue const& iTS, bool cleaningUpAfterException) {
-    iSubProcess.doStreamEndRunAsync(std::move(iHolder), i ,iPrincipal, iTS, cleaningUpAfterException);
+  inline void subProcessDoStreamBeginTransitionAsync(WaitingTaskHolder iHolder,
+                                                     SubProcess& iSubProcess,
+                                                     unsigned int i,
+                                                     LuminosityBlockPrincipal& iPrincipal,
+                                                     IOVSyncValue const& iTS) {
+    iSubProcess.doStreamBeginLuminosityBlockAsync(std::move(iHolder), i, iPrincipal, iTS);
   }
 
+  inline void subProcessDoStreamBeginTransitionAsync(WaitingTaskHolder iHolder,
+                                                     SubProcess& iSubProcess,
+                                                     unsigned int i,
+                                                     RunPrincipal& iPrincipal,
+                                                     IOVSyncValue const& iTS) {
+    iSubProcess.doStreamBeginRunAsync(std::move(iHolder), i, iPrincipal, iTS);
+  }
 
-  template<typename Traits, typename P, typename SC >
+  inline void subProcessDoStreamEndTransitionAsync(WaitingTaskHolder iHolder,
+                                                   SubProcess& iSubProcess,
+                                                   unsigned int i,
+                                                   LuminosityBlockPrincipal& iPrincipal,
+                                                   IOVSyncValue const& iTS,
+                                                   bool cleaningUpAfterException) {
+    iSubProcess.doStreamEndLuminosityBlockAsync(std::move(iHolder), i, iPrincipal, iTS, cleaningUpAfterException);
+  }
+
+  inline void subProcessDoStreamEndTransitionAsync(WaitingTaskHolder iHolder,
+                                                   SubProcess& iSubProcess,
+                                                   unsigned int i,
+                                                   RunPrincipal& iPrincipal,
+                                                   IOVSyncValue const& iTS,
+                                                   bool cleaningUpAfterException) {
+    iSubProcess.doStreamEndRunAsync(std::move(iHolder), i, iPrincipal, iTS, cleaningUpAfterException);
+  }
+
+  template <typename Traits, typename P, typename SC>
   void beginStreamTransitionAsync(WaitingTaskHolder iWait,
                                   Schedule& iSchedule,
                                   unsigned int iStreamIndex,
                                   P& iPrincipal,
-                                  IOVSyncValue const & iTS,
+                                  IOVSyncValue const& iTS,
                                   EventSetupImpl const& iES,
                                   ServiceToken const& token,
                                   SC& iSubProcesses) {
     //When we are done processing the stream for this process,
     // we need to run the stream for all SubProcesses
     //NOTE: The subprocesses set their own service tokens
-    auto subs = make_waiting_task(tbb::task::allocate_root(), [&iSubProcesses, iWait,iStreamIndex,&iPrincipal,iTS](std::exception_ptr const* iPtr) mutable {
-      if(iPtr) {
+    auto subs = make_waiting_task(tbb::task::allocate_root(), [&iSubProcesses, iWait, iStreamIndex, &iPrincipal,
+                                                               iTS](std::exception_ptr const* iPtr) mutable {
+      if (iPtr) {
         auto excpt = *iPtr;
-        auto delayError = make_waiting_task(tbb::task::allocate_root(), [iWait,excpt](std::exception_ptr const* ) mutable {
-          iWait.doneWaiting(excpt);
-        });
+        auto delayError =
+            make_waiting_task(tbb::task::allocate_root(),
+                              [iWait, excpt](std::exception_ptr const*) mutable { iWait.doneWaiting(excpt); });
         WaitingTaskHolder h(delayError);
-        for(auto& subProcess: iSubProcesses){
-          subProcessDoStreamBeginTransitionAsync(h,subProcess,iStreamIndex,iPrincipal, iTS);
-          
+        for (auto& subProcess : iSubProcesses) {
+          subProcessDoStreamBeginTransitionAsync(h, subProcess, iStreamIndex, iPrincipal, iTS);
         };
       } else {
-        for(auto& subProcess: iSubProcesses){
-          subProcessDoStreamBeginTransitionAsync(iWait,subProcess,iStreamIndex,iPrincipal, iTS);
+        for (auto& subProcess : iSubProcesses) {
+          subProcessDoStreamBeginTransitionAsync(iWait, subProcess, iStreamIndex, iPrincipal, iTS);
         };
       }
     });
-    
+
     WaitingTaskHolder h(subs);
-    iSchedule.processOneStreamAsync<Traits>(std::move(h), iStreamIndex,iPrincipal, iES,token);
+    iSchedule.processOneStreamAsync<Traits>(std::move(h), iStreamIndex, iPrincipal, iES, token);
   }
 
-  
-  template<typename Traits, typename P, typename SC >
+  template <typename Traits, typename P, typename SC>
   void beginStreamsTransitionAsync(WaitingTask* iWait,
-                                  Schedule& iSchedule,
-                                  unsigned int iNStreams,
-                                  P& iPrincipal,
-                                  IOVSyncValue const & iTS,
-                                  EventSetupImpl const& iES,
-                                  ServiceToken const& token,
-                                  SC& iSubProcesses)
-  {
+                                   Schedule& iSchedule,
+                                   unsigned int iNStreams,
+                                   P& iPrincipal,
+                                   IOVSyncValue const& iTS,
+                                   EventSetupImpl const& iES,
+                                   ServiceToken const& token,
+                                   SC& iSubProcesses) {
     WaitingTaskHolder holdUntilAllStreamsCalled(iWait);
-    for(unsigned int i=0; i<iNStreams;++i) {
-      beginStreamTransitionAsync<Traits>(WaitingTaskHolder(iWait), iSchedule,i,iPrincipal,iTS,iES,token, iSubProcesses);
+    for (unsigned int i = 0; i < iNStreams; ++i) {
+      beginStreamTransitionAsync<Traits>(WaitingTaskHolder(iWait), iSchedule, i, iPrincipal, iTS, iES, token,
+                                         iSubProcesses);
     }
   }
-  
-  template<typename Traits, typename P, typename SC >
+
+  template <typename Traits, typename P, typename SC>
   void endStreamTransitionAsync(WaitingTaskHolder iWait,
                                 Schedule& iSchedule,
                                 unsigned int iStreamIndex,
                                 P& iPrincipal,
-                                IOVSyncValue const & iTS,
+                                IOVSyncValue const& iTS,
                                 EventSetupImpl const& iES,
                                 ServiceToken const& token,
                                 SC& iSubProcesses,
-                                bool cleaningUpAfterException)
-  {
+                                bool cleaningUpAfterException) {
     //When we are done processing the stream for this process,
     // we need to run the stream for all SubProcesses
     //NOTE: The subprocesses set their own service tokens
 
-    auto subs = make_waiting_task(tbb::task::allocate_root(), [&iSubProcesses, iWait,iStreamIndex,&iPrincipal,iTS,cleaningUpAfterException](std::exception_ptr const* iPtr) mutable {
-      if(iPtr) {
+    auto subs = make_waiting_task(tbb::task::allocate_root(), [&iSubProcesses, iWait, iStreamIndex, &iPrincipal, iTS,
+                                                               cleaningUpAfterException](
+                                                                  std::exception_ptr const* iPtr) mutable {
+      if (iPtr) {
         auto excpt = *iPtr;
-        auto delayError = make_waiting_task(tbb::task::allocate_root(), [iWait,excpt](std::exception_ptr const* ) mutable {
-          iWait.doneWaiting(excpt);
-        });
+        auto delayError =
+            make_waiting_task(tbb::task::allocate_root(),
+                              [iWait, excpt](std::exception_ptr const*) mutable { iWait.doneWaiting(excpt); });
         WaitingTaskHolder h(delayError);
-        for(auto& subProcess: iSubProcesses) {
-          subProcessDoStreamEndTransitionAsync(h,subProcess,iStreamIndex,iPrincipal, iTS,cleaningUpAfterException);
+        for (auto& subProcess : iSubProcesses) {
+          subProcessDoStreamEndTransitionAsync(h, subProcess, iStreamIndex, iPrincipal, iTS, cleaningUpAfterException);
         }
       } else {
-        for(auto& subProcess: iSubProcesses) {
-          subProcessDoStreamEndTransitionAsync(iWait,subProcess,iStreamIndex,iPrincipal, iTS,cleaningUpAfterException);
+        for (auto& subProcess : iSubProcesses) {
+          subProcessDoStreamEndTransitionAsync(iWait, subProcess, iStreamIndex, iPrincipal, iTS,
+                                               cleaningUpAfterException);
         }
       }
     });
-    
-    iSchedule.processOneStreamAsync<Traits>(WaitingTaskHolder(subs), iStreamIndex,iPrincipal, iES, token, cleaningUpAfterException);
+
+    iSchedule.processOneStreamAsync<Traits>(WaitingTaskHolder(subs), iStreamIndex, iPrincipal, iES, token,
+                                            cleaningUpAfterException);
   }
 
-  template<typename Traits, typename P, typename SC >
+  template <typename Traits, typename P, typename SC>
   void endStreamsTransitionAsync(WaitingTaskHolder iWait,
                                  Schedule& iSchedule,
                                  unsigned int iNStreams,
                                  P& iPrincipal,
-                                 IOVSyncValue const & iTS,
+                                 IOVSyncValue const& iTS,
                                  EventSetupImpl const& iES,
                                  ServiceToken const& iToken,
                                  SC& iSubProcesses,
-                                 bool cleaningUpAfterException)
-  {
-    for(unsigned int i=0; i<iNStreams;++i) {
-      endStreamTransitionAsync<Traits>(iWait,
-                                       iSchedule,i,
-                                       iPrincipal,iTS,iES, iToken,
-                                       iSubProcesses,cleaningUpAfterException);
+                                 bool cleaningUpAfterException) {
+    for (unsigned int i = 0; i < iNStreams; ++i) {
+      endStreamTransitionAsync<Traits>(iWait, iSchedule, i, iPrincipal, iTS, iES, iToken, iSubProcesses,
+                                       cleaningUpAfterException);
     }
   }
-};
+};  // namespace edm
 
 #endif

--- a/FWCore/Framework/src/throwIfImproperDependencies.cc
+++ b/FWCore/Framework/src/throwIfImproperDependencies.cc
@@ -2,7 +2,7 @@
 //
 // Package:     FWCore/Framework
 // Function:    throwIfImproperDependencies
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -15,7 +15,6 @@
 // user include files
 #include "FWCore/Framework/src/throwIfImproperDependencies.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-
 
 #include "boost/graph/graph_traits.hpp"
 #include "boost/graph/adjacency_list.hpp"
@@ -63,101 +62,99 @@ namespace {
   //  Cycle: A consumes B, B consumes C, C consumes A
   //  Since this cycle has 0 path only edges it is unrunnable.
   //====================================
-  
+
   typedef std::pair<unsigned int, unsigned int> SimpleEdge;
   typedef std::map<SimpleEdge, std::vector<unsigned int>> EdgeToPathMap;
-  
+
   typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::bidirectionalS> Graph;
-  
+
   typedef boost::graph_traits<Graph>::edge_descriptor Edge;
-  
-  template<typename T>
+
+  template <typename T>
   std::unordered_set<T> intersect(std::unordered_set<T> const& iLHS, std::unordered_set<T> const& iRHS) {
     std::unordered_set<T> result;
-    if(iLHS.size() < iRHS.size()) {
+    if (iLHS.size() < iRHS.size()) {
       result.reserve(iLHS.size());
-      for(auto const& l: iLHS) {
-        if(iRHS.find(l) != iRHS.end()) {
+      for (auto const& l : iLHS) {
+        if (iRHS.find(l) != iRHS.end()) {
           result.insert(l);
         }
       }
       return result;
     }
     result.reserve(iRHS.size());
-    for(auto const& r: iRHS) {
-      if(iLHS.find(r) != iLHS.end()) {
+    for (auto const& r : iRHS) {
+      if (iLHS.find(r) != iLHS.end()) {
         result.insert(r);
       }
     }
     return result;
   }
-  
+
   struct cycle_detector : public boost::dfs_visitor<> {
-    
-    static const unsigned int kRootVertexIndex=0;
-    
+    static const unsigned int kRootVertexIndex = 0;
+
     cycle_detector(EdgeToPathMap const& iEdgeToPathMap,
                    std::vector<std::vector<unsigned int>> const& iPathIndexToModuleIndexOrder,
                    std::vector<std::string> const& iPathNames,
-                   std::unordered_map<unsigned int,std::string> const& iModuleIndexToNames):
-    m_edgeToPathMap(iEdgeToPathMap),
-    m_pathIndexToModuleIndexOrder(iPathIndexToModuleIndexOrder),
-    m_pathNames(iPathNames),
-    m_indexToNames(iModuleIndexToNames){}
-    
-    bool compare(Edge const& iLHS, Edge const& iRHS)  const;
-    
+                   std::unordered_map<unsigned int, std::string> const& iModuleIndexToNames)
+        : m_edgeToPathMap(iEdgeToPathMap),
+          m_pathIndexToModuleIndexOrder(iPathIndexToModuleIndexOrder),
+          m_pathNames(iPathNames),
+          m_indexToNames(iModuleIndexToNames) {}
+
+    bool compare(Edge const& iLHS, Edge const& iRHS) const;
+
     void tree_edge(Edge const& iEdge, Graph const& iGraph) {
       auto const& index = get(boost::vertex_index, iGraph);
-      
-      auto in = index[source(iEdge,iGraph)];
-      for( auto it = m_stack.begin(); it != m_stack.end(); ++it) {
-        if(in ==index[source(*it,iGraph)]) {
+
+      auto in = index[source(iEdge, iGraph)];
+      for (auto it = m_stack.begin(); it != m_stack.end(); ++it) {
+        if (in == index[source(*it, iGraph)]) {
           //this vertex is now being used to probe a new edge
           // so we should drop the rest of the tree
           m_stack.erase(it, m_stack.end());
           break;
         }
       }
-      
+
       m_stack.push_back(iEdge);
     }
-    
+
     void finish_vertex(unsigned int iVertex, Graph const& iGraph) {
-      if(not m_stack.empty()) {
+      if (not m_stack.empty()) {
         auto const& index = get(boost::vertex_index, iGraph);
 
-        if (iVertex ==index[source(m_stack.back(),iGraph)]) {
+        if (iVertex == index[source(m_stack.back(), iGraph)]) {
           m_stack.pop_back();
         }
       }
     }
-    
+
     //Called if a cycle happens
     void back_edge(Edge const& iEdge, Graph const& iGraph) {
-      
       auto const& index = get(boost::vertex_index, iGraph);
 
-      if(kRootVertexIndex != index[source(m_stack.front(),iGraph)]) {
+      if (kRootVertexIndex != index[source(m_stack.front(), iGraph)]) {
         //this part of the graph is not connected to data processing
         return;
       }
 
       m_stack.push_back(iEdge);
-      
+
       auto pop_stack = [](std::vector<Edge>* stack) { stack->pop_back(); };
-      std::unique_ptr<std::vector<Edge>,decltype(pop_stack)> guard(&m_stack,pop_stack);
+      std::unique_ptr<std::vector<Edge>, decltype(pop_stack)> guard(&m_stack, pop_stack);
 
       //This edge has not been added to the stack yet
       // making a copy allows us to add it in but not worry
       // about removing it at the end of the routine
       std::vector<Edge> tempStack;
-      
-      tempStack= findMinimumCycle(m_stack,iGraph);
-      checkCycleForProblem(tempStack,iGraph);
-      for(auto const& edge: tempStack) {
-        unsigned int in =index[source(edge,iGraph)];
-        unsigned int out =index[target(edge,iGraph)];
+
+      tempStack = findMinimumCycle(m_stack, iGraph);
+      checkCycleForProblem(tempStack, iGraph);
+      for (auto const& edge : tempStack) {
+        unsigned int in = index[source(edge, iGraph)];
+        unsigned int out = index[target(edge, iGraph)];
 
         m_verticiesInFundamentalCycles.insert(in);
         m_verticiesInFundamentalCycles.insert(out);
@@ -167,38 +164,36 @@ namespace {
       // which may not be part of the cycle
       m_fundamentalCycles.emplace_back(std::move(tempStack));
     }
-    
-    void forward_or_cross_edge(Edge iEdge, Graph const& iGraph)
-    {
 
+    void forward_or_cross_edge(Edge iEdge, Graph const& iGraph) {
       typedef typename boost::property_map<Graph, boost::vertex_index_t>::type IndexMap;
       IndexMap const& index = get(boost::vertex_index, iGraph);
 
-      if(kRootVertexIndex != index[source(m_stack.front(),iGraph)]) {
+      if (kRootVertexIndex != index[source(m_stack.front(), iGraph)]) {
         //this part of the graph is not connected to data processing
         return;
       }
 
-      const unsigned int out =index[target(iEdge,iGraph)];
-      
+      const unsigned int out = index[target(iEdge, iGraph)];
+
       //If this is a crossing edge whose out vertex is part of a fundamental cycle
       // then this path is also part of a cycle
-      if(m_verticiesInFundamentalCycles.end() == m_verticiesInFundamentalCycles.find(out)) {
+      if (m_verticiesInFundamentalCycles.end() == m_verticiesInFundamentalCycles.find(out)) {
         return;
       }
-      
-      for(auto const& cycle: m_fundamentalCycles) {
+
+      for (auto const& cycle : m_fundamentalCycles) {
         //Is the out vertex in this cycle?
         auto itStartMatch = cycle.end();
-        for(auto it =cycle.begin(); it!= cycle.end(); ++it) {
-          unsigned int inCycle =index[source(*it,iGraph)];
+        for (auto it = cycle.begin(); it != cycle.end(); ++it) {
+          unsigned int inCycle = index[source(*it, iGraph)];
 
-          if(out == inCycle) {
+          if (out == inCycle) {
             itStartMatch = it;
             break;
           }
         }
-        if(itStartMatch == cycle.end()) {
+        if (itStartMatch == cycle.end()) {
           //this cycle isn't the one which uses the vertex from the stack
           continue;
         }
@@ -207,115 +202,108 @@ namespace {
         // search if module to index ordering had been different
         m_stack.push_back(iEdge);
         auto pop_stack = [](std::vector<Edge>* stack) { stack->pop_back(); };
-        std::unique_ptr<std::vector<Edge>,decltype(pop_stack)> guard(&m_stack,pop_stack);
-        auto tempStack= findMinimumCycle(m_stack,iGraph);
-        
+        std::unique_ptr<std::vector<Edge>, decltype(pop_stack)> guard(&m_stack, pop_stack);
+        auto tempStack = findMinimumCycle(m_stack, iGraph);
+
         //the set of 'in' verticies presently in the stack is used to find where an 'out'
         // vertex from the fundamental cycle connects into the present stack
         std::set<unsigned int> verticiesInStack;
-        for(auto const& edge: tempStack) {
-          verticiesInStack.insert(index[source(edge,iGraph)]);
+        for (auto const& edge : tempStack) {
+          verticiesInStack.insert(index[source(edge, iGraph)]);
         }
-
-
 
         //Now find place in the fundamental cycle that attaches to the stack
         // First see if that happens later in the stack
         auto itLastMatch = cycle.end();
-        for(auto it=itStartMatch; it != cycle.end(); ++it) {
-          unsigned int outCycle =index[target(*it,iGraph)];
-          if(verticiesInStack.end() != verticiesInStack.find(outCycle)) {
+        for (auto it = itStartMatch; it != cycle.end(); ++it) {
+          unsigned int outCycle = index[target(*it, iGraph)];
+          if (verticiesInStack.end() != verticiesInStack.find(outCycle)) {
             itLastMatch = it;
             break;
           }
         }
-        if(itLastMatch==cycle.end()) {
+        if (itLastMatch == cycle.end()) {
           //See if we can find the attachment to the stack earlier in the cycle
-          tempStack.insert(tempStack.end(),itStartMatch,cycle.end());
-          for(auto it=cycle.begin(); it != itStartMatch;++it) {
-            unsigned int outCycle =index[target(*it,iGraph)];
-            if(verticiesInStack.end() != verticiesInStack.find(outCycle)) {
+          tempStack.insert(tempStack.end(), itStartMatch, cycle.end());
+          for (auto it = cycle.begin(); it != itStartMatch; ++it) {
+            unsigned int outCycle = index[target(*it, iGraph)];
+            if (verticiesInStack.end() != verticiesInStack.find(outCycle)) {
               itLastMatch = it;
               break;
             }
           }
-          if( itLastMatch==cycle.end()) {
+          if (itLastMatch == cycle.end()) {
             //need to use the full cycle
             //NOTE: this should just retest the same cycle but starting
             // from a different position. If everything is correct, then
             // this should also pass so in principal we could return here.
             //However, as long as this isn't a performance problem, having
             // this additional check could catch problems in the algorithm.
-            tempStack.insert(tempStack.end(),cycle.begin(),itStartMatch);
+            tempStack.insert(tempStack.end(), cycle.begin(), itStartMatch);
           } else {
-            tempStack.insert(tempStack.end(),cycle.begin(),itLastMatch+1);
+            tempStack.insert(tempStack.end(), cycle.begin(), itLastMatch + 1);
           }
         } else {
-          if( (itStartMatch == cycle.begin()) and (cycle.end() == (itLastMatch+1)) ) {
+          if ((itStartMatch == cycle.begin()) and (cycle.end() == (itLastMatch + 1))) {
             //This is just the entire cycle starting where we've already started
             // before. Given the cycle was OK before, it would also be OK this time
             return;
           }
-          tempStack.insert(tempStack.end(),itStartMatch,itLastMatch+1);
+          tempStack.insert(tempStack.end(), itStartMatch, itLastMatch + 1);
         }
-        
-        tempStack= findMinimumCycle(tempStack,iGraph);
-        checkCycleForProblem(tempStack,iGraph);
+
+        tempStack = findMinimumCycle(tempStack, iGraph);
+        checkCycleForProblem(tempStack, iGraph);
       }
-      
     }
+
   private:
-    std::string const& pathName(unsigned int iIndex) const {
-      return m_pathNames[iIndex];
-    }
-    
+    std::string const& pathName(unsigned int iIndex) const { return m_pathNames[iIndex]; }
+
     std::string const& moduleName(unsigned int iIndex) const {
-      auto itFound =m_indexToNames.find(iIndex);
+      auto itFound = m_indexToNames.find(iIndex);
       assert(itFound != m_indexToNames.end());
       return itFound->second;
     }
-    
-    void
-    throwOnError(std::vector<Edge>const& iEdges,
-                 boost::property_map<Graph, boost::vertex_index_t>::type const& iIndex,
-                 Graph const& iGraph) const {
+
+    void throwOnError(std::vector<Edge> const& iEdges,
+                      boost::property_map<Graph, boost::vertex_index_t>::type const& iIndex,
+                      Graph const& iGraph) const {
       std::stringstream oStream;
-      oStream <<"Module run order problem found: \n";
+      oStream << "Module run order problem found: \n";
       bool first_edge = true;
-      for(auto const& edge: iEdges) {
-        unsigned int in =iIndex[source(edge,iGraph)];
-        unsigned int out =iIndex[target(edge,iGraph)];
-        
-        if(first_edge) {
+      for (auto const& edge : iEdges) {
+        unsigned int in = iIndex[source(edge, iGraph)];
+        unsigned int out = iIndex[target(edge, iGraph)];
+
+        if (first_edge) {
           first_edge = false;
         } else {
-          oStream<<", ";
+          oStream << ", ";
         }
-        oStream <<moduleName(in);
-        
-        auto iFound = m_edgeToPathMap.find(SimpleEdge(in,out));
+        oStream << moduleName(in);
+
+        auto iFound = m_edgeToPathMap.find(SimpleEdge(in, out));
         bool pathDependencyOnly = true;
-        for(auto dependency : iFound->second) {
+        for (auto dependency : iFound->second) {
           if (dependency == edm::graph::kDataDependencyIndex) {
             pathDependencyOnly = false;
             break;
           }
         }
         if (pathDependencyOnly) {
-          oStream <<" after "<<moduleName(out)<<" [path "<<pathName(iFound->second[0])<<"]";
+          oStream << " after " << moduleName(out) << " [path " << pathName(iFound->second[0]) << "]";
         } else {
-          oStream <<" consumes "<<moduleName(out);
+          oStream << " consumes " << moduleName(out);
         }
       }
-      oStream<<"\n Running in the threaded framework would lead to indeterminate results."
-      "\n Please change order of modules in mentioned Path(s) to avoid inconsistent module ordering.";
-      
-      throw edm::Exception(edm::errors::ScheduleExecutionFailure, "Unrunnable schedule\n")
-      << oStream.str() << "\n";
+      oStream << "\n Running in the threaded framework would lead to indeterminate results."
+                 "\n Please change order of modules in mentioned Path(s) to avoid inconsistent module ordering.";
+
+      throw edm::Exception(edm::errors::ScheduleExecutionFailure, "Unrunnable schedule\n") << oStream.str() << "\n";
     }
-    
-    std::vector<Edge> findMinimumCycle(std::vector<Edge> const& iCycleEdges,
-                                       Graph const& iGraph) const {
+
+    std::vector<Edge> findMinimumCycle(std::vector<Edge> const& iCycleEdges, Graph const& iGraph) const {
       //Remove unnecessary edges
       // The graph library scans the verticies so we have edges in the list which are
       // not part of the cycle but are associated to a vertex contributes to the cycle.
@@ -323,22 +311,22 @@ namespace {
       // where the 'in' on the previous edge is not the 'out' for the next edge. When this
       // happens we know that there are additional edges for that same 'in' which can be
       // removed.
-      
+
       typedef typename boost::property_map<Graph, boost::vertex_index_t>::type IndexMap;
       IndexMap const& index = get(boost::vertex_index, iGraph);
 
       std::vector<Edge> reducedEdges;
       reducedEdges.reserve(iCycleEdges.size());
       reducedEdges.push_back(iCycleEdges.back());
-      unsigned int lastIn = index[source(iCycleEdges.back(),iGraph)];
-      const unsigned int finalVertex = index[target(iCycleEdges.back(),iGraph)];
-      for( auto it = iCycleEdges.rbegin()+1; it != iCycleEdges.rend(); ++it) {
-        unsigned int in =index[source(*it,iGraph)];
-        unsigned int out =index[target(*it,iGraph)];
-        if(lastIn == out) {
+      unsigned int lastIn = index[source(iCycleEdges.back(), iGraph)];
+      const unsigned int finalVertex = index[target(iCycleEdges.back(), iGraph)];
+      for (auto it = iCycleEdges.rbegin() + 1; it != iCycleEdges.rend(); ++it) {
+        unsigned int in = index[source(*it, iGraph)];
+        unsigned int out = index[target(*it, iGraph)];
+        if (lastIn == out) {
           reducedEdges.push_back(*it);
           lastIn = in;
-          if(in == finalVertex) {
+          if (in == finalVertex) {
             break;
           }
         }
@@ -347,31 +335,30 @@ namespace {
 
       return reducedEdges;
     }
-    
-    void checkCycleForProblem(std::vector<Edge> const& iCycleEdges,
-                              Graph const& iGraph) {
+
+    void checkCycleForProblem(std::vector<Edge> const& iCycleEdges, Graph const& iGraph) {
       //For a real problem, we need at least one data dependency
       // we already know we originate from a path because all tests
       // require starting from the root node which connects to all paths
-      bool hasDataDependency =false;
+      bool hasDataDependency = false;
       //Since we are dealing with a circle, we initialize the 'last' info with the end of the graph
       typedef typename boost::property_map<Graph, boost::vertex_index_t>::type IndexMap;
       IndexMap const& index = get(boost::vertex_index, iGraph);
 
-      unsigned int lastIn =index[source(iCycleEdges.back(),iGraph)];
-      unsigned int lastOut = index[target(iCycleEdges.back(),iGraph)];
+      unsigned int lastIn = index[source(iCycleEdges.back(), iGraph)];
+      unsigned int lastOut = index[target(iCycleEdges.back(), iGraph)];
       bool lastEdgeHasDataDepencency = false;
-      
+
       std::unordered_set<unsigned int> lastPathsSeen;
-      
+
       //If a data dependency appears to make us jump off a path but that module actually
       // appears on the path that was left, we need to see if we later come back to that
       // path somewhere before that module. If not than it is a false cycle
       std::unordered_multimap<unsigned int, unsigned int> pathToModulesWhichMustAppearLater;
       bool moduleAppearedEarlierInPath = false;
-      
-      for(auto dependency: m_edgeToPathMap.find(SimpleEdge(lastIn,lastOut))->second) {
-        if(dependency !=edm::graph::kDataDependencyIndex) {
+
+      for (auto dependency : m_edgeToPathMap.find(SimpleEdge(lastIn, lastOut))->second) {
+        if (dependency != edm::graph::kDataDependencyIndex) {
           lastPathsSeen.insert(dependency);
         } else {
           lastEdgeHasDataDepencency = true;
@@ -381,85 +368,85 @@ namespace {
       bool minimumInitialPathsSet = false;
       std::unordered_set<unsigned int> initialPaths(lastPathsSeen);
       std::unordered_set<unsigned int> sharedPaths;
-      for(auto const& edge: iCycleEdges) {
-        unsigned int in =index[source(edge,iGraph)];
-        unsigned int out =index[target(edge,iGraph)];
-        
-        auto iFound = m_edgeToPathMap.find(SimpleEdge(in,out));
+      for (auto const& edge : iCycleEdges) {
+        unsigned int in = index[source(edge, iGraph)];
+        unsigned int out = index[target(edge, iGraph)];
+
+        auto iFound = m_edgeToPathMap.find(SimpleEdge(in, out));
         std::unordered_set<unsigned int> pathsOnEdge;
         bool edgeHasDataDependency = false;
-        for(auto dependency : iFound->second) {
+        for (auto dependency : iFound->second) {
           if (dependency == edm::graph::kDataDependencyIndex) {
             //need to count only if this moves us to a new path
             hasDataDependency = true;
             edgeHasDataDependency = true;
           } else {
             pathsOnEdge.insert(dependency);
-            
+
             auto const& pathIndicies = m_pathIndexToModuleIndexOrder[dependency];
             auto pathToCheckRange = pathToModulesWhichMustAppearLater.equal_range(dependency);
-            for(auto it = pathToCheckRange.first; it != pathToCheckRange.second; ) {
+            for (auto it = pathToCheckRange.first; it != pathToCheckRange.second;) {
               auto moduleIDToCheck = it->second;
-              if(moduleIDToCheck == in or moduleIDToCheck==out) {
+              if (moduleIDToCheck == in or moduleIDToCheck == out) {
                 auto toErase = it;
                 ++it;
                 pathToModulesWhichMustAppearLater.erase(toErase);
                 continue;
               }
               bool alreadyAdvanced = false;
-              for(auto index : pathIndicies) {
-                if(index == out) {
+              for (auto index : pathIndicies) {
+                if (index == out) {
                   //we must have skipped over the module so the earlier worry about the
                   // module being called on the path was wrong
                   auto toErase = it;
                   ++it;
-                  alreadyAdvanced =true;
+                  alreadyAdvanced = true;
                   pathToModulesWhichMustAppearLater.erase(toErase);
                   break;
                 }
-                if(index == moduleIDToCheck) {
+                if (index == moduleIDToCheck) {
                   //module still earlier on the path
                   break;
                 }
               }
-              if(not alreadyAdvanced) {
+              if (not alreadyAdvanced) {
                 ++it;
               }
             }
           }
         }
-        sharedPaths = intersect(pathsOnEdge,lastPathsSeen);
-        if(sharedPaths.empty() ) {
+        sharedPaths = intersect(pathsOnEdge, lastPathsSeen);
+        if (sharedPaths.empty()) {
           minimumInitialPathsSet = true;
-          if((not edgeHasDataDependency) and (not lastEdgeHasDataDepencency) and (not lastPathsSeen.empty())) {
+          if ((not edgeHasDataDependency) and (not lastEdgeHasDataDepencency) and (not lastPathsSeen.empty())) {
             //If we jumped from one path to another without a data dependency
             // than the cycle is just because two independent modules were
             // scheduled in different arbitrary order on different paths
             return;
           }
-          if(edgeHasDataDependency and not lastPathsSeen.empty()) {
+          if (edgeHasDataDependency and not lastPathsSeen.empty()) {
             //If the paths we were on had this module we are going to earlier
             // on their paths than we do not have a real cycle
             bool atLeastOnePathFailed = false;
             std::vector<unsigned int> pathsToWatch;
             pathsToWatch.reserve(lastPathsSeen.size());
-            for(auto seenPath: lastPathsSeen) {
-              if(pathsOnEdge.end() == pathsOnEdge.find(seenPath)) {
+            for (auto seenPath : lastPathsSeen) {
+              if (pathsOnEdge.end() == pathsOnEdge.find(seenPath)) {
                 //we left this path so we now need to see if the module 'out'
                 // is on this path ahead of the module 'in'
                 bool foundOut = false;
-                for(auto index: m_pathIndexToModuleIndexOrder[seenPath]) {
-                  if(index == out) {
+                for (auto index : m_pathIndexToModuleIndexOrder[seenPath]) {
+                  if (index == out) {
                     foundOut = true;
                     pathsToWatch.push_back(seenPath);
                   }
-                  if(index == lastOut) {
-                    if(not foundOut) {
+                  if (index == lastOut) {
+                    if (not foundOut) {
                       atLeastOnePathFailed = true;
                     }
                     break;
                   }
-                  if(atLeastOnePathFailed) {
+                  if (atLeastOnePathFailed) {
                     break;
                   }
                 }
@@ -468,10 +455,10 @@ namespace {
             //If all the paths have the module earlier in their paths
             // then there was no need to jump between paths to get it
             // and this breaks the data cycle
-            if(not atLeastOnePathFailed) {
+            if (not atLeastOnePathFailed) {
               moduleAppearedEarlierInPath = true;
-              for(auto p: pathsToWatch) {
-                pathToModulesWhichMustAppearLater.emplace(p,out);
+              for (auto p : pathsToWatch) {
+                pathToModulesWhichMustAppearLater.emplace(p, out);
               }
             }
           }
@@ -483,54 +470,48 @@ namespace {
           }
         }
         lastOut = out;
-        lastEdgeHasDataDepencency =edgeHasDataDependency;
+        lastEdgeHasDataDepencency = edgeHasDataDependency;
       }
-      if(moduleAppearedEarlierInPath and not pathToModulesWhichMustAppearLater.empty()) {
+      if (moduleAppearedEarlierInPath and not pathToModulesWhichMustAppearLater.empty()) {
         return;
       }
-      if(not hasDataDependency) {
+      if (not hasDataDependency) {
         return;
       }
-      if( (not initialPaths.empty()) and intersect(initialPaths,sharedPaths).empty() ) {
+      if ((not initialPaths.empty()) and intersect(initialPaths, sharedPaths).empty()) {
         //The effective start and end paths for the first graph
         // node do not match. This can happen if the node
         // appears on multiple paths
         return;
       }
-      throwOnError(iCycleEdges,index,iGraph);
-
+      throwOnError(iCycleEdges, index, iGraph);
     }
-    
-    
+
     EdgeToPathMap const& m_edgeToPathMap;
     std::vector<std::vector<unsigned int>> const& m_pathIndexToModuleIndexOrder;
     std::vector<std::string> const& m_pathNames;
-    std::unordered_map<unsigned int,std::string> m_indexToNames;
+    std::unordered_map<unsigned int, std::string> m_indexToNames;
     std::unordered_map<unsigned int, std::vector<unsigned int>> m_pathToModuleIndex;
-    
+
     std::vector<Edge> m_stack;
     std::vector<std::vector<Edge>> m_fundamentalCycles;
     std::set<unsigned int> m_verticiesInFundamentalCycles;
   };
-}
+}  // namespace
 
-
-
-void
-edm::graph::throwIfImproperDependencies(EdgeToPathMap const& iEdgeToPathMap,
-                                        std::vector<std::vector<unsigned int>> const& iPathIndexToModuleIndexOrder,
-                                        std::vector<std::string> const& iPathNames,
-                                        std::unordered_map<unsigned int, std::string> const& iModuleIndexToNames) {
-
+void edm::graph::throwIfImproperDependencies(EdgeToPathMap const& iEdgeToPathMap,
+                                             std::vector<std::vector<unsigned int>> const& iPathIndexToModuleIndexOrder,
+                                             std::vector<std::string> const& iPathNames,
+                                             std::unordered_map<unsigned int, std::string> const& iModuleIndexToNames) {
   //Now use boost graph library to find cycles in the dependencies
   std::vector<SimpleEdge> outList;
   outList.reserve(iEdgeToPathMap.size());
-  for(auto const& edgeInfo: iEdgeToPathMap) {
+  for (auto const& edgeInfo : iEdgeToPathMap) {
     outList.push_back(edgeInfo.first);
   }
 
-  Graph g(outList.begin(),outList.end(), iModuleIndexToNames.size());
+  Graph g(outList.begin(), outList.end(), iModuleIndexToNames.size());
 
-  cycle_detector detector(iEdgeToPathMap,iPathIndexToModuleIndexOrder,iPathNames,iModuleIndexToNames);
-  boost::depth_first_search(g,boost::visitor(detector));
+  cycle_detector detector(iEdgeToPathMap, iPathIndexToModuleIndexOrder, iPathNames, iModuleIndexToNames);
+  boost::depth_first_search(g, boost::visitor(detector));
 }

--- a/FWCore/Framework/src/throwIfImproperDependencies.h
+++ b/FWCore/Framework/src/throwIfImproperDependencies.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Function:    throwIfImproperDependencies
-// 
+//
 /**\function throwIfImproperDependencies throwIfImproperDependencies.h "throwIfImproperDependencies.h"
 
  Description: Function which uses the graph of dependencies to determine if there are any cycles
@@ -35,15 +35,15 @@ namespace edm {
     //This index is used as the Path index for the case where we are
     // describing a data dependency and not a dependency on a Path
     constexpr auto kDataDependencyIndex = std::numeric_limits<unsigned int>::max();
-    
-    using SimpleEdge =  std::pair<unsigned int, unsigned int>;
+
+    using SimpleEdge = std::pair<unsigned int, unsigned int>;
     using EdgeToPathMap = std::map<SimpleEdge, std::vector<unsigned int>>;
-  
+
     void throwIfImproperDependencies(EdgeToPathMap const&,
                                      std::vector<std::vector<unsigned int>> const& iPathIndexToModuleIndexOrder,
                                      std::vector<std::string> const& iPathNames,
-                                     std::unordered_map<unsigned int,std::string> const& iModuleIndexToNames);
-  }
-};
+                                     std::unordered_map<unsigned int, std::string> const& iModuleIndexToNames);
+  }  // namespace graph
+};   // namespace edm
 
 #endif

--- a/FWCore/Framework/test/DepOn2Record.cc
+++ b/FWCore/Framework/test/DepOn2Record.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     DepOn2Record
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -18,4 +18,3 @@
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
 
 EVENTSETUP_RECORD_REG(DepOn2Record);
-

--- a/FWCore/Framework/test/DepOn2Record.h
+++ b/FWCore/Framework/test/DepOn2Record.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     DepOn2Record
-// 
+//
 /**\class DepOn2Record DepOn2Record.h FWCore/Framework/test/DepOn2Record.h
 
  Description: A test Record that is dependent on DummyRecord and Dummy2Record
@@ -28,9 +28,8 @@
 #include "FWCore/Framework/test/DummyRecord.h"
 #include "FWCore/Framework/test/Dummy2Record.h"
 
-class DepOn2Record 
-: public edm::eventsetup::DependentRecordImplementation<DepOn2Record, boost::mpl::vector<DummyRecord,Dummy2Record> >
-{
-};
+class DepOn2Record
+    : public edm::eventsetup::DependentRecordImplementation<DepOn2Record,
+                                                            boost::mpl::vector<DummyRecord, Dummy2Record> > {};
 
 #endif

--- a/FWCore/Framework/test/DepRecord.cc
+++ b/FWCore/Framework/test/DepRecord.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     DepRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -18,4 +18,3 @@
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
 
 EVENTSETUP_RECORD_REG(DepRecord);
-

--- a/FWCore/Framework/test/DepRecord.h
+++ b/FWCore/Framework/test/DepRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     DepRecord
-// 
+//
 /**\class DepRecord DepRecord.h FWCore/Framework/test/DepRecord.h
 
  Description: A test Record that is dependent on DummyRecord
@@ -27,9 +27,6 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "FWCore/Framework/test/DummyRecord.h"
 
-class DepRecord 
-: public edm::eventsetup::DependentRecordImplementation<DepRecord, boost::mpl::vector<DummyRecord> >
-{
-};
+class DepRecord : public edm::eventsetup::DependentRecordImplementation<DepRecord, boost::mpl::vector<DummyRecord> > {};
 
 #endif

--- a/FWCore/Framework/test/DummyData.h
+++ b/FWCore/Framework/test/DummyData.h
@@ -12,11 +12,12 @@
 #include "FWCore/Framework/test/DummyRecord.h"
 
 namespace edm::eventsetup::test {
-  struct DummyData { int value_;
-    DummyData(int iValue=0) : value_(iValue) {}
-    void dummy() {} // Just to suppress compilation warning message
+  struct DummyData {
+    int value_;
+    DummyData(int iValue = 0) : value_(iValue) {}
+    void dummy() {}  // Just to suppress compilation warning message
   };
-}
+}  // namespace edm::eventsetup::test
 
 #include "FWCore/Framework/interface/data_default_record_trait.h"
 EVENTSETUP_DATA_DEFAULT_RECORD(edm::eventsetup::test::DummyData, DummyRecord)

--- a/FWCore/Framework/test/DummyEventSetupData.h
+++ b/FWCore/Framework/test/DummyEventSetupData.h
@@ -12,11 +12,11 @@
 #include "FWCore/Framework/test/DummyEventSetupRecord.h"
 
 namespace edm {
-   struct DummyEventSetupData { 
-      DummyEventSetupData(int iValue) : value_(iValue) {}
-      int value_; 
-   };
-}
+  struct DummyEventSetupData {
+    DummyEventSetupData(int iValue) : value_(iValue) {}
+    int value_;
+  };
+}  // namespace edm
 
 #include "FWCore/Framework/interface/data_default_record_trait.h"
 EVENTSETUP_DATA_DEFAULT_RECORD(edm::DummyEventSetupData, edm::DummyEventSetupRecord)
@@ -27,4 +27,3 @@ EVENTSETUP_DATA_DEFAULT_RECORD(edm::DummyEventSetupData, edm::DummyEventSetupRec
 TYPELOOKUP_DATA_REG(edm::DummyEventSetupData);
 #endif
 #endif
-

--- a/FWCore/Framework/test/DummyEventSetupRecord.h
+++ b/FWCore/Framework/test/DummyEventSetupRecord.h
@@ -11,9 +11,8 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 
 namespace edm {
-   class DummyEventSetupRecord : 
-     public edm::eventsetup::EventSetupRecordImplementation<DummyEventSetupRecord> {};
-}
+  class DummyEventSetupRecord : public edm::eventsetup::EventSetupRecordImplementation<DummyEventSetupRecord> {};
+}  // namespace edm
 
 #if !defined(TEST_EXCLUDE_DEF)
 //NOTE: the following should really go into a DummyEventSetupRecord.cc file

--- a/FWCore/Framework/test/DummyEventSetupRecordRetriever.h
+++ b/FWCore/Framework/test/DummyEventSetupRecordRetriever.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     DummyEventSetupRecordRetriever
-// 
+//
 /**\class DummyEventSetupRecordRetriever DummyEventSetupRecordRetriever.h FWCore/Framework/interface/DummyEventSetupRecordRetriever.h
 
  Description: <one line class summary>
@@ -29,36 +29,30 @@
 
 // forward declarations
 namespace edm {
-   class DummyEventSetupRecordRetriever :
-     public EventSetupRecordIntervalFinder, 
-     public ESProducer
-   {
-   
-   public:
-      DummyEventSetupRecordRetriever() {
-         this->findingRecord<DummyEventSetupRecord>();
-         setWhatProduced(this);
-      }
-      
-      std::unique_ptr<DummyEventSetupData> produce(const DummyEventSetupRecord&) {
-         return std::make_unique<DummyEventSetupData>(1);
-      }
-   protected:
+  class DummyEventSetupRecordRetriever : public EventSetupRecordIntervalFinder, public ESProducer {
+  public:
+    DummyEventSetupRecordRetriever() {
+      this->findingRecord<DummyEventSetupRecord>();
+      setWhatProduced(this);
+    }
 
-      virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-                                   const edm::IOVSyncValue& /*iTime*/, 
-                                   edm::ValidityInterval& iInterval) {
-         iInterval = edm::ValidityInterval(IOVSyncValue::beginOfTime(),
-                                            IOVSyncValue::endOfTime());
-      }
+    std::unique_ptr<DummyEventSetupData> produce(const DummyEventSetupRecord&) {
+      return std::make_unique<DummyEventSetupData>(1);
+    }
 
-   private:
-      DummyEventSetupRecordRetriever(const DummyEventSetupRecordRetriever&); // stop default
+  protected:
+    virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                const edm::IOVSyncValue& /*iTime*/,
+                                edm::ValidityInterval& iInterval) {
+      iInterval = edm::ValidityInterval(IOVSyncValue::beginOfTime(), IOVSyncValue::endOfTime());
+    }
 
-      const DummyEventSetupRecordRetriever& operator=(const DummyEventSetupRecordRetriever&); // stop default
+  private:
+    DummyEventSetupRecordRetriever(const DummyEventSetupRecordRetriever&);  // stop default
 
-      // ---------- member data --------------------------------
+    const DummyEventSetupRecordRetriever& operator=(const DummyEventSetupRecordRetriever&);  // stop default
 
-};
-}
+    // ---------- member data --------------------------------
+  };
+}  // namespace edm
 #endif

--- a/FWCore/Framework/test/DummyFinder.h
+++ b/FWCore/Framework/test/DummyFinder.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     DummyFinder
-// 
+//
 /**\class DummyFinder DummyFinder.h FWCore/Framework/interface/DummyFinder.h
 
  Description: <one line class summary>
@@ -28,32 +28,28 @@
 
 class DummyFinder : public edm::EventSetupRecordIntervalFinder {
 public:
-   DummyFinder() :edm::EventSetupRecordIntervalFinder(), interval_() {
-      this->findingRecord<DummyRecord>();
-   }
-   
-   void setInterval(const edm::ValidityInterval& iInterval) {
-      interval_ = iInterval;
-   }
-protected:
-   virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-                                const edm::IOVSyncValue& iTime, 
-                                edm::ValidityInterval& iInterval) {
-      if(interval_.validFor(iTime)) {
-         iInterval = interval_;
-      } else {
-         if(interval_.last() == edm::IOVSyncValue::invalidIOVSyncValue() &&
-             interval_.first() != edm::IOVSyncValue::invalidIOVSyncValue() &&
-             interval_.first() <= iTime) {
-            iInterval = interval_;
-         }else {
-            iInterval = edm::ValidityInterval();
-         }
-      }
-   }
-private:
-   edm::ValidityInterval interval_;   
-};
+  DummyFinder() : edm::EventSetupRecordIntervalFinder(), interval_() { this->findingRecord<DummyRecord>(); }
 
+  void setInterval(const edm::ValidityInterval& iInterval) { interval_ = iInterval; }
+
+protected:
+  virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                              const edm::IOVSyncValue& iTime,
+                              edm::ValidityInterval& iInterval) {
+    if (interval_.validFor(iTime)) {
+      iInterval = interval_;
+    } else {
+      if (interval_.last() == edm::IOVSyncValue::invalidIOVSyncValue() &&
+          interval_.first() != edm::IOVSyncValue::invalidIOVSyncValue() && interval_.first() <= iTime) {
+        iInterval = interval_;
+      } else {
+        iInterval = edm::ValidityInterval();
+      }
+    }
+  }
+
+private:
+  edm::ValidityInterval interval_;
+};
 
 #endif

--- a/FWCore/Framework/test/DummyProxyProvider.h
+++ b/FWCore/Framework/test/DummyProxyProvider.h
@@ -19,7 +19,7 @@
 //
 
 // system include files
-#include<memory>
+#include <memory>
 
 // user include files
 #include "FWCore/Framework/test/DummyRecord.h"
@@ -35,26 +35,20 @@ namespace edm::eventsetup::test {
     WorkingDummyProxy(const DummyData* iDummy) : data_(iDummy) {}
 
   protected:
-    const value_type* make(const record_type&, const DataKey&) {
-      return data_ ;
-    }
-    void invalidateCache() {
-    }
+    const value_type* make(const record_type&, const DataKey&) { return data_; }
+    void invalidateCache() {}
 
   private:
     const DummyData* data_;
   };
 
-
   class DummyProxyProvider : public edm::eventsetup::DataProxyProvider {
   public:
-    DummyProxyProvider(const DummyData& iData=DummyData()): dummy_(iData) {
-      usingRecord<DummyRecord>();
-    }
-    void newInterval(const eventsetup::EventSetupRecordKey& /*iRecordType*/,
-                     const ValidityInterval& /*iInterval*/) {
+    DummyProxyProvider(const DummyData& iData = DummyData()) : dummy_(iData) { usingRecord<DummyRecord>(); }
+    void newInterval(const eventsetup::EventSetupRecordKey& /*iRecordType*/, const ValidityInterval& /*iInterval*/) {
       //do nothing
     }
+
   protected:
     void registerProxies(const eventsetup::EventSetupRecordKey&, KeyedProxies& iProxies) {
       std::shared_ptr<WorkingDummyProxy> pProxy = std::make_shared<WorkingDummyProxy>(&dummy_);
@@ -65,5 +59,5 @@ namespace edm::eventsetup::test {
     DummyData dummy_;
   };
 
-}
+}  // namespace edm::eventsetup::test
 #endif

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -16,27 +16,27 @@ namespace {
   };
 
   std::istream& operator>>(std::istream& is, token& t) {
-    if(is >> t.id) is >> t.value;
+    if (is >> t.id)
+      is >> t.value;
     return is;
   }
-  
+
   //The TransitionProcessors.icc uses the class name
   // EventProcessor (with no namespace) as the type
   // to which it interacts.
   using EventProcessor = edm::MockEventProcessor;
-  
-  
+
   class WaitingTaskHolder;
-}
+}  // namespace
 
 namespace edm {
-class LuminosityBlockPrincipal {
-public:
-  LuminosityBlockPrincipal(int iRun,int iLumi): run_(iRun),lumi_(iLumi){}
-  int run_;
-  int lumi_;
-};
-}
+  class LuminosityBlockPrincipal {
+  public:
+    LuminosityBlockPrincipal(int iRun, int iLumi) : run_(iRun), lumi_(iLumi) {}
+    int run_;
+    int lumi_;
+  };
+}  // namespace edm
 
 #define TEST_NO_FWD_DECL
 #include "FWCore/Framework/src/LuminosityBlockProcessingStatus.h"
@@ -47,196 +47,167 @@ namespace {
 
 namespace edm {
 
-  MockEventProcessor::MockEventProcessor(std::string const& mockData,
-                                         std::ostream& output,
-                                         bool iDoNotMerge) :
-    mockData_(mockData),
-    output_(output),
-    input_(mockData_),
-    run_(0),
-    lumi_(0),
-    doNotMerge_(iDoNotMerge),
-    shouldWeCloseOutput_(true),
-    shouldWeEndLoop_(true),
-    shouldWeStop_(false),
-    eventProcessed_(false),
-    reachedEndOfInput_(false),
-    shouldThrow_(false)
-  {
-  }
+  MockEventProcessor::MockEventProcessor(std::string const& mockData, std::ostream& output, bool iDoNotMerge)
+      : mockData_(mockData),
+        output_(output),
+        input_(mockData_),
+        run_(0),
+        lumi_(0),
+        doNotMerge_(iDoNotMerge),
+        shouldWeCloseOutput_(true),
+        shouldWeEndLoop_(true),
+        shouldWeStop_(false),
+        eventProcessed_(false),
+        reachedEndOfInput_(false),
+        shouldThrow_(false) {}
 
-  InputSource::ItemType
-  MockEventProcessor::nextTransitionType()
-  {
+  InputSource::ItemType MockEventProcessor::nextTransitionType() {
     token t;
-    if( not (input_ >> t)) {
+    if (not(input_ >> t)) {
       reachedEndOfInput_ = true;
-      return lastTransition_=InputSource::IsStop;
+      return lastTransition_ = InputSource::IsStop;
     }
 
     char ch = t.id;
 
     eventProcessed_ = false;
-    if(ch == 'r') {
+    if (ch == 'r') {
       output_ << "    *** nextItemType: Run " << t.value << " ***\n";
       run_ = t.value;
-      return lastTransition_=InputSource::IsRun;
-    } else if(ch == 'l') {
+      return lastTransition_ = InputSource::IsRun;
+    } else if (ch == 'l') {
       output_ << "    *** nextItemType: Lumi " << t.value << " ***\n";
       lumi_ = t.value;
-      return lastTransition_=InputSource::IsLumi;
-    } else if(ch == 'e') {
+      return lastTransition_ = InputSource::IsLumi;
+    } else if (ch == 'e') {
       output_ << "    *** nextItemType: Event ***\n";
       // a special value for test purposes only
-      if(t.value == 7) {
+      if (t.value == 7) {
         shouldWeStop_ = true;
         output_ << "    *** shouldWeStop will return true this event ***\n";
       } else {
         shouldWeStop_ = false;
       }
-      return lastTransition_=InputSource::IsEvent;
-    } else if(ch == 'f') {
+      return lastTransition_ = InputSource::IsEvent;
+    } else if (ch == 'f') {
       output_ << "    *** nextItemType: File " << t.value << " ***\n";
       // a special value for test purposes only
-      if(t.value == 0) shouldWeCloseOutput_ = false;
-      else shouldWeCloseOutput_ = true;
-      return lastTransition_=InputSource::IsFile;
-    } else if(ch == 's') {
+      if (t.value == 0)
+        shouldWeCloseOutput_ = false;
+      else
+        shouldWeCloseOutput_ = true;
+      return lastTransition_ = InputSource::IsFile;
+    } else if (ch == 's') {
       output_ << "    *** nextItemType: Stop " << t.value << " ***\n";
       // a special value for test purposes only
-      if(t.value == 0) shouldWeEndLoop_ = false;
-      else shouldWeEndLoop_ = true;
-      return lastTransition_=InputSource::IsStop;
-    } else if(ch == 'x') {
+      if (t.value == 0)
+        shouldWeEndLoop_ = false;
+      else
+        shouldWeEndLoop_ = true;
+      return lastTransition_ = InputSource::IsStop;
+    } else if (ch == 'x') {
       output_ << "    *** nextItemType: Restart " << t.value << " ***\n";
       shouldWeEndLoop_ = t.value;
-      return lastTransition_=InputSource::IsStop;
-    } else if(ch == 't') {
+      return lastTransition_ = InputSource::IsStop;
+    } else if (ch == 't') {
       output_ << "    *** nextItemType: Throw " << t.value << " ***\n";
       shouldThrow_ = true;
       return nextTransitionType();
     }
-    return lastTransition_=InputSource::IsInvalid;
+    return lastTransition_ = InputSource::IsInvalid;
   }
-  
-  InputSource::ItemType
-  MockEventProcessor::lastTransitionType() const {
-    return lastTransition_;
-  }
-  
-  std::pair<edm::ProcessHistoryID, edm::RunNumber_t>
-  MockEventProcessor::nextRunID() {
+
+  InputSource::ItemType MockEventProcessor::lastTransitionType() const { return lastTransition_; }
+
+  std::pair<edm::ProcessHistoryID, edm::RunNumber_t> MockEventProcessor::nextRunID() {
     return std::make_pair(edm::ProcessHistoryID{}, run_);
   }
 
-  edm::LuminosityBlockNumber_t
-  MockEventProcessor::nextLuminosityBlockID() {
-    return lumi_;
-  }
-  
-  InputSource::ItemType
-  MockEventProcessor::readAndProcessEvents() {
+  edm::LuminosityBlockNumber_t MockEventProcessor::nextLuminosityBlockID() { return lumi_; }
+
+  InputSource::ItemType MockEventProcessor::readAndProcessEvents() {
     bool first = true;
     do {
-      if(first) {
+      if (first) {
         first = false;
       } else {
         shouldWeStop();
       }
       readAndProcessEvent();
-      if(shouldWeStop()) {
+      if (shouldWeStop()) {
         return InputSource::IsEvent;
       }
-    }while(nextTransitionType() == InputSource::IsEvent);
-    
+    } while (nextTransitionType() == InputSource::IsEvent);
+
     return lastTransitionType();
   }
 
-
-  void
-  MockEventProcessor::runToCompletion() {
-
+  void MockEventProcessor::runToCompletion() {
     do {
       FilesProcessor fp(doNotMerge_);
 
       bool firstTime = true;
       do {
-        if(not firstTime) {
+        if (not firstTime) {
           prepareForNextLoop();
           rewindInput();
         } else {
           firstTime = false;
         }
         startingNewLoop();
-        
+
         auto trans = fp.processFiles(*this);
-        
+
         fp.normalEnd();
-        
-        if(trans != InputSource::IsStop) {
+
+        if (trans != InputSource::IsStop) {
           //problem with the source
           doErrorStuff();
           break;
         }
-      } while(not endOfLoop());
-      output_ <<"Left processing loop.\n";
-    } while(not reachedEndOfInput_ and not input_.eof());
-      
+      } while (not endOfLoop());
+      output_ << "Left processing loop.\n";
+    } while (not reachedEndOfInput_ and not input_.eof());
+
     return;
   }
-  
+
   void MockEventProcessor::readFile() {
     output_ << " \treadFile\n";
     throwIfNeeded();
   }
 
-  void MockEventProcessor::closeInputFile(bool /*cleaningUpAfterException*/) {
-    output_ << "\tcloseInputFile\n";
-  }
+  void MockEventProcessor::closeInputFile(bool /*cleaningUpAfterException*/) { output_ << "\tcloseInputFile\n"; }
 
-  void MockEventProcessor::openOutputFiles() {
-    output_ << "\topenOutputFiles\n";
-  }
+  void MockEventProcessor::openOutputFiles() { output_ << "\topenOutputFiles\n"; }
 
-  void MockEventProcessor::closeOutputFiles() {
-    output_ << "\tcloseOutputFiles\n";
-  }
+  void MockEventProcessor::closeOutputFiles() { output_ << "\tcloseOutputFiles\n"; }
 
-  void MockEventProcessor::respondToOpenInputFile() {
-    output_ << "\trespondToOpenInputFile\n";
-  }
+  void MockEventProcessor::respondToOpenInputFile() { output_ << "\trespondToOpenInputFile\n"; }
 
-  void MockEventProcessor::respondToCloseInputFile() {
-    output_ << "\trespondToCloseInputFile\n";
-  }
+  void MockEventProcessor::respondToCloseInputFile() { output_ << "\trespondToCloseInputFile\n"; }
 
-  void MockEventProcessor::startingNewLoop() {
-    output_ << "\tstartingNewLoop\n";
-  }
+  void MockEventProcessor::startingNewLoop() { output_ << "\tstartingNewLoop\n"; }
 
   bool MockEventProcessor::endOfLoop() {
     output_ << "\tendOfLoop\n";
     return shouldWeEndLoop_;
   }
 
-  void MockEventProcessor::rewindInput() {
-    output_ << "\trewind\n";
-  }
+  void MockEventProcessor::rewindInput() { output_ << "\trewind\n"; }
 
-  void MockEventProcessor::prepareForNextLoop() {
-    output_ << "\tprepareForNextLoop\n";
-  }
+  void MockEventProcessor::prepareForNextLoop() { output_ << "\tprepareForNextLoop\n"; }
 
   bool MockEventProcessor::shouldWeCloseOutput() const {
     output_ << "\tshouldWeCloseOutput\n";
     return shouldWeCloseOutput_;
   }
 
-  void MockEventProcessor::doErrorStuff() {
-    output_ << "\tdoErrorStuff\n";
-  }
+  void MockEventProcessor::doErrorStuff() { output_ << "\tdoErrorStuff\n"; }
 
-  void MockEventProcessor::beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalTransitionSucceeded,
+  void MockEventProcessor::beginRun(ProcessHistoryID const& phid,
+                                    RunNumber_t run,
+                                    bool& globalTransitionSucceeded,
                                     bool& eventSetupForInstanceSucceeded) {
     output_ << "\tbeginRun " << run << "\n";
     eventSetupForInstanceSucceeded = true;
@@ -244,47 +215,49 @@ namespace edm {
     globalTransitionSucceeded = true;
   }
 
-  void MockEventProcessor::endRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalTransitionSucceeded, bool /*cleaningUpAfterException*/ ) {
-    auto postfix = globalTransitionSucceeded? "\n" : " global failed\n";
+  void MockEventProcessor::endRun(ProcessHistoryID const& phid,
+                                  RunNumber_t run,
+                                  bool globalTransitionSucceeded,
+                                  bool /*cleaningUpAfterException*/) {
+    auto postfix = globalTransitionSucceeded ? "\n" : " global failed\n";
     output_ << "\tendRun " << run << postfix;
   }
 
-  void MockEventProcessor::endUnfinishedRun(ProcessHistoryID const& phid, RunNumber_t run,
-                                            bool globalTransitionSucceeded, bool cleaningUpAfterException,
-                                            bool eventSetupForInstanceSucceeded ) {
+  void MockEventProcessor::endUnfinishedRun(ProcessHistoryID const& phid,
+                                            RunNumber_t run,
+                                            bool globalTransitionSucceeded,
+                                            bool cleaningUpAfterException,
+                                            bool eventSetupForInstanceSucceeded) {
     if (eventSetupForInstanceSucceeded) {
-      endRun(phid,run,globalTransitionSucceeded,cleaningUpAfterException);
-      if(globalTransitionSucceeded) {
-        writeRun(phid,run);
+      endRun(phid, run, globalTransitionSucceeded, cleaningUpAfterException);
+      if (globalTransitionSucceeded) {
+        writeRun(phid, run);
       }
     }
-    deleteRunFromCache(phid,run);
+    deleteRunFromCache(phid, run);
   }
 
   InputSource::ItemType MockEventProcessor::processLumis(std::shared_ptr<void> iRunResource) {
-    
-    if(lumiStatus_ and
-       lumiStatus_->runResource() == iRunResource and
-       lumiStatus_->lumiPrincipal()->lumi_ == lumi_) {
+    if (lumiStatus_ and lumiStatus_->runResource() == iRunResource and lumiStatus_->lumiPrincipal()->lumi_ == lumi_) {
       readAndMergeLumi(*lumiStatus_);
-      
-      if(nextTransitionType() == InputSource::IsEvent) {
+
+      if (nextTransitionType() == InputSource::IsEvent) {
         readAndProcessEvents();
-        if(shouldWeStop()) {
+        if (shouldWeStop()) {
           return edm::InputSource::IsStop;
         }
       }
     } else {
       endUnfinishedLumi();
-      lumiStatus_ = std::make_shared<LuminosityBlockProcessingStatus>(this,1,iRunResource);
+      lumiStatus_ = std::make_shared<LuminosityBlockProcessingStatus>(this, 1, iRunResource);
       auto lumi = readLuminosityBlock(*lumiStatus_);
       output_ << "\tbeginLumi " << run_ << "/" << lumi << "\n";
       throwIfNeeded();
       lumiStatus_->globalBeginDidSucceed();
       //Need to do event processing here
-      if(nextTransitionType() == InputSource::IsEvent) {
+      if (nextTransitionType() == InputSource::IsEvent) {
         readAndProcessEvents();
-        if(shouldWeStop()) {
+        if (shouldWeStop()) {
           return edm::InputSource::IsStop;
         }
       }
@@ -293,35 +266,36 @@ namespace edm {
   }
 
   void MockEventProcessor::endUnfinishedLumi() {
-    if(lumiStatus_) {
+    if (lumiStatus_) {
       auto tmp = lumiStatus_;
       endLumi();
-      if(tmp->didGlobalBeginSucceed()) {
+      if (tmp->didGlobalBeginSucceed()) {
         writeLumi(*tmp);
       }
       deleteLumiFromCache(*tmp);
     }
   }
-  
+
   void MockEventProcessor::endLumi() {
-    auto postfix = lumiStatus_->didGlobalBeginSucceed()? "\n" : " global failed\n";
-    output_ << "\tendLumi " << lumiStatus_->lumiPrincipal()->run_ << "/" << lumiStatus_->lumiPrincipal()->lumi_ << postfix;
+    auto postfix = lumiStatus_->didGlobalBeginSucceed() ? "\n" : " global failed\n";
+    output_ << "\tendLumi " << lumiStatus_->lumiPrincipal()->run_ << "/" << lumiStatus_->lumiPrincipal()->lumi_
+            << postfix;
     lumiStatus_.reset();
   }
 
-  std::pair<ProcessHistoryID,RunNumber_t> MockEventProcessor::readRun() {
+  std::pair<ProcessHistoryID, RunNumber_t> MockEventProcessor::readRun() {
     output_ << "\treadRun " << run_ << "\n";
     return std::make_pair(ProcessHistoryID(), run_);
   }
 
-  std::pair<ProcessHistoryID,RunNumber_t> MockEventProcessor::readAndMergeRun() {
+  std::pair<ProcessHistoryID, RunNumber_t> MockEventProcessor::readAndMergeRun() {
     output_ << "\treadAndMergeRun " << run_ << "\n";
     return std::make_pair(ProcessHistoryID(), run_);
   }
 
   int MockEventProcessor::readLuminosityBlock(LuminosityBlockProcessingStatus& iStatus) {
     output_ << "\treadLuminosityBlock " << lumi_ << "\n";
-    iStatus.lumiPrincipal() = std::make_shared<LuminosityBlockPrincipal>(run_,lumi_);
+    iStatus.lumiPrincipal() = std::make_shared<LuminosityBlockPrincipal>(run_, lumi_);
     return lumi_;
   }
 
@@ -343,7 +317,8 @@ namespace edm {
   }
 
   void MockEventProcessor::deleteLumiFromCache(LuminosityBlockProcessingStatus& iStatus) {
-    output_ << "\tdeleteLumiFromCache " << iStatus.lumiPrincipal()->run_ << "/" << iStatus.lumiPrincipal()->lumi_ << "\n";
+    output_ << "\tdeleteLumiFromCache " << iStatus.lumiPrincipal()->run_ << "/" << iStatus.lumiPrincipal()->lumi_
+            << "\n";
   }
 
   void MockEventProcessor::readAndProcessEvent() {
@@ -359,17 +334,17 @@ namespace edm {
   }
 
   void MockEventProcessor::throwIfNeeded() {
-    if(shouldThrow_) {
+    if (shouldThrow_) {
       shouldThrow_ = false;
-      output_ <<"\tthrowing\n";
+      output_ << "\tthrowing\n";
       throw TestException();
     }
   }
-  
+
   void MockEventProcessor::setExceptionMessageFiles(std::string&) {}
   void MockEventProcessor::setExceptionMessageRuns(std::string&) {}
   void MockEventProcessor::setExceptionMessageLumis(std::string&) {}
 
-  bool MockEventProcessor::setDeferredException(std::exception_ptr) { return true;}
+  bool MockEventProcessor::setDeferredException(std::exception_ptr) { return true; }
 
-}
+}  // namespace edm

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -18,18 +18,15 @@ Original Authors: W. David Dagenhart, Marc Paterno
 
 namespace edm {
   class LuminosityBlockProcessingStatus;
-  
+
   class MockEventProcessor {
   public:
     class TestException : public std::exception {
     public:
-      TestException() noexcept
-      :std::exception() {}
+      TestException() noexcept : std::exception() {}
     };
-    
-    MockEventProcessor(std::string const& mockData,
-                       std::ostream& output,
-                       bool iDoNotMerge);
+
+    MockEventProcessor(std::string const& mockData, std::ostream& output, bool iDoNotMerge);
 
     void runToCompletion();
 
@@ -54,20 +51,27 @@ namespace edm {
 
     void doErrorStuff();
 
-    void beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalTransitionSucceeded,
+    void beginRun(ProcessHistoryID const& phid,
+                  RunNumber_t run,
+                  bool& globalTransitionSucceeded,
                   bool& eventSetupForInstanceSucceeded);
-    void endUnfinishedRun(ProcessHistoryID const& phid, RunNumber_t run,
-                          bool globalTranstitionSucceeded, bool cleaningUpAfterException,
+    void endUnfinishedRun(ProcessHistoryID const& phid,
+                          RunNumber_t run,
+                          bool globalTranstitionSucceeded,
+                          bool cleaningUpAfterException,
                           bool eventSetupForInstanceSucceeded);
 
-    void endRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalTranstitionSucceeded, bool cleaningUpAfterException);
+    void endRun(ProcessHistoryID const& phid,
+                RunNumber_t run,
+                bool globalTranstitionSucceeded,
+                bool cleaningUpAfterException);
 
     InputSource::ItemType processLumis(std::shared_ptr<void>);
     void endUnfinishedLumi();
 
-    std::pair<ProcessHistoryID,RunNumber_t> readRun();
-    std::pair<ProcessHistoryID,RunNumber_t> readAndMergeRun();
-    int readLuminosityBlock(LuminosityBlockProcessingStatus& );
+    std::pair<ProcessHistoryID, RunNumber_t> readRun();
+    std::pair<ProcessHistoryID, RunNumber_t> readAndMergeRun();
+    int readLuminosityBlock(LuminosityBlockProcessingStatus&);
     int readAndMergeLumi(LuminosityBlockProcessingStatus&);
     void writeRun(ProcessHistoryID const& phid, RunNumber_t run);
     void deleteRunFromCache(ProcessHistoryID const& phid, RunNumber_t run);
@@ -80,7 +84,6 @@ namespace edm {
     void setExceptionMessageRuns(std::string& message);
     void setExceptionMessageLumis(std::string& message);
 
-
     bool setDeferredException(std::exception_ptr);
 
   private:
@@ -90,12 +93,12 @@ namespace edm {
     void endLumi();
 
     std::string mockData_;
-    std::ostream & output_;
+    std::ostream& output_;
     std::istringstream input_;
-    
+
     std::shared_ptr<LuminosityBlockProcessingStatus> lumiStatus_;
     InputSource::ItemType lastTransition_;
-    
+
     int run_;
     int lumi_;
 
@@ -107,6 +110,6 @@ namespace edm {
     bool reachedEndOfInput_;
     bool shouldThrow_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/FWCore/Framework/test/callback_t.cppunit.cc
+++ b/FWCore/Framework/test/callback_t.cppunit.cc
@@ -14,79 +14,78 @@
 #include <cassert>
 
 namespace callbacktest {
-   struct Data {
-      Data() : value_(0) {}
-      Data(int iValue) : value_(iValue) {}
-      virtual ~Data() {}
-      int value_;
-   };
-   
-   struct Double {
-      Double() : value_(0) {}
-      Double(double iValue) : value_(iValue) {}
-      virtual ~Double() {}
-      double value_;
-   };
+  struct Data {
+    Data() : value_(0) {}
+    Data(int iValue) : value_(iValue) {}
+    virtual ~Data() {}
+    int value_;
+  };
 
-   struct Record { };
-   
-   struct ConstPtrProd {
-      ConstPtrProd() : data_() {}
-      const Data* method(const Record&) {
-         ++data_.value_;
-         return &data_;
-      }      
-      Data data_;
-   };
+  struct Double {
+    Double() : value_(0) {}
+    Double(double iValue) : value_(iValue) {}
+    virtual ~Double() {}
+    double value_;
+  };
 
-   struct UniquePtrProd {
-      UniquePtrProd() : value_(0) {}
-      std::unique_ptr<Data> method(const Record&) {
-         return std::make_unique<Data>(++value_);
-      }
-      
-      int value_;
-   };
+  struct Record {};
 
-   struct SharedPtrProd {
-      SharedPtrProd() : ptr_(new Data()) {}
-      std::shared_ptr<Data> method(const Record&) {
-         ++ptr_->value_;
-         return ptr_;
-      }      
-      std::shared_ptr<Data> ptr_;
-   };
-   
-   struct PtrProductsProd {
-      PtrProductsProd() : data_(), double_() {}
-      edm::ESProducts<std::shared_ptr<Data>, std::shared_ptr<Double>> method(const Record&) {
-         using namespace edm::es;
-         auto dataT = std::shared_ptr<Data>(&data_, edm::do_nothing_deleter());;
-         auto doubleT = std::shared_ptr<Double>(&double_, edm::do_nothing_deleter());
-         ++data_.value_;
-         ++double_.value_;
-         return products(dataT, doubleT);
-      }
-      Data data_;
-      Double double_;
-   };
-}
+  struct ConstPtrProd {
+    ConstPtrProd() : data_() {}
+    const Data* method(const Record&) {
+      ++data_.value_;
+      return &data_;
+    }
+    Data data_;
+  };
+
+  struct UniquePtrProd {
+    UniquePtrProd() : value_(0) {}
+    std::unique_ptr<Data> method(const Record&) { return std::make_unique<Data>(++value_); }
+
+    int value_;
+  };
+
+  struct SharedPtrProd {
+    SharedPtrProd() : ptr_(new Data()) {}
+    std::shared_ptr<Data> method(const Record&) {
+      ++ptr_->value_;
+      return ptr_;
+    }
+    std::shared_ptr<Data> ptr_;
+  };
+
+  struct PtrProductsProd {
+    PtrProductsProd() : data_(), double_() {}
+    edm::ESProducts<std::shared_ptr<Data>, std::shared_ptr<Double>> method(const Record&) {
+      using namespace edm::es;
+      auto dataT = std::shared_ptr<Data>(&data_, edm::do_nothing_deleter());
+      ;
+      auto doubleT = std::shared_ptr<Double>(&double_, edm::do_nothing_deleter());
+      ++data_.value_;
+      ++double_.value_;
+      return products(dataT, doubleT);
+    }
+    Data data_;
+    Double double_;
+  };
+}  // namespace callbacktest
 
 using namespace callbacktest;
 using namespace edm::eventsetup;
 
-class testCallback: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testCallback);
+class testCallback : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testCallback);
 
-CPPUNIT_TEST(uniquePtrTest);
-CPPUNIT_TEST(sharedPtrTest);
-CPPUNIT_TEST(ptrProductsTest);
+  CPPUNIT_TEST(uniquePtrTest);
+  CPPUNIT_TEST(sharedPtrTest);
+  CPPUNIT_TEST(ptrProductsTest);
 
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void uniquePtrTest();
   void sharedPtrTest();
@@ -98,101 +97,94 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testCallback);
 
 typedef Callback<UniquePtrProd, std::unique_ptr<Data>, Record> UniquePtrCallback;
 
-void testCallback::uniquePtrTest()
-{
-   UniquePtrProd prod;
-   
-   UniquePtrCallback callback(&prod, &UniquePtrProd::method);
-   std::unique_ptr<Data> handle;
-   
-   
-   callback.holdOntoPointer(&handle);
-   
-   Record record;
-   callback.newRecordComing();
-   callback(record);
-   CPPUNIT_ASSERT(0 != handle.get());
-   CPPUNIT_ASSERT(prod.value_ == 1);
-   assert(0 != handle.get());
-   CPPUNIT_ASSERT(prod.value_ == handle->value_);
-   
-   //since haven't cleared, should not have changed
-   callback(record);
-   CPPUNIT_ASSERT(prod.value_ == 1);
-   CPPUNIT_ASSERT(prod.value_ == handle->value_);
-   
-   handle.release();
+void testCallback::uniquePtrTest() {
+  UniquePtrProd prod;
 
-   callback.newRecordComing();
-   
-   callback(record);
-   CPPUNIT_ASSERT(0 != handle.get());
-   CPPUNIT_ASSERT(prod.value_ == 2);
-   assert(0 != handle.get());
-   CPPUNIT_ASSERT(prod.value_ == handle->value_);
-   
+  UniquePtrCallback callback(&prod, &UniquePtrProd::method);
+  std::unique_ptr<Data> handle;
+
+  callback.holdOntoPointer(&handle);
+
+  Record record;
+  callback.newRecordComing();
+  callback(record);
+  CPPUNIT_ASSERT(0 != handle.get());
+  CPPUNIT_ASSERT(prod.value_ == 1);
+  assert(0 != handle.get());
+  CPPUNIT_ASSERT(prod.value_ == handle->value_);
+
+  //since haven't cleared, should not have changed
+  callback(record);
+  CPPUNIT_ASSERT(prod.value_ == 1);
+  CPPUNIT_ASSERT(prod.value_ == handle->value_);
+
+  handle.release();
+
+  callback.newRecordComing();
+
+  callback(record);
+  CPPUNIT_ASSERT(0 != handle.get());
+  CPPUNIT_ASSERT(prod.value_ == 2);
+  assert(0 != handle.get());
+  CPPUNIT_ASSERT(prod.value_ == handle->value_);
 }
 
 typedef Callback<SharedPtrProd, std::shared_ptr<Data>, Record> SharedPtrCallback;
 
-void testCallback::sharedPtrTest()
-{
-   SharedPtrProd prod;
-   
-   SharedPtrCallback callback(&prod, &SharedPtrProd::method);
-   std::shared_ptr<Data> handle;
-   
-   
-   callback.holdOntoPointer(&handle);
-   
-   Record record;
-   callback.newRecordComing();
-   callback(record);
-   CPPUNIT_ASSERT(handle.get() == prod.ptr_.get());
-   CPPUNIT_ASSERT(prod.ptr_->value_ == 1);
-   
-   //since haven't cleared, should not have changed
-   callback(record);
-   CPPUNIT_ASSERT(handle.get() == prod.ptr_.get());
-   CPPUNIT_ASSERT(prod.ptr_->value_ == 1);
-   
-   handle.reset() ;
-   callback.newRecordComing();
-   
-   callback(record);
-   CPPUNIT_ASSERT(handle.get() == prod.ptr_.get());
-   CPPUNIT_ASSERT(prod.ptr_->value_ == 2);
-   
+void testCallback::sharedPtrTest() {
+  SharedPtrProd prod;
+
+  SharedPtrCallback callback(&prod, &SharedPtrProd::method);
+  std::shared_ptr<Data> handle;
+
+  callback.holdOntoPointer(&handle);
+
+  Record record;
+  callback.newRecordComing();
+  callback(record);
+  CPPUNIT_ASSERT(handle.get() == prod.ptr_.get());
+  CPPUNIT_ASSERT(prod.ptr_->value_ == 1);
+
+  //since haven't cleared, should not have changed
+  callback(record);
+  CPPUNIT_ASSERT(handle.get() == prod.ptr_.get());
+  CPPUNIT_ASSERT(prod.ptr_->value_ == 1);
+
+  handle.reset();
+  callback.newRecordComing();
+
+  callback(record);
+  CPPUNIT_ASSERT(handle.get() == prod.ptr_.get());
+  CPPUNIT_ASSERT(prod.ptr_->value_ == 2);
 }
 
-typedef Callback<PtrProductsProd, edm::ESProducts<std::shared_ptr<Data>, std::shared_ptr<Double>>, Record> PtrProductsCallback;
+typedef Callback<PtrProductsProd, edm::ESProducts<std::shared_ptr<Data>, std::shared_ptr<Double>>, Record>
+    PtrProductsCallback;
 
-void testCallback::ptrProductsTest()
-{
-   PtrProductsProd prod;
-   
-   PtrProductsCallback callback(&prod, &PtrProductsProd::method);
-   std::shared_ptr<Data> handle;
-   std::shared_ptr<Double> doubleHandle;
-   
-   callback.holdOntoPointer(&handle);
-   callback.holdOntoPointer(&doubleHandle);
-   
-   Record record;
-   callback.newRecordComing();
-   callback(record);
-   CPPUNIT_ASSERT(handle.get() == &(prod.data_));
-   CPPUNIT_ASSERT(prod.data_.value_ == 1);
-   
-   //since haven't cleared, should not have changed
-   callback(record);
-   CPPUNIT_ASSERT(handle.get() == &(prod.data_));
-   CPPUNIT_ASSERT(prod.data_.value_ == 1);
-   
-   callback.newRecordComing();
-   
-   callback(record);
-   CPPUNIT_ASSERT(handle.get() == &(prod.data_));
-   CPPUNIT_ASSERT(prod.data_.value_ == 2);
-   
+void testCallback::ptrProductsTest() {
+  PtrProductsProd prod;
+
+  PtrProductsCallback callback(&prod, &PtrProductsProd::method);
+  std::shared_ptr<Data> handle;
+  std::shared_ptr<Double> doubleHandle;
+
+  callback.holdOntoPointer(&handle);
+  callback.holdOntoPointer(&doubleHandle);
+
+  Record record;
+  callback.newRecordComing();
+  callback(record);
+  CPPUNIT_ASSERT(handle.get() == &(prod.data_));
+  CPPUNIT_ASSERT(prod.data_.value_ == 1);
+
+  //since haven't cleared, should not have changed
+  callback(record);
+  CPPUNIT_ASSERT(handle.get() == &(prod.data_));
+  CPPUNIT_ASSERT(prod.data_.value_ == 1);
+
+  callback.newRecordComing();
+
+  callback(record);
+  CPPUNIT_ASSERT(handle.get() == &(prod.data_));
+  CPPUNIT_ASSERT(prod.data_.value_ == 2);
 }

--- a/FWCore/Framework/test/datakey_t.cppunit.cc
+++ b/FWCore/Framework/test/datakey_t.cppunit.cc
@@ -14,8 +14,7 @@
 using namespace edm;
 using namespace edm::eventsetup;
 
-class testDataKey: public CppUnit::TestFixture {
-
+class testDataKey : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testDataKey);
 
   CPPUNIT_TEST(nametagConstructionTest);
@@ -29,9 +28,9 @@ class testDataKey: public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void setUp(){}
-  void tearDown(){}
-  
+  void setUp() {}
+  void tearDown() {}
+
   void nametagConstructionTest();
   void nametagComparisonTest();
   void nametagCopyTest();
@@ -39,129 +38,121 @@ public:
   void ComparisonTest();
   void CopyTest();
   void nocopyConstructionTest();
-}; 
+};
 
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testDataKey);
 
+void testDataKey::nametagConstructionTest() {
+  const NameTag defaultTag;
+  CPPUNIT_ASSERT(0 == std::strcmp("", defaultTag.value()));
 
-void testDataKey::nametagConstructionTest()
-{
-   const NameTag defaultTag;
-   CPPUNIT_ASSERT(0 == std::strcmp("", defaultTag.value()));
-   
-   const NameTag namedTag("fred");
-   CPPUNIT_ASSERT(0 == std::strcmp("fred", namedTag.value()));
+  const NameTag namedTag("fred");
+  CPPUNIT_ASSERT(0 == std::strcmp("fred", namedTag.value()));
 }
 
-void testDataKey::nametagComparisonTest()
-{
-   const NameTag defaultTag;
-   CPPUNIT_ASSERT(defaultTag == defaultTag);
-   
-   const NameTag fredTag("fred");
-   CPPUNIT_ASSERT(fredTag == fredTag);
-   
-   CPPUNIT_ASSERT(! (defaultTag == fredTag));
-   
-   const NameTag barneyTag("barney");
-   
-   CPPUNIT_ASSERT(barneyTag < fredTag);
+void testDataKey::nametagComparisonTest() {
+  const NameTag defaultTag;
+  CPPUNIT_ASSERT(defaultTag == defaultTag);
+
+  const NameTag fredTag("fred");
+  CPPUNIT_ASSERT(fredTag == fredTag);
+
+  CPPUNIT_ASSERT(!(defaultTag == fredTag));
+
+  const NameTag barneyTag("barney");
+
+  CPPUNIT_ASSERT(barneyTag < fredTag);
 }
 
-void testDataKey::nametagCopyTest()
-{
-   const NameTag defaultTag;
-   NameTag tester(defaultTag);
-   CPPUNIT_ASSERT(tester == defaultTag);
-   
-   const NameTag fredTag("fred");
-   tester = fredTag;
-   CPPUNIT_ASSERT(tester == fredTag);
+void testDataKey::nametagCopyTest() {
+  const NameTag defaultTag;
+  NameTag tester(defaultTag);
+  CPPUNIT_ASSERT(tester == defaultTag);
+
+  const NameTag fredTag("fred");
+  tester = fredTag;
+  CPPUNIT_ASSERT(tester == fredTag);
 }
 
 namespace datakey_t {
-   class Dummy {};
-   class Dummy2 {};
-}
+  class Dummy {};
+  class Dummy2 {};
+}  // namespace datakey_t
 using datakey_t::Dummy;
 using datakey_t::Dummy2;
 
 HCTYPETAG_HELPER_METHODS(Dummy)
 HCTYPETAG_HELPER_METHODS(Dummy2)
 
-void testDataKey::ConstructionTest()
-{
-   DataKey defaultKey;
-   CPPUNIT_ASSERT(TypeTag() == defaultKey.type());
-   CPPUNIT_ASSERT(0 == std::strcmp("", defaultKey.name().value()));
+void testDataKey::ConstructionTest() {
+  DataKey defaultKey;
+  CPPUNIT_ASSERT(TypeTag() == defaultKey.type());
+  CPPUNIT_ASSERT(0 == std::strcmp("", defaultKey.name().value()));
 
-   DataKey dummyKey(DataKey::makeTypeTag<Dummy>(), "");
-   CPPUNIT_ASSERT(DataKey::makeTypeTag<Dummy>() == dummyKey.type());
-   CPPUNIT_ASSERT(0 == std::strcmp("", dummyKey.name().value()));
+  DataKey dummyKey(DataKey::makeTypeTag<Dummy>(), "");
+  CPPUNIT_ASSERT(DataKey::makeTypeTag<Dummy>() == dummyKey.type());
+  CPPUNIT_ASSERT(0 == std::strcmp("", dummyKey.name().value()));
 
-   DataKey namedDummyKey(DataKey::makeTypeTag<Dummy>(), "fred");
-   CPPUNIT_ASSERT(DataKey::makeTypeTag<Dummy>() == namedDummyKey.type());
-   CPPUNIT_ASSERT(0 == std::strcmp("fred", namedDummyKey.name().value()));
+  DataKey namedDummyKey(DataKey::makeTypeTag<Dummy>(), "fred");
+  CPPUNIT_ASSERT(DataKey::makeTypeTag<Dummy>() == namedDummyKey.type());
+  CPPUNIT_ASSERT(0 == std::strcmp("fred", namedDummyKey.name().value()));
 }
 
-void testDataKey::ComparisonTest()
-{
-   const DataKey defaultKey;
-   CPPUNIT_ASSERT(defaultKey == defaultKey);
-   CPPUNIT_ASSERT(!(defaultKey < defaultKey));
-   
-   const DataKey dummyKey(DataKey::makeTypeTag<Dummy>(), "");
-   const DataKey fredDummyKey(DataKey::makeTypeTag<Dummy>(), "fred");
-   const DataKey barneyDummyKey(DataKey::makeTypeTag<Dummy>(), "barney");
+void testDataKey::ComparisonTest() {
+  const DataKey defaultKey;
+  CPPUNIT_ASSERT(defaultKey == defaultKey);
+  CPPUNIT_ASSERT(!(defaultKey < defaultKey));
 
-   CPPUNIT_ASSERT(! (defaultKey == dummyKey));
-   CPPUNIT_ASSERT(dummyKey == dummyKey);
-   CPPUNIT_ASSERT(! (dummyKey == fredDummyKey));
-   
-   CPPUNIT_ASSERT(barneyDummyKey == barneyDummyKey);
-   CPPUNIT_ASSERT(barneyDummyKey < fredDummyKey);
-   CPPUNIT_ASSERT(!(fredDummyKey < barneyDummyKey));
-   CPPUNIT_ASSERT(!(barneyDummyKey == fredDummyKey));
-   
-   const DataKey dummy2Key(DataKey::makeTypeTag<Dummy2>(), "");
+  const DataKey dummyKey(DataKey::makeTypeTag<Dummy>(), "");
+  const DataKey fredDummyKey(DataKey::makeTypeTag<Dummy>(), "fred");
+  const DataKey barneyDummyKey(DataKey::makeTypeTag<Dummy>(), "barney");
 
-   CPPUNIT_ASSERT(! (dummy2Key == dummyKey));
+  CPPUNIT_ASSERT(!(defaultKey == dummyKey));
+  CPPUNIT_ASSERT(dummyKey == dummyKey);
+  CPPUNIT_ASSERT(!(dummyKey == fredDummyKey));
+
+  CPPUNIT_ASSERT(barneyDummyKey == barneyDummyKey);
+  CPPUNIT_ASSERT(barneyDummyKey < fredDummyKey);
+  CPPUNIT_ASSERT(!(fredDummyKey < barneyDummyKey));
+  CPPUNIT_ASSERT(!(barneyDummyKey == fredDummyKey));
+
+  const DataKey dummy2Key(DataKey::makeTypeTag<Dummy2>(), "");
+
+  CPPUNIT_ASSERT(!(dummy2Key == dummyKey));
 }
 
-void testDataKey::CopyTest()
-{
-   const DataKey defaultKey;
-   DataKey tester(defaultKey);
-   CPPUNIT_ASSERT(tester == defaultKey);
-   
-   const DataKey dummyKey(DataKey::makeTypeTag<Dummy>(), "");
-   tester = dummyKey;
-   CPPUNIT_ASSERT(tester == dummyKey);
-   const DataKey fredDummyKey(DataKey::makeTypeTag<Dummy>(), "fred");
-   tester = fredDummyKey;
-   CPPUNIT_ASSERT(tester == fredDummyKey);
+void testDataKey::CopyTest() {
+  const DataKey defaultKey;
+  DataKey tester(defaultKey);
+  CPPUNIT_ASSERT(tester == defaultKey);
 
-   DataKey tester2(fredDummyKey);
-   CPPUNIT_ASSERT(tester2 == fredDummyKey);
+  const DataKey dummyKey(DataKey::makeTypeTag<Dummy>(), "");
+  tester = dummyKey;
+  CPPUNIT_ASSERT(tester == dummyKey);
+  const DataKey fredDummyKey(DataKey::makeTypeTag<Dummy>(), "fred");
+  tester = fredDummyKey;
+  CPPUNIT_ASSERT(tester == fredDummyKey);
+
+  DataKey tester2(fredDummyKey);
+  CPPUNIT_ASSERT(tester2 == fredDummyKey);
 }
 
-void testDataKey::nocopyConstructionTest()
-{
-   const DataKey fredDummyKey(DataKey::makeTypeTag<Dummy>(), "fred");
-   const DataKey noCopyFredDummyKey(DataKey::makeTypeTag<Dummy>(), "fred", DataKey::kDoNotCopyMemory);
+void testDataKey::nocopyConstructionTest() {
+  const DataKey fredDummyKey(DataKey::makeTypeTag<Dummy>(), "fred");
+  const DataKey noCopyFredDummyKey(DataKey::makeTypeTag<Dummy>(), "fred", DataKey::kDoNotCopyMemory);
 
-   CPPUNIT_ASSERT(fredDummyKey == noCopyFredDummyKey);
-   
-   const DataKey copyFredDummyKey(noCopyFredDummyKey);
-   CPPUNIT_ASSERT(copyFredDummyKey == noCopyFredDummyKey);
-   
-   DataKey copy2FredDummyKey;
-   copy2FredDummyKey = noCopyFredDummyKey;
-   CPPUNIT_ASSERT(copy2FredDummyKey == noCopyFredDummyKey);
-   
-   DataKey noCopyBarneyDummyKey(DataKey::makeTypeTag<Dummy>(), "barney", DataKey::kDoNotCopyMemory);
+  CPPUNIT_ASSERT(fredDummyKey == noCopyFredDummyKey);
 
-   noCopyBarneyDummyKey = noCopyFredDummyKey;
-   CPPUNIT_ASSERT(noCopyBarneyDummyKey == noCopyFredDummyKey);
+  const DataKey copyFredDummyKey(noCopyFredDummyKey);
+  CPPUNIT_ASSERT(copyFredDummyKey == noCopyFredDummyKey);
+
+  DataKey copy2FredDummyKey;
+  copy2FredDummyKey = noCopyFredDummyKey;
+  CPPUNIT_ASSERT(copy2FredDummyKey == noCopyFredDummyKey);
+
+  DataKey noCopyBarneyDummyKey(DataKey::makeTypeTag<Dummy>(), "barney", DataKey::kDoNotCopyMemory);
+
+  noCopyBarneyDummyKey = noCopyFredDummyKey;
+  CPPUNIT_ASSERT(noCopyBarneyDummyKey == noCopyFredDummyKey);
 }

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -25,31 +25,28 @@
 #include "cppunit/extensions/HelperMacros.h"
 #include <cstring>
 
-
 using namespace edm::eventsetup;
 
-class testdependentrecord: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testdependentrecord);
+class testdependentrecord : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testdependentrecord);
 
-CPPUNIT_TEST(dependentConstructorTest);
-CPPUNIT_TEST(dependentFinder1Test);
-CPPUNIT_TEST(dependentFinder2Test);
-CPPUNIT_TEST(timeAndRunTest);
-CPPUNIT_TEST(dependentSetproviderTest);
-CPPUNIT_TEST(getTest);
-CPPUNIT_TEST(oneOfTwoRecordTest);
-CPPUNIT_TEST(resetTest);
-CPPUNIT_TEST(alternateFinderTest);
-CPPUNIT_TEST(invalidRecordTest);
-CPPUNIT_TEST(extendIOVTest);
+  CPPUNIT_TEST(dependentConstructorTest);
+  CPPUNIT_TEST(dependentFinder1Test);
+  CPPUNIT_TEST(dependentFinder2Test);
+  CPPUNIT_TEST(timeAndRunTest);
+  CPPUNIT_TEST(dependentSetproviderTest);
+  CPPUNIT_TEST(getTest);
+  CPPUNIT_TEST(oneOfTwoRecordTest);
+  CPPUNIT_TEST(resetTest);
+  CPPUNIT_TEST(alternateFinderTest);
+  CPPUNIT_TEST(invalidRecordTest);
+  CPPUNIT_TEST(extendIOVTest);
 
-  
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void dependentConstructorTest();
   void dependentFinder1Test();
@@ -62,8 +59,8 @@ public:
   void alternateFinderTest();
   void invalidRecordTest();
   void extendIOVTest();
-  
-}; //Cppunit class declaration over
+
+};  //Cppunit class declaration over
 
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testdependentrecord);
@@ -77,844 +74,778 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testdependentrecord);
 
 namespace {
 
-edm::ActivityRegistry activityRegistry;
+  edm::ActivityRegistry activityRegistry;
 
-class DummyProxyProvider : public edm::eventsetup::DataProxyProvider {
-public:
-   DummyProxyProvider() {
-      usingRecord<DummyRecord>();
-   }
-   void newInterval(const edm::eventsetup::EventSetupRecordKey& /*iRecordType*/,
+  class DummyProxyProvider : public edm::eventsetup::DataProxyProvider {
+  public:
+    DummyProxyProvider() { usingRecord<DummyRecord>(); }
+    void newInterval(const edm::eventsetup::EventSetupRecordKey& /*iRecordType*/,
                      const edm::ValidityInterval& /*iInterval*/) {
       //do nothing
-   }
-protected:
-   void registerProxies(const edm::eventsetup::EventSetupRecordKey&, KeyedProxies& /*iHolder*/) {
-   }
-   
-};
+    }
 
-class DepRecordProxyProvider : public edm::eventsetup::DataProxyProvider {
-public:
-   DepRecordProxyProvider() {
-      usingRecord<DepRecord>();
-   }
-   void newInterval(const edm::eventsetup::EventSetupRecordKey& /*iRecordType*/,
+  protected:
+    void registerProxies(const edm::eventsetup::EventSetupRecordKey&, KeyedProxies& /*iHolder*/) {}
+  };
+
+  class DepRecordProxyProvider : public edm::eventsetup::DataProxyProvider {
+  public:
+    DepRecordProxyProvider() { usingRecord<DepRecord>(); }
+    void newInterval(const edm::eventsetup::EventSetupRecordKey& /*iRecordType*/,
                      const edm::ValidityInterval& /*iInterval*/) {
       //do nothing
-   }
-protected:
-   void registerProxies(const edm::eventsetup::EventSetupRecordKey&, KeyedProxies& /*iHolder*/) {
-   }
-   
-};
+    }
 
+  protected:
+    void registerProxies(const edm::eventsetup::EventSetupRecordKey&, KeyedProxies& /*iHolder*/) {}
+  };
 
-class DepOn2RecordProxyProvider : public edm::eventsetup::DataProxyProvider {
-public:
-  DepOn2RecordProxyProvider() {
-    usingRecord<DepOn2Record>();
-  }
-  void newInterval(const edm::eventsetup::EventSetupRecordKey& /*iRecordType*/,
-  const edm::ValidityInterval& /*iInterval*/) {
-    //do nothing
-  }
-protected:
-void registerProxies(const edm::eventsetup::EventSetupRecordKey&, KeyedProxies& /*iHolder*/) {
-}
+  class DepOn2RecordProxyProvider : public edm::eventsetup::DataProxyProvider {
+  public:
+    DepOn2RecordProxyProvider() { usingRecord<DepOn2Record>(); }
+    void newInterval(const edm::eventsetup::EventSetupRecordKey& /*iRecordType*/,
+                     const edm::ValidityInterval& /*iInterval*/) {
+      //do nothing
+    }
 
-};
+  protected:
+    void registerProxies(const edm::eventsetup::EventSetupRecordKey&, KeyedProxies& /*iHolder*/) {}
+  };
 
-class DepRecordFinder : public edm::EventSetupRecordIntervalFinder {
-public:
-  DepRecordFinder() :edm::EventSetupRecordIntervalFinder(), interval_() {
-    this->findingRecord<DepRecord>();
-  }
-  
-  void setInterval(const edm::ValidityInterval& iInterval) {
-    interval_ = iInterval;
-  }
-protected:
-  virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-                              const edm::IOVSyncValue& iTime, 
-                              edm::ValidityInterval& iInterval) {
-    if(interval_.validFor(iTime)) {
-      iInterval = interval_;
-    } else {
-      if(interval_.last() == edm::IOVSyncValue::invalidIOVSyncValue() &&
-         interval_.first() != edm::IOVSyncValue::invalidIOVSyncValue() &&
-         interval_.first() <= iTime) {
+  class DepRecordFinder : public edm::EventSetupRecordIntervalFinder {
+  public:
+    DepRecordFinder() : edm::EventSetupRecordIntervalFinder(), interval_() { this->findingRecord<DepRecord>(); }
+
+    void setInterval(const edm::ValidityInterval& iInterval) { interval_ = iInterval; }
+
+  protected:
+    virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                const edm::IOVSyncValue& iTime,
+                                edm::ValidityInterval& iInterval) {
+      if (interval_.validFor(iTime)) {
         iInterval = interval_;
-      }else {
-        iInterval = edm::ValidityInterval();
+      } else {
+        if (interval_.last() == edm::IOVSyncValue::invalidIOVSyncValue() &&
+            interval_.first() != edm::IOVSyncValue::invalidIOVSyncValue() && interval_.first() <= iTime) {
+          iInterval = interval_;
+        } else {
+          iInterval = edm::ValidityInterval();
+        }
       }
     }
-  }
-private:
-  edm::ValidityInterval interval_;   
-};
 
+  private:
+    edm::ValidityInterval interval_;
+  };
 
-class Dummy2RecordFinder : public edm::EventSetupRecordIntervalFinder {
-public:
-  Dummy2RecordFinder() :edm::EventSetupRecordIntervalFinder(), interval_() {
-    this->findingRecord<Dummy2Record>();
-  }
-  
-  void setInterval(const edm::ValidityInterval& iInterval) {
-    interval_ = iInterval;
-  }
-protected:
-  virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-                              const edm::IOVSyncValue& iTime, 
-                              edm::ValidityInterval& iInterval) {
-    if(interval_.validFor(iTime)) {
-      iInterval = interval_;
-    } else {
-      if(interval_.last() == edm::IOVSyncValue::invalidIOVSyncValue() &&
-         interval_.first() != edm::IOVSyncValue::invalidIOVSyncValue() &&
-         interval_.first() <= iTime) {
+  class Dummy2RecordFinder : public edm::EventSetupRecordIntervalFinder {
+  public:
+    Dummy2RecordFinder() : edm::EventSetupRecordIntervalFinder(), interval_() { this->findingRecord<Dummy2Record>(); }
+
+    void setInterval(const edm::ValidityInterval& iInterval) { interval_ = iInterval; }
+
+  protected:
+    virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                const edm::IOVSyncValue& iTime,
+                                edm::ValidityInterval& iInterval) {
+      if (interval_.validFor(iTime)) {
         iInterval = interval_;
-      }else {
-        iInterval = edm::ValidityInterval();
+      } else {
+        if (interval_.last() == edm::IOVSyncValue::invalidIOVSyncValue() &&
+            interval_.first() != edm::IOVSyncValue::invalidIOVSyncValue() && interval_.first() <= iTime) {
+          iInterval = interval_;
+        } else {
+          iInterval = edm::ValidityInterval();
+        }
       }
     }
-  }
-private:
-  edm::ValidityInterval interval_;   
-};
-}
+
+  private:
+    edm::ValidityInterval interval_;
+  };
+}  // namespace
 
 using namespace edm::eventsetup;
-void testdependentrecord::dependentConstructorTest()
-{
-   EventSetupRecordProvider depProvider(DepRecord::keyForClass());
-   
-   CPPUNIT_ASSERT(1 == depProvider.dependentRecords().size());
-   CPPUNIT_ASSERT(*(depProvider.dependentRecords().begin()) == DummyRecord::keyForClass());
-   
-   edm::print_eventsetup_record_dependencies<DepRecord>(std::cout);
+void testdependentrecord::dependentConstructorTest() {
+  EventSetupRecordProvider depProvider(DepRecord::keyForClass());
+
+  CPPUNIT_ASSERT(1 == depProvider.dependentRecords().size());
+  CPPUNIT_ASSERT(*(depProvider.dependentRecords().begin()) == DummyRecord::keyForClass());
+
+  edm::print_eventsetup_record_dependencies<DepRecord>(std::cout);
 }
 
-
-void testdependentrecord::dependentFinder1Test()
-{
-   auto dummyProvider = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
-   const edm::EventID eID_1(1, 1, 1);
-   const edm::IOVSyncValue sync_1(eID_1);
-   const edm::EventID eID_3(1, 1, 3);
-   const edm::ValidityInterval definedInterval(sync_1, 
-                                                edm::IOVSyncValue(eID_3));
-   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
-   dummyFinder->setInterval(definedInterval);
-   dummyProvider->addFinder(dummyFinder);
-   
-   const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
-   DependentRecordIntervalFinder finder(depRecordKey);
-   finder.addProviderWeAreDependentOn(dummyProvider);
-   
-   CPPUNIT_ASSERT(definedInterval == finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 2)))); 
-
-   dummyFinder->setInterval(edm::ValidityInterval::invalidInterval());
-   CPPUNIT_ASSERT(edm::ValidityInterval::invalidInterval() == finder.findIntervalFor(depRecordKey, 
-                                                                                     edm::IOVSyncValue(edm::EventID(1, 1, 4))));
-   
-   const edm::EventID eID_5(1, 1, 5);
-   const edm::IOVSyncValue sync_5(eID_5);
-   const edm::ValidityInterval unknownedEndInterval(sync_5 ,
-                                                     edm::IOVSyncValue::invalidIOVSyncValue());
-   dummyFinder->setInterval(unknownedEndInterval);
-
-   CPPUNIT_ASSERT(unknownedEndInterval == finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 5))));
-
-}
-
-void testdependentrecord::dependentFinder2Test()
-{
-   auto dummyProvider1 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
-   
-   const edm::EventID eID_1(1, 1, 1);
-   const edm::IOVSyncValue sync_1(eID_1);
-   const edm::ValidityInterval definedInterval1(sync_1, 
-                                                 edm::IOVSyncValue(edm::EventID(1, 1, 5)));
-   dummyProvider1->setValidityInterval(definedInterval1);
-   
-   auto dummyProvider2 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
-   
-   const edm::EventID eID_2(1, 1, 2);
-   const edm::IOVSyncValue sync_2(eID_2);
-   const edm::ValidityInterval definedInterval2(sync_2, 
-                                                 edm::IOVSyncValue(edm::EventID(1, 1, 6)));
-   dummyProvider2->setValidityInterval(definedInterval2);
-
-   const edm::ValidityInterval overlapInterval(std::max(definedInterval1.first(), definedInterval2.first()),
-                                                std::min(definedInterval1.last(), definedInterval2.last()));
-   
-   const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
-                                                     
-   DependentRecordIntervalFinder finder(depRecordKey);
-   finder.addProviderWeAreDependentOn(dummyProvider1);
-   finder.addProviderWeAreDependentOn(dummyProvider2);
-   
-   CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, 
-                                                            edm::IOVSyncValue(edm::EventID(1, 1, 4))));
-}
-
-
-void testdependentrecord::timeAndRunTest()
-{
-  //test case where we have two providers, one synching on time the other on run/lumi/event
-   auto dummyProvider1 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
-   
-   const edm::EventID eID_1(1, 1, 1);
-   const edm::IOVSyncValue sync_1(eID_1);
-   const edm::ValidityInterval definedInterval1(sync_1, 
-                                                 edm::IOVSyncValue(edm::EventID(1, 1, 5)));
-   dummyProvider1->setValidityInterval(definedInterval1);
-   
-   auto dummyProvider2 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
-
-   
-   const edm::Timestamp time_1(1);
-   const edm::IOVSyncValue sync_2(time_1);
-   const edm::ValidityInterval definedInterval2(sync_2, 
-						edm::IOVSyncValue(edm::Timestamp(6)));
-   dummyProvider2->setValidityInterval(definedInterval2);
-
-   const edm::ValidityInterval overlapInterval(definedInterval2.first(),
-					       edm::IOVSyncValue::invalidIOVSyncValue());
-   
-   const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
-                                                     
-   DependentRecordIntervalFinder finder(depRecordKey);
-   finder.addProviderWeAreDependentOn(dummyProvider1);
-   finder.addProviderWeAreDependentOn(dummyProvider2);
-   
-   CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, 
-                                                            edm::IOVSyncValue(edm::EventID(1, 1, 4),edm::Timestamp(3))));
-
-   //should give back same interval
-   CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, 
-                                                            edm::IOVSyncValue(edm::EventID(1, 1, 4),edm::Timestamp(4))));
-
-   //should give back same interval
-   CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, 
-                                                            edm::IOVSyncValue(edm::EventID(1, 1, 2),edm::Timestamp(3))));
-
-   //should give back same interval
-   CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, 
-                                                            edm::IOVSyncValue(edm::EventID(1, 1, 1),edm::Timestamp(2))));
-
-   //Change only run/lumi/event based provider
-   const edm::ValidityInterval definedInterval3( edm::IOVSyncValue(edm::EventID(1,1,6)), 
-                                                 edm::IOVSyncValue(edm::EventID(1, 1, 10)));
-   dummyProvider1->setValidityInterval(definedInterval3);
-
-   const edm::ValidityInterval overlapInterval2(definedInterval3.first(),
-					       edm::IOVSyncValue::invalidIOVSyncValue());
-
-   CPPUNIT_ASSERT(overlapInterval2 == finder.findIntervalFor(depRecordKey, 
-                                                            edm::IOVSyncValue(edm::EventID(1, 1, 6),edm::Timestamp(5))));
-
-   //Change only time based provider
-   const edm::ValidityInterval definedInterval4(edm::IOVSyncValue(edm::Timestamp(7)), 
-						edm::IOVSyncValue(edm::Timestamp(10)));
-   dummyProvider2->setValidityInterval(definedInterval4);
-
-   const edm::ValidityInterval overlapInterval3(definedInterval4.first(),
-					       edm::IOVSyncValue::invalidIOVSyncValue());
-
-   CPPUNIT_ASSERT(overlapInterval3 == finder.findIntervalFor(depRecordKey, 
-                                                            edm::IOVSyncValue(edm::EventID(1, 1, 7),edm::Timestamp(7))));
-   //Change both but make run/lumi/event 'closer' by having same lumi
-   {
-      const edm::ValidityInterval runLumiInterval( edm::IOVSyncValue(edm::EventID(1,2,11)), 
-                                                   edm::IOVSyncValue(edm::EventID(1, 3, 20)));
-      dummyProvider1->setValidityInterval(runLumiInterval);
-      
-      const edm::ValidityInterval timeInterval(edm::IOVSyncValue(edm::Timestamp(1ULL<<32)), 
-                                                   edm::IOVSyncValue(edm::Timestamp(5ULL<<32)));
-      dummyProvider2->setValidityInterval(timeInterval);
-
-      const edm::ValidityInterval overlapInterval(runLumiInterval.first(),
-                                                   edm::IOVSyncValue::invalidIOVSyncValue());
-      
-      CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, 
-                                                                edm::IOVSyncValue(edm::EventID(1, 2, 12),edm::Timestamp(3ULL<<32))));
-      
-   }
-
-   //Change both but make time 'closer'
-   {
-      const edm::ValidityInterval runLumiInterval( edm::IOVSyncValue(edm::EventID(1,3,21)), 
-                                                  edm::IOVSyncValue(edm::EventID(1, 10, 40)));
-      dummyProvider1->setValidityInterval(runLumiInterval);
-      
-      const edm::ValidityInterval timeInterval(edm::IOVSyncValue(edm::Timestamp(7ULL<<32)), 
-                                               edm::IOVSyncValue(edm::Timestamp(10ULL<<32)));
-      dummyProvider2->setValidityInterval(timeInterval);
-      
-      const edm::ValidityInterval overlapInterval(timeInterval.first(),
-                                                  edm::IOVSyncValue::invalidIOVSyncValue());
-      
-      CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, 
-                                                               edm::IOVSyncValue(edm::EventID(1, 4, 30),edm::Timestamp(8ULL<<32))));
-   }
-
-   //Change both but make run/lumi/event 'closer'
-   {
-      const edm::ValidityInterval runLumiInterval( edm::IOVSyncValue(edm::EventID(1,11,41)), 
-                                                  edm::IOVSyncValue(edm::EventID(1, 20, 60)));
-      dummyProvider1->setValidityInterval(runLumiInterval);
-      
-      const edm::ValidityInterval timeInterval(edm::IOVSyncValue(edm::Timestamp(11ULL<<32)), 
-                                               edm::IOVSyncValue(edm::Timestamp(100ULL<<32)));
-      dummyProvider2->setValidityInterval(timeInterval);
-      
-      const edm::ValidityInterval overlapInterval(runLumiInterval.first(),
-                                                  edm::IOVSyncValue::invalidIOVSyncValue());
-      
-      CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, 
-                                                               edm::IOVSyncValue(edm::EventID(1, 12, 50),edm::Timestamp(70ULL<<32))));
-   }
-
-   //Change both and make it ambiguous because of different run #
-   {
-      const edm::ValidityInterval runLumiInterval( edm::IOVSyncValue(edm::EventID(2,1,0)), 
-                                                  edm::IOVSyncValue(edm::EventID(6, 0, 0)));
-      dummyProvider1->setValidityInterval(runLumiInterval);
-      
-      const edm::ValidityInterval timeInterval(edm::IOVSyncValue(edm::Timestamp(200ULL<<32)), 
-                                               edm::IOVSyncValue(edm::Timestamp(500ULL<<32)));
-      dummyProvider2->setValidityInterval(timeInterval);
-      
-      const edm::ValidityInterval overlapInterval(timeInterval.first(),
-                                                  edm::IOVSyncValue::invalidIOVSyncValue());
-      
-      CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, 
-                                                               edm::IOVSyncValue(edm::EventID(4, 12, 50),edm::Timestamp(400ULL<<32))));
-   }
-   
-   //First reset back to the state expected by the following tests
-   dummyProvider1->setValidityInterval(definedInterval3);
-   dummyProvider2->setValidityInterval(definedInterval4);   
-   CPPUNIT_ASSERT(overlapInterval3 == finder.findIntervalFor(depRecordKey, 
-                                                             edm::IOVSyncValue(edm::EventID(1, 1, 7),edm::Timestamp(7))));
-   
-   //check with invalid intervals
-   const edm::ValidityInterval invalid(edm::IOVSyncValue::invalidIOVSyncValue(),edm::IOVSyncValue::invalidIOVSyncValue());
-   dummyProvider1->setValidityInterval(invalid);
-   CPPUNIT_ASSERT(overlapInterval3 == finder.findIntervalFor(depRecordKey, 
-                                                            edm::IOVSyncValue(edm::EventID(1, 1, 11),edm::Timestamp(8))));
-   
-   const edm::ValidityInterval definedInterval5( edm::IOVSyncValue(edm::EventID(1,1,12)), 
-                                                edm::IOVSyncValue(edm::EventID(1, 1, 20)));
-   dummyProvider1->setValidityInterval(definedInterval5);
-   dummyProvider2->setValidityInterval(invalid);
-   const edm::ValidityInterval overlapInterval4(definedInterval5.first(),
-					       edm::IOVSyncValue::invalidIOVSyncValue());
-
-   CPPUNIT_ASSERT(overlapInterval4 == finder.findIntervalFor(depRecordKey, 
-                                                            edm::IOVSyncValue(edm::EventID(1, 1, 13),edm::Timestamp(11))));
-   
-   {
-      //check for bug which only happens the first time we synchronize
-      // have the second one invalid
-      auto dummyProvider1 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
-
-      const edm::EventID eID_1(1, 1, 1);
-      const edm::IOVSyncValue sync_1(eID_1);
-      const edm::ValidityInterval definedInterval1(sync_1, 
-                                                    edm::IOVSyncValue(edm::EventID(1, 1, 6)));
-      dummyProvider1->setValidityInterval(definedInterval1);
-
-      auto dummyProvider2 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
-
-      dummyProvider2->setValidityInterval(invalid);
-
-      const edm::ValidityInterval overlapInterval(definedInterval1.first(),
-   					       edm::IOVSyncValue::invalidIOVSyncValue());
-
-      const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
-
-      DependentRecordIntervalFinder finder(depRecordKey);
-      finder.addProviderWeAreDependentOn(dummyProvider1);
-      finder.addProviderWeAreDependentOn(dummyProvider2);
-
-      CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, 
-                                                               edm::IOVSyncValue(edm::EventID(1, 1, 4),edm::Timestamp(1))));
-
-      const edm::Timestamp time_1(2);
-      const edm::IOVSyncValue sync_2(time_1);
-      const edm::ValidityInterval definedInterval2(sync_2, 
-   						edm::IOVSyncValue(edm::Timestamp(6)));
-      dummyProvider2->setValidityInterval(definedInterval2);
-
-      const edm::ValidityInterval overlapInterval2(definedInterval2.first(),
-   					       edm::IOVSyncValue::invalidIOVSyncValue());
-
-      CPPUNIT_ASSERT(overlapInterval2 == finder.findIntervalFor(depRecordKey, 
-                                                                edm::IOVSyncValue(edm::EventID(1, 1, 5),edm::Timestamp(3))));
-                     
-   }
-   {
-      //check for bug which only happens the first time we synchronize
-      // have the  first one invalid
-      
-      auto dummyProvider1 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
-
-      dummyProvider1->setValidityInterval(invalid);
-
-      auto dummyProvider2 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
-
-      const edm::Timestamp time_1(1);
-      const edm::IOVSyncValue sync_2(time_1);
-      const edm::ValidityInterval definedInterval2(sync_2, 
-   						edm::IOVSyncValue(edm::Timestamp(6)));
-      dummyProvider2->setValidityInterval(definedInterval2);
-
-      const edm::ValidityInterval overlapInterval(definedInterval2.first(),
-   					       edm::IOVSyncValue::invalidIOVSyncValue());
-
-      const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
-
-      DependentRecordIntervalFinder finder(depRecordKey);
-      finder.addProviderWeAreDependentOn(dummyProvider1);
-      finder.addProviderWeAreDependentOn(dummyProvider2);
-
-      CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, 
-                                                               edm::IOVSyncValue(edm::EventID(1, 1, 4),edm::Timestamp(3))));
-                                                               
-      const edm::EventID eID_1(1, 1, 5);
-      const edm::IOVSyncValue sync_1(eID_1);
-      const edm::ValidityInterval definedInterval1(sync_1, 
-                                                    edm::IOVSyncValue(edm::EventID(1, 1, 10)));
-      dummyProvider1->setValidityInterval(definedInterval1);
-      
-      const edm::ValidityInterval overlapInterval2(definedInterval2.first(),
-   					       edm::IOVSyncValue::invalidIOVSyncValue());
-
-      CPPUNIT_ASSERT(overlapInterval2 == finder.findIntervalFor(depRecordKey, 
-                                                               edm::IOVSyncValue(edm::EventID(1, 1, 5),edm::Timestamp(4))));
-      
-   }
-
-   {
-     //check that going all the way through EventSetup works properly
-     edm::eventsetup::EventSetupProvider provider(&activityRegistry);
-     std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
-     provider.add(dummyProv);
-     
-     std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
-     dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
-						    edm::IOVSyncValue(edm::EventID(1, 1, 5))));
-     provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
-     
-     std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
-     provider.add(depProv);
-
-     std::shared_ptr<Dummy2RecordFinder> dummy2Finder = std::make_shared<Dummy2RecordFinder>();
-     dummy2Finder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp( 1)), 
-						    edm::IOVSyncValue(edm::Timestamp( 5))));
-     provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
-     {
-       const auto&  eventSetup1 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
-       long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
-       
-
-       const auto&  eventSetup2 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(2)));
-       long long id2 = eventSetup2.get<DepOn2Record>().cacheIdentifier();
-       CPPUNIT_ASSERT(id1 == id2);
-
-       const auto&  eventSetup3 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 2), edm::Timestamp(2)));
-       long long id3 = eventSetup3.get<DepOn2Record>().cacheIdentifier();
-       CPPUNIT_ASSERT(id1 == id3);
-
-       dummy2Finder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp( 6)), 
-						       edm::IOVSyncValue(edm::Timestamp( 10))));
-
-       const auto&  eventSetup4 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(7)));
-       long long id4 = eventSetup4.get<DepOn2Record>().cacheIdentifier();
-       CPPUNIT_ASSERT(id1 != id4);
-
-       dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 6)), 
-						      edm::IOVSyncValue(edm::EventID(1, 1, 10))));
-
-       const auto&  eventSetup5 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(8)));
-       long long id5 = eventSetup5.get<DepOn2Record>().cacheIdentifier();
-       CPPUNIT_ASSERT(id4 != id5);
-     }
-   }
-   
-   {
-      //check that going all the way through EventSetup works properly
-      // using two records with open ended IOVs
-      edm::eventsetup::EventSetupProvider provider(&activityRegistry);
-      std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
-      provider.add(dummyProv);
-      
-      std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
-      dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
-                                                     edm::IOVSyncValue::invalidIOVSyncValue()));
-      provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
-      
-      std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
-      provider.add(depProv);
-      
-      std::shared_ptr<Dummy2RecordFinder> dummy2Finder = std::make_shared<Dummy2RecordFinder>();
-      dummy2Finder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp( 1)), 
-                                                      edm::IOVSyncValue::invalidIOVSyncValue()));
-      provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
-      {
-         const auto&  eventSetup1 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
-         long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
-         
-         
-         const auto&  eventSetup2 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(2)));
-         long long id2 = eventSetup2.get<DepOn2Record>().cacheIdentifier();
-         CPPUNIT_ASSERT(id1 == id2);
-         
-         const auto&  eventSetup3 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 2), edm::Timestamp(2)));
-         long long id3 = eventSetup3.get<DepOn2Record>().cacheIdentifier();
-         CPPUNIT_ASSERT(id1 == id3);
-         
-         dummy2Finder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp( 6)), 
-                                                         edm::IOVSyncValue::invalidIOVSyncValue()));
-         
-         const auto&  eventSetup4 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(7)));
-         long long id4 = eventSetup4.get<DepOn2Record>().cacheIdentifier();
-         CPPUNIT_ASSERT(id1 != id4);
-         
-         dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 6)), 
-                                                        edm::IOVSyncValue::invalidIOVSyncValue()));
-         
-         const auto&  eventSetup5 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(8)));
-         long long id5 = eventSetup5.get<DepOn2Record>().cacheIdentifier();
-         CPPUNIT_ASSERT(id4 != id5);
-      }
-   }
-   
-}
-
-
-void testdependentrecord::dependentSetproviderTest()
-{
-   auto depProvider = std::make_unique<EventSetupRecordProvider>(DepRecord::keyForClass());
-   
-   auto dummyProvider = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
-
-   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
-   dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)),
-                                                   edm::IOVSyncValue(edm::EventID(1, 1, 3))));
-   dummyProvider->addFinder(dummyFinder);
-   
-   CPPUNIT_ASSERT(*(depProvider->dependentRecords().begin()) == dummyProvider->key());
-   
-   std::vector< std::shared_ptr<EventSetupRecordProvider> > providers;
-   providers.push_back(dummyProvider);
-   depProvider->setDependentProviders(providers);
-}
-
-void testdependentrecord::getTest()
-{
-   edm::eventsetup::EventSetupProvider provider(&activityRegistry);
-   std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
-   provider.add(dummyProv);
-
-   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
-   dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
-                                                   edm::IOVSyncValue(edm::EventID(1, 1, 3))));
-   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
-   
-   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepRecordProxyProvider>();
-   provider.add(depProv);
-   {
-      const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
-      const DepRecord& depRecord = eventSetup.get<DepRecord>();
-
-      depRecord.getRecord<DummyRecord>();
-
-      auto dr = depRecord.tryToGetRecord<DummyRecord>();
-      CPPUNIT_ASSERT(dr.has_value());
-   }
-   {
-      const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4)));
-      CPPUNIT_ASSERT_THROW(eventSetup.get<DepRecord>(),edm::eventsetup::NoRecordException<DepRecord>);
-   }
-   
-}
-
-void testdependentrecord::oneOfTwoRecordTest()
-{
-  edm::eventsetup::EventSetupProvider provider(&activityRegistry);
-  std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
-  provider.add(dummyProv);
-  
+void testdependentrecord::dependentFinder1Test() {
+  auto dummyProvider = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
+  const edm::EventID eID_1(1, 1, 1);
+  const edm::IOVSyncValue sync_1(eID_1);
+  const edm::EventID eID_3(1, 1, 3);
+  const edm::ValidityInterval definedInterval(sync_1, edm::IOVSyncValue(eID_3));
   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
-  dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
-                                                 edm::IOVSyncValue(edm::EventID(1, 1, 3))));
-  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
-  
-  std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
-  provider.add(depProv);
-  {
-    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
-    const DepOn2Record& depRecord = eventSetup.get<DepOn2Record>();
-    
-    depRecord.getRecord<DummyRecord>();
-    CPPUNIT_ASSERT_THROW(depRecord.getRecord<Dummy2Record>(),edm::eventsetup::NoRecordException<Dummy2Record>);
+  dummyFinder->setInterval(definedInterval);
+  dummyProvider->addFinder(dummyFinder);
 
-    try {
-      depRecord.getRecord<Dummy2Record>();
-    } catch(edm::eventsetup::NoRecordException<Dummy2Record>& e) {
-       //make sure that the record name appears in the error message.
-       CPPUNIT_ASSERT(0!=strstr(e.what(), "DepOn2Record"));
-       CPPUNIT_ASSERT(0!=strstr(e.what(), "Dummy2Record"));
-       //	std::cout<<e.what()<<std::endl;
+  const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
+  DependentRecordIntervalFinder finder(depRecordKey);
+  finder.addProviderWeAreDependentOn(dummyProvider);
+
+  CPPUNIT_ASSERT(definedInterval == finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 2))));
+
+  dummyFinder->setInterval(edm::ValidityInterval::invalidInterval());
+  CPPUNIT_ASSERT(edm::ValidityInterval::invalidInterval() ==
+                 finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 4))));
+
+  const edm::EventID eID_5(1, 1, 5);
+  const edm::IOVSyncValue sync_5(eID_5);
+  const edm::ValidityInterval unknownedEndInterval(sync_5, edm::IOVSyncValue::invalidIOVSyncValue());
+  dummyFinder->setInterval(unknownedEndInterval);
+
+  CPPUNIT_ASSERT(unknownedEndInterval ==
+                 finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 5))));
+}
+
+void testdependentrecord::dependentFinder2Test() {
+  auto dummyProvider1 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
+
+  const edm::EventID eID_1(1, 1, 1);
+  const edm::IOVSyncValue sync_1(eID_1);
+  const edm::ValidityInterval definedInterval1(sync_1, edm::IOVSyncValue(edm::EventID(1, 1, 5)));
+  dummyProvider1->setValidityInterval(definedInterval1);
+
+  auto dummyProvider2 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
+
+  const edm::EventID eID_2(1, 1, 2);
+  const edm::IOVSyncValue sync_2(eID_2);
+  const edm::ValidityInterval definedInterval2(sync_2, edm::IOVSyncValue(edm::EventID(1, 1, 6)));
+  dummyProvider2->setValidityInterval(definedInterval2);
+
+  const edm::ValidityInterval overlapInterval(std::max(definedInterval1.first(), definedInterval2.first()),
+                                              std::min(definedInterval1.last(), definedInterval2.last()));
+
+  const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
+
+  DependentRecordIntervalFinder finder(depRecordKey);
+  finder.addProviderWeAreDependentOn(dummyProvider1);
+  finder.addProviderWeAreDependentOn(dummyProvider2);
+
+  CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 4))));
+}
+
+void testdependentrecord::timeAndRunTest() {
+  //test case where we have two providers, one synching on time the other on run/lumi/event
+  auto dummyProvider1 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
+
+  const edm::EventID eID_1(1, 1, 1);
+  const edm::IOVSyncValue sync_1(eID_1);
+  const edm::ValidityInterval definedInterval1(sync_1, edm::IOVSyncValue(edm::EventID(1, 1, 5)));
+  dummyProvider1->setValidityInterval(definedInterval1);
+
+  auto dummyProvider2 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
+
+  const edm::Timestamp time_1(1);
+  const edm::IOVSyncValue sync_2(time_1);
+  const edm::ValidityInterval definedInterval2(sync_2, edm::IOVSyncValue(edm::Timestamp(6)));
+  dummyProvider2->setValidityInterval(definedInterval2);
+
+  const edm::ValidityInterval overlapInterval(definedInterval2.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+
+  const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
+
+  DependentRecordIntervalFinder finder(depRecordKey);
+  finder.addProviderWeAreDependentOn(dummyProvider1);
+  finder.addProviderWeAreDependentOn(dummyProvider2);
+
+  CPPUNIT_ASSERT(overlapInterval ==
+                 finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(3))));
+
+  //should give back same interval
+  CPPUNIT_ASSERT(overlapInterval ==
+                 finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(4))));
+
+  //should give back same interval
+  CPPUNIT_ASSERT(overlapInterval ==
+                 finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 2), edm::Timestamp(3))));
+
+  //should give back same interval
+  CPPUNIT_ASSERT(overlapInterval ==
+                 finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(2))));
+
+  //Change only run/lumi/event based provider
+  const edm::ValidityInterval definedInterval3(edm::IOVSyncValue(edm::EventID(1, 1, 6)),
+                                               edm::IOVSyncValue(edm::EventID(1, 1, 10)));
+  dummyProvider1->setValidityInterval(definedInterval3);
+
+  const edm::ValidityInterval overlapInterval2(definedInterval3.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+
+  CPPUNIT_ASSERT(overlapInterval2 ==
+                 finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 6), edm::Timestamp(5))));
+
+  //Change only time based provider
+  const edm::ValidityInterval definedInterval4(edm::IOVSyncValue(edm::Timestamp(7)),
+                                               edm::IOVSyncValue(edm::Timestamp(10)));
+  dummyProvider2->setValidityInterval(definedInterval4);
+
+  const edm::ValidityInterval overlapInterval3(definedInterval4.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+
+  CPPUNIT_ASSERT(overlapInterval3 ==
+                 finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(7))));
+  //Change both but make run/lumi/event 'closer' by having same lumi
+  {
+    const edm::ValidityInterval runLumiInterval(edm::IOVSyncValue(edm::EventID(1, 2, 11)),
+                                                edm::IOVSyncValue(edm::EventID(1, 3, 20)));
+    dummyProvider1->setValidityInterval(runLumiInterval);
+
+    const edm::ValidityInterval timeInterval(edm::IOVSyncValue(edm::Timestamp(1ULL << 32)),
+                                             edm::IOVSyncValue(edm::Timestamp(5ULL << 32)));
+    dummyProvider2->setValidityInterval(timeInterval);
+
+    const edm::ValidityInterval overlapInterval(runLumiInterval.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+
+    CPPUNIT_ASSERT(
+        overlapInterval ==
+        finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 2, 12), edm::Timestamp(3ULL << 32))));
+  }
+
+  //Change both but make time 'closer'
+  {
+    const edm::ValidityInterval runLumiInterval(edm::IOVSyncValue(edm::EventID(1, 3, 21)),
+                                                edm::IOVSyncValue(edm::EventID(1, 10, 40)));
+    dummyProvider1->setValidityInterval(runLumiInterval);
+
+    const edm::ValidityInterval timeInterval(edm::IOVSyncValue(edm::Timestamp(7ULL << 32)),
+                                             edm::IOVSyncValue(edm::Timestamp(10ULL << 32)));
+    dummyProvider2->setValidityInterval(timeInterval);
+
+    const edm::ValidityInterval overlapInterval(timeInterval.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+
+    CPPUNIT_ASSERT(
+        overlapInterval ==
+        finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 4, 30), edm::Timestamp(8ULL << 32))));
+  }
+
+  //Change both but make run/lumi/event 'closer'
+  {
+    const edm::ValidityInterval runLumiInterval(edm::IOVSyncValue(edm::EventID(1, 11, 41)),
+                                                edm::IOVSyncValue(edm::EventID(1, 20, 60)));
+    dummyProvider1->setValidityInterval(runLumiInterval);
+
+    const edm::ValidityInterval timeInterval(edm::IOVSyncValue(edm::Timestamp(11ULL << 32)),
+                                             edm::IOVSyncValue(edm::Timestamp(100ULL << 32)));
+    dummyProvider2->setValidityInterval(timeInterval);
+
+    const edm::ValidityInterval overlapInterval(runLumiInterval.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+
+    CPPUNIT_ASSERT(
+        overlapInterval ==
+        finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 12, 50), edm::Timestamp(70ULL << 32))));
+  }
+
+  //Change both and make it ambiguous because of different run #
+  {
+    const edm::ValidityInterval runLumiInterval(edm::IOVSyncValue(edm::EventID(2, 1, 0)),
+                                                edm::IOVSyncValue(edm::EventID(6, 0, 0)));
+    dummyProvider1->setValidityInterval(runLumiInterval);
+
+    const edm::ValidityInterval timeInterval(edm::IOVSyncValue(edm::Timestamp(200ULL << 32)),
+                                             edm::IOVSyncValue(edm::Timestamp(500ULL << 32)));
+    dummyProvider2->setValidityInterval(timeInterval);
+
+    const edm::ValidityInterval overlapInterval(timeInterval.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+
+    CPPUNIT_ASSERT(
+        overlapInterval ==
+        finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(4, 12, 50), edm::Timestamp(400ULL << 32))));
+  }
+
+  //First reset back to the state expected by the following tests
+  dummyProvider1->setValidityInterval(definedInterval3);
+  dummyProvider2->setValidityInterval(definedInterval4);
+  CPPUNIT_ASSERT(overlapInterval3 ==
+                 finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(7))));
+
+  //check with invalid intervals
+  const edm::ValidityInterval invalid(edm::IOVSyncValue::invalidIOVSyncValue(),
+                                      edm::IOVSyncValue::invalidIOVSyncValue());
+  dummyProvider1->setValidityInterval(invalid);
+  CPPUNIT_ASSERT(overlapInterval3 ==
+                 finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 11), edm::Timestamp(8))));
+
+  const edm::ValidityInterval definedInterval5(edm::IOVSyncValue(edm::EventID(1, 1, 12)),
+                                               edm::IOVSyncValue(edm::EventID(1, 1, 20)));
+  dummyProvider1->setValidityInterval(definedInterval5);
+  dummyProvider2->setValidityInterval(invalid);
+  const edm::ValidityInterval overlapInterval4(definedInterval5.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+
+  CPPUNIT_ASSERT(overlapInterval4 ==
+                 finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 13), edm::Timestamp(11))));
+
+  {
+    //check for bug which only happens the first time we synchronize
+    // have the second one invalid
+    auto dummyProvider1 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
+
+    const edm::EventID eID_1(1, 1, 1);
+    const edm::IOVSyncValue sync_1(eID_1);
+    const edm::ValidityInterval definedInterval1(sync_1, edm::IOVSyncValue(edm::EventID(1, 1, 6)));
+    dummyProvider1->setValidityInterval(definedInterval1);
+
+    auto dummyProvider2 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
+
+    dummyProvider2->setValidityInterval(invalid);
+
+    const edm::ValidityInterval overlapInterval(definedInterval1.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+
+    const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
+
+    DependentRecordIntervalFinder finder(depRecordKey);
+    finder.addProviderWeAreDependentOn(dummyProvider1);
+    finder.addProviderWeAreDependentOn(dummyProvider2);
+
+    CPPUNIT_ASSERT(overlapInterval ==
+                   finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(1))));
+
+    const edm::Timestamp time_1(2);
+    const edm::IOVSyncValue sync_2(time_1);
+    const edm::ValidityInterval definedInterval2(sync_2, edm::IOVSyncValue(edm::Timestamp(6)));
+    dummyProvider2->setValidityInterval(definedInterval2);
+
+    const edm::ValidityInterval overlapInterval2(definedInterval2.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+
+    CPPUNIT_ASSERT(overlapInterval2 ==
+                   finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 5), edm::Timestamp(3))));
+  }
+  {
+    //check for bug which only happens the first time we synchronize
+    // have the  first one invalid
+
+    auto dummyProvider1 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
+
+    dummyProvider1->setValidityInterval(invalid);
+
+    auto dummyProvider2 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
+
+    const edm::Timestamp time_1(1);
+    const edm::IOVSyncValue sync_2(time_1);
+    const edm::ValidityInterval definedInterval2(sync_2, edm::IOVSyncValue(edm::Timestamp(6)));
+    dummyProvider2->setValidityInterval(definedInterval2);
+
+    const edm::ValidityInterval overlapInterval(definedInterval2.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+
+    const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
+
+    DependentRecordIntervalFinder finder(depRecordKey);
+    finder.addProviderWeAreDependentOn(dummyProvider1);
+    finder.addProviderWeAreDependentOn(dummyProvider2);
+
+    CPPUNIT_ASSERT(overlapInterval ==
+                   finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(3))));
+
+    const edm::EventID eID_1(1, 1, 5);
+    const edm::IOVSyncValue sync_1(eID_1);
+    const edm::ValidityInterval definedInterval1(sync_1, edm::IOVSyncValue(edm::EventID(1, 1, 10)));
+    dummyProvider1->setValidityInterval(definedInterval1);
+
+    const edm::ValidityInterval overlapInterval2(definedInterval2.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+
+    CPPUNIT_ASSERT(overlapInterval2 ==
+                   finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 5), edm::Timestamp(4))));
+  }
+
+  {
+    //check that going all the way through EventSetup works properly
+    edm::eventsetup::EventSetupProvider provider(&activityRegistry);
+    std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+    provider.add(dummyProv);
+
+    std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+    dummyFinder->setInterval(
+        edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), edm::IOVSyncValue(edm::EventID(1, 1, 5))));
+    provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
+    std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
+    provider.add(depProv);
+
+    std::shared_ptr<Dummy2RecordFinder> dummy2Finder = std::make_shared<Dummy2RecordFinder>();
+    dummy2Finder->setInterval(
+        edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp(1)), edm::IOVSyncValue(edm::Timestamp(5))));
+    provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
+    {
+      const auto& eventSetup1 =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
+      long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
+
+      const auto& eventSetup2 =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(2)));
+      long long id2 = eventSetup2.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id1 == id2);
+
+      const auto& eventSetup3 =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 2), edm::Timestamp(2)));
+      long long id3 = eventSetup3.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id1 == id3);
+
+      dummy2Finder->setInterval(
+          edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp(6)), edm::IOVSyncValue(edm::Timestamp(10))));
+
+      const auto& eventSetup4 =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(7)));
+      long long id4 = eventSetup4.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id1 != id4);
+
+      dummyFinder->setInterval(
+          edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 6)), edm::IOVSyncValue(edm::EventID(1, 1, 10))));
+
+      const auto& eventSetup5 =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(8)));
+      long long id5 = eventSetup5.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id4 != id5);
+    }
+  }
+
+  {
+    //check that going all the way through EventSetup works properly
+    // using two records with open ended IOVs
+    edm::eventsetup::EventSetupProvider provider(&activityRegistry);
+    std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+    provider.add(dummyProv);
+
+    std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+    dummyFinder->setInterval(
+        edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), edm::IOVSyncValue::invalidIOVSyncValue()));
+    provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
+    std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
+    provider.add(depProv);
+
+    std::shared_ptr<Dummy2RecordFinder> dummy2Finder = std::make_shared<Dummy2RecordFinder>();
+    dummy2Finder->setInterval(
+        edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp(1)), edm::IOVSyncValue::invalidIOVSyncValue()));
+    provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
+    {
+      const auto& eventSetup1 =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
+      long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
+
+      const auto& eventSetup2 =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(2)));
+      long long id2 = eventSetup2.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id1 == id2);
+
+      const auto& eventSetup3 =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 2), edm::Timestamp(2)));
+      long long id3 = eventSetup3.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id1 == id3);
+
+      dummy2Finder->setInterval(
+          edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp(6)), edm::IOVSyncValue::invalidIOVSyncValue()));
+
+      const auto& eventSetup4 =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(7)));
+      long long id4 = eventSetup4.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id1 != id4);
+
+      dummyFinder->setInterval(
+          edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 6)), edm::IOVSyncValue::invalidIOVSyncValue()));
+
+      const auto& eventSetup5 =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(8)));
+      long long id5 = eventSetup5.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id4 != id5);
     }
   }
 }
-void testdependentrecord::resetTest()
-{
+
+void testdependentrecord::dependentSetproviderTest() {
+  auto depProvider = std::make_unique<EventSetupRecordProvider>(DepRecord::keyForClass());
+
+  auto dummyProvider = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
+
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+  dummyFinder->setInterval(
+      edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), edm::IOVSyncValue(edm::EventID(1, 1, 3))));
+  dummyProvider->addFinder(dummyFinder);
+
+  CPPUNIT_ASSERT(*(depProvider->dependentRecords().begin()) == dummyProvider->key());
+
+  std::vector<std::shared_ptr<EventSetupRecordProvider> > providers;
+  providers.push_back(dummyProvider);
+  depProvider->setDependentProviders(providers);
+}
+
+void testdependentrecord::getTest() {
   edm::eventsetup::EventSetupProvider provider(&activityRegistry);
   std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
   provider.add(dummyProv);
-  
+
   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
-  dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), 
-                                                 edm::IOVSyncValue(edm::EventID(1, 1, 3))));
+  dummyFinder->setInterval(
+      edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), edm::IOVSyncValue(edm::EventID(1, 1, 3))));
   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
-  
+
   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepRecordProxyProvider>();
   provider.add(depProv);
   {
-    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
+    const auto& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
+    const DepRecord& depRecord = eventSetup.get<DepRecord>();
+
+    depRecord.getRecord<DummyRecord>();
+
+    auto dr = depRecord.tryToGetRecord<DummyRecord>();
+    CPPUNIT_ASSERT(dr.has_value());
+  }
+  {
+    const auto& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4)));
+    CPPUNIT_ASSERT_THROW(eventSetup.get<DepRecord>(), edm::eventsetup::NoRecordException<DepRecord>);
+  }
+}
+
+void testdependentrecord::oneOfTwoRecordTest() {
+  edm::eventsetup::EventSetupProvider provider(&activityRegistry);
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+  provider.add(dummyProv);
+
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+  dummyFinder->setInterval(
+      edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), edm::IOVSyncValue(edm::EventID(1, 1, 3))));
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
+  provider.add(depProv);
+  {
+    const auto& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
+    const DepOn2Record& depRecord = eventSetup.get<DepOn2Record>();
+
+    depRecord.getRecord<DummyRecord>();
+    CPPUNIT_ASSERT_THROW(depRecord.getRecord<Dummy2Record>(), edm::eventsetup::NoRecordException<Dummy2Record>);
+
+    try {
+      depRecord.getRecord<Dummy2Record>();
+    } catch (edm::eventsetup::NoRecordException<Dummy2Record>& e) {
+      //make sure that the record name appears in the error message.
+      CPPUNIT_ASSERT(0 != strstr(e.what(), "DepOn2Record"));
+      CPPUNIT_ASSERT(0 != strstr(e.what(), "Dummy2Record"));
+      //	std::cout<<e.what()<<std::endl;
+    }
+  }
+}
+void testdependentrecord::resetTest() {
+  edm::eventsetup::EventSetupProvider provider(&activityRegistry);
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+  provider.add(dummyProv);
+
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+  dummyFinder->setInterval(
+      edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)), edm::IOVSyncValue(edm::EventID(1, 1, 3))));
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepRecordProxyProvider>();
+  provider.add(depProv);
+  {
+    const auto& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
     const DepRecord& depRecord = eventSetup.get<DepRecord>();
     unsigned long long depCacheID = depRecord.cacheIdentifier();
     const DummyRecord& dummyRecord = depRecord.getRecord<DummyRecord>();
     unsigned long long dummyCacheID = dummyRecord.cacheIdentifier();
-    
+
     provider.resetRecordPlusDependentRecords(dummyRecord.key());
     CPPUNIT_ASSERT(dummyCacheID != dummyRecord.cacheIdentifier());
     CPPUNIT_ASSERT(depCacheID != depRecord.cacheIdentifier());
   }
 }
-void testdependentrecord::alternateFinderTest()
-{
-   auto dummyProvider = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
-   
+void testdependentrecord::alternateFinderTest() {
+  auto dummyProvider = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
+
   const edm::EventID eID_1(1, 1, 1);
   const edm::IOVSyncValue sync_1(eID_1);
   const edm::EventID eID_3(1, 1, 3);
   const edm::IOVSyncValue sync_3(eID_3);
   const edm::EventID eID_4(1, 1, 4);
-  const edm::ValidityInterval definedInterval(sync_1, 
-                                              edm::IOVSyncValue(eID_4));
+  const edm::ValidityInterval definedInterval(sync_1, edm::IOVSyncValue(eID_4));
   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
   dummyFinder->setInterval(definedInterval);
   dummyProvider->addFinder(dummyFinder);
-  
+
   std::shared_ptr<DepRecordFinder> depFinder = std::make_shared<DepRecordFinder>();
   const edm::EventID eID_2(1, 1, 2);
   const edm::IOVSyncValue sync_2(eID_2);
-  const edm::ValidityInterval depInterval(sync_1, 
-                                          sync_2);
+  const edm::ValidityInterval depInterval(sync_1, sync_2);
   depFinder->setInterval(depInterval);
-  
+
   const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
   DependentRecordIntervalFinder finder(depRecordKey);
   finder.setAlternateFinder(depFinder);
   finder.addProviderWeAreDependentOn(dummyProvider);
-  
-  CPPUNIT_ASSERT(depInterval == finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 1)))); 
-  
-  const edm::ValidityInterval dep2Interval(sync_3, 
-                                           edm::IOVSyncValue(eID_4));
+
+  CPPUNIT_ASSERT(depInterval == finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 1))));
+
+  const edm::ValidityInterval dep2Interval(sync_3, edm::IOVSyncValue(eID_4));
   depFinder->setInterval(dep2Interval);
   /*const edm::ValidityInterval tempIOV = */ finder.findIntervalFor(depRecordKey, sync_3);
   //std::cout <<  tempIOV.first().eventID()<<" to "<<tempIOV.last().eventID() <<std::endl;
-  CPPUNIT_ASSERT(dep2Interval == finder.findIntervalFor(depRecordKey, sync_3)); 
-  
+  CPPUNIT_ASSERT(dep2Interval == finder.findIntervalFor(depRecordKey, sync_3));
+
   dummyFinder->setInterval(edm::ValidityInterval::invalidInterval());
   depFinder->setInterval(edm::ValidityInterval::invalidInterval());
-  CPPUNIT_ASSERT(edm::ValidityInterval::invalidInterval() == finder.findIntervalFor(depRecordKey, 
-                                                                                    edm::IOVSyncValue(edm::EventID(1, 1, 5))));
-  
+  CPPUNIT_ASSERT(edm::ValidityInterval::invalidInterval() ==
+                 finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 5))));
+
   const edm::EventID eID_6(1, 1, 6);
   const edm::IOVSyncValue sync_6(eID_6);
-  const edm::ValidityInterval unknownedEndInterval(sync_6 ,
-                                                   edm::IOVSyncValue::invalidIOVSyncValue());
+  const edm::ValidityInterval unknownedEndInterval(sync_6, edm::IOVSyncValue::invalidIOVSyncValue());
   dummyFinder->setInterval(unknownedEndInterval);
-  
+
   const edm::EventID eID_7(1, 1, 7);
   const edm::IOVSyncValue sync_7(eID_7);
-  const edm::ValidityInterval iov6_7(sync_6,sync_7);
+  const edm::ValidityInterval iov6_7(sync_6, sync_7);
   depFinder->setInterval(iov6_7);
-  
+
   CPPUNIT_ASSERT(unknownedEndInterval == finder.findIntervalFor(depRecordKey, sync_6));
-  
+
   //see if dependent record can override the finder
   dummyFinder->setInterval(depInterval);
   depFinder->setInterval(definedInterval);
-  CPPUNIT_ASSERT(depInterval == finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 1)))); 
+  CPPUNIT_ASSERT(depInterval == finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 1))));
 
   dummyFinder->setInterval(dep2Interval);
-  CPPUNIT_ASSERT(dep2Interval == finder.findIntervalFor(depRecordKey, sync_3)); 
+  CPPUNIT_ASSERT(dep2Interval == finder.findIntervalFor(depRecordKey, sync_3));
 }
 
-void testdependentrecord::invalidRecordTest()
-{
-   auto dummyProvider1 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
+void testdependentrecord::invalidRecordTest() {
+  auto dummyProvider1 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
 
-   const edm::ValidityInterval invalid( edm::IOVSyncValue::invalidIOVSyncValue(),
-					edm::IOVSyncValue::invalidIOVSyncValue());
+  const edm::ValidityInterval invalid(edm::IOVSyncValue::invalidIOVSyncValue(),
+                                      edm::IOVSyncValue::invalidIOVSyncValue());
 
-   dummyProvider1->setValidityInterval(invalid);
-   
-   auto dummyProvider2 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
-   dummyProvider2->setValidityInterval(invalid);
+  dummyProvider1->setValidityInterval(invalid);
 
-   const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
-   DependentRecordIntervalFinder finder(depRecordKey);
-   finder.addProviderWeAreDependentOn(dummyProvider1);
-   finder.addProviderWeAreDependentOn(dummyProvider2);
+  auto dummyProvider2 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass());
+  dummyProvider2->setValidityInterval(invalid);
 
-   CPPUNIT_ASSERT(invalid == finder.findIntervalFor(depRecordKey, 
-						    edm::IOVSyncValue(edm::EventID(1, 1, 2))));
+  const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
+  DependentRecordIntervalFinder finder(depRecordKey);
+  finder.addProviderWeAreDependentOn(dummyProvider1);
+  finder.addProviderWeAreDependentOn(dummyProvider2);
 
+  CPPUNIT_ASSERT(invalid == finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 2))));
 
-   const edm::EventID eID_1(1, 1, 5);
-   const edm::IOVSyncValue sync_1(eID_1);
-   const edm::ValidityInterval definedInterval1(sync_1, 
-                                                 edm::IOVSyncValue(edm::EventID(1, 1, 10))); 
-   const edm::EventID eID_2(1, 1, 2);
-   const edm::IOVSyncValue sync_2(eID_2);
-   const edm::ValidityInterval definedInterval2(sync_2, 
-                                                 edm::IOVSyncValue(edm::EventID(1, 1, 6)));
-   dummyProvider2->setValidityInterval(definedInterval2);
- 
-   const edm::ValidityInterval openEnded1(definedInterval2.first(),
-					       edm::IOVSyncValue::invalidIOVSyncValue());
-  
-                                                     
-   
-   CPPUNIT_ASSERT(openEnded1 == finder.findIntervalFor(depRecordKey, 
-						       edm::IOVSyncValue(edm::EventID(1, 1, 4))));
+  const edm::EventID eID_1(1, 1, 5);
+  const edm::IOVSyncValue sync_1(eID_1);
+  const edm::ValidityInterval definedInterval1(sync_1, edm::IOVSyncValue(edm::EventID(1, 1, 10)));
+  const edm::EventID eID_2(1, 1, 2);
+  const edm::IOVSyncValue sync_2(eID_2);
+  const edm::ValidityInterval definedInterval2(sync_2, edm::IOVSyncValue(edm::EventID(1, 1, 6)));
+  dummyProvider2->setValidityInterval(definedInterval2);
 
+  const edm::ValidityInterval openEnded1(definedInterval2.first(), edm::IOVSyncValue::invalidIOVSyncValue());
 
-   dummyProvider1->setValidityInterval(definedInterval1);
+  CPPUNIT_ASSERT(openEnded1 == finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 4))));
 
-   const edm::ValidityInterval overlapInterval(std::max(definedInterval1.first(), definedInterval2.first()),
-                                                std::min(definedInterval1.last(), definedInterval2.last()));
+  dummyProvider1->setValidityInterval(definedInterval1);
 
-   CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, 
-							    edm::IOVSyncValue(edm::EventID(1, 1, 5))));
+  const edm::ValidityInterval overlapInterval(std::max(definedInterval1.first(), definedInterval2.first()),
+                                              std::min(definedInterval1.last(), definedInterval2.last()));
 
+  CPPUNIT_ASSERT(overlapInterval == finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 5))));
 
-   dummyProvider2->setValidityInterval(invalid);
-   const edm::ValidityInterval openEnded2(definedInterval1.first(),
-					       edm::IOVSyncValue::invalidIOVSyncValue());
+  dummyProvider2->setValidityInterval(invalid);
+  const edm::ValidityInterval openEnded2(definedInterval1.first(), edm::IOVSyncValue::invalidIOVSyncValue());
 
-   CPPUNIT_ASSERT(openEnded2 == finder.findIntervalFor(depRecordKey, 
-						       edm::IOVSyncValue(edm::EventID(1, 1, 7))));
+  CPPUNIT_ASSERT(openEnded2 == finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 7))));
 }
 
-void testdependentrecord::extendIOVTest()
-{
-   edm::eventsetup::EventSetupProvider provider(&activityRegistry);
-   std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
-   provider.add(dummyProv);
-   
-   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
-   
-   edm::IOVSyncValue startSyncValue{edm::EventID{1, 1, 1}};
-   dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, 
-                                                  edm::IOVSyncValue{edm::EventID{1, 1, 5}}});
-   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>{dummyFinder});
-   
-   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
-   provider.add(depProv);
-   
-   std::shared_ptr<Dummy2RecordFinder> dummy2Finder = std::make_shared<Dummy2RecordFinder>();
-   dummy2Finder->setInterval(edm::ValidityInterval{startSyncValue, 
-                                                   edm::IOVSyncValue{edm::EventID{1, 1, 6}}});
-   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
-   {
-      const auto&  eventSetup1 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
-      unsigned long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
-      CPPUNIT_ASSERT(id1 == eventSetup1.get<DummyRecord>().cacheIdentifier());
-      CPPUNIT_ASSERT(id1 == eventSetup1.get<Dummy2Record>().cacheIdentifier());
-      
-      {
-         const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 5), edm::Timestamp(2)));
-         unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
-         CPPUNIT_ASSERT(id1 == id);
-         CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
-         CPPUNIT_ASSERT(id1 == eventSetup.get<Dummy2Record>().cacheIdentifier());
-      }
-      //extend the IOV DummyRecord while Dummy2Record still covers this range
-      dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, 
-                                                     edm::IOVSyncValue{edm::EventID{1, 1, 7}}});
-      {
-         const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 6), edm::Timestamp(7)));
-         unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
-         CPPUNIT_ASSERT(id1 == id);
-         CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
-         CPPUNIT_ASSERT(id1 == eventSetup.get<Dummy2Record>().cacheIdentifier());
-      }
-      
-      //extend the IOV Dummy2Record while DummyRecord still covers this range
-      dummy2Finder->setInterval(edm::ValidityInterval{startSyncValue, 
-         edm::IOVSyncValue{edm::EventID{1, 1, 7}}});
+void testdependentrecord::extendIOVTest() {
+  edm::eventsetup::EventSetupProvider provider(&activityRegistry);
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+  provider.add(dummyProv);
 
-      {
-         const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(7)));
-         unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
-         CPPUNIT_ASSERT(id1 == id);
-         CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
-         CPPUNIT_ASSERT(id1 == eventSetup.get<Dummy2Record>().cacheIdentifier());
-      }
-      //extend the both IOVs
-      dummy2Finder->setInterval(edm::ValidityInterval{startSyncValue, 
-                                                      edm::IOVSyncValue{edm::EventID{1, 1, 8}}});
-      
-      dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, 
-         edm::IOVSyncValue{edm::EventID{1, 1, 8}}});
-      {
-         const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 8), edm::Timestamp(7)));
-         unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
-         CPPUNIT_ASSERT(id1 == id);
-         CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
-         CPPUNIT_ASSERT(id1 == eventSetup.get<Dummy2Record>().cacheIdentifier());
-      }
-      //extend only one and create a new IOV for the other
-      dummy2Finder->setInterval(edm::ValidityInterval{startSyncValue, 
-                                                      edm::IOVSyncValue{edm::EventID{1, 1, 9}}});
-      
-      dummyFinder->setInterval(edm::ValidityInterval{edm::IOVSyncValue{edm::EventID{1, 1, 9}}, 
-                                                     edm::IOVSyncValue{edm::EventID{1, 1, 9}}});
-      {
-         const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 9), edm::Timestamp(7)));
-         unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
-         CPPUNIT_ASSERT(id1+1 == id);
-         CPPUNIT_ASSERT(id1+1 == eventSetup.get<DummyRecord>().cacheIdentifier());
-         CPPUNIT_ASSERT(id1 == eventSetup.get<Dummy2Record>().cacheIdentifier());
-      }
-      //extend the otherone and create a new IOV for the other
-      dummy2Finder->setInterval(edm::ValidityInterval{edm::IOVSyncValue{edm::EventID{1, 1, 10}}, 
-                                                      edm::IOVSyncValue{edm::EventID{1, 1, 10}} });
-      
-      dummyFinder->setInterval(edm::ValidityInterval{edm::IOVSyncValue{edm::EventID{1, 1, 9}}, 
-                                                     edm::IOVSyncValue{edm::EventID{1, 1, 10}} });
-      
-      {
-         const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 10), edm::Timestamp(7)));
-         unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
-         CPPUNIT_ASSERT(id1+2 == id);
-         CPPUNIT_ASSERT(id1+1 == eventSetup.get<DummyRecord>().cacheIdentifier());
-         CPPUNIT_ASSERT(id1+1 == eventSetup.get<Dummy2Record>().cacheIdentifier());
-      }
-      
-   }
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
 
+  edm::IOVSyncValue startSyncValue{edm::EventID{1, 1, 1}};
+  dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, edm::IOVSyncValue{edm::EventID{1, 1, 5}}});
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>{dummyFinder});
+
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
+  provider.add(depProv);
+
+  std::shared_ptr<Dummy2RecordFinder> dummy2Finder = std::make_shared<Dummy2RecordFinder>();
+  dummy2Finder->setInterval(edm::ValidityInterval{startSyncValue, edm::IOVSyncValue{edm::EventID{1, 1, 6}}});
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
+  {
+    const auto& eventSetup1 =
+        provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
+    unsigned long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
+    CPPUNIT_ASSERT(id1 == eventSetup1.get<DummyRecord>().cacheIdentifier());
+    CPPUNIT_ASSERT(id1 == eventSetup1.get<Dummy2Record>().cacheIdentifier());
+
+    {
+      const auto& eventSetup =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 5), edm::Timestamp(2)));
+      unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id1 == id);
+      CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
+      CPPUNIT_ASSERT(id1 == eventSetup.get<Dummy2Record>().cacheIdentifier());
+    }
+    //extend the IOV DummyRecord while Dummy2Record still covers this range
+    dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, edm::IOVSyncValue{edm::EventID{1, 1, 7}}});
+    {
+      const auto& eventSetup =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 6), edm::Timestamp(7)));
+      unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id1 == id);
+      CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
+      CPPUNIT_ASSERT(id1 == eventSetup.get<Dummy2Record>().cacheIdentifier());
+    }
+
+    //extend the IOV Dummy2Record while DummyRecord still covers this range
+    dummy2Finder->setInterval(edm::ValidityInterval{startSyncValue, edm::IOVSyncValue{edm::EventID{1, 1, 7}}});
+
+    {
+      const auto& eventSetup =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(7)));
+      unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id1 == id);
+      CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
+      CPPUNIT_ASSERT(id1 == eventSetup.get<Dummy2Record>().cacheIdentifier());
+    }
+    //extend the both IOVs
+    dummy2Finder->setInterval(edm::ValidityInterval{startSyncValue, edm::IOVSyncValue{edm::EventID{1, 1, 8}}});
+
+    dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, edm::IOVSyncValue{edm::EventID{1, 1, 8}}});
+    {
+      const auto& eventSetup =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 8), edm::Timestamp(7)));
+      unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id1 == id);
+      CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
+      CPPUNIT_ASSERT(id1 == eventSetup.get<Dummy2Record>().cacheIdentifier());
+    }
+    //extend only one and create a new IOV for the other
+    dummy2Finder->setInterval(edm::ValidityInterval{startSyncValue, edm::IOVSyncValue{edm::EventID{1, 1, 9}}});
+
+    dummyFinder->setInterval(
+        edm::ValidityInterval{edm::IOVSyncValue{edm::EventID{1, 1, 9}}, edm::IOVSyncValue{edm::EventID{1, 1, 9}}});
+    {
+      const auto& eventSetup =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 9), edm::Timestamp(7)));
+      unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id1 + 1 == id);
+      CPPUNIT_ASSERT(id1 + 1 == eventSetup.get<DummyRecord>().cacheIdentifier());
+      CPPUNIT_ASSERT(id1 == eventSetup.get<Dummy2Record>().cacheIdentifier());
+    }
+    //extend the otherone and create a new IOV for the other
+    dummy2Finder->setInterval(
+        edm::ValidityInterval{edm::IOVSyncValue{edm::EventID{1, 1, 10}}, edm::IOVSyncValue{edm::EventID{1, 1, 10}}});
+
+    dummyFinder->setInterval(
+        edm::ValidityInterval{edm::IOVSyncValue{edm::EventID{1, 1, 9}}, edm::IOVSyncValue{edm::EventID{1, 1, 10}}});
+
+    {
+      const auto& eventSetup =
+          provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 10), edm::Timestamp(7)));
+      unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
+      CPPUNIT_ASSERT(id1 + 2 == id);
+      CPPUNIT_ASSERT(id1 + 1 == eventSetup.get<DummyRecord>().cacheIdentifier());
+      CPPUNIT_ASSERT(id1 + 1 == eventSetup.get<Dummy2Record>().cacheIdentifier());
+    }
+  }
 }

--- a/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
+++ b/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Package
 // Class  :     edconsumerbase_t
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -31,7 +31,6 @@
 
 #include "DataFormats/Common/interface/View.h"
 
-
 class TestEDConsumerBase : public CppUnit::TestFixture {
 public:
   CPPUNIT_TEST_SUITE(TestEDConsumerBase);
@@ -42,110 +41,101 @@ public:
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  
   void setUp();
-  void tearDown() { }
+  void tearDown() {}
 
   void testRegularType();
   void testViewType();
   void testMany();
   void testMay();
-
 };
 
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(TestEDConsumerBase);
 
-void TestEDConsumerBase::setUp() {
-}
+void TestEDConsumerBase::setUp() {}
 
 namespace {
   class IntsConsumer : public edm::EDConsumerBase {
-    public:
+  public:
     IntsConsumer(std::vector<edm::InputTag> const& iTags) {
       m_tokens.reserve(iTags.size());
-      for(auto const& tag : iTags) {
+      for (auto const& tag : iTags) {
         m_tokens.push_back(consumes<std::vector<int>>(tag));
       }
     }
-    
+
     std::vector<edm::EDGetTokenT<std::vector<int>>> m_tokens;
   };
 
   class IntsMayConsumer : public edm::EDConsumerBase {
   public:
-    IntsMayConsumer(std::vector<edm::InputTag> const& iTags,
-                    std::vector<edm::InputTag> const& iMayTags) {
+    IntsMayConsumer(std::vector<edm::InputTag> const& iTags, std::vector<edm::InputTag> const& iMayTags) {
       m_tokens.reserve(iTags.size());
       m_mayTokens.reserve(iMayTags.size());
-      for(auto const& tag : iTags) {
+      for (auto const& tag : iTags) {
         m_tokens.push_back(consumes<std::vector<int>>(tag));
       }
-      for(auto const& tag : iMayTags) {
+      for (auto const& tag : iMayTags) {
         m_mayTokens.push_back(mayConsume<std::vector<int>>(tag));
       }
     }
-    
+
     std::vector<edm::EDGetTokenT<std::vector<int>>> m_tokens;
     std::vector<edm::EDGetTokenT<std::vector<int>>> m_mayTokens;
   };
 
-  
-  
   class TypeToGetConsumer : public edm::EDConsumerBase {
   public:
-    TypeToGetConsumer(std::vector<std::pair<edm::TypeToGet,edm::InputTag>> const& iTags) {
+    TypeToGetConsumer(std::vector<std::pair<edm::TypeToGet, edm::InputTag>> const& iTags) {
       m_tokens.reserve(iTags.size());
-      for(auto const& typeTag : iTags) {
-        m_tokens.push_back(consumes(typeTag.first,typeTag.second));
+      for (auto const& typeTag : iTags) {
+        m_tokens.push_back(consumes(typeTag.first, typeTag.second));
       }
     }
-    
-    std::vector<edm::EDGetToken> m_tokens;  
+
+    std::vector<edm::EDGetToken> m_tokens;
   };
-  
+
   class IntsConsumesCollectorConsumer : public edm::EDConsumerBase {
   public:
     IntsConsumesCollectorConsumer(std::vector<edm::InputTag> const& iTags) {
       m_tokens.reserve(iTags.size());
-      edm::ConsumesCollector c{ consumesCollector() };
-      for(auto const& tag : iTags) {
+      edm::ConsumesCollector c{consumesCollector()};
+      for (auto const& tag : iTags) {
         m_tokens.push_back(c.consumes<std::vector<int>>(tag));
       }
     }
-    
+
     std::vector<edm::EDGetTokenT<std::vector<int>>> m_tokens;
   };
 
-}
+}  // namespace
 
-void
-TestEDConsumerBase::testRegularType()
-{
-  
+void TestEDConsumerBase::testRegularType() {
   edm::ProductResolverIndexHelper helper;
-  
+
   edm::TypeID typeIDProductID(typeid(edm::ProductID));
   edm::TypeID typeIDEventID(typeid(edm::EventID));
   edm::TypeID typeIDVectorInt(typeid(std::vector<int>));
   edm::TypeID typeIDSetInt(typeid(std::set<int>));
   edm::TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
-  
-  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
-  helper.insert(typeIDVectorInt, "label",  "instance",  "process");  // 3, 4, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");   // 6, 7
-  helper.insert(typeIDEventID, "label",  "instanceB", "processB");   // 8, 9
-  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");   // 10, 11
-  helper.insert(typeIDEventID, "labelB", "instance",  "processB");   // 12, 13
-  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");   // 14, 15
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");  // 16, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");  // 17, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");  // 18, 5
-  helper.insert(typeIDProductID, "label",  "instance",  "process");  // 19, 20
-  helper.insert(typeIDEventID, "label",  "instance",  "process");    // 21, 22
-  helper.insert(typeIDProductID, "labelA", "instanceA", "processA"); // 23, 24
-  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC"); // 25, 26
-  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
+
+  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC");       // 0, 1, 2
+  helper.insert(typeIDVectorInt, "label", "instance", "process");          // 3, 4, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");         // 6, 7
+  helper.insert(typeIDEventID, "label", "instanceB", "processB");          // 8, 9
+  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");         // 10, 11
+  helper.insert(typeIDEventID, "labelB", "instance", "processB");          // 12, 13
+  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");         // 14, 15
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");        // 16, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");        // 17, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");        // 18, 5
+  helper.insert(typeIDProductID, "label", "instance", "process");          // 19, 20
+  helper.insert(typeIDEventID, "label", "instance", "process");            // 21, 22
+  helper.insert(typeIDProductID, "labelA", "instanceA", "processA");       // 23, 24
+  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC");          // 25, 26
+  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC");  // 27, 28, 29, 30
 
   helper.setFrozen();
 
@@ -153,184 +143,200 @@ TestEDConsumerBase::testRegularType()
   const auto vint_c = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", "processC");
   const auto vint_c_no_proc = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", 0);
   const auto vint_blank = helper.index(edm::PRODUCT_TYPE, typeID_vint, "label", "instance", "process");
-  const auto vint_blank_no_proc = helper.index(edm::PRODUCT_TYPE, typeID_vint, "label", "instance",0);
+  const auto vint_blank_no_proc = helper.index(edm::PRODUCT_TYPE, typeID_vint, "label", "instance", 0);
   {
-    std::vector<edm::InputTag> vTags={ {"label","instance","process"}, {"labelC","instanceC","processC"} };
+    std::vector<edm::InputTag> vTags = {{"label", "instance", "process"}, {"labelC", "instanceC", "processC"}};
     IntsConsumer intConsumer{vTags};
-    intConsumer.updateLookup(edm::InEvent,helper,false);
-  
-    CPPUNIT_ASSERT(intConsumer.m_tokens[0].index()==0);
-    CPPUNIT_ASSERT(intConsumer.m_tokens[1].index()==1);
+    intConsumer.updateLookup(edm::InEvent, helper, false);
 
-    CPPUNIT_ASSERT(vint_c == intConsumer.indexFrom(intConsumer.m_tokens[1],edm::InEvent,typeID_vint).productResolverIndex());
-    CPPUNIT_ASSERT(vint_blank == intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint).productResolverIndex());
-    
+    CPPUNIT_ASSERT(intConsumer.m_tokens[0].index() == 0);
+    CPPUNIT_ASSERT(intConsumer.m_tokens[1].index() == 1);
+
+    CPPUNIT_ASSERT(vint_c ==
+                   intConsumer.indexFrom(intConsumer.m_tokens[1], edm::InEvent, typeID_vint).productResolverIndex());
+    CPPUNIT_ASSERT(vint_blank ==
+                   intConsumer.indexFrom(intConsumer.m_tokens[0], edm::InEvent, typeID_vint).productResolverIndex());
+
     std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-    intConsumer.itemsToGet(edm::InEvent,indices);
-    
+    intConsumer.itemsToGet(edm::InEvent, indices);
+
     CPPUNIT_ASSERT(2 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
+    CPPUNIT_ASSERT(indices.end() !=
+                   std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
+    CPPUNIT_ASSERT(indices.end() !=
+                   std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
 
     std::vector<edm::ProductResolverIndexAndSkipBit> indicesMay;
-    intConsumer.itemsMayGet(edm::InEvent,indicesMay);
+    intConsumer.itemsMayGet(edm::InEvent, indicesMay);
     CPPUNIT_ASSERT(0 == indicesMay.size());
-
   }
   {
-    std::vector<edm::InputTag> vTags={ {"label","instance","process"}, {"labelC","instanceC","processC"} };
+    std::vector<edm::InputTag> vTags = {{"label", "instance", "process"}, {"labelC", "instanceC", "processC"}};
     IntsConsumesCollectorConsumer intConsumer{vTags};
-    intConsumer.updateLookup(edm::InEvent,helper,false);
-    
-    CPPUNIT_ASSERT(intConsumer.m_tokens[0].index()==0);
-    CPPUNIT_ASSERT(intConsumer.m_tokens[1].index()==1);
+    intConsumer.updateLookup(edm::InEvent, helper, false);
 
-    CPPUNIT_ASSERT(vint_c == intConsumer.indexFrom(intConsumer.m_tokens[1],edm::InEvent,typeID_vint).productResolverIndex());
-    CPPUNIT_ASSERT(vint_blank == intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint).productResolverIndex());
-    
+    CPPUNIT_ASSERT(intConsumer.m_tokens[0].index() == 0);
+    CPPUNIT_ASSERT(intConsumer.m_tokens[1].index() == 1);
+
+    CPPUNIT_ASSERT(vint_c ==
+                   intConsumer.indexFrom(intConsumer.m_tokens[1], edm::InEvent, typeID_vint).productResolverIndex());
+    CPPUNIT_ASSERT(vint_blank ==
+                   intConsumer.indexFrom(intConsumer.m_tokens[0], edm::InEvent, typeID_vint).productResolverIndex());
+
     std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-    intConsumer.itemsToGet(edm::InEvent,indices);
-    
+    intConsumer.itemsToGet(edm::InEvent, indices);
+
     CPPUNIT_ASSERT(2 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
-    
+    CPPUNIT_ASSERT(indices.end() !=
+                   std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
+    CPPUNIT_ASSERT(indices.end() !=
+                   std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
+
     std::vector<edm::ProductResolverIndexAndSkipBit> indicesMay;
-    intConsumer.itemsMayGet(edm::InEvent,indicesMay);
+    intConsumer.itemsMayGet(edm::InEvent, indicesMay);
     CPPUNIT_ASSERT(0 == indicesMay.size());
-    
   }
   {
-    std::vector<edm::InputTag> vTagsRev={ {"labelC","instanceC","processC"},{"label","instance","process"} };
+    std::vector<edm::InputTag> vTagsRev = {{"labelC", "instanceC", "processC"}, {"label", "instance", "process"}};
     IntsConsumer intConsumerRev{vTagsRev};
-    intConsumerRev.updateLookup(edm::InEvent,helper,false);
+    intConsumerRev.updateLookup(edm::InEvent, helper, false);
 
-    CPPUNIT_ASSERT(intConsumerRev.m_tokens[0].index()==0);
-    CPPUNIT_ASSERT(intConsumerRev.m_tokens[1].index()==1);
+    CPPUNIT_ASSERT(intConsumerRev.m_tokens[0].index() == 0);
+    CPPUNIT_ASSERT(intConsumerRev.m_tokens[1].index() == 1);
 
-    CPPUNIT_ASSERT(vint_c == intConsumerRev.indexFrom(intConsumerRev.m_tokens[0],edm::InEvent,typeID_vint).productResolverIndex());
-    CPPUNIT_ASSERT(vint_blank == intConsumerRev.indexFrom(intConsumerRev.m_tokens[1],edm::InEvent,typeID_vint).productResolverIndex());
+    CPPUNIT_ASSERT(
+        vint_c ==
+        intConsumerRev.indexFrom(intConsumerRev.m_tokens[0], edm::InEvent, typeID_vint).productResolverIndex());
+    CPPUNIT_ASSERT(
+        vint_blank ==
+        intConsumerRev.indexFrom(intConsumerRev.m_tokens[1], edm::InEvent, typeID_vint).productResolverIndex());
 
     std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-    intConsumerRev.itemsToGet(edm::InEvent,indices);
-    
+    intConsumerRev.itemsToGet(edm::InEvent, indices);
+
     CPPUNIT_ASSERT(2 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
-    
+    CPPUNIT_ASSERT(indices.end() !=
+                   std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
+    CPPUNIT_ASSERT(indices.end() !=
+                   std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
+
     std::vector<edm::ProductResolverIndexAndSkipBit> indicesMay;
-    intConsumerRev.itemsMayGet(edm::InEvent,indicesMay);
+    intConsumerRev.itemsMayGet(edm::InEvent, indicesMay);
     CPPUNIT_ASSERT(0 == indicesMay.size());
   }
   {
-    std::vector<edm::InputTag> vTagsRev={ {"labelC","instanceC","processC"},{"label","instance","process"} };
+    std::vector<edm::InputTag> vTagsRev = {{"labelC", "instanceC", "processC"}, {"label", "instance", "process"}};
     IntsConsumesCollectorConsumer intConsumerRev{vTagsRev};
-    intConsumerRev.updateLookup(edm::InEvent,helper,false);
-    
-    CPPUNIT_ASSERT(intConsumerRev.m_tokens[0].index()==0);
-    CPPUNIT_ASSERT(intConsumerRev.m_tokens[1].index()==1);
+    intConsumerRev.updateLookup(edm::InEvent, helper, false);
+
+    CPPUNIT_ASSERT(intConsumerRev.m_tokens[0].index() == 0);
+    CPPUNIT_ASSERT(intConsumerRev.m_tokens[1].index() == 1);
 
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_c, false) ==
-                   intConsumerRev.indexFrom(intConsumerRev.m_tokens[0],edm::InEvent,typeID_vint));
+                   intConsumerRev.indexFrom(intConsumerRev.m_tokens[0], edm::InEvent, typeID_vint));
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_blank, false) ==
-                   intConsumerRev.indexFrom(intConsumerRev.m_tokens[1],edm::InEvent,typeID_vint));
-    
+                   intConsumerRev.indexFrom(intConsumerRev.m_tokens[1], edm::InEvent, typeID_vint));
+
     std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-    intConsumerRev.itemsToGet(edm::InEvent,indices);
-    
+    intConsumerRev.itemsToGet(edm::InEvent, indices);
+
     CPPUNIT_ASSERT(2 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
-    
+    CPPUNIT_ASSERT(indices.end() !=
+                   std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
+    CPPUNIT_ASSERT(indices.end() !=
+                   std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
+
     std::vector<edm::ProductResolverIndexAndSkipBit> indicesMay;
-    intConsumerRev.itemsMayGet(edm::InEvent,indicesMay);
+    intConsumerRev.itemsMayGet(edm::InEvent, indicesMay);
     CPPUNIT_ASSERT(0 == indicesMay.size());
   }
   {
     //test default process
-    std::vector<edm::InputTag> vTags={ {"label","instance"}, {"labelC","instanceC","@skipCurrentProcess"} };
+    std::vector<edm::InputTag> vTags = {{"label", "instance"}, {"labelC", "instanceC", "@skipCurrentProcess"}};
     IntsConsumer intConsumer{vTags};
-    intConsumer.updateLookup(edm::InEvent,helper,false);
-    
-    CPPUNIT_ASSERT(intConsumer.m_tokens[0].index()==0);
-    CPPUNIT_ASSERT(intConsumer.m_tokens[1].index()==1);
+    intConsumer.updateLookup(edm::InEvent, helper, false);
+
+    CPPUNIT_ASSERT(intConsumer.m_tokens[0].index() == 0);
+    CPPUNIT_ASSERT(intConsumer.m_tokens[1].index() == 1);
 
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_c_no_proc, true) ==
-                   intConsumer.indexFrom(intConsumer.m_tokens[1],edm::InEvent,typeID_vint));
+                   intConsumer.indexFrom(intConsumer.m_tokens[1], edm::InEvent, typeID_vint));
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_blank_no_proc, false) ==
-                   intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint));
+                   intConsumer.indexFrom(intConsumer.m_tokens[0], edm::InEvent, typeID_vint));
 
     std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-    intConsumer.itemsToGet(edm::InEvent,indices);
-    
+    intConsumer.itemsToGet(edm::InEvent, indices);
+
     CPPUNIT_ASSERT(2 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(vint_c_no_proc, true)));
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(vint_blank_no_proc, false)));
-    
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(), indices.end(),
+                                              edm::ProductResolverIndexAndSkipBit(vint_c_no_proc, true)));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(), indices.end(),
+                                              edm::ProductResolverIndexAndSkipBit(vint_blank_no_proc, false)));
+
     std::vector<edm::ProductResolverIndexAndSkipBit> indicesMay;
-    intConsumer.itemsMayGet(edm::InEvent,indicesMay);
+    intConsumer.itemsMayGet(edm::InEvent, indicesMay);
     CPPUNIT_ASSERT(0 == indicesMay.size());
   }
   {
     //Ask for something that doesn't exist
-    std::vector<edm::InputTag> vTags={ {"notHere"} };
+    std::vector<edm::InputTag> vTags = {{"notHere"}};
     IntsConsumer intConsumer{vTags};
-    intConsumer.updateLookup(edm::InEvent,helper,false);
-    
-    CPPUNIT_ASSERT(intConsumer.m_tokens[0].index()==0);
-    CPPUNIT_ASSERT(edm::ProductResolverIndexInvalid == intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint).productResolverIndex());
+    intConsumer.updateLookup(edm::InEvent, helper, false);
+
+    CPPUNIT_ASSERT(intConsumer.m_tokens[0].index() == 0);
+    CPPUNIT_ASSERT(edm::ProductResolverIndexInvalid ==
+                   intConsumer.indexFrom(intConsumer.m_tokens[0], edm::InEvent, typeID_vint).productResolverIndex());
 
     std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-    intConsumer.itemsToGet(edm::InEvent,indices);
+    intConsumer.itemsToGet(edm::InEvent, indices);
     //nothing to get since not here
     CPPUNIT_ASSERT(0 == indices.size());
   }
 
   {
     //Use an empty tag
-    std::vector<edm::InputTag> vTags={ {} };
+    std::vector<edm::InputTag> vTags = {{}};
     IntsConsumer intConsumer{vTags};
-    intConsumer.updateLookup(edm::InEvent,helper,false);
-    
-    CPPUNIT_ASSERT(intConsumer.m_tokens[0].index()==0);
-    CPPUNIT_ASSERT(edm::ProductResolverIndexInvalid == intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint).productResolverIndex());
-    
+    intConsumer.updateLookup(edm::InEvent, helper, false);
+
+    CPPUNIT_ASSERT(intConsumer.m_tokens[0].index() == 0);
+    CPPUNIT_ASSERT(edm::ProductResolverIndexInvalid ==
+                   intConsumer.indexFrom(intConsumer.m_tokens[0], edm::InEvent, typeID_vint).productResolverIndex());
+
     std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-    intConsumer.itemsToGet(edm::InEvent,indices);
+    intConsumer.itemsToGet(edm::InEvent, indices);
     //nothing to get since not here
     CPPUNIT_ASSERT(0 == indices.size());
   }
 }
 
-void
-TestEDConsumerBase::testViewType()
-{
+void TestEDConsumerBase::testViewType() {
   edm::ProductResolverIndexHelper helper;
-  
+
   edm::TypeID typeIDProductID(typeid(edm::ProductID));
   edm::TypeID typeIDEventID(typeid(edm::EventID));
   edm::TypeID typeIDVectorInt(typeid(std::vector<int>));
   edm::TypeID typeIDSetInt(typeid(std::set<int>));
   edm::TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
-  
-  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
-  helper.insert(typeIDVectorInt, "label",  "instance",  "process");  // 3, 4, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");   // 6, 7
-  helper.insert(typeIDEventID, "label",  "instanceB", "processB");   // 8, 9
-  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");   // 10, 11
-  helper.insert(typeIDEventID, "labelB", "instance",  "processB");   // 12, 13
-  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");   // 14, 15
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");  // 16, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");  // 17, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");  // 18, 5
-  helper.insert(typeIDProductID, "label",  "instance",  "process");  // 19, 20
-  helper.insert(typeIDEventID, "label",  "instance",  "process");    // 21, 22
-  helper.insert(typeIDProductID, "labelA", "instanceA", "processA"); // 23, 24
-  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC"); // 25, 26
-  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
-  
+
+  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC");       // 0, 1, 2
+  helper.insert(typeIDVectorInt, "label", "instance", "process");          // 3, 4, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");         // 6, 7
+  helper.insert(typeIDEventID, "label", "instanceB", "processB");          // 8, 9
+  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");         // 10, 11
+  helper.insert(typeIDEventID, "labelB", "instance", "processB");          // 12, 13
+  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");         // 14, 15
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");        // 16, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");        // 17, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");        // 18, 5
+  helper.insert(typeIDProductID, "label", "instance", "process");          // 19, 20
+  helper.insert(typeIDEventID, "label", "instance", "process");            // 21, 22
+  helper.insert(typeIDProductID, "labelA", "instanceA", "processA");       // 23, 24
+  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC");          // 25, 26
+  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC");  // 27, 28, 29, 30
+
   helper.setFrozen();
-  
+
   edm::TypeID typeID_int(typeid(int));
   edm::TypeID typeID_Simple(typeid(edmtest::Simple));
 
@@ -341,73 +347,75 @@ TestEDConsumerBase::testViewType()
   const auto v_simple_no_proc = helper.index(edm::ELEMENT_TYPE, typeID_Simple, "labelC", "instanceC");
 
   {
-    std::vector<std::pair<edm::TypeToGet,edm::InputTag>> vT = {
-      {edm::TypeToGet::make<edm::View<int>>(),{"label",  "instance",  "process"}},
-      {edm::TypeToGet::make<edm::View<edmtest::Simple>>(),{"labelC", "instanceC", "processC"}}
-    };
+    std::vector<std::pair<edm::TypeToGet, edm::InputTag>> vT = {
+        {edm::TypeToGet::make<edm::View<int>>(), {"label", "instance", "process"}},
+        {edm::TypeToGet::make<edm::View<edmtest::Simple>>(), {"labelC", "instanceC", "processC"}}};
     TypeToGetConsumer consumer{vT};
-    
-    consumer.updateLookup(edm::InEvent,helper,false);
+
+    consumer.updateLookup(edm::InEvent, helper, false);
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(v_int, false) ==
-                   consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_int));
+                   consumer.indexFrom(consumer.m_tokens[0], edm::InEvent, typeID_int));
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(v_simple, false) ==
-                   consumer.indexFrom(consumer.m_tokens[1],edm::InEvent,typeID_Simple));
+                   consumer.indexFrom(consumer.m_tokens[1], edm::InEvent, typeID_Simple));
 
     {
       std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-      consumer.itemsToGet(edm::InEvent,indices);
-    
+      consumer.itemsToGet(edm::InEvent, indices);
+
       CPPUNIT_ASSERT(2 == indices.size());
-      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(v_int, false)));
-      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(v_simple, false)));
+      CPPUNIT_ASSERT(indices.end() !=
+                     std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(v_int, false)));
+      CPPUNIT_ASSERT(indices.end() !=
+                     std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(v_simple, false)));
 
       std::vector<edm::ProductResolverIndexAndSkipBit> indicesMay;
-      consumer.itemsMayGet(edm::InEvent,indicesMay);
+      consumer.itemsMayGet(edm::InEvent, indicesMay);
       CPPUNIT_ASSERT(0 == indicesMay.size());
     }
   }
 
   {
-    std::vector<std::pair<edm::TypeToGet,edm::InputTag>> vT = {
-      {edm::TypeToGet::make<edm::View<int>>(),{"label",  "instance"}},
-      {edm::TypeToGet::make<edm::View<edmtest::Simple>>(),{"labelC", "instanceC","@skipCurrentProcess"}}
-    };
+    std::vector<std::pair<edm::TypeToGet, edm::InputTag>> vT = {
+        {edm::TypeToGet::make<edm::View<int>>(), {"label", "instance"}},
+        {edm::TypeToGet::make<edm::View<edmtest::Simple>>(), {"labelC", "instanceC", "@skipCurrentProcess"}}};
     TypeToGetConsumer consumer{vT};
 
-    consumer.updateLookup(edm::InEvent,helper,false);
+    consumer.updateLookup(edm::InEvent, helper, false);
 
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(v_int_no_proc, false) ==
-                   consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_int));
+                   consumer.indexFrom(consumer.m_tokens[0], edm::InEvent, typeID_int));
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(v_simple_no_proc, true) ==
-                   consumer.indexFrom(consumer.m_tokens[1],edm::InEvent,typeID_Simple));
+                   consumer.indexFrom(consumer.m_tokens[1], edm::InEvent, typeID_Simple));
     {
       std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-      consumer.itemsToGet(edm::InEvent,indices);
-      
+      consumer.itemsToGet(edm::InEvent, indices);
+
       CPPUNIT_ASSERT(2 == indices.size());
-      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(v_int_no_proc, false)));
-      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(v_simple_no_proc, true)));
-      
+      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(), indices.end(),
+                                                edm::ProductResolverIndexAndSkipBit(v_int_no_proc, false)));
+      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(), indices.end(),
+                                                edm::ProductResolverIndexAndSkipBit(v_simple_no_proc, true)));
+
       std::vector<edm::ProductResolverIndexAndSkipBit> indicesMay;
-      consumer.itemsMayGet(edm::InEvent,indicesMay);
+      consumer.itemsMayGet(edm::InEvent, indicesMay);
       CPPUNIT_ASSERT(0 == indicesMay.size());
     }
   }
 
   {
     //Ask for something that doesn't exist
-    std::vector<std::pair<edm::TypeToGet,edm::InputTag>> vT = {
-      {edm::TypeToGet::make<edm::View<int>>(),{"notHere",  ""}}
-    };
+    std::vector<std::pair<edm::TypeToGet, edm::InputTag>> vT = {
+        {edm::TypeToGet::make<edm::View<int>>(), {"notHere", ""}}};
     TypeToGetConsumer consumer{vT};
-    consumer.updateLookup(edm::InEvent,helper,false);
-    
-    CPPUNIT_ASSERT(consumer.m_tokens[0].index()==0);
-    CPPUNIT_ASSERT(edm::ProductResolverIndexInvalid == consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_int).productResolverIndex());
+    consumer.updateLookup(edm::InEvent, helper, false);
+
+    CPPUNIT_ASSERT(consumer.m_tokens[0].index() == 0);
+    CPPUNIT_ASSERT(edm::ProductResolverIndexInvalid ==
+                   consumer.indexFrom(consumer.m_tokens[0], edm::InEvent, typeID_int).productResolverIndex());
     {
       std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-      consumer.itemsToGet(edm::InEvent,indices);
-      
+      consumer.itemsToGet(edm::InEvent, indices);
+
       CPPUNIT_ASSERT(0 == indices.size());
     }
   }
@@ -416,40 +424,35 @@ TestEDConsumerBase::testViewType()
 namespace {
   class ManyEventIDConsumer : public edm::EDConsumerBase {
   public:
-    ManyEventIDConsumer() {
-      consumesMany<edm::EventID>();
-    }
+    ManyEventIDConsumer() { consumesMany<edm::EventID>(); }
   };
-}
+}  // namespace
 
-void
-TestEDConsumerBase::testMany()
-{
-  
+void TestEDConsumerBase::testMany() {
   edm::ProductResolverIndexHelper helper;
-  
+
   edm::TypeID typeIDProductID(typeid(edm::ProductID));
   edm::TypeID typeIDEventID(typeid(edm::EventID));
   edm::TypeID typeIDVectorInt(typeid(std::vector<int>));
   edm::TypeID typeIDSetInt(typeid(std::set<int>));
   edm::TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
-  
-  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
-  helper.insert(typeIDVectorInt, "label",  "instance",  "process");  // 3, 4, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");   // 6, 7
-  helper.insert(typeIDEventID, "label",  "instanceB", "processB");   // 8, 9
-  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");   // 10, 11
-  helper.insert(typeIDEventID, "labelB", "instance",  "processB");   // 12, 13
-  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");   // 14, 15
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");  // 16, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");  // 17, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");  // 18, 5
-  helper.insert(typeIDProductID, "label",  "instance",  "process");  // 19, 20
-  helper.insert(typeIDEventID, "label",  "instance",  "process");    // 21, 22
-  helper.insert(typeIDProductID, "labelA", "instanceA", "processA"); // 23, 24
-  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC"); // 25, 26
-  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
-  
+
+  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC");       // 0, 1, 2
+  helper.insert(typeIDVectorInt, "label", "instance", "process");          // 3, 4, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");         // 6, 7
+  helper.insert(typeIDEventID, "label", "instanceB", "processB");          // 8, 9
+  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");         // 10, 11
+  helper.insert(typeIDEventID, "labelB", "instance", "processB");          // 12, 13
+  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");         // 14, 15
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");        // 16, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");        // 17, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");        // 18, 5
+  helper.insert(typeIDProductID, "label", "instance", "process");          // 19, 20
+  helper.insert(typeIDEventID, "label", "instance", "process");            // 21, 22
+  helper.insert(typeIDProductID, "labelA", "instanceA", "processA");       // 23, 24
+  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC");          // 25, 26
+  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC");  // 27, 28, 29, 30
+
   helper.setFrozen();
 
   edm::TypeID typeID_EventID(typeid(edm::EventID));
@@ -458,141 +461,149 @@ TestEDConsumerBase::testMany()
 
   {
     ManyEventIDConsumer consumer{};
-    consumer.updateLookup(edm::InEvent,helper,false);
+    consumer.updateLookup(edm::InEvent, helper, false);
 
     std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-    consumer.itemsToGet(edm::InEvent,indices);
+    consumer.itemsToGet(edm::InEvent, indices);
 
     CPPUNIT_ASSERT(9 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(productIndex, false)));
+    CPPUNIT_ASSERT(indices.end() !=
+                   std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(productIndex, false)));
   }
 }
 
-void
-TestEDConsumerBase::testMay()
-{
- 
+void TestEDConsumerBase::testMay() {
   edm::ProductResolverIndexHelper helper;
-  
+
   edm::TypeID typeIDProductID(typeid(edm::ProductID));
   edm::TypeID typeIDEventID(typeid(edm::EventID));
   edm::TypeID typeIDVectorInt(typeid(std::vector<int>));
   edm::TypeID typeIDSetInt(typeid(std::set<int>));
   edm::TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
-  
-  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC"); // 0, 1, 2
-  helper.insert(typeIDVectorInt, "label",  "instance",  "process");  // 3, 4, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");   // 6, 7
-  helper.insert(typeIDEventID, "label",  "instanceB", "processB");   // 8, 9
-  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");   // 10, 11
-  helper.insert(typeIDEventID, "labelB", "instance",  "processB");   // 12, 13
-  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");   // 14, 15
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");  // 16, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");  // 17, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");  // 18, 5
-  helper.insert(typeIDProductID, "label",  "instance",  "process");  // 19, 20
-  helper.insert(typeIDEventID, "label",  "instance",  "process");    // 21, 22
-  helper.insert(typeIDProductID, "labelA", "instanceA", "processA"); // 23, 24
-  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC"); // 25, 26
-  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
-  
+
+  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC");       // 0, 1, 2
+  helper.insert(typeIDVectorInt, "label", "instance", "process");          // 3, 4, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");         // 6, 7
+  helper.insert(typeIDEventID, "label", "instanceB", "processB");          // 8, 9
+  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");         // 10, 11
+  helper.insert(typeIDEventID, "labelB", "instance", "processB");          // 12, 13
+  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");         // 14, 15
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");        // 16, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");        // 17, 5
+  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");        // 18, 5
+  helper.insert(typeIDProductID, "label", "instance", "process");          // 19, 20
+  helper.insert(typeIDEventID, "label", "instance", "process");            // 21, 22
+  helper.insert(typeIDProductID, "labelA", "instanceA", "processA");       // 23, 24
+  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC");          // 25, 26
+  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC");  // 27, 28, 29, 30
+
   helper.setFrozen();
   edm::TypeID typeID_vint(typeid(std::vector<int>));
   const auto vint_c = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", "processC");
   const auto vint_c_no_proc = helper.index(edm::PRODUCT_TYPE, typeID_vint, "labelC", "instanceC", 0);
   const auto vint_blank = helper.index(edm::PRODUCT_TYPE, typeID_vint, "label", "instance", "process");
-  const auto vint_blank_no_proc = helper.index(edm::PRODUCT_TYPE, typeID_vint, "label", "instance",0);
+  const auto vint_blank_no_proc = helper.index(edm::PRODUCT_TYPE, typeID_vint, "label", "instance", 0);
   {
-    std::vector<edm::InputTag> vTags={ {"label","instance","process"}, {"labelC","instanceC","processC"} };
+    std::vector<edm::InputTag> vTags = {{"label", "instance", "process"}, {"labelC", "instanceC", "processC"}};
     std::vector<edm::InputTag> vMayTags;
-    IntsMayConsumer consumer{vTags,vMayTags};
-    consumer.updateLookup(edm::InEvent,helper,false);
-    
-    CPPUNIT_ASSERT(consumer.m_tokens[0].index()==0);
-    CPPUNIT_ASSERT(consumer.m_tokens[1].index()==1);
-    CPPUNIT_ASSERT(consumer.m_mayTokens.size()==0);
+    IntsMayConsumer consumer{vTags, vMayTags};
+    consumer.updateLookup(edm::InEvent, helper, false);
+
+    CPPUNIT_ASSERT(consumer.m_tokens[0].index() == 0);
+    CPPUNIT_ASSERT(consumer.m_tokens[1].index() == 1);
+    CPPUNIT_ASSERT(consumer.m_mayTokens.size() == 0);
 
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_c, false) ==
-                   consumer.indexFrom(consumer.m_tokens[1],edm::InEvent,typeID_vint));
+                   consumer.indexFrom(consumer.m_tokens[1], edm::InEvent, typeID_vint));
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_blank, false) ==
-                   consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_vint));
+                   consumer.indexFrom(consumer.m_tokens[0], edm::InEvent, typeID_vint));
 
     std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-    consumer.itemsToGet(edm::InEvent,indices);
-    
+    consumer.itemsToGet(edm::InEvent, indices);
+
     CPPUNIT_ASSERT(2 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
-    
+    CPPUNIT_ASSERT(indices.end() !=
+                   std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
+    CPPUNIT_ASSERT(indices.end() !=
+                   std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
+
     std::vector<edm::ProductResolverIndexAndSkipBit> indicesMay;
-    consumer.itemsMayGet(edm::InEvent,indicesMay);
+    consumer.itemsMayGet(edm::InEvent, indicesMay);
     CPPUNIT_ASSERT(0 == indicesMay.size());
   }
 
   {
     std::vector<edm::InputTag> vTags;
-    std::vector<edm::InputTag> vMayTags={ {"label","instance","process"}, {"labelC","instanceC","processC"} };
-    IntsMayConsumer consumer{vTags,vMayTags};
-    consumer.updateLookup(edm::InEvent,helper,false);
-    
-    CPPUNIT_ASSERT(consumer.m_mayTokens.size()==2);
-    CPPUNIT_ASSERT(consumer.m_mayTokens[0].index()==0);
-    CPPUNIT_ASSERT(consumer.m_mayTokens[1].index()==1);
-    CPPUNIT_ASSERT(consumer.m_tokens.size()==0);
+    std::vector<edm::InputTag> vMayTags = {{"label", "instance", "process"}, {"labelC", "instanceC", "processC"}};
+    IntsMayConsumer consumer{vTags, vMayTags};
+    consumer.updateLookup(edm::InEvent, helper, false);
 
-    CPPUNIT_ASSERT(vint_c == consumer.indexFrom(consumer.m_mayTokens[1],edm::InEvent,typeID_vint).productResolverIndex());
-    CPPUNIT_ASSERT(vint_blank == consumer.indexFrom(consumer.m_mayTokens[0],edm::InEvent,typeID_vint).productResolverIndex());
-    
+    CPPUNIT_ASSERT(consumer.m_mayTokens.size() == 2);
+    CPPUNIT_ASSERT(consumer.m_mayTokens[0].index() == 0);
+    CPPUNIT_ASSERT(consumer.m_mayTokens[1].index() == 1);
+    CPPUNIT_ASSERT(consumer.m_tokens.size() == 0);
+
+    CPPUNIT_ASSERT(vint_c ==
+                   consumer.indexFrom(consumer.m_mayTokens[1], edm::InEvent, typeID_vint).productResolverIndex());
+    CPPUNIT_ASSERT(vint_blank ==
+                   consumer.indexFrom(consumer.m_mayTokens[0], edm::InEvent, typeID_vint).productResolverIndex());
+
     std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-    consumer.itemsToGet(edm::InEvent,indices);
+    consumer.itemsToGet(edm::InEvent, indices);
     CPPUNIT_ASSERT(0 == indices.size());
-    
+
     std::vector<edm::ProductResolverIndexAndSkipBit> indicesMay;
-    consumer.itemsMayGet(edm::InEvent,indicesMay);
+    consumer.itemsMayGet(edm::InEvent, indicesMay);
     CPPUNIT_ASSERT(2 == indicesMay.size());
-    CPPUNIT_ASSERT(indicesMay.end() != std::find(indicesMay.begin(),indicesMay.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
-    CPPUNIT_ASSERT(indicesMay.end() != std::find(indicesMay.begin(),indicesMay.end(), edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
+    CPPUNIT_ASSERT(indicesMay.end() !=
+                   std::find(indicesMay.begin(), indicesMay.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
+    CPPUNIT_ASSERT(indicesMay.end() != std::find(indicesMay.begin(), indicesMay.end(),
+                                                 edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
   }
 
   {
-    std::vector<edm::InputTag> vTags={ {"label","instance","process"} };
-    std::vector<edm::InputTag> vMayTags={{"labelC","instanceC","processC"} };
-    IntsMayConsumer consumer{vTags,vMayTags};
-    consumer.updateLookup(edm::InEvent,helper,false);
-    
-    CPPUNIT_ASSERT(consumer.m_mayTokens.size()==1);
-    CPPUNIT_ASSERT(consumer.m_tokens.size()==1);
-    CPPUNIT_ASSERT(consumer.m_tokens[0].index()==0);
-    CPPUNIT_ASSERT(consumer.m_mayTokens[0].index()==1);
+    std::vector<edm::InputTag> vTags = {{"label", "instance", "process"}};
+    std::vector<edm::InputTag> vMayTags = {{"labelC", "instanceC", "processC"}};
+    IntsMayConsumer consumer{vTags, vMayTags};
+    consumer.updateLookup(edm::InEvent, helper, false);
 
-    CPPUNIT_ASSERT(vint_c == consumer.indexFrom(consumer.m_mayTokens[0],edm::InEvent,typeID_vint).productResolverIndex());
-    CPPUNIT_ASSERT(vint_blank == consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_vint).productResolverIndex());
-    
+    CPPUNIT_ASSERT(consumer.m_mayTokens.size() == 1);
+    CPPUNIT_ASSERT(consumer.m_tokens.size() == 1);
+    CPPUNIT_ASSERT(consumer.m_tokens[0].index() == 0);
+    CPPUNIT_ASSERT(consumer.m_mayTokens[0].index() == 1);
+
+    CPPUNIT_ASSERT(vint_c ==
+                   consumer.indexFrom(consumer.m_mayTokens[0], edm::InEvent, typeID_vint).productResolverIndex());
+    CPPUNIT_ASSERT(vint_blank ==
+                   consumer.indexFrom(consumer.m_tokens[0], edm::InEvent, typeID_vint).productResolverIndex());
+
     std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-    consumer.itemsToGet(edm::InEvent,indices);
-    
+    consumer.itemsToGet(edm::InEvent, indices);
+
     CPPUNIT_ASSERT(1 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
-    
+    CPPUNIT_ASSERT(indices.end() !=
+                   std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(vint_blank, false)));
+
     std::vector<edm::ProductResolverIndexAndSkipBit> indicesMay;
-    consumer.itemsMayGet(edm::InEvent,indicesMay);
+    consumer.itemsMayGet(edm::InEvent, indicesMay);
     CPPUNIT_ASSERT(1 == indicesMay.size());
-    CPPUNIT_ASSERT(indicesMay.end() != std::find(indicesMay.begin(),indicesMay.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
+    CPPUNIT_ASSERT(indicesMay.end() !=
+                   std::find(indicesMay.begin(), indicesMay.end(), edm::ProductResolverIndexAndSkipBit(vint_c, false)));
   }
   {
     std::vector<edm::InputTag> vTags;
-    std::vector<edm::InputTag> vMayTags={ {"label","instance",""}, {"labelC","instanceC","@skipCurrentProcess"} };
-    IntsMayConsumer consumer{vTags,vMayTags};
-    consumer.updateLookup(edm::InEvent,helper,false);
-    
-    CPPUNIT_ASSERT(consumer.m_mayTokens.size()==2);
-    CPPUNIT_ASSERT(consumer.m_mayTokens[0].index()==0);
-    CPPUNIT_ASSERT(consumer.m_mayTokens[1].index()==1);
-    CPPUNIT_ASSERT(consumer.m_tokens.size()==0);
+    std::vector<edm::InputTag> vMayTags = {{"label", "instance", ""}, {"labelC", "instanceC", "@skipCurrentProcess"}};
+    IntsMayConsumer consumer{vTags, vMayTags};
+    consumer.updateLookup(edm::InEvent, helper, false);
+
+    CPPUNIT_ASSERT(consumer.m_mayTokens.size() == 2);
+    CPPUNIT_ASSERT(consumer.m_mayTokens[0].index() == 0);
+    CPPUNIT_ASSERT(consumer.m_mayTokens[1].index() == 1);
+    CPPUNIT_ASSERT(consumer.m_tokens.size() == 0);
 
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_c_no_proc, true) ==
-                   consumer.indexFrom(consumer.m_mayTokens[1],edm::InEvent,typeID_vint));
+                   consumer.indexFrom(consumer.m_mayTokens[1], edm::InEvent, typeID_vint));
     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_blank_no_proc, false) ==
-                   consumer.indexFrom(consumer.m_mayTokens[0],edm::InEvent,typeID_vint));
+                   consumer.indexFrom(consumer.m_mayTokens[0], edm::InEvent, typeID_vint));
   }
 }

--- a/FWCore/Framework/test/edproducer_productregistry_callback.cc
+++ b/FWCore/Framework/test/edproducer_productregistry_callback.cc
@@ -6,7 +6,6 @@
    \date 21 July 2005
 */
 
-
 #include <iostream>
 #include "cppunit/extensions/HelperMacros.h"
 #include <memory>
@@ -30,22 +29,21 @@
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 
-class testEDProducerProductRegistryCallback: public CppUnit::TestFixture {
-   CPPUNIT_TEST_SUITE(testEDProducerProductRegistryCallback);
+class testEDProducerProductRegistryCallback : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testEDProducerProductRegistryCallback);
 
-   CPPUNIT_TEST_EXCEPTION(testCircularRef,cms::Exception);
-   CPPUNIT_TEST_EXCEPTION(testCircularRef2,cms::Exception);
-   CPPUNIT_TEST(testTwoListeners);
+  CPPUNIT_TEST_EXCEPTION(testCircularRef, cms::Exception);
+  CPPUNIT_TEST_EXCEPTION(testCircularRef2, cms::Exception);
+  CPPUNIT_TEST(testTwoListeners);
 
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE_END();
 
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
   void testCircularRef();
   void testCircularRef2();
   void testTwoListeners();
-
 };
 
 ///registration of the test so that the runner can find it
@@ -54,288 +52,288 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testEDProducerProductRegistryCallback);
 using namespace edm;
 
 namespace {
-   class TestMod : public EDProducer {
-     public:
-      explicit TestMod(ParameterSet const& p);
-      
-      void produce(Event& e, EventSetup const&);
-      
-      void listen(BranchDescription const&);
-   };
-   
-   TestMod::TestMod(ParameterSet const&)
-   { produces<int>();}
-   
-   void TestMod::produce(Event&, EventSetup const&) {
-   }
+  class TestMod : public EDProducer {
+  public:
+    explicit TestMod(ParameterSet const& p);
 
-   class ListenMod : public EDProducer {
-     public:
-      explicit ListenMod(ParameterSet const&);
-      void produce(Event& e, EventSetup const&);
-      void listen(BranchDescription const&);
-   };
-   
-   ListenMod::ListenMod(ParameterSet const&) {
-     callWhenNewProductsRegistered([this](BranchDescription const& branchDescription){this->listen(branchDescription);});
-   }
-   void ListenMod::produce(Event&, EventSetup const&) {
-   }
-   
-   void ListenMod::listen(BranchDescription const& iDesc) {
-      edm::TypeID intType(typeid(int));
-      //std::cout << "see class " << iDesc.typeName() << std::endl;
-      if(iDesc.friendlyClassName() == intType.friendlyClassName()) {
-         produces<int>(iDesc.moduleLabel() + "-" + iDesc.productInstanceName());
-         //std::cout << iDesc.moduleLabel() << "-" << iDesc.productInstanceName() << std::endl;
-      }
-   }
+    void produce(Event& e, EventSetup const&);
 
-   class ListenFloatMod : public EDProducer {
-public:
-      explicit ListenFloatMod(ParameterSet const&);
-      void produce(Event& e, EventSetup const&);
-      void listen(BranchDescription const&);
-   };
-   
-   ListenFloatMod::ListenFloatMod(ParameterSet const&) {
-      callWhenNewProductsRegistered([this](BranchDescription const& branchDescription){this->listen(branchDescription);});
-   }
-   void ListenFloatMod::produce(Event&, EventSetup const&) {
-   }
-   
-   void ListenFloatMod::listen(BranchDescription const& iDesc) {
-      edm::TypeID intType(typeid(int));
-      //std::cout <<"see class "<<iDesc.typeName()<<std::endl;
-      if(iDesc.friendlyClassName() == intType.friendlyClassName()) {
-         produces<float>(iDesc.moduleLabel()+"-"+iDesc.productInstanceName());
-         //std::cout <<iDesc.moduleLabel()<<"-"<<iDesc.productInstanceName()<<std::endl;
-      }
-   }
+    void listen(BranchDescription const&);
+  };
+
+  TestMod::TestMod(ParameterSet const&) { produces<int>(); }
+
+  void TestMod::produce(Event&, EventSetup const&) {}
+
+  class ListenMod : public EDProducer {
+  public:
+    explicit ListenMod(ParameterSet const&);
+    void produce(Event& e, EventSetup const&);
+    void listen(BranchDescription const&);
+  };
+
+  ListenMod::ListenMod(ParameterSet const&) {
+    callWhenNewProductsRegistered(
+        [this](BranchDescription const& branchDescription) { this->listen(branchDescription); });
+  }
+  void ListenMod::produce(Event&, EventSetup const&) {}
+
+  void ListenMod::listen(BranchDescription const& iDesc) {
+    edm::TypeID intType(typeid(int));
+    //std::cout << "see class " << iDesc.typeName() << std::endl;
+    if (iDesc.friendlyClassName() == intType.friendlyClassName()) {
+      produces<int>(iDesc.moduleLabel() + "-" + iDesc.productInstanceName());
+      //std::cout << iDesc.moduleLabel() << "-" << iDesc.productInstanceName() << std::endl;
+    }
+  }
+
+  class ListenFloatMod : public EDProducer {
+  public:
+    explicit ListenFloatMod(ParameterSet const&);
+    void produce(Event& e, EventSetup const&);
+    void listen(BranchDescription const&);
+  };
+
+  ListenFloatMod::ListenFloatMod(ParameterSet const&) {
+    callWhenNewProductsRegistered(
+        [this](BranchDescription const& branchDescription) { this->listen(branchDescription); });
+  }
+  void ListenFloatMod::produce(Event&, EventSetup const&) {}
+
+  void ListenFloatMod::listen(BranchDescription const& iDesc) {
+    edm::TypeID intType(typeid(int));
+    //std::cout <<"see class "<<iDesc.typeName()<<std::endl;
+    if (iDesc.friendlyClassName() == intType.friendlyClassName()) {
+      produces<float>(iDesc.moduleLabel() + "-" + iDesc.productInstanceName());
+      //std::cout <<iDesc.moduleLabel()<<"-"<<iDesc.productInstanceName()<<std::endl;
+    }
+  }
+}  // namespace
+
+void testEDProducerProductRegistryCallback::testCircularRef() {
+  using namespace edm;
+
+  SignallingProductRegistry preg;
+
+  //Need access to the ConstProductRegistry service
+  auto cReg = std::make_unique<ConstProductRegistry>(preg);
+  ServiceToken token = ServiceRegistry::createContaining(std::move(cReg));
+  ServiceRegistry::Operate startServices(token);
+
+  std::unique_ptr<Maker> f = std::make_unique<WorkerMaker<TestMod>>();
+
+  ParameterSet p1;
+  p1.addParameter("@module_type", std::string("TestMod"));
+  p1.addParameter("@module_label", std::string("t1"));
+  p1.addParameter("@module_edm_type", std::string("EDProducer"));
+  p1.registerIt();
+
+  ParameterSet p2;
+  p2.addParameter("@module_type", std::string("TestMod"));
+  p2.addParameter("@module_label", std::string("t2"));
+  p2.addParameter("@module_edm_type", std::string("EDProducer"));
+  p2.registerIt();
+
+  edm::ExceptionToActionTable table;
+  edm::PreallocationConfiguration prealloc;
+
+  edm::ParameterSet dummyProcessPset;
+  dummyProcessPset.registerIt();
+  auto pc =
+      std::make_shared<ProcessConfiguration>("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
+
+  edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
+  edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);
+
+  std::unique_ptr<Maker> lM = std::make_unique<WorkerMaker<ListenMod>>();
+  ParameterSet l1;
+  l1.addParameter("@module_type", std::string("ListenMod"));
+  l1.addParameter("@module_label", std::string("l1"));
+  l1.addParameter("@module_edm_type", std::string("EDProducer"));
+  l1.registerIt();
+
+  ParameterSet l2;
+  l2.addParameter("@module_type", std::string("ListenMod"));
+  l2.addParameter("@module_label", std::string("l2"));
+  l2.addParameter("@module_edm_type", std::string("EDProducer"));
+  l2.registerIt();
+
+  edm::MakeModuleParams paramsl1(&l1, preg, &prealloc, pc);
+  edm::MakeModuleParams paramsl2(&l2, preg, &prealloc, pc);
+
+  signalslot::Signal<void(const ModuleDescription&)> aSignal;
+
+  auto m1 = f->makeModule(params1, aSignal, aSignal);
+  std::unique_ptr<Worker> w1 = m1->makeWorker(&table);
+  auto ml1 = lM->makeModule(paramsl1, aSignal, aSignal);
+  std::unique_ptr<Worker> wl1 = ml1->makeWorker(&table);
+  auto ml2 = lM->makeModule(paramsl2, aSignal, aSignal);
+  std::unique_ptr<Worker> wl2 = ml2->makeWorker(&table);
+  auto m2 = f->makeModule(params2, aSignal, aSignal);
+  std::unique_ptr<Worker> w2 = m2->makeWorker(&table);
+
+  //Should be 5 products
+  // 1 from the module 't1'
+  //    1 from 'l1' in response
+  //       1 from 'l2' in response to 'l1'
+  //    1 from 'l2' in response to 't1'
+  //       1 from 'l1' in response to 'l2'
+  // 1 from the module 't2'
+  //    1 from 'l1' in response
+  //       1 from 'l2' in response to 'l1'
+  //    1 from 'l2' in response to 't2'
+  //       1 from 'l1' in response to 'l2'
+  //std::cout <<"# products "<<preg.size()<<std::endl;
+  CPPUNIT_ASSERT(10 == preg.size());
 }
 
-void  testEDProducerProductRegistryCallback::testCircularRef() {
-   using namespace edm;
-   
-   SignallingProductRegistry preg;
+void testEDProducerProductRegistryCallback::testCircularRef2() {
+  using namespace edm;
 
-   //Need access to the ConstProductRegistry service
-   auto cReg = std::make_unique<ConstProductRegistry>(preg);
-   ServiceToken token = ServiceRegistry::createContaining(std::move(cReg));
-   ServiceRegistry::Operate startServices(token);
-   
-   std::unique_ptr<Maker> f = std::make_unique<WorkerMaker<TestMod>>();
-   
-   ParameterSet p1;
-   p1.addParameter("@module_type",std::string("TestMod") );
-   p1.addParameter("@module_label",std::string("t1") );
-   p1.addParameter("@module_edm_type",std::string("EDProducer") );
-   p1.registerIt();
-   
-   ParameterSet p2;
-   p2.addParameter("@module_type",std::string("TestMod") );
-   p2.addParameter("@module_label",std::string("t2") );
-   p2.addParameter("@module_edm_type",std::string("EDProducer") );
-   p2.registerIt();
-   
-   edm::ExceptionToActionTable table;
-   edm::PreallocationConfiguration prealloc;
-  
-   edm::ParameterSet dummyProcessPset;
-   dummyProcessPset.registerIt();
-   auto pc = std::make_shared<ProcessConfiguration>("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
+  SignallingProductRegistry preg;
 
-   edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
-   edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);
-   
-   std::unique_ptr<Maker> lM = std::make_unique<WorkerMaker<ListenMod>>();
-   ParameterSet l1;
-   l1.addParameter("@module_type",std::string("ListenMod") );
-   l1.addParameter("@module_label",std::string("l1") );
-   l1.addParameter("@module_edm_type",std::string("EDProducer") );
-   l1.registerIt();
-   
-   ParameterSet l2;
-   l2.addParameter("@module_type",std::string("ListenMod") );
-   l2.addParameter("@module_label",std::string("l2") );
-   l2.addParameter("@module_edm_type",std::string("EDProducer") );
-   l2.registerIt();
+  //Need access to the ConstProductRegistry service
+  auto cReg = std::make_unique<ConstProductRegistry>(preg);
+  ServiceToken token = ServiceRegistry::createContaining(std::move(cReg));
+  ServiceRegistry::Operate startServices(token);
 
-   edm::MakeModuleParams paramsl1(&l1, preg, &prealloc, pc);
-   edm::MakeModuleParams paramsl2(&l2, preg, &prealloc, pc);
+  std::unique_ptr<Maker> f = std::make_unique<WorkerMaker<TestMod>>();
 
-   signalslot::Signal<void(const ModuleDescription&)> aSignal;
+  ParameterSet p1;
+  p1.addParameter("@module_type", std::string("TestMod"));
+  p1.addParameter("@module_label", std::string("t1"));
+  p1.addParameter("@module_edm_type", std::string("EDProducer"));
+  p1.registerIt();
 
-   auto m1 = f->makeModule(params1,aSignal,aSignal);
-   std::unique_ptr<Worker> w1 = m1->makeWorker(&table);
-   auto ml1 = lM->makeModule(paramsl1,aSignal,aSignal);
-   std::unique_ptr<Worker> wl1 = ml1->makeWorker(&table);
-   auto ml2 = lM->makeModule(paramsl2,aSignal,aSignal);
-   std::unique_ptr<Worker> wl2 = ml2->makeWorker(&table);
-   auto m2 = f->makeModule(params2,aSignal,aSignal);
-   std::unique_ptr<Worker> w2 = m2->makeWorker(&table);
+  ParameterSet p2;
+  p2.addParameter("@module_type", std::string("TestMod"));
+  p2.addParameter("@module_label", std::string("t2"));
+  p2.addParameter("@module_edm_type", std::string("EDProducer"));
+  p2.registerIt();
 
-   //Should be 5 products
-   // 1 from the module 't1'
-   //    1 from 'l1' in response
-   //       1 from 'l2' in response to 'l1'
-   //    1 from 'l2' in response to 't1'
-   //       1 from 'l1' in response to 'l2'
-   // 1 from the module 't2'
-   //    1 from 'l1' in response
-   //       1 from 'l2' in response to 'l1'
-   //    1 from 'l2' in response to 't2'
-   //       1 from 'l1' in response to 'l2'
-   //std::cout <<"# products "<<preg.size()<<std::endl;
-   CPPUNIT_ASSERT(10 == preg.size());
+  edm::ExceptionToActionTable table;
+  edm::PreallocationConfiguration prealloc;
+
+  edm::ParameterSet dummyProcessPset;
+  dummyProcessPset.registerIt();
+  auto pc =
+      std::make_shared<ProcessConfiguration>("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
+
+  edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
+  edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);
+
+  std::unique_ptr<Maker> lM = std::make_unique<WorkerMaker<ListenMod>>();
+  ParameterSet l1;
+  l1.addParameter("@module_type", std::string("ListenMod"));
+  l1.addParameter("@module_label", std::string("l1"));
+  l1.addParameter("@module_edm_type", std::string("EDProducer"));
+  l1.registerIt();
+
+  ParameterSet l2;
+  l2.addParameter("@module_type", std::string("ListenMod"));
+  l2.addParameter("@module_label", std::string("l2"));
+  l2.addParameter("@module_edm_type", std::string("EDProducer"));
+  l2.registerIt();
+
+  edm::MakeModuleParams paramsl1(&l1, preg, &prealloc, pc);
+  edm::MakeModuleParams paramsl2(&l2, preg, &prealloc, pc);
+
+  signalslot::Signal<void(const ModuleDescription&)> aSignal;
+  auto ml1 = lM->makeModule(paramsl1, aSignal, aSignal);
+  std::unique_ptr<Worker> wl1 = ml1->makeWorker(&table);
+  auto ml2 = lM->makeModule(paramsl2, aSignal, aSignal);
+  std::unique_ptr<Worker> wl2 = ml2->makeWorker(&table);
+  auto m1 = f->makeModule(params1, aSignal, aSignal);
+  std::unique_ptr<Worker> w1 = m1->makeWorker(&table);
+  auto m2 = f->makeModule(params2, aSignal, aSignal);
+  std::unique_ptr<Worker> w2 = m2->makeWorker(&table);
+
+  //Would be 10 products
+  // 1 from the module 't1'
+  //    1 from 'l1' in response
+  //       1 from 'l2' in response to 'l1' <-- circular
+  //    1 from 'l2' in response to 't1'                  |
+  //       1 from 'l1' in response to 'l2' <-- circular /
+  // 1 from the module 't2'
+  //    1 from 'l1' in response
+  //       1 from 'l2' in response to 'l1'
+  //    1 from 'l2' in response to 't2'
+  //       1 from 'l1' in response to 'l2'
+  //std::cout <<"# products "<<preg.size()<<std::endl;
+  CPPUNIT_ASSERT(10 == preg.size());
 }
 
-void  testEDProducerProductRegistryCallback::testCircularRef2() {
-   using namespace edm;
-   
-   SignallingProductRegistry preg;
-   
-   //Need access to the ConstProductRegistry service
-   auto cReg = std::make_unique<ConstProductRegistry>(preg);
-   ServiceToken token = ServiceRegistry::createContaining(std::move(cReg));
-   ServiceRegistry::Operate startServices(token);
-   
-   std::unique_ptr<Maker> f = std::make_unique<WorkerMaker<TestMod>>();
-   
-   ParameterSet p1;
-   p1.addParameter("@module_type",std::string("TestMod") );
-   p1.addParameter("@module_label",std::string("t1") );
-   p1.addParameter("@module_edm_type",std::string("EDProducer") );
-   p1.registerIt();
-   
-   ParameterSet p2;
-   p2.addParameter("@module_type",std::string("TestMod") );
-   p2.addParameter("@module_label",std::string("t2") );
-   p2.addParameter("@module_edm_type",std::string("EDProducer") );
-   p2.registerIt();
-   
-   edm::ExceptionToActionTable table;
-   edm::PreallocationConfiguration prealloc;
-  
-   edm::ParameterSet dummyProcessPset;
-   dummyProcessPset.registerIt();
-   auto pc = std::make_shared<ProcessConfiguration>("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
+void testEDProducerProductRegistryCallback::testTwoListeners() {
+  using namespace edm;
 
-   edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
-   edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);
-   
-   std::unique_ptr<Maker> lM = std::make_unique<WorkerMaker<ListenMod>>();
-   ParameterSet l1;
-   l1.addParameter("@module_type",std::string("ListenMod") );
-   l1.addParameter("@module_label",std::string("l1") );
-   l1.addParameter("@module_edm_type",std::string("EDProducer") );
-   l1.registerIt();
-   
-   ParameterSet l2;
-   l2.addParameter("@module_type",std::string("ListenMod") );
-   l2.addParameter("@module_label",std::string("l2") );
-   l2.addParameter("@module_edm_type",std::string("EDProducer") );
-   l2.registerIt();
-   
-   edm::MakeModuleParams paramsl1(&l1, preg, &prealloc, pc);
-   edm::MakeModuleParams paramsl2(&l2, preg, &prealloc, pc);
-   
-   signalslot::Signal<void(const ModuleDescription&)> aSignal;
-   auto ml1 = lM->makeModule(paramsl1,aSignal,aSignal);
-   std::unique_ptr<Worker> wl1 = ml1->makeWorker(&table);
-   auto ml2 = lM->makeModule(paramsl2,aSignal,aSignal);
-   std::unique_ptr<Worker> wl2 = ml2->makeWorker(&table);
-   auto m1 = f->makeModule(params1,aSignal,aSignal);
-   std::unique_ptr<Worker> w1 = m1->makeWorker(&table);
-   auto m2 = f->makeModule(params2,aSignal,aSignal);
-   std::unique_ptr<Worker> w2 = m2->makeWorker(&table);
-   
-   //Would be 10 products
-   // 1 from the module 't1'
-   //    1 from 'l1' in response
-   //       1 from 'l2' in response to 'l1' <-- circular 
-   //    1 from 'l2' in response to 't1'                  | 
-   //       1 from 'l1' in response to 'l2' <-- circular / 
-   // 1 from the module 't2'
-   //    1 from 'l1' in response
-   //       1 from 'l2' in response to 'l1'
-   //    1 from 'l2' in response to 't2'
-   //       1 from 'l1' in response to 'l2'
-   //std::cout <<"# products "<<preg.size()<<std::endl;
-   CPPUNIT_ASSERT(10 == preg.size());
-}
+  SignallingProductRegistry preg;
 
-void  testEDProducerProductRegistryCallback::testTwoListeners(){
-   using namespace edm;
-   
-   SignallingProductRegistry preg;
-   
-   //Need access to the ConstProductRegistry service
-   auto cReg = std::make_unique<ConstProductRegistry>(preg);
-   ServiceToken token = ServiceRegistry::createContaining(std::move(cReg));
-   ServiceRegistry::Operate startServices(token);
-   
-   std::unique_ptr<Maker> f = std::make_unique<WorkerMaker<TestMod>>();
-   
-   ParameterSet p1;
-   p1.addParameter("@module_type",std::string("TestMod") );
-   p1.addParameter("@module_label",std::string("t1") );
-   p1.addParameter("@module_edm_type",std::string("EDProducer") );
-   p1.registerIt();
-   
-   ParameterSet p2;
-   p2.addParameter("@module_type",std::string("TestMod") );
-   p2.addParameter("@module_label",std::string("t2") );
-   p2.addParameter("@module_edm_type",std::string("EDProducer") );
-   p2.registerIt();
-   
-   edm::ExceptionToActionTable table;
-   edm::PreallocationConfiguration prealloc;
-  
-   edm::ParameterSet dummyProcessPset;
-   dummyProcessPset.registerIt();
-   auto pc = std::make_shared<ProcessConfiguration>("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
+  //Need access to the ConstProductRegistry service
+  auto cReg = std::make_unique<ConstProductRegistry>(preg);
+  ServiceToken token = ServiceRegistry::createContaining(std::move(cReg));
+  ServiceRegistry::Operate startServices(token);
 
-   edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
-   edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);
-   
-   std::unique_ptr<Maker> lM = std::make_unique<WorkerMaker<ListenMod>>();
-   ParameterSet l1;
-   l1.addParameter("@module_type",std::string("ListenMod") );
-   l1.addParameter("@module_label",std::string("l1") );
-   l1.addParameter("@module_edm_type",std::string("EDProducer") );
-   l1.registerIt();
-   
-   std::unique_ptr<Maker> lFM = std::make_unique<WorkerMaker<ListenFloatMod>>();
-   ParameterSet l2;
-   l2.addParameter("@module_type",std::string("ListenMod") );
-   l2.addParameter("@module_label",std::string("l2") );
-   l2.addParameter("@module_edm_type",std::string("EDProducer") );
-   l2.registerIt();
-   
-   edm::MakeModuleParams paramsl1(&l1, preg, &prealloc, pc);
-   edm::MakeModuleParams paramsl2(&l2, preg, &prealloc, pc);
-   
-   
-   signalslot::Signal<void(const ModuleDescription&)> aSignal;
-   auto m1 = f->makeModule(params1,aSignal,aSignal);
-   std::unique_ptr<Worker> w1 = m1->makeWorker(&table);
-   auto ml1 = lM->makeModule(paramsl1,aSignal,aSignal);
-   std::unique_ptr<Worker> wl1 = ml1->makeWorker(&table);
-   auto ml2 = lFM->makeModule(paramsl2,aSignal,aSignal);
-   std::unique_ptr<Worker> wl2 = ml2->makeWorker(&table);
-   auto m2 = f->makeModule(params2,aSignal,aSignal);
-   std::unique_ptr<Worker> w2 = m2->makeWorker(&table);
+  std::unique_ptr<Maker> f = std::make_unique<WorkerMaker<TestMod>>();
 
-   //Should be 8 products
-   // 1 from the module 't1'
-   //    1 from 'l1' in response
-   //       1 from 'l2' in response to 'l1'
-   //    1 from 'l2' in response to 't1'
-   // 1 from the module 't2'
-   //    1 from 'l1' in response
-   //       1 from 'l2' in response to 'l1'
-   //    1 from 'l2' in response to 't2'
-   //std::cout <<"# products "<<preg.size()<<std::endl;
-   CPPUNIT_ASSERT(8 == preg.size());
+  ParameterSet p1;
+  p1.addParameter("@module_type", std::string("TestMod"));
+  p1.addParameter("@module_label", std::string("t1"));
+  p1.addParameter("@module_edm_type", std::string("EDProducer"));
+  p1.registerIt();
+
+  ParameterSet p2;
+  p2.addParameter("@module_type", std::string("TestMod"));
+  p2.addParameter("@module_label", std::string("t2"));
+  p2.addParameter("@module_edm_type", std::string("EDProducer"));
+  p2.registerIt();
+
+  edm::ExceptionToActionTable table;
+  edm::PreallocationConfiguration prealloc;
+
+  edm::ParameterSet dummyProcessPset;
+  dummyProcessPset.registerIt();
+  auto pc =
+      std::make_shared<ProcessConfiguration>("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
+
+  edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
+  edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);
+
+  std::unique_ptr<Maker> lM = std::make_unique<WorkerMaker<ListenMod>>();
+  ParameterSet l1;
+  l1.addParameter("@module_type", std::string("ListenMod"));
+  l1.addParameter("@module_label", std::string("l1"));
+  l1.addParameter("@module_edm_type", std::string("EDProducer"));
+  l1.registerIt();
+
+  std::unique_ptr<Maker> lFM = std::make_unique<WorkerMaker<ListenFloatMod>>();
+  ParameterSet l2;
+  l2.addParameter("@module_type", std::string("ListenMod"));
+  l2.addParameter("@module_label", std::string("l2"));
+  l2.addParameter("@module_edm_type", std::string("EDProducer"));
+  l2.registerIt();
+
+  edm::MakeModuleParams paramsl1(&l1, preg, &prealloc, pc);
+  edm::MakeModuleParams paramsl2(&l2, preg, &prealloc, pc);
+
+  signalslot::Signal<void(const ModuleDescription&)> aSignal;
+  auto m1 = f->makeModule(params1, aSignal, aSignal);
+  std::unique_ptr<Worker> w1 = m1->makeWorker(&table);
+  auto ml1 = lM->makeModule(paramsl1, aSignal, aSignal);
+  std::unique_ptr<Worker> wl1 = ml1->makeWorker(&table);
+  auto ml2 = lFM->makeModule(paramsl2, aSignal, aSignal);
+  std::unique_ptr<Worker> wl2 = ml2->makeWorker(&table);
+  auto m2 = f->makeModule(params2, aSignal, aSignal);
+  std::unique_ptr<Worker> w2 = m2->makeWorker(&table);
+
+  //Should be 8 products
+  // 1 from the module 't1'
+  //    1 from 'l1' in response
+  //       1 from 'l2' in response to 'l1'
+  //    1 from 'l2' in response to 't1'
+  // 1 from the module 't2'
+  //    1 from 'l1' in response
+  //       1 from 'l2' in response to 'l1'
+  //    1 from 'l2' in response to 't2'
+  //std::cout <<"# products "<<preg.size()<<std::endl;
+  CPPUNIT_ASSERT(8 == preg.size());
 }

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -28,8 +28,7 @@ namespace {
   edm::ActivityRegistry activityRegistry;
 }
 
-class testEsproducer: public CppUnit::TestFixture
-{
+class testEsproducer : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testEsproducer);
 
   CPPUNIT_TEST(registerTest);
@@ -40,13 +39,14 @@ class testEsproducer: public CppUnit::TestFixture
   CPPUNIT_TEST(decoratorTest);
   CPPUNIT_TEST(dependsOnTest);
   CPPUNIT_TEST(labelTest);
-  CPPUNIT_TEST_EXCEPTION(failMultipleRegistration,cms::Exception);
+  CPPUNIT_TEST_EXCEPTION(failMultipleRegistration, cms::Exception);
   CPPUNIT_TEST(forceCacheClearTest);
 
   CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void registerTest();
   void getFromTest();
@@ -62,26 +62,24 @@ public:
 private:
   class Test1Producer : public ESProducer {
   public:
-    Test1Producer() {
-      setWhatProduced(this);
-    }
+    Test1Producer() { setWhatProduced(this); }
     std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
       ++data_.value_;
-      return std::shared_ptr<DummyData>(&data_,edm::do_nothing_deleter{});
+      return std::shared_ptr<DummyData>(&data_, edm::do_nothing_deleter{});
     }
+
   private:
     DummyData data_{0};
   };
 
   class OptionalProducer : public ESProducer {
   public:
-    OptionalProducer() {
-      setWhatProduced(this);
-    }
+    OptionalProducer() { setWhatProduced(this); }
     std::optional<DummyData> produce(const DummyRecord& /*iRecord*/) {
       ++data_.value_;
       return data_;
     }
+
   private:
     DummyData data_{0};
   };
@@ -95,43 +93,42 @@ private:
     std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
       return std::shared_ptr<DummyData>(&data_, edm::do_nothing_deleter{});
     }
+
   private:
     DummyData data_{0};
   };
 
   class ShareProducer : public ESProducer {
   public:
-    ShareProducer() {
-      setWhatProduced(this);
-    }
+    ShareProducer() { setWhatProduced(this); }
     std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
       ++ptr_->value_;
       return ptr_;
     }
+
   private:
     std::shared_ptr<DummyData> ptr_{std::make_shared<DummyData>(0)};
   };
 
   class UniqueProducer : public ESProducer {
   public:
-    UniqueProducer() {
-      setWhatProduced(this);
-    }
+    UniqueProducer() { setWhatProduced(this); }
     std::unique_ptr<DummyData> produce(const DummyRecord&) {
       ++data_.value_;
       return std::make_unique<DummyData>(data_);
     }
+
   private:
     DummyData data_;
   };
 
   class LabelledProducer : public ESProducer {
   public:
-    enum {kFi, kFum};
-    typedef edm::ESProducts< edm::es::L<DummyData,kFi>, edm::es::L<DummyData,kFum> > ReturnProducts;
+    enum { kFi, kFum };
+    typedef edm::ESProducts<edm::es::L<DummyData, kFi>, edm::es::L<DummyData, kFum> > ReturnProducts;
     LabelledProducer() {
-      setWhatProduced(this,"foo");
-      setWhatProduced(this, &LabelledProducer::produceMore, edm::es::label("fi",kFi)("fum",kFum));
+      setWhatProduced(this, "foo");
+      setWhatProduced(this, &LabelledProducer::produceMore, edm::es::label("fi", kFi)("fum", kFum));
     }
 
     std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
@@ -139,51 +136,47 @@ private:
       return ptr_;
     }
 
-    ReturnProducts produceMore(const DummyRecord&){
+    ReturnProducts produceMore(const DummyRecord&) {
       using edm::es::L;
       using namespace edm;
       ++fi_->value_;
 
-      L<DummyData,kFum> fum( std::make_shared<DummyData>());
+      L<DummyData, kFum> fum(std::make_shared<DummyData>());
       fum->value_ = fi_->value_;
 
-      return edm::es::products(fum, es::l<kFi>(fi_) );
+      return edm::es::products(fum, es::l<kFi>(fi_));
     }
+
   private:
     std::shared_ptr<DummyData> ptr_{std::make_shared<DummyData>(0)};
     std::shared_ptr<DummyData> fi_{std::make_shared<DummyData>(0)};
   };
-
 };
 
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testEsproducer);
 
-
-void testEsproducer::registerTest()
-{
+void testEsproducer::registerTest() {
   Test1Producer testProd;
   EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
   CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
 
-  const DataProxyProvider::KeyedProxies& keyedProxies =
-    testProd.keyedProxies(dummyRecordKey);
+  const DataProxyProvider::KeyedProxies& keyedProxies = testProd.keyedProxies(dummyRecordKey);
 
   CPPUNIT_ASSERT(keyedProxies.size() == 1);
 }
 
-void testEsproducer::getFromTest()
-{
+void testEsproducer::getFromTest() {
   EventSetupProvider provider(&activityRegistry);
   provider.add(std::make_shared<Test1Producer>());
 
   auto pFinder = std::make_shared<DummyFinder>();
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
-  for(int iTime=1; iTime != 6; ++iTime) {
+  for (int iTime = 1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
-    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
+    const auto& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -191,8 +184,7 @@ void testEsproducer::getFromTest()
   }
 }
 
-void testEsproducer::getfromShareTest()
-{
+void testEsproducer::getfromShareTest() {
   EventSetupProvider provider(&activityRegistry);
 
   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<ShareProducer>();
@@ -201,10 +193,10 @@ void testEsproducer::getfromShareTest()
   auto pFinder = std::make_shared<DummyFinder>();
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
-  for(int iTime=1; iTime != 6; ++iTime) {
+  for (int iTime = 1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
-    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
+    const auto& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -212,8 +204,7 @@ void testEsproducer::getfromShareTest()
   }
 }
 
-void testEsproducer::getfromUniqueTest()
-{
+void testEsproducer::getfromUniqueTest() {
   EventSetupProvider provider(&activityRegistry);
 
   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<UniqueProducer>();
@@ -222,10 +213,10 @@ void testEsproducer::getfromUniqueTest()
   auto pFinder = std::make_shared<DummyFinder>();
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
-  for(int iTime=1; iTime != 6; ++iTime) {
+  for (int iTime = 1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
-    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
+    const auto& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -233,18 +224,17 @@ void testEsproducer::getfromUniqueTest()
   }
 }
 
-void testEsproducer::getfromOptionalTest()
-{
+void testEsproducer::getfromOptionalTest() {
   EventSetupProvider provider(&activityRegistry);
   provider.add(std::make_shared<OptionalProducer>());
 
   auto pFinder = std::make_shared<DummyFinder>();
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
-  for(int iTime=1; iTime != 6; ++iTime) {
+  for (int iTime = 1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
-    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
+    const auto& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -252,8 +242,7 @@ void testEsproducer::getfromOptionalTest()
   }
 }
 
-void testEsproducer::labelTest()
-{
+void testEsproducer::labelTest() {
   try {
     EventSetupProvider provider(&activityRegistry);
 
@@ -263,25 +252,25 @@ void testEsproducer::labelTest()
     auto pFinder = std::make_shared<DummyFinder>();
     provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
-    for(int iTime=1; iTime != 6; ++iTime) {
+    for (int iTime = 1; iTime != 6; ++iTime) {
       const edm::Timestamp time(iTime);
-      pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-      const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+      pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
+      const auto& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
       edm::ESHandle<DummyData> pDummy;
-      eventSetup.get<DummyRecord>().get("foo",pDummy);
+      eventSetup.get<DummyRecord>().get("foo", pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
       CPPUNIT_ASSERT(iTime == pDummy->value_);
 
-      eventSetup.get<DummyRecord>().get("fi",pDummy);
+      eventSetup.get<DummyRecord>().get("fi", pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
       CPPUNIT_ASSERT(iTime == pDummy->value_);
 
-      eventSetup.get<DummyRecord>().get("fum",pDummy);
+      eventSetup.get<DummyRecord>().get("fum", pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
       CPPUNIT_ASSERT(iTime == pDummy->value_);
     }
-  } catch(const cms::Exception& iException) {
-    std::cout <<"caught exception "<<iException.explainSelf()<<std::endl;
+  } catch (const cms::Exception& iException) {
+    std::cout << "caught exception " << iException.explainSelf() << std::endl;
     throw;
   }
 }
@@ -290,13 +279,9 @@ struct TestDecorator {
   static int s_pre;
   static int s_post;
 
-  void pre(const DummyRecord&) {
-    ++s_pre;
-  }
+  void pre(const DummyRecord&) { ++s_pre; }
 
-  void post(const DummyRecord&) {
-    ++s_post;
-  }
+  void post(const DummyRecord&) { ++s_post; }
 };
 
 int TestDecorator::s_pre = 0;
@@ -304,29 +289,27 @@ int TestDecorator::s_post = 0;
 
 class DecoratorProducer : public ESProducer {
 public:
-  DecoratorProducer() {
-    setWhatProduced(this, TestDecorator{});
-  }
+  DecoratorProducer() { setWhatProduced(this, TestDecorator{}); }
   std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
     ++ptr_->value_;
     return ptr_;
   }
+
 private:
   std::shared_ptr<DummyData> ptr_{std::make_shared<DummyData>(0)};
 };
 
-void testEsproducer::decoratorTest()
-{
+void testEsproducer::decoratorTest() {
   EventSetupProvider provider(&activityRegistry);
   provider.add(std::make_shared<DecoratorProducer>());
 
   auto pFinder = std::make_shared<DummyFinder>();
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
-  for(int iTime=1; iTime != 6; ++iTime) {
+  for (int iTime = 1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
-    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    const auto& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
     edm::ESHandle<DummyData> pDummy;
 
     CPPUNIT_ASSERT(iTime - 1 == TestDecorator::s_pre);
@@ -342,54 +325,40 @@ void testEsproducer::decoratorTest()
 class DepProducer : public ESProducer {
 public:
   DepProducer() {
-    setWhatProduced(this , dependsOn(&DepProducer::callWhenDummyChanges,
-                                     &DepProducer::callWhenDummyChanges2,
-                                     &DepProducer::callWhenDummyChanges3));
+    setWhatProduced(this, dependsOn(&DepProducer::callWhenDummyChanges, &DepProducer::callWhenDummyChanges2,
+                                    &DepProducer::callWhenDummyChanges3));
   }
-  std::shared_ptr<DummyData> produce(const DepRecord& /*iRecord*/) {
-    return ptr_;
-  }
-  void callWhenDummyChanges(const DummyRecord&) {
-    ++ptr_->value_;
-  }
-  void callWhenDummyChanges2(const DummyRecord&) {
-    ++ptr_->value_;
-  }
-  void callWhenDummyChanges3(const DummyRecord&) {
-    ++ptr_->value_;
-  }
+  std::shared_ptr<DummyData> produce(const DepRecord& /*iRecord*/) { return ptr_; }
+  void callWhenDummyChanges(const DummyRecord&) { ++ptr_->value_; }
+  void callWhenDummyChanges2(const DummyRecord&) { ++ptr_->value_; }
+  void callWhenDummyChanges3(const DummyRecord&) { ++ptr_->value_; }
 
 private:
   std::shared_ptr<DummyData> ptr_{std::make_shared<DummyData>(0)};
 };
 
-void testEsproducer::dependsOnTest()
-{
+void testEsproducer::dependsOnTest() {
   EventSetupProvider provider(&activityRegistry);
   provider.add(std::make_shared<DepProducer>());
 
   auto pFinder = std::make_shared<DummyFinder>();
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
-  for(int iTime=1; iTime != 6; ++iTime) {
+  for (int iTime = 1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
-    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    const auto& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
     edm::ESHandle<DummyData> pDummy;
 
     eventSetup.get<DepRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
-    CPPUNIT_ASSERT(3*iTime == pDummy->value_);
+    CPPUNIT_ASSERT(3 * iTime == pDummy->value_);
   }
 }
 
-void testEsproducer::failMultipleRegistration()
-{
-  MultiRegisterProducer dummy;
-}
+void testEsproducer::failMultipleRegistration() { MultiRegisterProducer dummy; }
 
-void testEsproducer::forceCacheClearTest()
-{
+void testEsproducer::forceCacheClearTest() {
   EventSetupProvider provider(&activityRegistry);
   provider.add(std::make_shared<Test1Producer>());
 
@@ -397,8 +366,8 @@ void testEsproducer::forceCacheClearTest()
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
 
   const edm::Timestamp time(1);
-  pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-  const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+  pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
+  const auto& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
   {
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);

--- a/FWCore/Framework/test/esproducts_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducts_t.cppunit.cc
@@ -13,17 +13,17 @@
 using edm::ESProducts;
 using edm::es::products;
 
-class testEsproducts: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testEsproducts);
-CPPUNIT_TEST(constPtrTest);
-CPPUNIT_TEST(uniquePtrTest);
-CPPUNIT_TEST(sharedPtrTest);
-CPPUNIT_TEST(manyTest);
-CPPUNIT_TEST_SUITE_END();
+class testEsproducts : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testEsproducts);
+  CPPUNIT_TEST(constPtrTest);
+  CPPUNIT_TEST(uniquePtrTest);
+  CPPUNIT_TEST(sharedPtrTest);
+  CPPUNIT_TEST(manyTest);
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
   void constPtrTest();
   void uniquePtrTest();
   void sharedPtrTest();
@@ -33,95 +33,82 @@ public:
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testEsproducts);
 
-
-ESProducts<const int*, const float*>
-returnPointers(const int* iInt, const float* iFloat)
-{
-   return products(iInt, iFloat);
+ESProducts<const int*, const float*> returnPointers(const int* iInt, const float* iFloat) {
+  return products(iInt, iFloat);
 }
 
-void testEsproducts::constPtrTest()
-{
-   int int_ = 0;
-   float float_ = 0;
-   
-   ESProducts<const int*, const float*> product = 
-      returnPointers(&int_, &float_);
-   
-   const int* readInt = 0;
-   const float* readFloat = 0;
+void testEsproducts::constPtrTest() {
+  int int_ = 0;
+  float float_ = 0;
 
-   product.moveTo(readInt);
-   product.moveTo(readFloat);
-   
-   CPPUNIT_ASSERT(readInt == &int_);
-   CPPUNIT_ASSERT(readFloat == &float_);
+  ESProducts<const int*, const float*> product = returnPointers(&int_, &float_);
+
+  const int* readInt = 0;
+  const float* readFloat = 0;
+
+  product.moveTo(readInt);
+  product.moveTo(readFloat);
+
+  CPPUNIT_ASSERT(readInt == &int_);
+  CPPUNIT_ASSERT(readFloat == &float_);
 }
 
-void testEsproducts::uniquePtrTest()
-{
+void testEsproducts::uniquePtrTest() {
   constexpr int kInt = 5;
   auto int_ = std::make_unique<int>(kInt);
   constexpr float kFloat = 3.1;
   auto float_ = std::make_unique<float>(kFloat);
-  
+
   ESProducts<std::unique_ptr<int>, std::unique_ptr<float>> product = products(std::move(int_), std::move(float_));
-  
+
   std::unique_ptr<int> readInt;
   std::unique_ptr<float> readFloat;
-  
+
   product.moveTo(readInt);
   product.moveTo(readFloat);
-  
+
   CPPUNIT_ASSERT(*readInt == kInt);
   CPPUNIT_ASSERT(*readFloat == kFloat);
 }
 
-void testEsproducts::sharedPtrTest()
-{
+void testEsproducts::sharedPtrTest() {
   auto int_ = std::make_shared<int>(5);
   auto float_ = std::make_shared<float>(3.1);
-  
-  ESProducts<std::shared_ptr<int>, std::shared_ptr<float>> product =
-  products(int_,float_);
-  
+
+  ESProducts<std::shared_ptr<int>, std::shared_ptr<float>> product = products(int_, float_);
+
   std::shared_ptr<int> readInt;
   std::shared_ptr<float> readFloat;
-  
+
   product.moveTo(readInt);
   product.moveTo(readFloat);
-  
+
   CPPUNIT_ASSERT(readInt.get() == int_.get());
   CPPUNIT_ASSERT(readFloat.get() == float_.get());
 }
 
-
-ESProducts<const int*, const float*, const double*>
-returnManyPointers(const int* iInt, const float* iFloat, const double* iDouble)
-{
-   return edm::es::products(iInt, iFloat,  iDouble);
+ESProducts<const int*, const float*, const double*> returnManyPointers(const int* iInt,
+                                                                       const float* iFloat,
+                                                                       const double* iDouble) {
+  return edm::es::products(iInt, iFloat, iDouble);
 }
 
-void testEsproducts::manyTest()
-{
-   int int_ = 0;
-   float float_ = 0;
-   double double_ = 0;
-   
-   ESProducts<const int*, const float*, const double*> product = 
-      returnManyPointers(&int_, &float_,&double_);
-   
-   const int* readInt = 0;
-   const float* readFloat = 0;
-   const double* readDouble = 0;
-   
-   product.moveTo(readInt);
-   product.moveTo(readFloat);
-   product.moveTo(readDouble);
-   
-   CPPUNIT_ASSERT(readInt == &int_);
-   CPPUNIT_ASSERT(readFloat == &float_);
-   CPPUNIT_ASSERT(readDouble == &double_);
-}
+void testEsproducts::manyTest() {
+  int int_ = 0;
+  float float_ = 0;
+  double double_ = 0;
 
-   
+  ESProducts<const int*, const float*, const double*> product = returnManyPointers(&int_, &float_, &double_);
+
+  const int* readInt = 0;
+  const float* readFloat = 0;
+  const double* readDouble = 0;
+
+  product.moveTo(readInt);
+  product.moveTo(readFloat);
+  product.moveTo(readDouble);
+
+  CPPUNIT_ASSERT(readInt == &int_);
+  CPPUNIT_ASSERT(readFloat == &float_);
+  CPPUNIT_ASSERT(readDouble == &double_);
+}

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -39,17 +39,18 @@ Test of the EventPrincipal class.
 
 #include "FWCore/Framework/interface/Event.h"
 
-class testEventGetRefBeforePut: public CppUnit::TestFixture {
-CPPUNIT_TEST_SUITE(testEventGetRefBeforePut);
-CPPUNIT_TEST(failGetProductNotRegisteredTest);
-CPPUNIT_TEST(getRefTest);
-CPPUNIT_TEST_SUITE_END();
+class testEventGetRefBeforePut : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testEventGetRefBeforePut);
+  CPPUNIT_TEST(failGetProductNotRegisteredTest);
+  CPPUNIT_TEST(getRefTest);
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){
-  }
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
   void failGetProductNotRegisteredTest();
   void getRefTest();
+
 private:
   edm::HistoryAppender historyAppender_;
 };
@@ -58,7 +59,6 @@ private:
 CPPUNIT_TEST_SUITE_REGISTRATION(testEventGetRefBeforePut);
 
 void testEventGetRefBeforePut::failGetProductNotRegisteredTest() {
-
   auto preg = std::make_unique<edm::ProductRegistry>();
   preg->setFrozen();
   auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
@@ -70,56 +70,55 @@ void testEventGetRefBeforePut::failGetProductNotRegisteredTest() {
   edm::ProcessConfiguration pc("PROD", edm::ParameterSetID(), edm::getReleaseVersion(), edm::getPassID());
   std::shared_ptr<edm::ProductRegistry const> pregc(preg.release());
   auto runAux = std::make_shared<edm::RunAuxiliary>(col.run(), fakeTime, fakeTime);
-  auto rp = std::make_shared<edm::RunPrincipal>(runAux, pregc, pc, &historyAppender_,0);
+  auto rp = std::make_shared<edm::RunPrincipal>(runAux, pregc, pc, &historyAppender_, 0);
   edm::LuminosityBlockAuxiliary lumiAux(rp->run(), 1, fakeTime, fakeTime);
-  auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(pregc, pc, &historyAppender_,0);
+  auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(pregc, pc, &historyAppender_, 0);
   lbp->setAux(lumiAux);
   lbp->setRunPrincipal(rp);
   edm::EventAuxiliary eventAux(col, uuid, fakeTime, true);
-  edm::EventPrincipal ep(pregc, branchIDListHelper, thinnedAssociationsHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
+  edm::EventPrincipal ep(pregc, branchIDListHelper, thinnedAssociationsHelper, pc, &historyAppender_,
+                         edm::StreamID::invalidStreamID());
   edm::ProcessHistoryRegistry phr;
   ep.fillEventPrincipal(eventAux, phr);
   ep.setLuminosityBlockPrincipal(lbp.get());
   try {
-     edm::ParameterSet pset;
-     pset.registerIt();
-     auto processConfiguration = std::make_shared<edm::ProcessConfiguration>();
-     edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs", processConfiguration.get(), edm::ModuleDescription::getUniqueID());
-     edm::Event event(ep, modDesc, nullptr);
-     edm::ProducerBase prod;
-     event.setProducer(&prod,nullptr);
+    edm::ParameterSet pset;
+    pset.registerIt();
+    auto processConfiguration = std::make_shared<edm::ProcessConfiguration>();
+    edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs", processConfiguration.get(),
+                                   edm::ModuleDescription::getUniqueID());
+    edm::Event event(ep, modDesc, nullptr);
+    edm::ProducerBase prod;
+    event.setProducer(&prod, nullptr);
 
-     std::string label("this does not exist");
-     edm::RefProd<edmtest::DummyProduct> ref = event.getRefBeforePut<edmtest::DummyProduct>(label);
-     CPPUNIT_ASSERT("Failed to throw required exception" == 0);
-  }
-  catch (edm::Exception& x) {
+    std::string label("this does not exist");
+    edm::RefProd<edmtest::DummyProduct> ref = event.getRefBeforePut<edmtest::DummyProduct>(label);
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+  } catch (edm::Exception& x) {
     // nothing to do
-  }
-  catch (...) {
+  } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
-  
+
   try {
     edm::ParameterSet pset;
     pset.registerIt();
     auto processConfiguration = std::make_shared<edm::ProcessConfiguration>();
-    edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs", processConfiguration.get(), edm::ModuleDescription::getUniqueID());
+    edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs", processConfiguration.get(),
+                                   edm::ModuleDescription::getUniqueID());
     edm::Event event(ep, modDesc, nullptr);
     edm::ProducerBase prod;
-    event.setProducer(&prod,nullptr);
-    
+    event.setProducer(&prod, nullptr);
+
     std::string label("this does not exist");
-    edm::RefProd<edmtest::DummyProduct> ref = event.getRefBeforePut<edmtest::DummyProduct>(edm::EDPutTokenT<edmtest::DummyProduct>{});
+    edm::RefProd<edmtest::DummyProduct> ref =
+        event.getRefBeforePut<edmtest::DummyProduct>(edm::EDPutTokenT<edmtest::DummyProduct>{});
     CPPUNIT_ASSERT("Failed to throw required exception" == 0);
-  }
-  catch (edm::Exception& x) {
+  } catch (edm::Exception& x) {
     // nothing to do
-  }
-  catch (...) {
+  } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
-
 }
 
 void testEventGetRefBeforePut::getRefTest() {
@@ -140,16 +139,8 @@ void testEventGetRefBeforePut::getRefTest() {
   edm::ParameterSet pset;
   pset.registerIt();
 
-  edm::BranchDescription product(edm::InEvent,
-                                 label,
-                                 processName,
-                                 dummytype.userClassName(),
-                                 className,
-                                 productInstanceName,
-                                 "",
-                                 pset.id(),
-                                 dummytype
-                              );
+  edm::BranchDescription product(edm::InEvent, label, processName, dummytype.userClassName(), className,
+                                 productInstanceName, "", pset.id(), dummytype);
 
   product.init();
 
@@ -162,17 +153,19 @@ void testEventGetRefBeforePut::getRefTest() {
   edm::EventID col(1L, 1L, 1L);
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp fakeTime;
-  auto pcPtr = std::make_shared<edm::ProcessConfiguration>(processName, dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
+  auto pcPtr = std::make_shared<edm::ProcessConfiguration>(processName, dummyProcessPset.id(), edm::getReleaseVersion(),
+                                                           edm::getPassID());
   edm::ProcessConfiguration& pc = *pcPtr;
   std::shared_ptr<edm::ProductRegistry const> pregc(preg.release());
   auto runAux = std::make_shared<edm::RunAuxiliary>(col.run(), fakeTime, fakeTime);
-  auto rp = std::make_shared<edm::RunPrincipal>(runAux, pregc, pc, &historyAppender_,0);
+  auto rp = std::make_shared<edm::RunPrincipal>(runAux, pregc, pc, &historyAppender_, 0);
   edm::LuminosityBlockAuxiliary lumiAux(rp->run(), 1, fakeTime, fakeTime);
-  auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(pregc, pc, &historyAppender_,0);
+  auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(pregc, pc, &historyAppender_, 0);
   lbp->setAux(lumiAux);
   lbp->setRunPrincipal(rp);
   edm::EventAuxiliary eventAux(col, uuid, fakeTime, true);
-  edm::EventPrincipal ep(pregc, branchIDListHelper, thinnedAssociationsHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
+  edm::EventPrincipal ep(pregc, branchIDListHelper, thinnedAssociationsHelper, pc, &historyAppender_,
+                         edm::StreamID::invalidStreamID());
   edm::ProcessHistoryRegistry phr;
   ep.fillEventPrincipal(eventAux, phr);
   ep.setLuminosityBlockPrincipal(lbp.get());
@@ -185,26 +178,22 @@ void testEventGetRefBeforePut::getRefTest() {
     edm::ProducerBase prod;
     prod.produces<edmtest::IntProduct>(productInstanceName);
     const_cast<std::vector<edm::ProductResolverIndex>&>(prod.putTokenIndexToProductResolverIndex()).push_back(0);
-    event.setProducer(&prod,nullptr);
+    event.setProducer(&prod, nullptr);
     auto pr = std::make_unique<edmtest::IntProduct>();
     pr->value = 10;
 
     refToProd = event.getRefBeforePut<edmtest::IntProduct>(productInstanceName);
-    event.put(std::move(pr),productInstanceName);
+    event.put(std::move(pr), productInstanceName);
     event.commit_(std::vector<edm::ProductResolverIndex>());
-  }
-  catch (cms::Exception& x) {
-    std::cerr << x.explainSelf()<< std::endl;
+  } catch (cms::Exception& x) {
+    std::cerr << x.explainSelf() << std::endl;
     CPPUNIT_ASSERT("Threw exception unexpectedly" == 0);
-  }
-  catch(std::exception& x){
-     std::cerr <<x.what()<<std::endl;
-     CPPUNIT_ASSERT("threw std::exception"==0);
-  }
-  catch (...) {
+  } catch (std::exception& x) {
+    std::cerr << x.what() << std::endl;
+    CPPUNIT_ASSERT("threw std::exception" == 0);
+  } catch (...) {
     std::cerr << "Unknown exception type\n";
     CPPUNIT_ASSERT("Threw exception unexpectedly" == 0);
   }
   CPPUNIT_ASSERT(refToProd->value == 10);
 }
-

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -42,7 +42,7 @@ Test of the EventPrincipal class.
 #include <string>
 #include <typeinfo>
 
-class test_ep: public CppUnit::TestFixture {
+class test_ep : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(test_ep);
   CPPUNIT_TEST(failgetbyIdTest);
   CPPUNIT_TEST(failgetbyLabelTest);
@@ -50,6 +50,7 @@ class test_ep: public CppUnit::TestFixture {
   CPPUNIT_TEST(failgetbyInvalidIdTest);
   CPPUNIT_TEST(failgetProvenanceTest);
   CPPUNIT_TEST_SUITE_END();
+
 public:
   void setUp();
   void tearDown();
@@ -60,26 +61,23 @@ public:
   void failgetProvenanceTest();
 
 private:
+  std::shared_ptr<edm::ProcessConfiguration> fake_single_module_process(
+      std::string const& tag,
+      std::string const& processName,
+      edm::ParameterSet const& moduleParams,
+      std::string const& release = edm::getReleaseVersion(),
+      std::string const& pass = edm::getPassID());
+  std::shared_ptr<edm::BranchDescription> fake_single_process_branch(
+      std::string const& tag, std::string const& processName, std::string const& productInstanceName = std::string());
 
-  std::shared_ptr<edm::ProcessConfiguration>
-  fake_single_module_process(std::string const& tag,
-                             std::string const& processName,
-                             edm::ParameterSet const& moduleParams,
-                             std::string const& release = edm::getReleaseVersion(),
-                             std::string const& pass = edm::getPassID());
-  std::shared_ptr<edm::BranchDescription>
-  fake_single_process_branch(std::string const& tag,
-                             std::string const& processName,
-                             std::string const& productInstanceName = std::string());
-
-  std::map<std::string, std::shared_ptr<edm::BranchDescription> >    branchDescriptions_;
+  std::map<std::string, std::shared_ptr<edm::BranchDescription> > branchDescriptions_;
   std::map<std::string, std::shared_ptr<edm::ProcessConfiguration> > processConfigurations_;
 
-  std::shared_ptr<edm::ProductRegistry>   pProductRegistry_;
+  std::shared_ptr<edm::ProductRegistry> pProductRegistry_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> lbp_;
-  std::shared_ptr<edm::EventPrincipal>    pEvent_;
+  std::shared_ptr<edm::EventPrincipal> pEvent_;
 
-  edm::EventID               eventID_;
+  edm::EventID eventID_;
 
   edm::HistoryAppender historyAppender_;
 };
@@ -91,16 +89,14 @@ CPPUNIT_TEST_SUITE_REGISTRATION(test_ep);
 
 //----------------------------------------------------------------------
 
-std::shared_ptr<edm::ProcessConfiguration>
-test_ep::fake_single_module_process(std::string const& tag,
-                                    std::string const& processName,
-                                    edm::ParameterSet const& moduleParams,
-                                    std::string const& release,
-                                    std::string const& pass) {
+std::shared_ptr<edm::ProcessConfiguration> test_ep::fake_single_module_process(std::string const& tag,
+                                                                               std::string const& processName,
+                                                                               edm::ParameterSet const& moduleParams,
+                                                                               std::string const& release,
+                                                                               std::string const& pass) {
   edm::ParameterSet processParams;
   processParams.addParameter(processName, moduleParams);
-  processParams.addParameter<std::string>("@process_name",
-                                          processName);
+  processParams.addParameter<std::string>("@process_name", processName);
 
   processParams.registerIt();
   auto result = std::make_shared<edm::ProcessConfiguration>(processName, processParams.id(), release, pass);
@@ -108,10 +104,9 @@ test_ep::fake_single_module_process(std::string const& tag,
   return result;
 }
 
-std::shared_ptr<edm::BranchDescription>
-test_ep::fake_single_process_branch(std::string const& tag,
-                                    std::string const& processName,
-                                    std::string const& productInstanceName) {
+std::shared_ptr<edm::BranchDescription> test_ep::fake_single_process_branch(std::string const& tag,
+                                                                            std::string const& processName,
+                                                                            std::string const& productInstanceName) {
   std::string moduleLabel = processName + "dummyMod";
   std::string moduleClass("DummyModule");
   edm::TypeWithDict dummyType(typeid(edmtest::DummyProduct));
@@ -123,29 +118,21 @@ test_ep::fake_single_process_branch(std::string const& tag,
   modParams.registerIt();
   std::shared_ptr<edm::ProcessConfiguration> process(fake_single_module_process(tag, processName, modParams));
 
-  auto result = std::make_shared<edm::BranchDescription>(
-                               edm::InEvent,
-                               moduleLabel,
-                               processName,
-                               productClassName,
-                               friendlyProductClassName,
-                               productInstanceName,
-                               moduleClass,
-                               modParams.id(),
-                               dummyType);
+  auto result = std::make_shared<edm::BranchDescription>(edm::InEvent, moduleLabel, processName, productClassName,
+                                                         friendlyProductClassName, productInstanceName, moduleClass,
+                                                         modParams.id(), dummyType);
   branchDescriptions_[tag] = result;
   return result;
 }
 
 void test_ep::setUp() {
-
   // Making a functional EventPrincipal is not trivial, so we do it
   // all here.
   eventID_ = edm::EventID(101, 1, 20);
 
   // We can only insert products registered in the ProductRegistry.
   pProductRegistry_.reset(new edm::ProductRegistry);
-  pProductRegistry_->addProduct(*fake_single_process_branch("hlt",  "HLT"));
+  pProductRegistry_->addProduct(*fake_single_process_branch("hlt", "HLT"));
   pProductRegistry_->addProduct(*fake_single_process_branch("prod", "PROD"));
   pProductRegistry_->addProduct(*fake_single_process_branch("test", "TEST"));
   pProductRegistry_->addProduct(*fake_single_process_branch("user", "USER"));
@@ -157,7 +144,6 @@ void test_ep::setUp() {
 
   // Put products we'll look for into the EventPrincipal.
   {
-
     typedef edmtest::DummyProduct PRODUCT_TYPE;
     typedef edm::Wrapper<PRODUCT_TYPE> WDP;
 
@@ -183,13 +169,14 @@ void test_ep::setUp() {
     std::string uuid = edm::createGlobalIdentifier();
     edm::Timestamp now(1234567UL);
     auto runAux = std::make_shared<edm::RunAuxiliary>(eventID_.run(), now, now);
-    auto rp = std::make_shared<edm::RunPrincipal>(runAux, pProductRegistry_, *process, &historyAppender_,0);
+    auto rp = std::make_shared<edm::RunPrincipal>(runAux, pProductRegistry_, *process, &historyAppender_, 0);
     edm::LuminosityBlockAuxiliary lumiAux(rp->run(), 1, now, now);
-    lbp_ = std::make_shared<edm::LuminosityBlockPrincipal>(pProductRegistry_, *process, &historyAppender_,0);
+    lbp_ = std::make_shared<edm::LuminosityBlockPrincipal>(pProductRegistry_, *process, &historyAppender_, 0);
     lbp_->setAux(lumiAux);
     lbp_->setRunPrincipal(rp);
     edm::EventAuxiliary eventAux(eventID_, uuid, now, true);
-    pEvent_.reset(new edm::EventPrincipal(pProductRegistry_, branchIDListHelper, thinnedAssociationsHelper, *process, &historyAppender_,edm::StreamID::invalidStreamID()));
+    pEvent_.reset(new edm::EventPrincipal(pProductRegistry_, branchIDListHelper, thinnedAssociationsHelper, *process,
+                                          &historyAppender_, edm::StreamID::invalidStreamID()));
     edm::ProcessHistoryRegistry phr;
     pEvent_->fillEventPrincipal(eventAux, phr);
     pEvent_->setLuminosityBlockPrincipal(lbp_.get());
@@ -198,21 +185,18 @@ void test_ep::setUp() {
   CPPUNIT_ASSERT(pEvent_->size() == 1);
 }
 
-template <class MAP>
-void clear_map(MAP& m) {
+template <class MAP> void clear_map(MAP& m) {
   for (typename MAP::iterator i = m.begin(), e = m.end(); i != e; ++i)
     i->second.reset();
 }
 
 void test_ep::tearDown() {
-
   clear_map(branchDescriptions_);
   clear_map(processConfigurations_);
 
   pEvent_.reset();
 
   pProductRegistry_.reset();
-
 }
 
 //----------------------------------------------------------------------
@@ -234,14 +218,15 @@ void test_ep::failgetbyLabelTest() {
 
   std::string label("this does not exist");
 
-  edm::BasicHandle h(pEvent_->getByLabel(edm::PRODUCT_TYPE, tid, label, std::string(), std::string(), nullptr, nullptr, nullptr));
+  edm::BasicHandle h(
+      pEvent_->getByLabel(edm::PRODUCT_TYPE, tid, label, std::string(), std::string(), nullptr, nullptr, nullptr));
   CPPUNIT_ASSERT(h.failedToGet());
 }
 
 void test_ep::failgetManybyTypeTest() {
   edmtest::IntProduct dummy;
   edm::TypeID tid(dummy);
-  std::vector<edm::BasicHandle > handles;
+  std::vector<edm::BasicHandle> handles;
 
   pEvent_->getManyByType(tid, handles, nullptr, nullptr, nullptr);
   CPPUNIT_ASSERT(handles.empty());

--- a/FWCore/Framework/test/eventprocessor2_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor2_t.cppunit.cc
@@ -2,7 +2,7 @@
 
 Test of the EventProcessor class.
 
-----------------------------------------------------------------------*/  
+----------------------------------------------------------------------*/
 #include <exception>
 #include <iostream>
 #include <string>
@@ -17,38 +17,34 @@ Test of the EventProcessor class.
 
 // to be called also by the other cppunit...
 void doInit() {
-   static bool firstTime=true;
-   if(firstTime) {
-      //std::cout << "common init" << std::endl;
-      if(not edmplugin::PluginManager::isAvailable()) {
-        edmplugin::PluginManager::configure(edmplugin::standard::config());
-     }
-      firstTime = false;
-   }
+  static bool firstTime = true;
+  if (firstTime) {
+    //std::cout << "common init" << std::endl;
+    if (not edmplugin::PluginManager::isAvailable()) {
+      edmplugin::PluginManager::configure(edmplugin::standard::config());
+    }
+    firstTime = false;
+  }
 }
 
+class testeventprocessor2 : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testeventprocessor2);
+  CPPUNIT_TEST(eventprocessor2Test);
+  CPPUNIT_TEST_SUITE_END();
 
-class testeventprocessor2: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testeventprocessor2);
-CPPUNIT_TEST(eventprocessor2Test);
-CPPUNIT_TEST_SUITE_END();
 public:
-  void setUp(){
-      //std::cout << "setting up testeventprocessor2" << std::endl;
-      doInit();
+  void setUp() {
+    //std::cout << "setting up testeventprocessor2" << std::endl;
+    doInit();
   }
-  void tearDown(){}
+  void tearDown() {}
   void eventprocessor2Test();
 };
 
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testeventprocessor2);
 
-
-
-void work()
-{
+void work() {
   //std::cout << "work in testeventprocessor2" << std::endl;
   std::string configuration(
       "import FWCore.ParameterSet.Config as cms\n"
@@ -70,21 +66,17 @@ void work()
   proc.endJob();
 }
 
-void testeventprocessor2::eventprocessor2Test()
-{
-  try { work();}
-  catch (cms::Exception& e) {
-      std::cerr << "CMS exception caught: "
-		<< e.explainSelf() << std::endl;
-      CPPUNIT_ASSERT("cms Exception caught in testeventprocessor2::eventprocessor2Test"==0);
-  }
-  catch (std::runtime_error& e) {
-      std::cerr << "Standard library exception caught: "
-		<< e.what() << std::endl;
-      CPPUNIT_ASSERT("std Exception caught in testeventprocessor2::eventprocessor2Test"==0);
-  }
-  catch (...) {
-      std::cerr << "Unknown exception caught" << std::endl;
-      CPPUNIT_ASSERT("unkown Exception caught in testeventprocessor2::eventprocessor2Test"==0);
+void testeventprocessor2::eventprocessor2Test() {
+  try {
+    work();
+  } catch (cms::Exception& e) {
+    std::cerr << "CMS exception caught: " << e.explainSelf() << std::endl;
+    CPPUNIT_ASSERT("cms Exception caught in testeventprocessor2::eventprocessor2Test" == 0);
+  } catch (std::runtime_error& e) {
+    std::cerr << "Standard library exception caught: " << e.what() << std::endl;
+    CPPUNIT_ASSERT("std Exception caught in testeventprocessor2::eventprocessor2Test" == 0);
+  } catch (...) {
+    std::cerr << "Unknown exception caught" << std::endl;
+    CPPUNIT_ASSERT("unkown Exception caught in testeventprocessor2::eventprocessor2Test" == 0);
   }
 }

--- a/FWCore/Framework/test/eventprocessor_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor_t.cppunit.cc
@@ -33,7 +33,7 @@ Test of the EventProcessor class.
 // defined in the other cppunit
 void doInit();
 
-class testeventprocessor: public CppUnit::TestFixture {
+class testeventprocessor : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testeventprocessor);
   CPPUNIT_TEST(parseTest);
   CPPUNIT_TEST(beginEndTest);
@@ -44,12 +44,11 @@ class testeventprocessor: public CppUnit::TestFixture {
   CPPUNIT_TEST(serviceConfigSaveTest);
   CPPUNIT_TEST_SUITE_END();
 
- public:
-
+public:
   void setUp() {
     //std::cout << "setting up testeventprocessor" << std::endl;
     doInit();
-    m_handler = std::make_unique<edm::AssertHandler>(); // propagate_const<T> has no reset() function
+    m_handler = std::make_unique<edm::AssertHandler>();  // propagate_const<T> has no reset() function
     sleep_secs_ = 0;
   }
 
@@ -62,21 +61,21 @@ class testeventprocessor: public CppUnit::TestFixture {
   void endpathTest();
   void serviceConfigSaveTest();
 
- private:
+private:
   edm::propagate_const<std::unique_ptr<edm::AssertHandler>> m_handler;
   void work() {
     //std::cout << "work in testeventprocessor" << std::endl;
     std::string configuration(
-      "import FWCore.ParameterSet.Config as cms\n"
-      "process = cms.Process('p')\n"
-      "process.maxEvents = cms.untracked.PSet(\n"
-      "    input = cms.untracked.int32(5))\n"
-      "process.source = cms.Source('EmptySource')\n"
-      "process.m1 = cms.EDProducer('TestMod',\n"
-      "    ivalue = cms.int32(10))\n"
-      "process.m2 = cms.EDProducer('TestMod',\n"
-      "    ivalue = cms.int32(-3))\n"
-      "process.p1 = cms.Path(process.m1*process.m2)\n");
+        "import FWCore.ParameterSet.Config as cms\n"
+        "process = cms.Process('p')\n"
+        "process.maxEvents = cms.untracked.PSet(\n"
+        "    input = cms.untracked.int32(5))\n"
+        "process.source = cms.Source('EmptySource')\n"
+        "process.m1 = cms.EDProducer('TestMod',\n"
+        "    ivalue = cms.int32(10))\n"
+        "process.m2 = cms.EDProducer('TestMod',\n"
+        "    ivalue = cms.int32(-3))\n"
+        "process.p1 = cms.Path(process.m1*process.m2)\n");
     edm::EventProcessor proc(edm::getPSetFromConfig(configuration));
     proc.beginJob();
     proc.run();
@@ -89,19 +88,16 @@ class testeventprocessor: public CppUnit::TestFixture {
 CPPUNIT_TEST_SUITE_REGISTRATION(testeventprocessor);
 
 void testeventprocessor::parseTest() {
-  try { work();}
-  catch (cms::Exception& e) {
-      std::cerr << "cms exception caught: "
-                << e.explainSelf() << std::endl;
-      CPPUNIT_ASSERT("Caught cms::Exception " == 0);
-  }
-  catch (std::exception& e) {
-      std::cerr << "Standard library exception caught: "
-                << e.what() << std::endl;
-      CPPUNIT_ASSERT("Caught std::exception " == 0);
-  }
-  catch (...) {
-      CPPUNIT_ASSERT("Caught unknown exception " == 0);
+  try {
+    work();
+  } catch (cms::Exception& e) {
+    std::cerr << "cms exception caught: " << e.explainSelf() << std::endl;
+    CPPUNIT_ASSERT("Caught cms::Exception " == 0);
+  } catch (std::exception& e) {
+    std::cerr << "Standard library exception caught: " << e.what() << std::endl;
+    CPPUNIT_ASSERT("Caught std::exception " == 0);
+  } catch (...) {
+    CPPUNIT_ASSERT("Caught unknown exception " == 0);
   }
 }
 
@@ -134,9 +130,9 @@ void testeventprocessor::beginEndTest() {
     CPPUNIT_ASSERT(0 == proc.totalEvents());
 
     proc.beginJob();
- 
+
     //std::cout << "beginEndTest 1 af" << std::endl;
- 
+
     CPPUNIT_ASSERT(TestBeginEndJobAnalyzer::control().beginJobCalled);
     CPPUNIT_ASSERT(!TestBeginEndJobAnalyzer::control().endJobCalled);
     CPPUNIT_ASSERT(!TestBeginEndJobAnalyzer::control().beginRunCalled);
@@ -155,7 +151,7 @@ void testeventprocessor::beginEndTest() {
     CPPUNIT_ASSERT(!TestBeginEndJobAnalyzer::control().endLumiCalled);
     CPPUNIT_ASSERT(0 == proc.totalEvents());
 
-     CPPUNIT_ASSERT(not edm::pset::Registry::instance()->empty());
+    CPPUNIT_ASSERT(not edm::pset::Registry::instance()->empty());
   }
   CPPUNIT_ASSERT(edm::pset::Registry::instance()->empty());
 
@@ -238,13 +234,12 @@ void testeventprocessor::beginEndTest() {
     CPPUNIT_ASSERT(TestBeginEndJobAnalyzer::control().beginLumiCalled);
     CPPUNIT_ASSERT(TestBeginEndJobAnalyzer::control().endLumiCalled);
     CPPUNIT_ASSERT(10 == proc.totalEvents());
-    
+
     proc.endJob();
-    
+
     // Check that these are not called again
     TestBeginEndJobAnalyzer::control().endRunCalled = false;
     TestBeginEndJobAnalyzer::control().endLumiCalled = false;
-
   }
   CPPUNIT_ASSERT(!TestBeginEndJobAnalyzer::control().endRunCalled);
   CPPUNIT_ASSERT(!TestBeginEndJobAnalyzer::control().endLumiCalled);
@@ -315,9 +310,8 @@ void testeventprocessor::beginEndTest() {
   CPPUNIT_ASSERT(TestBeginEndJobAnalyzer::control().endLumiCalled);
 }
 
-void testeventprocessor::cleanupJobTest()
-{
-  //std::cout << "cleanup " << std::endl; 
+void testeventprocessor::cleanupJobTest() {
+  //std::cout << "cleanup " << std::endl;
   std::string configuration(
       "import FWCore.ParameterSet.Config as cms\n"
       "process = cms.Process('p')\n"
@@ -327,7 +321,7 @@ void testeventprocessor::cleanupJobTest()
       "process.m1 = cms.EDAnalyzer('TestBeginEndJobAnalyzer')\n"
       "process.p1 = cms.Path(process.m1)\n");
   {
-      //std::cout << "cleanup 1" << std::endl;
+    //std::cout << "cleanup 1" << std::endl;
 
     TestBeginEndJobAnalyzer::control().destructorCalled = false;
     edm::EventProcessor proc(edm::getPSetFromConfig(configuration));
@@ -340,7 +334,7 @@ void testeventprocessor::cleanupJobTest()
   }
   CPPUNIT_ASSERT(TestBeginEndJobAnalyzer::control().destructorCalled);
   {
-      //std::cout << "cleanup 2" << std::endl;
+    //std::cout << "cleanup 2" << std::endl;
 
     TestBeginEndJobAnalyzer::control().destructorCalled = false;
     edm::EventProcessor proc(edm::getPSetFromConfig(configuration));
@@ -349,44 +343,37 @@ void testeventprocessor::cleanupJobTest()
     proc.run();
     CPPUNIT_ASSERT(2 == proc.totalEvents());
     CPPUNIT_ASSERT(!TestBeginEndJobAnalyzer::control().destructorCalled);
-
   }
   CPPUNIT_ASSERT(TestBeginEndJobAnalyzer::control().destructorCalled);
 }
 
 namespace {
-  struct Listener{
-    Listener(edm::ActivityRegistry& iAR) :
-      postBeginJob_(0),
-      postEndJob_(0),
-      preEventProcessing_(0),
-      postEventProcessing_(0),
-      preModule_(0),
-      postModule_(0) {
-        iAR.watchPostBeginJob(this, &Listener::postBeginJob);
-        iAR.watchPostEndJob(this, &Listener::postEndJob);
+  struct Listener {
+    Listener(edm::ActivityRegistry& iAR)
+        : postBeginJob_(0),
+          postEndJob_(0),
+          preEventProcessing_(0),
+          postEventProcessing_(0),
+          preModule_(0),
+          postModule_(0) {
+      iAR.watchPostBeginJob(this, &Listener::postBeginJob);
+      iAR.watchPostEndJob(this, &Listener::postEndJob);
 
-        iAR.watchPreEvent(this, &Listener::preEventProcessing);
-        iAR.watchPostEvent(this, &Listener::postEventProcessing);
+      iAR.watchPreEvent(this, &Listener::preEventProcessing);
+      iAR.watchPostEvent(this, &Listener::postEventProcessing);
 
-        iAR.watchPreModuleEvent(this, &Listener::preModule);
-        iAR.watchPostModuleEvent(this, &Listener::postModule);
-      }
-
-    void postBeginJob() {++postBeginJob_;}
-    void postEndJob() {++postEndJob_;}
-
-    void preEventProcessing(edm::StreamContext const&) {
-      ++preEventProcessing_;}
-    void postEventProcessing(edm::StreamContext const&) {
-      ++postEventProcessing_;}
-
-    void preModule(edm::StreamContext const&, edm::ModuleCallingContext const&) {
-      ++preModule_;
+      iAR.watchPreModuleEvent(this, &Listener::preModule);
+      iAR.watchPostModuleEvent(this, &Listener::postModule);
     }
-    void postModule(edm::StreamContext const&, edm::ModuleCallingContext const&) {
-      ++postModule_;
-    }
+
+    void postBeginJob() { ++postBeginJob_; }
+    void postEndJob() { ++postEndJob_; }
+
+    void preEventProcessing(edm::StreamContext const&) { ++preEventProcessing_; }
+    void postEventProcessing(edm::StreamContext const&) { ++postEventProcessing_; }
+
+    void preModule(edm::StreamContext const&, edm::ModuleCallingContext const&) { ++preModule_; }
+    void postModule(edm::StreamContext const&, edm::ModuleCallingContext const&) { ++postModule_; }
 
     unsigned int postBeginJob_;
     unsigned int postEndJob_;
@@ -395,10 +382,9 @@ namespace {
     unsigned int preModule_;
     unsigned int postModule_;
   };
-}
+}  // namespace
 
-void
-testeventprocessor::activityRegistryTest() {
+void testeventprocessor::activityRegistryTest() {
   std::string configuration(
       "import FWCore.ParameterSet.Config as cms\n"
       "process = cms.Process('p')\n"
@@ -437,11 +423,9 @@ testeventprocessor::activityRegistryTest() {
 
   typedef std::vector<edm::ModuleDescription const*> ModuleDescs;
   ModuleDescs allModules = proc.getAllModuleDescriptions();
-  CPPUNIT_ASSERT(3 == allModules.size()); // TestMod & TriggerResults
+  CPPUNIT_ASSERT(3 == allModules.size());  // TestMod & TriggerResults
   //std::cout << "\nModuleDescriptions in testeventprocessor::activityRegistryTest()---\n";
-  for (ModuleDescs::const_iterator i = allModules.begin(), e = allModules.end();
-       i != e ;
-       ++i) {
+  for (ModuleDescs::const_iterator i = allModules.begin(), e = allModules.end(); i != e; ++i) {
     CPPUNIT_ASSERT(*i != 0);
     //std::cout << **i << '\n';
   }
@@ -451,38 +435,34 @@ testeventprocessor::activityRegistryTest() {
   CPPUNIT_ASSERT(5 == proc.totalEventsPassed());
 }
 
-static
-bool
-findModuleName(std::string const& iMessage) {
+static bool findModuleName(std::string const& iMessage) {
   static std::regex const expr("TestFailuresAnalyzer");
   return regex_search(iMessage, expr);
 }
 
-void
-testeventprocessor::moduleFailureTest() {
+void testeventprocessor::moduleFailureTest() {
   try {
-
     std::string const preC(
-      "import FWCore.ParameterSet.Config as cms\n"
-      "process = cms.Process('p')\n"
-      "process.maxEvents = cms.untracked.PSet(\n"
-      "    input = cms.untracked.int32(2))\n"
-      "process.source = cms.Source('EmptySource')\n"
-      "process.m1 = cms.EDAnalyzer('TestFailuresAnalyzer',\n"
-      "    whichFailure = cms.int32(");
+        "import FWCore.ParameterSet.Config as cms\n"
+        "process = cms.Process('p')\n"
+        "process.maxEvents = cms.untracked.PSet(\n"
+        "    input = cms.untracked.int32(2))\n"
+        "process.source = cms.Source('EmptySource')\n"
+        "process.m1 = cms.EDAnalyzer('TestFailuresAnalyzer',\n"
+        "    whichFailure = cms.int32(");
 
     std::string const postC(
-      "))\n"
-      "process.p1 = cms.Path(process.m1)\n");
+        "))\n"
+        "process.p1 = cms.Path(process.m1)\n");
 
     {
-      std::string const configuration = preC +"0"+postC;
+      std::string const configuration = preC + "0" + postC;
       bool threw = true;
       try {
         edm::EventProcessor proc(edm::getPSetFromConfig(configuration));
         threw = false;
-      } catch(cms::Exception const& iException) {
-        if(!findModuleName(iException.explainSelf())) {
+      } catch (cms::Exception const& iException) {
+        if (!findModuleName(iException.explainSelf())) {
           std::cout << iException.explainSelf() << std::endl;
           CPPUNIT_ASSERT(0 == "module name not in exception message");
         }
@@ -490,15 +470,15 @@ testeventprocessor::moduleFailureTest() {
       CPPUNIT_ASSERT(threw && 0 != "exception never thrown");
     }
     {
-      std::string const configuration = preC +"1"+postC;
+      std::string const configuration = preC + "1" + postC;
       bool threw = true;
       edm::EventProcessor proc(edm::getPSetFromConfig(configuration));
 
       try {
         proc.beginJob();
         threw = false;
-      } catch(cms::Exception const& iException) {
-        if(!findModuleName(iException.explainSelf())) {
+      } catch (cms::Exception const& iException) {
+        if (!findModuleName(iException.explainSelf())) {
           std::cout << iException.explainSelf() << std::endl;
           CPPUNIT_ASSERT(0 == "module name not in exception message");
         }
@@ -507,7 +487,7 @@ testeventprocessor::moduleFailureTest() {
     }
 
     {
-      std::string const configuration = preC +"2"+postC;
+      std::string const configuration = preC + "2" + postC;
       bool threw = true;
       edm::EventProcessor proc(edm::getPSetFromConfig(configuration));
 
@@ -515,8 +495,8 @@ testeventprocessor::moduleFailureTest() {
       try {
         proc.run();
         threw = false;
-      } catch(cms::Exception const& iException) {
-        if(!findModuleName(iException.explainSelf())) {
+      } catch (cms::Exception const& iException) {
+        if (!findModuleName(iException.explainSelf())) {
           std::cout << iException.explainSelf() << std::endl;
           CPPUNIT_ASSERT(0 == "module name not in exception message");
         }
@@ -525,7 +505,7 @@ testeventprocessor::moduleFailureTest() {
       proc.endJob();
     }
     {
-      std::string const configuration = preC +"3"+postC;
+      std::string const configuration = preC + "3" + postC;
       bool threw = true;
       edm::EventProcessor proc(edm::getPSetFromConfig(configuration));
 
@@ -533,8 +513,8 @@ testeventprocessor::moduleFailureTest() {
       try {
         proc.endJob();
         threw = false;
-      } catch(cms::Exception const& iException) {
-        if(!findModuleName(iException.explainSelf())) {
+      } catch (cms::Exception const& iException) {
+        if (!findModuleName(iException.explainSelf())) {
           std::cout << iException.explainSelf() << std::endl;
           CPPUNIT_ASSERT(0 == "module name not in exception message");
         }
@@ -546,49 +526,46 @@ testeventprocessor::moduleFailureTest() {
       bool threw = true;
       try {
         std::string configuration(
-          "import FWCore.ParameterSet.Config as cms\n"
-          "process = cms.Process('p')\n"
-          "process.maxEvents = cms.untracked.PSet(\n"
-          "    input = cms.untracked.int32(2))\n"
-          "process.source = cms.Source('EmptySource')\n"
-          "process.p1 = cms.Path(process.m1)\n");
+            "import FWCore.ParameterSet.Config as cms\n"
+            "process = cms.Process('p')\n"
+            "process.maxEvents = cms.untracked.PSet(\n"
+            "    input = cms.untracked.int32(2))\n"
+            "process.source = cms.Source('EmptySource')\n"
+            "process.p1 = cms.Path(process.m1)\n");
         edm::EventProcessor proc(edm::getPSetFromConfig(configuration));
 
         threw = false;
-      } catch(cms::Exception const& iException) {
+      } catch (cms::Exception const& iException) {
         static std::regex const expr("m1");
-        if(!regex_search(iException.explainSelf(), expr)) {
+        if (!regex_search(iException.explainSelf(), expr)) {
           std::cout << iException.explainSelf() << std::endl;
           CPPUNIT_ASSERT(0 == "module name not in exception message");
         }
       }
       CPPUNIT_ASSERT(threw && 0 != "exception never thrown");
     }
-  } catch(cms::Exception const& iException) {
+  } catch (cms::Exception const& iException) {
     std::cout << "Unexpected exception " << iException.explainSelf() << std::endl;
     throw;
   }
 }
 
-void
-testeventprocessor::serviceConfigSaveTest() {
-   std::string configuration(
-                             "import FWCore.ParameterSet.Config as cms\n"
-                             "process = cms.Process('p')\n"
-                             "process.add_(cms.Service('DummyStoreConfigService'))\n"
-                             "process.maxEvents = cms.untracked.PSet(\n"
-                             "    input = cms.untracked.int32(5))\n"
-                             "process.source = cms.Source('EmptySource')\n"
-                             "process.m1 = cms.EDProducer('TestMod',\n"
-                             "   ivalue = cms.int32(-3))\n"
-                             "process.p1 = cms.Path(process.m1)\n");
+void testeventprocessor::serviceConfigSaveTest() {
+  std::string configuration(
+      "import FWCore.ParameterSet.Config as cms\n"
+      "process = cms.Process('p')\n"
+      "process.add_(cms.Service('DummyStoreConfigService'))\n"
+      "process.maxEvents = cms.untracked.PSet(\n"
+      "    input = cms.untracked.int32(5))\n"
+      "process.source = cms.Source('EmptySource')\n"
+      "process.m1 = cms.EDProducer('TestMod',\n"
+      "   ivalue = cms.int32(-3))\n"
+      "process.p1 = cms.Path(process.m1)\n");
 
-   edm::EventProcessor proc(edm::getPSetFromConfig(configuration));
-   edm::ProcessConfiguration const& processConfiguration = proc.processConfiguration();
-   edm::ParameterSet const& topPset(edm::getParameterSet(processConfiguration.parameterSetID()));
-   CPPUNIT_ASSERT(topPset.existsAs<edm::ParameterSet>("DummyStoreConfigService", true));
+  edm::EventProcessor proc(edm::getPSetFromConfig(configuration));
+  edm::ProcessConfiguration const& processConfiguration = proc.processConfiguration();
+  edm::ParameterSet const& topPset(edm::getParameterSet(processConfiguration.parameterSetID()));
+  CPPUNIT_ASSERT(topPset.existsAs<edm::ParameterSet>("DummyStoreConfigService", true));
 }
 
-void
-testeventprocessor::endpathTest() {
-}
+void testeventprocessor::endpathTest() {}

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -22,7 +22,6 @@
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/IOVSyncValue.h"
 
-
 #include "FWCore/Framework/test/DummyRecord.h"
 #include "FWCore/Framework/test/DummyProxyProvider.h"
 
@@ -36,31 +35,28 @@
 
 using namespace edm;
 namespace {
-  bool non_null(const void* iPtr) {
-    return iPtr != nullptr;
-  }
-}
+  bool non_null(const void* iPtr) { return iPtr != nullptr; }
+}  // namespace
 
-class testEventsetup: public CppUnit::TestFixture
-{
+class testEventsetup : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testEventsetup);
 
   CPPUNIT_TEST(constructTest);
   CPPUNIT_TEST(getTest);
   CPPUNIT_TEST(tryToGetTest);
-  CPPUNIT_TEST_EXCEPTION(getExcTest,edm::eventsetup::NoRecordException<DummyRecord>);
+  CPPUNIT_TEST_EXCEPTION(getExcTest, edm::eventsetup::NoRecordException<DummyRecord>);
   CPPUNIT_TEST(recordProviderTest);
   CPPUNIT_TEST(provenanceTest);
   CPPUNIT_TEST(getDataWithLabelTest);
   CPPUNIT_TEST(getDataWithESInputTagTest);
   CPPUNIT_TEST(getDataWithESGetTokenTest);
   CPPUNIT_TEST(getHandleWithESGetTokenTest);
-  CPPUNIT_TEST_EXCEPTION(recordValidityTest,edm::eventsetup::NoRecordException<DummyRecord>);
-  CPPUNIT_TEST_EXCEPTION(recordValidityExcTest,edm::eventsetup::NoRecordException<DummyRecord>);
+  CPPUNIT_TEST_EXCEPTION(recordValidityTest, edm::eventsetup::NoRecordException<DummyRecord>);
+  CPPUNIT_TEST_EXCEPTION(recordValidityExcTest, edm::eventsetup::NoRecordException<DummyRecord>);
   CPPUNIT_TEST(proxyProviderTest);
 
-  CPPUNIT_TEST_EXCEPTION(producerConflictTest,cms::Exception);
-  CPPUNIT_TEST_EXCEPTION(sourceConflictTest,cms::Exception);
+  CPPUNIT_TEST_EXCEPTION(producerConflictTest, cms::Exception);
+  CPPUNIT_TEST_EXCEPTION(sourceConflictTest, cms::Exception);
   CPPUNIT_TEST(twoSourceTest);
   CPPUNIT_TEST(sourceProducerResolutionTest);
   CPPUNIT_TEST(preferTest);
@@ -70,9 +66,10 @@ class testEventsetup: public CppUnit::TestFixture
   CPPUNIT_TEST(iovExtentionTest);
 
   CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void constructTest();
   void getTest();
@@ -97,7 +94,6 @@ public:
   void introspectionTest();
 
   void iovExtentionTest();
-
 };
 
 ///registration of the test so that the runner can find it
@@ -107,8 +103,7 @@ namespace {
   edm::ActivityRegistry activityRegistry;
 }
 
-void testEventsetup::constructTest()
-{
+void testEventsetup::constructTest() {
   eventsetup::EventSetupProvider provider(&activityRegistry);
   const Timestamp time(1);
   const IOVSyncValue timestamp(time);
@@ -116,54 +111,47 @@ void testEventsetup::constructTest()
   CPPUNIT_ASSERT(non_null(&eventSetup));
 }
 
-void testEventsetup::getTest()
-{
+void testEventsetup::getTest() {
   eventsetup::EventSetupProvider provider(&activityRegistry);
   auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
   CPPUNIT_ASSERT(non_null(&eventSetup));
 
-  eventsetup::EventSetupRecordImpl dummyRecord{ eventsetup::EventSetupRecordKey::makeKey<DummyRecord>() };
+  eventsetup::EventSetupRecordImpl dummyRecord{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
   provider.addRecordToEventSetup(dummyRecord);
   const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
   CPPUNIT_ASSERT(non_null(&gottenRecord));
   CPPUNIT_ASSERT(&dummyRecord == gottenRecord.impl_);
 }
 
-void testEventsetup::tryToGetTest()
-{
+void testEventsetup::tryToGetTest() {
   eventsetup::EventSetupProvider provider(&activityRegistry);
   auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
   CPPUNIT_ASSERT(non_null(&eventSetup));
 
-  eventsetup::EventSetupRecordImpl dummyRecord{ eventsetup::EventSetupRecordKey::makeKey<DummyRecord>() };
+  eventsetup::EventSetupRecordImpl dummyRecord{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
   provider.addRecordToEventSetup(dummyRecord);
   auto gottenRecord = eventSetup.tryToGet<DummyRecord>();
   CPPUNIT_ASSERT(gottenRecord);
   CPPUNIT_ASSERT(&dummyRecord == gottenRecord->impl_);
 }
 
-void testEventsetup::getExcTest()
-{
+void testEventsetup::getExcTest() {
   eventsetup::EventSetupProvider provider(&activityRegistry);
   auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
   CPPUNIT_ASSERT(non_null(&eventSetup));
   eventSetup.get<DummyRecord>();
 }
 
-
 class DummyEventSetupProvider : public edm::eventsetup::EventSetupProvider {
 public:
+  DummyEventSetupProvider(ActivityRegistry* activityRegistry) : EventSetupProvider(activityRegistry) {}
 
-  DummyEventSetupProvider(ActivityRegistry* activityRegistry) : EventSetupProvider(activityRegistry) { }
-
-  template<class T>
-  void insert(std::unique_ptr<T> iRecord) {
+  template <class T> void insert(std::unique_ptr<T> iRecord) {
     edm::eventsetup::EventSetupProvider::insert(std::move(iRecord));
   }
 };
 
-void testEventsetup::recordProviderTest()
-{
+void testEventsetup::recordProviderTest() {
   DummyEventSetupProvider provider(&activityRegistry);
   typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
   provider.insert(std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass()));
@@ -178,33 +166,28 @@ void testEventsetup::recordProviderTest()
   CPPUNIT_ASSERT(non_null(&gottenRecord));
 }
 
-
 class DummyFinder : public EventSetupRecordIntervalFinder {
 public:
-  DummyFinder() : EventSetupRecordIntervalFinder(), interval_()  {
-    this->findingRecord<DummyRecord>();
-  }
+  DummyFinder() : EventSetupRecordIntervalFinder(), interval_() { this->findingRecord<DummyRecord>(); }
 
-  void setInterval(const ValidityInterval& iInterval) {
-    interval_ = iInterval;
-  }
+  void setInterval(const ValidityInterval& iInterval) { interval_ = iInterval; }
+
 protected:
   virtual void setIntervalFor(const eventsetup::EventSetupRecordKey&,
                               const IOVSyncValue& iTime,
                               ValidityInterval& iInterval) {
-    if(interval_.validFor(iTime)) {
+    if (interval_.validFor(iTime)) {
       iInterval = interval_;
     } else {
       iInterval = ValidityInterval();
     }
   }
+
 private:
   ValidityInterval interval_;
 };
 
-
-void testEventsetup::recordValidityTest()
-{
+void testEventsetup::recordValidityTest() {
   DummyEventSetupProvider provider(&activityRegistry);
   typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
   auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
@@ -232,12 +215,9 @@ void testEventsetup::recordValidityTest()
     auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(4)));
     eventSetup.get<DummyRecord>();
   }
-
-
 }
 
-void testEventsetup::recordValidityExcTest()
-{
+void testEventsetup::recordValidityExcTest() {
   DummyEventSetupProvider provider(&activityRegistry);
   typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
   auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
@@ -249,29 +229,23 @@ void testEventsetup::recordValidityExcTest()
     auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(1)));
     eventSetup.get<DummyRecord>();
   }
-
 }
 
 class DummyProxyProvider : public eventsetup::DataProxyProvider {
 public:
-  DummyProxyProvider() {
-    usingRecord<DummyRecord>();
-  }
-  void newInterval(const eventsetup::EventSetupRecordKey& /*iRecordType*/,
-                   const ValidityInterval& /*iInterval*/) {
+  DummyProxyProvider() { usingRecord<DummyRecord>(); }
+  void newInterval(const eventsetup::EventSetupRecordKey& /*iRecordType*/, const ValidityInterval& /*iInterval*/) {
     //do nothing
   }
-protected:
-  void registerProxies(const eventsetup::EventSetupRecordKey&, KeyedProxies& /*iHolder*/) {
-  }
 
+protected:
+  void registerProxies(const eventsetup::EventSetupRecordKey&, KeyedProxies& /*iHolder*/) {}
 };
 
 //create an instance of the register
 static eventsetup::RecordDependencyRegister<DummyRecord> s_factory;
 
-void testEventsetup::proxyProviderTest()
-{
+void testEventsetup::proxyProviderTest() {
   eventsetup::EventSetupProvider provider(&activityRegistry);
   provider.add(std::make_shared<DummyProxyProvider>());
 
@@ -280,9 +254,8 @@ void testEventsetup::proxyProviderTest()
   CPPUNIT_ASSERT(non_null(&gottenRecord));
 }
 
-void testEventsetup::producerConflictTest()
-{
-  edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
+void testEventsetup::producerConflictTest() {
+  edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", false);
   using edm::eventsetup::test::DummyProxyProvider;
   eventsetup::EventSetupProvider provider(&activityRegistry);
   {
@@ -297,11 +270,9 @@ void testEventsetup::producerConflictTest()
   }
   //checking for conflicts is now delayed until first time EventSetup is requested
   /*auto const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-
 }
-void testEventsetup::sourceConflictTest()
-{
-  edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+void testEventsetup::sourceConflictTest() {
+  edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
   using edm::eventsetup::test::DummyProxyProvider;
   eventsetup::EventSetupProvider provider(&activityRegistry);
   {
@@ -316,13 +287,11 @@ void testEventsetup::sourceConflictTest()
   }
   //checking for conflicts is now delayed until first time EventSetup is requested
   /*auto const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-
 }
 //#define TEST_EXCLUDE_DEF
 
-void testEventsetup::twoSourceTest()
-{
-  edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+void testEventsetup::twoSourceTest() {
+  edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
   using edm::eventsetup::test::DummyProxyProvider;
   eventsetup::EventSetupProvider provider(&activityRegistry);
   {
@@ -334,26 +303,24 @@ void testEventsetup::twoSourceTest()
     auto dummyProv = std::make_shared<edm::DummyEventSetupRecordRetriever>();
     std::shared_ptr<eventsetup::DataProxyProvider> providerPtr(dummyProv);
     std::shared_ptr<edm::EventSetupRecordIntervalFinder> finderPtr(dummyProv);
-    edm::eventsetup::ComponentDescription description2("DummyEventSetupRecordRetriever","",true);
+    edm::eventsetup::ComponentDescription description2("DummyEventSetupRecordRetriever", "", true);
     dummyProv->setDescription(description2);
     provider.add(providerPtr);
     provider.add(finderPtr);
   }
   //checking for conflicts is now delayed until first time EventSetup is requested
   /*auto const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-
 }
-void testEventsetup::provenanceTest()
-{
-  using edm::eventsetup::test::DummyProxyProvider;
+void testEventsetup::provenanceTest() {
   using edm::eventsetup::test::DummyData;
+  using edm::eventsetup::test::DummyProxyProvider;
   DummyData kGood{1};
   DummyData kBad{0};
 
   eventsetup::EventSetupProvider provider(&activityRegistry);
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -363,7 +330,7 @@ void testEventsetup::provenanceTest()
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","testLabel",false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testLabel", false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test22");
       ps.registerIt();
@@ -375,26 +342,25 @@ void testEventsetup::provenanceTest()
     auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
-    CPPUNIT_ASSERT(kGood.value_==data->value_);
+    CPPUNIT_ASSERT(kGood.value_ == data->value_);
     const edm::eventsetup::ComponentDescription* desc = data.description();
-    CPPUNIT_ASSERT( desc->label_ == "testLabel");
+    CPPUNIT_ASSERT(desc->label_ == "testLabel");
   } catch (const cms::Exception& iException) {
-    std::cout <<"caught "<<iException.explainSelf()<<std::endl;
+    std::cout << "caught " << iException.explainSelf() << std::endl;
     throw;
   }
 }
 
-void testEventsetup::getDataWithLabelTest()
-{
-  using edm::eventsetup::test::DummyProxyProvider;
+void testEventsetup::getDataWithLabelTest() {
   using edm::eventsetup::test::DummyData;
+  using edm::eventsetup::test::DummyProxyProvider;
   DummyData kGood{1};
   DummyData kBad{0};
 
   eventsetup::EventSetupProvider provider(&activityRegistry);
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -404,10 +370,10 @@ void testEventsetup::getDataWithLabelTest()
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","testLabel",false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testLabel", false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test22");
-      ps.addParameter<std::string>("appendToDataLabel","blah");
+      ps.addParameter<std::string>("appendToDataLabel", "blah");
       ps.registerIt();
       description.pid_ = ps.id();
       auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
@@ -417,27 +383,26 @@ void testEventsetup::getDataWithLabelTest()
     }
     auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
     edm::ESHandle<DummyData> data;
-    eventSetup.getData("blah",data);
-    CPPUNIT_ASSERT(kGood.value_==data->value_);
+    eventSetup.getData("blah", data);
+    CPPUNIT_ASSERT(kGood.value_ == data->value_);
     const edm::eventsetup::ComponentDescription* desc = data.description();
-    CPPUNIT_ASSERT( desc->label_ == "testLabel");
+    CPPUNIT_ASSERT(desc->label_ == "testLabel");
   } catch (const cms::Exception& iException) {
-    std::cout <<"caught "<<iException.explainSelf()<<std::endl;
+    std::cout << "caught " << iException.explainSelf() << std::endl;
     throw;
   }
 }
 
-void testEventsetup::getDataWithESInputTagTest()
-{
-  using edm::eventsetup::test::DummyProxyProvider;
+void testEventsetup::getDataWithESInputTagTest() {
   using edm::eventsetup::test::DummyData;
+  using edm::eventsetup::test::DummyProxyProvider;
   DummyData kGood{1};
   DummyData kBad{0};
 
   eventsetup::EventSetupProvider provider(&activityRegistry);
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","testOne",true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -447,10 +412,10 @@ void testEventsetup::getDataWithESInputTagTest()
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","testTwo",false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testTwo", false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test22");
-      ps.addParameter<std::string>("appendToDataLabel","blah");
+      ps.addParameter<std::string>("appendToDataLabel", "blah");
       ps.registerIt();
       description.pid_ = ps.id();
       auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
@@ -461,65 +426,62 @@ void testEventsetup::getDataWithESInputTagTest()
     auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
     {
       edm::ESHandle<DummyData> data;
-      edm::ESInputTag blahTag("","blah");
-      eventSetup.getData(blahTag,data);
-      CPPUNIT_ASSERT(kGood.value_==data->value_);
+      edm::ESInputTag blahTag("", "blah");
+      eventSetup.getData(blahTag, data);
+      CPPUNIT_ASSERT(kGood.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
-      CPPUNIT_ASSERT( desc->label_ == "testTwo");
+      CPPUNIT_ASSERT(desc->label_ == "testTwo");
     }
 
     {
       edm::ESHandle<DummyData> data;
-      edm::ESInputTag nullTag("","");
-      eventSetup.getData(nullTag,data);
-      CPPUNIT_ASSERT(kBad.value_==data->value_);
+      edm::ESInputTag nullTag("", "");
+      eventSetup.getData(nullTag, data);
+      CPPUNIT_ASSERT(kBad.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
-      CPPUNIT_ASSERT( desc->label_ == "testOne");
+      CPPUNIT_ASSERT(desc->label_ == "testOne");
     }
 
     {
       edm::ESHandle<DummyData> data;
-      edm::ESInputTag blahTag("testTwo","blah");
-      eventSetup.getData(blahTag,data);
-      CPPUNIT_ASSERT(kGood.value_==data->value_);
+      edm::ESInputTag blahTag("testTwo", "blah");
+      eventSetup.getData(blahTag, data);
+      CPPUNIT_ASSERT(kGood.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
-      CPPUNIT_ASSERT( desc->label_ == "testTwo");
+      CPPUNIT_ASSERT(desc->label_ == "testTwo");
     }
 
     {
       edm::ESHandle<DummyData> data;
-      edm::ESInputTag badTag("DoesNotExist","blah");
+      edm::ESInputTag badTag("DoesNotExist", "blah");
       CPPUNIT_ASSERT_THROW(eventSetup.getData(badTag, data), cms::Exception);
     }
 
-
   } catch (const cms::Exception& iException) {
-    std::cout <<"caught "<<iException.explainSelf()<<std::endl;
+    std::cout << "caught " << iException.explainSelf() << std::endl;
     throw;
   }
 }
 
 namespace {
   struct DummyDataConsumer : public EDConsumerBase {
-    explicit DummyDataConsumer( ESInputTag const& iTag):
-    m_token{esConsumes<edm::eventsetup::test::DummyData, edm::DefaultRecord>(iTag)}
-    {}
-    
+    explicit DummyDataConsumer(ESInputTag const& iTag)
+        : m_token{esConsumes<edm::eventsetup::test::DummyData, edm::DefaultRecord>(iTag)} {}
+
     ESGetToken<edm::eventsetup::test::DummyData, edm::DefaultRecord> m_token;
   };
-}
+}  // namespace
 
-void testEventsetup::getDataWithESGetTokenTest()
-{
-  using edm::eventsetup::test::DummyProxyProvider;
+void testEventsetup::getDataWithESGetTokenTest() {
   using edm::eventsetup::test::DummyData;
+  using edm::eventsetup::test::DummyProxyProvider;
   DummyData kGood{1};
   DummyData kBad{0};
-  
+
   eventsetup::EventSetupProvider provider(&activityRegistry);
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","testOne",true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -529,10 +491,10 @@ void testEventsetup::getDataWithESGetTokenTest()
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","testTwo",false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testTwo", false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test22");
-      ps.addParameter<std::string>("appendToDataLabel","blah");
+      ps.addParameter<std::string>("appendToDataLabel", "blah");
       ps.registerIt();
       description.pid_ = ps.id();
       auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
@@ -543,47 +505,45 @@ void testEventsetup::getDataWithESGetTokenTest()
     auto const& eventSetupImpl = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
     EventSetup eventSetup{eventSetupImpl};
     {
-      DummyDataConsumer consumer{edm::ESInputTag("","blah")};
-      
+      DummyDataConsumer consumer{edm::ESInputTag("", "blah")};
+
       auto const& data = eventSetup.getData(consumer.m_token);
-      CPPUNIT_ASSERT(kGood.value_==data.value_);
+      CPPUNIT_ASSERT(kGood.value_ == data.value_);
     }
-    
+
     {
-      DummyDataConsumer consumer{edm::ESInputTag("","")};
+      DummyDataConsumer consumer{edm::ESInputTag("", "")};
       const DummyData& data = eventSetup.getData(consumer.m_token);
-      CPPUNIT_ASSERT(kBad.value_==data.value_);
+      CPPUNIT_ASSERT(kBad.value_ == data.value_);
     }
-    
+
     {
-      DummyDataConsumer consumer{edm::ESInputTag("testTwo","blah")};
+      DummyDataConsumer consumer{edm::ESInputTag("testTwo", "blah")};
       auto const& data = eventSetup.getData(consumer.m_token);
-      CPPUNIT_ASSERT(kGood.value_==data.value_);
+      CPPUNIT_ASSERT(kGood.value_ == data.value_);
     }
-    
+
     {
-      DummyDataConsumer consumer{edm::ESInputTag("DoesNotExist","blah")};
+      DummyDataConsumer consumer{edm::ESInputTag("DoesNotExist", "blah")};
       CPPUNIT_ASSERT_THROW(eventSetup.getData(consumer.m_token), cms::Exception);
     }
-    
-    
+
   } catch (const cms::Exception& iException) {
-    std::cout <<"caught "<<iException.explainSelf()<<std::endl;
+    std::cout << "caught " << iException.explainSelf() << std::endl;
     throw;
   }
 }
 
-void testEventsetup::getHandleWithESGetTokenTest()
-{
-  using edm::eventsetup::test::DummyProxyProvider;
+void testEventsetup::getHandleWithESGetTokenTest() {
   using edm::eventsetup::test::DummyData;
+  using edm::eventsetup::test::DummyProxyProvider;
   DummyData kGood{1};
   DummyData kBad{0};
-  
+
   eventsetup::EventSetupProvider provider(&activityRegistry);
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","testOne",true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -593,10 +553,10 @@ void testEventsetup::getHandleWithESGetTokenTest()
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","testTwo",false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testTwo", false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test22");
-      ps.addParameter<std::string>("appendToDataLabel","blah");
+      ps.addParameter<std::string>("appendToDataLabel", "blah");
       ps.registerIt();
       description.pid_ = ps.id();
       auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
@@ -607,59 +567,57 @@ void testEventsetup::getHandleWithESGetTokenTest()
     auto const& eventSetupImpl = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
     EventSetup eventSetup{eventSetupImpl};
     {
-      DummyDataConsumer consumer{edm::ESInputTag("","blah")};
-      
+      DummyDataConsumer consumer{edm::ESInputTag("", "blah")};
+
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
-      CPPUNIT_ASSERT(kGood.value_==data->value_);
+      CPPUNIT_ASSERT(kGood.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
-      CPPUNIT_ASSERT( desc->label_ == "testTwo");
+      CPPUNIT_ASSERT(desc->label_ == "testTwo");
     }
-    
+
     {
-      DummyDataConsumer consumer{edm::ESInputTag("","")};
+      DummyDataConsumer consumer{edm::ESInputTag("", "")};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
-      CPPUNIT_ASSERT(kBad.value_==data->value_);
+      CPPUNIT_ASSERT(kBad.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
-      CPPUNIT_ASSERT( desc->label_ == "testOne");
+      CPPUNIT_ASSERT(desc->label_ == "testOne");
     }
-    
+
     {
-      DummyDataConsumer consumer{edm::ESInputTag("testTwo","blah")};
+      DummyDataConsumer consumer{edm::ESInputTag("testTwo", "blah")};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
-      CPPUNIT_ASSERT(kGood.value_==data->value_);
+      CPPUNIT_ASSERT(kGood.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
-      CPPUNIT_ASSERT( desc->label_ == "testTwo");
+      CPPUNIT_ASSERT(desc->label_ == "testTwo");
     }
-    
+
     {
-      DummyDataConsumer consumer{edm::ESInputTag("DoesNotExist","blah")};
+      DummyDataConsumer consumer{edm::ESInputTag("DoesNotExist", "blah")};
       CPPUNIT_ASSERT_THROW(eventSetup.getHandle(consumer.m_token), cms::Exception);
     }
-    
-    
+
   } catch (const cms::Exception& iException) {
-    std::cout <<"caught "<<iException.explainSelf()<<std::endl;
+    std::cout << "caught " << iException.explainSelf() << std::endl;
     throw;
   }
 }
 
-void testEventsetup::sourceProducerResolutionTest()
-{
-  using edm::eventsetup::test::DummyProxyProvider;
+void testEventsetup::sourceProducerResolutionTest() {
   using edm::eventsetup::test::DummyData;
+  using edm::eventsetup::test::DummyProxyProvider;
   DummyData kGood{1};
   DummyData kBad{0};
 
   {
     eventsetup::EventSetupProvider provider(&activityRegistry);
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
       auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", false);
       auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
@@ -672,20 +630,20 @@ void testEventsetup::sourceProducerResolutionTest()
     auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
-    CPPUNIT_ASSERT(kGood.value_==data->value_);
+    CPPUNIT_ASSERT(kGood.value_ == data->value_);
   }
 
   //reverse order
   {
     eventsetup::EventSetupProvider provider(&activityRegistry);
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", false);
       auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
       auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
@@ -698,17 +656,14 @@ void testEventsetup::sourceProducerResolutionTest()
     auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
-    CPPUNIT_ASSERT(kGood.value_==data->value_);
+    CPPUNIT_ASSERT(kGood.value_ == data->value_);
   }
-
 }
 
-
-void testEventsetup::preferTest()
-{
+void testEventsetup::preferTest() {
   try {
-    using edm::eventsetup::test::DummyProxyProvider;
     using edm::eventsetup::test::DummyData;
+    using edm::eventsetup::test::DummyProxyProvider;
     DummyData kGood{1};
     DummyData kBad{0};
 
@@ -717,17 +672,17 @@ void testEventsetup::preferTest()
       EventSetupProvider::PreferredProviderInfo preferInfo;
       EventSetupProvider::RecordToDataMap recordToData;
       //default means use all proxies
-      preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
+      preferInfo[ComponentDescription("DummyProxyProvider", "", false)] = recordToData;
 
       eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
       {
-        edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",false);
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "bad", false);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
       {
-        edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", false);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
@@ -740,7 +695,7 @@ void testEventsetup::preferTest()
       auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
-      CPPUNIT_ASSERT(kGood.value_==data->value_);
+      CPPUNIT_ASSERT(kGood.value_ == data->value_);
     }
 
     //sources
@@ -749,16 +704,16 @@ void testEventsetup::preferTest()
       EventSetupProvider::PreferredProviderInfo preferInfo;
       EventSetupProvider::RecordToDataMap recordToData;
       //default means use all proxies
-      preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
+      preferInfo[ComponentDescription("DummyProxyProvider", "", false)] = recordToData;
       eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
       {
-        edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
       {
-        edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",true);
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "bad", true);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
@@ -771,7 +726,7 @@ void testEventsetup::preferTest()
       auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
-      CPPUNIT_ASSERT(kGood.value_==data->value_);
+      CPPUNIT_ASSERT(kGood.value_ == data->value_);
     }
 
     //specific name
@@ -779,18 +734,18 @@ void testEventsetup::preferTest()
       using namespace edm::eventsetup;
       EventSetupProvider::PreferredProviderInfo preferInfo;
       EventSetupProvider::RecordToDataMap recordToData;
-      recordToData.insert(std::make_pair(std::string("DummyRecord"),
-                                         std::make_pair(std::string("DummyData"),std::string())));
-      preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
+      recordToData.insert(
+          std::make_pair(std::string("DummyRecord"), std::make_pair(std::string("DummyData"), std::string())));
+      preferInfo[ComponentDescription("DummyProxyProvider", "", false)] = recordToData;
       eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
       {
-        edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
       {
-        edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",true);
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "bad", true);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
@@ -803,26 +758,25 @@ void testEventsetup::preferTest()
       auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
-      CPPUNIT_ASSERT(kGood.value_==data->value_);
+      CPPUNIT_ASSERT(kGood.value_ == data->value_);
     }
 
-  }catch(const cms::Exception& iException) {
-    std::cout <<"caught "<<iException.explainSelf()<<std::endl;
+  } catch (const cms::Exception& iException) {
+    std::cout << "caught " << iException.explainSelf() << std::endl;
     throw;
   }
 }
 
-void testEventsetup::introspectionTest()
-{
-  using edm::eventsetup::test::DummyProxyProvider;
+void testEventsetup::introspectionTest() {
   using edm::eventsetup::test::DummyData;
+  using edm::eventsetup::test::DummyProxyProvider;
   DummyData kGood{1};
   DummyData kBad{0};
 
   eventsetup::EventSetupProvider provider(&activityRegistry);
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -832,7 +786,7 @@ void testEventsetup::introspectionTest()
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test22");
       ps.registerIt();
@@ -845,17 +799,16 @@ void testEventsetup::introspectionTest()
 
     std::vector<edm::eventsetup::EventSetupRecordKey> recordKeys;
     eventSetup.fillAvailableRecordKeys(recordKeys);
-    CPPUNIT_ASSERT(1==recordKeys.size());
+    CPPUNIT_ASSERT(1 == recordKeys.size());
     auto record = eventSetup.find(recordKeys[0]);
     CPPUNIT_ASSERT(record.has_value());
   } catch (const cms::Exception& iException) {
-    std::cout <<"caught "<<iException.explainSelf()<<std::endl;
+    std::cout << "caught " << iException.explainSelf() << std::endl;
     throw;
   }
 }
 
-void testEventsetup::iovExtentionTest()
-{
+void testEventsetup::iovExtentionTest() {
   DummyEventSetupProvider provider(&activityRegistry);
   typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
   auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
@@ -869,25 +822,24 @@ void testEventsetup::iovExtentionTest()
   finder->setInterval(ValidityInterval(IOVSyncValue{time_2}, IOVSyncValue{Timestamp{3}}));
   {
     auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue{time_2});
-    CPPUNIT_ASSERT(2==eventSetup.get<DummyRecord>().cacheIdentifier());
+    CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
   {
     auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue{Timestamp{3}});
     eventSetup.get<DummyRecord>();
-    CPPUNIT_ASSERT(2==eventSetup.get<DummyRecord>().cacheIdentifier());
+    CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
   //extending the IOV should not cause the cache to be reset
   finder->setInterval(ValidityInterval(IOVSyncValue{time_2}, IOVSyncValue{Timestamp{4}}));
   {
     auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue{Timestamp{4}});
-    CPPUNIT_ASSERT(2==eventSetup.get<DummyRecord>().cacheIdentifier());
+    CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
 
   //this is a new IOV so should get cache reset
   finder->setInterval(ValidityInterval(IOVSyncValue{Timestamp{5}}, IOVSyncValue{Timestamp{6}}));
   {
     auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue{Timestamp{5}});
-    CPPUNIT_ASSERT(3==eventSetup.get<DummyRecord>().cacheIdentifier());
+    CPPUNIT_ASSERT(3 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
-
 }

--- a/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     eventsetup_plugin_t
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -30,16 +30,16 @@ namespace {
   edm::ActivityRegistry activityRegistry;
 }
 
-class testEventsetupplugin: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testEventsetupplugin);
+class testEventsetupplugin : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testEventsetupplugin);
 
-CPPUNIT_TEST(finderTest);
+  CPPUNIT_TEST(finderTest);
 
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void finderTest();
 };
@@ -48,56 +48,52 @@ public:
 CPPUNIT_TEST_SUITE_REGISTRATION(testEventsetupplugin);
 
 static void doInit() {
-   static bool firstTime=true;
-   if(firstTime) {
-      if(not edmplugin::PluginManager::isAvailable()) {
-        edmplugin::PluginManager::configure(edmplugin::standard::config());
-     }
-      firstTime = false;
-   }
+  static bool firstTime = true;
+  if (firstTime) {
+    if (not edmplugin::PluginManager::isAvailable()) {
+      edmplugin::PluginManager::configure(edmplugin::standard::config());
+    }
+    firstTime = false;
+  }
 }
 
 void testEventsetupplugin::finderTest()
 
 {
-   doInit();
-   EventSetupsController esController;
-   EventSetupProvider provider(&activityRegistry);
-   
-   edm::ParameterSet dummyFinderPSet;
-   dummyFinderPSet.addParameter("@module_type", std::string("LoadableDummyFinder"));
-   dummyFinderPSet.addParameter("@module_label", std::string(""));
-   dummyFinderPSet.registerIt();
-   SourceFactory::get()->addTo(esController, provider, dummyFinderPSet);
+  doInit();
+  EventSetupsController esController;
+  EventSetupProvider provider(&activityRegistry);
 
-   
-   ComponentDescription descFinder("LoadableDummyFinder","",true);
-   std::set<ComponentDescription> descriptions(provider.proxyProviderDescriptions());
-   //should not be found since not a provider
-   CPPUNIT_ASSERT(descriptions.find(descFinder) == descriptions.end());
+  edm::ParameterSet dummyFinderPSet;
+  dummyFinderPSet.addParameter("@module_type", std::string("LoadableDummyFinder"));
+  dummyFinderPSet.addParameter("@module_label", std::string(""));
+  dummyFinderPSet.registerIt();
+  SourceFactory::get()->addTo(esController, provider, dummyFinderPSet);
 
-   
-   edm::ParameterSet dummyProviderPSet;
-   dummyProviderPSet.addParameter("@module_type",  std::string("LoadableDummyProvider"));
-   dummyProviderPSet.addParameter("@module_label", std::string(""));
-   dummyProviderPSet.registerIt();
-   ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet);
+  ComponentDescription descFinder("LoadableDummyFinder", "", true);
+  std::set<ComponentDescription> descriptions(provider.proxyProviderDescriptions());
+  //should not be found since not a provider
+  CPPUNIT_ASSERT(descriptions.find(descFinder) == descriptions.end());
 
-   ComponentDescription desc("LoadableDummyProvider","",false);
-   descriptions = provider.proxyProviderDescriptions();
-   CPPUNIT_ASSERT(descriptions.find(desc) != descriptions.end());
-   CPPUNIT_ASSERT(*(descriptions.find(desc)) == desc);
+  edm::ParameterSet dummyProviderPSet;
+  dummyProviderPSet.addParameter("@module_type", std::string("LoadableDummyProvider"));
+  dummyProviderPSet.addParameter("@module_label", std::string(""));
+  dummyProviderPSet.registerIt();
+  ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet);
 
-   
-   edm::ParameterSet dummySourcePSet;
-   dummySourcePSet.addParameter("@module_type",  std::string("LoadableDummyESSource"));
-   dummySourcePSet.addParameter("@module_label", std::string(""));
-   dummySourcePSet.registerIt();
-   SourceFactory::get()->addTo(esController, provider, dummySourcePSet);
-   
-   ComponentDescription descSource("LoadableDummyESSource","",true);
-   descriptions = provider.proxyProviderDescriptions();
-   CPPUNIT_ASSERT(descriptions.find(descSource) != descriptions.end());
-   CPPUNIT_ASSERT(*(descriptions.find(descSource)) == descSource);
-   
+  ComponentDescription desc("LoadableDummyProvider", "", false);
+  descriptions = provider.proxyProviderDescriptions();
+  CPPUNIT_ASSERT(descriptions.find(desc) != descriptions.end());
+  CPPUNIT_ASSERT(*(descriptions.find(desc)) == desc);
+
+  edm::ParameterSet dummySourcePSet;
+  dummySourcePSet.addParameter("@module_type", std::string("LoadableDummyESSource"));
+  dummySourcePSet.addParameter("@module_label", std::string(""));
+  dummySourcePSet.registerIt();
+  SourceFactory::get()->addTo(esController, provider, dummySourcePSet);
+
+  ComponentDescription descSource("LoadableDummyESSource", "", true);
+  descriptions = provider.proxyProviderDescriptions();
+  CPPUNIT_ASSERT(descriptions.find(descSource) != descriptions.end());
+  CPPUNIT_ASSERT(*(descriptions.find(descSource)) == descSource);
 }

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -34,12 +34,13 @@ namespace {
 using namespace edm;
 using namespace edm::eventsetup;
 namespace eventsetuprecord_t {
-class DummyRecord : public edm::eventsetup::EventSetupRecordImplementation<DummyRecord> { public:
-   const DataProxy* find(const edm::eventsetup::DataKey& iKey) const {
+  class DummyRecord : public edm::eventsetup::EventSetupRecordImplementation<DummyRecord> {
+  public:
+    const DataProxy* find(const edm::eventsetup::DataKey& iKey) const {
       return edm::eventsetup::EventSetupRecord::find(iKey);
-   }
-};
-}
+    }
+  };
+}  // namespace eventsetuprecord_t
 //HCMethods<T, T, EventSetup, EventSetupRecordKey, EventSetupRecordKey::IdTag >
 HCTYPETAG_HELPER_METHODS(eventsetuprecord_t::DummyRecord)
 
@@ -47,34 +48,34 @@ HCTYPETAG_HELPER_METHODS(eventsetuprecord_t::DummyRecord)
 static eventsetup::RecordDependencyRegister<eventsetuprecord_t::DummyRecord> const s_factory;
 
 namespace eventsetuprecord_t {
-class Dummy {};
-}
+  class Dummy {};
+}  // namespace eventsetuprecord_t
 using eventsetuprecord_t::Dummy;
 using eventsetuprecord_t::DummyRecord;
 typedef edm::eventsetup::MakeDataException ExceptionType;
 typedef edm::eventsetup::NoDataException<Dummy> NoDataExceptionType;
 
-class testEventsetupRecord: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testEventsetupRecord);
+class testEventsetupRecord : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testEventsetupRecord);
 
-CPPUNIT_TEST(proxyTest);
-CPPUNIT_TEST(getTest);
-CPPUNIT_TEST(getHandleTest);
-CPPUNIT_TEST(getWithTokenTest);
-CPPUNIT_TEST(doGetTest);
-CPPUNIT_TEST(proxyResetTest);
-CPPUNIT_TEST(introspectionTest);
-CPPUNIT_TEST(transientTest);
+  CPPUNIT_TEST(proxyTest);
+  CPPUNIT_TEST(getTest);
+  CPPUNIT_TEST(getHandleTest);
+  CPPUNIT_TEST(getWithTokenTest);
+  CPPUNIT_TEST(doGetTest);
+  CPPUNIT_TEST(proxyResetTest);
+  CPPUNIT_TEST(introspectionTest);
+  CPPUNIT_TEST(transientTest);
 
-CPPUNIT_TEST_EXCEPTION(getNodataExpTest,NoDataExceptionType);
-CPPUNIT_TEST_EXCEPTION(getExepTest,ExceptionType);
-CPPUNIT_TEST_EXCEPTION(doGetExepTest,ExceptionType);
+  CPPUNIT_TEST_EXCEPTION(getNodataExpTest, NoDataExceptionType);
+  CPPUNIT_TEST_EXCEPTION(getExepTest, ExceptionType);
+  CPPUNIT_TEST_EXCEPTION(doGetExepTest, ExceptionType);
 
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void proxyTest();
   void getTest();
@@ -84,7 +85,7 @@ public:
   void proxyResetTest();
   void introspectionTest();
   void transientTest();
-  
+
   void getNodataExpTest();
   void getExepTest();
   void doGetExepTest();
@@ -97,396 +98,344 @@ HCTYPETAG_HELPER_METHODS(Dummy)
 
 class FailingDummyProxy : public eventsetup::DataProxyTemplate<DummyRecord, Dummy> {
 protected:
-   const value_type* make(const record_type&, const DataKey&) {
-      return 0 ;
-   }
-   void invalidateCache() {
-   }   
+  const value_type* make(const record_type&, const DataKey&) { return 0; }
+  void invalidateCache() {}
 };
 
 class WorkingDummyProxy : public eventsetup::DataProxyTemplate<DummyRecord, Dummy> {
 public:
-   WorkingDummyProxy(const Dummy* iDummy) : data_(iDummy), invalidateCalled_(false),
-  invalidateTransientCalled_(false){}
+  WorkingDummyProxy(const Dummy* iDummy) : data_(iDummy), invalidateCalled_(false), invalidateTransientCalled_(false) {}
 
-   bool invalidateCalled() const {
-      return invalidateCalled_;
-  }
-  
-  bool invalidateTransientCalled() const {
-    return invalidateTransientCalled_;
-  }
-   
-  void set(Dummy* iDummy) {
-    data_ = iDummy;
-  }
+  bool invalidateCalled() const { return invalidateCalled_; }
+
+  bool invalidateTransientCalled() const { return invalidateTransientCalled_; }
+
+  void set(Dummy* iDummy) { data_ = iDummy; }
+
 protected:
-   
-   const value_type* make(const record_type&, const DataKey&) {
-      invalidateCalled_=false;
-      invalidateTransientCalled_=false;
-      return data_ ;
-   }
-   void invalidateCache() {
-      invalidateCalled_=true;
-   }
-  
-   void invalidateTransientCache() {
-     invalidateTransientCalled_=true;
-     //check default behavior
-     eventsetup::DataProxyTemplate<DummyRecord, Dummy>::invalidateTransientCache();
-   }
-  
-private:
-   const Dummy* data_;
-   bool invalidateCalled_;
-   bool invalidateTransientCalled_;
+  const value_type* make(const record_type&, const DataKey&) {
+    invalidateCalled_ = false;
+    invalidateTransientCalled_ = false;
+    return data_;
+  }
+  void invalidateCache() { invalidateCalled_ = true; }
 
+  void invalidateTransientCache() {
+    invalidateTransientCalled_ = true;
+    //check default behavior
+    eventsetup::DataProxyTemplate<DummyRecord, Dummy>::invalidateTransientCache();
+  }
+
+private:
+  const Dummy* data_;
+  bool invalidateCalled_;
+  bool invalidateTransientCalled_;
 };
 
 class WorkingDummyProvider : public edm::eventsetup::DataProxyProvider {
 public:
-  WorkingDummyProvider( const edm::eventsetup::DataKey& iKey, std::shared_ptr<WorkingDummyProxy> iProxy) :
-  m_key(iKey),
-  m_proxy(iProxy) {
+  WorkingDummyProvider(const edm::eventsetup::DataKey& iKey, std::shared_ptr<WorkingDummyProxy> iProxy)
+      : m_key(iKey), m_proxy(iProxy) {
     usingRecord<DummyRecord>();
   }
-  
-  virtual void newInterval(const EventSetupRecordKey&,
-                           const ValidityInterval&) {}
+
+  virtual void newInterval(const EventSetupRecordKey&, const ValidityInterval&) {}
 
 protected:
-  virtual void registerProxies(const EventSetupRecordKey&,
-                               KeyedProxies& aProxyList) {
+  virtual void registerProxies(const EventSetupRecordKey&, KeyedProxies& aProxyList) {
     aProxyList.emplace_back(m_key, m_proxy);
   }
+
 private:
   edm::eventsetup::DataKey m_key;
   std::shared_ptr<WorkingDummyProxy> m_proxy;
-
 };
 
-void testEventsetupRecord::proxyTest()
-{
-   eventsetup::EventSetupRecordImpl dummyRecord{ eventsetup::EventSetupRecordKey::makeKey<DummyRecord>() };
-   FailingDummyProxy dummyProxy;
-   
-   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),
-                              "");
-   
-   CPPUNIT_ASSERT(0 == dummyRecord.find(dummyDataKey));
+void testEventsetupRecord::proxyTest() {
+  eventsetup::EventSetupRecordImpl dummyRecord{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
+  FailingDummyProxy dummyProxy;
 
-   
-   dummyRecord.add(dummyDataKey,
-                    &dummyProxy);
-   
-   CPPUNIT_ASSERT(&dummyProxy == dummyRecord.find(dummyDataKey));
+  const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
 
-   const DataKey dummyFredDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),
-                                  "fred");
-   CPPUNIT_ASSERT(0 == dummyRecord.find(dummyFredDataKey));
+  CPPUNIT_ASSERT(0 == dummyRecord.find(dummyDataKey));
 
+  dummyRecord.add(dummyDataKey, &dummyProxy);
+
+  CPPUNIT_ASSERT(&dummyProxy == dummyRecord.find(dummyDataKey));
+
+  const DataKey dummyFredDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "fred");
+  CPPUNIT_ASSERT(0 == dummyRecord.find(dummyFredDataKey));
 }
 
-void testEventsetupRecord::getTest()
-{
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   eventsetup::EventSetupRecordImpl dummyRecordImpl{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
-   provider.addRecordToEventSetup(dummyRecordImpl);
+void testEventsetupRecord::getTest() {
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  eventsetup::EventSetupRecordImpl dummyRecordImpl{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
+  provider.addRecordToEventSetup(dummyRecordImpl);
 
-   FailingDummyProxy dummyProxy;
+  FailingDummyProxy dummyProxy;
 
-   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),
-                              "");
+  const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
 
-   DummyRecord dummyRecord;
-   dummyRecord.setImpl(&dummyRecordImpl);
-   ESHandle<Dummy> dummyPtr;
-   CPPUNIT_ASSERT(not dummyRecord.get(dummyPtr));
-   CPPUNIT_ASSERT(not dummyPtr.isValid());
-   CPPUNIT_ASSERT(not dummyPtr);
-   CPPUNIT_ASSERT(dummyPtr.failedToGet());
-   CPPUNIT_ASSERT_THROW(*dummyPtr, NoDataExceptionType) ;
-   CPPUNIT_ASSERT_THROW(makeESValid(dummyPtr), cms::Exception) ;
-   //CDJ do this replace
-   //CPPUNIT_ASSERT_THROW(dummyRecord.get(dummyPtr),NoDataExceptionType);
+  DummyRecord dummyRecord;
+  dummyRecord.setImpl(&dummyRecordImpl);
+  ESHandle<Dummy> dummyPtr;
+  CPPUNIT_ASSERT(not dummyRecord.get(dummyPtr));
+  CPPUNIT_ASSERT(not dummyPtr.isValid());
+  CPPUNIT_ASSERT(not dummyPtr);
+  CPPUNIT_ASSERT(dummyPtr.failedToGet());
+  CPPUNIT_ASSERT_THROW(*dummyPtr, NoDataExceptionType);
+  CPPUNIT_ASSERT_THROW(makeESValid(dummyPtr), cms::Exception);
+  //CDJ do this replace
+  //CPPUNIT_ASSERT_THROW(dummyRecord.get(dummyPtr),NoDataExceptionType);
 
-   dummyRecordImpl.add(dummyDataKey,
-                    &dummyProxy);
+  dummyRecordImpl.add(dummyDataKey, &dummyProxy);
 
-   //dummyRecord.get(dummyPtr);
-   CPPUNIT_ASSERT_THROW(dummyRecord.get(dummyPtr), ExceptionType);
+  //dummyRecord.get(dummyPtr);
+  CPPUNIT_ASSERT_THROW(dummyRecord.get(dummyPtr), ExceptionType);
 
-   Dummy myDummy;
-   WorkingDummyProxy workingProxy(&myDummy);
-   ComponentDescription cd;
-   cd.label_ = "";
-   cd.type_ = "DummyProd";
-   workingProxy.setProviderDescription(&cd);
-   
-   const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(),
-                              "working");
+  Dummy myDummy;
+  WorkingDummyProxy workingProxy(&myDummy);
+  ComponentDescription cd;
+  cd.label_ = "";
+  cd.type_ = "DummyProd";
+  workingProxy.setProviderDescription(&cd);
 
-   dummyRecordImpl.add(workingDataKey,
-                    &workingProxy);
+  const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(), "working");
 
-   dummyRecord.get("working",dummyPtr);
-   CPPUNIT_ASSERT(!dummyPtr.failedToGet());
-   CPPUNIT_ASSERT(dummyPtr.isValid());
-   CPPUNIT_ASSERT(dummyPtr);
-   (void) makeESValid(dummyPtr);
+  dummyRecordImpl.add(workingDataKey, &workingProxy);
 
-   CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
+  dummyRecord.get("working", dummyPtr);
+  CPPUNIT_ASSERT(!dummyPtr.failedToGet());
+  CPPUNIT_ASSERT(dummyPtr.isValid());
+  CPPUNIT_ASSERT(dummyPtr);
+  (void)makeESValid(dummyPtr);
 
-   const std::string workingString("working");
-   
-   dummyRecord.get(workingString,dummyPtr);
-   CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
-   
-   edm::ESInputTag it_working("","working");
-   dummyRecord.get(it_working,dummyPtr);
-   CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
-   
-   edm::ESInputTag it_prov("DummyProd","working");
-   dummyRecord.get(it_prov,dummyPtr);
-   CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
+  CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
 
-   edm::ESInputTag it_bad("SmartProd","working");
-   CPPUNIT_ASSERT_THROW(dummyRecord.get(it_bad,dummyPtr), cms::Exception);
-   
-   //check if label is set
-   cd.label_ = "foo";
-   edm::ESInputTag it_label("foo","working");
-   dummyRecord.get(it_label,dummyPtr);
-   CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
+  const std::string workingString("working");
 
-   edm::ESInputTag it_prov_bad("DummyProd","working");
-   CPPUNIT_ASSERT_THROW(dummyRecord.get(it_prov_bad,dummyPtr), cms::Exception);
-   
+  dummyRecord.get(workingString, dummyPtr);
+  CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
+
+  edm::ESInputTag it_working("", "working");
+  dummyRecord.get(it_working, dummyPtr);
+  CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
+
+  edm::ESInputTag it_prov("DummyProd", "working");
+  dummyRecord.get(it_prov, dummyPtr);
+  CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
+
+  edm::ESInputTag it_bad("SmartProd", "working");
+  CPPUNIT_ASSERT_THROW(dummyRecord.get(it_bad, dummyPtr), cms::Exception);
+
+  //check if label is set
+  cd.label_ = "foo";
+  edm::ESInputTag it_label("foo", "working");
+  dummyRecord.get(it_label, dummyPtr);
+  CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
+
+  edm::ESInputTag it_prov_bad("DummyProd", "working");
+  CPPUNIT_ASSERT_THROW(dummyRecord.get(it_prov_bad, dummyPtr), cms::Exception);
 }
 
 namespace {
-   struct DummyDataConsumer : public EDConsumerBase {
-      explicit DummyDataConsumer( ESInputTag const& iTag):
-      m_token{esConsumes<Dummy, DummyRecord>(iTag)}
-      {}
-      
-      ESGetToken<Dummy, DummyRecord> m_token;
-   };
+  struct DummyDataConsumer : public EDConsumerBase {
+    explicit DummyDataConsumer(ESInputTag const& iTag) : m_token{esConsumes<Dummy, DummyRecord>(iTag)} {}
+
+    ESGetToken<Dummy, DummyRecord> m_token;
+  };
+}  // namespace
+
+void testEventsetupRecord::getHandleTest() {
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  eventsetup::EventSetupRecordImpl dummyRecordImpl{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
+  provider.addRecordToEventSetup(dummyRecordImpl);
+
+  FailingDummyProxy dummyProxy;
+
+  const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
+
+  DummyRecord dummyRecord;
+  dummyRecord.setImpl(&dummyRecordImpl);
+  ESHandle<Dummy> dummyPtr;
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("", "")};
+
+    CPPUNIT_ASSERT(not dummyRecord.getHandle(consumer.m_token));
+    dummyPtr = dummyRecord.getHandle(consumer.m_token);
+    CPPUNIT_ASSERT(not dummyPtr.isValid());
+    CPPUNIT_ASSERT(not dummyPtr);
+    CPPUNIT_ASSERT(dummyPtr.failedToGet());
+    CPPUNIT_ASSERT_THROW(*dummyPtr, NoDataExceptionType);
+    CPPUNIT_ASSERT_THROW(makeESValid(dummyPtr), cms::Exception);
+  }
+  dummyRecordImpl.add(dummyDataKey, &dummyProxy);
+
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("", "")};
+    CPPUNIT_ASSERT_THROW(dummyRecord.getHandle(consumer.m_token), ExceptionType);
+  }
+  Dummy myDummy;
+  WorkingDummyProxy workingProxy(&myDummy);
+  ComponentDescription cd;
+  cd.label_ = "";
+  cd.type_ = "DummyProd";
+  workingProxy.setProviderDescription(&cd);
+
+  const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(), "working");
+
+  dummyRecordImpl.add(workingDataKey, &workingProxy);
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("", "working")};
+    dummyPtr = dummyRecord.getHandle(consumer.m_token);
+    CPPUNIT_ASSERT(!dummyPtr.failedToGet());
+    CPPUNIT_ASSERT(dummyPtr.isValid());
+    CPPUNIT_ASSERT(dummyPtr);
+
+    CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
+  }
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("DummyProd", "working")};
+    dummyPtr = dummyRecord.getHandle(consumer.m_token);
+    CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
+  }
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("SmartProd", "working")};
+    CPPUNIT_ASSERT_THROW(dummyRecord.getHandle(consumer.m_token), cms::Exception);
+  }
+  //check if label is set
+  cd.label_ = "foo";
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("foo", "working")};
+    dummyPtr = dummyRecord.getHandle(consumer.m_token);
+    CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
+  }
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("DummyProd", "working")};
+    CPPUNIT_ASSERT_THROW(dummyRecord.getHandle(consumer.m_token), cms::Exception);
+  }
 }
 
-void testEventsetupRecord::getHandleTest()
-{
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   eventsetup::EventSetupRecordImpl dummyRecordImpl{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
-   provider.addRecordToEventSetup(dummyRecordImpl);
-   
-   FailingDummyProxy dummyProxy;
-   
-   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),
-                              "");
-   
-   
-   DummyRecord dummyRecord;
-   dummyRecord.setImpl(&dummyRecordImpl);
-   ESHandle<Dummy> dummyPtr;
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("","")};
+void testEventsetupRecord::getWithTokenTest() {
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  eventsetup::EventSetupRecordImpl dummyRecordImpl{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
+  provider.addRecordToEventSetup(dummyRecordImpl);
 
-      CPPUNIT_ASSERT(not dummyRecord.getHandle(consumer.m_token));
-      dummyPtr = dummyRecord.getHandle(consumer.m_token);
-      CPPUNIT_ASSERT(not dummyPtr.isValid());
-      CPPUNIT_ASSERT(not dummyPtr);
-      CPPUNIT_ASSERT(dummyPtr.failedToGet());
-      CPPUNIT_ASSERT_THROW(*dummyPtr, NoDataExceptionType) ;
-      CPPUNIT_ASSERT_THROW(makeESValid(dummyPtr), cms::Exception) ;
-   }
-   dummyRecordImpl.add(dummyDataKey,
-                       &dummyProxy);
-   
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("","")};
-      CPPUNIT_ASSERT_THROW(dummyRecord.getHandle(consumer.m_token), ExceptionType);
-   }
-   Dummy myDummy;
-   WorkingDummyProxy workingProxy(&myDummy);
-   ComponentDescription cd;
-   cd.label_ = "";
-   cd.type_ = "DummyProd";
-   workingProxy.setProviderDescription(&cd);
-   
-   const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(),
-                                "working");
-   
-   dummyRecordImpl.add(workingDataKey,
-                       &workingProxy);
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("","working")};
-      dummyPtr = dummyRecord.getHandle(consumer.m_token);
-      CPPUNIT_ASSERT(!dummyPtr.failedToGet());
-      CPPUNIT_ASSERT(dummyPtr.isValid());
-      CPPUNIT_ASSERT(dummyPtr);
-   
-      CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
-   }
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("DummyProd","working")};
-      dummyPtr = dummyRecord.getHandle(consumer.m_token);
-      CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
-   }
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("SmartProd","working")};
-      CPPUNIT_ASSERT_THROW(dummyRecord.getHandle(consumer.m_token), cms::Exception);
-   }
-   //check if label is set
-   cd.label_ = "foo";
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("foo","working")};
-      dummyPtr = dummyRecord.getHandle(consumer.m_token);
-      CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
-   }
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("DummyProd","working")};
-      CPPUNIT_ASSERT_THROW(dummyRecord.getHandle(consumer.m_token), cms::Exception);
-   }
+  FailingDummyProxy dummyProxy;
+
+  const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
+
+  DummyRecord dummyRecord;
+  dummyRecord.setImpl(&dummyRecordImpl);
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("", "")};
+
+    CPPUNIT_ASSERT_THROW(dummyRecord.get(consumer.m_token), NoDataExceptionType);
+  }
+  dummyRecordImpl.add(dummyDataKey, &dummyProxy);
+
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("", "")};
+    CPPUNIT_ASSERT_THROW(dummyRecord.get(consumer.m_token), ExceptionType);
+  }
+  Dummy myDummy;
+  WorkingDummyProxy workingProxy(&myDummy);
+  ComponentDescription cd;
+  cd.label_ = "";
+  cd.type_ = "DummyProd";
+  workingProxy.setProviderDescription(&cd);
+
+  const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(), "working");
+
+  dummyRecordImpl.add(workingDataKey, &workingProxy);
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("", "working")};
+    auto const& dummyData = dummyRecord.get(consumer.m_token);
+
+    CPPUNIT_ASSERT(&dummyData == &myDummy);
+  }
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("DummyProd", "working")};
+    auto const& dummyData = dummyRecord.get(consumer.m_token);
+    CPPUNIT_ASSERT(&dummyData == &myDummy);
+  }
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("SmartProd", "working")};
+    CPPUNIT_ASSERT_THROW(dummyRecord.get(consumer.m_token), cms::Exception);
+  }
+  //check if label is set
+  cd.label_ = "foo";
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("foo", "working")};
+    auto const& dummyData = dummyRecord.get(consumer.m_token);
+    CPPUNIT_ASSERT(&dummyData == &myDummy);
+  }
+  {
+    DummyDataConsumer consumer{edm::ESInputTag("DummyProd", "working")};
+    CPPUNIT_ASSERT_THROW(dummyRecord.get(consumer.m_token), cms::Exception);
+  }
 }
 
-void testEventsetupRecord::getWithTokenTest()
-{
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   eventsetup::EventSetupRecordImpl dummyRecordImpl{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
-   provider.addRecordToEventSetup(dummyRecordImpl);
-   
-   FailingDummyProxy dummyProxy;
-   
-   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),
-                              "");
-   
-   
-   DummyRecord dummyRecord;
-   dummyRecord.setImpl(&dummyRecordImpl);
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("","")};
-      
-      CPPUNIT_ASSERT_THROW(dummyRecord.get(consumer.m_token), NoDataExceptionType);
-   }
-   dummyRecordImpl.add(dummyDataKey,
-                       &dummyProxy);
-   
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("","")};
-      CPPUNIT_ASSERT_THROW(dummyRecord.get(consumer.m_token), ExceptionType);
-   }
-   Dummy myDummy;
-   WorkingDummyProxy workingProxy(&myDummy);
-   ComponentDescription cd;
-   cd.label_ = "";
-   cd.type_ = "DummyProd";
-   workingProxy.setProviderDescription(&cd);
-   
-   const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(),
-                                "working");
-   
-   dummyRecordImpl.add(workingDataKey,
-                       &workingProxy);
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("","working")};
-      auto const& dummyData = dummyRecord.get(consumer.m_token);
-      
-      CPPUNIT_ASSERT(&dummyData == &myDummy);
-   }
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("DummyProd","working")};
-      auto const& dummyData = dummyRecord.get(consumer.m_token);
-      CPPUNIT_ASSERT(&dummyData == &myDummy);
-   }
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("SmartProd","working")};
-      CPPUNIT_ASSERT_THROW(dummyRecord.get(consumer.m_token), cms::Exception);
-   }
-   //check if label is set
-   cd.label_ = "foo";
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("foo","working")};
-      auto const& dummyData = dummyRecord.get(consumer.m_token);
-      CPPUNIT_ASSERT(&dummyData == &myDummy);
-   }
-   {
-      DummyDataConsumer consumer{edm::ESInputTag("DummyProd","working")};
-      CPPUNIT_ASSERT_THROW(dummyRecord.get(consumer.m_token), cms::Exception);
-   }
+void testEventsetupRecord::getNodataExpTest() {
+  EventSetupRecordImpl recImpl(DummyRecord::keyForClass());
+  DummyRecord dummyRecord;
+  dummyRecord.setImpl(&recImpl);
+  FailingDummyProxy dummyProxy;
+
+  const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
+  ESHandle<Dummy> dummyPtr;
+  dummyRecord.get(dummyPtr);
+  *dummyPtr;
+  //CPPUNIT_ASSERT_THROW(dummyRecord.get(dummyPtr), NoDataExceptionType) ;
 }
 
-void testEventsetupRecord::getNodataExpTest()
-{
-   EventSetupRecordImpl recImpl(DummyRecord::keyForClass());
-   DummyRecord dummyRecord;
-   dummyRecord.setImpl(&recImpl);
-   FailingDummyProxy dummyProxy;
+void testEventsetupRecord::getExepTest() {
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  eventsetup::EventSetupRecordImpl dummyRecordImpl{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
+  provider.addRecordToEventSetup(dummyRecordImpl);
+  FailingDummyProxy dummyProxy;
 
-   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),"");
-   ESHandle<Dummy> dummyPtr;
-   dummyRecord.get(dummyPtr);
-   *dummyPtr;
-   //CPPUNIT_ASSERT_THROW(dummyRecord.get(dummyPtr), NoDataExceptionType) ;
+  const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
 
+  ESHandle<Dummy> dummyPtr;
+
+  dummyRecordImpl.add(dummyDataKey, &dummyProxy);
+
+  DummyRecord dummyRecord;
+  dummyRecord.setImpl(&dummyRecordImpl);
+  dummyRecord.get(dummyPtr);
+  //CPPUNIT_ASSERT_THROW(dummyRecord.get(dummyPtr), ExceptionType);
 }
 
-void testEventsetupRecord::getExepTest()
-{
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   eventsetup::EventSetupRecordImpl dummyRecordImpl{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
-   provider.addRecordToEventSetup(dummyRecordImpl);
-   FailingDummyProxy dummyProxy;
+void testEventsetupRecord::doGetTest() {
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  eventsetup::EventSetupRecordImpl dummyRecordImpl{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
+  provider.addRecordToEventSetup(dummyRecordImpl);
 
-   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),"");
+  FailingDummyProxy dummyProxy;
 
-   ESHandle<Dummy> dummyPtr;
-   
-   dummyRecordImpl.add(dummyDataKey,&dummyProxy);
+  const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
 
-   DummyRecord dummyRecord;
-   dummyRecord.setImpl(&dummyRecordImpl);
-   dummyRecord.get(dummyPtr);
-   //CPPUNIT_ASSERT_THROW(dummyRecord.get(dummyPtr), ExceptionType);
+  DummyRecord dummyRecord;
+  dummyRecord.setImpl(&dummyRecordImpl);
+  CPPUNIT_ASSERT(!dummyRecord.doGet(dummyDataKey));
+
+  dummyRecordImpl.add(dummyDataKey, &dummyProxy);
+
+  //dummyRecord.doGet(dummyDataKey);
+  CPPUNIT_ASSERT_THROW(dummyRecord.doGet(dummyDataKey), ExceptionType);
+
+  Dummy myDummy;
+  WorkingDummyProxy workingProxy(&myDummy);
+
+  const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(), "working");
+
+  dummyRecordImpl.add(workingDataKey, &workingProxy);
+
+  CPPUNIT_ASSERT(dummyRecord.doGet(workingDataKey));
 }
 
-void testEventsetupRecord::doGetTest()
-{
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   eventsetup::EventSetupRecordImpl dummyRecordImpl{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
-   provider.addRecordToEventSetup(dummyRecordImpl);
-
-   FailingDummyProxy dummyProxy;
-   
-   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),
-                              "");
-   
-   DummyRecord dummyRecord;
-   dummyRecord.setImpl(&dummyRecordImpl);
-   CPPUNIT_ASSERT(!dummyRecord.doGet(dummyDataKey)) ;
-   
-   dummyRecordImpl.add(dummyDataKey,
-                       &dummyProxy);
-   
-   //dummyRecord.doGet(dummyDataKey);
-   CPPUNIT_ASSERT_THROW(dummyRecord.doGet(dummyDataKey), ExceptionType);
-   
-   Dummy myDummy;
-   WorkingDummyProxy workingProxy(&myDummy);
-   
-   const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(),
-                                "working");
-   
-   dummyRecordImpl.add(workingDataKey,
-                   &workingProxy);
-   
-   CPPUNIT_ASSERT(dummyRecord.doGet(workingDataKey));
-   
-}
-
-void testEventsetupRecord::introspectionTest()
-{
+void testEventsetupRecord::introspectionTest() {
   eventsetup::EventSetupRecordImpl dummyRecordImpl{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
   FailingDummyProxy dummyProxy;
 
@@ -497,27 +446,25 @@ void testEventsetupRecord::introspectionTest()
   cd1.isLooper_ = false;
   dummyProxy.setProviderDescription(&cd1);
 
-  const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),
-                             "");
+  const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
 
   std::vector<edm::eventsetup::DataKey> keys;
   dummyRecordImpl.fillRegisteredDataKeys(keys);
-  CPPUNIT_ASSERT(keys.empty()) ;
+  CPPUNIT_ASSERT(keys.empty());
 
   DummyRecord dummyRecord;
   dummyRecord.setImpl(&dummyRecordImpl);
-  
+
   std::vector<ComponentDescription const*> esproducers;
   dummyRecordImpl.getESProducers(esproducers);
-  CPPUNIT_ASSERT(esproducers.empty()) ;
+  CPPUNIT_ASSERT(esproducers.empty());
 
   std::map<DataKey, ComponentDescription const*> referencedDataKeys;
   dummyRecordImpl.fillReferencedDataKeys(referencedDataKeys);
-  CPPUNIT_ASSERT(referencedDataKeys.empty()) ;  
+  CPPUNIT_ASSERT(referencedDataKeys.empty());
 
-  dummyRecordImpl.add(dummyDataKey,
-                  &dummyProxy);
-  
+  dummyRecordImpl.add(dummyDataKey, &dummyProxy);
+
   dummyRecord.fillRegisteredDataKeys(keys);
   CPPUNIT_ASSERT(1 == keys.size());
 
@@ -526,8 +473,8 @@ void testEventsetupRecord::introspectionTest()
   CPPUNIT_ASSERT(esproducers[0] == &cd1);
 
   dummyRecordImpl.fillReferencedDataKeys(referencedDataKeys);
-  CPPUNIT_ASSERT(referencedDataKeys.size() == 1);  
-  CPPUNIT_ASSERT(referencedDataKeys[dummyDataKey] == &cd1);  
+  CPPUNIT_ASSERT(referencedDataKeys.size() == 1);
+  CPPUNIT_ASSERT(referencedDataKeys[dummyDataKey] == &cd1);
 
   Dummy myDummy;
   WorkingDummyProxy workingProxy(&myDummy);
@@ -539,12 +486,10 @@ void testEventsetupRecord::introspectionTest()
   cd2.isLooper_ = false;
   workingProxy.setProviderDescription(&cd2);
 
-  const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(),
-                               "working");
-  
-  dummyRecordImpl.add(workingDataKey,
-                  &workingProxy);
-  
+  const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(), "working");
+
+  dummyRecordImpl.add(workingDataKey, &workingProxy);
+
   dummyRecord.fillRegisteredDataKeys(keys);
   CPPUNIT_ASSERT(2 == keys.size());
 
@@ -552,8 +497,8 @@ void testEventsetupRecord::introspectionTest()
   CPPUNIT_ASSERT(esproducers.size() == 1);
 
   dummyRecordImpl.fillReferencedDataKeys(referencedDataKeys);
-  CPPUNIT_ASSERT(referencedDataKeys.size() == 2);  
-  CPPUNIT_ASSERT(referencedDataKeys[workingDataKey] == &cd2);  
+  CPPUNIT_ASSERT(referencedDataKeys.size() == 2);
+  CPPUNIT_ASSERT(referencedDataKeys[workingDataKey] == &cd2);
 
   Dummy myDummy3;
   WorkingDummyProxy workingProxy3(&myDummy3);
@@ -565,18 +510,16 @@ void testEventsetupRecord::introspectionTest()
   cd3.isLooper_ = true;
   workingProxy3.setProviderDescription(&cd3);
 
-  const DataKey workingDataKey3(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(),
-                                "working3");
+  const DataKey workingDataKey3(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(), "working3");
 
-  dummyRecordImpl.add(workingDataKey3,
-                  &workingProxy3);
-  
+  dummyRecordImpl.add(workingDataKey3, &workingProxy3);
+
   dummyRecordImpl.getESProducers(esproducers);
   CPPUNIT_ASSERT(esproducers.size() == 1);
 
   dummyRecordImpl.fillReferencedDataKeys(referencedDataKeys);
-  CPPUNIT_ASSERT(referencedDataKeys.size() == 3);  
-  CPPUNIT_ASSERT(referencedDataKeys[workingDataKey3] == &cd3);  
+  CPPUNIT_ASSERT(referencedDataKeys.size() == 3);
+  CPPUNIT_ASSERT(referencedDataKeys[workingDataKey3] == &cd3);
 
   Dummy myDummy4;
   WorkingDummyProxy workingProxy4(&myDummy4);
@@ -588,52 +531,45 @@ void testEventsetupRecord::introspectionTest()
   cd4.isLooper_ = false;
   workingProxy4.setProviderDescription(&cd4);
 
-  const DataKey workingDataKey4(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(),
-                                "working4");
+  const DataKey workingDataKey4(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(), "working4");
 
-  dummyRecordImpl.add(workingDataKey4,
-                  &workingProxy4);
-  
+  dummyRecordImpl.add(workingDataKey4, &workingProxy4);
+
   dummyRecordImpl.getESProducers(esproducers);
   CPPUNIT_ASSERT(esproducers.size() == 2);
   CPPUNIT_ASSERT(esproducers[1] == &cd4);
 
   dummyRecordImpl.fillReferencedDataKeys(referencedDataKeys);
-  CPPUNIT_ASSERT(referencedDataKeys.size() == 4);  
-  CPPUNIT_ASSERT(referencedDataKeys[workingDataKey4] == &cd4);  
+  CPPUNIT_ASSERT(referencedDataKeys.size() == 4);
+  CPPUNIT_ASSERT(referencedDataKeys[workingDataKey4] == &cd4);
 
   dummyRecordImpl.clearProxies();
   dummyRecord.fillRegisteredDataKeys(keys);
   CPPUNIT_ASSERT(0 == keys.size());
 }
 
-void testEventsetupRecord::doGetExepTest()
-{
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   eventsetup::EventSetupRecordImpl dummyRecordImpl{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
-   provider.addRecordToEventSetup(dummyRecordImpl);
-   FailingDummyProxy dummyProxy;
-   
-   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),
-                              "");
-  
-   DummyRecord dummyRecord;
-   dummyRecord.setImpl(&dummyRecordImpl);
-   CPPUNIT_ASSERT(!dummyRecord.doGet(dummyDataKey)) ;
-   
-   dummyRecordImpl.add(dummyDataKey,
-                       &dummyProxy);
-   
-   //typedef edm::eventsetup::MakeDataException<DummyRecord,Dummy> ExceptionType;
-   dummyRecord.doGet(dummyDataKey);
-   //CPPUNIT_ASSERT_THROW(dummyRecord.doGet(dummyDataKey), ExceptionType);
-   
+void testEventsetupRecord::doGetExepTest() {
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  eventsetup::EventSetupRecordImpl dummyRecordImpl{eventsetup::EventSetupRecordKey::makeKey<DummyRecord>()};
+  provider.addRecordToEventSetup(dummyRecordImpl);
+  FailingDummyProxy dummyProxy;
+
+  const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
+
+  DummyRecord dummyRecord;
+  dummyRecord.setImpl(&dummyRecordImpl);
+  CPPUNIT_ASSERT(!dummyRecord.doGet(dummyDataKey));
+
+  dummyRecordImpl.add(dummyDataKey, &dummyProxy);
+
+  //typedef edm::eventsetup::MakeDataException<DummyRecord,Dummy> ExceptionType;
+  dummyRecord.doGet(dummyDataKey);
+  //CPPUNIT_ASSERT_THROW(dummyRecord.doGet(dummyDataKey), ExceptionType);
 }
 
-void testEventsetupRecord::proxyResetTest()
-{
-   auto dummyProvider = std::make_unique<EventSetupRecordProvider>(DummyRecord::keyForClass());
-  
+void testEventsetupRecord::proxyResetTest() {
+  auto dummyProvider = std::make_unique<EventSetupRecordProvider>(DummyRecord::keyForClass());
+
   auto const constProv = dummyProvider.get();
 
   eventsetup::EventSetupProvider provider(&activityRegistry);
@@ -645,19 +581,19 @@ void testEventsetupRecord::proxyResetTest()
   unsigned long long cacheID = dummyRecord.cacheIdentifier();
   Dummy myDummy;
   std::shared_ptr<WorkingDummyProxy> workingProxy = std::make_shared<WorkingDummyProxy>(&myDummy);
-  
-  const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(),
-                               "");
+
+  const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(), "");
 
   std::shared_ptr<WorkingDummyProvider> wdProv = std::make_shared<WorkingDummyProvider>(workingDataKey, workingProxy);
   CPPUNIT_ASSERT(0 != wdProv.get());
-  if(wdProv.get() == 0) return; // To silence Coverity
-  dummyProvider->add( wdProv );
+  if (wdProv.get() == 0)
+    return;  // To silence Coverity
+  dummyProvider->add(wdProv);
 
   //this causes the proxies to actually be placed in the Record
   edm::eventsetup::EventSetupRecordProvider::DataToPreferredProviderMap pref;
   dummyProvider->usePreferred(pref);
-  
+
   CPPUNIT_ASSERT(dummyRecord.doGet(workingDataKey));
 
   edm::ESHandle<Dummy> hDummy;
@@ -665,7 +601,7 @@ void testEventsetupRecord::proxyResetTest()
 
   CPPUNIT_ASSERT(&myDummy == &(*hDummy));
   CPPUNIT_ASSERT(cacheID == dummyRecord.cacheIdentifier());
-  
+
   Dummy myDummy2;
   workingProxy->set(&myDummy2);
 
@@ -680,106 +616,99 @@ void testEventsetupRecord::proxyResetTest()
   CPPUNIT_ASSERT(cacheID != dummyRecord.cacheIdentifier());
 }
 
-void testEventsetupRecord::transientTest()
-{
-   auto dummyProvider = std::make_unique<EventSetupRecordProvider>(DummyRecord::keyForClass());
-   
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   dummyProvider->addRecordTo(provider);
-   
-   const auto* constProv = dummyProvider.get();
-   DummyRecord dummyRecordNoConst;
-   dummyRecordNoConst.setImpl( & constProv->record() );
-   EventSetupRecord const& dummyRecord = dummyRecordNoConst;
+void testEventsetupRecord::transientTest() {
+  auto dummyProvider = std::make_unique<EventSetupRecordProvider>(DummyRecord::keyForClass());
 
-   eventsetup::EventSetupRecordImpl& nonConstDummyRecord = *const_cast<EventSetupRecordImpl*>(dummyRecord.impl_);
-   
-   unsigned long long cacheID = dummyRecord.cacheIdentifier();
-   Dummy myDummy;
-   std::shared_ptr<WorkingDummyProxy> workingProxy = std::make_shared<WorkingDummyProxy>(&myDummy);
-   
-   const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(),
-                                "");
-   
-   std::shared_ptr<WorkingDummyProvider> wdProv = std::make_shared<WorkingDummyProvider>(workingDataKey, workingProxy);
-   dummyProvider->add( wdProv );
-   
-   //this causes the proxies to actually be placed in the Record
-   edm::eventsetup::EventSetupRecordProvider::DataToPreferredProviderMap pref;
-   dummyProvider->usePreferred(pref);
-   
-   //do a transient access to see if it clears properly
-   edm::ESTransientHandle<Dummy> hTDummy;
-   CPPUNIT_ASSERT(hTDummy.transientAccessOnly);
-   dummyRecord.get(hTDummy);
-   
-   CPPUNIT_ASSERT(&myDummy == &(*hTDummy));
-   CPPUNIT_ASSERT(cacheID == dummyRecord.cacheIdentifier());
-   CPPUNIT_ASSERT(workingProxy->invalidateCalled()==false);
-   CPPUNIT_ASSERT(workingProxy->invalidateTransientCalled()==false);
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  dummyProvider->addRecordTo(provider);
 
-   CPPUNIT_ASSERT(nonConstDummyRecord.transientReset());
-   wdProv->resetProxiesIfTransient(dummyRecord.key());//   workingProxy->resetIfTransient();
-   CPPUNIT_ASSERT(workingProxy->invalidateCalled());
-   CPPUNIT_ASSERT(workingProxy->invalidateTransientCalled());
+  const auto* constProv = dummyProvider.get();
+  DummyRecord dummyRecordNoConst;
+  dummyRecordNoConst.setImpl(&constProv->record());
+  EventSetupRecord const& dummyRecord = dummyRecordNoConst;
 
+  eventsetup::EventSetupRecordImpl& nonConstDummyRecord = *const_cast<EventSetupRecordImpl*>(dummyRecord.impl_);
 
-   Dummy myDummy2;
-   workingProxy->set(&myDummy2);
-   
-   //do non-transient access to make sure nothing resets now
-   edm::ESHandle<Dummy> hDummy;
-   dummyRecord.get(hDummy);
-   
+  unsigned long long cacheID = dummyRecord.cacheIdentifier();
+  Dummy myDummy;
+  std::shared_ptr<WorkingDummyProxy> workingProxy = std::make_shared<WorkingDummyProxy>(&myDummy);
 
-   dummyRecord.get(hDummy);
-   CPPUNIT_ASSERT(&myDummy2 == &(*hDummy));
-   CPPUNIT_ASSERT(not nonConstDummyRecord.transientReset());
-   wdProv->resetProxiesIfTransient(dummyRecord.key());//workingProxy->resetIfTransient();
-   CPPUNIT_ASSERT(workingProxy->invalidateCalled()==false);
-   CPPUNIT_ASSERT(workingProxy->invalidateTransientCalled()==false);
+  const DataKey workingDataKey(DataKey::makeTypeTag<WorkingDummyProxy::value_type>(), "");
 
-   //do another transient access which should not do a reset since we have a non-transient access outstanding
-   dummyRecord.get(hDummy);
-   dummyRecord.get(hTDummy);
+  std::shared_ptr<WorkingDummyProvider> wdProv = std::make_shared<WorkingDummyProvider>(workingDataKey, workingProxy);
+  dummyProvider->add(wdProv);
 
-   CPPUNIT_ASSERT(nonConstDummyRecord.transientReset());
-   wdProv->resetProxiesIfTransient(dummyRecord.key());//workingProxy->resetIfTransient();
-   CPPUNIT_ASSERT(workingProxy->invalidateCalled()==false);
-   CPPUNIT_ASSERT(workingProxy->invalidateTransientCalled()==false);
+  //this causes the proxies to actually be placed in the Record
+  edm::eventsetup::EventSetupRecordProvider::DataToPreferredProviderMap pref;
+  dummyProvider->usePreferred(pref);
 
-  
-   //Ask for a transient then a non transient to be sure we don't have an ordering problem
-   {
-     dummyProvider->resetProxies();
-     Dummy myDummy3;
-     workingProxy->set(&myDummy3);
-     
-     dummyRecord.get(hTDummy);
-     dummyRecord.get(hDummy);
+  //do a transient access to see if it clears properly
+  edm::ESTransientHandle<Dummy> hTDummy;
+  CPPUNIT_ASSERT(hTDummy.transientAccessOnly);
+  dummyRecord.get(hTDummy);
 
-     CPPUNIT_ASSERT(&myDummy3 == &(*hDummy));
-     CPPUNIT_ASSERT(&myDummy3 == &(*hTDummy));
-     CPPUNIT_ASSERT(nonConstDummyRecord.transientReset());
-     wdProv->resetProxiesIfTransient(dummyRecord.key());//workingProxy->resetIfTransient();
-     CPPUNIT_ASSERT(workingProxy->invalidateCalled()==false);
-     CPPUNIT_ASSERT(workingProxy->invalidateTransientCalled()==false);
+  CPPUNIT_ASSERT(&myDummy == &(*hTDummy));
+  CPPUNIT_ASSERT(cacheID == dummyRecord.cacheIdentifier());
+  CPPUNIT_ASSERT(workingProxy->invalidateCalled() == false);
+  CPPUNIT_ASSERT(workingProxy->invalidateTransientCalled() == false);
 
-   }
-   //system should wait until the second event of a run before invalidating the transients
-   // need to do 'resetProxies' in order to force the Record to reset since we do not have a Finder
-   // associated with the record provider
-   dummyProvider->resetProxies();
-   workingProxy->set(&myDummy);
-   dummyRecord.get(hTDummy);
-   CPPUNIT_ASSERT(&myDummy == &(*hTDummy));
-   dummyProvider->setValidityIntervalFor(edm::IOVSyncValue(edm::EventID(1,0,0)));
-   CPPUNIT_ASSERT(workingProxy->invalidateCalled()==false);
-   dummyProvider->setValidityIntervalFor(edm::IOVSyncValue(edm::EventID(1,1,0)));
-   CPPUNIT_ASSERT(workingProxy->invalidateCalled()==false);
-   dummyProvider->setValidityIntervalFor(edm::IOVSyncValue(edm::EventID(1,1,1)));
-   CPPUNIT_ASSERT(workingProxy->invalidateCalled()==false);
-   dummyProvider->setValidityIntervalFor(edm::IOVSyncValue(edm::EventID(1,1,2)));
-   CPPUNIT_ASSERT(workingProxy->invalidateCalled()==true);
-   
+  CPPUNIT_ASSERT(nonConstDummyRecord.transientReset());
+  wdProv->resetProxiesIfTransient(dummyRecord.key());  //   workingProxy->resetIfTransient();
+  CPPUNIT_ASSERT(workingProxy->invalidateCalled());
+  CPPUNIT_ASSERT(workingProxy->invalidateTransientCalled());
+
+  Dummy myDummy2;
+  workingProxy->set(&myDummy2);
+
+  //do non-transient access to make sure nothing resets now
+  edm::ESHandle<Dummy> hDummy;
+  dummyRecord.get(hDummy);
+
+  dummyRecord.get(hDummy);
+  CPPUNIT_ASSERT(&myDummy2 == &(*hDummy));
+  CPPUNIT_ASSERT(not nonConstDummyRecord.transientReset());
+  wdProv->resetProxiesIfTransient(dummyRecord.key());  //workingProxy->resetIfTransient();
+  CPPUNIT_ASSERT(workingProxy->invalidateCalled() == false);
+  CPPUNIT_ASSERT(workingProxy->invalidateTransientCalled() == false);
+
+  //do another transient access which should not do a reset since we have a non-transient access outstanding
+  dummyRecord.get(hDummy);
+  dummyRecord.get(hTDummy);
+
+  CPPUNIT_ASSERT(nonConstDummyRecord.transientReset());
+  wdProv->resetProxiesIfTransient(dummyRecord.key());  //workingProxy->resetIfTransient();
+  CPPUNIT_ASSERT(workingProxy->invalidateCalled() == false);
+  CPPUNIT_ASSERT(workingProxy->invalidateTransientCalled() == false);
+
+  //Ask for a transient then a non transient to be sure we don't have an ordering problem
+  {
+    dummyProvider->resetProxies();
+    Dummy myDummy3;
+    workingProxy->set(&myDummy3);
+
+    dummyRecord.get(hTDummy);
+    dummyRecord.get(hDummy);
+
+    CPPUNIT_ASSERT(&myDummy3 == &(*hDummy));
+    CPPUNIT_ASSERT(&myDummy3 == &(*hTDummy));
+    CPPUNIT_ASSERT(nonConstDummyRecord.transientReset());
+    wdProv->resetProxiesIfTransient(dummyRecord.key());  //workingProxy->resetIfTransient();
+    CPPUNIT_ASSERT(workingProxy->invalidateCalled() == false);
+    CPPUNIT_ASSERT(workingProxy->invalidateTransientCalled() == false);
+  }
+  //system should wait until the second event of a run before invalidating the transients
+  // need to do 'resetProxies' in order to force the Record to reset since we do not have a Finder
+  // associated with the record provider
+  dummyProvider->resetProxies();
+  workingProxy->set(&myDummy);
+  dummyRecord.get(hTDummy);
+  CPPUNIT_ASSERT(&myDummy == &(*hTDummy));
+  dummyProvider->setValidityIntervalFor(edm::IOVSyncValue(edm::EventID(1, 0, 0)));
+  CPPUNIT_ASSERT(workingProxy->invalidateCalled() == false);
+  dummyProvider->setValidityIntervalFor(edm::IOVSyncValue(edm::EventID(1, 1, 0)));
+  CPPUNIT_ASSERT(workingProxy->invalidateCalled() == false);
+  dummyProvider->setValidityIntervalFor(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
+  CPPUNIT_ASSERT(workingProxy->invalidateCalled() == false);
+  dummyProvider->setValidityIntervalFor(edm::IOVSyncValue(edm::EventID(1, 1, 2)));
+  CPPUNIT_ASSERT(workingProxy->invalidateCalled() == true);
 }

--- a/FWCore/Framework/test/eventsetupscontroller_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetupscontroller_t.cppunit.cc
@@ -18,11 +18,10 @@
 #include <vector>
 
 namespace {
-edm::ActivityRegistry activityRegistry;
+  edm::ActivityRegistry activityRegistry;
 }
 
-class TestEventSetupsController: public CppUnit::TestFixture
-{
+class TestEventSetupsController : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(TestEventSetupsController);
 
   CPPUNIT_TEST(constructorTest);
@@ -30,9 +29,10 @@ class TestEventSetupsController: public CppUnit::TestFixture
   CPPUNIT_TEST(esSourceGetAndPutTest);
 
   CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void constructorTest();
   void esProducerGetAndPutTest();
@@ -43,12 +43,11 @@ public:
 CPPUNIT_TEST_SUITE_REGISTRATION(TestEventSetupsController);
 
 void TestEventSetupsController::constructorTest() {
-
   edm::eventsetup::EventSetupsController esController;
-  
-  CPPUNIT_ASSERT(esController.providers().empty());   
-  CPPUNIT_ASSERT(esController.esproducers().empty());   
-  CPPUNIT_ASSERT(esController.essources().empty());   
+
+  CPPUNIT_ASSERT(esController.providers().empty());
+  CPPUNIT_ASSERT(esController.esproducers().empty());
+  CPPUNIT_ASSERT(esController.essources().empty());
   CPPUNIT_ASSERT(esController.mustFinishConfiguration() == true);
 
   edm::ParameterSet pset;
@@ -72,24 +71,28 @@ void TestEventSetupsController::esProducerGetAndPutTest() {
 
   edm::ParameterSet pset1;
   pset1.registerIt();
-  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider1 = std::make_shared<edm::eventsetup::test::DummyProxyProvider>();
+  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider1 =
+      std::make_shared<edm::eventsetup::test::DummyProxyProvider>();
 
   edm::ParameterSet pset2;
-  pset2.addUntrackedParameter<int>("p1", 1); 
+  pset2.addUntrackedParameter<int>("p1", 1);
   pset2.registerIt();
-  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider2 = std::make_shared<edm::eventsetup::test::DummyProxyProvider>();
+  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider2 =
+      std::make_shared<edm::eventsetup::test::DummyProxyProvider>();
   CPPUNIT_ASSERT(pset2.id() == pset1.id());
 
   edm::ParameterSet pset3;
-  pset3.addUntrackedParameter<int>("p1", 2); 
+  pset3.addUntrackedParameter<int>("p1", 2);
   pset3.registerIt();
-  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider3 = std::make_shared<edm::eventsetup::test::DummyProxyProvider>();
+  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider3 =
+      std::make_shared<edm::eventsetup::test::DummyProxyProvider>();
   CPPUNIT_ASSERT(pset3.id() == pset1.id());
 
   edm::ParameterSet pset4;
-  pset4.addParameter<int>("p1", 1); 
+  pset4.addParameter<int>("p1", 1);
   pset4.registerIt();
-  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider4 = std::make_shared<edm::eventsetup::test::DummyProxyProvider>();
+  std::shared_ptr<edm::eventsetup::test::DummyProxyProvider> proxyProvider4 =
+      std::make_shared<edm::eventsetup::test::DummyProxyProvider>();
   CPPUNIT_ASSERT(pset4.id() != pset1.id());
 
   edm::eventsetup::ParameterSetIDHolder psetIDHolder1(pset1.id());
@@ -100,7 +103,8 @@ void TestEventSetupsController::esProducerGetAndPutTest() {
   CPPUNIT_ASSERT(!(psetIDHolder1 == psetIDHolder4));
   CPPUNIT_ASSERT((pset1.id() < pset4.id()) == (psetIDHolder1 < psetIDHolder4));
 
-  std::shared_ptr<edm::eventsetup::DataProxyProvider> ptrFromGet = esController.getESProducerAndRegisterProcess(pset1, 0);
+  std::shared_ptr<edm::eventsetup::DataProxyProvider> ptrFromGet =
+      esController.getESProducerAndRegisterProcess(pset1, 0);
   CPPUNIT_ASSERT(!ptrFromGet);
   esController.putESProducer(pset1, proxyProvider1, 0);
 
@@ -141,7 +145,7 @@ void TestEventSetupsController::esProducerGetAndPutTest() {
   bool isPresent2 = false;
   bool isPresent3 = false;
   bool isPresent4 = false;
-  
+
   CPPUNIT_ASSERT(esproducers.size() == 4);
   for (auto esproducer : esproducers) {
     auto const& esproducer1 = esproducer;
@@ -196,37 +200,21 @@ void TestEventSetupsController::esProducerGetAndPutTest() {
   bool firstProcessWithThisPSet = false;
   bool precedingHasMatchingPSet = false;
 
-  esController.lookForMatches(pset4.id(),
-                              0,
-                              0,
-                              firstProcessWithThisPSet,
-                              precedingHasMatchingPSet);
+  esController.lookForMatches(pset4.id(), 0, 0, firstProcessWithThisPSet, precedingHasMatchingPSet);
   CPPUNIT_ASSERT(firstProcessWithThisPSet == true);
   CPPUNIT_ASSERT(precedingHasMatchingPSet == false);
 
-  esController.lookForMatches(pset4.id(),
-                              4,
-                              0,
-                              firstProcessWithThisPSet,
-                              precedingHasMatchingPSet);
+  esController.lookForMatches(pset4.id(), 4, 0, firstProcessWithThisPSet, precedingHasMatchingPSet);
   CPPUNIT_ASSERT(firstProcessWithThisPSet == false);
   CPPUNIT_ASSERT(precedingHasMatchingPSet == true);
 
-  esController.lookForMatches(pset4.id(),
-                              4,
-                              1,
-                              firstProcessWithThisPSet,
-                              precedingHasMatchingPSet);
+  esController.lookForMatches(pset4.id(), 4, 1, firstProcessWithThisPSet, precedingHasMatchingPSet);
   CPPUNIT_ASSERT(firstProcessWithThisPSet == false);
   CPPUNIT_ASSERT(precedingHasMatchingPSet == false);
 
-
-  CPPUNIT_ASSERT_THROW(esController.lookForMatches(pset4.id(),
-                                                   6,
-                                                   0,
-                                                   firstProcessWithThisPSet,
-                                                   precedingHasMatchingPSet),
-                       cms::Exception);
+  CPPUNIT_ASSERT_THROW(
+      esController.lookForMatches(pset4.id(), 6, 0, firstProcessWithThisPSet, precedingHasMatchingPSet),
+      cms::Exception);
 
   CPPUNIT_ASSERT(esController.isFirstMatch(pset4.id(), 5, 0));
   CPPUNIT_ASSERT(!esController.isFirstMatch(pset4.id(), 5, 4));
@@ -255,7 +243,6 @@ void TestEventSetupsController::esProducerGetAndPutTest() {
 }
 
 void TestEventSetupsController::esSourceGetAndPutTest() {
-
   edm::eventsetup::EventSetupsController esController;
 
   edm::ParameterSet pset1;
@@ -263,25 +250,25 @@ void TestEventSetupsController::esSourceGetAndPutTest() {
   std::shared_ptr<DummyFinder> finder1 = std::make_shared<DummyFinder>();
 
   edm::ParameterSet pset2;
-  pset2.addUntrackedParameter<int>("p1", 1); 
+  pset2.addUntrackedParameter<int>("p1", 1);
   pset2.registerIt();
   std::shared_ptr<DummyFinder> finder2 = std::make_shared<DummyFinder>();
   CPPUNIT_ASSERT(pset2.id() == pset1.id());
 
   edm::ParameterSet pset3;
-  pset3.addUntrackedParameter<int>("p1", 2); 
+  pset3.addUntrackedParameter<int>("p1", 2);
   pset3.registerIt();
   std::shared_ptr<DummyFinder> finder3 = std::make_shared<DummyFinder>();
   CPPUNIT_ASSERT(pset3.id() == pset1.id());
 
   edm::ParameterSet pset4;
-  pset4.addParameter<int>("p1", 1); 
+  pset4.addParameter<int>("p1", 1);
   pset4.registerIt();
   std::shared_ptr<DummyFinder> finder4 = std::make_shared<DummyFinder>();
   CPPUNIT_ASSERT(pset4.id() != pset1.id());
 
-
-  std::shared_ptr<edm::EventSetupRecordIntervalFinder> ptrFromGet = esController.getESSourceAndRegisterProcess(pset1, 0);
+  std::shared_ptr<edm::EventSetupRecordIntervalFinder> ptrFromGet =
+      esController.getESSourceAndRegisterProcess(pset1, 0);
   CPPUNIT_ASSERT(!ptrFromGet);
   esController.putESSource(pset1, finder1, 0);
 
@@ -322,7 +309,7 @@ void TestEventSetupsController::esSourceGetAndPutTest() {
   bool isPresent2 = false;
   bool isPresent3 = false;
   bool isPresent4 = false;
-  
+
   CPPUNIT_ASSERT(essources.size() == 4);
   for (auto essource : essources) {
     auto const& essource1 = essource;

--- a/FWCore/Framework/test/fullchain_t.cppunit.cc
+++ b/FWCore/Framework/test/fullchain_t.cppunit.cc
@@ -24,19 +24,19 @@ using namespace edm::eventsetup;
 using namespace edm::eventsetup::test;
 
 namespace {
-edm::ActivityRegistry activityRegistry;
+  edm::ActivityRegistry activityRegistry;
 }
 
-class testfullChain: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testfullChain);
+class testfullChain : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testfullChain);
 
-CPPUNIT_TEST(getfromDataproxyproviderTest);
+  CPPUNIT_TEST(getfromDataproxyproviderTest);
 
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void getfromDataproxyproviderTest();
 };
@@ -44,28 +44,27 @@ public:
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testfullChain);
 
-void testfullChain::getfromDataproxyproviderTest()
-{
-   eventsetup::EventSetupProvider provider(&activityRegistry);
+void testfullChain::getfromDataproxyproviderTest() {
+  eventsetup::EventSetupProvider provider(&activityRegistry);
 
-   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<DummyProxyProvider>();
-   provider.add(pProxyProv);
-   
-   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
-   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+  std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<DummyProxyProvider>();
+  provider.add(pProxyProv);
 
-   const Timestamp time_1(1);
-   const IOVSyncValue sync_1(time_1);
-   pFinder->setInterval(ValidityInterval(sync_1, IOVSyncValue(Timestamp(5))));
-   for(unsigned int iTime=1; iTime != 6; ++iTime) {
-      const Timestamp time(iTime);
-      auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(time));
-      ESHandle<DummyData> pDummy;
-      eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != pDummy.product());
-      
-      eventSetup.getData(pDummy);
-   
-      CPPUNIT_ASSERT(0 != pDummy.product());
-   }
+  std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
+  provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+
+  const Timestamp time_1(1);
+  const IOVSyncValue sync_1(time_1);
+  pFinder->setInterval(ValidityInterval(sync_1, IOVSyncValue(Timestamp(5))));
+  for (unsigned int iTime = 1; iTime != 6; ++iTime) {
+    const Timestamp time(iTime);
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(time));
+    ESHandle<DummyData> pDummy;
+    eventSetup.get<DummyRecord>().get(pDummy);
+    CPPUNIT_ASSERT(0 != pDummy.product());
+
+    eventSetup.getData(pDummy);
+
+    CPPUNIT_ASSERT(0 != pDummy.product());
+  }
 }

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -35,22 +35,22 @@ Test of GenericHandle class.
 
 // This is a gross hack, to allow us to test the event
 namespace edm {
-   class ProducerBase {
-      public:
-         static void commitEvent(Event& e) { e.commit_(std::vector<ProductResolverIndex>()); }
-   };
-}
+  class ProducerBase {
+  public:
+    static void commitEvent(Event& e) { e.commit_(std::vector<ProductResolverIndex>()); }
+  };
+}  // namespace edm
 
 class testGenericHandle : public CppUnit::TestFixture {
-CPPUNIT_TEST_SUITE(testGenericHandle);
-CPPUNIT_TEST(failgetbyLabelTest);
-CPPUNIT_TEST(getbyLabelTest);
-CPPUNIT_TEST(failWrongType);
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE(testGenericHandle);
+  CPPUNIT_TEST(failgetbyLabelTest);
+  CPPUNIT_TEST(getbyLabelTest);
+  CPPUNIT_TEST(failWrongType);
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){
-  }
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
   void failgetbyLabelTest();
   void failWrongType();
   void getbyLabelTest();
@@ -62,20 +62,17 @@ public:
 CPPUNIT_TEST_SUITE_REGISTRATION(testGenericHandle);
 
 void testGenericHandle::failWrongType() {
-   try {
-      //intentionally misspelled type
-      edm::GenericHandle h("edmtest::DmmyProduct");
-      CPPUNIT_ASSERT("Failed to throw" == nullptr);
-   }
-   catch (cms::Exception& x) {
-      // nothing to do
-   }
-   catch (...) {
-      CPPUNIT_ASSERT("Threw wrong kind of exception" == nullptr);
-   }
+  try {
+    //intentionally misspelled type
+    edm::GenericHandle h("edmtest::DmmyProduct");
+    CPPUNIT_ASSERT("Failed to throw" == nullptr);
+  } catch (cms::Exception& x) {
+    // nothing to do
+  } catch (...) {
+    CPPUNIT_ASSERT("Threw wrong kind of exception" == nullptr);
+  }
 }
 void testGenericHandle::failgetbyLabelTest() {
-
   edm::EventID id = edm::EventID::firstValidEvent();
   edm::Timestamp time;
   std::string uuid = edm::createGlobalIdentifier();
@@ -83,45 +80,42 @@ void testGenericHandle::failgetbyLabelTest() {
   auto preg = std::make_shared<edm::ProductRegistry>();
   preg->setFrozen();
   auto runAux = std::make_shared<edm::RunAuxiliary>(id.run(), time, time);
-  auto rp = std::make_shared<edm::RunPrincipal>(runAux, preg, pc, &historyAppender_,0);
-  auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(preg, pc, &historyAppender_,0);
+  auto rp = std::make_shared<edm::RunPrincipal>(runAux, preg, pc, &historyAppender_, 0);
+  auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(preg, pc, &historyAppender_, 0);
   lbp->setAux(edm::LuminosityBlockAuxiliary(rp->run(), 1, time, time));
   lbp->setRunPrincipal(rp);
   auto branchIDListHelper = std::make_shared<edm::BranchIDListHelper>();
   branchIDListHelper->updateFromRegistry(*preg);
   auto thinnedAssociationsHelper = std::make_shared<edm::ThinnedAssociationsHelper>();
   edm::EventAuxiliary eventAux(id, uuid, time, true);
-  edm::EventPrincipal ep(preg, branchIDListHelper, thinnedAssociationsHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
-  edm::ProcessHistoryRegistry phr; 
+  edm::EventPrincipal ep(preg, branchIDListHelper, thinnedAssociationsHelper, pc, &historyAppender_,
+                         edm::StreamID::invalidStreamID());
+  edm::ProcessHistoryRegistry phr;
   ep.fillEventPrincipal(eventAux, phr);
   ep.setLuminosityBlockPrincipal(lbp.get());
   edm::GenericHandle h("edmtest::DummyProduct");
-  bool didThrow=true;
+  bool didThrow = true;
   try {
-     edm::ParameterSet pset;
-     pset.registerIt();
-     edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs");
-     edm::Event event(ep, modDesc, nullptr);
+    edm::ParameterSet pset;
+    pset.registerIt();
+    edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs");
+    edm::Event event(ep, modDesc, nullptr);
 
-     std::string label("this does not exist");
-     event.getByLabel(label,h);
-     *h;
-     didThrow=false;
-  }
-  catch (cms::Exception& x) {
+    std::string label("this does not exist");
+    event.getByLabel(label, h);
+    *h;
+    didThrow = false;
+  } catch (cms::Exception& x) {
     // nothing to do
-  }
-  catch (std::exception& x) {
-    std::cout <<"caught std exception "<<x.what()<<std::endl;
+  } catch (std::exception& x) {
+    std::cout << "caught std exception " << x.what() << std::endl;
     CPPUNIT_ASSERT("Threw std::exception!" == nullptr);
-  }
-  catch (...) {
+  } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == nullptr);
   }
   if (!didThrow) {
     CPPUNIT_ASSERT("Failed to throw required exception" == nullptr);
   }
-
 }
 
 void testGenericHandle::getbyLabelTest() {
@@ -146,16 +140,8 @@ void testGenericHandle::getbyLabelTest() {
   edm::ParameterSet pset;
   pset.registerIt();
 
-  edm::BranchDescription product(edm::InEvent,
-                                 label,
-                                 processName,
-                                 dummytype.userClassName(),
-                                 className,
-                                 productInstanceName,
-                                 "",
-                                 pset.id(),
-                                 dummytype
-                              );
+  edm::BranchDescription product(edm::InEvent, label, processName, dummytype.userClassName(), className,
+                                 productInstanceName, "", pset.id(), dummytype);
 
   product.init();
 
@@ -176,13 +162,14 @@ void testGenericHandle::getbyLabelTest() {
   edm::ProcessConfiguration pc("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
   std::shared_ptr<edm::ProductRegistry const> pregc(preg.release());
   auto runAux = std::make_shared<edm::RunAuxiliary>(col.run(), fakeTime, fakeTime);
-  auto rp = std::make_shared<edm::RunPrincipal>(runAux, pregc, pc, &historyAppender_,0);
-  auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(pregc, pc, &historyAppender_,0);
+  auto rp = std::make_shared<edm::RunPrincipal>(runAux, pregc, pc, &historyAppender_, 0);
+  auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(pregc, pc, &historyAppender_, 0);
   lbp->setAux(edm::LuminosityBlockAuxiliary(rp->run(), 1, fakeTime, fakeTime));
   lbp->setRunPrincipal(rp);
   edm::EventAuxiliary eventAux(col, uuid, fakeTime, true);
-  edm::EventPrincipal ep(pregc, branchIDListHelper, thinnedAssociationsHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
-  edm::ProcessHistoryRegistry phr; 
+  edm::EventPrincipal ep(pregc, branchIDListHelper, thinnedAssociationsHelper, pc, &historyAppender_,
+                         edm::StreamID::invalidStreamID());
+  edm::ProcessHistoryRegistry phr;
   ep.fillEventPrincipal(eventAux, phr);
   ep.setLuminosityBlockPrincipal(lbp.get());
   edm::BranchDescription const& branchFromRegistry = it->second;
@@ -200,20 +187,18 @@ void testGenericHandle::getbyLabelTest() {
 
     edm::ParameterSet pset;
     pset.registerIt();
-    edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs", processConfiguration.get(),edm::ModuleDescription::getUniqueID());
+    edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs", processConfiguration.get(),
+                                   edm::ModuleDescription::getUniqueID());
     edm::Event event(ep, modDesc, nullptr);
 
-    event.getByLabel(label, productInstanceName,h);
-  }
-  catch (cms::Exception& x) {
-    std::cerr << x.explainSelf()<< std::endl;
+    event.getByLabel(label, productInstanceName, h);
+  } catch (cms::Exception& x) {
+    std::cerr << x.explainSelf() << std::endl;
     CPPUNIT_ASSERT("Threw cms::Exception unexpectedly" == nullptr);
-  }
-  catch(std::exception& x){
-     std::cerr <<x.what()<<std::endl;
-     CPPUNIT_ASSERT("threw std::exception" == nullptr);
-  }
-  catch (...) {
+  } catch (std::exception& x) {
+    std::cerr << x.what() << std::endl;
+    CPPUNIT_ASSERT("threw std::exception" == nullptr);
+  } catch (...) {
     std::cerr << "Unknown exception type\n";
     CPPUNIT_ASSERT("Threw exception unexpectedly" == nullptr);
   }

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -25,15 +25,13 @@
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
-
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "cppunit/extensions/HelperMacros.h"
 
-class testGlobalModule: public CppUnit::TestFixture 
-{
+class testGlobalModule : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testGlobalModule);
-  
+
   CPPUNIT_TEST(basicTest);
   CPPUNIT_TEST(streamTest);
   CPPUNIT_TEST(runTest);
@@ -46,13 +44,14 @@ class testGlobalModule: public CppUnit::TestFixture
   CPPUNIT_TEST(endLumiProdTest);
   CPPUNIT_TEST(endRunSummaryProdTest);
   CPPUNIT_TEST(endLumiSummaryProdTest);
-  
+
   CPPUNIT_TEST_SUITE_END();
+
 public:
   testGlobalModule();
-  
-  void setUp(){}
-  void tearDown(){}
+
+  void setUp() {}
+  void tearDown() {}
 
   void basicTest();
   void streamTest();
@@ -86,10 +85,8 @@ public:
   typedef std::vector<Trans> Expectations;
 
 private:
+  std::map<Trans, std::function<void(edm::Worker*)>> m_transToFunc;
 
-  
-  std::map<Trans,std::function<void(edm::Worker*)>> m_transToFunc;
-  
   edm::ProcessConfiguration m_procConfig;
   edm::PreallocationConfiguration m_preallocConfig;
   std::shared_ptr<edm::ProductRegistry> m_prodReg;
@@ -99,122 +96,104 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
+  std::shared_ptr<edm::ActivityRegistry>
+      m_actReg;  // We do not use propagate_const because the registry itself is mutable.
   edm::EventSetupImpl* m_es = nullptr;
-  edm::ModuleDescription m_desc = {"Dummy","dummy"};
-  
-  template<typename T>
-  void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
-  
+  edm::ModuleDescription m_desc = {"Dummy", "dummy"};
+
+  template <typename T> void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
+
   class BasicProd : public edm::global::EDProducer<> {
   public:
-    mutable unsigned int m_count = 0; //[[cms-thread-safe]]
-    
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    mutable unsigned int m_count = 0;  //[[cms-thread-safe]]
+
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
   };
   class StreamProd : public edm::global::EDProducer<edm::StreamCache<int>> {
   public:
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
     std::unique_ptr<int> beginStream(edm::StreamID) const override {
       ++m_count;
       return std::unique_ptr<int>{};
     }
-    
-    virtual void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const  override{
+
+    virtual void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override { ++m_count; }
+    virtual void streamBeginLuminosityBlock(edm::StreamID,
+                                            edm::LuminosityBlock const&,
+                                            edm::EventSetup const&) const override {
       ++m_count;
     }
-    virtual void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+    virtual void streamEndLuminosityBlock(edm::StreamID,
+                                          edm::LuminosityBlock const&,
+                                          edm::EventSetup const&) const override {
       ++m_count;
     }
-    virtual void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    virtual void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    void endStream(edm::StreamID) const override {
-      ++m_count;
-    }
+    virtual void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override { ++m_count; }
+    void endStream(edm::StreamID) const override { ++m_count; }
   };
-  
+
   class RunProd : public edm::global::EDProducer<edm::RunCache<int>> {
   public:
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
     std::shared_ptr<int> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override {
       ++m_count;
       return std::shared_ptr<int>{};
     }
 
-    void globalEndRun(edm::Run const&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    void globalEndRun(edm::Run const&, edm::EventSetup const&) const override { ++m_count; }
   };
-
 
   class LumiProd : public edm::global::EDProducer<edm::LuminosityBlockCache<int>> {
   public:
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
-    std::shared_ptr<int> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
+    std::shared_ptr<int> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                    edm::EventSetup const&) const override {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
-    void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+
+    void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override { ++m_count; }
   };
-  
+
   class RunSummaryProd : public edm::global::EDProducer<edm::RunSummaryCache<int>> {
   public:
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
     std::shared_ptr<int> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
-    void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int*) const override {
-      ++m_count;
-    }
-    
-    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override {
-      ++m_count;
-    }
+
+    void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int*) const override { ++m_count; }
+
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override { ++m_count; }
   };
 
   class LumiSummaryProd : public edm::global::EDProducer<edm::LuminosityBlockSummaryCache<int>> {
   public:
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
-    std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
+    std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                                           edm::EventSetup const&) const override {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
-    void streamEndLuminosityBlockSummary(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
+
+    void streamEndLuminosityBlockSummary(edm::StreamID,
+                                         edm::LuminosityBlock const&,
+                                         edm::EventSetup const&,
+                                         int*) const override {
       ++m_count;
     }
-    
+
     void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
       ++m_count;
     }
@@ -223,93 +202,71 @@ private:
   class BeginRunProd : public edm::global::EDProducer<edm::BeginRunProducer> {
   public:
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
 
-    void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override { ++m_count; }
   };
 
   class BeginLumiProd : public edm::global::EDProducer<edm::BeginLuminosityBlockProducer> {
   public:
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
-    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
+    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override { ++m_count; }
   };
 
   class EndRunProd : public edm::global::EDProducer<edm::EndRunProducer> {
   public:
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
-    void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
+    void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const override { ++m_count; }
   };
-  
+
   class EndLumiProd : public edm::global::EDProducer<edm::EndLuminosityBlockProducer> {
   public:
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
-    void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-  };
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
 
+    void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override { ++m_count; }
+  };
 
   class EndRunSummaryProd : public edm::global::EDProducer<edm::EndRunProducer, edm::RunSummaryCache<int>> {
   public:
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
     std::shared_ptr<int> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
-    void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int*) const override {
-      ++m_count;
-    }
-    
-    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override {
-      ++m_count;
-    }
 
-    void globalEndRunProduce(edm::Run&, edm::EventSetup const&, int const*) const override {
-      ++m_count;
-    }
+    void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int*) const override { ++m_count; }
+
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override { ++m_count; }
+
+    void globalEndRunProduce(edm::Run&, edm::EventSetup const&, int const*) const override { ++m_count; }
   };
-  
-  class EndLumiSummaryProd : public edm::global::EDProducer<edm::EndLuminosityBlockProducer, edm::LuminosityBlockSummaryCache<int>> {
+
+  class EndLumiSummaryProd
+      : public edm::global::EDProducer<edm::EndLuminosityBlockProducer, edm::LuminosityBlockSummaryCache<int>> {
   public:
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
 
-    std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+    std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                                           edm::EventSetup const&) const override {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
-    void streamEndLuminosityBlockSummary(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
+
+    void streamEndLuminosityBlockSummary(edm::StreamID,
+                                         edm::LuminosityBlock const&,
+                                         edm::EventSetup const&,
+                                         int*) const override {
       ++m_count;
     }
-    
+
     void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
       ++m_count;
     }
@@ -322,16 +279,16 @@ private:
 
 namespace {
   struct ShadowStreamID {
-    constexpr ShadowStreamID():value(0){}
+    constexpr ShadowStreamID() : value(0) {}
     unsigned int value;
   };
-  
+
   union IDUnion {
-    IDUnion(): m_shadow() {}
+    IDUnion() : m_shadow() {}
     ShadowStreamID m_shadow;
     edm::StreamID m_id;
   };
-}
+}  // namespace
 static edm::StreamID makeID() {
   IDUnion u;
   assert(u.m_id.value() == 0);
@@ -339,221 +296,214 @@ static edm::StreamID makeID() {
 }
 static const edm::StreamID s_streamID0 = makeID();
 
-
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testGlobalModule);
 
-testGlobalModule::testGlobalModule():
-m_preallocConfig{},
-m_prodReg(new edm::ProductRegistry{}),
-m_idHelper(new edm::BranchIDListHelper{}),
-m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
-m_ep()
-{
+testGlobalModule::testGlobalModule()
+    : m_preallocConfig{},
+      m_prodReg(new edm::ProductRegistry{}),
+      m_idHelper(new edm::BranchIDListHelper{}),
+      m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
+      m_ep() {
   //Setup the principals
   m_prodReg->setFrozen();
   m_idHelper->updateFromRegistry(*m_prodReg);
   edm::EventID eventID = edm::EventID::firstValidEvent();
-  
+
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
   auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_,0));
+  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
   auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(m_rp->run(), 1, now, now);
-  m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_,0));
+  m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(*lumiAux);
   m_lbp->setRunPrincipal(m_rp);
   edm::EventAuxiliary eventAux(eventID, uuid, now, true);
 
-  m_ep.reset(new edm::EventPrincipal(m_prodReg,
-                                     m_idHelper,
-                                     m_associationsHelper,
-                                     m_procConfig,nullptr));
+  m_ep.reset(new edm::EventPrincipal(m_prodReg, m_idHelper, m_associationsHelper, m_procConfig, nullptr));
   edm::ProcessHistoryRegistry phr;
   m_ep->fillEventPrincipal(eventAux, phr);
   m_ep->setLuminosityBlockPrincipal(m_lbp.get());
   m_actReg.reset(new edm::ActivityRegistry);
 
-
   //For each transition, bind a lambda which will call the proper method of the Worker
   m_transToFunc[Trans::kBeginStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
-    iBase->beginStream(s_streamID0, streamContext); };
+    iBase->beginStream(s_streamID0, streamContext);
+  };
 
-  
   m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_rp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
   m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
-  
+    iBase->doWork<Traits>(*m_rp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
+
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_lbp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
   m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, nullParentContext, nullptr); };
-  
+    iBase->doWork<Traits>(*m_lbp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
+
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::StreamContext streamContext(s_streamID0, nullptr);
     edm::ParentContext nullParentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
-    iBase->doWork<Traits>(*m_ep,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_ep, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
 
   m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_lbp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_lbp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
 
   m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_rp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_rp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
 
   m_transToFunc[Trans::kEndStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
-    iBase->endStream(s_streamID0, streamContext); };
-
+    iBase->endStream(s_streamID0, streamContext);
+  };
 }
 
-
 namespace {
-  template<typename T>
-  void
-  testTransition(std::shared_ptr<T> iMod, edm::Worker* iWorker, testGlobalModule::Trans iTrans, testGlobalModule::Expectations const& iExpect, std::function<void(edm::Worker*)> iFunc) {
-    assert(0==iMod->m_count);
+  template <typename T>
+  void testTransition(std::shared_ptr<T> iMod,
+                      edm::Worker* iWorker,
+                      testGlobalModule::Trans iTrans,
+                      testGlobalModule::Expectations const& iExpect,
+                      std::function<void(edm::Worker*)> iFunc) {
+    assert(0 == iMod->m_count);
     iFunc(iWorker);
-    auto count = std::count(iExpect.begin(),iExpect.end(),iTrans);
-    if(count != iMod->m_count) {
-      std::cout<<"For trans " <<static_cast<std::underlying_type<testGlobalModule::Trans>::type >(iTrans)<< " expected "<<count<<" and got "<<iMod->m_count<<std::endl;
+    auto count = std::count(iExpect.begin(), iExpect.end(), iTrans);
+    if (count != iMod->m_count) {
+      std::cout << "For trans " << static_cast<std::underlying_type<testGlobalModule::Trans>::type>(iTrans)
+                << " expected " << count << " and got " << iMod->m_count << std::endl;
     }
     CPPUNIT_ASSERT(iMod->m_count == count);
     iMod->m_count = 0;
     iWorker->reset();
   }
-}
+}  // namespace
 
-template<typename T>
-void
-testGlobalModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
-  edm::maker::ModuleHolderT<edm::global::EDProducerBase> h(iMod,nullptr);
+template <typename T> void testGlobalModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
+  edm::maker::ModuleHolderT<edm::global::EDProducerBase> h(iMod, nullptr);
   h.preallocate(edm::PreallocationConfiguration{});
 
-  edm::WorkerT<edm::global::EDProducerBase> w{iMod,m_desc,nullptr};
-  for(auto& keyVal: m_transToFunc) {
-    testTransition(iMod,&w,keyVal.first,iExpect,keyVal.second);
+  edm::WorkerT<edm::global::EDProducerBase> w{iMod, m_desc, nullptr};
+  for (auto& keyVal : m_transToFunc) {
+    testTransition(iMod, &w, keyVal.first, iExpect, keyVal.second);
   }
 }
 
-
-void testGlobalModule::basicTest()
-{
+void testGlobalModule::basicTest() {
   auto testProd = std::make_shared<BasicProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kEvent});
 }
 
-void testGlobalModule::streamTest()
-{
+void testGlobalModule::streamTest() {
   auto testProd = std::make_shared<StreamProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kBeginStream, Trans::kStreamBeginRun, Trans::kStreamBeginLuminosityBlock, Trans::kEvent,
-    Trans::kStreamEndLuminosityBlock,Trans::kStreamEndRun,Trans::kEndStream});
+  testTransitions(testProd, {Trans::kBeginStream, Trans::kStreamBeginRun, Trans::kStreamBeginLuminosityBlock,
+                             Trans::kEvent, Trans::kStreamEndLuminosityBlock, Trans::kStreamEndRun, Trans::kEndStream});
 }
 
-void testGlobalModule::runTest()
-{
+void testGlobalModule::runTest() {
   auto testProd = std::make_shared<RunProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndRun});
 }
 
-void testGlobalModule::runSummaryTest()
-{
+void testGlobalModule::runSummaryTest() {
   auto testProd = std::make_shared<RunSummaryProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kStreamEndRun, Trans::kGlobalEndRun});
 }
 
-void testGlobalModule::lumiTest()
-{
+void testGlobalModule::lumiTest() {
   auto testProd = std::make_shared<LumiProd>();
 
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock});
 }
 
-void testGlobalModule::lumiSummaryTest()
-{
+void testGlobalModule::lumiSummaryTest() {
   auto testProd = std::make_shared<LumiSummaryProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock});
+  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kStreamEndLuminosityBlock,
+                             Trans::kGlobalEndLuminosityBlock});
 }
 
-void testGlobalModule::beginRunProdTest()
-{
+void testGlobalModule::beginRunProdTest() {
   auto testProd = std::make_shared<BeginRunProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent});
 }
 
-void testGlobalModule::beginLumiProdTest()
-{
+void testGlobalModule::beginLumiProdTest() {
   auto testProd = std::make_shared<BeginLumiProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent});
 }
 
-void testGlobalModule::endRunProdTest()
-{
+void testGlobalModule::endRunProdTest() {
   auto testProd = std::make_shared<EndRunProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalEndRun, Trans::kEvent});
 }
 
-void testGlobalModule::endLumiProdTest()
-{
+void testGlobalModule::endLumiProdTest() {
   auto testProd = std::make_shared<EndLumiProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalEndLuminosityBlock, Trans::kEvent});
 }
 
-void testGlobalModule::endRunSummaryProdTest()
-{
+void testGlobalModule::endRunSummaryProdTest() {
   auto testProd = std::make_shared<EndRunSummaryProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kGlobalEndRun, Trans::kEvent, Trans::kGlobalBeginRun, Trans::kStreamEndRun, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kGlobalEndRun, Trans::kEvent, Trans::kGlobalBeginRun, Trans::kStreamEndRun,
+                             Trans::kGlobalEndRun});
 }
 
-void testGlobalModule::endLumiSummaryProdTest()
-{
+void testGlobalModule::endLumiSummaryProdTest() {
   auto testProd = std::make_shared<EndLumiSummaryProd>();
-  
-  CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kGlobalEndLuminosityBlock, Trans::kEvent, Trans::kGlobalBeginLuminosityBlock, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock}); 
-}
 
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalEndLuminosityBlock, Trans::kEvent, Trans::kGlobalBeginLuminosityBlock,
+                             Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock});
+}

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -27,7 +27,6 @@
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
-
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "cppunit/extensions/HelperMacros.h"
@@ -36,19 +35,19 @@ namespace edm {
   class ModuleCallingContext;
 }
 
-class testGlobalOutputModule: public CppUnit::TestFixture 
-{
+class testGlobalOutputModule : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testGlobalOutputModule);
-  
+
   CPPUNIT_TEST(basicTest);
   CPPUNIT_TEST(fileTest);
-  
+
   CPPUNIT_TEST_SUITE_END();
+
 public:
   testGlobalOutputModule();
-  
-  void setUp(){}
-  void tearDown(){}
+
+  void setUp() {}
+  void tearDown() {}
 
   void basicTest();
   void fileTest();
@@ -65,13 +64,12 @@ public:
     kGlobalCloseInputFile,
     kEndJob
   };
-  
+
   typedef std::vector<Trans> Expectations;
 
 private:
+  std::map<Trans, std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)>> m_transToFunc;
 
-  std::map<Trans,std::function<void(edm::Worker*,edm::OutputModuleCommunicator*)>> m_transToFunc;
-  
   edm::ProcessConfiguration m_procConfig;
   edm::PreallocationConfiguration m_preallocConfig;
   std::shared_ptr<edm::ProductRegistry> m_prodReg;
@@ -81,61 +79,45 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
+  std::shared_ptr<edm::ActivityRegistry>
+      m_actReg;  // We do not use propagate_const because the registry itself is mutable.
   edm::EventSetupImpl* m_es = nullptr;
-  edm::ModuleDescription m_desc = {"Dummy","dummy"};
+  edm::ModuleDescription m_desc = {"Dummy", "dummy"};
   edm::WorkerParams m_params;
-  
+
   typedef edm::service::TriggerNamesService TNS;
   typedef edm::serviceregistry::ServiceWrapper<TNS> w_TNS;
   std::shared_ptr<w_TNS> tnsptr_;
   edm::ServiceToken serviceToken_;
-  
-  template<typename T>
-  void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
-  
+
+  template <typename T> void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
+
   class BasicOutputModule : public edm::global::OutputModule<> {
   public:
     using edm::global::OutputModuleBase::doPreallocate;
-    BasicOutputModule(edm::ParameterSet const& iPSet): edm::global::OutputModuleBase(iPSet),edm::global::OutputModule<>(iPSet){}
+    BasicOutputModule(edm::ParameterSet const& iPSet)
+        : edm::global::OutputModuleBase(iPSet), edm::global::OutputModule<>(iPSet) {}
     unsigned int m_count = 0;
-    
-    void write(edm::EventForOutput const&) override {
-      ++m_count;
-    }
-    void writeRun(edm::RunForOutput const&) override {
-      ++m_count;
-    }
-    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
-      ++m_count;
-    }
 
+    void write(edm::EventForOutput const&) override { ++m_count; }
+    void writeRun(edm::RunForOutput const&) override { ++m_count; }
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override { ++m_count; }
   };
-  
+
   class FileOutputModule : public edm::global::OutputModule<edm::WatchInputFiles> {
   public:
     using edm::global::OutputModuleBase::doPreallocate;
-    FileOutputModule(edm::ParameterSet const& iPSet) : edm::global::OutputModuleBase(iPSet), edm::global::OutputModule<edm::WatchInputFiles>(iPSet) {}
+    FileOutputModule(edm::ParameterSet const& iPSet)
+        : edm::global::OutputModuleBase(iPSet), edm::global::OutputModule<edm::WatchInputFiles>(iPSet) {}
     unsigned int m_count = 0;
-    void write(edm::EventForOutput const&) override {
-      ++m_count;
-    }
-    void writeRun(edm::RunForOutput const&) override {
-      ++m_count;
-    }
-    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
-      ++m_count;
-    }
-    
-    void respondToOpenInputFile(edm::FileBlock const&)  override {
-      ++m_count;
-    }
-    
-    void respondToCloseInputFile(edm::FileBlock const&) override {
-      ++m_count;
-    }
+    void write(edm::EventForOutput const&) override { ++m_count; }
+    void writeRun(edm::RunForOutput const&) override { ++m_count; }
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override { ++m_count; }
+
+    void respondToOpenInputFile(edm::FileBlock const&) override { ++m_count; }
+
+    void respondToCloseInputFile(edm::FileBlock const&) override { ++m_count; }
   };
-  
 };
 
 namespace {
@@ -143,16 +125,16 @@ namespace {
   edm::ActivityRegistry activityRegistry;
 
   struct ShadowStreamID {
-    constexpr ShadowStreamID():value(0){}
+    constexpr ShadowStreamID() : value(0) {}
     unsigned int value;
   };
-  
+
   union IDUnion {
-    IDUnion(): m_shadow() {}
+    IDUnion() : m_shadow() {}
     ShadowStreamID m_shadow;
     edm::StreamID m_id;
   };
-}
+}  // namespace
 static edm::StreamID makeID() {
   IDUnion u;
   assert(u.m_id.value() == 0);
@@ -163,31 +145,27 @@ static const edm::StreamID s_streamID0 = makeID();
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testGlobalOutputModule);
 
-testGlobalOutputModule::testGlobalOutputModule():
-m_prodReg(new edm::ProductRegistry{}),
-m_idHelper(new edm::BranchIDListHelper{}),
-m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
-m_ep()
-{
+testGlobalOutputModule::testGlobalOutputModule()
+    : m_prodReg(new edm::ProductRegistry{}),
+      m_idHelper(new edm::BranchIDListHelper{}),
+      m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
+      m_ep() {
   //Setup the principals
   m_prodReg->setFrozen();
   m_idHelper->updateFromRegistry(*m_prodReg);
   edm::EventID eventID = edm::EventID::firstValidEvent();
-  
+
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
   auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_,0));
+  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
   edm::LuminosityBlockAuxiliary lumiAux(m_rp->run(), 1, now, now);
-  m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_,0));
+  m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(lumiAux);
   m_lbp->setRunPrincipal(m_rp);
   edm::EventAuxiliary eventAux(eventID, uuid, now, true);
 
-  m_ep.reset(new edm::EventPrincipal(m_prodReg,
-                                     m_idHelper,
-                                     m_associationsHelper,
-                                     m_procConfig,nullptr));
+  m_ep.reset(new edm::EventPrincipal(m_prodReg, m_idHelper, m_associationsHelper, m_procConfig, nullptr));
   edm::ProcessHistoryRegistry phr;
   m_ep->fillEventPrincipal(eventAux, phr);
   m_ep->setLuminosityBlockPrincipal(m_lbp.get());
@@ -199,33 +177,35 @@ m_ep()
     iBase->respondToOpenInputFile(fb);
   };
 
-
   m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr); };
-  
+    iBase->doWork<Traits>(*m_rp, *m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+  };
+
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr); };
-  
+    iBase->doWork<Traits>(*m_lbp, *m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+  };
+
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::StreamContext streamContext(s_streamID0, nullptr);
     edm::ParentContext parentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
-    iBase->doWork<Traits>(*m_ep,*m_es, s_streamID0, parentContext, nullptr); };
+    iBase->doWork<Traits>(*m_ep, *m_es, s_streamID0, parentContext, nullptr);
+  };
 
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    iBase->doWork<Traits>(*m_lbp, *m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
     iComm->writeLumiAsync(edm::WaitingTaskHolder(t.get()), *m_lbp, nullptr, &activityRegistry);
     t->wait_for_all();
-    if(t->exceptionPtr() != nullptr) {
+    if (t->exceptionPtr() != nullptr) {
       std::rethrow_exception(*t->exceptionPtr());
     }
   };
@@ -233,97 +213,94 @@ m_ep()
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    iBase->doWork<Traits>(*m_rp, *m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
     iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry, nullptr);
     t->wait_for_all();
-    if(t->exceptionPtr() != nullptr) {
+    if (t->exceptionPtr() != nullptr) {
       std::rethrow_exception(*t->exceptionPtr());
     }
   };
-  
+
   m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     edm::FileBlock fb;
     iBase->respondToCloseInputFile(fb);
   };
-
 
   // We want to create the TriggerNamesService because it is used in
   // the tests.  We do that here, but first we need to build a minimal
   // parameter set to pass to its constructor.  Then we build the
   // service and setup the service system.
   edm::ParameterSet proc_pset;
-  
+
   std::string processName("HLT");
   proc_pset.addParameter<std::string>("@process_name", processName);
-  
+
   std::vector<std::string> paths;
   edm::ParameterSet trigPaths;
   trigPaths.addParameter<std::vector<std::string>>("@trigger_paths", paths);
   proc_pset.addParameter<edm::ParameterSet>("@trigger_paths", trigPaths);
-  
+
   std::vector<std::string> endPaths;
   proc_pset.addParameter<std::vector<std::string>>("@end_paths", endPaths);
 
   // Now create and setup the service
   tnsptr_.reset(new w_TNS(std::make_unique<TNS>(proc_pset)));
-  
-  serviceToken_ = edm::ServiceRegistry::createContaining(tnsptr_);
-  
 
+  serviceToken_ = edm::ServiceRegistry::createContaining(tnsptr_);
 }
 
-
 namespace {
-  template<typename T>
-  void
-  testTransition(std::shared_ptr<T> iMod, edm::Worker* iWorker, edm::OutputModuleCommunicator* iComm, testGlobalOutputModule::Trans iTrans, testGlobalOutputModule::Expectations const& iExpect, std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)> iFunc) {
-    assert(0==iMod->m_count);
-    iFunc(iWorker,iComm);
-    auto count = std::count(iExpect.begin(),iExpect.end(),iTrans);
-    if(count != iMod->m_count) {
-      std::cout<<"For trans " <<static_cast<std::underlying_type<testGlobalOutputModule::Trans>::type >(iTrans)<< " expected "<<count<<" and got "<<iMod->m_count<<std::endl;
+  template <typename T>
+  void testTransition(std::shared_ptr<T> iMod,
+                      edm::Worker* iWorker,
+                      edm::OutputModuleCommunicator* iComm,
+                      testGlobalOutputModule::Trans iTrans,
+                      testGlobalOutputModule::Expectations const& iExpect,
+                      std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)> iFunc) {
+    assert(0 == iMod->m_count);
+    iFunc(iWorker, iComm);
+    auto count = std::count(iExpect.begin(), iExpect.end(), iTrans);
+    if (count != iMod->m_count) {
+      std::cout << "For trans " << static_cast<std::underlying_type<testGlobalOutputModule::Trans>::type>(iTrans)
+                << " expected " << count << " and got " << iMod->m_count << std::endl;
     }
     CPPUNIT_ASSERT(iMod->m_count == count);
     iMod->m_count = 0;
     iWorker->reset();
   }
-}
+}  // namespace
 
-template<typename T>
-void
-testGlobalOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
+template <typename T>
+void testGlobalOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
   iMod->doPreallocate(m_preallocConfig);
-  edm::WorkerT<edm::global::OutputModuleBase> w{iMod,m_desc,m_params.actions_};
+  edm::WorkerT<edm::global::OutputModuleBase> w{iMod, m_desc, m_params.actions_};
   edm::OutputModuleCommunicatorT<edm::global::OutputModuleBase> comm(iMod.get());
-  for(auto& keyVal: m_transToFunc) {
-    testTransition(iMod,&w,&comm,keyVal.first,iExpect,keyVal.second);
+  for (auto& keyVal : m_transToFunc) {
+    testTransition(iMod, &w, &comm, keyVal.first, iExpect, keyVal.second);
   }
 }
 
-
-void testGlobalOutputModule::basicTest()
-{
+void testGlobalOutputModule::basicTest() {
   //make the services available
   edm::ServiceRegistry::Operate operate(serviceToken_);
 
   edm::ParameterSet pset;
   auto testProd = std::make_shared<BasicOutputModule>(pset);
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kEvent,Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
 }
 
-void testGlobalOutputModule::fileTest()
-{
+void testGlobalOutputModule::fileTest() {
   //make the services available
   edm::ServiceRegistry::Operate operate(serviceToken_);
-  
+
   edm::ParameterSet pset;
   auto testProd = std::make_shared<FileOutputModule>(pset);
-  
-  CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kGlobalOpenInputFile, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalCloseInputFile});
-}
 
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalOpenInputFile, Trans::kEvent, Trans::kGlobalEndLuminosityBlock,
+                             Trans::kGlobalEndRun, Trans::kGlobalCloseInputFile});
+}

--- a/FWCore/Framework/test/intersectingiovrecordintervalfinder_t.cppunit.cc
+++ b/FWCore/Framework/test/intersectingiovrecordintervalfinder_t.cppunit.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     intersectingiovrecordintervalfinder_t_cppunit
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -20,204 +20,189 @@
 #include "cppunit/extensions/HelperMacros.h"
 using namespace edm::eventsetup;
 
-class testintersectingiovrecordintervalfinder: public CppUnit::TestFixture
-{
-   CPPUNIT_TEST_SUITE(testintersectingiovrecordintervalfinder);
-   
-   CPPUNIT_TEST(constructorTest);
-   CPPUNIT_TEST(intersectionTest);
-   
-   CPPUNIT_TEST_SUITE_END();
+class testintersectingiovrecordintervalfinder : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testintersectingiovrecordintervalfinder);
+
+  CPPUNIT_TEST(constructorTest);
+  CPPUNIT_TEST(intersectionTest);
+
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-   
-   void setUp(){}
-   void tearDown(){}
-   
-   void constructorTest();
-   void intersectionTest();
-   
-}; //Cppunit class declaration over
+  void setUp() {}
+  void tearDown() {}
+
+  void constructorTest();
+  void intersectionTest();
+
+};  //Cppunit class declaration over
 
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testintersectingiovrecordintervalfinder);
-namespace  {
-   class DepRecordFinder : public edm::EventSetupRecordIntervalFinder {
-   public:
-      DepRecordFinder() :edm::EventSetupRecordIntervalFinder(), interval_() {
-         this->findingRecord<DummyRecord>();
+namespace {
+  class DepRecordFinder : public edm::EventSetupRecordIntervalFinder {
+  public:
+    DepRecordFinder() : edm::EventSetupRecordIntervalFinder(), interval_() { this->findingRecord<DummyRecord>(); }
+
+    void setInterval(const edm::ValidityInterval& iInterval) { interval_ = iInterval; }
+
+  protected:
+    virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                const edm::IOVSyncValue& iTime,
+                                edm::ValidityInterval& iInterval) {
+      if (interval_.validFor(iTime)) {
+        iInterval = interval_;
+      } else {
+        if (interval_.last() == edm::IOVSyncValue::invalidIOVSyncValue() &&
+            interval_.first() != edm::IOVSyncValue::invalidIOVSyncValue() && interval_.first() <= iTime) {
+          iInterval = interval_;
+        } else {
+          iInterval = edm::ValidityInterval();
+        }
       }
-      
-      void setInterval(const edm::ValidityInterval& iInterval) {
-         interval_ = iInterval;
-      }
-   protected:
-      virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-                                  const edm::IOVSyncValue& iTime, 
-                                  edm::ValidityInterval& iInterval) {
-         if(interval_.validFor(iTime)) {
-            iInterval = interval_;
-         } else {
-            if(interval_.last() == edm::IOVSyncValue::invalidIOVSyncValue() &&
-               interval_.first() != edm::IOVSyncValue::invalidIOVSyncValue() &&
-               interval_.first() <= iTime) {
-               iInterval = interval_;
-            }else {
-               iInterval = edm::ValidityInterval();
-            }
-         }
-      }
-   private:
-      edm::ValidityInterval interval_;   
-   };   
+    }
+
+  private:
+    edm::ValidityInterval interval_;
+  };
+}  // namespace
+
+void testintersectingiovrecordintervalfinder::constructorTest() {
+  IntersectingIOVRecordIntervalFinder finder(DummyRecord::keyForClass());
+  CPPUNIT_ASSERT(finder.findingForRecords().size() == 1);
+  std::set<EventSetupRecordKey> s = finder.findingForRecords();
+  CPPUNIT_ASSERT(s.find(DummyRecord::keyForClass()) != s.end());
 }
 
-void 
-testintersectingiovrecordintervalfinder::constructorTest()
-{
-   IntersectingIOVRecordIntervalFinder finder(DummyRecord::keyForClass());
-   CPPUNIT_ASSERT(finder.findingForRecords().size() == 1);
-   std::set<EventSetupRecordKey> s = finder.findingForRecords();
-   CPPUNIT_ASSERT(s.find(DummyRecord::keyForClass()) != s.end());
-}
+void testintersectingiovrecordintervalfinder::intersectionTest() {
+  const EventSetupRecordKey dummyRecordKey = DummyRecord::keyForClass();
 
-void 
-testintersectingiovrecordintervalfinder::intersectionTest()
-{
-   const EventSetupRecordKey dummyRecordKey = DummyRecord::keyForClass();
+  IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
+  std::vector<edm::propagate_const<std::shared_ptr<edm::EventSetupRecordIntervalFinder>>> finders;
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+  {
+    const edm::EventID eID_1(1, 1, 1);
+    const edm::IOVSyncValue sync_1(eID_1);
+    const edm::EventID eID_3(1, 1, 3);
+    const edm::ValidityInterval definedInterval(sync_1, edm::IOVSyncValue(eID_3));
+    finders.push_back(dummyFinder);
+    dummyFinder->setInterval(definedInterval);
+    intFinder.swapFinders(finders);
 
-   IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
-   std::vector<edm::propagate_const<std::shared_ptr<edm::EventSetupRecordIntervalFinder>>> finders;
-   std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
-   {
-      const edm::EventID eID_1(1, 1, 1);
-      const edm::IOVSyncValue sync_1(eID_1);
-      const edm::EventID eID_3(1, 1, 3);
-      const edm::ValidityInterval definedInterval(sync_1, 
-                                                  edm::IOVSyncValue(eID_3));
-      finders.push_back(dummyFinder);
-      dummyFinder->setInterval(definedInterval);
-      intFinder.swapFinders(finders);
-      
-      CPPUNIT_ASSERT(definedInterval == intFinder.findIntervalFor(dummyRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 2)))); 
-   }
+    CPPUNIT_ASSERT(definedInterval ==
+                   intFinder.findIntervalFor(dummyRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 2))));
+  }
 
-   {
-      const edm::EventID eID_5(1, 1, 5);
-      const edm::IOVSyncValue sync_5(eID_5);
-      const edm::ValidityInterval unknownedEndInterval(sync_5 ,
-                                                       edm::IOVSyncValue::invalidIOVSyncValue());
-      dummyFinder->setInterval(unknownedEndInterval);
-   
-      CPPUNIT_ASSERT(unknownedEndInterval == intFinder.findIntervalFor(dummyRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 5))));
-   }
-   
-   {
-      finders.clear();
-      
-      const edm::EventID eID_1(1, 1, 1);
-      const edm::IOVSyncValue sync_1(eID_1);
-      const edm::EventID eID_3(1, 1, 3);
-      const edm::IOVSyncValue sync_3(eID_3);
-      const edm::EventID eID_4(1, 1, 4);
-      const edm::IOVSyncValue sync_4(eID_4);
-      const edm::EventID eID_5(1, 1, 5);
-      const edm::IOVSyncValue sync_5(eID_5);
-      const edm::ValidityInterval definedInterval(sync_1, 
-                                                  sync_4);
-      dummyFinder->setInterval(definedInterval);
-      finders.push_back(dummyFinder);
+  {
+    const edm::EventID eID_5(1, 1, 5);
+    const edm::IOVSyncValue sync_5(eID_5);
+    const edm::ValidityInterval unknownedEndInterval(sync_5, edm::IOVSyncValue::invalidIOVSyncValue());
+    dummyFinder->setInterval(unknownedEndInterval);
 
-      std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
-      dummyFinder2->setInterval(edm::ValidityInterval(sync_3, sync_5));
-      finders.push_back(dummyFinder2);
-      IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
-      intFinder.swapFinders(finders);
+    CPPUNIT_ASSERT(unknownedEndInterval ==
+                   intFinder.findIntervalFor(dummyRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 5))));
+  }
 
-      CPPUNIT_ASSERT(edm::ValidityInterval(sync_3,sync_4) ==
-                     intFinder.findIntervalFor(dummyRecordKey, sync_3));
-   }
-   
-   {
-      finders.clear();
-      const edm::EventID eID_1(1, 1, 1);
-      const edm::IOVSyncValue sync_1(eID_1);
-      const edm::EventID eID_3(1, 1, 3);
-      const edm::IOVSyncValue sync_3(eID_3);
-      const edm::EventID eID_4(1, 1, 4);
-      const edm::IOVSyncValue sync_4(eID_4);
-      const edm::EventID eID_5(1, 1, 5);
-      const edm::IOVSyncValue sync_5(eID_5);
-      const edm::ValidityInterval definedInterval(sync_1, 
-                                                  sync_4);
-      dummyFinder->setInterval(definedInterval);
-      finders.push_back(dummyFinder);
-      
-      std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
-      dummyFinder2->setInterval(edm::ValidityInterval::invalidInterval());
-      finders.push_back(dummyFinder2);
-      IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
-      intFinder.swapFinders(finders);
-      
-      CPPUNIT_ASSERT(edm::ValidityInterval::invalidInterval() ==
-                     dummyFinder2->findIntervalFor(dummyRecordKey,sync_3));
-      
-      CPPUNIT_ASSERT(edm::ValidityInterval(sync_1,edm::IOVSyncValue::invalidIOVSyncValue()) ==
-                     intFinder.findIntervalFor(dummyRecordKey, sync_3));
-   }
-   
-   {
-      finders.clear();
-      const edm::EventID eID_1(1, 1, 1);
-      const edm::IOVSyncValue sync_1(eID_1);
-      const edm::EventID eID_3(1, 1, 3);
-      const edm::IOVSyncValue sync_3(eID_3);
-      const edm::EventID eID_4(1, 1, 4);
-      const edm::IOVSyncValue sync_4(eID_4);
-      const edm::ValidityInterval definedInterval(sync_1, 
-                                                  sync_4);
-      dummyFinder->setInterval(definedInterval);
-      finders.push_back(dummyFinder);
-      
-      std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
-      dummyFinder2->setInterval(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()));
-      finders.push_back(dummyFinder2);
-      IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
-      intFinder.swapFinders(finders);
-      
-      CPPUNIT_ASSERT(edm::ValidityInterval(sync_3,edm::IOVSyncValue::invalidIOVSyncValue()) ==
-                     dummyFinder2->findIntervalFor(dummyRecordKey,sync_3));
-      
-      CPPUNIT_ASSERT(edm::ValidityInterval(sync_3,edm::IOVSyncValue::invalidIOVSyncValue()) ==
-                     intFinder.findIntervalFor(dummyRecordKey, sync_3));
-   }
+  {
+    finders.clear();
 
-   {
-      //reverse order so invalid ending is first in list
-      finders.clear();
-      const edm::EventID eID_1(1, 1, 1);
-      const edm::IOVSyncValue sync_1(eID_1);
-      const edm::EventID eID_3(1, 1, 3);
-      const edm::IOVSyncValue sync_3(eID_3);
-      const edm::EventID eID_4(1, 1, 4);
-      const edm::IOVSyncValue sync_4(eID_4);
-      const edm::ValidityInterval definedInterval(sync_1, 
-                                                  sync_4);
-      
-      std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
-      dummyFinder2->setInterval(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()));
-      finders.push_back(dummyFinder2);
+    const edm::EventID eID_1(1, 1, 1);
+    const edm::IOVSyncValue sync_1(eID_1);
+    const edm::EventID eID_3(1, 1, 3);
+    const edm::IOVSyncValue sync_3(eID_3);
+    const edm::EventID eID_4(1, 1, 4);
+    const edm::IOVSyncValue sync_4(eID_4);
+    const edm::EventID eID_5(1, 1, 5);
+    const edm::IOVSyncValue sync_5(eID_5);
+    const edm::ValidityInterval definedInterval(sync_1, sync_4);
+    dummyFinder->setInterval(definedInterval);
+    finders.push_back(dummyFinder);
 
-      dummyFinder->setInterval(definedInterval);
-      finders.push_back(dummyFinder);
+    std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
+    dummyFinder2->setInterval(edm::ValidityInterval(sync_3, sync_5));
+    finders.push_back(dummyFinder2);
+    IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
+    intFinder.swapFinders(finders);
 
-      IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
-      intFinder.swapFinders(finders);
-      
-      CPPUNIT_ASSERT(edm::ValidityInterval(sync_3,edm::IOVSyncValue::invalidIOVSyncValue()) ==
-                     dummyFinder2->findIntervalFor(dummyRecordKey,sync_3));
-      
-      CPPUNIT_ASSERT(edm::ValidityInterval(sync_3,edm::IOVSyncValue::invalidIOVSyncValue()) ==
-                     intFinder.findIntervalFor(dummyRecordKey, sync_3));
-   }
-   
+    CPPUNIT_ASSERT(edm::ValidityInterval(sync_3, sync_4) == intFinder.findIntervalFor(dummyRecordKey, sync_3));
+  }
+
+  {
+    finders.clear();
+    const edm::EventID eID_1(1, 1, 1);
+    const edm::IOVSyncValue sync_1(eID_1);
+    const edm::EventID eID_3(1, 1, 3);
+    const edm::IOVSyncValue sync_3(eID_3);
+    const edm::EventID eID_4(1, 1, 4);
+    const edm::IOVSyncValue sync_4(eID_4);
+    const edm::EventID eID_5(1, 1, 5);
+    const edm::IOVSyncValue sync_5(eID_5);
+    const edm::ValidityInterval definedInterval(sync_1, sync_4);
+    dummyFinder->setInterval(definedInterval);
+    finders.push_back(dummyFinder);
+
+    std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
+    dummyFinder2->setInterval(edm::ValidityInterval::invalidInterval());
+    finders.push_back(dummyFinder2);
+    IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
+    intFinder.swapFinders(finders);
+
+    CPPUNIT_ASSERT(edm::ValidityInterval::invalidInterval() == dummyFinder2->findIntervalFor(dummyRecordKey, sync_3));
+
+    CPPUNIT_ASSERT(edm::ValidityInterval(sync_1, edm::IOVSyncValue::invalidIOVSyncValue()) ==
+                   intFinder.findIntervalFor(dummyRecordKey, sync_3));
+  }
+
+  {
+    finders.clear();
+    const edm::EventID eID_1(1, 1, 1);
+    const edm::IOVSyncValue sync_1(eID_1);
+    const edm::EventID eID_3(1, 1, 3);
+    const edm::IOVSyncValue sync_3(eID_3);
+    const edm::EventID eID_4(1, 1, 4);
+    const edm::IOVSyncValue sync_4(eID_4);
+    const edm::ValidityInterval definedInterval(sync_1, sync_4);
+    dummyFinder->setInterval(definedInterval);
+    finders.push_back(dummyFinder);
+
+    std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
+    dummyFinder2->setInterval(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()));
+    finders.push_back(dummyFinder2);
+    IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
+    intFinder.swapFinders(finders);
+
+    CPPUNIT_ASSERT(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()) ==
+                   dummyFinder2->findIntervalFor(dummyRecordKey, sync_3));
+
+    CPPUNIT_ASSERT(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()) ==
+                   intFinder.findIntervalFor(dummyRecordKey, sync_3));
+  }
+
+  {
+    //reverse order so invalid ending is first in list
+    finders.clear();
+    const edm::EventID eID_1(1, 1, 1);
+    const edm::IOVSyncValue sync_1(eID_1);
+    const edm::EventID eID_3(1, 1, 3);
+    const edm::IOVSyncValue sync_3(eID_3);
+    const edm::EventID eID_4(1, 1, 4);
+    const edm::IOVSyncValue sync_4(eID_4);
+    const edm::ValidityInterval definedInterval(sync_1, sync_4);
+
+    std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
+    dummyFinder2->setInterval(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()));
+    finders.push_back(dummyFinder2);
+
+    dummyFinder->setInterval(definedInterval);
+    finders.push_back(dummyFinder);
+
+    IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
+    intFinder.swapFinders(finders);
+
+    CPPUNIT_ASSERT(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()) ==
+                   dummyFinder2->findIntervalFor(dummyRecordKey, sync_3));
+
+    CPPUNIT_ASSERT(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()) ==
+                   intFinder.findIntervalFor(dummyRecordKey, sync_3));
+  }
 }

--- a/FWCore/Framework/test/interval_t.cppunit.cc
+++ b/FWCore/Framework/test/interval_t.cppunit.cc
@@ -11,22 +11,22 @@
 #include "FWCore/Framework/interface/ValidityInterval.h"
 #include "cppunit/extensions/HelperMacros.h"
 
-using edm::Timestamp;
 using edm::IOVSyncValue;
+using edm::Timestamp;
 using edm::ValidityInterval;
 
-class testinterval: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testinterval);
+class testinterval : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testinterval);
 
-CPPUNIT_TEST(comparisonTest);
-CPPUNIT_TEST(timestampAssignmentTest);
-CPPUNIT_TEST(intervalAssignmentTest);
+  CPPUNIT_TEST(comparisonTest);
+  CPPUNIT_TEST(timestampAssignmentTest);
+  CPPUNIT_TEST(intervalAssignmentTest);
 
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void comparisonTest();
   void timestampAssignmentTest();
@@ -36,56 +36,52 @@ public:
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testinterval);
 
+void testinterval::comparisonTest() {
+  const IOVSyncValue invalid(IOVSyncValue::invalidIOVSyncValue());
 
-void testinterval::comparisonTest()
-{
-   const IOVSyncValue invalid(IOVSyncValue::invalidIOVSyncValue());
-   
-   const Timestamp t_1(1);
-   const IOVSyncValue one(t_1);
-   const Timestamp t_2(2);
-   const IOVSyncValue two(t_2);
-   
-   CPPUNIT_ASSERT(invalid == IOVSyncValue::invalidIOVSyncValue());
-   CPPUNIT_ASSERT(one == IOVSyncValue(t_1));
-   
-   CPPUNIT_ASSERT(invalid != one);
+  const Timestamp t_1(1);
+  const IOVSyncValue one(t_1);
+  const Timestamp t_2(2);
+  const IOVSyncValue two(t_2);
 
-   CPPUNIT_ASSERT(one < two);
-   CPPUNIT_ASSERT(!(one > two));
-   CPPUNIT_ASSERT(two > one);
-   CPPUNIT_ASSERT(!(two < one));
-   
-   CPPUNIT_ASSERT(one != two);
-   CPPUNIT_ASSERT(! (one == two));
+  CPPUNIT_ASSERT(invalid == IOVSyncValue::invalidIOVSyncValue());
+  CPPUNIT_ASSERT(one == IOVSyncValue(t_1));
 
-   CPPUNIT_ASSERT(one <= two);
-   CPPUNIT_ASSERT(one <= one);
-   CPPUNIT_ASSERT(one >= one);
-   CPPUNIT_ASSERT(!(one >= two));
+  CPPUNIT_ASSERT(invalid != one);
+
+  CPPUNIT_ASSERT(one < two);
+  CPPUNIT_ASSERT(!(one > two));
+  CPPUNIT_ASSERT(two > one);
+  CPPUNIT_ASSERT(!(two < one));
+
+  CPPUNIT_ASSERT(one != two);
+  CPPUNIT_ASSERT(!(one == two));
+
+  CPPUNIT_ASSERT(one <= two);
+  CPPUNIT_ASSERT(one <= one);
+  CPPUNIT_ASSERT(one >= one);
+  CPPUNIT_ASSERT(!(one >= two));
 }
 
-void testinterval::timestampAssignmentTest()
-{
-   const Timestamp t_1(1);
-   const IOVSyncValue one(t_1);
-   
-   IOVSyncValue temp(IOVSyncValue::invalidIOVSyncValue());
-   CPPUNIT_ASSERT(temp != one);
-   temp = one;
-   CPPUNIT_ASSERT(temp == one);
+void testinterval::timestampAssignmentTest() {
+  const Timestamp t_1(1);
+  const IOVSyncValue one(t_1);
+
+  IOVSyncValue temp(IOVSyncValue::invalidIOVSyncValue());
+  CPPUNIT_ASSERT(temp != one);
+  temp = one;
+  CPPUNIT_ASSERT(temp == one);
 }
 
-void testinterval::intervalAssignmentTest()
-{
-   ValidityInterval temp;
-   const Timestamp t_1(1);
-   const IOVSyncValue s_1(t_1);
-   const ValidityInterval oneAndTwo(s_1, IOVSyncValue(Timestamp(2)));
-   
-   CPPUNIT_ASSERT(temp != oneAndTwo);
-   CPPUNIT_ASSERT(! (temp == oneAndTwo));
-   
-   temp = oneAndTwo;
-   CPPUNIT_ASSERT(temp == oneAndTwo);
+void testinterval::intervalAssignmentTest() {
+  ValidityInterval temp;
+  const Timestamp t_1(1);
+  const IOVSyncValue s_1(t_1);
+  const ValidityInterval oneAndTwo(s_1, IOVSyncValue(Timestamp(2)));
+
+  CPPUNIT_ASSERT(temp != oneAndTwo);
+  CPPUNIT_ASSERT(!(temp == oneAndTwo));
+
+  temp = oneAndTwo;
+  CPPUNIT_ASSERT(temp == oneAndTwo);
 }

--- a/FWCore/Framework/test/iovsyncvalue_t.cppunit.cc
+++ b/FWCore/Framework/test/iovsyncvalue_t.cppunit.cc
@@ -13,171 +13,160 @@
 
 using namespace edm;
 
-class testIOVSyncValue: public CppUnit::TestFixture
-{
-   CPPUNIT_TEST_SUITE(testIOVSyncValue);
-   
-   CPPUNIT_TEST(constructTest);
-   CPPUNIT_TEST(constructTimeTest);
-   CPPUNIT_TEST(comparisonTest);
-   CPPUNIT_TEST(comparisonTimeTest);
-   CPPUNIT_TEST(invalidComparisonTest);
-   
-   CPPUNIT_TEST_SUITE_END();
+class testIOVSyncValue : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testIOVSyncValue);
+
+  CPPUNIT_TEST(constructTest);
+  CPPUNIT_TEST(constructTimeTest);
+  CPPUNIT_TEST(comparisonTest);
+  CPPUNIT_TEST(comparisonTimeTest);
+  CPPUNIT_TEST(invalidComparisonTest);
+
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-      void setUp(){}
-   void tearDown(){}
-   
-   void constructTest();
-   void comparisonTest();
-   void constructTimeTest();
-   void comparisonTimeTest();
-   void invalidComparisonTest();
+  void setUp() {}
+  void tearDown() {}
+
+  void constructTest();
+  void comparisonTest();
+  void constructTimeTest();
+  void comparisonTimeTest();
+  void invalidComparisonTest();
 };
 
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testIOVSyncValue);
 
+void testIOVSyncValue::constructTest() {
+  {
+    const EventID t(2, 0, 0);
 
-void testIOVSyncValue::constructTest()
-{
-   {
-      const EventID t(2,0,0);
-      
-      IOVSyncValue temp(t);
-      
-      CPPUNIT_ASSERT(temp.eventID() == t);
-      
-      
-      CPPUNIT_ASSERT(IOVSyncValue::invalidIOVSyncValue() != temp);
-      CPPUNIT_ASSERT(!(IOVSyncValue::invalidIOVSyncValue() == temp));
-      CPPUNIT_ASSERT(IOVSyncValue::beginOfTime() < temp);
-      CPPUNIT_ASSERT(IOVSyncValue::endOfTime() > temp);
-   }
-   CPPUNIT_ASSERT(IOVSyncValue::invalidIOVSyncValue() < IOVSyncValue::beginOfTime());
-   CPPUNIT_ASSERT(IOVSyncValue::beginOfTime() < IOVSyncValue::endOfTime());
+    IOVSyncValue temp(t);
 
-   {
-      const EventID t(2,3,1);
-      
-      IOVSyncValue temp(t);
-      
-      CPPUNIT_ASSERT(temp.eventID() == t);
-      CPPUNIT_ASSERT(temp.luminosityBlockNumber() == 3);
-      
-      CPPUNIT_ASSERT(IOVSyncValue::invalidIOVSyncValue() != temp);
-      CPPUNIT_ASSERT(!(IOVSyncValue::invalidIOVSyncValue() == temp));
-      CPPUNIT_ASSERT(IOVSyncValue::beginOfTime() < temp);
-      CPPUNIT_ASSERT(IOVSyncValue::endOfTime() > temp);
-   }
-   
+    CPPUNIT_ASSERT(temp.eventID() == t);
+
+    CPPUNIT_ASSERT(IOVSyncValue::invalidIOVSyncValue() != temp);
+    CPPUNIT_ASSERT(!(IOVSyncValue::invalidIOVSyncValue() == temp));
+    CPPUNIT_ASSERT(IOVSyncValue::beginOfTime() < temp);
+    CPPUNIT_ASSERT(IOVSyncValue::endOfTime() > temp);
+  }
+  CPPUNIT_ASSERT(IOVSyncValue::invalidIOVSyncValue() < IOVSyncValue::beginOfTime());
+  CPPUNIT_ASSERT(IOVSyncValue::beginOfTime() < IOVSyncValue::endOfTime());
+
+  {
+    const EventID t(2, 3, 1);
+
+    IOVSyncValue temp(t);
+
+    CPPUNIT_ASSERT(temp.eventID() == t);
+    CPPUNIT_ASSERT(temp.luminosityBlockNumber() == 3);
+
+    CPPUNIT_ASSERT(IOVSyncValue::invalidIOVSyncValue() != temp);
+    CPPUNIT_ASSERT(!(IOVSyncValue::invalidIOVSyncValue() == temp));
+    CPPUNIT_ASSERT(IOVSyncValue::beginOfTime() < temp);
+    CPPUNIT_ASSERT(IOVSyncValue::endOfTime() > temp);
+  }
 }
 
-void testIOVSyncValue::constructTimeTest()
-{
-   const Timestamp t(2);
-   
-   IOVSyncValue temp(t);
-   
-   CPPUNIT_ASSERT(temp.time() == t);
-   
-   CPPUNIT_ASSERT(IOVSyncValue::invalidIOVSyncValue() < IOVSyncValue::beginOfTime());
-   CPPUNIT_ASSERT(IOVSyncValue::beginOfTime() < IOVSyncValue::endOfTime());
-   
-   CPPUNIT_ASSERT(IOVSyncValue::invalidIOVSyncValue() != temp);
-   CPPUNIT_ASSERT(!(IOVSyncValue::invalidIOVSyncValue() == temp));
-   CPPUNIT_ASSERT(IOVSyncValue::beginOfTime() < temp);
-   CPPUNIT_ASSERT(IOVSyncValue::endOfTime() > temp);
+void testIOVSyncValue::constructTimeTest() {
+  const Timestamp t(2);
+
+  IOVSyncValue temp(t);
+
+  CPPUNIT_ASSERT(temp.time() == t);
+
+  CPPUNIT_ASSERT(IOVSyncValue::invalidIOVSyncValue() < IOVSyncValue::beginOfTime());
+  CPPUNIT_ASSERT(IOVSyncValue::beginOfTime() < IOVSyncValue::endOfTime());
+
+  CPPUNIT_ASSERT(IOVSyncValue::invalidIOVSyncValue() != temp);
+  CPPUNIT_ASSERT(!(IOVSyncValue::invalidIOVSyncValue() == temp));
+  CPPUNIT_ASSERT(IOVSyncValue::beginOfTime() < temp);
+  CPPUNIT_ASSERT(IOVSyncValue::endOfTime() > temp);
 }
 
-void testIOVSyncValue::comparisonTest()
-{
-   {
-      const IOVSyncValue small(EventID(1,1,1));
-      const IOVSyncValue med(EventID(2,1,2));
-      
-      CPPUNIT_ASSERT(small.comparable(med));
-      CPPUNIT_ASSERT(small < med);
-      CPPUNIT_ASSERT(small <= med);
-      CPPUNIT_ASSERT(!(small == med));
-      CPPUNIT_ASSERT(small != med);
-      CPPUNIT_ASSERT(!(small > med));
-      CPPUNIT_ASSERT(!(small >= med));
-   }
-   {
-      const IOVSyncValue small(EventID(2,1,1));
-      const IOVSyncValue med(EventID(2,1,2));
-      
-      CPPUNIT_ASSERT(small < med);
-      CPPUNIT_ASSERT(small <= med);
-      CPPUNIT_ASSERT(!(small == med));
-      CPPUNIT_ASSERT(small != med);
-      CPPUNIT_ASSERT(!(small > med));
-      CPPUNIT_ASSERT(!(small >= med));
-   }
-   {
-      const IOVSyncValue small(EventID(2,1,2));
-      const IOVSyncValue med(EventID(3,1,1));
-      
-      CPPUNIT_ASSERT(small < med);
-      CPPUNIT_ASSERT(small <= med);
-      CPPUNIT_ASSERT(!(small == med));
-      CPPUNIT_ASSERT(small != med);
-      CPPUNIT_ASSERT(!(small > med));
-      CPPUNIT_ASSERT(!(small >= med));
-   }
-   {
-      const IOVSyncValue small(EventID(2,2,1));
-      const IOVSyncValue med(EventID(2,2,2));
-      
-      CPPUNIT_ASSERT(small < med);
-      CPPUNIT_ASSERT(small <= med);
-      CPPUNIT_ASSERT(!(small == med));
-      CPPUNIT_ASSERT(small != med);
-      CPPUNIT_ASSERT(!(small > med));
-      CPPUNIT_ASSERT(!(small >= med));
-   }
-   {
-      const IOVSyncValue small(EventID(2,1,3));
-      const IOVSyncValue med(EventID(2,2,2));
-      
-      CPPUNIT_ASSERT(small < med);
-      CPPUNIT_ASSERT(small <= med);
-      CPPUNIT_ASSERT(!(small == med));
-      CPPUNIT_ASSERT(small != med);
-      CPPUNIT_ASSERT(!(small > med));
-      CPPUNIT_ASSERT(!(small >= med));
-   }
+void testIOVSyncValue::comparisonTest() {
+  {
+    const IOVSyncValue small(EventID(1, 1, 1));
+    const IOVSyncValue med(EventID(2, 1, 2));
+
+    CPPUNIT_ASSERT(small.comparable(med));
+    CPPUNIT_ASSERT(small < med);
+    CPPUNIT_ASSERT(small <= med);
+    CPPUNIT_ASSERT(!(small == med));
+    CPPUNIT_ASSERT(small != med);
+    CPPUNIT_ASSERT(!(small > med));
+    CPPUNIT_ASSERT(!(small >= med));
+  }
+  {
+    const IOVSyncValue small(EventID(2, 1, 1));
+    const IOVSyncValue med(EventID(2, 1, 2));
+
+    CPPUNIT_ASSERT(small < med);
+    CPPUNIT_ASSERT(small <= med);
+    CPPUNIT_ASSERT(!(small == med));
+    CPPUNIT_ASSERT(small != med);
+    CPPUNIT_ASSERT(!(small > med));
+    CPPUNIT_ASSERT(!(small >= med));
+  }
+  {
+    const IOVSyncValue small(EventID(2, 1, 2));
+    const IOVSyncValue med(EventID(3, 1, 1));
+
+    CPPUNIT_ASSERT(small < med);
+    CPPUNIT_ASSERT(small <= med);
+    CPPUNIT_ASSERT(!(small == med));
+    CPPUNIT_ASSERT(small != med);
+    CPPUNIT_ASSERT(!(small > med));
+    CPPUNIT_ASSERT(!(small >= med));
+  }
+  {
+    const IOVSyncValue small(EventID(2, 2, 1));
+    const IOVSyncValue med(EventID(2, 2, 2));
+
+    CPPUNIT_ASSERT(small < med);
+    CPPUNIT_ASSERT(small <= med);
+    CPPUNIT_ASSERT(!(small == med));
+    CPPUNIT_ASSERT(small != med);
+    CPPUNIT_ASSERT(!(small > med));
+    CPPUNIT_ASSERT(!(small >= med));
+  }
+  {
+    const IOVSyncValue small(EventID(2, 1, 3));
+    const IOVSyncValue med(EventID(2, 2, 2));
+
+    CPPUNIT_ASSERT(small < med);
+    CPPUNIT_ASSERT(small <= med);
+    CPPUNIT_ASSERT(!(small == med));
+    CPPUNIT_ASSERT(small != med);
+    CPPUNIT_ASSERT(!(small > med));
+    CPPUNIT_ASSERT(!(small >= med));
+  }
 }
 
+void testIOVSyncValue::comparisonTimeTest() {
+  const IOVSyncValue small(Timestamp(1));
+  const IOVSyncValue med(Timestamp(2));
 
-void testIOVSyncValue::comparisonTimeTest()
-{
-   const IOVSyncValue small(Timestamp(1));
-   const IOVSyncValue med(Timestamp(2));
-
-   CPPUNIT_ASSERT(small.comparable(med));
-   CPPUNIT_ASSERT(small < med);
-   CPPUNIT_ASSERT(small <= med);
-   CPPUNIT_ASSERT(!(small == med));
-   CPPUNIT_ASSERT(small != med);
-   CPPUNIT_ASSERT(!(small > med));
-   CPPUNIT_ASSERT(!(small >= med));
-
+  CPPUNIT_ASSERT(small.comparable(med));
+  CPPUNIT_ASSERT(small < med);
+  CPPUNIT_ASSERT(small <= med);
+  CPPUNIT_ASSERT(!(small == med));
+  CPPUNIT_ASSERT(small != med);
+  CPPUNIT_ASSERT(!(small > med));
+  CPPUNIT_ASSERT(!(small >= med));
 }
 
-void 
-testIOVSyncValue::invalidComparisonTest()
-{
+void testIOVSyncValue::invalidComparisonTest() {
   const IOVSyncValue timeBased(Timestamp(1));
-  const IOVSyncValue eventBased(EventID(3,2,1));
+  const IOVSyncValue eventBased(EventID(3, 2, 1));
 
-  CPPUNIT_ASSERT(! timeBased.comparable(eventBased));
-  CPPUNIT_ASSERT(! eventBased.comparable(timeBased));
-  CPPUNIT_ASSERT_THROW( [&](){return timeBased < eventBased;}()  , cms::Exception);
-  CPPUNIT_ASSERT_THROW( [&](){return timeBased <= eventBased;}() , cms::Exception);
-  CPPUNIT_ASSERT( !(timeBased == eventBased));
-  CPPUNIT_ASSERT( timeBased != eventBased);
-  CPPUNIT_ASSERT_THROW( [&]() {return timeBased > eventBased;}()  , cms::Exception);
-  CPPUNIT_ASSERT_THROW( [&]() {return timeBased >= eventBased;}() , cms::Exception);
+  CPPUNIT_ASSERT(!timeBased.comparable(eventBased));
+  CPPUNIT_ASSERT(!eventBased.comparable(timeBased));
+  CPPUNIT_ASSERT_THROW([&]() { return timeBased < eventBased; }(), cms::Exception);
+  CPPUNIT_ASSERT_THROW([&]() { return timeBased <= eventBased; }(), cms::Exception);
+  CPPUNIT_ASSERT(!(timeBased == eventBased));
+  CPPUNIT_ASSERT(timeBased != eventBased);
+  CPPUNIT_ASSERT_THROW([&]() { return timeBased > eventBased; }(), cms::Exception);
+  CPPUNIT_ASSERT_THROW([&]() { return timeBased >= eventBased; }(), cms::Exception);
 }

--- a/FWCore/Framework/test/limited_module_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_module_t.cppunit.cc
@@ -25,7 +25,6 @@
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
-
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "cppunit/extensions/HelperMacros.h"
@@ -34,17 +33,16 @@ namespace {
   edm::ParameterSet makePSet() {
     edm::ParameterSet pset;
     const unsigned int kLimit = 1;
-    pset.addUntrackedParameter("concurrencyLimit",kLimit);
+    pset.addUntrackedParameter("concurrencyLimit", kLimit);
     return pset;
   }
-  
-  const edm::ParameterSet s_pset = makePSet();
-}
 
-class testLimitedModule: public CppUnit::TestFixture 
-{
+  const edm::ParameterSet s_pset = makePSet();
+}  // namespace
+
+class testLimitedModule : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testLimitedModule);
-  
+
   CPPUNIT_TEST(basicTest);
   CPPUNIT_TEST(streamTest);
   CPPUNIT_TEST(runTest);
@@ -57,13 +55,14 @@ class testLimitedModule: public CppUnit::TestFixture
   CPPUNIT_TEST(endLumiProdTest);
   CPPUNIT_TEST(endRunSummaryProdTest);
   CPPUNIT_TEST(endLumiSummaryProdTest);
-  
+
   CPPUNIT_TEST_SUITE_END();
+
 public:
   testLimitedModule();
-  
-  void setUp(){}
-  void tearDown(){}
+
+  void setUp() {}
+  void tearDown() {}
 
   void basicTest();
   void streamTest();
@@ -97,10 +96,8 @@ public:
   typedef std::vector<Trans> Expectations;
 
 private:
+  std::map<Trans, std::function<void(edm::Worker*)>> m_transToFunc;
 
-  
-  std::map<Trans,std::function<void(edm::Worker*)>> m_transToFunc;
-  
   edm::ProcessConfiguration m_procConfig;
   std::shared_ptr<edm::ProductRegistry> m_prodReg;
   std::shared_ptr<edm::BranchIDListHelper> m_idHelper;
@@ -109,128 +106,114 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
+  std::shared_ptr<edm::ActivityRegistry>
+      m_actReg;  // We do not use propagate_const because the registry itself is mutable.
   edm::EventSetupImpl* m_es = nullptr;
-  edm::ModuleDescription m_desc = {"Dummy","dummy"};
-  
-  template<typename T>
-  void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
-  
+  edm::ModuleDescription m_desc = {"Dummy", "dummy"};
+
+  template <typename T> void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
+
   class BasicProd : public edm::limited::EDProducer<> {
   public:
-    BasicProd(): edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<>(s_pset)  {}
-    mutable unsigned int m_count = 0; //[[cms-thread-safe]]
-    
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    BasicProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<>(s_pset) {}
+    mutable unsigned int m_count = 0;  //[[cms-thread-safe]]
+
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
   };
   class StreamProd : public edm::limited::EDProducer<edm::StreamCache<int>> {
   public:
-    StreamProd(): edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::StreamCache<int>>(s_pset) {}
+    StreamProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::StreamCache<int>>(s_pset) {}
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
     std::unique_ptr<int> beginStream(edm::StreamID) const override {
       ++m_count;
       return std::unique_ptr<int>{};
     }
-    
-    virtual void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const  override{
+
+    virtual void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override { ++m_count; }
+    virtual void streamBeginLuminosityBlock(edm::StreamID,
+                                            edm::LuminosityBlock const&,
+                                            edm::EventSetup const&) const override {
       ++m_count;
     }
-    virtual void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+    virtual void streamEndLuminosityBlock(edm::StreamID,
+                                          edm::LuminosityBlock const&,
+                                          edm::EventSetup const&) const override {
       ++m_count;
     }
-    virtual void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    virtual void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    void endStream(edm::StreamID) const override {
-      ++m_count;
-    }
+    virtual void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override { ++m_count; }
+    void endStream(edm::StreamID) const override { ++m_count; }
   };
-  
+
   class RunProd : public edm::limited::EDProducer<edm::RunCache<int>> {
   public:
-    RunProd(): edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::RunCache<int>>(s_pset) {}
+    RunProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::RunCache<int>>(s_pset) {}
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
     std::shared_ptr<int> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override {
       ++m_count;
       return std::shared_ptr<int>{};
     }
 
-    void globalEndRun(edm::Run const&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    void globalEndRun(edm::Run const&, edm::EventSetup const&) const override { ++m_count; }
   };
-
 
   class LumiProd : public edm::limited::EDProducer<edm::LuminosityBlockCache<int>> {
   public:
-    LumiProd(): edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::LuminosityBlockCache<int>>(s_pset) {}
+    LumiProd()
+        : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::LuminosityBlockCache<int>>(s_pset) {}
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
-    std::shared_ptr<int> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
+    std::shared_ptr<int> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                    edm::EventSetup const&) const override {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
-    void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+
+    void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override { ++m_count; }
   };
-  
+
   class RunSummaryProd : public edm::limited::EDProducer<edm::RunSummaryCache<int>> {
   public:
-    RunSummaryProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::RunSummaryCache<int>>(s_pset){}
+    RunSummaryProd()
+        : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::RunSummaryCache<int>>(s_pset) {}
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
     std::shared_ptr<int> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
-    void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int*) const override {
-      ++m_count;
-    }
-    
-    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override {
-      ++m_count;
-    }
+
+    void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int*) const override { ++m_count; }
+
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override { ++m_count; }
   };
 
   class LumiSummaryProd : public edm::limited::EDProducer<edm::LuminosityBlockSummaryCache<int>> {
   public:
-    LumiSummaryProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::LuminosityBlockSummaryCache<int>>(s_pset) {}
+    LumiSummaryProd()
+        : edm::limited::EDProducerBase(s_pset),
+          edm::limited::EDProducer<edm::LuminosityBlockSummaryCache<int>>(s_pset) {}
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
-    std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
+    std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                                           edm::EventSetup const&) const override {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
-    void streamEndLuminosityBlockSummary(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
+
+    void streamEndLuminosityBlockSummary(edm::StreamID,
+                                         edm::LuminosityBlock const&,
+                                         edm::EventSetup const&,
+                                         int*) const override {
       ++m_count;
     }
-    
+
     void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
       ++m_count;
     }
@@ -240,102 +223,82 @@ private:
   public:
     BeginRunProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::BeginRunProducer>(s_pset) {}
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
 
-    void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override { ++m_count; }
   };
 
   class BeginLumiProd : public edm::limited::EDProducer<edm::BeginLuminosityBlockProducer> {
   public:
-    BeginLumiProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::BeginLuminosityBlockProducer>(s_pset) {}
+    BeginLumiProd()
+        : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::BeginLuminosityBlockProducer>(s_pset) {}
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
-    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
+    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override { ++m_count; }
   };
 
   class EndRunProd : public edm::limited::EDProducer<edm::EndRunProducer> {
   public:
     EndRunProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::EndRunProducer>(s_pset) {}
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
-    void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-  };
-  
-  class EndLumiProd : public edm::limited::EDProducer<edm::EndLuminosityBlockProducer> {
-  public:
-    EndLumiProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::EndLuminosityBlockProducer>(s_pset) {}
-    mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
-    void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
+    void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const override { ++m_count; }
   };
 
+  class EndLumiProd : public edm::limited::EDProducer<edm::EndLuminosityBlockProducer> {
+  public:
+    EndLumiProd()
+        : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::EndLuminosityBlockProducer>(s_pset) {}
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
+    void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override { ++m_count; }
+  };
 
   class EndRunSummaryProd : public edm::limited::EDProducer<edm::EndRunProducer, edm::RunSummaryCache<int>> {
   public:
     EndRunSummaryProd()
-    : edm::limited::EDProducerBase(s_pset),
-      edm::limited::EDProducer<edm::EndRunProducer, edm::RunSummaryCache<int>>(s_pset) {}
+        : edm::limited::EDProducerBase(s_pset),
+          edm::limited::EDProducer<edm::EndRunProducer, edm::RunSummaryCache<int>>(s_pset) {}
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
-    
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
+
     std::shared_ptr<int> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
-    void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int*) const override {
-      ++m_count;
-    }
-    
-    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override {
-      ++m_count;
-    }
 
-    void globalEndRunProduce(edm::Run&, edm::EventSetup const&, int const*) const override {
-      ++m_count;
-    }
+    void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int*) const override { ++m_count; }
+
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override { ++m_count; }
+
+    void globalEndRunProduce(edm::Run&, edm::EventSetup const&, int const*) const override { ++m_count; }
   };
-  
-  class EndLumiSummaryProd : public edm::limited::EDProducer<edm::EndLuminosityBlockProducer, edm::LuminosityBlockSummaryCache<int>> {
+
+  class EndLumiSummaryProd
+      : public edm::limited::EDProducer<edm::EndLuminosityBlockProducer, edm::LuminosityBlockSummaryCache<int>> {
   public:
     EndLumiSummaryProd()
-    : edm::limited::EDProducerBase(s_pset) ,
-      edm::limited::EDProducer<edm::EndLuminosityBlockProducer, edm::LuminosityBlockSummaryCache<int>>(s_pset){}
+        : edm::limited::EDProducerBase(s_pset),
+          edm::limited::EDProducer<edm::EndLuminosityBlockProducer, edm::LuminosityBlockSummaryCache<int>>(s_pset) {}
     mutable unsigned int m_count = 0;
-    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
-      ++m_count;
-    }
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override { ++m_count; }
 
-    std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+    std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                                           edm::EventSetup const&) const override {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
-    void streamEndLuminosityBlockSummary(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
+
+    void streamEndLuminosityBlockSummary(edm::StreamID,
+                                         edm::LuminosityBlock const&,
+                                         edm::EventSetup const&,
+                                         int*) const override {
       ++m_count;
     }
-    
+
     void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
       ++m_count;
     }
@@ -348,16 +311,16 @@ private:
 
 namespace {
   struct ShadowStreamID {
-    constexpr ShadowStreamID():value(0){}
+    constexpr ShadowStreamID() : value(0) {}
     unsigned int value;
   };
-  
+
   union IDUnion {
-    IDUnion(): m_shadow() {}
+    IDUnion() : m_shadow() {}
     ShadowStreamID m_shadow;
     edm::StreamID m_id;
   };
-}
+}  // namespace
 static edm::StreamID makeID() {
   IDUnion u;
   assert(u.m_id.value() == 0);
@@ -365,219 +328,212 @@ static edm::StreamID makeID() {
 }
 static const edm::StreamID s_streamID0 = makeID();
 
-
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testLimitedModule);
 
-testLimitedModule::testLimitedModule():
-m_prodReg(new edm::ProductRegistry{}),
-m_idHelper(new edm::BranchIDListHelper{}),
-m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
-m_ep()
-{
+testLimitedModule::testLimitedModule()
+    : m_prodReg(new edm::ProductRegistry{}),
+      m_idHelper(new edm::BranchIDListHelper{}),
+      m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
+      m_ep() {
   //Setup the principals
   m_prodReg->setFrozen();
   m_idHelper->updateFromRegistry(*m_prodReg);
   edm::EventID eventID = edm::EventID::firstValidEvent();
-  
+
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
   auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_,0));
+  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
   edm::LuminosityBlockAuxiliary lumiAux(m_rp->run(), 1, now, now);
-  m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_,0));
+  m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(lumiAux);
   m_lbp->setRunPrincipal(m_rp);
   edm::EventAuxiliary eventAux(eventID, uuid, now, true);
 
-  m_ep.reset(new edm::EventPrincipal(m_prodReg,
-                                     m_idHelper,
-                                     m_associationsHelper,
-                                     m_procConfig,nullptr));
+  m_ep.reset(new edm::EventPrincipal(m_prodReg, m_idHelper, m_associationsHelper, m_procConfig, nullptr));
   edm::ProcessHistoryRegistry phr;
   m_ep->fillEventPrincipal(eventAux, phr);
   m_ep->setLuminosityBlockPrincipal(m_lbp.get());
   m_actReg.reset(new edm::ActivityRegistry);
 
-
   //For each transition, bind a lambda which will call the proper method of the Worker
   m_transToFunc[Trans::kBeginStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
-    iBase->beginStream(s_streamID0, streamContext); };
+    iBase->beginStream(s_streamID0, streamContext);
+  };
 
-  
   m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_rp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
   m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
-  
+    iBase->doWork<Traits>(*m_rp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
+
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_lbp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
   m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, nullParentContext, nullptr); };
-  
+    iBase->doWork<Traits>(*m_lbp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
+
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::StreamContext streamContext(s_streamID0, nullptr);
     edm::ParentContext nullParentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
-    iBase->doWork<Traits>(*m_ep,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_ep, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
 
   m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_lbp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_lbp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
 
   m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_rp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext nullParentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
+    iBase->doWork<Traits>(*m_rp, *m_es, s_streamID0, nullParentContext, nullptr);
+  };
 
   m_transToFunc[Trans::kEndStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
-    iBase->endStream(s_streamID0, streamContext); };
-
+    iBase->endStream(s_streamID0, streamContext);
+  };
 }
 
-
 namespace {
-  template<typename T>
-  void
-  testTransition(std::shared_ptr<T> iMod, edm::Worker* iWorker, testLimitedModule::Trans iTrans, testLimitedModule::Expectations const& iExpect, std::function<void(edm::Worker*)> iFunc) {
-    assert(0==iMod->m_count);
+  template <typename T>
+  void testTransition(std::shared_ptr<T> iMod,
+                      edm::Worker* iWorker,
+                      testLimitedModule::Trans iTrans,
+                      testLimitedModule::Expectations const& iExpect,
+                      std::function<void(edm::Worker*)> iFunc) {
+    assert(0 == iMod->m_count);
     iFunc(iWorker);
-    auto count = std::count(iExpect.begin(),iExpect.end(),iTrans);
-    if(count != iMod->m_count) {
-      std::cout<<"For trans " <<static_cast<std::underlying_type<testLimitedModule::Trans>::type >(iTrans)<< " expected "<<count<<" and got "<<iMod->m_count<<std::endl;
+    auto count = std::count(iExpect.begin(), iExpect.end(), iTrans);
+    if (count != iMod->m_count) {
+      std::cout << "For trans " << static_cast<std::underlying_type<testLimitedModule::Trans>::type>(iTrans)
+                << " expected " << count << " and got " << iMod->m_count << std::endl;
     }
     CPPUNIT_ASSERT(iMod->m_count == count);
     iMod->m_count = 0;
     iWorker->reset();
   }
-}
+}  // namespace
 
-template<typename T>
-void
-testLimitedModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
-  edm::maker::ModuleHolderT<edm::limited::EDProducerBase> h(iMod,nullptr);
+template <typename T> void testLimitedModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
+  edm::maker::ModuleHolderT<edm::limited::EDProducerBase> h(iMod, nullptr);
   h.preallocate(edm::PreallocationConfiguration{});
-  edm::WorkerT<edm::limited::EDProducerBase> w{iMod,m_desc,nullptr};
-  for(auto& keyVal: m_transToFunc) {
-    testTransition(iMod,&w,keyVal.first,iExpect,keyVal.second);
+  edm::WorkerT<edm::limited::EDProducerBase> w{iMod, m_desc, nullptr};
+  for (auto& keyVal : m_transToFunc) {
+    testTransition(iMod, &w, keyVal.first, iExpect, keyVal.second);
   }
 }
 
-
-void testLimitedModule::basicTest()
-{
+void testLimitedModule::basicTest() {
   auto testProd = std::make_shared<BasicProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kEvent});
 }
 
-void testLimitedModule::streamTest()
-{
+void testLimitedModule::streamTest() {
   auto testProd = std::make_shared<StreamProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kBeginStream, Trans::kStreamBeginRun, Trans::kStreamBeginLuminosityBlock, Trans::kEvent,
-    Trans::kStreamEndLuminosityBlock,Trans::kStreamEndRun,Trans::kEndStream});
+  testTransitions(testProd, {Trans::kBeginStream, Trans::kStreamBeginRun, Trans::kStreamBeginLuminosityBlock,
+                             Trans::kEvent, Trans::kStreamEndLuminosityBlock, Trans::kStreamEndRun, Trans::kEndStream});
 }
 
-void testLimitedModule::runTest()
-{
+void testLimitedModule::runTest() {
   auto testProd = std::make_shared<RunProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndRun});
 }
 
-void testLimitedModule::runSummaryTest()
-{
+void testLimitedModule::runSummaryTest() {
   auto testProd = std::make_shared<RunSummaryProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kStreamEndRun, Trans::kGlobalEndRun});
 }
 
-void testLimitedModule::lumiTest()
-{
+void testLimitedModule::lumiTest() {
   auto testProd = std::make_shared<LumiProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock});
 }
 
-void testLimitedModule::lumiSummaryTest()
-{
+void testLimitedModule::lumiSummaryTest() {
   auto testProd = std::make_shared<LumiSummaryProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock});
+  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kStreamEndLuminosityBlock,
+                             Trans::kGlobalEndLuminosityBlock});
 }
 
-void testLimitedModule::beginRunProdTest()
-{
+void testLimitedModule::beginRunProdTest() {
   auto testProd = std::make_shared<BeginRunProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent});
 }
 
-void testLimitedModule::beginLumiProdTest()
-{
+void testLimitedModule::beginLumiProdTest() {
   auto testProd = std::make_shared<BeginLumiProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent});
 }
 
-void testLimitedModule::endRunProdTest()
-{
+void testLimitedModule::endRunProdTest() {
   auto testProd = std::make_shared<EndRunProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalEndRun, Trans::kEvent});
 }
 
-void testLimitedModule::endLumiProdTest()
-{
+void testLimitedModule::endLumiProdTest() {
   auto testProd = std::make_shared<EndLumiProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalEndLuminosityBlock, Trans::kEvent});
 }
 
-void testLimitedModule::endRunSummaryProdTest()
-{
+void testLimitedModule::endRunSummaryProdTest() {
   auto testProd = std::make_shared<EndRunSummaryProd>();
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kGlobalEndRun, Trans::kEvent, Trans::kGlobalBeginRun, Trans::kStreamEndRun, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kGlobalEndRun, Trans::kEvent, Trans::kGlobalBeginRun, Trans::kStreamEndRun,
+                             Trans::kGlobalEndRun});
 }
 
-void testLimitedModule::endLumiSummaryProdTest()
-{
+void testLimitedModule::endLumiSummaryProdTest() {
   auto testProd = std::make_shared<EndLumiSummaryProd>();
-  
-  CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kGlobalEndLuminosityBlock, Trans::kEvent, Trans::kGlobalBeginLuminosityBlock, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock}); 
-}
 
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalEndLuminosityBlock, Trans::kEvent, Trans::kGlobalBeginLuminosityBlock,
+                             Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock});
+}

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -27,7 +27,6 @@
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
-
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "cppunit/extensions/HelperMacros.h"
@@ -36,19 +35,19 @@ namespace edm {
   class ModuleCallingContext;
 }
 
-class testLimitedOutputModule: public CppUnit::TestFixture 
-{
+class testLimitedOutputModule : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testLimitedOutputModule);
-  
+
   CPPUNIT_TEST(basicTest);
   CPPUNIT_TEST(fileTest);
-  
+
   CPPUNIT_TEST_SUITE_END();
+
 public:
   testLimitedOutputModule();
-  
-  void setUp(){}
-  void tearDown(){}
+
+  void setUp() {}
+  void tearDown() {}
 
   void basicTest();
   void fileTest();
@@ -65,13 +64,12 @@ public:
     kGlobalCloseInputFile,
     kEndJob
   };
-  
+
   typedef std::vector<Trans> Expectations;
 
 private:
+  std::map<Trans, std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)>> m_transToFunc;
 
-  std::map<Trans,std::function<void(edm::Worker*,edm::OutputModuleCommunicator*)>> m_transToFunc;
-  
   edm::ProcessConfiguration m_procConfig;
   edm::PreallocationConfiguration m_preallocConfig;
   std::shared_ptr<edm::ProductRegistry> m_prodReg;
@@ -81,61 +79,45 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
+  std::shared_ptr<edm::ActivityRegistry>
+      m_actReg;  // We do not use propagate_const because the registry itself is mutable.
   edm::EventSetupImpl* m_es = nullptr;
-  edm::ModuleDescription m_desc = {"Dummy","dummy"};
+  edm::ModuleDescription m_desc = {"Dummy", "dummy"};
   edm::WorkerParams m_params;
-  
+
   typedef edm::service::TriggerNamesService TNS;
   typedef edm::serviceregistry::ServiceWrapper<TNS> w_TNS;
   std::shared_ptr<w_TNS> tnsptr_;
   edm::ServiceToken serviceToken_;
-  
-  template<typename T>
-  void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
-  
+
+  template <typename T> void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
+
   class BasicOutputModule : public edm::limited::OutputModule<> {
   public:
     using edm::limited::OutputModuleBase::doPreallocate;
-    BasicOutputModule(edm::ParameterSet const& iPSet): edm::limited::OutputModuleBase(iPSet),edm::limited::OutputModule<>(iPSet){}
+    BasicOutputModule(edm::ParameterSet const& iPSet)
+        : edm::limited::OutputModuleBase(iPSet), edm::limited::OutputModule<>(iPSet) {}
     std::atomic<unsigned int> m_count{0};
-    
-    void write(edm::EventForOutput const&) override {
-      ++m_count;
-    }
-    void writeRun(edm::RunForOutput const&) override {
-      ++m_count;
-    }
-    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
-      ++m_count;
-    }
 
+    void write(edm::EventForOutput const&) override { ++m_count; }
+    void writeRun(edm::RunForOutput const&) override { ++m_count; }
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override { ++m_count; }
   };
-  
+
   class FileOutputModule : public edm::limited::OutputModule<edm::WatchInputFiles> {
   public:
     using edm::limited::OutputModuleBase::doPreallocate;
-    FileOutputModule(edm::ParameterSet const& iPSet) : edm::limited::OutputModuleBase(iPSet), edm::limited::OutputModule<edm::WatchInputFiles>(iPSet) {}
+    FileOutputModule(edm::ParameterSet const& iPSet)
+        : edm::limited::OutputModuleBase(iPSet), edm::limited::OutputModule<edm::WatchInputFiles>(iPSet) {}
     std::atomic<unsigned int> m_count{0};
-    void write(edm::EventForOutput const&) override {
-      ++m_count;
-    }
-    void writeRun(edm::RunForOutput const&) override {
-      ++m_count;
-    }
-    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
-      ++m_count;
-    }
-    
-    void respondToOpenInputFile(edm::FileBlock const&)  override {
-      ++m_count;
-    }
-    
-    void respondToCloseInputFile(edm::FileBlock const&) override {
-      ++m_count;
-    }
+    void write(edm::EventForOutput const&) override { ++m_count; }
+    void writeRun(edm::RunForOutput const&) override { ++m_count; }
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override { ++m_count; }
+
+    void respondToOpenInputFile(edm::FileBlock const&) override { ++m_count; }
+
+    void respondToCloseInputFile(edm::FileBlock const&) override { ++m_count; }
   };
-  
 };
 
 namespace {
@@ -143,16 +125,16 @@ namespace {
   edm::ActivityRegistry activityRegistry;
 
   struct ShadowStreamID {
-    constexpr ShadowStreamID():value(0){}
+    constexpr ShadowStreamID() : value(0) {}
     unsigned int value;
   };
-  
+
   union IDUnion {
-    IDUnion(): m_shadow() {}
+    IDUnion() : m_shadow() {}
     ShadowStreamID m_shadow;
     edm::StreamID m_id;
   };
-}
+}  // namespace
 static edm::StreamID makeID() {
   IDUnion u;
   assert(u.m_id.value() == 0);
@@ -163,30 +145,26 @@ static const edm::StreamID s_streamID0 = makeID();
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testLimitedOutputModule);
 
-testLimitedOutputModule::testLimitedOutputModule():
-m_prodReg(new edm::ProductRegistry{}),
-m_idHelper(new edm::BranchIDListHelper{}),
-m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
-m_ep()
-{
+testLimitedOutputModule::testLimitedOutputModule()
+    : m_prodReg(new edm::ProductRegistry{}),
+      m_idHelper(new edm::BranchIDListHelper{}),
+      m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
+      m_ep() {
   //Setup the principals
   m_prodReg->setFrozen();
   m_idHelper->updateFromRegistry(*m_prodReg);
   edm::EventID eventID = edm::EventID::firstValidEvent();
-  
+
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
   auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_,0));
-  m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_,0));
+  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(edm::LuminosityBlockAuxiliary(m_rp->run(), 1, now, now));
   m_lbp->setRunPrincipal(m_rp);
   edm::EventAuxiliary eventAux(eventID, uuid, now, true);
 
-  m_ep.reset(new edm::EventPrincipal(m_prodReg,
-                                     m_idHelper,
-                                     m_associationsHelper,
-                                     m_procConfig,nullptr));
+  m_ep.reset(new edm::EventPrincipal(m_prodReg, m_idHelper, m_associationsHelper, m_procConfig, nullptr));
   edm::ProcessHistoryRegistry phr;
   m_ep->fillEventPrincipal(eventAux, phr);
   m_ep->setLuminosityBlockPrincipal(m_lbp.get());
@@ -198,33 +176,35 @@ m_ep()
     iBase->respondToOpenInputFile(fb);
   };
 
-
   m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr); };
-  
+    iBase->doWork<Traits>(*m_rp, *m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+  };
+
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr); };
-  
+    iBase->doWork<Traits>(*m_lbp, *m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+  };
+
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::StreamContext streamContext(s_streamID0, nullptr);
     edm::ParentContext parentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
-    iBase->doWork<Traits>(*m_ep,*m_es, s_streamID0, parentContext, nullptr); };
+    iBase->doWork<Traits>(*m_ep, *m_es, s_streamID0, parentContext, nullptr);
+  };
 
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    iBase->doWork<Traits>(*m_lbp, *m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
     iComm->writeLumiAsync(edm::WaitingTaskHolder(t.get()), *m_lbp, nullptr, &activityRegistry);
     t->wait_for_all();
-    if(t->exceptionPtr() != nullptr) {
+    if (t->exceptionPtr() != nullptr) {
       std::rethrow_exception(*t->exceptionPtr());
     }
   };
@@ -232,101 +212,98 @@ m_ep()
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    iBase->doWork<Traits>(*m_rp, *m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
     iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry, nullptr);
     t->wait_for_all();
-    if(t->exceptionPtr() != nullptr) {
+    if (t->exceptionPtr() != nullptr) {
       std::rethrow_exception(*t->exceptionPtr());
     }
   };
-  
+
   m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     edm::FileBlock fb;
     iBase->respondToCloseInputFile(fb);
   };
-
 
   // We want to create the TriggerNamesService because it is used in
   // the tests.  We do that here, but first we need to build a minimal
   // parameter set to pass to its constructor.  Then we build the
   // service and setup the service system.
   edm::ParameterSet proc_pset;
-  
+
   std::string processName("HLT");
   proc_pset.addParameter<std::string>("@process_name", processName);
-  
+
   std::vector<std::string> paths;
   edm::ParameterSet trigPaths;
   trigPaths.addParameter<std::vector<std::string>>("@trigger_paths", paths);
   proc_pset.addParameter<edm::ParameterSet>("@trigger_paths", trigPaths);
-  
+
   std::vector<std::string> endPaths;
   proc_pset.addParameter<std::vector<std::string>>("@end_paths", endPaths);
 
   // Now create and setup the service
   tnsptr_.reset(new w_TNS(std::make_unique<TNS>(proc_pset)));
-  
-  serviceToken_ = edm::ServiceRegistry::createContaining(tnsptr_);
-  
 
+  serviceToken_ = edm::ServiceRegistry::createContaining(tnsptr_);
 }
 
-
 namespace {
-  template<typename T>
-  void
-  testTransition(std::shared_ptr<T> iMod, edm::Worker* iWorker, edm::OutputModuleCommunicator* iComm, testLimitedOutputModule::Trans iTrans, testLimitedOutputModule::Expectations const& iExpect, std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)> iFunc) {
-    assert(0==iMod->m_count);
-    iFunc(iWorker,iComm);
-    auto count = std::count(iExpect.begin(),iExpect.end(),iTrans);
-    if(count != iMod->m_count) {
-      std::cout<<"For trans " <<static_cast<std::underlying_type<testLimitedOutputModule::Trans>::type >(iTrans)<< " expected "<<count<<" and got "<<iMod->m_count<<std::endl;
+  template <typename T>
+  void testTransition(std::shared_ptr<T> iMod,
+                      edm::Worker* iWorker,
+                      edm::OutputModuleCommunicator* iComm,
+                      testLimitedOutputModule::Trans iTrans,
+                      testLimitedOutputModule::Expectations const& iExpect,
+                      std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)> iFunc) {
+    assert(0 == iMod->m_count);
+    iFunc(iWorker, iComm);
+    auto count = std::count(iExpect.begin(), iExpect.end(), iTrans);
+    if (count != iMod->m_count) {
+      std::cout << "For trans " << static_cast<std::underlying_type<testLimitedOutputModule::Trans>::type>(iTrans)
+                << " expected " << count << " and got " << iMod->m_count << std::endl;
     }
     CPPUNIT_ASSERT(iMod->m_count == count);
     iMod->m_count = 0;
     iWorker->reset();
   }
-}
+}  // namespace
 
-template<typename T>
-void
-testLimitedOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
+template <typename T>
+void testLimitedOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
   iMod->doPreallocate(m_preallocConfig);
-  edm::WorkerT<edm::limited::OutputModuleBase> w{iMod,m_desc,m_params.actions_};
+  edm::WorkerT<edm::limited::OutputModuleBase> w{iMod, m_desc, m_params.actions_};
   edm::OutputModuleCommunicatorT<edm::limited::OutputModuleBase> comm(iMod.get());
-  for(auto& keyVal: m_transToFunc) {
-    testTransition(iMod,&w,&comm,keyVal.first,iExpect,keyVal.second);
+  for (auto& keyVal : m_transToFunc) {
+    testTransition(iMod, &w, &comm, keyVal.first, iExpect, keyVal.second);
   }
 }
 
-
-void testLimitedOutputModule::basicTest()
-{
+void testLimitedOutputModule::basicTest() {
   //make the services available
   edm::ServiceRegistry::Operate operate(serviceToken_);
 
   edm::ParameterSet pset;
   const unsigned int kLimit = 1;
-  pset.addUntrackedParameter("concurrencyLimit",kLimit);
+  pset.addUntrackedParameter("concurrencyLimit", kLimit);
   auto testProd = std::make_shared<BasicOutputModule>(pset);
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kEvent,Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
 }
 
-void testLimitedOutputModule::fileTest()
-{
+void testLimitedOutputModule::fileTest() {
   //make the services available
   edm::ServiceRegistry::Operate operate(serviceToken_);
-  
+
   edm::ParameterSet pset;
   const unsigned int kLimit = 1;
-  pset.addUntrackedParameter("concurrencyLimit",kLimit);
+  pset.addUntrackedParameter("concurrencyLimit", kLimit);
   auto testProd = std::make_shared<FileOutputModule>(pset);
-  
-  CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kGlobalOpenInputFile, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalCloseInputFile});
-}
 
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalOpenInputFile, Trans::kEvent, Trans::kGlobalEndLuminosityBlock,
+                             Trans::kGlobalEndRun, Trans::kGlobalCloseInputFile});
+}

--- a/FWCore/Framework/test/maker2_t.cppunit.cc
+++ b/FWCore/Framework/test/maker2_t.cppunit.cc
@@ -20,30 +20,26 @@
 
 using namespace edm;
 
-class TestMod : public EDProducer
-{
- public:
+class TestMod : public EDProducer {
+public:
   explicit TestMod(ParameterSet const& p);
 
   void produce(Event& e, EventSetup const&);
 };
 
-TestMod::TestMod(ParameterSet const&)
-{ produces<int>();}
+TestMod::TestMod(ParameterSet const&) { produces<int>(); }
 
-void TestMod::produce(Event&, EventSetup const&)
-{
-}
+void TestMod::produce(Event&, EventSetup const&) {}
 
 // ----------------------------------------------
-class testmaker2: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testmaker2);
-CPPUNIT_TEST(maker2Test);
-CPPUNIT_TEST_SUITE_END();
+class testmaker2 : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testmaker2);
+  CPPUNIT_TEST(maker2Test);
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
   void maker2Test();
 };
 
@@ -56,30 +52,31 @@ void testmaker2::maker2Test()
   std::unique_ptr<Maker> f = std::make_unique<WorkerMaker<TestMod>>();
 
   ParameterSet p1;
-  p1.addParameter("@module_type",std::string("TestMod") );
-  p1.addParameter("@module_label",std::string("t1") );
-  p1.addParameter("@module_edm_type",std::string("EDProducer") );
+  p1.addParameter("@module_type", std::string("TestMod"));
+  p1.addParameter("@module_label", std::string("t1"));
+  p1.addParameter("@module_edm_type", std::string("EDProducer"));
   p1.registerIt();
 
   ParameterSet p2;
-  p2.addParameter("@module_type",std::string("TestMod") );
-  p2.addParameter("@module_label",std::string("t2") );
-  p2.addParameter("@module_edm_type",std::string("EDProducer") );
+  p2.addParameter("@module_type", std::string("TestMod"));
+  p2.addParameter("@module_label", std::string("t2"));
+  p2.addParameter("@module_edm_type", std::string("EDProducer"));
   p2.registerIt();
 
   edm::ExceptionToActionTable table;
 
   edm::ProductRegistry preg;
   edm::PreallocationConfiguration prealloc;
-  auto pc = std::make_shared<ProcessConfiguration>("PROD", edm::ParameterSetID(), edm::getReleaseVersion(), edm::getPassID());
+  auto pc =
+      std::make_shared<ProcessConfiguration>("PROD", edm::ParameterSetID(), edm::getReleaseVersion(), edm::getPassID());
   edm::MakeModuleParams params1(&p1, preg, &prealloc, pc);
   edm::MakeModuleParams params2(&p2, preg, &prealloc, pc);
 
   signalslot::Signal<void(const ModuleDescription&)> aSignal;
-  auto m1 = f->makeModule(params1,aSignal,aSignal);
+  auto m1 = f->makeModule(params1, aSignal, aSignal);
   std::unique_ptr<Worker> w1 = m1->makeWorker(&table);
-  auto m2 = f->makeModule(params2,aSignal,aSignal);
+  auto m2 = f->makeModule(params2, aSignal, aSignal);
   std::unique_ptr<Worker> w2 = m2->makeWorker(&table);
 
-//  return 0;
+  //  return 0;
 }

--- a/FWCore/Framework/test/maker_t.cppunit.cc
+++ b/FWCore/Framework/test/maker_t.cppunit.cc
@@ -1,18 +1,17 @@
 
 #include <iostream>
 
-
 #include "cppunit/extensions/HelperMacros.h"
 
 // ----------------------------------------------
-class testmaker: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testmaker);
-CPPUNIT_TEST(makerTest);
-CPPUNIT_TEST_SUITE_END();
+class testmaker : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testmaker);
+  CPPUNIT_TEST(makerTest);
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
   void makerTest();
 };
 
@@ -22,14 +21,14 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testmaker);
 void testmaker::makerTest()
 //int main()
 {
-  std::string param1 = 
-    "string module_type = \"TestMod\"\n "
-    " string module_label = \"t1\"";
+  std::string param1 =
+      "string module_type = \"TestMod\"\n "
+      " string module_label = \"t1\"";
 
-  std::string param2 = 
-    "string module_type = \"TestMod\" "
-    "string module_label = \"t2\"";
-    
+  std::string param2 =
+      "string module_type = \"TestMod\" "
+      "string module_label = \"t2\"";
+
   /*try {
 
     edmplugin::PluginManager::configure(edmplugin::standard::config());

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -37,22 +37,22 @@ namespace edm {
   class ModuleCallingContext;
 }
 
-class testOneOutputModule: public CppUnit::TestFixture 
-{
+class testOneOutputModule : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testOneOutputModule);
-  
+
   CPPUNIT_TEST(basicTest);
   CPPUNIT_TEST(runTest);
   CPPUNIT_TEST(lumiTest);
   CPPUNIT_TEST(fileTest);
   CPPUNIT_TEST(resourceTest);
-  
+
   CPPUNIT_TEST_SUITE_END();
+
 public:
   testOneOutputModule();
-  
-  void setUp(){}
-  void tearDown(){}
+
+  void setUp() {}
+  void tearDown() {}
 
   void basicTest();
   void runTest();
@@ -72,13 +72,12 @@ public:
     kGlobalCloseInputFile,
     kEndJob
   };
-  
+
   typedef std::vector<Trans> Expectations;
 
 private:
+  std::map<Trans, std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)>> m_transToFunc;
 
-  std::map<Trans,std::function<void(edm::Worker*,edm::OutputModuleCommunicator*)>> m_transToFunc;
-  
   edm::ProcessConfiguration m_procConfig;
   edm::PreallocationConfiguration m_preallocConfig;
   std::shared_ptr<edm::ProductRegistry> m_prodReg;
@@ -88,131 +87,88 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
+  std::shared_ptr<edm::ActivityRegistry>
+      m_actReg;  // We do not use propagate_const because the registry itself is mutable.
   edm::EventSetupImpl* m_es = nullptr;
-  edm::ModuleDescription m_desc = {"Dummy","dummy"};
+  edm::ModuleDescription m_desc = {"Dummy", "dummy"};
   edm::WorkerParams m_params;
-  
+
   typedef edm::service::TriggerNamesService TNS;
   typedef edm::serviceregistry::ServiceWrapper<TNS> w_TNS;
   std::shared_ptr<w_TNS> tnsptr_;
   edm::ServiceToken serviceToken_;
-  
-  template<typename T>
-  void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
-  
+
+  template <typename T> void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
+
   class BasicOutputModule : public edm::one::OutputModule<> {
   public:
     using edm::one::OutputModuleBase::doPreallocate;
-    BasicOutputModule(edm::ParameterSet const& iPSet): edm::one::OutputModuleBase(iPSet),edm::one::OutputModule<>(iPSet){}
+    BasicOutputModule(edm::ParameterSet const& iPSet)
+        : edm::one::OutputModuleBase(iPSet), edm::one::OutputModule<>(iPSet) {}
     unsigned int m_count = 0;
-    
-    void write(edm::EventForOutput const&) override {
-      ++m_count;
-    }
-    void writeRun(edm::RunForOutput const&) override {
-      ++m_count;
-    }
-    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
-      ++m_count;
-    }
 
+    void write(edm::EventForOutput const&) override { ++m_count; }
+    void writeRun(edm::RunForOutput const&) override { ++m_count; }
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override { ++m_count; }
   };
-  
+
   class RunOutputModule : public edm::one::OutputModule<edm::one::WatchRuns> {
   public:
     using edm::one::OutputModuleBase::doPreallocate;
-    RunOutputModule(edm::ParameterSet const& iPSet) : edm::one::OutputModuleBase(iPSet), edm::one::OutputModule<edm::one::WatchRuns>(iPSet) {}
+    RunOutputModule(edm::ParameterSet const& iPSet)
+        : edm::one::OutputModuleBase(iPSet), edm::one::OutputModule<edm::one::WatchRuns>(iPSet) {}
     unsigned int m_count = 0;
-    void write(edm::EventForOutput const&) override {
-      ++m_count;
-    }
-    void writeRun(edm::RunForOutput const&) override {
-      ++m_count;
-    }
-    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
-      ++m_count;
-    }
-    
-    void beginRun(edm::RunForOutput const&)  override {
-      ++m_count;
-    }
+    void write(edm::EventForOutput const&) override { ++m_count; }
+    void writeRun(edm::RunForOutput const&) override { ++m_count; }
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override { ++m_count; }
 
-    void endRun(edm::RunForOutput const&)  override {
-      ++m_count;
-    }
+    void beginRun(edm::RunForOutput const&) override { ++m_count; }
+
+    void endRun(edm::RunForOutput const&) override { ++m_count; }
   };
-
 
   class LumiOutputModule : public edm::one::OutputModule<edm::one::WatchLuminosityBlocks> {
   public:
     using edm::one::OutputModuleBase::doPreallocate;
-    LumiOutputModule(edm::ParameterSet const& iPSet) : edm::one::OutputModuleBase(iPSet), edm::one::OutputModule<edm::one::WatchLuminosityBlocks>(iPSet) {}
+    LumiOutputModule(edm::ParameterSet const& iPSet)
+        : edm::one::OutputModuleBase(iPSet), edm::one::OutputModule<edm::one::WatchLuminosityBlocks>(iPSet) {}
     unsigned int m_count = 0;
-    void write(edm::EventForOutput const&) override {
-      ++m_count;
-    }
-    void writeRun(edm::RunForOutput const&) override {
-      ++m_count;
-    }
-    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
-      ++m_count;
-    }
-    
-    
-    void beginLuminosityBlock(edm::LuminosityBlockForOutput const&)  override {
-      ++m_count;
-    }
-    
-    void endLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
-      ++m_count;
-    }
+    void write(edm::EventForOutput const&) override { ++m_count; }
+    void writeRun(edm::RunForOutput const&) override { ++m_count; }
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override { ++m_count; }
+
+    void beginLuminosityBlock(edm::LuminosityBlockForOutput const&) override { ++m_count; }
+
+    void endLuminosityBlock(edm::LuminosityBlockForOutput const&) override { ++m_count; }
   };
   class FileOutputModule : public edm::one::OutputModule<edm::WatchInputFiles> {
   public:
     using edm::one::OutputModuleBase::doPreallocate;
-    FileOutputModule(edm::ParameterSet const& iPSet) : edm::one::OutputModuleBase(iPSet), edm::one::OutputModule<edm::WatchInputFiles>(iPSet) {}
+    FileOutputModule(edm::ParameterSet const& iPSet)
+        : edm::one::OutputModuleBase(iPSet), edm::one::OutputModule<edm::WatchInputFiles>(iPSet) {}
     unsigned int m_count = 0;
-    void write(edm::EventForOutput const&) override {
-      ++m_count;
-    }
-    void writeRun(edm::RunForOutput const&) override {
-      ++m_count;
-    }
-    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
-      ++m_count;
-    }
-    
-    void respondToOpenInputFile(edm::FileBlock const&)  override {
-      ++m_count;
-    }
-    
-    void respondToCloseInputFile(edm::FileBlock const&) override {
-      ++m_count;
-    }
+    void write(edm::EventForOutput const&) override { ++m_count; }
+    void writeRun(edm::RunForOutput const&) override { ++m_count; }
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override { ++m_count; }
+
+    void respondToOpenInputFile(edm::FileBlock const&) override { ++m_count; }
+
+    void respondToCloseInputFile(edm::FileBlock const&) override { ++m_count; }
   };
-  
+
   class ResourceOutputModule : public edm::one::OutputModule<edm::one::SharedResources> {
   public:
     using edm::one::OutputModuleBase::doPreallocate;
-    ResourceOutputModule(edm::ParameterSet const& iPSet): edm::one::OutputModuleBase(iPSet),edm::one::OutputModule<edm::one::SharedResources>(iPSet){
+    ResourceOutputModule(edm::ParameterSet const& iPSet)
+        : edm::one::OutputModuleBase(iPSet), edm::one::OutputModule<edm::one::SharedResources>(iPSet) {
       usesResource();
     }
     unsigned int m_count = 0;
-    
-    void write(edm::EventForOutput const&) override {
-      ++m_count;
-    }
-    void writeRun(edm::RunForOutput const&) override {
-      ++m_count;
-    }
-    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
-      ++m_count;
-    }
-    
+
+    void write(edm::EventForOutput const&) override { ++m_count; }
+    void writeRun(edm::RunForOutput const&) override { ++m_count; }
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override { ++m_count; }
   };
-
-
 };
 
 namespace {
@@ -220,16 +176,16 @@ namespace {
   edm::ActivityRegistry activityRegistry;
 
   struct ShadowStreamID {
-    constexpr ShadowStreamID():value(0){}
+    constexpr ShadowStreamID() : value(0) {}
     unsigned int value;
   };
-  
+
   union IDUnion {
-    IDUnion(): m_shadow() {}
+    IDUnion() : m_shadow() {}
     ShadowStreamID m_shadow;
     edm::StreamID m_id;
   };
-}
+}  // namespace
 static edm::StreamID makeID() {
   IDUnion u;
   assert(u.m_id.value() == 0);
@@ -240,31 +196,27 @@ static const edm::StreamID s_streamID0 = makeID();
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testOneOutputModule);
 
-testOneOutputModule::testOneOutputModule():
-m_prodReg(new edm::ProductRegistry{}),
-m_idHelper(new edm::BranchIDListHelper{}),
-m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
-m_ep()
-{
+testOneOutputModule::testOneOutputModule()
+    : m_prodReg(new edm::ProductRegistry{}),
+      m_idHelper(new edm::BranchIDListHelper{}),
+      m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
+      m_ep() {
   //Setup the principals
   m_prodReg->setFrozen();
   m_idHelper->updateFromRegistry(*m_prodReg);
   edm::EventID eventID = edm::EventID::firstValidEvent();
-  
+
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
   auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_,0));
+  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
   edm::LuminosityBlockAuxiliary lumiAux(m_rp->run(), 1, now, now);
-  m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_,0));
+  m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(lumiAux);
   m_lbp->setRunPrincipal(m_rp);
   edm::EventAuxiliary eventAux(eventID, uuid, now, true);
 
-  m_ep.reset(new edm::EventPrincipal(m_prodReg,
-                                     m_idHelper,
-                                     m_associationsHelper,
-                                     m_procConfig,nullptr));
+  m_ep.reset(new edm::EventPrincipal(m_prodReg, m_idHelper, m_associationsHelper, m_procConfig, nullptr));
   edm::ProcessHistoryRegistry phr;
   m_ep->fillEventPrincipal(eventAux, phr);
   m_ep->setLuminosityBlockPrincipal(m_lbp.get());
@@ -276,33 +228,35 @@ m_ep()
     iBase->respondToOpenInputFile(fb);
   };
 
-
   m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr); };
-  
+    iBase->doWork<Traits>(*m_rp, *m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+  };
+
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr); };
-  
+    iBase->doWork<Traits>(*m_lbp, *m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+  };
+
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::StreamContext streamContext(s_streamID0, nullptr);
     edm::ParentContext parentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
-    iBase->doWork<Traits>(*m_ep,*m_es, s_streamID0, parentContext, nullptr); };
+    iBase->doWork<Traits>(*m_ep, *m_es, s_streamID0, parentContext, nullptr);
+  };
 
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    iBase->doWork<Traits>(*m_lbp, *m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
     iComm->writeLumiAsync(edm::WaitingTaskHolder(t.get()), *m_lbp, nullptr, &activityRegistry);
     t->wait_for_all();
-    if(t->exceptionPtr() != nullptr) {
+    if (t->exceptionPtr() != nullptr) {
       std::rethrow_exception(*t->exceptionPtr());
     }
   };
@@ -310,134 +264,129 @@ m_ep()
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    iBase->doWork<Traits>(*m_rp, *m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
     iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry, nullptr);
     t->wait_for_all();
-    if(t->exceptionPtr() != nullptr) {
+    if (t->exceptionPtr() != nullptr) {
       std::rethrow_exception(*t->exceptionPtr());
     }
   };
-  
+
   m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     edm::FileBlock fb;
     iBase->respondToCloseInputFile(fb);
   };
-
 
   // We want to create the TriggerNamesService because it is used in
   // the tests.  We do that here, but first we need to build a minimal
   // parameter set to pass to its constructor.  Then we build the
   // service and setup the service system.
   edm::ParameterSet proc_pset;
-  
+
   std::string processName("HLT");
   proc_pset.addParameter<std::string>("@process_name", processName);
-  
+
   std::vector<std::string> paths;
   edm::ParameterSet trigPaths;
   trigPaths.addParameter<std::vector<std::string>>("@trigger_paths", paths);
   proc_pset.addParameter<edm::ParameterSet>("@trigger_paths", trigPaths);
-  
+
   std::vector<std::string> endPaths;
   proc_pset.addParameter<std::vector<std::string>>("@end_paths", endPaths);
 
   // Now create and setup the service
   tnsptr_.reset(new w_TNS(std::make_unique<TNS>(proc_pset)));
-  
-  serviceToken_ = edm::ServiceRegistry::createContaining(tnsptr_);
-  
 
+  serviceToken_ = edm::ServiceRegistry::createContaining(tnsptr_);
 }
 
-
 namespace {
-  template<typename T>
-  void
-  testTransition(std::shared_ptr<T> iMod, edm::Worker* iWorker, edm::OutputModuleCommunicator* iComm, testOneOutputModule::Trans iTrans, testOneOutputModule::Expectations const& iExpect, std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)> iFunc) {
-    assert(0==iMod->m_count);
-    iFunc(iWorker,iComm);
-    auto count = std::count(iExpect.begin(),iExpect.end(),iTrans);
-    if(count != iMod->m_count) {
-      std::cout<<"For trans " <<static_cast<std::underlying_type<testOneOutputModule::Trans>::type >(iTrans)<< " expected "<<count<<" and got "<<iMod->m_count<<std::endl;
+  template <typename T>
+  void testTransition(std::shared_ptr<T> iMod,
+                      edm::Worker* iWorker,
+                      edm::OutputModuleCommunicator* iComm,
+                      testOneOutputModule::Trans iTrans,
+                      testOneOutputModule::Expectations const& iExpect,
+                      std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)> iFunc) {
+    assert(0 == iMod->m_count);
+    iFunc(iWorker, iComm);
+    auto count = std::count(iExpect.begin(), iExpect.end(), iTrans);
+    if (count != iMod->m_count) {
+      std::cout << "For trans " << static_cast<std::underlying_type<testOneOutputModule::Trans>::type>(iTrans)
+                << " expected " << count << " and got " << iMod->m_count << std::endl;
     }
     CPPUNIT_ASSERT(iMod->m_count == count);
     iMod->m_count = 0;
     iWorker->reset();
   }
-}
+}  // namespace
 
-template<typename T>
-void
-testOneOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
+template <typename T> void testOneOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
   iMod->doPreallocate(m_preallocConfig);
-  edm::WorkerT<edm::one::OutputModuleBase> w{iMod,m_desc,m_params.actions_};
+  edm::WorkerT<edm::one::OutputModuleBase> w{iMod, m_desc, m_params.actions_};
   w.beginJob();
   edm::OutputModuleCommunicatorT<edm::one::OutputModuleBase> comm(iMod.get());
-  for(auto& keyVal: m_transToFunc) {
-    testTransition(iMod,&w,&comm,keyVal.first,iExpect,keyVal.second);
+  for (auto& keyVal : m_transToFunc) {
+    testTransition(iMod, &w, &comm, keyVal.first, iExpect, keyVal.second);
   }
 }
 
-
-void testOneOutputModule::basicTest()
-{
+void testOneOutputModule::basicTest() {
   //make the services available
   edm::ServiceRegistry::Operate operate(serviceToken_);
 
   edm::ParameterSet pset;
   auto testProd = std::make_shared<BasicOutputModule>(pset);
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kEvent,Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
 }
 
-void testOneOutputModule::runTest()
-{
+void testOneOutputModule::runTest() {
   //make the services available
   edm::ServiceRegistry::Operate operate(serviceToken_);
 
   edm::ParameterSet pset;
   auto testProd = std::make_shared<RunOutputModule>(pset);
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndLuminosityBlock,
+                             Trans::kGlobalEndRun, Trans::kGlobalEndRun});
 }
 
-void testOneOutputModule::lumiTest()
-{
+void testOneOutputModule::lumiTest() {
   //make the services available
   edm::ServiceRegistry::Operate operate(serviceToken_);
 
   edm::ParameterSet pset;
   auto testProd = std::make_shared<LumiOutputModule>(pset);
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
+  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock,
+                             Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
 }
 
-void testOneOutputModule::fileTest()
-{
+void testOneOutputModule::fileTest() {
   //make the services available
   edm::ServiceRegistry::Operate operate(serviceToken_);
-  
+
   edm::ParameterSet pset;
   auto testProd = std::make_shared<FileOutputModule>(pset);
-  
+
   CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kGlobalOpenInputFile, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalCloseInputFile});
+  testTransitions(testProd, {Trans::kGlobalOpenInputFile, Trans::kEvent, Trans::kGlobalEndLuminosityBlock,
+                             Trans::kGlobalEndRun, Trans::kGlobalCloseInputFile});
 }
 
-void testOneOutputModule::resourceTest()
-{
+void testOneOutputModule::resourceTest() {
   //make the services available
   edm::ServiceRegistry::Operate operate(serviceToken_);
-  
+
   edm::ParameterSet pset;
   auto testProd = std::make_shared<ResourceOutputModule>(pset);
-  
-  CPPUNIT_ASSERT(0 == testProd->m_count);
-  testTransitions(testProd, {Trans::kEvent,Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
-}
 
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
+}

--- a/FWCore/Framework/test/productregistry.cppunit.cc
+++ b/FWCore/Framework/test/productregistry.cppunit.cc
@@ -6,7 +6,6 @@
    \date 21 July 2005
 */
 
-
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -24,17 +23,17 @@
 
 #include <iostream>
 
-class testProductRegistry: public CppUnit::TestFixture {
-CPPUNIT_TEST_SUITE(testProductRegistry);
+class testProductRegistry : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testProductRegistry);
 
-CPPUNIT_TEST(testSignal);
-CPPUNIT_TEST(testWatch);
-CPPUNIT_TEST_EXCEPTION(testCircular,cms::Exception);
+  CPPUNIT_TEST(testSignal);
+  CPPUNIT_TEST(testWatch);
+  CPPUNIT_TEST_EXCEPTION(testCircular, cms::Exception);
 
-CPPUNIT_TEST(testProductRegistration);
-CPPUNIT_TEST(testAddAlias);
+  CPPUNIT_TEST(testProductRegistration);
+  CPPUNIT_TEST(testAddAlias);
 
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE_END();
 
 public:
   testProductRegistry();
@@ -46,7 +45,7 @@ public:
   void testProductRegistration();
   void testAddAlias();
 
- private:
+private:
   std::shared_ptr<edm::BranchDescription> intBranch_;
   std::shared_ptr<edm::BranchDescription> floatBranch_;
 };
@@ -55,48 +54,34 @@ public:
 CPPUNIT_TEST_SUITE_REGISTRATION(testProductRegistry);
 
 namespace {
-   struct Listener {
-      int* heard_;
-      Listener(int& hear) : heard_(&hear) {}
-      void operator()(edm::BranchDescription const&) {
-         ++(*heard_);
-      }
-   };
+  struct Listener {
+    int* heard_;
+    Listener(int& hear) : heard_(&hear) {}
+    void operator()(edm::BranchDescription const&) { ++(*heard_); }
+  };
 
-   struct Responder {
-      std::string name_;
-      edm::ProductRegistry* reg_;
-      Responder(std::string const& iName,
-                edm::ConstProductRegistry& iConstReg,
-                edm::ProductRegistry& iReg) : name_(iName),reg_(&iReg) {
-        iConstReg.watchProductAdditions(this, &Responder::respond);
-      }
-      void respond(edm::BranchDescription const& iDesc) {
-         edm::ParameterSet dummyProcessPset;
-         dummyProcessPset.registerIt();
-         auto pc = std::make_shared<edm::ProcessConfiguration>();
-         pc->setParameterSetID(dummyProcessPset.id());
+  struct Responder {
+    std::string name_;
+    edm::ProductRegistry* reg_;
+    Responder(std::string const& iName, edm::ConstProductRegistry& iConstReg, edm::ProductRegistry& iReg)
+        : name_(iName), reg_(&iReg) {
+      iConstReg.watchProductAdditions(this, &Responder::respond);
+    }
+    void respond(edm::BranchDescription const& iDesc) {
+      edm::ParameterSet dummyProcessPset;
+      dummyProcessPset.registerIt();
+      auto pc = std::make_shared<edm::ProcessConfiguration>();
+      pc->setParameterSetID(dummyProcessPset.id());
 
-         edm::BranchDescription prod(iDesc.branchType(),
-                                     name_,
-                                     iDesc.processName(),
-                                     iDesc.fullClassName(),
-                                     iDesc.friendlyClassName(),
-                                     iDesc.productInstanceName() + "-" + name_,
-                                     "",
-                                     iDesc.parameterSetID(),
-                                     iDesc.unwrappedType()
-                                    );
-         reg_->addProduct(prod);
-      }
-   };
-}
+      edm::BranchDescription prod(iDesc.branchType(), name_, iDesc.processName(), iDesc.fullClassName(),
+                                  iDesc.friendlyClassName(), iDesc.productInstanceName() + "-" + name_, "",
+                                  iDesc.parameterSetID(), iDesc.unwrappedType());
+      reg_->addProduct(prod);
+    }
+  };
+}  // namespace
 
-testProductRegistry::testProductRegistry() :
-  intBranch_(),
-  floatBranch_() {
-}
-
+testProductRegistry::testProductRegistry() : intBranch_(), floatBranch_() {}
 
 void testProductRegistry::setUp() {
   edm::ParameterSet dummyProcessPset;
@@ -106,99 +91,94 @@ void testProductRegistry::setUp() {
 
   edm::ParameterSet pset;
   pset.registerIt();
-  intBranch_.reset(new edm::BranchDescription(edm::InEvent, "labeli", "PROD",
-                                          "int", "int", "int",
-                                          "", pset.id(),
-                                          edm::TypeWithDict(typeid(int))));
+  intBranch_.reset(new edm::BranchDescription(edm::InEvent, "labeli", "PROD", "int", "int", "int", "", pset.id(),
+                                              edm::TypeWithDict(typeid(int))));
 
-  floatBranch_.reset(new edm::BranchDescription(edm::InEvent, "labelf", "PROD",
-                                            "float", "float", "float",
-                                            "", pset.id(),
-                                            edm::TypeWithDict(typeid(float))));
-
+  floatBranch_.reset(new edm::BranchDescription(edm::InEvent, "labelf", "PROD", "float", "float", "float", "",
+                                                pset.id(), edm::TypeWithDict(typeid(float))));
 }
 
 namespace {
   template <class T> void kill_and_clear(std::shared_ptr<T>& p) { p.reset(); }
-}
+}  // namespace
 
 void testProductRegistry::tearDown() {
   kill_and_clear(floatBranch_);
   kill_and_clear(intBranch_);
 }
 
-void testProductRegistry:: testSignal() {
-   using namespace edm;
-   SignallingProductRegistry reg;
+void testProductRegistry::testSignal() {
+  using namespace edm;
+  SignallingProductRegistry reg;
 
-   int hear=0;
-   Listener listening(hear);
-   reg.productAddedSignal_.connect(listening);
+  int hear = 0;
+  Listener listening(hear);
+  reg.productAddedSignal_.connect(listening);
 
-   //BranchDescription prod(InEvent, "label", "PROD", "int", "int", "int", md);
+  //BranchDescription prod(InEvent, "label", "PROD", "int", "int", "int", md);
 
-   //   reg.addProduct(prod);
-   reg.addProduct(*intBranch_);
-   CPPUNIT_ASSERT(1 == hear);
+  //   reg.addProduct(prod);
+  reg.addProduct(*intBranch_);
+  CPPUNIT_ASSERT(1 == hear);
 }
 
-void testProductRegistry:: testWatch() {
-   using namespace edm;
-   SignallingProductRegistry reg;
-   ConstProductRegistry constReg(reg);
+void testProductRegistry::testWatch() {
+  using namespace edm;
+  SignallingProductRegistry reg;
+  ConstProductRegistry constReg(reg);
 
-   int hear=0;
-   Listener listening(hear);
-   constReg.watchProductAdditions(listening);
-   constReg.watchProductAdditions(listening, &Listener::operator());
+  int hear = 0;
+  Listener listening(hear);
+  constReg.watchProductAdditions(listening);
+  constReg.watchProductAdditions(listening, &Listener::operator());
 
-   Responder one("one",constReg, reg);
+  Responder one("one", constReg, reg);
 
-   //BranchDescription prod(InEvent, "label", "PROD", "int", "int", "int");
-   //reg.addProduct(prod);
-   reg.addProduct(*intBranch_);
+  //BranchDescription prod(InEvent, "label", "PROD", "int", "int", "int");
+  //reg.addProduct(prod);
+  reg.addProduct(*intBranch_);
 
-   //BranchDescription prod2(InEvent, "label", "PROD", "float", "float", "float");
-   //   reg.addProduct(prod2);
-   reg.addProduct(*floatBranch_);
+  //BranchDescription prod2(InEvent, "label", "PROD", "float", "float", "float");
+  //   reg.addProduct(prod2);
+  reg.addProduct(*floatBranch_);
 
-   //Should be 4 products
-   // 1 from the 'int' in this routine
-   // 1 from 'one' responding to this call
-   // 1 from the 'float'
-   // 1 from 'one' responding to the original call
-   CPPUNIT_ASSERT(4 * 2 == hear);
-   CPPUNIT_ASSERT(4 == reg.size());
+  //Should be 4 products
+  // 1 from the 'int' in this routine
+  // 1 from 'one' responding to this call
+  // 1 from the 'float'
+  // 1 from 'one' responding to the original call
+  CPPUNIT_ASSERT(4 * 2 == hear);
+  CPPUNIT_ASSERT(4 == reg.size());
 }
-void testProductRegistry:: testCircular() {
-   using namespace edm;
-   SignallingProductRegistry reg;
-   ConstProductRegistry constReg(reg);
+void testProductRegistry::testCircular() {
+  using namespace edm;
+  SignallingProductRegistry reg;
+  ConstProductRegistry constReg(reg);
 
-   int hear=0;
-   Listener listening(hear);
-   constReg.watchProductAdditions(listening);
-   constReg.watchProductAdditions(listening, &Listener::operator());
+  int hear = 0;
+  Listener listening(hear);
+  constReg.watchProductAdditions(listening);
+  constReg.watchProductAdditions(listening, &Listener::operator());
 
-   Responder one("one", constReg, reg);
-   Responder two("two", constReg, reg);
+  Responder one("one", constReg, reg);
+  Responder two("two", constReg, reg);
 
-   //BranchDescription prod(InEvent, "label","PROD","int","int","int");
-   //reg.addProduct(prod);
-   reg.addProduct(*intBranch_);
+  //BranchDescription prod(InEvent, "label","PROD","int","int","int");
+  //reg.addProduct(prod);
+  reg.addProduct(*intBranch_);
 
-   //Should be 5 products
-   // 1 from the original 'add' in this routine
-   // 1 from 'one' responding to this call
-   // 1 from 'two' responding to 'one'
-   // 1 from 'two' responding to the original call
-   // 1 from 'one' responding to 'two'
-   CPPUNIT_ASSERT(5 * 2 == hear);
-   CPPUNIT_ASSERT(5 == reg.size());
+  //Should be 5 products
+  // 1 from the original 'add' in this routine
+  // 1 from 'one' responding to this call
+  // 1 from 'two' responding to 'one'
+  // 1 from 'two' responding to the original call
+  // 1 from 'one' responding to 'two'
+  CPPUNIT_ASSERT(5 * 2 == hear);
+  CPPUNIT_ASSERT(5 == reg.size());
 }
 
-void testProductRegistry:: testProductRegistration() {
-   edm::AssertHandler ah;
+void testProductRegistry::testProductRegistration() {
+  edm::AssertHandler ah;
 
   std::string configuration(
       "import FWCore.ParameterSet.Config as cms\n"
@@ -211,7 +191,7 @@ void testProductRegistry:: testProductRegistration() {
       "process.p = cms.Path(process.m1*process.m2)\n");
   try {
     edm::EventProcessor proc(edm::getPSetFromConfig(configuration));
-  } catch(cms::Exception const& iException) {
+  } catch (cms::Exception const& iException) {
     std::cout << "caught " << iException.explainSelf() << std::endl;
     throw;
   }
@@ -228,8 +208,6 @@ void testProductRegistry::testAddAlias() {
 
   reg.setFrozen(false);
   std::vector<std::pair<std::string, std::string> > const& v = reg.aliasToOriginal();
-  CPPUNIT_ASSERT(v.at(0).first == "aliasf" &&
-                 v.at(0).second == "labelf" &&
-                 v.at(1).first == "aliasi" &&
+  CPPUNIT_ASSERT(v.at(0).first == "aliasf" && v.at(0).second == "labelf" && v.at(1).first == "aliasi" &&
                  v.at(1).second == "labeli");
 }

--- a/FWCore/Framework/test/proxyfactoryproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/proxyfactoryproducer_t.cppunit.cc
@@ -21,42 +21,37 @@ using edm::ESProxyFactoryProducer;
 
 class DummyProxy : public DataProxyTemplate<DummyRecord, DummyData> {
 public:
-   DummyProxy() {}
+  DummyProxy() {}
+
 protected:
-   const value_type* make(const record_type&, const DataKey&) {
-      return static_cast<const value_type*>(nullptr) ;
-   }
-   void invalidateCache() {
-   }   
+  const value_type* make(const record_type&, const DataKey&) { return static_cast<const value_type*>(nullptr); }
+  void invalidateCache() {}
+
 private:
 };
 
 class Test1Producer : public ESProxyFactoryProducer {
 public:
-   Test1Producer() {
-      registerFactory(std::make_unique<ProxyFactoryTemplate<DummyProxy>>());
-   }
+  Test1Producer() { registerFactory(std::make_unique<ProxyFactoryTemplate<DummyProxy>>()); }
 };
 
 class TestLabelProducer : public ESProxyFactoryProducer {
 public:
-   TestLabelProducer() {
-      registerFactory(std::make_unique<ProxyFactoryTemplate<DummyProxy>>(), "fred");
-   }
+  TestLabelProducer() { registerFactory(std::make_unique<ProxyFactoryTemplate<DummyProxy>>(), "fred"); }
 };
 
-class testProxyfactor: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testProxyfactor);
+class testProxyfactor : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testProxyfactor);
 
-CPPUNIT_TEST(registerProxyfactorytemplateTest);
-CPPUNIT_TEST(labelTest);
-CPPUNIT_TEST(appendLabelTest);
+  CPPUNIT_TEST(registerProxyfactorytemplateTest);
+  CPPUNIT_TEST(labelTest);
+  CPPUNIT_TEST(appendLabelTest);
 
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void registerProxyfactorytemplateTest();
   void appendLabelTest();
@@ -66,50 +61,43 @@ public:
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testProxyfactor);
 
-void testProxyfactor::registerProxyfactorytemplateTest()
-{
-   Test1Producer testProd;
-   EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
-   CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
+void testProxyfactor::registerProxyfactorytemplateTest() {
+  Test1Producer testProd;
+  EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
+  CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
 
-   const DataProxyProvider::KeyedProxies& keyedProxies =
-      testProd.keyedProxies(dummyRecordKey);
+  const DataProxyProvider::KeyedProxies& keyedProxies = testProd.keyedProxies(dummyRecordKey);
 
-   CPPUNIT_ASSERT(keyedProxies.size() == 1);
-   CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
+  CPPUNIT_ASSERT(keyedProxies.size() == 1);
+  CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
 }
 
-void testProxyfactor::labelTest()
-{
-   TestLabelProducer testProd;
-   EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
-   CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
-   
-   const DataProxyProvider::KeyedProxies& keyedProxies =
-      testProd.keyedProxies(dummyRecordKey);
-   
-   CPPUNIT_ASSERT(keyedProxies.size() == 1);
-   CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
-   const std::string kFred("fred");
-   CPPUNIT_ASSERT(kFred == keyedProxies.front().first.name().value());
+void testProxyfactor::labelTest() {
+  TestLabelProducer testProd;
+  EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
+  CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
+
+  const DataProxyProvider::KeyedProxies& keyedProxies = testProd.keyedProxies(dummyRecordKey);
+
+  CPPUNIT_ASSERT(keyedProxies.size() == 1);
+  CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
+  const std::string kFred("fred");
+  CPPUNIT_ASSERT(kFred == keyedProxies.front().first.name().value());
 }
 
-void testProxyfactor::appendLabelTest()
-{
+void testProxyfactor::appendLabelTest() {
   edm::ParameterSet pset;
   std::string kToAppend("Barney");
-  pset.addParameter("appendToDataLabel",
-                    kToAppend);
+  pset.addParameter("appendToDataLabel", kToAppend);
   pset.registerIt();
   {
     TestLabelProducer testProd;
     testProd.setAppendToDataLabel(pset);
     EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
     CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
-  
-    const DataProxyProvider::KeyedProxies& keyedProxies =
-      testProd.keyedProxies(dummyRecordKey);
-    
+
+    const DataProxyProvider::KeyedProxies& keyedProxies = testProd.keyedProxies(dummyRecordKey);
+
     CPPUNIT_ASSERT(keyedProxies.size() == 1);
     CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
     const std::string kFredBarney("fredBarney");
@@ -120,13 +108,11 @@ void testProxyfactor::appendLabelTest()
   testProd.setAppendToDataLabel(pset);
   EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
   CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
-  
-  const DataProxyProvider::KeyedProxies& keyedProxies =
-    testProd.keyedProxies(dummyRecordKey);
-  
+
+  const DataProxyProvider::KeyedProxies& keyedProxies = testProd.keyedProxies(dummyRecordKey);
+
   CPPUNIT_ASSERT(keyedProxies.size() == 1);
   CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
   const std::string kBarney("Barney");
   CPPUNIT_ASSERT(kBarney == keyedProxies.front().first.name().value());
-  
 }

--- a/FWCore/Framework/test/sharedresourcesregistry_t.cppunit.cc
+++ b/FWCore/Framework/test/sharedresourcesregistry_t.cppunit.cc
@@ -14,30 +14,28 @@
 
 using namespace edm;
 
-class testSharedResourcesRegistry: public CppUnit::TestFixture
-{
-   CPPUNIT_TEST_SUITE(testSharedResourcesRegistry);
-   
-   CPPUNIT_TEST(oneTest);
-   CPPUNIT_TEST(legacyTest);
-   CPPUNIT_TEST(multipleTest);
-  
-   CPPUNIT_TEST_SUITE_END();
+class testSharedResourcesRegistry : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testSharedResourcesRegistry);
+
+  CPPUNIT_TEST(oneTest);
+  CPPUNIT_TEST(legacyTest);
+  CPPUNIT_TEST(multipleTest);
+
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-      void setUp(){}
-   void tearDown(){}
-   
-   void oneTest();
-   void legacyTest();
-   void multipleTest();
+  void setUp() {}
+  void tearDown() {}
+
+  void oneTest();
+  void legacyTest();
+  void multipleTest();
 };
 
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testSharedResourcesRegistry);
 
-
-void testSharedResourcesRegistry::oneTest()
-{
+void testSharedResourcesRegistry::oneTest() {
   edm::SharedResourcesRegistry reg;
 
   CPPUNIT_ASSERT(reg.resourceMap().size() == 0);
@@ -47,25 +45,24 @@ void testSharedResourcesRegistry::oneTest()
   reg.registerSharedResource("zoo");
 
   {
-    std::vector<std::string> res{"foo","bar","zoo"};
+    std::vector<std::string> res{"foo", "bar", "zoo"};
     auto tester = reg.createAcquirer(res);
-    
+
     CPPUNIT_ASSERT(1 == tester.numberOfResources());
   }
   {
     std::vector<std::string> res{"foo"};
     auto tester = reg.createAcquirer(res);
-    
+
     CPPUNIT_ASSERT(1 == tester.numberOfResources());
   }
 }
 
-void testSharedResourcesRegistry::legacyTest()
-{
+void testSharedResourcesRegistry::legacyTest() {
   std::vector<std::string> res{edm::SharedResourcesRegistry::kLegacyModuleResourceName};
   {
     edm::SharedResourcesRegistry reg;
-    
+
     reg.registerSharedResource(edm::SharedResourcesRegistry::kLegacyModuleResourceName);
     auto tester = reg.createAcquirer(res);
 
@@ -73,14 +70,13 @@ void testSharedResourcesRegistry::legacyTest()
   }
   {
     edm::SharedResourcesRegistry reg;
-    
+
     reg.registerSharedResource(edm::SharedResourcesRegistry::kLegacyModuleResourceName);
     reg.registerSharedResource(edm::SharedResourcesRegistry::kLegacyModuleResourceName);
 
     auto tester = reg.createAcquirer(res);
-    
+
     CPPUNIT_ASSERT(1 == tester.numberOfResources());
-    
   }
   {
     edm::SharedResourcesRegistry reg;
@@ -119,11 +115,10 @@ void testSharedResourcesRegistry::legacyTest()
   }
 }
 
-void testSharedResourcesRegistry::multipleTest()
-{
+void testSharedResourcesRegistry::multipleTest() {
   edm::SharedResourcesRegistry reg;
   auto const& resourceMap = reg.resourceMap();
-  
+
   reg.registerSharedResource("foo");
   reg.registerSharedResource("bar");
   reg.registerSharedResource("zoo");
@@ -140,22 +135,21 @@ void testSharedResourcesRegistry::multipleTest()
   CPPUNIT_ASSERT(resourceMap.size() == 3);
 
   {
-    std::vector<std::string> res{"foo","bar","zoo"};
+    std::vector<std::string> res{"foo", "bar", "zoo"};
     auto tester = reg.createAcquirer(res);
-    
+
     CPPUNIT_ASSERT(2 == tester.numberOfResources());
   }
   {
     std::vector<std::string> res{"foo"};
     auto tester = reg.createAcquirer(res);
-    
+
     CPPUNIT_ASSERT(1 == tester.numberOfResources());
   }
   {
     std::vector<std::string> res{"bar"};
     auto tester = reg.createAcquirer(res);
-    
+
     CPPUNIT_ASSERT(1 == tester.numberOfResources());
   }
-
 }

--- a/FWCore/Framework/test/statemachine_t.cc
+++ b/FWCore/Framework/test/statemachine_t.cc
@@ -2,7 +2,7 @@
 
 Test of the statemachine classes.
 
-----------------------------------------------------------------------*/  
+----------------------------------------------------------------------*/
 
 #include "FWCore/Framework/test/MockEventProcessor.h"
 
@@ -12,7 +12,6 @@ Test of the statemachine classes.
 #include <iostream>
 #include <fstream>
 
-
 int main(int argc, char* argv[]) try {
   std::cout << "Running test in statemachine_t.cc\n";
 
@@ -20,10 +19,10 @@ int main(int argc, char* argv[]) try {
   std::string inputFile;
   std::string outputFile;
   boost::program_options::options_description desc("Allowed options");
-  desc.add_options()
-    ("help,h", "produce help message")
-    ("inputFile,i", boost::program_options::value<std::string>(&inputFile)->default_value(""))
-    ("outputFile,o", boost::program_options::value<std::string>(&outputFile)->default_value("statemachine_test_output.txt"));
+  desc.add_options()("help,h", "produce help message")(
+      "inputFile,i", boost::program_options::value<std::string>(&inputFile)->default_value(""))(
+      "outputFile,o",
+      boost::program_options::value<std::string>(&outputFile)->default_value("statemachine_test_output.txt"));
   boost::program_options::variables_map vm;
   boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), vm);
   boost::program_options::notify(vm);
@@ -47,8 +46,7 @@ int main(int argc, char* argv[]) try {
     std::ifstream input;
     input.open(inputFile.c_str());
     if (input.fail()) {
-      std::cerr << "Error, Unable to open mock input file named " 
-                << inputFile << "\n";
+      std::cerr << "Error, Unable to open mock input file named " << inputFile << "\n";
       return 1;
     }
     std::getline(input, mockData, '.');
@@ -60,25 +58,24 @@ int main(int argc, char* argv[]) try {
   fileModes.push_back(true);
   fileModes.push_back(false);
 
-  for (auto mode: fileModes) {
-
+  for (auto mode : fileModes) {
     output << "\nMachine parameters:  ";
-    if (mode) output << "mode = NOMERGE";
-    else output << "mode = FULLMERGE";
+    if (mode)
+      output << "mode = NOMERGE";
+    else
+      output << "mode = FULLMERGE";
 
     output << "\n";
 
-    edm::MockEventProcessor mockEventProcessor(mockData,
-                                               output,
-                                               mode);
+    edm::MockEventProcessor mockEventProcessor(mockData, output, mode);
     try {
       mockEventProcessor.runToCompletion();
-    } catch(edm::MockEventProcessor::TestException const& e) {
-      output <<"caught test exception\n";
+    } catch (edm::MockEventProcessor::TestException const& e) {
+      output << "caught test exception\n";
     }
   }
   return 0;
-} catch(std::exception const& e) {
+} catch (std::exception const& e) {
   std::cerr << e.what() << std::endl;
   return 1;
 }

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -25,15 +25,13 @@
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
-
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "cppunit/extensions/HelperMacros.h"
 
-class testStreamModule: public CppUnit::TestFixture 
-{
+class testStreamModule : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testStreamModule);
-  
+
   CPPUNIT_TEST(basicTest);
   CPPUNIT_TEST(globalTest);
   CPPUNIT_TEST(runTest);
@@ -46,13 +44,14 @@ class testStreamModule: public CppUnit::TestFixture
   CPPUNIT_TEST(endLumiProdTest);
   CPPUNIT_TEST(endRunSummaryProdTest);
   CPPUNIT_TEST(endLumiSummaryProdTest);
-  
+
   CPPUNIT_TEST_SUITE_END();
+
 public:
   testStreamModule();
-  
-  void setUp(){}
-  void tearDown(){}
+
+  void setUp() {}
+  void tearDown() {}
 
   void basicTest();
   void globalTest();
@@ -68,27 +67,26 @@ public:
   void endLumiSummaryProdTest();
 
   enum class Trans {
-    kBeginJob, //0
-    kBeginStream, //1
-    kGlobalBeginRun, //2
-    kStreamBeginRun, //3
-    kGlobalBeginLuminosityBlock, //4
-    kStreamBeginLuminosityBlock, //5
-    kEvent, //6
-    kStreamEndLuminosityBlock, //7
-    kGlobalEndLuminosityBlock, //8
-    kStreamEndRun, //9
-    kGlobalEndRun, //10
-    kEndStream, //11
-    kEndJob //12
+    kBeginJob,                    //0
+    kBeginStream,                 //1
+    kGlobalBeginRun,              //2
+    kStreamBeginRun,              //3
+    kGlobalBeginLuminosityBlock,  //4
+    kStreamBeginLuminosityBlock,  //5
+    kEvent,                       //6
+    kStreamEndLuminosityBlock,    //7
+    kGlobalEndLuminosityBlock,    //8
+    kStreamEndRun,                //9
+    kGlobalEndRun,                //10
+    kEndStream,                   //11
+    kEndJob                       //12
   };
-  
+
   typedef std::vector<Trans> Expectations;
 
 private:
+  std::map<Trans, std::function<void(edm::Worker*)>> m_transToFunc;
 
-  std::map<Trans,std::function<void(edm::Worker*)>> m_transToFunc;
-  
   edm::ProcessConfiguration m_procConfig;
   std::shared_ptr<edm::ProductRegistry> m_prodReg;
   std::shared_ptr<edm::BranchIDListHelper> m_idHelper;
@@ -97,123 +95,109 @@ private:
   edm::HistoryAppender historyAppender_;
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
-  std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
+  std::shared_ptr<edm::ActivityRegistry>
+      m_actReg;  // We do not use propagate_const because the registry itself is mutable.
   edm::EventSetupImpl* m_es = nullptr;
-  edm::ModuleDescription m_desc = {"Dummy","dummy"};
-  
-  template<typename T, typename U>
-  void testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect);
-  
-  template<typename T>
-  void runTest(Expectations const& iExpect);
-  
+  edm::ModuleDescription m_desc = {"Dummy", "dummy"};
+
+  template <typename T, typename U> void testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect);
+
+  template <typename T> void runTest(Expectations const& iExpect);
+
   class BasicProd : public edm::stream::EDProducer<> {
   public:
     static unsigned int m_count;
-    
+
     BasicProd(edm::ParameterSet const&) {}
-    
-    void produce(edm::Event&, edm::EventSetup const&) override {
-      ++m_count;
-    }
+
+    void produce(edm::Event&, edm::EventSetup const&) override { ++m_count; }
   };
-  
+
   class GlobalProd : public edm::stream::EDProducer<edm::GlobalCache<int>> {
   public:
     static unsigned int m_count;
-    
-    static std::unique_ptr<int> initializeGlobalCache(edm::ParameterSet const&) {
-      return std::make_unique<int>(1);
-    }
+
+    static std::unique_ptr<int> initializeGlobalCache(edm::ParameterSet const&) { return std::make_unique<int>(1); }
     GlobalProd(edm::ParameterSet const&, const int* iGlobal) { CPPUNIT_ASSERT(*iGlobal == 1); }
-    
-    void produce(edm::Event&, edm::EventSetup const&) override {
-      ++m_count;
-    }
-    
+
+    void produce(edm::Event&, edm::EventSetup const&) override { ++m_count; }
+
     static void globalEndJob(int* iGlobal) {
-      CPPUNIT_ASSERT(1==*iGlobal);
+      CPPUNIT_ASSERT(1 == *iGlobal);
       ++m_count;
     }
-    
   };
   class RunProd : public edm::stream::EDProducer<edm::RunCache<int>> {
   public:
     static unsigned int m_count;
     RunProd(edm::ParameterSet const&) {}
-    void produce(edm::Event&, edm::EventSetup const&) override {
-      ++m_count;
-    }
-    
+    void produce(edm::Event&, edm::EventSetup const&) override { ++m_count; }
+
     static std::shared_ptr<int> globalBeginRun(edm::Run const&, edm::EventSetup const&, GlobalCache const*) {
       ++m_count;
       return std::shared_ptr<int>{};
     }
 
-    static void globalEndRun(edm::Run const&, edm::EventSetup const&, RunProd::RunContext const*) {
-      ++m_count;
-    }
+    static void globalEndRun(edm::Run const&, edm::EventSetup const&, RunProd::RunContext const*) { ++m_count; }
   };
-
 
   class LumiProd : public edm::stream::EDProducer<edm::LuminosityBlockCache<int>> {
   public:
     static unsigned int m_count;
     LumiProd(edm::ParameterSet const&) {}
-    void produce(edm::Event&, edm::EventSetup const&) override {
-      ++m_count;
-    }
-    
-    static std::shared_ptr<int> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&, RunContext const*) {
+    void produce(edm::Event&, edm::EventSetup const&) override { ++m_count; }
+
+    static std::shared_ptr<int> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                           edm::EventSetup const&,
+                                                           RunContext const*) {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
-    static void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*) {
+
+    static void globalEndLuminosityBlock(edm::LuminosityBlock const&,
+                                         edm::EventSetup const&,
+                                         LuminosityBlockContext const*) {
       ++m_count;
     }
   };
-  
+
   class RunSummaryProd : public edm::stream::EDProducer<edm::RunSummaryCache<int>> {
   public:
     static unsigned int m_count;
     RunSummaryProd(edm::ParameterSet const&) {}
-    void produce(edm::Event&, edm::EventSetup const&) override {
-      ++m_count;
-    }
-    
+    void produce(edm::Event&, edm::EventSetup const&) override { ++m_count; }
+
     static std::shared_ptr<int> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&, GlobalCache const*) {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
-    void endRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override {
-      ++m_count;
-    }
-    
-    static void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, RunContext const*, int*){
-      ++m_count;
-    }
+
+    void endRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override { ++m_count; }
+
+    static void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, RunContext const*, int*) { ++m_count; }
   };
 
   class LumiSummaryProd : public edm::stream::EDProducer<edm::LuminosityBlockSummaryCache<int>> {
   public:
     static unsigned int m_count;
     LumiSummaryProd(edm::ParameterSet const&) {}
-    void produce(edm::Event&, edm::EventSetup const&) override {
-      ++m_count;
-    }
-    
-    static std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*){
+    void produce(edm::Event&, edm::EventSetup const&) override { ++m_count; }
+
+    static std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                                                  edm::EventSetup const&,
+                                                                  LuminosityBlockContext const*) {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
+
     void endLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
       ++m_count;
     }
-    
-    static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*, int*){
+
+    static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                                edm::EventSetup const&,
+                                                LuminosityBlockContext const*,
+                                                int*) {
       ++m_count;
     }
   };
@@ -223,13 +207,9 @@ private:
     static unsigned int m_count;
     BeginRunProd(edm::ParameterSet const&) {}
 
-    void produce(edm::Event&, edm::EventSetup const&) override {
-      ++m_count;
-    }
+    void produce(edm::Event&, edm::EventSetup const&) override { ++m_count; }
 
-    static void globalBeginRunProduce(edm::Run&, edm::EventSetup const&, RunContext const*) {
-      ++m_count;
-    }
+    static void globalBeginRunProduce(edm::Run&, edm::EventSetup const&, RunContext const*) { ++m_count; }
   };
 
   class BeginLumiProd : public edm::stream::EDProducer<edm::BeginLuminosityBlockProducer> {
@@ -237,11 +217,11 @@ private:
     static unsigned int m_count;
     BeginLumiProd(edm::ParameterSet const&) {}
 
-    void produce(edm::Event&, edm::EventSetup const&) override {
-      ++m_count;
-    }
-    
-    static void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&, LuminosityBlockContext const*) {
+    void produce(edm::Event&, edm::EventSetup const&) override { ++m_count; }
+
+    static void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&,
+                                                  edm::EventSetup const&,
+                                                  LuminosityBlockContext const*) {
       ++m_count;
     }
   };
@@ -251,84 +231,77 @@ private:
     static unsigned int m_count;
     EndRunProd(edm::ParameterSet const&) {}
 
-    void produce(edm::Event&, edm::EventSetup const&) override {
-      ++m_count;
-    }
-    
-    static void globalEndRunProduce(edm::Run&, edm::EventSetup const&, RunContext const*) {
-      ++m_count;
-    }
+    void produce(edm::Event&, edm::EventSetup const&) override { ++m_count; }
+
+    static void globalEndRunProduce(edm::Run&, edm::EventSetup const&, RunContext const*) { ++m_count; }
   };
-  
+
   class EndLumiProd : public edm::stream::EDProducer<edm::EndLuminosityBlockProducer> {
   public:
     static unsigned int m_count;
     EndLumiProd(edm::ParameterSet const&) {}
 
-    void produce(edm::Event&, edm::EventSetup const&) override {
-      ++m_count;
-    }
-    
-    static void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&, LuminosityBlockContext const*) {
+    void produce(edm::Event&, edm::EventSetup const&) override { ++m_count; }
+
+    static void globalEndLuminosityBlockProduce(edm::LuminosityBlock&,
+                                                edm::EventSetup const&,
+                                                LuminosityBlockContext const*) {
       ++m_count;
     }
   };
-
 
   class EndRunSummaryProd : public edm::stream::EDProducer<edm::EndRunProducer, edm::RunSummaryCache<int>> {
   public:
     static unsigned int m_count;
     EndRunSummaryProd(edm::ParameterSet const&) {}
 
-    void produce(edm::Event&, edm::EventSetup const&) override {
-      ++m_count;
-    }
-    
+    void produce(edm::Event&, edm::EventSetup const&) override { ++m_count; }
+
     static std::shared_ptr<int> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&, RunContext const*) {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
-    void endRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override {
-      ++m_count;
-    }
-    
-    static void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, RunContext const*, int*) {
-      ++m_count;
-    }
 
-    static void globalEndRunProduce(edm::Run&, edm::EventSetup const&, RunContext const*, int const*) {
-      ++m_count;
-    }
+    void endRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override { ++m_count; }
+
+    static void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, RunContext const*, int*) { ++m_count; }
+
+    static void globalEndRunProduce(edm::Run&, edm::EventSetup const&, RunContext const*, int const*) { ++m_count; }
   };
-  
-  class EndLumiSummaryProd : public edm::stream::EDProducer<edm::EndLuminosityBlockProducer, edm::LuminosityBlockSummaryCache<int>> {
+
+  class EndLumiSummaryProd
+      : public edm::stream::EDProducer<edm::EndLuminosityBlockProducer, edm::LuminosityBlockSummaryCache<int>> {
   public:
     static unsigned int m_count;
     EndLumiSummaryProd(edm::ParameterSet const&) {}
 
-    void produce(edm::Event&, edm::EventSetup const&) override {
-      ++m_count;
-    }
+    void produce(edm::Event&, edm::EventSetup const&) override { ++m_count; }
 
-    static std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*) {
+    static std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                                                  edm::EventSetup const&,
+                                                                  LuminosityBlockContext const*) {
       ++m_count;
       return std::shared_ptr<int>{};
     }
-    
+
     void endLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
       ++m_count;
     }
-    
-    static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*, int*) {
+
+    static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                                edm::EventSetup const&,
+                                                LuminosityBlockContext const*,
+                                                int*) {
       ++m_count;
     }
 
-    static void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&, LuminosityBlockContext const*, int const*) {
+    static void globalEndLuminosityBlockProduce(edm::LuminosityBlock&,
+                                                edm::EventSetup const&,
+                                                LuminosityBlockContext const*,
+                                                int const*) {
       ++m_count;
     }
   };
-   
 };
 unsigned int testStreamModule::BasicProd::m_count = 0;
 unsigned int testStreamModule::GlobalProd::m_count = 0;
@@ -347,16 +320,16 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testStreamModule);
 
 namespace {
   struct ShadowStreamID {
-    constexpr ShadowStreamID():value(0){}
+    constexpr ShadowStreamID() : value(0) {}
     unsigned int value;
   };
-  
+
   union IDUnion {
-    IDUnion(): m_shadow() {}
+    IDUnion() : m_shadow() {}
     ShadowStreamID m_shadow;
     edm::StreamID m_id;
   };
-}
+}  // namespace
 static edm::StreamID makeID() {
   IDUnion u;
   assert(u.m_id.value() == 0);
@@ -364,24 +337,22 @@ static edm::StreamID makeID() {
 }
 static const edm::StreamID s_streamID0 = makeID();
 
-
-testStreamModule::testStreamModule():
-m_prodReg(new edm::ProductRegistry{}),
-m_idHelper(new edm::BranchIDListHelper{}),
-m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
-m_ep()
-{
+testStreamModule::testStreamModule()
+    : m_prodReg(new edm::ProductRegistry{}),
+      m_idHelper(new edm::BranchIDListHelper{}),
+      m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
+      m_ep() {
   //Setup the principals
   m_prodReg->setFrozen();
   m_idHelper->updateFromRegistry(*m_prodReg);
   edm::EventID eventID = edm::EventID::firstValidEvent();
-  
+
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
   auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_,0));
+  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
   auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(m_rp->run(), 1, now, now);
-  m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_,0));
+  m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(*lumiAux);
   m_lbp->setRunPrincipal(m_rp);
   edm::EventAuxiliary eventAux(eventID, uuid, now, true);
@@ -391,170 +362,152 @@ m_ep()
   shadowID.value = 0;
   edm::StreamID* pID = reinterpret_cast<edm::StreamID*>(&shadowID);
   assert(pID->value() == 0);
-  
-  m_ep.reset(new edm::EventPrincipal(m_prodReg,
-                                     m_idHelper,
-                                     m_associationsHelper,
-                                     m_procConfig,nullptr,*pID));
+
+  m_ep.reset(new edm::EventPrincipal(m_prodReg, m_idHelper, m_associationsHelper, m_procConfig, nullptr, *pID));
   edm::ProcessHistoryRegistry phr;
   m_ep->fillEventPrincipal(eventAux, phr);
   m_ep->setLuminosityBlockPrincipal(m_lbp.get());
   m_actReg.reset(new edm::ActivityRegistry);
 
-
   //For each transition, bind a lambda which will call the proper method of the Worker
   m_transToFunc[Trans::kBeginStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
-    iBase->beginStream(s_streamID0, streamContext); };
-  
+    iBase->beginStream(s_streamID0, streamContext);
+  };
+
   m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, parentContext, nullptr); };
+    iBase->doWork<Traits>(*m_rp, *m_es, s_streamID0, parentContext, nullptr);
+  };
   m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, parentContext, nullptr); };
-  
+    iBase->doWork<Traits>(*m_rp, *m_es, s_streamID0, parentContext, nullptr);
+  };
+
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, parentContext, nullptr); };
+    iBase->doWork<Traits>(*m_lbp, *m_es, s_streamID0, parentContext, nullptr);
+  };
   m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, parentContext, nullptr); };
-  
+    iBase->doWork<Traits>(*m_lbp, *m_es, s_streamID0, parentContext, nullptr);
+  };
+
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::StreamContext streamContext(s_streamID0, nullptr);
     edm::ParentContext parentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
-    iBase->doWork<Traits>(*m_ep,*m_es, s_streamID0, parentContext, nullptr); };
+    iBase->doWork<Traits>(*m_ep, *m_es, s_streamID0, parentContext, nullptr);
+  };
 
   m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, parentContext, nullptr); };
+    iBase->doWork<Traits>(*m_lbp, *m_es, s_streamID0, parentContext, nullptr);
+  };
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, parentContext, nullptr); };
+    iBase->doWork<Traits>(*m_lbp, *m_es, s_streamID0, parentContext, nullptr);
+  };
 
   m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, parentContext, nullptr); };
+    iBase->doWork<Traits>(*m_rp, *m_es, s_streamID0, parentContext, nullptr);
+  };
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
-    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, parentContext, nullptr); };
+    iBase->doWork<Traits>(*m_rp, *m_es, s_streamID0, parentContext, nullptr);
+  };
 
   m_transToFunc[Trans::kEndStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
-    iBase->endStream(s_streamID0, streamContext); };
-
+    iBase->endStream(s_streamID0, streamContext);
+  };
 }
 
-
 namespace {
-  template<typename T>
-  std::shared_ptr<edm::stream::EDProducerAdaptorBase> createModule() {
+  template <typename T> std::shared_ptr<edm::stream::EDProducerAdaptorBase> createModule() {
     edm::ParameterSet pset;
-    std::shared_ptr<edm::stream::EDProducerAdaptorBase> retValue = std::make_shared<edm::stream::EDProducerAdaptor<T>>(pset);
-    edm::maker::ModuleHolderT<edm::stream::EDProducerAdaptorBase> h(retValue,nullptr);
+    std::shared_ptr<edm::stream::EDProducerAdaptorBase> retValue =
+        std::make_shared<edm::stream::EDProducerAdaptor<T>>(pset);
+    edm::maker::ModuleHolderT<edm::stream::EDProducerAdaptorBase> h(retValue, nullptr);
     h.preallocate(edm::PreallocationConfiguration{});
     return retValue;
   }
-  template<typename T>
-  void
-  testTransition(edm::Worker* iWorker, testStreamModule::Trans iTrans, testStreamModule::Expectations const& iExpect, std::function<void(edm::Worker*)> iFunc) {
-    assert(0==T::m_count);
+  template <typename T>
+  void testTransition(edm::Worker* iWorker,
+                      testStreamModule::Trans iTrans,
+                      testStreamModule::Expectations const& iExpect,
+                      std::function<void(edm::Worker*)> iFunc) {
+    assert(0 == T::m_count);
     iFunc(iWorker);
-    auto count = std::count(iExpect.begin(),iExpect.end(),iTrans);
-    if(count != T::m_count) {
-      std::cout<<"For trans " <<static_cast<std::underlying_type<testStreamModule::Trans>::type >(iTrans)<< " expected "<<count<<" and got "<<T::m_count<<std::endl;
+    auto count = std::count(iExpect.begin(), iExpect.end(), iTrans);
+    if (count != T::m_count) {
+      std::cout << "For trans " << static_cast<std::underlying_type<testStreamModule::Trans>::type>(iTrans)
+                << " expected " << count << " and got " << T::m_count << std::endl;
     }
     CPPUNIT_ASSERT(T::m_count == count);
     T::m_count = 0;
     iWorker->reset();
   }
-}
+}  // namespace
 
-template<typename T, typename U>
-void
-testStreamModule::testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect) {
-  edm::WorkerT<edm::stream::EDProducerAdaptorBase> w{iMod,m_desc,nullptr};
-  for(auto& keyVal: m_transToFunc) {
-    testTransition<T>(&w,keyVal.first,iExpect,keyVal.second);
+template <typename T, typename U>
+void testStreamModule::testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect) {
+  edm::WorkerT<edm::stream::EDProducerAdaptorBase> w{iMod, m_desc, nullptr};
+  for (auto& keyVal : m_transToFunc) {
+    testTransition<T>(&w, keyVal.first, iExpect, keyVal.second);
   }
 }
-template<typename T>
-void
-testStreamModule::runTest(Expectations const& iExpect) {
+template <typename T> void testStreamModule::runTest(Expectations const& iExpect) {
   auto mod = createModule<T>();
   CPPUNIT_ASSERT(0 == T::m_count);
-  testTransitions<T>(mod,iExpect);
+  testTransitions<T>(mod, iExpect);
 }
 
+void testStreamModule::basicTest() { runTest<BasicProd>({Trans::kEvent}); }
 
-void testStreamModule::basicTest()
-{
-  runTest<BasicProd>({Trans::kEvent} );
+void testStreamModule::globalTest() { runTest<GlobalProd>({Trans::kBeginJob, Trans::kEvent, Trans::kEndJob}); }
+
+void testStreamModule::runTest() { runTest<RunProd>({Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndRun}); }
+
+void testStreamModule::runSummaryTest() {
+  runTest<RunSummaryProd>({Trans::kGlobalBeginRun, Trans::kEvent, Trans::kStreamEndRun, Trans::kGlobalEndRun});
 }
 
-void testStreamModule::globalTest()
-{
-  runTest<GlobalProd>({Trans::kBeginJob, Trans::kEvent, Trans::kEndJob} );
+void testStreamModule::lumiTest() {
+  runTest<LumiProd>({Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock});
 }
 
-void testStreamModule::runTest()
-{
-  runTest<RunProd>({Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndRun} );
+void testStreamModule::lumiSummaryTest() {
+  runTest<LumiSummaryProd>({Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kStreamEndLuminosityBlock,
+                            Trans::kGlobalEndLuminosityBlock});
 }
 
-void testStreamModule::runSummaryTest()
-{
-  runTest<RunSummaryProd>({Trans::kGlobalBeginRun, Trans::kEvent, Trans::kStreamEndRun, Trans::kGlobalEndRun} );
+void testStreamModule::beginRunProdTest() { runTest<BeginRunProd>({Trans::kGlobalBeginRun, Trans::kEvent}); }
+
+void testStreamModule::beginLumiProdTest() {
+  runTest<BeginLumiProd>({Trans::kGlobalBeginLuminosityBlock, Trans::kEvent});
 }
 
-void testStreamModule::lumiTest()
-{
-  runTest<LumiProd>({Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock} );
+void testStreamModule::endRunProdTest() { runTest<EndRunProd>({Trans::kGlobalEndRun, Trans::kEvent}); }
+
+void testStreamModule::endLumiProdTest() { runTest<EndLumiProd>({Trans::kGlobalEndLuminosityBlock, Trans::kEvent}); }
+
+void testStreamModule::endRunSummaryProdTest() {
+  runTest<EndRunSummaryProd>(
+      {Trans::kGlobalEndRun, Trans::kEvent, Trans::kGlobalBeginRun, Trans::kStreamEndRun, Trans::kGlobalEndRun});
 }
 
-void testStreamModule::lumiSummaryTest()
-{
-  runTest<LumiSummaryProd>({Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock} );
+void testStreamModule::endLumiSummaryProdTest() {
+  runTest<EndLumiSummaryProd>({Trans::kGlobalEndLuminosityBlock, Trans::kEvent, Trans::kGlobalBeginLuminosityBlock,
+                               Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock});
 }
-
-void testStreamModule::beginRunProdTest()
-{
-  runTest<BeginRunProd>({Trans::kGlobalBeginRun, Trans::kEvent} );
-}
-
-void testStreamModule::beginLumiProdTest()
-{
-  runTest<BeginLumiProd>({Trans::kGlobalBeginLuminosityBlock, Trans::kEvent} );
-}
-
-void testStreamModule::endRunProdTest()
-{
-  runTest<EndRunProd>({Trans::kGlobalEndRun, Trans::kEvent} );
-}
-
-void testStreamModule::endLumiProdTest()
-{
-  runTest<EndLumiProd>({Trans::kGlobalEndLuminosityBlock, Trans::kEvent} );
-}
-
-void testStreamModule::endRunSummaryProdTest()
-{
-  runTest<EndRunSummaryProd>({Trans::kGlobalEndRun, Trans::kEvent, Trans::kGlobalBeginRun, Trans::kStreamEndRun, Trans::kGlobalEndRun} );
-}
-
-void testStreamModule::endLumiSummaryProdTest()
-{
-  runTest<EndLumiSummaryProd>({Trans::kGlobalEndLuminosityBlock, Trans::kEvent, Trans::kGlobalBeginLuminosityBlock, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock} );
-}
-

--- a/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
+++ b/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
@@ -23,9 +23,7 @@
 #include <vector>
 
 TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
-
   SECTION("test nested class MetadataForProcess") {
-
     edm::MergeableRunProductMetadata::MetadataForProcess metaDataForProcess;
     REQUIRE(metaDataForProcess.lumis().empty());
     REQUIRE(metaDataForProcess.valid());
@@ -66,101 +64,50 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
   }
 
   SECTION("test main functions") {
-
     edm::ProductRegistry productRegistry;
     edm::ParameterSet dummyPset;
     dummyPset.registerIt();
 
     // not mergeable
-    edm::BranchDescription prod1(edm::InRun,
-                                "label",
-                                "PROD",
-                                "edmtest::Thing",
-                                "edmtestThing",
-                                "instance",
-                                "aModule",
-                                dummyPset.id(),
-                                edm::TypeWithDict::byName("edmtest::Thing"),
-                                false);
+    edm::BranchDescription prod1(edm::InRun, "label", "PROD", "edmtest::Thing", "edmtestThing", "instance", "aModule",
+                                 dummyPset.id(), edm::TypeWithDict::byName("edmtest::Thing"), false);
     productRegistry.copyProduct(prod1);
 
     // This one should be used
-    edm::BranchDescription prod2(edm::InRun,
-                                "aLabel",
-                                "APROD",
-                                "edmtest::ThingWithMerge",
-                                "edmtestThingWithMerge",
-                                "instance",
-                                "aModule",
-                                dummyPset.id(),
-                                edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
-                                false);
+    edm::BranchDescription prod2(edm::InRun, "aLabel", "APROD", "edmtest::ThingWithMerge", "edmtestThingWithMerge",
+                                 "instance", "aModule", dummyPset.id(),
+                                 edm::TypeWithDict::byName("edmtest::ThingWithMerge"), false);
     productRegistry.copyProduct(prod2);
 
     //not in a Run
-    edm::BranchDescription prod3(edm::InLumi,
-                                "bLabel",
-                                "BPROD",
-                                "edmtest::ThingWithMerge",
-                                "edmtestThingWithMerge",
-                                "instance",
-                                "aModule",
-                                dummyPset.id(),
-                                edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
-                                false);
+    edm::BranchDescription prod3(edm::InLumi, "bLabel", "BPROD", "edmtest::ThingWithMerge", "edmtestThingWithMerge",
+                                 "instance", "aModule", dummyPset.id(),
+                                 edm::TypeWithDict::byName("edmtest::ThingWithMerge"), false);
     productRegistry.copyProduct(prod3);
 
     // produced
-    edm::BranchDescription prod4(edm::InRun,
-                                "cLabel",
-                                "CPROD",
-                                "edmtest::ThingWithMerge",
-                                "edmtestThingWithMerge",
-                                "instance",
-                                "aModule",
-                                dummyPset.id(),
-                                edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
-                                true);
+    edm::BranchDescription prod4(edm::InRun, "cLabel", "CPROD", "edmtest::ThingWithMerge", "edmtestThingWithMerge",
+                                 "instance", "aModule", dummyPset.id(),
+                                 edm::TypeWithDict::byName("edmtest::ThingWithMerge"), true);
     productRegistry.addProduct(prod4);
 
     // dropped
-    edm::BranchDescription prod5(edm::InRun,
-                                "dLabel",
-                                "DPROD",
-                                "edmtest::ThingWithMerge",
-                                "edmtestThingWithMerge",
-                                "instance",
-                                "aModule",
-                                dummyPset.id(),
-                                edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
-                                false);
+    edm::BranchDescription prod5(edm::InRun, "dLabel", "DPROD", "edmtest::ThingWithMerge", "edmtestThingWithMerge",
+                                 "instance", "aModule", dummyPset.id(),
+                                 edm::TypeWithDict::byName("edmtest::ThingWithMerge"), false);
     prod5.setDropped(true);
     productRegistry.copyProduct(prod5);
 
     // Should be used but the same process name
-    edm::BranchDescription prod6(edm::InRun,
-                                "eLabel",
-                                "APROD",
-                                "edmtest::ThingWithMerge",
-                                "edmtestThingWithMerge",
-                                "instance",
-                                "aModule",
-                                dummyPset.id(),
-                                edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
-                                false);
+    edm::BranchDescription prod6(edm::InRun, "eLabel", "APROD", "edmtest::ThingWithMerge", "edmtestThingWithMerge",
+                                 "instance", "aModule", dummyPset.id(),
+                                 edm::TypeWithDict::byName("edmtest::ThingWithMerge"), false);
     productRegistry.copyProduct(prod6);
 
     // Should be used
-    edm::BranchDescription prod7(edm::InRun,
-                                "fLabel",
-                                "AAPROD",
-                                "edmtest::ThingWithMerge",
-                                "edmtestThingWithMerge",
-                                "instance",
-                                "aModule",
-                                dummyPset.id(),
-                                edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
-                                false);
+    edm::BranchDescription prod7(edm::InRun, "fLabel", "AAPROD", "edmtest::ThingWithMerge", "edmtestThingWithMerge",
+                                 "instance", "aModule", dummyPset.id(),
+                                 edm::TypeWithDict::byName("edmtest::ThingWithMerge"), false);
     productRegistry.copyProduct(prod7);
 
     edm::MergeableRunProductProcesses mergeableRunProductProcesses;
@@ -171,31 +118,27 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
 
     REQUIRE(mergeableRunProductProcesses.size() == 2);
 
-    std::vector<std::string> expected { "AAPROD", "APROD" };
+    std::vector<std::string> expected{"AAPROD", "APROD"};
     REQUIRE(mergeableRunProductProcesses.processesWithMergeableRunProducts() == expected);
 
-    std::vector<std::string> storedProcesses { "AAAPROD", "AAPROD", "APROD", "ZPROD" };
+    std::vector<std::string> storedProcesses{"AAAPROD", "AAPROD", "APROD", "ZPROD"};
     edm::StoredMergeableRunProductMetadata storedMetadata(storedProcesses);
     REQUIRE(storedMetadata.processesWithMergeableRunProducts() == storedProcesses);
     REQUIRE(storedMetadata.allValidAndUseIndexIntoFile());
 
-    unsigned long long iBeginProcess { 100 };
-    unsigned long long iEndProcess { 101 };
+    unsigned long long iBeginProcess{100};
+    unsigned long long iEndProcess{101};
     edm::StoredMergeableRunProductMetadata::SingleRunEntry singleRunEntry(iBeginProcess, iEndProcess);
     REQUIRE(singleRunEntry.beginProcess() == 100);
     REQUIRE(singleRunEntry.endProcess() == 101);
 
-    unsigned long long iBeginLumi { 200 };
-    unsigned long long iEndLumi { 201 };
-    unsigned int iProcess { 202 };
-    bool iValid { true };
-    bool iUseIndexIntoFile { false };
+    unsigned long long iBeginLumi{200};
+    unsigned long long iEndLumi{201};
+    unsigned int iProcess{202};
+    bool iValid{true};
+    bool iUseIndexIntoFile{false};
     edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess singleRunEntryAndProcess(
-      iBeginLumi,
-      iEndLumi,
-      iProcess,
-      iValid,
-      iUseIndexIntoFile);
+        iBeginLumi, iEndLumi, iProcess, iValid, iUseIndexIntoFile);
     REQUIRE(singleRunEntryAndProcess.beginLumi() == 200);
     REQUIRE(singleRunEntryAndProcess.endLumi() == 201);
     REQUIRE(singleRunEntryAndProcess.process() == 202);
@@ -211,25 +154,27 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     //              not there at all
     //              there with a vector and invalid
     // Let AAAPROD and ZPROD be there for all entries 0, 2, 3, 4
-    std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntry>& singleRunEntries = storedMetadata.singleRunEntries();
-    singleRunEntries.emplace_back(0,3);
-    singleRunEntries.emplace_back(3,3);
-    singleRunEntries.emplace_back(3,6);
-    singleRunEntries.emplace_back(6,8);
-    singleRunEntries.emplace_back(8,11);
-    singleRunEntries.emplace_back(11,12);
-    singleRunEntries.emplace_back(12,13);
-    singleRunEntries.emplace_back(13,14);
-    singleRunEntries.emplace_back(14,15);
+    std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntry>& singleRunEntries =
+        storedMetadata.singleRunEntries();
+    singleRunEntries.emplace_back(0, 3);
+    singleRunEntries.emplace_back(3, 3);
+    singleRunEntries.emplace_back(3, 6);
+    singleRunEntries.emplace_back(6, 8);
+    singleRunEntries.emplace_back(8, 11);
+    singleRunEntries.emplace_back(11, 12);
+    singleRunEntries.emplace_back(12, 13);
+    singleRunEntries.emplace_back(13, 14);
+    singleRunEntries.emplace_back(14, 15);
 
-    std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess>& singleRunEntryAndProcesses = storedMetadata.singleRunEntryAndProcesses();
+    std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess>& singleRunEntryAndProcesses =
+        storedMetadata.singleRunEntryAndProcesses();
     std::vector<edm::LuminosityBlockNumber_t>& lumis = storedMetadata.lumis();
 
     // arguments: beginLumi, endLumi, process Index, valid, useIndexIntoFile
-    unsigned int iAAAPROD { 0 };
+    unsigned int iAAAPROD{0};
     // unsigned int iAAPROD { 1 };
-    unsigned int iAPROD { 2 };
-    unsigned int iZPROD { 3 };
+    unsigned int iAPROD{2};
+    unsigned int iZPROD{3};
 
     // 0th run entry
     iBeginLumi = lumis.size();
@@ -340,7 +285,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     REQUIRE(storedMetadata.getLumiContent(0, std::string("APROD"), valid, lumisBegin, lumisEnd));
     {
       std::vector<edm::LuminosityBlockNumber_t> test(lumisBegin, lumisEnd);
-      std::vector<edm::LuminosityBlockNumber_t> expected { 101, 102 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{101, 102};
       REQUIRE(test == expected);
       REQUIRE(valid);
     }
@@ -353,7 +298,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     REQUIRE(storedMetadata.getLumiContent(4, std::string("APROD"), valid, lumisBegin, lumisEnd));
     {
       std::vector<edm::LuminosityBlockNumber_t> test(lumisBegin, lumisEnd);
-      std::vector<edm::LuminosityBlockNumber_t> expected { 111, 112 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{111, 112};
       REQUIRE(test == expected);
       REQUIRE(!valid);
     }
@@ -374,40 +319,39 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     processHistory2->push_back(pc);
     fakePHID2 = ph2.id();
 
-    indexIntoFile.addEntry(fakePHID1, 11, 1001, 7, 0); // Event
-    indexIntoFile.addEntry(fakePHID1, 11, 1001, 6, 1); // Event
-    indexIntoFile.addEntry(fakePHID1, 11, 1001, 0, 0); // Lumi
-    indexIntoFile.addEntry(fakePHID1, 11, 1001, 0, 1); // Lumi
-    indexIntoFile.addEntry(fakePHID1, 11, 1001, 5, 2); // Event
-    indexIntoFile.addEntry(fakePHID1, 11, 1001, 4, 3); // Event
-    indexIntoFile.addEntry(fakePHID1, 11, 1001, 0, 2); // Lumi
-    indexIntoFile.addEntry(fakePHID1, 11, 1003, 5, 4); // Event
-    indexIntoFile.addEntry(fakePHID1, 11, 1003, 4, 5); // Event
-    indexIntoFile.addEntry(fakePHID1, 11, 1003, 0, 3); // Lumi
-    indexIntoFile.addEntry(fakePHID1, 11,   0, 0, 0); // Run
-    indexIntoFile.addEntry(fakePHID2, 11,   0, 0, 1); // Run
-    indexIntoFile.addEntry(fakePHID2, 11, 1001, 0, 4); // Lumi
-    indexIntoFile.addEntry(fakePHID2, 11, 1003, 0, 5); // Lumi
-    indexIntoFile.addEntry(fakePHID2, 11, 1003, 4, 6); // Event
-    indexIntoFile.addEntry(fakePHID2, 11, 1003, 0, 6); // Lumi
-    indexIntoFile.addEntry(fakePHID2, 11,   0, 0, 2); // Run
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 7, 0);  // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 6, 1);  // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 0, 0);  // Lumi
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 0, 1);  // Lumi
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 5, 2);  // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 4, 3);  // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 0, 2);  // Lumi
+    indexIntoFile.addEntry(fakePHID1, 11, 1003, 5, 4);  // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 1003, 4, 5);  // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 1003, 0, 3);  // Lumi
+    indexIntoFile.addEntry(fakePHID1, 11, 0, 0, 0);     // Run
+    indexIntoFile.addEntry(fakePHID2, 11, 0, 0, 1);     // Run
+    indexIntoFile.addEntry(fakePHID2, 11, 1001, 0, 4);  // Lumi
+    indexIntoFile.addEntry(fakePHID2, 11, 1003, 0, 5);  // Lumi
+    indexIntoFile.addEntry(fakePHID2, 11, 1003, 4, 6);  // Event
+    indexIntoFile.addEntry(fakePHID2, 11, 1003, 0, 6);  // Lumi
+    indexIntoFile.addEntry(fakePHID2, 11, 0, 0, 2);     // Run
     indexIntoFile.sortVector_Run_Or_Lumi_Entries();
     edm::IndexIntoFile::IndexIntoFileItr iter = indexIntoFile.begin(edm::IndexIntoFile::firstAppearanceOrder);
-
 
     edm::MergeableRunProductMetadata mergeableRunProductMetadata(mergeableRunProductProcesses);
 
     edm::MergeableRunProductMetadata::MetadataForProcess const* APRODMetadataForProcess =
-      mergeableRunProductMetadata.metadataForOneProcess("APROD");
+        mergeableRunProductMetadata.metadataForOneProcess("APROD");
     REQUIRE(APRODMetadataForProcess);
 
     edm::MergeableRunProductMetadata::MetadataForProcess const* NullMetadataForProcess =
-      mergeableRunProductMetadata.metadataForOneProcess("DOESNOTEXIST");
+        mergeableRunProductMetadata.metadataForOneProcess("DOESNOTEXIST");
     REQUIRE(NullMetadataForProcess == nullptr);
 
     mergeableRunProductMetadata.readRun(0, storedMetadata, edm::IndexIntoFileItrHolder(iter));
     {
-      std::vector<edm::LuminosityBlockNumber_t> expected { 101, 102 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{101, 102};
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::REPLACE);
       REQUIRE(mergeableRunProductMetadata.getMergeDecision("APROD") == edm::MergeableRunProductMetadata::REPLACE);
@@ -419,7 +363,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     // Same one again for test purposes
     mergeableRunProductMetadata.readRun(0, storedMetadata, edm::IndexIntoFileItrHolder(iter));
     {
-      std::vector<edm::LuminosityBlockNumber_t> expected { 101, 102 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{101, 102};
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::IGNORE);
       REQUIRE(mergeableRunProductMetadata.getMergeDecision("APROD") == edm::MergeableRunProductMetadata::IGNORE);
@@ -430,7 +374,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     // disjoint with newly read ones coming first
     mergeableRunProductMetadata.readRun(5, storedMetadata, edm::IndexIntoFileItrHolder(iter));
     {
-      std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 101, 102 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{91, 92, 101, 102};
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
       REQUIRE(mergeableRunProductMetadata.getMergeDecision("APROD") == edm::MergeableRunProductMetadata::MERGE);
@@ -441,7 +385,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     // disjoint with newly read ones coming last
     mergeableRunProductMetadata.readRun(6, storedMetadata, edm::IndexIntoFileItrHolder(iter));
     {
-      std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 101, 102, 121, 122 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{91, 92, 101, 102, 121, 122};
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
       REQUIRE(APRODMetadataForProcess->valid());
@@ -451,7 +395,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     // impossible to merge case, shared elements and both also have at least one non-shared element
     mergeableRunProductMetadata.readRun(7, storedMetadata, edm::IndexIntoFileItrHolder(iter));
     {
-      std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 95, 101, 102, 105, 121, 122 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{91, 92, 95, 101, 102, 105, 121, 122};
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
       REQUIRE(!APRODMetadataForProcess->valid());
@@ -460,13 +404,13 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     }
     mergeableRunProductMetadata.preReadFile();
     {
-      std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 95, 101, 102, 105, 121, 122 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{91, 92, 95, 101, 102, 105, 121, 122};
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
     }
     mergeableRunProductMetadata.readRun(3, storedMetadata, edm::IndexIntoFileItrHolder(iter));
     {
-      std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 95, 101, 102, 105, 121, 122 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{91, 92, 95, 101, 102, 105, 121, 122};
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
       REQUIRE(!APRODMetadataForProcess->valid());
@@ -475,7 +419,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     }
     mergeableRunProductMetadata.preReadFile();
     {
-      std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 95, 101, 102, 105, 121, 122, 1001, 1003 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{91, 92, 95, 101, 102, 105, 121, 122, 1001, 1003};
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
     }
@@ -491,7 +435,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     }
     mergeableRunProductMetadata.readRun(0, storedMetadata, edm::IndexIntoFileItrHolder(iter));
     {
-      std::vector<edm::LuminosityBlockNumber_t> expected { 101, 102 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{101, 102};
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::REPLACE);
       REQUIRE(APRODMetadataForProcess->valid());
@@ -500,7 +444,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     }
     mergeableRunProductMetadata.readRun(4, storedMetadata, edm::IndexIntoFileItrHolder(iter));
     {
-      std::vector<edm::LuminosityBlockNumber_t> expected { 101, 102, 111, 112 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{101, 102, 111, 112};
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
       REQUIRE(!APRODMetadataForProcess->valid());
@@ -524,7 +468,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
       REQUIRE(APRODMetadataForProcess->useIndexIntoFile());
       REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
 
-      std::vector<edm::LuminosityBlockNumber_t> expected2 { 1001, 1003 };
+      std::vector<edm::LuminosityBlockNumber_t> expected2{1001, 1003};
       REQUIRE(expected2 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
       REQUIRE(mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
     }
@@ -534,7 +478,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
       REQUIRE(expected3 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
       REQUIRE(!mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
 
-      std::vector<edm::LuminosityBlockNumber_t> expected {1001, 1003 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{1001, 1003};
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
       REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
@@ -551,18 +495,18 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
       REQUIRE(APRODMetadataForProcess->useIndexIntoFile());
       REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
 
-      std::vector<edm::LuminosityBlockNumber_t> expected2 { 1001, 1003 };
+      std::vector<edm::LuminosityBlockNumber_t> expected2{1001, 1003};
       REQUIRE(expected2 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
       REQUIRE(mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
     }
     {
       mergeableRunProductMetadata.readRun(8, storedMetadata, edm::IndexIntoFileItrHolder(iter));
-      std::vector<edm::LuminosityBlockNumber_t> expected { 1000, 1002, 1003, 1004 };
+      std::vector<edm::LuminosityBlockNumber_t> expected{1000, 1002, 1003, 1004};
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       mergeableRunProductMetadata.readRun(2, storedMetadata, edm::IndexIntoFileItrHolder(iter));
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       mergeableRunProductMetadata.preReadFile();
-      std::vector<edm::LuminosityBlockNumber_t> expected2 { 1000, 1001, 1002, 1003, 1004 };
+      std::vector<edm::LuminosityBlockNumber_t> expected2{1000, 1001, 1002, 1003, 1004};
       REQUIRE(APRODMetadataForProcess->lumis() == expected2);
     }
     mergeableRunProductMetadata.postWriteRun();
@@ -571,11 +515,11 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
       mergeableRunProductMetadata.readRun(2, storedMetadata, edm::IndexIntoFileItrHolder(iter));
       mergeableRunProductMetadata.readRun(8, storedMetadata, edm::IndexIntoFileItrHolder(iter));
 
-      std::vector<edm::LuminosityBlockNumber_t> expected1 { 1001, 1003 };
+      std::vector<edm::LuminosityBlockNumber_t> expected1{1001, 1003};
       REQUIRE(expected1 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
       REQUIRE(mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
 
-      std::vector<edm::LuminosityBlockNumber_t> expected2 { 1000, 1002, 1003, 1004 };
+      std::vector<edm::LuminosityBlockNumber_t> expected2{1000, 1002, 1003, 1004};
       REQUIRE(APRODMetadataForProcess->lumis() == expected2);
 
       mergeableRunProductMetadata.writeLumi(1004);
@@ -588,16 +532,15 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
       REQUIRE(!mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
       REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
 
-      std::vector<edm::LuminosityBlockNumber_t> expected4 { 1000, 1001, 1002, 1003, 1004 };
+      std::vector<edm::LuminosityBlockNumber_t> expected4{1000, 1001, 1002, 1003, 1004};
       REQUIRE(APRODMetadataForProcess->lumis() == expected4);
-
     }
     mergeableRunProductMetadata.postWriteRun();
     REQUIRE(mergeableRunProductMetadata.lumisProcessed().empty());
     {
       // ----------------------------------------------------
 
-      std::vector<std::string> storedProcessesOutput { "AAAPROD", "AAPROD", "APROD", "ZPROD" };
+      std::vector<std::string> storedProcessesOutput{"AAAPROD", "AAPROD", "APROD", "ZPROD"};
       edm::StoredMergeableRunProductMetadata storedMetadataOutput(storedProcesses);
 
       mergeableRunProductMetadata.readRun(1, storedMetadata, edm::IndexIntoFileItrHolder(iter));
@@ -614,11 +557,11 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
       mergeableRunProductMetadata.readRun(2, storedMetadata, edm::IndexIntoFileItrHolder(iter));
       mergeableRunProductMetadata.readRun(8, storedMetadata, edm::IndexIntoFileItrHolder(iter));
 
-      std::vector<edm::LuminosityBlockNumber_t> expected1 { 1001, 1003 };
+      std::vector<edm::LuminosityBlockNumber_t> expected1{1001, 1003};
       REQUIRE(expected1 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
       REQUIRE(mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
 
-      std::vector<edm::LuminosityBlockNumber_t> expected2 { 1000, 1002, 1003, 1004 };
+      std::vector<edm::LuminosityBlockNumber_t> expected2{1000, 1002, 1003, 1004};
       REQUIRE(APRODMetadataForProcess->lumis() == expected2);
 
       mergeableRunProductMetadata.writeLumi(1004);
@@ -634,7 +577,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
       REQUIRE(!mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
       REQUIRE(APRODMetadataForProcess->allLumisProcessed());
 
-      std::vector<edm::LuminosityBlockNumber_t> expected4 { 1000, 1001, 1002, 1003, 1004 };
+      std::vector<edm::LuminosityBlockNumber_t> expected4{1000, 1001, 1002, 1003, 1004};
       REQUIRE(APRODMetadataForProcess->lumis() == expected4);
 
       mergeableRunProductMetadata.addEntryToStoredMetadata(storedMetadataOutput);
@@ -661,7 +604,8 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
 
       // ---------------------------------------------------
 
-      std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntry>& singleRunEntries = storedMetadataOutput.singleRunEntries();
+      std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntry>& singleRunEntries =
+          storedMetadataOutput.singleRunEntries();
       REQUIRE(singleRunEntries.size() == 4);
       REQUIRE(singleRunEntries[0].beginProcess() == 0);
       REQUIRE(singleRunEntries[0].endProcess() == 0);
@@ -672,7 +616,8 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
       REQUIRE(singleRunEntries[3].beginProcess() == 3);
       REQUIRE(singleRunEntries[3].endProcess() == 5);
 
-      std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess>& singleRunEntryAndProcesses = storedMetadataOutput.singleRunEntryAndProcesses();
+      std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess>& singleRunEntryAndProcesses =
+          storedMetadataOutput.singleRunEntryAndProcesses();
       REQUIRE(singleRunEntryAndProcesses.size() == 5);
 
       REQUIRE(singleRunEntryAndProcesses[0].beginLumi() == 0);

--- a/FWCore/Framework/test/throwIfImproperDependencies_t.cppunit.cc
+++ b/FWCore/Framework/test/throwIfImproperDependencies_t.cppunit.cc
@@ -15,20 +15,19 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "cppunit/extensions/HelperMacros.h"
 
-
-class test_throwIfImproperDependencies: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(test_throwIfImproperDependencies);
+class test_throwIfImproperDependencies : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(test_throwIfImproperDependencies);
 
   CPPUNIT_TEST(onePathNoCycleTest);
   CPPUNIT_TEST(onePathHasCycleTest);
   CPPUNIT_TEST(twoPathsNoCycleTest);
   CPPUNIT_TEST(twoPathsWithCycleTest);
 
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void onePathNoCycleTest();
   void onePathHasCycleTest();
@@ -38,44 +37,43 @@ public:
 
   using ModuleDependsOnMap = std::map<std::string, std::vector<std::string>>;
   using PathToModules = std::unordered_map<std::string, std::vector<std::string>>;
-  
+
 private:
   static unsigned int indexForModule(std::string const& iName,
-                              std::unordered_map<std::string, unsigned int>& modsToIndex,
-                              std::unordered_map<unsigned int, std::string>& indexToMods) {
+                                     std::unordered_map<std::string, unsigned int>& modsToIndex,
+                                     std::unordered_map<unsigned int, std::string>& indexToMods) {
     auto found = modsToIndex.find(iName);
     unsigned int fromIndex;
-    if(found == modsToIndex.end()) {
+    if (found == modsToIndex.end()) {
       fromIndex = modsToIndex.size();
-      modsToIndex.emplace( iName, fromIndex);
+      modsToIndex.emplace(iName, fromIndex);
       indexToMods.emplace(fromIndex, iName);
     } else {
       fromIndex = found->second;
     }
     return fromIndex;
   }
-  
-  bool testCase( ModuleDependsOnMap const& iModDeps, PathToModules const& iPaths) const {
+
+  bool testCase(ModuleDependsOnMap const& iModDeps, PathToModules const& iPaths) const {
     using namespace edm::graph;
-    
+
     EdgeToPathMap edgeToPathMap;
-    
+
     std::unordered_map<std::string, unsigned int> modsToIndex;
     std::unordered_map<unsigned int, std::string> indexToMods;
-    
+
     //We have an artificial case to be the root of the graph
     const std::string kFinishedProcessing("FinishedProcessing");
     const unsigned int kFinishedProcessingIndex{0};
-    modsToIndex.emplace(kFinishedProcessing,kFinishedProcessingIndex);
-    indexToMods.emplace(kFinishedProcessingIndex,kFinishedProcessing);
-    
+    modsToIndex.emplace(kFinishedProcessing, kFinishedProcessingIndex);
+    indexToMods.emplace(kFinishedProcessingIndex, kFinishedProcessing);
+
     //Setup the module to index map by using all module names used in both containers
     //Start with keys from the module dependency to allow control of the numbering scheme
-    for(auto const& md : iModDeps) {
-      indexForModule(md.first,modsToIndex,indexToMods);
+    for (auto const& md : iModDeps) {
+      indexForModule(md.first, modsToIndex, indexToMods);
     }
-    
-    
+
     std::vector<std::vector<unsigned int>> pathIndexToModuleIndexOrder(iPaths.size());
 
     //Need to be able to quickly look up which paths a module appears on
@@ -83,255 +81,242 @@ private:
 
     std::vector<std::string> pathNames;
     std::unordered_map<std::string, unsigned int> pathToIndexMap;
-    for(auto const& path: iPaths) {
+    for (auto const& path : iPaths) {
       unsigned int lastModuleIndex = kInvalidIndex;
       pathNames.push_back(path.first);
       unsigned int pathIndex = pathToIndexMap.size();
       auto& pathOrder = pathIndexToModuleIndexOrder[pathIndex];
       pathToIndexMap.emplace(path.first, pathIndex);
-      for( auto const& mod: path.second) {
-        unsigned int index =indexForModule(mod,modsToIndex,indexToMods);
+      for (auto const& mod : path.second) {
+        unsigned int index = indexForModule(mod, modsToIndex, indexToMods);
         pathOrder.push_back(index);
         moduleIndexToPathIndex[index].push_back(pathIndex);
 
-        if(lastModuleIndex != kInvalidIndex) {
+        if (lastModuleIndex != kInvalidIndex) {
           edgeToPathMap[std::make_pair(index, lastModuleIndex)].push_back(pathIndex);
         }
         lastModuleIndex = index;
       }
       pathOrder.push_back(kFinishedProcessingIndex);
-      if(lastModuleIndex != kInvalidIndex) {
+      if (lastModuleIndex != kInvalidIndex) {
         edgeToPathMap[std::make_pair(kFinishedProcessingIndex, lastModuleIndex)].push_back(pathIndex);
       }
     }
 
-    for(auto const& md : iModDeps) {
-      unsigned int fromIndex =indexForModule(md.first,modsToIndex,indexToMods);
-      for( auto const& dependsOn: md.second) {
-        unsigned int toIndex = indexForModule(dependsOn,modsToIndex,indexToMods);
-        
+    for (auto const& md : iModDeps) {
+      unsigned int fromIndex = indexForModule(md.first, modsToIndex, indexToMods);
+      for (auto const& dependsOn : md.second) {
+        unsigned int toIndex = indexForModule(dependsOn, modsToIndex, indexToMods);
+
         //see if all paths containing this module also contain the dependent module earlier in the path
         // if it does, then treat this only as a path dependency and not a data dependency as this
         // simplifies the circular dependency checking logic
 
         auto itPathsFound = moduleIndexToPathIndex.find(fromIndex);
         bool keepDataDependency = true;
-        if(itPathsFound != moduleIndexToPathIndex.end() and moduleIndexToPathIndex.find(toIndex) != moduleIndexToPathIndex.end()) {
+        if (itPathsFound != moduleIndexToPathIndex.end() and
+            moduleIndexToPathIndex.find(toIndex) != moduleIndexToPathIndex.end()) {
           keepDataDependency = false;
-          for(auto const pathIndex: itPathsFound->second) {
-            for(auto idToCheck: pathIndexToModuleIndexOrder[pathIndex]) {
-              if(idToCheck == toIndex) {
+          for (auto const pathIndex : itPathsFound->second) {
+            for (auto idToCheck : pathIndexToModuleIndexOrder[pathIndex]) {
+              if (idToCheck == toIndex) {
                 //found dependent module first so check next path
                 break;
               }
-              if(idToCheck == fromIndex) {
+              if (idToCheck == fromIndex) {
                 //did not find dependent module earlier on path so
                 // must keep data dependency
                 keepDataDependency = true;
                 break;
               }
             }
-            if(keepDataDependency) {
+            if (keepDataDependency) {
               break;
             }
           }
         }
-        if(keepDataDependency) {
+        if (keepDataDependency) {
           edgeToPathMap[std::make_pair(fromIndex, toIndex)].push_back(kDataDependencyIndex);
         }
       }
     }
 
     throwIfImproperDependencies(edgeToPathMap, pathIndexToModuleIndexOrder, pathNames, indexToMods);
-    
+
     return true;
-    
   }
 };
 
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(test_throwIfImproperDependencies);
 
+void test_throwIfImproperDependencies::onePathNoCycleTest() {
+  {
+    ModuleDependsOnMap md = {{"C", {"B"}}, {"B", {"A"}}};
+    PathToModules paths = {{"p", {"A", "B", "C"}}};
 
-void test_throwIfImproperDependencies::onePathNoCycleTest()
-{
-  {
-    ModuleDependsOnMap md = { {"C", {"B"} },
-                              {"B", {"A" } } };
-    PathToModules paths = { {"p", {"A", "B", "C" } } };
-    
-    CPPUNIT_ASSERT( testCase(md,paths));
+    CPPUNIT_ASSERT(testCase(md, paths));
   }
-  
+
   {
-    ModuleDependsOnMap md = { };
-    PathToModules paths = { {"p", {"A", "B", "C" } } };
-    
-    CPPUNIT_ASSERT( testCase(md,paths));
+    ModuleDependsOnMap md = {};
+    PathToModules paths = {{"p", {"A", "B", "C"}}};
+
+    CPPUNIT_ASSERT(testCase(md, paths));
   }
-  
+
   {
     //Circular dependency but not connected to any path
     // NOTE: "A" is on the list since the ROOT of the
     // tree in the job is actually TriggerResults which
     // always connects to paths and end paths
-    ModuleDependsOnMap md = { {"E", {"F"} },
-      {"F", {"G"} },
-      {"G", {"E"} },
-      {"A",{}}};
-    PathToModules paths = { {"p", {"A", "B", "C" } } };
-    
-    CPPUNIT_ASSERT( testCase(md,paths));
-  }
+    ModuleDependsOnMap md = {{"E", {"F"}}, {"F", {"G"}}, {"G", {"E"}}, {"A", {}}};
+    PathToModules paths = {{"p", {"A", "B", "C"}}};
 
+    CPPUNIT_ASSERT(testCase(md, paths));
+  }
 }
 
-void test_throwIfImproperDependencies::onePathHasCycleTest()
-{
+void test_throwIfImproperDependencies::onePathHasCycleTest() {
   {
-    ModuleDependsOnMap md = { {"C", {"B"} },
-      {"B", {"A" } } };
+    ModuleDependsOnMap md = {{"C", {"B"}}, {"B", {"A"}}};
     {
-      PathToModules paths = { {"p", {"B", "A", "C" } } };
-    
-      CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
-    }
-    {
-      PathToModules paths = { {"p", {"B", "A" } } };
-      
-      CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
-    }
-    {
-      PathToModules paths = { {"p", {"C", "A" } } };
-      
-      CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
-    }
-    {
-      PathToModules paths = { {"p", {"C", "B" } } };
-      
-      CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
-    }
+      PathToModules paths = {{"p", {"B", "A", "C"}}};
 
-  }
-  
-  {
-    ModuleDependsOnMap md = { {"C", {"B"} } };
-    {
-      PathToModules paths = { {"p", {"C", "A", "B" } } };
-      
-      CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+      CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
     }
     {
-      PathToModules paths = { {"p", {"A", "C", "B" } } };
-      
-      CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+      PathToModules paths = {{"p", {"B", "A"}}};
+
+      CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
     }
     {
-      PathToModules paths = { {"p", {"C", "B", "A" } } };
-      
-      CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+      PathToModules paths = {{"p", {"C", "A"}}};
+
+      CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
+    }
+    {
+      PathToModules paths = {{"p", {"C", "B"}}};
+
+      CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
     }
   }
 
+  {
+    ModuleDependsOnMap md = {{"C", {"B"}}};
+    {
+      PathToModules paths = {{"p", {"C", "A", "B"}}};
+
+      CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
+    }
+    {
+      PathToModules paths = {{"p", {"A", "C", "B"}}};
+
+      CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
+    }
+    {
+      PathToModules paths = {{"p", {"C", "B", "A"}}};
+
+      CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
+    }
+  }
 }
 
-void test_throwIfImproperDependencies::twoPathsNoCycleTest()
-{
+void test_throwIfImproperDependencies::twoPathsNoCycleTest() {
   {
-    ModuleDependsOnMap md = { {"C", {"B"} } };
+    ModuleDependsOnMap md = {{"C", {"B"}}};
 
     {
-      PathToModules paths = { {"p1", {"A", "B", "C" } },
-                              {"p2", {"A", "B","C"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"A", "B", "C"}}, {"p2", {"A", "B", "C"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
 
     {
       //CDJ DEBUG THIS IS NOW FAILING
-      PathToModules paths = { {"p1", {"A", "B", "C" } },
-                              {"p2", {"B", "A","C"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"A", "B", "C"}}, {"p2", {"B", "A", "C"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
     {
-      PathToModules paths = { {"p1", {"A", "B", "C" } },
-                              {"p2", {"B", "C","A"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"A", "B", "C"}}, {"p2", {"B", "C", "A"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
     {
-      PathToModules paths = { {"p1", {"B", "A", "C" } },
-                              {"p2", {"A", "B","C"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"B", "A", "C"}}, {"p2", {"A", "B", "C"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
     {
-      PathToModules paths = { {"p1", {"B", "A", "C" } },
-                              {"p2", {"B", "A","C"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"B", "A", "C"}}, {"p2", {"B", "A", "C"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
     {
-      PathToModules paths = { {"p1", {"B", "A", "C" } },
-                              {"p2", {"B", "C","A"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"B", "A", "C"}}, {"p2", {"B", "C", "A"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
     {
-      PathToModules paths = { {"p1", {"B", "C", "A" } },
-                              {"p2", {"A", "B","C"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"B", "C", "A"}}, {"p2", {"A", "B", "C"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
     {
-      PathToModules paths = { {"p1", {"B", "C", "A" } },
-                              {"p2", {"B", "A","C"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"B", "C", "A"}}, {"p2", {"B", "A", "C"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
     {
-      PathToModules paths = { {"p1", {"B", "C", "A" } },
-                              {"p2", {"B", "C","A"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"B", "C", "A"}}, {"p2", {"B", "C", "A"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
   }
-  
+
   {
     //Test all possible 3 module combinations
     ModuleDependsOnMap md = {};
-    std::vector<std::string> moduleName = {"A","B","C"};
+    std::vector<std::string> moduleName = {"A", "B", "C"};
     std::vector<std::string> pathModules;
-    for(unsigned int i=0; i<3; ++i) {
+    for (unsigned int i = 0; i < 3; ++i) {
       pathModules.push_back(moduleName[i]);
-      for(unsigned int j=0; j<3; ++j) {
-        if(j == i) {continue;}
+      for (unsigned int j = 0; j < 3; ++j) {
+        if (j == i) {
+          continue;
+        }
         pathModules.push_back(moduleName[j]);
-        for(unsigned int k=0; k<3; ++k) {
-          if(j==k or i ==k) {continue;}
+        for (unsigned int k = 0; k < 3; ++k) {
+          if (j == k or i == k) {
+            continue;
+          }
           pathModules.push_back(moduleName[k]);
 
           std::vector<std::string> path2Modules;
-          for(unsigned int i=0; i<3; ++i) {
+          for (unsigned int i = 0; i < 3; ++i) {
             path2Modules.push_back(moduleName[i]);
-            for(unsigned int j=0; j<3; ++j) {
-              if(j == i) {continue;}
+            for (unsigned int j = 0; j < 3; ++j) {
+              if (j == i) {
+                continue;
+              }
               path2Modules.push_back(moduleName[j]);
-              for(unsigned int k=0; k<3; ++k) {
-                if(j==k or i ==k) {continue;}
+              for (unsigned int k = 0; k < 3; ++k) {
+                if (j == k or i == k) {
+                  continue;
+                }
                 path2Modules.push_back(moduleName[k]);
                 PathToModules paths;
-                paths["p1"]=pathModules;
-                paths["p2"]=path2Modules;
-                CPPUNIT_ASSERT( testCase(md,paths));
+                paths["p1"] = pathModules;
+                paths["p2"] = path2Modules;
+                CPPUNIT_ASSERT(testCase(md, paths));
                 path2Modules.pop_back();
               }
               path2Modules.pop_back();
             }
             path2Modules.pop_back();
           }
-          
+
           pathModules.pop_back();
         }
         pathModules.pop_back();
@@ -339,182 +324,130 @@ void test_throwIfImproperDependencies::twoPathsNoCycleTest()
       pathModules.pop_back();
     }
   }
-  
+
   {
-    ModuleDependsOnMap md = { {"C", {"B"} },
-                              {"B", {"A"}},
-                              {"D", {"C"}} };
-    
+    ModuleDependsOnMap md = {{"C", {"B"}}, {"B", {"A"}}, {"D", {"C"}}};
+
     {
-      PathToModules paths = { {"p1", {"A", "C" } },
-                              {"p2", {"B","D"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"A", "C"}}, {"p2", {"B", "D"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
 
     {
-      PathToModules paths = { {"p1", {"A", "D" } },
-                              {"p2", {"B","C"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"A", "D"}}, {"p2", {"B", "C"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
     {
-      PathToModules paths = { {"p1", {"A", "B" } },
-                              {"p2", {"C","D"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"A", "B"}}, {"p2", {"C", "D"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
 
     {
-      PathToModules paths = { {"p1", {"A"} },
-                              {"p2", {"C","D"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"A"}}, {"p2", {"C", "D"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
     {
-      PathToModules paths = { {"p1", {"A"} },
-                              {"p2", {"D"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"A"}}, {"p2", {"D"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
     {
-      PathToModules paths = { {"p1", {"A"} },
-                              {"p2", {"C"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
-    }
-    
-    {
-      PathToModules paths = { {"p1", {"B" } },
-                              {"p2", {"D"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"A"}}, {"p2", {"C"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
 
     {
-      PathToModules paths = { {"p1", {"B" } },
-                              {"p2", {"C"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
-    }
-    {
-      PathToModules paths = { {"p1", {"C" } },
-                              {"p2", {"D"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"B"}}, {"p2", {"D"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
 
     {
-      PathToModules paths = { {"p1", {"A", "C" } },
-                              {"p2", {"A","D"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"B"}}, {"p2", {"C"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
     {
-      PathToModules paths = { {"p1", {"A", "C" } },
-                              {"p2", {"A","D"} } };
-      
-      CPPUNIT_ASSERT( testCase(md,paths));
+      PathToModules paths = {{"p1", {"C"}}, {"p2", {"D"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
     }
 
-  }
-  
-  {
-    ModuleDependsOnMap md = { {"B", {"C"} },
-      {"D", {"A" } } };
-    PathToModules paths = { {"p1", {"A", "B" } },
-      {"p2", {"C","D"}} };
-    
-    CPPUNIT_ASSERT( testCase(md,paths));
+    {
+      PathToModules paths = {{"p1", {"A", "C"}}, {"p2", {"A", "D"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
+    }
+    {
+      PathToModules paths = {{"p1", {"A", "C"}}, {"p2", {"A", "D"}}};
+
+      CPPUNIT_ASSERT(testCase(md, paths));
+    }
   }
 
   {
-    ModuleDependsOnMap md = { {"B", {"E"} },
-      {"E", {"C"}},
-      {"D", {"F" }},
-      {"F", {"A"}}};
-    PathToModules paths = { {"p1", {"A", "B" } },
-      {"p2", {"C","D"}} };
-    
-    CPPUNIT_ASSERT(testCase(md,paths));
+    ModuleDependsOnMap md = {{"B", {"C"}}, {"D", {"A"}}};
+    PathToModules paths = {{"p1", {"A", "B"}}, {"p2", {"C", "D"}}};
+
+    CPPUNIT_ASSERT(testCase(md, paths));
   }
 
   {
-    ModuleDependsOnMap md = { {"B", {"E"} },
-      {"E", {"C"}},
-      {"D", {"E" }},
-      {"E", {"A"}}};
-    PathToModules paths = { {"p1", {"A", "B"} },
-                            {"p2", {"C","D"}} };
-    
-    CPPUNIT_ASSERT( testCase(md,paths));
+    ModuleDependsOnMap md = {{"B", {"E"}}, {"E", {"C"}}, {"D", {"F"}}, {"F", {"A"}}};
+    PathToModules paths = {{"p1", {"A", "B"}}, {"p2", {"C", "D"}}};
+
+    CPPUNIT_ASSERT(testCase(md, paths));
   }
 
   {
-    ModuleDependsOnMap md = { {"B", {"E"}},
-                              {"C", {"E"}},
-                              {"D", {"E"}},
-                              {"A", {"E"}} };
-    PathToModules paths = { {"p1", {"A", "B"} },
-                            {"p2", {"C","D"}} };
-    
-    CPPUNIT_ASSERT( testCase(md,paths));
+    ModuleDependsOnMap md = {{"B", {"E"}}, {"E", {"C"}}, {"D", {"E"}}, {"E", {"A"}}};
+    PathToModules paths = {{"p1", {"A", "B"}}, {"p2", {"C", "D"}}};
+
+    CPPUNIT_ASSERT(testCase(md, paths));
+  }
+
+  {
+    ModuleDependsOnMap md = {{"B", {"E"}}, {"C", {"E"}}, {"D", {"E"}}, {"A", {"E"}}};
+    PathToModules paths = {{"p1", {"A", "B"}}, {"p2", {"C", "D"}}};
+
+    CPPUNIT_ASSERT(testCase(md, paths));
   }
 
   {
     //Simplified schedule which was failing
-    ModuleDependsOnMap md = {{"H", {"A"}} };
-    PathToModules paths = {
-      {"reco", {"I", "A","H","G","F","E"} },
-      {"val", {"E","D","C","B","A"}} };
-  
-  CPPUNIT_ASSERT( testCase(md,paths));
+    ModuleDependsOnMap md = {{"H", {"A"}}};
+    PathToModules paths = {{"reco", {"I", "A", "H", "G", "F", "E"}}, {"val", {"E", "D", "C", "B", "A"}}};
+
+    CPPUNIT_ASSERT(testCase(md, paths));
   }
 
   {
     //Simplified schedule which was failing
-    ModuleDependsOnMap md = {
-      {"B", {"X"}},
-      {"Y", {"Z"}},
-      {"Z", {"A"}} };
-    PathToModules paths = {
-      {"p1", {"X", "B","A"}},
-      {"p2", {"A","Z","?","Y","X"}} };
-    
-    CPPUNIT_ASSERT( testCase(md,paths));
+    ModuleDependsOnMap md = {{"B", {"X"}}, {"Y", {"Z"}}, {"Z", {"A"}}};
+    PathToModules paths = {{"p1", {"X", "B", "A"}}, {"p2", {"A", "Z", "?", "Y", "X"}}};
+
+    CPPUNIT_ASSERT(testCase(md, paths));
   }
   {
     //Simplified schedule which was failing
-    ModuleDependsOnMap md = {
-      {"B", {"X"}},
-      {"Y", {"Z"}},
-      {"Z", {"A"}},
-      {"?", {}},
-      {"A", {}},
-      {"X",{}}
-    };
-    PathToModules paths = {
-      {"p1", {"X", "B","A"}},
-      {"p2", {"A","Z","?","Y","X"}} };
-    CPPUNIT_ASSERT( testCase(md,paths));
+    ModuleDependsOnMap md = {{"B", {"X"}}, {"Y", {"Z"}}, {"Z", {"A"}}, {"?", {}}, {"A", {}}, {"X", {}}};
+    PathToModules paths = {{"p1", {"X", "B", "A"}}, {"p2", {"A", "Z", "?", "Y", "X"}}};
+    CPPUNIT_ASSERT(testCase(md, paths));
   }
-  
+
   {
     //Simplified schedule which was failing
     // The data dependency for 'D" can be met
     // by the order of modules on path p2
-    ModuleDependsOnMap md = {
-      {"A_TR", {"zEP1","zEP2"}},
-      {"D", {"B"}},
-      {"E", {"D"}},
-      {"zSEP3", {"A_TR"}}
-    };
-    PathToModules paths = {
-      {"p1", {"E","F","zEP1"}},
-      {"p2", {"B","C","D","zEP2"}},
-      {"p3", {"zSEP3","B","zEP3"}} };
-    
-    CPPUNIT_ASSERT( testCase(md,paths));
+    ModuleDependsOnMap md = {{"A_TR", {"zEP1", "zEP2"}}, {"D", {"B"}}, {"E", {"D"}}, {"zSEP3", {"A_TR"}}};
+    PathToModules paths = {{"p1", {"E", "F", "zEP1"}}, {"p2", {"B", "C", "D", "zEP2"}}, {"p3", {"zSEP3", "B", "zEP3"}}};
+
+    CPPUNIT_ASSERT(testCase(md, paths));
   }
 
   {
@@ -522,183 +455,113 @@ void test_throwIfImproperDependencies::twoPathsNoCycleTest()
     // Check that the framework does not get confused when jumping
     // from one path to the other path just because of the
     // TriggerResults connection.
-    
-    ModuleDependsOnMap md = {
-      {"A_TR", {"zEP1"}},
-      {"A", {"B"}},
-      {"B", {"H"}},
-      {"C", {}},
-      {"D" ,{}},
-      {"E" , {}},
-      {"G",{"D"}},
-      {"H",{"D"}},
-      {"zEP1", {}},
-      {"zSEP2", {"A_TR"}}
-    };
-    PathToModules paths = {
-      {"p2", {"D", "G","H","B","C","zEP1"}},
-      {"p3", {"A"}}, //Needed to make graph search start here
-      {"p1", {"zSEP2","E","D","G","H","B", "C"}} };
-  
-    
-    CPPUNIT_ASSERT( testCase(md,paths));
-    
+
+    ModuleDependsOnMap md = {{"A_TR", {"zEP1"}}, {"A", {"B"}}, {"B", {"H"}}, {"C", {}},    {"D", {}},
+                             {"E", {}},          {"G", {"D"}}, {"H", {"D"}}, {"zEP1", {}}, {"zSEP2", {"A_TR"}}};
+    PathToModules paths = {{"p2", {"D", "G", "H", "B", "C", "zEP1"}},
+                           {"p3", {"A"}},  //Needed to make graph search start here
+                           {"p1", {"zSEP2", "E", "D", "G", "H", "B", "C"}}};
+
+    CPPUNIT_ASSERT(testCase(md, paths));
   }
 }
 
-void test_throwIfImproperDependencies::twoPathsWithCycleTest()
-{
-  
+void test_throwIfImproperDependencies::twoPathsWithCycleTest() {
   {
-    ModuleDependsOnMap md = { {"C", {"B"}},
-                              {"A", {"D"}} };
-    PathToModules paths = { {"p1", {"A","B"}},
-                            {"p2", {"C","D"}} };
-    
-    CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+    ModuleDependsOnMap md = {{"C", {"B"}}, {"A", {"D"}}};
+    PathToModules paths = {{"p1", {"A", "B"}}, {"p2", {"C", "D"}}};
+
+    CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
   }
 
   {
     //Add additional dependencies to test that they are ignored
-    ModuleDependsOnMap md = {
-      {"C", {"E","F","G","B"}},
-      {"A", {"D"}} };
-    PathToModules paths = {
-      {"p1", {"A","B"}},
-      {"p2", {"C","D"}} };
-    
-    CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+    ModuleDependsOnMap md = {{"C", {"E", "F", "G", "B"}}, {"A", {"D"}}};
+    PathToModules paths = {{"p1", {"A", "B"}}, {"p2", {"C", "D"}}};
+
+    CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
   }
 
   {
-    ModuleDependsOnMap md = { {"C", {"B"}},
-                              {"A", {"D"}} };
-    PathToModules paths = { {"p1", {"A","B"}},
-                            {"p2", {"C","D", "A"}} };
-    
-    CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+    ModuleDependsOnMap md = {{"C", {"B"}}, {"A", {"D"}}};
+    PathToModules paths = {{"p1", {"A", "B"}}, {"p2", {"C", "D", "A"}}};
+
+    CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
   }
 
   {
-    ModuleDependsOnMap md = { {"C", {"B"}},
-                              {"A", {"D"}},
-                              {"B", {"A"}},
-                              {"D", {"C"}} };
-    PathToModules paths = { {"p1", {"A","B"}},
-                            {"p2", {"C","D"}} };
-    
-    CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+    ModuleDependsOnMap md = {{"C", {"B"}}, {"A", {"D"}}, {"B", {"A"}}, {"D", {"C"}}};
+    PathToModules paths = {{"p1", {"A", "B"}}, {"p2", {"C", "D"}}};
+
+    CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
   }
 
   {
-    ModuleDependsOnMap md = { {"E", {"B"} },
-                              {"C", {"E"}},
-                              {"A", {"D"}}};
-    PathToModules paths = { {"p1", {"A", "B" } },
-                            {"p2", {"C","D"}} };
-    
-    CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+    ModuleDependsOnMap md = {{"E", {"B"}}, {"C", {"E"}}, {"A", {"D"}}};
+    PathToModules paths = {{"p1", {"A", "B"}}, {"p2", {"C", "D"}}};
+
+    CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
   }
 
   {
-    ModuleDependsOnMap md = { {"A", {"B"} },
-      {"B", {"C"}},
-      {"C", {"D"}},
-      {"D",{"B"}}};
-    PathToModules paths = { {"p1", {"A","EP"} } };
-    
-    CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+    ModuleDependsOnMap md = {{"A", {"B"}}, {"B", {"C"}}, {"C", {"D"}}, {"D", {"B"}}};
+    PathToModules paths = {{"p1", {"A", "EP"}}};
+
+    CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
   }
 
-  
   {
     //Simplified schedule which was failing
-    ModuleDependsOnMap md = {
-      {"B", {"X"}},
-      {"Y", {"Z"}},
-      {"Z", {"A"}},
-      {"?", {}},
-      {"A", {}},
-      {"X",{}}
-    };
+    ModuleDependsOnMap md = {{"B", {"X"}}, {"Y", {"Z"}}, {"Z", {"A"}}, {"?", {}}, {"A", {}}, {"X", {}}};
     //NOTE: p1 is inconsistent but with p2 it would be runnable.
-    PathToModules paths = {
-      {"p1", {"B","A", "X"}},
-      {"p2", {"A","Z","?","Y","X"}} };
-    CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+    PathToModules paths = {{"p1", {"B", "A", "X"}}, {"p2", {"A", "Z", "?", "Y", "X"}}};
+    CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
   }
 
   {
-    ModuleDependsOnMap md = {
-      {"A_TR", {"EP1","EP2"}}, //assigned aTR==0, EP1==1, EP2==2
-      {"C", {"A"}},
-      {"D", {"A"}},
-      {"E",{"D"}},
-      {"BP",{"A_TR"}}
-    };
-    
-    PathToModules paths = {
-      {"p1", {"A","B", "C","EP1"}},
-      {"p2", {"E","EP2"}},
-      {"ep", {"BP","A","D"}}
-    };
-    CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
-  }
-  
-  {
-    // The data dependency for 'D" can be met
-    // by the order of modules on path p2
-    // but NOT by path3
-    ModuleDependsOnMap md = {
-      {"A_TR", {"zEP1","zEP2","zEP3"}},
-      {"D", {"B"}},
-      {"E", {"D"}},
-      {"zSEP4", {"A_TR"}}
-    };
-    PathToModules paths = {
-      {"p1", {"E","F","zEP1"}},
-      {"p2", {"Filter", "B","C","D","zEP2"}},
-      {"p3", {"C","D","zEP3"}},
-      {"p4", {"zSEP4","B","zEP4"}} };
-    
-    CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+    ModuleDependsOnMap md = {{"A_TR", {"EP1", "EP2"}},  //assigned aTR==0, EP1==1, EP2==2
+                             {"C", {"A"}},
+                             {"D", {"A"}},
+                             {"E", {"D"}},
+                             {"BP", {"A_TR"}}};
+
+    PathToModules paths = {{"p1", {"A", "B", "C", "EP1"}}, {"p2", {"E", "EP2"}}, {"ep", {"BP", "A", "D"}}};
+    CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
   }
 
   {
     // The data dependency for 'D" can be met
     // by the order of modules on path p2
     // but NOT by path3
-    ModuleDependsOnMap md = {
-      {"A_TR", {"zEP1","zEP2","zEP3"}},
-      {"D", {"B"}},
-      {"E", {"D"}},
-      {"zSEP4", {"A_TR"}}
-    };
-    PathToModules paths = {
-      {"p1", {"E","F","zEP1"}},
-      {"p2", {"Filter", "B", "D","zEP2"}},
-      {"p3", {"C","D","zEP3"}},
-      {"p4", {"zSEP4","B","zEP4"}} };
-    
-    CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+    ModuleDependsOnMap md = {{"A_TR", {"zEP1", "zEP2", "zEP3"}}, {"D", {"B"}}, {"E", {"D"}}, {"zSEP4", {"A_TR"}}};
+    PathToModules paths = {{"p1", {"E", "F", "zEP1"}},
+                           {"p2", {"Filter", "B", "C", "D", "zEP2"}},
+                           {"p3", {"C", "D", "zEP3"}},
+                           {"p4", {"zSEP4", "B", "zEP4"}}};
+
+    CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
   }
 
   {
     // The data dependency for 'D" can be met
     // by the order of modules on path p2
     // but NOT by path3
-    ModuleDependsOnMap md = {
-      {"A_TR", {"zEP1","zEP2"}},
-      { "B",{}},
-      {"zFilter", {"A_TR"}}
-    };
-    PathToModules paths = {
-      {"p1", {"zFilter","B","zEP1"}},
-      {"p2", {"zFilter", "B","zEP2"}}
-    };
-    
-    CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+    ModuleDependsOnMap md = {{"A_TR", {"zEP1", "zEP2", "zEP3"}}, {"D", {"B"}}, {"E", {"D"}}, {"zSEP4", {"A_TR"}}};
+    PathToModules paths = {{"p1", {"E", "F", "zEP1"}},
+                           {"p2", {"Filter", "B", "D", "zEP2"}},
+                           {"p3", {"C", "D", "zEP3"}},
+                           {"p4", {"zSEP4", "B", "zEP4"}}};
+
+    CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
   }
 
+  {
+    // The data dependency for 'D" can be met
+    // by the order of modules on path p2
+    // but NOT by path3
+    ModuleDependsOnMap md = {{"A_TR", {"zEP1", "zEP2"}}, {"B", {}}, {"zFilter", {"A_TR"}}};
+    PathToModules paths = {{"p1", {"zFilter", "B", "zEP1"}}, {"p2", {"zFilter", "B", "zEP2"}}};
+
+    CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
+  }
 }
-


### PR DESCRIPTION
Relative to the last iterations - adjusting the treatment of comments (trying to leave multiline comments alone) and template (not requiring line breaks)

I just did FWCore/Framework this time. I'd propose to discuss potential deficiencies in the next (or next to next) core meeting..