### PR TITLE
HCAL M0 timing update/cleanup

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
@@ -220,13 +220,13 @@ float SimpleHBHEPhase1Algo::m0Time(const HBHEChannelInfo& info,
             // Simplified evaluation for Phase1
             float emax0 = info.tsEnergy(maxI);
             float emax1 = info.tsEnergy(maxI + 1U);
-            float esum  = emax0 + emax1;
 
 	    // consider soi reference for collisions  
-            if(nSamplesToExamine < (int)nSamples) maxI  -= soi;
-       
-            time = 25.f * (float)maxI;                   
-            if(emax1 > 0.f)  time += 25.f * emax1/esum; // 1-st order correction 
+            int position = (int)maxI;
+            if(nSamplesToExamine < (int)nSamples) position  -= soi;
+     
+            time = 25.f * (float)position;                   
+            if(emax1 > 0.f)  time += 25.f * emax1/(emax0+emax1); // 1-st order correction 
 
             // TimeSlew correction
             time -= hcalTimeSlew_delay_->delay(std::max(1.0, fc_ampl), HcalTimeSlew::Medium);

--- a/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
@@ -207,7 +207,7 @@ float SimpleHBHEPhase1Algo::m0Time(const HBHEChannelInfo& info,
         int ibeg = soi + firstSampleShift_;
         if (ibeg < 0)
             ibeg = 0;
-        const int iend = std::min(ibeg + nSamplesToExamine, (int)nSamples); // actual array
+        const int iend = std::min(ibeg + nSamplesToExamine, (int)nSamples - 1); // actual array
 
         unsigned maxI = info.peakEnergyTS((unsigned)ibeg, (unsigned)iend);  // requires unsigned params
         if (maxI < HBHEChannelInfo::MAXSAMPLES)
@@ -217,7 +217,8 @@ float SimpleHBHEPhase1Algo::m0Time(const HBHEChannelInfo& info,
   
             // Simplified evaluation for Phase1
             float emax0 = info.tsEnergy(maxI);
-            float emax1 = info.tsEnergy(maxI + 1U);
+            float emax1 = 0.;        
+            if(maxI < (nSamples - 1U)) emax1 = info.tsEnergy(maxI + 1U);
 
 	    // consider soi reference for collisions  
             int position = (int)maxI;

--- a/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
@@ -224,8 +224,9 @@ float SimpleHBHEPhase1Algo::m0Time(const HBHEChannelInfo& info,
 
 	    // consider soi reference for collisions  
             if(nSamplesToExamine < (int)nSamples) maxI  -= soi;
-
-            time = 25.f * ((float)maxI + emax1/esum);
+       
+            time = 25.f * (float)maxI;                   
+            if(emax1 > 0.f)  time += 25.f * emax1/esum; // 1-st order correction 
 
             // TimeSlew correction
             time -= hcalTimeSlew_delay_->delay(std::max(1.0, fc_ampl), HcalTimeSlew::Medium);


### PR DESCRIPTION
As discussed at HCAL DPG on Friday
https://indico.cern.ch/event/795881/ 
current M0 timing is suboptimal both for Phase1 collisions and for Cosmics/Splashes, as it uses 
(i) tabulated corrections for old HPD pulse shape;
(ii) timing adjustment from obsolete (Run 1) DB conditions. 

Both (i) and (ii) are now removed, SOI reference is used solely for collisions, not for Cosmics/Splashes. MC Cosmics-config and collisions [*] tests (including debugging printout inspection of ~100 ev) show expected behaviour: M0 timing vs energy is narrow and stable above several GeV.     

--------
[*]
NB: green color is for new M0 timing, the red one - for current default MAHI timing.
The latter is a pending issue  https://github.com/cms-sw/cmssw/issues/25526  and is being revised now.

HB : 
https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/10_X/10_5_0_pre2_2018_newM0timing_vs_10_5_0_pre2_2018_SinglePi/RecHitsTask_timing_vs_energy_profile_HB.gif

HE : 
https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/10_X/10_5_0_pre2_2018_newM0timing_vs_10_5_0_pre2_2018_SinglePi/RecHitsTask_timing_vs_energy_profile_HE.gif