### PR TITLE
Bug fix to EventSetupImpl::find

### DIFF
--- a/FWCore/Framework/src/EventSetupImpl.cc
+++ b/FWCore/Framework/src/EventSetupImpl.cc
@@ -67,6 +67,9 @@ EventSetupImpl::find(const eventsetup::EventSetupRecordKey& iKey) const
       return std::nullopt;
    }
    auto index = std::distance(keysBegin_, lb);
+   if (recordImpls_[index] == nullptr) {
+      return std::nullopt;
+   }
    return eventsetup::EventSetupRecordGeneric(recordImpls_[index]);
 }
 


### PR DESCRIPTION
This is a fix to a bug that was merged last week.
Affects the EventSetup::find function which is used by about
a dozen specialized modules (for example
EventSetupRecordDataGetter), but not used for most things.
If the bug affected something it would most likely cause
a seg fault (although certain circumstances would be necessary
for any problem to occur)