### PR TITLE
Update GT in CMSSW to 105X for ultra legacy

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,15 +24,15 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '103X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '105X_dataRun2_v1',
+    'run1_data'         :   '105X_dataRun2_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '105X_dataRun2_v1',
+    'run2_data'         :   '105X_dataRun2_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '105X_dataRun2_relval_v1',
+    'run2_data_relval'  :   '105X_dataRun2_relval_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v1',
+    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v2',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v1',
+    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v2',
     'run2_data_promptlike_hi' : '103X_dataRun2_PromptLike_HI_v2',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,15 +24,15 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '103X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '105X_dataRun2_v5',
+    'run1_data'         :   '105X_dataRun2_v6',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '105X_dataRun2_v5',
+    'run2_data'         :   '105X_dataRun2_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '105X_dataRun2_relval_v4',
+    'run2_data_relval'  :   '105X_dataRun2_relval_v5',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v2',
+    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v3',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v3',
+    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v4',
     'run2_data_promptlike_hi' : '103X_dataRun2_PromptLike_HI_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
@@ -46,11 +46,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v3',
+    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v3',
+    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v4',
+    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '105X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
@@ -65,8 +65,8 @@ autoCond = {
     'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '105X_postLS2_design_v1', # GT containing design conditions for postLS2
-    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'    : '105X_postLS2_realistic_v2', # GT containing realistic conditions for postLS2
+    # GlobalTag for MC production with realistic conditions for Phase1 2019
+    'phase1_2019_realistic'    : '105X_postLS2_realistic_v3', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
     'phase2_realistic'         : '105X_upgrade2023_realistic_v2'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,16 +24,16 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '103X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '105X_dataRun2_v2',
+    'run1_data'         :   '105X_dataRun2_v5',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '105X_dataRun2_v2',
+    'run2_data'         :   '105X_dataRun2_v5',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '105X_dataRun2_relval_v2',
+    'run2_data_relval'  :   '105X_dataRun2_relval_v4',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v2',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v2',
-    'run2_data_promptlike_hi' : '103X_dataRun2_PromptLike_HI_v2',
+    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v3',
+    'run2_data_promptlike_hi' : '103X_dataRun2_PromptLike_HI_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -44,31 +44,31 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v2',
+    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v2',
+    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '105X_upgrade2018_design_v1',
+    'phase1_2018_design'       :  '105X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '103X_upgrade2018_realistic_HI_v11',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v2',
+    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v2',
+    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v2',
+    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '105X_postLS2_design_v1', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'    : '105X_postLS2_realistic_v1', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'    : '105X_postLS2_realistic_v2', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '105X_upgrade2023_realistic_v1'
+    'phase2_realistic'         : '105X_upgrade2023_realistic_v2'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -9,30 +9,30 @@ autoCond = {
     'run1_mc_hi'        :   '103X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '103X_mcRun1_pA_v1',
-    # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '103X_mcRun2_design_v3',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
     'run2_mc_50ns'      :   '103X_mcRun2_startup_v3',
-    #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '103X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '103X_mcRun2_asymptotic_l1stage1_v1',
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
+    'run2_design'       :   '105X_mcRun2_design_v1',
+    #GlobalTag for MC production with optimistic alignment and calibrations for Run2
+    'run2_mc'           :   '105X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '103X_mcRun2cosmics_startup_deco_v3',
+    'run2_mc_cosmics'   :   '105X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '103X_mcRun2_HeavyIon_v3',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '103X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '103X_dataRun2_v6',
+    'run1_data'         :   '105X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '103X_dataRun2_v6',
+    'run2_data'         :   '105X_dataRun2_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '103X_dataRun2_relval_v10',
+    'run2_data_relval'  :   '105X_dataRun2_relval_v1',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '103X_dataRun2_PromptLike_HEfail_v4',
+    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '103X_dataRun2_PromptLike_v6',
+    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v1',
     'run2_data_promptlike_hi' : '103X_dataRun2_PromptLike_HI_v2',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
@@ -44,31 +44,31 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '103X_mc2017_design_IdealBS_v2',
+    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '103X_mc2017_realistic_v2',
+    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '103X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '103X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '103X_upgrade2018_design_v4',
+    'phase1_2018_design'       :  '105X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '103X_upgrade2018_realistic_v8',
+    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' : '103X_upgrade2018_realistic_HI_v11',
+    'phase1_2018_realistic_hi' :  '103X_upgrade2018_realistic_HI_v11',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail'    : '103X_upgrade2018_realistic_HEfail_v4',
+    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_deco_v7',
+    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '103X_upgrade2018cosmics_realistic_peak_v1',
+    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '103X_postLS2_design_v4', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '105X_postLS2_design_v1', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'    : '103X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'    : '105X_postLS2_realistic_v1', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '103X_upgrade2023_realistic_v2'
+    'phase2_realistic'         : '105X_upgrade2023_realistic_v1'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,7 +33,7 @@ autoCond = {
     'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v3',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v4',
-    'run2_data_promptlike_hi' : '103X_dataRun2_PromptLike_HI_v3',
+    'run2_data_promptlike_hi' : '103X_dataRun2_PromptLike_HI_v2',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -32,7 +32,7 @@ autoCond = {
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v3',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v4',
+    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v5',
     'run2_data_promptlike_hi' : '103X_dataRun2_PromptLike_HI_v2',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',


### PR DESCRIPTION
Hello,

The PR is to migrate the GTs in CMSSW release (autoCond) to **105X GTs**,
and includes the most update data/MC conditions for ultra legacy preparation.
In addition, new GEM emap, PPS timing, LHCInfo are included in data GTs.

### **Offline data GT for run1 and run2**
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_dataRun2_v6
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_dataRun2_v6/103X_dataRun2_v6

- New GEM eMap to support #25158 for new unpacker
- New PPS timing and LHCInfo to support #25495 for PPS proton reconstruction
(- New PPS timing correction to support #25858 to use timing in PPS local reconstruction)
- New HCAL data condition announced in AlCa-hn :
   https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4075.html

### Offline relval data GT
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_dataRun2_relval_v5
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_dataRun2_relval_v5/103X_dataRun2_relval_v10

- ECAL pedestal changes from prompt to offline
- New GEM eMap to support #25158 for new unpacker
- New PPS timing and LHCInfo to support #25495 for PPS proton reconstruction
(- New PPS timing correction to support #25858 to use timing in PPS local reconstruction)
- Updated HCAL data condition announced in AlCa-hn :
   https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4075.html

### Prompt like data GT
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_dataRun2_PromptLike_HEfail_v3
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_dataRun2_PromptLike_v5
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_dataRun2_PromptLike_HEfail_v3/103X_dataRun2_PromptLike_HEfail_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_dataRun2_PromptLike_v5/103X_dataRun2_PromptLike_v6

- New GEM eMap to support #25158 for new unpacker
- New PPS timing and LHCInfo to support #25495 for PPS proton reconstruction
(- New PPS timing correction to support #25858 to use timing in PPS local reconstruction)


### **2017 Realistic GT**
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mc2017_realistic_v4
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mc2017_realistic_v4/103X_mc2017_realistic_v2

- Update ECAL condition and PF rechit threshold. 
   https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4085.html
- Updated HCAL MC condition announced in AlCa-hn :
   https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4075.html
- Update pixel  local reconstruction conditions
- Update pixel  2D template for cluster charge reweighting

### **2017 Design GT**
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mc2017_design_IdealBS_v3
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mc2017_design_IdealBS_v3/103X_mc2017_design_IdealBS_v2

- Update ES inter-calibration/pedestal. See talk at AlCaDB meeting 
   https://indico.cern.ch/event/791536/contributions/3288530/attachments/1782158/2899777/AlCaDB_21_01_2019.pdf
- Updated HCAL MC condition announced in AlCa-hn :
   https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4075.html

### **2017 Cosmic MC GT**
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mc2017cosmics_realistic_peak_v5
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mc2017cosmics_realistic_deco_v4
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mc2017cosmics_realistic_peak_v5/103X_mc2017cosmics_realistic_peak_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mc2017cosmics_realistic_deco_v4/103X_mc2017cosmics_realistic_deco_v2

- Update ECAL condition and PF rechit threshold. 
   https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4085.html
- Updated HCAL MC condition announced in AlCa-hn :
   https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4075.html
- Update pixel  local reconstruction conditions
- Update pixel  2D template for cluster charge reweighting

### **2018 Realistic GT (with HE fail)**
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_upgrade2018_realistic_v2
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_upgrade2018_realistic_HEfail_v3
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018_realistic_v2/103X_upgrade2018_realistic_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018_realistic_HEfail_v3/103X_upgrade2018_realistic_HEfail_v4

- Update ES inter-calibration/pedestal. See talk at AlCaDB meeting 
   https://indico.cern.ch/event/791536/contributions/3288530/attachments/1782158/2899777/AlCaDB_21_01_2019.pdf
- Updated HCAL MC condition announced in AlCa-hn :
   https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4075.html
- Update pixel  local reconstruction conditions
- Update pixel  2D template for cluster charge reweighting
- New labelled pixel quality to support new digitizer #25885 

### **2018 Design GT**
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_upgrade2018_design_v2
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018_design_v2/103X_upgrade2018_design_v4

- Update ES inter-calibration/pedestal. See talk at AlCaDB meeting 
   https://indico.cern.ch/event/791536/contributions/3288530/attachments/1782158/2899777/AlCaDB_21_01_2019.pdf
- Updated HCAL MC condition announced in AlCa-hn :
   https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4075.html
- New labelled pixel quality to support new digitizer #25885 

### **2018 Cosmic GT**
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_upgrade2018cosmics_realistic_peak_v3
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_upgrade2018cosmics_realistic_deco_v3
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018cosmics_realistic_peak_v3/103X_upgrade2018cosmics_realistic_peak_v1
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018cosmics_realistic_deco_v3/103X_upgrade2018cosmics_realistic_deco_v7

- Update ES inter-calibration/pedestal. See talk at AlCaDB meeting 
   https://indico.cern.ch/event/791536/contributions/3288530/attachments/1782158/2899777/AlCaDB_21_01_2019.pdf
- Updated HCAL MC condition announced in AlCa-hn :
   https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4075.html
- Update pixel  local reconstruction conditions
- Update pixel  2D template for cluster charge reweighting
- New labelled pixel quality to support new digitizer #25885 

### **2016 Realistic GT**
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mcRun2_asymptotic_v1
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mcRun2_asymptotic_v1/103X_mcRun2_asymptotic_v3

- Update ES inter-calibration/pedestal. See talk at AlCaDB meeting 
   https://indico.cern.ch/event/791536/contributions/3288530/attachments/1782158/2899777/AlCaDB_21_01_2019.pdf
- Updated HCAL MC condition announced in AlCa-hn :
   https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4075.html

### **2016 MC Design GT**
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mcRun2cosmics_startup_deco_v1
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mcRun2cosmics_startup_deco_v1/103X_mcRun2_design_v3
- Updated HCAL data condition announced in AlCa-hn :
   https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4075.html

### **2016 Cosmic MC GT**
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mcRun2_design_v1
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mcRun2cosmics_startup_deco_v1/103X_mcRun2cosmics_startup_deco_v3
- Update ES inter-calibration/pedestal. See talk at AlCaDB meeting 
   https://indico.cern.ch/event/791536/contributions/3288530/attachments/1782158/2899777/AlCaDB_21_01_2019.pdf
- Updated HCAL data condition announced in AlCa-hn :
   https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4075.html

### **Run-3 MC Realistic GT**
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_postLS2_realistic_v3
Diff : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_postLS2_realistic_v3/103X_postLS2_realistic_v4
- include labelled pixel quality to support digitizer development #25885 

### **Run-3 MC Design GT**
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_postLS2_design_v1
Diff : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_postLS2_design_v1/103X_postLS2_design_v4
- include labelled pixel quality to support digitizer development #25885 

### **Phase-2 GT**
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_upgrade2023_realistic_v2
Diff : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2023_realistic_v2/103X_upgrade2023_realistic_v2
- include labelled pixel quality to support digitizer development #25885 
