### PR TITLE
Fix wrong delete called in Herwig6Instance

### DIFF
--- a/GeneratorInterface/Herwig6Interface/interface/Herwig6Instance.h
+++ b/GeneratorInterface/Herwig6Interface/interface/Herwig6Instance.h
@@ -15,6 +15,9 @@ extern "C" {
 	void cms_hwwarn_(char fn[6], int*, int*);
 }
 
+//Forward declare here to avoid system dependency
+struct TimeoutHolder;
+
 class Herwig6Instance : public FortranInstance {
     public:
 	Herwig6Instance();
@@ -56,7 +59,7 @@ class Herwig6Instance : public FortranInstance {
 	CLHEP::HepRandomEngine	*randomEngine;
 
 	// for timeout facility
-	void			*timeoutPrivate;
+        std::unique_ptr<TimeoutHolder> timeoutPrivate;
 };
 
 } // namespace gen


### PR DESCRIPTION
The opaque system structure sigjmp_buf is actually an array so must be deleted appropriately. Wrapping the type in a struct and then new/delete the struct avoids the problem of knowing the opaque type.

This was found by clang.