### PR TITLE
Add alias for PixelFEDChannelCollection.

### DIFF
--- a/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
+++ b/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
@@ -56,3 +56,13 @@ fastSim.toModify(simSiStripDigis, mix = None)
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(simCastorDigis, mix = None)
+
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(
+    simSiPixelDigis,
+    mix = cms.VPSet(
+        cms.PSet(type = cms.string('PixelDigiedmDetSetVector')),
+        cms.PSet(type = cms.string('PixelDigiSimLinkedmDetSetVector')),
+        cms.PSet(type = cms.string('PixelFEDChanneledmNewDetSetVector'))
+        )
+    )

--- a/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
+++ b/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
@@ -22,12 +22,13 @@ simHcalUnsuppressedDigis = cms.EDAlias()
 #)
 simHGCalUnsuppressedDigis = cms.EDAlias()
 simHFNoseUnsuppressedDigis = cms.EDAlias()
-simSiPixelDigis = cms.EDAlias(
-    mix = cms.VPSet(
-      cms.PSet(type = cms.string('PixelDigiedmDetSetVector')),
-      cms.PSet(type = cms.string('PixelDigiSimLinkedmDetSetVector'))
-    )
+_pixelCommon = cms.VPSet(
+    cms.PSet(type = cms.string('PixelDigiedmDetSetVector')),
+    cms.PSet(type = cms.string('PixelDigiSimLinkedmDetSetVector'))
 )
+simSiPixelDigis = cms.EDAlias(
+    mix = _pixelCommon + [cms.PSet(type = cms.string('PixelFEDChanneledmNewDetSetVector'))]
+) 
 simSiStripDigis = cms.EDAlias(
     mix = cms.VPSet(
       cms.PSet(type = cms.string('SiStripDigiedmDetSetVector')),
@@ -48,21 +49,14 @@ genPUProtons = cms.EDAlias(
     )
 )
 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(simCastorDigis, mix = None)
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(simSiPixelDigis, mix = _pixelCommon) 
+
 # no castor,pixel,strip digis in fastsim
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(simCastorDigis, mix = None)
 fastSim.toModify(simSiPixelDigis, mix = None)
 fastSim.toModify(simSiStripDigis, mix = None)
-
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(simCastorDigis, mix = None)
-
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(
-    simSiPixelDigis,
-    mix = cms.VPSet(
-        cms.PSet(type = cms.string('PixelDigiedmDetSetVector')),
-        cms.PSet(type = cms.string('PixelDigiSimLinkedmDetSetVector')),
-        cms.PSet(type = cms.string('PixelFEDChanneledmNewDetSetVector'))
-        )
-    )

--- a/SimGeneral/MixingModule/python/aliases_cfi.py
+++ b/SimGeneral/MixingModule/python/aliases_cfi.py
@@ -87,3 +87,13 @@ from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
 (~phase2_hfnose).toModify(simHFNoseUnsuppressedDigis, mix = None)
+
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(
+    simSiPixelDigis,
+    mix = cms.VPSet(
+        cms.PSet(type = cms.string('PixelDigiedmDetSetVector')),
+        cms.PSet(type = cms.string('PixelDigiSimLinkedmDetSetVector')),
+        cms.PSet(type = cms.string('PixelFEDChanneledmNewDetSetVector'))
+        )
+    )

--- a/SimGeneral/MixingModule/python/aliases_cfi.py
+++ b/SimGeneral/MixingModule/python/aliases_cfi.py
@@ -22,12 +22,13 @@ simHcalUnsuppressedDigis = cms.EDAlias(
       cms.PSet(type = cms.string('QIE11DataFrameHcalDataFrameContainer'))
     )
 )
-simSiPixelDigis = cms.EDAlias(
-    mix = cms.VPSet(
-      cms.PSet(type = cms.string('PixelDigiedmDetSetVector')),
-      cms.PSet(type = cms.string('PixelDigiSimLinkedmDetSetVector'))
-    )
+_pixelCommon = cms.VPSet(
+    cms.PSet(type = cms.string('PixelDigiedmDetSetVector')),
+    cms.PSet(type = cms.string('PixelDigiSimLinkedmDetSetVector'))
 )
+simSiPixelDigis = cms.EDAlias(
+    mix = _pixelCommon + [cms.PSet(type = cms.string('PixelFEDChanneledmNewDetSetVector'))]
+) 
 simSiStripDigis = cms.EDAlias(
     mix = cms.VPSet(
       cms.PSet(type = cms.string('SiStripDigiedmDetSetVector')),
@@ -64,12 +65,6 @@ simHFNoseUnsuppressedDigis = cms.EDAlias(
     )
 )
 
-# no castor,pixel,strip digis in fastsim
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(simCastorDigis, mix = None)
-fastSim.toModify(simSiPixelDigis, mix = None)
-fastSim.toModify(simSiStripDigis, mix = None)
-
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(simCastorDigis, mix = None)
 
@@ -88,12 +83,11 @@ from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
 (~phase2_hfnose).toModify(simHFNoseUnsuppressedDigis, mix = None)
 
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(
-    simSiPixelDigis,
-    mix = cms.VPSet(
-        cms.PSet(type = cms.string('PixelDigiedmDetSetVector')),
-        cms.PSet(type = cms.string('PixelDigiSimLinkedmDetSetVector')),
-        cms.PSet(type = cms.string('PixelFEDChanneledmNewDetSetVector'))
-        )
-    )
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(simSiPixelDigis, mix = _pixelCommon) 
+
+# no castor,pixel,strip digis in fastsim
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toModify(simCastorDigis, mix = None)
+fastSim.toModify(simSiPixelDigis, mix = None)
+fastSim.toModify(simSiStripDigis, mix = None)

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -115,11 +115,9 @@ namespace cms
         "which is not present in the configuration file.  You must add the service\n"
         "in the configuration file or remove the modules that require it.";
     }
-
+    
     _pixeldigialgo.reset(new SiPixelDigitizerAlgorithm(iConfig));
-    if (_pixeldigialgo->killBadFEDChannels()){
-      mixMod.produces<PixelFEDChannelCollection>();
-    }
+    mixMod.produces<PixelFEDChannelCollection>();
   }
   
   SiPixelDigitizer::~SiPixelDigitizer(){  


### PR DESCRIPTION
This PR is the follow up of the PRs: #25466 and #25748 that introduced the simulation of the StuckTBMs. In the current implementation the code does not work properly, due to the fact that the same "InputLabel" is used in DigiToRaw for two collections [DetSetVector<PixelDigi> and PixelFEDChannelCollection]. In EventFilter/SiPixelRawToDigi/python/SiPixelDigiToRaw_cfi.py "InputLabel" is set to "simSiPixelDigis" and  there is no PixelFEDChannelCollection with that label, instead PixelFEDChannelCollection has the label "mix" or "mixData". In order to fix the problem, the same label "simSiPixelDigis" is also set for PixelFEDChannelCollection in digitizer
.