### PR TITLE
Use unique_ptr constructor for PluginFactory plugins in RecoParticleFlow

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
@@ -23,13 +23,11 @@ class PFClusterBuilderBase {
     _nSeeds(0), _nClustersFound(0),    
     _minFractionToKeep(conf.getParameter<double>("minFractionToKeep")),
     _algoName(conf.getParameter<std::string>("algoName")) {
-    _positionCalc.reset(nullptr);
     if( conf.exists("positionCalc") ) {
       const edm::ParameterSet& pcConf = conf.getParameterSet("positionCalc");
       const std::string& algo = pcConf.getParameter<std::string>("algoName");
-      PosCalc* calcp = PFCPositionCalculatorFactory::get()->create(algo, 
-								   pcConf);
-      _positionCalc.reset(calcp);
+      _positionCalc = std::unique_ptr<PosCalc>{PFCPositionCalculatorFactory::get()->create(algo,
+                                                                                           pcConf)};
     }
   }
   virtual ~PFClusterBuilderBase() = default;

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
@@ -71,26 +71,20 @@ Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf) :
     _recHitEnergyNorms.emplace(_layerMap.find(det)->second,std::make_pair(depths,rhE_norm));
   }
   
-  _allCellsPosCalc.reset(nullptr);
   if( conf.exists("allCellsPositionCalc") ) {
     const edm::ParameterSet& acConf = 
       conf.getParameterSet("allCellsPositionCalc");
     const std::string& algoac = 
       acConf.getParameter<std::string>("algoName");
-    PosCalc* accalc = 
-      PFCPositionCalculatorFactory::get()->create(algoac, acConf);
-    _allCellsPosCalc.reset(accalc);
+    _allCellsPosCalc = std::unique_ptr<PosCalc>{PFCPositionCalculatorFactory::get()->create(algoac, acConf)};
   }
   // if necessary a third pos calc for convergence testing
-  _convergencePosCalc.reset(nullptr);
   if( conf.exists("positionCalcForConvergence") ) {
     const edm::ParameterSet& convConf = 
       conf.getParameterSet("positionCalcForConvergence");
     const std::string& algoconv = 
       convConf.getParameter<std::string>("algoName");
-    PosCalc* convcalc = 
-      PFCPositionCalculatorFactory::get()->create(algoconv, convConf);
-    _convergencePosCalc.reset(convcalc);
+    _convergencePosCalc = std::unique_ptr<PosCalc>{PFCPositionCalculatorFactory::get()->create(algoconv, convConf)};
   }
 }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.cc
@@ -109,7 +109,7 @@ PFCTRecHitProducer::PFCTRecHitProducer(const edm::ParameterSet& iConfig)
 
 					       
   edm::ParameterSet navSet = iConfig.getParameter<edm::ParameterSet>("navigator");
-  navigator_ = PFRecHitNavigationFactory::get()->create(navSet.getParameter<std::string>("name"),navSet);
+  navigator_ = std::unique_ptr<PFRecHitNavigatorBase>{PFRecHitNavigationFactory::get()->create(navSet.getParameter<std::string>("name"),navSet)};
 					  
   //--ab
   produces<reco::PFRecHitCollection>();

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
@@ -122,7 +122,7 @@ class dso_hidden PFCTRecHitProducer final : public edm::stream::EDProducer<> {
   int m_maxDepthHB;
   int m_maxDepthHE;
 
-  PFRecHitNavigatorBase* navigator_;
+  std::unique_ptr<PFRecHitNavigatorBase> navigator_;
 
 
 };

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
@@ -15,20 +15,16 @@
 PFMultiDepthClusterProducer::PFMultiDepthClusterProducer(const edm::ParameterSet& conf)
 {
   _clustersLabel = consumes<reco::PFClusterCollection>(conf.getParameter<edm::InputTag>("clustersSource")); 
-  _pfClusterBuilder.reset(nullptr);
   const edm::ParameterSet& pfcConf = conf.getParameterSet("pfClusterBuilder");
   if( !pfcConf.empty() ) {
     const std::string& pfcName = pfcConf.getParameter<std::string>("algoName");
-    PFCBB* pfcb = PFClusterBuilderFactory::get()->create(pfcName,pfcConf);
-    _pfClusterBuilder.reset(pfcb);
+    _pfClusterBuilder = std::unique_ptr<PFCBB>{PFClusterBuilderFactory::get()->create(pfcName,pfcConf)};
   }
   // see if new need to apply corrections, setup if there.
   const edm::ParameterSet& cConf =  conf.getParameterSet("energyCorrector");
   if( !cConf.empty() ) {
     const std::string& cName = cConf.getParameter<std::string>("algoName");
-    PFClusterEnergyCorrectorBase* eCorr =
-      PFClusterEnergyCorrectorFactory::get()->create(cName,cConf);
-    _energyCorrector.reset(eCorr);
+    _energyCorrector = std::unique_ptr<PFClusterEnergyCorrectorBase>{PFClusterEnergyCorrectorFactory::get()->create(cName,cConf)};
   }
   
   produces<reco::PFClusterCollection>();

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
@@ -16,15 +16,12 @@ PFMultiDepthClusterizer(const edm::ParameterSet& conf) :
   PFClusterBuilderBase(conf) 
 {
   
-  _allCellsPosCalc.reset(nullptr);
   if( conf.exists("allCellsPositionCalc") ) {
     const edm::ParameterSet& acConf = 
       conf.getParameterSet("allCellsPositionCalc");
     const std::string& algoac = 
       acConf.getParameter<std::string>("algoName");
-    PosCalc* accalc = 
-      PFCPositionCalculatorFactory::get()->create(algoac, acConf);
-    _allCellsPosCalc.reset(accalc);
+    _allCellsPosCalc = std::unique_ptr<PosCalc>{PFCPositionCalculatorFactory::get()->create(algoac, acConf)};
   }
 
   nSigmaEta_ = pow(conf.getParameter<double>("nSigmaEta"),2);

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
@@ -28,7 +28,7 @@ namespace {
 
   edm::ParameterSet navSet = iConfig.getParameter<edm::ParameterSet>("navigator");
 
-  navigator_.reset(PFRecHitNavigationFactory::get()->create(navSet.getParameter<std::string>("name"),navSet));
+  navigator_ = std::unique_ptr<PFRecHitNavigatorBase>{PFRecHitNavigationFactory::get()->create(navSet.getParameter<std::string>("name"),navSet)};
     
 }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
@@ -64,40 +64,32 @@ PFlow2DClusterizerWithTime(const edm::ParameterSet& conf) :
     _recHitEnergyNorms.emplace(_layerMap.find(det)->second,rhE_norm);
   }
   
-  _allCellsPosCalc.reset(nullptr);
   if( conf.exists("allCellsPositionCalc") ) {
     const edm::ParameterSet& acConf = 
       conf.getParameterSet("allCellsPositionCalc");
     const std::string& algoac = 
       acConf.getParameter<std::string>("algoName");
-    PosCalc* accalc = 
-      PFCPositionCalculatorFactory::get()->create(algoac, acConf);
-    _allCellsPosCalc.reset(accalc);
+    _allCellsPosCalc = std::unique_ptr<PFCPositionCalculatorBase>{PFCPositionCalculatorFactory::get()->create(algoac, acConf)};
   }
   // if necessary a third pos calc for convergence testing
-  _convergencePosCalc.reset(nullptr);
   if( conf.exists("positionCalcForConvergence") ) {
     const edm::ParameterSet& convConf = 
       conf.getParameterSet("positionCalcForConvergence");
     const std::string& algoconv = 
       convConf.getParameter<std::string>("algoName");
-    PosCalc* convcalc = 
-      PFCPositionCalculatorFactory::get()->create(algoconv, convConf);
-    _convergencePosCalc.reset(convcalc);
+    _convergencePosCalc = std::unique_ptr<PFCPositionCalculatorBase>{PFCPositionCalculatorFactory::get()->create(algoconv, convConf)};
   }
-  _timeResolutionCalcBarrel.reset(nullptr);
   if( conf.exists("timeResolutionCalcBarrel") ) {
     const edm::ParameterSet& timeResConf = 
       conf.getParameterSet("timeResolutionCalcBarrel");
-      _timeResolutionCalcBarrel.reset(new CaloRecHitResolutionProvider(
-        timeResConf));
+    _timeResolutionCalcBarrel = std::make_unique<CaloRecHitResolutionProvider>(
+        timeResConf);
   }
-  _timeResolutionCalcEndcap.reset(nullptr);
   if( conf.exists("timeResolutionCalcEndcap") ) {
     const edm::ParameterSet& timeResConf = 
       conf.getParameterSet("timeResolutionCalcEndcap");
-      _timeResolutionCalcEndcap.reset(new CaloRecHitResolutionProvider(
-        timeResConf));
+    _timeResolutionCalcEndcap = std::make_unique<CaloRecHitResolutionProvider>(
+        timeResConf);
   }
 }
 

--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -113,9 +113,7 @@ void PFBlockAlgo::setLinkers(const std::vector<edm::ParameterSet>& confs) {
     const PFBlockElement::Type type1 = elementTypes_.at(link1);
     const PFBlockElement::Type type2 = elementTypes_.at(link2);    
     const unsigned index  = rowsize*std::max(type1,type2)+std::min(type1,type2);
-    BlockElementLinkerBase * linker =
-      BlockElementLinkerFactory::get()->create(linkerName,conf);
-    linkTests_[index].reset(linker);
+    linkTests_[index] = LinkTestPtr{BlockElementLinkerFactory::get()->create(linkerName,conf)};
     linkTestSquare_[type1][type2] = index;
     linkTestSquare_[type2][type1] = index;
     // setup KDtree if requested
@@ -135,9 +133,7 @@ void PFBlockAlgo::setImporters(const std::vector<edm::ParameterSet>& confs,
   for( const auto& conf : confs ) {
     const std::string& importerName = 
       conf.getParameter<std::string>("importerName");    
-    BlockElementImporterBase * importer =
-      BlockElementImporterFactory::get()->create(importerName,conf,sumes);
-    importers_.emplace_back(importer);
+    importers_.emplace_back(BlockElementImporterFactory::get()->create(importerName,conf,sumes));
   }
 }
 

--- a/RecoParticleFlow/PFSimProducer/plugins/EcalBarrelClusterFastTimer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/EcalBarrelClusterFastTimer.cc
@@ -84,8 +84,7 @@ EcalBarrelClusterFastTimer::EcalBarrelClusterFastTimer(const edm::ParameterSet& 
   const std::vector<edm::ParameterSet>& resos = conf.getParameterSetVector("resolutionModels");
   for( const auto& reso : resos ) {
     const std::string& name = reso.getParameter<std::string>("modelName");
-    ResolutionModel* resomod = ResolutionModelFactory::get()->create(name,reso);
-    _resolutions.emplace_back( resomod );  
+    _resolutions.emplace_back( ResolutionModelFactory::get()->create(name,reso) );
 
     // times and time resolutions for general tracks
     produces<edm::ValueMap<float> >(name); 


### PR DESCRIPTION
Also replace a raw pointer with `unique_ptr` in PFCTRecHitProducer.

This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-02-05-1100 , no changes expected.