### PR TITLE
Store HCAL RecHits for volumes crossed by muon trajectory

### DIFF
--- a/DataFormats/MuonReco/interface/MuonEnergy.h
+++ b/DataFormats/MuonReco/interface/MuonEnergy.h
@@ -3,6 +3,8 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/Math/interface/Point3D.h"
+#include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
+#include <vector>
 namespace reco {
     struct MuonEnergy {
        /// CaloTower based energy
@@ -49,13 +51,36 @@ namespace reco {
        /// DetId of the central HCAL tower with smallest depth
        DetId hcal_id;
        
+       ///
+       /// RecHits
+       ///
+       /// crossed HCAL rechits
+       const std::vector<HBHERecHit>* getHadRecHits() const
+       {
+	 if (hadRecHitsValid) return &hadRecHits;
+	 return nullptr;
+       }
+		 
+       void setHadRecHits(const std::vector<const HBHERecHit*>& rechits)
+       {
+	 hadRecHitsValid = true;
+	 hadRecHits.clear();
+	 for (auto hit: rechits)
+	   hadRecHits.push_back(*hit);
+       }
+
        MuonEnergy():
        tower(0), towerS9(0),
        em(0), emS9(0), emS25(0), emMax(0),
        had(0), hadS9(0), hadMax(0),
-	   ho(0), hoS9(0), ecal_time(0), ecal_timeError(0), hcal_time(0), hcal_timeError(0)
+	 ho(0), hoS9(0), ecal_time(0), ecal_timeError(0), hcal_time(0), hcal_timeError(0),
+	 hadRecHitsValid(false)
 	 { }
-       
+
+    private:
+       /// crossed HCAL rechits
+       std::vector<HBHERecHit> hadRecHits;
+       bool hadRecHitsValid;
     };
 }
 #endif

--- a/DataFormats/MuonReco/interface/MuonEnergy.h
+++ b/DataFormats/MuonReco/interface/MuonEnergy.h
@@ -65,34 +65,12 @@ namespace reco {
        ///
        /// crossed HCAL rechits
        std::vector<HcalMuonRecHit> crossedHadRecHits;
-       bool crossedHadRecHitsValid;
-
-       const std::vector<HcalMuonRecHit>* getCrossedHadRecHits() const
-       {
-	 if (crossedHadRecHitsValid) return &crossedHadRecHits;
-	 return nullptr;
-       }
-		 
-       void setCrossedHadRecHits(const std::vector<const HBHERecHit*>& rechits)
-       {
-	 crossedHadRecHitsValid = true;
-	 crossedHadRecHits.clear();
-	 for (auto hit: rechits){
-	   HcalMuonRecHit mhit;
-	   mhit.energy = hit->energy();
-	   mhit.chi2   = hit->chi2();
-	   mhit.time   = hit->time();
-	   mhit.detId  = hit->id();
-	   crossedHadRecHits.push_back(mhit);
-	 }
-       }
 
        MuonEnergy():
        tower(0), towerS9(0),
        em(0), emS9(0), emS25(0), emMax(0),
        had(0), hadS9(0), hadMax(0),
-	 ho(0), hoS9(0), ecal_time(0), ecal_timeError(0), hcal_time(0), hcal_timeError(0),
-	 crossedHadRecHitsValid(false)
+	 ho(0), hoS9(0), ecal_time(0), ecal_timeError(0), hcal_time(0), hcal_timeError(0)
 	 { }
 
     };

--- a/DataFormats/MuonReco/interface/MuonEnergy.h
+++ b/DataFormats/MuonReco/interface/MuonEnergy.h
@@ -3,7 +3,6 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/Math/interface/Point3D.h"
-#include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
 #include <vector>
 namespace reco {
     struct HcalMuonRecHit{

--- a/DataFormats/MuonReco/interface/MuonEnergy.h
+++ b/DataFormats/MuonReco/interface/MuonEnergy.h
@@ -6,6 +6,15 @@
 #include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
 #include <vector>
 namespace reco {
+    struct HcalMuonRecHit{
+      float energy;
+      float chi2;
+      float time;
+      HcalDetId detId;
+      HcalMuonRecHit():
+      energy(0),chi2(0),time(0){}
+    };
+
     struct MuonEnergy {
        /// CaloTower based energy
        /// total energy
@@ -55,10 +64,10 @@ namespace reco {
        /// RecHits
        ///
        /// crossed HCAL rechits
-       std::vector<HBHERecHit> crossedHadRecHits;
+       std::vector<HcalMuonRecHit> crossedHadRecHits;
        bool crossedHadRecHitsValid;
 
-       const std::vector<HBHERecHit>* getCrossedHadRecHits() const
+       const std::vector<HcalMuonRecHit>* getCrossedHadRecHits() const
        {
 	 if (crossedHadRecHitsValid) return &crossedHadRecHits;
 	 return nullptr;
@@ -68,8 +77,14 @@ namespace reco {
        {
 	 crossedHadRecHitsValid = true;
 	 crossedHadRecHits.clear();
-	 for (auto hit: rechits)
-	   crossedHadRecHits.push_back(*hit);
+	 for (auto hit: rechits){
+	   HcalMuonRecHit mhit;
+	   mhit.energy = hit->energy();
+	   mhit.chi2   = hit->chi2();
+	   mhit.time   = hit->time();
+	   mhit.detId  = hit->id();
+	   crossedHadRecHits.push_back(mhit);
+	 }
        }
 
        MuonEnergy():

--- a/DataFormats/MuonReco/interface/MuonEnergy.h
+++ b/DataFormats/MuonReco/interface/MuonEnergy.h
@@ -55,18 +55,21 @@ namespace reco {
        /// RecHits
        ///
        /// crossed HCAL rechits
-       const std::vector<HBHERecHit>* getHadRecHits() const
+       std::vector<HBHERecHit> crossedHadRecHits;
+       bool crossedHadRecHitsValid;
+
+       const std::vector<HBHERecHit>* getCrossedHadRecHits() const
        {
-	 if (hadRecHitsValid) return &hadRecHits;
+	 if (crossedHadRecHitsValid) return &crossedHadRecHits;
 	 return nullptr;
        }
 		 
-       void setHadRecHits(const std::vector<const HBHERecHit*>& rechits)
+       void setCrossedHadRecHits(const std::vector<const HBHERecHit*>& rechits)
        {
-	 hadRecHitsValid = true;
-	 hadRecHits.clear();
+	 crossedHadRecHitsValid = true;
+	 crossedHadRecHits.clear();
 	 for (auto hit: rechits)
-	   hadRecHits.push_back(*hit);
+	   crossedHadRecHits.push_back(*hit);
        }
 
        MuonEnergy():
@@ -74,13 +77,9 @@ namespace reco {
        em(0), emS9(0), emS25(0), emMax(0),
        had(0), hadS9(0), hadMax(0),
 	 ho(0), hoS9(0), ecal_time(0), ecal_timeError(0), hcal_time(0), hcal_timeError(0),
-	 hadRecHitsValid(false)
+	 crossedHadRecHitsValid(false)
 	 { }
 
-    private:
-       /// crossed HCAL rechits
-       std::vector<HBHERecHit> hadRecHits;
-       bool hadRecHitsValid;
     };
 }
 #endif

--- a/DataFormats/MuonReco/interface/MuonEnergy.h
+++ b/DataFormats/MuonReco/interface/MuonEnergy.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/Math/interface/Point3D.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include <vector>
 namespace reco {
     struct HcalMuonRecHit{

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -51,11 +51,11 @@ initial version number of a class which has never been stored before.
   <class name="edm::Wrapper<reco::MuonTimeExtraMap>"/>
 
   <class name="reco::MuonEnergy" ClassVersion="11">
-   <version ClassVersion="11" checksum="3277243089"/>
+   <version ClassVersion="11" checksum="1884744911"/>
    <version ClassVersion="10" checksum="1493325087"/>
   </class>
-  <class name="reco::HcalMuonRecHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="2031556424"/>
+  <class name="reco::HcalMuonRecHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="2031556424"/>
   </class>
   <class name="reco::MuonChamberMatch" ClassVersion="12">
    <version ClassVersion="12" checksum="2575855272"/>

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -50,7 +50,8 @@ initial version number of a class which has never been stored before.
   <class name="edm::Wrapper<std::vector<reco::MuonTimeExtra> >"/>
   <class name="edm::Wrapper<reco::MuonTimeExtraMap>"/>
 
-  <class name="reco::MuonEnergy" ClassVersion="10">
+  <class name="reco::MuonEnergy" ClassVersion="11">
+   <version ClassVersion="11" checksum="1798833422"/>
    <version ClassVersion="10" checksum="1493325087"/>
   </class>
   <class name="reco::MuonChamberMatch" ClassVersion="12">

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -51,8 +51,11 @@ initial version number of a class which has never been stored before.
   <class name="edm::Wrapper<reco::MuonTimeExtraMap>"/>
 
   <class name="reco::MuonEnergy" ClassVersion="11">
-   <version ClassVersion="11" checksum="647141114"/>
+   <version ClassVersion="11" checksum="3277243089"/>
    <version ClassVersion="10" checksum="1493325087"/>
+  </class>
+  <class name="reco::HcalMuonRecHit" ClassVersion="10">
+   <version ClassVersion="10" checksum="2031556424"/>
   </class>
   <class name="reco::MuonChamberMatch" ClassVersion="12">
    <version ClassVersion="12" checksum="2575855272"/>

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -51,7 +51,7 @@ initial version number of a class which has never been stored before.
   <class name="edm::Wrapper<reco::MuonTimeExtraMap>"/>
 
   <class name="reco::MuonEnergy" ClassVersion="11">
-   <version ClassVersion="11" checksum="1798833422"/>
+   <version ClassVersion="11" checksum="647141114"/>
    <version ClassVersion="10" checksum="1493325087"/>
   </class>
   <class name="reco::MuonChamberMatch" ClassVersion="12">

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -814,7 +814,17 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
       muonEnergy.hadS9   = info.nXnEnergy(TrackDetMatchInfo::HcalRecHits,1); // 3x3 energy
       muonEnergy.hoS9    = info.nXnEnergy(TrackDetMatchInfo::HORecHits,1);   // 3x3 energy
       muonEnergy.towerS9 = info.nXnEnergy(TrackDetMatchInfo::TowerTotal,1);  // 3x3 energy
-      if (storeCrossedHcalRecHits_) muonEnergy.setCrossedHadRecHits(info.crossedHcalRecHits);
+      if (storeCrossedHcalRecHits_) {
+	muonEnergy.crossedHadRecHits.clear();
+	for (auto hit: info.crossedHcalRecHits){
+	  reco::HcalMuonRecHit mhit;
+	  mhit.energy = hit->energy();
+	  mhit.chi2   = hit->chi2();
+	  mhit.time   = hit->time();
+	  mhit.detId  = hit->id();
+	  muonEnergy.crossedHadRecHits.push_back(mhit);
+	}
+      }
       muonEnergy.ecal_position = info.trkGlobPosAtEcal;
       muonEnergy.hcal_position = info.trkGlobPosAtHcal;
       if (! info.crossedEcalIds.empty() ) muonEnergy.ecal_id = info.crossedEcalIds.front();

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -56,6 +56,7 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
    maxAbsPullY_             = iConfig.getParameter<double>("maxAbsPullY");
    fillCaloCompatibility_   = iConfig.getParameter<bool>("fillCaloCompatibility");
    fillEnergy_              = iConfig.getParameter<bool>("fillEnergy");
+   storeHcalRecHits_        = iConfig.getParameter<bool>("storeHcalRecHits");
    fillMatching_            = iConfig.getParameter<bool>("fillMatching");
    fillIsolation_           = iConfig.getParameter<bool>("fillIsolation");
    writeIsoDeposits_        = iConfig.getParameter<bool>("writeIsoDeposits");
@@ -813,6 +814,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
       muonEnergy.hadS9   = info.nXnEnergy(TrackDetMatchInfo::HcalRecHits,1); // 3x3 energy
       muonEnergy.hoS9    = info.nXnEnergy(TrackDetMatchInfo::HORecHits,1);   // 3x3 energy
       muonEnergy.towerS9 = info.nXnEnergy(TrackDetMatchInfo::TowerTotal,1);  // 3x3 energy
+      if (storeHcalRecHits_) muonEnergy.setHadRecHits(info.hcalRecHits);
       muonEnergy.ecal_position = info.trkGlobPosAtEcal;
       muonEnergy.hcal_position = info.trkGlobPosAtHcal;
       if (! info.crossedEcalIds.empty() ) muonEnergy.ecal_id = info.crossedEcalIds.front();

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -56,7 +56,7 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
    maxAbsPullY_             = iConfig.getParameter<double>("maxAbsPullY");
    fillCaloCompatibility_   = iConfig.getParameter<bool>("fillCaloCompatibility");
    fillEnergy_              = iConfig.getParameter<bool>("fillEnergy");
-   storeHcalRecHits_        = iConfig.getParameter<bool>("storeHcalRecHits");
+   storeCrossedHcalRecHits_ = iConfig.getParameter<bool>("storeCrossedHcalRecHits");
    fillMatching_            = iConfig.getParameter<bool>("fillMatching");
    fillIsolation_           = iConfig.getParameter<bool>("fillIsolation");
    writeIsoDeposits_        = iConfig.getParameter<bool>("writeIsoDeposits");
@@ -814,7 +814,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
       muonEnergy.hadS9   = info.nXnEnergy(TrackDetMatchInfo::HcalRecHits,1); // 3x3 energy
       muonEnergy.hoS9    = info.nXnEnergy(TrackDetMatchInfo::HORecHits,1);   // 3x3 energy
       muonEnergy.towerS9 = info.nXnEnergy(TrackDetMatchInfo::TowerTotal,1);  // 3x3 energy
-      if (storeHcalRecHits_) muonEnergy.setHadRecHits(info.crossedHcalRecHits);
+      if (storeCrossedHcalRecHits_) muonEnergy.setCrossedHadRecHits(info.crossedHcalRecHits);
       muonEnergy.ecal_position = info.trkGlobPosAtEcal;
       muonEnergy.hcal_position = info.trkGlobPosAtHcal;
       if (! info.crossedEcalIds.empty() ) muonEnergy.ecal_id = info.crossedEcalIds.front();
@@ -1313,7 +1313,7 @@ void MuonIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.setAllowAnything();
   
   desc.add<bool>("arbitrateTrackerMuons",false);
-  desc.add<bool>("storeHcalRecHits",false);
+  desc.add<bool>("storeCrossedHcalRecHits",false);
 
   edm::ParameterSetDescription descTrkAsoPar;
   descTrkAsoPar.add<edm::InputTag>("GEMSegmentCollectionLabel",edm::InputTag("gemSegments"));

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -1313,6 +1313,7 @@ void MuonIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.setAllowAnything();
   
   desc.add<bool>("arbitrateTrackerMuons",false);
+  desc.add<bool>("storeHcalRecHits",false);
 
   edm::ParameterSetDescription descTrkAsoPar;
   descTrkAsoPar.add<edm::InputTag>("GEMSegmentCollectionLabel",edm::InputTag("gemSegments"));

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -814,7 +814,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
       muonEnergy.hadS9   = info.nXnEnergy(TrackDetMatchInfo::HcalRecHits,1); // 3x3 energy
       muonEnergy.hoS9    = info.nXnEnergy(TrackDetMatchInfo::HORecHits,1);   // 3x3 energy
       muonEnergy.towerS9 = info.nXnEnergy(TrackDetMatchInfo::TowerTotal,1);  // 3x3 energy
-      if (storeHcalRecHits_) muonEnergy.setHadRecHits(info.hcalRecHits);
+      if (storeHcalRecHits_) muonEnergy.setHadRecHits(info.crossedHcalRecHits);
       muonEnergy.ecal_position = info.trkGlobPosAtEcal;
       muonEnergy.hcal_position = info.trkGlobPosAtHcal;
       if (! info.crossedEcalIds.empty() ) muonEnergy.ecal_id = info.crossedEcalIds.front();

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -194,7 +194,7 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    // what information to fill
    bool fillCaloCompatibility_;
    bool fillEnergy_;
-   bool storeHcalRecHits_;
+   bool storeCrossedHcalRecHits_;
    bool fillMatching_;
    bool fillIsolation_;
    bool writeIsoDeposits_;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -194,6 +194,7 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    // what information to fill
    bool fillCaloCompatibility_;
    bool fillEnergy_;
+   bool storeHcalRecHits_;
    bool fillMatching_;
    bool fillIsolation_;
    bool writeIsoDeposits_;

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -19,6 +19,8 @@ muons1stStep = cms.EDProducer("MuonIdProducer",
     TrackerKinkFinderParametersBlock,
 
     fillEnergy = cms.bool(True),
+    storeHcalRecHits = cms.bool(False),
+
     # OR
     maxAbsPullX = cms.double(3.0),
     maxAbsEta = cms.double(3.0),

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -19,7 +19,7 @@ muons1stStep = cms.EDProducer("MuonIdProducer",
     TrackerKinkFinderParametersBlock,
 
     fillEnergy = cms.bool(True),
-    storeHcalRecHits = cms.bool(True),
+    storeCrossedHcalRecHits = cms.bool(True),
 
     # OR
     maxAbsPullX = cms.double(3.0),

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -19,7 +19,7 @@ muons1stStep = cms.EDProducer("MuonIdProducer",
     TrackerKinkFinderParametersBlock,
 
     fillEnergy = cms.bool(True),
-    storeHcalRecHits = cms.bool(False),
+    storeHcalRecHits = cms.bool(True),
 
     # OR
     maxAbsPullX = cms.double(3.0),


### PR DESCRIPTION
Added an options to store HBHERecHits that were crossed by muon. It's needed for muon identification studies and commissioning of the HB new readout. There should be no impact on CPU time, since the information is already extracted. We just need to make sure it won't cause significant increase in the output. If it does we will use it only in special requests. Quick check on Run2018 data shows ~1% increase of MiniAOD, which should be Ok.