### PR TITLE
Add support for EDAlias as a case in SwitchProducer

### DIFF
--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -59,6 +59,8 @@ namespace edm {
                    std::set<TypeID> const& elementTypesConsumed,
                    std::string const& processName);
 
+    void setUnscheduledProducts(std::set<std::string> const& unscheduledLabels);
+
     std::string merge(ProductRegistry const& other,
         std::string const& fileName,
         BranchDescription::MatchMode branchesMustMatch = BranchDescription::Permissive);

--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -254,7 +254,7 @@ namespace edm {
     }
 
     branchAliases_ = aliasForBranch.branchAliases();
-    transient_.switchAliasForBranchID_ = aliasForBranch.branchID();
+    transient_.switchAliasForBranchID_ = aliasForBranch.originalBranchID();
     transient_.availableOnlyAtEndTransition_ = aliasForBranch.availableOnlyAtEndTransition();
   }
 

--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -100,7 +100,7 @@ namespace edm {
       transient_() {
     setDropped(false);
     setProduced(aliasForBranch.produced());
-    setOnDemand(aliasForBranch.onDemand());
+    setOnDemand(false); // will be re-set externally to the aliasForBranch.onDemand() after that one has been set
     transient_.availableOnlyAtEndTransition_=aliasForBranch.availableOnlyAtEndTransition();
     transient_.moduleName_ = aliasForBranch.moduleName();
     transient_.parameterSetID_ = aliasForBranch.parameterSetID();

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -46,8 +46,6 @@ namespace edm {
                                  std::set<std::string>& unscheduledLabels,
                                  std::vector<std::string>& shouldBeUsedLabels);
 
-    void setOnDemandProducts(ProductRegistry& pregistry, std::set<std::string> const& unscheduledLabels) const;
-
     template <typename T, typename U>
       void processOneOccurrence(typename T::MyPrincipal& principal,
                                 EventSetupImpl const& eventSetup,

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -656,7 +656,7 @@ namespace edm {
   }
   
 
-  SwitchBaseProductResolver::SwitchBaseProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct):
+  SwitchBaseProductResolver::SwitchBaseProductResolver(std::shared_ptr<BranchDescription const> bd, DataManagingOrAliasProductResolver& realProduct):
     realProduct_(realProduct),
     productData_(std::move(bd)),
     prefetchRequested_(false),
@@ -664,7 +664,7 @@ namespace edm {
   {
     // Parentage of this branch is always the same by construction, so we can compute the ID just "once" here.
     Parentage p;
-    p.setParents(std::vector<BranchID>{realProduct.branchDescription().branchID()});
+    p.setParents(std::vector<BranchID>{realProduct.branchDescription().originalBranchID()});
     parentageID_ = p.id();
     ParentageRegistry::instance()->insertMapped(p);
   }

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -33,7 +33,15 @@ namespace edm {
   class Worker;
   class ServiceToken;
 
-  class DataManagingProductResolver : public ProductResolverBase {
+  class DataManagingOrAliasProductResolver: public ProductResolverBase {
+  public:
+    DataManagingOrAliasProductResolver(): ProductResolverBase{} {}
+
+    // Give AliasProductResolver and SwitchBaseProductResolver access by moving this method to public
+    void resetProductData_(bool deleteEarly) override = 0;
+  };
+
+  class DataManagingProductResolver : public DataManagingOrAliasProductResolver {
   public:
     enum class ProductStatus {
       ProductSet,
@@ -43,7 +51,7 @@ namespace edm {
       ProductDeleted
     };
 
-    DataManagingProductResolver(std::shared_ptr<BranchDescription const> bd,ProductStatus iDefaultStatus): ProductResolverBase(),
+    DataManagingProductResolver(std::shared_ptr<BranchDescription const> bd,ProductStatus iDefaultStatus): DataManagingOrAliasProductResolver(),
     productData_(bd),
     theStatus_(iDefaultStatus),
     defaultStatus_(iDefaultStatus){}
@@ -52,7 +60,6 @@ namespace edm {
 
     void resetStatus() {theStatus_ = defaultStatus_;}
 
-    //Give AliasProductResolver access
     void resetProductData_(bool deleteEarly) override;
 
   protected:
@@ -204,10 +211,10 @@ namespace edm {
       mutable std::atomic<bool> prefetchRequested_;
   };
 
-  class AliasProductResolver : public ProductResolverBase {
+  class AliasProductResolver : public DataManagingOrAliasProductResolver {
     public:
       typedef ProducedProductResolver::ProductStatus ProductStatus;
-      explicit AliasProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct) : ProductResolverBase(), realProduct_(realProduct), bd_(bd) {}
+      explicit AliasProductResolver(std::shared_ptr<BranchDescription const> bd, DataManagingOrAliasProductResolver& realProduct) : DataManagingOrAliasProductResolver(), realProduct_(realProduct), bd_(bd) {}
 
       void connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) final {
         realProduct_.connectTo(iOther, iParentPrincipal );
@@ -249,15 +256,15 @@ namespace edm {
       void resetProductData_(bool deleteEarly) override;
       bool singleProduct_() const override;
 
-      ProducedProductResolver& realProduct_;
+      DataManagingOrAliasProductResolver& realProduct_;
       std::shared_ptr<BranchDescription const> bd_;
   };
 
   // Switch is a mixture of DataManaging (for worker and provenance) and Alias (for product)
-  class SwitchBaseProductResolver: public ProductResolverBase {
+  class SwitchBaseProductResolver: public DataManagingOrAliasProductResolver {
   public:
     using ProductStatus = DataManagingProductResolver::ProductStatus;
-    SwitchBaseProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct);
+    SwitchBaseProductResolver(std::shared_ptr<BranchDescription const> bd, DataManagingOrAliasProductResolver& realProduct);
 
     void connectTo(ProductResolverBase const& iOther, Principal const *iParentPrincipal) final;
     void setupUnscheduled(UnscheduledConfigurator const& iConfigure) final;
@@ -267,7 +274,7 @@ namespace edm {
     WaitingTaskList& waitingTasks() const {return waitingTasks_;}
     Worker *worker() const {return worker_;}
     ProductStatus status() const {return status_;}
-    ProducedProductResolver const& realProduct() const {return realProduct_;}
+    DataManagingOrAliasProductResolver const& realProduct() const {return realProduct_;}
     std::atomic<bool>& prefetchRequested() const {return prefetchRequested_;}
     
   private:
@@ -289,7 +296,7 @@ namespace edm {
     constexpr static const ProductStatus defaultStatus_ = ProductStatus::NotPut;
 
     // for "alias" view
-    ProducedProductResolver& realProduct_;
+    DataManagingOrAliasProductResolver& realProduct_;
     // for "product" view
     ProductData productData_;
     Worker *worker_ = nullptr;
@@ -304,7 +311,7 @@ namespace edm {
   // For the case when SwitchProducer is on a Path
   class SwitchProducerProductResolver: public SwitchBaseProductResolver {
   public:
-    SwitchProducerProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct):
+    SwitchProducerProductResolver(std::shared_ptr<BranchDescription const> bd, DataManagingOrAliasProductResolver& realProduct):
       SwitchBaseProductResolver(std::move(bd), realProduct) {}
   private:
     Resolution resolveProduct_(Principal const& principal,
@@ -324,7 +331,7 @@ namespace edm {
   // For the case when SwitchProducer is not on any Path
   class SwitchAliasProductResolver: public SwitchBaseProductResolver {
   public:
-    SwitchAliasProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct):
+    SwitchAliasProductResolver(std::shared_ptr<BranchDescription const> bd, DataManagingOrAliasProductResolver& realProduct):
       SwitchBaseProductResolver(std::move(bd), realProduct) {}
   private:
     Resolution resolveProduct_(Principal const& principal,

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -648,7 +648,6 @@ namespace edm {
 
     // At this point all BranchDescriptions are created. Mark now the
     // ones of unscheduled workers to be on-demand.
-    // TODO: what to do for alias branches???
     if(nUnscheduledModules > 0) {
       std::vector<std::string> unscheduledModules(modulesToUse.begin(), modulesToUse.begin()+nUnscheduledModules);
       std::sort(unscheduledModules.begin(), unscheduledModules.end());

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -184,6 +184,17 @@ namespace edm {
         }
       }
 
+      if(auto iter = aliasMap.find(key); iter != aliasMap.end()) {
+        // If the same EDAlias defines multiple products pointing to the same product, throw
+        if(iter->second.moduleLabel() == alias) {
+          throw Exception(errors::Configuration, "EDAlias conflict\n")
+            << "The module label alias '" << alias << "' is used for multiple products of type '"
+            << friendlyClassName << "' with module label '" << moduleLabel << "' and instance name '"
+            << productInstanceName << "'. One alias has the instance name '" << iter->first.productInstanceName()
+            << "' and the other has the instance name '" << instanceAlias << "'.";
+        }
+      }
+
       std::string const& theInstanceAlias(instanceAlias == star ? productInstanceName : instanceAlias);
       BranchKey aliasKey(friendlyClassName, alias, theInstanceAlias, processName);
       if(preg.productList().find(aliasKey) != preg.productList().end()) {

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -234,11 +234,7 @@ namespace edm {
           << "\n";
       }
     }
-    if (!unscheduledLabels.empty()) {
-      number_of_unscheduled_modules_=unscheduledLabels.size();
-      workerManager_.setOnDemandProducts(preg, unscheduledLabels);
-    }
-
+    number_of_unscheduled_modules_ = unscheduledLabels.size();
 
     initializeEarlyDelete(*modReg, opts,preg,allowEarlyDelete);
     

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -67,16 +67,6 @@ namespace edm {
     }
   }
 
-  void WorkerManager::setOnDemandProducts(ProductRegistry& pregistry, std::set<std::string> const& unscheduledLabels) const {
-    for(auto& prod : pregistry.productListUpdator()) {
-      if(prod.second.produced() &&
-          prod.second.branchType() == InEvent &&
-          unscheduledLabels.end() != unscheduledLabels.find(prod.second.moduleLabel())) {
-        prod.second.setOnDemand(true);
-      }
-    }
-  }
-  
   void WorkerManager::endJob() {
     for(auto& worker : allWorkers_) {
       worker->endJob();

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -114,6 +114,10 @@
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_TestSwitchProducer.sh"/>
     <use   name="FWCore/Utilities"/>
   </bin>
+  <bin   file="TestIntegration.cpp" name="TestIntegration_TestEDAlias">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_TestEDAlias.sh"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
   <bin   file="TestIntegration.cpp" name="CatchStdExceptiontest">
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test CatchStdExceptiontest.sh"/>
     <use   name="FWCore/Utilities"/>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -139,6 +139,13 @@
     <use   name="DataFormats/Provenance"/>
     <use   name="catch2"/>
   </bin>
+  <bin   file="EDAlias_t.cpp">
+    <use   name="FWCore/Framework"/>
+    <use   name="FWCore/ParameterSet"/>
+    <use   name="FWCore/TestProcessor"/>
+    <use   name="DataFormats/Provenance"/>
+    <use   name="catch2"/>
+  </bin>
   <library   file="TestPSetAnalyzer.cc" name="TestPSetAnalyzer">
     <flags   EDM_PLUGIN="1"/>
     <use   name="DataFormats/Provenance"/>

--- a/FWCore/Integration/test/EDAlias_t.cpp
+++ b/FWCore/Integration/test/EDAlias_t.cpp
@@ -1,0 +1,114 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+
+#include <iostream>
+
+static constexpr auto s_tag = "[EDAlias]";
+
+TEST_CASE("Configuration", s_tag) {
+  const std::string baseConfig{
+R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+process = TestProcess()
+
+process.intprod = cms.EDProducer('IntProducer', ivalue = cms.int32(1))
+process.intalias = cms.EDAlias(intprod = cms.VPSet(cms.PSet(type = cms.string('edmtestIntProduct'))))
+
+# Module to be tested can not be an EDAlias
+process.test = cms.EDProducer('AddIntsProducer', labels = cms.vstring('intalias'))
+
+process.moduleToTest(process.test, cms.Task(process.intprod))
+)_"};
+
+  edm::test::TestProcessor::Config config{ baseConfig };
+
+  SECTION("Base configuration is OK") {
+    REQUIRE_NOTHROW(edm::test::TestProcessor(config));
+  }
+
+  SECTION("No event data") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.test());
+  }
+
+  SECTION("beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+
+  SECTION("LuminosityBlock with no Events") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  }
+
+  SECTION("Getting value") {
+    edm::test::TestProcessor tester(config);
+    auto event = tester.test();
+    REQUIRE(event.get<edmtest::IntProduct>()->value == 1);
+  }
+}
+
+TEST_CASE("Configuration with two instance aliases to a single product", s_tag) {
+  const std::string baseConfig{
+R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+process = TestProcess()
+
+process.intprod = cms.EDProducer('IntProducer', ivalue = cms.int32(1))
+process.intalias = cms.EDAlias(intprod = cms.VPSet(cms.PSet(type = cms.string('edmtestIntProduct')),
+                                                   cms.PSet(type = cms.string('edmtestIntProduct'),
+                                                            fromProductInstance = cms.string(''),
+                                                            toProductInstance = cms.string('bar'))
+                                                  )
+)
+
+# Module to be tested can not be an EDAlias
+process.test = cms.EDProducer('AddIntsProducer', labels = cms.vstring('intalias', 'intalias:bar'))
+
+process.moduleToTest(process.test, cms.Task(process.intprod))
+)_"};
+
+  edm::test::TestProcessor::Config config{ baseConfig };
+
+  SECTION("Alias with two instances pointing to the same product is not allowed") {
+    REQUIRE_THROWS_WITH(edm::test::TestProcessor(config), Catch::Contains("EDAlias conflict") && Catch::Contains("is used for multiple products of type") && Catch::Contains("with module label") && Catch::Contains("and instance name") && Catch::Contains("alias has the instance name") && Catch::Contains("and the other has the instance name"));
+  }
+}
+
+TEST_CASE("Configuration with two identical aliases pointing to different products") {
+  const std::string baseConfig{
+R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+process = TestProcess()
+
+process.intprod = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(3))))
+process.intalias = cms.EDAlias(intprod = cms.VPSet(cms.PSet(type = cms.string('edmtestIntProduct'), toProductInstance = cms.string(''), fromProductInstance = cms.string('')),
+                                                   cms.PSet(type = cms.string('edmtestIntProduct'), toProductInstance = cms.string(''), fromProductInstance = cms.string('foo'))
+                                                  )
+)
+
+# Module to be tested can not be an EDAlias
+process.test = cms.EDProducer('AddIntsProducer', labels = cms.vstring('intalias'))
+
+process.moduleToTest(process.test, cms.Task(process.intprod))
+)_"};
+
+  edm::test::TestProcessor::Config config{ baseConfig };
+
+  SECTION("Alias with two instances pointing to the same product is not allowed") {
+    REQUIRE_THROWS_WITH(edm::test::TestProcessor(config), Catch::Contains("EDAlias conflict") && Catch::Contains("and product instance alias") && Catch::Contains("are used for multiple products of type") && Catch::Contains("One has module label") && Catch::Contains("the other has module label"));
+  }
+}

--- a/FWCore/Integration/test/SwitchProducer_t.cpp
+++ b/FWCore/Integration/test/SwitchProducer_t.cpp
@@ -11,7 +11,15 @@
 static constexpr auto s_tag = "[SwitchProducer]";
 
 namespace {
-  std::string makeConfig(bool test2Enabled, const std::string& test1, const std::string& test2) {
+  std::string makeConfig(bool test2Enabled, const std::string& test1, const std::string& test2,
+                         const std::string& otherprod = "", const std::string& othername = "") {
+    std::string otherline;
+    std::string othertask;
+    if(not otherprod.empty()) {
+      otherline = "process."+othername+" = "+otherprod+"\n";
+      othertask = ", cms.Task(process."+othername+")";
+    }
+
     return std::string{
 R"_(from FWCore.TestProcessor.TestProcess import *
 import FWCore.ParameterSet.Config as cms
@@ -24,11 +32,12 @@ class SwitchProducerTest(cms.SwitchProducer):
                 test2 = lambda: ()_"} + (test2Enabled ? "True" : "False") + ", -9)\n" +
 R"_(            ), **kargs)
 process = TestProcess()
-process.s = SwitchProducerTest(
+)_" + otherline +
+R"_(process.s = SwitchProducerTest(
    test1 = )_" + test1 + ",\n" +
 "   test2 = " + test2 + "\n" +
 ")\n" +
-"process.moduleToTest(process.s)\n";
+"process.moduleToTest(process.s"+othertask+")\n";
   }
 }
 
@@ -38,6 +47,64 @@ TEST_CASE("Configuration", s_tag) {
 
   const std::string baseConfig = makeConfig(true, test1, test2);
   const std::string baseConfigTest2Disabled = makeConfig(false, test1, test2);
+
+  SECTION("Configuration hash is not changed") {
+    auto pset = edm::boost_python::readConfig(baseConfig);
+    auto psetTest2Disabled = edm::boost_python::readConfig(baseConfigTest2Disabled);
+    pset->registerIt();
+    psetTest2Disabled->registerIt();
+    REQUIRE(pset->id() == psetTest2Disabled->id());
+  }
+
+  edm::test::TestProcessor::Config config{ baseConfig };
+  edm::test::TestProcessor::Config configTest2Disabled{ baseConfigTest2Disabled };
+
+  SECTION("Base configuration is OK") {
+    REQUIRE_NOTHROW(edm::test::TestProcessor(config));
+  }
+
+  SECTION("No event data") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.test());
+  }
+
+  SECTION("beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+
+  SECTION("LuminosityBlock with no Events") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  }
+
+  SECTION("Test2 enabled") {
+    edm::test::TestProcessor tester(config);
+    auto event = tester.test();
+    REQUIRE(event.get<edmtest::IntProduct>()->value == 2);
+  }
+
+  SECTION("Test2 disabled") {
+    edm::test::TestProcessor tester(configTest2Disabled);
+    auto event = tester.test();
+    REQUIRE(event.get<edmtest::IntProduct>()->value == 1);
+  }
+}
+
+TEST_CASE("Configuration with EDAlias", s_tag) {
+  const std::string otherprod{"cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet())"};
+  const std::string othername{"intprod"};
+
+  const std::string test1{"cms.EDProducer('IntProducer', ivalue = cms.int32(1))"};
+  const std::string test2{"cms.EDAlias(intprod = cms.VPSet(cms.PSet(type = cms.string('edmtestIntProduct'))))"};
+
+  const std::string baseConfig = makeConfig(true, test1, test2, otherprod, othername);
+  const std::string baseConfigTest2Disabled = makeConfig(false, test1, test2, otherprod, othername);
 
   SECTION("Configuration hash is not changed") {
     auto pset = edm::boost_python::readConfig(baseConfig);
@@ -115,6 +182,41 @@ TEST_CASE("Configuration with many branches", s_tag) {
     REQUIRE(event.get<edmtest::IntProduct>("foo")->value == 11);
     REQUIRE(event.get<edmtest::IntProduct>("bar")->value == 21);
   }
+}
+
+TEST_CASE("Configuration with many branches with EDAlias", s_tag) {
+  const std::string otherprod{R"_(cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(12)),
+                                                                                       cms.PSet(instance=cms.string('bar'),value=cms.int32(22))))
+)_"};
+  const std::string othername{"intprod"};
+
+  const std::string test1{R"_(cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(11)),
+                                                                                       cms.PSet(instance=cms.string('bar'),value=cms.int32(21)))))_"};
+  const std::string test2{R"_(cms.EDAlias(intprod = cms.VPSet(cms.PSet(type = cms.string('edmtestIntProduct'), fromProductInstance = cms.string(''), toProductInstance = cms.string('')),
+                                                              cms.PSet(type = cms.string('edmtestIntProduct'), fromProductInstance = cms.string('foo'), toProductInstance = cms.string('foo')),
+                                                              cms.PSet(type = cms.string('edmtestIntProduct'), fromProductInstance = cms.string('bar'), toProductInstance = cms.string('bar')))))_"};
+
+  const std::string baseConfig = makeConfig(true, test1, test2, otherprod, othername);
+  const std::string baseConfigTest2Disabled = makeConfig(false, test1, test2, otherprod, othername);
+
+  edm::test::TestProcessor::Config config{ baseConfig };
+  edm::test::TestProcessor::Config configTest2Disabled{ baseConfigTest2Disabled };
+
+  SECTION("Test2 enabled") {
+    edm::test::TestProcessor tester(config);
+    auto event = tester.test();
+    REQUIRE(event.get<edmtest::IntProduct>()->value == 2);
+    REQUIRE(event.get<edmtest::IntProduct>("foo")->value == 12);
+    REQUIRE(event.get<edmtest::IntProduct>("bar")->value == 22);
+  }
+
+  SECTION("Test2 disabled") {
+    edm::test::TestProcessor tester(configTest2Disabled);
+    auto event = tester.test();
+    REQUIRE(event.get<edmtest::IntProduct>()->value == 1);
+    REQUIRE(event.get<edmtest::IntProduct>("foo")->value == 11);
+    REQUIRE(event.get<edmtest::IntProduct>("bar")->value == 21);
+  }
 
 }
 
@@ -125,6 +227,26 @@ TEST_CASE("Configuration with different branches", s_tag) {
 
   const std::string baseConfig1 = makeConfig(true, test1, test2);
   const std::string baseConfig2 = makeConfig(false, test1, test2);
+
+  SECTION("Different branches are not allowed") {
+    edm::test::TestProcessor::Config config1{ baseConfig1 };
+    REQUIRE_THROWS_WITH(edm::test::TestProcessor(config1), Catch::Contains("that does not produce a product") && Catch::Contains("that is produced by the chosen case"));
+
+    edm::test::TestProcessor::Config config2{ baseConfig2 };
+    REQUIRE_THROWS(edm::test::TestProcessor(config1), Catch::Contains("with a product") && Catch::Contains("that is not produced by the chosen case"));
+  }
+}
+
+TEST_CASE("Configuration with different branches with EDAlias", s_tag) {
+  const std::string otherprod{"cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(3))))"};
+  const std::string othername{"intprod"};
+
+  const std::string test1{"cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet())"};
+  const std::string test2{R"_(cms.EDAlias(intprod = cms.VPSet(cms.PSet(type = cms.string('edmtestIntProduct'), fromProductInstance = cms.string(''), toProductInstance = cms.string('')),
+                                                              cms.PSet(type = cms.string('edmtestIntProduct'), fromProductInstance = cms.string('foo'), toProductInstance = cms.string('foo')))))_"};
+
+  const std::string baseConfig1 = makeConfig(true, test1, test2, otherprod, othername);
+  const std::string baseConfig2 = makeConfig(false, test1, test2, otherprod, othername);
 
   SECTION("Different branches are not allowed") {
     edm::test::TestProcessor::Config config1{ baseConfig1 };

--- a/FWCore/Integration/test/SwitchProducer_t.cpp
+++ b/FWCore/Integration/test/SwitchProducer_t.cpp
@@ -10,46 +10,34 @@
 
 static constexpr auto s_tag = "[SwitchProducer]";
 
+namespace {
+  std::string makeConfig(bool test2Enabled, const std::string& test1, const std::string& test2) {
+    return std::string{
+R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: ()_"} + (test2Enabled ? "True" : "False") + ", -9)\n" +
+R"_(            ), **kargs)
+process = TestProcess()
+process.s = SwitchProducerTest(
+   test1 = )_" + test1 + ",\n" +
+"   test2 = " + test2 + "\n" +
+")\n" +
+"process.moduleToTest(process.s)\n";
+  }
+}
+
 TEST_CASE("Configuration", s_tag) {
-  const std::string baseConfig{
-R"_(from FWCore.TestProcessor.TestProcess import *
-import FWCore.ParameterSet.Config as cms
+  const std::string test1{"cms.EDProducer('IntProducer', ivalue = cms.int32(1))"};
+  const std::string test2{"cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet())"};
 
-class SwitchProducerTest(cms.SwitchProducer):
-    def __init__(self, **kargs):
-        super(SwitchProducerTest,self).__init__(
-            dict(
-                test1 = lambda: (True, -10),
-                test2 = lambda: (True, -9)
-            ), **kargs)
-
-process = TestProcess()
-process.s = SwitchProducerTest(
-   test1 = cms.EDProducer('IntProducer', ivalue = cms.int32(1)),
-   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet())
-)
-process.moduleToTest(process.s)
-)_"};
-
-  const std::string baseConfigTest2Disabled{
-R"_(from FWCore.TestProcessor.TestProcess import *
-import FWCore.ParameterSet.Config as cms
-
-class SwitchProducerTest(cms.SwitchProducer):
-    def __init__(self, **kargs):
-        super(SwitchProducerTest,self).__init__(
-            dict(
-                test1 = lambda: (True, -10),
-                test2 = lambda: (False, -9)
-            ), **kargs)
-
-process = TestProcess()
-process.s = SwitchProducerTest(
-   test1 = cms.EDProducer('IntProducer', ivalue = cms.int32(1)),
-   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet())
-)
-process.moduleToTest(process.s)
-)_"};
+  const std::string baseConfig = makeConfig(true, test1, test2);
+  const std::string baseConfigTest2Disabled = makeConfig(false, test1, test2);
 
   SECTION("Configuration hash is not changed") {
     auto pset = edm::boost_python::readConfig(baseConfig);
@@ -97,51 +85,17 @@ process.moduleToTest(process.s)
     auto event = tester.test();
     REQUIRE(event.get<edmtest::IntProduct>()->value == 1);
   }
-};
+}
+
 
 TEST_CASE("Configuration with many branches", s_tag) {
-  const std::string baseConfig{
-R"_(from FWCore.TestProcessor.TestProcess import *
-import FWCore.ParameterSet.Config as cms
+  const std::string test1{R"_(cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(11)),
+                                                                                       cms.PSet(instance=cms.string('bar'),value=cms.int32(21)))))_"};
+  const std::string test2{R"_(cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(12)),
+                                                                                       cms.PSet(instance=cms.string('bar'),value=cms.int32(22)))))_"};
 
-class SwitchProducerTest(cms.SwitchProducer):
-    def __init__(self, **kargs):
-        super(SwitchProducerTest,self).__init__(
-            dict(
-                test1 = lambda: (True, -10),
-                test2 = lambda: (True, -9)
-            ), **kargs)
-
-process = TestProcess()
-process.s = SwitchProducerTest(
-   test1 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(11)),
-                                                                                       cms.PSet(instance=cms.string('bar'),value=cms.int32(21)))),
-   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(12)),
-                                                                                       cms.PSet(instance=cms.string('bar'),value=cms.int32(22))))
-)
-process.moduleToTest(process.s)
-)_"};
-  const std::string baseConfigTest2Disabled{
-R"_(from FWCore.TestProcessor.TestProcess import *
-import FWCore.ParameterSet.Config as cms
-
-class SwitchProducerTest(cms.SwitchProducer):
-    def __init__(self, **kargs):
-        super(SwitchProducerTest,self).__init__(
-            dict(
-                test1 = lambda: (True, -10),
-                test2 = lambda: (False, -9)
-            ), **kargs)
-
-process = TestProcess()
-process.s = SwitchProducerTest(
-   test1 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(11)),
-                                                                                       cms.PSet(instance=cms.string('bar'),value=cms.int32(21)))),
-   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(12)),
-                                                                                       cms.PSet(instance=cms.string('bar'),value=cms.int32(22))))
-)
-process.moduleToTest(process.s)
-)_"};
+  const std::string baseConfig = makeConfig(true, test1, test2);
+  const std::string baseConfigTest2Disabled = makeConfig(false, test1, test2);
 
   edm::test::TestProcessor::Config config{ baseConfig };
   edm::test::TestProcessor::Config configTest2Disabled{ baseConfigTest2Disabled };
@@ -166,45 +120,11 @@ process.moduleToTest(process.s)
 
 
 TEST_CASE("Configuration with different branches", s_tag) {
-  const std::string baseConfig1{
-R"_(from FWCore.TestProcessor.TestProcess import *
-import FWCore.ParameterSet.Config as cms
+  const std::string test1{"cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet())"};
+  const std::string test2{"cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(3))))"};
 
-class SwitchProducerTest(cms.SwitchProducer):
-    def __init__(self, **kargs):
-        super(SwitchProducerTest,self).__init__(
-            dict(
-                test1 = lambda: (True, -10),
-                test2 = lambda: (True, -9)
-            ), **kargs)
-
-process = TestProcess()
-process.s = SwitchProducerTest(
-   test1 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet()),
-   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(3))))
-)
-process.moduleToTest(process.s)
-)_"};
-
-    const std::string baseConfig2{
-R"_(from FWCore.TestProcessor.TestProcess import *
-import FWCore.ParameterSet.Config as cms
-
-class SwitchProducerTest(cms.SwitchProducer):
-    def __init__(self, **kargs):
-        super(SwitchProducerTest,self).__init__(
-            dict(
-                test1 = lambda: (True, -10),
-                test2 = lambda: (True, -9)
-            ), **kargs)
-
-process = TestProcess()
-process.s = SwitchProducerTest(
-   test1 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(3)))),
-   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet())
-)
-process.moduleToTest(process.s, cms.Task(process.i))
-)_"};
+  const std::string baseConfig1 = makeConfig(true, test1, test2);
+  const std::string baseConfig2 = makeConfig(false, test1, test2);
 
   SECTION("Different branches are not allowed") {
     edm::test::TestProcessor::Config config1{ baseConfig1 };
@@ -218,25 +138,9 @@ process.moduleToTest(process.s, cms.Task(process.i))
 
 
 TEST_CASE("Configuration with lumi and run", s_tag) {
-  const std::string baseConfig{
-R"_(from FWCore.TestProcessor.TestProcess import *
-import FWCore.ParameterSet.Config as cms
-
-class SwitchProducerTest(cms.SwitchProducer):
-    def __init__(self, **kargs):
-        super(SwitchProducerTest,self).__init__(
-            dict(
-                test1 = lambda: (True, -10),
-                test2 = lambda: (True, -9)
-            ), **kargs)
-
-process = TestProcess()
-process.s = SwitchProducerTest(
-   test1 = cms.EDProducer('ThingProducer', nThings = cms.int32(10)),
-   test2 = cms.EDProducer('ThingProducer', nThings = cms.int32(20))
-)
-process.moduleToTest(process.s)
-)_"};
+  const std::string test1{"cms.EDProducer('ThingProducer', nThings = cms.int32(10))"};
+  const std::string test2{"cms.EDProducer('ThingProducer', nThings = cms.int32(20))"};
+  const std::string baseConfig = makeConfig(true, test1, test2);
 
   edm::test::TestProcessor::Config config{ baseConfig };
 
@@ -247,45 +151,11 @@ process.moduleToTest(process.s)
 
 
 TEST_CASE("Configuration with ROOT branch alias", s_tag) {
-  const std::string baseConfig1{
-R"_(from FWCore.TestProcessor.TestProcess import *
-import FWCore.ParameterSet.Config as cms
+  const std::string test1{"cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(3))))"};
+  const std::string test2{"cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(4),branchAlias=cms.string('bar'))))"};
 
-class SwitchProducerTest(cms.SwitchProducer):
-    def __init__(self, **kargs):
-        super(SwitchProducerTest,self).__init__(
-            dict(
-                test1 = lambda: (True, -10),
-                test2 = lambda: (True, -9)
-            ), **kargs)
-
-process = TestProcess()
-process.s = SwitchProducerTest(
-   test1 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(3)))),
-   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(4),branchAlias=cms.string('bar'))))
-)
-process.moduleToTest(process.s)
-)_"};
-
-    const std::string baseConfig2{
-R"_(from FWCore.TestProcessor.TestProcess import *
-import FWCore.ParameterSet.Config as cms
-
-class SwitchProducerTest(cms.SwitchProducer):
-    def __init__(self, **kargs):
-        super(SwitchProducerTest,self).__init__(
-            dict(
-                test1 = lambda: (True, -10),
-                test2 = lambda: (True, -9)
-            ), **kargs)
-
-process = TestProcess()
-process.s = SwitchProducerTest(
-   test1 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(3),branchAlias=cms.string('bar')))),
-   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(4))))
-)
-process.moduleToTest(process.s)
-)_"};
+  const std::string baseConfig1 = makeConfig(true, test1, test2);
+  const std::string baseConfig2 = makeConfig(false, test1, test2);
 
   SECTION("ROOT branch aliases are not supported for the chosen case") {
     edm::test::TestProcessor::Config config{ baseConfig1 };

--- a/FWCore/Integration/test/run_TestEDAlias.sh
+++ b/FWCore/Integration/test/run_TestEDAlias.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+test=testEDAlias
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+pushd ${LOCAL_TMP_DIR}
+
+  echo "*************************************************"
+  echo "EDAlias consumer in a Task"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Task_cfg.py || die "cmsRun ${test}Task_cfg.py 1" $?
+
+  echo "*************************************************"
+  echo "Test output"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Analyze_cfg.py testEDAliasTask.root || die "cmsRun ${test}Analyze_cfg.py testEDAliasTask.root" $?
+
+  echo "*************************************************"
+  echo "EDAlias consumer in a Path"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Path_cfg.py || die "cmsRun ${test}Path_cfg.py 1" $?
+
+  echo "*************************************************"
+  echo "Test output"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Analyze_cfg.py testEDAliasTask.root || die "cmsRun ${test}Analyze_cfg.py testEDAliasPath.root" $?
+
+popd
+
+exit 0

--- a/FWCore/Integration/test/run_TestSwitchProducer.sh
+++ b/FWCore/Integration/test/run_TestSwitchProducer.sh
@@ -46,6 +46,18 @@ pushd ${LOCAL_TMP_DIR}
   echo "SwitchProducer in a Path after a failing filter, case test2 disabled"
   cmsRun ${LOCAL_TEST_DIR}/${test}PathFilter_cfg.py disableTest2 || die "cmsRun ${test}PathFilter_cfg.py 2" $?
 
+
+  echo "*************************************************"
+  echo "Keeping SwitchProducer-with-EDAlias and the aliased-for product should fail"
+  cmsRun ${LOCAL_TEST_DIR}/${test}AliasOutput_cfg.py && die "cmsRun ${test}AliasOutput_cfg.py did not throw an exception" $?
+
+  echo "*************************************************"
+  echo "SwitchProducer-with-EDAlias being before the aliased-for producer in a Path should fail"
+  cmsRun ${LOCAL_TEST_DIR}/${test}PathWrongOrder_cfg.py && die "cmsRun ${test}PathWrongOrder_cfg.py did not throw an exception" $?
+
+  echo "SwitchProducer tests succeeded"
+  echo "*************************************************"
+
 popd
 
 exit 0

--- a/FWCore/Integration/test/run_TestSwitchProducer.sh
+++ b/FWCore/Integration/test/run_TestSwitchProducer.sh
@@ -52,6 +52,10 @@ pushd ${LOCAL_TMP_DIR}
   cmsRun ${LOCAL_TEST_DIR}/${test}AliasOutput_cfg.py && die "cmsRun ${test}AliasOutput_cfg.py did not throw an exception" $?
 
   echo "*************************************************"
+  echo "Alias to non-existent product should fail only when a corresponding product is accessed"
+  cmsRun ${LOCAL_TEST_DIR}/${test}AliasToNonExistent_cfg.py && die "cmsRun ${test}AliasToNonExistent_cfg.py did not throw an exception" $?
+
+  echo "*************************************************"
   echo "SwitchProducer-with-EDAlias being before the aliased-for producer in a Path should fail"
   cmsRun ${LOCAL_TEST_DIR}/${test}PathWrongOrder_cfg.py && die "cmsRun ${test}PathWrongOrder_cfg.py did not throw an exception" $?
 

--- a/FWCore/Integration/test/testEDAliasAnalyze_cfg.py
+++ b/FWCore/Integration/test/testEDAliasAnalyze_cfg.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+import sys
+
+process = cms.Process("ANA1")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring("file:"+sys.argv[-1])
+)
+
+process.analyzer = cms.EDAnalyzer("IntTestAnalyzer",
+    moduleLabel = cms.untracked.string("intProducer"),
+    valueMustMatch = cms.untracked.int32(1)
+)
+
+process.p = cms.Path(process.analyzer)

--- a/FWCore/Integration/test/testEDAliasPath_cfg.py
+++ b/FWCore/Integration/test/testEDAliasPath_cfg.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD1")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
+)
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testEDAliasPath.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *_intProducer_*_*',
+    )
+)
+
+process.intProducerOrig = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
+
+process.intAlias = cms.EDAlias(
+    intProducerOrig = cms.VPSet(cms.PSet(type = cms.string("edmtestIntProduct")))
+)
+
+process.intProducer = cms.EDProducer("ManyIntWhenRegisteredProducer", src = cms.string("intAlias"))
+
+process.t = cms.Task(process.intProducerOrig)
+process.p = cms.Path(process.intProducer, process.t)
+
+process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testEDAliasTask_cfg.py
+++ b/FWCore/Integration/test/testEDAliasTask_cfg.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD1")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
+)
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testEDAliasTask.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *_intProducer_*_*',
+    )
+)
+
+process.intProducerOrig = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
+
+process.intAlias = cms.EDAlias(
+    intProducerOrig = cms.VPSet(cms.PSet(type = cms.string("edmtestIntProduct")))
+)
+
+process.intProducer = cms.EDProducer("ManyIntWhenRegisteredProducer", src = cms.string("intAlias"))
+
+process.t = cms.Task(process.intProducer, process.intProducerOrig)
+process.p = cms.Path(process.t)
+
+process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testSwitchProducerAliasOutput_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerAliasOutput_cfg.py
@@ -1,13 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-import sys
-enableTest2 = (sys.argv[-1] != "disableTest2")
 class SwitchProducerTest(cms.SwitchProducer):
     def __init__(self, **kargs):
         super(SwitchProducerTest,self).__init__(
             dict(
                 test1 = lambda: (True, -10),
-                test2 = lambda: (enableTest2, -9)
+                test2 = lambda: (True, -9)
             ), **kargs)
 
 process = cms.Process("PROD1")
@@ -19,48 +17,29 @@ process.options = cms.untracked.PSet(
 )
 
 process.source = cms.Source("EmptySource")
-if enableTest2:
-    process.source.firstLuminosityBlock = cms.untracked.uint32(2)
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(3)
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testSwitchProducerTask%d.root' % (1 if enableTest2 else 2,)),
+    fileName = cms.untracked.string('testSwitchProducerAliasOutput.root'),
     outputCommands = cms.untracked.vstring(
-        'keep *_intProducer_*_*',
-        'keep *_intProducerOther_*_*',
+        'keep *_intProducer3_*_*',
         'keep *_intProducerAlias_*_*'
     )
 )
 
-process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
-process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2))
+process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1), throw = cms.untracked.bool(True))
 process.intProducer3 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(2))))
-if enableTest2:
-    process.intProducer1.throw = cms.untracked.bool(True)
-else:
-    process.intProducer2.throw = cms.untracked.bool(True)
-    process.intProducer3.throw = cms.untracked.bool(True)
 
-process.intProducer = SwitchProducerTest(
-    test1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1")),
-    test2 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer2"))
-)
-# Test also existence of another SwitchProducer here
-process.intProducerOther = SwitchProducerTest(
-    test1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1")),
-    test2 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer2"))
-)
-# SwitchProducer with an alias
 process.intProducerAlias = SwitchProducerTest(
     test1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1")),
     test2 = cms.EDAlias(intProducer3 = cms.VPSet(cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string(""), toProductInstance = cms.string("")),
                                                  cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string("other"))))
 )
 
-process.t = cms.Task(process.intProducer, process.intProducerOther, process.intProducerAlias, process.intProducer1, process.intProducer2, process.intProducer3)
+process.t = cms.Task(process.intProducerAlias, process.intProducer1, process.intProducer3)
 process.p = cms.Path(process.t)
 
 process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testSwitchProducerAliasToNonExistent_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerAliasToNonExistent_cfg.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: (True, -9)
+            ), **kargs)
+
+process = cms.Process("PROD1")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
+)
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSwitchProducerAliasOutput.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *_intProducer3_*_*',
+        'keep *_intProducerAlias__*'
+    )
+)
+
+process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1), throw = cms.untracked.bool(True))
+process.intProducer4 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(42), throw = cms.untracked.bool(True))
+
+process.intProducerAlias = SwitchProducerTest(
+    test1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1")),
+    test2 = cms.EDAlias(intProducer4 = cms.VPSet(cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string(""), toProductInstance = cms.string(""))),
+                        intProducer3 = cms.VPSet(cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string(""))
+))
+)
+
+process.t = cms.Task(process.intProducerAlias, process.intProducer1, process.intProducer4)
+process.p = cms.Path(process.t)
+
+process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testSwitchProducerPathFilter_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerPathFilter_cfg.py
@@ -35,15 +35,27 @@ process.out = cms.OutputModule("PoolOutputModule",
 
 process.intProducer1 = cms.EDProducer("FailingProducer")
 process.intProducer2 = cms.EDProducer("FailingProducer")
+process.intProducer3 = cms.EDProducer("ManyIntProducer",
+    ivalue = cms.int32(3),
+    values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(31))),
+    throw = cms.untracked.bool(True)
+)
 
 process.intProducer = SwitchProducerTest(
     test1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1")),
     test2 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer2"))
 )
+# SwitchProducer with an alias
+process.intProducerAlias = SwitchProducerTest(
+    test1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1")),
+    test2 = cms.EDAlias(intProducer3 = cms.VPSet(cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string(""), toProductInstance = cms.string("")),
+                                                 cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string("other"))))
+)
+
 
 process.f = cms.EDFilter("TestFilterModule", acceptValue = cms.untracked.int32(-1))
 
-process.t = cms.Task(process.intProducer1, process.intProducer2)
+process.t = cms.Task(process.intProducer1, process.intProducer2, process.intProducer3)
 process.p = cms.Path(process.f+process.intProducer, process.t)
 
 process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testSwitchProducerPathWrongOrder_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerPathWrongOrder_cfg.py
@@ -1,13 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-import sys
-enableTest2 = (sys.argv[-1] != "disableTest2")
 class SwitchProducerTest(cms.SwitchProducer):
     def __init__(self, **kargs):
         super(SwitchProducerTest,self).__init__(
             dict(
                 test1 = lambda: (True, -10),
-                test2 = lambda: (enableTest2, -9)
+                test2 = lambda: (True, -9)
             ), **kargs)
 
 process = cms.Process("PROD1")
@@ -19,33 +17,21 @@ process.options = cms.untracked.PSet(
 )
 
 process.source = cms.Source("EmptySource")
-if enableTest2:
-    process.source.firstLuminosityBlock = cms.untracked.uint32(2)
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(3)
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testSwitchProducerPathFilter%d.root' % (1 if enableTest2 else 2,)),
+    fileName = cms.untracked.string('testSwitchProducerPathWrongOrder.root'),
     outputCommands = cms.untracked.vstring(
-        'keep *_intProducer_*_*'
+        'keep *_intProducerAlias_*_*'
     )
 )
 
-process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
-process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2))
+process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1), throw = cms.untracked.bool(True))
 process.intProducer3 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(3), values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(31))))
-if enableTest2:
-    process.intProducer1.throw = cms.untracked.bool(True)
-else:
-    process.intProducer2.throw = cms.untracked.bool(True)
-    process.intProducer3.throw = cms.untracked.bool(True)
 
-process.intProducer = SwitchProducerTest(
-    test1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1")),
-    test2 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer2"))
-)
 # SwitchProducer with an alias
 process.intProducerAlias = SwitchProducerTest(
     test1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1")),
@@ -53,7 +39,7 @@ process.intProducerAlias = SwitchProducerTest(
                                                  cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string("other"))))
 )
 
-process.t = cms.Task(process.intProducer1, process.intProducer2, process.intProducer3)
-process.p = cms.Path(process.intProducer + process.intProducerAlias, process.t)
+process.t = cms.Task(process.intProducer1)
+process.p = cms.Path(process.intProducerAlias + process.intProducer3, process.t)
 
 process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testSwitchProducerProvenanceAnalyzer_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerProvenanceAnalyzer_cfg.py
@@ -9,7 +9,16 @@ process.source = cms.Source("PoolSource",
 
 process.analyzer = cms.EDAnalyzer("SwitchProducerProvenanceAnalyzer",
     src1 = cms.InputTag("intProducer"),
-    src2 = cms.InputTag("intProducer", "other")
+    src2 = cms.InputTag("intProducer", "other"),
+    producerPrefix = cms.string("intProducer"),
+    aliasMode = cms.bool(False)
 )
 
-process.p = cms.Path(process.analyzer)
+process.analyzerAlias = cms.EDAnalyzer("SwitchProducerProvenanceAnalyzer",
+    src1 = cms.InputTag("intProducerAlias"),
+    src2 = cms.InputTag("intProducerAlias", "other"),
+    producerPrefix = cms.string("intProducer"),
+    aliasMode = cms.bool(True)
+)
+
+process.p = cms.Path(process.analyzer + process.analyzerAlias)

--- a/FWCore/Integration/test/testSwitchProducerTask_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerTask_cfg.py
@@ -31,13 +31,15 @@ process.out = cms.OutputModule("PoolOutputModule",
     outputCommands = cms.untracked.vstring(
         'keep *_intProducer_*_*',
         'keep *_intProducerOther_*_*',
-        'keep *_intProducerAlias_*_*'
+        'keep *_intProducerAlias_*_*',
+        'keep *_intProducerAlias2_foo_*',
     )
 )
 
 process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
 process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2))
 process.intProducer3 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(2))))
+process.intProducer4 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(42), throw = cms.untracked.bool(True))
 if enableTest2:
     process.intProducer1.throw = cms.untracked.bool(True)
 else:
@@ -60,7 +62,14 @@ process.intProducerAlias = SwitchProducerTest(
                                                  cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string("other"))))
 )
 
-process.t = cms.Task(process.intProducer, process.intProducerOther, process.intProducerAlias, process.intProducer1, process.intProducer2, process.intProducer3)
+process.intProducerAlias2 = SwitchProducerTest(
+    test1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1")),
+    test2 = cms.EDAlias(intProducer4 = cms.VPSet(cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string(""), toProductInstance = cms.string(""))),
+                        intProducer3 = cms.VPSet(cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string("other"))))
+)
+
+process.t = cms.Task(process.intProducer, process.intProducerOther, process.intProducerAlias, process.intProducerAlias2,
+                     process.intProducer1, process.intProducer2, process.intProducer3, process.intProducer4)
 process.p = cms.Path(process.t)
 
 process.e = cms.EndPath(process.out)

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -3224,6 +3224,28 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             (m3 | m4).toReplaceWith(p.a, EDAnalyzer("YourAnalyzer4"))
             self.assertEqual(p.a.type_(), "YourAnalyzer3")
 
+            # EDAlias
+            a = EDAlias(foo2 = VPSet(PSet(type = string("Foo2"))))
+            m = Modifier()
+            m._setChosen()
+            # Modify parameters
+            m.toModify(a, foo2 = {0: dict(type = "Foo3")})
+            self.assertEqual(a.foo2[0].type, "Foo3")
+            # Add an alias
+            m.toModify(a, foo4 = VPSet(PSet(type = string("Foo4"))))
+            self.assertEqual(a.foo2[0].type, "Foo3")
+            self.assertEqual(a.foo4[0].type, "Foo4")
+            # Remove an alias
+            m.toModify(a, foo2 = None)
+            self.assertFalse(hasattr(a, "foo2"))
+            self.assertEqual(a.foo4[0].type, "Foo4")
+            # Replace (doesn't work out of the box because EDAlias is not _Parameterizable
+            m.toReplaceWith(a, EDAlias(bar = VPSet(PSet(type = string("Bar")))))
+            self.assertFalse(hasattr(a, "foo2"))
+            self.assertFalse(hasattr(a, "foo4"))
+            self.assertTrue(hasattr(a, "bar"))
+            self.assertEqual(a.bar[0].type, "Bar")
+
             # SwitchProducer
             sp = SwitchProducerTest(test1 = EDProducer("Foo",
                                                        a = int32(1),

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -2725,6 +2725,7 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             self.assertEqual((True,"Bar"), p.values["sp@test1"][1].values["@module_type"])
             self.assertEqual((True,"EDProducer"), p.values["sp@test2"][1].values["@module_edm_type"])
             self.assertEqual((True,"Foo"), p.values["sp@test2"][1].values["@module_type"])
+            self.assertEqual(proc.dumpPython().find('@'), -1)
 
             # EDAlias as non-chosen case
             proc = Process("test")

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -663,12 +663,12 @@ def _modifyParametersFromDict(params, newParams, errorRaiser, keyDepth=""):
                             plist[k] = v
                     else:
                         raise ValueError("Attempted to change non PSet value "+keyDepth+" using a dictionary")
-                elif isinstance(value,_ParameterTypeBase) or (isinstance(key, int)) or isinstance(value, _TypedParameterizable):
+                elif isinstance(value,_ParameterTypeBase) or (isinstance(key, int)) or isinstance(value, _Parameterizable):
                     params[key] = value
                 else:
                     params[key].setValue(value)
             else:
-                if isinstance(value,_ParameterTypeBase) or isinstance(value, _TypedParameterizable):
+                if isinstance(value,_ParameterTypeBase) or isinstance(value, _Parameterizable):
                     params[key]=value
                 else:
                     errorRaiser(key)

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -19,6 +19,37 @@ class PrintOptions(object):
     def unindent(self):
         self.indent_ -= self.deltaIndent_
 
+class _SpecialImportRegistry(object):
+    """This class collects special import statements of configuration types"""
+    def __init__(self):
+        self._registry = {}
+
+    def _reset(self):
+        for lst in six.itervalues(self._registry):
+            lst[1] = False
+
+    def registerSpecialImportForType(self, cls, impStatement):
+        className = cls.__name__
+        if className in self._registry:
+            raise RuntimeError("Error: the configuration type '%s' already has an import statement registered '%s'" % (className, self._registry[className][0]))
+        self._registry[className] = [impStatement, False]
+
+    def registerUse(self, obj):
+        className = obj.__class__.__name__
+        try:
+            self._registry[className][1] = True
+        except KeyError:
+            pass
+
+    def getSpecialImports(self):
+        coll = set()
+        for (imp, used) in six.itervalues(self._registry):
+            if used:
+                coll.add(imp)
+        return sorted(coll)
+
+specialImportRegistry = _SpecialImportRegistry()
+
 class _ParameterTypeBase(object):
     """base class for classes which are used as the 'parameters' for a ParameterSet"""
     def __init__(self):
@@ -38,6 +69,7 @@ class _ParameterTypeBase(object):
             return 'cms.'+type(self).__name__
         return 'cms.untracked.'+type(self).__name__
     def dumpPython(self, options=PrintOptions()):
+        specialImportRegistry.registerUse(self)
         return self.pythonTypeName()+"("+self.pythonValue(options)+")"
     def __repr__(self):
         return self.dumpPython()
@@ -248,6 +280,7 @@ class _Parameterizable(object):
     def __raiseBadSetAttr(name):
         raise TypeError(name+" does not already exist, so it can only be set to a CMS python configuration type")
     def dumpPython(self, options=PrintOptions()):
+        specialImportRegistry.registerUse(self)
         sortedNames = sorted(self.parameterNames_())
         if len(sortedNames) > 200:
         #Too many parameters for a python function call
@@ -417,6 +450,7 @@ class _TypedParameterizable(_Parameterizable):
         return config
 
     def dumpPython(self, options=PrintOptions()):
+        specialImportRegistry.registerUse(self)
         result = "cms."+str(type(self).__name__)+'("'+self.type_()+'"'
         nparam = len(self.parameterNames_())
         if nparam == 0:
@@ -591,6 +625,7 @@ class _ValidatingParameterListBase(_ValidatingListBase,_ParameterTypeBase):
     def __repr__(self):
         return self.dumpPython()
     def dumpPython(self, options=PrintOptions()):
+        specialImportRegistry.registerUse(self)
         result = self.pythonTypeName()+"("
         n = len(self)
         if hasattr(self, "_nPerLine"):
@@ -797,4 +832,19 @@ if __name__ == "__main__":
             p = tLPTest("MyType",** dict( [ ("a"+str(x), tLPTestType(x)) for x in xrange(0,300) ] ) )
             #check they are the same
             self.assertEqual(p.dumpPython(), eval(p.dumpPython(),{"cms": __DummyModule()}).dumpPython())
+        def testSpecialImportRegistry(self):
+            reg = _SpecialImportRegistry()
+            reg.registerSpecialImportForType(int, "import foo")
+            self.assertRaises(lambda x: reg.registerSpecialImportForType(int, "import bar"))
+            reg.registerSpecialImportForType(str, "import bar")
+            self.assertEqual(reg.getSpecialImports(), [])
+            reg.registerUse([1])
+            self.assertEqual(reg.getSpecialImports(), [])
+            reg.registerUse(1)
+            self.assertEqual(reg.getSpecialImports(), ["import foo"])
+            reg.registerUse(1)
+            self.assertEqual(reg.getSpecialImports(), ["import foo"])
+            reg.registerUse("a")
+            self.assertEqual(reg.getSpecialImports(), ["import bar", "import foo"])
+
     unittest.main()

--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -2,7 +2,7 @@ from Mixins import _ConfigureComponent, saveOrigin
 from Mixins import _Unlabelable, _Labelable
 from Mixins import _TypedParameterizable, _Parameterizable, PrintOptions
 from SequenceTypes import _SequenceLeaf
-from Types import vstring
+from Types import vstring, EDAlias
 
 import six
 import copy
@@ -272,9 +272,13 @@ class SwitchProducer(EDProducer):
         """Returns the EDroducer of the chosen case"""
         return self.__dict__[self._chooseCase()]
 
+    @staticmethod
+    def __typeIsValid(typ):
+        return (isinstance(typ, EDProducer) and not isinstance(typ, SwitchProducer)) or isinstance(typ, EDAlias)
+
     def __addParameter(self, name, value):
-        if not (isinstance(value, EDProducer) and not isinstance(value, SwitchProducer)):
-            raise TypeError(name+" does not already exist, so it can only be set to a cms.EDProducer")
+        if not self.__typeIsValid(value):
+            raise TypeError(name+" does not already exist, so it can only be set to a cms.EDProducer or cms.EDAlias")
         if name not in self._caseFunctionDict:
             raise ValueError("Case '%s' is not allowed (allowed ones are %s)" % (name, ",".join(six.iterkeys(self._caseFunctionDict))))
         if name in self.__dict__:
@@ -309,8 +313,8 @@ class SwitchProducer(EDProducer):
             self.__addParameter(name, value)
             self._isModified = True
         else:
-            if not (isinstance(value, EDProducer) and not isinstance(value, SwitchProducer)):
-                raise TypeError(name+" can only be set to a cms.EDProducer")
+            if not self.__typeIsValid(value):
+                raise TypeError(name+" can only be set to a cms.EDProducer or cms.EDAlias")
             # We should always receive an cms.EDProducer
             self.__dict__[name] = value
             self._isModified = True
@@ -358,12 +362,15 @@ class SwitchProducer(EDProducer):
         return myname
     def caseLabel_(self, name, case):
         return name+"@"+case
-    def appendToProcessDescList_(self, lst, myname):
+    def appendToProcessDescLists_(self, modules, aliases, myname):
         # This way we can insert the chosen EDProducer to @all_modules
         # so that we get easily a worker for it
-        lst.append(myname)
+        modules.append(myname)
         for case in self.parameterNames_():
-            lst.append(self.caseLabel_(myname, case))
+            if isinstance(self.__dict__[case], EDAlias):
+                aliases.append(self.caseLabel_(myname, case))
+            else:
+                modules.append(self.caseLabel_(myname, case))
 
     def insertInto(self, parameterSet, myname):
         for case in self.parameterNames_():
@@ -378,12 +385,19 @@ class SwitchProducer(EDProducer):
         parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
 
     def _placeImpl(self,name,proc):
-        proc._placeProducer(name,self)
-        for case in self.parameterNames_():
-            # Note that these don't end up in @all_modules
-            # automatically because they're not part of any
-            # Task/Sequence/Path
-            proc._placeProducer(self.caseLabel_(name, case), self.__dict__[case])
+        proc._placeSwitchProducer(name,self)
+#        for case in self.parameterNames_():
+#            caseLabel = self.caseLabel_(name, case)
+#            caseObj = self.__dict__[case]
+#
+#            if isinstance(caseObj, EDAlias):
+#                # EDAliases end up in @all_aliases automatically
+#                proc._placeAlias(caseLabel, caseObj)
+#            else:
+#                # Note that these don't end up in @all_modules
+#                # automatically because they're not part of any
+#                # Task/Sequence/Path
+#                proc._placeProducer(caseLabel, caseObj)
 
     def _clonesequence(self, lookuptable):
         try:
@@ -539,7 +553,6 @@ if __name__ == "__main__":
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = Source("Foo")))
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = OutputModule("Foo")))
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = Looper("Foo")))
-            self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = EDAlias()))
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = Service("Foo")))
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = ESSource("Foo")))
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = ESProducer("Foo")))
@@ -574,6 +587,7 @@ if __name__ == "__main__":
             self.assertEqual(cl.test2.type_(), "Bar")
             self.assertEqual(cl.test2.aa.value(), 11)
             self.assertEqual(cl.test2.bb.cc.value(), 12)
+            self.assertEqual(sp._getProducer().type_(), "Bar")
             # Modify clone
             cl.test1.a = 3
             self.assertEqual(cl.test1.a.value(), 3)
@@ -635,4 +649,58 @@ if __name__ == "__main__":
             unpkl = pickle.loads(pkl)
             self.assertEqual(unpkl.cpu.type_(), "Foo")
 
+        def testSwithProducerWithAlias(self):
+            # Constructor
+            sp = SwitchProducerTest(test1 = EDProducer("Foo"), test2 = EDAlias())
+            self.assertEqual(sp.test1.type_(), "Foo")
+            self.assertTrue(isinstance(sp.test2, EDAlias))
+
+            # Modifications
+            from Types import int32, string, PSet, VPSet
+            sp = SwitchProducerTest(test1 = EDProducer("Foo"),
+                                    test2 = EDAlias(foo = VPSet(PSet(type = string("Foo2")))))
+
+            # Simple clone
+            cl = sp.clone()
+            self.assertTrue(hasattr(cl.test2, "foo"))
+            # Modify clone
+            cl.test2.foo[0].type = "Foo3"
+            self.assertEqual(cl.test2.foo[0].type, "Foo3")
+            # Modify values with a dict
+            cl = sp.clone(test2 = dict(foo = {0: dict(type = "Foo4")}))
+            self.assertEqual(cl.test2.foo[0].type, "Foo4")
+            # Replace or add EDAlias
+            cl = sp.clone(test1 = EDAlias(foo = VPSet(PSet(type = string("Foo5")))),
+                          test3 = EDAlias(foo = VPSet(PSet(type = string("Foo6")))))
+            self.assertEqual(cl.test1.foo[0].type, "Foo5")
+            self.assertEqual(cl.test3.foo[0].type, "Foo6")
+            # Modify clone
+            cl.test1 = EDProducer("Xyzzy")
+            self.assertEqual(cl.test1.type_(), "Xyzzy")
+            cl.test1 = EDAlias(foo = VPSet(PSet(type = string("Foo7"))))
+            self.assertEqual(cl.test1.foo[0].type, "Foo7")
+
+
+            # Dump
+            from Types import int32, string, PSet, VPSet
+            sp = SwitchProducerTest(test1 = EDProducer("Foo"),
+                                    test2 = EDAlias(foo = VPSet(PSet(type = string("Foo2")))))
+
+            self.assertEqual(sp.dumpPython(),
+"""SwitchProducerTest(
+    test1 = cms.EDProducer("Foo"),
+    test2 = cms.EDAlias(
+        foo = cms.VPSet(cms.PSet(
+            type = cms.string('Foo2')
+        ))
+)
+)
+""")
+
+            # Pickle
+            import pickle
+            sp = SwitchProducerPickleable(cpu = EDAlias(foo = VPSet(PSet(type = string("Foo2")))))
+            pkl = pickle.dumps(sp)
+            unpkl = pickle.loads(pkl)
+            self.assertEqual(sp.cpu.foo[0].type, "Foo2")
     unittest.main()

--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -1,6 +1,6 @@
 from Mixins import _ConfigureComponent, saveOrigin
 from Mixins import _Unlabelable, _Labelable
-from Mixins import _TypedParameterizable, _Parameterizable, PrintOptions
+from Mixins import _TypedParameterizable, _Parameterizable, PrintOptions, specialImportRegistry
 from SequenceTypes import _SequenceLeaf
 from Types import vstring, EDAlias
 
@@ -346,6 +346,7 @@ class SwitchProducer(EDProducer):
         # Note that if anyone uses the generic SwitchProducer instead
         # of a derived-one, the information on the functions for the
         # producer decision is lost
+        specialImportRegistry.registerUse(self)
         result = "%s(" % self.__class__.__name__ # not including cms. since the deriving classes are not in cms "namespace"
         options.indent()
         for resource in sorted(self.parameterNames_()):

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -1,4 +1,4 @@
-from Mixins import PrintOptions, _SimpleParameterTypeBase, _ParameterTypeBase, _Parameterizable, _ConfigureComponent, _Labelable, _TypedParameterizable, _Unlabelable, _modifyParametersFromDict
+from Mixins import PrintOptions, _SimpleParameterTypeBase, _ParameterTypeBase, _Parameterizable, _ConfigureComponent, _Labelable, _TypedParameterizable, _Unlabelable, _modifyParametersFromDict, saveOrigin
 from Mixins import _ValidatingParameterListBase
 from ExceptionHandling import format_typename, format_outerframe
 
@@ -1136,30 +1136,21 @@ def convertToVPSet( **kw ):
     return returnValue
 
 
-class EDAlias(_ConfigureComponent,_Labelable):
+class EDAlias(_ConfigureComponent,_Labelable,_Parameterizable):
     def __init__(self,*arg,**kargs):
-        super(EDAlias,self).__init__()
-        self.__dict__['_EDAlias__parameterNames'] = []
-        self.__setParameters(kargs)
+        super(EDAlias,self).__init__(**kargs)
 
-    def parameterNames_(self):
-        """Returns the name of the parameters"""
-        return self.__parameterNames[:]
+    def clone(self, *args, **params):
+        returnValue = EDAlias.__new__(type(self))
+        myparams = self.parameters_()
+        if len(myparams) == 0 and len(params) and len(args):
+            args.append(None)
 
-    def __addParameter(self, name, value):
-        if not isinstance(value,_ParameterTypeBase):
-            self.__raiseBadSetAttr(name)
-        self.__dict__[name]=value
-        self.__parameterNames.append(name)
+        _modifyParametersFromDict(myparams, params, self._Parameterizable__raiseBadSetAttr)
 
-    def __delattr__(self,attr):
-        if attr in self.__parameterNames:
-            self.__parameterNames.remove(attr)
-        return super(EDAlias,self).__delattr__(attr)
-
-    def __setParameters(self,parameters):
-        for name,value in six.iteritems(parameters):
-            self.__addParameter(name, value)
+        returnValue.__init__(*args, **myparams)
+        saveOrigin(returnValue, 1)
+        return returnValue
 
     def _place(self,name,proc):
         proc._placeAlias(name,self)
@@ -1438,6 +1429,21 @@ if __name__ == "__main__":
             del aliasfoo2.foo2
             self.assert_(not hasattr(aliasfoo2,"foo2"))
             self.assert_("foo2" not in aliasfoo2.parameterNames_())
+
+            aliasfoo2 = EDAlias(foo2 = VPSet(PSet(type = string("Foo2"))))
+            aliasfoo3 = aliasfoo2.clone(
+                foo2 = {0: dict(type = "Foo4")},
+                foo3 = VPSet(PSet(type = string("Foo3")))
+            )
+            self.assertTrue(hasattr(aliasfoo3, "foo2"))
+            self.assertTrue(hasattr(aliasfoo3, "foo3"))
+            self.assertEqual(aliasfoo3.foo2[0].type, "Foo4")
+            self.assertEqual(aliasfoo3.foo3[0].type, "Foo3")
+
+            aliasfoo4 = aliasfoo3.clone(foo2 = None)
+            self.assertFalse(hasattr(aliasfoo4, "foo2"))
+            self.assertTrue(hasattr(aliasfoo4, "foo3"))
+            self.assertEqual(aliasfoo4.foo3[0].type, "Foo3")
 
         def testFileInPath(self):
             f = FileInPath("FWCore/ParameterSet/python/Types.py")

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -1,5 +1,5 @@
 from Mixins import PrintOptions, _SimpleParameterTypeBase, _ParameterTypeBase, _Parameterizable, _ConfigureComponent, _Labelable, _TypedParameterizable, _Unlabelable, _modifyParametersFromDict, saveOrigin
-from Mixins import _ValidatingParameterListBase
+from Mixins import _ValidatingParameterListBase, specialImportRegistry
 from ExceptionHandling import format_typename, format_outerframe
 
 import copy
@@ -1172,6 +1172,7 @@ class EDAlias(_ConfigureComponent,_Labelable,_Parameterizable):
         parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
 
     def dumpPython(self, options=PrintOptions()):
+        specialImportRegistry.registerUse(self)
         resultList = ['cms.EDAlias(']
         separator = ""
         for name in self.parameterNames_():

--- a/Mixing/Base/src/SecondaryEventProvider.cc
+++ b/Mixing/Base/src/SecondaryEventProvider.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
 
 namespace edm {
   SecondaryEventProvider::SecondaryEventProvider(std::vector<ParameterSet>& psets,
@@ -24,7 +25,7 @@ namespace edm {
                                                shouldBeUsedLabels);
     }
     if(!unscheduledLabels.empty()) {
-      workerManager_.setOnDemandProducts(preg, unscheduledLabels);
+      preg.setUnscheduledProducts(unscheduledLabels);
     }
   } // SecondaryEventProvider::SecondaryEventProvider
 


### PR DESCRIPTION
In a heterogeneous workflow it may happen that the (legacy) CPU and non-CPU modules are naturally defined so differently that the final legacy CPU products are produced in a very asymmetric way (e.g.
* CPU: producer `A` produces `a1`, `a2`, producer `B` produces `b1
* non-CPU: producer `D` produces `a1`, producer `C` produces `a2` and `b1`

). In order to be able to handle such cases flexibly and efficiently, this PR extends the SwitchProducer mechanism to allow EDAliases as cases (in addition to EDProducers). This required first some fixes to EDAliases:
* Throw if an EDAlias defines two instances pointing to the same real product
   * Currently the OutputModule will complain if an alias and the alias-for branches are attempted to be kept. This check does not work with SwitchProducer, whose output branches are not exactly alias branches (even if they're very close to). The premise is that it does not make sense to have both the alias and alias-for branches.
* If a job has an unscheduled EDProducer that registers a callback for new product registration such that the callback calls `produces()`, and that callback gets triggered by EDAlias (output) BranchDescriptions, the EDProducer BranchDescriptions have an incorrect on-demand status leading to a wrong ProductResolver and eventually a job to hang because of starvation in the TBB scheduler. This situation happens because the on-demand status for EDProducer BranchDescriptions is set before the EDAliases are processed in the Schedule. The fix is to move the setting of the on-demand status of BranchDescriptions to be done after the EDAlias output BranchDescriptions have been created.
  * The setting is also a bit more efficient now that it is done once instead of once per stream
* Made the python `EDAlias` cloneable and to inherit from `_Parameterizable`
  * Latter reduces copy-paste and enables `Modifier.toReplaceWith()`

Adding the support for EDAlias cases in SwitchProducer required the following changes
* SwitchProducer ProductResolvers can be set only after all EDAlias ProductResolvers have been set
* Added a new (intermediate) base class `DataManagingOrAliasProductResolver`, from which the `DataManaging`, `Alias`, and `SwitchBase` ProductResolvers inherit from, in order to be able use both `DataManaging` and `Alias` ProductResolvers as the `realProduct` in `SwitchBaseProductResolver`
* Added a special treatment for SwitchProducer in `ProductSelector` to detect the case when one attempts to keep in OutputModule both the real product, and the EDAlias-within-SwitchProducer. Similar check is already done for regular EDAliases (as mentioned above)
  * The same check does not work for SwitchProducers because there the `BranchID` of the SwitchProducer and the case product/alias are different, while in case of EDAlias the `BranchID` of the alias and the alias-for product as the same.
* In python `Process`, separate `SwitchProducers` from the normal `EDProducers`. This change is needed in order to append elements to both `@all_modules` and `@all_aliases` `vstring`s when filling the ProcessDescription. This way the case-EDAlias can away from the `Process.aliases_()` (as the case-EDProducers are not in `Process.producers_()`).
* As an additional sanity check, mark all case BranchDescriptions as transient in order to ignore them in OutputModule keep statements like `keep *_foo*_*_*`.
  * I also tried to "implicitly drop" all branches with '@' in `ProductSelector`, but that lead to SwitchProducer branches being dropped on inputs as they would be interpreted as branches depending on a dropped branch.

This PR also adds a generic mechanism to allow customized configuration entities to pass import statements to configuration dump. Related, currently the case-producer fragments end up in the configuration dump while they should not, this PR fixes that (as a byproduct).


Tested in CMSSW_10_5_X_2019-02-08-1100, no changes expected in current workflows.