### PR TITLE
Manage PluginFactory plugins with unique_ptr in RecoMuon

### DIFF
--- a/RecoMuon/L2MuonIsolationProducer/src/L2MuonIsolationProducer.cc
+++ b/RecoMuon/L2MuonIsolationProducer/src/L2MuonIsolationProducer.cc
@@ -34,9 +34,7 @@ using namespace muonisolation;
 
 /// constructor with config
 L2MuonIsolationProducer::L2MuonIsolationProducer(const ParameterSet& par) :
-  theSACollectionLabel(par.getParameter<edm::InputTag>("StandAloneCollectionLabel")),
-  theExtractor(nullptr),
-  theDepositIsolator(nullptr)
+  theSACollectionLabel(par.getParameter<edm::InputTag>("StandAloneCollectionLabel"))
 {
   LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")<<" L2MuonIsolationProducer constructor called";
 
@@ -47,7 +45,7 @@ L2MuonIsolationProducer::L2MuonIsolationProducer(const ParameterSet& par) :
   //
   edm::ParameterSet extractorPSet = par.getParameter<edm::ParameterSet>("ExtractorPSet");
   std::string extractorName = extractorPSet.getParameter<std::string>("ComponentName");
-  theExtractor = IsoDepositExtractorFactory::get()->create( extractorName, extractorPSet, consumesCollector());
+  theExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( extractorName, extractorPSet, consumesCollector())};
 
 
   edm::ParameterSet isolatorPSet = par.getParameter<edm::ParameterSet>("IsolatorPSet");
@@ -55,7 +53,7 @@ L2MuonIsolationProducer::L2MuonIsolationProducer(const ParameterSet& par) :
   optOutputDecision = haveIsolator;
   if (optOutputDecision){
     std::string type = isolatorPSet.getParameter<std::string>("ComponentName");
-    theDepositIsolator = MuonIsolatorFactory::get()->create(type, isolatorPSet, consumesCollector());
+    theDepositIsolator = std::unique_ptr<muonisolation::MuIsoBaseIsolator>{MuonIsolatorFactory::get()->create(type, isolatorPSet, consumesCollector())};
   }
   if (optOutputDecision) produces<edm::ValueMap<bool> >();
   produces<reco::IsoDepositMap>();
@@ -69,7 +67,6 @@ L2MuonIsolationProducer::L2MuonIsolationProducer(const ParameterSet& par) :
 /// destructor
 L2MuonIsolationProducer::~L2MuonIsolationProducer(){
   LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")<<" L2MuonIsolationProducer destructor called";
-  if (theExtractor) delete theExtractor;
 }
 
 /// ParameterSet descriptions

--- a/RecoMuon/L2MuonIsolationProducer/src/L2MuonIsolationProducer.h
+++ b/RecoMuon/L2MuonIsolationProducer/src/L2MuonIsolationProducer.h
@@ -49,10 +49,10 @@ class L2MuonIsolationProducer : public edm::stream::EDProducer<> {
   bool optOutputIsolatorFloat;
 
   // MuIsoExtractor
-  reco::isodeposit::IsoDepositExtractor* theExtractor;
+  std::unique_ptr<reco::isodeposit::IsoDepositExtractor> theExtractor;
 
   // muon isolator 
-  muonisolation::MuIsoBaseIsolator * theDepositIsolator;
+  std::unique_ptr<muonisolation::MuIsoBaseIsolator> theDepositIsolator;
 
 };
 

--- a/RecoMuon/L3MuonIsolationProducer/src/L3MuonCombinedRelativeIsolationProducer.cc
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3MuonCombinedRelativeIsolationProducer.cc
@@ -46,8 +46,6 @@ L3MuonCombinedRelativeIsolationProducer::L3MuonCombinedRelativeIsolationProducer
   theCaloDepsLabel(par.existsAs<InputTag>("CaloDepositsLabel") ?
                    par.getParameter<InputTag>("CaloDepositsLabel") :
                    InputTag("hltL3CaloMuonCorrectedIsolations")),
-  caloExtractor(nullptr),
-  trkExtractor(nullptr),
   theTrackPt_Min(-1),
   printDebug (par.getParameter<bool>("printDebug"))
   {
@@ -74,7 +72,7 @@ L3MuonCombinedRelativeIsolationProducer::L3MuonCombinedRelativeIsolationProducer
     edm::ParameterSet caloExtractorPSet = theConfig.getParameter<edm::ParameterSet>("CaloExtractorPSet");
 
     std::string caloExtractorName = caloExtractorPSet.getParameter<std::string>("ComponentName");
-    caloExtractor = IsoDepositExtractorFactory::get()->create( caloExtractorName, caloExtractorPSet, consumesCollector());
+    caloExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( caloExtractorName, caloExtractorPSet, consumesCollector())};
     //std::string caloDepositType = caloExtractorPSet.getUntrackedParameter<std::string>("DepositLabel"); // N.B. Not used in the following!
   }
 
@@ -84,7 +82,7 @@ L3MuonCombinedRelativeIsolationProducer::L3MuonCombinedRelativeIsolationProducer
 
   theTrackPt_Min = theConfig.getParameter<double>("TrackPt_Min");
   std::string trkExtractorName = trkExtractorPSet.getParameter<std::string>("ComponentName");
-  trkExtractor = IsoDepositExtractorFactory::get()->create( trkExtractorName, trkExtractorPSet, consumesCollector());
+  trkExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( trkExtractorName, trkExtractorPSet, consumesCollector())};
   //std::string trkDepositType = trkExtractorPSet.getUntrackedParameter<std::string>("DepositLabel"); // N.B. Not used in the following!
 
   //
@@ -119,8 +117,6 @@ L3MuonCombinedRelativeIsolationProducer::L3MuonCombinedRelativeIsolationProducer
 /// destructor
 L3MuonCombinedRelativeIsolationProducer::~L3MuonCombinedRelativeIsolationProducer(){
   LogDebug("RecoMuon|L3MuonCombinedRelativeIsolationProducer")<<" L3MuonCombinedRelativeIsolationProducer DTOR";
-  if (caloExtractor) delete caloExtractor;
-  if (trkExtractor) delete trkExtractor;
 }
 
 /// ParameterSet descriptions

--- a/RecoMuon/L3MuonIsolationProducer/src/L3MuonCombinedRelativeIsolationProducer.h
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3MuonCombinedRelativeIsolationProducer.h
@@ -58,8 +58,8 @@ private:
   edm::EDGetTokenT<edm::ValueMap<float> > theCaloDepsToken;
 
   // MuIsoExtractor
-  reco::isodeposit::IsoDepositExtractor * caloExtractor;
-  reco::isodeposit::IsoDepositExtractor * trkExtractor;
+  std::unique_ptr<reco::isodeposit::IsoDepositExtractor> caloExtractor;
+  std::unique_ptr<reco::isodeposit::IsoDepositExtractor> trkExtractor;
 
   //! pt cut to consider track in sumPt after extracting iso deposit
   //! better split this off into a filter

--- a/RecoMuon/L3MuonIsolationProducer/src/L3MuonIsolationProducer.cc
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3MuonIsolationProducer.cc
@@ -37,7 +37,6 @@ L3MuonIsolationProducer::L3MuonIsolationProducer(const ParameterSet& par) :
   theConfig(par),
   theMuonCollectionLabel(par.getParameter<InputTag>("inputMuonCollection")),
   optOutputIsoDeposits(par.getParameter<bool>("OutputMuIsoDeposits")),
-  theExtractor(nullptr),
   theTrackPt_Min(-1)
   {
   LogDebug("RecoMuon|L3MuonIsolationProducer")<<" L3MuonIsolationProducer CTOR";
@@ -54,7 +53,7 @@ L3MuonIsolationProducer::L3MuonIsolationProducer(const ParameterSet& par) :
   //! get min pt for the track to go into sumPt
   theTrackPt_Min = theConfig.getParameter<double>("TrackPt_Min");
   std::string extractorName = extractorPSet.getParameter<std::string>("ComponentName");
-  theExtractor = IsoDepositExtractorFactory::get()->create( extractorName, extractorPSet, consumesCollector());
+  theExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( extractorName, extractorPSet, consumesCollector())};
   std::string depositType = extractorPSet.getUntrackedParameter<std::string>("DepositLabel");
 
   //
@@ -88,7 +87,6 @@ L3MuonIsolationProducer::L3MuonIsolationProducer(const ParameterSet& par) :
 /// destructor
 L3MuonIsolationProducer::~L3MuonIsolationProducer(){
   LogDebug("RecoMuon|L3MuonIsolationProducer")<<" L3MuonIsolationProducer DTOR";
-  if (theExtractor) delete theExtractor;
 }
 
 void L3MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup){

--- a/RecoMuon/L3MuonIsolationProducer/src/L3MuonIsolationProducer.h
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3MuonIsolationProducer.h
@@ -45,7 +45,7 @@ private:
   double optOutputIsoDeposits;
 
   // MuIsoExtractor
-  reco::isodeposit::IsoDepositExtractor * theExtractor;
+  std::unique_ptr<reco::isodeposit::IsoDepositExtractor> theExtractor;
 
   //! pt cut to consider track in sumPt after extracting iso deposit
   //! better split this off into a filter

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -33,8 +33,7 @@
 
 #include "RecoMuon/MuonIdentification/interface/MuonKinkFinder.h"
 
-MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig):
-muIsoExtractorCalo_(nullptr),muIsoExtractorTrack_(nullptr),muIsoExtractorJet_(nullptr)
+MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
 {
   
   LogTrace("MuonIdentification") << "RecoMuon/MuonIdProducer :: Constructor called";
@@ -79,7 +78,7 @@ muIsoExtractorCalo_(nullptr),muIsoExtractorTrack_(nullptr),muIsoExtractorJet_(nu
 
    // Load parameters for the TimingFiller
    edm::ParameterSet timingParameters = iConfig.getParameter<edm::ParameterSet>("TimingFillerParameters");
-   theTimingFiller_ = new MuonTimingFiller(timingParameters,consumesCollector());
+   theTimingFiller_ = std::make_unique<MuonTimingFiller>(timingParameters,consumesCollector());
    
 
    if (fillCaloCompatibility_){
@@ -92,15 +91,15 @@ muIsoExtractorCalo_(nullptr),muIsoExtractorTrack_(nullptr),muIsoExtractorJet_(nu
       // Load MuIsoExtractor parameters
       edm::ParameterSet caloExtractorPSet = iConfig.getParameter<edm::ParameterSet>("CaloExtractorPSet");
       std::string caloExtractorName = caloExtractorPSet.getParameter<std::string>("ComponentName");
-      muIsoExtractorCalo_ = IsoDepositExtractorFactory::get()->create( caloExtractorName, caloExtractorPSet,consumesCollector());
+      muIsoExtractorCalo_ = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( caloExtractorName, caloExtractorPSet,consumesCollector())};
 
       edm::ParameterSet trackExtractorPSet = iConfig.getParameter<edm::ParameterSet>("TrackExtractorPSet");
       std::string trackExtractorName = trackExtractorPSet.getParameter<std::string>("ComponentName");
-      muIsoExtractorTrack_ = IsoDepositExtractorFactory::get()->create( trackExtractorName, trackExtractorPSet,consumesCollector());
+      muIsoExtractorTrack_ = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( trackExtractorName, trackExtractorPSet,consumesCollector())};
 
       edm::ParameterSet jetExtractorPSet = iConfig.getParameter<edm::ParameterSet>("JetExtractorPSet");
       std::string jetExtractorName = jetExtractorPSet.getParameter<std::string>("ComponentName");
-      muIsoExtractorJet_ = IsoDepositExtractorFactory::get()->create( jetExtractorName, jetExtractorPSet,consumesCollector());
+      muIsoExtractorJet_ = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( jetExtractorName, jetExtractorPSet,consumesCollector())};
    }
    if (fillIsolation_ && writeIsoDeposits_){
      trackDepositName_ = iConfig.getParameter<std::string>("trackDepositName");
@@ -138,7 +137,7 @@ muIsoExtractorCalo_(nullptr),muIsoExtractorTrack_(nullptr),muIsoExtractorJet_(nu
    }
 
    //create mesh holder
-   meshAlgo_ = new MuonMesh(iConfig.getParameter<edm::ParameterSet>("arbitrationCleanerOptions"));
+   meshAlgo_ = std::make_unique<MuonMesh>(iConfig.getParameter<edm::ParameterSet>("arbitrationCleanerOptions"));
 
 
    edm::InputTag rpcHitTag("rpcRecHits");
@@ -181,11 +180,6 @@ muIsoExtractorCalo_(nullptr),muIsoExtractorTrack_(nullptr),muIsoExtractorJet_(nu
 
 MuonIdProducer::~MuonIdProducer()
 {
-   if (muIsoExtractorCalo_) delete muIsoExtractorCalo_;
-   if (muIsoExtractorTrack_) delete muIsoExtractorTrack_;
-   if (muIsoExtractorJet_) delete muIsoExtractorJet_;
-   if (theTimingFiller_) delete theTimingFiller_;
-   if (meshAlgo_) delete meshAlgo_;
    // TimingReport::current()->dump(std::cout);
 }
 

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -175,7 +175,7 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    std::vector<edm::InputTag> inputCollectionLabels_;
    std::vector<ICTypes::ICTypeKey> inputCollectionTypes_;
 
-   MuonTimingFiller* theTimingFiller_;
+  std::unique_ptr<MuonTimingFiller> theTimingFiller_;
 
    // selections
    double minPt_;
@@ -227,9 +227,9 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    edm::Handle<edm::ValueMap<reco::MuonQuality> > glbQualHandle_;
    
    MuonCaloCompatibility muonCaloCompatibility_;
-   reco::isodeposit::IsoDepositExtractor* muIsoExtractorCalo_;
-   reco::isodeposit::IsoDepositExtractor* muIsoExtractorTrack_;
-   reco::isodeposit::IsoDepositExtractor* muIsoExtractorJet_;
+   std::unique_ptr<reco::isodeposit::IsoDepositExtractor> muIsoExtractorCalo_;
+   std::unique_ptr<reco::isodeposit::IsoDepositExtractor> muIsoExtractorTrack_;
+   std::unique_ptr<reco::isodeposit::IsoDepositExtractor> muIsoExtractorJet_;
    std::string trackDepositName_;
    std::string ecalDepositName_;
    std::string hcalDepositName_;
@@ -246,7 +246,7 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    double caloCut_;
    
    bool arbClean_;
-   MuonMesh* meshAlgo_;
+   std::unique_ptr<MuonMesh> meshAlgo_;
 
 };
 #endif

--- a/RecoMuon/MuonIsolation/interface/MuIsoByTrackPt.h
+++ b/RecoMuon/MuonIsolation/interface/MuIsoByTrackPt.h
@@ -32,13 +32,13 @@ public:
   void setConeSize(float dr);
   void setCut(float cut) { theCut = cut; }
 
-  virtual reco::isodeposit::IsoDepositExtractor * extractor() { return theExtractor; }
-  virtual muonisolation::IsolatorByDeposit * isolator() { return theIsolator; }
+  virtual reco::isodeposit::IsoDepositExtractor * extractor() { return theExtractor.get(); }
+  virtual muonisolation::IsolatorByDeposit * isolator() { return theIsolator.get(); }
 
 private:
   float theCut;
-  reco::isodeposit::IsoDepositExtractor * theExtractor;
-  muonisolation::IsolatorByDeposit * theIsolator;
+  std::unique_ptr<reco::isodeposit::IsoDepositExtractor> theExtractor;
+  std::unique_ptr<muonisolation::IsolatorByDeposit> theIsolator;
 };
 
 #endif

--- a/RecoMuon/MuonIsolation/src/MuIsoByTrackPt.cc
+++ b/RecoMuon/MuonIsolation/src/MuIsoByTrackPt.cc
@@ -20,23 +20,18 @@ using namespace muonisolation;
 
 
 MuIsoByTrackPt::MuIsoByTrackPt(const edm::ParameterSet& conf, edm::ConsumesCollector && iC)
-  : theExtractor(nullptr), theIsolator(nullptr)
 {
   edm::ParameterSet extractorPSet = conf.getParameter<edm::ParameterSet>("ExtractorPSet");
   string extractorName = extractorPSet.getParameter<string>("ComponentName");
-  theExtractor = IsoDepositExtractorFactoryFromHelper::get()->create(extractorName, extractorPSet, iC);
+  theExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>(IsoDepositExtractorFactoryFromHelper::get()->create(extractorName, extractorPSet, iC));
 
   theCut = conf.getUntrackedParameter<double>("Threshold", 0.);
   float coneSize =  conf.getUntrackedParameter<double>("ConeSize", 0.);
   vector<double> weights(1,1.);
-  theIsolator = new IsolatorByDeposit(coneSize, weights);
+  theIsolator = std::make_unique<IsolatorByDeposit>(coneSize, weights);
 }
 
-MuIsoByTrackPt::~MuIsoByTrackPt()
-{
-  delete theExtractor;
-  delete theIsolator;
-}
+MuIsoByTrackPt::~MuIsoByTrackPt() = default;
 
 void MuIsoByTrackPt::setConeSize(float dr)
 {

--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.cc
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.cc
@@ -35,8 +35,7 @@ using namespace muonisolation;
 //! constructor with config
 MuIsoDepositProducer::MuIsoDepositProducer(const ParameterSet& par) :
   theConfig(par),
-  theDepositNames(std::vector<std::string>(1,std::string())),
-  theExtractor(nullptr)
+  theDepositNames(std::vector<std::string>(1,std::string()))
 {
   static const std::string metname = "RecoMuon|MuonIsolationProducers|MuIsoDepositProducer";
   LogDebug(metname)<<" MuIsoDepositProducer CTOR";
@@ -75,20 +74,15 @@ MuIsoDepositProducer::MuIsoDepositProducer(const ParameterSet& par) :
     produces<reco::IsoDepositMap>(theDepositNames[i]).setBranchAlias(alias);
   }
 
-  if (!theExtractor) {
-    edm::ParameterSet extractorPSet = theConfig.getParameter<edm::ParameterSet>("ExtractorPSet");
-    std::string extractorName = extractorPSet.getParameter<std::string>("ComponentName");
-    theExtractor = IsoDepositExtractorFactory::get()->create( extractorName, extractorPSet, consumesCollector());
-    LogDebug(metname)<<" Load extractor..."<<extractorName;
-  }
-
-
+  edm::ParameterSet extractorPSet = theConfig.getParameter<edm::ParameterSet>("ExtractorPSet");
+  std::string extractorName = extractorPSet.getParameter<std::string>("ComponentName");
+  theExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( extractorName, extractorPSet, consumesCollector())};
+  LogDebug(metname)<<" Load extractor..."<<extractorName;
 }
 
 //! destructor
 MuIsoDepositProducer::~MuIsoDepositProducer(){
   LogDebug("RecoMuon/MuIsoDepositProducer")<<" MuIsoDepositProducer DTOR";
-  delete theExtractor;
 }
 
 //! build deposits

--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.cc
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.cc
@@ -69,7 +69,7 @@ MuIsoDepositProducer::MuIsoDepositProducer(const ParameterSet& par) :
 
   for (unsigned int i = 0; i < theDepositNames.size(); ++i){
     std::string alias = par.getParameter<std::string>("@module_label");
-    if (theDepositNames[i] != "") alias += "_" + theDepositNames[i];
+    if (!theDepositNames[i].empty()) alias += "_" + theDepositNames[i];
     produces<reco::IsoDepositMap>(theDepositNames[i]).setBranchAlias(alias);
   }
 

--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.cc
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.cc
@@ -34,7 +34,6 @@ using namespace muonisolation;
 
 //! constructor with config
 MuIsoDepositProducer::MuIsoDepositProducer(const ParameterSet& par) :
-  theConfig(par),
   theDepositNames(std::vector<std::string>(1,std::string()))
 {
   static const std::string metname = "RecoMuon|MuonIsolationProducers|MuIsoDepositProducer";
@@ -69,12 +68,12 @@ MuIsoDepositProducer::MuIsoDepositProducer(const ParameterSet& par) :
   }
 
   for (unsigned int i = 0; i < theDepositNames.size(); ++i){
-    std::string alias = theConfig.getParameter<std::string>("@module_label");
+    std::string alias = par.getParameter<std::string>("@module_label");
     if (theDepositNames[i] != "") alias += "_" + theDepositNames[i];
     produces<reco::IsoDepositMap>(theDepositNames[i]).setBranchAlias(alias);
   }
 
-  edm::ParameterSet extractorPSet = theConfig.getParameter<edm::ParameterSet>("ExtractorPSet");
+  edm::ParameterSet extractorPSet = par.getParameter<edm::ParameterSet>("ExtractorPSet");
   std::string extractorName = extractorPSet.getParameter<std::string>("ComponentName");
   theExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( extractorName, extractorPSet, consumesCollector())};
   LogDebug(metname)<<" Load extractor..."<<extractorName;

--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.h
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.h
@@ -37,7 +37,6 @@ private:
   edm::EDGetToken theMuonCollectionTag;
   std::vector<std::string> theDepositNames;
   bool theMultipleDepositsFlag;
-  reco::isodeposit::IsoDepositExtractor * theExtractor;
-
+  std::unique_ptr<reco::isodeposit::IsoDepositExtractor> theExtractor;
 };
 #endif

--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.h
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.h
@@ -24,9 +24,6 @@ public:
   void produce(edm::Event&, const edm::EventSetup&) override;
   
 private:
-  //! module configuration
-  edm::ParameterSet theConfig;
-
   //! input type. Choose from:
   //! 
   std::string theInputType;

--- a/RecoMuon/TrackerSeedGenerator/plugins/CompositeTSG.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/CompositeTSG.cc
@@ -14,20 +14,17 @@ CompositeTSG::CompositeTSG(const edm::ParameterSet & par,edm::ConsumesCollector&
     edm::ParameterSet TSGpset = par.getParameter<edm::ParameterSet>(*nIt);
     if (TSGpset.empty()) {
       theNames.push_back((*nIt)+":"+"NULL");
-      theTSGs.push_back((TrackerSeedGenerator*)nullptr);
+      theTSGs.emplace_back(nullptr);
     }else {
       std::string SeedGenName = TSGpset.getParameter<std::string>("ComponentName");
       theNames.push_back((*nIt)+":"+SeedGenName);
-      theTSGs.push_back(TrackerSeedGeneratorFactory::get()->create(SeedGenName,TSGpset,IC));
+      theTSGs.emplace_back(TrackerSeedGeneratorFactory::get()->create(SeedGenName,TSGpset,IC));
     }
   }
   
 }
 
-CompositeTSG::~CompositeTSG(){
-  //delete the components ?
-}
-
+CompositeTSG::~CompositeTSG() = default;
 
 void CompositeTSG::init(const MuonServiceProxy* service){
   theProxyService = service;

--- a/RecoMuon/TrackerSeedGenerator/plugins/CompositeTSG.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/CompositeTSG.h
@@ -38,7 +38,7 @@ public:
  protected:
 
   unsigned int nTSGs() { return theTSGs.size();}
-  std::vector<TrackerSeedGenerator*> theTSGs;
+  std::vector<std::unique_ptr<TrackerSeedGenerator>> theTSGs;
   std::vector<std::string> theNames;
   std::string theCategory;
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.h
@@ -25,7 +25,6 @@ class TSGFromL1Muon : public edm::stream::EDProducer<> {
 public:
   TSGFromL1Muon(const edm::ParameterSet& cfg);
   ~TSGFromL1Muon() override;
-  void beginRun(const edm::Run & run, const edm::EventSetup&es) override;
   void produce(edm::Event& ev, const edm::EventSetup& es) override;
 private:
  
@@ -36,9 +35,9 @@ private:
   edm::EDGetTokenT<PixelTrackFilter> theFilterToken;
 
   std::unique_ptr<L1MuonRegionProducer> theRegionProducer;
-  OrderedHitsGenerator * theHitGenerator;
+  std::unique_ptr<OrderedHitsGenerator> theHitGenerator;
   std::unique_ptr<L1MuonPixelTrackFitter> theFitter;
-  L1MuonSeedsMerger * theMerger;
+  std::unique_ptr<L1MuonSeedsMerger> theMerger;
 
 };
 #endif

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.h
@@ -30,13 +30,12 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  edm::ParameterSet theConfig;
   edm::InputTag theL2CollectionLabel;
-  MuonServiceProxy* theService;
+  std::unique_ptr<MuonServiceProxy> theService;
   double thePtCut,thePCut;
-  MuonTrackingRegionBuilder* theRegionBuilder;
-  TrackerSeedGenerator* theTkSeedGenerator;
-  TrackerSeedCleaner* theSeedCleaner;
+  std::unique_ptr<MuonTrackingRegionBuilder> theRegionBuilder;
+  std::unique_ptr<TrackerSeedGenerator> theTkSeedGenerator;
+  std::unique_ptr<TrackerSeedCleaner> theSeedCleaner;
   edm::EDGetTokenT<reco::TrackCollection> l2muonToken;
 };
 #endif

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromOrderedHits.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromOrderedHits.cc
@@ -11,27 +11,23 @@
 
 
 TSGFromOrderedHits::TSGFromOrderedHits(const edm::ParameterSet &pset,edm::ConsumesCollector & iC)
-  : theLastRun(0), theConfig(pset), theGenerator(nullptr)
+  : theLastRun(0)
 {
   edm::ParameterSet hitsfactoryPSet =
-      theConfig.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet");
+      pset.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet");
   std::string hitsfactoryName = hitsfactoryPSet.getParameter<std::string>("ComponentName");
-  OrderedHitsGenerator*  hitsGenerator =
-        OrderedHitsGeneratorFactory::get()->create( hitsfactoryName, hitsfactoryPSet, iC);
 
-  edm::ParameterSet seedCreatorPSet = theConfig.getParameter<edm::ParameterSet>("SeedCreatorPSet");
+  edm::ParameterSet seedCreatorPSet = pset.getParameter<edm::ParameterSet>("SeedCreatorPSet");
   std::string seedCreatorType = seedCreatorPSet.getParameter<std::string>("ComponentName");
 
-  theGenerator = new SeedGeneratorFromRegionHits(hitsGenerator, nullptr, 
-						 SeedCreatorFactory::get()->create(seedCreatorType, seedCreatorPSet)
-						 );
+  theGenerator = std::make_unique<SeedGeneratorFromRegionHits>(OrderedHitsGeneratorFactory::get()->create( hitsfactoryName, hitsfactoryPSet, iC),
+                                                               nullptr,
+                                                               SeedCreatorFactory::get()->create(seedCreatorType, seedCreatorPSet)
+                                                               );
 
 }
 
-TSGFromOrderedHits::~TSGFromOrderedHits()
-{
-  delete theGenerator; 
-}
+TSGFromOrderedHits::~TSGFromOrderedHits() = default;
 
 void TSGFromOrderedHits::run(TrajectorySeedCollection &seeds, 
       const edm::Event &ev, const edm::EventSetup &es, const TrackingRegion& region)

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromOrderedHits.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromOrderedHits.h
@@ -17,16 +17,12 @@ public:
 
   ~TSGFromOrderedHits() override;
 
-  using TrackerSeedGenerator::init;
 private:
   void run(TrajectorySeedCollection &seeds, 
       const edm::Event &ev, const edm::EventSetup &es, const TrackingRegion& region) override;
 
-private:
-  void init();
   edm::RunNumber_t theLastRun;
-  edm::ParameterSet theConfig;
-  SeedGeneratorFromRegionHits * theGenerator; 
+  std::unique_ptr<SeedGeneratorFromRegionHits> theGenerator;
 };
 
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGSmart.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGSmart.cc
@@ -8,56 +8,46 @@
 
 
 TSGSmart::TSGSmart(const edm::ParameterSet &pset,edm::ConsumesCollector& iC)
-  : theConfig(pset), thePairGenerator(nullptr), theTripletGenerator(nullptr), theMixedGenerator(nullptr)
 {
 
-  theEtaBound = theConfig.getParameter<double>("EtaBound");
+  theEtaBound = pset.getParameter<double>("EtaBound");
 
   // FIXME??
   edm::ParameterSet creatorPSet;
   creatorPSet.addParameter<std::string>("propagator","PropagatorWithMaterial");
 
-  edm::ParameterSet PairPSet = theConfig.getParameter<edm::ParameterSet>("PixelPairGeneratorSet"); 
+  edm::ParameterSet PairPSet = pset.getParameter<edm::ParameterSet>("PixelPairGeneratorSet");
   edm::ParameterSet pairhitsfactoryPSet =
     PairPSet.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet");
   std::string pairhitsfactoryName = pairhitsfactoryPSet.getParameter<std::string>("ComponentName");
-  OrderedHitsGenerator*  pairhitsGenerator =
-    OrderedHitsGeneratorFactory::get()->create( pairhitsfactoryName, pairhitsfactoryPSet, iC);
 
+  thePairGenerator = std::make_unique<SeedGeneratorFromRegionHits>( OrderedHitsGeneratorFactory::get()->create( pairhitsfactoryName, pairhitsfactoryPSet, iC),
+                                                                    nullptr,
+                                                                    SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)
+                                                                    );
 
-  thePairGenerator = new SeedGeneratorFromRegionHits( pairhitsGenerator, nullptr, 
-						 SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)
-						 );
-
-  edm::ParameterSet TripletPSet = theConfig.getParameter<edm::ParameterSet>("PixelTripletGeneratorSet"); 
+  edm::ParameterSet TripletPSet = pset.getParameter<edm::ParameterSet>("PixelTripletGeneratorSet"); 
   edm::ParameterSet triplethitsfactoryPSet =
     TripletPSet.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet");
   std::string triplethitsfactoryName = triplethitsfactoryPSet.getParameter<std::string>("ComponentName");
-  OrderedHitsGenerator*  triplethitsGenerator =
-    OrderedHitsGeneratorFactory::get()->create( triplethitsfactoryName, triplethitsfactoryPSet, iC);
-  theTripletGenerator = new SeedGeneratorFromRegionHits( triplethitsGenerator, nullptr, 
-						 SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)
-						 );
 
-  edm::ParameterSet MixedPSet = theConfig.getParameter<edm::ParameterSet>("MixedGeneratorSet"); 
+  theTripletGenerator = std::make_unique<SeedGeneratorFromRegionHits>( OrderedHitsGeneratorFactory::get()->create( triplethitsfactoryName, triplethitsfactoryPSet, iC),
+                                                                       nullptr,
+                                                                       SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)
+                                                                       );
+
+  edm::ParameterSet MixedPSet = pset.getParameter<edm::ParameterSet>("MixedGeneratorSet");
   edm::ParameterSet mixedhitsfactoryPSet =
     MixedPSet.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet");
   std::string mixedhitsfactoryName = mixedhitsfactoryPSet.getParameter<std::string>("ComponentName");
-  OrderedHitsGenerator*  mixedhitsGenerator =
-    OrderedHitsGeneratorFactory::get()->create( mixedhitsfactoryName, mixedhitsfactoryPSet, iC);
-  theMixedGenerator = new SeedGeneratorFromRegionHits( mixedhitsGenerator, nullptr, 
-						 SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)
-						 );
-  
- 
+
+  theMixedGenerator = std::make_unique<SeedGeneratorFromRegionHits>( OrderedHitsGeneratorFactory::get()->create( mixedhitsfactoryName, mixedhitsfactoryPSet, iC),
+                                                                     nullptr,
+                                                                     SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)
+                                                                     );
 }
 
-TSGSmart::~TSGSmart()
-{
-  delete thePairGenerator; 
-  delete theTripletGenerator; 
-  delete theMixedGenerator; 
-}
+TSGSmart::~TSGSmart() = default;
 
 void TSGSmart::run(TrajectorySeedCollection &seeds, 
       const edm::Event &ev, const edm::EventSetup &es, const TrackingRegion& region)

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGSmart.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGSmart.h
@@ -21,9 +21,9 @@ private:
 
 private:
   edm::ParameterSet theConfig;
-  SeedGeneratorFromRegionHits * thePairGenerator; 
-  SeedGeneratorFromRegionHits * theTripletGenerator; 
-  SeedGeneratorFromRegionHits * theMixedGenerator; 
+  std::unique_ptr<SeedGeneratorFromRegionHits> thePairGenerator;
+  std::unique_ptr<SeedGeneratorFromRegionHits> theTripletGenerator;
+  std::unique_ptr<SeedGeneratorFromRegionHits> theMixedGenerator;
 
   double theEtaBound;
 };


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

In addition I removed an unnecessary `ParameterSet` member from `MuIsoDepositProducer`, and did more thorough migration from raw pointers to `unique_ptr` and cleanup in `RecoMuon/TrackerSeedGenerator`.

Tested in CMSSW_10_5_X_2019-02-05-1100 , no changes expected.