### PR TITLE
Final BDT models based on 10.2 MC samples

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
@@ -72,9 +72,9 @@ void LowPtGsfElectronIDProducer::fillDescriptions( edm::ConfigurationDescription
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("electrons",edm::InputTag("lowPtGsfElectrons"));
   desc.add<edm::InputTag>("rho",edm::InputTag("fixedGridRhoFastjetAllTmp"));
-  desc.add< std::vector<std::string> >("ModelNames",std::vector<std::string>({""}));
-  desc.add< std::vector<std::string> >("ModelWeights",std::vector<std::string>({"RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Fall17_LowPtElectrons_mva_id.xml.gz"}));
-  desc.add< std::vector<double> >("ModelThresholds",std::vector<double>({-1.}));
+  desc.add< std::vector<std::string> >("ModelNames",std::vector<std::string>());
+  desc.add< std::vector<std::string> >("ModelWeights",std::vector<std::string>());
+  desc.add< std::vector<double> >("ModelThresholds",std::vector<double>());
   desc.add<bool>("PassThrough",false);
   desc.add<double>("MinPtThreshold",0.5);
   desc.add<double>("MaxPtThreshold",15.);

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSCProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSCProducer.cc
@@ -166,7 +166,6 @@ void LowPtGsfElectronSCProducer::produce( edm::Event& event, const edm::EventSet
       sc.setCorrectedEnergy(energy);
       sc.setSeed(seed);
       sc.setClusters(clusters);
-      for ( const auto clu : clusters ) { sc.addCluster(clu); }
       PFClusterWidthAlgo pfwidth(barePtrs);
       sc.setEtaWidth(pfwidth.pflowEtaWidth());
       sc.setPhiWidth(pfwidth.pflowPhiWidth());

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSCProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSCProducer.cc
@@ -80,7 +80,7 @@ void LowPtGsfElectronSCProducer::produce( edm::Event& event, const edm::EventSet
     points[itrk].reserve(trk->PFRecBrem().size()+1);
     points[itrk].push_back( &trk->extrapolatedPoint(reco::PFTrajectoryPoint::LayerType::ECALShowerMax) );
     // Extrapolated brem trajectories
-    for ( auto brem : trk->PFRecBrem() ) {
+    for ( auto const& brem : trk->PFRecBrem() ) {
       points[itrk].push_back( &brem.extrapolatedPoint(reco::PFTrajectoryPoint::LayerType::ECALShowerMax) ); 
     }
     // Resize containers

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
@@ -1,11 +1,10 @@
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectronCore.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackExtra.h"
 #include "DataFormats/ParticleFlowReco/interface/PreId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -14,7 +13,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 LowPtGsfElectronSeedValueMapsProducer::LowPtGsfElectronSeedValueMapsProducer( const edm::ParameterSet& conf ) :
-  gsfElectrons_(consumes<reco::GsfElectronCollection>(conf.getParameter<edm::InputTag>("electrons"))),
+  gsfTracks_(consumes<reco::GsfTrackCollection>(conf.getParameter<edm::InputTag>("gsfTracks"))),
   preIdsValueMap_(consumes< edm::ValueMap<reco::PreIdRef> >(conf.getParameter<edm::InputTag>("preIdsValueMap"))),
   names_(conf.getParameter< std::vector<std::string> >("ModelNames"))
 {
@@ -29,33 +28,32 @@ LowPtGsfElectronSeedValueMapsProducer::~LowPtGsfElectronSeedValueMapsProducer() 
 //
 void LowPtGsfElectronSeedValueMapsProducer::produce( edm::Event& event, const edm::EventSetup& setup ) {
 
-  // Retrieve GsfElectrons from Event
-  edm::Handle<reco::GsfElectronCollection> gsfElectrons;
-  event.getByToken(gsfElectrons_,gsfElectrons);
-  if ( !gsfElectrons.isValid() ) { edm::LogError("Problem with gsfElectrons handle"); }
+  // Retrieve GsfTracks from Event
+  edm::Handle<reco::GsfTrackCollection> gsfTracks;
+  event.getByToken(gsfTracks_,gsfTracks);
+  if ( !gsfTracks.isValid() ) { edm::LogError("Problem with gsfTracks handle"); }
 
   // Retrieve PreIds from Event
   edm::Handle< edm::ValueMap<reco::PreIdRef> > preIdsValueMap;
   event.getByToken(preIdsValueMap_,preIdsValueMap);
   if ( !preIdsValueMap.isValid() ) { edm::LogError("Problem with preIdsValueMap handle"); }
   
-  // Iterate through Electrons, extract BDT output, and store result in ValueMap for each model
+  // Iterate through GsfTracks, extract BDT output, and store result in ValueMap for each model
   std::vector< std::vector<float> > output;
   for ( unsigned int iname = 0; iname < names_.size(); ++iname ) { 
-    output.push_back( std::vector<float>(gsfElectrons->size(),-999.) );
+    output.push_back( std::vector<float>(gsfTracks->size(),-999.) );
   }
-  for ( unsigned int iele = 0; iele < gsfElectrons->size(); iele++ ) {
-    reco::GsfElectronRef ele(gsfElectrons,iele);
-    if ( ele->core().isNonnull() && 
-	 ele->core()->gsfTrack().isNonnull() && 
-	 ele->core()->gsfTrack()->extra().isNonnull() && 
-	 ele->core()->gsfTrack()->extra()->seedRef().isNonnull() ) {
-      reco::ElectronSeedRef seed = ele->core()->gsfTrack()->extra()->seedRef().castTo<reco::ElectronSeedRef>();
+  for ( unsigned int igsf = 0; igsf < gsfTracks->size(); igsf++ ) {
+    reco::GsfTrackRef gsf(gsfTracks,igsf);
+    if ( gsf.isNonnull() && 
+	 gsf->extra().isNonnull() && 
+	 gsf->extra()->seedRef().isNonnull() ) {
+      reco::ElectronSeedRef seed = gsf->extra()->seedRef().castTo<reco::ElectronSeedRef>();
       if ( seed.isNonnull() && seed->ctfTrack().isNonnull() ) {
 	const reco::PreIdRef preid = (*preIdsValueMap)[seed->ctfTrack()];
 	if ( preid.isNonnull() ) {
 	  for ( unsigned int iname = 0; iname < names_.size(); ++iname ) {
-	    output[iname][iele] = preid->mva(iname);
+	    output[iname][igsf] = preid->mva(iname);
 	  }
 	}
       }
@@ -66,7 +64,7 @@ void LowPtGsfElectronSeedValueMapsProducer::produce( edm::Event& event, const ed
   for ( unsigned int iname = 0; iname < names_.size(); ++iname ) {
     auto ptr = std::make_unique< edm::ValueMap<float> >( edm::ValueMap<float>() );
     edm::ValueMap<float>::Filler filler(*ptr);
-    filler.insert(gsfElectrons, output[iname].begin(), output[iname].end());
+    filler.insert(gsfTracks, output[iname].begin(), output[iname].end());
     filler.fill();
     event.put(std::move(ptr),names_[iname]);
   }
@@ -78,9 +76,9 @@ void LowPtGsfElectronSeedValueMapsProducer::produce( edm::Event& event, const ed
 void LowPtGsfElectronSeedValueMapsProducer::fillDescriptions( edm::ConfigurationDescriptions& descriptions )
 {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("electrons",edm::InputTag("lowPtGsfElectrons"));
+  desc.add<edm::InputTag>("gsfTracks",edm::InputTag("lowPtGsfEleGsfTracks"));
   desc.add<edm::InputTag>("preIdsValueMap",edm::InputTag("lowPtGsfElectronSeeds"));
-  desc.add< std::vector<std::string> >("ModelNames",std::vector<std::string>({"default"}));
+  desc.add< std::vector<std::string> >("ModelNames",std::vector<std::string>());
   descriptions.add("defaultLowPtGsfElectronSeedValueMaps",desc);
 }
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.h
@@ -2,7 +2,7 @@
 #define RecoEgamma_EgammaElectronProducers_LowPtGsfElectronSeedValueMapsProducer_h
 
 #include "DataFormats/Common/interface/ValueMap.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PreIdFwd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -24,11 +24,10 @@ class LowPtGsfElectronSeedValueMapsProducer : public edm::stream::EDProducer<> {
 
  private:
   
-  const edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectrons_;
+  const edm::EDGetTokenT<reco::GsfTrackCollection> gsfTracks_;
   const edm::EDGetTokenT< edm::ValueMap<reco::PreIdRef> > preIdsValueMap_;
   const std::vector<std::string> names_;
 
 };
 
 #endif // RecoEgamma_EgammaElectronProducers_LowPtGsfElectronSeedValueMapsProducer_h
-

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
@@ -2,4 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoEgamma.EgammaElectronProducers.defaultLowPtGsfElectronID_cfi import defaultLowPtGsfElectronID
 
-lowPtGsfElectronID = defaultLowPtGsfElectronID.clone()
+lowPtGsfElectronID = defaultLowPtGsfElectronID.clone(
+    ModelNames = cms.vstring(['']),
+    ModelWeights = cms.vstring([
+            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Autumn18_LowPtElectrons_mva_id.xml.gz',
+            ]),
+    ModelThresholds = cms.vdouble([-10.])
+    )

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 def thresholds( wp ) :
-    return cms.vdouble([{"L": 1.03,"M":1.75,"T":2.61}.get(wp,1.e6),  # unbiased
-                        {"L":-0.48,"M":0.76,"T":1.83}.get(wp,1.e6)]) # ptbiased
+    return cms.vdouble([{"L": 1.20,"M":2.02,"T":3.05}.get(wp,1.e6),  # unbiased
+                        {"L": 0.01,"M":1.29,"T":2.42}.get(wp,1.e6)]) # ptbiased
 
 lowPtGsfElectronSeeds = cms.EDProducer(
     "LowPtGsfElectronSeedProducer",
@@ -22,8 +22,8 @@ lowPtGsfElectronSeeds = cms.EDProducer(
             'ptbiased',
             ]),
     ModelWeights = cms.vstring([
-            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Fall17_LowPtElectrons_unbiased.xml.gz',
-            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Fall17_LowPtElectrons_displaced_pt_eta_biased.xml.gz',
+            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Autumn18_LowPtElectrons_unbiased.xml.gz',
+            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Autumn18_LowPtElectrons_displaced_pt_eta_biased.xml.gz',
             ]),
     ModelThresholds = thresholds("T"),
     PassThrough = cms.bool(False),


### PR DESCRIPTION
__This PR provides incremental changes on top of #25887.__

__This PR includes fixes to the SuperCluster class included in #25960 and #25974.__

__This PR requires the following external: cms-data/RecoEgamma-ElectronIdentification#13__

---

This PR provide three changes:

__1) It includes fixes to the SuperCluster class.__

The fixes are back ported from #25960 and #25974: 
- fix a memory use after free error caught by ASAN;
- avoid creating and using unnecessary edm::Refs; 
- removes a single line of code that was responsible for duplicating edm::Refs to ECAL clusters. 

The timing and footprint numbers below have been updated to reflect these fixes.

__2) It provides the back port of #25915.__

The change is very small and concerns the only the `LowPtGsfElectronSeedValueMapsProducer` class, which produces ValueMaps that store the discriminator values from the BDT models used in the `LowPtGsfElectronSeedProducer`.

The ValueMaps originally stored the BDT outputs per GsfElectrons, but we need them per GsfTrack. There is a near (but not exact) 1-to-1 correspondence between GsfElectrons and GsfTracks, so the ValueMaps will increase moderately in size (at the few tens of % level, not orders of magnitude!) and they will use a different key. Quantitive numbers on timing and footprint can be found in the conversation of #25915.

__3) It uses new BDT models and working points.__

The models are found in cms-data/RecoEgamma-ElectronIdentification#13.

The working points have been tuned to rate balance w.r.t. the old WPs. Updated numbers are provided below, based on 11024 TTbar (PU50).

__Timing:__
```
The same excluding the first 1 events
  delta/mean delta/orJob     original                   new       module name
  ---------- ------------     --------                  ----       ------------
       added      +0.00%         0.00 ms/ev ->         0.15 ms/ev selectedPatLowPtElectrons
       added      +8.21%         0.00 ms/ev ->      1222.58 ms/ev lowPtGsfElectronSeeds
       added      +0.00%         0.00 ms/ev ->         0.57 ms/ev slimmedLowPtElectrons
       added      +0.01%         0.00 ms/ev ->         0.85 ms/ev lowPtElectronMatch
       added      +2.22%         0.00 ms/ev ->       330.50 ms/ev lowPtGsfEleGsfTracks
       added      +0.01%         0.00 ms/ev ->         2.06 ms/ev patLowPtElectrons
       added      +0.43%         0.00 ms/ev ->        63.31 ms/ev lowPtGsfEleCkfTrackCandidates
       added      +0.07%         0.00 ms/ev ->        10.39 ms/ev lowPtGsfElePfTracks
       added      +0.38%         0.00 ms/ev ->        56.14 ms/ev lowPtGsfElePfGsfTracks
       added      +0.00%         0.00 ms/ev ->         0.05 ms/ev lowPtGsfElectronSeedValueMaps
       added      +0.02%         0.00 ms/ev ->         2.77 ms/ev lowPtGsfElectronID
       added      +0.13%         0.00 ms/ev ->        18.65 ms/ev lowPtGsfElectronCores
       added      +0.89%         0.00 ms/ev ->       132.60 ms/ev lowPtGsfElectrons
       added      +0.20%         0.00 ms/ev ->        29.43 ms/ev lowPtGsfElectronSuperClusters
                 +12.57%                            1870.05 ms/ev
  ---------- ------------     --------                  ----       ------------
Job total:  14.8827 s/ev ==> 16.9203 s/ev
```

__RECO footprint:__
```
-----------------------------------------------------------------
   or, B         new, B      delta, B   delta, %   deltaJ, %    branch
-----------------------------------------------------------------
      0.0 ->       312.3        312     NEWO   0.01     recoGsfElectronCores_lowPtGsfElectronCores__RECO
      0.0 ->       252.9        253     NEWO   0.01     floatedmValueMap_lowPtGsfElectronID__RECO
      0.0 ->     13477.6      13478     NEWO   0.38     recoCaloClusters_lowPtGsfElectronSuperClusters__RECO
      0.0 ->      2198.6       2199     NEWO   0.06     recoSuperClusters_lowPtGsfElectronSuperClusters__RECO
      0.0 ->      6474.3       6474     NEWO   0.18     recoGsfTracks_lowPtGsfEleGsfTracks__RECO
      0.0 ->       264.5        264     NEWO   0.01     floatedmValueMap_lowPtGsfElectronSeedValueMaps_ptbiased_RECO
      0.0 ->       262.8        263     NEWO   0.01     floatedmValueMap_lowPtGsfElectronSeedValueMaps_unbiased_RECO
      0.0 ->     14082.6      14083     NEWO   0.40     recoGsfElectrons_lowPtGsfElectrons__RECO
-------------------------------------------------------------
  3541675 ->     3578709      37035             1.0     ALL BRANCHES
```

__MINIAOD footprint:__
```
-----------------------------------------------------------------
   or, B         new, B      delta, B   delta, %   deltaJ, %    branch
-----------------------------------------------------------------
      0.0 ->     12017.7      12018     NEWO   15.22    recoCaloClusters_lowPtGsfElectronSuperClusters__RECO
      0.0 ->     19327.0      19327     NEWO   24.48    patElectrons_slimmedLowPtElectrons__RECO
      0.0 ->       345.5        346     NEWO   0.44     recoGsfElectronCores_lowPtGsfElectronCores__RECO
      0.0 ->       200.8        201     NEWO   0.25     floatedmValueMap_lowPtGsfElectronSeedValueMaps_ptbiased_RECO
      0.0 ->       195.3        195     NEWO   0.25     floatedmValueMap_lowPtGsfElectronID__RECO
      0.0 ->       199.4        199     NEWO   0.25     floatedmValueMap_lowPtGsfElectronSeedValueMaps_unbiased_RECO
      0.0 ->      6594.4       6594     NEWO   8.35     recoGsfTracks_lowPtGsfEleGsfTracks__RECO
      0.0 ->      2125.1       2125     NEWO   2.69     recoSuperClusters_lowPtGsfElectronSuperClusters__RECO
-------------------------------------------------------------
    78956 ->      120018      41062            52.0     ALL BRANCHES
```
