### PR TITLE
fix typo in FS2018 PU input string

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -584,7 +584,7 @@ baseDataSetRelease=[
     'CMSSW_10_2_0-102X_upgrade2018_realistic_v9_gcc7-v1',  #16 - GENSIM input 2018
     'CMSSW_10_2_8-102X_mc2017_realistic_v5_FastSim-v1',    # 17 - fastSim MinBias for mixing UP17
     'CMSSW_10_2_9-PU25ns_102X_mc2017_realistic_v5_FastSim-v1',# 18 - fastSim premixed MinBias UP17
-    'CMSSW_10_2_11_102X_upgrade2018_realistic_v15_FastSim-v1',    # 19 - fastSim MinBias for mixing UP18
+    'CMSSW_10_2_11-102X_upgrade2018_realistic_v15_FastSim-v1',    # 19 - fastSim MinBias for mixing UP18
     'CMSSW_10_2_11-PU25ns_102X_upgrade2018_realistic_v15_FastSim-v1',# 20 - fastSim premix library UP18 
     ]
 


### PR DESCRIPTION
A bug (typo) was introduced in PR #25754 
https://github.com/cms-sw/cmssw/pull/25754/files#diff-819af2ec677272fddf1fef50e788a88bR587 
, which caused the recent IB failures in fastsim 2018 PU workflows:  
https://cmssdt.cern.ch/SDT/html/cmssdt-ib/#/relVal/CMSSW_10_2/2019-02-19-1100?selectedArchs=slc6_amd64_gcc700&selectedFlavors=X&selectedStatus=failed
This PR will fix the bug. 