### PR TITLE
Use unique_ptr constructor for PluginFactory plugins RecoTauTag

### DIFF
--- a/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
@@ -95,7 +95,7 @@ RecoTauCleanerImpl<Prod>::RecoTauCleanerImpl(const edm::ParameterSet& pset)
   // Check if we want to apply a final output selection
   if ( pset.exists("outputSelection") ) {
     std::string selection = pset.getParameter<std::string>("outputSelection");
-    if ( selection != "" ) {
+    if ( !selection.empty() ) {
       outputSelector_ = std::make_unique<StringCutObjectSelector<reco::PFTau>>(selection);
     }
   }

--- a/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
@@ -82,21 +82,21 @@ RecoTauCleanerImpl<Prod>::RecoTauCleanerImpl(const edm::ParameterSet& pset)
   const VPSet& cleaners = pset.getParameter<VPSet>("cleaners");
   for ( VPSet::const_iterator cleanerPSet = cleaners.begin();
 	cleanerPSet != cleaners.end(); ++cleanerPSet ) {
-    CleanerEntryType* cleanerEntry = new CleanerEntryType();
+    auto cleanerEntry = std::make_unique<CleanerEntryType>();
     // Get plugin name
     const std::string& pluginType = cleanerPSet->getParameter<std::string>("plugin");
     // Build the plugin
-    cleanerEntry->plugin_.reset(RecoTauCleanerPluginFactory::get()->create(pluginType, *cleanerPSet, consumesCollector()));
+    cleanerEntry->plugin_ = std::unique_ptr<Cleaner>{RecoTauCleanerPluginFactory::get()->create(pluginType, *cleanerPSet, consumesCollector())};
     cleanerEntry->tolerance_ = ( cleanerPSet->exists("tolerance") ) ?
     cleanerPSet->getParameter<double>("tolerance") : 0.;
-    cleaners_.emplace_back(cleanerEntry);
+    cleaners_.emplace_back(std::move(cleanerEntry));
   }
 
   // Check if we want to apply a final output selection
   if ( pset.exists("outputSelection") ) {
     std::string selection = pset.getParameter<std::string>("outputSelection");
     if ( selection != "" ) {
-      outputSelector_.reset(new StringCutObjectSelector<reco::PFTau>(selection));
+      outputSelector_ = std::make_unique<StringCutObjectSelector<reco::PFTau>>(selection);
     }
   }
 

--- a/RecoTauTag/TauTagTools/plugins/PFTauMVAInputDiscriminantTranslator.cc
+++ b/RecoTauTag/TauTagTools/plugins/PFTauMVAInputDiscriminantTranslator.cc
@@ -71,7 +71,7 @@ PFTauMVAInputDiscriminantTranslator::PFTauMVAInputDiscriminantTranslator(
         newDisc.collName = collectionName.str();
         // Build the plugin
         edm::ParameterSet fakePSet;
-        newDisc.plugin.reset(
+        newDisc.plugin = std::unique_ptr<reco::tau::RecoTauDiscriminantPlugin>(
             RecoTauDiscriminantPluginFactory::get()->create(
                 reco::tau::discPluginName(name), fakePSet));
         discriminators_.push_back(newDisc);
@@ -85,7 +85,7 @@ PFTauMVAInputDiscriminantTranslator::PFTauMVAInputDiscriminantTranslator(
       newDisc.defaultValue = defaultValue;
       // Build the plugin
       edm::ParameterSet fakePSet;
-      newDisc.plugin.reset(
+      newDisc.plugin = std::unique_ptr<reco::tau::RecoTauDiscriminantPlugin>(
           RecoTauDiscriminantPluginFactory::get()->create(
               reco::tau::discPluginName(name), fakePSet));
       discriminators_.push_back(newDisc);


### PR DESCRIPTION
Also replace use of `boost::ptr_vector<T>` with `std::vector<std::unique_ptr<T>>` in RecoTauProducer.

This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-02-05-1100 , no changes expected.