### PR TITLE
Fix failing tests in FWCore/ParameterSet

### DIFF
--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -659,7 +659,7 @@ if __name__ == "__main__":
             self.assertTrue(isinstance(sp.test2, EDAlias))
 
             # Modifications
-            from Types import int32, string, PSet, VPSet
+            from .Types import int32, string, PSet, VPSet
             sp = SwitchProducerTest(test1 = EDProducer("Foo"),
                                     test2 = EDAlias(foo = VPSet(PSet(type = string("Foo2")))))
 
@@ -685,7 +685,7 @@ if __name__ == "__main__":
 
 
             # Dump
-            from Types import int32, string, PSet, VPSet
+            from .Types import int32, string, PSet, VPSet
             sp = SwitchProducerTest(test1 = EDProducer("Foo"),
                                     test2 = EDAlias(foo = VPSet(PSet(type = string("Foo2")))))
 

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from .Mixins import PrintOptions, _SimpleParameterTypeBase, _ParameterTypeBase, _Parameterizable, _ConfigureComponent, _Labelable, _TypedParameterizable, _Unlabelable, _modifyParametersFromDict
 from .Mixins import _ValidatingParameterListBase, specialImportRegistry
+from .Mixins import saveOrigin
 from .ExceptionHandling import format_typename, format_outerframe
 
 


### PR DESCRIPTION
Fixed tests that had been in the works during the initial transition to using pythone 3 syntax.