### PR TITLE
Removed incorrect virtual functions in DQMOffline/L1Trigger

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TDiffHarvesting.h
+++ b/DQMOffline/L1Trigger/interface/L1TDiffHarvesting.h
@@ -24,8 +24,6 @@ public:
 protected:
 
   void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) override;
-  virtual void dqmEndLuminosityBlock(DQMStore::IGetter &igetter, edm::LuminosityBlock const& lumiBlock,
-      edm::EventSetup const& c);
 
 private:
   class L1TDiffPlotHandler {

--- a/DQMOffline/L1Trigger/interface/L1TEfficiencyHarvesting.h
+++ b/DQMOffline/L1Trigger/interface/L1TEfficiencyHarvesting.h
@@ -80,8 +80,6 @@ public:
 protected:
 
   void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) override;
-  virtual void dqmEndLuminosityBlock(DQMStore::IGetter &igetter, edm::LuminosityBlock const& lumiBlock,
-      edm::EventSetup const& c);
 
 private:
 

--- a/DQMOffline/L1Trigger/src/L1TDiffHarvesting.cc
+++ b/DQMOffline/L1Trigger/src/L1TDiffHarvesting.cc
@@ -179,11 +179,6 @@ void L1TDiffHarvesting::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter 
   }
 }
 
-void L1TDiffHarvesting::dqmEndLuminosityBlock(DQMStore::IGetter &igetter, edm::LuminosityBlock const& lumiBlock,
-    edm::EventSetup const& c)
-{
-}
-
 DEFINE_FWK_MODULE (L1TDiffHarvesting);
 
 } // l1t

--- a/DQMOffline/L1Trigger/src/L1TEfficiencyHarvesting.cc
+++ b/DQMOffline/L1Trigger/src/L1TEfficiencyHarvesting.cc
@@ -156,15 +156,6 @@ void L1TEfficiencyHarvesting::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
   }
 }
 
-//_____________________________________________________________________
-void L1TEfficiencyHarvesting::dqmEndLuminosityBlock(DQMStore::IGetter &igetter, LuminosityBlock const& lumiBlock,
-    EventSetup const& c)
-{
-  if (verbose_) {
-    edm::LogInfo("L1TEfficiencyHarvesting") << "Called endLuminosityBlock at LS=" << lumiBlock.id().luminosityBlock()
-        << endl;
-  }
-}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE (L1TEfficiencyHarvesting);


### PR DESCRIPTION
Both modules were using the wrong function arguments for the dqmEndLuminosityBlock function. Given the functions did not do any real work, they were removed.

This fixes clang warnings.