### PR TITLE
Fixed include guard in DaqScopeModeHistosUsingDb.h

### DIFF
--- a/DQM/SiStripCommissioningDbClients/interface/DaqScopeModeHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/DaqScopeModeHistosUsingDb.h
@@ -1,5 +1,5 @@
 #ifndef DQM_SiStripCommissioningClients_DaqScopeModeHistosUsingDb_H
-#define DQM_SiStripCommissioningClients_DaqScopeModeHistosUsingD_H
+#define DQM_SiStripCommissioningClients_DaqScopeModeHistosUsingDb_H
 
 #include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
 #include "DQM/SiStripCommissioningClients/interface/DaqScopeModeHistograms.h"


### PR DESCRIPTION
Fixes a clang warning.