### PR TITLE
Manage PluginFactory plugins with unique_ptr in SimMuon

### DIFF
--- a/SimMuon/DTDigitizer/src/DTDigitizer.cc
+++ b/SimMuon/DTDigitizer/src/DTDigitizer.cc
@@ -54,7 +54,11 @@ using namespace edm;
 using namespace std;
 
 // Constructor
-DTDigitizer::DTDigitizer(const ParameterSet& conf_) {
+DTDigitizer::DTDigitizer(const ParameterSet& conf_):
+  // Sync Algo
+  theSync{DTDigiSyncFactory::get()->create(conf_.getParameter<string>("SyncName"),
+                                           conf_.getParameter<ParameterSet>("pset"))}
+ {
   
   // Set verbose output
   debug=conf_.getUntrackedParameter<bool>("debug"); 
@@ -86,10 +90,6 @@ DTDigitizer::DTDigitizer(const ParameterSet& conf_) {
   
   // further configurable smearing
   smearing=conf_.getParameter<double>("Smearing"); // 3.
-
-  // Sync Algo
-  syncName = conf_.getParameter<string>("SyncName");
-  theSync.reset( DTDigiSyncFactory::get()->create(syncName,conf_.getParameter<ParameterSet>("pset")) );
 
   // Debug flag to switch to the Ideal model
   // it uses a constant drift velocity and doesn't set any external delay

--- a/SimMuon/GEMDigitizer/interface/GEMDigiProducer.h
+++ b/SimMuon/GEMDigitizer/interface/GEMDigiProducer.h
@@ -38,8 +38,7 @@ private:
   //Name of Collection used for create the XF 
   edm::EDGetTokenT<CrossingFrame<PSimHit> > cf_token; 
   
-  std::string digiModelString_;
-  GEMDigiModel* gemDigiModel_;
+  std::unique_ptr<GEMDigiModel> gemDigiModel_;
 };
 
 #endif

--- a/SimMuon/GEMDigitizer/interface/ME0DigiPreRecoProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0DigiPreRecoProducer.h
@@ -32,7 +32,7 @@ private:
   edm::EDGetTokenT<CrossingFrame<PSimHit> > cf_token; 
 
   std::string digiPreRecoModelString_;
-  ME0DigiPreRecoModel* me0DigiPreRecoModel_;
+  std::unique_ptr<ME0DigiPreRecoModel> me0DigiPreRecoModel_;
 };
 
 #endif

--- a/SimMuon/GEMDigitizer/interface/ME0DigiProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0DigiProducer.h
@@ -38,8 +38,7 @@ private:
   //Name of Collection used for create the XF 
   edm::EDGetTokenT<CrossingFrame<PSimHit> > cf_token; 
   
-  std::string me0digiModelString_;
-  ME0DigiModel* ME0DigiModel_;
+  std::unique_ptr<ME0DigiModel> ME0DigiModel_;
 };
 
 #endif

--- a/SimMuon/GEMDigitizer/src/GEMDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/GEMDigiProducer.cc
@@ -27,7 +27,8 @@ namespace CLHEP {
 }
 
 GEMDigiProducer::GEMDigiProducer(const edm::ParameterSet& ps)
-  : digiModelString_(ps.getParameter<std::string>("digiModelString"))
+  : gemDigiModel_{GEMDigiModelFactory::get()->create("GEM" + ps.getParameter<std::string>("digiModelString") + "Model",
+                                                     ps)}
 {
   produces<GEMDigiCollection>();
   produces<StripDigiSimLinks>("GEM");
@@ -39,8 +40,8 @@ GEMDigiProducer::GEMDigiProducer(const edm::ParameterSet& ps)
       << "GEMDigiProducer::GEMDigiProducer() - RandomNumberGeneratorService is not present in configuration file.\n"
       << "Add the service in the configuration file or remove the modules that require it.";
   }
-  gemDigiModel_ = GEMDigiModelFactory::get()->create("GEM" + digiModelString_ + "Model", ps);
-  LogDebug("GEMDigiProducer") << "Using GEM" + digiModelString_ + "Model";
+
+  LogDebug("GEMDigiProducer").log([&](auto& l){ l << "Using GEM" + ps.getParameter<std::string>("digiModelString") + "Model"; });
 
   std::string mix_(ps.getParameter<std::string>("mixLabel"));
   std::string collection_(ps.getParameter<std::string>("inputCollection"));
@@ -49,10 +50,7 @@ GEMDigiProducer::GEMDigiProducer(const edm::ParameterSet& ps)
 }
 
 
-GEMDigiProducer::~GEMDigiProducer()
-{
-  delete gemDigiModel_;
-}
+GEMDigiProducer::~GEMDigiProducer() = default;
 
 
 void GEMDigiProducer::beginRun(const edm::Run&, const edm::EventSetup& eventSetup)
@@ -72,16 +70,16 @@ void GEMDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup)
   edm::Handle<CrossingFrame<PSimHit> > cf;
   e.getByToken(cf_token, cf);
 
-  std::unique_ptr<MixCollection<PSimHit> > hits(new MixCollection<PSimHit>(cf.product()));
+  MixCollection<PSimHit> hits{cf.product()};
 
   // Create empty output
-  std::unique_ptr<GEMDigiCollection> digis(new GEMDigiCollection());
-  std::unique_ptr<StripDigiSimLinks> stripDigiSimLinks(new StripDigiSimLinks() );
-  std::unique_ptr<GEMDigiSimLinks> gemDigiSimLinks(new GEMDigiSimLinks() );
+  auto digis = std::make_unique<GEMDigiCollection>();
+  auto stripDigiSimLinks = std::make_unique<StripDigiSimLinks>();
+  auto gemDigiSimLinks = std::make_unique<GEMDigiSimLinks>();
 
   // arrange the hits by eta partition
   std::map<uint32_t, edm::PSimHitContainer> hitMap;
-  for (const auto& hit: *hits){
+  for (const auto& hit: hits){
     hitMap[hit.detUnitId()].emplace_back(hit);
   }
 

--- a/SimMuon/GEMDigitizer/src/GEMDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/GEMDigiProducer.cc
@@ -41,7 +41,7 @@ GEMDigiProducer::GEMDigiProducer(const edm::ParameterSet& ps)
       << "Add the service in the configuration file or remove the modules that require it.";
   }
 
-  LogDebug("GEMDigiProducer").log([&](auto& l){ l << "Using GEM" + ps.getParameter<std::string>("digiModelString") + "Model"; });
+  LogDebug("GEMDigiProducer") << "Using GEM" + ps.getParameter<std::string>("digiModelString") + "Model";
 
   std::string mix_(ps.getParameter<std::string>("mixLabel"));
   std::string collection_(ps.getParameter<std::string>("inputCollection"));

--- a/SimMuon/GEMDigitizer/src/ME0DigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0DigiProducer.cc
@@ -27,7 +27,8 @@ namespace CLHEP {
 }
 
 ME0DigiProducer::ME0DigiProducer(const edm::ParameterSet& ps)
-  : me0digiModelString_(ps.getParameter<std::string>("digiModelString"))
+  : ME0DigiModel_{ME0DigiModelFactory::get()->create("ME0" + ps.getParameter<std::string>("digiModelString") + "Model",
+                                                     ps)}
 {
   produces<ME0DigiCollection>();
   produces<StripDigiSimLinks>("ME0");
@@ -39,8 +40,8 @@ ME0DigiProducer::ME0DigiProducer(const edm::ParameterSet& ps)
       << "ME0DigiProducer::ME0DigiProducer() - RandomNumberGeneratorService is not present in configuration file.\n"
       << "Add the service in the configuration file or remove the modules that require it.";
   }
-  ME0DigiModel_ = ME0DigiModelFactory::get()->create("ME0" + me0digiModelString_ + "Model", ps);
-  LogDebug("ME0DigiProducer") << "Using ME0" + me0digiModelString_ + "Model";
+
+  LogDebug("ME0DigiProducer").log([&](auto& l) { l << "Using ME0" + ps.getParameter<std::string>("digiModelString") + "Model"; });
 
   std::string mix_(ps.getParameter<std::string>("mixLabel"));
   std::string collection_(ps.getParameter<std::string>("inputCollection"));
@@ -49,10 +50,7 @@ ME0DigiProducer::ME0DigiProducer(const edm::ParameterSet& ps)
 }
 
 
-ME0DigiProducer::~ME0DigiProducer()
-{
-  delete ME0DigiModel_;
-}
+ME0DigiProducer::~ME0DigiProducer() = default;
 
 
 void ME0DigiProducer::beginRun(const edm::Run&, const edm::EventSetup& eventSetup)
@@ -72,16 +70,16 @@ void ME0DigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup)
   edm::Handle<CrossingFrame<PSimHit> > cf;
   e.getByToken(cf_token, cf);
 
-  std::unique_ptr<MixCollection<PSimHit> > hits(new MixCollection<PSimHit>(cf.product()));
+  MixCollection<PSimHit> hits{cf.product()};
 
   // Create empty output
-  std::unique_ptr<ME0DigiCollection> digis(new ME0DigiCollection());
-  std::unique_ptr<StripDigiSimLinks> stripDigiSimLinks(new StripDigiSimLinks() );
-  std::unique_ptr<ME0DigiSimLinks> me0DigiSimLinks(new ME0DigiSimLinks() );
+  auto digis = std::make_unique<ME0DigiCollection>();
+  auto stripDigiSimLinks = std::make_unique<StripDigiSimLinks>();
+  auto me0DigiSimLinks = std::make_unique<ME0DigiSimLinks>();
 
   // arrange the hits by eta partition
   std::map<uint32_t, edm::PSimHitContainer> hitMap;
-  for (const auto& hit: *hits){
+  for (const auto& hit: hits){
     hitMap[hit.detUnitId()].emplace_back(hit);
   }
 

--- a/SimMuon/GEMDigitizer/src/ME0DigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0DigiProducer.cc
@@ -41,7 +41,7 @@ ME0DigiProducer::ME0DigiProducer(const edm::ParameterSet& ps)
       << "Add the service in the configuration file or remove the modules that require it.";
   }
 
-  LogDebug("ME0DigiProducer").log([&](auto& l) { l << "Using ME0" + ps.getParameter<std::string>("digiModelString") + "Model"; });
+  LogDebug("ME0DigiProducer") << "Using ME0" + ps.getParameter<std::string>("digiModelString") + "Model";
 
   std::string mix_(ps.getParameter<std::string>("mixLabel"));
   std::string collection_(ps.getParameter<std::string>("inputCollection"));

--- a/SimMuon/RPCDigitizer/src/IRPCDigitizer.cc
+++ b/SimMuon/RPCDigitizer/src/IRPCDigitizer.cc
@@ -9,17 +9,14 @@
 
 // default constructor allocates default wire and strip digitizers
 
-IRPCDigitizer::IRPCDigitizer(const edm::ParameterSet& config) {
-  theName = config.getParameter<std::string>("digiIRPCModel");
-  theRPCSim = RPCSimFactory::get()->create(theName,config.getParameter<edm::ParameterSet>("digiIRPCModelConfig"));
+IRPCDigitizer::IRPCDigitizer(const edm::ParameterSet& config):
+  theRPCSim{RPCSimFactory::get()->create(config.getParameter<std::string>("digiIRPCModel"),
+                                         config.getParameter<edm::ParameterSet>("digiIRPCModelConfig"))}
+{
   theNoise=config.getParameter<bool>("doBkgNoise");
 }
 
-IRPCDigitizer::~IRPCDigitizer() {
-  if( theRPCSim )
-    delete theRPCSim;
-  theRPCSim = nullptr;
-}
+IRPCDigitizer::~IRPCDigitizer() = default;
 
 void IRPCDigitizer::doAction(MixCollection<PSimHit> & simHits, 
                             RPCDigiCollection & rpcDigis,

--- a/SimMuon/RPCDigitizer/src/IRPCDigitizer.h
+++ b/SimMuon/RPCDigitizer/src/IRPCDigitizer.h
@@ -55,7 +55,7 @@ public:
 
 private:
   const RPCGeometry * theGeometry;
-  RPCSim* theRPCSim;
+  std::unique_ptr<RPCSim> theRPCSim;
   RPCSimSetUp * theSimSetUp;
   std::string theName;
   bool theNoise;

--- a/SimMuon/RPCDigitizer/src/RPCDigitizer.cc
+++ b/SimMuon/RPCDigitizer/src/RPCDigitizer.cc
@@ -9,17 +9,13 @@
 
 // default constructor allocates default wire and strip digitizers
 
-RPCDigitizer::RPCDigitizer(const edm::ParameterSet& config) {
-  theName = config.getParameter<std::string>("digiModel");
-  theRPCSim = RPCSimFactory::get()->create(theName,config.getParameter<edm::ParameterSet>("digiModelConfig"));
-  theNoise=config.getParameter<bool>("doBkgNoise");
-}
+RPCDigitizer::RPCDigitizer(const edm::ParameterSet& config):
+  theRPCSim{RPCSimFactory::get()->create(config.getParameter<std::string>("digiModel"),
+                                         config.getParameter<edm::ParameterSet>("digiModelConfig"))},
+  theNoise{config.getParameter<bool>("doBkgNoise")}
+{}
 
-RPCDigitizer::~RPCDigitizer() {
-  if( theRPCSim )
-    delete theRPCSim;
-  theRPCSim = nullptr;
-}
+RPCDigitizer::~RPCDigitizer() = default;
 
 void RPCDigitizer::doAction(MixCollection<PSimHit> & simHits, 
                             RPCDigiCollection & rpcDigis,

--- a/SimMuon/RPCDigitizer/src/RPCDigitizer.h
+++ b/SimMuon/RPCDigitizer/src/RPCDigitizer.h
@@ -55,9 +55,8 @@ public:
 
 private:
   const RPCGeometry * theGeometry;
-  RPCSim* theRPCSim;
+  std::unique_ptr<RPCSim> theRPCSim;
   RPCSimSetUp * theSimSetUp;
-  std::string theName;
   bool theNoise;
 };
 


### PR DESCRIPTION
Also some further cleanup. This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-02-05-1100 , no changes expected.