### PR TITLE
 Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc const-cast fix

### DIFF
--- a/Geometry/GEMGeometry/interface/GEMGeometry.h
+++ b/Geometry/GEMGeometry/interface/GEMGeometry.h
@@ -119,7 +119,7 @@ class GEMGeometry : public TrackingGeometry {
   mapIdToDet theMap;
 
   std::vector<const GEMEtaPartition*> allEtaPartitions; // Are not owned by this class; are owned by their chamber.
-  std::vector<const GEMChamber*> allChambers; // Are not owned by this class; are owned by their chamber.
+  std::vector<const GEMChamber*> allChambers; // Are not owned by this class; are owned by their superchamber.
   std::vector<const GEMSuperChamber*> allSuperChambers; // Are owned by this class.
   std::vector<const GEMRing*> allRings; // Are owned by this class.
   std::vector<const GEMStation*> allStations; // Are owned by this class.

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
@@ -49,6 +49,7 @@ GEMGeometryBuilderFromDDD::build( GEMGeometry& theGeometry,
   bool doSuper = fv.firstChild();
   LogDebug("GEMGeometryBuilderFromDDD") << "doSuperChamber = " << doSuper;
   // loop over superchambers
+  std::vector<GEMSuperChamber*> superChambers;
   while (doSuper){
 
     // getting chamber id from eta partitions
@@ -66,6 +67,7 @@ GEMGeometryBuilderFromDDD::build( GEMGeometry& theGeometry,
     if (detIdCh.layer() == 1){// only make superChambers when doing layer 1
       GEMSuperChamber *gemSuperChamber = buildSuperChamber(fv, detIdCh);
       theGeometry.add(gemSuperChamber);
+      superChambers.push_back(gemSuperChamber);
     }
     GEMChamber *gemChamber = buildChamber(fv, detIdCh);
     
@@ -103,7 +105,7 @@ GEMGeometryBuilderFromDDD::build( GEMGeometry& theGeometry,
   }
   
   auto& superChambers(theGeometry.superChambers());
-  // construct the regions, stations and rings. 
+  // construct the regions, stations and rings.
   for (int re = -1; re <= 1; re = re+2) {
     GEMRegion* region = new GEMRegion(re);
     for (int st=1; st<=GEMDetId::maxStationId; ++st) {
@@ -113,8 +115,7 @@ GEMGeometryBuilderFromDDD::build( GEMGeometry& theGeometry,
       station->setName(name);
       for (int ri=1; ri<=1; ++ri) {
 	GEMRing* ring = new GEMRing(re, st, ri);
-	for (auto sch : superChambers){
-	  GEMSuperChamber* superChamber = const_cast<GEMSuperChamber*>(sch);
+	for (auto superChamber : superChambers){
 	  const GEMDetId detId(superChamber->id());
 	  if (detId.region() != re || detId.station() != st || detId.ring() != ri) continue;
 	  

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
@@ -104,7 +104,6 @@ GEMGeometryBuilderFromDDD::build( GEMGeometry& theGeometry,
     if (!loopExecuted) delete gemChamber;
   }
   
-  auto& superChambers(theGeometry.superChambers());
   // construct the regions, stations and rings.
   for (int re = -1; re <= 1; re = re+2) {
     GEMRegion* region = new GEMRegion(re);

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
@@ -66,7 +66,6 @@ GEMGeometryBuilderFromDDD::build( GEMGeometry& theGeometry,
     // making superchamber out of the first chamber layer including the gap between chambers
     if (detIdCh.layer() == 1){// only make superChambers when doing layer 1
       GEMSuperChamber *gemSuperChamber = buildSuperChamber(fv, detIdCh);
-      theGeometry.add(gemSuperChamber);
       superChambers.push_back(gemSuperChamber);
     }
     GEMChamber *gemChamber = buildChamber(fv, detIdCh);
@@ -122,6 +121,7 @@ GEMGeometryBuilderFromDDD::build( GEMGeometry& theGeometry,
 	  superChamber->add( theGeometry.chamber(GEMDetId(detId.region(),detId.ring(),detId.station(),2,detId.chamber(),0)));
 	  
 	  ring->add(superChamber);
+	  theGeometry.add(superChamber);
 	  LogDebug("GEMGeometryBuilderFromDDD") << "Adding super chamber " << detId << " to ring: " 
 						<< "re " << re << " st " << st << " ri " << ri << std::endl;
  	}


### PR DESCRIPTION
This PR is to fix a static analyzer error in the code above. The code was using a const_cast when building the GEM geometry. By storing the superchambers in a vector, we avoid the need to call the superchambers() function and therefore avoid the const cast.

@jshlee 