### PR TITLE
Another pybind11 fix for setting argv correctly in python session from cmsRun

### DIFF
--- a/FWCore/PyDevParameterSet/src/PyBind11Wrapper.h
+++ b/FWCore/PyDevParameterSet/src/PyBind11Wrapper.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #include <iostream>
 
 namespace edm {
@@ -15,10 +16,7 @@ void
 
   template<typename T>
     pybind11::list toPython11List(const std::vector<T> & v) {
-    pybind11::list result;
-    for(const auto & i: v) {
-       result.append(i);
-    }
+    pybind11::list result=pybind11::cast(v);
     return result;
   }
 


### PR DESCRIPTION
As I don't find a way to set the types correctly otherwise, the code for parsing and setting argv for the embedded python session is now done in a python2 vs 3 dependent way. 

This should resolve failing unit tests in the DEVEL build. (I didn't test the python3 version fully yet)
