### PR TITLE
Fix excessive stack use when storing HepMCProduct

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -21,6 +21,9 @@
 
 //needed for backward compatibility between HepMC 2.06.xx and 2.05.yy
 namespace hepmc_rootio {
+  void add_to_particles_in(HepMC::GenVertex*, HepMC::GenParticle*);
+  void clear_particles_in(HepMC::GenVertex*);
+
   inline void weightcontainer_set_default_names(unsigned int n, std::map<std::string,HepMC::WeightContainer::size_type>& names) {
       std::ostringstream name;
       for ( HepMC::WeightContainer::size_type count = 0; count<n; ++count ) 

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -5,14 +5,28 @@
   <version ClassVersion="11" checksum="2967452289"/>
   <version ClassVersion="10" checksum="2993730389"/>
  </class>
-	<class name="HepMC::GenVertex" ClassVersion="10">
+	<class name="HepMC::GenVertex" ClassVersion="11">
   <version ClassVersion="10" checksum="1541111972"/>
+  <version ClassVersion="11" checksum="360579277"/>
+  <field name=" m_particles_in" transient="true"/>
  </class>
+ <ioread sourceClass = "HepMC::GenVertex" source="int m_id" version="[1-]" targetClass="HepMC::GenVertex" target="m_id">
+	  <![CDATA[m_id = onfile.m_id; 
+            hepmc_rootio::clear_particles_in(newObj);
+]]>
+ </ioread>
 	<class name="HepMC::GenParticle" ClassVersion="10">
   <version ClassVersion="10" checksum="3138667414"/>
 		<!-- <field name="itsParticleData" transient="true"/> -->
 		<!-- <field name="itsDecayData" transient="true"/> -->
 	</class>
+        <!-- This should really be attached to m_end_vertex but we cannot since in ROOT the class.rules file already has a rule for that member -->
+        <ioread sourceClass = "HepMC::GenParticle" source="int m_barcode" version="[1-]" targetClass="HepMC::GenParticle" target="m_barcode">
+	  <![CDATA[m_barcode = onfile.m_barcode;
+                  if(newObj->end_vertex()) { hepmc_rootio::add_to_particles_in(newObj->end_vertex(), newObj); }
+]]> 
+	</ioread>
+
     <class name="HepMC::GenCrossSection" ClassVersion="10">
      <version ClassVersion="10" checksum="920043842"/>
     </class>

--- a/SimDataFormats/GeneratorProducts/src/hepmc_rootio.cc
+++ b/SimDataFormats/GeneratorProducts/src/hepmc_rootio.cc
@@ -2,9 +2,12 @@
 #include <HepMC/GenVertex.h>
 #include <iostream>
 
-//HACK
+//HACK We need to change the internals of GenVertex when reading
+// back via ROOT. We use the private access of GenEvent to 
+// accomplish it.
 namespace HepMC {
-  struct GenEvent {
+  class GenEvent {
+  public:
     static void clear_particles_in(HepMC::GenVertex* iVertex) {
       iVertex->m_particles_in.clear();
     }

--- a/SimDataFormats/GeneratorProducts/src/hepmc_rootio.cc
+++ b/SimDataFormats/GeneratorProducts/src/hepmc_rootio.cc
@@ -1,0 +1,26 @@
+#include <HepMC/GenParticle.h>
+#include <HepMC/GenVertex.h>
+#include <iostream>
+
+//HACK
+namespace HepMC {
+  struct GenEvent {
+    static void clear_particles_in(HepMC::GenVertex* iVertex) {
+      iVertex->m_particles_in.clear();
+    }
+    static void add_to_particles_in(HepMC::GenVertex* iVertex, HepMC::GenParticle* iPart) {
+      iVertex->m_particles_in.push_back(iPart);
+    }
+  };
+}
+
+
+namespace hepmc_rootio {                                                                                                                
+  void add_to_particles_in(HepMC::GenVertex* iVertex, HepMC::GenParticle* iPart) {
+    HepMC::GenEvent::add_to_particles_in(iVertex, iPart);
+  }
+
+  void clear_particles_in(HepMC::GenVertex* iVertex) {
+    HepMC::GenEvent::clear_particles_in(iVertex);
+  }
+}

--- a/SimDataFormats/GeneratorProducts/test/BuildFile.xml
+++ b/SimDataFormats/GeneratorProducts/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<bin file="rootio_t.cc" name="SimDataFormatsGeneratorProductsRootTest">
+  <use name="root"/>
+  <use   name="SimDataFormats/GeneratorProducts"/>
+</bin>

--- a/SimDataFormats/GeneratorProducts/test/rootio_t.cc
+++ b/SimDataFormats/GeneratorProducts/test/rootio_t.cc
@@ -1,0 +1,89 @@
+#include "TFile.h"
+#include "TTree.h"
+
+#include "HepMC/GenEvent.h"
+#include <cassert>
+
+int main() {
+  //Write
+
+  constexpr int eventNumber = 10;
+  {
+    TFile oFile("rootio_t.root", "RECREATE");
+    TTree events("Events","Events");
+
+    HepMC::GenEvent event;
+
+    auto vtx = new HepMC::GenVertex( HepMC::FourVector(0.,0.,0.));
+
+    constexpr double kMass = 1.;
+    constexpr double kMom = 1.;
+    constexpr double kEnergy = sqrt( kMass*kMass+kMom*kMom);
+    constexpr int id = 11;
+
+    auto p1 = new HepMC::GenParticle(HepMC::FourVector{kMom,0.,0.,kEnergy}, id, 1);
+
+    p1->suggest_barcode(1);
+    vtx->add_particle_out(p1);
+
+
+    auto p2 = new HepMC::GenParticle(HepMC::FourVector{-kMom,0.,0.,kEnergy}, -id, 1);
+
+    p2->suggest_barcode(2);
+    vtx->add_particle_out(p2);
+
+    auto decayVtx = new HepMC::GenVertex(HepMC::FourVector(1.,0.,0.));
+    decayVtx->add_particle_in(p1);
+
+    event.add_vertex(vtx);
+    event.add_vertex(decayVtx);
+
+    event.set_event_number(eventNumber);
+    event.set_signal_process_id(20);
+
+    HepMC::GenEvent* pEv = &event;
+
+    events.Branch("GenEvent",&pEv);
+
+    events.Fill();
+    
+    oFile.Write();
+    oFile.Close();
+  }
+
+  //Read
+  {
+    TFile iFile("rootio_t.root");
+
+    TTree* events = dynamic_cast<TTree*>( iFile.Get("Events") );
+
+    HepMC::GenEvent event;
+    HepMC::GenEvent* pEv = &event;
+    events->SetBranchAddress("GenEvent",&pEv);
+
+    events->GetEntry(0);
+
+    assert(event.event_number() == eventNumber);
+    assert(event.particles_size() == 2);
+    assert(event.vertices_size() == 2);
+    
+    int barcode = 1;
+    for(auto it = event.particles_begin(); it != event.particles_end(); ++it) {
+      if((*it)->production_vertex()) {
+        auto vtx = (*it)->production_vertex();
+        assert( std::find(vtx->particles_out_const_begin(), vtx->particles_out_const_end(), *it) != vtx->particles_out_const_end());
+      }
+      if((*it)->end_vertex()) {
+        auto vtx = (*it)->end_vertex();
+        assert( std::find(vtx->particles_in_const_begin(), vtx->particles_in_const_end(), *it) != vtx->particles_in_const_end());
+      }
+
+      assert( (*it)->barcode() == barcode);
+      assert( *it == event.barcode_to_particle( (*it)->barcode() ) );
+      ++barcode;
+    }
+
+    
+  }
+
+}

--- a/SimDataFormats/GeneratorProducts/test/rootio_t.cc
+++ b/SimDataFormats/GeneratorProducts/test/rootio_t.cc
@@ -18,7 +18,7 @@ int main() {
 
     constexpr double kMass = 1.;
     constexpr double kMom = 1.;
-    constexpr double kEnergy = sqrt( kMass*kMass+kMom*kMom);
+    const double kEnergy = sqrt( kMass*kMass+kMom*kMom);
     constexpr int id = 11;
 
     auto p1 = new HepMC::GenParticle(HepMC::FourVector{kMom,0.,0.,kEnergy}, id, 1);


### PR DESCRIPTION
When storing the HepMCProduct, we need to avoid a fully connected GenParticle/GenVertex graph to keep ROOT's recursion in check. This can be done by not stroring GenVertex::m_particles_in. We then refill that container in a ROOT ioread rule.