### PR TITLE
Move duplicate getCtfTrackRef function to its own file

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -334,7 +334,6 @@ class GsfElectronAlgo {
          const reco::BeamSpot & bs ) ;
 
       // utilities
-      void checkCtfTrack( edm::Handle<reco::TrackCollection> currentCtfTracks ) ;
       void computeCharge( int & charge, reco::GsfElectron::ChargeInfo & info ) ;
       reco::CaloClusterPtr getEleBasicCluster( MultiTrajectoryStateTransform const& ) ;
       bool calculateTSOS( MultiTrajectoryStateTransform const&, GsfConstraintAtVertex const& ) ;

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronTools.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronTools.h
@@ -1,0 +1,18 @@
+#ifndef RecoEgamma_EgammaElectronAlgos_GsfElectronTools_h
+#define RecoEgamma_EgammaElectronAlgos_GsfElectronTools_h
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+namespace GsfElectronTools {
+
+  // From Puneeth Kalavase : returns the CTF track that has the highest fraction
+  // of shared hits in Pixels and the inner strip tracker with the electron Track
+  std::pair<reco::TrackRef,float> getClosestCtfToGsf( reco::GsfTrackRef const&,
+                                                      edm::Handle<reco::TrackCollection> const& ctfTracksH );
+
+}
+
+
+#endif

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronTools.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronTools.cc
@@ -1,0 +1,104 @@
+#include "DataFormats/EgammaCandidates/interface/GsfElectronCoreFwd.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronCore.h"
+#include "DataFormats/ParticleFlowReco/interface/GsfPFRecTrack.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
+#include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronTools.h"
+
+namespace GsfElectronTools {
+
+  using namespace reco ;
+
+  //=======================================================================================
+  // Code from Puneeth Kalavase
+  //=======================================================================================
+
+  std::pair<TrackRef,float> getClosestCtfToGsf( GsfTrackRef const& gsfTrackRef,
+                                                edm::Handle<reco::TrackCollection> const& ctfTracksH )
+  {
+    float maxFracShared = 0;
+    TrackRef ctfTrackRef = TrackRef() ;
+    const TrackCollection * ctfTrackCollection = ctfTracksH.product() ;
+
+    // get the Hit Pattern for the gsfTrack
+    const HitPattern& gsfHitPattern = gsfTrackRef->hitPattern();
+
+    unsigned int counter = 0;
+    for (auto  ctfTkIter = ctfTrackCollection->begin();
+          ctfTkIter != ctfTrackCollection->end() ; ctfTkIter++, counter++ )
+     {
+
+      double dEta = gsfTrackRef->eta() - ctfTkIter->eta();
+      double dPhi = gsfTrackRef->phi() - ctfTkIter->phi();
+      double pi = acos(-1.);
+      if(std::abs(dPhi) > pi) dPhi = 2*pi - std::abs(dPhi);
+
+      // dont want to look at every single track in the event!
+      if(sqrt(dEta*dEta + dPhi*dPhi) > 0.3) continue;
+
+      unsigned int shared = 0 ;
+      int gsfHitCounter = 0 ;
+      int numGsfInnerHits = 0 ;
+      int numCtfInnerHits = 0 ;
+      // get the CTF Track Hit Pattern
+      const HitPattern& ctfHitPattern = ctfTkIter->hitPattern();
+
+      for ( auto elHitsIt = gsfTrackRef->recHitsBegin() ;
+            elHitsIt != gsfTrackRef->recHitsEnd() ;
+            elHitsIt++, gsfHitCounter++ )
+       {
+        if(!((**elHitsIt).isValid()))  //count only valid Hits
+         { continue ; }
+
+        // look only in the pixels/TIB/TID
+        uint32_t gsfHit = gsfHitPattern.getHitPattern(HitPattern::TRACK_HITS, gsfHitCounter);
+        if (!(HitPattern::pixelHitFilter(gsfHit) ||
+            HitPattern::stripTIBHitFilter(gsfHit) ||
+            HitPattern::stripTIDHitFilter(gsfHit)))
+         { continue ; }
+
+        numGsfInnerHits++ ;
+
+        int ctfHitsCounter = 0 ;
+        numCtfInnerHits = 0 ;
+        for ( auto ctfHitsIt = ctfTkIter->recHitsBegin() ;
+              ctfHitsIt != ctfTkIter->recHitsEnd() ;
+              ctfHitsIt++, ctfHitsCounter++ )
+         {
+          if(!((**ctfHitsIt).isValid())) //count only valid Hits!
+           { continue ; }
+
+        uint32_t ctfHit = ctfHitPattern.getHitPattern(HitPattern::TRACK_HITS, ctfHitsCounter);
+        if(!(HitPattern::pixelHitFilter(ctfHit) ||
+              HitPattern::stripTIBHitFilter(ctfHit) ||
+              HitPattern::stripTIDHitFilter(ctfHit)))
+         { continue ; }
+
+        numCtfInnerHits++ ;
+
+          if( (**elHitsIt).sharesInput(&(**ctfHitsIt),TrackingRecHit::all) )
+           {
+            shared++ ;
+            break ;
+           }
+
+         } //ctfHits iterator
+
+       } //gsfHits iterator
+
+      if ((numGsfInnerHits==0)||(numCtfInnerHits==0))
+       { continue ; }
+
+      if ( static_cast<float>(shared)/std::min(numGsfInnerHits,numCtfInnerHits) > maxFracShared )
+       {
+        maxFracShared = static_cast<float>(shared)/std::min(numGsfInnerHits, numCtfInnerHits);
+        ctfTrackRef = TrackRef(ctfTracksH,counter);
+       }
+
+     } //ctfTrack iterator
+
+    return make_pair(ctfTrackRef,maxFracShared) ;
+  }
+
+}

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreBaseProducer.cc
@@ -1,19 +1,15 @@
-
-#include "GsfElectronCoreBaseProducer.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-
 #include "DataFormats/EgammaCandidates/interface/GsfElectronCoreFwd.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronCore.h"
 #include "DataFormats/ParticleFlowReco/interface/GsfPFRecTrack.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
-//#include "DataFormats/Common/interface/ValueMap.h"
+#include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronTools.h"
 
-//#include <map>
+#include "GsfElectronCoreBaseProducer.h"
 
 using namespace reco ;
 
@@ -55,104 +51,6 @@ void GsfElectronCoreBaseProducer::fillElectronCore( reco::GsfElectronCore * eleC
  {
   const GsfTrackRef & gsfTrackRef = eleCore->gsfTrack() ;
 
-  std::pair<TrackRef,float> ctfpair = getCtfTrackRef(gsfTrackRef) ;
+  std::pair<TrackRef,float> ctfpair = GsfElectronTools::getClosestCtfToGsf(gsfTrackRef,ctfTracksH_) ;
   eleCore->setCtfTrack(ctfpair.first,ctfpair.second) ;
  }
-
-
-//=======================================================================================
-// Code from Puneeth Kalavase
-//=======================================================================================
-
-std::pair<TrackRef,float> GsfElectronCoreBaseProducer::getCtfTrackRef
- ( const GsfTrackRef & gsfTrackRef )
- {
-  float maxFracShared = 0;
-  TrackRef ctfTrackRef = TrackRef() ;
-  const TrackCollection * ctfTrackCollection = ctfTracksH_.product() ;
-
-  // get the Hit Pattern for the gsfTrack
-  const HitPattern& gsfHitPattern = gsfTrackRef->hitPattern();
-
-  unsigned int counter ;
-  TrackCollection::const_iterator ctfTkIter ;
-  for ( ctfTkIter = ctfTrackCollection->begin() , counter = 0 ;
-        ctfTkIter != ctfTrackCollection->end() ; ctfTkIter++, counter++ )
-   {
-
-    double dEta = gsfTrackRef->eta() - ctfTkIter->eta();
-    double dPhi = gsfTrackRef->phi() - ctfTkIter->phi();
-    double pi = acos(-1.);
-    if(std::abs(dPhi) > pi) dPhi = 2*pi - std::abs(dPhi);
-
-    // dont want to look at every single track in the event!
-    if(sqrt(dEta*dEta + dPhi*dPhi) > 0.3) continue;
-
-    unsigned int shared = 0 ;
-    int gsfHitCounter = 0 ;
-    int numGsfInnerHits = 0 ;
-    int numCtfInnerHits = 0 ;
-    // get the CTF Track Hit Pattern
-    const HitPattern& ctfHitPattern = ctfTkIter->hitPattern();
-
-    trackingRecHit_iterator elHitsIt ;
-    for ( elHitsIt = gsfTrackRef->recHitsBegin() ;
-          elHitsIt != gsfTrackRef->recHitsEnd() ;
-          elHitsIt++, gsfHitCounter++ )
-     {
-      if(!((**elHitsIt).isValid()))  //count only valid Hits
-       { continue ; }
-
-      // look only in the pixels/TIB/TID
-      uint32_t gsfHit = gsfHitPattern.getHitPattern(HitPattern::TRACK_HITS, gsfHitCounter);
-      if (!(HitPattern::pixelHitFilter(gsfHit) ||
-          HitPattern::stripTIBHitFilter(gsfHit) ||
-          HitPattern::stripTIDHitFilter(gsfHit)))
-       { continue ; }
-
-      numGsfInnerHits++ ;
-
-      int ctfHitsCounter = 0 ;
-      numCtfInnerHits = 0 ;
-      trackingRecHit_iterator ctfHitsIt ;
-      for ( ctfHitsIt = ctfTkIter->recHitsBegin() ;
-            ctfHitsIt != ctfTkIter->recHitsEnd() ;
-            ctfHitsIt++, ctfHitsCounter++ )
-       {
-        if(!((**ctfHitsIt).isValid())) //count only valid Hits!
-         { continue ; }
-
-      uint32_t ctfHit = ctfHitPattern.getHitPattern(HitPattern::TRACK_HITS, ctfHitsCounter);
-      if(!(HitPattern::pixelHitFilter(ctfHit) ||
-            HitPattern::stripTIBHitFilter(ctfHit) ||
-            HitPattern::stripTIDHitFilter(ctfHit)))
-       { continue ; }
-
-      numCtfInnerHits++ ;
-
-        if( (**elHitsIt).sharesInput(&(**ctfHitsIt),TrackingRecHit::all) )
-         {
-          shared++ ;
-          break ;
-         }
-
-       } //ctfHits iterator
-
-     } //gsfHits iterator
-
-    if ((numGsfInnerHits==0)||(numCtfInnerHits==0))
-     { continue ; }
-
-    if ( static_cast<float>(shared)/std::min(numGsfInnerHits,numCtfInnerHits) > maxFracShared )
-     {
-      maxFracShared = static_cast<float>(shared)/std::min(numGsfInnerHits, numCtfInnerHits);
-      ctfTrackRef = TrackRef(ctfTracksH_,counter);
-     }
-
-   } //ctfTrack iterator
-
-  return make_pair(ctfTrackRef,maxFracShared) ;
- }
-
-
-

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreBaseProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreBaseProducer.h
@@ -54,12 +54,6 @@ class GsfElectronCoreBaseProducer : public edm::stream::EDProducer<>
     edm::EDGetTokenT<reco::GsfPFRecTrackCollection> gsfPfRecTracksTag_ ;
     edm::EDGetTokenT<reco::GsfTrackCollection> gsfTracksTag_ ;
     edm::EDGetTokenT<reco::TrackCollection> ctfTracksTag_ ;
-
-    // From Puneeth Kalavase : returns the CTF track that has the highest fraction
-    // of shared hits in Pixels and the inner strip tracker with the electron Track
-    std::pair<reco::TrackRef,float> getCtfTrackRef
-     ( const reco::GsfTrackRef & ) ;
-
  } ;
 
 


### PR DESCRIPTION
Just some reorganization of duplicate code in RecoEgamma, which also goes in the direction of slimming down a bit GsfElectronAlgo aka. "the electron god class".

Are there any convention related to names of files holding free functions like this? And do you maybe share my sentiment that the function should be maybe given a more clear name like `getClosestCtfToGsf`?