### PR TITLE
Manage PluginFactory plugins with unique_ptr in RecoEcal and RecoLocalCalo/EcalRecProducers

### DIFF
--- a/RecoEcal/EgammaClusterProducers/interface/EgammaSCCorrectionMaker.h
+++ b/RecoEcal/EgammaClusterProducers/interface/EgammaSCCorrectionMaker.h
@@ -44,13 +44,13 @@ class EgammaSCCorrectionMaker : public edm::stream::EDProducer<> {
 
    private:
 
-     EcalClusterFunctionBaseClass* energyCorrectionFunction_;
-     EcalClusterFunctionBaseClass* crackCorrectionFunction_;
-     EcalClusterFunctionBaseClass* localContCorrectionFunction_;
+     std::unique_ptr<EcalClusterFunctionBaseClass> energyCorrectionFunction_;
+     std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction_;
+     std::unique_ptr<EcalClusterFunctionBaseClass> localContCorrectionFunction_;
 
 
      // pointer to the correction algo object
-     EgammaSCEnergyCorrectionAlgo *energyCorrector_;
+     std::unique_ptr<EgammaSCEnergyCorrectionAlgo> energyCorrector_;
     
      
 

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterFunctions.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterFunctions.cc
@@ -39,28 +39,21 @@ Implementation:
 class testEcalClusterFunctions : public edm::EDAnalyzer {
         public:
                 explicit testEcalClusterFunctions(const edm::ParameterSet&);
-                ~testEcalClusterFunctions();
+                ~testEcalClusterFunctions() override = default;
 
         private:
-                virtual void analyze(const edm::Event&, const edm::EventSetup&);
-                EcalClusterFunctionBaseClass *ff_;
+                void analyze(const edm::Event&, const edm::EventSetup&) override;
+                std::unique_ptr<EcalClusterFunctionBaseClass> ff_;
 
 };
 
 
 
-testEcalClusterFunctions::testEcalClusterFunctions(const edm::ParameterSet& ps) :
-        ff_(0)
+testEcalClusterFunctions::testEcalClusterFunctions(const edm::ParameterSet& ps)
 {
         std::string functionName = ps.getParameter<std::string>("functionName");
-        ff_ = EcalClusterFunctionFactory::get()->create( functionName, ps );
-        std::cout << "got " << functionName << " function at: " << ff_ << "\n";
-}
-
-
-
-testEcalClusterFunctions::~testEcalClusterFunctions()
-{
+        ff_ = std::unique_ptr<EcalClusterFunctionBaseClass>{EcalClusterFunctionFactory::get()->create( functionName, ps )};
+        std::cout << "got " << functionName << " function at: " << ff_.get() << "\n";
 }
 
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/ESRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/ESRecHitProducer.cc
@@ -14,18 +14,13 @@
 
 ESRecHitProducer::ESRecHitProducer(edm::ParameterSet const& ps) :
   digiToken_( consumes<ESDigiCollection>(ps.getParameter<edm::InputTag>("ESdigiCollection")) ),
-  rechitCollection_( ps.getParameter<std::string>("ESrechitCollection") )
+  rechitCollection_( ps.getParameter<std::string>("ESrechitCollection") ),
+  worker_{ESRecHitWorkerFactory::get()->create(ps.getParameter<std::string>("algo"), ps )}
 {
   produces<ESRecHitCollection>(rechitCollection_);
-  
-  std::string const & componentType = ps.getParameter<std::string>("algo");
-  worker_ = ESRecHitWorkerFactory::get()->create( componentType, ps );
 }
 
-ESRecHitProducer::~ESRecHitProducer() {
-
-  delete worker_;
-}
+ESRecHitProducer::~ESRecHitProducer()  = default;
 
 void ESRecHitProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/ESRecHitProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/ESRecHitProducer.h
@@ -27,6 +27,6 @@ class ESRecHitProducer : public edm::stream::EDProducer<> {
   const edm::EDGetTokenT<ESDigiCollection> digiToken_;
   const std::string rechitCollection_; // secondary name to be given to collection of hits
 
-  ESRecHitWorkerBaseClass * worker_;
+  std::unique_ptr<ESRecHitWorkerBaseClass> worker_;
 };
 #endif

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.cc
@@ -64,23 +64,18 @@ EcalRecHitProducer::EcalRecHitProducer(const edm::ParameterSet& ps)
 
         std::string componentType = ps.getParameter<std::string>("algo");
 	edm::ConsumesCollector c{consumesCollector()};
-        worker_ = EcalRecHitWorkerFactory::get()->create(componentType, ps, c);
+        worker_ = std::unique_ptr<EcalRecHitWorkerBaseClass>{EcalRecHitWorkerFactory::get()->create(componentType, ps, c)};
 
         // to recover problematic channels
         componentType = ps.getParameter<std::string>("algoRecover");
-        workerRecover_ = EcalRecHitWorkerFactory::get()->create(componentType, ps, c);
+        workerRecover_ = std::unique_ptr<EcalRecHitWorkerBaseClass>{EcalRecHitWorkerFactory::get()->create(componentType, ps, c)};
 
 	edm::ParameterSet cleaningPs = 
 	  ps.getParameter<edm::ParameterSet>("cleaningConfig");
-	cleaningAlgo_ = new EcalCleaningAlgo(cleaningPs);
+	cleaningAlgo_ = std::make_unique<EcalCleaningAlgo>(cleaningPs);
 }
 
-EcalRecHitProducer::~EcalRecHitProducer()
-{
-        delete worker_;
-        delete workerRecover_;
-	delete cleaningAlgo_;
-}
+EcalRecHitProducer::~EcalRecHitProducer() = default;
 
 void
 EcalRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es)

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.h
@@ -44,10 +44,10 @@ class EcalRecHitProducer : public edm::stream::EDProducer<> {
                 bool killDeadChannels_;
 
 
-                EcalRecHitWorkerBaseClass * worker_;
-                EcalRecHitWorkerBaseClass * workerRecover_;
+                std::unique_ptr<EcalRecHitWorkerBaseClass> worker_;
+                std::unique_ptr<EcalRecHitWorkerBaseClass> workerRecover_;
 
-		EcalCleaningAlgo * cleaningAlgo_;  
+                std::unique_ptr<EcalCleaningAlgo> cleaningAlgo_;
 		
 		edm::EDGetTokenT<EBUncalibratedRecHitCollection> ebUncalibRecHitToken_;
 		edm::EDGetTokenT<EEUncalibratedRecHitCollection> eeUncalibRecHitToken_;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
@@ -34,13 +34,10 @@ EcalUncalibRecHitProducer::EcalUncalibRecHitProducer(const edm::ParameterSet& ps
 	edm::ParameterSet algoConf = ps.getParameter<edm::ParameterSet>("algoPSet");
 
 	edm::ConsumesCollector c{consumesCollector()};
-        worker_ = EcalUncalibRecHitWorkerFactory::get()->create(componentType, algoConf, c);
+        worker_ = std::unique_ptr<EcalUncalibRecHitWorkerBaseClass>{EcalUncalibRecHitWorkerFactory::get()->create(componentType, algoConf, c)};
 }
 
-EcalUncalibRecHitProducer::~EcalUncalibRecHitProducer()
-{
-        delete worker_;
-}
+EcalUncalibRecHitProducer::~EcalUncalibRecHitProducer() = default;
 
 void EcalUncalibRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.h
@@ -31,6 +31,6 @@ class EcalUncalibRecHitProducer : public edm::stream::EDProducer<> {
                 std::string ebHitCollection_; 
                 std::string eeHitCollection_; 
 		
-                EcalUncalibRecHitWorkerBaseClass * worker_;
+                std::unique_ptr<EcalUncalibRecHitWorkerBaseClass> worker_;
 };
 #endif


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`. Also replace some other raw pointers with `unique_ptr`.

Tested in CMSSW_10_5_X_2019-02-05-1100 , no changes expected.