### PR TITLE
Fix ECAL pedestal tag to be prompt sync and remove PPS alignment tag in GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,11 +28,11 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '105X_dataRun2_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '105X_dataRun2_relval_v5',
+    'run2_data_relval'  :   '105X_dataRun2_relval_v6',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v3',
+    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v5',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v5',
+    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v6',
     'run2_data_promptlike_hi' : '103X_dataRun2_PromptLike_HI_v2',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',


### PR DESCRIPTION
Hello all,

The PR is used to fix the issue reported at https://github.com/cms-sw/cmssw/issues/25959
brought from merging PR #25929 which updated GTs in CMSSW to 105X.
There are two issues fixed in the PR
1. The relval data GT in CMSSW is used to test PCL workflows, so the tags involved into the PCL workflow have to be prompt synced or maybe pcl synced in the relval data GT

2. The Prompt-Like data GT with HE sector failure contains a tag for PPS alignment. This tag needs to be removed because the current PPS alignment ES producer uses alignment from local XML file.
In addition, the prompt synced tags with the same payloads are used in Prompt-Like GT to be on the safe side.

The following GT updates are included :
### Offline relval data GT
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_dataRun2_relval_v6
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_dataRun2_relval_v6/105X_dataRun2_relval_v5

- ECAL pedestal changes from prompt to offline

### Prompt like data GT with HE sector failure
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_dataRun2_PromptLike_HEfail_v5
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_dataRun2_PromptLike_HEfail_v5/105X_dataRun2_PromptLike_HEfail_v3

- remove PPS alignment tag which has conflict with the current PPS alignment ES producer
- use prompt synced PPS timing tag with the same payloads as the offline synced one to be on the safer side

### Prompt like data GT 
The updated GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_dataRun2_PromptLike_v6
Diff :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_dataRun2_PromptLike_v6/105X_dataRun2_PromptLike_v5

- use prompt synced PPS timing tag with the same payloads as the offline synced one to be on the safer side
- remove unlabelled pixel 2D template because it is used at nowhere



