### PR TITLE
MultiTrajectoryStateMode from class to namespace

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -253,7 +253,6 @@ class GsfElectronAlgo {
 
        std::unique_ptr<const MultiTrajectoryStateTransform> mtsTransform ;
        std::unique_ptr<GsfConstraintAtVertex> constraintAtVtx ;
-       const MultiTrajectoryStateMode mtsMode ;
     } ;
 
     //===================================================================
@@ -324,7 +323,7 @@ class GsfElectronAlgo {
       void computeCharge( int & charge, reco::GsfElectron::ChargeInfo & info ) ;
       reco::CaloClusterPtr getEleBasicCluster( MultiTrajectoryStateTransform const& ) ;
       bool calculateTSOS( MultiTrajectoryStateTransform const&, GsfConstraintAtVertex const& ) ;
-      void calculateMode( MultiTrajectoryStateMode const& mtsMode ) ;
+      void calculateMode() ;
       reco::Candidate::LorentzVector calculateMomentum() ;
 
       // TSOS

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -43,7 +43,7 @@ using namespace reco ;
 
 GsfElectronAlgo::EventSetupData::EventSetupData()
  : cacheIDGeom(0), cacheIDTopo(0), cacheIDTDGeom(0), cacheIDMagField(0),
-   cacheSevLevel(0), mtsTransform(nullptr), constraintAtVtx(nullptr), mtsMode()
+   cacheSevLevel(0), mtsTransform(nullptr), constraintAtVtx(nullptr)
  {}
 
 void GsfElectronAlgo::EventData::retreiveOriginalTrackCollections
@@ -158,21 +158,21 @@ bool GsfElectronAlgo::ElectronData::calculateTSOS
   return true ;
  }
 
-void GsfElectronAlgo::ElectronData::calculateMode( MultiTrajectoryStateMode const& mtsMode )
+void GsfElectronAlgo::ElectronData::calculateMode()
  {
-  mtsMode.momentumFromModeCartesian(innTSOS,innMom) ;
-  mtsMode.positionFromModeCartesian(innTSOS,innPos) ;
-  mtsMode.momentumFromModeCartesian(seedTSOS,seedMom) ;
-  mtsMode.positionFromModeCartesian(seedTSOS,seedPos) ;
-  mtsMode.momentumFromModeCartesian(eleTSOS,eleMom) ;
-  mtsMode.positionFromModeCartesian(eleTSOS,elePos) ;
-  mtsMode.momentumFromModeCartesian(sclTSOS,sclMom) ;
-  mtsMode.positionFromModeCartesian(sclTSOS,sclPos) ;
-  mtsMode.momentumFromModeCartesian(vtxTSOS,vtxMom) ;
-  mtsMode.positionFromModeCartesian(vtxTSOS,vtxPos) ;
-  mtsMode.momentumFromModeCartesian(outTSOS,outMom);
-  mtsMode.positionFromModeCartesian(outTSOS,outPos) ;
-  mtsMode.momentumFromModeCartesian(constrainedVtxTSOS,vtxMomWithConstraint);
+  multiTrajectoryStateMode::momentumFromModeCartesian(innTSOS,innMom) ;
+  multiTrajectoryStateMode::positionFromModeCartesian(innTSOS,innPos) ;
+  multiTrajectoryStateMode::momentumFromModeCartesian(seedTSOS,seedMom) ;
+  multiTrajectoryStateMode::positionFromModeCartesian(seedTSOS,seedPos) ;
+  multiTrajectoryStateMode::momentumFromModeCartesian(eleTSOS,eleMom) ;
+  multiTrajectoryStateMode::positionFromModeCartesian(eleTSOS,elePos) ;
+  multiTrajectoryStateMode::momentumFromModeCartesian(sclTSOS,sclMom) ;
+  multiTrajectoryStateMode::positionFromModeCartesian(sclTSOS,sclPos) ;
+  multiTrajectoryStateMode::momentumFromModeCartesian(vtxTSOS,vtxMom) ;
+  multiTrajectoryStateMode::positionFromModeCartesian(vtxTSOS,vtxPos) ;
+  multiTrajectoryStateMode::momentumFromModeCartesian(outTSOS,outMom);
+  multiTrajectoryStateMode::positionFromModeCartesian(outTSOS,outPos) ;
+  multiTrajectoryStateMode::momentumFromModeCartesian(constrainedVtxTSOS,vtxMomWithConstraint);
  }
 
 Candidate::LorentzVector GsfElectronAlgo::ElectronData::calculateMomentum()
@@ -587,7 +587,7 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection & electrons, El
   // temporary, till CaloCluster->seed() is made available
   DetId seedXtalId = seedCluster.hitsAndFractions()[0].first ;
 
-  electronData.calculateMode(eventSetupData_.mtsMode) ;
+  electronData.calculateMode() ;
 
 
   //====================================================

--- a/RecoEgamma/EgammaHLTAlgos/interface/EgammaHLTPixelMatchElectronAlgo.h
+++ b/RecoEgamma/EgammaHLTAlgos/interface/EgammaHLTPixelMatchElectronAlgo.h
@@ -26,7 +26,6 @@
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
-class MultiTrajectoryStateMode;
 class MultiTrajectoryStateTransform;
 
 class EgammaHLTPixelMatchElectronAlgo {
@@ -58,7 +57,6 @@ public:
   bool useGsfTracks_;
   edm::EDGetTokenT<reco::BeamSpot> bsProducer_; 
 
-  MultiTrajectoryStateMode* mtsMode_; //its not clear to me why this is a pointer but its not the only one so changing things wouldnt make this class safer
   MultiTrajectoryStateTransform* mtsTransform_;
 
   edm::ESHandle<MagneticField> magField_;

--- a/RecoEgamma/EgammaHLTAlgos/src/EgammaHLTPixelMatchElectronAlgo.cc
+++ b/RecoEgamma/EgammaHLTAlgos/src/EgammaHLTPixelMatchElectronAlgo.cc
@@ -51,7 +51,6 @@ EgammaHLTPixelMatchElectronAlgo::EgammaHLTPixelMatchElectronAlgo(const edm::Para
   gsfTrackProducer_(iC.consumes<reco::GsfTrackCollection>(conf.getParameter<edm::InputTag>("GsfTrackProducer"))),
   useGsfTracks_(conf.getParameter<bool>("UseGsfTracks")),
   bsProducer_(iC.consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("BSProducer"))), 
-  mtsMode_(new MultiTrajectoryStateMode()),
   mtsTransform_(nullptr),
   cacheIDTDGeom_(0),
   cacheIDMagField_(0)
@@ -62,7 +61,6 @@ EgammaHLTPixelMatchElectronAlgo::EgammaHLTPixelMatchElectronAlgo(const edm::Para
   EgammaHLTPixelMatchElectronAlgo::~EgammaHLTPixelMatchElectronAlgo() 
 {
   delete mtsTransform_;
-  delete mtsMode_;
  }
 
 void EgammaHLTPixelMatchElectronAlgo::setupES(const edm::EventSetup& es) {
@@ -164,7 +162,7 @@ void EgammaHLTPixelMatchElectronAlgo::process(edm::Handle<TrackCollection> track
       GlobalVector innMom;
       float pin1 = trackRef1->pMode();
       if (fts.isValid()) {
-	mtsMode_->momentumFromModeCartesian(fts, innMom);  
+	multiTrajectoryStateMode::momentumFromModeCartesian(fts, innMom);  
 	pin1 = innMom.mag();
       }
 
@@ -178,7 +176,7 @@ void EgammaHLTPixelMatchElectronAlgo::process(edm::Handle<TrackCollection> track
 	GlobalVector innMom;
 	float pin2 = trackRef2->pMode();
 	if (fts.isValid()) {
-	  mtsMode_->momentumFromModeCartesian(fts, innMom);  
+	  multiTrajectoryStateMode::momentumFromModeCartesian(fts, innMom);  
 	  pin2 = innMom.mag();
 	}
 	
@@ -210,9 +208,9 @@ void EgammaHLTPixelMatchElectronAlgo::process(edm::Handle<TrackCollection> track
       TrajectoryStateOnSurface inTSOS = mtsTransform_->innerStateOnSurface((*trackRef));
       TrajectoryStateOnSurface fts = mtsTransform_->extrapolatedState(inTSOS, bs);
       GlobalVector innMom;
-      mtsMode_->momentumFromModeCartesian(inTSOS, innMom);
+      multiTrajectoryStateMode::momentumFromModeCartesian(inTSOS, innMom);
       if (fts.isValid()) {
-	mtsMode_->momentumFromModeCartesian(fts, innMom);  
+	multiTrajectoryStateMode::momentumFromModeCartesian(fts, innMom);  
       }
       
       float scale = scRef->energy()/innMom.mag();

--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTGsfTrackVarProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTGsfTrackVarProducer.h
@@ -47,7 +47,6 @@ class EgammaHLTGsfTrackVarProducer : public edm::stream::EDProducer<> {
     edm::ESHandle<MagneticField> magField_;
     edm::ESHandle<TrackerGeometry> trackerHandle_;
     
-    MultiTrajectoryStateMode mtsMode_; 
     const MultiTrajectoryStateTransform * mtsTransform_; //we own it
     
   public:
@@ -63,7 +62,6 @@ class EgammaHLTGsfTrackVarProducer : public edm::stream::EDProducer<> {
     
     edm::ESHandle<TrackerGeometry> trackerGeomHandle()const{return trackerHandle_;}
     const MultiTrajectoryStateTransform * mtsTransform()const{return mtsTransform_;}
-    const MultiTrajectoryStateMode* mtsMode()const{return &mtsMode_;}
   };
   
  public:

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
@@ -219,9 +219,7 @@ EgammaHLTGsfTrackVarProducer::TrackExtrapolator::TrackExtrapolator(const EgammaH
   cacheIDTDGeom_(rhs.cacheIDTDGeom_),
   cacheIDMagField_(rhs.cacheIDMagField_),
   magField_(rhs.magField_),
-  trackerHandle_(rhs.trackerHandle_),
-  mtsMode_(rhs.mtsMode_)
- 
+  trackerHandle_(rhs.trackerHandle_)
 {
   if(rhs.mtsTransform_) mtsTransform_ = new MultiTrajectoryStateTransform(*rhs.mtsTransform_);
   else mtsTransform_ =nullptr;
@@ -235,7 +233,6 @@ EgammaHLTGsfTrackVarProducer::TrackExtrapolator* EgammaHLTGsfTrackVarProducer::T
     cacheIDMagField_ = rhs.cacheIDMagField_;
     magField_ = rhs.magField_;
     trackerHandle_ = rhs.trackerHandle_;
-    mtsMode_ = rhs.mtsMode_;
     
     delete mtsTransform_;
     if(rhs.mtsTransform_) mtsTransform_ = new MultiTrajectoryStateTransform(*rhs.mtsTransform_);
@@ -271,7 +268,7 @@ GlobalPoint EgammaHLTGsfTrackVarProducer::TrackExtrapolator::extrapolateTrackPos
   TrajectoryStateOnSurface innTSOS = mtsTransform()->innerStateOnSurface(gsfTrack);
   TrajectoryStateOnSurface posTSOS = mtsTransform()->extrapolatedState(innTSOS,pointToExtrapTo);
   GlobalPoint  extrapolatedPos;
-  mtsMode()->positionFromModeCartesian(posTSOS,extrapolatedPos);
+  multiTrajectoryStateMode::positionFromModeCartesian(posTSOS,extrapolatedPos);
   return extrapolatedPos;
 }
 
@@ -280,7 +277,7 @@ GlobalVector EgammaHLTGsfTrackVarProducer::TrackExtrapolator::extrapolateTrackMo
   TrajectoryStateOnSurface innTSOS = mtsTransform()->innerStateOnSurface(gsfTrack);
   TrajectoryStateOnSurface posTSOS = mtsTransform()->extrapolatedState(innTSOS,pointToExtrapTo);
   GlobalVector  extrapolatedMom;
-  mtsMode()->momentumFromModeCartesian(posTSOS,extrapolatedMom);
+  multiTrajectoryStateMode::momentumFromModeCartesian(posTSOS,extrapolatedMom);
   return extrapolatedMom;
 }
 

--- a/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
@@ -135,7 +135,6 @@ class PFElecTkProducer final : public edm::stream::EDProducer<edm::GlobalCache<c
 
       ///PFTrackTransformer
       std::unique_ptr<PFTrackTransformer> pfTransformer_;     
-      const MultiTrajectoryStateMode *mtsMode_;
       MultiTrajectoryStateTransform  mtsTransform_;
       std::unique_ptr<ConvBremPFTrackFinder> convBremFinder_;
 

--- a/RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h
@@ -66,7 +66,6 @@ class PFTrackTransformer{
  private:
   ///B field
    math::XYZVector B_;
-   const MultiTrajectoryStateMode *mtsMode_;
    PFGeometry pfGeometry_;
 };
 

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -175,7 +175,7 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
     TrajectoryStateOnSurface i_inTSOS = mtsTransform_.innerStateOnSurface((*trackRef));
     GlobalVector i_innMom;
     if(i_inTSOS.isValid()){
-      mtsMode_->momentumFromModeCartesian(i_inTSOS,i_innMom);  
+      multiTrajectoryStateMode::momentumFromModeCartesian(i_inTSOS,i_innMom);  
       gsfInnerMomentumCache_.back() = i_innMom.mag();
     }
   }
@@ -513,7 +513,7 @@ PFElecTkProducer::resolveGsfTracks(const vector<reco::GsfPFRecTrack>  & GsfPFVec
   GlobalVector ninnMom;
   float nPin =  nGsfTrack->pMode();
   if(inTSOS.isValid()){
-    mtsMode_->momentumFromModeCartesian(inTSOS,ninnMom);
+    multiTrajectoryStateMode::momentumFromModeCartesian(inTSOS,ninnMom);
     nPin = ninnMom.mag();
   }
   */
@@ -555,7 +555,7 @@ PFElecTkProducer::resolveGsfTracks(const vector<reco::GsfPFRecTrack>  & GsfPFVec
 	GlobalVector i_innMom;
 	float iPin = iGsfTrack->pMode();
 	if(i_inTSOS.isValid()){
-	  mtsMode_->momentumFromModeCartesian(i_inTSOS,i_innMom);  
+	  multiTrajectoryStateMode::momentumFromModeCartesian(i_inTSOS,i_innMom);  
 	  iPin = i_innMom.mag();
 	}
         */

--- a/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
@@ -594,8 +594,8 @@ PFTrackTransformer::addPointsAndBrems( reco::GsfPFRecTrack& pftrack,
   GlobalVector InMom;
   GlobalPoint InPos;
   if(inTSOS.isValid()) {
-    mtsMode_->momentumFromModeCartesian(inTSOS,InMom);
-    mtsMode_->positionFromModeCartesian(inTSOS,InPos);
+    multiTrajectoryStateMode::momentumFromModeCartesian(inTSOS,InMom);
+    multiTrajectoryStateMode::positionFromModeCartesian(inTSOS,InPos);
   }
   else {
     InMom = GlobalVector(track.pxMode(),track.pyMode(),track.pzMode());
@@ -957,8 +957,8 @@ PFTrackTransformer::addPointsAndBrems( reco::GsfPFRecTrack& pftrack,
     // DANIELE ?????  if the out is not valid maybe take the last tangent?
     // From Wolfgang. It should be always valid 
 
-    mtsMode_->momentumFromModeCartesian(outTSOS,OutMom);
-    mtsMode_->positionFromModeCartesian(outTSOS,OutPos);
+    multiTrajectoryStateMode::momentumFromModeCartesian(outTSOS,OutMom);
+    multiTrajectoryStateMode::positionFromModeCartesian(outTSOS,OutPos);
 
 
 

--- a/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
@@ -356,9 +356,9 @@ GsfTrackProducerBase::computeModeAtTM (const TrajectoryMeasurement& tm,
   //
   // states
   //
-  TrajectoryStateOnSurface fwdState = tm.forwardPredictedState();
-  TrajectoryStateOnSurface bwdState = tm.backwardPredictedState();
-  TrajectoryStateOnSurface upState  = tm.updatedState();
+  TrajectoryStateOnSurface const& fwdState = tm.forwardPredictedState();
+  TrajectoryStateOnSurface const& bwdState = tm.backwardPredictedState();
+  TrajectoryStateOnSurface const& upState  = tm.updatedState();
 
 
   if ( !fwdState.isValid() || !bwdState.isValid() || !upState.isValid() ) {
@@ -370,9 +370,8 @@ GsfTrackProducerBase::computeModeAtTM (const TrajectoryMeasurement& tm,
   //
   GlobalPoint pos = upState.globalPosition();
   position = reco::GsfTrackExtra::Point(pos.x(),pos.y(),pos.z());
-  MultiTrajectoryStateMode mts;
   GlobalVector mom;
-  bool result = mts.momentumFromModeCartesian(upState,mom);
+  bool result = multiTrajectoryStateMode::momentumFromModeCartesian(upState,mom);
   if ( !result ) {
 //     std::cout << "momentumFromModeCartesian failed" << std::endl;
     return false;

--- a/TrackingTools/GsfTools/interface/MultiTrajectoryStateMode.h
+++ b/TrackingTools/GsfTools/interface/MultiTrajectoryStateMode.h
@@ -1,5 +1,5 @@
-#ifndef MultiTrajectoryStateMode_H_
-#define MultiTrajectoryStateMode_H_
+#ifndef TrackingTools_GsfTools_MultiTrajectoryStateMode_h
+#define TrackingTools_GsfTools_MultiTrajectoryStateMode_h
 
 /** Extract mode information from a TrajectoryStateOnSurface. */
 
@@ -8,36 +8,28 @@
 
 class TrajectoryStateOnSurface;
 
-class MultiTrajectoryStateMode {
-public:
+namespace multiTrajectoryStateMode {
   /** Cartesian momentum from 1D mode calculation in cartesian co-ordinates.
    *  Return value true for success. */
-  bool momentumFromModeCartesian (const TrajectoryStateOnSurface tsos,
-				  GlobalVector& momentum) const;
+  bool momentumFromModeCartesian (TrajectoryStateOnSurface const& tsos, GlobalVector& momentum);
   /** Cartesian position from 1D mode calculation in cartesian co-ordinates.
    *  Return value true for success. */
-  bool positionFromModeCartesian (const TrajectoryStateOnSurface tsos,
-				  GlobalPoint& position) const;
+  bool positionFromModeCartesian (TrajectoryStateOnSurface const& tsos, GlobalPoint& position);
   /** Cartesian momentum from 1D mode calculation in local co-ordinates (q/p, dx/dz, dy/dz).
    *  Return value true for success. */
-  bool momentumFromModeLocal (const TrajectoryStateOnSurface tsos,
-			      GlobalVector& momentum) const;
+  bool momentumFromModeLocal (TrajectoryStateOnSurface const& tsos, GlobalVector& momentum);
   /** Cartesian position from 1D mode calculation in local co-ordinates (x, y).
    *  Return value true for success. */
-  bool positionFromModeLocal (const TrajectoryStateOnSurface tsos,
-			      GlobalPoint& position) const;
+  bool positionFromModeLocal (TrajectoryStateOnSurface const& tsos, GlobalPoint& position);
   /** Momentum from 1D mode calculation in q/p. Return value true for sucess. */
-  bool momentumFromModeQP (const TrajectoryStateOnSurface tsos,
-			   double& momentum) const;
+  bool momentumFromModeQP (TrajectoryStateOnSurface const& tsos, double& momentum);
   /** Momentum from 1D mode calculation in p. Return value true for sucess. */
-  bool momentumFromModeP (const TrajectoryStateOnSurface tsos,
-			  double& momentum) const;
+  bool momentumFromModeP (TrajectoryStateOnSurface const& tsos, double& momentum);
   /** Cartesian momentum from 1D mode calculation in p, phi, eta.
    *  Return value true for success. */
-  bool momentumFromModePPhiEta (const TrajectoryStateOnSurface tsos,
-				GlobalVector& momentum) const;
+  bool momentumFromModePPhiEta (TrajectoryStateOnSurface const& tsos, GlobalVector& momentum);
   /** Charge from 1D mode calculation in q/p. Q=0 in case of failure. */
-  int chargeFromMode (const TrajectoryStateOnSurface tsos) const;
+  int chargeFromMode (TrajectoryStateOnSurface const& tsos);
 };
 
 

--- a/TrackingTools/GsfTools/src/MultiTrajectoryStateMode.cc
+++ b/TrackingTools/GsfTools/src/MultiTrajectoryStateMode.cc
@@ -11,16 +11,17 @@
 
 #include <iostream>
 
+namespace multiTrajectoryStateMode {
+
 bool
-MultiTrajectoryStateMode::momentumFromModeCartesian (const TrajectoryStateOnSurface tsos,
-						     GlobalVector& momentum) const
+momentumFromModeCartesian (TrajectoryStateOnSurface const& tsos, GlobalVector& momentum)
 {
   //
   // clear result vector and check validity of the TSOS
   //
   momentum = GlobalVector(0.,0.,0.);
   if ( !tsos.isValid() ) {
-    edm::LogInfo("MultiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
+    edm::LogInfo("multiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
     return false;
   }
   //  
@@ -60,15 +61,14 @@ MultiTrajectoryStateMode::momentumFromModeCartesian (const TrajectoryStateOnSurf
 }
 
 bool
-MultiTrajectoryStateMode::positionFromModeCartesian (const TrajectoryStateOnSurface tsos,
-						     GlobalPoint& position) const
+positionFromModeCartesian (TrajectoryStateOnSurface const& tsos, GlobalPoint& position)
 {
   //
   // clear result vector and check validity of the TSOS
   //
   position = GlobalPoint(0.,0.,0.);
   if ( !tsos.isValid() ) {
-    edm::LogInfo("MultiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
+    edm::LogInfo("multiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
     return false;
   }
   //  
@@ -109,15 +109,14 @@ MultiTrajectoryStateMode::positionFromModeCartesian (const TrajectoryStateOnSurf
 }
 
 bool
-MultiTrajectoryStateMode::momentumFromModeLocal (const TrajectoryStateOnSurface tsos,
-						 GlobalVector& momentum) const
+momentumFromModeLocal (TrajectoryStateOnSurface const& tsos, GlobalVector& momentum)
 {
   //
   // clear result vector and check validity of the TSOS
   //
   momentum = GlobalVector(0.,0.,0.);
   if ( !tsos.isValid() ) {
-    edm::LogInfo("MultiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
+    edm::LogInfo("multiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
     return false;
   }
   //  
@@ -150,15 +149,14 @@ MultiTrajectoryStateMode::momentumFromModeLocal (const TrajectoryStateOnSurface 
 }
 
 bool
-MultiTrajectoryStateMode::momentumFromModeQP (const TrajectoryStateOnSurface tsos,
-					      double& momentum) const
+momentumFromModeQP (TrajectoryStateOnSurface const& tsos, double& momentum)
 {
   //
   // clear result vector and check validity of the TSOS
   //
   momentum = 0.;
   if ( !tsos.isValid() ) {
-    edm::LogInfo("MultiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
+    edm::LogInfo("multiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
     return false;
   }
   //  
@@ -180,15 +178,14 @@ MultiTrajectoryStateMode::momentumFromModeQP (const TrajectoryStateOnSurface tso
 }
 
 bool
-MultiTrajectoryStateMode::momentumFromModeP (const TrajectoryStateOnSurface tsos,
-					     double& momentum) const
+momentumFromModeP (TrajectoryStateOnSurface const& tsos, double& momentum)
 {
   //
   // clear result vector and check validity of the TSOS
   //
   momentum = 0.;
   if ( !tsos.isValid() ) {
-    edm::LogInfo("MultiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
+    edm::LogInfo("multiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
     return false;
   }
   //  
@@ -217,15 +214,14 @@ MultiTrajectoryStateMode::momentumFromModeP (const TrajectoryStateOnSurface tsos
 }
 
 bool
-MultiTrajectoryStateMode::positionFromModeLocal (const TrajectoryStateOnSurface tsos,
-						 GlobalPoint& position) const
+positionFromModeLocal (TrajectoryStateOnSurface const& tsos, GlobalPoint& position)
 {
   //
   // clear result vector and check validity of the TSOS
   //
   position = GlobalPoint(0.,0.,0.);
   if ( !tsos.isValid() ) {
-    edm::LogInfo("MultiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
+    edm::LogInfo("multiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
     return false;
   }
   //  
@@ -254,15 +250,14 @@ MultiTrajectoryStateMode::positionFromModeLocal (const TrajectoryStateOnSurface 
 }
 
 bool
-MultiTrajectoryStateMode::momentumFromModePPhiEta (const TrajectoryStateOnSurface tsos,
-						   GlobalVector& momentum) const
+momentumFromModePPhiEta (TrajectoryStateOnSurface const& tsos, GlobalVector& momentum)
 {
   //
   // clear result vector and check validity of the TSOS
   //
   momentum = GlobalVector(0.,0.,0.);
   if ( !tsos.isValid() ) {
-    edm::LogInfo("MultiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
+    edm::LogInfo("multiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
     return false;
   }
   //  
@@ -334,13 +329,13 @@ MultiTrajectoryStateMode::momentumFromModePPhiEta (const TrajectoryStateOnSurfac
 }
 
 int
-MultiTrajectoryStateMode::chargeFromMode (const TrajectoryStateOnSurface tsos) const
+chargeFromMode (TrajectoryStateOnSurface const& tsos)
 {
   //
   // clear result vector and check validity of the TSOS
   //
   if ( !tsos.isValid() ) {
-    edm::LogInfo("MultiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
+    edm::LogInfo("multiTrajectoryStateMode") << "Cannot calculate mode from invalid TSOS";
     return 0;
   }
   //  
@@ -355,3 +350,4 @@ MultiTrajectoryStateMode::chargeFromMode (const TrajectoryStateOnSurface tsos) c
   return result>0. ? 1 : -1;
 }
 
+} // namespace multiTrajectoryStateMode

--- a/TrackingTools/GsfTools/src/MultiTrajectoryStateTransform.cc
+++ b/TrackingTools/GsfTools/src/MultiTrajectoryStateTransform.cc
@@ -32,14 +32,14 @@ bool
 MultiTrajectoryStateTransform::outerMomentumFromMode (const reco::GsfTrack& tk,
 						      GlobalVector& momentum) const
 {
-  return MultiTrajectoryStateMode().momentumFromModeCartesian(outerStateOnSurface(tk),momentum);
+  return multiTrajectoryStateMode::momentumFromModeCartesian(outerStateOnSurface(tk),momentum);
 }
 
 bool
 MultiTrajectoryStateTransform::innerMomentumFromMode (const reco::GsfTrack& tk,
 						      GlobalVector& momentum) const
 {
-  return MultiTrajectoryStateMode().momentumFromModeCartesian(outerStateOnSurface(tk),momentum);
+  return multiTrajectoryStateMode::momentumFromModeCartesian(outerStateOnSurface(tk),momentum);
 }
 
 TrajectoryStateOnSurface 


### PR DESCRIPTION
Trivial conversion of `MultiTrajectoryStateMode` from class to namespace, as this class confused quite a bit in the GsfElectronAlgo until I realized it's actually empty (has no member data). It does not need to be a class then.