### PR TITLE
Removed unused functions in ClusteringTest

### DIFF
--- a/CommonTools/Clustering1D/test/ClusteringTest.cpp
+++ b/CommonTools/Clustering1D/test/ClusteringTest.cpp
@@ -36,76 +36,6 @@ namespace
       cout << endl;
   }
     
-  void print ( const vector < Cluster1D<string> > & obj )
-  {
-      for ( vector< Cluster1D<string> >::const_iterator i=obj.begin();
-              i!=obj.end() ; ++i )
-      {
-        print ( *i );
-      }
-  }
-
-  void print ( const pair < vector < Cluster1D<string> >,
-               vector < const string * > > & obj )
-  {
-      vector < Cluster1D<string > > sol = obj.first;
-      for ( vector< Cluster1D<string> >::const_iterator i=sol.begin();
-              i!=sol.end() ; ++i )
-      {
-          cout << "   Cluster1D: ";
-          vector < const string * > names = i->tracks();
-          for ( vector< const string * >::iterator nm=names.begin();
-                  nm!=names.end() ; ++nm )
-          {
-              cout << **nm;
-          };
-          cout << " at " << i->position().value() << " +/- "
-          << i->position().error() << " weight " << i->weight() << endl;
-      }
-
-      cout << " Discarded: ";
-      vector <const string * > disc = obj.second;
-      for ( vector< const string * >::const_iterator i=disc.begin();
-              i!=disc.end() ; ++i )
-      {
-          cout << **i;
-      }
-      cout << endl;
-  }
-
-  inline void run ( const vector < Cluster1D<string> > & input )
-  {
-    cout << endl << "Input: " << endl;
-    print ( input );
-    cout << endl;
-
-
-    /* Cluster1Dize */
-    #ifdef HaveFsmw
-    FsmwClusterizer1D<string> fsmw;
-    pair < vector < Cluster1D<string> >, vector < const string * > > ret=
-        fsmw( input );
-    cout << endl << "Fsmw finds: " << endl;
-    print ( ret );
-    #endif
-
-    #ifdef HaveMtv
-    MtvClusterizer1D<string> mtv;
-    ret= mtv( input );
-    cout << endl << "Mtv finds: " << endl;
-    print ( ret );
-    #endif
-
-    #ifdef HaveDivisive
-    DivisiveClusterizer1D<string> div(50., 1,true, 10.,true);
-    ret = div( input );
-    cout << endl << "Divisive finds: " << endl;
-    print ( ret );
-    #endif
-
-    cout << endl;
-  }
-
   void mergingResult ( const Cluster1D<string> & one,
                        const Cluster1D<string> & two )
   {
@@ -141,23 +71,4 @@ namespace
 int main( int argc, char ** argv )
 {
     mergerTest();
-    /*
-
-    cout << "Three Items:" << endl
-              << "============" << endl;
-    vector < Cluster1D<string> > input = threeItems();
-    run ( input );
-    cout << endl
-              << "Four Items:" << endl
-              << "============" << endl;
-    input = fourItems();
-    run ( input );
-    */
-
-    /*
-    cout << endl
-              << "Seven:" << endl
-              << "============" << endl;
-    input = createInput( 7 );
-    run ( input );*/
 }


### PR DESCRIPTION
The removed functions have not been called since the second commit to the file which occured in 2006.

This fixes a clang warning.