### PR TITLE
Delay writing the EventAuxiliary branch to file closing

### DIFF
--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -164,6 +164,7 @@ namespace edm {
     void writeBranchIDListRegistry();
     void writeThinnedAssociationsHelper();
     void writeProductDependencies();
+    void writeEventAuxiliary();
     void finishEndFile();
 
     void fillSelectedItemList(BranchType branchtype, TTree* theInputTree);

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -288,6 +288,7 @@ namespace edm {
   }
 
   void PoolOutputModule::reallyCloseFile() {
+    writeEventAuxiliary();
     fillDependencyGraph();
     branchParents_.clear();
     startEndFile();
@@ -323,6 +324,7 @@ namespace edm {
   void PoolOutputModule::writeBranchIDListRegistry() { rootOutputFile_->writeBranchIDListRegistry(); }
   void PoolOutputModule::writeThinnedAssociationsHelper() { rootOutputFile_->writeThinnedAssociationsHelper(); }
   void PoolOutputModule::writeProductDependencies() { rootOutputFile_->writeProductDependencies(); }
+  void PoolOutputModule::writeEventAuxiliary() { rootOutputFile_->writeEventAuxiliary(); }
   void PoolOutputModule::finishEndFile() { rootOutputFile_->finishEndFile(); rootOutputFile_ = nullptr; } // propagate_const<T> has no reset() function
   void PoolOutputModule::doExtrasAfterCloseFile() {}
   bool PoolOutputModule::isFileOpen() const { return rootOutputFile_.get() != nullptr; }

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -128,7 +128,7 @@ namespace edm {
     }
     eventTree_.addAuxiliary<EventAuxiliary>(BranchTypeToAuxiliaryBranchName(InEvent),
                                             pEventAux_, om_->auxItems()[InEvent].basketSize_, false);
-    eventTree_.tree()->SetBranchStatus(BranchTypeToAuxiliaryBranchName(InEvent).c_str(), 0); // see writeEventAuxiliary
+    eventTree_.tree()->SetBranchStatus(BranchTypeToAuxiliaryBranchName(InEvent).c_str(), false); // see writeEventAuxiliary
 
     eventTree_.addAuxiliary<StoredProductProvenanceVector>(BranchTypeToProductProvenanceBranchName(InEvent),
                                                      pEventEntryInfoVector(), om_->auxItems()[InEvent].basketSize_);
@@ -624,7 +624,7 @@ namespace edm {
     auto tree = eventTree_.tree();
     auto bname = BranchTypeToAuxiliaryBranchName(InEvent).c_str();
 
-    tree->SetBranchStatus(bname, 1);
+    tree->SetBranchStatus(bname, true);
     auto basketsize = eventAuxiliaryVector_.size()*(sizeof(EventAuxiliary)+26); // 26 is an empirical fudge factor
     tree->SetBasketSize(bname, basketsize);
     auto b = tree->GetBranch(bname);

--- a/IOPool/Output/src/RootOutputFile.h
+++ b/IOPool/Output/src/RootOutputFile.h
@@ -66,6 +66,7 @@ namespace edm {
     void writeBranchIDListRegistry();
     void writeThinnedAssociationsHelper();
     void writeProductDependencies();
+    void writeEventAuxiliary();
 
     void finishEndFile();
     void beginInputFile(FileBlock const& fb, int remainingEvents);
@@ -142,6 +143,7 @@ namespace edm {
     std::map<ParentageID,unsigned int> parentageIDs_;
     std::set<BranchID> branchesWithStoredHistory_;
     edm::propagate_const<TClass*> wrapperBaseTClass_;
+    std::vector<std::pair<EventAuxiliary, ProcessHistoryID>> eventAuxiliaryVector_;
   };
 
 }

--- a/IOPool/Output/src/RootOutputFile.h
+++ b/IOPool/Output/src/RootOutputFile.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include <memory>
+#include <variant>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/MessageLogger/interface/JobReport.h"
@@ -143,7 +144,8 @@ namespace edm {
     std::map<ParentageID,unsigned int> parentageIDs_;
     std::set<BranchID> branchesWithStoredHistory_;
     edm::propagate_const<TClass*> wrapperBaseTClass_;
-    std::vector<std::pair<EventAuxiliary, ProcessHistoryID>> eventAuxiliaryVector_;
+    using AuxVariant = std::variant<EventAuxiliary, LuminosityBlockAuxiliary, RunAuxiliary>;
+    std::vector<std::pair<AuxVariant, ProcessHistoryID>> auxiliaryVector_;
   };
 
 }


### PR DESCRIPTION
When removal of duplicate events and fast cloning are enabled (the current defaults), the input module reads the entire EventAuxiliary branch when it opens the file in order to determine if fast cloning is possible.  This currently results in many small reads scattered throughout the entire file, which is not a good IO pattern for storage systems optimized for large-block throughput.  In some cases large files cannot be served from some sites, see

https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3853/1/1/1/1.html

This PR delays writing the EventAuxiliary branch until the file close sequence, with the branch stored entirely in one basket near the end of the file that can be read in one operation.

In a runTheMatrix 'limited' test I am getting a segmentation fault in wf 10824.0 in `Rivet::Analysis::numEvents()`.  On my test system I get the same segmentation fault with an unmodified ASAN build, so I believe this is unrelated to the modifications in this PR.

@bbockelm please review.