### PR TITLE
Manage PluginFactory plugins with unique_ptr in RecoLocalMuon

### DIFF
--- a/RecoLocalMuon/CSCSegment/src/CSCSegmentBuilder.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegmentBuilder.cc
@@ -51,20 +51,13 @@ CSCSegmentBuilder::CSCSegmentBuilder(const edm::ParameterSet& ps) : geom_(nullpt
     // Ask factory to build this algorithm, giving it appropriate ParameterSet
             
     for (size_t j=0; j<chType.size(); ++j) {
-        algoMap[chType[j]] = CSCSegmentBuilderPluginFactory::get()->
-                create(algoName, segAlgoPSet[algoToType[j]-1]);
+        algoMap.emplace(chType[j], CSCSegmentBuilderPluginFactory::get()->
+                        create(algoName, segAlgoPSet[algoToType[j]-1]));
 	edm::LogVerbatim("CSCSegment|CSC")<< "using algorithm #" << algoToType[j] << " for chamber type " << chType[j];
     }
 }
 
-CSCSegmentBuilder::~CSCSegmentBuilder() {
-  //
-  // loop on algomap and delete them
-  //
-  for (std::map<std::string, CSCSegmentAlgorithm*>::iterator it = algoMap.begin();it != algoMap.end(); it++){
-    delete ((*it).second);
-  }
-}
+CSCSegmentBuilder::~CSCSegmentBuilder() = default;
 
 void CSCSegmentBuilder::build(const CSCRecHit2DCollection* recHits, CSCSegmentCollection& oc) {
   	

--- a/RecoLocalMuon/CSCSegment/src/CSCSegmentBuilder.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegmentBuilder.h
@@ -45,7 +45,7 @@ public:
 private:
 
     const CSCGeometry* geom_;
-    std::map<std::string, CSCSegmentAlgorithm*> algoMap;
+    std::map<std::string, std::unique_ptr<CSCSegmentAlgorithm>> algoMap;
 };
 
 #endif

--- a/RecoLocalMuon/DTRecHit/interface/DTRecHitBaseAlgo.h
+++ b/RecoLocalMuon/DTRecHit/interface/DTRecHitBaseAlgo.h
@@ -89,7 +89,7 @@ class DTRecHitBaseAlgo {
 
  protected:
   // The module to be used for digi time synchronization
-  DTTTrigBaseSync *theSync;
+  std::unique_ptr<DTTTrigBaseSync> theSync;
   
 };
 #endif

--- a/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.cc
@@ -32,7 +32,10 @@ using namespace std;
 
 DTRecHitProducer::DTRecHitProducer(const ParameterSet& config) :
   // Set verbose output
-  debug(config.getUntrackedParameter<bool>("debug", false))
+  debug(config.getUntrackedParameter<bool>("debug", false)),
+  // Get the concrete reconstruction algo from the factory
+  theAlgo{DTRecHitAlgoFactory::get()->create(config.getParameter<string>("recAlgo"),
+                                             config.getParameter<ParameterSet>("recAlgoConfig"))}
 {
   if(debug)
     cout << "[DTRecHitProducer] Constructor called" << endl;
@@ -40,17 +43,11 @@ DTRecHitProducer::DTRecHitProducer(const ParameterSet& config) :
   produces<DTRecHitCollection>();
 
   DTDigiToken_ = consumes<DTDigiCollection>(config.getParameter<InputTag>("dtDigiLabel"));
-
-  // Get the concrete reconstruction algo from the factory
-  string theAlgoName = config.getParameter<string>("recAlgo");
-  theAlgo = DTRecHitAlgoFactory::get()->create(theAlgoName,
-					       config.getParameter<ParameterSet>("recAlgoConfig"));
 }
 
 DTRecHitProducer::~DTRecHitProducer(){
   if(debug)
     cout << "[DTRecHitProducer] Destructor called" << endl;
-  delete theAlgo;
 }
 
 

--- a/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.h
@@ -38,9 +38,7 @@ private:
   // The label to be used to retrieve DT digis from the event
   edm::EDGetTokenT<DTDigiCollection> DTDigiToken_;
   // The reconstruction algorithm
-  DTRecHitBaseAlgo *theAlgo;
-//   static string theAlgoName;
-
+  std::unique_ptr<DTRecHitBaseAlgo> theAlgo;
 };
 #endif
 

--- a/RecoLocalMuon/DTRecHit/src/DTRecHitBaseAlgo.cc
+++ b/RecoLocalMuon/DTRecHit/src/DTRecHitBaseAlgo.cc
@@ -9,6 +9,7 @@
 #include "RecoLocalMuon/DTRecHit/interface/DTRecHitBaseAlgo.h"
 
 #include "Geometry/DTGeometry/interface/DTLayer.h"
+#include "CalibMuon/DTDigiSync/interface/DTTTrigBaseSync.h"
 #include "CalibMuon/DTDigiSync/interface/DTTTrigSyncFactory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -16,10 +17,10 @@ using namespace std;
 using namespace edm;
 
 
-DTRecHitBaseAlgo::DTRecHitBaseAlgo(const ParameterSet& config) {
-  theSync = DTTTrigSyncFactory::get()->create(config.getParameter<string>("tTrigMode"),
-					      config.getParameter<ParameterSet>("tTrigModeConfig"));
-}
+DTRecHitBaseAlgo::DTRecHitBaseAlgo(const ParameterSet& config):
+  theSync{DTTTrigSyncFactory::get()->create(config.getParameter<string>("tTrigMode"),
+                                            config.getParameter<ParameterSet>("tTrigModeConfig"))}
+{}
 
 DTRecHitBaseAlgo::~DTRecHitBaseAlgo(){}
 
@@ -44,13 +45,13 @@ OwnVector<DTRecHit1DPair> DTRecHitBaseAlgo::reconstruct(const DTLayer* layer,
     if (!OK) continue;
 
     // Build a new pair of 1D rechit    
-    DTRecHit1DPair*  recHitPair = new DTRecHit1DPair(wireId, *digi);
+    auto recHitPair = std::make_unique<DTRecHit1DPair>(wireId, *digi);
 
     // Set the position and the error of the 1D rechits
     recHitPair->setPositionAndError(DTEnums::Left, lpoint, tmpErr);
     recHitPair->setPositionAndError(DTEnums::Right, rpoint, tmpErr);        
 
-    result.push_back(recHitPair);
+    result.push_back(std::move(recHitPair));
   }
   return result;
 }

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment2DProducer.cc
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment2DProducer.cc
@@ -33,7 +33,10 @@ using namespace std;
 /* ====================================================================== */
 
 /// Constructor
-DTRecSegment2DProducer::DTRecSegment2DProducer(const edm::ParameterSet& pset) {
+DTRecSegment2DProducer::DTRecSegment2DProducer(const edm::ParameterSet& pset):
+  theAlgo{DTRecSegment2DAlgoFactory::get()->create(pset.getParameter<string>("Reco2DAlgoName"),
+                                                   pset.getParameter<ParameterSet>("Reco2DAlgoConfig"))}
+ {
   // Set verbose output
   debug = pset.getUntrackedParameter<bool>("debug"); 
 
@@ -46,17 +49,13 @@ DTRecSegment2DProducer::DTRecSegment2DProducer(const edm::ParameterSet& pset) {
   produces<DTRecSegment2DCollection>();
 
   // Get the concrete reconstruction algo from the factory
-  string theAlgoName = pset.getParameter<string>("Reco2DAlgoName");
-  if(debug) cout << "the Reco2D AlgoName is " << theAlgoName << endl;
-  theAlgo = DTRecSegment2DAlgoFactory::get()->create(theAlgoName,
-                                                     pset.getParameter<ParameterSet>("Reco2DAlgoConfig"));
+  if(debug) cout << "the Reco2D AlgoName is " << pset.getParameter<string>("Reco2DAlgoName") << endl;
 }
 
 /// Destructor
 DTRecSegment2DProducer::~DTRecSegment2DProducer() {
   if(debug)
     cout << "[DTRecSegment2DProducer] Destructor called" << endl;
-  delete theAlgo;
 }
 
 /* Operations */ 

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment2DProducer.h
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment2DProducer.h
@@ -50,7 +50,7 @@ class DTRecSegment2DProducer : public edm::stream::EDProducer<> {
   bool debug;
 
   // The 2D-segments reconstruction algorithm
-  DTRecSegment2DBaseAlgo* theAlgo;
+  std::unique_ptr<DTRecSegment2DBaseAlgo> theAlgo;
 
   //static std::string theAlgoName;
   edm::EDGetTokenT<DTRecHitCollection> recHits1DToken_;

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment4DProducer.cc
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment4DProducer.cc
@@ -23,7 +23,11 @@
 using namespace edm;
 using namespace std;
 
-DTRecSegment4DProducer::DTRecSegment4DProducer(const ParameterSet& pset){
+DTRecSegment4DProducer::DTRecSegment4DProducer(const ParameterSet& pset):
+  // Get the concrete 4D-segments reconstruction algo from the factory
+  the4DAlgo{DTRecSegment4DAlgoFactory::get()->create(pset.getParameter<string>("Reco4DAlgoName"),
+                                                     pset.getParameter<ParameterSet>("Reco4DAlgoConfig"))}
+{
   produces<DTRecSegment4DCollection>();
   
   // debug parameter
@@ -38,18 +42,13 @@ DTRecSegment4DProducer::DTRecSegment4DProducer(const ParameterSet& pset){
   // the name of the 2D rec hits collection
   recHits2DToken_ = consumes<DTRecSegment2DCollection>(pset.getParameter<InputTag>("recHits2DLabel"));
   
-  // Get the concrete 4D-segments reconstruction algo from the factory
-  string theReco4DAlgoName = pset.getParameter<string>("Reco4DAlgoName");
-  if(debug) cout << "the Reco4D AlgoName is " << theReco4DAlgoName << endl;
-  the4DAlgo = DTRecSegment4DAlgoFactory::get()->create(theReco4DAlgoName,
-						       pset.getParameter<ParameterSet>("Reco4DAlgoConfig"));
+  if(debug) cout << "the Reco4D AlgoName is " << pset.getParameter<string>("Reco4DAlgoName") << endl;
 }
 
 /// Destructor
 DTRecSegment4DProducer::~DTRecSegment4DProducer(){
   if(debug)
     cout << "[DTRecSegment4DProducer] Destructor called" << endl;
-  delete the4DAlgo;
 }
 
 void DTRecSegment4DProducer::produce(Event& event, const EventSetup& setup){

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment4DProducer.h
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment4DProducer.h
@@ -40,10 +40,9 @@ private:
   bool debug;
 
   edm::EDGetTokenT<DTRecHitCollection> recHits1DToken_;
-  //static std::string theAlgoName;
   edm::EDGetTokenT<DTRecSegment2DCollection> recHits2DToken_;
   // The 4D-segments reconstruction algorithm
-  DTRecSegment4DBaseAlgo* the4DAlgo;
+  std::unique_ptr<DTRecSegment4DBaseAlgo> the4DAlgo;
 };
 #endif
 

--- a/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
@@ -45,15 +45,14 @@ using namespace edm;
 
 /// Constructor
 DTSegmentUpdator::DTSegmentUpdator(const ParameterSet& config) :
-  theFitter(new DTLinearFit()) ,
+  theFitter{std::make_unique<DTLinearFit>()},
+  theAlgo{DTRecHitAlgoFactory::get()->create(config.getParameter<string>("recAlgo"),
+                                             config.getParameter<ParameterSet>("recAlgoConfig"))},
   vdrift_4parfit(config.getParameter<bool>("performT0_vdriftSegCorrection")),
   T0_hit_resolution(config.getParameter<double>("hit_afterT0_resolution")),
   perform_delta_rejecting(config.getParameter<bool>("perform_delta_rejecting")),
   debug(config.getUntrackedParameter<bool>("debug",false)) 
 {  
-  string theAlgoName = config.getParameter<string>("recAlgo");
-  theAlgo = DTRecHitAlgoFactory::get()->create(theAlgoName, 
-                                               config.getParameter<ParameterSet>("recAlgoConfig"));
   intime_cut=20.;
   if (config.exists("intime_cut"))
     intime_cut = config.getParameter<double>("intime_cut");
@@ -63,9 +62,7 @@ DTSegmentUpdator::DTSegmentUpdator(const ParameterSet& config) :
 }
 
 /// Destructor
-DTSegmentUpdator::~DTSegmentUpdator() {
-  delete theFitter;
-}
+DTSegmentUpdator::~DTSegmentUpdator() = default;
 
 /* Operations */ 
 

--- a/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.h
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.h
@@ -79,8 +79,8 @@ class DTSegmentUpdator{
   protected:
 
   private:
-    DTLinearFit* theFitter; // the linear fitter
-    DTRecHitBaseAlgo* theAlgo; // the algo for hit reconstruction
+    std::unique_ptr<DTLinearFit> theFitter; // the linear fitter
+    std::unique_ptr<DTRecHitBaseAlgo> theAlgo; // the algo for hit reconstruction
     edm::ESHandle<DTGeometry> theGeom; // the geometry
 
     void updateHits(DTRecSegment2D* seg,

--- a/RecoLocalMuon/DTSegment/test/DTAnalyzerDetailed.cc
+++ b/RecoLocalMuon/DTSegment/test/DTAnalyzerDetailed.cc
@@ -60,11 +60,10 @@ using namespace std;
 /* ====================================================================== */
 
 /* Constructor */ 
-DTAnalyzerDetailed::DTAnalyzerDetailed(const ParameterSet& pset) : _ev(0){
-
-  theSync =
-    DTTTrigSyncFactory::get()->create(pset.getUntrackedParameter<string>("tTrigMode"),
-                                      pset.getUntrackedParameter<ParameterSet>("tTrigModeConfig"));
+DTAnalyzerDetailed::DTAnalyzerDetailed(const ParameterSet& pset) : _ev(0),
+  theSync{DTTTrigSyncFactory::get()->create(pset.getUntrackedParameter<string>("tTrigMode"),
+                                            pset.getUntrackedParameter<ParameterSet>("tTrigModeConfig"))}
+{
   // Get the debug parameter for verbose output
   debug = pset.getUntrackedParameter<bool>("debug");
   theRootFileName = pset.getUntrackedParameter<string>("rootFileName");
@@ -347,7 +346,7 @@ void DTAnalyzerDetailed::analyzeDTHits(const Event & event,
     DTSuperLayerId slid = (*sl)->id();
 
     DTMeanTimer meanTimer(dtGeom->superLayer(slid), dtRecHits, eventSetup,
-                          theSync);
+                          theSync.get());
     vector<double> tMaxs=meanTimer.run();
     for (vector<double>::const_iterator tMax=tMaxs.begin() ; tMax!=tMaxs.end();
          ++tMax) {
@@ -414,7 +413,7 @@ void DTAnalyzerDetailed::analyzeDTSegments(const Event & event,
 
         DTSuperLayerId slid1(phiSeg->chamberId(),1);
         /// Mean timer analysis
-        DTMeanTimer meanTimer1(dtGeom->superLayer(slid1), phiHits, eventSetup, theSync);
+        DTMeanTimer meanTimer1(dtGeom->superLayer(slid1), phiHits, eventSetup, theSync.get());
         vector<double> tMaxs1=meanTimer1.run();
         for (vector<double>::const_iterator tMax=tMaxs1.begin() ; tMax!=tMaxs1.end();
              ++tMax) {
@@ -431,7 +430,7 @@ void DTAnalyzerDetailed::analyzeDTSegments(const Event & event,
 
         DTSuperLayerId slid3(phiSeg->chamberId(),3);
         /// Mean timer analysis
-        DTMeanTimer meanTimer3(dtGeom->superLayer(slid3), phiHits, eventSetup, theSync);
+        DTMeanTimer meanTimer3(dtGeom->superLayer(slid3), phiHits, eventSetup, theSync.get());
         vector<double> tMaxs3=meanTimer3.run();
         for (vector<double>::const_iterator tMax=tMaxs3.begin() ; tMax!=tMaxs3.end();
              ++tMax) {
@@ -455,7 +454,7 @@ void DTAnalyzerDetailed::analyzeDTSegments(const Event & event,
         zedHits= zedSeg->specificRecHits();
         DTSuperLayerId slid(zedSeg->superLayerId());
         /// Mean timer analysis
-        DTMeanTimer meanTimer(dtGeom->superLayer(slid), zedHits, eventSetup, theSync);
+        DTMeanTimer meanTimer(dtGeom->superLayer(slid), zedHits, eventSetup, theSync.get());
         vector<double> tMaxs=meanTimer.run();
         for (vector<double>::const_iterator tMax=tMaxs.begin() ; tMax!=tMaxs.end();
              ++tMax) {

--- a/RecoLocalMuon/DTSegment/test/DTAnalyzerDetailed.h
+++ b/RecoLocalMuon/DTSegment/test/DTAnalyzerDetailed.h
@@ -91,10 +91,7 @@ class DTAnalyzerDetailed : public edm::EDAnalyzer {
     bool doHits;
     bool doSegs;
 
-    DTTTrigBaseSync *theSync;
-
-  protected:
-
+    std::unique_ptr<DTTTrigBaseSync> theSync;
 };
 #endif // DTANALYZER_H
 

--- a/RecoLocalMuon/DTSegment/test/DTSegAnalyzer.cc
+++ b/RecoLocalMuon/DTSegment/test/DTSegAnalyzer.cc
@@ -60,11 +60,10 @@ using namespace std;
 /* ====================================================================== */
 
 /* Constructor */ 
-DTSegAnalyzer::DTSegAnalyzer(const ParameterSet& pset) : _ev(0){
-
-  theSync =
-    DTTTrigSyncFactory::get()->create(pset.getUntrackedParameter<string>("tTrigMode"),
-                                      pset.getUntrackedParameter<ParameterSet>("tTrigModeConfig"));
+DTSegAnalyzer::DTSegAnalyzer(const ParameterSet& pset) : _ev(0),
+  theSync{DTTTrigSyncFactory::get()->create(pset.getUntrackedParameter<string>("tTrigMode"),
+                                            pset.getUntrackedParameter<ParameterSet>("tTrigModeConfig"))}
+{
   // Get the debug parameter for verbose output
   debug = pset.getUntrackedParameter<bool>("debug");
   theRootFileName = pset.getUntrackedParameter<string>("rootFileName");
@@ -214,7 +213,7 @@ void DTSegAnalyzer::analyzeDTHits(const Event & event,
     DTSuperLayerId slid = (*sl)->id();
 
     DTMeanTimer meanTimer(dtGeom->superLayer(slid), dtRecHits, eventSetup,
-                          theSync);
+                          theSync.get());
     vector<double> tMaxs=meanTimer.run();
     for (vector<double>::const_iterator tMax=tMaxs.begin() ; tMax!=tMaxs.end();
          ++tMax) {
@@ -278,7 +277,7 @@ void DTSegAnalyzer::analyzeDTSegments(const Event & event,
 
         DTSuperLayerId slid1(phiSeg->chamberId(),1);
         /// Mean timer analysis
-        DTMeanTimer meanTimer1(dtGeom->superLayer(slid1), phiHits, eventSetup, theSync);
+        DTMeanTimer meanTimer1(dtGeom->superLayer(slid1), phiHits, eventSetup, theSync.get());
         vector<double> tMaxs1=meanTimer1.run();
         for (vector<double>::const_iterator tMax=tMaxs1.begin() ; tMax!=tMaxs1.end();
              ++tMax) {
@@ -292,7 +291,7 @@ void DTSegAnalyzer::analyzeDTSegments(const Event & event,
 
         DTSuperLayerId slid3(phiSeg->chamberId(),3);
         /// Mean timer analysis
-        DTMeanTimer meanTimer3(dtGeom->superLayer(slid3), phiHits, eventSetup, theSync);
+        DTMeanTimer meanTimer3(dtGeom->superLayer(slid3), phiHits, eventSetup, theSync.get());
         vector<double> tMaxs3=meanTimer3.run();
         for (vector<double>::const_iterator tMax=tMaxs3.begin() ; tMax!=tMaxs3.end();
              ++tMax) {
@@ -313,7 +312,7 @@ void DTSegAnalyzer::analyzeDTSegments(const Event & event,
         zedHits= zedSeg->specificRecHits();
         DTSuperLayerId slid(zedSeg->superLayerId());
         /// Mean timer analysis
-        DTMeanTimer meanTimer(dtGeom->superLayer(slid), zedHits, eventSetup, theSync);
+        DTMeanTimer meanTimer(dtGeom->superLayer(slid), zedHits, eventSetup, theSync.get());
         vector<double> tMaxs=meanTimer.run();
         for (vector<double>::const_iterator tMax=tMaxs.begin() ; tMax!=tMaxs.end();
              ++tMax) {

--- a/RecoLocalMuon/DTSegment/test/DTSegAnalyzer.h
+++ b/RecoLocalMuon/DTSegment/test/DTSegAnalyzer.h
@@ -91,10 +91,7 @@ class DTSegAnalyzer : public edm::EDAnalyzer {
     bool doHits;
     bool doSegs;
 
-    DTTTrigBaseSync *theSync;
-
-  protected:
-
+    std::unique_ptr<DTTTrigBaseSync> theSync;
 };
 #endif // DTANALYZER_H
 

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilder.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilder.cc
@@ -30,24 +30,17 @@
 #include <DataFormats/GEMRecHit/interface/GEMRecHitCollection.h>
 
 
-GEMCSCSegmentBuilder::GEMCSCSegmentBuilder(const edm::ParameterSet& ps) : gemgeom_(nullptr), cscgeom_(nullptr) 
-{
-
-    // Algo name
-    std::string algoName = ps.getParameter<std::string>("algo_name");
-    edm::LogVerbatim("GEMCSCSegmentBuilder")<< "[GEMCSCSegmentBuilder :: ctor] algorithm name: " << algoName;
-
-    // SegAlgo parameter set 	  
-    edm::ParameterSet segAlgoPSet = ps.getParameter<edm::ParameterSet>("algo_psets");
- 
+GEMCSCSegmentBuilder::GEMCSCSegmentBuilder(const edm::ParameterSet& ps) :
     // Ask factory to build this algorithm, giving it appropriate ParameterSet
-    algo = GEMCSCSegmentBuilderPluginFactory::get()->create(algoName, segAlgoPSet);
-
+  algo{GEMCSCSegmentBuilderPluginFactory::get()->create(ps.getParameter<std::string>("algo_name"),
+                                                        ps.getParameter<edm::ParameterSet>("algo_psets"))},
+  gemgeom_{nullptr}, cscgeom_{nullptr}
+{
+    edm::LogVerbatim("GEMCSCSegmentBuilder")<< "[GEMCSCSegmentBuilder :: ctor] algorithm name: " << ps.getParameter<std::string>("algo_name");
 }
 
 GEMCSCSegmentBuilder::~GEMCSCSegmentBuilder() 
 {
-    delete algo;
     edm::LogVerbatim("GEMCSCSegmentBuilder")<<"[GEMCSCSegmentBuilder :: dstor] deleted the algorithm";
 }
 

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilder.h
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilder.h
@@ -81,7 +81,7 @@ class GEMCSCSegmentBuilder {
   std::map<CSCStationIndex,std::set<GEMDetId> > rollstoreCSC;
 
  private:
-  GEMCSCSegmentAlgorithm* algo;
+  std::unique_ptr<GEMCSCSegmentAlgorithm> algo;
   const GEMGeometry* gemgeom_;
   const CSCGeometry* cscgeom_;
   

--- a/RecoLocalMuon/GEMRecHit/src/GEMRecHitProducer.cc
+++ b/RecoLocalMuon/GEMRecHit/src/GEMRecHitProducer.cc
@@ -34,19 +34,18 @@ using namespace edm;
 using namespace std;
 
 
-GEMRecHitProducer::GEMRecHitProducer(const ParameterSet& config){
+GEMRecHitProducer::GEMRecHitProducer(const ParameterSet& config):
+  // Get the concrete reconstruction algo from the factory
+  theAlgo{GEMRecHitAlgoFactory::get()->create(config.getParameter<string>("recAlgo"),
+                                              config.getParameter<ParameterSet>("recAlgoConfig"))}
+{
+
 
   // Set verbose output
 
   produces<GEMRecHitCollection>();
 
   theGEMDigiToken = consumes<GEMDigiCollection>(config.getParameter<edm::InputTag>("gemDigiLabel"));  
-
-  // Get the concrete reconstruction algo from the factory
-
-  string theAlgoName = config.getParameter<string>("recAlgo");
-  theAlgo = GEMRecHitAlgoFactory::get()->create(theAlgoName,
-						config.getParameter<ParameterSet>("recAlgoConfig"));
 
   // Get masked- and dead-strip information
 
@@ -91,15 +90,7 @@ GEMRecHitProducer::GEMRecHitProducer(const ParameterSet& config){
 }
 
 
-GEMRecHitProducer::~GEMRecHitProducer(){
-
-  delete theAlgo;
-  // delete GEMMaskedStripsObj;
-  // delete GEMDeadStripsObj;
-
-}
-
-
+GEMRecHitProducer::~GEMRecHitProducer() = default;
 
 void GEMRecHitProducer::beginRun(const edm::Run& r, const edm::EventSetup& setup){
 

--- a/RecoLocalMuon/GEMRecHit/src/GEMRecHitProducer.h
+++ b/RecoLocalMuon/GEMRecHit/src/GEMRecHitProducer.h
@@ -58,8 +58,7 @@ private:
   edm::EDGetTokenT<GEMDigiCollection> theGEMDigiToken;
 
   // The reconstruction algorithm
-  GEMRecHitBaseAlgo *theAlgo;
-  //   static std::string theAlgoName;
+  std::unique_ptr<GEMRecHitBaseAlgo> theAlgo;
 
   // GEMMaskedStrips* GEMMaskedStripsObj;
   // Object with mask-strips-vector for all the GEM Detectors

--- a/RecoLocalMuon/GEMRecHit/src/ME0RecHitProducer.cc
+++ b/RecoLocalMuon/GEMRecHit/src/ME0RecHitProducer.cc
@@ -8,31 +8,17 @@
 #include "ME0RecHitProducer.h"
 
 
-ME0RecHitProducer::ME0RecHitProducer(const edm::ParameterSet& config){
-
+ME0RecHitProducer::ME0RecHitProducer(const edm::ParameterSet& config):
+  // Get the concrete reconstruction algo from the factory
+  theAlgo{ME0RecHitAlgoFactory::get()->create(config.getParameter<std::string>("recAlgo"),
+                                              config.getParameter<edm::ParameterSet>("recAlgoConfig"))}
+{
   produces<ME0RecHitCollection>();
  
   m_token = consumes<ME0DigiPreRecoCollection>( config.getParameter<edm::InputTag>("me0DigiLabel") ); 
-
- 
-  // Get the concrete reconstruction algo from the factory
-
-  std::string theAlgoName = config.getParameter<std::string>("recAlgo");
-  theAlgo = ME0RecHitAlgoFactory::get()->create(theAlgoName,
-						config.getParameter<edm::ParameterSet>("recAlgoConfig"));
 }
 
-
-ME0RecHitProducer::~ME0RecHitProducer(){
-  delete theAlgo;
-}
-
-
-
-void ME0RecHitProducer::beginRun(const edm::Run& r, const edm::EventSetup& setup){
-}
-
-
+ME0RecHitProducer::~ME0RecHitProducer() = default;
 
 void ME0RecHitProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
 

--- a/RecoLocalMuon/GEMRecHit/src/ME0RecHitProducer.h
+++ b/RecoLocalMuon/GEMRecHit/src/ME0RecHitProducer.h
@@ -50,9 +50,6 @@ public:
   /// Destructor
   ~ME0RecHitProducer() override;
 
-  // Method that access the EventSetup for each run
-  void beginRun(const edm::Run&, const edm::EventSetup& ) override;
-
   /// The method which produces the rechits
   void produce(edm::Event& event, const edm::EventSetup& setup) override;
 
@@ -63,8 +60,7 @@ private:
   edm::EDGetTokenT<ME0DigiPreRecoCollection> m_token;
 
   // The reconstruction algorithm
-  ME0RecHitBaseAlgo *theAlgo;
-  //   static std::string theAlgoName;
+  std::unique_ptr<ME0RecHitBaseAlgo> theAlgo;
 };
 
 #endif

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.cc
@@ -28,15 +28,13 @@ using namespace std;
 
 RPCRecHitProducer::RPCRecHitProducer(const ParameterSet& config):
   theRPCDigiLabel(consumes<RPCDigiCollection>(config.getParameter<InputTag>("rpcDigiLabel"))),
+  // Get the concrete reconstruction algo from the factory
+  theAlgo{RPCRecHitAlgoFactory::get()->create(config.getParameter<string>("recAlgo"),
+                                              config.getParameter<ParameterSet>("recAlgoConfig"))},
   maskSource_(MaskSource::EventSetup), deadSource_(MaskSource::EventSetup)
 {
   // Set verbose output
   produces<RPCRecHitCollection>();
-
-  // Get the concrete reconstruction algo from the factory
-  const string theAlgoName = config.getParameter<string>("recAlgo");
-  theAlgo.reset(RPCRecHitAlgoFactory::get()->create(theAlgoName,
-                config.getParameter<ParameterSet>("recAlgoConfig")));
 
   // Get masked- and dead-strip information
   theRPCMaskedStripsObj = std::make_unique<RPCMaskedStrips>();


### PR DESCRIPTION
Changed also some other raw pointers to `unique_ptr`, and used `unique_ptr` constructor in `RPCRecHitProducer`. This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-02-05-1100 , no changes expected.