### PR TITLE
Manage PluginFactory plugins with unique_ptr in PhysicsTools

### DIFF
--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducer.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducer.cc
@@ -87,7 +87,7 @@ namespace citk {
       if( decimal != std::string::npos ) coneName.erase(decimal,1);
       const std::string& isotype = 
 	isodef.getParameter<std::string>("isolateAgainst");
-      IsolationConeDefinitionBase* theisolator =
+      auto theisolator =
 	CITKIsolationConeDefinitionFactory::get()->create(name,isodef);
       theisolator->setConsumes(consumesCollector());
       const auto thetype = _typeMap.find(isotype);
@@ -96,7 +96,7 @@ namespace citk {
 	  << "Isolation type: " << isotype << " is not available in the "
 	  << "list of allowed isolations!.";
       }
-      _isolation_types[thetype->second].emplace_back(theisolator);
+      _isolation_types[thetype->second].emplace_back(std::move(theisolator));
       const std::string dash("-");
       std::string pname = isotype+dash+coneName+dash+theisolator->additionalCode();
       _product_names[thetype->second].emplace_back(pname);

--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
@@ -93,7 +93,7 @@ namespace citk {
       if( decimal != std::string::npos ) coneName.erase(decimal,1);
       const std::string& isotype = 
 	isodef.getParameter<std::string>("isolateAgainst");
-      IsolationConeDefinitionBase* theisolator =
+      auto theisolator =
 	CITKIsolationConeDefinitionFactory::get()->create(name,isodef);
       theisolator->setConsumes(consumesCollector());
       const auto thetype = _typeMap.find(isotype);
@@ -102,7 +102,7 @@ namespace citk {
 	  << "Isolation type: " << isotype << " is not available in the "
 	  << "list of allowed isolations!.";
       }
-      _isolation_types[thetype->second].emplace_back(theisolator);
+      _isolation_types[thetype->second].emplace_back(std::move(theisolator));
       const std::string dash("-");
       std::string pname = isotype+dash+coneName+dash+theisolator->additionalCode();
       _product_names[thetype->second].emplace_back(pname);

--- a/PhysicsTools/IsolationAlgos/plugins/CandIsoDepositProducer.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CandIsoDepositProducer.cc
@@ -34,14 +34,13 @@ CandIsoDepositProducer::CandIsoDepositProducer(const ParameterSet& par) :
   theConfig(par),
   theCandCollectionToken(consumes< edm::View<reco::Candidate> >(par.getParameter<edm::InputTag>("src"))),
   theDepositNames(std::vector<std::string>(1,"")),
-  theMultipleDepositsFlag(par.getParameter<bool>("MultipleDepositsFlag")),
-  theExtractor(nullptr)
+  theMultipleDepositsFlag(par.getParameter<bool>("MultipleDepositsFlag"))
   {
   LogDebug("PhysicsTools|MuonIsolation")<<" CandIsoDepositProducer CTOR";
 
   edm::ParameterSet extractorPSet = theConfig.getParameter<edm::ParameterSet>("ExtractorPSet");
   std::string extractorName = extractorPSet.getParameter<std::string>("ComponentName");
-  theExtractor = IsoDepositExtractorFactory::get()->create( extractorName, extractorPSet, consumesCollector());
+  theExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( extractorName, extractorPSet, consumesCollector())};
 
   if (! theMultipleDepositsFlag) produces<reco::IsoDepositMap>();
   else {
@@ -67,7 +66,6 @@ CandIsoDepositProducer::CandIsoDepositProducer(const ParameterSet& par) :
 /// destructor
 CandIsoDepositProducer::~CandIsoDepositProducer(){
   LogDebug("PhysicsTools/CandIsoDepositProducer")<<" CandIsoDepositProducer DTOR";
-  delete theExtractor;
 }
 
 inline const reco::Track * CandIsoDepositProducer::extractTrack(const reco::Candidate &c, reco::Track *dummy) const {

--- a/PhysicsTools/IsolationAlgos/plugins/CandIsoDepositProducer.h
+++ b/PhysicsTools/IsolationAlgos/plugins/CandIsoDepositProducer.h
@@ -34,7 +34,7 @@ private:
   TrackType     theTrackType;
   std::vector<std::string> theDepositNames;
   bool theMultipleDepositsFlag;
-  reco::isodeposit::IsoDepositExtractor * theExtractor;
+  std::unique_ptr<reco::isodeposit::IsoDepositExtractor> theExtractor;
 
 };
 #endif

--- a/PhysicsTools/MVAComputer/src/VarProcessor.cc
+++ b/PhysicsTools/MVAComputer/src/VarProcessor.cc
@@ -100,8 +100,8 @@ VarProcessor *ProcessRegistry<VarProcessor, Calibration::VarProcessor,
 	if (!result) {
 		// try to load the shared library and retry
 		try {
-			delete VPPluginFactory::get()->create(
-					std::string("VarProcessor/") + name);
+			std::unique_ptr<PhysicsTools::VarProcessor::Dummy> tmp {VPPluginFactory::get()->create(
+					std::string("VarProcessor/") + name)};
 			result = ProcessRegistry::create(name, calib, parent);
 		} catch(const cms::Exception &e) {
 			// caller will have to deal with the null pointer

--- a/PhysicsTools/MVATrainer/src/TrainProcessor.cc
+++ b/PhysicsTools/MVATrainer/src/TrainProcessor.cc
@@ -154,8 +154,8 @@ TrainProcessor *ProcessRegistry<TrainProcessor, AtomicId,
 	if (!result) {
 		// try to load the shared library and retry
 		try {
-			delete TrainProcessor::PluginFactory::get()->create(
-				std::string("TrainProcessor/") + name);
+			std::unique_ptr<PhysicsTools::TrainProcessor::Dummy> tmp{TrainProcessor::PluginFactory::get()->create(
+				std::string("TrainProcessor/") + name)};
 			result = ProcessRegistry::create(name, id, trainer);
 		} catch(const cms::Exception &e) {
 			// caller will have to deal with the null pointer

--- a/PhysicsTools/PatAlgos/interface/ObjectModifier.h
+++ b/PhysicsTools/PatAlgos/interface/ObjectModifier.h
@@ -39,9 +39,7 @@ namespace pat {
     for(unsigned i = 0; i < mods.size(); ++i ) {
       const edm::ParameterSet& iconf = mods[i];
       const std::string& mname = iconf.getParameter<std::string>("modifierName");
-      ModifyObjectValueBase* plugin = 
-        ModifyObjectValueFactory::get()->create(mname,iconf,cc);
-      modifiers_.emplace_back(plugin);
+      modifiers_.emplace_back(ModifyObjectValueFactory::get()->create(mname,iconf,cc));
     }
   }
 }

--- a/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
@@ -222,14 +222,7 @@ initialize( const edm::ParameterSet& conf ) {
     const bool needsContent = 
       icut->getParameter<bool>("needsAdditionalProducts");     
     const bool ignored = icut->getParameter<bool>("isIgnored");
-    candf::CandidateCut* plugin = nullptr;
-    CINT_GUARD(plugin = CutApplicatorFactory::get()->create(name,*icut));
-    if( plugin != nullptr ) {
-      cuts_.push_back(SHARED_PTR(candf::CandidateCut)(plugin));
-    } else {
-      throw cms::Exception("BadPluginName")
-	<< "The requested cut: " << name << " is not available!";
-    }
+    CINT_GUARD(cuts_.emplace_back(CutApplicatorFactory::get()->create(name,*icut)));
     needs_event_content_.push_back(needsContent);
     const std::string therealname = realname.str();
     this->push_back(therealname);

--- a/PhysicsTools/UtilAlgos/interface/CachingVariable.h
+++ b/PhysicsTools/UtilAlgos/interface/CachingVariable.h
@@ -163,7 +163,7 @@ class ComputedVariable : public CachingVariable {
     return cache_;
   }
  private:
-  const VariableComputer * myComputer;
+  std::unique_ptr<const VariableComputer> myComputer;
 };
 
 class VariableComputerTest : public VariableComputer {

--- a/PhysicsTools/UtilAlgos/interface/CachingVariable.h
+++ b/PhysicsTools/UtilAlgos/interface/CachingVariable.h
@@ -523,8 +523,7 @@ class SimpleValueVariable : public CachingVariable {
     src_(iC.consumes<TYPE>(edm::Service<InputTagDistributorService>()->retrieve("src",arg.iConfig))) { arg.m[arg.n]=this;}
   CachingVariable::evalType eval(const edm::Event & iEvent) const override{
     edm::Handle<TYPE> value;
-    try{    iEvent.getByToken(src_,value);   }
-    catch(...){ return std::make_pair(false,0); }
+    iEvent.getByToken(src_,value);
     if (value.failedToGet() || !value.isValid()) return std::make_pair(false,0);
     else return std::make_pair(true, *value);
   }
@@ -541,8 +540,7 @@ class SimpleValueVectorVariable : public CachingVariable {
     index_(arg.iConfig.getParameter<unsigned int>("index")) { arg.m[arg.n]=this;}
   CachingVariable::evalType eval(const edm::Event & iEvent) const override{
     edm::Handle<std::vector<TYPE> > values;
-    try { iEvent.getByToken(src_,values);}
-    catch(...){ return std::make_pair(false,0); }
+    iEvent.getByToken(src_,values);
     if (values.failedToGet() || !values.isValid()) return std::make_pair(false,0);
     else if (index_>=values->size()) return std::make_pair(false,0);
     else return std::make_pair(true, (*values)[index_]);

--- a/PhysicsTools/UtilAlgos/interface/Selections.h
+++ b/PhysicsTools/UtilAlgos/interface/Selections.h
@@ -11,17 +11,17 @@
 
 class Filter {
  public:
-  Filter() :  selector_(nullptr){}
+  Filter() = default;
   Filter(const edm::ParameterSet& iConfig, edm::ConsumesCollector & iC);
   Filter(std::string name, edm::ParameterSet& iConfig, edm::ConsumesCollector & iC) :
-  name_(name), selector_(nullptr),cached_decision_(false),eventCacheID_(0)
+  name_(name), cached_decision_(false),eventCacheID_(0)
   {
     dump_=iConfig.dump();
     if (!iConfig.empty()){
       const std::string d("name");
       iConfig.addUntrackedParameter<std::string>(d,name);
       std::string componentName = iConfig.getParameter<std::string>("selector");
-      selector_ = EventSelectorFactoryFromHelper::get()->create(componentName, iConfig, iC);
+      selector_ = std::unique_ptr<EventSelector>(EventSelectorFactoryFromHelper::get()->create(componentName, iConfig, iC));
       if (iConfig.exists("description"))
 	description_=iConfig.getParameter<std::vector<std::string> >("description");
       else
@@ -29,6 +29,11 @@ class Filter {
     }
   }
   virtual ~Filter(){}
+
+  Filter(const Filter&) = delete;
+  Filter& operator=(const Filter&) = delete;
+  Filter(Filter&&) = default;
+  Filter& operator=(Filter&&) = default;
 
   const std::string & name() {return name_;}
   const std::string & dump() { return dump_;}
@@ -58,7 +63,7 @@ class Filter {
  protected:
   std::string name_;
   std::vector<std::string> description_;
-  EventSelector * selector_;
+  std::unique_ptr<EventSelector> selector_;
   mutable bool cached_decision_;
   mutable edm::Event::CacheIdentifier_t eventCacheID_ = 0;
   std::string dump_;
@@ -159,6 +164,11 @@ class FilterSelection : public Filter {
     if (makeDetailledPrintout_)
       detailledPrintoutCategory_ = iConfig.getParameter<std::string>("detailledPrintoutCategory");
   }
+
+  FilterSelection(const FilterSelection&) = delete;
+  FilterSelection& operator=(const FilterSelection&) = delete;
+  FilterSelection(FilterSelection&&) = default;
+  FilterSelection& operator=(FilterSelection&&) = default;
 
   const std::string & name() {return name_;}
   iterator begin() { return filters_.begin();}

--- a/PhysicsTools/UtilAlgos/plugins/NTuplingDevice.cc
+++ b/PhysicsTools/UtilAlgos/plugins/NTuplingDevice.cc
@@ -46,7 +46,7 @@ class NTuplingDevice : public edm::EDProducer {
       void endJob() override ;
       
       // ----------member data ---------------------------
-  NTupler * ntupler_;
+  std::unique_ptr<NTupler> ntupler_;
 };
 
 //
@@ -65,7 +65,7 @@ NTuplingDevice::NTuplingDevice(const edm::ParameterSet& iConfig)
   //this Ntupler can work with the InputTagDistributor, but should not be configured as such.
   edm::ParameterSet ntPset = iConfig.getParameter<edm::ParameterSet>("Ntupler");
   std::string ntuplerName=ntPset.getParameter<std::string>("ComponentName");
-  ntupler_ = NTuplerFactory::get()->create(ntuplerName, ntPset);
+  ntupler_ = std::unique_ptr<NTupler>(NTuplerFactory::get()->create(ntuplerName, ntPset));
 
   //register the leaves from the ntupler
   ntupler_->registerleaves(this);

--- a/PhysicsTools/UtilAlgos/plugins/PlottingDevice.cc
+++ b/PhysicsTools/UtilAlgos/plugins/PlottingDevice.cc
@@ -49,7 +49,7 @@ class PlottingDevice : public edm::EDAnalyzer {
       // ----------member data ---------------------------
   std::string vHelperInstance_;
   std::string plotDirectoryName_;
-  Plotter * plotter_;
+  std::unique_ptr<Plotter> plotter_;
 };
 
 //
@@ -78,7 +78,7 @@ PlottingDevice::PlottingDevice(const edm::ParameterSet& iConfig)
   //configure the plotting device
   edm::ParameterSet plotPset = iConfig.getParameter<edm::ParameterSet>("Plotter");
   std::string plotterName = plotPset.getParameter<std::string>("ComponentName");
-  plotter_ = PlotterFactory::get()->create(plotterName, plotPset);
+  plotter_ = std::unique_ptr<Plotter>(PlotterFactory::get()->create(plotterName, plotPset));
 }
 
 

--- a/PhysicsTools/UtilAlgos/src/CachingVariable.cc
+++ b/PhysicsTools/UtilAlgos/src/CachingVariable.cc
@@ -83,12 +83,9 @@ void VariableComputer::doesNotCompute(std::string var) const{
 
 
 ComputedVariable::ComputedVariable(const CachingVariableFactoryArg& arg, edm::ConsumesCollector& iC ) :
-  CachingVariable("ComputedVariable",arg.n,arg.iConfig,iC){
-  // instanciate the computer
-    std::string computerType = arg.iConfig.getParameter<std::string>("computer");
-    myComputer = VariableComputerFactory::get()->create(computerType,arg,iC);
-    //there is a memory leak here, because the object we are in is not register anywhere. since it happens once per job, this is not a big deal.
-}
+  CachingVariable("ComputedVariable",arg.n,arg.iConfig,iC),
+  myComputer{VariableComputerFactory::get()->create(arg.iConfig.getParameter<std::string>("computer"),arg,iC)}
+{}
 
 VariableComputerTest::VariableComputerTest(const CachingVariable::CachingVariableFactoryArg& arg, edm::ConsumesCollector& iC) : VariableComputer(arg, iC){
   declare("toto", iC);


### PR DESCRIPTION
In addition use `unique_ptr` or `shared_ptr` constructor where needed to prepare for PluginFactory returnning `std::unique_ptr`. Also removed useless try-catches from `CachingVariable`.

Tested in CMSSW_10_5_X_2019-02-05-1100 , no changes expected.