### PR TITLE
Low pT electrons: modify value maps storing Seed BDT outputs

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
@@ -1,11 +1,10 @@
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectronCore.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackExtra.h"
 #include "DataFormats/ParticleFlowReco/interface/PreId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -14,7 +13,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 LowPtGsfElectronSeedValueMapsProducer::LowPtGsfElectronSeedValueMapsProducer( const edm::ParameterSet& conf ) :
-  gsfElectrons_(consumes<reco::GsfElectronCollection>(conf.getParameter<edm::InputTag>("electrons"))),
+  gsfTracks_(consumes<reco::GsfTrackCollection>(conf.getParameter<edm::InputTag>("gsfTracks"))),
   preIdsValueMap_(consumes< edm::ValueMap<reco::PreIdRef> >(conf.getParameter<edm::InputTag>("preIdsValueMap"))),
   names_(conf.getParameter< std::vector<std::string> >("ModelNames"))
 {
@@ -29,33 +28,32 @@ LowPtGsfElectronSeedValueMapsProducer::~LowPtGsfElectronSeedValueMapsProducer() 
 //
 void LowPtGsfElectronSeedValueMapsProducer::produce( edm::Event& event, const edm::EventSetup& setup ) {
 
-  // Retrieve GsfElectrons from Event
-  edm::Handle<reco::GsfElectronCollection> gsfElectrons;
-  event.getByToken(gsfElectrons_,gsfElectrons);
-  if ( !gsfElectrons.isValid() ) { edm::LogError("Problem with gsfElectrons handle"); }
+  // Retrieve GsfTracks from Event
+  edm::Handle<reco::GsfTrackCollection> gsfTracks;
+  event.getByToken(gsfTracks_,gsfTracks);
+  if ( !gsfTracks.isValid() ) { edm::LogError("Problem with gsfTracks handle"); }
 
   // Retrieve PreIds from Event
   edm::Handle< edm::ValueMap<reco::PreIdRef> > preIdsValueMap;
   event.getByToken(preIdsValueMap_,preIdsValueMap);
   if ( !preIdsValueMap.isValid() ) { edm::LogError("Problem with preIdsValueMap handle"); }
   
-  // Iterate through Electrons, extract BDT output, and store result in ValueMap for each model
+  // Iterate through GsfTracks, extract BDT output, and store result in ValueMap for each model
   std::vector< std::vector<float> > output;
   for ( unsigned int iname = 0; iname < names_.size(); ++iname ) { 
-    output.push_back( std::vector<float>(gsfElectrons->size(),-999.) );
+    output.push_back( std::vector<float>(gsfTracks->size(),-999.) );
   }
-  for ( unsigned int iele = 0; iele < gsfElectrons->size(); iele++ ) {
-    reco::GsfElectronRef ele(gsfElectrons,iele);
-    if ( ele->core().isNonnull() && 
-	 ele->core()->gsfTrack().isNonnull() && 
-	 ele->core()->gsfTrack()->extra().isNonnull() && 
-	 ele->core()->gsfTrack()->extra()->seedRef().isNonnull() ) {
-      reco::ElectronSeedRef seed = ele->core()->gsfTrack()->extra()->seedRef().castTo<reco::ElectronSeedRef>();
+  for ( unsigned int igsf = 0; igsf < gsfTracks->size(); igsf++ ) {
+    reco::GsfTrackRef gsf(gsfTracks,igsf);
+    if ( gsf.isNonnull() && 
+	 gsf->extra().isNonnull() && 
+	 gsf->extra()->seedRef().isNonnull() ) {
+      reco::ElectronSeedRef seed = gsf->extra()->seedRef().castTo<reco::ElectronSeedRef>();
       if ( seed.isNonnull() && seed->ctfTrack().isNonnull() ) {
 	const reco::PreIdRef preid = (*preIdsValueMap)[seed->ctfTrack()];
 	if ( preid.isNonnull() ) {
 	  for ( unsigned int iname = 0; iname < names_.size(); ++iname ) {
-	    output[iname][iele] = preid->mva(iname);
+	    output[iname][igsf] = preid->mva(iname);
 	  }
 	}
       }
@@ -66,7 +64,7 @@ void LowPtGsfElectronSeedValueMapsProducer::produce( edm::Event& event, const ed
   for ( unsigned int iname = 0; iname < names_.size(); ++iname ) {
     auto ptr = std::make_unique< edm::ValueMap<float> >( edm::ValueMap<float>() );
     edm::ValueMap<float>::Filler filler(*ptr);
-    filler.insert(gsfElectrons, output[iname].begin(), output[iname].end());
+    filler.insert(gsfTracks, output[iname].begin(), output[iname].end());
     filler.fill();
     event.put(std::move(ptr),names_[iname]);
   }
@@ -78,9 +76,9 @@ void LowPtGsfElectronSeedValueMapsProducer::produce( edm::Event& event, const ed
 void LowPtGsfElectronSeedValueMapsProducer::fillDescriptions( edm::ConfigurationDescriptions& descriptions )
 {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("electrons",edm::InputTag("lowPtGsfElectrons"));
+  desc.add<edm::InputTag>("gsfTracks",edm::InputTag("lowPtGsfEleGsfTracks"));
   desc.add<edm::InputTag>("preIdsValueMap",edm::InputTag("lowPtGsfElectronSeeds"));
-  desc.add< std::vector<std::string> >("ModelNames",std::vector<std::string>({"default"}));
+  desc.add< std::vector<std::string> >("ModelNames",std::vector<std::string>());
   descriptions.add("defaultLowPtGsfElectronSeedValueMaps",desc);
 }
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.h
@@ -2,7 +2,7 @@
 #define RecoEgamma_EgammaElectronProducers_LowPtGsfElectronSeedValueMapsProducer_h
 
 #include "DataFormats/Common/interface/ValueMap.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PreIdFwd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -24,11 +24,10 @@ class LowPtGsfElectronSeedValueMapsProducer : public edm::stream::EDProducer<> {
 
  private:
   
-  const edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectrons_;
+  const edm::EDGetTokenT<reco::GsfTrackCollection> gsfTracks_;
   const edm::EDGetTokenT< edm::ValueMap<reco::PreIdRef> > preIdsValueMap_;
   const std::vector<std::string> names_;
 
 };
 
 #endif // RecoEgamma_EgammaElectronProducers_LowPtGsfElectronSeedValueMapsProducer_h
-


### PR DESCRIPTION
This PR is a small modification to the code base in the now-merged PR #25753. 

The back port of this PR to 10.2.X is #25887.

The change is very small and concerns the only the ```LowPtGsfElectronSeedValueMapsProducer``` class, which produces ValueMaps that store the discriminator values from the BDT models used in the ```LowPtGsfElectronSeedProducer```.  

The ValueMaps originally stored the BDT outputs per GsfElectrons, but we need them per GsfTrack. There is a near (but not exact) 1-to-1 correspondence between GsfElectrons and GsfTracks, so the ValueMaps will increase moderately in size (at the few tens of % level, not orders of magnitude!) and they will use a different key.  

No externals are needed nor changed for this PR. 

__We will need to back port this PR to the 10.2.X release cycle.__

To give a sense of scale, below are the timing and footprint metrics for the _original_ code. We do not expect these to change dramatically. 

__Timing__:
```
The same excluding the first 1 events
  delta/mean delta/orJob     original                   new       module name
  ---------- ------------     --------                  ----       ------------
       added      +0.00%         0.00 ms/ev ->         0.03 ms/ev lowPtGsfElectronSeedValueMaps
  ---------- ------------     --------                  ----       ------------
```
__RECO footprint__:
```
Compare packed values
-----------------------------------------------------------------
   or, B         new, B      delta, B   delta, %   deltaJ, %    branch 
-----------------------------------------------------------------
      0.0 ->        98.5         98     NEWO   0.00     floatedmValueMap_lowPtGsfElectronSeedValueMaps_ptbiased_RECO.
      0.0 ->        97.8         98     NEWO   0.00     floatedmValueMap_lowPtGsfElectronSeedValueMaps_unbiased_RECO.
 -----------------------------------------------------------------
  3748472 ->     3755317       6845             0.2     ALL BRANCHES
```

