### PR TITLE
Added extra protection to Geant4 SteppingAction 

### DIFF
--- a/SimG4Core/Application/interface/SteppingAction.h
+++ b/SimG4Core/Application/interface/SteppingAction.h
@@ -23,7 +23,8 @@ enum TrackStatus {
   sDeadRegion = 2, 
   sOutOfTime = 3, 
   sLowEnergy = 4, 
-  sLowEnergyInVacuum = 5
+  sLowEnergyInVacuum = 5,
+  sEnergyDepNaN = 6
 };
 
 class SteppingAction: public G4UserSteppingAction {
@@ -65,6 +66,7 @@ private:
   unsigned int                  numberEkins;
   unsigned int                  numberPart;
   unsigned int                  ndeadRegions;
+  unsigned int                  nWarnings;
 
   bool                          initialized;
   bool                          killBeamPipe;

--- a/SimG4Core/Application/src/SteppingAction.cc
+++ b/SimG4Core/Application/src/SteppingAction.cc
@@ -87,8 +87,8 @@ void SteppingAction::UserSteppingAction(const G4Step * aStep)
 {
   if (!initialized) { initialized = initPointer(); }
 
-  if(hasWatcher) { m_g4StepSignal(aStep); }
-  //m_g4StepSignal(aStep); 
+  //if(hasWatcher) { m_g4StepSignal(aStep); }
+  m_g4StepSignal(aStep); 
 
   G4Track * theTrack = aStep->GetTrack();
   TrackStatus tstat = (theTrack->GetTrackStatus() == fAlive) ? sAlive : sKilledByProcess;
@@ -127,14 +127,12 @@ void SteppingAction::UserSteppingAction(const G4Step * aStep)
     if(sAlive == tstat && numberEkins > 0 && isLowEnergy(aStep)) { tstat = sLowEnergy; }
 
     // kill low-energy in vacuum
-    if(sAlive == tstat && killBeamPipe) {
-      G4double kinEnergy = theTrack->GetKineticEnergy();
-      if(kinEnergy < theCriticalEnergyForVacuum
-	 && theTrack->GetDefinition()->GetPDGCharge() != 0.0 && kinEnergy > 0.0
-	 && theTrack->GetNextVolume()->GetLogicalVolume()->GetMaterial()->GetDensity() 
-	 <= theCriticalDensity) {
-	tstat = sLowEnergyInVacuum;
-      }
+    G4double kinEnergy = theTrack->GetKineticEnergy();
+    if(sAlive == tstat && killBeamPipe && kinEnergy < theCriticalEnergyForVacuum
+       && theTrack->GetDefinition()->GetPDGCharge() != 0.0 && kinEnergy > 0.0
+       && theTrack->GetNextVolume()->GetLogicalVolume()->GetMaterial()->GetDensity() 
+       <= theCriticalDensity) {
+      tstat = sLowEnergyInVacuum;
     }
 
     // check transition tracker/calo

--- a/SimG4Core/Application/src/SteppingAction.cc
+++ b/SimG4Core/Application/src/SteppingAction.cc
@@ -11,13 +11,14 @@
 #include "G4SystemOfUnits.hh"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 //#define DebugLog
 
 SteppingAction::SteppingAction(EventAction* e, const edm::ParameterSet & p,
 			       const CMSSteppingVerbose* sv, bool hasW) 
   : eventAction_(e), tracker(nullptr), calo(nullptr), steppingVerbose(sv),
-    initialized(false), killBeamPipe(false),hasWatcher(hasW)
+    nWarnings(0),initialized(false), killBeamPipe(false),hasWatcher(hasW)
 {
   theCriticalEnergyForVacuum = 
     (p.getParameter<double>("CriticalEnergyForVacuum")*CLHEP::MeV);
@@ -86,14 +87,15 @@ void SteppingAction::UserSteppingAction(const G4Step * aStep)
 {
   if (!initialized) { initialized = initPointer(); }
 
-  //  if(hasWatcher) { m_g4StepSignal(aStep); }
-  m_g4StepSignal(aStep); 
+  if(hasWatcher) { m_g4StepSignal(aStep); }
+  //m_g4StepSignal(aStep); 
 
   G4Track * theTrack = aStep->GetTrack();
   TrackStatus tstat = (theTrack->GetTrackStatus() == fAlive) ? sAlive : sKilledByProcess;
+
   G4StepPoint* postStep = aStep->GetPostStepPoint();
 
-  if(0 == tstat && postStep->GetPhysicalVolume() != nullptr) {
+  if(sAlive == tstat && postStep->GetPhysicalVolume() != nullptr) {
 
     G4StepPoint* preStep = aStep->GetPreStepPoint();
     const G4Region* theRegion = 
@@ -102,23 +104,41 @@ void SteppingAction::UserSteppingAction(const G4Step * aStep)
     // kill in dead regions
     if(isInsideDeadRegion(theRegion)) { tstat = sDeadRegion; }
 
+    // NaN energy deposit
+    if(sAlive == tstat && edm::isNotFinite(aStep->GetTotalEnergyDeposit())) {
+      tstat = sEnergyDepNaN;
+      if(nWarnings < 20) {
+	++nWarnings;
+	edm::LogWarning("SimG4CoreApplication") 
+	  << "Track #" << theTrack->GetTrackID()
+	  << " " << theTrack->GetDefinition()->GetParticleName()
+	  << " E(MeV)= " << preStep->GetKineticEnergy()/MeV  
+	  << " is killed due to edep=NaN inside PV: " 
+	  << preStep->GetPhysicalVolume()->GetName()
+	  << " at " << theTrack->GetPosition()
+          << " StepLen(mm)= " << aStep->GetStepLength();
+      }
+    }
+
     // kill out of time
-    if(0 == tstat && isOutOfTimeWindow(theTrack, theRegion)) { tstat = sOutOfTime; }
+    if(sAlive == tstat && isOutOfTimeWindow(theTrack, theRegion)) { tstat = sOutOfTime; }
 
     // kill low-energy in volumes on demand
-    if(0 == tstat && numberEkins > 0 && isLowEnergy(aStep)) { tstat = sLowEnergy; }
+    if(sAlive == tstat && numberEkins > 0 && isLowEnergy(aStep)) { tstat = sLowEnergy; }
 
     // kill low-energy in vacuum
-    G4double kinEnergy = theTrack->GetKineticEnergy();
-    if(0 == tstat && killBeamPipe && kinEnergy < theCriticalEnergyForVacuum
-	&& theTrack->GetDefinition()->GetPDGCharge() != 0.0 && kinEnergy > 0.0
-        && theTrack->GetNextVolume()->GetLogicalVolume()->GetMaterial()->GetDensity() 
-       <= theCriticalDensity) {
-      tstat = sLowEnergyInVacuum;
+    if(sAlive == tstat && killBeamPipe) {
+      G4double kinEnergy = theTrack->GetKineticEnergy();
+      if(kinEnergy < theCriticalEnergyForVacuum
+	 && theTrack->GetDefinition()->GetPDGCharge() != 0.0 && kinEnergy > 0.0
+	 && theTrack->GetNextVolume()->GetLogicalVolume()->GetMaterial()->GetDensity() 
+	 <= theCriticalDensity) {
+	tstat = sLowEnergyInVacuum;
+      }
     }
 
     // check transition tracker/calo
-    if(0 == tstat) {
+    if(sAlive == tstat) {
 
       if(isThisVolume(preStep->GetTouchable(),tracker) &&
 	 isThisVolume(postStep->GetTouchable(),calo)) {
@@ -274,6 +294,9 @@ void SteppingAction::PrintKilledTrack(const G4Track* aTrack,
     break;
   case sLowEnergyInVacuum:
     typ = " low energy limit in vacuum ";
+    break;
+  case sEnergyDepNaN:
+    typ = " energy deposition is NaN ";
     break;
   default:
     break;

--- a/SimG4Core/Notification/interface/CMSSteppingVerbose.h
+++ b/SimG4Core/Notification/interface/CMSSteppingVerbose.h
@@ -20,6 +20,7 @@ class G4Event;
 class G4Track;
 class G4Step;
 class G4SteppingManager;
+class G4SteppingVerbose;
 
 class CMSSteppingVerbose 
 {
@@ -42,6 +43,7 @@ private:
 
   G4bool m_PrintEvent;
   G4bool m_PrintTrack;
+  G4bool m_smInitialized;
   G4int m_verbose;
   G4int m_nEvents;
   G4int m_nVertex;
@@ -50,6 +52,7 @@ private:
   std::vector<G4int> m_PrimaryVertex;
   std::vector<G4int> m_TrackNumbers;
   G4double m_EkinThreshold;
+  G4SteppingVerbose* m_g4SteppingVerbose;
 };
 
 #endif


### PR DESCRIPTION
During R&D studies with FTFP_BERT_EMZ Physics List a weird problem was identified. To fix this problem an extra protection is added to the SteppingAction class: on each step check on NaN values and kill problematic tracks. This may be also useful for production (no reports so far from production about such cases).

CMSSteppingVerbose class is used only for debugging of a problem. It is extended in order to be more informative for debugging on complicated crashes.

Results of normal runs should not be affected. 