### PR TITLE
New option to the ExternalLHEProducer to enable UNLOPS merging

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -97,7 +97,7 @@ private:
   std::string outputContents_;
 
   // Used only if nPartonMapping is in the configuration
-  std::map<unsigned, std::pair<unsigned, unsigned>> nPartonMapping_;
+  std::map<unsigned, std::pair<unsigned, unsigned>> nPartonMapping_{};
 
   std::unique_ptr<lhef::LHEReader>	reader_;
   std::shared_ptr<lhef::LHERunInfo>	runInfoLast;

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -96,6 +96,9 @@ private:
   unsigned int nThreads_{1};
   std::string outputContents_;
 
+  // Used only if nPartonMapping is in the configuration
+  std::map<unsigned, std::pair<unsigned, unsigned>> nPartonMapping_;
+
   std::unique_ptr<lhef::LHEReader>	reader_;
   std::shared_ptr<lhef::LHERunInfo>	runInfoLast;
   std::shared_ptr<lhef::LHERunInfo>	runInfo;
@@ -117,15 +120,6 @@ private:
 };
 
 //
-// constants, enums and typedefs
-//
-
-
-//
-// static data member definitions
-//
-
-//
 // constructors and destructor
 //
 ExternalLHEProducer::ExternalLHEProducer(const edm::ParameterSet& iConfig) :
@@ -138,6 +132,27 @@ ExternalLHEProducer::ExternalLHEProducer(const edm::ParameterSet& iConfig) :
 {
   if (npars_ != args_.size())
     throw cms::Exception("ExternalLHEProducer") << "Problem with configuration: " << args_.size() << " script arguments given, expected " << npars_;
+
+  if (iConfig.exists("nPartonMapping")) {
+    auto& processMap(iConfig.getParameterSetVector("nPartonMapping"));
+    for (auto& cfg : processMap) {
+      unsigned processId(cfg.getParameter<unsigned>("idprup"));
+
+      auto orderStr(cfg.getParameter<std::string>("order"));
+      unsigned order(0);
+      if (orderStr == "LO")
+        order = 0;
+      else if (orderStr == "NLO")
+        order = 1;
+      else
+        throw cms::Exception("ExternalLHEProducer") << "Invalid order specification for process " << processId << ": " << orderStr;
+      
+      unsigned np(cfg.getParameter<unsigned>("np"));
+      
+      nPartonMapping_.emplace(processId, std::make_pair(order, np));
+    }
+  }
+
   produces<LHEXMLStringProduct, edm::Transition::BeginRun>("LHEScriptOutput"); 
 
   produces<LHEEventProduct>();
@@ -185,8 +200,38 @@ ExternalLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                 boost::bind(&LHEEventProduct::addWeight,
                             product.get(), _1));
   product->setScales(partonLevel->scales());
-  product->setNpLO(partonLevel->npLO());
-  product->setNpNLO(partonLevel->npNLO());
+  if (nPartonMapping_.empty()) {
+    product->setNpLO(partonLevel->npLO());
+    product->setNpNLO(partonLevel->npNLO());
+  }
+  else {
+    // overwrite npLO and npNLO values by user-specified mapping
+    unsigned processId(partonLevel->getHEPEUP()->IDPRUP);
+    unsigned order(0);
+    unsigned np(0);
+    try {
+      auto procDef(nPartonMapping_.at(processId));
+      order = procDef.first;
+      np = procDef.second;
+    }
+    catch (std::out_of_range&) {
+      throw cms::Exception("ExternalLHEProducer") << "Unexpected IDPRUP encountered: " << partonLevel->getHEPEUP()->IDPRUP;
+    }
+
+    switch (order) {
+    case 0:
+      product->setNpLO(np);
+      product->setNpNLO(-1);
+      break;
+    case 1:
+      product->setNpLO(-1);
+      product->setNpNLO(np);
+      break;
+    default:
+      break;
+    }
+  }
+
   std::for_each(partonLevel->getComments().begin(),
                 partonLevel->getComments().end(),
                 boost::bind(&LHEEventProduct::addComment,
@@ -498,6 +543,12 @@ ExternalLHEProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<uint32_t>("numberOfParameters");
   desc.addUntracked<uint32_t>("nEvents");
   desc.addUntracked<bool>("storeXML", false);
+
+  edm::ParameterSetDescription nPartonMappingDesc;
+  nPartonMappingDesc.add<unsigned>("idprup");
+  nPartonMappingDesc.add<std::string>("order");
+  nPartonMappingDesc.add<unsigned>("np");
+  desc.addVPSetOptional("nPartonMapping", nPartonMappingDesc);
 
   descriptions.addDefault(desc);
 }


### PR DESCRIPTION
Following a presentation made at the Generator meeting in November: [Event](https://indico.cern.ch/event/746822/overview) and [Presentation](https://indico.cern.ch/event/746822/contributions/3168659/attachments/1745485/2825857/unlops.pdf)

We would like to merge multijet NLO samples using the UNLOPS scheme. Most of the infrastructure already exists in CMSSW. In the presentation I reported that we still need a new LHE parsing module that can read from multiple gridpacks (NLO and LO), but Josh pointed out that there is a feature in MG5_aMC@NLO that allows a creation of a single NLO/LO mixed gridpack (using directive [ LOonly=QCD ]), which means the existing ExternalLHEProducer suffices. The only feature we need is then to have `npLO` and `npNLO` correctly set in the LHEEvent. MG5_aMC@NLO does this only when `ickkw = 4`, but for processes such as gamma+jets, this option is not available.

The proposal with this PR is to enable the users of ExternalLHEProducer to specify the npLO and npNLO values by hand. These values simply correspond to the number of "j"s in the MG5 proc card, so they are uniquely determined by the process id (e.g. "0" in `p p > a j @0`). The process id is stored in IDPRUP of the HEPEUP block, so a simple map (IDPRUP -> (order, nparton)) created in the constructor  does the job.

The feature is optional and can be turned on by giving a VPSet in the job configuration
```
process.externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
    args = cms.vstring('gridpack.tar.xz'),
    numberOfParameters = cms.uint32(1),
    nEvents = cms.untracked.uint32(100),
    outputFile = cms.string('cmsgrid_final.lhe'),
    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
    ## new option ##
    nPartonMapping = cms.VPSet(
        cms.PSet(
            idprup = cms.uint32(0),
            order = cms.string('NLO'),
            np = cms.uint32(0)
        ),
        cms.PSet(
            idprup = cms.uint32(1),
            order = cms.string('LO'),
            np = cms.uint32(1)
        )
    )
)
```