### PR TITLE
Use unique_ptr constructor for PluginFactory plugins in RecoTracker

### DIFF
--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -66,8 +66,8 @@ public:
 
   // Claims ownership of TrajectoryFilter pointers
   BaseCkfTrajectoryBuilder(const edm::ParameterSet& conf,
-                           TrajectoryFilter *filter,
-                           TrajectoryFilter *inOutFilter=nullptr);
+                           std::unique_ptr<TrajectoryFilter> filter,
+                           std::unique_ptr<TrajectoryFilter> inOutFilter=nullptr);
   BaseCkfTrajectoryBuilder(const BaseCkfTrajectoryBuilder &) = delete;
   BaseCkfTrajectoryBuilder& operator=(const BaseCkfTrajectoryBuilder&) = delete;
   ~BaseCkfTrajectoryBuilder() override;
@@ -102,7 +102,7 @@ public:
   const TransientTrackingRecHitBuilder* hitBuilder() const { return theTTRHBuilder;}
 
  protected:    
-  static TrajectoryFilter *createTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC);
+  static std::unique_ptr<TrajectoryFilter> createTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC);
 
   virtual void setEvent_(const edm::Event& iEvent, const edm::EventSetup& iSetup) = 0;
 

--- a/RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h
@@ -68,7 +68,7 @@ namespace cms
     std::string theNavigationSchoolName;
     const NavigationSchool*       theNavigationSchool;
     
-    RedundantSeedCleaner*  theSeedCleaner;
+    std::unique_ptr<RedundantSeedCleaner>  theSeedCleaner;
 
     unsigned int maxSeedsBeforeCleaning_;
     

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
@@ -39,7 +39,7 @@ public:
   typedef std::vector<TempTrajectory>     TempTrajectoryContainer;
 
   CkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
-  CkfTrajectoryBuilder(const edm::ParameterSet& conf, TrajectoryFilter *filter);
+  CkfTrajectoryBuilder(const edm::ParameterSet& conf, std::unique_ptr<TrajectoryFilter> filter);
 
   ~CkfTrajectoryBuilder() override {}
 

--- a/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
@@ -26,16 +26,16 @@
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 
 BaseCkfTrajectoryBuilder::BaseCkfTrajectoryBuilder(const edm::ParameterSet& conf,
-                                                   TrajectoryFilter *filter,
-                                                   TrajectoryFilter *inOutFilter):
+                                                   std::unique_ptr<TrajectoryFilter> filter,
+                                                   std::unique_ptr<TrajectoryFilter> inOutFilter):
   theUpdator(nullptr),
   thePropagatorAlong(nullptr),
   thePropagatorOpposite(nullptr),
   theEstimator(nullptr),
   theTTRHBuilder(nullptr),
   theMeasurementTracker(nullptr),
-  theFilter(filter),
-  theInOutFilter(inOutFilter),
+  theFilter(std::move(filter)),
+  theInOutFilter(std::move(inOutFilter)),
   theUpdatorName(conf.getParameter<std::string>("updator")),
   thePropagatorAlongName(conf.getParameter<std::string>("propagatorAlong")),
   thePropagatorOppositeName(conf.getParameter<std::string>("propagatorOpposite")),
@@ -49,8 +49,8 @@ BaseCkfTrajectoryBuilder::BaseCkfTrajectoryBuilder(const edm::ParameterSet& conf
 BaseCkfTrajectoryBuilder::~BaseCkfTrajectoryBuilder(){
 }
 
-TrajectoryFilter *BaseCkfTrajectoryBuilder::createTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC) {
-  return TrajectoryFilterFactory::get()->create(pset.getParameter<std::string>("ComponentType"), pset, iC);
+std::unique_ptr<TrajectoryFilter> BaseCkfTrajectoryBuilder::createTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC) {
+  return std::unique_ptr<TrajectoryFilter>{TrajectoryFilterFactory::get()->create(pset.getParameter<std::string>("ComponentType"), pset, iC)};
 }
 
 void

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -51,8 +51,8 @@ using namespace edm;
 using namespace std;
 
 namespace {
-  BaseCkfTrajectoryBuilder *createBaseCkfTrajectoryBuilder(const edm::ParameterSet& pset, edm::ConsumesCollector& iC) {
-    return BaseCkfTrajectoryBuilderFactory::get()->create(pset.getParameter<std::string>("ComponentType"), pset, iC);
+  std::unique_ptr<BaseCkfTrajectoryBuilder> createBaseCkfTrajectoryBuilder(const edm::ParameterSet& pset, edm::ConsumesCollector& iC) {
+    return std::unique_ptr<BaseCkfTrajectoryBuilder>{BaseCkfTrajectoryBuilderFactory::get()->create(pset.getParameter<std::string>("ComponentType"), pset, iC)};
   }
 }
 
@@ -68,11 +68,10 @@ namespace cms{
     theTrajectoryBuilder(createBaseCkfTrajectoryBuilder(conf.getParameter<edm::ParameterSet>("TrajectoryBuilderPSet"), iC)),
     theTrajectoryCleanerName(conf.getParameter<std::string>("TrajectoryCleaner")),
     theTrajectoryCleaner(nullptr),
-    theInitialState(new TransientInitialStateEstimator(conf.getParameter<ParameterSet>("TransientInitialStateEstimatorParameters"))),
+    theInitialState(std::make_unique<TransientInitialStateEstimator>(conf.getParameter<ParameterSet>("TransientInitialStateEstimatorParameters"))),
     theMagFieldName(conf.exists("SimpleMagneticField") ? conf.getParameter<std::string>("SimpleMagneticField") : ""),
     theNavigationSchoolName(conf.getParameter<std::string>("NavigationSchool")),
     theNavigationSchool(nullptr),
-    theSeedCleaner(nullptr),
     maxSeedsBeforeCleaning_(0),
     theMTELabel(iC.consumes<MeasurementTrackerEvent>(conf.getParameter<edm::InputTag>("MeasurementTrackerEvent"))),
     skipClusters_(false),
@@ -101,10 +100,8 @@ namespace cms{
 	conf.getParameter<int>("numHitsForSeedCleaner") : 4;
       int onlyPixelHits = conf.existsAs<bool>("onlyPixelHitsForSeedCleaner") ?
 	conf.getParameter<bool>("onlyPixelHitsForSeedCleaner") : false;
-      theSeedCleaner = new CachingSeedCleanerBySharedInput(numHitsForSeedCleaner,onlyPixelHits);
-    } else if (cleaner == "none") {
-        theSeedCleaner = nullptr;
-    } else {
+      theSeedCleaner = std::make_unique<CachingSeedCleanerBySharedInput>(numHitsForSeedCleaner,onlyPixelHits);
+    } else if (cleaner != "none") {
         throw cms::Exception("RedundantSeedCleaner not found, please use CachingSeedCleanerBySharedInput ro none", cleaner);
     }
 #endif
@@ -119,9 +116,7 @@ namespace cms{
 
 
   // Virtual destructor needed.
-  CkfTrackCandidateMakerBase::~CkfTrackCandidateMakerBase() noexcept(false) {
-    if (theSeedCleaner) delete theSeedCleaner;
-  }
+  CkfTrackCandidateMakerBase::~CkfTrackCandidateMakerBase() noexcept(false) {}
 
   void CkfTrackCandidateMakerBase::beginRunBase (edm::Run const & r, EventSetup const & es)
   {

--- a/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
@@ -23,6 +23,7 @@
 #include "RecoTracker/CkfPattern/interface/IntermediateTrajectoryCleaner.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/PatternTools/interface/TransverseImpactPointExtrapolator.h"
+#include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
 using namespace std;
 
@@ -31,8 +32,8 @@ CkfTrajectoryBuilder::CkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::C
                        BaseCkfTrajectoryBuilder::createTrajectoryFilter(conf.getParameter<edm::ParameterSet>("trajectoryFilter"), iC))
 {}
 
-CkfTrajectoryBuilder::CkfTrajectoryBuilder(const edm::ParameterSet& conf, TrajectoryFilter *filter):
-  BaseCkfTrajectoryBuilder(conf, filter)
+CkfTrajectoryBuilder::CkfTrajectoryBuilder(const edm::ParameterSet& conf, std::unique_ptr<TrajectoryFilter> filter):
+  BaseCkfTrajectoryBuilder(conf, std::move(filter))
 {
   theMaxCand              = conf.getParameter<int>("maxCand");
   theLostHitPenalty       = conf.getParameter<double>("lostHitPenalty");

--- a/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversionFromQuadruplets.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversionFromQuadruplets.cc
@@ -46,7 +46,7 @@ SeedForPhotonConversionFromQuadruplets::SeedForPhotonConversionFromQuadruplets(e
 {
   std::string comparitorName = SeedComparitorPSet.getParameter<std::string>("ComponentName");
   if(comparitorName != "none") {
-    theComparitor.reset(SeedComparitorFactory::get()->create( comparitorName, SeedComparitorPSet, iC));
+    theComparitor = std::unique_ptr<SeedComparitor>{SeedComparitorFactory::get()->create( comparitorName, SeedComparitorPSet, iC)};
   }
 }
 

--- a/RecoTracker/DebugTools/plugins/CkfDebugTrackCandidateMaker.h
+++ b/RecoTracker/DebugTools/plugins/CkfDebugTrackCandidateMaker.h
@@ -6,6 +6,7 @@
 #include "CkfDebugTrajectoryBuilder.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "DataFormats/TrackReco/interface/SeedStopInfo.h"
+#include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
 namespace cms {
   class CkfDebugTrackCandidateMaker : public edm::EDProducer, public CkfTrackCandidateMakerBase {

--- a/RecoTracker/DebugTools/plugins/CkfDebugTrackCandidateMaker.h
+++ b/RecoTracker/DebugTools/plugins/CkfDebugTrackCandidateMaker.h
@@ -6,7 +6,6 @@
 #include "CkfDebugTrajectoryBuilder.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "DataFormats/TrackReco/interface/SeedStopInfo.h"
-#include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
 namespace cms {
   class CkfDebugTrackCandidateMaker : public edm::EDProducer, public CkfTrackCandidateMakerBase {

--- a/RecoTracker/DebugTools/plugins/CkfDebugTrajectoryBuilder.h
+++ b/RecoTracker/DebugTools/plugins/CkfDebugTrajectoryBuilder.h
@@ -4,12 +4,12 @@
 #include "RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h"
 #include "CkfDebugger.h"
 #include "TrackingTools/PatternTools/interface/TempTrajectory.h"
-
+#include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
 class CkfDebugTrajectoryBuilder: public CkfTrajectoryBuilder{
  public:
   CkfDebugTrajectoryBuilder(const edm::ParameterSet& conf):
-    CkfTrajectoryBuilder(conf, nullptr)
+    CkfTrajectoryBuilder(conf, std::unique_ptr<TrajectoryFilter>{})
     {
       //edm::LogVerbatim("CkfDebugger") <<"CkfDebugTrajectoryBuilder::CkfDebugTrajectoryBuilder";
     }

--- a/RecoTracker/SpecialSeedGenerators/interface/CtfSpecialSeedGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CtfSpecialSeedGenerator.h
@@ -85,9 +85,9 @@ class CtfSpecialSeedGenerator : public edm::stream::EDProducer<>
   std::vector<std::unique_ptr<OrderedHitsGenerator> > theGenerators;
   std::vector<PropagationDirection> thePropDirs;
   std::vector<NavigationDirection>  theNavDirs; 
-  TrackingRegionProducer* theRegionProducer;	
+  std::unique_ptr<TrackingRegionProducer> theRegionProducer;
   //TrajectoryStateTransform theTransformer;
-  SeedFromGenericPairOrTriplet* theSeedBuilder; 
+  std::unique_ptr<SeedFromGenericPairOrTriplet> theSeedBuilder;
   bool useScintillatorsConstraint;
   BoundPlane::BoundPlanePointer upperScintillator;
   BoundPlane::BoundPlanePointer lowerScintillator;

--- a/RecoTracker/TkSeedGenerator/interface/SeedCreatorFromRegionHitsEDProducerT.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedCreatorFromRegionHitsEDProducerT.h
@@ -42,7 +42,9 @@ SeedCreatorFromRegionHitsEDProducerT<T_SeedCreator>::SeedCreatorFromRegionHitsED
   edm::ConsumesCollector iC = consumesCollector();
   edm::ParameterSet comparitorPSet = iConfig.getParameter<edm::ParameterSet>("SeedComparitorPSet");
   std::string comparitorName = comparitorPSet.getParameter<std::string>("ComponentName");
-  comparitor_.reset((comparitorName == "none") ? nullptr : SeedComparitorFactory::get()->create(comparitorName, comparitorPSet, iC));
+  if(comparitorName != "none") {
+    comparitor_ = std::unique_ptr<SeedComparitor>{SeedComparitorFactory::get()->create(comparitorName, comparitorPSet, iC)};
+  }
 
   produces<TrajectorySeedCollection>();
 }

--- a/RecoTracker/TkSeedGenerator/interface/SeedGeneratorFromRegionHits.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedGeneratorFromRegionHits.h
@@ -17,11 +17,17 @@ namespace edm { class Event; class EventSetup; }
 class SeedGeneratorFromRegionHits {
 public:
 
-  SeedGeneratorFromRegionHits(
-      OrderedHitsGenerator * aGenerator, 
-      SeedComparitor * aComparitor = nullptr,
-      SeedCreator * aSeedCreator = nullptr
-    );
+  template <typename GEN>
+  SeedGeneratorFromRegionHits(GEN aGenerator): SeedGeneratorFromRegionHits(std::move(aGenerator), nullptr, nullptr) {}
+
+  template <typename GEN, typename COMP>
+  SeedGeneratorFromRegionHits(GEN aGenerator, COMP aComparitor): SeedGeneratorFromRegionHits(std::move(aGenerator), std::move(aComparitor), nullptr) {}
+
+  template <typename GEN, typename COMP, typename CREA>
+  SeedGeneratorFromRegionHits(GEN aGenerator, COMP aComparitor, CREA aSeedCreator):
+    theHitsGenerator{std::move(aGenerator)}, theComparitor{std::move(aComparitor)}, theSeedCreator{std::move(aSeedCreator)}
+  {}
+
 
 
   // make job

--- a/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.cc
@@ -13,7 +13,7 @@ CombinedMultiHitGenerator::CombinedMultiHitGenerator(const edm::ParameterSet& cf
 {
   edm::ParameterSet generatorPSet = cfg.getParameter<edm::ParameterSet>("GeneratorPSet");
   std::string       generatorName = generatorPSet.getParameter<std::string>("ComponentName");
-  theGenerator.reset(MultiHitGeneratorFromPairAndLayersFactory::get()->create(generatorName, generatorPSet));
+  theGenerator = std::unique_ptr<MultiHitGeneratorFromPairAndLayers>{MultiHitGeneratorFromPairAndLayersFactory::get()->create(generatorName, generatorPSet)};
   theGenerator->init(std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache), &theLayerCache);
 }
 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
@@ -37,25 +37,26 @@ SeedGeneratorFromRegionHitsEDProducer::SeedGeneratorFromRegionHitsEDProducer(
   edm::ParameterSet regfactoryPSet = 
       cfg.getParameter<edm::ParameterSet>("RegionFactoryPSet");
   std::string regfactoryName = regfactoryPSet.getParameter<std::string>("ComponentName");
-  theRegionProducer.reset(TrackingRegionProducerFactory::get()->create(regfactoryName,regfactoryPSet, consumesCollector()));
+  theRegionProducer = std::unique_ptr<TrackingRegionProducer>{TrackingRegionProducerFactory::get()->create(regfactoryName,regfactoryPSet, consumesCollector())};
 
   edm::ConsumesCollector iC = consumesCollector();
   edm::ParameterSet hitsfactoryPSet =
       cfg.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet");
   std::string hitsfactoryName = hitsfactoryPSet.getParameter<std::string>("ComponentName");
-  OrderedHitsGenerator*  hitsGenerator =
-    OrderedHitsGeneratorFactory::get()->create( hitsfactoryName, hitsfactoryPSet, iC);
 
   edm::ParameterSet comparitorPSet =
       cfg.getParameter<edm::ParameterSet>("SeedComparitorPSet");
   std::string comparitorName = comparitorPSet.getParameter<std::string>("ComponentName");
-  SeedComparitor * aComparitor = (comparitorName == "none") ?
-      nullptr :  SeedComparitorFactory::get()->create( comparitorName, comparitorPSet, iC);
+  std::unique_ptr<SeedComparitor> aComparitor;
+  if(comparitorName == "none") {
+    aComparitor = std::unique_ptr<SeedComparitor>{SeedComparitorFactory::get()->create( comparitorName, comparitorPSet, iC)};
+  }
 
   std::string creatorName = creatorPSet.getParameter<std::string>("ComponentName");
-  SeedCreator * aCreator = SeedCreatorFactory::get()->create( creatorName, creatorPSet);
 
-  theGenerator.reset(new SeedGeneratorFromRegionHits(hitsGenerator, aComparitor, aCreator));
+  theGenerator = std::make_unique<SeedGeneratorFromRegionHits>(OrderedHitsGeneratorFactory::get()->create( hitsfactoryName, hitsfactoryPSet, iC),
+                                                               std::move(aComparitor),
+                                                               SeedCreatorFactory::get()->create( creatorName, creatorPSet));
 
   produces<TrajectorySeedCollection>();
 }

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
@@ -48,7 +48,7 @@ SeedGeneratorFromRegionHitsEDProducer::SeedGeneratorFromRegionHitsEDProducer(
       cfg.getParameter<edm::ParameterSet>("SeedComparitorPSet");
   std::string comparitorName = comparitorPSet.getParameter<std::string>("ComponentName");
   std::unique_ptr<SeedComparitor> aComparitor;
-  if(comparitorName == "none") {
+  if(comparitorName != "none") {
     aComparitor = std::unique_ptr<SeedComparitor>{SeedComparitorFactory::get()->create( comparitorName, comparitorPSet, iC)};
   }
 

--- a/RecoTracker/TkSeedGenerator/src/SeedGeneratorFromRegionHits.cc
+++ b/RecoTracker/TkSeedGenerator/src/SeedGeneratorFromRegionHits.cc
@@ -4,15 +4,6 @@
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
 #include "RecoTracker/TkSeedGenerator/interface/SeedCreator.h"
 
-
-
-
-SeedGeneratorFromRegionHits::SeedGeneratorFromRegionHits(
-    OrderedHitsGenerator *ohg, SeedComparitor* asc, SeedCreator* asp)
-  : theHitsGenerator(ohg), theComparitor(asc), theSeedCreator(asp)
-{ }
-
-
 void SeedGeneratorFromRegionHits::run(TrajectorySeedCollection & seedCollection, 
     const TrackingRegion & region, const edm::Event& ev, const edm::EventSetup& es)
 {


### PR DESCRIPTION
Also manage a plugin with `unique_ptr` in `CtfSpecialSeedGenerator`, and use templated parameters for `SeedGeneratorFromRegionHits` constructor (for the migration time) in order to support any mixture of raw pointers and `unique_ptr`'s.

This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-02-18-1100, no changes expected.