### PR TITLE
add DQMEventInfo to SiPixelQuality PCL workflow

### DIFF
--- a/CalibTracker/SiPixelQuality/python/DQMEventInfoSiPixelQuality_cff.py
+++ b/CalibTracker/SiPixelQuality/python/DQMEventInfoSiPixelQuality_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+dqmEnvSiPixelQuality = DQMEDAnalyzer('DQMEventInfo',
+                                     subSystemFolder = cms.untracked.string('PixelPhase1')
+                                    )
+                            

--- a/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
+++ b/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
@@ -9,6 +9,7 @@ from Alignment.CommonAlignmentProducer.AlcaSiPixelAliHarvester_cff import *
 from Calibration.EcalCalibAlgos.AlcaEcalPedestalsHarvester_cff import *
 from Calibration.LumiAlCaRecoProducers.AlcaLumiPCCHarvester_cff import *
 from CalibTracker.SiPixelQuality.SiPixelStatusHarvester_cfi import *
+from CalibTracker.SiPixelQuality.DQMEventInfoSiPixelQuality_cff import *
 
 from Calibration.TkAlCaRecoProducers.PCLMetadataWriter_cfi import *
 
@@ -225,7 +226,7 @@ SiPixelAli     = cms.Path(ALCAHARVESTSiPixelAli)
 EcalPedestals  = cms.Path(ALCAHARVESTEcalPedestals)
 SiStripGainsAAG = cms.Path(ALCAHARVESTSiStripGainsAAG)
 LumiPCC = cms.Path(ALCAHARVESTLumiPCC)
-SiPixelQuality = cms.Path(ALCAHARVESTSiPixelQuality)#+siPixelPhase1DQMHarvester)
+SiPixelQuality = cms.Path(dqmEnvSiPixelQuality+ALCAHARVESTSiPixelQuality)#+siPixelPhase1DQMHarvester)
 
 ALCAHARVESTDQMSaveAndMetadataWriter = cms.Path(dqmSaver+pclMetadataWriter)
 


### PR DESCRIPTION
Greetings,
this PR aims to provide to the harvested `ALCAPROMPT` files for the `SiPixelQuality` bad components flavour the necessary input histograms to show the run/ LS / start time info to be displayed in the DQM GUI header, as it is done for the standard DQM, in the same spirit of what done for other PCL workflows in PR https://github.com/cms-sw/cmssw/pull/20097 and https://github.com/cms-sw/cmssw/pull/19385.
This should fix the annoying lack of reference when browsing the GUI for such histograms.
The changes have been tested via `runTheMatrix.py -l 1001.0` and the output harvested files have been uploaded to a local development GUI.
I am attaching here the results of the test:

   * before:
![image](https://user-images.githubusercontent.com/5082376/53476689-441e5780-3a73-11e9-89e9-f29cea2f6160.png)

   * after:
![image](https://user-images.githubusercontent.com/5082376/53476729-5ac4ae80-3a73-11e9-90eb-53a0ed73d2c9.png)
