### PR TITLE
Low pT electrons: bug fix for SuperCluster class

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSCProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSCProducer.cc
@@ -167,7 +167,6 @@ void LowPtGsfElectronSCProducer::produce( edm::Event& event, const edm::EventSet
       sc.setCorrectedEnergy(energy);
       sc.setSeed(seed);
       sc.setClusters(clusters);
-      for ( const auto clu : clusters ) { sc.addCluster(clu); }
       PFClusterWidthAlgo pfwidth(barePtrs);
       sc.setEtaWidth(pfwidth.pflowEtaWidth());
       sc.setPhiWidth(pfwidth.pflowPhiWidth());


### PR DESCRIPTION
@slava77 @perrotta 

This bug fix removes a single line of code that was responsible for duplicating edm::Refs to ECAL clusters. This will reduce slightly the footprint of the GsfElectron collection. 

This PR provides an incremental (1-line) change on top of CMSSW_10_5_X_2019-02-18-2300, which includes already #25960.

This bug fix, along with the changes in #25960, will be back ported to 10.2.X. These changes will invalidate the BDT model used for the ID in cms-data/RecoEgamma-ElectronIdentification#13. However, this model can be, and will be, retrained on MINIAOD inputs at a later date. 

@mverzett @nancymarinelli @gkaratha 