### PR TITLE
Continue GsfElectronAlgo refactoring

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -198,66 +198,11 @@ class GsfElectronAlgo {
       
       ) ;
 
-    //===================================================================
-    // GsfElectronAlgo::EventData
-    //===================================================================
-
-    struct EventData
-     {
-      // utilities
-      void retreiveOriginalTrackCollections
-       ( const reco::TrackRef &, const reco::GsfTrackRef & ) ;
-
-      // general
-      edm::Event * event ;
-      const reco::BeamSpot * beamspot ;
-
-      // input collections
-      edm::Handle<reco::GsfElectronCollection> previousElectrons ;
-      edm::Handle<reco::GsfElectronCollection> pflowElectrons ;
-      edm::Handle<reco::GsfElectronCoreCollection> coreElectrons ;
-      edm::Handle<EcalRecHitCollection> barrelRecHits ;
-      edm::Handle<EcalRecHitCollection> endcapRecHits ;
-      edm::Handle<reco::TrackCollection> currentCtfTracks ;
-      edm::Handle<reco::ElectronSeedCollection> seeds ;
-      edm::Handle<reco::GsfPFRecTrackCollection> gsfPfRecTracks ;
-      edm::Handle<reco::VertexCollection> vertices;
-
-      // isolation helpers
-      EgammaTowerIsolation hadDepth1Isolation03, hadDepth1Isolation04 ;
-      EgammaTowerIsolation hadDepth2Isolation03, hadDepth2Isolation04 ;
-      EgammaTowerIsolation hadDepth1Isolation03Bc, hadDepth1Isolation04Bc ;
-      EgammaTowerIsolation hadDepth2Isolation03Bc, hadDepth2Isolation04Bc ;
-      EgammaRecHitIsolation ecalBarrelIsol03, ecalBarrelIsol04 ;
-      EgammaRecHitIsolation ecalEndcapIsol03, ecalEndcapIsol04 ;
-
-      //Isolation Value Maps for PF and EcalDriven electrons
-      typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsolationValueMaps;
-      IsolationValueMaps pfIsolationValues;
-      IsolationValueMaps edIsolationValues;
-
-      edm::Handle<reco::TrackCollection> originalCtfTracks ;
-      edm::Handle<reco::GsfTrackCollection> originalGsfTracks ;
-
-      bool originalCtfTrackCollectionRetreived = false ;
-      bool originalGsfTrackCollectionRetreived = false ;
-     } ;
-
     // main methods
-    void checkSetup( const edm::EventSetup & ) ;
-    EventData beginEvent( edm::Event & ) ;
-    void displayElectrons( reco::GsfElectronCollection const& electrons, edm::Event const& event, const std::string & title ) const ;
-    reco::GsfElectronCollection clonePreviousElectrons(EventData const& eventData) ;
-    void completeElectrons(reco::GsfElectronCollection & electrons, EventData & eventData, const gsfAlgoHelpers::HeavyObjectCache*) ; // do not redo cloned electrons done previously
-    void addPflowInfo(reco::GsfElectronCollection & electrons, EventData const& eventData) ; // now deprecated
-    void setAmbiguityData( reco::GsfElectronCollection & electrons, EventData const& eventData, bool ignoreNotPreselected = true ) ;
-    void removeNotPreselectedElectrons(reco::GsfElectronCollection & electrons) ;
-    void removeAmbiguousElectrons(reco::GsfElectronCollection & electrons) ;
-    void setMVAInputs(reco::GsfElectronCollection & electrons, const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaInput> & mvaInputs)  ;
-    void setMVAOutputs(reco::GsfElectronCollection & electrons,
-                       const gsfAlgoHelpers::HeavyObjectCache*,
-                       const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaOutput> & mvaOutputs,
-                       EventData const& eventData);
+    void completeElectrons( reco::GsfElectronCollection & electrons, // do not redo cloned electrons done previously
+                            edm::Event const& event,
+                            edm::EventSetup const& eventSetup,
+                            const gsfAlgoHelpers::HeavyObjectCache* hoc);
 
   private :
 
@@ -312,6 +257,51 @@ class GsfElectronAlgo {
     } ;
 
     //===================================================================
+    // GsfElectronAlgo::EventData
+    //===================================================================
+
+    struct EventData
+     {
+      // utilities
+      void retreiveOriginalTrackCollections
+       ( const reco::TrackRef &, const reco::GsfTrackRef & ) ;
+
+      // general
+      edm::Event const* event ;
+      const reco::BeamSpot * beamspot ;
+
+      // input collections
+      edm::Handle<reco::GsfElectronCollection> previousElectrons ;
+      edm::Handle<reco::GsfElectronCollection> pflowElectrons ;
+      edm::Handle<reco::GsfElectronCoreCollection> coreElectrons ;
+      edm::Handle<EcalRecHitCollection> barrelRecHits ;
+      edm::Handle<EcalRecHitCollection> endcapRecHits ;
+      edm::Handle<reco::TrackCollection> currentCtfTracks ;
+      edm::Handle<reco::ElectronSeedCollection> seeds ;
+      edm::Handle<reco::GsfPFRecTrackCollection> gsfPfRecTracks ;
+      edm::Handle<reco::VertexCollection> vertices;
+
+      // isolation helpers
+      EgammaTowerIsolation hadDepth1Isolation03, hadDepth1Isolation04 ;
+      EgammaTowerIsolation hadDepth2Isolation03, hadDepth2Isolation04 ;
+      EgammaTowerIsolation hadDepth1Isolation03Bc, hadDepth1Isolation04Bc ;
+      EgammaTowerIsolation hadDepth2Isolation03Bc, hadDepth2Isolation04Bc ;
+      EgammaRecHitIsolation ecalBarrelIsol03, ecalBarrelIsol04 ;
+      EgammaRecHitIsolation ecalEndcapIsol03, ecalEndcapIsol04 ;
+
+      //Isolation Value Maps for PF and EcalDriven electrons
+      typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsolationValueMaps;
+      IsolationValueMaps pfIsolationValues;
+      IsolationValueMaps edIsolationValues;
+
+      edm::Handle<reco::TrackCollection> originalCtfTracks ;
+      edm::Handle<reco::GsfTrackCollection> originalGsfTracks ;
+
+      bool originalCtfTrackCollectionRetreived = false ;
+      bool originalGsfTrackCollectionRetreived = false ;
+     } ;
+
+    //===================================================================
     // GsfElectronAlgo::ElectronData
     //===================================================================
 
@@ -358,12 +348,13 @@ class GsfElectronAlgo {
     EleTkIsolFromCands tkIsol03Calc_;
     EleTkIsolFromCands tkIsol04Calc_;
 
+    void checkSetup( edm::EventSetup const& eventSetup ) ;
+    EventData beginEvent( edm::Event const& event ) ;
+
     void createElectron(reco::GsfElectronCollection & electrons, ElectronData & electronData, EventData & eventData, const gsfAlgoHelpers::HeavyObjectCache*) ;
 
     void setMVAepiBasedPreselectionFlag(reco::GsfElectron & ele);
     void setCutBasedPreselectionFlag( reco::GsfElectron & ele, const reco::BeamSpot & ) ;
-    void setPflowPreselectionFlag( reco::GsfElectron & ele ) ;
-    bool isPreselected( reco::GsfElectron const& ele ) ;
 
     template<bool full5x5>
     void calculateShowerShape( const reco::SuperClusterRef &,

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -198,21 +198,66 @@ class GsfElectronAlgo {
       
       ) ;
 
+    //===================================================================
+    // GsfElectronAlgo::EventData
+    //===================================================================
+
+    struct EventData
+     {
+      // utilities
+      void retreiveOriginalTrackCollections
+       ( const reco::TrackRef &, const reco::GsfTrackRef & ) ;
+
+      // general
+      edm::Event * event ;
+      const reco::BeamSpot * beamspot ;
+
+      // input collections
+      edm::Handle<reco::GsfElectronCollection> previousElectrons ;
+      edm::Handle<reco::GsfElectronCollection> pflowElectrons ;
+      edm::Handle<reco::GsfElectronCoreCollection> coreElectrons ;
+      edm::Handle<EcalRecHitCollection> barrelRecHits ;
+      edm::Handle<EcalRecHitCollection> endcapRecHits ;
+      edm::Handle<reco::TrackCollection> currentCtfTracks ;
+      edm::Handle<reco::ElectronSeedCollection> seeds ;
+      edm::Handle<reco::GsfPFRecTrackCollection> gsfPfRecTracks ;
+      edm::Handle<reco::VertexCollection> vertices;
+
+      // isolation helpers
+      EgammaTowerIsolation hadDepth1Isolation03, hadDepth1Isolation04 ;
+      EgammaTowerIsolation hadDepth2Isolation03, hadDepth2Isolation04 ;
+      EgammaTowerIsolation hadDepth1Isolation03Bc, hadDepth1Isolation04Bc ;
+      EgammaTowerIsolation hadDepth2Isolation03Bc, hadDepth2Isolation04Bc ;
+      EgammaRecHitIsolation ecalBarrelIsol03, ecalBarrelIsol04 ;
+      EgammaRecHitIsolation ecalEndcapIsol03, ecalEndcapIsol04 ;
+
+      //Isolation Value Maps for PF and EcalDriven electrons
+      typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsolationValueMaps;
+      IsolationValueMaps pfIsolationValues;
+      IsolationValueMaps edIsolationValues;
+
+      edm::Handle<reco::TrackCollection> originalCtfTracks ;
+      edm::Handle<reco::GsfTrackCollection> originalGsfTracks ;
+
+      bool originalCtfTrackCollectionRetreived = false ;
+      bool originalGsfTrackCollectionRetreived = false ;
+     } ;
+
     // main methods
     void checkSetup( const edm::EventSetup & ) ;
-    void beginEvent( edm::Event & ) ;
-    void displayInternalElectrons( const std::string & title ) const ;
-    void clonePreviousElectrons() ;
-    void completeElectrons(const gsfAlgoHelpers::HeavyObjectCache*) ; // do not redo cloned electrons done previously
-    void addPflowInfo() ; // now deprecated
-    void setAmbiguityData( bool ignoreNotPreselected = true ) ;
-    void removeNotPreselectedElectrons() ;
-    void removeAmbiguousElectrons() ;
-    reco::GsfElectronCollection & electrons() ;
-    void setMVAInputs(const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaInput> & mvaInputs)  ;
-    void setMVAOutputs(const gsfAlgoHelpers::HeavyObjectCache*,
-                       const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaOutput> & mvaOutputs) ;
-    void endEvent() ;
+    EventData beginEvent( edm::Event & ) ;
+    void displayElectrons( reco::GsfElectronCollection const& electrons, edm::Event const& event, const std::string & title ) const ;
+    reco::GsfElectronCollection clonePreviousElectrons(EventData const& eventData) ;
+    void completeElectrons(reco::GsfElectronCollection & electrons, EventData & eventData, const gsfAlgoHelpers::HeavyObjectCache*) ; // do not redo cloned electrons done previously
+    void addPflowInfo(reco::GsfElectronCollection & electrons, EventData const& eventData) ; // now deprecated
+    void setAmbiguityData( reco::GsfElectronCollection & electrons, EventData const& eventData, bool ignoreNotPreselected = true ) ;
+    void removeNotPreselectedElectrons(reco::GsfElectronCollection & electrons) ;
+    void removeAmbiguousElectrons(reco::GsfElectronCollection & electrons) ;
+    void setMVAInputs(reco::GsfElectronCollection & electrons, const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaInput> & mvaInputs)  ;
+    void setMVAOutputs(reco::GsfElectronCollection & electrons,
+                       const gsfAlgoHelpers::HeavyObjectCache*,
+                       const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaOutput> & mvaOutputs,
+                       EventData const& eventData);
 
   private :
 
@@ -266,54 +311,6 @@ class GsfElectronAlgo {
        const MultiTrajectoryStateMode mtsMode ;
     } ;
 
-
-    //===================================================================
-    // GsfElectronAlgo::EventData
-    //===================================================================
-
-    struct EventData
-     {
-      // utilities
-      void retreiveOriginalTrackCollections
-       ( const reco::TrackRef &, const reco::GsfTrackRef & ) ;
-
-      // general
-      edm::Event * event ;
-      const reco::BeamSpot * beamspot ;
-
-      // input collections
-      edm::Handle<reco::GsfElectronCollection> previousElectrons ;
-      edm::Handle<reco::GsfElectronCollection> pflowElectrons ;
-      edm::Handle<reco::GsfElectronCoreCollection> coreElectrons ;
-      edm::Handle<EcalRecHitCollection> barrelRecHits ;
-      edm::Handle<EcalRecHitCollection> endcapRecHits ;
-      edm::Handle<reco::TrackCollection> currentCtfTracks ;
-      edm::Handle<reco::ElectronSeedCollection> seeds ;
-      edm::Handle<reco::GsfPFRecTrackCollection> gsfPfRecTracks ;
-      edm::Handle<reco::VertexCollection> vertices;
-
-      // isolation helpers
-      EgammaTowerIsolation hadDepth1Isolation03, hadDepth1Isolation04 ;
-      EgammaTowerIsolation hadDepth2Isolation03, hadDepth2Isolation04 ;
-      EgammaTowerIsolation hadDepth1Isolation03Bc, hadDepth1Isolation04Bc ;
-      EgammaTowerIsolation hadDepth2Isolation03Bc, hadDepth2Isolation04Bc ;
-      EgammaRecHitIsolation ecalBarrelIsol03, ecalBarrelIsol04 ;
-      EgammaRecHitIsolation ecalEndcapIsol03, ecalEndcapIsol04 ;
-
-      //Isolation Value Maps for PF and EcalDriven electrons
-      typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsolationValueMaps;
-      IsolationValueMaps pfIsolationValues;
-      IsolationValueMaps edIsolationValues;
-
-      edm::Handle<reco::TrackCollection> originalCtfTracks ;
-      edm::Handle<reco::GsfTrackCollection> originalGsfTracks ;
-
-      bool originalCtfTrackCollectionRetreived = false ;
-      bool originalGsfTrackCollectionRetreived = false ;
-
-      reco::GsfElectronCollection electrons ;
-     } ;
-
     //===================================================================
     // GsfElectronAlgo::ElectronData
     //===================================================================
@@ -357,13 +354,11 @@ class GsfElectronAlgo {
 
     GeneralData generalData_ ;
     EventSetupData eventSetupData_ ;
-    std::unique_ptr<EventData> eventData_ ;
-    std::unique_ptr<ElectronData> electronData_ ;
 
     EleTkIsolFromCands tkIsol03Calc_;
     EleTkIsolFromCands tkIsol04Calc_;
 
-    void createElectron(const gsfAlgoHelpers::HeavyObjectCache*) ;
+    void createElectron(reco::GsfElectronCollection & electrons, ElectronData & electronData, EventData & eventData, const gsfAlgoHelpers::HeavyObjectCache*) ;
 
     void setMVAepiBasedPreselectionFlag(reco::GsfElectron & ele);
     void setCutBasedPreselectionFlag( reco::GsfElectron & ele, const reco::BeamSpot & ) ;
@@ -371,9 +366,12 @@ class GsfElectronAlgo {
     bool isPreselected( reco::GsfElectron const& ele ) ;
 
     template<bool full5x5>
-    void calculateShowerShape( const reco::SuperClusterRef &, bool pflow, 
-                               reco::GsfElectron::ShowerShape & ) ;
-    void calculateSaturationInfo(const reco::SuperClusterRef&, reco::GsfElectron::SaturationInfo&);
+    void calculateShowerShape( const reco::SuperClusterRef &,
+                               ElectronHcalHelper const& hcalHelper,
+                               reco::GsfElectron::ShowerShape &,
+                               EventData const& eventData );
+    void calculateSaturationInfo(const reco::SuperClusterRef&, reco::GsfElectron::SaturationInfo&,
+                                 EventData const& eventData);
 
     // associations
     const reco::SuperClusterRef getTrSuperCluster( const reco::GsfTrackRef & trackRef ) ;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
@@ -132,23 +132,18 @@ void GEDGsfElectronProducer::matchWithPFCandidates(edm::Event & event)
   }
 }
 
-void GEDGsfElectronProducer::setMVAOutputs(reco::GsfElectronCollection & electrons,
-                                    const gsfAlgoHelpers::HeavyObjectCache* hoc,
-                                    const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaOutput> & mvaOutputs,
-                                    reco::VertexCollection const& vertices) const
+
+void GEDGsfElectronProducer::setMVAOutputs(reco::GsfElectronCollection& electrons,
+                                           const gsfAlgoHelpers::HeavyObjectCache* hoc,
+                                           const std::map<reco::GsfTrackRef, reco::GsfElectron::MvaOutput>& mvaOutputs,
+                                           reco::VertexCollection const& vertices) const
 {
-  for( auto el = electrons.begin() ; el != electrons.end() ; el++ ) {
-    if(strategyCfg_.gedElectronMode==true) {
-      float mva_NIso_Value=	hoc->sElectronMVAEstimator->mva( *el, vertices);
-      float mva_Iso_Value =   hoc->iElectronMVAEstimator->mva( *el, vertices.size() );
-      GsfElectron::MvaOutput mvaOutput ;
-      mvaOutput.mva_e_pi = mva_NIso_Value ;
-      mvaOutput.mva_Isolated = mva_Iso_Value ;
-      el->setMvaOutput(mvaOutput);
-    }
-    else {
-      el->setMvaOutput(mvaOutputs.find(el->gsfTrack())->second);
-    }
+  for (auto el = electrons.begin(); el != electrons.end(); el++) {
+    float mva_NIso_Value = hoc->sElectronMVAEstimator->mva(*el, vertices);
+    float mva_Iso_Value = hoc->iElectronMVAEstimator->mva(*el, vertices.size());
+    GsfElectron::MvaOutput mvaOutput;
+    mvaOutput.mva_e_pi = mva_NIso_Value;
+    mvaOutput.mva_Isolated = mva_Iso_Value;
+    el->setMvaOutput(mvaOutput);
   }
 }
-

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
@@ -40,12 +40,13 @@ GEDGsfElectronProducer::~GEDGsfElectronProducer() {}
 // ------------ method called to produce the data  ------------
 void GEDGsfElectronProducer::produce( edm::Event & event, const edm::EventSetup & setup )
  {
-  beginEvent(event,setup) ;
+  auto eventData = beginEvent(event,setup) ;
   matchWithPFCandidates(event);
-  algo_->completeElectrons(globalCache()) ;
-  algo_->setMVAOutputs(globalCache(),gsfMVAOutputMap_);
-  algo_->setMVAInputs(gsfMVAInputMap_);
-  fillEvent(event) ;
+  reco::GsfElectronCollection electrons;
+  algo_->completeElectrons(electrons, eventData, globalCache()) ;
+  algo_->setMVAOutputs(electrons, globalCache(),gsfMVAOutputMap_, eventData);
+  algo_->setMVAInputs(electrons, gsfMVAInputMap_);
+  fillEvent(electrons, eventData, event) ;
 
   // ValueMap
   auto valMap_p = std::make_unique<edm::ValueMap<reco::GsfElectronRef>>();
@@ -54,8 +55,6 @@ void GEDGsfElectronProducer::produce( edm::Event & event, const edm::EventSetup 
   valMapFiller.fill();
   event.put(std::move(valMap_p));  
   // Done with the ValueMap
-
-  endEvent() ;
  }
 
 void GEDGsfElectronProducer::fillGsfElectronValueMap(edm::Event & event, edm::ValueMap<reco::GsfElectronRef>::Filler & filler)

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.h
@@ -10,8 +10,7 @@ class GEDGsfElectronProducer : public GsfElectronBaseProducer
  {
   public:
 
-   explicit GEDGsfElectronProducer( const edm::ParameterSet &, const gsfAlgoHelpers::HeavyObjectCache* ) ;
-    ~GEDGsfElectronProducer() override ;
+    explicit GEDGsfElectronProducer( const edm::ParameterSet &, const gsfAlgoHelpers::HeavyObjectCache* ) ;
     void produce( edm::Event &, const edm::EventSetup & ) override ;
 
  private:
@@ -22,6 +21,10 @@ class GEDGsfElectronProducer : public GsfElectronBaseProducer
  private:
     void fillGsfElectronValueMap(edm::Event & event, edm::ValueMap<reco::GsfElectronRef>::Filler & filler);
     void matchWithPFCandidates(edm::Event & event);
+    void setMVAOutputs(reco::GsfElectronCollection & electrons,
+                       const gsfAlgoHelpers::HeavyObjectCache*,
+                       const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaOutput> & mvaOutputs,
+                       reco::VertexCollection const& vertices) const;
 
  } ;
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -28,20 +28,20 @@
 
 namespace {
 
-  void logElectrons( reco::GsfElectronCollection const& electrons, edm::Event const& event, const std::string & title )
-   {
+  void logElectrons(reco::GsfElectronCollection const& electrons, edm::Event const& event, const std::string& title)
+  {
     LogTrace("GsfElectronAlgo") << "========== " << title << " ==========";
     LogTrace("GsfElectronAlgo") << "Event: " << event.id();
-    LogTrace("GsfElectronAlgo") << "Number of electrons: " << electrons.size() ;
-    for(auto const& ele : electrons)
-     {
-      LogTrace("GsfElectronAlgo") << "Electron with charge, pt, eta, phi: "  << ele.charge() << " , "
-          << ele.pt() << " , " << ele.eta() << " , " << ele.phi();
-     }
+    LogTrace("GsfElectronAlgo") << "Number of electrons: " << electrons.size();
+    for (auto const& ele : electrons) {
+      LogTrace("GsfElectronAlgo") << "Electron with charge, pt, eta, phi: " << ele.charge() << " , " << ele.pt()
+                                  << " , " << ele.eta() << " , " << ele.phi();
+    }
     LogTrace("GsfElectronAlgo") << "=================================================";
-   }
+  }
 
-}
+}  // namespace
+
 
 using namespace reco;
 
@@ -426,13 +426,14 @@ void GsfElectronBaseProducer::checkEcalSeedingParameters( edm::ParameterSet cons
    { edm::LogWarning("GsfElectronAlgo|InconsistentParameters") <<"The minimum super-cluster Et in endcaps is lower than during ecal seeding." ; }
  }
 
-
 //=======================================================================================
 // Ambiguity solving
 //=======================================================================================
 
-void GsfElectronBaseProducer::setAmbiguityData( reco::GsfElectronCollection & electrons, edm::Event const& event , bool ignoreNotPreselected) const
- {
+void GsfElectronBaseProducer::setAmbiguityData(reco::GsfElectronCollection& electrons,
+                                               edm::Event const& event,
+                                               bool ignoreNotPreselected) const
+{
   // Getting required event data
   auto const& beamspot = event.get(inputCfg_.beamSpotTag);
   auto gsfPfRecTracks = strategyCfg_.useGsfPfRecTracks ? event.getHandle(inputCfg_.gsfPfRecTracksTag)
@@ -440,131 +441,112 @@ void GsfElectronBaseProducer::setAmbiguityData( reco::GsfElectronCollection & el
   auto const& barrelRecHits = event.get(inputCfg_.barrelRecHitCollection);
   auto const& endcapRecHits = event.get(inputCfg_.endcapRecHitCollection);
 
-  if (strategyCfg_.ambSortingStrategy==0) {
-    std::sort(electrons.begin(), electrons.end(), EgAmbiguityTools::isBetter) ;
+  if (strategyCfg_.ambSortingStrategy == 0) {
+    std::sort(electrons.begin(), electrons.end(), EgAmbiguityTools::isBetter);
+  } else if (strategyCfg_.ambSortingStrategy == 1) {
+    std::sort(electrons.begin(), electrons.end(), EgAmbiguityTools::isInnerMost);
+  } else {
+    throw cms::Exception("GsfElectronAlgo|UnknownAmbiguitySortingStrategy")
+        << "value of strategyCfg_.ambSortingStrategy is : " << strategyCfg_.ambSortingStrategy;
   }
-  else if (strategyCfg_.ambSortingStrategy==1) {
-    std::sort(electrons.begin(), electrons.end(), EgAmbiguityTools::isInnerMost) ;
-  }
-  else
-   { throw cms::Exception("GsfElectronAlgo|UnknownAmbiguitySortingStrategy")<<"value of strategyCfg_.ambSortingStrategy is : " << strategyCfg_.ambSortingStrategy ; }
 
   // init
-  for
-   ( auto e1 = electrons.begin() ; e1 != electrons.end() ; ++e1 )
-   {
-    e1->clearAmbiguousGsfTracks() ;
-    e1->setAmbiguous(false) ;
-   }
+  for (auto e1 = electrons.begin(); e1 != electrons.end(); ++e1) {
+    e1->clearAmbiguousGsfTracks();
+    e1->setAmbiguous(false);
+  }
 
   // get ambiguous from GsfPfRecTracks
-  if (strategyCfg_.useGsfPfRecTracks)
-   {
-    for(auto& e1 : electrons)
-     {
-      bool found = false ;
-      for(auto const& gsfPfRecTrack : *gsfPfRecTracks.product())
-       {
-        if (gsfPfRecTrack.gsfTrackRef() == e1.gsfTrack())
-         {
-          if (found)
-           {
-            edm::LogWarning("GsfElectronAlgo")<<"associated gsfPfRecTrack already found" ;
-           }
-          else
-           {
-            found = true ;
-            for(auto const& duplicate : gsfPfRecTrack.convBremGsfPFRecTrackRef()) {
-                e1.addAmbiguousGsfTrack(duplicate->gsfTrackRef()) ;
+  if (strategyCfg_.useGsfPfRecTracks) {
+    for (auto& e1 : electrons) {
+      bool found = false;
+      for (auto const& gsfPfRecTrack : *gsfPfRecTracks.product()) {
+        if (gsfPfRecTrack.gsfTrackRef() == e1.gsfTrack()) {
+          if (found) {
+            edm::LogWarning("GsfElectronAlgo") << "associated gsfPfRecTrack already found";
+          } else {
+            found = true;
+            for (auto const& duplicate : gsfPfRecTrack.convBremGsfPFRecTrackRef()) {
+              e1.addAmbiguousGsfTrack(duplicate->gsfTrackRef());
             }
-           }
-         }
-       }
-     }
-   }
+          }
+        }
+      }
+    }
+  }
   // or search overlapping clusters
-  else
-   {
-    for
-     ( auto e1 = electrons.begin() ; e1 != electrons.end() ; ++e1 )
-     {
-      if (e1->ambiguous()) continue ;
-      if ( ignoreNotPreselected && !isPreselected(*e1)) continue ;
+  else {
+    for (auto e1 = electrons.begin(); e1 != electrons.end(); ++e1) {
+      if (e1->ambiguous())
+        continue;
+      if (ignoreNotPreselected && !isPreselected(*e1))
+        continue;
 
       SuperClusterRef scRef1 = e1->superCluster();
       CaloClusterPtr eleClu1 = e1->electronCluster();
-      LogDebug("GsfElectronAlgo")
-        << "Blessing electron with E/P " << e1->eSuperClusterOverP()
-        << ", cluster " << scRef1.get()
-        << " & track " << e1->gsfTrack().get() ;
+      LogDebug("GsfElectronAlgo") << "Blessing electron with E/P " << e1->eSuperClusterOverP() << ", cluster "
+                                  << scRef1.get() << " & track " << e1->gsfTrack().get();
 
-      for
-       ( auto e2 = e1 + 1 ; e2 != electrons.end() ; ++e2 )
-       {
-        if (e2->ambiguous()) continue ;
-        if ( ignoreNotPreselected && !isPreselected(*e2)) continue ;
+      for (auto e2 = e1 + 1; e2 != electrons.end(); ++e2) {
+        if (e2->ambiguous())
+          continue;
+        if (ignoreNotPreselected && !isPreselected(*e2))
+          continue;
 
         SuperClusterRef scRef2 = e2->superCluster();
         CaloClusterPtr eleClu2 = e2->electronCluster();
 
         // search if same cluster
-        bool sameCluster = false ;
-        if (strategyCfg_.ambClustersOverlapStrategy==0)
-         { sameCluster = (scRef1==scRef2) ; }
-        else if (strategyCfg_.ambClustersOverlapStrategy==1)
-         {
-          float eMin = 1. ;
-          float threshold = eMin*cosh(EleRelPoint(scRef1->position(),beamspot.position()).eta()) ;
+        bool sameCluster = false;
+        if (strategyCfg_.ambClustersOverlapStrategy == 0) {
+          sameCluster = (scRef1 == scRef2);
+        } else if (strategyCfg_.ambClustersOverlapStrategy == 1) {
+          float eMin = 1.;
+          float threshold = eMin * cosh(EleRelPoint(scRef1->position(), beamspot.position()).eta());
           sameCluster =
-           ( (EgAmbiguityTools::sharedEnergy(*eleClu1,*eleClu2,barrelRecHits,endcapRecHits)>=threshold) ||
-             (EgAmbiguityTools::sharedEnergy(*scRef1->seed(),*eleClu2,barrelRecHits,endcapRecHits)>=threshold) ||
-             (EgAmbiguityTools::sharedEnergy(*eleClu1,*scRef2->seed(),barrelRecHits,endcapRecHits)>=threshold) ||
-             (EgAmbiguityTools::sharedEnergy(*scRef1->seed(),*scRef2->seed(),barrelRecHits,endcapRecHits)>=threshold) ) ;
-         }
-        else
-         { throw cms::Exception("GsfElectronAlgo|UnknownAmbiguityClustersOverlapStrategy")<<"value of strategyCfg_.ambClustersOverlapStrategy is : "<<strategyCfg_.ambClustersOverlapStrategy ; }
+              ((EgAmbiguityTools::sharedEnergy(*eleClu1, *eleClu2, barrelRecHits, endcapRecHits) >= threshold) ||
+               (EgAmbiguityTools::sharedEnergy(*scRef1->seed(), *eleClu2, barrelRecHits, endcapRecHits) >= threshold) ||
+               (EgAmbiguityTools::sharedEnergy(*eleClu1, *scRef2->seed(), barrelRecHits, endcapRecHits) >= threshold) ||
+               (EgAmbiguityTools::sharedEnergy(*scRef1->seed(), *scRef2->seed(), barrelRecHits, endcapRecHits) >=
+                threshold));
+        } else {
+          throw cms::Exception("GsfElectronAlgo|UnknownAmbiguityClustersOverlapStrategy")
+              << "value of strategyCfg_.ambClustersOverlapStrategy is : " << strategyCfg_.ambClustersOverlapStrategy;
+        }
 
         // main instructions
-        if (sameCluster)
-         {
-          LogDebug("GsfElectronAlgo")
-            << "Discarding electron with E/P " << e2->eSuperClusterOverP()
-            << ", cluster " << scRef2.get()
-            << " and track " << e2->gsfTrack().get() ;
-          e1->addAmbiguousGsfTrack(e2->gsfTrack()) ;
-          e2->setAmbiguous(true) ;
-         }
-        else if (e1->gsfTrack()==e2->gsfTrack())
-         {
-          edm::LogWarning("GsfElectronAlgo")
-            << "Forgetting electron with E/P " << e2->eSuperClusterOverP()
-            << ", cluster " << scRef2.get()
-            << " and track " << e2->gsfTrack().get() ;
-          e2->setAmbiguous(true) ;
-         }
-       }
-     }
-   }
- }
+        if (sameCluster) {
+          LogDebug("GsfElectronAlgo") << "Discarding electron with E/P " << e2->eSuperClusterOverP() << ", cluster "
+                                      << scRef2.get() << " and track " << e2->gsfTrack().get();
+          e1->addAmbiguousGsfTrack(e2->gsfTrack());
+          e2->setAmbiguous(true);
+        } else if (e1->gsfTrack() == e2->gsfTrack()) {
+          edm::LogWarning("GsfElectronAlgo") << "Forgetting electron with E/P " << e2->eSuperClusterOverP()
+                                             << ", cluster " << scRef2.get() << " and track " << e2->gsfTrack().get();
+          e2->setAmbiguous(true);
+        }
+      }
+    }
+  }
+}
 
 
-bool GsfElectronBaseProducer::isPreselected( GsfElectron const& ele ) const
+bool GsfElectronBaseProducer::isPreselected(GsfElectron const& ele) const
 {
-  bool passCutBased=ele.passingCutBasedPreselection();
-  bool passPF  = ele.passingPflowPreselection();
+  bool passCutBased = ele.passingCutBasedPreselection();
+  bool passPF = ele.passingPflowPreselection();
   // it is worth nothing for gedGsfElectrons, this does nothing as its not set
   // till GedGsfElectron finaliser, this is always false
-  if(strategyCfg_.gedElectronMode) {
-    bool passmva=ele.passingMvaPreselection();
-    if(!ele.ecalDrivenSeed()) {
-      if(ele.pt() > strategyCfg_.MaxElePtForOnlyMVA)
+  if (strategyCfg_.gedElectronMode) {
+    bool passmva = ele.passingMvaPreselection();
+    if (!ele.ecalDrivenSeed()) {
+      if (ele.pt() > strategyCfg_.MaxElePtForOnlyMVA)
         return passmva && passCutBased;
       else
         return passmva;
-    }
-    else return (passCutBased || passPF || passmva);
-  }
-  else {
+    } else
+      return (passCutBased || passPF || passmva);
+  } else {
     return passCutBased || passPF;
   }
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -21,6 +21,28 @@
 #include "DataFormats/EcalRecHit/interface/EcalSeverityLevel.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
+#include "RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h"
+#include "RecoEgamma/EgammaElectronAlgos/interface/ElectronUtilities.h"
+#include "DataFormats/ParticleFlowReco/interface/GsfPFRecTrack.h"
+
+
+namespace {
+
+  void logElectrons( reco::GsfElectronCollection const& electrons, edm::Event const& event, const std::string & title )
+   {
+    LogTrace("GsfElectronAlgo") << "========== " << title << " ==========";
+    LogTrace("GsfElectronAlgo") << "Event: " << event.id();
+    LogTrace("GsfElectronAlgo") << "Number of electrons: " << electrons.size() ;
+    for(auto const& ele : electrons)
+     {
+      LogTrace("GsfElectronAlgo") << "Electron with charge, pt, eta, phi: "  << ele.charge() << " , "
+          << ele.pt() << " , " << ele.eta() << " , " << ele.phi();
+     }
+    LogTrace("GsfElectronAlgo") << "=================================================";
+   }
+
+}
+
 using namespace reco;
 
 void GsfElectronBaseProducer::fillDescriptions( edm::ConfigurationDescriptions & descriptions )
@@ -338,7 +360,7 @@ GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg, 
 
 GsfElectronBaseProducer::~GsfElectronBaseProducer() { delete algo_ ; }
 
-GsfElectronAlgo::EventData GsfElectronBaseProducer::beginEvent( edm::Event & event, const edm::EventSetup & setup )
+void GsfElectronBaseProducer::beginEvent( edm::Event & event, const edm::EventSetup & setup )
  {
   // check configuration
   if (!ecalSeedingParametersChecked_)
@@ -357,28 +379,26 @@ GsfElectronAlgo::EventData GsfElectronBaseProducer::beginEvent( edm::Event & eve
       checkEcalSeedingParameters(edm::parameterSet(*seeds.provenance())) ;
      }
    }
-
-  // init the algo
-  algo_->checkSetup(setup) ;
-  return algo_->beginEvent(event) ;
  }
 
-void GsfElectronBaseProducer::fillEvent( reco::GsfElectronCollection & electrons, GsfElectronAlgo::EventData const& eventData, edm::Event & event )
+void GsfElectronBaseProducer::fillEvent( reco::GsfElectronCollection & electrons, edm::Event & event )
  {
   // all electrons
-  algo_->displayElectrons(electrons, event, "GsfElectronAlgo Info (before preselection)") ;
+  logElectrons(electrons, event, "GsfElectronAlgo Info (before preselection)") ;
   // preselection
   if (strategyCfg_.applyPreselection)
    {
-    algo_->removeNotPreselectedElectrons(electrons) ;
-    algo_->displayElectrons(electrons, event, "GsfElectronAlgo Info (after preselection)") ;
+    electrons.erase( std::remove_if(electrons.begin(), electrons.end(),
+                     [this](auto const& ele){ return !isPreselected(ele); }), electrons.end() );
+    logElectrons(electrons, event, "GsfElectronAlgo Info (after preselection)") ;
    }
   // ambiguity
-  algo_->setAmbiguityData(electrons,eventData) ;
+  setAmbiguityData(electrons,event) ;
   if (strategyCfg_.applyAmbResolution)
    {
-    algo_->removeAmbiguousElectrons(electrons) ;
-    algo_->displayElectrons(electrons, event, "GsfElectronAlgo Info (after amb. solving)") ;
+    electrons.erase( std::remove_if(electrons.begin(), electrons.end(),
+                     std::mem_fn(&reco::GsfElectron::ambiguous)), electrons.end() );
+    logElectrons(electrons, event, "GsfElectronAlgo Info (after amb. solving)") ;
    }
   // final filling
   orphanHandle_ = event.emplace(electronPutToken_, std::move(electrons));
@@ -405,3 +425,148 @@ void GsfElectronBaseProducer::checkEcalSeedingParameters( edm::ParameterSet cons
   if (cutsCfg_.minSCEtEndcaps<seedConfiguration.getParameter<double>("SCEtCut"))
    { edm::LogWarning("GsfElectronAlgo|InconsistentParameters") <<"The minimum super-cluster Et in endcaps is lower than during ecal seeding." ; }
  }
+
+
+//=======================================================================================
+// Ambiguity solving
+//=======================================================================================
+
+void GsfElectronBaseProducer::setAmbiguityData( reco::GsfElectronCollection & electrons, edm::Event const& event , bool ignoreNotPreselected) const
+ {
+  // Getting required event data
+  auto const& beamspot = event.get(inputCfg_.beamSpotTag);
+  auto gsfPfRecTracks = strategyCfg_.useGsfPfRecTracks ? event.getHandle(inputCfg_.gsfPfRecTracksTag)
+                                                       : edm::Handle<reco::GsfPFRecTrackCollection>{};
+  auto const& barrelRecHits = event.get(inputCfg_.barrelRecHitCollection);
+  auto const& endcapRecHits = event.get(inputCfg_.endcapRecHitCollection);
+
+  if (strategyCfg_.ambSortingStrategy==0) {
+    std::sort(electrons.begin(), electrons.end(), EgAmbiguityTools::isBetter) ;
+  }
+  else if (strategyCfg_.ambSortingStrategy==1) {
+    std::sort(electrons.begin(), electrons.end(), EgAmbiguityTools::isInnerMost) ;
+  }
+  else
+   { throw cms::Exception("GsfElectronAlgo|UnknownAmbiguitySortingStrategy")<<"value of strategyCfg_.ambSortingStrategy is : " << strategyCfg_.ambSortingStrategy ; }
+
+  // init
+  for
+   ( auto e1 = electrons.begin() ; e1 != electrons.end() ; ++e1 )
+   {
+    e1->clearAmbiguousGsfTracks() ;
+    e1->setAmbiguous(false) ;
+   }
+
+  // get ambiguous from GsfPfRecTracks
+  if (strategyCfg_.useGsfPfRecTracks)
+   {
+    for(auto& e1 : electrons)
+     {
+      bool found = false ;
+      for(auto const& gsfPfRecTrack : *gsfPfRecTracks.product())
+       {
+        if (gsfPfRecTrack.gsfTrackRef() == e1.gsfTrack())
+         {
+          if (found)
+           {
+            edm::LogWarning("GsfElectronAlgo")<<"associated gsfPfRecTrack already found" ;
+           }
+          else
+           {
+            found = true ;
+            for(auto const& duplicate : gsfPfRecTrack.convBremGsfPFRecTrackRef()) {
+                e1.addAmbiguousGsfTrack(duplicate->gsfTrackRef()) ;
+            }
+           }
+         }
+       }
+     }
+   }
+  // or search overlapping clusters
+  else
+   {
+    for
+     ( auto e1 = electrons.begin() ; e1 != electrons.end() ; ++e1 )
+     {
+      if (e1->ambiguous()) continue ;
+      if ( ignoreNotPreselected && !isPreselected(*e1)) continue ;
+
+      SuperClusterRef scRef1 = e1->superCluster();
+      CaloClusterPtr eleClu1 = e1->electronCluster();
+      LogDebug("GsfElectronAlgo")
+        << "Blessing electron with E/P " << e1->eSuperClusterOverP()
+        << ", cluster " << scRef1.get()
+        << " & track " << e1->gsfTrack().get() ;
+
+      for
+       ( auto e2 = e1 + 1 ; e2 != electrons.end() ; ++e2 )
+       {
+        if (e2->ambiguous()) continue ;
+        if ( ignoreNotPreselected && !isPreselected(*e2)) continue ;
+
+        SuperClusterRef scRef2 = e2->superCluster();
+        CaloClusterPtr eleClu2 = e2->electronCluster();
+
+        // search if same cluster
+        bool sameCluster = false ;
+        if (strategyCfg_.ambClustersOverlapStrategy==0)
+         { sameCluster = (scRef1==scRef2) ; }
+        else if (strategyCfg_.ambClustersOverlapStrategy==1)
+         {
+          float eMin = 1. ;
+          float threshold = eMin*cosh(EleRelPoint(scRef1->position(),beamspot.position()).eta()) ;
+          sameCluster =
+           ( (EgAmbiguityTools::sharedEnergy(*eleClu1,*eleClu2,barrelRecHits,endcapRecHits)>=threshold) ||
+             (EgAmbiguityTools::sharedEnergy(*scRef1->seed(),*eleClu2,barrelRecHits,endcapRecHits)>=threshold) ||
+             (EgAmbiguityTools::sharedEnergy(*eleClu1,*scRef2->seed(),barrelRecHits,endcapRecHits)>=threshold) ||
+             (EgAmbiguityTools::sharedEnergy(*scRef1->seed(),*scRef2->seed(),barrelRecHits,endcapRecHits)>=threshold) ) ;
+         }
+        else
+         { throw cms::Exception("GsfElectronAlgo|UnknownAmbiguityClustersOverlapStrategy")<<"value of strategyCfg_.ambClustersOverlapStrategy is : "<<strategyCfg_.ambClustersOverlapStrategy ; }
+
+        // main instructions
+        if (sameCluster)
+         {
+          LogDebug("GsfElectronAlgo")
+            << "Discarding electron with E/P " << e2->eSuperClusterOverP()
+            << ", cluster " << scRef2.get()
+            << " and track " << e2->gsfTrack().get() ;
+          e1->addAmbiguousGsfTrack(e2->gsfTrack()) ;
+          e2->setAmbiguous(true) ;
+         }
+        else if (e1->gsfTrack()==e2->gsfTrack())
+         {
+          edm::LogWarning("GsfElectronAlgo")
+            << "Forgetting electron with E/P " << e2->eSuperClusterOverP()
+            << ", cluster " << scRef2.get()
+            << " and track " << e2->gsfTrack().get() ;
+          e2->setAmbiguous(true) ;
+         }
+       }
+     }
+   }
+ }
+
+
+bool GsfElectronBaseProducer::isPreselected( GsfElectron const& ele ) const
+{
+  bool passCutBased=ele.passingCutBasedPreselection();
+  bool passPF  = ele.passingPflowPreselection();
+  // it is worth nothing for gedGsfElectrons, this does nothing as its not set
+  // till GedGsfElectron finaliser, this is always false
+  if(strategyCfg_.gedElectronMode) {
+    bool passmva=ele.passingMvaPreselection();
+    if(!ele.ecalDrivenSeed()) {
+      if(ele.pt() > strategyCfg_.MaxElePtForOnlyMVA)
+        return passmva && passCutBased;
+      else
+        return passmva;
+    }
+    else return (passCutBased || passPF || passmva);
+  }
+  else {
+    return passCutBased || passPF;
+  }
+
+  return true;
+}

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
@@ -47,8 +47,8 @@ class GsfElectronBaseProducer : public edm::stream::EDProducer< edm::GlobalCache
 
     GsfElectronAlgo * algo_ ;
 
-    GsfElectronAlgo::EventData beginEvent( edm::Event &, const edm::EventSetup & ) ;
-    void fillEvent( reco::GsfElectronCollection & electrons, GsfElectronAlgo::EventData const&, edm::Event & ) ;
+    void beginEvent( edm::Event &, const edm::EventSetup & ) ;
+    void fillEvent( reco::GsfElectronCollection & electrons, edm::Event & event ) ;
     const edm::OrphanHandle<reco::GsfElectronCollection> & orphanHandle() const { return orphanHandle_;}
 
     // configurables
@@ -63,6 +63,9 @@ class GsfElectronBaseProducer : public edm::stream::EDProducer< edm::GlobalCache
     edm::EDGetTokenT<edm::ValueMap<float>> pfMVA_;
 
   private :
+
+    bool isPreselected( reco::GsfElectron const& ele ) const ;
+    void setAmbiguityData( reco::GsfElectronCollection & electrons, edm::Event const& event, bool ignoreNotPreselected = true ) const ;
 
     // check expected configuration of previous modules
     bool ecalSeedingParametersChecked_ ;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
@@ -47,9 +47,8 @@ class GsfElectronBaseProducer : public edm::stream::EDProducer< edm::GlobalCache
 
     GsfElectronAlgo * algo_ ;
 
-    void beginEvent( edm::Event &, const edm::EventSetup & ) ;
-    void fillEvent( edm::Event & ) ;
-    void endEvent() ;
+    GsfElectronAlgo::EventData beginEvent( edm::Event &, const edm::EventSetup & ) ;
+    void fillEvent( reco::GsfElectronCollection & electrons, GsfElectronAlgo::EventData const&, edm::Event & ) ;
     const edm::OrphanHandle<reco::GsfElectronCollection> & orphanHandle() const { return orphanHandle_;}
 
     // configurables

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronEcalDrivenProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronEcalDrivenProducer.cc
@@ -31,8 +31,7 @@ GsfElectronEcalDrivenProducer::~GsfElectronEcalDrivenProducer()
 // ------------ method called to produce the data  ------------
 void GsfElectronEcalDrivenProducer::produce( edm::Event & event, const edm::EventSetup & setup )
  {
-  auto eventData = beginEvent(event,setup) ;
   reco::GsfElectronCollection electrons;
-  algo_->completeElectrons(electrons, eventData, globalCache()) ;
-  fillEvent(electrons, eventData, event) ;
+  algo_->completeElectrons(electrons, event, setup, globalCache()) ;
+  fillEvent(electrons, event) ;
  }

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronEcalDrivenProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronEcalDrivenProducer.cc
@@ -31,8 +31,8 @@ GsfElectronEcalDrivenProducer::~GsfElectronEcalDrivenProducer()
 // ------------ method called to produce the data  ------------
 void GsfElectronEcalDrivenProducer::produce( edm::Event & event, const edm::EventSetup & setup )
  {
-  beginEvent(event,setup) ;
-  algo_->completeElectrons(globalCache()) ;
-  fillEvent(event) ;
-  endEvent() ;
+  auto eventData = beginEvent(event,setup) ;
+  reco::GsfElectronCollection electrons;
+  algo_->completeElectrons(electrons, eventData, globalCache()) ;
+  fillEvent(electrons, eventData, event) ;
  }

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -27,21 +27,44 @@ GsfElectronProducer::GsfElectronProducer( const edm::ParameterSet & cfg, const g
   : GsfElectronBaseProducer(cfg,hoc), pfTranslatorParametersChecked_(false)
  {}
 
-GsfElectronProducer::~GsfElectronProducer()
- {}
+
+reco::GsfElectronCollection GsfElectronProducer::clonePreviousElectrons(edm::Event const& event) const
+{
+  reco::GsfElectronCollection electrons;
+
+  auto coreElectrons = event.getHandle(inputCfg_.gsfElectronCores);
+  const GsfElectronCoreCollection * newCores = coreElectrons.product() ;
+
+  for( auto const& oldElectron : event.get(inputCfg_.previousGsfElectrons))
+   {
+    const GsfElectronCoreRef oldCoreRef = oldElectron.core() ;
+    const GsfTrackRef oldElectronGsfTrackRef = oldCoreRef->gsfTrack() ;
+    unsigned int icore ;
+    for ( icore=0 ; icore<newCores->size() ; ++icore )
+     {
+      if (oldElectronGsfTrackRef==(*newCores)[icore].gsfTrack())
+       {
+        const GsfElectronCoreRef coreRef = edm::Ref<GsfElectronCoreCollection>(coreElectrons,icore) ;
+        electrons.emplace_back(oldElectron,coreRef) ;
+        break ;
+       }
+     }
+   }
+  return electrons;
+}
+
 
 void GsfElectronProducer::produce( edm::Event & event, const edm::EventSetup & setup )
  {
-  auto eventData = beginEvent(event,setup) ;
-  auto electrons = algo_->clonePreviousElectrons(eventData) ;
+  auto electrons = clonePreviousElectrons(event) ;
   // don't add pflow only electrons if one so wish
   if (strategyCfg_.addPflowElectrons)
-    { algo_->completeElectrons(electrons, eventData, globalCache()) ; }
-  algo_->addPflowInfo(electrons, eventData) ;
-  fillEvent(electrons, eventData, event) ;
+    { algo_->completeElectrons(electrons, event, setup, globalCache()) ; }
+  addPflowInfo(electrons, event) ;
+  fillEvent(electrons, event) ;
  }
 
-GsfElectronAlgo::EventData GsfElectronProducer::beginEvent( edm::Event & event, const edm::EventSetup & setup )
+void GsfElectronProducer::beginEvent( edm::Event & event, const edm::EventSetup & setup )
  {
   // extra configuration checks
   if (!pfTranslatorParametersChecked_)
@@ -90,3 +113,138 @@ void GsfElectronProducer::checkPfTranslatorParameters( edm::ParameterSet const &
      }
    }
  }
+
+
+// now deprecated
+void GsfElectronProducer::addPflowInfo(reco::GsfElectronCollection & electrons, edm::Event const& event) const
+{
+  //Isolation Value Maps for PF and EcalDriven electrons
+  typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsolationValueMaps;
+  IsolationValueMaps pfIsolationValues;
+  IsolationValueMaps edIsolationValues;
+
+  //Fill in the Isolation Value Maps for PF and EcalDriven electrons
+  std::vector<edm::InputTag> inputTagIsoVals;
+  if(! inputCfg_.pfIsoVals.empty() ) {
+    inputTagIsoVals.push_back(inputCfg_.pfIsoVals.getParameter<edm::InputTag>("pfSumChargedHadronPt"));
+    inputTagIsoVals.push_back(inputCfg_.pfIsoVals.getParameter<edm::InputTag>("pfSumPhotonEt"));
+    inputTagIsoVals.push_back(inputCfg_.pfIsoVals.getParameter<edm::InputTag>("pfSumNeutralHadronEt"));
+
+    pfIsolationValues.resize(inputTagIsoVals.size());
+
+    for (size_t j = 0; j<inputTagIsoVals.size(); ++j) {
+      event.getByLabel(inputTagIsoVals[j], pfIsolationValues[j]);
+    }
+
+  }
+
+  if(! inputCfg_.edIsoVals.empty() ) {
+    inputTagIsoVals.clear();
+    inputTagIsoVals.push_back(inputCfg_.edIsoVals.getParameter<edm::InputTag>("edSumChargedHadronPt"));
+    inputTagIsoVals.push_back(inputCfg_.edIsoVals.getParameter<edm::InputTag>("edSumPhotonEt"));
+    inputTagIsoVals.push_back(inputCfg_.edIsoVals.getParameter<edm::InputTag>("edSumNeutralHadronEt"));
+
+    edIsolationValues.resize(inputTagIsoVals.size());
+
+    for (size_t j = 0; j<inputTagIsoVals.size(); ++j) {
+      event.getByLabel(inputTagIsoVals[j], edIsolationValues[j]);
+    }
+  }
+
+  bool found ;
+  auto edElectrons = event.getHandle(inputCfg_.previousGsfElectrons);
+  auto pfElectrons = event.getHandle(inputCfg_.pflowGsfElectronsTag);
+  reco::GsfElectronCollection::const_iterator pfElectron, edElectron ;
+  unsigned int edIndex, pfIndex ;
+
+  for(auto& el : electrons)
+   {
+
+    // Retreive info from pflow electrons
+    found = false ;
+    for
+     ( pfIndex = 0, pfElectron = pfElectrons->begin() ; pfElectron != pfElectrons->end() ; pfIndex++, pfElectron++ )
+     {
+      if (pfElectron->gsfTrack() == el.gsfTrack())
+       {
+        if (found)
+         {
+          edm::LogWarning("GsfElectronProducer")<<"associated pfGsfElectron already found" ;
+         }
+        else
+         {
+          found = true ;
+
+        // Isolation Values
+        if( !(pfIsolationValues).empty() )
+        {
+          reco::GsfElectronRef pfElectronRef(pfElectrons, pfIndex);
+          reco::GsfElectron::PflowIsolationVariables isoVariables;
+          isoVariables.sumChargedHadronPt =(*(pfIsolationValues)[0])[pfElectronRef];
+          isoVariables.sumPhotonEt        =(*(pfIsolationValues)[1])[pfElectronRef];
+          isoVariables.sumNeutralHadronEt =(*(pfIsolationValues)[2])[pfElectronRef];
+          el.setPfIsolationVariables(isoVariables);
+        }
+
+          // el.setPfIsolationVariables(pfElectron->pfIsolationVariables()) ;
+          el.setMvaInput(pfElectron->mvaInput()) ;
+          el.setMvaOutput(pfElectron->mvaOutput()) ;
+          if (el.ecalDrivenSeed())
+           { el.setP4(GsfElectron::P4_PFLOW_COMBINATION,pfElectron->p4(GsfElectron::P4_PFLOW_COMBINATION),pfElectron->p4Error(GsfElectron::P4_PFLOW_COMBINATION),false) ; }
+          else
+           { el.setP4(GsfElectron::P4_PFLOW_COMBINATION,pfElectron->p4(GsfElectron::P4_PFLOW_COMBINATION),pfElectron->p4Error(GsfElectron::P4_PFLOW_COMBINATION),true) ; }
+          double noCutMin = -999999999. ;
+          if (el.mva_e_pi()<noCutMin) { throw cms::Exception("GsfElectronAlgo|UnexpectedMvaValue")<<"unexpected MVA value: "<<el.mva_e_pi() ; }
+         }
+       }
+     }
+
+   // Isolation Values
+   // Retreive not found info from ed electrons
+   if( !(edIsolationValues).empty() )
+   {
+     edIndex = 0, edElectron = edElectrons->begin() ;
+     while ((found == false)&&(edElectron != edElectrons->end()))
+     {
+        if (edElectron->gsfTrack() == el.gsfTrack())
+        {
+          found = true ;
+
+          // CONSTRUCTION D UNE REF dans le handle previousElectrons avec l'indice edIndex,
+          // puis recuperation dans la ValueMap ED
+
+          reco::GsfElectronRef edElectronRef(edElectrons, edIndex);
+          reco::GsfElectron::PflowIsolationVariables isoVariables;
+          isoVariables.sumChargedHadronPt =(*(edIsolationValues)[0])[edElectronRef];
+          isoVariables.sumPhotonEt        =(*(edIsolationValues)[1])[edElectronRef];
+          isoVariables.sumNeutralHadronEt =(*(edIsolationValues)[2])[edElectronRef];
+          el.setPfIsolationVariables(isoVariables);
+        }
+
+        edIndex++ ;
+        edElectron++ ;
+     }
+   }
+
+   // Preselection
+   setPflowPreselectionFlag(el) ;
+
+   }
+}
+
+
+void GsfElectronProducer::setPflowPreselectionFlag( GsfElectron & ele ) const
+{
+  ele.setPassMvaPreselection(false) ;
+
+  if (ele.core()->ecalDrivenSeed())
+   { if (ele.mvaOutput().mva_e_pi>=cutsCfg_.minMVA) ele.setPassMvaPreselection(true) ; }
+  else
+   { if (ele.mvaOutput().mva_e_pi>=cutsCfgPflow_.minMVA) ele.setPassMvaPreselection(true) ; }
+
+  if (ele.passingMvaPreselection())
+   { LogTrace("GsfElectronAlgo") << "Main mva criterion is satisfied" ; }
+
+  ele.setPassPflowPreselection(ele.passingMvaPreselection()) ;
+
+}

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -32,17 +32,16 @@ GsfElectronProducer::~GsfElectronProducer()
 
 void GsfElectronProducer::produce( edm::Event & event, const edm::EventSetup & setup )
  {
-  beginEvent(event,setup) ;
-  algo_->clonePreviousElectrons() ;
+  auto eventData = beginEvent(event,setup) ;
+  auto electrons = algo_->clonePreviousElectrons(eventData) ;
   // don't add pflow only electrons if one so wish
   if (strategyCfg_.addPflowElectrons)
-    { algo_->completeElectrons(globalCache()) ; }
-  algo_->addPflowInfo() ;
-  fillEvent(event) ;
-  endEvent() ;
+    { algo_->completeElectrons(electrons, eventData, globalCache()) ; }
+  algo_->addPflowInfo(electrons, eventData) ;
+  fillEvent(electrons, eventData, event) ;
  }
 
-void GsfElectronProducer::beginEvent( edm::Event & event, const edm::EventSetup & setup )
+GsfElectronAlgo::EventData GsfElectronProducer::beginEvent( edm::Event & event, const edm::EventSetup & setup )
  {
   // extra configuration checks
   if (!pfTranslatorParametersChecked_)
@@ -54,7 +53,7 @@ void GsfElectronProducer::beginEvent( edm::Event & event, const edm::EventSetup 
    }
 
   // call to base class
-  GsfElectronBaseProducer::beginEvent(event,setup) ;
+  return GsfElectronBaseProducer::beginEvent(event,setup) ;
  }
 
 void GsfElectronProducer::checkPfTranslatorParameters( edm::ParameterSet const & pset )

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.h
@@ -9,14 +9,17 @@ class GsfElectronProducer : public GsfElectronBaseProducer
   public:
 
     explicit GsfElectronProducer( const edm::ParameterSet &, const gsfAlgoHelpers::HeavyObjectCache* ) ;
-    ~GsfElectronProducer() override;
     void produce( edm::Event &, const edm::EventSetup & ) override ;
 
   protected:
 
-    GsfElectronAlgo::EventData beginEvent( edm::Event &, const edm::EventSetup & ) ;
+    void beginEvent( edm::Event &, const edm::EventSetup & ) ;
 
   private :
+
+    reco::GsfElectronCollection clonePreviousElectrons(edm::Event const& event) const ;
+    void addPflowInfo(reco::GsfElectronCollection & electrons, edm::Event const& event) const ; // now deprecated
+    void setPflowPreselectionFlag( reco::GsfElectron & ele ) const;
 
     // check expected configuration of previous modules
     bool pfTranslatorParametersChecked_ ;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.h
@@ -14,7 +14,7 @@ class GsfElectronProducer : public GsfElectronBaseProducer
 
   protected:
 
-    void beginEvent( edm::Event &, const edm::EventSetup & ) ;
+    GsfElectronAlgo::EventData beginEvent( edm::Event &, const edm::EventSetup & ) ;
 
   private :
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronProducer.cc
@@ -18,10 +18,10 @@ LowPtGsfElectronProducer::~LowPtGsfElectronProducer()
 
 void LowPtGsfElectronProducer::produce( edm::Event& event, const edm::EventSetup& setup )
 {
-  beginEvent(event,setup);
-  algo_->completeElectrons(globalCache());
-  fillEvent(event);
-  endEvent();
+  auto eventData = beginEvent(event,setup);
+  reco::GsfElectronCollection electrons;
+  algo_->completeElectrons(electrons, eventData, globalCache());
+  fillEvent(electrons, eventData, event);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronProducer.cc
@@ -18,10 +18,9 @@ LowPtGsfElectronProducer::~LowPtGsfElectronProducer()
 
 void LowPtGsfElectronProducer::produce( edm::Event& event, const edm::EventSetup& setup )
 {
-  auto eventData = beginEvent(event,setup);
   reco::GsfElectronCollection electrons;
-  algo_->completeElectrons(electrons, eventData, globalCache());
-  fillEvent(electrons, eventData, event);
+  algo_->completeElectrons(electrons, event, setup, globalCache());
+  fillEvent(electrons, event);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Continue the campaign of making lifetimes and ownerships of objects in the GsfElectronAlgo more restrictive such that the GsfElectronBaseProducer and derived classes are easier to grasp and factorize.

* more appropriate lifetime for EventData and ElectronData objects, therefore no `endEvent` functions necessary anymore
* move member functions which are only used by one of the derived producers to this exact producer. 
* move remaining functions from GsfElectronAlgo which are not used for it's "main function" (`completeElectrons`) to the GsfElectronBaseProducer.

Local matrix tests pass, no changes expected.