### PR TITLE
FWCore/ParameterSet changes for python3 compatibility

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -629,10 +629,7 @@ class Process(object):
                 self.extend(item)
 
         #now create a sequence that uses the newly made items
-        for name in seqs.iterkeys():
-            seq = seqs[name]
-            #newSeq = seq.copy()
-            #
+        for name,seq in six.iteritems(seqs):
             if id(seq) not in self._cloneToObjectDict:
                 self.__setattr__(name,seq)
             else:
@@ -642,8 +639,7 @@ class Process(object):
                 #now put in proper bucket
                 newSeq._place(name,self)
 
-        for name in tasksToAttach.iterkeys():
-            task = tasksToAttach[name]
+        for name, task in six.iteritems(tasksToAttach):
             self.__setattr__(name, task)
 
         #apply modifiers now that all names have been added
@@ -1298,11 +1294,11 @@ class _ParameterModifier(object):
         self.__args = args
     def __call__(self,obj):
         params = {}
-        for k in self.__args.iterkeys():
+        for k in six.iterkeys(self.__args):
             if hasattr(obj,k):
                 params[k] = getattr(obj,k)
         _modifyParametersFromDict(params, self.__args, self._raiseUnknownKey)
-        for k in self.__args.iterkeys():
+        for k in six.iterkeys(self.__args):
             if k in params:
                 setattr(obj,k,params[k])
             else:
@@ -1676,7 +1672,7 @@ if __name__=="__main__":
         def testProcessExtend(self):
             class FromArg(object):
                 def __init__(self,*arg,**args):
-                    for name in args.iterkeys():
+                    for name in six.iterkeys(args):
                         self.__dict__[name]=args[name]
 
             a=EDAnalyzer("MyAnalyzer")

--- a/FWCore/ParameterSet/python/DictTypes.py
+++ b/FWCore/ParameterSet/python/DictTypes.py
@@ -17,7 +17,7 @@ class SortedKeysDict(dict):
             else:
                 self.list = list(args[0].iterkeys())
             return
-        self.list = list(super(SortedKeysDict,self).iterkeys())
+        self.list = list(six.iterkeys(super(SortedKeysDict,self)))
 
     def __repr__(self):
         meat = ', '.join([ '%s: %s' % (repr(key), repr(val)) for key,val in six.iteritems(self) ])

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -656,13 +656,11 @@ class _ValidatingParameterListBase(_ValidatingListBase,_ParameterTypeBase):
         return (converter(x).value() for x in strings)
 
 def saveOrigin(obj, level):
-    #frame = inspect.stack()[level+1]
-    frame = inspect.getframeinfo(inspect.currentframe(level+1))
-    # not safe under old python versions
-    #obj._filename = frame.filename
-    #obj._lineNumber = frame.lineno
-    obj._filename = frame[0]
-    obj._lineNumber = frame[1]
+    frame = inspect.stack()[level+1]
+    if isinstance(frame,tuple): frame=frame[0] #python3 changes this to a tuple where the first thing is the frame
+    fInfo=inspect.getframeinfo(frame)
+    obj._filename = fInfo.filename
+    obj._lineNumber =fInfo.lineno
 
 def _modifyParametersFromDict(params, newParams, errorRaiser, keyDepth=""):
     if len(newParams):

--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -582,7 +582,7 @@ class Schedule(_ValidatingParameterListBase,_ConfigureComponent,_Unlabelable):
     def __init__(self,*arg,**argv):
         super(Schedule,self).__init__(*arg)
         self._tasks = OrderedSet()
-        theKeys = argv.keys()
+        theKeys = list(argv.keys())
         if theKeys:
             if len(theKeys) > 1 or theKeys[0] != "tasks":
                 raise RuntimeError("The Schedule constructor can only have one keyword argument after its Path and\nEndPath arguments and it must use the keyword 'tasks'")

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from .Mixins import PrintOptions, _SimpleParameterTypeBase, _ParameterTypeBase, _Parameterizable, _ConfigureComponent, _Labelable, _TypedParameterizable, _Unlabelable, _modifyParametersFromDict
 from .Mixins import _ValidatingParameterListBase, specialImportRegistry
 from .ExceptionHandling import format_typename, format_outerframe
-
+from past.builtins import long
 
 import copy
 import math


### PR DESCRIPTION
Unit tests in FWCore/PyDevParameterSet now run correctly if python3 is used (in addition to already working with python2)