### PR TITLE
Made base and inheriting class agree on checkForCompatibility in CalibTracker

### DIFF
--- a/DQMOffline/CalibTracker/plugins/SiStripDQMPopConSourceHandler.h
+++ b/DQMOffline/CalibTracker/plugins/SiStripDQMPopConSourceHandler.h
@@ -35,7 +35,7 @@ public:
   virtual T* getObj() const = 0;
 
   virtual std::string getMetaDataString() const;
-  virtual bool checkForCompatibility( const std::string otherMetaData ) const { return otherMetaData != getMetaDataString(); }
+  virtual bool checkForCompatibility( const std::string& otherMetaData ) const { return otherMetaData != getMetaDataString(); }
 
   // additional methods needed for SiStripPopConDQMEDHarvester
   virtual void initES(const edm::EventSetup&) {}

--- a/DQMOffline/CalibTracker/plugins/SiStripDQMPopConSourceHandler.h
+++ b/DQMOffline/CalibTracker/plugins/SiStripDQMPopConSourceHandler.h
@@ -89,7 +89,7 @@ void SiStripDQMPopConSourceHandler<T>::getNewObjects()
          << this->logDBEntry().payloadToken  << "\n"
          << this->logDBEntry().exectime      << "\n"
          << this->logDBEntry().execmessage   << "\n";
-      if ( this->logDBEntry().usertext != "" )
+      if ( !this->logDBEntry().usertext.empty() )
         ss<< "\n-- user text " << this->logDBEntry().usertext.substr(this->logDBEntry().usertext.find_last_of("@")) ;
     } else {
       ss << " First object for this tag ";
@@ -121,7 +121,7 @@ bool SiStripDQMPopConSourceHandler<T>::isTransferNeeded()
   std::string ss_logdb{};
 
   //get log information from previous upload
-  if ( this->logDBEntry().usertext != "" )
+  if ( !this->logDBEntry().usertext.empty() )
     ss_logdb = this->logDBEntry().usertext.substr(this->logDBEntry().usertext.find_last_of("@")+2);
 
   std::string ss = getMetaDataString();

--- a/DQMOffline/CalibTracker/plugins/SiStripPopConHistoryDQMBase.cc
+++ b/DQMOffline/CalibTracker/plugins/SiStripPopConHistoryDQMBase.cc
@@ -14,7 +14,7 @@ SiStripPopConHistoryDQMBase::~SiStripPopConHistoryDQMBase()
   edm::LogInfo("SiStripHistoryDQMService") <<  "[SiStripHistoryDQMService::~SiStripHistoryDQMService]";
 }
 
-bool SiStripPopConHistoryDQMBase::checkForCompatibility(const std::string& otherMetaData)
+bool SiStripPopConHistoryDQMBase::checkForCompatibility(const std::string& otherMetaData) const
 {
   if ( otherMetaData.empty() )
     return true;

--- a/DQMOffline/CalibTracker/plugins/SiStripPopConHistoryDQMBase.h
+++ b/DQMOffline/CalibTracker/plugins/SiStripPopConHistoryDQMBase.h
@@ -14,7 +14,7 @@ public:
   ~SiStripPopConHistoryDQMBase() override;
   void dqmEndJob(DQMStore::IBooker& booker, DQMStore::IGetter& getter) override;
   HDQMSummary* getObj() const override;
-  bool checkForCompatibility( const std::string& otherMetaData );
+  bool checkForCompatibility( const std::string& otherMetaData ) const override;
 private:
   std::unique_ptr<HDQMfitUtilities> fitME_;
   std::string MEDir_;


### PR DESCRIPTION
Both the base class and the one inheriting class that tried to override checkForCompatibility now agree on the function signature.

This fixes a clang warning.