### PR TITLE
Corrected forward declaration in SiStripSpyEventMatcher

### DIFF
--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
@@ -20,7 +20,7 @@ class FEDRawDataCollection;
 class SiStripRawDigi;
 namespace edm {
   template<class T> class DetSetVector;
-  template<class T> class DetSet;
+  template<class T> struct DetSet;
   class EventID;
   class ParameterSet;
 }


### PR DESCRIPTION
This fixes a clang warning.