### PR TITLE
Avoid race condition in WaitingTaskList cache

### DIFF
--- a/FWCore/Concurrency/src/WaitingTaskList.cc
+++ b/FWCore/Concurrency/src/WaitingTaskList.cc
@@ -163,13 +163,16 @@ WaitingTaskList::announce()
     if(UNLIKELY(bool(m_exceptionPtr))) {
       t->dependentTaskFailed(m_exceptionPtr);
     }
-    if(0==t->decrement_ref_count()){
-      tbb::task::spawn(*t);
-    }
     if(!n->m_fromCache ) {
       delete n;
     }
     n=next;
+
+    //the task may indirectly call WaitingTaskList::reset
+    // so we need to call spawn after we are done using the node.
+    if(0==t->decrement_ref_count()){
+      tbb::task::spawn(*t);
+    }
   }
 }
 


### PR DESCRIPTION
ASAN found WaitingTaskList::announce was still reading an address in the cache after WaitingTaskList::reset was called. This could happen if the task spawned in ::announce indirectly calls ::reset and the task happens to finish before ::announce finishes.

Moving the call to spawn to after the last use of the Node should avoid such problems.