### PR TITLE
Update GT for ultra legacy : MC ECAL, GEM eMap, PF calibration

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,9 +16,9 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '105X_mcRun2_design_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '105X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '105X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '105X_mcRun2cosmics_startup_deco_v1',
+    'run2_mc_cosmics'   :   '105X_mcRun2cosmics_startup_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '103X_mcRun2_HeavyIon_v3',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
@@ -54,15 +54,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '105X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v3',
+    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v1',
+    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v4',
+    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v4',
+    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v4',
+    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '105X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase1 2019

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,7 +33,7 @@ autoCond = {
     'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v5',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v6',
-    'run2_data_promptlike_hi' : '103X_dataRun2_PromptLike_HI_v2',
+    'run2_data_promptlike_hi' : '105X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -44,31 +44,31 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v3',
+    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v4',
+    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v4',
+    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v5',
+    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '105X_upgrade2018_design_v2',
+    'phase1_2018_design'       :  '105X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v2',
+    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '103X_upgrade2018_realistic_HI_v12',
+    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v3',
+    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v3',
+    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v3',
+    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '105X_postLS2_design_v1', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '105X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase1 2019
-    'phase1_2019_realistic'    : '105X_postLS2_realistic_v3', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'    : '105X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '105X_upgrade2023_realistic_v2'
+    'phase2_realistic'         : '105X_upgrade2023_realistic_3'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,38 +2,38 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '103X_mcRun1_design_v1',
+    'run1_design'       :   '105X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '103X_mcRun1_realistic_v1',
+    'run1_mc'           :   '105X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '103X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '105X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '103X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '105X_mcRun1_pA_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '103X_mcRun2_startup_v3',
+    'run2_mc_50ns'      :   '105X_mcRun2_startup_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '103X_mcRun2_asymptotic_l1stage1_v1',
+    'run2_mc_l1stage1'  :   '105X_mcRun2_asymptotic_l1stage1_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '105X_mcRun2_design_v1',
+    'run2_design'       :   '105X_mcRun2_design_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '105X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '105X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '105X_mcRun2cosmics_startup_deco_v2',
+    'run2_mc_cosmics'   :   '105X_mcRun2cosmics_startup_deco_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '103X_mcRun2_HeavyIon_v3',
+    'run2_mc_hi'        :   '105X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '103X_mcRun2_pA_v3',
+    'run2_mc_pa'        :   '105X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '105X_dataRun2_v6',
+    'run1_data'         :   '105X_dataRun2_v7',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '105X_dataRun2_v6',
+    'run2_data'         :   '105X_dataRun2_v7',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '105X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '105X_dataRun2_relval_v7',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v5',
+    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v6',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v6',
-    'run2_data_promptlike_hi' : '105X_dataRun2_PromptLike_HI_v1',
+    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v7',
+    'run2_data_promptlike_hi' : '105X_dataRun2_PromptLike_HI_v2',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -44,31 +44,31 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v4',
+    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v5',
+    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v6',
+    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v7',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v6',
+    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '105X_upgrade2018_design_v3',
+    'phase1_2018_design'       :  '105X_upgrade2018_design_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v4',
+    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v2',
+    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v5',
+    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v5',
+    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v5',
+    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '105X_postLS2_design_v2', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '105X_postLS2_design_v3', # GT containing design conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase1 2019
-    'phase1_2019_realistic'    : '105X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'    : '105X_postLS2_realistic_v5', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '105X_upgrade2023_realistic_v3'
+    'phase2_realistic'         : '105X_upgrade2023_realistic_v4'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,7 +68,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2019
     'phase1_2019_realistic'    : '105X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '105X_upgrade2023_realistic_3'
+    'phase2_realistic'         : '105X_upgrade2023_realistic_v3'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -48,7 +48,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
     'phase1_2017_realistic'    :  '105X_mc2017_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v5',
+    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -35,14 +35,14 @@ autoCond = {
     'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v8',
     'run2_data_promptlike_hi' : '105X_dataRun2_PromptLike_HI_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
+    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v8',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
+    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v8',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'      :   '103X_dataRun2_HLT_relval_v4',
-    'run2_hlt_relval_hi'   :   '103X_dataRun2_HLT_relval_HI_v2',
-    # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
+    'run2_hlt_relval'      :   '103X_dataRun2_HLT_relval_v7',
+    'run2_hlt_relval_hi'   :   '103X_dataRun2_HLT_relval_HI_v3',
+    # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
+    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,30 +10,30 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '105X_mcRun1_pA_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '105X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '105X_mcRun2_startup_v2',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '105X_mcRun2_asymptotic_l1stage1_v1',
+    'run2_mc_l1stage1'  :   '105X_mcRun2_asymptotic_l1stage1_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '105X_mcRun2_design_v2',
+    'run2_design'       :   '105X_mcRun2_design_v3',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '105X_mcRun2_asymptotic_v3',
+    'run2_mc'           :   '105X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '105X_mcRun2cosmics_startup_deco_v3',
+    'run2_mc_cosmics'   :   '105X_mcRun2cosmics_startup_deco_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '105X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'        :   '105X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '105X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '105X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '105X_dataRun2_v7',
+    'run1_data'         :   '105X_dataRun2_v8',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '105X_dataRun2_v7',
+    'run2_data'         :   '105X_dataRun2_v8',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '105X_dataRun2_relval_v7',
+    'run2_data_relval'  :   '105X_dataRun2_relval_v8',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v6',
+    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v7',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v7',
-    'run2_data_promptlike_hi' : '105X_dataRun2_PromptLike_HI_v2',
+    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v8',
+    'run2_data_promptlike_hi' : '105X_dataRun2_PromptLike_HI_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -44,31 +44,31 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v5',
+    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v6',
+    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v7',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v7',
+    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v8',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v7',
+    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '105X_upgrade2018_design_v4',
+    'phase1_2018_design'       :  '105X_upgrade2018_design_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v5',
+    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v3',
+    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
     'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v6',
+    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v6',
+    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '105X_postLS2_design_v3', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '105X_postLS2_design_v4', # GT containing design conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase1 2019
-    'phase1_2019_realistic'    : '105X_postLS2_realistic_v5', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'    : '105X_postLS2_realistic_v6', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '105X_upgrade2023_realistic_v4'
+    'phase2_realistic'         : '105X_upgrade2023_realistic_v5'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -54,7 +54,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '105X_upgrade2018_design_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v7',
+    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail


### PR DESCRIPTION
### The PR includes update of GTs in autoCond to document the conditons and support the developments for ultra legacy. The updates cover **ECAL MC conditions for ultra legacy in 2016 and 2018**, **PF calibration including eta dependence**, new GEM eMap for MC (>=2017). 

### **Ecal condition changes can be referred to**
ECAL 2016 : [AlCa hn](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4094.html)
ECAL 2018 : [AlCa hn](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4095.html)

### **PF calibration**

- PF calibration is to support PR #25883 
- The change is only a change of dataformat. The formulas are the same (just putting the eta-dependent formulas from CMSSW to the condition in DB) 
- There will be a new commit or new PR to update the PF calibration used in HLT or the update will be part of PR #25883**

### **GEM eMap is to support PR #25158** 

### **Run-1 MC**
New GTs are
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mcRun1_design_v1
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mcRun1_realistic_v1
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mcRun1_HeavyIon_v1
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mcRun1_pA_v1
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mcRun1_design_v1/103X_mcRun1_design_v1
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mcRun1_realistic_v1/103X_mcRun1_realistic_v1
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mcRun1_HeavyIon_v1/103X_mcRun1_HeavyIon_v1
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mcRun1_pA_v1/103X_mcRun1_pA_v1
- update PF calibration

### **Run-2 MC 2016**
New ideal GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mcRun2_design_v2
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mcRun2_design_v2/105X_mcRun2_design_v1
- update PF calibration

New GT for Stage-1 L1 trigger (2015)
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mcRun2_asymptotic_l1stage1_v1
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mcRun2_asymptotic_l1stage1_v1/103X_mcRun2_asymptotic_l1stage1_v1
- update PF calibration

New realistic GT and cosmic GT are
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mcRun2_asymptotic_v3
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mcRun2cosmics_startup_deco_v3
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mcRun2_asymptotic_v3/105X_mcRun2_asymptotic_v1
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mcRun2cosmics_startup_deco_v3/105X_mcRun2cosmics_startup_deco_v1
- ECAL MC conditions for ultra legacy announced at [AlCa-hn](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4094.html)
- PF calibration

### **Run-2 MC 2017**
New GTs are
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mc2017_design_IdealBS_v5
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mc2017_realistic_v6
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mc2017cosmics_realistic_peak_v7
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_mc2017cosmics_realistic_deco_v7
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mc2017_design_IdealBS_v5/105X_mc2017_design_IdealBS_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mc2017_realistic_v6/105X_mc2017_realistic_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mc2017cosmics_realistic_peak_v7/105X_mc2017cosmics_realistic_peak_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_mc2017cosmics_realistic_deco_v7/105X_mc2017cosmics_realistic_deco_v5

- add new GEM MC eMap
- PF calibration

### **Run-2 MC 2018**
New GTs are
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_upgrade2018_design_v4
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_upgrade2018_realistic_v5
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_upgrade2018_realistic_HEfail_v6
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_upgrade2018cosmics_realistic_deco_v6
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_upgrade2018cosmics_realistic_peak_v6
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018_design_v4/105X_upgrade2018_design_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018_realistic_v5/105X_upgrade2018_realistic_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018_realistic_HEfail_v6/105X_upgrade2018_realistic_HEfail_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018cosmics_realistic_deco_v6/105X_upgrade2018cosmics_realistic_deco_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018cosmics_realistic_peak_v6/105X_upgrade2018cosmics_realistic_peak_v3
- ECAL MC conditions for ultra legacy announced at [AlCa-hn](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4095.html)
- add new GEM MC eMap
- PF calibration

### **Run-2 heavy Ion MC 2018**
New GTs are
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_upgrade2018_realistic_HI_v3
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018_realistic_HI_v3/103X_upgrade2018_realistic_HI_v12
- add new GEM MC eMap
- PF calibration

### **Run-3/Phase-2 MC**
New GTs are
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_postLS2_design_v3
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_postLS2_realistic_v5
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_upgrade2023_realistic_v4
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_postLS2_design_v3/105X_postLS2_design_v1
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_postLS2_realistic_v5/105X_postLS2_realistic_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2023_realistic_v4/105X_upgrade2023_realistic_v2
- add new GEM MC eMap
- PF calibration

### **Data**
New offline GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_dataRun2_v7
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_dataRun2_v7/105X_dataRun2_v6
- PF calibration

New relval offline GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_dataRun2_relval_v7
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_dataRun2_relval_v7/105X_dataRun2_relval_v6
- PF calibration

New prompt like GTs are
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_dataRun2_PromptLike_v7
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_dataRun2_PromptLike_HEfail_v6
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_dataRun2_PromptLike_v7/105X_dataRun2_PromptLike_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_dataRun2_PromptLike_HEfail_v6/105X_dataRun2_PromptLike_HEfail_v5
- PF calibration

New prompt like heavy Ion GT 
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_dataRun2_PromptLike_HI_v2
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_dataRun2_PromptLike_HI_v2/103X_dataRun2_PromptLike_HI_v3
- Add PPS timing and LHC info
- Freeze Hcal quality to be the condition with HE sector failure
- new GEM eMap
- PF calibration