### PR TITLE
Use unique_ptr constructor for PluginFactory plugins in RecoPixelVertexing

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CombinedHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CombinedHitTripletGenerator.cc
@@ -13,7 +13,7 @@ CombinedHitTripletGenerator::CombinedHitTripletGenerator(const edm::ParameterSet
 {
   edm::ParameterSet generatorPSet = cfg.getParameter<edm::ParameterSet>("GeneratorPSet");
   std::string       generatorName = generatorPSet.getParameter<std::string>("ComponentName");
-  theGenerator.reset(HitTripletGeneratorFromPairAndLayersFactory::get()->create(generatorName, generatorPSet, iC));
+  theGenerator = std::unique_ptr<HitTripletGeneratorFromPairAndLayers>{HitTripletGeneratorFromPairAndLayersFactory::get()->create(generatorName, generatorPSet, iC)};
   theGenerator->init(std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache), &theLayerCache);
 }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -47,7 +47,7 @@ PixelTripletHLTGenerator:: PixelTripletHLTGenerator(const edm::ParameterSet& cfg
     cfg.getParameter<edm::ParameterSet>("SeedComparitorPSet");
   std::string comparitorName = comparitorPSet.getParameter<std::string>("ComponentName");
   if(comparitorName != "none") {
-    theComparitor.reset( SeedComparitorFactory::get()->create( comparitorName, comparitorPSet, iC) );
+    theComparitor = std::unique_ptr<SeedComparitor>{SeedComparitorFactory::get()->create( comparitorName, comparitorPSet, iC)};
   }
 }
 

--- a/RecoPixelVertexing/PixelTriplets/src/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CAHitQuadrupletGenerator.cc
@@ -40,7 +40,7 @@ caHardPtCut(cfg.getParameter<double>("CAHardPtCut"))
   std::string comparitorName = comparitorPSet.getParameter<std::string>("ComponentName");
   if (comparitorName != "none")
   {
-    theComparitor.reset(SeedComparitorFactory::get()->create(comparitorName, comparitorPSet, iC));
+    theComparitor = std::unique_ptr<SeedComparitor>{SeedComparitorFactory::get()->create(comparitorName, comparitorPSet, iC)};
   }
 }
 

--- a/RecoPixelVertexing/PixelTriplets/src/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CAHitTripletGenerator.cc
@@ -40,9 +40,8 @@ CAHitTripletGenerator::CAHitTripletGenerator(const edm::ParameterSet& cfg,
 	std::string comparitorName = comparitorPSet.getParameter < std::string > ("ComponentName");
 	if (comparitorName != "none")
 	{
-		theComparitor.reset(
-				SeedComparitorFactory::get()->create(comparitorName,
-						comparitorPSet, iC));
+          theComparitor = std::unique_ptr<SeedComparitor>{SeedComparitorFactory::get()->create(comparitorName,
+                                                                                               comparitorPSet, iC)};
 	}
 }
 


### PR DESCRIPTION
Also manage a plugin with unique_ptr and cleanup further `HitTripletProducer`.

This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-02-05-1100 , no changes expected.