### PR TITLE
Added monopole ionisation classes

### DIFF
--- a/SimG4Core/PhysicsLists/interface/CMSmplIonisation.h
+++ b/SimG4Core/PhysicsLists/interface/CMSmplIonisation.h
@@ -1,0 +1,73 @@
+//
+// -------------------------------------------------------------------
+//
+// GEANT4 Class header file
+//
+//
+// File name:     CMSmplIonisation
+//
+// Author:        Vladimir Ivanchenko copied from Geant4 10.5p01
+//
+// Creation date: 02.03.2019
+//
+// Class Description:
+//
+// This class manages the ionisation process for a magnetic monopole
+// it inherites from G4VContinuousDiscreteProcess via G4VEnergyLossProcess.
+// Magnetic charge of the monopole should be defined in the constructor of 
+// the process, unless it is assumed that it is classic Dirac monopole with 
+// the charge 67.5*eplus. The name of the particle should be "monopole".
+//
+
+// -------------------------------------------------------------------
+//
+
+#ifndef CMSmplIonisation_h
+#define CMSmplIonisation_h 1
+
+#include "G4VEnergyLossProcess.hh"
+#include "globals.hh"
+#include "G4VEmModel.hh"
+
+class G4Material;
+class G4VEmFluctuationModel;
+
+class CMSmplIonisation : public G4VEnergyLossProcess
+{
+
+public:
+
+  explicit CMSmplIonisation(G4double mCharge = 0.0, 
+                           const G4String& name = "mplIoni");
+
+  virtual ~CMSmplIonisation();
+
+  virtual G4bool IsApplicable(const G4ParticleDefinition& p) override;
+
+  virtual G4double MinPrimaryEnergy(const G4ParticleDefinition* p,
+                                    const G4Material*, G4double cut) final;
+
+  // Print out of the class parameters
+  virtual void PrintInfo() override;
+
+  // print description in html
+  virtual void ProcessDescription(std::ostream&) const override;
+
+protected:
+
+  virtual void InitialiseEnergyLossProcess(const G4ParticleDefinition*,
+                                           const G4ParticleDefinition*) override;
+
+private:
+
+  // hide assignment operator
+  CMSmplIonisation & operator=(const CMSmplIonisation &right) = delete;
+  CMSmplIonisation(const CMSmplIonisation&) = delete;
+
+  G4double    magneticCharge;
+  G4bool      isInitialised;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+#endif

--- a/SimG4Core/PhysicsLists/interface/CMSmplIonisation.h
+++ b/SimG4Core/PhysicsLists/interface/CMSmplIonisation.h
@@ -40,7 +40,7 @@ public:
   explicit CMSmplIonisation(G4double mCharge = 0.0, 
                            const G4String& name = "mplIoni");
 
-  ~CMSmplIonisation() override override;
+  ~CMSmplIonisation() override;
 
   G4bool IsApplicable(const G4ParticleDefinition& p) override;
 
@@ -56,13 +56,13 @@ public:
 protected:
 
   void InitialiseEnergyLossProcess(const G4ParticleDefinition*,
-                                           const G4ParticleDefinition*) override;
+                                   const G4ParticleDefinition*) override;
 
 private:
 
   // hide assignment operator
-  CMSmplIonisation & operator=(const CMSmplIonisation &right) = delete;
-  CMSmplIonisation(const CMSmplIonisation&) = delete;
+  CMSmplIonisation & operator=(const CMSmplIonisation &right);
+  CMSmplIonisation(const CMSmplIonisation&);
 
   G4double    magneticCharge;
   G4bool      isInitialised;

--- a/SimG4Core/PhysicsLists/interface/CMSmplIonisation.h
+++ b/SimG4Core/PhysicsLists/interface/CMSmplIonisation.h
@@ -53,16 +53,16 @@ public:
   // print description in html
   void ProcessDescription(std::ostream&) const override;
 
+  // hide assignment operator
+  CMSmplIonisation & operator=(const CMSmplIonisation &right) = delete;
+  CMSmplIonisation(const CMSmplIonisation&) = delete;
+
 protected:
 
   void InitialiseEnergyLossProcess(const G4ParticleDefinition*,
                                    const G4ParticleDefinition*) override;
 
 private:
-
-  // hide assignment operator
-  CMSmplIonisation & operator=(const CMSmplIonisation &right);
-  CMSmplIonisation(const CMSmplIonisation&);
 
   G4double    magneticCharge;
   G4bool      isInitialised;

--- a/SimG4Core/PhysicsLists/interface/CMSmplIonisation.h
+++ b/SimG4Core/PhysicsLists/interface/CMSmplIonisation.h
@@ -40,22 +40,22 @@ public:
   explicit CMSmplIonisation(G4double mCharge = 0.0, 
                            const G4String& name = "mplIoni");
 
-  virtual ~CMSmplIonisation();
+  ~CMSmplIonisation() override override;
 
-  virtual G4bool IsApplicable(const G4ParticleDefinition& p) override;
+  G4bool IsApplicable(const G4ParticleDefinition& p) override;
 
-  virtual G4double MinPrimaryEnergy(const G4ParticleDefinition* p,
+  G4double MinPrimaryEnergy(const G4ParticleDefinition* p,
                                     const G4Material*, G4double cut) final;
 
   // Print out of the class parameters
-  virtual void PrintInfo() override;
+  void PrintInfo() override;
 
   // print description in html
-  virtual void ProcessDescription(std::ostream&) const override;
+  void ProcessDescription(std::ostream&) const override;
 
 protected:
 
-  virtual void InitialiseEnergyLossProcess(const G4ParticleDefinition*,
+  void InitialiseEnergyLossProcess(const G4ParticleDefinition*,
                                            const G4ParticleDefinition*) override;
 
 private:

--- a/SimG4Core/PhysicsLists/interface/CMSmplIonisation.h
+++ b/SimG4Core/PhysicsLists/interface/CMSmplIonisation.h
@@ -53,10 +53,6 @@ public:
   // print description in html
   void ProcessDescription(std::ostream&) const override;
 
-  // hide assignment operator
-  CMSmplIonisation & operator=(const CMSmplIonisation &right) = delete;
-  CMSmplIonisation(const CMSmplIonisation&) = delete;
-
 protected:
 
   void InitialiseEnergyLossProcess(const G4ParticleDefinition*,

--- a/SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h
+++ b/SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h
@@ -80,11 +80,6 @@ public:
 
   void SetParticle(const G4ParticleDefinition* p);
 
-  // hide assignment operator
-  CMSmplIonisationWithDeltaModel & 
-    operator=(const  CMSmplIonisationWithDeltaModel &right) = delete;
-  CMSmplIonisationWithDeltaModel(const  CMSmplIonisationWithDeltaModel&) = delete;
-
 protected:
 
   G4double MaxSecondaryEnergy(const G4ParticleDefinition*,

--- a/SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h
+++ b/SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h
@@ -34,7 +34,7 @@ public:
   explicit CMSmplIonisationWithDeltaModel(G4double mCharge, 
                                 const G4String& nam = "mplIonisationWithDelta");
 
-  ~CMSmplIonisationWithDeltaModel() override override;
+  ~CMSmplIonisationWithDeltaModel() override;
 
   void Initialise(const G4ParticleDefinition*, 
                           const G4DataVector&) override;
@@ -92,8 +92,8 @@ private:
 
   // hide assignment operator
   CMSmplIonisationWithDeltaModel & 
-    operator=(const  CMSmplIonisationWithDeltaModel &right) = delete;
-  CMSmplIonisationWithDeltaModel(const  CMSmplIonisationWithDeltaModel&) = delete;
+    operator=(const  CMSmplIonisationWithDeltaModel &right);
+  CMSmplIonisationWithDeltaModel(const  CMSmplIonisationWithDeltaModel&);
 
   const G4ParticleDefinition* monopole;
   G4ParticleDefinition*       theElectron;

--- a/SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h
+++ b/SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h
@@ -1,0 +1,119 @@
+//
+// -------------------------------------------------------------------
+//
+// GEANT4 Class header file
+//
+//
+// File name:     CMSmplIonisationWithDeltaModel
+//
+// Author:        Vladimir Ivanchenko copied from Geant4 10.5p01
+//
+// Creation date: 02.03.2019
+//
+// Class Description:
+//
+// Implementation of model of energy loss of the magnetic monopole
+
+// -------------------------------------------------------------------
+//
+
+#ifndef CMSmplIonisationWithDeltaModel_h
+#define CMSmplIonisationWithDeltaModel_h 1
+
+#include "G4VEmModel.hh"
+#include "G4VEmFluctuationModel.hh"
+#include <vector>
+
+class G4ParticleChangeForLoss;
+
+class CMSmplIonisationWithDeltaModel : public G4VEmModel, public G4VEmFluctuationModel
+{
+
+public:
+
+  explicit CMSmplIonisationWithDeltaModel(G4double mCharge, 
+                                const G4String& nam = "mplIonisationWithDelta");
+
+  virtual ~CMSmplIonisationWithDeltaModel();
+
+  virtual void Initialise(const G4ParticleDefinition*, 
+                          const G4DataVector&) override;
+
+  virtual G4double ComputeDEDXPerVolume(const G4Material*,
+                                        const G4ParticleDefinition*,
+                                        G4double kineticEnergy,
+                                        G4double cutEnergy) override;
+
+  virtual G4double ComputeCrossSectionPerElectron(
+                                 const G4ParticleDefinition*,
+                                 G4double kineticEnergy,
+                                 G4double cutEnergy,
+                                 G4double maxEnergy);
+
+  virtual G4double ComputeCrossSectionPerAtom(
+                                 const G4ParticleDefinition*,
+                                 G4double kineticEnergy,
+                                 G4double Z, G4double A,
+                                 G4double cutEnergy,
+                                 G4double maxEnergy) override;
+
+  virtual void SampleSecondaries(std::vector<G4DynamicParticle*>*,
+                                 const G4MaterialCutsCouple*,
+                                 const G4DynamicParticle*,
+                                 G4double tmin,
+                                 G4double maxEnergy) override;
+
+
+  virtual G4double SampleFluctuations(const G4MaterialCutsCouple*,
+                                      const G4DynamicParticle*,
+                                      G4double tmax,
+                                      G4double length,
+                                      G4double meanLoss) override;
+
+  virtual G4double Dispersion(const G4Material*,
+                              const G4DynamicParticle*,
+                              G4double tmax,
+                              G4double length) override;
+
+  virtual G4double MinEnergyCut(const G4ParticleDefinition*,
+                                const G4MaterialCutsCouple* couple) override;
+
+  void SetParticle(const G4ParticleDefinition* p);
+
+protected:
+
+  virtual G4double MaxSecondaryEnergy(const G4ParticleDefinition*,
+                                      G4double kinEnergy) override;
+
+private:
+
+  G4double ComputeDEDXAhlen(const G4Material* material, G4double bg2, 
+                            G4double cut);
+
+  // hide assignment operator
+  CMSmplIonisationWithDeltaModel & 
+    operator=(const  CMSmplIonisationWithDeltaModel &right) = delete;
+  CMSmplIonisationWithDeltaModel(const  CMSmplIonisationWithDeltaModel&) = delete;
+
+  const G4ParticleDefinition* monopole;
+  G4ParticleDefinition*       theElectron;
+  G4ParticleChangeForLoss*    fParticleChange;
+
+  G4double mass;
+  G4double magCharge;
+  G4double twoln10;
+  G4double betalow;
+  G4double betalim;
+  G4double beta2lim;
+  G4double bg2lim;
+  G4double chargeSquare;
+  G4double dedxlim;
+  G4int    nmpl;
+  G4double pi_hbarc2_over_mc2;
+
+  static std::vector<G4double>* dedx0;
+};
+
+#endif
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....

--- a/SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h
+++ b/SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h
@@ -80,6 +80,11 @@ public:
 
   void SetParticle(const G4ParticleDefinition* p);
 
+  // hide assignment operator
+  CMSmplIonisationWithDeltaModel & 
+    operator=(const  CMSmplIonisationWithDeltaModel &right) = delete;
+  CMSmplIonisationWithDeltaModel(const  CMSmplIonisationWithDeltaModel&) = delete;
+
 protected:
 
   G4double MaxSecondaryEnergy(const G4ParticleDefinition*,
@@ -89,11 +94,6 @@ private:
 
   G4double ComputeDEDXAhlen(const G4Material* material, G4double bg2, 
                             G4double cut);
-
-  // hide assignment operator
-  CMSmplIonisationWithDeltaModel & 
-    operator=(const  CMSmplIonisationWithDeltaModel &right);
-  CMSmplIonisationWithDeltaModel(const  CMSmplIonisationWithDeltaModel&);
 
   const G4ParticleDefinition* monopole;
   G4ParticleDefinition*       theElectron;

--- a/SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h
+++ b/SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h
@@ -34,12 +34,12 @@ public:
   explicit CMSmplIonisationWithDeltaModel(G4double mCharge, 
                                 const G4String& nam = "mplIonisationWithDelta");
 
-  virtual ~CMSmplIonisationWithDeltaModel();
+  ~CMSmplIonisationWithDeltaModel() override override;
 
-  virtual void Initialise(const G4ParticleDefinition*, 
+  void Initialise(const G4ParticleDefinition*, 
                           const G4DataVector&) override;
 
-  virtual G4double ComputeDEDXPerVolume(const G4Material*,
+  G4double ComputeDEDXPerVolume(const G4Material*,
                                         const G4ParticleDefinition*,
                                         G4double kineticEnergy,
                                         G4double cutEnergy) override;
@@ -50,39 +50,39 @@ public:
                                  G4double cutEnergy,
                                  G4double maxEnergy);
 
-  virtual G4double ComputeCrossSectionPerAtom(
+  G4double ComputeCrossSectionPerAtom(
                                  const G4ParticleDefinition*,
                                  G4double kineticEnergy,
                                  G4double Z, G4double A,
                                  G4double cutEnergy,
                                  G4double maxEnergy) override;
 
-  virtual void SampleSecondaries(std::vector<G4DynamicParticle*>*,
+  void SampleSecondaries(std::vector<G4DynamicParticle*>*,
                                  const G4MaterialCutsCouple*,
                                  const G4DynamicParticle*,
                                  G4double tmin,
                                  G4double maxEnergy) override;
 
 
-  virtual G4double SampleFluctuations(const G4MaterialCutsCouple*,
+  G4double SampleFluctuations(const G4MaterialCutsCouple*,
                                       const G4DynamicParticle*,
                                       G4double tmax,
                                       G4double length,
                                       G4double meanLoss) override;
 
-  virtual G4double Dispersion(const G4Material*,
+  G4double Dispersion(const G4Material*,
                               const G4DynamicParticle*,
                               G4double tmax,
                               G4double length) override;
 
-  virtual G4double MinEnergyCut(const G4ParticleDefinition*,
+  G4double MinEnergyCut(const G4ParticleDefinition*,
                                 const G4MaterialCutsCouple* couple) override;
 
   void SetParticle(const G4ParticleDefinition* p);
 
 protected:
 
-  virtual G4double MaxSecondaryEnergy(const G4ParticleDefinition*,
+  G4double MaxSecondaryEnergy(const G4ParticleDefinition*,
                                       G4double kinEnergy) override;
 
 private:

--- a/SimG4Core/PhysicsLists/src/CMSMonopolePhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSMonopolePhysics.cc
@@ -1,13 +1,12 @@
 #include "SimG4Core/PhysicsLists/interface/CMSMonopolePhysics.h"
 #include "SimG4Core/PhysicsLists/interface/MonopoleTransportation.h"
+#include "SimG4Core/PhysicsLists/interface/CMSmplIonisation.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4ParticleDefinition.hh"
 #include "G4ProcessManager.hh"
 
 #include "G4StepLimiter.hh"
-#include "G4mplIonisation.hh"
-#include "G4mplIonisationWithDeltaModel.hh"
 #include "G4hMultipleScattering.hh"
 #include "G4hIonisation.hh"
 #include "G4hhIonisation.hh"
@@ -124,7 +123,7 @@ void CMSMonopolePhysics::ConstructProcess() {
 	ph->RegisterProcess(hioni, mpl);
       }
       if(magn != 0.0) {
-	G4mplIonisation* mplioni = new G4mplIonisation(magn);
+	CMSmplIonisation* mplioni = new CMSmplIonisation(magn);
 	ph->RegisterProcess(mplioni, mpl);
       }
       pmanager->AddDiscreteProcess(new G4StepLimiter());

--- a/SimG4Core/PhysicsLists/src/CMSmplIonisation.cc
+++ b/SimG4Core/PhysicsLists/src/CMSmplIonisation.cc
@@ -73,7 +73,7 @@ void CMSmplIonisation::InitialiseEnergyLossProcess(const G4ParticleDefinition* p
 {
   if(isInitialised) { return; }
 
-  SetBaseParticle(0);
+  SetBaseParticle(nullptr);
 
   // monopole model is responsible both for energy loss and fluctuations
   CMSmplIonisationWithDeltaModel* ion =

--- a/SimG4Core/PhysicsLists/src/CMSmplIonisation.cc
+++ b/SimG4Core/PhysicsLists/src/CMSmplIonisation.cc
@@ -1,0 +1,114 @@
+//
+// -------------------------------------------------------------------
+//
+// GEANT4 Class file
+//
+//
+// File name:     CMSmplIonisation
+//
+// Author:        Vladimir Ivanchenko copied from Geant4 10.5p01
+//
+// Creation date: 02.03.2019
+//
+//
+// -------------------------------------------------------------------
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+#include "SimG4Core/PhysicsLists/interface/CMSmplIonisation.h"
+#include "SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4Electron.hh"
+#include "G4EmParameters.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+using namespace std;
+
+CMSmplIonisation::CMSmplIonisation(G4double mCharge, const G4String& name)
+  : G4VEnergyLossProcess(name),
+    magneticCharge(mCharge),
+    isInitialised(false)
+{
+  // By default classical magnetic charge is used
+  if(magneticCharge == 0.0) { magneticCharge = eplus*0.5/fine_structure_const; }
+
+  SetVerboseLevel(0);
+  SetProcessSubType(fIonisation);
+  SetStepFunction(0.2, 1*mm);
+  SetSecondaryParticle(G4Electron::Electron());
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+CMSmplIonisation::~CMSmplIonisation()
+{}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+G4bool CMSmplIonisation::IsApplicable(const G4ParticleDefinition&)
+{
+  return true;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+G4double CMSmplIonisation::MinPrimaryEnergy(const G4ParticleDefinition* mpl,
+                                           const G4Material*,
+                                           G4double cut)
+{
+  G4double x = 0.5*cut/electron_mass_c2;
+  G4double mass  = mpl->GetPDGMass();
+  G4double ratio = electron_mass_c2/mass;
+  G4double gam   = x*ratio + std::sqrt((1. + x)*(1. + x*ratio*ratio));
+  return mass*(gam - 1.0);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+void CMSmplIonisation::InitialiseEnergyLossProcess(const G4ParticleDefinition* p,
+                                                   const G4ParticleDefinition*)
+{
+  if(isInitialised) { return; }
+
+  SetBaseParticle(0);
+
+  // monopole model is responsible both for energy loss and fluctuations
+  CMSmplIonisationWithDeltaModel* ion =
+    new CMSmplIonisationWithDeltaModel(magneticCharge,"PAI");
+  ion->SetParticle(p);
+
+  // define size of dedx and range tables
+  G4EmParameters* param = G4EmParameters::Instance();
+  G4double emin  = std::min(param->MinKinEnergy(),ion->LowEnergyLimit());
+  G4double emax  = std::max(param->MaxKinEnergy(),ion->HighEnergyLimit());
+  G4int bin = G4lrint(param->NumberOfBinsPerDecade()*std::log10(emax/emin));
+  ion->SetLowEnergyLimit(emin);
+  ion->SetHighEnergyLimit(emax);
+  SetMinKinEnergy(emin);
+  SetMaxKinEnergy(emax);
+  SetDEDXBinning(bin);
+
+  SetEmModel(ion);
+  AddEmModel(1,ion,ion);
+
+  isInitialised = true;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+void CMSmplIonisation::PrintInfo()
+{}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+void CMSmplIonisation::ProcessDescription(std::ostream& out) const
+{
+  out << "No description available." << G4endl;
+  G4VEnergyLossProcess::ProcessDescription(out);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+

--- a/SimG4Core/PhysicsLists/src/CMSmplIonisationWithDeltaModel.cc
+++ b/SimG4Core/PhysicsLists/src/CMSmplIonisationWithDeltaModel.cc
@@ -1,0 +1,352 @@
+//
+// -------------------------------------------------------------------
+//
+//
+// File name:     CMSmplIonisationWithDeltaModel
+//
+// Author:        Vladimir Ivanchenko 
+//
+// Creation date: 02.03.2019 copied from Geant4 10.5p01
+//
+//
+// -------------------------------------------------------------------
+// References
+// [1] Steven P. Ahlen: Energy loss of relativistic heavy ionizing particles, 
+//     S.P. Ahlen, Rev. Mod. Phys 52(1980), p121
+// [2] K.A. Milton arXiv:hep-ex/0602040
+// [3] S.P. Ahlen and K. Kinoshita, Phys. Rev. D26 (1982) 2347
+
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+#include "SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h"
+#include "Randomize.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4ParticleChangeForLoss.hh"
+#include "G4Electron.hh"
+#include "G4DynamicParticle.hh"
+#include "G4ProductionCutsTable.hh"
+#include "G4MaterialCutsCouple.hh"
+#include "G4Log.hh"
+#include "G4Pow.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+using namespace std;
+
+std::vector<G4double>* CMSmplIonisationWithDeltaModel::dedx0 = nullptr;
+
+CMSmplIonisationWithDeltaModel::CMSmplIonisationWithDeltaModel(G4double mCharge,
+                                                               const G4String& nam)
+  : G4VEmModel(nam),G4VEmFluctuationModel(nam),
+  magCharge(mCharge),
+  twoln10(std::log(100.0)),
+  betalow(0.01),
+  betalim(0.1),
+  beta2lim(betalim*betalim),
+  bg2lim(beta2lim*(1.0 + beta2lim))
+{
+  nmpl = G4lrint(std::abs(magCharge) * 2 * fine_structure_const);
+  if(nmpl > 6)      { nmpl = 6; }
+  else if(nmpl < 1) { nmpl = 1; }
+  pi_hbarc2_over_mc2 = pi * hbarc * hbarc / electron_mass_c2;
+  chargeSquare = magCharge * magCharge;
+  dedxlim = 45.*nmpl*nmpl*GeV*cm2/g;
+  fParticleChange = nullptr;
+  theElectron = G4Electron::Electron();
+  G4cout << "### Monopole ionisation model with d-electron production, Gmag= " 
+         << magCharge/eplus << G4endl;
+  monopole = nullptr;
+  mass = 0.0;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+CMSmplIonisationWithDeltaModel::~CMSmplIonisationWithDeltaModel()
+{
+  if(IsMaster()) { delete dedx0; }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+void CMSmplIonisationWithDeltaModel::SetParticle(const G4ParticleDefinition* p)
+{
+  monopole = p;
+  mass     = monopole->GetPDGMass();
+  G4double emin = 
+    std::min(LowEnergyLimit(),0.1*mass*(1./sqrt(1. - betalow*betalow) - 1.)); 
+  G4double emax = 
+    std::max(HighEnergyLimit(),10*mass*(1./sqrt(1. - beta2lim) - 1.)); 
+  SetLowEnergyLimit(emin);
+  SetHighEnergyLimit(emax);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+void 
+CMSmplIonisationWithDeltaModel::Initialise(const G4ParticleDefinition* p,
+                                           const G4DataVector&)
+{
+  if(!monopole) { SetParticle(p); }
+  if(!fParticleChange) { fParticleChange = GetParticleChangeForLoss(); }
+  if(IsMaster()) {
+    if(!dedx0) { dedx0 = new std::vector<G4double>; }
+    G4ProductionCutsTable* theCoupleTable=
+      G4ProductionCutsTable::GetProductionCutsTable();
+    G4int numOfCouples = theCoupleTable->GetTableSize();
+    G4int n = dedx0->size();
+    if(n < numOfCouples) { dedx0->resize(numOfCouples); }
+    G4Pow* g4calc = G4Pow::GetInstance();
+
+    // initialise vector
+    for(G4int i=0; i<numOfCouples; ++i) {
+
+      const G4Material* material = 
+        theCoupleTable->GetMaterialCutsCouple(i)->GetMaterial();
+      G4double eDensity = material->GetElectronDensity();
+      G4double vF = electron_Compton_length*g4calc->A13(3.*pi*pi*eDensity);
+      (*dedx0)[i] = pi_hbarc2_over_mc2*eDensity*nmpl*nmpl*
+        (G4Log(2*vF/fine_structure_const) - 0.5)/vF;
+    }
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+G4double 
+CMSmplIonisationWithDeltaModel::MinEnergyCut(const G4ParticleDefinition*,
+                                             const G4MaterialCutsCouple* couple)
+{
+  return couple->GetMaterial()->GetIonisation()->GetMeanExcitationEnergy();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+G4double 
+CMSmplIonisationWithDeltaModel::ComputeDEDXPerVolume(const G4Material* material,
+                                                     const G4ParticleDefinition* p,
+                                                     G4double kineticEnergy,
+                                                     G4double maxEnergy)
+{
+  if(!monopole) { SetParticle(p); }
+  G4double tmax = MaxSecondaryEnergy(p,kineticEnergy);
+  G4double cutEnergy = std::min(tmax, maxEnergy);
+  cutEnergy = std::max(LowEnergyLimit(), cutEnergy);
+  G4double tau   = kineticEnergy / mass;
+  G4double gam   = tau + 1.0;
+  G4double bg2   = tau * (tau + 2.0);
+  G4double beta2 = bg2 / (gam * gam);
+  G4double beta  = sqrt(beta2);
+
+  // low-energy asymptotic formula
+  G4double dedx = (*dedx0)[CurrentCouple()->GetIndex()]*beta;
+
+  // above asymptotic
+  if(beta > betalow) {
+
+    // high energy
+    if(beta >= betalim) {
+      dedx = ComputeDEDXAhlen(material, bg2, cutEnergy);
+
+    } else {
+      G4double dedx1 = (*dedx0)[CurrentCouple()->GetIndex()]*betalow;
+      G4double dedx2 = ComputeDEDXAhlen(material, bg2lim, cutEnergy);
+
+      // extrapolation between two formula 
+      G4double kapa2 = beta - betalow;
+      G4double kapa1 = betalim - beta;
+      dedx = (kapa1*dedx1 + kapa2*dedx2)/(kapa1 + kapa2);
+    }
+  }
+  return dedx;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+G4double 
+CMSmplIonisationWithDeltaModel::ComputeDEDXAhlen(const G4Material* material, 
+                                                 G4double bg2, 
+                                                 G4double cutEnergy)
+{
+  G4double eDensity = material->GetElectronDensity();
+  G4double eexc  = material->GetIonisation()->GetMeanExcitationEnergy();
+
+  // Ahlen's formula for nonconductors, [1]p157, f(5.7)
+  G4double dedx = 
+    0.5*(G4Log(2.0*electron_mass_c2*bg2*cutEnergy/(eexc*eexc)) -1.0);
+
+  // Kazama et al. cross-section correction
+  G4double  k = 0.406;
+  if(nmpl > 1) { k = 0.346; }
+
+  // Bloch correction
+  const G4double B[7] = { 0.0, 0.248, 0.672, 1.022, 1.243, 1.464, 1.685}; 
+
+  dedx += 0.5 * k - B[nmpl];
+
+  // density effect correction
+  G4double x = G4Log(bg2)/twoln10;
+  dedx -= material->GetIonisation()->DensityCorrection(x);
+
+  // now compute the total ionization loss
+  dedx *=  pi_hbarc2_over_mc2 * eDensity * nmpl * nmpl;
+
+  dedx = std::max(dedx, 0.0);
+  return dedx;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+G4double
+CMSmplIonisationWithDeltaModel::ComputeCrossSectionPerElectron(
+                                           const G4ParticleDefinition* p,
+                                           G4double kineticEnergy,
+                                           G4double cut,
+                                           G4double maxKinEnergy)
+{
+  if(!monopole) { SetParticle(p); }
+  G4double tmax = MaxSecondaryEnergy(p, kineticEnergy);
+  G4double maxEnergy = std::min(tmax, maxKinEnergy);
+  G4double cutEnergy = std::max(LowEnergyLimit(), cut);
+  G4double cross = (cutEnergy < maxEnergy) 
+    ? (0.5/cutEnergy - 0.5/maxEnergy)*pi_hbarc2_over_mc2 * nmpl * nmpl : 0.0;
+  return cross;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+G4double 
+CMSmplIonisationWithDeltaModel::ComputeCrossSectionPerAtom(
+                                          const G4ParticleDefinition* p,
+                                          G4double kineticEnergy,
+                                          G4double Z, G4double,
+                                          G4double cutEnergy,
+                                          G4double maxEnergy)
+{
+  G4double cross = 
+    Z*ComputeCrossSectionPerElectron(p,kineticEnergy,cutEnergy,maxEnergy);
+  return cross;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+void 
+CMSmplIonisationWithDeltaModel::SampleSecondaries(vector<G4DynamicParticle*>* vdp,
+                                                  const G4MaterialCutsCouple*,
+                                                  const G4DynamicParticle* dp,
+                                                  G4double minKinEnergy,
+                                                  G4double maxEnergy)
+{
+  G4double kineticEnergy = dp->GetKineticEnergy();
+  G4double tmax = MaxSecondaryEnergy(dp->GetDefinition(),kineticEnergy);
+
+  G4double maxKinEnergy = std::min(maxEnergy,tmax);
+  if(minKinEnergy >= maxKinEnergy) { return; }
+
+  //G4cout << "CMSmplIonisationWithDeltaModel::SampleSecondaries: E(GeV)= "
+  //         << kineticEnergy/GeV << " M(GeV)= " << mass/GeV
+  //         << " tmin(MeV)= " << minKinEnergy/MeV << G4endl;
+
+  G4double totEnergy     = kineticEnergy + mass;
+  G4double etot2         = totEnergy*totEnergy;
+  G4double beta2         = kineticEnergy*(kineticEnergy + 2.0*mass)/etot2;
+  
+  // sampling without nuclear size effect
+  G4double q = G4UniformRand();
+  G4double deltaKinEnergy = minKinEnergy*maxKinEnergy
+    /(minKinEnergy*(1.0 - q) + maxKinEnergy*q);
+
+  // delta-electron is produced
+  G4double totMomentum = totEnergy*sqrt(beta2);
+  G4double deltaMomentum =
+           sqrt(deltaKinEnergy * (deltaKinEnergy + 2.0*electron_mass_c2));
+  G4double cost = deltaKinEnergy * (totEnergy + electron_mass_c2) /
+                                   (deltaMomentum * totMomentum);
+  cost = std::min(cost, 1.0);
+
+  G4double sint = sqrt((1.0 - cost)*(1.0 + cost));
+
+  G4double phi = twopi * G4UniformRand() ;
+
+  G4ThreeVector deltaDirection(sint*cos(phi),sint*sin(phi), cost);
+  G4ThreeVector direction = dp->GetMomentumDirection();
+  deltaDirection.rotateUz(direction);
+
+  // create G4DynamicParticle object for delta ray
+  G4DynamicParticle* delta = 
+    new G4DynamicParticle(theElectron,deltaDirection,deltaKinEnergy);
+
+  vdp->push_back(delta);
+
+  // Change kinematics of primary particle
+  kineticEnergy       -= deltaKinEnergy;
+  G4ThreeVector finalP = direction*totMomentum - deltaDirection*deltaMomentum;
+  finalP               = finalP.unit();
+
+  fParticleChange->SetProposedKineticEnergy(kineticEnergy);
+  fParticleChange->SetProposedMomentumDirection(finalP);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+G4double CMSmplIonisationWithDeltaModel::SampleFluctuations(
+                                       const G4MaterialCutsCouple* couple,
+                                       const G4DynamicParticle* dp,
+                                       G4double tmax,
+                                       G4double length,
+                                       G4double meanLoss)
+{
+  G4double siga = Dispersion(couple->GetMaterial(),dp,tmax,length);
+  G4double loss = meanLoss;
+  siga = sqrt(siga);
+  G4double twomeanLoss = meanLoss + meanLoss;
+
+  if(twomeanLoss < siga) {
+    G4double x;
+    do {
+      loss = twomeanLoss*G4UniformRand();
+      x = (loss - meanLoss)/siga;
+      // Loop checking, 07-Aug-2015, Vladimir Ivanchenko
+    } while (1.0 - 0.5*x*x < G4UniformRand());
+  } else {
+    do {
+      loss = G4RandGauss::shoot(meanLoss,siga);
+      // Loop checking, 07-Aug-2015, Vladimir Ivanchenko
+    } while (0.0 > loss || loss > twomeanLoss);
+  }
+  return loss;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+G4double 
+CMSmplIonisationWithDeltaModel::Dispersion(const G4Material* material,
+                                           const G4DynamicParticle* dp,
+                                           G4double tmax,
+                                           G4double length)
+{
+  G4double siga = 0.0;
+  G4double tau   = dp->GetKineticEnergy()/mass;
+  if(tau > 0.0) { 
+    G4double electronDensity = material->GetElectronDensity();
+    G4double gam   = tau + 1.0;
+    G4double invbeta2 = (gam*gam)/(tau * (tau+2.0));
+    siga  = (invbeta2 - 0.5) * twopi_mc2_rcl2 * tmax * length
+      * electronDensity * chargeSquare;
+  }
+  return siga;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+G4double 
+CMSmplIonisationWithDeltaModel::MaxSecondaryEnergy(const G4ParticleDefinition*,
+                                                   G4double kinEnergy)
+{
+  G4double tau = kinEnergy/mass;
+  return 2.0*electron_mass_c2*tau*(tau + 2.);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....

--- a/SimG4Core/PhysicsLists/src/CMSmplIonisationWithDeltaModel.cc
+++ b/SimG4Core/PhysicsLists/src/CMSmplIonisationWithDeltaModel.cc
@@ -271,7 +271,7 @@ CMSmplIonisationWithDeltaModel::SampleSecondaries(vector<G4DynamicParticle*>* vd
   G4double phi = twopi * G4UniformRand() ;
 
   G4ThreeVector deltaDirection(sint*cos(phi),sint*sin(phi), cost);
-  G4ThreeVector direction = dp->GetMomentumDirection();
+  const G4ThreeVector& direction = dp->GetMomentumDirection();
   deltaDirection.rotateUz(direction);
 
   // create G4DynamicParticle object for delta ray


### PR DESCRIPTION
In the Geant4 model of monopole ionisation a problem was identified, which is fixed and included into Geant4 development branch. This PR is a backport of the fix, which will be further to SIM production releases. No effect on mainstream simulation is expected.