### PR TITLE
Introduce SiStripCalCosmics ALCARECO

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmics_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmics_Output_cff.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+# AlCaReco for track based calibration using Cosmics events
+OutALCARECOSiStripCalCosmics_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOSiStripCalCosmics')
+    ),
+    outputCommands = cms.untracked.vstring( 
+        'keep *_ALCARECOSiStripCalCosmics_*_*', 
+        'keep *_siStripClusters_*_*', 
+        'keep *_siPixelClusters_*_*',
+        'keep DetIdedmEDCollection_siStripDigis_*_*',
+        'keep L1AcceptBunchCrossings_*_*_*',
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep LumiScalerss_scalersRawToDigi_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
+        'keep *_TriggerResults_*_*')
+    )
+
+import copy
+OutALCARECOSiStripCalCosmics=copy.deepcopy(OutALCARECOSiStripCalCosmics_noDrop)
+OutALCARECOSiStripCalCosmics.outputCommands.insert(0,"drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmics_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmics_cff.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+# Set the HLT paths
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+ALCARECOSiStripCalCosmicsHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
+    andOr = True, ## choose logical OR between Triggerbits
+    HLTPaths = ["HLT_*"],
+    # eventually this needs to sterred via Global Tag in AlCaRecoTriggerBits
+    #eventSetupPathsKey = 'SiStripCalCosmics',
+    throw = False # tolerate triggers stated above, but not available
+    )
+
+# Select only events where tracker had HV on (according to DCS bit information)
+# AND respective partition is in the run (according to FED information)
+import CalibTracker.SiStripCommon.SiStripDCSFilter_cfi
+DCSStatusForSiStripCalCosmics = CalibTracker.SiStripCommon.SiStripDCSFilter_cfi.siStripDCSFilter.clone(
+    DetectorType = cms.vstring('TIBTID','TOB','TECp','TECm'),
+    ApplyFilter  = cms.bool(True),
+    AndOr        = cms.bool(True),
+    DebugOn      = cms.untracked.bool(False)
+    )
+
+# Select only good tracks
+import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi
+ALCARECOSiStripCalCosmics = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone()
+
+ALCARECOSiStripCalCosmics.filter         = True ##do not store empty events	
+ALCARECOSiStripCalCosmics.src            = 'ctfWithMaterialTracksP5'
+ALCARECOSiStripCalCosmics.applyBasicCuts = True
+ALCARECOSiStripCalCosmics.ptMin          = 0. ##GeV
+ALCARECOSiStripCalCosmics.nHitMin        = 6  ## at least 6 hits required
+ALCARECOSiStripCalCosmics.chi2nMax       = 10.
+
+ALCARECOSiStripCalCosmics.GlobalSelector.applyIsolationtest    = False
+ALCARECOSiStripCalCosmics.GlobalSelector.applyGlobalMuonFilter = False
+ALCARECOSiStripCalCosmics.GlobalSelector.applyJetCountFilter   = False
+
+ALCARECOSiStripCalCosmics.TwoBodyDecaySelector.applyMassrangeFilter    = False
+ALCARECOSiStripCalCosmics.TwoBodyDecaySelector.applyChargeFilter       = False
+ALCARECOSiStripCalCosmics.TwoBodyDecaySelector.applyAcoplanarityFilter = False
+ALCARECOSiStripCalCosmics.TwoBodyDecaySelector.applyMissingETFilter    = False
+
+# Sequence #
+seqALCARECOSiStripCalCosmics = cms.Sequence(ALCARECOSiStripCalCosmicsHLT*DCSStatusForSiStripCalCosmics*ALCARECOSiStripCalCosmics)

--- a/Configuration/AlCa/python/autoAlca.py
+++ b/Configuration/AlCa/python/autoAlca.py
@@ -1,7 +1,7 @@
 AlCaRecoMatrix = {"AlCaLumiPixels" : "AlCaPCCZeroBias+AlCaPCCRandom",
                   "Charmonium"     : "TkAlJpsiMuMu",
                   "Commissioning"  : "HcalCalIsoTrk+HcalCalIsolatedBunchSelector+TkAlMinBias+SiStripCalMinBias",
-                  "Cosmics"        : "TkAlCosmics0T+MuAlGlobalCosmics+DtCalibCosmics",
+                  "Cosmics"        : "SiStripCalCosmics+TkAlCosmics0T+MuAlGlobalCosmics+DtCalibCosmics",
                   "DoubleEG"       : "EcalCalZElectron+EcalUncalZElectron+HcalCalIterativePhiSym+HcalCalIsoTrkFilter",
                   "DoubleMuon"     : "TkAlZMuMu+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu+DtCalib+HcalCalLowPUHBHEMuonFilter",
                   # New PD in 2018 to replace SinglePhoton SingleElectron and DoubleEG in 2017

--- a/Configuration/EventContent/python/AlCaRecoOutput_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_cff.py
@@ -47,6 +47,8 @@ from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalSmallBiasScan_Output_cff 
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalZeroBias_Output_cff import *
 # AlCaReco for SiPixel Bad Component using ZeroBias events
 from CalibTracker.SiPixelQuality.ALCARECOSiPixelCalZeroBias_Output_cff import *
+# AlCaReco for tracker calibration using Cosmics events 
+from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalCosmics_Output_cff import *
 
 # AlCaReco for tracker based alignment using beam halo
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlBeamHalo_Output_cff import *

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2318,7 +2318,7 @@ steps['ALCACOSD']={'--conditions':'auto:run1_data',
                    '-s':'ALCA:TkAlCosmics0T+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'
                    }
 
-steps['ALCACOSDRUN2']=merge([{'--conditions':'auto:run2_data','--era':'Run2_2016','-s':'ALCA:TkAlCosmics0T+MuAlGlobalCosmics+HcalCalHOCosmics+DtCalibCosmics+DQM'},steps['ALCACOSD']])
+steps['ALCACOSDRUN2']=merge([{'--conditions':'auto:run2_data','--era':'Run2_2016','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+MuAlGlobalCosmics+HcalCalHOCosmics+DtCalibCosmics+DQM'},steps['ALCACOSD']])
 
 steps['ALCAPROMPT']={'-s':'ALCA:PromptCalibProd',
                      '--filein':'file:TkAlMinBias.root',
@@ -2372,9 +2372,9 @@ steps['ALCACOS']=merge([{'-s':'ALCA:TkAlCosmics0T+MuAlGlobalCosmics+HcalCalHOCos
 steps['ALCABH']=merge([{'-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo'},stCond,step4Defaults])
 steps['ALCAHAL']=merge([{'-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo'},step4Up2015Defaults])
 steps['ALCACOS_UP15']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo'},step4Up2015Defaults])
-steps['ALCACOS_UP16']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'ALCA:TkAlCosmics0T+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2016'},step4Up2015Defaults])
-steps['ALCACOS_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics','-s':'ALCA:TkAlCosmics0T+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2017'},step4Up2015Defaults])
-steps['ALCACOS_UP18']=merge([{'--conditions':'auto:phase1_2018_cosmics','-s':'ALCA:TkAlCosmics0T+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2018'},step4Up2015Defaults])
+steps['ALCACOS_UP16']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2016'},step4Up2015Defaults])
+steps['ALCACOS_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2017'},step4Up2015Defaults])
+steps['ALCACOS_UP18']=merge([{'--conditions':'auto:phase1_2018_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2018'},step4Up2015Defaults])
 steps['ALCAHARVD']={'-s':'ALCAHARVEST:BeamSpotByRun+BeamSpotByLumi+SiStripQuality',
                     '--conditions':'auto:run1_data',
                     '--scenario':'pp',

--- a/Configuration/StandardSequences/python/AlCaRecoStreamsHeavyIons_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreamsHeavyIons_cff.py
@@ -36,6 +36,8 @@ from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalMinBiasAAGHI_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalZeroBiasHI_cff import *
 # AlCaReco for SiPixel Bad Components using ZeroBias events
 from CalibTracker.SiPixelQuality.ALCARECOSiPixelCalZeroBias_cff import *
+# AlCaReco for tracker calibration using Cosmics events 
+from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalCosmics_cff import *
 
 ###############################################################
 # ECAL Calibration
@@ -126,6 +128,7 @@ pathALCARECOTkAlMinBiasHI = cms.Path(seqALCARECOTkAlMinBiasHI*ALCARECOTkAlMinBia
 pathALCARECOSiPixelLorentzAngle = cms.Path(seqALCARECOSiPixelLorentzAngle)
 pathALCARECOSiStripCalMinBias = cms.Path(seqALCARECOSiStripCalMinBias*ALCARECOSiStripCalMinBiasDQM)
 pathALCARECOSiStripCalMinBiasAAG = cms.Path(seqALCARECOSiStripCalMinBiasAAG*ALCARECOSiStripCalMinBiasAAGDQM)
+pathALCARECOSiStripCalCosmics = cms.Path(seqALCARECOSiStripCalCosmics)
 pathALCARECOSiStripCalZeroBias = cms.Path(seqALCARECOSiStripCalZeroBias*ALCARECOSiStripCalZeroBiasDQM)
 pathALCARECOSiPixelCalZeroBias = cms.Path(seqALCARECOSiPixelCalZeroBias)
 
@@ -252,6 +255,14 @@ ALCARECOStreamSiStripCalMinBiasAAG = cms.FilteredStream(
         dataTier = cms.untracked.string('ALCARECO')
         )
 
+ALCARECOStreamSiStripCalCosmics = cms.FilteredStream(
+	responsible = 'Marco Musich',
+	name = 'SiStripCalCosmics',
+	paths  = (pathALCARECOSiStripCalCosmics),
+	content = OutALCARECOSiStripCalCosmics.outputCommands,
+	selectEvents = OutALCARECOSiStripCalCosmics.SelectEvents,
+	dataTier = cms.untracked.string('ALCARECO')
+	)
 
 ALCARECOStreamSiStripCalZeroBias = cms.FilteredStream(
 	responsible = 'Gordon Kaussen',

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -44,6 +44,8 @@ from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalSmallBiasScan_cff import 
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalZeroBias_cff import *
 # AlCaReco for SiPixel Bad Components using ZeroBias events in ExpressPhysics stream
 from CalibTracker.SiPixelQuality.ALCARECOSiPixelCalZeroBias_cff import *
+# AlCaReco for tracker calibration using Cosmics events 
+from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalCosmics_cff import *
 
 ###############################################################
 # LUMI Calibration
@@ -169,6 +171,7 @@ pathALCARECOTkAlMinBias = cms.Path(seqALCARECOTkAlMinBias*ALCARECOTkAlMinBiasDQM
 pathALCARECOTkAlMinBias = cms.Path(seqALCARECOTkAlMinBias*ALCARECOTkAlMinBiasDQM)
 pathALCARECOSiPixelLorentzAngle = cms.Path(seqALCARECOSiPixelLorentzAngle)
 pathALCARECOSiStripCalMinBias = cms.Path(seqALCARECOSiStripCalMinBias*ALCARECOSiStripCalMinBiasDQM)
+pathALCARECOSiStripCalCosmics = cms.Path(seqALCARECOSiStripCalCosmics)
 pathALCARECOSiStripCalMinBiasAAG = cms.Path(seqALCARECOSiStripCalMinBiasAAG*ALCARECOSiStripCalMinBiasAAGDQM)
 pathALCARECOSiStripCalSmallBiasScan = cms.Path(seqALCARECOSiStripCalSmallBiasScan)
 pathALCARECOSiStripCalZeroBias = cms.Path(seqALCARECOSiStripCalZeroBias*ALCARECOSiStripCalZeroBiasDQM)
@@ -379,6 +382,14 @@ ALCARECOStreamSiStripCalMinBiasAAG = cms.FilteredStream(
         dataTier = cms.untracked.string('ALCARECO')
         )
 
+ALCARECOStreamSiStripCalCosmics = cms.FilteredStream(
+	responsible = 'Marco Musich',
+	name = 'SiStripCalCosmics',
+	paths  = (pathALCARECOSiStripCalCosmics),
+	content = OutALCARECOSiStripCalCosmics.outputCommands,
+	selectEvents = OutALCARECOSiStripCalCosmics.SelectEvents,
+	dataTier = cms.untracked.string('ALCARECO')
+	)
 
 ALCARECOStreamSiStripCalZeroBias = cms.FilteredStream(
 	responsible = 'Gordon Kaussen',


### PR DESCRIPTION
Greetings,
the aim of this PR is to introduce a new SiStrip AlCaReco workflow meant as intermediate step for the production of SiStrip calibration trees to be used for monitoring and calibration purposes. 
An archetypal example of monitorable quantity with cosmic rays is the Strip Lorentz Angle, see e.g. details in this [presentation](https://indico.cern.ch/event/787656/contributions/3334666/attachments/1803298/2941971/20190227_SiStripCalib_LorentzAngle.pdf).
The new AlCaReco is in essence the cosmics version of `SiStripCalMinBias` adapted to work with a different input track collection and adjusting the acceptance cuts.
The new workflow has been fully interlaced with RelVals and AlCaReco matrix via `autoAlCa`.
Typical output file sizes are ~ 2kB/evt (for comparison the output of the whole 2018 Commissioning dataset is <0.5TB).
Tested locally via: `runTheMatrix.py -l 7.21,7.22,7.3,7.4`
@robervalwalsh FYI