### PR TITLE
fastsim to use firstStepPrimaryVerticesBeforeMixing in all iter tracking classifiers

### DIFF
--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -260,6 +260,7 @@ trackingPhase1.toReplaceWith(detachedTripletStep, TrackLwtnnClassifier.clone(
      src = 'detachedTripletStepTracks',
      qualityCuts = [0.0, 0.4, 0.8],
 ))
+(trackingPhase1 & fastSim).toModify(detachedTripletStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
 
 highBetaStar_2018.toReplaceWith(detachedTripletStep, detachedTripletStepClassifier1.clone(
      qualityCuts = [-0.5,0.0,0.5],

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -297,6 +297,7 @@ trackingPhase1.toReplaceWith(initialStep, TrackLwtnnClassifier.clone(
 	src = 'initialStepTracks',
 	qualityCuts = [0.0, 0.3, 0.6],
 ))
+(trackingPhase1 & fastSim).toModify(initialStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
 
 pp_on_AA_2018.toReplaceWith(initialStep, initialStepClassifier1.clone( 
      qualityCuts = [-0.9, -0.5, 0.2],

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -196,6 +196,7 @@ trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackLwtnnClassifier.clone(
      src = 'jetCoreRegionalStepTracks',
      qualityCuts = [0.6, 0.7, 0.8],
 ))
+(trackingPhase1 & fastSim).toModify(jetCoreRegionalStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
 
 # Final sequence
 JetCoreRegionalStepTask = cms.Task(jetsForCoreTracking,                 

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -344,6 +344,7 @@ trackingPhase1.toReplaceWith(mixedTripletStep, TrackLwtnnClassifier.clone(
      src = 'mixedTripletStepTracks',
      qualityCuts = [-0.8, -0.35, 0.1],
 ))
+(trackingPhase1 & fastSim).toModify(mixedTripletStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
 
 highBetaStar_2018.toReplaceWith(mixedTripletStep, mixedTripletStepClassifier1.clone(
      qualityCuts = [-0.7,0.0,0.5],

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -295,6 +295,7 @@ trackingPhase1.toReplaceWith(pixelLessStep, TrackLwtnnClassifier.clone(
      src = 'pixelLessStepTracks',
      qualityCuts = [-0.6, -0.05, 0.5],
 ))
+(trackingPhase1 & fastSim).toModify(pixelLessStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
 
 pp_on_AA_2018.toReplaceWith(pixelLessStep, pixelLessStepClassifier1.clone(
      qualityCuts = [-0.4,0.0,0.8],

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -369,6 +369,7 @@ trackingPhase1.toReplaceWith(tobTecStep, TrackLwtnnClassifier.clone(
      src = 'tobTecStepTracks',
      qualityCuts = [-0.4, -0.25, -0.1]
 ))
+(trackingPhase1 & fastSim).toModify(tobTecStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
 
 pp_on_AA_2018.toReplaceWith(tobTecStep, TrackMVAClassifierDetached.clone(
      src = 'tobTecStepTracks',


### PR DESCRIPTION
this is needed now that we are using the TrackLwtnnClassifier for the track classification after merging #21717 

I checked that wf 2017.1 works now