### PR TITLE
LowPtElectrons: bug fixes + minor updates + Autumn18 models + new VL WP

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronIDProducer.cc
@@ -72,9 +72,9 @@ void LowPtGsfElectronIDProducer::fillDescriptions( edm::ConfigurationDescription
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("electrons",edm::InputTag("lowPtGsfElectrons"));
   desc.add<edm::InputTag>("rho",edm::InputTag("fixedGridRhoFastjetAllTmp"));
-  desc.add< std::vector<std::string> >("ModelNames",std::vector<std::string>({""}));
-  desc.add< std::vector<std::string> >("ModelWeights",std::vector<std::string>({"RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Fall17_LowPtElectrons_mva_id.xml.gz"}));
-  desc.add< std::vector<double> >("ModelThresholds",std::vector<double>({-1.}));
+  desc.add< std::vector<std::string> >("ModelNames",std::vector<std::string>());
+  desc.add< std::vector<std::string> >("ModelWeights",std::vector<std::string>());
+  desc.add< std::vector<double> >("ModelThresholds",std::vector<double>());
   desc.add<bool>("PassThrough",false);
   desc.add<double>("MinPtThreshold",0.5);
   desc.add<double>("MaxPtThreshold",15.);

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSCProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSCProducer.cc
@@ -166,7 +166,6 @@ void LowPtGsfElectronSCProducer::produce( edm::Event& event, const edm::EventSet
       sc.setCorrectedEnergy(energy);
       sc.setSeed(seed);
       sc.setClusters(clusters);
-      for ( const auto clu : clusters ) { sc.addCluster(clu); }
       PFClusterWidthAlgo pfwidth(barePtrs);
       sc.setEtaWidth(pfwidth.pflowEtaWidth());
       sc.setPhiWidth(pfwidth.pflowPhiWidth());

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSCProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSCProducer.cc
@@ -80,7 +80,7 @@ void LowPtGsfElectronSCProducer::produce( edm::Event& event, const edm::EventSet
     points[itrk].reserve(trk->PFRecBrem().size()+1);
     points[itrk].push_back( &trk->extrapolatedPoint(reco::PFTrajectoryPoint::LayerType::ECALShowerMax) );
     // Extrapolated brem trajectories
-    for ( auto brem : trk->PFRecBrem() ) {
+    for ( auto const& brem : trk->PFRecBrem() ) {
       points[itrk].push_back( &brem.extrapolatedPoint(reco::PFTrajectoryPoint::LayerType::ECALShowerMax) ); 
     }
     // Resize containers

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
@@ -1,11 +1,10 @@
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectronCore.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackExtra.h"
 #include "DataFormats/ParticleFlowReco/interface/PreId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -14,7 +13,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 LowPtGsfElectronSeedValueMapsProducer::LowPtGsfElectronSeedValueMapsProducer( const edm::ParameterSet& conf ) :
-  gsfElectrons_(consumes<reco::GsfElectronCollection>(conf.getParameter<edm::InputTag>("electrons"))),
+  gsfTracks_(consumes<reco::GsfTrackCollection>(conf.getParameter<edm::InputTag>("gsfTracks"))),
   preIdsValueMap_(consumes< edm::ValueMap<reco::PreIdRef> >(conf.getParameter<edm::InputTag>("preIdsValueMap"))),
   names_(conf.getParameter< std::vector<std::string> >("ModelNames"))
 {
@@ -29,33 +28,32 @@ LowPtGsfElectronSeedValueMapsProducer::~LowPtGsfElectronSeedValueMapsProducer() 
 //
 void LowPtGsfElectronSeedValueMapsProducer::produce( edm::Event& event, const edm::EventSetup& setup ) {
 
-  // Retrieve GsfElectrons from Event
-  edm::Handle<reco::GsfElectronCollection> gsfElectrons;
-  event.getByToken(gsfElectrons_,gsfElectrons);
-  if ( !gsfElectrons.isValid() ) { edm::LogError("Problem with gsfElectrons handle"); }
+  // Retrieve GsfTracks from Event
+  edm::Handle<reco::GsfTrackCollection> gsfTracks;
+  event.getByToken(gsfTracks_,gsfTracks);
+  if ( !gsfTracks.isValid() ) { edm::LogError("Problem with gsfTracks handle"); }
 
   // Retrieve PreIds from Event
   edm::Handle< edm::ValueMap<reco::PreIdRef> > preIdsValueMap;
   event.getByToken(preIdsValueMap_,preIdsValueMap);
   if ( !preIdsValueMap.isValid() ) { edm::LogError("Problem with preIdsValueMap handle"); }
   
-  // Iterate through Electrons, extract BDT output, and store result in ValueMap for each model
+  // Iterate through GsfTracks, extract BDT output, and store result in ValueMap for each model
   std::vector< std::vector<float> > output;
   for ( unsigned int iname = 0; iname < names_.size(); ++iname ) { 
-    output.push_back( std::vector<float>(gsfElectrons->size(),-999.) );
+    output.push_back( std::vector<float>(gsfTracks->size(),-999.) );
   }
-  for ( unsigned int iele = 0; iele < gsfElectrons->size(); iele++ ) {
-    reco::GsfElectronRef ele(gsfElectrons,iele);
-    if ( ele->core().isNonnull() && 
-	 ele->core()->gsfTrack().isNonnull() && 
-	 ele->core()->gsfTrack()->extra().isNonnull() && 
-	 ele->core()->gsfTrack()->extra()->seedRef().isNonnull() ) {
-      reco::ElectronSeedRef seed = ele->core()->gsfTrack()->extra()->seedRef().castTo<reco::ElectronSeedRef>();
+  for ( unsigned int igsf = 0; igsf < gsfTracks->size(); igsf++ ) {
+    reco::GsfTrackRef gsf(gsfTracks,igsf);
+    if ( gsf.isNonnull() && 
+	 gsf->extra().isNonnull() && 
+	 gsf->extra()->seedRef().isNonnull() ) {
+      reco::ElectronSeedRef seed = gsf->extra()->seedRef().castTo<reco::ElectronSeedRef>();
       if ( seed.isNonnull() && seed->ctfTrack().isNonnull() ) {
 	const reco::PreIdRef preid = (*preIdsValueMap)[seed->ctfTrack()];
 	if ( preid.isNonnull() ) {
 	  for ( unsigned int iname = 0; iname < names_.size(); ++iname ) {
-	    output[iname][iele] = preid->mva(iname);
+	    output[iname][igsf] = preid->mva(iname);
 	  }
 	}
       }
@@ -66,7 +64,7 @@ void LowPtGsfElectronSeedValueMapsProducer::produce( edm::Event& event, const ed
   for ( unsigned int iname = 0; iname < names_.size(); ++iname ) {
     auto ptr = std::make_unique< edm::ValueMap<float> >( edm::ValueMap<float>() );
     edm::ValueMap<float>::Filler filler(*ptr);
-    filler.insert(gsfElectrons, output[iname].begin(), output[iname].end());
+    filler.insert(gsfTracks, output[iname].begin(), output[iname].end());
     filler.fill();
     event.put(std::move(ptr),names_[iname]);
   }
@@ -78,9 +76,9 @@ void LowPtGsfElectronSeedValueMapsProducer::produce( edm::Event& event, const ed
 void LowPtGsfElectronSeedValueMapsProducer::fillDescriptions( edm::ConfigurationDescriptions& descriptions )
 {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("electrons",edm::InputTag("lowPtGsfElectrons"));
+  desc.add<edm::InputTag>("gsfTracks",edm::InputTag("lowPtGsfEleGsfTracks"));
   desc.add<edm::InputTag>("preIdsValueMap",edm::InputTag("lowPtGsfElectronSeeds"));
-  desc.add< std::vector<std::string> >("ModelNames",std::vector<std::string>({"default"}));
+  desc.add< std::vector<std::string> >("ModelNames",std::vector<std::string>());
   descriptions.add("defaultLowPtGsfElectronSeedValueMaps",desc);
 }
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.h
@@ -2,7 +2,7 @@
 #define RecoEgamma_EgammaElectronProducers_LowPtGsfElectronSeedValueMapsProducer_h
 
 #include "DataFormats/Common/interface/ValueMap.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PreIdFwd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -24,11 +24,10 @@ class LowPtGsfElectronSeedValueMapsProducer : public edm::stream::EDProducer<> {
 
  private:
   
-  const edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectrons_;
+  const edm::EDGetTokenT<reco::GsfTrackCollection> gsfTracks_;
   const edm::EDGetTokenT< edm::ValueMap<reco::PreIdRef> > preIdsValueMap_;
   const std::vector<std::string> names_;
 
 };
 
 #endif // RecoEgamma_EgammaElectronProducers_LowPtGsfElectronSeedValueMapsProducer_h
-

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronID_cff.py
@@ -2,4 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoEgamma.EgammaElectronProducers.defaultLowPtGsfElectronID_cfi import defaultLowPtGsfElectronID
 
-lowPtGsfElectronID = defaultLowPtGsfElectronID.clone()
+lowPtGsfElectronID = defaultLowPtGsfElectronID.clone(
+    ModelNames = cms.vstring(['']),
+    ModelWeights = cms.vstring([
+            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Autumn18_LowPtElectrons_mva_id.xml.gz',
+            ]),
+    ModelThresholds = cms.vdouble([-10.])
+    )

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 def thresholds( wp ) :
-    return cms.vdouble([{"L": 1.20,"M":2.02,"T":3.05}.get(wp,1.e6),  # unbiased
-                        {"L": 0.01,"M":1.29,"T":2.42}.get(wp,1.e6)]) # ptbiased
+    return cms.vdouble([{"VL": 0.19,"L":1.20,"M":2.02,"T":3.05}.get(wp,1.e6),  # unbiased
+                        {"VL":-1.99,"L":0.01,"M":1.29,"T":2.42}.get(wp,1.e6)]) # ptbiased
 
 lowPtGsfElectronSeeds = cms.EDProducer(
     "LowPtGsfElectronSeedProducer",
@@ -49,5 +49,5 @@ phase2_tracker.toModify(lowPtGsfElectronSeeds, TTRHBuilder  = 'WithTrackAngle')
 
 # Modifiers for BParking
 from Configuration.Eras.Modifier_bParking_cff import bParking
-bParking.toModify(lowPtGsfElectronSeeds, ModelThresholds = thresholds("L") )
+bParking.toModify(lowPtGsfElectronSeeds, ModelThresholds = thresholds("VL") )
 bParking.toModify(lowPtGsfElectronSeeds, MinPtThreshold = 0.5)

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 def thresholds( wp ) :
-    return cms.vdouble([{"L": 1.03,"M":1.75,"T":2.61}.get(wp,1.e6),  # unbiased
-                        {"L":-0.48,"M":0.76,"T":1.83}.get(wp,1.e6)]) # ptbiased
+    return cms.vdouble([{"L": 1.20,"M":2.02,"T":3.05}.get(wp,1.e6),  # unbiased
+                        {"L": 0.01,"M":1.29,"T":2.42}.get(wp,1.e6)]) # ptbiased
 
 lowPtGsfElectronSeeds = cms.EDProducer(
     "LowPtGsfElectronSeedProducer",
@@ -22,8 +22,8 @@ lowPtGsfElectronSeeds = cms.EDProducer(
             'ptbiased',
             ]),
     ModelWeights = cms.vstring([
-            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Fall17_LowPtElectrons_unbiased.xml.gz',
-            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Fall17_LowPtElectrons_displaced_pt_eta_biased.xml.gz',
+            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Autumn18_LowPtElectrons_unbiased.xml.gz',
+            'RecoEgamma/ElectronIdentification/data/LowPtElectrons/RunII_Autumn18_LowPtElectrons_displaced_pt_eta_biased.xml.gz',
             ]),
     ModelThresholds = thresholds("T"),
     PassThrough = cms.bool(False),


### PR DESCRIPTION
__This PR provides incremental changes on top of #25887.__

__This PR requires the following external: cms-data/RecoEgamma-ElectronIdentification#13__

This PR supersedes #25936. 

---

This PR provides four changes:

__1) Fixes to the SuperCluster class.__

The fixes are back ported from #25960 and #25974: 
- fix a memory use after free error caught by ASAN;
- avoid creating and using unnecessary edm::Refs; 
- removes a single line of code that was responsible for duplicating edm::Refs to ECAL clusters. 

The timing and footprint numbers below have been updated to reflect these fixes.

__2) Modifies ValueMaps to store BDT output per GsfTrack track.__

This is the back port of #25915. The change is very small and concerns the only the `LowPtGsfElectronSeedValueMapsProducer` class, which produces ValueMaps that store the discriminator values from the BDT models used in the `LowPtGsfElectronSeedProducer`.

The ValueMaps originally stored the BDT outputs per GsfElectrons, but we need them per GsfTrack. There is a near (but not exact) 1-to-1 correspondence between GsfElectrons and GsfTracks, so the ValueMaps will increase moderately in size (at the few tens of % level, not orders of magnitude!) and they will use a different key. Quantitive numbers on timing and footprint can be found in the conversation of #25915.

__3) Use new "Autumn18" BDT models and provide updated L, M, and T working points.__

This is the back port of #26012. 

**4) This PR switches to a Very Loose working point in the ElectronSeed module of the low pT electron chain. This change is only enabled for the ```bParking``` era.**

This is the back port of #26012. 

---

__Timing and footprint studies for the Very Loose WP used by the bParking era:__

The increases in timing and footprint w.r.t. nominal are provided below. In short:
- the timing increases by 25%,
- the MINIAOD footprint increases by 137%.

**RECO timing increase, bParking era only, Very Loose WP:**
```
The same excluding the first 1 events
  delta/mean delta/orJob     original                   new       module name
  ---------- ------------     --------                  ----       ------------
       added      +0.00%         0.00 ms/ev ->         0.50 ms/ev selectedPatLowPtElectrons
       added      +8.23%         0.00 ms/ev ->      1225.09 ms/ev lowPtGsfElectronSeeds
       added      +0.01%         0.00 ms/ev ->         1.45 ms/ev slimmedLowPtElectrons
       added      +0.02%         0.00 ms/ev ->         2.56 ms/ev lowPtElectronMatch
       added      +8.92%         0.00 ms/ev ->      1328.09 ms/ev lowPtGsfEleGsfTracks
       added      +0.04%         0.00 ms/ev ->         6.17 ms/ev patLowPtElectrons
       added      +2.00%         0.00 ms/ev ->       297.88 ms/ev lowPtGsfEleCkfTrackCandidates
       added      +0.07%         0.00 ms/ev ->         9.84 ms/ev lowPtGsfElePfTracks
       added      +1.55%         0.00 ms/ev ->       230.25 ms/ev lowPtGsfElePfGsfTracks
       added      +0.00%         0.00 ms/ev ->         0.15 ms/ev lowPtGsfElectronSeedValueMaps
       added      +0.04%         0.00 ms/ev ->         5.93 ms/ev lowPtGsfElectronID
       added      +0.53%         0.00 ms/ev ->        78.90 ms/ev lowPtGsfElectronCores
       added      +2.86%         0.00 ms/ev ->       425.63 ms/ev lowPtGsfElectrons
       added      +0.81%         0.00 ms/ev ->       120.77 ms/ev lowPtGsfElectronSuperClusters
                 +25.08%                            3732.71 ms/ev
  ---------- ------------     --------                  ----       ------------
Job total:  14.8827 s/ev ==> 18.9492 s/ev
```

**RECO footprint increase, bParking era only, Very Loose WP:**
```
-----------------------------------------------------------------
   or, B         new, B      delta, B   delta, %   deltaJ, %    branch
-----------------------------------------------------------------
      0.0 ->      1126.5       1127     NEWO   0.03     recoGsfElectronCores_lowPtGsfElectronCores__RECO
      0.0 ->      2121.7       2122     NEWO   0.06     recoConversions_gsfTracksOpenConversions_gsfTracksOpenConversions_RECO
   8870.8 ->      8425.3       -446     -5.2  -0.01     edmErrorSummaryEntrys_logErrorHarvester__RECO
      0.0 ->       601.4        601     NEWO   0.02     floatedmValueMap_lowPtGsfElectronID__RECO
      0.0 ->     18855.2      18855     NEWO   0.53     recoCaloClusters_lowPtGsfElectronSuperClusters__RECO
      0.0 ->      6125.4       6125     NEWO   0.17     recoSuperClusters_lowPtGsfElectronSuperClusters__RECO
      0.0 ->     27324.7      27325     NEWO   0.77     recoGsfTracks_lowPtGsfEleGsfTracks__RECO
      0.0 ->       773.9        774     NEWO   0.02     floatedmValueMap_lowPtGsfElectronSeedValueMaps_ptbiased_RECO
      0.0 ->       790.8        791     NEWO   0.02     floatedmValueMap_lowPtGsfElectronSeedValueMaps_unbiased_RECO
      0.0 ->     43295.5      43296     NEWO   1.22     recoGsfElectrons_lowPtGsfElectrons__RECO
-------------------------------------------------------------
  3541675 ->     3642021     100346             2.8     ALL BRANCHES
```

**MINIAOD footprint increase, bParking era only, Very Loose WP:**
```
-----------------------------------------------------------------
   or, B         new, B      delta, B   delta, %   deltaJ, %    branch
-----------------------------------------------------------------
      0.0 ->     16480.1      16480     NEWO   20.87     recoCaloClusters_lowPtGsfElectronSuperClusters__RECO
      0.0 ->     57850.4      57850     NEWO   73.27     patElectrons_slimmedLowPtElectrons__RECO
      0.0 ->       985.8        986     NEWO   1.25     recoGsfElectronCores_lowPtGsfElectronCores__RECO
      0.0 ->       723.1        723     NEWO   0.92     floatedmValueMap_lowPtGsfElectronSeedValueMaps_ptbiased_RECO
      0.0 ->       555.0        555     NEWO   0.70     floatedmValueMap_lowPtGsfElectronID__RECO
      0.0 ->       742.8        743     NEWO   0.94     floatedmValueMap_lowPtGsfElectronSeedValueMaps_unbiased_RECO
      0.0 ->     25644.5      25644     NEWO   32.48     recoGsfTracks_lowPtGsfEleGsfTracks__RECO
      0.0 ->      5431.8       5432     NEWO   6.88     recoSuperClusters_lowPtGsfElectronSuperClusters__RECO
-------------------------------------------------------------
    78956 ->      187349     108393            137.3     ALL BRANCHES
```

---

__Timing and footprint studies for the Loose WP used by the bParking era:__

For the record: the numbers below are for the original Loose working point, which has been tuned to rate balance w.r.t. the old Fall17 models. 

RECO timing increase, bParking era only, Loose WP:
```
The same excluding the first 1 events
  delta/mean delta/orJob     original                   new       module name
  ---------- ------------     --------                  ----       ------------
       added      +0.00%         0.00 ms/ev ->         0.15 ms/ev selectedPatLowPtElectrons
       added      +8.21%         0.00 ms/ev ->      1222.58 ms/ev lowPtGsfElectronSeeds
       added      +0.00%         0.00 ms/ev ->         0.57 ms/ev slimmedLowPtElectrons
       added      +0.01%         0.00 ms/ev ->         0.85 ms/ev lowPtElectronMatch
       added      +2.22%         0.00 ms/ev ->       330.50 ms/ev lowPtGsfEleGsfTracks
       added      +0.01%         0.00 ms/ev ->         2.06 ms/ev patLowPtElectrons
       added      +0.43%         0.00 ms/ev ->        63.31 ms/ev lowPtGsfEleCkfTrackCandidates
       added      +0.07%         0.00 ms/ev ->        10.39 ms/ev lowPtGsfElePfTracks
       added      +0.38%         0.00 ms/ev ->        56.14 ms/ev lowPtGsfElePfGsfTracks
       added      +0.00%         0.00 ms/ev ->         0.05 ms/ev lowPtGsfElectronSeedValueMaps
       added      +0.02%         0.00 ms/ev ->         2.77 ms/ev lowPtGsfElectronID
       added      +0.13%         0.00 ms/ev ->        18.65 ms/ev lowPtGsfElectronCores
       added      +0.89%         0.00 ms/ev ->       132.60 ms/ev lowPtGsfElectrons
       added      +0.20%         0.00 ms/ev ->        29.43 ms/ev lowPtGsfElectronSuperClusters
                 +12.57%                            1870.05 ms/ev
  ---------- ------------     --------                  ----       ------------
Job total:  14.8827 s/ev ==> 16.9203 s/ev
```

RECO footprint increase, bParking era only, Loose WP:
```
-----------------------------------------------------------------
   or, B         new, B      delta, B   delta, %   deltaJ, %    branch
-----------------------------------------------------------------
      0.0 ->       312.3        312     NEWO   0.01     recoGsfElectronCores_lowPtGsfElectronCores__RECO
      0.0 ->       252.9        253     NEWO   0.01     floatedmValueMap_lowPtGsfElectronID__RECO
      0.0 ->     13477.6      13478     NEWO   0.38     recoCaloClusters_lowPtGsfElectronSuperClusters__RECO
      0.0 ->      2198.6       2199     NEWO   0.06     recoSuperClusters_lowPtGsfElectronSuperClusters__RECO
      0.0 ->      6474.3       6474     NEWO   0.18     recoGsfTracks_lowPtGsfEleGsfTracks__RECO
      0.0 ->       264.5        264     NEWO   0.01     floatedmValueMap_lowPtGsfElectronSeedValueMaps_ptbiased_RECO
      0.0 ->       262.8        263     NEWO   0.01     floatedmValueMap_lowPtGsfElectronSeedValueMaps_unbiased_RECO
      0.0 ->     14082.6      14083     NEWO   0.40     recoGsfElectrons_lowPtGsfElectrons__RECO
-------------------------------------------------------------
  3541675 ->     3578709      37035             1.0     ALL BRANCHES
```

MINIAOD footprint increase, bParking era only, Loose WP:
```
-----------------------------------------------------------------
   or, B         new, B      delta, B   delta, %   deltaJ, %    branch
-----------------------------------------------------------------
      0.0 ->     12017.7      12018     NEWO   15.22    recoCaloClusters_lowPtGsfElectronSuperClusters__RECO
      0.0 ->     19327.0      19327     NEWO   24.48    patElectrons_slimmedLowPtElectrons__RECO
      0.0 ->       345.5        346     NEWO   0.44     recoGsfElectronCores_lowPtGsfElectronCores__RECO
      0.0 ->       200.8        201     NEWO   0.25     floatedmValueMap_lowPtGsfElectronSeedValueMaps_ptbiased_RECO
      0.0 ->       195.3        195     NEWO   0.25     floatedmValueMap_lowPtGsfElectronID__RECO
      0.0 ->       199.4        199     NEWO   0.25     floatedmValueMap_lowPtGsfElectronSeedValueMaps_unbiased_RECO
      0.0 ->      6594.4       6594     NEWO   8.35     recoGsfTracks_lowPtGsfEleGsfTracks__RECO
      0.0 ->      2125.1       2125     NEWO   2.69     recoSuperClusters_lowPtGsfElectronSuperClusters__RECO
-------------------------------------------------------------
    78956 ->      120018      41062            52.0     ALL BRANCHES
```

