### PR TITLE
Apply some cleaning in RecoEcal/Egamma*

### DIFF
--- a/RecoEcal/EgammaClusterProducers/src/PreshowerClusterShapeProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PreshowerClusterShapeProducer.cc
@@ -137,11 +137,9 @@ void PreshowerClusterShapeProducer::produce(Event& evt, const EventSetup& es) {
 
       SuperClusterRef it_super(reco::SuperClusterRef(pSuperClusters,SC_index));
       
-      float SC_Et   = it_super->energy()*sin(2*atan(exp(-it_super->eta())));
       float SC_eta  = it_super->eta();
-      float SC_phi  = it_super->phi();
 
-      LogTrace("EcalClusters") << "PreshowerClusterShapeProducer: superCl_E = " << it_super->energy() << " superCl_Et = " << SC_Et << " superCl_Eta = " << SC_eta << " superCl_Phi = " << SC_phi ;
+      LogTrace("EcalClusters") << "PreshowerClusterShapeProducer: superCl_E = " << it_super->energy() << " superCl_Et = " << it_super->energy()*sin(2*atan(exp(-it_super->eta()))) << " superCl_Eta = " << SC_eta << " superCl_Phi = " << it_super->phi() ;
 
       
       if(fabs(SC_eta) >= 1.65 && fabs(SC_eta) <= 2.5) 

--- a/RecoEcal/EgammaCoreTools/src/ClusterShapeAlgo.cc
+++ b/RecoEcal/EgammaCoreTools/src/ClusterShapeAlgo.cc
@@ -384,8 +384,8 @@ void ClusterShapeAlgo::Calculate_BarrelBasketEnergyFraction(const reco::BasicClu
                                                             const int EtaPhi,
                                                             const CaloSubdetectorGeometry* geometry) 
 {
-  if(  (hits!=nullptr) && ( ((*hits)[0]).id().subdetId() != EcalBarrel )  ) {
-     //std::cout << "No basket correction for endacap!" << std::endl;
+  if(  (hits==nullptr) || ( ((*hits)[0]).id().subdetId() != EcalBarrel )  ) {
+     //std::cout << "No basket correction if no hits or for endacap!" << std::endl;
      return;
   }
 


### PR DESCRIPTION
- In RecoEcal/EgammaClusterProducers/src/PreshowerClusterShapeProducer.cc: avoid uselessly defining and computing quantities only used inside a LogTrace
- In RecoEcal/EgammaCoreTools/src/ClusterShapeAlgo.cc: add a probably redundant but costless protection for missing hits

Both issues were pointed out by the static analyzer as triggered in the review of #25958

@argiro 