### PR TITLE
DAQ limited output module (10_5_X)

### DIFF
--- a/EventFilter/Utilities/interface/EvFOutputModule.h
+++ b/EventFilter/Utilities/interface/EvFOutputModule.h
@@ -1,0 +1,49 @@
+#ifndef EventFilter_Utilities_EvFOutputModule_h
+#define EventFilter_Utilities_EvFOutputModule_h
+
+#include "FWCore/Framework/interface/limited/OutputModule.h"
+#include "IOPool/Streamer/interface/StreamerOutputModuleCommon.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+typedef edm::detail::TriggerResultsBasedEventSelector::handle_t Trig;
+
+namespace evf {
+
+  class FastMonitoringService;
+  class EvFOutputEventWriter;
+  class EvFOutputJSONWriter;
+
+  typedef edm::limited::OutputModule<edm::LuminosityBlockCache<evf::EvFOutputEventWriter>,edm::RunCache<evf::EvFOutputJSONWriter>> EvFOutputModuleType;
+
+  class EvFOutputModule : 
+    public EvFOutputModuleType
+  {
+  public:
+    explicit EvFOutputModule(edm::ParameterSet const& ps);
+    ~EvFOutputModule() override;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+    
+  private:
+    //pure in parent class but unused here
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {}
+    void globalEndRun(edm::Run const&, edm::EventSetup const&) const override {}
+    void writeRun(edm::RunForOutput const&) override {}
+
+    std::shared_ptr<EvFOutputJSONWriter> globalBeginRun(edm::Run const& run, edm::EventSetup const& setup) const override;
+    std::shared_ptr<EvFOutputEventWriter> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override;
+    void write(edm::EventForOutput const& e) override;
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override;
+
+    Trig getTriggerResults(edm::EDGetTokenT<edm::TriggerResults> const& token, edm::EventForOutput const& e) const;
+
+    edm::ParameterSet const& ps_;
+    std::string streamLabel_;
+    edm::EDGetTokenT<edm::TriggerResults> trToken_;
+
+    evf::FastMonitoringService *fms_;
+
+  }; //end-of-class-def
+
+} // end of namespace-evf
+
+#endif

--- a/EventFilter/Utilities/interface/EvFOutputModule.h
+++ b/EventFilter/Utilities/interface/EvFOutputModule.h
@@ -13,7 +13,7 @@ namespace evf {
   class EvFOutputEventWriter;
   class EvFOutputJSONWriter;
 
-  typedef edm::limited::OutputModule<edm::LuminosityBlockCache<evf::EvFOutputEventWriter>,edm::RunCache<evf::EvFOutputJSONWriter>> EvFOutputModuleType;
+  typedef edm::limited::OutputModule<edm::RunCache<evf::EvFOutputJSONWriter>,edm::LuminosityBlockCache<evf::EvFOutputEventWriter>> EvFOutputModuleType;
 
   class EvFOutputModule : 
     public EvFOutputModuleType

--- a/EventFilter/Utilities/interface/EvFOutputModule.h
+++ b/EventFilter/Utilities/interface/EvFOutputModule.h
@@ -24,15 +24,16 @@ namespace evf {
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
     
   private:
+    void write(edm::EventForOutput const& e) override;
+
     //pure in parent class but unused here
     void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {}
-    void globalEndRun(edm::Run const&, edm::EventSetup const&) const override {}
     void writeRun(edm::RunForOutput const&) override {}
+    void globalEndRun(edm::RunForOutput const&) const override {}
 
-    std::shared_ptr<EvFOutputJSONWriter> globalBeginRun(edm::Run const& run, edm::EventSetup const& setup) const override;
-    std::shared_ptr<EvFOutputEventWriter> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override;
-    void write(edm::EventForOutput const& e) override;
-    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override;
+    std::shared_ptr<EvFOutputJSONWriter> globalBeginRun(edm::RunForOutput const& run) const override;
+    std::shared_ptr<EvFOutputEventWriter> globalBeginLuminosityBlock(edm::LuminosityBlockForOutput const& iLB) const override;
+    void globalEndLuminosityBlock(edm::LuminosityBlockForOutput const& iLB) const override;
 
     Trig getTriggerResults(edm::EDGetTokenT<edm::TriggerResults> const& token, edm::EventForOutput const& e) const;
 

--- a/EventFilter/Utilities/plugins/SealModule.cc
+++ b/EventFilter/Utilities/plugins/SealModule.cc
@@ -2,6 +2,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "EventFilter/Utilities/interface/EvFDaqDirector.h"
 #include "EventFilter/Utilities/interface/FastMonitoringService.h"
+#include "EventFilter/Utilities/interface/EvFOutputModule.h"
 #include "EventFilter/Utilities/plugins/ExceptionGenerator.h"
 #include "EventFilter/Utilities/plugins/EvFBuildingThrottle.h"
 #include "EventFilter/Utilities/plugins/EvFFEDSelector.h"
@@ -20,10 +21,9 @@ using namespace evf;
 typedef edm::serviceregistry::AllArgsMaker<MicroStateService, FastMonitoringService> FastMonitoringServiceMaker;
 
 typedef RawEventOutputModuleForBU<RawEventFileWriterForBU> RawStreamFileWriterForBU;
-typedef RecoEventOutputModuleForFU<RecoEventWriterForFU> EvFOutputModule;
+typedef RecoEventOutputModuleForFU<RecoEventWriterForFU> ShmStreamConsumer;
 
 //legacy name for ConfDB compatibility
-typedef EvFOutputModule ShmStreamConsumer;
 
 //DEFINE_FWK_SERVICE_MAKER(MicroStateService, MicroStateServiceMaker);
 

--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -247,18 +247,8 @@ namespace evf {
     std::shared_ptr<StreamerOutputFile> stream_writer_preamble;
     stream_writer_preamble.reset(new StreamerOutputFile(openIniFileName));
     uint32 preamble_adler32 = 1;
+    edm::BranchIDLists const* bidlPtr =  branchIDLists();
 
-    edm::BranchIDLists const* bidlPtr;
-    std::unique_ptr<edm::BranchIDLists> branchIDListsCopyTmp;
-    if (!droppedBranchIDToKeptBranchID().empty()) {
-     //copy unique_ptr will lose scope when beginRun returns 
-     branchIDListsCopyTmp = branchIDListsCopy();
-     bidlPtr = branchIDListsCopyTmp.get();
-    }
-    else {
-     //get pointer to original
-     bidlPtr = branchIDListsOrig();
-    }
     std::unique_ptr<InitMsgBuilder> init_message = 
       rc->streamerCommonWrapper_.serializeRegistry(*bidlPtr, *thinnedAssociationsHelper(), 
                         OutputModule::processName(), description().moduleLabel(), moduleDescription().mainParameterSetID());

--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -235,7 +235,7 @@ namespace evf {
 
 
   std::shared_ptr<EvFOutputJSONWriter>
-  EvFOutputModule::globalBeginRun(edm::Run const& run, edm::EventSetup const& setup) const
+  EvFOutputModule::globalBeginRun(edm::RunForOutput const& run, edm::EventSetup const& setup) const
   {
     //create run Cache holding JSON file writer and variables
     auto rc = std::make_shared<EvFOutputJSONWriter>(ps_,&keptProducts()[edm::InEvent],streamLabel_);
@@ -309,7 +309,7 @@ namespace evf {
 
 
   std::shared_ptr<EvFOutputEventWriter>
-  EvFOutputModule::globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB,  edm::EventSetup const&) const
+  EvFOutputModule::globalBeginLuminosityBlock(edm::LuminosityBlockForOutput const& iLB,  edm::EventSetup const&) const
   {
     auto openDatFilePath = edm::Service<evf::EvFDaqDirector>()->getOpenDatFilePath(iLB.luminosityBlock(),streamLabel_);
     auto lumiWriter = std::make_shared<EvFOutputEventWriter>(openDatFilePath);
@@ -332,7 +332,7 @@ namespace evf {
 
 
   void
-  EvFOutputModule::globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const
+  EvFOutputModule::globalEndLuminosityBlock(edm::LuminosityBlockForOutput const& iLB) const
   {
     //edm::LogInfo("EvFOutputModule") << "end lumi";
     auto lumiWriter = luminosityBlockCache(edm::LuminosityBlockIndex::invalidLuminosityBlockIndex());

--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -1,0 +1,385 @@
+#include "EventFilter/Utilities/interface/EvFOutputModule.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "EventFilter/Utilities/interface/FastMonitoringService.h"
+#include "EventFilter/Utilities/interface/EvFDaqDirector.h"
+
+#include "EventFilter/Utilities/interface/JsonMonitorable.h"
+#include "EventFilter/Utilities/interface/FastMonitor.h"
+#include "EventFilter/Utilities/interface/JSONSerializer.h"
+#include "EventFilter/Utilities/interface/FileIO.h"
+#include "FWCore/Utilities/interface/Adler32Calculator.h"
+
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+
+#include "IOPool/Streamer/interface/StreamerOutputFile.h"
+#include "IOPool/Streamer/interface/InitMsgBuilder.h"
+#include "IOPool/Streamer/interface/EventMsgBuilder.h"
+
+#include <sys/stat.h>
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+
+namespace evf {
+
+  class EvFOutputEventWriter
+  {
+  public:
+
+    explicit EvFOutputEventWriter(std::string const& filePath):
+      filePath_(filePath),
+      accepted_(0)
+    {
+      stream_writer_events_.reset(new StreamerOutputFile(filePath));
+    }
+
+    ~EvFOutputEventWriter() {
+    }
+
+    void reset() {
+        stream_writer_events_.reset();
+    }
+
+    void doOutputEvent(EventMsgBuilder const& msg) {
+      EventMsgView eview(msg.startAddress());
+      stream_writer_events_->write(eview);
+    }
+
+    uint32 get_adler32() const {
+      return stream_writer_events_->adler32();
+    }
+
+    std::string const& getFilePath() const {return filePath_;}
+
+    unsigned long getAccepted() const {return accepted_;}
+    void incAccepted() {accepted_++;}
+
+  private:
+    std::string filePath_;
+    unsigned long accepted_;
+    std::shared_ptr<StreamerOutputFile> stream_writer_events_;
+
+  };
+
+  class StreamerCommonWrapper:public edm::StreamerOutputModuleCommon {
+    public:
+    StreamerCommonWrapper(edm::ParameterSet const& ps, edm::SelectedProducts const* selections):
+    StreamerOutputModuleCommon(ps)
+    {
+     selections_ = selections;
+    }
+
+    void getSelections() {
+      serializer_.reset(new edm::StreamSerializer(selections_));
+    }
+  };
+
+
+  class EvFOutputJSONWriter {
+    public:
+    EvFOutputJSONWriter(edm::ParameterSet const& ps, edm::SelectedProducts const* selections, std::string const& streamLabel):
+      streamerCommonWrapper_(ps, selections),
+      processed_(0),
+      accepted_(0),
+      errorEvents_(0),
+      retCodeMask_(0),
+      filelist_(),
+      filesize_(0),
+      inputFiles_(),
+      fileAdler32_(1),
+      hltErrorEvents_(0)
+    {
+
+      transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(streamLabel);
+      mergeType_ = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType(streamLabel,evf::MergeTypeDAT);
+ 
+      std::string baseRunDir = edm::Service<evf::EvFDaqDirector>()->baseRunDir();
+      LogDebug("EvFOutputModule") << "writing .dat files to -: " << baseRunDir;
+
+      edm::Service<evf::EvFDaqDirector>()->createRunOpendirMaybe();
+
+      processed_.setName("Processed");
+      accepted_.setName("Accepted");
+      errorEvents_.setName("ErrorEvents");
+      retCodeMask_.setName("ReturnCodeMask");
+      filelist_.setName("Filelist");
+      filesize_.setName("Filesize");
+      inputFiles_.setName("InputFiles");
+      fileAdler32_.setName("FileAdler32");
+      transferDestination_.setName("TransferDestination");
+      mergeType_.setName("MergeType");
+      hltErrorEvents_.setName("HLTErrorEvents");
+
+      outJsonDef_.setDefaultGroup("data");
+      outJsonDef_.addLegendItem("Processed","integer",jsoncollector::DataPointDefinition::SUM);
+      outJsonDef_.addLegendItem("Accepted","integer",jsoncollector::DataPointDefinition::SUM);
+      outJsonDef_.addLegendItem("ErrorEvents","integer",jsoncollector::DataPointDefinition::SUM);
+      outJsonDef_.addLegendItem("ReturnCodeMask","integer",jsoncollector::DataPointDefinition::BINARYOR);
+      outJsonDef_.addLegendItem("Filelist","string",jsoncollector::DataPointDefinition::MERGE);
+      outJsonDef_.addLegendItem("Filesize","integer",jsoncollector::DataPointDefinition::SUM);
+      outJsonDef_.addLegendItem("InputFiles","string",jsoncollector::DataPointDefinition::CAT);
+      outJsonDef_.addLegendItem("FileAdler32","integer",jsoncollector::DataPointDefinition::ADLER32);
+      outJsonDef_.addLegendItem("TransferDestination","string",jsoncollector::DataPointDefinition::SAME);
+      outJsonDef_.addLegendItem("MergeType","string",jsoncollector::DataPointDefinition::SAME);
+      outJsonDef_.addLegendItem("HLTErrorEvents","integer",jsoncollector::DataPointDefinition::SUM);
+
+      std::stringstream tmpss,ss;
+      tmpss << baseRunDir << "/open/" << "output_" << getpid() << ".jsd";
+      ss << baseRunDir << "/" << "output_" << getpid() << ".jsd";
+      std::string outTmpJsonDefName = tmpss.str();
+      std::string outJsonDefName = ss.str();
+
+      edm::Service<evf::EvFDaqDirector>()->lockInitLock();
+      struct stat fstat;
+      if (stat (outJsonDefName.c_str(), &fstat) != 0) { //file does not exist
+        LogDebug("EvFOutputModule") << "writing output definition file -: " << outJsonDefName;
+        std::string content;
+        jsoncollector::JSONSerializer::serialize(&outJsonDef_,content);
+        jsoncollector::FileIO::writeStringToFile(outTmpJsonDefName, content);
+        boost::filesystem::rename(outTmpJsonDefName,outJsonDefName);
+      }
+      edm::Service<evf::EvFDaqDirector>()->unlockInitLock();
+
+      jsonMonitor_.reset(new jsoncollector::FastMonitor(&outJsonDef_,true));
+      jsonMonitor_->setDefPath(outJsonDefName);
+      jsonMonitor_->registerGlobalMonitorable(&processed_,false);
+      jsonMonitor_->registerGlobalMonitorable(&accepted_,false);
+      jsonMonitor_->registerGlobalMonitorable(&errorEvents_,false);
+      jsonMonitor_->registerGlobalMonitorable(&retCodeMask_,false);
+      jsonMonitor_->registerGlobalMonitorable(&filelist_,false);
+      jsonMonitor_->registerGlobalMonitorable(&filesize_,false);
+      jsonMonitor_->registerGlobalMonitorable(&inputFiles_,false);
+      jsonMonitor_->registerGlobalMonitorable(&fileAdler32_,false);
+      jsonMonitor_->registerGlobalMonitorable(&transferDestination_,false);
+      jsonMonitor_->registerGlobalMonitorable(&mergeType_,false);
+      jsonMonitor_->registerGlobalMonitorable(&hltErrorEvents_,false);
+      jsonMonitor_->commit(nullptr);
+    }
+
+    StreamerCommonWrapper streamerCommonWrapper_;
+
+    jsoncollector::IntJ processed_;
+    jsoncollector::IntJ accepted_;
+    jsoncollector::IntJ errorEvents_; 
+    jsoncollector::IntJ retCodeMask_; 
+    jsoncollector::StringJ filelist_;
+    jsoncollector::IntJ filesize_; 
+    jsoncollector::StringJ inputFiles_;
+    jsoncollector::IntJ fileAdler32_; 
+    jsoncollector::StringJ transferDestination_; 
+    jsoncollector::StringJ mergeType_;
+    jsoncollector::IntJ hltErrorEvents_; 
+    std::shared_ptr<jsoncollector::FastMonitor> jsonMonitor_;
+    jsoncollector::DataPointDefinition outJsonDef_;
+
+  };
+
+  EvFOutputModule::EvFOutputModule(edm::ParameterSet const& ps) :
+    edm::limited::OutputModuleBase(ps),
+    EvFOutputModuleType(ps),
+    ps_(ps),
+    streamLabel_(ps.getParameter<std::string>("@module_label")),
+    trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults")))
+  {
+    unsigned int concurrencyLimit = ps.getUntrackedParameter<unsigned int>("concurrencyLimit");
+    if (concurrencyLimit!=1) {
+      throw cms::Exception("EvFOutputModule")
+        << "Concurrency limit " << concurrencyLimit << " detected. Parameter values other than 1 are not supported by this output module";
+    }
+    //replace hltOutoputA with stream if the HLT menu uses this convention
+    std::string testPrefix="hltOutput";
+    if (streamLabel_.find(testPrefix)==0) 
+      streamLabel_=std::string("stream")+streamLabel_.substr(testPrefix.size());
+
+    if (streamLabel_.find("_")!=std::string::npos) {
+      throw cms::Exception("EvFOutputModule")
+        << "Underscore character is reserved can not be used for stream names in FFF, but was detected in stream name -: " << streamLabel_;
+    }
+
+    std::string streamLabelLow = streamLabel_;
+    boost::algorithm::to_lower(streamLabelLow);
+    auto streampos = streamLabelLow.rfind("stream");
+    if (streampos !=0 && streampos!=std::string::npos)
+      throw cms::Exception("EvFOutputModule")
+        << "stream (case-insensitive) sequence was found in stream suffix. This is reserved and can not be used for names in FFF based HLT, but was detected in stream name";
+
+    fms_ = (evf::FastMonitoringService *)(edm::Service<evf::MicroStateService>().operator->());
+  }
+
+
+  EvFOutputModule::~EvFOutputModule() {}
+
+
+  void EvFOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    edm::StreamerOutputModuleCommon::fillDescription(desc);
+    EvFOutputModuleType::fillDescription(desc);
+
+    // Use addDefault here instead of add for 4 reasons:
+    // 1. Because EvFOutputModule_cfi.py is explicitly defined it does not need to be autogenerated
+    // The explicitly defined version overrides the autogenerated version of the cfi file.
+    // 2. That cfi file is not used anywhere in the release anyway
+    // 3. There are two plugin names used for the same template instantiation of this
+    // type, "ShmStreamConsumer" and "EvFOutputModule" and this causes name conflict
+    // problems for the cfi generation code which are avoided with addDefault.
+    // 4. At the present time, there is only one type of Consumer used to instantiate
+    // instances of this template, but if there were more than one type then this function
+    // would need to be specialized for each type unless the descriptions were the same
+    // and addDefault was used.
+    descriptions.addDefault(desc);
+  }
+
+
+  std::shared_ptr<EvFOutputJSONWriter>
+  EvFOutputModule::globalBeginRun(edm::Run const& run, edm::EventSetup const& setup) const
+  {
+    //create run Cache holding JSON file writer and variables
+    auto rc = std::make_shared<EvFOutputJSONWriter>(ps_,&keptProducts()[edm::InEvent],streamLabel_);
+
+    //output INI file (non-const). This doesn't require globalBeginRun to be finished
+    const std::string openIniFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(streamLabel_);
+    edm::LogInfo("EvFOutputModule") << "beginRun init stream -: " << openIniFileName;
+    
+    std::shared_ptr<StreamerOutputFile> stream_writer_preamble;
+    stream_writer_preamble.reset(new StreamerOutputFile(openIniFileName));
+    uint32 preamble_adler32 = 1;
+
+    edm::BranchIDLists const* bidlPtr;
+    std::unique_ptr<edm::BranchIDLists> branchIDListsCopyTmp;
+    if (!droppedBranchIDToKeptBranchID().empty()) {
+     //copy unique_ptr will lose scope when beginRun returns 
+     branchIDListsCopyTmp = branchIDListsCopy();
+     bidlPtr = branchIDListsCopyTmp.get();
+    }
+    else {
+     //get pointer to original
+     bidlPtr = branchIDListsOrig();
+    }
+    std::unique_ptr<InitMsgBuilder> init_message = 
+      rc->streamerCommonWrapper_.serializeRegistry(*bidlPtr, *thinnedAssociationsHelper(), 
+                        OutputModule::processName(), description().moduleLabel(), moduleDescription().mainParameterSetID());
+ 
+    //Let us turn it into a View
+    InitMsgView view(init_message->startAddress());
+
+    //output header
+    stream_writer_preamble->write(view);
+    preamble_adler32 = stream_writer_preamble->adler32();
+    stream_writer_preamble.reset();
+
+    struct stat istat;
+    stat(openIniFileName.c_str(), &istat);
+    //read back file to check integrity of what was written
+    off_t readInput=0;
+    uint32_t adlera=1,adlerb=0;
+    FILE *src = fopen(openIniFileName.c_str(),"r");
+
+    //allocate buffer to write INI file
+    unsigned char * outBuf = new unsigned char[1024*1024];
+    while (readInput<istat.st_size)
+    {
+      size_t toRead=  readInput+1024*1024 < istat.st_size ? 1024*1024 : istat.st_size-readInput;
+      fread(outBuf,toRead,1,src);
+      cms::Adler32((const char*)outBuf,toRead,adlera,adlerb);
+      readInput+=toRead;
+    }
+    fclose(src);
+
+    //clear serialization buffers
+    rc->streamerCommonWrapper_.clearSerializeDataBuffer();
+
+    //free output buffer needed only for the file write
+    delete [] outBuf;
+    outBuf=nullptr;
+
+    uint32_t adler32c = (adlerb << 16) | adlera;
+    if (adler32c != preamble_adler32) {
+      throw cms::Exception("EvFOutputModule") << "Checksum mismatch of ini file -: " << openIniFileName
+                           << " expected:" << preamble_adler32 << " obtained:" << adler32c;
+    }
+    else {
+      LogDebug("EvFOutputModule") << "Ini file checksum -: "<< streamLabel_ << " " << adler32c;
+      boost::filesystem::rename(openIniFileName,edm::Service<evf::EvFDaqDirector>()->getInitFilePath(streamLabel_));
+    }
+
+    return rc;
+  }
+
+
+  Trig
+  EvFOutputModule::getTriggerResults(edm::EDGetTokenT<edm::TriggerResults> const& token, edm::EventForOutput const& e) const {
+    Trig result;
+    e.getByToken<edm::TriggerResults>(token, result);
+    return result;
+  }
+
+
+  std::shared_ptr<EvFOutputEventWriter>
+  EvFOutputModule::globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB,  edm::EventSetup const&) const
+  {
+    auto openDatFilePath = edm::Service<evf::EvFDaqDirector>()->getOpenDatFilePath(iLB.luminosityBlock(),streamLabel_);
+    auto lumiWriter = std::make_shared<EvFOutputEventWriter>(openDatFilePath);
+    return lumiWriter;
+  }
+
+
+  void
+  EvFOutputModule::write(edm::EventForOutput const& e) {
+
+    edm::Handle<edm::TriggerResults> const& triggerResults = getTriggerResults(trToken_, e);
+    //use invalid index as this parameter is anyway ignored by the cache getter function
+    auto rc = const_cast<EvFOutputJSONWriter*>(EvFOutputModuleType::runCache(edm::RunIndex::invalidRunIndex()));
+    std::unique_ptr<EventMsgBuilder> msg = rc->streamerCommonWrapper_.serializeEvent(e, triggerResults, selectorConfig());
+
+    auto lumiWriter = const_cast<EvFOutputEventWriter*>(luminosityBlockCache(edm::LuminosityBlockIndex::invalidLuminosityBlockIndex()));
+    lumiWriter->incAccepted();
+    lumiWriter->doOutputEvent(*msg); //msg is written and discarded at this point
+  }
+
+
+  void
+  EvFOutputModule::globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const
+  {
+    //edm::LogInfo("EvFOutputModule") << "end lumi";
+    auto lumiWriter = luminosityBlockCache(edm::LuminosityBlockIndex::invalidLuminosityBlockIndex());
+    auto rc = const_cast<EvFOutputJSONWriter*>(EvFOutputModuleType::runCache(edm::RunIndex::invalidRunIndex()));
+
+    rc->fileAdler32_.value() = lumiWriter->get_adler32();
+    const_cast<EvFOutputEventWriter*>(lumiWriter)->reset();
+
+    bool abortFlag = false;
+    rc->processed_.value() = fms_->getEventsProcessedForLumi(iLB.luminosityBlock(),&abortFlag);
+    rc->accepted_.value() = lumiWriter->getAccepted();
+    if (abortFlag) {
+        edm::LogInfo("EvFOutputModule") << "Abort flag has been set. Output is suppressed";
+        return;
+    }
+    
+    if(rc->processed_.value()!=0) {
+      struct stat istat;
+      boost::filesystem::path openDatFilePath = lumiWriter->getFilePath();
+      stat(openDatFilePath.string().c_str(), &istat);
+      rc->filesize_ = istat.st_size;
+      boost::filesystem::rename(openDatFilePath.string().c_str(), edm::Service<evf::EvFDaqDirector>()->getDatFilePath(iLB.luminosityBlock(),streamLabel_));
+      rc->filelist_ = openDatFilePath.filename().string();
+    } else {
+      //remove empty file when no event processing has occurred
+      remove(lumiWriter->getFilePath().c_str());
+      rc->filesize_ = 0;
+      rc->filelist_ = "";
+      rc->fileAdler32_.value()=-1; //no files in signed long
+    }
+
+    //produce JSON file
+    rc->jsonMonitor_->snap(iLB.luminosityBlock());
+    const std::string outputJsonNameStream =
+      edm::Service<evf::EvFDaqDirector>()->getOutputJsonFilePath(iLB.luminosityBlock(),streamLabel_);
+    rc->jsonMonitor_->outputFullJSON(outputJsonNameStream,iLB.luminosityBlock());
+  }
+
+} // end of namespace-evf
+

--- a/EventFilter/Utilities/test/startBU.py
+++ b/EventFilter/Utilities/test/startBU.py
@@ -16,12 +16,24 @@ options.register ('runNumber',
                   "Run Number")
 
 options.register ('buBaseDir',
-                  '/fff/BU0/ramdisk/', # default value
+                  'ramdisk/', # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "BU base directory")
 
+options.register ('fffBaseDir',
+                  '.', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "FFF base directory")
+
 options.parseArguments()
+
+#try to create 'ramdisk' directory
+try:
+    os.makedirs(options.fffBaseDir+"/"+options.buBaseDir)
+except:pass
+
 
 cmsswbase = os.path.expandvars("$CMSSW_BASE/")
 
@@ -49,14 +61,14 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.source = cms.Source("EmptySource",
      firstRun= cms.untracked.uint32(options.runNumber),
-     numberEventsInLuminosityBlock = cms.untracked.uint32(200),
+     numberEventsInLuminosityBlock = cms.untracked.uint32(5),
      numberEventsInRun       = cms.untracked.uint32(0)    
 )
 
 process.EvFDaqDirector = cms.Service("EvFDaqDirector",
     runNumber = cms.untracked.uint32(options.runNumber),
-    baseDir = cms.untracked.string(options.buBaseDir),
-    buBaseDir = cms.untracked.string(options.buBaseDir),
+    baseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir),
+    buBaseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir),
     directorIsBu = cms.untracked.bool(True),
     copyRunDir = cms.untracked.bool(False))
     #obsolete:

--- a/EventFilter/Utilities/test/startBU.py
+++ b/EventFilter/Utilities/test/startBU.py
@@ -43,9 +43,6 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.options = cms.untracked.PSet(
-    multiProcesses = cms.untracked.PSet(
-    maxChildProcesses = cms.untracked.int32(0)
-    )
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
@@ -61,7 +58,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.source = cms.Source("EmptySource",
      firstRun= cms.untracked.uint32(options.runNumber),
-     numberEventsInLuminosityBlock = cms.untracked.uint32(5),
+     numberEventsInLuminosityBlock = cms.untracked.uint32(105),
      numberEventsInRun       = cms.untracked.uint32(0)    
 )
 
@@ -94,7 +91,7 @@ process.s = cms.EDProducer("DaqFakeReader",
 process.out = cms.OutputModule("RawStreamFileWriterForBU",
     ProductLabel = cms.untracked.string("s"),
     numWriters = cms.untracked.uint32(1),
-    eventBufferSize = cms.untracked.uint32(100),
+    eventBufferSize = cms.untracked.uint32(105),
     numEventsPerFile= cms.untracked.uint32(20),
     jsonDefLocation = cms.untracked.string(cmsswbase+"/src/EventFilter/Utilities/plugins/budef.jsd"),
     jsonEoLDefLocation = cms.untracked.string(cmsswbase+"/src/EventFilter/Utilities/plugins/eols.jsd"),

--- a/EventFilter/Utilities/test/startFU.py
+++ b/EventFilter/Utilities/test/startFU.py
@@ -12,23 +12,37 @@ options.register ('runNumber',
                   "Run Number")
 
 options.register ('buBaseDir',
-                  '/fff/BU0/ramdisk', # default value
+                  'ramdisk', # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "BU base directory")
 
 
 options.register ('fuBaseDir',
-                  '/fff/data', # default value
+                  'data', # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "BU base directory")
 
+options.register ('fffBaseDir',
+                  '.', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "FFF base directory")
+
+
 options.register ('numThreads',
-                  1, # default value
+                  2, # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.int,          # string, int, or float
                   "Number of CMSSW threads")
+
+options.register ('numFwkStreams',
+                  2, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Number of CMSSW streams")
+
 
 options.parseArguments()
 
@@ -41,7 +55,7 @@ process.maxEvents = cms.untracked.PSet(
 
 process.options = cms.untracked.PSet(
     numberOfThreads = cms.untracked.uint32(options.numThreads),
-    numberOfStreams = cms.untracked.uint32(options.numThreads),
+    numberOfStreams = cms.untracked.uint32(options.numThreads)
 )
 process.MessageLogger = cms.Service("MessageLogger",
     cout = cms.untracked.PSet(threshold = cms.untracked.string( "INFO" )),
@@ -58,8 +72,8 @@ process.EvFDaqDirector = cms.Service("EvFDaqDirector",
     useFileService = cms.untracked.bool(False),
     fileServiceHost = cms.untracked.string("htcp40.cern.ch"),
     runNumber = cms.untracked.uint32(options.runNumber),
-    baseDir = cms.untracked.string(options.fuBaseDir),
-    buBaseDir = cms.untracked.string(options.buBaseDir),
+    baseDir = cms.untracked.string(options.fffBaseDir +"/"+options.fuBaseDir),
+    buBaseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir),
     directorIsBu = cms.untracked.bool(False),
     testModeNoBuilderUnit = cms.untracked.bool(False))
 
@@ -68,20 +82,6 @@ try:
 except Exception as ex:
   print(str(ex))
   pass
-
-process.PrescaleService = cms.Service( "PrescaleService",
-    lvl1DefaultLabel = cms.string( "B" ),
-    lvl1Labels = cms.vstring( 'A',
-                              'B'
-                            ),
-    prescaleTable = cms.VPSet(
-               cms.PSet(  pathName = cms.string( "p1" ),                                                                                                                
-                          prescales = cms.vuint32( 0, 10)
-                       ),                                                                                                                                   
-               cms.PSet(  pathName = cms.string( "p2" ),                                                                                                           
-                          prescales = cms.vuint32( 0, 100)                                                                                                                   
-                       )
-    ))
 
 process.source = cms.Source("FedRawDataInputSource",
     runNumber = cms.untracked.uint32(options.runNumber),

--- a/EventFilter/Utilities/test/startFU.py
+++ b/EventFilter/Utilities/test/startFU.py
@@ -55,7 +55,7 @@ process.maxEvents = cms.untracked.PSet(
 
 process.options = cms.untracked.PSet(
     numberOfThreads = cms.untracked.uint32(options.numThreads),
-    numberOfStreams = cms.untracked.uint32(options.numThreads)
+    numberOfStreams = cms.untracked.uint32(options.numFwkStreams)
 )
 process.MessageLogger = cms.Service("MessageLogger",
     cout = cms.untracked.PSet(threshold = cms.untracked.string( "INFO" )),
@@ -135,4 +135,14 @@ process.streamB = cms.OutputModule("EvFOutputModule",
     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
 )
 
-process.ep = cms.EndPath(process.streamA+process.streamB)
+process.streamC = cms.OutputModule("ShmStreamConsumer",
+    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
+)
+
+#process.streamD = cms.OutputModule("EventStreamFileWriter",
+#    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
+#)
+
+process.ep = cms.EndPath(process.streamA+process.streamB+process.streamC
+  #+process.streamD
+)

--- a/IOPool/Streamer/interface/StreamSerializer.h
+++ b/IOPool/Streamer/interface/StreamSerializer.h
@@ -78,7 +78,7 @@ namespace edm
 
     int serializeEvent(EventForOutput const& event, ParameterSetID const& selectorConfig,
                        bool use_compression, int compression_level,
-                       SerializeDataBuffer &data_buffer);
+                       SerializeDataBuffer &data_buffer) const;
 
     /**
      * Compresses the data in the specified input buffer into the

--- a/IOPool/Streamer/interface/StreamerFileIO.h
+++ b/IOPool/Streamer/interface/StreamerFileIO.h
@@ -34,6 +34,7 @@ class OutputFile
 
      void set_do_adler(bool v)             { do_adler_ = v; }
      void set_current_offset(uint64 v)     { current_offset_ = v; }
+     void close();
 
   private:
      uint64 current_offset_;  /** Location of current ioptr */

--- a/IOPool/Streamer/interface/StreamerOutputFile.h
+++ b/IOPool/Streamer/interface/StreamerOutputFile.h
@@ -56,6 +56,8 @@ class StreamerOutputFile
 
      uint32 adler32() const { return streamerfile_->adler32(); }
 
+     void close() { streamerfile_->close(); }
+
   private:
      void writeEventHeader(const EventMsgView& ineview);
      void writeStart(const InitMsgView& inview);

--- a/IOPool/Streamer/interface/StreamerOutputModuleBase.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleBase.h
@@ -39,8 +39,6 @@ namespace edm {
 
     Trig getTriggerResults(EDGetTokenT<TriggerResults> const& token, EventForOutput const& e) const;
 
-    virtual void getSelections() override;
-
   private:
     edm::EDGetTokenT<edm::TriggerResults> trToken_;
 

--- a/IOPool/Streamer/interface/StreamerOutputModuleBase.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleBase.h
@@ -1,12 +1,13 @@
 #ifndef IOPool_Streamer_StreamerOutputModuleBase_h
 #define IOPool_Streamer_StreamerOutputModuleBase_h
 
+#include "IOPool/Streamer/interface/StreamerOutputModuleCommon.h"
 #include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "IOPool/Streamer/interface/MsgTools.h"
-#include "IOPool/Streamer/interface/StreamSerializer.h"
-#include <memory>
-#include <vector>
+//#include "IOPool/Streamer/interface/StreamSerializer.h"
+//#include <memory>
+//#include <vector>
 
 class InitMsgBuilder;
 class EventMsgBuilder;
@@ -15,7 +16,8 @@ namespace edm {
 
   typedef detail::TriggerResultsBasedEventSelector::handle_t Trig;
 
-  class StreamerOutputModuleBase : public one::OutputModule<one::WatchRuns, one::WatchLuminosityBlocks> {
+  class StreamerOutputModuleBase : public one::OutputModule<one::WatchRuns, one::WatchLuminosityBlocks>,
+                                   StreamerOutputModuleCommon {
   public:
     explicit StreamerOutputModuleBase(ParameterSet const& ps);
     ~StreamerOutputModuleBase() override;
@@ -35,39 +37,15 @@ namespace edm {
     virtual void doOutputHeader(InitMsgBuilder const& init_message) = 0;
     virtual void doOutputEvent(EventMsgBuilder const& msg) = 0;
 
-    std::unique_ptr<InitMsgBuilder> serializeRegistry();
-    std::unique_ptr<EventMsgBuilder> serializeEvent(EventForOutput const& e); 
     Trig getTriggerResults(EDGetTokenT<TriggerResults> const& token, EventForOutput const& e) const;
-    void setHltMask(EventForOutput const& e);
-    void setLumiSection();
+
+    virtual void getSelections() override;
 
   private:
-    SelectedProducts const* selections_;
-
-    int maxEventSize_;
-    bool useCompression_;
-    int compressionLevel_;
-
-    // test luminosity sections
-    int lumiSectionInterval_;  
-    double timeInSecSinceUTC;
-
-    StreamSerializer serializer_;
-
-    SerializeDataBuffer serializeDataBuffer_;
-
-    //Event variables, made class memebers to avoid re instatiation for each event.
-    unsigned int hltsize_;
-    uint32 lumi_;
-    std::vector<bool> l1bit_;
-    std::vector<unsigned char> hltbits_;
-    uint32 origSize_;
-    char host_name_[255];
-
     edm::EDGetTokenT<edm::TriggerResults> trToken_;
-    Strings hltTriggerSelections_;
-    uint32 outputModuleId_;
+
   }; //end-of-class-def
+
 } // end of namespace-edm
 
 #endif

--- a/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
@@ -19,7 +19,7 @@ namespace edm {
 
   class StreamerOutputModuleCommon {
   public:
-    explicit StreamerOutputModuleCommon(ParameterSet const& ps);
+    explicit StreamerOutputModuleCommon(ParameterSet const& ps, SelectedProducts const* selections) :
     ~StreamerOutputModuleCommon();
     static void fillDescription(ParameterSetDescription & desc);
 
@@ -39,7 +39,7 @@ namespace edm {
     }
 
   protected:
-    virtual void getSelections() = 0;
+    //virtual void getSelections() = 0;
 
     SelectedProducts const* selections_;
     std::unique_ptr<StreamSerializer> serializer_;

--- a/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
@@ -1,0 +1,71 @@
+#ifndef IOPool_Streamer_StreamerOutputModuleCommon_h
+#define IOPool_Streamer_StreamerOutputModuleCommon_h
+
+#include "IOPool/Streamer/interface/MsgTools.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "IOPool/Streamer/interface/StreamSerializer.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include <memory>
+#include <vector>
+
+class InitMsgBuilder;
+class EventMsgBuilder;
+namespace edm {
+  class ParameterSet;
+  class ParameterSetDescription;
+  class EventForOutput;
+  class ThinnedAssociationsHelper;
+  class TriggerResults;
+
+  class StreamerOutputModuleCommon {
+  public:
+    explicit StreamerOutputModuleCommon(ParameterSet const& ps);
+    ~StreamerOutputModuleCommon();
+    static void fillDescription(ParameterSetDescription & desc);
+
+    std::unique_ptr<InitMsgBuilder> serializeRegistry(BranchIDLists const& branchLists,
+                                                      ThinnedAssociationsHelper const& helper,
+                                                      std::string const& processName,
+                                                      std::string const& moduleLabel,
+                                                      ParameterSetID const& toplevel);
+
+    std::unique_ptr<EventMsgBuilder> serializeEvent(EventForOutput const& e,
+                                                    Handle<TriggerResults> const& triggerResults,
+                                                    ParameterSetID const& selectorCfg);
+
+    void clearSerializeDataBuffer() {
+      serializeDataBuffer_.header_buf_.clear();
+      serializeDataBuffer_.header_buf_.shrink_to_fit();
+    }
+
+  protected:
+    virtual void getSelections() = 0;
+
+    SelectedProducts const* selections_;
+    std::unique_ptr<StreamSerializer> serializer_;
+
+  private:
+    void setHltMask(EventForOutput const& e, Handle<TriggerResults> const& triggerResults, std::vector<unsigned char>& hltbits) const;
+
+    int maxEventSize_;
+    bool useCompression_;
+    int compressionLevel_;
+
+    // test luminosity sections
+    int lumiSectionInterval_;  
+    double timeInSecSinceUTC;
+
+    SerializeDataBuffer serializeDataBuffer_;
+
+    unsigned int hltsize_;
+    uint32 origSize_;
+    char host_name_[255];
+
+    Strings hltTriggerSelections_;
+    uint32 outputModuleId_;
+
+  }; //end-of-class-def
+
+} // end of namespace-edm
+
+#endif

--- a/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
@@ -19,7 +19,7 @@ namespace edm {
 
   class StreamerOutputModuleCommon {
   public:
-    explicit StreamerOutputModuleCommon(ParameterSet const& ps, SelectedProducts const* selections) :
+    explicit StreamerOutputModuleCommon(ParameterSet const& ps, SelectedProducts const* selections);
     ~StreamerOutputModuleCommon();
     static void fillDescription(ParameterSetDescription & desc);
 
@@ -38,14 +38,10 @@ namespace edm {
       serializeDataBuffer_.header_buf_.shrink_to_fit();
     }
 
-  protected:
-    //virtual void getSelections() = 0;
-
-    SelectedProducts const* selections_;
-    std::unique_ptr<StreamSerializer> serializer_;
-
   private:
     void setHltMask(EventForOutput const& e, Handle<TriggerResults> const& triggerResults, std::vector<unsigned char>& hltbits) const;
+
+    StreamSerializer serializer_;
 
     int maxEventSize_;
     bool useCompression_;

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -128,7 +128,7 @@ namespace edm {
   int StreamSerializer::serializeEvent(EventForOutput const& event,
                                        ParameterSetID const& selectorConfig,
                                        bool use_compression, int compression_level,
-                                       SerializeDataBuffer& data_buffer) {
+                                       SerializeDataBuffer& data_buffer) const {
 
     EventSelectionIDVector selectionIDs = event.eventSelectionIDs();
     selectionIDs.push_back(selectorConfig);

--- a/IOPool/Streamer/src/StreamerFileIO.cc
+++ b/IOPool/Streamer/src/StreamerFileIO.cc
@@ -36,3 +36,7 @@
     return true;
   }
 
+  void OutputFile::close()
+  {
+    ost_->close();
+  }

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -16,16 +16,13 @@ namespace edm {
   StreamerOutputModuleBase::StreamerOutputModuleBase(ParameterSet const& ps) :
     one::OutputModuleBase::OutputModuleBase(ps),
     one::OutputModule<one::WatchRuns, one::WatchLuminosityBlocks>(ps),
-    StreamerOutputModuleCommon(ps),
-    trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))) {
+    StreamerOutputModuleCommon(ps,&keptProducts()[InEvent]),
+    trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))),
+    selections_(&keptProducts()[InEvent]),
+    serializer_(selections_) {
   }
 
   StreamerOutputModuleBase::~StreamerOutputModuleBase() {}
-
-  void StreamerOutputModuleBase::getSelections() {
-    selections_ = &keptProducts()[InEvent];
-    serializer_.reset(new StreamSerializer(selections_));
-  }
 
   void
   StreamerOutputModuleBase::beginRun(RunForOutput const&) {

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -17,10 +17,8 @@ namespace edm {
     one::OutputModuleBase::OutputModuleBase(ps),
     one::OutputModule<one::WatchRuns, one::WatchLuminosityBlocks>(ps),
     StreamerOutputModuleCommon(ps,&keptProducts()[InEvent]),
-    trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))),
-    selections_(&keptProducts()[InEvent]),
-    serializer_(selections_) {
-  }
+    trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults")))
+  {}
 
   StreamerOutputModuleBase::~StreamerOutputModuleBase() {}
 

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -4,114 +4,39 @@
 #include "IOPool/Streamer/interface/InitMsgBuilder.h"
 #include "IOPool/Streamer/interface/EventMsgBuilder.h"
 #include "FWCore/Framework/interface/EventForOutput.h"
-#include "FWCore/Framework/interface/EventSelector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/Utilities/interface/DebugMacros.h"
-//#include "FWCore/Utilities/interface/Digest.h"
-#include "FWCore/Version/interface/GetReleaseVersion.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 
-#include <iostream>
-#include <memory>
-#include <string>
-#include <sys/time.h>
-#include <unistd.h>
-#include <vector>
 #include "zlib.h"
-
-namespace {
-  //A utility function that packs bits from source into bytes, with
-  // packInOneByte as the numeber of bytes that are packed from source to dest.
-/*  inline void printBits(unsigned char c) {
-    for (int i = 7; i >= 0; --i) {
-      int bit = ((c >> i) & 1);
-      std::cout << " " << bit;
-    }
-  } */
-
-  void packIntoString(std::vector<unsigned char> const& source,
-                      std::vector<unsigned char>& package) {
-     if (source.empty()) {return;}
-     unsigned int packInOneByte = 4;
-     unsigned int sizeOfPackage = 1+((source.size()-1)/packInOneByte); //Two bits per HLT
-
-     package.resize(sizeOfPackage);
-     memset(&package[0], 0x00, sizeOfPackage);
-
-     for (std::vector<unsigned char>::size_type i=0; i != source.size() ; ++i) {
-       unsigned int whichByte = i/packInOneByte;
-       unsigned int indxWithinByte = i % packInOneByte;
-       package[whichByte] = package[whichByte] | (source[i] << (indxWithinByte*2));
-     }
-    //for (unsigned int i=0; i !=package.size() ; ++i)
-    //   printBits(package[i]);
-    // std::cout << std::endl;
-
-  }
-}
 
 namespace edm {
   StreamerOutputModuleBase::StreamerOutputModuleBase(ParameterSet const& ps) :
     one::OutputModuleBase::OutputModuleBase(ps),
     one::OutputModule<one::WatchRuns, one::WatchLuminosityBlocks>(ps),
-    selections_(&keptProducts()[InEvent]),
-    maxEventSize_(ps.getUntrackedParameter<int>("max_event_size")),
-    useCompression_(ps.getUntrackedParameter<bool>("use_compression")),
-    compressionLevel_(ps.getUntrackedParameter<int>("compression_level")),
-    lumiSectionInterval_(ps.getUntrackedParameter<int>("lumiSection_interval")),
-    serializer_(selections_),
-    serializeDataBuffer_(),
-    hltsize_(0),
-    lumi_(0),
-    l1bit_(0),
-    hltbits_(0),
-    origSize_(0),
-    host_name_(),
-    trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))),
-    hltTriggerSelections_(),
-    outputModuleId_(0) {
-    // no compression as default value - we need this!
-
-    // test luminosity sections
-    struct timeval now;
-    struct timezone dummyTZ;
-    gettimeofday(&now, &dummyTZ);
-    timeInSecSinceUTC = static_cast<double>(now.tv_sec) + (static_cast<double>(now.tv_usec)/1000000.0);
-
-    if(useCompression_ == true) {
-      if(compressionLevel_ <= 0) {
-        FDEBUG(9) << "Compression Level = " << compressionLevel_
-                  << " no compression" << std::endl;
-        compressionLevel_ = 0;
-        useCompression_ = false;
-      } else if(compressionLevel_ > 9) {
-        FDEBUG(9) << "Compression Level = " << compressionLevel_
-                  << " using max compression level 9" << std::endl;
-        compressionLevel_ = 9;
-      }
-    }
-    serializeDataBuffer_.bufs_.resize(maxEventSize_);
-    int got_host = gethostname(host_name_, 255);
-    if(got_host != 0) strncpy(host_name_, "noHostNameFoundOrTooLong", sizeof(host_name_));
-    //loadExtraClasses();
-
-    // 25-Jan-2008, KAB - pull out the trigger selection request
-    // which we need for the INIT message
-    hltTriggerSelections_ = EventSelector::getEventSelectionVString(ps);
+    StreamerOutputModuleCommon(ps),
+    trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))) {
   }
 
   StreamerOutputModuleBase::~StreamerOutputModuleBase() {}
 
+  void StreamerOutputModuleBase::getSelections() {
+    selections_ = &keptProducts()[InEvent];
+    serializer_.reset(new StreamSerializer(selections_));
+  }
+
   void
   StreamerOutputModuleBase::beginRun(RunForOutput const&) {
     start();
-    std::unique_ptr<InitMsgBuilder>  init_message = serializeRegistry();
+
+    std::unique_ptr<InitMsgBuilder> init_message = 
+      serializeRegistry(*branchIDLists(), *thinnedAssociationsHelper(), 
+                        OutputModule::processName(), description().moduleLabel(), moduleDescription().mainParameterSetID());
+
     doOutputHeader(*init_message);
-    serializeDataBuffer_.header_buf_.clear();
-    serializeDataBuffer_.header_buf_.shrink_to_fit();
+    clearSerializeDataBuffer();
   }
 
   void
@@ -124,7 +49,7 @@ namespace edm {
 
   void
   StreamerOutputModuleBase::endJob() {
-    stop();  // for closing of files, notify storage manager, etc.
+    stop();
   }
 
   void
@@ -135,66 +60,9 @@ namespace edm {
 
   void
   StreamerOutputModuleBase::write(EventForOutput const& e) {
-    std::unique_ptr<EventMsgBuilder> msg = serializeEvent(e);
+    Handle<TriggerResults> const& triggerResults = getTriggerResults(trToken_, e);
+    std::unique_ptr<EventMsgBuilder> msg = serializeEvent(e, triggerResults, selectorConfig());
     doOutputEvent(*msg); // You can't use msg in StreamerOutputModuleBase after this point
-  }
-
-  std::unique_ptr<InitMsgBuilder>
-  StreamerOutputModuleBase::serializeRegistry() {
-
-    serializer_.serializeRegistry(serializeDataBuffer_, *branchIDLists(), *thinnedAssociationsHelper());
-
-    // resize bufs_ to reflect space used in serializer_ + header
-    // I just added an overhead for header of 50000 for now
-    unsigned int src_size = serializeDataBuffer_.currentSpaceUsed();
-    unsigned int new_size = src_size + 50000;
-    if(serializeDataBuffer_.header_buf_.size() < new_size) serializeDataBuffer_.header_buf_.resize(new_size);
-
-    //Build the INIT Message
-    //Following values are strictly DUMMY and will be replaced
-    // once available with Utility function etc.
-    uint32 run = 1;
-
-    //Get the Process PSet ID
-    ParameterSetID toplevel = moduleDescription().mainParameterSetID();
-
-    //In case we need to print it
-    //  cms::Digest dig(toplevel.compactForm());
-    //  cms::MD5Result r1 = dig.digest();
-    //  std::string hexy = r1.toString();
-    //  std::cout << "HEX Representation of Process PSetID: " << hexy << std::endl;
-
-    Strings hltTriggerNames = getAllTriggerNames();
-    hltsize_ = hltTriggerNames.size();
-
-    //L1 stays dummy as of today
-    Strings l1_names;  //3
-    l1_names.push_back("t1");
-    l1_names.push_back("t10");
-    l1_names.push_back("t2");
-
-    //Setting the process name to HLT
-    std::string processName = OutputModule::processName();
-
-    std::string moduleLabel = description().moduleLabel();
-    uLong crc = crc32(0L, Z_NULL, 0);
-    Bytef const* buf = (Bytef const*)(moduleLabel.data());
-    crc = crc32(crc, buf, moduleLabel.length());
-    outputModuleId_ = static_cast<uint32>(crc);
-
-    auto init_message = std::make_unique<InitMsgBuilder>(
-                           &serializeDataBuffer_.header_buf_[0], serializeDataBuffer_.header_buf_.size(),
-                           run, Version((uint8 const*)toplevel.compactForm().c_str()),
-                           getReleaseVersion().c_str() , processName.c_str(),
-                           moduleLabel.c_str(), outputModuleId_,
-                           hltTriggerNames, hltTriggerSelections_, l1_names,
-                           (uint32)serializeDataBuffer_.adler32_chksum());
-
-    // copy data into the destination message
-    unsigned char* src = serializeDataBuffer_.bufferPointer();
-    std::copy(src, src + src_size, init_message->dataAddress());
-    init_message->setDataLength(src_size);
-    return init_message;
   }
 
   Trig
@@ -205,109 +73,8 @@ namespace edm {
   }
 
   void
-  StreamerOutputModuleBase::setHltMask(EventForOutput const& e) {
-
-    hltbits_.clear();  // If there was something left over from last event
-
-    Handle<TriggerResults> const& prod = getTriggerResults(trToken_, e);
-    //Trig const& prod = getTrigMask(e);
-    std::vector<unsigned char> vHltState;
-
-    if (prod.isValid()) {
-      for(std::vector<unsigned char>::size_type i=0; i != hltsize_ ; ++i) {
-        vHltState.push_back(((prod->at(i)).state()));
-      }
-    } else {
-     // We fill all Trigger bits to valid state.
-     for(std::vector<unsigned char>::size_type i=0; i != hltsize_ ; ++i) {
-           vHltState.push_back(hlt::Pass);
-      }
-    }
-    //Pack into member hltbits_
-    packIntoString(vHltState, hltbits_);
-
-    //This is Just a printing code.
-    //std::cout << "Size of hltbits:" << hltbits_.size() << std::endl;
-    //for(unsigned int i=0; i != hltbits_.size() ; ++i) {
-    //  printBits(hltbits_[i]);
-    //}
-    //std::cout << "\n";
-  }
-
-// test luminosity sections
-  void
-  StreamerOutputModuleBase::setLumiSection() {
-    struct timeval now;
-    struct timezone dummyTZ;
-    gettimeofday(&now, &dummyTZ);
-    double timeInSec = static_cast<double>(now.tv_sec) + (static_cast<double>(now.tv_usec)/1000000.0) - timeInSecSinceUTC;
-    // what about overflows?
-    if(lumiSectionInterval_ > 0) lumi_ = static_cast<uint32>(timeInSec/lumiSectionInterval_) + 1;
-  }
-
-  std::unique_ptr<EventMsgBuilder>
-  StreamerOutputModuleBase::serializeEvent(EventForOutput const& e) {
-    //Lets Build the Event Message first
-
-    //Following is strictly DUMMY Data for L! Trig and will be replaced with actual
-    // once figured out, there is no logic involved here.
-    l1bit_.push_back(true);
-    l1bit_.push_back(true);
-    l1bit_.push_back(false);
-    //End of dummy data
-
-    setHltMask(e);
-
-    if (lumiSectionInterval_ == 0) {
-      lumi_ = e.luminosityBlock();
-    } else {
-      setLumiSection();
-    }
-
-    serializer_.serializeEvent(e, selectorConfig(), useCompression_, compressionLevel_, serializeDataBuffer_);
-
-    // resize bufs_ to reflect space used in serializer_ + header
-    // I just added an overhead for header of 50000 for now
-    unsigned int src_size = serializeDataBuffer_.currentSpaceUsed();
-    unsigned int new_size = src_size + 50000;
-    if(serializeDataBuffer_.bufs_.size() < new_size) serializeDataBuffer_.bufs_.resize(new_size);
-
-    auto msg = std::make_unique<EventMsgBuilder>(
-                              &serializeDataBuffer_.bufs_[0], serializeDataBuffer_.bufs_.size(), e.id().run(),
-                              e.id().event(), lumi_, outputModuleId_, 0,
-                              l1bit_, (uint8*)&hltbits_[0], hltsize_,
-                              (uint32)serializeDataBuffer_.adler32_chksum(), host_name_);
-    msg->setOrigDataSize(origSize_); // we need this set to zero
-
-    // copy data into the destination message
-    // an alternative is to have serializer only to the serialization
-    // in serializeEvent, and then call a new member "getEventData" that
-    // takes the compression arguments and a place to put the data.
-    // This will require one less copy.  The only catch is that the
-    // space provided in bufs_ should be at least the uncompressed
-    // size + overhead for header because we will not know the actual
-    // compressed size.
-
-    unsigned char* src = serializeDataBuffer_.bufferPointer();
-    std::copy(src,src + src_size, msg->eventAddr());
-    msg->setEventLength(src_size);
-    if(useCompression_) msg->setOrigDataSize(serializeDataBuffer_.currentEventSize());
-
-    l1bit_.clear();  //Clear up for the next event to come.
-    return msg;
-  }
-
-  void
   StreamerOutputModuleBase::fillDescription(ParameterSetDescription& desc) {
-    desc.addUntracked<int>("max_event_size", 7000000)
-        ->setComment("Starting size in bytes of the serialized event buffer.");
-    desc.addUntracked<bool>("use_compression", true)
-        ->setComment("If True, compression will be used to write streamer file.");
-    desc.addUntracked<int>("compression_level", 1)
-        ->setComment("ROOT compression level to use.");
-    desc.addUntracked<int>("lumiSection_interval", 0)
-        ->setComment("If 0, use lumi section number from event.\n"
-                     "If not 0, the interval in seconds between fake lumi sections.");
+    StreamerOutputModuleCommon::fillDescription(desc);
     OutputModule::fillDescription(desc);
   }
 } // end of namespace-edm

--- a/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
@@ -1,0 +1,249 @@
+#include "IOPool/Streamer/interface/StreamerOutputModuleCommon.h"
+
+#include "IOPool/Streamer/interface/InitMsgBuilder.h"
+#include "IOPool/Streamer/interface/EventMsgBuilder.h"
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/Framework/interface/EventSelector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/DebugMacros.h"
+#include "FWCore/Version/interface/GetReleaseVersion.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "DataFormats/Provenance/interface/ParameterSetID.h"
+#include "DataFormats/Provenance/interface/SelectedProducts.h"
+#include "FWCore/Framework/interface/getAllTriggerNames.h"
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <sys/time.h>
+#include <unistd.h>
+#include <vector>
+#include <zlib.h>
+
+namespace edm {
+  StreamerOutputModuleCommon::StreamerOutputModuleCommon(ParameterSet const& ps) :
+    maxEventSize_(ps.getUntrackedParameter<int>("max_event_size")),
+    useCompression_(ps.getUntrackedParameter<bool>("use_compression")),
+    compressionLevel_(ps.getUntrackedParameter<int>("compression_level")),
+    lumiSectionInterval_(ps.getUntrackedParameter<int>("lumiSection_interval")),
+    serializeDataBuffer_(),
+    hltsize_(0),
+    origSize_(0),
+    host_name_(),
+    hltTriggerSelections_(),
+    outputModuleId_(0) {
+    // no compression as default value - we need this!
+
+    //inheriting class must implement getSelections method to retrieve selection from base output module
+    //::getSelections {
+    //  selections_(&keptProducts()[InEvent]),
+    //  serializer_(selections_),
+    //  selectionsInitialized_=true;
+    //}
+
+    // test luminosity sections
+    struct timeval now;
+    struct timezone dummyTZ;
+    gettimeofday(&now, &dummyTZ);
+    timeInSecSinceUTC = static_cast<double>(now.tv_sec) + (static_cast<double>(now.tv_usec)/1000000.0);
+
+    if(useCompression_ == true) {
+      if(compressionLevel_ <= 0) {
+        FDEBUG(9) << "Compression Level = " << compressionLevel_
+                  << " no compression" << std::endl;
+        compressionLevel_ = 0;
+        useCompression_ = false;
+      } else if(compressionLevel_ > 9) {
+        FDEBUG(9) << "Compression Level = " << compressionLevel_
+                  << " using max compression level 9" << std::endl;
+        compressionLevel_ = 9;
+      }
+    }
+    serializeDataBuffer_.bufs_.resize(maxEventSize_);
+    int got_host = gethostname(host_name_, 255);
+    if(got_host != 0) strncpy(host_name_, "noHostNameFoundOrTooLong", sizeof(host_name_));
+    //loadExtraClasses();
+
+    // 25-Jan-2008, KAB - pull out the trigger selection request
+    // which we need for the INIT message
+    hltTriggerSelections_ = EventSelector::getEventSelectionVString(ps);
+  }
+
+  StreamerOutputModuleCommon::~StreamerOutputModuleCommon() {}
+
+
+  std::unique_ptr<InitMsgBuilder>
+  StreamerOutputModuleCommon::serializeRegistry( const BranchIDLists &branchLists,
+                                                 ThinnedAssociationsHelper const& helper,
+                                                 std::string const& processName,
+                                                 std::string const& moduleLabel,
+                                                 ParameterSetID const& toplevel)
+  {
+
+    if (serializer_.get()==nullptr) getSelections();
+
+    serializer_->serializeRegistry(serializeDataBuffer_, branchLists, helper);
+
+    // resize bufs_ to reflect space used in serializer_ + header
+    // I just added an overhead for header of 50000 for now
+    unsigned int src_size = serializeDataBuffer_.currentSpaceUsed();
+    unsigned int new_size = src_size + 50000;
+    if(serializeDataBuffer_.header_buf_.size() < new_size) serializeDataBuffer_.header_buf_.resize(new_size);
+
+    //Build the INIT Message
+    //Following values are strictly DUMMY and will be replaced
+    // once available with Utility function etc.
+    uint32 run = 1;
+
+    //Get the Process PSet ID
+
+    //In case we need to print it
+    //  cms::Digest dig(toplevel.compactForm());
+    //  cms::MD5Result r1 = dig.digest();
+    //  std::string hexy = r1.toString();
+    //  std::cout << "HEX Representation of Process PSetID: " << hexy << std::endl;
+    Strings const& hltTriggerNames = edm::getAllTriggerNames();
+    hltsize_ = hltTriggerNames.size();
+
+    //L1 stays dummy as of today
+    Strings l1_names;  //3
+    l1_names.push_back("t1");
+    l1_names.push_back("t10");
+    l1_names.push_back("t2");
+
+    //Setting the process name to HLT
+    uLong crc = crc32(0L, Z_NULL, 0);
+    Bytef const* buf = (Bytef const*)(moduleLabel.data());
+    crc = crc32(crc, buf, moduleLabel.length());
+    outputModuleId_ = static_cast<uint32>(crc);
+
+    auto init_message = std::make_unique<InitMsgBuilder>(
+                           &serializeDataBuffer_.header_buf_[0], serializeDataBuffer_.header_buf_.size(),
+                           run, Version((uint8 const*)toplevel.compactForm().c_str()),
+                           getReleaseVersion().c_str() , processName.c_str(),
+                           moduleLabel.c_str(), outputModuleId_,
+                           hltTriggerNames, hltTriggerSelections_, l1_names,
+                           (uint32)serializeDataBuffer_.adler32_chksum());
+
+    // copy data into the destination message
+    unsigned char* src = serializeDataBuffer_.bufferPointer();
+    std::copy(src, src + src_size, init_message->dataAddress());
+    init_message->setDataLength(src_size);
+    return init_message;
+  }
+
+  void
+  StreamerOutputModuleCommon::setHltMask(EventForOutput const& e, Handle<TriggerResults> const& triggerResults, std::vector<unsigned char>& hltbits) const {
+
+    hltbits.clear();
+
+    std::vector<unsigned char> vHltState;
+
+    if (triggerResults.isValid()) {
+      for(std::vector<unsigned char>::size_type i=0; i != hltsize_ ; ++i) {
+        vHltState.push_back(((triggerResults->at(i)).state()));
+      }
+    } else {
+     // We fill all Trigger bits to valid state.
+     for(std::vector<unsigned char>::size_type i=0; i != hltsize_ ; ++i) {
+           vHltState.push_back(hlt::Pass);
+      }
+    }
+
+    //Pack into member hltbits
+    if (!vHltState.empty()) {
+      unsigned int packInOneByte = 4;
+      unsigned int sizeOfPackage = 1+((vHltState.size()-1)/packInOneByte); //Two bits per HLT
+
+      hltbits.resize(sizeOfPackage);
+      std::fill(hltbits.begin(), hltbits.end(), 0);
+
+      for (std::vector<unsigned char>::size_type i=0; i != vHltState.size() ; ++i) {
+        unsigned int whichByte = i/packInOneByte;
+        unsigned int indxWithinByte = i % packInOneByte;
+        hltbits[whichByte] = hltbits[whichByte] | (vHltState[i] << (indxWithinByte*2));
+      }
+    }
+
+    //This is Just a printing code.
+    //std::cout << "Size of hltbits:" << hltbits_.size() << std::endl;
+    //for(unsigned int i=0; i != hltbits_.size() ; ++i) {
+    //  printBits(hltbits_[i]);
+    //}
+    //std::cout << "\n";
+  }
+
+  std::unique_ptr<EventMsgBuilder>
+  StreamerOutputModuleCommon::serializeEvent(EventForOutput const& e, Handle<TriggerResults> const& triggerResults, ParameterSetID const& selectorCfg) {
+    //Lets Build the Event Message first
+
+    //Following is strictly DUMMY Data for L! Trig and will be replaced with actual
+    // once figured out, there is no logic involved here.
+    std::vector<bool> l1bit = {true,true,false};
+    //End of dummy data
+
+    std::vector<unsigned char> hltbits;
+    setHltMask(e, triggerResults, hltbits);
+
+    uint32 lumi;
+    if (lumiSectionInterval_ == 0) {
+      lumi = e.luminosityBlock();
+    } else {
+
+      struct timeval now;
+      struct timezone dummyTZ;
+      gettimeofday(&now, &dummyTZ);
+      double timeInSec = static_cast<double>(now.tv_sec) + (static_cast<double>(now.tv_usec)/1000000.0) - timeInSecSinceUTC;
+      // what about overflows?
+      if(lumiSectionInterval_ > 0) lumi = static_cast<uint32>(timeInSec/lumiSectionInterval_) + 1;
+    }
+
+    if (serializer_.get()==nullptr) getSelections();
+
+    serializer_->serializeEvent(e, selectorCfg, useCompression_, compressionLevel_, serializeDataBuffer_);
+
+    // resize bufs_ to reflect space used in serializer_ + header
+    // I just added an overhead for header of 50000 for now
+    unsigned int src_size = serializeDataBuffer_.currentSpaceUsed();
+    unsigned int new_size = src_size + 50000;
+    if(serializeDataBuffer_.bufs_.size() < new_size) serializeDataBuffer_.bufs_.resize(new_size);
+
+    auto msg = std::make_unique<EventMsgBuilder>(
+                              &serializeDataBuffer_.bufs_[0], serializeDataBuffer_.bufs_.size(), e.id().run(),
+                              e.id().event(), lumi, outputModuleId_, 0,
+                              l1bit, (uint8*)&hltbits[0], hltsize_,
+                              (uint32)serializeDataBuffer_.adler32_chksum(), host_name_);
+    msg->setOrigDataSize(origSize_); // we need this set to zero
+
+    // copy data into the destination message
+    // an alternative is to have serializer only to the serialization
+    // in serializeEvent, and then call a new member "getEventData" that
+    // takes the compression arguments and a place to put the data.
+    // This will require one less copy.  The only catch is that the
+    // space provided in bufs_ should be at least the uncompressed
+    // size + overhead for header because we will not know the actual
+    // compressed size.
+
+    unsigned char* src = serializeDataBuffer_.bufferPointer();
+    std::copy(src,src + src_size, msg->eventAddr());
+    msg->setEventLength(src_size);
+    if(useCompression_) msg->setOrigDataSize(serializeDataBuffer_.currentEventSize());
+
+    return msg;
+  }
+
+  void
+  StreamerOutputModuleCommon::fillDescription(ParameterSetDescription& desc) {
+    desc.addUntracked<int>("max_event_size", 7000000)
+        ->setComment("Starting size in bytes of the serialized event buffer.");
+    desc.addUntracked<bool>("use_compression", true)
+        ->setComment("If True, compression will be used to write streamer file.");
+    desc.addUntracked<int>("compression_level", 1)
+        ->setComment("ROOT compression level to use.");
+    desc.addUntracked<int>("lumiSection_interval", 0)
+        ->setComment("If 0, use lumi section number from event.\n"
+                     "If not 0, the interval in seconds between fake lumi sections.");
+  }
+} // end of namespace-edm

--- a/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
@@ -25,8 +25,7 @@
 namespace edm {
   StreamerOutputModuleCommon::StreamerOutputModuleCommon(ParameterSet const& ps, SelectedProducts const* selections) :
 
-    selections_(selections),
-    serializer_(selections_),
+    serializer_(selections),
     maxEventSize_(ps.getUntrackedParameter<int>("max_event_size")),
     useCompression_(ps.getUntrackedParameter<bool>("use_compression")),
     compressionLevel_(ps.getUntrackedParameter<int>("compression_level")),
@@ -78,7 +77,7 @@ namespace edm {
                                                  ParameterSetID const& toplevel)
   {
 
-    serializer_->serializeRegistry(serializeDataBuffer_, branchLists, helper);
+    serializer_.serializeRegistry(serializeDataBuffer_, branchLists, helper);
 
     // resize bufs_ to reflect space used in serializer_ + header
     // I just added an overhead for header of 50000 for now
@@ -194,7 +193,7 @@ namespace edm {
       if(lumiSectionInterval_ > 0) lumi = static_cast<uint32>(timeInSec/lumiSectionInterval_) + 1;
     }
 
-    serializer_->serializeEvent(e, selectorCfg, useCompression_, compressionLevel_, serializeDataBuffer_);
+    serializer_.serializeEvent(e, selectorCfg, useCompression_, compressionLevel_, serializeDataBuffer_);
 
     // resize bufs_ to reflect space used in serializer_ + header
     // I just added an overhead for header of 50000 for now

--- a/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
@@ -23,7 +23,10 @@
 #include <zlib.h>
 
 namespace edm {
-  StreamerOutputModuleCommon::StreamerOutputModuleCommon(ParameterSet const& ps) :
+  StreamerOutputModuleCommon::StreamerOutputModuleCommon(ParameterSet const& ps, SelectedProducts const* selections) :
+
+    selections_(selections),
+    serializer_(selections_),
     maxEventSize_(ps.getUntrackedParameter<int>("max_event_size")),
     useCompression_(ps.getUntrackedParameter<bool>("use_compression")),
     compressionLevel_(ps.getUntrackedParameter<int>("compression_level")),
@@ -35,13 +38,6 @@ namespace edm {
     hltTriggerSelections_(),
     outputModuleId_(0) {
     // no compression as default value - we need this!
-
-    //inheriting class must implement getSelections method to retrieve selection from base output module
-    //::getSelections {
-    //  selections_(&keptProducts()[InEvent]),
-    //  serializer_(selections_),
-    //  selectionsInitialized_=true;
-    //}
 
     // test luminosity sections
     struct timeval now;
@@ -81,8 +77,6 @@ namespace edm {
                                                  std::string const& moduleLabel,
                                                  ParameterSetID const& toplevel)
   {
-
-    if (serializer_.get()==nullptr) getSelections();
 
     serializer_->serializeRegistry(serializeDataBuffer_, branchLists, helper);
 
@@ -199,8 +193,6 @@ namespace edm {
       // what about overflows?
       if(lumiSectionInterval_ > 0) lumi = static_cast<uint32>(timeInSec/lumiSectionInterval_) + 1;
     }
-
-    if (serializer_.get()==nullptr) getSelections();
 
     serializer_->serializeEvent(e, selectorCfg, useCompression_, compressionLevel_, serializeDataBuffer_);
 


### PR DESCRIPTION
This is DAQ (HLT/Filter Farm) output module implementation based on limited::OutputModule. This implementation removes limitation of handling only one LS at the time present in current one DAQ module.

- New module also rely on changes introduced here: https://github.com/cms-sw/cmssw/pull/21830

- StreamerOutputModuleBase (inheriting one::OutputModule) base is restructured and serializer code (shared with the new, limited implementation) extracted to a common class which can be used by both one and limited module. Currently, "base" is used by: DQM test module, Streamer writer module and previous DAQ output module which we'll still keep.

- new module is called EvFOutputModule while previous DAQ module remains as ShmStreamConsumer (this name is currently still used in production configurations).

- Limited OutputModule transitions used to write event and end global lumisection are const functions. There are a few problems associated with this, for which a workaround is to apply const_cast:

1. This is too strict for streamer serializer, which is therefore included in a helper class stored in RunCache. Serializer keeps internally a buffer which is reallocated only if too small to accommodate serialized event. To allow access, const_cast is applied in event write callback.

2. File writer in LuminosityBlockCache object also needs const_cast in event write and global EoL ( where file is written to / closed). Also it needs to update the object to do per-LS event count bookkeeping.

3. JSON writer, which is initialized once with JSON definitions, is also stored in RunCache, and needs to be allowed modification at the time of global EoL.

- Those const_casts should be thread-safe since this limited output module strictly requires concurrencyLimit = 1 at runtime, and will throw exception if another configuration value is set.
