### PR TITLE
Minor fix of p/pbar NIEL sampling

### DIFF
--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
@@ -389,7 +389,6 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       ph->RegisterProcess(pb, particle);
       ph->RegisterProcess(pp, particle);
       ph->RegisterProcess(pss, particle);
-      ph->RegisterProcess(pnuc, particle);
 
     } else if (particleName == "B+" ||
 	       particleName == "B-" ||


### PR DESCRIPTION
In this PR double counting of NIEL of protons and anti-protons is removed in the EM physics prepared for neutron background studies. Not affecting base line production. This PR is inspired by discussion at the workshop: "Radiation effects in the LHC experiments and impact on operation and performance"  https://indico.cern.ch/event/769192/ 