### PR TITLE
LowPtElectrons: switch to Autumn18 models

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
@@ -72,9 +72,9 @@ void LowPtGsfElectronIDProducer::fillDescriptions( edm::ConfigurationDescription
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("electrons",edm::InputTag("lowPtGsfElectrons"));
   desc.add<edm::InputTag>("rho",edm::InputTag("fixedGridRhoFastjetAllTmp"));
-  desc.add< std::vector<std::string> >("ModelNames",std::vector<std::string>({""}));
-  desc.add< std::vector<std::string> >("ModelWeights",std::vector<std::string>({"RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Fall17_LowPtElectrons_mva_id.xml.gz"}));
-  desc.add< std::vector<double> >("ModelThresholds",std::vector<double>({-1.}));
+  desc.add< std::vector<std::string> >("ModelNames",std::vector<std::string>());
+  desc.add< std::vector<std::string> >("ModelWeights",std::vector<std::string>());
+  desc.add< std::vector<double> >("ModelThresholds",std::vector<double>());
   desc.add<bool>("PassThrough",false);
   desc.add<double>("MinPtThreshold",0.5);
   desc.add<double>("MaxPtThreshold",15.);

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
@@ -5,7 +5,7 @@ from RecoEgamma.EgammaElectronProducers.defaultLowPtGsfElectronID_cfi import def
 lowPtGsfElectronID = defaultLowPtGsfElectronID.clone(
     ModelNames = cms.vstring(['']),
     ModelWeights = cms.vstring([
-            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Fall17_LowPtElectrons_mva_id.xml.gz',
+            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Autumn18_LowPtElectrons_mva_id.xml.gz',
             ]),
     ModelThresholds = cms.vdouble([-10.])
     )

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
@@ -2,4 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoEgamma.EgammaElectronProducers.defaultLowPtGsfElectronID_cfi import defaultLowPtGsfElectronID
 
-lowPtGsfElectronID = defaultLowPtGsfElectronID.clone()
+lowPtGsfElectronID = defaultLowPtGsfElectronID.clone(
+    ModelNames = cms.vstring(['']),
+    ModelWeights = cms.vstring([
+            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Fall17_LowPtElectrons_mva_id.xml.gz',
+            ]),
+    ModelThresholds = cms.vdouble([-10.])
+    )

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 def thresholds( wp ) :
-    return cms.vdouble([{"L": 1.03,"M":1.75,"T":2.61}.get(wp,1.e6),  # unbiased
-                        {"L":-0.48,"M":0.76,"T":1.83}.get(wp,1.e6)]) # ptbiased
+    return cms.vdouble([{"VL": 0.19,"L":1.20,"M":2.02,"T":3.05}.get(wp,1.e6),  # unbiased
+                        {"VL":-1.99,"L":0.01,"M":1.29,"T":2.42}.get(wp,1.e6)]) # ptbiased
 
 lowPtGsfElectronSeeds = cms.EDProducer(
     "LowPtGsfElectronSeedProducer",
@@ -22,8 +22,8 @@ lowPtGsfElectronSeeds = cms.EDProducer(
             'ptbiased',
             ]),
     ModelWeights = cms.vstring([
-            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Fall17_LowPtElectrons_unbiased.xml.gz',
-            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Fall17_LowPtElectrons_displaced_pt_eta_biased.xml.gz',
+            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Autumn18_LowPtElectrons_unbiased.xml.gz',
+            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Autumn18_LowPtElectrons_displaced_pt_eta_biased.xml.gz',
             ]),
     ModelThresholds = thresholds("T"),
     PassThrough = cms.bool(False),

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
@@ -49,5 +49,5 @@ phase2_tracker.toModify(lowPtGsfElectronSeeds, TTRHBuilder  = 'WithTrackAngle')
 
 # Modifiers for BParking
 from Configuration.Eras.Modifier_bParking_cff import bParking
-bParking.toModify(lowPtGsfElectronSeeds, ModelThresholds = thresholds("L") )
+bParking.toModify(lowPtGsfElectronSeeds, ModelThresholds = thresholds("VL") )
 bParking.toModify(lowPtGsfElectronSeeds, MinPtThreshold = 0.5)


### PR DESCRIPTION
This PR updates the models used by the lowPtGsfElectrons chain. The old models were "Fall17"; the new are "Autumn18". The Autumn18 models are available as externals in this (merged) PR:
cms-data/RecoEgamma-ElectronIdentification#13.

__This PR also switches to a "Very Loose" working point for the low pT ElectronSeed module.__

1) Commit 23e8326: Trivially moves some default configuration values (concerning the models) from the ```fillDescriptions()``` method of LowPtGsfElectronIDProducer to an explicit declaration in ```RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py```. This commit was (accidentally) added to 10_2_X before master in the ad31169 commit as part of #25936. 

2) Commit 48fead2: Points to the new Autumn18 files and updates the corresponding L,M, and T working points

3) Commit 9f8467b: Adds the thresholds for a Very Loose WP __and makes VL the new default for the bParking era__. The back port of this commit can be found in #26013.

The timing and footprint increases w.r.t. nominal when using the Autumn18 models and the __default Tight working point used by all standard sequences__ are provided below. 

Timing, standard workflows, Tight WP:
```
The same excluding the first 1 events
  delta/mean delta/orJob     original                   new       module name
  ---------- ------------     --------                  ----       ------------
       added      +3.46%         0.00 ms/ev ->       540.15 ms/ev lowPtGsfElectronSeeds
       added      +0.52%         0.00 ms/ev ->        81.78 ms/ev lowPtGsfEleGsfTracks
       added      +0.09%         0.00 ms/ev ->        13.45 ms/ev lowPtGsfEleCkfTrackCandidates
       added      +0.06%         0.00 ms/ev ->        10.07 ms/ev lowPtGsfElePfTracks
       added      +0.08%         0.00 ms/ev ->        12.86 ms/ev lowPtGsfElePfGsfTracks
       added      +0.00%         0.00 ms/ev ->         0.03 ms/ev lowPtGsfElectronSeedValueMaps
       added      +0.01%         0.00 ms/ev ->         1.15 ms/ev lowPtGsfElectronID
       added      +0.03%         0.00 ms/ev ->         4.04 ms/ev lowPtGsfElectronCores
       added      +0.21%         0.00 ms/ev ->        32.58 ms/ev lowPtGsfElectrons
       added      +0.04%         0.00 ms/ev ->         6.76 ms/ev lowPtGsfElectronSuperClusters
                  +4.50%                             702.87 ms/ev
  ---------- ------------     --------                  ----       ------------
Job total:  15.6045 s/ev ==> 16.2956 s/ev
```

RECO footprint, standard workflows, Tight WP:
```
-----------------------------------------------------------------
   or, B         new, B      delta, B   delta, %   deltaJ, %    branch
-----------------------------------------------------------------
      0.0 ->       143.7        144     NEWO   0.00     recoGsfElectronCores_lowPtGsfElectronCores__RECO
      0.0 ->       120.6        121     NEWO   0.00     floatedmValueMap_lowPtGsfElectronID__RECO
      0.0 ->      5864.6       5865     NEWO   0.18     recoCaloClusters_lowPtGsfElectronSuperClusters__RECO
      0.0 ->       595.2        595     NEWO   0.02     recoSuperClusters_lowPtGsfElectronSuperClusters__RECO
      0.0 ->      1531.2       1531     NEWO   0.05     recoGsfTracks_lowPtGsfEleGsfTracks__RECO
      0.0 ->       127.5        127     NEWO   0.00     floatedmValueMap_lowPtGsfElectronSeedValueMaps_ptbiased_RECO
      0.0 ->       127.0        127     NEWO   0.00     floatedmValueMap_lowPtGsfElectronSeedValueMaps_unbiased_RECO
      0.0 ->      3456.4       3456     NEWO   0.10     recoGsfElectrons_lowPtGsfElectrons__RECO
-------------------------------------------------------------
  3348098 ->     3360658      12212            0.35     ALL BRANCHES
```

The lowPtGsfElectrons are not added to miniAOD for all standard workflows.

@slava77 @perrotta @mverzett @nancymarinelli @gkaratha 