### PR TITLE
[10.6.X] Python2to3 fixes

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
@@ -159,7 +159,7 @@ class BetterConfigParser(ConfigParser.ConfigParser):
             "datadir":os.getcwd(),
             "logdir":os.getcwd(),
             }
-	mandatories = [
+        mandatories = [
             "eosdir",
         ]
         self.checkInput("general", knownSimpleOptions = defaults.keys() + mandatories)

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
 from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import patDiscriminationByIsolationMVArun2v1raw, patDiscriminationByIsolationMVArun2v1VLoose
 import os
@@ -50,14 +51,14 @@ class TauIDEmbedder(object):
     def get_cmssw_version(debug = False):
         """returns 'CMSSW_X_Y_Z'"""
         cmssw_version = os.environ["CMSSW_VERSION"]
-        if debug: print "get_cmssw_version:", cmssw_version
+        if debug: print ("get_cmssw_version:", cmssw_version)
         return cmssw_version
 
     @classmethod
     def get_cmssw_version_number(klass, debug = False):
         """returns '(release, subversion, patch)' (without 'CMSSW_')"""
         v = klass.get_cmssw_version().split("CMSSW_")[1].split("_")[0:3]
-        if debug: print "get_cmssw_version_number:", v
+        if debug: print ("get_cmssw_version_number:", v)
         if v[2] == "X":
             patch = -1
         else:
@@ -67,7 +68,7 @@ class TauIDEmbedder(object):
     @staticmethod
     def versionToInt(release=9, subversion=4, patch=0, debug = False):
         version = release * 10000 + subversion * 100 + patch + 1 # shifted by one to account for pre-releases.
-        if debug: print "versionToInt:", version
+        if debug: print ("versionToInt:", version)
         return version
 
 
@@ -75,14 +76,14 @@ class TauIDEmbedder(object):
     def is_above_cmssw_version(klass, release=9, subversion=4, patch=0, debug = False):
         split_cmssw_version = klass.get_cmssw_version_number()
         if klass.versionToInt(release, subversion, patch) > klass.versionToInt(split_cmssw_version[0], split_cmssw_version[1], split_cmssw_version[2]):
-            if debug: print "is_above_cmssw_version:", False
+            if debug: print ("is_above_cmssw_version:", False)
             return False
         else:
-            if debug: print "is_above_cmssw_version:", True
+            if debug: print ("is_above_cmssw_version:", True)
             return True
 
     def loadMVA_WPs_run2_2017(self):
-        if self.debug: print "loadMVA_WPs_run2_2017: performed"
+        if self.debug: print ("loadMVA_WPs_run2_2017: performed")
         global cms
         for training, gbrForestName in self.tauIdDiscrMVA_trainings_run2_2017.items():
 
@@ -135,7 +136,7 @@ class TauIDEmbedder(object):
             }
             # update the list of available in DB samples
             if not self.is_above_cmssw_version(9, 4, 4, self.debug):
-                if self.debug: print "runTauID: not is_above_cmssw_version(9, 4, 4). Will update the list of available in DB samples to access 2017v1"
+                if self.debug: print ("runTauID: not is_above_cmssw_version(9, 4, 4). Will update the list of available in DB samples to access 2017v1")
                 self.loadMVA_WPs_run2_2017()
 
             self.process.rerunDiscriminationByIsolationOldDMMVArun2017v1raw = patDiscriminationByIsolationMVArun2v1raw.clone(
@@ -218,7 +219,7 @@ class TauIDEmbedder(object):
             }
 
             if not self.is_above_cmssw_version(9, 4, 5, self.debug):
-                if self.debug: print "runTauID: not is_above_cmssw_version(9, 4, 5). Will update the list of available in DB samples to access 2017v2"
+                if self.debug: print ("runTauID: not is_above_cmssw_version(9, 4, 5). Will update the list of available in DB samples to access 2017v2")
                 self.loadMVA_WPs_run2_2017()
 
             self.process.rerunDiscriminationByIsolationOldDMMVArun2017v2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
@@ -301,7 +302,7 @@ class TauIDEmbedder(object):
             }
 
             if not self.is_above_cmssw_version(9, 4, 5, self.debug):
-                if self.debug: print "runTauID: not is_above_cmssw_version(9, 4, 5). Will update the list of available in DB samples to access newDM2017v2"
+                if self.debug: print ("runTauID: not is_above_cmssw_version(9, 4, 5). Will update the list of available in DB samples to access newDM2017v2")
                 self.loadMVA_WPs_run2_2017()
 
             self.process.rerunDiscriminationByIsolationNewDMMVArun2017v2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
@@ -384,7 +385,7 @@ class TauIDEmbedder(object):
             }
 
             if not self.is_above_cmssw_version(9, 4, 5, self.debug):
-                if self.debug: print "runTauID: not is_above_cmssw_version(9, 4, 5). Will update the list of available in DB samples to access dR0p32017v2"
+                if self.debug: print ("runTauID: not is_above_cmssw_version(9, 4, 5). Will update the list of available in DB samples to access dR0p32017v2")
                 self.loadMVA_WPs_run2_2017()
 
             self.process.rerunDiscriminationByIsolationOldDMdR0p3MVArun2017v2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
@@ -599,7 +600,7 @@ class TauIDEmbedder(object):
             tauIDSources.byVVTightIsolationMVArun2v1DBnewDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VVTight')
 
         if "deepTau2017v1" in self.toKeep:
-            print "Adding DeepTau IDs"
+            print ("Adding DeepTau IDs")
 
             workingPoints_ = {
                 "e": {
@@ -649,7 +650,7 @@ class TauIDEmbedder(object):
             self.process.rerunMvaIsolationSequence += self.process.deepTau2017v1
 
         if "DPFTau_2016_v0" in self.toKeep:
-            print "Adding DPFTau isolation (v0)"
+            print ("Adding DPFTau isolation (v0)")
 
             workingPoints_ = {
                 "all": {
@@ -682,9 +683,9 @@ class TauIDEmbedder(object):
 
 
         if "DPFTau_2016_v1" in self.toKeep:
-            print "Adding DPFTau isolation (v1)"
-            print "WARNING: WPs are not defined for DPFTau_2016_v1"
-            print "WARNING: The score of DPFTau_2016_v1 is inverted: i.e. for Sig->0, for Bkg->1 with -1 for undefined input (preselection not passed)."
+            print ("Adding DPFTau isolation (v1)")
+            print ("WARNING: WPs are not defined for DPFTau_2016_v1")
+            print ("WARNING: The score of DPFTau_2016_v1 is inverted: i.e. for Sig->0, for Bkg->1 with -1 for undefined input (preselection not passed).")
 
             workingPoints_ = {
                 "all": {"Tight" : 0.123} #FIXME: define WP

--- a/RecoTracker/IterativeTracking/python/customise_MVAPhase1_cfi.py
+++ b/RecoTracker/IterativeTracking/python/customise_MVAPhase1_cfi.py
@@ -18,11 +18,11 @@ from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 
 
 def customise_MVAPhase1(process):
-	trackingPhase1.toReplaceWith(detachedQuadStep, TrackMVAClassifierDetached.clone(
-		mva = dict(GBRForestLabel = 'MVASelectorDetachedQuadStep_Phase1'),
-		src = 'detachedQuadStepTracks',
-		qualityCuts = [-0.5,0.0,0.5]
-	))
+        trackingPhase1.toReplaceWith(detachedQuadStep, TrackMVAClassifierDetached.clone(
+                mva = dict(GBRForestLabel = 'MVASelectorDetachedQuadStep_Phase1'),
+                src = 'detachedQuadStepTracks',
+                qualityCuts = [-0.5,0.0,0.5]
+        ))
 
         trackingPhase1.toReplaceWith(detachedTripletStep, TrackMVAClassifierDetached.clone(
                 mva = dict(GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1'),
@@ -36,13 +36,13 @@ def customise_MVAPhase1(process):
                 qualityCuts = [0.2,0.3,0.4]
         ))
 
-	trackingPhase1.toReplaceWith(initialStep, TrackMVAClassifierPrompt.clone(
-		mva = dict(GBRForestLabel = 'MVASelectorInitialStep_Phase1'),
-		src = 'initialStepTracks',
-		qualityCuts = [-0.95,-0.85,-0.75]
-	))
+        trackingPhase1.toReplaceWith(initialStep, TrackMVAClassifierPrompt.clone(
+                mva = dict(GBRForestLabel = 'MVASelectorInitialStep_Phase1'),
+                src = 'initialStepTracks',
+                qualityCuts = [-0.95,-0.85,-0.75]
+        ))
 
-	trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackMVAClassifierPrompt.clone(
+        trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackMVAClassifierPrompt.clone(
                 mva = dict(GBRForestLabel = 'MVASelectorJetCoreRegionalStep_Phase1'),
                 src = 'jetCoreRegionalStepTracks',
                 qualityCuts = [-0.2,0.0,0.4]
@@ -60,7 +60,7 @@ def customise_MVAPhase1(process):
                 qualityCuts = [-0.4,0.0,0.3]
         ))
 
-	trackingPhase1.toReplaceWith(mixedTripletStep, TrackMVAClassifierDetached.clone(
+        trackingPhase1.toReplaceWith(mixedTripletStep, TrackMVAClassifierDetached.clone(
                 mva = dict(GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1'),
                 src = 'mixedTripletStepTracks',
                 qualityCuts = [-0.5,0.0,0.5]
@@ -84,4 +84,4 @@ def customise_MVAPhase1(process):
                 qualityCuts = [-0.6,-0.45,-0.3]
         ))
 
-	return process
+        return process

--- a/SimPPS/PPSSimTrackProducer/python/SimTrackProducerForFastSim_cff.py
+++ b/SimPPS/PPSSimTrackProducer/python/SimTrackProducerForFastSim_cff.py
@@ -1,52 +1,51 @@
 import FWCore.ParameterSet.Config as cms
 
 def customise(process):
-	if hasattr(process.VtxSmeared,"X0"):
-		VertexX = process.VtxSmeared.X0
-		VertexY = process.VtxSmeared.Y0
-		VertexZ = process.VtxSmeared.Z0
+        if hasattr(process.VtxSmeared,"X0"):
+                VertexX = process.VtxSmeared.X0
+                VertexY = process.VtxSmeared.Y0
+                VertexZ = process.VtxSmeared.Z0
 
-	if hasattr(process.VtxSmeared,"MeanX"):
-		VertexX = process.VtxSmeared.MeanX
-		VertexY = process.VtxSmeared.MeanY
-		VertexZ = process.VtxSmeared.MeanZ
+        if hasattr(process.VtxSmeared,"MeanX"):
+                VertexX = process.VtxSmeared.MeanX
+                VertexY = process.VtxSmeared.MeanY
+                VertexZ = process.VtxSmeared.MeanZ
 
-	
-	#process.load('SimTransport.PPSProtonTransport.HectorTransport_cfi')
-	process.load('SimTransport.PPSProtonTransport.TotemTransport_cfi')
-	process.LHCTransport.VtxMeanX  = VertexX
-	process.LHCTransport.VtxMeanY  = VertexY
-	process.LHCTransport.VtxMeanZ = VertexZ
 
-	###################################
-	process.load('FastSimulation.CTPPSSimHitProducer.CTPPSSimHitProducer_cfi')
-	process.load('FastSimulation.CTPPSRecHitProducer.CTPPSRecHitProducer_cfi')
-	process.load('FastSimulation.CTPPSFastTrackingProducer.CTPPSFastTrackingProducer_cfi')
-	###################################
-	process.mix.mixObjects.mixSH.crossingFrames.append('CTPPSHits')
-	process.mix.mixObjects.mixSH.input.append(cms.InputTag("CTPPSSimHits","CTPPSHits"))
-	process.mix.mixObjects.mixSH.subdets.append('CTPPSHits')
-       
-			
-	# PPS simHit sequence 
-	process.simulation_step.replace(process.psim,process.psim+process.CTPPSSimHits)
+        #process.load('SimTransport.PPSProtonTransport.HectorTransport_cfi')
+        process.load('SimTransport.PPSProtonTransport.TotemTransport_cfi')
+        process.LHCTransport.VtxMeanX  = VertexX
+        process.LHCTransport.VtxMeanY  = VertexY
+        process.LHCTransport.VtxMeanZ = VertexZ
+
+        ###################################
+        process.load('FastSimulation.CTPPSSimHitProducer.CTPPSSimHitProducer_cfi')
+        process.load('FastSimulation.CTPPSRecHitProducer.CTPPSRecHitProducer_cfi')
+        process.load('FastSimulation.CTPPSFastTrackingProducer.CTPPSFastTrackingProducer_cfi')
+        ###################################
+        process.mix.mixObjects.mixSH.crossingFrames.append('CTPPSHits')
+        process.mix.mixObjects.mixSH.input.append(cms.InputTag("CTPPSSimHits","CTPPSHits"))
+        process.mix.mixObjects.mixSH.subdets.append('CTPPSHits')
+
+
+        # PPS simHit sequence
+        process.simulation_step.replace(process.psim,process.psim+process.CTPPSSimHits)
         # SimTransport on path
         process.transport_step = cms.Path(process.generator+process.LHCTransport)
 
-	#process.schedule.insert(2,process.transport_step)
+        #process.schedule.insert(2,process.transport_step)
 
         process.load("IOMC.RandomEngine.IOMC_cff")
         process.RandomNumberGeneratorService.LHCTransport.engineName   = cms.untracked.string('TRandom3')
 
-	# output
-    	outputModule = None
-    	outdict = process.outputModules_()
-    	if outdict.has_key("AODSIMoutput"):
-	    process.AODSIMoutput.outputCommands.extend(cms.untracked.vstring('keep *_CTPPSSimHits_*_*','keep *_CTPPSFastRecHits_*_*','keep *_CTPPSFastTracks_*_*'))
-	    process.reconstruction_step.replace(process.reconstruction,process.reconstruction*process.CTPPSFastRecHits*process.CTPPSFastTracks) 	
-    	elif outdict.has_key("FASTPUoutput"):
-	    process.FASTPUoutput.outputCommands.extend(cms.untracked.vstring('keep *_CTPPSSimHits_*_*')) 	
-			
-	
-	return(process)
+        # output
+        outputModule = None
+        outdict = process.outputModules_()
+        if outdict.has_key("AODSIMoutput"):
+            process.AODSIMoutput.outputCommands.extend(cms.untracked.vstring('keep *_CTPPSSimHits_*_*','keep *_CTPPSFastRecHits_*_*','keep *_CTPPSFastTracks_*_*'))
+            process.reconstruction_step.replace(process.reconstruction,process.reconstruction*process.CTPPSFastRecHits*process.CTPPSFastTracks)
+        elif outdict.has_key("FASTPUoutput"):
+            process.FASTPUoutput.outputCommands.extend(cms.untracked.vstring('keep *_CTPPSSimHits_*_*'))
+
+        return(process)
 


### PR DESCRIPTION
This should fix the python3 compilation errors https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/python3/slc7_amd64_gcc700/CMSSW_10_6_X_2019-03-03-2300/python3.log
```
*** Error compiling 'src/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py'...
Sorry: TabError: inconsistent use of tabs and spaces in indentation (betterConfigParser.py, line 162)
```
```
*** Error compiling 'src/RecoTracker/IterativeTracking/python/customise_MVAPhase1_cfi.py'...
Sorry: TabError: inconsistent use of tabs and spaces in indentation (customise_MVAPhase1_cfi.py, line 27)
```
```
*** Error compiling 'src/SimPPS/PPSSimTrackProducer/python/SimTrackProducerForFastSim_cff.py'...
Sorry: TabError: inconsistent use of tabs and spaces in indentation (SimTrackProducerForFastSim_cff.py, line 34)
```
```
*** Error compiling 'src/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py'...
  File "src/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py", line 53
    if debug: print "get_cmssw_version:", cmssw_version
                                       ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(if debug: print "get_cmssw_version:", cmssw_version)?
```
