### PR TITLE
Use emplace_back() directly for PluginFactory plugins in SimFastTiming and SimTracker

### DIFF
--- a/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.cc
+++ b/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.cc
@@ -18,8 +18,7 @@ FTLDigiProducer::FTLDigiProducer(edm::ParameterSet const& pset, edm::ProducerBas
   for(const auto& psname : psetNames) {
     const auto& ps = pset.getParameterSet(psname);
     const std::string& digitizerName = ps.getParameter<std::string>("digitizerName");
-    auto temp = FTLDigitizerFactory::get()->create(digitizerName,ps,iC,mixMod);
-    theDigitizers_.emplace_back(temp);
+    theDigitizers_.emplace_back(FTLDigitizerFactory::get()->create(digitizerName,ps,iC,mixMod));
   } 
 }
 

--- a/SimFastTiming/FastTimingCommon/plugins/MTDDigiProducer.cc
+++ b/SimFastTiming/FastTimingCommon/plugins/MTDDigiProducer.cc
@@ -18,8 +18,7 @@ MTDDigiProducer::MTDDigiProducer(edm::ParameterSet const& pset, edm::ProducerBas
   for(const auto& psname : psetNames) {
     const auto& ps = pset.getParameterSet(psname);
     const std::string& digitizerName = ps.getParameter<std::string>("digitizerName");
-    auto temp = MTDDigitizerFactory::get()->create(digitizerName,ps,iC,mixMod);
-    theDigitizers_.emplace_back(temp);
+    theDigitizers_.emplace_back(MTDDigitizerFactory::get()->create(digitizerName,ps,iC,mixMod));
   } 
 }
 

--- a/SimTracker/TrackAssociation/plugins/TrackTimeValueMapProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/TrackTimeValueMapProducer.cc
@@ -98,8 +98,7 @@ TrackTimeValueMapProducer::TrackTimeValueMapProducer(const edm::ParameterSet& co
   const std::vector<edm::ParameterSet>& resos = conf.getParameterSetVector("resolutionModels");
   for( const auto& reso : resos ) {
     const std::string& name = reso.getParameter<std::string>("modelName");
-    ResolutionModel* resomod = ResolutionModelFactory::get()->create(name,reso);
-    resolutions_.emplace_back( resomod );  
+    resolutions_.emplace_back( ResolutionModelFactory::get()->create(name,reso) );
 
     // times and time resolutions for general tracks
     produces<edm::ValueMap<float> >(tracksName_+name);


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-02-05-1100 , no changes expected.