### PR TITLE
[HGCAL trigger] New implementation for the V9 geometry (squashed history of #25949)

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCalClusterT.h
+++ b/DataFormats/L1THGCal/interface/HGCalClusterT.h
@@ -7,6 +7,9 @@
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/ClusterShapes.h"
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
 
 /* ROOT */
 #include "Math/Vector3D.h"
@@ -62,7 +65,7 @@ namespace l1t
 
         if( constituents_.empty() )
         {
-          detId_ = HGCalDetId( c->detId() );
+          detId_ = DetId( c->detId() );
           seedMipPt_ = cMipt;
           /* if the centre will not be dynamically calculated
              the seed centre is considere as cluster centre */
@@ -125,21 +128,21 @@ namespace l1t
 
         for(const auto& id_constituent : constituents())
         {
+          DetId id(id_constituent.first);
           auto id_fraction = constituentsFraction_.find(id_constituent.first);
           double fraction = (id_fraction!=constituentsFraction_.end() ? id_fraction->second : 1.);
-          switch( id_constituent.second->subdetId() )
-          {
-            case HGCEE:
-              pt_em += id_constituent.second->pt() * fraction;
-              break;
-            case HGCHEF:
-              pt_had += id_constituent.second->pt() * fraction;
-              break;
-            case HGCHEB:
-              pt_had += id_constituent.second->pt() * fraction;
-              break;
-            default:
-              break;
+          if ((id.det() == DetId::Forward && id.subdetId()==HGCEE) ||
+              (id.det() == DetId::HGCalEE) ||
+              (id.det() == DetId::HGCalTrigger && HGCalTriggerDetId(id).subdet()==HGCalTriggerSubdetector::HGCalEETrigger)
+              ) {
+            pt_em += id_constituent.second->pt() * fraction;
+          } else if((id.det() == DetId::Forward && id.subdetId()==HGCHEF) ||
+               (id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) ||
+               (id.det() == DetId::HGCalHSi) ||
+               (id.det() == DetId::HGCalHSc) ||
+               (id.det() == DetId::HGCalTrigger && HGCalTriggerDetId(id).subdet()==HGCalTriggerSubdetector::HGCalHSiTrigger)
+              ) {
+            pt_had += id_constituent.second->pt() * fraction;
           }
         }
         if(pt_em>0) hOe = pt_had / pt_em ;
@@ -148,8 +151,6 @@ namespace l1t
       }
 
       uint32_t subdetId() const {return detId_.subdetId();} 
-      uint32_t layer() const {return detId_.layer();}
-      int32_t zside() const {return detId_.zside();}
 
 
       //shower shape
@@ -192,7 +193,7 @@ namespace l1t
     private:
 
       bool valid_;
-      HGCalDetId detId_;
+      DetId detId_;
 
       std::unordered_map<uint32_t, edm::Ptr<C>> constituents_;
       std::unordered_map<uint32_t, double> constituentsFraction_;

--- a/DataFormats/L1THGCal/interface/HGCalMulticluster.h
+++ b/DataFormats/L1THGCal/interface/HGCalMulticluster.h
@@ -12,7 +12,7 @@ namespace l1t {
     
     public:
        
-      HGCalMulticluster(){}
+      HGCalMulticluster() : hOverEValid_(false) {}
       HGCalMulticluster( const LorentzVector p4,
           int pt=0,
           int eta=0,
@@ -23,7 +23,22 @@ namespace l1t {
       
       ~HGCalMulticluster() override;
 
+      float hOverE() const { 
+        // --- this below would be faster when reading old objects, as HoE will only be computed once, 
+        // --- but it may not be allowed by CMS rules because of the const_cast
+        // --- and could potentially cause a data race
+        // if (!hOverEValid_) (const_cast<HGCalMulticluster*>(this))->saveHOverE();
+        // --- this below is safe in any case
+        return hOverEValid_ ? hOverE_ : l1t::HGCalClusterT<l1t::HGCalCluster>::hOverE(); 
+      }
 
+      void saveHOverE() { 
+        hOverE_ = l1t::HGCalClusterT<l1t::HGCalCluster>::hOverE(); 
+        hOverEValid_ = true;
+      }
+    private:
+      float hOverE_;
+      bool hOverEValid_;
   };
     
   typedef BXVector<HGCalMulticluster> HGCalMulticlusterBxCollection;  

--- a/DataFormats/L1THGCal/interface/HGCalTriggerCell.h
+++ b/DataFormats/L1THGCal/interface/HGCalTriggerCell.h
@@ -5,7 +5,7 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/DetId/interface/DetId.h"
 
 namespace l1t 
 {
@@ -29,7 +29,7 @@ namespace l1t
 
             ~HGCalTriggerCell() override;
 
-            void setDetId(uint32_t detid) {detid_ = HGCalDetId(detid);}
+            void setDetId(uint32_t detid) {detid_ = DetId(detid);}
             void setPosition(const GlobalPoint& position) {position_ = position;}
 
             uint32_t detId() const {return detid_.rawId();}
@@ -37,12 +37,6 @@ namespace l1t
             
             int subdetId() const {                
                 return detid_.subdetId();               
-            }
-            int zside() const {                
-                return detid_.zside();               
-            }
-            int layer() const {                
-                return detid_.layer();               
             }
             
             void   setMipPt( double value ) { mipPt_ = value; }
@@ -58,7 +52,7 @@ namespace l1t
             
         private:
             
-            HGCalDetId detid_;
+            DetId detid_;
             GlobalPoint position_;
             
             double mipPt_{0.};

--- a/DataFormats/L1THGCal/interface/HGCalTriggerSums.h
+++ b/DataFormats/L1THGCal/interface/HGCalTriggerSums.h
@@ -5,7 +5,7 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/DetId/interface/DetId.h"
 
 namespace l1t 
 {
@@ -29,25 +29,19 @@ namespace l1t
 
             ~HGCalTriggerSums() override;
 
-            void setDetId(uint32_t detid) {detid_ = HGCalDetId(detid);}
+            void setDetId(uint32_t detid) {detid_ = DetId(detid);}
             void setPosition(const GlobalPoint& position) {position_ = position;}
 
             uint32_t detId() const {return detid_.rawId();}
             const GlobalPoint& position() const {return position_;}
             
-            int zside() const {                
-                return detid_.zside();               
-            }
-            int layer() const {                
-                return detid_.layer();               
-            }
             
             void   setMipPt( double value ) { mipPt_ = value; }
             double mipPt() const            { return mipPt_;  }
             
         private:
             
-            HGCalDetId detid_;
+            DetId detid_;
             GlobalPoint position_;
             
             double mipPt_;

--- a/DataFormats/L1THGCal/src/HGCalMulticluster.cc
+++ b/DataFormats/L1THGCal/src/HGCalMulticluster.cc
@@ -6,13 +6,17 @@ HGCalMulticluster::HGCalMulticluster( const LorentzVector p4,
                             int pt,
                             int eta,
                             int phi )
-   : HGCalClusterT<l1t::HGCalCluster>(p4, pt, eta, phi)
+   : HGCalClusterT<l1t::HGCalCluster>(p4, pt, eta, phi),
+     hOverE_(-99),
+     hOverEValid_(false)
 {
 }
 
 
 HGCalMulticluster::HGCalMulticluster( const edm::Ptr<l1t::HGCalCluster> &clusterSeed )
-    : HGCalClusterT<l1t::HGCalCluster>(clusterSeed)
+    : HGCalClusterT<l1t::HGCalCluster>(clusterSeed),
+      hOverE_(-99),
+      hOverEValid_(false)
 {
 }
 

--- a/DataFormats/L1THGCal/src/classes_def.xml
+++ b/DataFormats/L1THGCal/src/classes_def.xml
@@ -30,7 +30,8 @@
 
   <class name="l1t::HGCalClusterT<l1t::HGCalTriggerCell>" />
   <class name="l1t::HGCalClusterT<l1t::HGCalTriggerSums>" />
-  <class name="l1t::HGCalCluster" ClassVersion="14">
+  <class name="l1t::HGCalCluster" ClassVersion="15">
+   <version ClassVersion="15" checksum="2522149132"/>
   <version ClassVersion="14" checksum="3289642235"/>
   <version ClassVersion="13" checksum="3397489079"/>
   <version ClassVersion="12" checksum="623703096"/>
@@ -42,18 +43,23 @@
   <class name="edm::Wrapper<l1t::HGCalClusterBxCollection>"/>
 
   <class name="l1t::HGCalClusterT<l1t::HGCalCluster>" />
-  <class name="l1t::HGCalMulticluster" ClassVersion="14">
+  <class name="l1t::HGCalMulticluster" ClassVersion="16">
+   <version ClassVersion="16" checksum="1276395758"/>
+   <version ClassVersion="15" checksum="777879934"/>
   <version ClassVersion="14" checksum="2315302819"/>
   <version ClassVersion="13" checksum="816077951"/>
   <version ClassVersion="12" checksum="4221677522"/>
   <version ClassVersion="11" checksum="1508179045"/>
   <version ClassVersion="10" checksum="1878482802"/>
   </class>
+  <ioread sourceClass="l1t::HGCalMulticluster"  targetClass="l1t::HGCalMulticluster" version="[-15]" target="hOverE_" source="" embed="false"> <![CDATA[ hOverE_ = -99; ]]> </ioread>
+  <ioread sourceClass="l1t::HGCalMulticluster"  targetClass="l1t::HGCalMulticluster" version="[-15]" target="hOverEValid_" source="" embed="false"> <![CDATA[ hOverEValid_ = false; ]]> </ioread>
   <class name="std::vector<l1t::HGCalMulticluster>" />
   <class name="l1t::HGCalMulticlusterBxCollection"/>
   <class name="edm::Wrapper<l1t::HGCalMulticlusterBxCollection>"/>
 
-  <class name="l1t::HGCalTriggerCell" ClassVersion="11">
+  <class name="l1t::HGCalTriggerCell" ClassVersion="12">
+   <version ClassVersion="12" checksum="3538848072"/>
    <version ClassVersion="11" checksum="646735227"/>
     <version ClassVersion="10" checksum="1275348814"/>
   </class>
@@ -61,7 +67,8 @@
   <class name="l1t::HGCalTriggerCellBxCollection"/>
   <class name="edm::Wrapper<l1t::HGCalTriggerCellBxCollection>"/>
   
-  <class name="l1t::HGCalTriggerSums" ClassVersion="11">
+  <class name="l1t::HGCalTriggerSums" ClassVersion="12">
+   <version ClassVersion="12" checksum="1802885417"/>
     <version ClassVersion="11" checksum="4058188392"/>
   </class>
   <class name="std::vector<l1t::HGCalTriggerSums>" />

--- a/L1Trigger/L1THGCal/BuildFile.xml
+++ b/L1Trigger/L1THGCal/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="DataFormats/L1THGCal"/>
 <use   name="CommonTools/Utils"/>
 <use   name="Geometry/HcalTowerAlgo"/>
+<use   name="SimDataFormats/CaloTest"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -18,8 +18,11 @@
 #include <vector>
 #include "DataFormats/L1Trigger/interface/BXVector.h"
 
+#include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 
 class HGCalTriggerGeometryBase;
 class DetId;
@@ -39,9 +42,18 @@ class HGCalTriggerTools {
     void eventSetup(const edm::EventSetup&);
     GlobalPoint getTCPosition(const DetId& id) const;
     unsigned layers(ForwardSubdetector type) const;
+    unsigned layers(DetId::Detector type) const ;
     unsigned layer(const DetId&) const;
     unsigned layerWithOffset(const DetId&) const;
-    int thicknessIndex(const DetId&) const;
+    bool isEm(const DetId&) const;
+    bool isHad(const DetId& id) const {return !isEm(id);}
+    bool isSilicon(const DetId&) const;
+    bool isScintillator(const DetId& id) const {return !isSilicon(id);}
+    int zside(const DetId&) const;
+    // tc argument is needed because of the impossibility
+    // to know whether the ID is a TC or a sensor cell
+    // in the v8 geometry detid scheme
+    int thicknessIndex(const DetId&, bool tc=false) const;
 
     unsigned lastLayerEE() const {return eeLayers_;}
     unsigned lastLayerFH() const {return eeLayers_+fhLayers_;}
@@ -70,12 +82,17 @@ class HGCalTriggerTools {
       return outputVector;
     }
 
+    DetId simToReco(const DetId&, const HGCalTopology&) const ;
+    DetId simToReco(const DetId&, const HcalTopology&) const ;
+
   private:
     const HGCalTriggerGeometryBase* geom_;
     unsigned eeLayers_;
     unsigned fhLayers_;
     unsigned bhLayers_;
     unsigned totalLayers_;
+
+    int sensorCellThicknessV8(const DetId& id) const;
 };
 
 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
@@ -12,6 +12,7 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerID.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 
 #include <vector>
 #include <unordered_map>
@@ -27,6 +28,11 @@ class HGCalTriggerTowerGeometryHelper {
     HGCalTriggerTowerGeometryHelper(const edm::ParameterSet& conf);
 
     ~HGCalTriggerTowerGeometryHelper() {}
+
+    void eventSetup(const edm::EventSetup& es) 
+    {
+        triggerTools_.eventSetup(es);
+    }
 
     const std::vector<l1t::HGCalTowerCoord>& getTowerCoordinates() const;
 
@@ -46,6 +52,8 @@ class HGCalTriggerTowerGeometryHelper {
 
     std::vector<double> binsEta_;
     std::vector<double> binsPhi_;
+
+    HGCalTriggerTools triggerTools_;
 
   };
 

--- a/L1Trigger/L1THGCal/interface/backend/HGCalClusteringDummyImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalClusteringDummyImpl.h
@@ -6,7 +6,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"

--- a/L1Trigger/L1THGCal/interface/backend/HGCalClusteringImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalClusteringImpl.h
@@ -6,7 +6,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"

--- a/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTowerMap2DImpl.h
@@ -25,6 +25,7 @@ class HGCalTowerMap2DImpl{
 
   void eventSetup(const edm::EventSetup& es) {
         triggerTools_.eventSetup(es);
+        towerGeometryHelper_.eventSetup(es);
   }
 
  private:

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSelectionImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSelectionImpl.h
@@ -32,6 +32,10 @@ class HGCalConcentratorSelectionImpl
     int      TCThresholdBH_ADC() const {return TCThresholdBH_ADC_;}
     double   TCThresholdBH_MIP() const {return TCThresholdBH_MIP_;} 
 
+    void eventSetup(const edm::EventSetup& es) {
+      triggerTools_.eventSetup(es);
+    }
+
   private:
 
     size_t   nData_;

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalTriggerCellCalibration.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalTriggerCellCalibration.h
@@ -9,7 +9,6 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFECompressionImpl.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFECompressionImpl.h
@@ -4,7 +4,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 
 class HGCalVFECompressionImpl
 {

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer1Processor2DClustering.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer1Processor2DClustering.cc
@@ -1,6 +1,5 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalBackendLayer2Processor3DClustering.cc
@@ -1,6 +1,5 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerMapProcessor.cc
@@ -1,6 +1,5 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTowerProcessor.cc
@@ -1,6 +1,5 @@
 #include "L1Trigger/L1THGCal/interface/HGCalProcessorBase.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalTowerMap.h"
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"

--- a/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
+++ b/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
@@ -33,6 +33,7 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
                                               l1t::HGCalTriggerCellBxCollection& triggerCellCollOutput,
                                               const edm::EventSetup& es)
 { 
+  if(concentratorProcImpl_) concentratorProcImpl_->eventSetup(es);
   const l1t::HGCalTriggerCellBxCollection& collInput = *triggerCellCollInput;
 
   std::unordered_map<uint32_t, std::vector<l1t::HGCalTriggerCell>> tc_modules;

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryHexLayerBasedImp1.cc
@@ -137,8 +137,9 @@ initialize(const edm::ESHandle<CaloGeometry>& calo_geometry)
     bhOffset_ = fhOffset_ + fhTopology().dddConstants().layers(true);
     totalLayers_ =  bhOffset_ + bhTopology().dddConstants()->getMaxDepth(1);
     trigger_layers_.resize(totalLayers_+1);
-    unsigned trigger_layer = 0;
-    for(unsigned layer=0; layer<trigger_layers_.size(); layer++)
+    trigger_layers_[0] = 0; // layer number 0 doesn't exist
+    unsigned trigger_layer = 1;
+    for(unsigned layer=1; layer<trigger_layers_.size(); layer++)
     {
         if(disconnected_layers_.find(layer)==disconnected_layers_.end())
         {

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp1.cc
@@ -160,8 +160,9 @@ initialize(const edm::ESHandle<HGCalGeometry>& hgc_ee_geometry,
     heOffset_ = eeTopology().dddConstants().layers(true);
     totalLayers_ = heOffset_ + hsiTopology().dddConstants().layers(true);
     trigger_layers_.resize(totalLayers_+1);
-    unsigned trigger_layer = 0;
-    for(unsigned layer=0; layer<trigger_layers_.size(); layer++)
+    trigger_layers_[0] = 0; // layer number 0 doesn't exist
+    unsigned trigger_layer = 1;
+    for(unsigned layer=1; layer<trigger_layers_.size(); layer++)
     {
         if(disconnected_layers_.find(layer)==disconnected_layers_.end())
         {

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
@@ -1,0 +1,671 @@
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetIdToROC.h"
+
+#include <vector>
+#include <iostream>
+#include <fstream>
+#include <regex>
+
+
+class HGCalTriggerGeometryV9Imp2 : public HGCalTriggerGeometryBase
+{
+    public:
+        HGCalTriggerGeometryV9Imp2(const edm::ParameterSet& conf);
+
+        void initialize(const edm::ESHandle<CaloGeometry>& ) final;
+        void initialize(const edm::ESHandle<HGCalGeometry>&,
+                const edm::ESHandle<HGCalGeometry>&,
+                const edm::ESHandle<HGCalGeometry>&) final;
+        void reset() final;
+
+        unsigned getTriggerCellFromCell( const unsigned ) const final;
+        unsigned getModuleFromCell( const unsigned ) const final;
+        unsigned getModuleFromTriggerCell( const unsigned ) const final;
+
+        geom_set getCellsFromTriggerCell( const unsigned ) const final;
+        geom_set getCellsFromModule( const unsigned ) const final;
+        geom_set getTriggerCellsFromModule( const unsigned ) const final;
+
+        geom_ordered_set getOrderedCellsFromModule( const unsigned ) const final;
+        geom_ordered_set getOrderedTriggerCellsFromModule( const unsigned ) const final;
+
+        geom_set getNeighborsFromTriggerCell( const unsigned ) const final;
+
+        GlobalPoint getTriggerCellPosition(const unsigned ) const final;
+        GlobalPoint getModulePosition(const unsigned ) const final;
+
+        bool validTriggerCell( const unsigned ) const final;
+        bool disconnectedModule(const unsigned) const final;
+        unsigned triggerLayer(const unsigned) const final;
+
+    private:
+        // HSc trigger cell grouping
+        unsigned hSc_triggercell_size_ = 2;
+        unsigned hSc_module_size_ = 12; // in TC units (144 TC / panel = 36 e-links)
+
+        edm::FileInPath l1tModulesMapping_;
+
+        // module related maps
+        std::unordered_map<unsigned, unsigned> wafer_to_module_;
+        std::unordered_multimap<unsigned, unsigned> module_to_wafers_;
+
+        // Disconnected modules and layers
+        std::unordered_set<unsigned> disconnected_layers_;
+        std::vector<unsigned> trigger_layers_;
+
+        // layer offsets 
+        unsigned heOffset_;
+        unsigned totalLayers_;
+
+        void fillMaps();
+        bool validCellId(unsigned det, unsigned cell_id) const;
+        bool validTriggerCellFromCells( const unsigned ) const;
+
+        int detIdWaferType(unsigned det, unsigned layer, short waferU, short waferV) const;
+        unsigned packWaferId(int waferU, int waferV) const;
+        void unpackWaferId(unsigned wafer, int& waferU, int& waferV) const;
+
+        unsigned layerWithOffset(unsigned) const;
+};
+
+
+HGCalTriggerGeometryV9Imp2::
+HGCalTriggerGeometryV9Imp2(const edm::ParameterSet& conf):
+    HGCalTriggerGeometryBase(conf),
+    hSc_triggercell_size_(conf.getParameter<unsigned>("ScintillatorTriggerCellSize")),
+    hSc_module_size_(conf.getParameter<unsigned>("ScintillatorModuleSize")),
+    l1tModulesMapping_(conf.getParameter<edm::FileInPath>("L1TModulesMapping")),
+    disconnected_layers_(conf.getParameter<std::vector<unsigned>>("DisconnectedLayers").begin(),conf.getParameter<std::vector<unsigned>>("DisconnectedLayers").end())
+{
+}
+
+void
+HGCalTriggerGeometryV9Imp2::
+reset()
+{
+    wafer_to_module_.clear();
+    module_to_wafers_.clear();
+}
+
+void
+HGCalTriggerGeometryV9Imp2::
+initialize(const edm::ESHandle<CaloGeometry>& calo_geometry)
+{
+    throw cms::Exception("BadGeometry")
+        << "HGCalTriggerGeometryV9Imp2 geometry cannot be initialized with the V7/V8 HGCAL geometry";
+}
+
+void
+HGCalTriggerGeometryV9Imp2::
+initialize(const edm::ESHandle<HGCalGeometry>& hgc_ee_geometry,
+        const edm::ESHandle<HGCalGeometry>& hgc_hsi_geometry,
+        const edm::ESHandle<HGCalGeometry>& hgc_hsc_geometry
+        )
+{
+    setEEGeometry(hgc_ee_geometry);
+    setHSiGeometry(hgc_hsi_geometry);
+    setHScGeometry(hgc_hsc_geometry);
+    heOffset_ = eeTopology().dddConstants().layers(true);
+    totalLayers_ = heOffset_ + hsiTopology().dddConstants().layers(true);
+    trigger_layers_.resize(totalLayers_+1);
+    trigger_layers_[0] = 0; // layer number 0 doesn't exist
+    unsigned trigger_layer = 1;
+    for(unsigned layer=1; layer<trigger_layers_.size(); layer++)
+    {
+        if(disconnected_layers_.find(layer)==disconnected_layers_.end())
+        {
+            // Increase trigger layer number if the layer is not disconnected
+            trigger_layers_[layer] = trigger_layer;
+            trigger_layer++;
+        }
+        else
+        {
+            trigger_layers_[layer] = 0;
+        }
+    }
+    fillMaps();
+
+}
+
+unsigned 
+HGCalTriggerGeometryV9Imp2::
+getTriggerCellFromCell( const unsigned cell_id ) const
+{
+    unsigned det = DetId(cell_id).det();
+    unsigned trigger_cell_id = 0;
+    // Scintillator
+    if(det == DetId::HGCalHSc)
+    {
+        // Very rough mapping from cells to TC
+        HGCScintillatorDetId cell_sc_id(cell_id);
+        int ieta = ( (cell_sc_id.ietaAbs()-1)/hSc_triggercell_size_+1 )*cell_sc_id.zside();
+        int iphi = (cell_sc_id.iphi()-1)/hSc_triggercell_size_+1;
+        trigger_cell_id = HGCScintillatorDetId(cell_sc_id.type(), cell_sc_id.layer(), ieta, iphi);
+    }
+    // Silicon
+    else if(det == DetId::HGCalEE || det == DetId::HGCalHSi)
+    {
+        HGCSiliconDetId cell_si_id(cell_id);
+        trigger_cell_id = HGCalTriggerDetId(
+                det==DetId::HGCalEE ? HGCalTriggerSubdetector::HGCalEETrigger : HGCalTriggerSubdetector::HGCalHSiTrigger,
+                cell_si_id.zside(),
+                cell_si_id.type(),
+                cell_si_id.layer(),
+                cell_si_id.waferU(), cell_si_id.waferV(),
+                cell_si_id.triggerCellU(), cell_si_id.triggerCellV()
+                );
+    }
+    return trigger_cell_id;
+
+}
+
+unsigned 
+HGCalTriggerGeometryV9Imp2::
+getModuleFromCell( const unsigned cell_id ) const
+{
+    return getModuleFromTriggerCell(getTriggerCellFromCell(cell_id));
+}
+
+unsigned 
+HGCalTriggerGeometryV9Imp2::
+getModuleFromTriggerCell( const unsigned trigger_cell_id ) const
+{
+    unsigned det = DetId(trigger_cell_id).det();
+    unsigned module = 0;
+    unsigned subdet_old = 0;
+    int zside = 0;
+    unsigned tc_type = 1;
+    unsigned layer = 0;
+    unsigned module_id = 0;
+    // Scintillator
+    if(det == DetId::HGCalHSc)
+    {
+        HGCScintillatorDetId trigger_cell_sc_id(trigger_cell_id);
+        tc_type = trigger_cell_sc_id.type();
+        layer = trigger_cell_sc_id.layer();
+        zside = trigger_cell_sc_id.zside();
+        int ieta = ( (trigger_cell_sc_id.ietaAbs()-1)/hSc_module_size_+1 )*zside;
+        int iphi = (trigger_cell_sc_id.iphi()-1)/hSc_module_size_+1;
+        module_id = HGCScintillatorDetId(tc_type, layer, ieta, iphi);
+    }
+    // Silicon
+    else
+    {
+        HGCalTriggerDetId trigger_cell_trig_id(trigger_cell_id);
+        unsigned subdet = trigger_cell_trig_id.subdet();
+        subdet_old = (subdet==HGCalTriggerSubdetector::HGCalEETrigger ? ForwardSubdetector::HGCEE : ForwardSubdetector::HGCHEF);
+        layer = trigger_cell_trig_id.layer();
+        zside = trigger_cell_trig_id.zside();
+        if(subdet == HGCalTriggerSubdetector::HGCalEETrigger || subdet == HGCalTriggerSubdetector::HGCalHSiTrigger)
+        {
+            int waferu = trigger_cell_trig_id.waferU();
+            int waferv = trigger_cell_trig_id.waferV();
+            auto module_itr = wafer_to_module_.find(packWaferId(waferu,waferv));
+            if(module_itr==wafer_to_module_.end())
+            {
+                throw cms::Exception("BadGeometry")
+                    <<trigger_cell_trig_id
+                    << "HGCalTriggerGeometry: Wafer (" <<waferu<<","<<waferv << ") is not mapped to any trigger module. The module mapping should be modified. \n";
+            }
+            module = module_itr->second;
+        }
+        module_id = HGCalDetId((ForwardSubdetector)subdet_old, zside, layer, tc_type, module, HGCalDetId::kHGCalCellMask).rawId();
+    }
+    return module_id;
+}
+
+HGCalTriggerGeometryBase::geom_set 
+HGCalTriggerGeometryV9Imp2::
+getCellsFromTriggerCell( const unsigned trigger_cell_id ) const
+{
+    DetId trigger_cell_det_id(trigger_cell_id);
+    unsigned det = trigger_cell_det_id.det();
+    geom_set cell_det_ids;
+    // Scintillator
+    if(det==DetId::HGCalHSc)
+    {
+        HGCScintillatorDetId trigger_cell_sc_id(trigger_cell_id);
+        int ieta0 = (trigger_cell_sc_id.ietaAbs()-1)*hSc_triggercell_size_+1;
+        int iphi0 = (trigger_cell_sc_id.iphi()-1)*hSc_triggercell_size_+1;
+        for(int ietaAbs=ieta0; ietaAbs<ieta0+(int)hSc_triggercell_size_; ietaAbs++)
+        {
+            int ieta = ietaAbs*trigger_cell_sc_id.zside();
+            for(int iphi=iphi0; iphi<iphi0+(int)hSc_triggercell_size_; iphi++)
+            {
+                unsigned cell_id = HGCScintillatorDetId(trigger_cell_sc_id.type(), trigger_cell_sc_id.layer(), ieta, iphi);
+                if(validCellId(DetId::HGCalHSc, cell_id)) cell_det_ids.emplace(cell_id);
+            }
+        }
+    }
+    // Silicon
+    else 
+    {
+        HGCalTriggerDetId trigger_cell_trig_id(trigger_cell_id);
+        unsigned subdet = trigger_cell_trig_id.subdet();
+        if(subdet == HGCalTriggerSubdetector::HGCalEETrigger || subdet == HGCalTriggerSubdetector::HGCalHSiTrigger)
+        {
+            DetId::Detector cell_det = (subdet==HGCalTriggerSubdetector::HGCalEETrigger ? DetId::HGCalEE : DetId::HGCalHSi);
+            int layer = trigger_cell_trig_id.layer();
+            int zside = trigger_cell_trig_id.zside();
+            int type =  trigger_cell_trig_id.type();
+            int waferu = trigger_cell_trig_id.waferU();
+            int waferv = trigger_cell_trig_id.waferV();
+            std::vector<int> cellus = trigger_cell_trig_id.cellU();
+            std::vector<int> cellvs = trigger_cell_trig_id.cellV();
+            for(unsigned ic=0; ic<cellus.size(); ic++)
+            {
+                HGCSiliconDetId cell_det_id(cell_det, zside, type, layer, waferu, waferv, cellus[ic], cellvs[ic]);
+                cell_det_ids.emplace(cell_det_id.rawId());
+            }
+        }
+    }
+    return cell_det_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set 
+HGCalTriggerGeometryV9Imp2::
+getCellsFromModule( const unsigned module_id ) const
+{
+    geom_set cell_det_ids;
+    geom_set trigger_cells = getTriggerCellsFromModule(module_id);
+    for(auto trigger_cell_id : trigger_cells)
+    {
+        geom_set cells = getCellsFromTriggerCell(trigger_cell_id);
+        cell_det_ids.insert(cells.begin(), cells.end());
+    }
+    return cell_det_ids;
+}
+
+HGCalTriggerGeometryBase::geom_ordered_set 
+HGCalTriggerGeometryV9Imp2::
+getOrderedCellsFromModule( const unsigned module_id ) const
+{
+    geom_ordered_set cell_det_ids;
+    geom_ordered_set trigger_cells = getOrderedTriggerCellsFromModule(module_id);
+    for(auto trigger_cell_id : trigger_cells)
+    {
+        geom_set cells = getCellsFromTriggerCell(trigger_cell_id);
+        cell_det_ids.insert(cells.begin(), cells.end());
+    }
+    return cell_det_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set 
+HGCalTriggerGeometryV9Imp2::
+getTriggerCellsFromModule( const unsigned module_id ) const
+{
+    DetId module_det_id(module_id);
+    unsigned det = module_det_id.det();
+    geom_set trigger_cell_det_ids;
+    // Scintillator
+    if(det==DetId::HGCalHSc)
+    {
+        HGCScintillatorDetId module_sc_id(module_id);
+        int ieta0 = (module_sc_id.ietaAbs()-1)*hSc_module_size_+1;
+        int iphi0 = (module_sc_id.iphi()-1)*hSc_module_size_+1;
+        for(int ietaAbs=ieta0; ietaAbs<ieta0+(int)hSc_module_size_; ietaAbs++)
+        {
+            int ieta = ietaAbs*module_sc_id.zside();
+            for(int iphi=iphi0; iphi<iphi0+(int)hSc_module_size_; iphi++)
+            {
+                unsigned trigger_cell_id = HGCScintillatorDetId(module_sc_id.type(), module_sc_id.layer(), ieta, iphi);
+                if(validTriggerCellFromCells(trigger_cell_id)) trigger_cell_det_ids.emplace(trigger_cell_id);
+            }
+        }
+    }
+    // Silicon
+    else
+    {
+        HGCalDetId module_si_id(module_id);
+        unsigned module = module_si_id.wafer();
+        HGCSiliconDetIdToROC tc2roc;
+        auto wafer_itrs = module_to_wafers_.equal_range(module);
+        // loop on the wafers included in the module
+        for(auto wafer_itr=wafer_itrs.first; wafer_itr!=wafer_itrs.second; wafer_itr++)
+        {
+            int waferu = 0;
+            int waferv = 0;
+            unpackWaferId(wafer_itr->second, waferu, waferv);
+            DetId::Detector det = (module_si_id.subdetId()==ForwardSubdetector::HGCEE ? DetId::HGCalEE : DetId::HGCalHSi);
+            HGCalTriggerSubdetector subdet = (module_si_id.subdetId()==ForwardSubdetector::HGCEE ? HGCalTriggerSubdetector::HGCalEETrigger : HGCalTriggerSubdetector::HGCalHSiTrigger);
+            unsigned layer = module_si_id.layer();
+            unsigned wafer_type = detIdWaferType(det, layer, waferu, waferv);
+            int nroc = (wafer_type==HGCSiliconDetId::HGCalFine ? 6 : 3);
+            // Loop on ROCs in wafer
+            for(int roc=1; roc<=nroc; roc++)
+            {
+                // loop on TCs in ROC
+                auto tc_uvs = tc2roc.getTriggerId(roc, wafer_type);
+                for(const auto& tc_uv : tc_uvs)
+                {
+                    HGCalTriggerDetId trigger_cell_id(subdet, module_si_id.zside(), wafer_type, layer, waferu, waferv, tc_uv.first, tc_uv.second);
+                    if(validTriggerCellFromCells(trigger_cell_id)) trigger_cell_det_ids.emplace(trigger_cell_id.rawId());
+                }
+            }
+        }
+    }
+    return trigger_cell_det_ids;
+}
+
+HGCalTriggerGeometryBase::geom_ordered_set 
+HGCalTriggerGeometryV9Imp2::
+getOrderedTriggerCellsFromModule( const unsigned module_id ) const
+{
+    DetId module_det_id(module_id);
+    unsigned det = module_det_id.det();
+    geom_ordered_set trigger_cell_det_ids;
+    // Scintillator
+    if(det==DetId::HGCalHSc)
+    {
+        HGCScintillatorDetId module_sc_id(module_id);
+        int ieta0 = (module_sc_id.ietaAbs()-1)*hSc_module_size_+1;
+        int iphi0 = (module_sc_id.iphi()-1)*hSc_module_size_+1;
+        for(int ietaAbs=ieta0; ietaAbs<ieta0+(int)hSc_module_size_; ietaAbs++)
+        {
+            int ieta = ietaAbs*module_sc_id.zside();
+            for(int iphi=iphi0; iphi<iphi0+(int)hSc_module_size_; iphi++)
+            {
+                unsigned trigger_cell_id = HGCScintillatorDetId(module_sc_id.type(), module_sc_id.layer(), ieta, iphi);
+                if(validTriggerCellFromCells(trigger_cell_id)) trigger_cell_det_ids.emplace(trigger_cell_id);
+            }
+        }
+    }
+    // EE or FH
+    else
+    {
+        HGCalDetId module_si_id(module_id);
+        unsigned module = module_si_id.wafer();
+        HGCSiliconDetIdToROC tc2roc;
+        auto wafer_itrs = module_to_wafers_.equal_range(module);
+        // loop on the wafers included in the module
+        for(auto wafer_itr=wafer_itrs.first; wafer_itr!=wafer_itrs.second; wafer_itr++)
+        {
+            int waferu = 0;
+            int waferv = 0;
+            unpackWaferId(wafer_itr->second, waferu, waferv);
+            DetId::Detector det = (module_si_id.subdetId()==ForwardSubdetector::HGCEE ? DetId::HGCalEE : DetId::HGCalHSi);
+            HGCalTriggerSubdetector subdet = (module_si_id.subdetId()==ForwardSubdetector::HGCEE ? HGCalTriggerSubdetector::HGCalEETrigger : HGCalTriggerSubdetector::HGCalHSiTrigger);
+            unsigned layer = module_si_id.layer();
+            unsigned wafer_type = detIdWaferType(det, layer, waferu, waferv);
+            int nroc = (wafer_type==HGCSiliconDetId::HGCalFine ? 6 : 3);
+            // Loop on ROCs in wafer
+            for(int roc=1; roc<=nroc; roc++)
+            {
+                // loop on TCs in ROC
+                auto tc_uvs = tc2roc.getTriggerId(roc, wafer_type);
+                for(const auto& tc_uv : tc_uvs)
+                {
+                    HGCalTriggerDetId trigger_cell_id(subdet, module_si_id.zside(), wafer_type, layer, waferu, waferv, tc_uv.first, tc_uv.second);
+                    trigger_cell_det_ids.emplace(trigger_cell_id.rawId());
+                }
+            }
+        }
+    }
+    return trigger_cell_det_ids;
+}
+
+
+
+HGCalTriggerGeometryBase::geom_set
+HGCalTriggerGeometryV9Imp2::
+getNeighborsFromTriggerCell( const unsigned trigger_cell_id ) const
+{
+    HGCalDetId trigger_cell_det_id(trigger_cell_id);
+    geom_set neighbor_detids;
+    return neighbor_detids;
+}
+
+
+GlobalPoint 
+HGCalTriggerGeometryV9Imp2::
+getTriggerCellPosition(const unsigned trigger_cell_det_id) const
+{
+    unsigned det = DetId(trigger_cell_det_id).det();
+    // Position: barycenter of the trigger cell.
+    Basic3DVector<float> triggerCellVector(0.,0.,0.);
+    const auto cell_ids = getCellsFromTriggerCell(trigger_cell_det_id);
+    // Scintillator
+    if(det==DetId::HGCalHSc)
+    {
+        for(const auto& cell : cell_ids)
+        {
+            HGCScintillatorDetId cellDetId(cell);
+            triggerCellVector += hscGeometry()->getPosition(cellDetId).basicVector();
+        }
+    }
+    // Silicon
+    else
+    {
+        for(const auto& cell : cell_ids)
+        {
+            HGCSiliconDetId cellDetId(cell);
+            triggerCellVector += (cellDetId.det()==DetId::HGCalEE ? eeGeometry()->getPosition(cellDetId) : hsiGeometry()->getPosition(cellDetId)).basicVector();
+        }
+    }
+    return GlobalPoint( triggerCellVector/cell_ids.size() );
+
+}
+
+GlobalPoint 
+HGCalTriggerGeometryV9Imp2::
+getModulePosition(const unsigned module_det_id) const
+{
+    unsigned det = DetId(module_det_id).det();
+    // Position: barycenter of the module.
+    Basic3DVector<float> moduleVector(0.,0.,0.);
+    const auto cell_ids = getCellsFromModule(module_det_id);
+    // Scintillator
+    if(det==DetId::HGCalHSc)
+    {
+        for(const auto& cell : cell_ids)
+        {
+            HGCScintillatorDetId cellDetId(cell);
+            moduleVector += hscGeometry()->getPosition(cellDetId).basicVector();
+        }
+    }
+    // Silicon
+    else
+    {
+        for(const auto& cell : cell_ids)
+        {
+            HGCSiliconDetId cellDetId(cell);
+            moduleVector += (cellDetId.det()==DetId::HGCalEE ? eeGeometry()->getPosition(cellDetId) :  hsiGeometry()->getPosition(cellDetId)).basicVector();
+        }
+    }
+    return GlobalPoint( moduleVector/cell_ids.size() );
+}
+
+
+void 
+HGCalTriggerGeometryV9Imp2::
+fillMaps()
+{
+    // read module mapping file
+    std::ifstream l1tModulesMappingStream(l1tModulesMapping_.fullPath());
+    if(!l1tModulesMappingStream.is_open()) 
+    {
+        throw cms::Exception("MissingDataFile")
+            << "Cannot open HGCalTriggerGeometry L1TModulesMapping file\n";
+    }
+    short waferu = 0;
+    short waferv = 0;
+    short module  = 0;
+    for(; l1tModulesMappingStream>>waferu>>waferv>>module; )
+    { 
+        unsigned wafer_key = packWaferId(waferu,waferv);
+        wafer_to_module_.emplace(wafer_key,module);
+        module_to_wafers_.emplace(module, wafer_key);
+    }
+    if(!l1tModulesMappingStream.eof())
+    {
+        throw cms::Exception("BadGeometryFile")
+            << "Error reading L1TModulesMapping '"<<waferu<<" "<<waferv<<" "<<module<<"' \n";
+    }
+    l1tModulesMappingStream.close();
+}
+
+
+unsigned 
+HGCalTriggerGeometryV9Imp2::
+packWaferId(int waferU, int waferV) const
+{
+    unsigned packed_value = 0;
+    unsigned waferUsign = (waferU >= 0) ? 0 : 1;
+    unsigned waferVsign = (waferV >= 0) ? 0 : 1;
+    packed_value |= ((std::abs(waferU) & HGCSiliconDetId::kHGCalWaferUMask) << HGCSiliconDetId::kHGCalWaferUOffset);
+    packed_value |= ((waferUsign & HGCSiliconDetId::kHGCalWaferUSignMask) << HGCSiliconDetId::kHGCalWaferUSignOffset);
+    packed_value |= ((std::abs(waferV) & HGCSiliconDetId::kHGCalWaferVMask) << HGCSiliconDetId::kHGCalWaferVOffset);
+    packed_value |= ((waferVsign & HGCSiliconDetId::kHGCalWaferVSignMask) << HGCSiliconDetId::kHGCalWaferVSignOffset);
+    return packed_value;
+}
+
+
+void
+HGCalTriggerGeometryV9Imp2::
+unpackWaferId(unsigned wafer, int& waferU, int& waferV) const
+{
+    unsigned waferUAbs = (wafer >> HGCSiliconDetId::kHGCalWaferUOffset) & HGCSiliconDetId::kHGCalWaferUMask;
+    unsigned waferVAbs = (wafer >> HGCSiliconDetId::kHGCalWaferVOffset) & HGCSiliconDetId::kHGCalWaferVMask;
+    waferU = ( ((wafer >> HGCSiliconDetId::kHGCalWaferUSignOffset) & HGCSiliconDetId::kHGCalWaferUSignMask) ? -waferUAbs : waferUAbs );
+    waferV = ( ((wafer >> HGCSiliconDetId::kHGCalWaferVSignOffset) & HGCSiliconDetId::kHGCalWaferVSignMask) ? -waferVAbs : waferVAbs );
+}
+
+
+bool 
+HGCalTriggerGeometryV9Imp2::
+validTriggerCell(const unsigned trigger_cell_id) const
+{
+    return validTriggerCellFromCells(trigger_cell_id);
+}
+
+bool 
+HGCalTriggerGeometryV9Imp2::
+disconnectedModule(const unsigned module_id) const
+{
+    bool disconnected = false;
+    if(disconnected_layers_.find(layerWithOffset(module_id))!=disconnected_layers_.end()) disconnected = true;
+    return disconnected;
+}
+
+unsigned 
+HGCalTriggerGeometryV9Imp2::
+triggerLayer(const unsigned id) const
+{
+    unsigned layer = layerWithOffset(id);
+    if(layer>=trigger_layers_.size()) return 0;
+    return trigger_layers_[layer];
+}
+
+bool 
+HGCalTriggerGeometryV9Imp2::
+validTriggerCellFromCells(const unsigned trigger_cell_id) const
+{
+    // Check the validity of a trigger cell with the
+    // validity of the cells. One valid cell in the 
+    // trigger cell is enough to make the trigger cell
+    // valid.
+    const geom_set cells = getCellsFromTriggerCell(trigger_cell_id);
+    bool is_valid = false;
+    for(const auto cell_id : cells)
+    {
+        unsigned det = DetId(cell_id).det();
+        is_valid |= validCellId(det, cell_id);
+        if(is_valid) break;
+    }
+    return is_valid;
+}
+
+bool
+HGCalTriggerGeometryV9Imp2::
+validCellId(unsigned subdet, unsigned cell_id) const
+{
+    bool is_valid = false;
+    switch(subdet)
+    {
+        case DetId::HGCalEE:
+            is_valid = eeTopology().valid(cell_id);
+            break;
+        case DetId::HGCalHSi:
+            is_valid = hsiTopology().valid(cell_id);
+            break;
+        case DetId::HGCalHSc:
+            is_valid = hscTopology().valid(cell_id);
+            break;
+        default:
+            is_valid = false;
+            break;
+    } 
+    return is_valid;
+}
+
+
+
+int 
+HGCalTriggerGeometryV9Imp2::
+detIdWaferType(unsigned det, unsigned layer, short waferU, short waferV) const
+{
+    int wafer_type = 0;
+    switch(det)
+    {
+        case DetId::HGCalEE:
+            wafer_type = eeTopology().dddConstants().getTypeHex(layer, waferU, waferV);
+            break;
+        case DetId::HGCalHSi:
+            wafer_type = hsiTopology().dddConstants().getTypeHex(layer, waferU, waferV);
+            break;
+        default:
+            break;
+    };
+    return wafer_type;
+}
+
+
+unsigned
+HGCalTriggerGeometryV9Imp2::
+layerWithOffset(unsigned id) const
+{
+    unsigned det = DetId(id).det();
+    unsigned layer = 0;
+    if(det==DetId::HGCalTrigger)
+    {
+        unsigned subdet = HGCalTriggerDetId(id).subdet();
+        if(subdet==HGCalTriggerSubdetector::HGCalEETrigger)
+        {
+            layer = HGCalTriggerDetId(id).layer();
+        }
+        else if(subdet==HGCalTriggerSubdetector::HGCalHSiTrigger)
+        {
+            layer = heOffset_ + HGCalTriggerDetId(id).layer();
+        }
+    }
+    else if(det==DetId::HGCalHSc)
+    {
+        layer = heOffset_ + HGCScintillatorDetId(id).layer();
+    }
+    else if(det==DetId::Forward)
+    {
+        unsigned subdet = HGCalDetId(id).subdetId();
+        if(subdet==ForwardSubdetector::HGCEE)
+        {
+            layer = HGCalDetId(id).layer();
+        }
+        else if(subdet==ForwardSubdetector::HGCHEF || subdet==ForwardSubdetector::HGCHEB)
+        {
+            layer = heOffset_ + HGCalTriggerDetId(id).layer();
+        }
+    }
+    return layer;
+}
+
+
+
+DEFINE_EDM_PLUGIN(HGCalTriggerGeometryFactory, 
+        HGCalTriggerGeometryV9Imp2,
+        "HGCalTriggerGeometryV9Imp2");

--- a/L1Trigger/L1THGCal/plugins/geometries/README.md
+++ b/L1Trigger/L1THGCal/plugins/geometries/README.md
@@ -1,11 +1,19 @@
 Trigger geometries provide the following interfaces:
-* Mapping between HGCAL cells, trigger cells and trigger modules
+* Mapping between HGCAL sensor cells, trigger cells and motherboards
 * Navigation between trigger cells
 
 The available HGCAL trigger geometries are the following:
 * `HGCalTriggerGeometryHexLayerBasedImp1` (DEFAULT)
   - The trigger cell mapping is defined over a full layer and is not constrained by wafer boundaries
-* `HGCalTriggerGeometryHexImp2`
+  - Compatible with the V8 HGCAL geometry
+* `HGCalTriggerGeometryV9Imp2`
+  - Implementation without trigger cell external mappings. Makes use of the `HGCSiliconDetId`, `HGCScintillatorDetId`, and `HGCalTriggerDetId`
+  - Compatible with the V9 HGCAL geometry
+  - The trigger cell neighbors are not defined (no navigation)
+* `HGCalTriggerGeometryV9Imp1`
+  - Similar implementation as `HGCalTriggerGeometryHexLayerBasedImp1`, but for the V9 geometry
+  - Compatible with the V9 HGCAL geometry
+* `HGCalTriggerGeometryHexImp2` (DEPRECATED)
   - The trigger cell mapping is defined within single wafers. Trigger cells are therefore constrained by the wafer boundaries
   - The trigger cells in the BH section are not defined
 * `HGCalTriggerGeometryHexImp1` (DEPRECATED)

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
@@ -1,7 +1,6 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
 

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCClusters.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCClusters.cc
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCDigis.cc
@@ -11,8 +11,6 @@
 
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
-#include "SimDataFormats/CaloTest/interface/HGCalTestNumbering.h"
-#include "Geometry/HcalCommonData/interface/HcalHitRelabeller.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 
 
@@ -40,15 +38,21 @@ class HGCalTriggerNtupleHGCDigis : public HGCalTriggerNtupleBase
         std::vector<int> hgcdigi_subdet_;
         std::vector<int> hgcdigi_side_;
         std::vector<int> hgcdigi_layer_;
-        std::vector<int> hgcdigi_wafer_;
         std::vector<int> hgcdigi_wafertype_ ;
-        std::vector<int> hgcdigi_cell_;
         std::vector<float> hgcdigi_eta_;
         std::vector<float> hgcdigi_phi_;
         std::vector<float> hgcdigi_z_;
         std::vector<uint32_t> hgcdigi_data_;
         std::vector<int> hgcdigi_isadc_;
         std::vector<float> hgcdigi_simenergy_;
+        // V8 detid scheme
+        std::vector<int> hgcdigi_wafer_;
+        std::vector<int> hgcdigi_cell_;
+        // V9 detid scheme
+        std::vector<int> hgcdigi_waferu_;
+        std::vector<int> hgcdigi_waferv_;
+        std::vector<int> hgcdigi_cellu_;
+        std::vector<int> hgcdigi_cellv_;
 
         int bhdigi_n_ ;
         std::vector<int> bhdigi_id_;
@@ -83,7 +87,6 @@ void
 HGCalTriggerNtupleHGCDigis::
 initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
 {
-
     ee_token_ = collector.consumes<HGCalDigiCollection>(conf.getParameter<edm::InputTag>("HGCDigisEE"));
     fh_token_ = collector.consumes<HGCalDigiCollection>(conf.getParameter<edm::InputTag>("HGCDigisFH"));
     bh_token_ = collector.consumes<HGCalDigiCollection>(conf.getParameter<edm::InputTag>("HGCDigisBH"));
@@ -97,14 +100,20 @@ initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& 
     tree.Branch("hgcdigi_subdet", &hgcdigi_subdet_);
     tree.Branch("hgcdigi_zside", &hgcdigi_side_);
     tree.Branch("hgcdigi_layer", &hgcdigi_layer_);
-    tree.Branch("hgcdigi_wafer", &hgcdigi_wafer_);
     tree.Branch("hgcdigi_wafertype", &hgcdigi_wafertype_);
-    tree.Branch("hgcdigi_cell", &hgcdigi_cell_);
     tree.Branch("hgcdigi_eta", &hgcdigi_eta_);
     tree.Branch("hgcdigi_phi", &hgcdigi_phi_);
     tree.Branch("hgcdigi_z", &hgcdigi_z_);
     tree.Branch("hgcdigi_data", &hgcdigi_data_);
     tree.Branch("hgcdigi_isadc", &hgcdigi_isadc_);
+    // V9 detid scheme
+    tree.Branch("hgcdigi_waferu", &hgcdigi_waferu_);
+    tree.Branch("hgcdigi_waferv", &hgcdigi_waferv_);
+    tree.Branch("hgcdigi_cellu", &hgcdigi_cellu_);
+    tree.Branch("hgcdigi_cellv", &hgcdigi_cellv_);
+    // V8 detid scheme
+    tree.Branch("hgcdigi_wafer", &hgcdigi_wafer_);
+    tree.Branch("hgcdigi_cell", &hgcdigi_cell_);
     if (is_Simhit_comp_) tree.Branch("hgcdigi_simenergy", &hgcdigi_simenergy_);
 
     tree.Branch("bhdigi_n", &bhdigi_n_, "bhdigi_n/I");
@@ -151,14 +160,24 @@ fill(const edm::Event& e, const edm::EventSetup& es)
     hgcdigi_subdet_.reserve(hgcdigi_n_);
     hgcdigi_side_.reserve(hgcdigi_n_);
     hgcdigi_layer_.reserve(hgcdigi_n_);
-    hgcdigi_wafer_.reserve(hgcdigi_n_);
     hgcdigi_wafertype_.reserve(hgcdigi_n_);
-    hgcdigi_cell_.reserve(hgcdigi_n_);
     hgcdigi_eta_.reserve(hgcdigi_n_);
     hgcdigi_phi_.reserve(hgcdigi_n_);
     hgcdigi_z_.reserve(hgcdigi_n_);
     hgcdigi_data_.reserve(hgcdigi_n_);
     hgcdigi_isadc_.reserve(hgcdigi_n_);
+    if(triggerGeometry_->isV9Geometry())
+    {
+        hgcdigi_waferu_.reserve(hgcdigi_n_);
+        hgcdigi_waferv_.reserve(hgcdigi_n_);
+        hgcdigi_cellu_.reserve(hgcdigi_n_);
+        hgcdigi_cellv_.reserve(hgcdigi_n_);
+    }
+    else
+    {
+        hgcdigi_wafer_.reserve(hgcdigi_n_);
+        hgcdigi_cell_.reserve(hgcdigi_n_);
+    }
     if (is_Simhit_comp_) hgcdigi_simenergy_.reserve(hgcdigi_n_);
 
     bhdigi_n_ = bh_digis.size();
@@ -176,19 +195,32 @@ fill(const edm::Event& e, const edm::EventSetup& es)
     const int kIntimeSample = 2;
     for(const auto& digi : ee_digis)
       {
-        const HGCalDetId id(digi.id());
+        const DetId id(digi.id());
         hgcdigi_id_.emplace_back(id.rawId());
-        hgcdigi_subdet_.emplace_back(ForwardSubdetector::HGCEE);
-        hgcdigi_side_.emplace_back(id.zside());
+        hgcdigi_subdet_.emplace_back(id.subdetId());
+        hgcdigi_side_.emplace_back(triggerTools_.zside(id));
         hgcdigi_layer_.emplace_back(triggerTools_.layerWithOffset(id));
-        hgcdigi_wafer_.emplace_back(id.wafer());
-        hgcdigi_wafertype_.emplace_back(id.waferType());
-        hgcdigi_cell_.emplace_back(id.cell());
         GlobalPoint cellpos = triggerGeometry_->eeGeometry()->getPosition(id.rawId());
         hgcdigi_eta_.emplace_back(cellpos.eta());
         hgcdigi_phi_.emplace_back(cellpos.phi());
         hgcdigi_z_.emplace_back(cellpos.z());
         hgcdigi_data_.emplace_back(digi[kIntimeSample].data());
+        if(triggerGeometry_->isV9Geometry())
+        {
+            const HGCSiliconDetId idv9(digi.id());
+            hgcdigi_waferu_.emplace_back(idv9.waferU());
+            hgcdigi_waferv_.emplace_back(idv9.waferV());
+            hgcdigi_wafertype_.emplace_back(idv9.type());
+            hgcdigi_cellu_.emplace_back(idv9.cellU());
+            hgcdigi_cellv_.emplace_back(idv9.cellV());
+        }
+        else
+        {
+            const HGCalDetId idv8(digi.id());
+            hgcdigi_wafer_.emplace_back(idv8.wafer());
+            hgcdigi_wafertype_.emplace_back(idv8.waferType());
+            hgcdigi_cell_.emplace_back(idv8.cell());
+        }
         int is_adc=0;
         if (!(digi[kIntimeSample].mode())) is_adc =1;
         hgcdigi_isadc_.emplace_back(is_adc);
@@ -202,19 +234,32 @@ fill(const edm::Event& e, const edm::EventSetup& es)
 
     for(const auto& digi : fh_digis)
       {
-        const HGCalDetId id(digi.id());
+        const DetId id(digi.id());
         hgcdigi_id_.emplace_back(id.rawId());
-        hgcdigi_subdet_.emplace_back(ForwardSubdetector::HGCHEF);
-        hgcdigi_side_.emplace_back(id.zside());
+        hgcdigi_subdet_.emplace_back(id.subdetId());
+        hgcdigi_side_.emplace_back(triggerTools_.zside(id));
         hgcdigi_layer_.emplace_back(triggerTools_.layerWithOffset(id));
-        hgcdigi_wafer_.emplace_back(id.wafer());
-        hgcdigi_wafertype_.emplace_back(id.waferType());
-        hgcdigi_cell_.emplace_back(id.cell());
-        GlobalPoint cellpos = triggerGeometry_->fhGeometry()->getPosition(id.rawId());
+        GlobalPoint cellpos = triggerGeometry_->hsiGeometry()->getPosition(id.rawId());
         hgcdigi_eta_.emplace_back(cellpos.eta());
         hgcdigi_phi_.emplace_back(cellpos.phi());
         hgcdigi_z_.emplace_back(cellpos.z());
         hgcdigi_data_.emplace_back(digi[kIntimeSample].data());
+        if(triggerGeometry_->isV9Geometry())
+        {
+            const HGCSiliconDetId idv9(digi.id());
+            hgcdigi_waferu_.emplace_back(idv9.waferU());
+            hgcdigi_waferv_.emplace_back(idv9.waferV());
+            hgcdigi_wafertype_.emplace_back(idv9.type());
+            hgcdigi_cellu_.emplace_back(idv9.cellU());
+            hgcdigi_cellv_.emplace_back(idv9.cellV());
+        }
+        else
+        {
+            const HGCalDetId idv8(digi.id());
+            hgcdigi_wafer_.emplace_back(idv8.wafer());
+            hgcdigi_wafertype_.emplace_back(idv8.waferType());
+            hgcdigi_cell_.emplace_back(idv8.cell());
+        }
         int is_adc=0;
         if (!(digi[kIntimeSample].mode())) is_adc =1;
         hgcdigi_isadc_.emplace_back(is_adc);
@@ -228,18 +273,30 @@ fill(const edm::Event& e, const edm::EventSetup& es)
 
      for(const auto& digi : bh_digis)
       {
-        const HcalDetId id(digi.id());
+        const DetId id(digi.id());
         bhdigi_id_.emplace_back(id.rawId());
         bhdigi_subdet_.emplace_back(id.subdetId());
-        bhdigi_side_.emplace_back(id.zside());
+        bhdigi_side_.emplace_back(triggerTools_.zside(id));
         bhdigi_layer_.emplace_back(triggerTools_.layerWithOffset(id));
-        bhdigi_ieta_.emplace_back(id.ieta());
-        bhdigi_iphi_.emplace_back(id.iphi());
-        GlobalPoint cellpos = triggerGeometry_->bhGeometry()->getPosition(id.rawId());
+        GlobalPoint cellpos = (triggerGeometry_->isV9Geometry() ?
+                triggerGeometry_->hscGeometry()->getPosition(id.rawId()) :
+                triggerGeometry_->bhGeometry()->getPosition(id.rawId()) );
         bhdigi_eta_.emplace_back(cellpos.eta());
         bhdigi_phi_.emplace_back(cellpos.phi());
         bhdigi_z_.emplace_back(cellpos.z());
         bhdigi_data_.emplace_back(digi[kIntimeSample].data());
+        if(triggerGeometry_->isV9Geometry())
+        {
+            const HGCScintillatorDetId idv9(digi.id());
+            bhdigi_ieta_.emplace_back(idv9.ietaAbs());
+            bhdigi_iphi_.emplace_back(idv9.iphi());
+        }
+        else
+        {
+            const HcalDetId idv8(digi.id());
+            bhdigi_ieta_.emplace_back(idv8.ieta());
+            bhdigi_iphi_.emplace_back(idv8.iphi());
+        }
         if (is_Simhit_comp_) {
           double hit_energy=0;
           auto itr = simhits_bh.find(id);
@@ -254,55 +311,39 @@ HGCalTriggerNtupleHGCDigis::
 simhits(const edm::Event& e, std::unordered_map<uint32_t, double>& simhits_ee, std::unordered_map<uint32_t, double>& simhits_fh, std::unordered_map<uint32_t, double>& simhits_bh)
 {
 
-      edm::Handle<edm::PCaloHitContainer> ee_simhits_h;
-      e.getByToken(SimHits_inputee_,ee_simhits_h);
-      const edm::PCaloHitContainer& ee_simhits = *ee_simhits_h;
-      edm::Handle<edm::PCaloHitContainer> fh_simhits_h;
-      e.getByToken(SimHits_inputfh_,fh_simhits_h);
-      const edm::PCaloHitContainer& fh_simhits = *fh_simhits_h;
-      edm::Handle<edm::PCaloHitContainer> bh_simhits_h;
-      e.getByToken(SimHits_inputbh_,bh_simhits_h);
-      const edm::PCaloHitContainer& bh_simhits = *bh_simhits_h;
+    edm::Handle<edm::PCaloHitContainer> ee_simhits_h;
+    e.getByToken(SimHits_inputee_,ee_simhits_h);
+    const edm::PCaloHitContainer& ee_simhits = *ee_simhits_h;
+    edm::Handle<edm::PCaloHitContainer> fh_simhits_h;
+    e.getByToken(SimHits_inputfh_,fh_simhits_h);
+    const edm::PCaloHitContainer& fh_simhits = *fh_simhits_h;
+    edm::Handle<edm::PCaloHitContainer> bh_simhits_h;
+    e.getByToken(SimHits_inputbh_,bh_simhits_h);
+    const edm::PCaloHitContainer& bh_simhits = *bh_simhits_h;
 
-      //EE
-      int layer=0,cell=0, sec=0, subsec=0, zp=0,subdet=0;
-      ForwardSubdetector mysubdet;
-
-      for( const auto& simhit : ee_simhits ) {
-        HGCalTestNumbering::unpackHexagonIndex(simhit.id(), subdet, zp, layer, sec, subsec, cell);
-        mysubdet = (ForwardSubdetector)(subdet);
-        std::pair<int,int> recoLayerCell = triggerGeometry_->eeTopology().dddConstants().simToReco(cell,layer,sec,triggerGeometry_->eeTopology().detectorType());
-        cell  = recoLayerCell.first;
-        layer = recoLayerCell.second;
-        if (layer<0 || cell<0) {
-          continue;
-        }
-        auto itr_insert = simhits_ee.emplace(HGCalDetId(mysubdet,zp,layer,subsec,sec,cell), 0.);
+    //EE
+    for( const auto& simhit : ee_simhits ) {
+        DetId id = triggerTools_.simToReco(simhit.id(), triggerGeometry_->eeTopology());
+        if(id.rawId()==0) continue;
+        auto itr_insert = simhits_ee.emplace(id, 0.);
         itr_insert.first->second += simhit.energy();
-      }
-
-      //  FH
-      layer=0; cell=0; sec=0; subsec=0; zp=0; subdet=0;
-
-      for( const auto& simhit : fh_simhits ) {
-        HGCalTestNumbering::unpackHexagonIndex(simhit.id(), subdet, zp, layer, sec, subsec, cell);
-        mysubdet = (ForwardSubdetector)(subdet);
-        std::pair<int,int> recoLayerCell = triggerGeometry_->fhTopology().dddConstants().simToReco(cell,layer,sec,triggerGeometry_->fhTopology().detectorType());
-        cell  = recoLayerCell.first;
-        layer = recoLayerCell.second;
-        if (layer<0 || cell<0) {
-          continue;
-        }
-        auto itr_insert = simhits_fh.emplace(HGCalDetId(mysubdet,zp,layer,subsec,sec,cell), 0.);
+    }
+    //  FH
+    for( const auto& simhit : fh_simhits ) {
+        DetId id = triggerTools_.simToReco(simhit.id(), triggerGeometry_->fhTopology());
+        if(id.rawId()==0) continue;
+        auto itr_insert = simhits_fh.emplace(id, 0.);
         itr_insert.first->second += simhit.energy();
-      }
-      //  BH
-      for( const auto& simhit : bh_simhits ) {
-        HcalDetId id = HcalHitRelabeller::relabel(simhit.id(), triggerGeometry_->bhTopology().dddConstants());
-        if (id.subdetId()!=HcalEndcap) continue;
+    }
+    //  BH
+    for( const auto& simhit : bh_simhits ) {
+        DetId id = (triggerGeometry_->isV9Geometry() ?
+                triggerTools_.simToReco(simhit.id(), triggerGeometry_->hscTopology()) :
+                triggerTools_.simToReco(simhit.id(), triggerGeometry_->bhTopology()) );
+        if(id.rawId()==0) continue;
         auto itr_insert = simhits_bh.emplace(id, 0.);
         itr_insert.first->second += simhit.energy();
-      }
+    }
 }
 
 
@@ -316,8 +357,12 @@ clear()
     hgcdigi_side_.clear();
     hgcdigi_layer_.clear();
     hgcdigi_wafer_.clear();
+    hgcdigi_waferu_.clear();
+    hgcdigi_waferv_.clear();
     hgcdigi_wafertype_.clear();
     hgcdigi_cell_.clear();
+    hgcdigi_cellu_.clear();
+    hgcdigi_cellv_.clear();
     hgcdigi_eta_.clear();
     hgcdigi_phi_.clear();
     hgcdigi_z_.clear();

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
@@ -1,5 +1,4 @@
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCTriggerCells.cc
@@ -271,39 +271,28 @@ simhits(const edm::Event& e, std::unordered_map<uint32_t, double>& simhits_ee, s
   const edm::PCaloHitContainer& bh_simhits = *bh_simhits_h;
 
   //EE
-  int layer=0,cell=0, sec=0, subsec=0, zp=0,subdet=0;
-  ForwardSubdetector mysubdet;
   for( const auto& simhit : ee_simhits )
   { 
-    HGCalTestNumbering::unpackHexagonIndex(simhit.id(), subdet, zp, layer, sec, subsec, cell); 
-    mysubdet = (ForwardSubdetector)subdet;
-    std::pair<int,int> recoLayerCell = geometry_->eeTopology().dddConstants().simToReco(cell,layer,sec,geometry_->eeTopology().detectorType());
-    cell  = recoLayerCell.first;
-    layer = recoLayerCell.second;
-    if (layer<0 || cell<0) continue;
-    auto itr_insert = simhits_ee.emplace(HGCalDetId(mysubdet,zp,layer,subsec,sec,cell), 0.);
+    DetId id = triggerTools_.simToReco(simhit.id(), geometry_->eeTopology());
+    if(id.rawId()==0) continue;
+    auto itr_insert = simhits_ee.emplace(id, 0.);
     itr_insert.first->second += simhit.energy();
   }
-
   //  FH
-  layer=0; cell=0; sec=0; subsec=0; zp=0; subdet=0;
   for( const auto& simhit : fh_simhits ) 
   { 
-    HGCalTestNumbering::unpackHexagonIndex(simhit.id(), subdet, zp, layer, sec, subsec, cell); 
-    mysubdet = (ForwardSubdetector)(subdet);
-    std::pair<int,int> recoLayerCell = geometry_->fhTopology().dddConstants().simToReco(cell,layer,sec,geometry_->fhTopology().detectorType());
-    cell  = recoLayerCell.first;
-    layer = recoLayerCell.second;
-    if (layer<0 || cell<0) continue;
-    auto itr_insert = simhits_fh.emplace(HGCalDetId(mysubdet,zp,layer,subsec,sec,cell), 0.);
+    DetId id = triggerTools_.simToReco(simhit.id(), geometry_->fhTopology());
+    if(id.rawId()==0) continue;
+    auto itr_insert = simhits_fh.emplace(id, 0.);
     itr_insert.first->second += simhit.energy();
   }      
-
   //  BH
   for( const auto& simhit : bh_simhits ) 
   { 
-    HcalDetId id = HcalHitRelabeller::relabel(simhit.id(), geometry_->bhTopology().dddConstants());
-    if (id.subdetId()!=HcalEndcap) continue;
+    DetId id = (geometry_->isV9Geometry() ?
+        triggerTools_.simToReco(simhit.id(), geometry_->hscTopology()) :
+        triggerTools_.simToReco(simhit.id(), geometry_->bhTopology()) );
+    if(id.rawId()==0) continue;
     auto itr_insert = simhits_bh.emplace(id, 0.);
     itr_insert.first->second += simhit.energy();
   }      

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleTowers.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleTowers.cc
@@ -1,5 +1,4 @@
 #include "DataFormats/L1THGCal/interface/HGCalTower.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerNtupleBase.h"

--- a/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
+++ b/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
@@ -4,7 +4,6 @@
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 
 DEFINE_EDM_PLUGIN(HGCalVFEProcessorBaseFactory, 
         HGCalVFEProcessorSums,

--- a/L1Trigger/L1THGCal/python/customNtuples.py
+++ b/L1Trigger/L1THGCal/python/customNtuples.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+def custom_ntuples_V9(process):
+    ntuples = process.hgcalTriggerNtuplizer.Ntuples
+    for ntuple in ntuples:
+        if ntuple.NtupleName=='HGCalTriggerNtupleHGCDigis' or \
+           ntuple.NtupleName=='HGCalTriggerNtupleHGCTriggerCells':
+            ntuple.bhSimHits = cms.InputTag('g4SimHits:HGCHitsHEback')
+    return process

--- a/L1Trigger/L1THGCal/python/customTriggerGeometry.py
+++ b/L1Trigger/L1THGCal/python/customTriggerGeometry.py
@@ -1,15 +1,23 @@
 import FWCore.ParameterSet.Config as cms
 
 
-def custom_geometry_V9(process):
-    process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp1')
-    process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping_8inch_aligned_192_432_V9_1.txt")
-    process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TWafersMapping = cms.FileInPath("L1Trigger/L1THGCal/data/wafer_mapping_V9_1.txt")
-    process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/panel_mapping_tdr_0.txt")
-    process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TCellNeighborsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_neighbor_mapping_8inch_aligned_192_432_0.txt")
-    process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TCellsSciMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping_sci_2x2_V9_1.txt")
-    process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TCellNeighborsSciMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_neighbor_mapping_sci_2x2_V9_1.txt")
-    process.hgcalTriggerGeometryESProducer.TriggerGeometry.DisconnectedModules = cms.vuint32(0)
+
+
+def custom_geometry_V9(process, implementation=1):
+    if implementation==1:
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp1')
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TCellsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping_8inch_aligned_192_432_V9_1.txt")
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TWafersMapping = cms.FileInPath("L1Trigger/L1THGCal/data/wafer_mapping_V9_1.txt")
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/panel_mapping_tdr_0.txt")
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TCellNeighborsMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_neighbor_mapping_8inch_aligned_192_432_0.txt")
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TCellsSciMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_mapping_sci_2x2_V9_1.txt")
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TCellNeighborsSciMapping = cms.FileInPath("L1Trigger/L1THGCal/data/triggercell_neighbor_mapping_sci_2x2_V9_1.txt")
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.DisconnectedModules = cms.vuint32(0)
+    elif implementation==2:
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp2')
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorTriggerCellSize = cms.uint32(2)
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.ScintillatorModuleSize = cms.uint32(12)
+        process.hgcalTriggerGeometryESProducer.TriggerGeometry.L1TModulesMapping = cms.FileInPath("L1Trigger/L1THGCal/data/panel_mapping_V9_tdr_0.txt")
     process.hgcalConcentratorProducer.ProcessorParameters.MaxCellsInModule = cms.uint32(288)
     return process
 

--- a/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerNtuples_cff.py
@@ -4,5 +4,8 @@ from L1Trigger.L1THGCal.hgcalTriggerNtuples_cfi import *
 
 hgcalTriggerNtuples = cms.Sequence(hgcalTriggerNtuplizer)
 
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+from L1Trigger.L1THGCal.customNtuples import custom_ntuples_V9
+modifyHgcalTriggerNtuplesWithV9Geometry_ = phase2_hgcalV9.makeProcessModifier(custom_ntuples_V9)
 
 

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
@@ -2,7 +2,7 @@
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <cmath>
@@ -77,7 +77,7 @@ HGCalTriggerTowerGeometryHelper::HGCalTriggerTowerGeometryHelper(const edm::Para
           << " to TT iEta: " << iEta << " iPhi: " << iPhi
           << " when max #bins eta: "  << nBinsEta_ << " phi: " << nBinsPhi_ << std::endl;
       }
-      l1t::HGCalTowerID towerId(HGCalDetId(trigger_cell_id).zside(), iEta, iPhi);
+      l1t::HGCalTowerID towerId(triggerTools_.zside(DetId(trigger_cell_id)), iEta, iPhi);
       cells_to_trigger_towers_[trigger_cell_id] = towerId.rawId();
     }
     l1tTriggerTowerMappingStream.close();

--- a/L1Trigger/L1THGCal/src/backend/HGCalClusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalClusteringImpl.cc
@@ -31,11 +31,11 @@ bool HGCalClusteringImpl::isPertinent( const l1t::HGCalTriggerCell & tc,
                                        double distXY ) const 
 {
 
-    HGCalDetId tcDetId( tc.detId() );
-    HGCalDetId cluDetId( clu.detId() );
-    if( (tcDetId.layer() != cluDetId.layer()) ||
+    DetId tcDetId( tc.detId() );
+    DetId cluDetId( clu.detId() );
+    if( (triggerTools_.layer(tcDetId) != triggerTools_.layer(cluDetId)) ||
         (tcDetId.subdetId() != cluDetId.subdetId()) ||
-        (tcDetId.zside() != cluDetId.zside()) ){
+        (triggerTools_.zside(tcDetId) != triggerTools_.zside(cluDetId) )){
         return false;
     }   
     if ( clu.distance((tc)) < distXY ){
@@ -115,8 +115,8 @@ void HGCalClusteringImpl::triggerCellReshuffling( const std::vector<edm::Ptr<l1t
     ){
 
     for( const auto& tc : triggerCellsPtrs ){
-        int endcap = tc->zside() == -1 ? 0 : 1 ;
-        HGCalDetId tcDetId( tc->detId() );
+        DetId tcDetId( tc->detId() );
+        int endcap = triggerTools_.zside(tcDetId) == -1 ? 0 : 1 ;
         unsigned layer = triggerTools_.layerWithOffset(tc->detId());
         
         reshuffledTriggerCells[endcap][layer-1].emplace_back(tc);

--- a/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringHistoImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringHistoImpl.cc
@@ -88,7 +88,7 @@ HGCalMulticlusteringHistoImpl::Histogram HGCalMulticlusteringHistoImpl::fillHist
         int bin_R = int( (ROverZ-kROverZMin_) * nBinsRHisto_ / (kROverZMax_-kROverZMin_) );
         int bin_phi = int( (reco::reduceRange(clu->phi())+M_PI) * nBinsPhiHisto_ / (2*M_PI) );
 
-        histoClusters[{{clu->zside(), bin_R, bin_phi}}]+=clu->mipPt();
+        histoClusters[{{triggerTools_.zside(clu->detId()), bin_R, bin_phi}}]+=clu->mipPt();
 
     }
 
@@ -335,8 +335,7 @@ std::vector<l1t::HGCalMulticluster> HGCalMulticlusteringHistoImpl::clusterSeedMu
     for(auto & clu : clustersPtrs){
 
 
-        HGCalDetId cluDetId( clu->detId() );
-        int z_side = cluDetId.zside();
+        int z_side = triggerTools_.zside(clu->detId());
 
         double minDist = dr_;
         int targetSeed = -1;
@@ -438,6 +437,8 @@ finalizeClusters(std::vector<l1t::HGCalMulticluster>& multiclusters_in,
             multicluster.eMax(shape_.eMax(multicluster));
             // fill quality flag
             multicluster.setHwQual(id_->decision(multicluster));
+            // fill H/E
+            multicluster.saveHOverE();            
 
             multiclusters_out.push_back( 0, multicluster);
         }

--- a/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringImpl.cc
@@ -24,10 +24,10 @@ bool HGCalMulticlusteringImpl::isPertinent( const l1t::HGCalCluster & clu,
                                             const l1t::HGCalMulticluster & mclu, 
                                             double dR ) const
 {
-    HGCalDetId cluDetId( clu.detId() );
-    HGCalDetId firstClusterDetId( mclu.detId() );
+    DetId cluDetId( clu.detId() );
+    DetId firstClusterDetId( mclu.detId() );
     
-    if( cluDetId.zside() != firstClusterDetId.zside() ){
+    if( triggerTools_.zside(cluDetId) != triggerTools_.zside(firstClusterDetId) ){
         return false;
     }
     if( ( mclu.centreProj() - clu.centreProj() ).mag() < dR ){
@@ -121,7 +121,7 @@ void HGCalMulticlusteringImpl::clusterizeDBSCAN( const std::vector<edm::Ptr<l1t:
     double dist = 0.;
 
     for(std::vector<edm::Ptr<l1t::HGCalCluster>>::const_iterator clu = clustersPtrs.begin(); clu != clustersPtrs.end(); ++clu, ++iclu){
-        dist = (*clu)->centreProj().mag()*HGCalDetId((*clu)->detId()).zside();
+        dist = (*clu)->centreProj().mag()*triggerTools_.zside((*clu)->detId());
         rankedList.push_back(std::make_pair(iclu,dist));
     }  
     iclu = 0;
@@ -205,6 +205,8 @@ finalizeClusters(std::vector<l1t::HGCalMulticluster>& multiclusters_in,
             multicluster.eMax(shape_.eMax(multicluster));
             // fill quality flag
             multicluster.setHwQual(id_->decision(multicluster));
+            // fill H/E
+            multicluster.saveHOverE();            
 
             multiclusters_out.push_back( 0, multicluster);
         }

--- a/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalShowerShape.cc
@@ -1,7 +1,6 @@
 #include "L1Trigger/L1THGCal/interface/backend/HGCalShowerShape.h"
 #include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 #include <unordered_map>
@@ -89,8 +88,9 @@ int HGCalShowerShape::coreShowerLength(const l1t::HGCalMulticluster& c3d, const 
   std::vector<bool> layers(nlayers);
   for(const auto& id_cluster : clustersPtrs)
   {
-    int layer = triggerGeometry.triggerLayer(id_cluster.second->detId());
-    layers[layer-1] = true;
+    unsigned layer = triggerGeometry.triggerLayer(id_cluster.second->detId());
+    if(layer==0 || layer>nlayers) continue;
+    layers[layer-1] = true; //layer 0 doesn't exist, so shift by -1
   }
   int length = 0;
   int maxlength = 0;

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSelectionImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSelectionImpl.cc
@@ -25,8 +25,9 @@ thresholdSelectImpl(const std::vector<l1t::HGCalTriggerCell>& trigCellVecInput, 
 { 
   for (const auto& trigCell: trigCellVecInput){
   
-    int threshold = (HGCalDetId(trigCell.detId()).subdetId()==ForwardSubdetector::HGCHEB ? TCThresholdBH_ADC_ : TCThreshold_ADC_);
-    double triggercell_threshold = (HGCalDetId(trigCell.detId()).subdetId()==HGCHEB ? triggercell_threshold_scintillator_ : triggercell_threshold_silicon_);
+    bool isScintillator = triggerTools_.isScintillator(trigCell.detId());
+    int threshold = (isScintillator ? TCThresholdBH_ADC_ : TCThreshold_ADC_);
+    double triggercell_threshold = (isScintillator ? triggercell_threshold_scintillator_ : triggercell_threshold_silicon_);
   
     if ((trigCell.hwPt() >= threshold) && (trigCell.mipPt() >= triggercell_threshold)){ 
       trigCellVecOutput.push_back(trigCell);      

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -8,6 +8,7 @@ HGCalConcentratorSuperTriggerCellImpl(const edm::ParameterSet& conf){}
 
 int
 HGCalConcentratorSuperTriggerCellImpl::getSuperTriggerCellId(int detid) const {
+  // FIXME: won't work in the V9 geometry
   HGCalDetId TC_id(detid);
   if(TC_id.subdetId()==HGCHEB) {
     return TC_id.cell(); //scintillator

--- a/L1Trigger/L1THGCal/test/BuildFile.xml
+++ b/L1Trigger/L1THGCal/test/BuildFile.xml
@@ -7,6 +7,6 @@
 <use   name="DataFormats/L1Trigger"/>
 <use   name="SimDataFormats/CaloTest"/>
 
-<library name="testL1TriggerL1THGCal"  file="HGCalTriggerGeomTester.cc,HGCalTriggerGeomTesterV9.cc,calib/*.cc">
+<library name="testL1TriggerL1THGCal"  file="HGCalTriggerGeomTester.cc,HGCalTriggerGeomTesterV9.cc,HGCalTriggerGeomTesterV9Imp2.cc,calib/*.cc">
 <flags   EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp2.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp2.cc
@@ -1,0 +1,1155 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "TTree.h"
+
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/HGCalCommonData/interface/HGCalGeometryMode.h"
+#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+
+#include <cstdlib> 
+
+namespace 
+{  
+    template<typename T>
+    struct array_deleter
+    {
+        void operator () (T* arr) { delete [] arr; }
+    };
+}
+
+
+class HGCalTriggerGeomTesterV9Imp2 : public edm::stream::EDAnalyzer<>
+{
+    public:
+        explicit HGCalTriggerGeomTesterV9Imp2(const edm::ParameterSet& );
+        ~HGCalTriggerGeomTesterV9Imp2();
+
+        virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+        virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
+
+    private:
+        void fillTriggerGeometry();
+        bool checkMappingConsistency();
+        bool checkNeighborConsistency();
+        void setTreeModuleSize(const size_t n);
+        void setTreeModuleCellSize(const size_t n);
+        void setTreeTriggerCellSize(const size_t n);
+        void setTreeCellCornerSize(const size_t n);
+        void setTreeTriggerCellNeighborSize(const size_t n);
+
+        edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
+        edm::ESHandle<HGCalGeometry> eeGeometry_;
+        edm::ESHandle<HGCalGeometry> hsiGeometry_;
+        edm::ESHandle<HGCalGeometry> hscGeometry_;
+        edm::Service<TFileService> fs_;
+        bool no_trigger_;
+        bool no_neighbors_;
+        TTree* treeModules_;
+        TTree* treeTriggerCells_;
+        TTree* treeCells_;
+        TTree* treeCellsBH_;
+        // tree variables
+        int   moduleId_     ;
+        int   moduleSide_   ;
+        int   moduleSubdet_ ;
+        int   moduleLayer_  ;
+        int   moduleIEta_       ;
+        int   moduleIPhi_       ;
+        int   module_       ;
+        float moduleX_      ;
+        float moduleY_      ;
+        float moduleZ_      ;
+        int   moduleTC_N_   ;
+        std::shared_ptr<int>   moduleTC_id_    ;
+        std::shared_ptr<int>   moduleTC_zside_ ;
+        std::shared_ptr<int>   moduleTC_subdet_;
+        std::shared_ptr<int>   moduleTC_layer_ ;
+        std::shared_ptr<int>   moduleTC_waferU_;
+        std::shared_ptr<int>   moduleTC_waferV_;
+        std::shared_ptr<int>   moduleTC_cellU_  ;
+        std::shared_ptr<int>   moduleTC_cellV_  ;
+        std::shared_ptr<int>   moduleTC_ieta_  ;
+        std::shared_ptr<int>   moduleTC_iphi_  ;
+        std::shared_ptr<float> moduleTC_x_     ;
+        std::shared_ptr<float> moduleTC_y_     ;
+        std::shared_ptr<float> moduleTC_z_     ;
+        int   moduleCell_N_   ;
+        std::shared_ptr<int>   moduleCell_id_    ;
+        std::shared_ptr<int>   moduleCell_zside_ ;
+        std::shared_ptr<int>   moduleCell_subdet_;
+        std::shared_ptr<int>   moduleCell_layer_ ;
+        std::shared_ptr<int>   moduleCell_waferU_;
+        std::shared_ptr<int>   moduleCell_waferV_;
+        std::shared_ptr<int>   moduleCell_cellU_  ;
+        std::shared_ptr<int>   moduleCell_cellV_  ;
+        std::shared_ptr<float> moduleCell_x_     ;
+        std::shared_ptr<float> moduleCell_y_     ;
+        std::shared_ptr<float> moduleCell_z_     ;
+        int   triggerCellId_     ;
+        int   triggerCellSide_   ;
+        int   triggerCellSubdet_ ;
+        int   triggerCellLayer_  ;
+        int   triggerCellWaferU_ ;
+        int   triggerCellWaferV_ ;
+        int   triggerCellU_       ;
+        int   triggerCellV_       ;
+        int   triggerCellIEta_       ;
+        int   triggerCellIPhi_       ;
+        float triggerCellX_      ;
+        float triggerCellY_      ;
+        float triggerCellZ_      ;
+        int triggerCellNeighbor_N_;
+        std::shared_ptr<int>   triggerCellNeighbor_id_    ;
+        std::shared_ptr<int>   triggerCellNeighbor_zside_ ;
+        std::shared_ptr<int>   triggerCellNeighbor_subdet_;
+        std::shared_ptr<int>   triggerCellNeighbor_layer_ ;
+        std::shared_ptr<int>   triggerCellNeighbor_waferU_;
+        std::shared_ptr<int>   triggerCellNeighbor_waferV_;
+        std::shared_ptr<int>   triggerCellNeighbor_cellU_  ;
+        std::shared_ptr<int>   triggerCellNeighbor_cellV_  ;
+        std::shared_ptr<int>   triggerCellNeighbor_cellIEta_  ;
+        std::shared_ptr<int>   triggerCellNeighbor_cellIPhi_  ;
+        std::shared_ptr<float>   triggerCellNeighbor_distance_  ;
+        int   triggerCellCell_N_ ;
+        std::shared_ptr<int>   triggerCellCell_id_    ;
+        std::shared_ptr<int>   triggerCellCell_zside_ ;
+        std::shared_ptr<int>   triggerCellCell_subdet_;
+        std::shared_ptr<int>   triggerCellCell_layer_ ;
+        std::shared_ptr<int>   triggerCellCell_waferU_;
+        std::shared_ptr<int>   triggerCellCell_waferV_;
+        std::shared_ptr<int>   triggerCellCell_cellU_  ;
+        std::shared_ptr<int>   triggerCellCell_cellV_  ;
+        std::shared_ptr<int>   triggerCellCell_ieta_  ;
+        std::shared_ptr<int>   triggerCellCell_iphi_  ;
+        std::shared_ptr<float> triggerCellCell_x_     ;
+        std::shared_ptr<float> triggerCellCell_y_     ;
+        std::shared_ptr<float> triggerCellCell_z_     ;
+        int   cellId_     ;
+        int   cellSide_   ;
+        int   cellSubdet_ ;
+        int   cellLayer_  ;
+        int   cellWaferU_ ;
+        int   cellWaferV_ ;
+        int   cellWaferType_ ;
+        int cellWaferRow_;
+        int cellWaferColumn_;
+        int   cellU_       ;
+        int   cellV_       ;
+        float cellX_      ;
+        float cellY_      ;
+        float cellZ_      ;
+        int cellCornersN_;
+        std::shared_ptr<float> cellCornersX_      ;
+        std::shared_ptr<float> cellCornersY_      ;
+        std::shared_ptr<float> cellCornersZ_      ;
+        int   cellBHId_     ;
+        int   cellBHType_     ;
+        int   cellBHSide_   ;
+        int   cellBHSubdet_ ;
+        int   cellBHLayer_  ;
+        int   cellBHIEta_ ;
+        int   cellBHIPhi_ ;
+        float cellBHEta_      ;
+        float cellBHPhi_      ;
+        float cellBHX_      ;
+        float cellBHY_      ;
+        float cellBHZ_      ;
+        float cellBHX1_     ;
+        float cellBHY1_     ;
+        float cellBHX2_     ;
+        float cellBHY2_     ;
+        float cellBHX3_     ;
+        float cellBHY3_     ;
+        float cellBHX4_     ;
+        float cellBHY4_     ;
+
+    private:
+        typedef std::unordered_map<uint32_t, std::unordered_set<uint32_t>>  trigger_map_set;
+        
+};
+
+
+/*****************************************************************/
+HGCalTriggerGeomTesterV9Imp2::HGCalTriggerGeomTesterV9Imp2(const edm::ParameterSet& conf):
+    no_trigger_(false),
+    no_neighbors_(false)
+/*****************************************************************/
+{
+
+    // initialize output trees
+    treeModules_ = fs_->make<TTree>("TreeModules","Tree of all HGC modules");
+    treeModules_->Branch("id"             , &moduleId_            , "id/I");
+    treeModules_->Branch("zside"          , &moduleSide_          , "zside/I");
+    treeModules_->Branch("subdet"         , &moduleSubdet_        , "subdet/I");
+    treeModules_->Branch("layer"          , &moduleLayer_         , "layer/I");
+    treeModules_->Branch("ieta"         , &moduleIEta_              , "ieta/I");
+    treeModules_->Branch("iphi"         , &moduleIPhi_              , "iphi/I");
+    treeModules_->Branch("module"         , &module_              , "module/I");
+    treeModules_->Branch("x"              , &moduleX_             , "x/F");
+    treeModules_->Branch("y"              , &moduleY_             , "y/F");
+    treeModules_->Branch("z"              , &moduleZ_             , "z/F");
+    treeModules_->Branch("tc_n"           , &moduleTC_N_          , "tc_n/I");
+    moduleTC_id_    .reset(new int[1],   array_deleter<int>());
+    moduleTC_zside_ .reset(new int[1],   array_deleter<int>());
+    moduleTC_subdet_.reset(new int[1],   array_deleter<int>());
+    moduleTC_layer_ .reset(new int[1],   array_deleter<int>());
+    moduleTC_waferU_ .reset(new int[1],   array_deleter<int>());
+    moduleTC_waferV_ .reset(new int[1],   array_deleter<int>());
+    moduleTC_cellU_  .reset(new int[1],   array_deleter<int>());
+    moduleTC_cellV_  .reset(new int[1],   array_deleter<int>());
+    moduleTC_x_     .reset(new float[1], array_deleter<float>());
+    moduleTC_y_     .reset(new float[1], array_deleter<float>());
+    moduleTC_z_     .reset(new float[1], array_deleter<float>());
+    treeModules_->Branch("tc_id"          , moduleTC_id_.get()     , "tc_id[tc_n]/I");
+    treeModules_->Branch("tc_zside"       , moduleTC_zside_.get()  , "tc_zside[tc_n]/I");
+    treeModules_->Branch("tc_subdet"      , moduleTC_subdet_.get() , "tc_subdet[tc_n]/I");
+    treeModules_->Branch("tc_layer"       , moduleTC_layer_.get()  , "tc_layer[tc_n]/I");
+    treeModules_->Branch("tc_waferu"      , moduleTC_waferU_.get()  , "tc_waferu[tc_n]/I");
+    treeModules_->Branch("tc_waferv"      , moduleTC_waferV_.get()  , "tc_waferv[tc_n]/I");
+    treeModules_->Branch("tc_cellu"        , moduleTC_cellU_.get()   , "tc_cellu[tc_n]/I");
+    treeModules_->Branch("tc_cellv"        , moduleTC_cellV_.get()   , "tc_cellv[tc_n]/I");
+    treeModules_->Branch("tc_ieta"        , moduleTC_ieta_.get()   , "tc_ieta[tc_n]/I");
+    treeModules_->Branch("tc_iphi"        , moduleTC_iphi_.get()   , "tc_iphi[tc_n]/I");
+    treeModules_->Branch("tc_x"           , moduleTC_x_.get()      , "tc_x[tc_n]/F");
+    treeModules_->Branch("tc_y"           , moduleTC_y_.get()      , "tc_y[tc_n]/F");
+    treeModules_->Branch("tc_z"           , moduleTC_z_.get()      , "tc_z[tc_n]/F");
+    treeModules_->Branch("c_n"           , &moduleCell_N_          , "c_n/I");
+    moduleCell_id_    .reset(new int[1],   array_deleter<int>());
+    moduleCell_zside_ .reset(new int[1],   array_deleter<int>());
+    moduleCell_subdet_.reset(new int[1],   array_deleter<int>());
+    moduleCell_layer_ .reset(new int[1],   array_deleter<int>());
+    moduleCell_waferU_ .reset(new int[1],   array_deleter<int>());
+    moduleCell_waferV_ .reset(new int[1],   array_deleter<int>());
+    moduleCell_cellU_  .reset(new int[1],   array_deleter<int>());
+    moduleCell_cellV_  .reset(new int[1],   array_deleter<int>());
+    moduleCell_x_     .reset(new float[1], array_deleter<float>());
+    moduleCell_y_     .reset(new float[1], array_deleter<float>());
+    moduleCell_z_     .reset(new float[1], array_deleter<float>());
+    treeModules_->Branch("c_id"          , moduleCell_id_.get()     , "c_id[c_n]/I");
+    treeModules_->Branch("c_zside"       , moduleCell_zside_.get()  , "c_zside[c_n]/I");
+    treeModules_->Branch("c_subdet"      , moduleCell_subdet_.get() , "c_subdet[c_n]/I");
+    treeModules_->Branch("c_layer"       , moduleCell_layer_.get()  , "c_layer[c_n]/I");
+    treeModules_->Branch("c_waferu"       , moduleCell_waferU_.get()  , "c_waferu[c_n]/I");
+    treeModules_->Branch("c_waferv"       , moduleCell_waferV_.get()  , "c_waferv[c_n]/I");
+    treeModules_->Branch("c_cellu"        , moduleCell_cellU_.get()   , "c_cellu[c_n]/I");
+    treeModules_->Branch("c_cellv"        , moduleCell_cellV_.get()   , "c_cellv[c_n]/I");
+    treeModules_->Branch("c_x"           , moduleCell_x_.get()      , "c_x[c_n]/F");
+    treeModules_->Branch("c_y"           , moduleCell_y_.get()      , "c_y[c_n]/F");
+    treeModules_->Branch("c_z"           , moduleCell_z_.get()      , "c_z[c_n]/F");
+    //
+    treeTriggerCells_ = fs_->make<TTree>("TreeTriggerCells","Tree of all HGC trigger cells");
+    treeTriggerCells_->Branch("id"             , &triggerCellId_            , "id/I");
+    treeTriggerCells_->Branch("zside"          , &triggerCellSide_          , "zside/I");
+    treeTriggerCells_->Branch("subdet"         , &triggerCellSubdet_        , "subdet/I");
+    treeTriggerCells_->Branch("layer"          , &triggerCellLayer_         , "layer/I");
+    treeTriggerCells_->Branch("waferu"          , &triggerCellWaferU_          , "waferu/I");
+    treeTriggerCells_->Branch("waferv"          , &triggerCellWaferV_          , "waferv/I");
+    treeTriggerCells_->Branch("triggercellu"    , &triggerCellU_              , "triggercellu/I");
+    treeTriggerCells_->Branch("triggercellv"    , &triggerCellV_              , "triggercellv/I");
+    treeTriggerCells_->Branch("triggercellieta"    , &triggerCellIEta_              , "triggercellieta/I");
+    treeTriggerCells_->Branch("triggercelliphi"    , &triggerCellIPhi_              , "triggercelliphi/I");
+    treeTriggerCells_->Branch("x"              , &triggerCellX_             , "x/F");
+    treeTriggerCells_->Branch("y"              , &triggerCellY_             , "y/F");
+    treeTriggerCells_->Branch("z"              , &triggerCellZ_             , "z/F");
+    treeTriggerCells_->Branch("neighbor_n"     , &triggerCellNeighbor_N_    , "neighbor_n/I");
+    triggerCellNeighbor_id_ .reset(new int[1],   array_deleter<int>());
+    triggerCellNeighbor_zside_ .reset(new int[1],   array_deleter<int>());
+    triggerCellNeighbor_subdet_ .reset(new int[1],   array_deleter<int>());
+    triggerCellNeighbor_layer_ .reset(new int[1],   array_deleter<int>());
+    triggerCellNeighbor_waferU_ .reset(new int[1],   array_deleter<int>());
+    triggerCellNeighbor_waferV_ .reset(new int[1],   array_deleter<int>());
+    triggerCellNeighbor_cellU_  .reset(new int[1],   array_deleter<int>());
+    triggerCellNeighbor_cellV_  .reset(new int[1],   array_deleter<int>());
+    triggerCellNeighbor_distance_  .reset(new float[1],   array_deleter<float>());
+    treeTriggerCells_->Branch("neighbor_id", triggerCellNeighbor_id_.get(), "neighbor_id[neighbor_n]/I");
+    treeTriggerCells_->Branch("neighbor_zside", triggerCellNeighbor_zside_.get()  , "neighbor_zside[neighbor_n]/I");
+    treeTriggerCells_->Branch("neighbor_subdet", triggerCellNeighbor_subdet_.get() , "neighbor_subdet[neighbor_n]/I");
+    treeTriggerCells_->Branch("neighbor_layer", triggerCellNeighbor_layer_.get()  , "neighbor_layer[neighbor_n]/I");
+    treeTriggerCells_->Branch("neighbor_waferu", triggerCellNeighbor_waferU_.get()  , "neighbor_waferu[neighbor_n]/I");
+    treeTriggerCells_->Branch("neighbor_waferv", triggerCellNeighbor_waferV_.get()  , "neighbor_waferv[neighbor_n]/I");
+    treeTriggerCells_->Branch("neighbor_cellu", triggerCellNeighbor_cellU_.get()   , "neighbor_cellu[neighbor_n]/I");
+    treeTriggerCells_->Branch("neighbor_cellv", triggerCellNeighbor_cellV_.get()   , "neighbor_cellv[neighbor_n]/I");
+    treeTriggerCells_->Branch("neighbor_distance", triggerCellNeighbor_distance_.get()   , "neighbor_distance[neighbor_n]/F");
+    treeTriggerCells_->Branch("c_n"            , &triggerCellCell_N_        , "c_n/I");
+    triggerCellCell_id_    .reset(new int[1],   array_deleter<int>());
+    triggerCellCell_zside_ .reset(new int[1],   array_deleter<int>());
+    triggerCellCell_subdet_ .reset(new int[1],   array_deleter<int>());
+    triggerCellCell_layer_ .reset(new int[1],   array_deleter<int>());
+    triggerCellCell_waferU_ .reset(new int[1],   array_deleter<int>());
+    triggerCellCell_waferV_ .reset(new int[1],   array_deleter<int>());
+    triggerCellCell_cellU_  .reset(new int[1],   array_deleter<int>());
+    triggerCellCell_cellV_  .reset(new int[1],   array_deleter<int>());
+    triggerCellCell_ieta_  .reset(new int[1],   array_deleter<int>());
+    triggerCellCell_iphi_  .reset(new int[1],   array_deleter<int>());
+    triggerCellCell_x_     .reset(new float[1], array_deleter<float>());
+    triggerCellCell_y_     .reset(new float[1], array_deleter<float>());
+    triggerCellCell_z_     .reset(new float[1], array_deleter<float>());
+    treeTriggerCells_->Branch("c_id"           , triggerCellCell_id_.get()     , "c_id[c_n]/I");
+    treeTriggerCells_->Branch("c_zside"        , triggerCellCell_zside_.get()  , "c_zside[c_n]/I");
+    treeTriggerCells_->Branch("c_subdet"       , triggerCellCell_subdet_.get() , "c_subdet[c_n]/I");
+    treeTriggerCells_->Branch("c_layer"        , triggerCellCell_layer_.get()  , "c_layer[c_n]/I");
+    treeTriggerCells_->Branch("c_waferu"        , triggerCellCell_waferU_.get()  , "c_waferu[c_n]/I");
+    treeTriggerCells_->Branch("c_waferv"        , triggerCellCell_waferV_.get()  , "c_waferv[c_n]/I");
+    treeTriggerCells_->Branch("c_cellu"         , triggerCellCell_cellU_.get()   , "c_cellu[c_n]/I");
+    treeTriggerCells_->Branch("c_cellv"         , triggerCellCell_cellV_.get()   , "c_cellv[c_n]/I");
+    treeTriggerCells_->Branch("c_ieta"         , triggerCellCell_ieta_.get()   , "c_cell[c_n]/I");
+    treeTriggerCells_->Branch("c_iphi"         , triggerCellCell_iphi_.get()   , "c_cell[c_n]/I");
+    treeTriggerCells_->Branch("c_x"            , triggerCellCell_x_.get()      , "c_x[c_n]/F");
+    treeTriggerCells_->Branch("c_y"            , triggerCellCell_y_.get()      , "c_y[c_n]/F");
+    treeTriggerCells_->Branch("c_z"            , triggerCellCell_z_.get()      , "c_z[c_n]/F");
+    //
+    treeCells_ = fs_->make<TTree>("TreeCells","Tree of all HGC cells");
+    treeCells_->Branch("id"             , &cellId_            , "id/I");
+    treeCells_->Branch("zside"          , &cellSide_          , "zside/I");
+    treeCells_->Branch("subdet"         , &cellSubdet_        , "subdet/I");
+    treeCells_->Branch("layer"          , &cellLayer_         , "layer/I");
+    treeCells_->Branch("waferu"          , &cellWaferU_         , "waferu/I");
+    treeCells_->Branch("waferv"          , &cellWaferV_         , "waferv/I");
+    treeCells_->Branch("wafertype"      , &cellWaferType_     , "wafertype/I");
+    treeCells_->Branch("waferrow"          , &cellWaferRow_         , "waferrow/I");
+    treeCells_->Branch("wafercolumn"          , &cellWaferColumn_         , "wafercolumn/I");
+    treeCells_->Branch("cellu"           , &cellU_              , "cellu/I");
+    treeCells_->Branch("cellv"           , &cellV_              , "cellv/I");
+    treeCells_->Branch("x"              , &cellX_             , "x/F");
+    treeCells_->Branch("y"              , &cellY_             , "y/F");
+    treeCells_->Branch("z"              , &cellZ_             , "z/F");
+    treeCells_->Branch("corner_n"       , &cellCornersN_     , "corner_n/I");
+    treeCells_->Branch("corner_x"       , cellCornersX_.get()      , "corner_x[corner_n]/F");
+    treeCells_->Branch("corner_y"       , cellCornersY_.get()      , "corner_y[corner_n]/F");
+    treeCells_->Branch("corner_z"       , cellCornersZ_.get()      , "corner_z[corner_n]/F");
+    //
+    treeCellsBH_ = fs_->make<TTree>("TreeCellsBH","Tree of all BH cells");
+    treeCellsBH_->Branch("id", &cellBHId_, "id/I");
+    treeCellsBH_->Branch("type", &cellBHType_, "type/I");
+    treeCellsBH_->Branch("zside", &cellBHSide_, "zside/I");
+    treeCellsBH_->Branch("subdet", &cellBHSubdet_, "subdet/I");
+    treeCellsBH_->Branch("layer", &cellBHLayer_, "layer/I");
+    treeCellsBH_->Branch("ieta", &cellBHIEta_, "ieta/I");
+    treeCellsBH_->Branch("iphi", &cellBHIPhi_, "iphi/I");
+    treeCellsBH_->Branch("eta", &cellBHEta_, "eta/F");
+    treeCellsBH_->Branch("phi", &cellBHPhi_, "phi/F");
+    treeCellsBH_->Branch("x", &cellBHX_, "x/F");
+    treeCellsBH_->Branch("y", &cellBHY_, "y/F");
+    treeCellsBH_->Branch("z", &cellBHZ_, "z/F");
+    treeCellsBH_->Branch("x1", &cellBHX1_, "x1/F");
+    treeCellsBH_->Branch("y1", &cellBHY1_, "y1/F");
+    treeCellsBH_->Branch("x2", &cellBHX2_, "x2/F");
+    treeCellsBH_->Branch("y2", &cellBHY2_, "y2/F");
+    treeCellsBH_->Branch("x3", &cellBHX3_, "x3/F");
+    treeCellsBH_->Branch("y3", &cellBHY3_, "y3/F");
+    treeCellsBH_->Branch("x4", &cellBHX4_, "x4/F");
+    treeCellsBH_->Branch("y4", &cellBHY4_, "y4/F");
+}
+
+
+
+/*****************************************************************/
+HGCalTriggerGeomTesterV9Imp2::~HGCalTriggerGeomTesterV9Imp2() 
+/*****************************************************************/
+{
+}
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp2::beginRun(const edm::Run& /*run*/, 
+                                          const edm::EventSetup& es)
+/*****************************************************************/
+{
+    es.get<CaloGeometryRecord>().get("", triggerGeometry_);
+
+    no_trigger_ = !checkMappingConsistency();
+    no_neighbors_ = !checkNeighborConsistency();
+    fillTriggerGeometry();
+}
+
+
+bool HGCalTriggerGeomTesterV9Imp2::checkMappingConsistency()
+{
+    try
+    {
+        trigger_map_set modules_to_triggercells;
+        trigger_map_set modules_to_cells;
+        trigger_map_set triggercells_to_cells;
+
+        // EE
+        for(const auto& id : triggerGeometry_->eeGeometry()->getValidDetIds())
+        {
+            HGCSiliconDetId detid(id); 
+            if(!triggerGeometry_->eeTopology().valid(id)) continue;
+            // fill trigger cells
+            uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+            HGCalTriggerDetId tcid(trigger_cell);
+            auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+            itr_insert.first->second.emplace(id);
+            // fill modules
+            uint32_t module = triggerGeometry_->getModuleFromCell(id);
+            if(module!=0)
+            {
+                itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
+                itr_insert.first->second.emplace(id);
+            }
+        }
+        // HSi
+        for(const auto& id : triggerGeometry_->hsiGeometry()->getValidDetIds())
+        {
+            HGCSiliconDetId detid(id); 
+            if(!triggerGeometry_->hsiTopology().valid(id)) continue;
+            // fill trigger cells
+            uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+            HGCalTriggerDetId tcid(trigger_cell);
+            auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+            itr_insert.first->second.emplace(id);
+            // fill modules
+            uint32_t module = triggerGeometry_->getModuleFromCell(id);
+            if(module!=0)
+            {
+                itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
+                itr_insert.first->second.emplace(id);
+            }
+        }
+        // HSc
+        for(const auto& id : triggerGeometry_->hscGeometry()->getValidDetIds())
+        {
+            // fill trigger cells
+            unsigned layer = HGCScintillatorDetId(id).layer();
+            if(HGCScintillatorDetId(id).type()!=triggerGeometry_->hscTopology().dddConstants().getTypeTrap(layer))
+            {
+                std::cout<<"Sci cell type = "<<HGCScintillatorDetId(id).type()<<" != "<<triggerGeometry_->hscTopology().dddConstants().getTypeTrap(layer)<<"\n";
+            }
+            uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+            auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+            itr_insert.first->second.emplace(id);
+            // fill modules
+            uint32_t module = triggerGeometry_->getModuleFromCell(id);
+            if(module!=0)
+            {
+                itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
+                itr_insert.first->second.emplace(id);
+            }
+        }
+
+
+
+        edm::LogPrint("TriggerCellCheck")<<"Checking cell -> trigger cell -> cell consistency";
+        // Loop over trigger cells
+        for( const auto& triggercell_cells : triggercells_to_cells )
+        {
+            DetId id(triggercell_cells.first);
+            HGCalTriggerDetId trig_id(triggercell_cells.first);
+            // fill modules
+            uint32_t module = triggerGeometry_->getModuleFromTriggerCell(id);
+            if(module!=0)
+            {
+                if(id.det()!=DetId::HGCalHSc)
+                {
+                    auto itr_insert = modules_to_triggercells.emplace(module, std::unordered_set<uint32_t>());
+                    itr_insert.first->second.emplace(id);
+                }
+            }
+            // Check consistency of cells included in trigger cell
+            HGCalTriggerGeometryBase::geom_set cells_geom = triggerGeometry_->getCellsFromTriggerCell(id);
+            const auto& cells = triggercell_cells.second;
+            for(auto cell : cells)
+            {
+                if(cells_geom.find(cell)==cells_geom.end())
+                {
+                    if(id.det()==DetId::HGCalHSc)
+                    {
+                        edm::LogProblem("BadTriggerCell")<<"Error: \n Cell "<<cell<<"("<<HGCScintillatorDetId(cell)<<")\n has not been found in \n trigger cell "<<HGCScintillatorDetId(id);
+                        std::stringstream output;
+                        output<<" Available cells are:\n";
+                        for(auto cell_geom : cells_geom) output<<"     "<<HGCScintillatorDetId(cell_geom)<<"\n";
+                        edm::LogProblem("BadTriggerCell")<<output.str();
+                    }
+                    else if(trig_id.subdet()==HGCalTriggerSubdetector::HGCalEETrigger || trig_id.subdet()==HGCalTriggerSubdetector::HGCalHSiTrigger)
+                    {
+                        edm::LogProblem("BadTriggerCell")<<"Error: \n Cell "<<cell<<"("<<HGCSiliconDetId(cell)<<")\n has not been found in \n trigger cell "<<trig_id;
+                        std::stringstream output;
+                        output<<" Available cells are:\n";
+                        for(auto cell_geom : cells_geom) output<<"     "<<HGCSiliconDetId(cell_geom)<<"\n";
+                        edm::LogProblem("BadTriggerCell")<<output.str();
+                    }
+                    else
+                    {
+                        edm::LogProblem("BadTriggerCell")<<"Unknown detector type "<<id.det()<<" "<<trig_id.subdet()<<"\n";
+                        edm::LogProblem("BadTriggerCell")<<"Cell ID "<<HGCSiliconDetId(cell)<<"\n";
+                    }
+                    throw cms::Exception("BadGeometry")
+                        << "HGCalTriggerGeometry: Found inconsistency in cell <-> trigger cell mapping";
+                }
+            }
+        }
+        edm::LogPrint("ModuleCheck")<<"Checking trigger cell -> module -> trigger cell consistency";
+        // Loop over modules
+        for( const auto& module_triggercells : modules_to_triggercells )
+        {
+            DetId id(module_triggercells.first);
+            // Check consistency of trigger cells included in module
+            HGCalTriggerGeometryBase::geom_set triggercells_geom = triggerGeometry_->getTriggerCellsFromModule(id);
+            const auto& triggercells = module_triggercells.second;
+            for(auto cell : triggercells)
+            {
+                if(triggercells_geom.find(cell)==triggercells_geom.end())
+                {
+                    if(id.det()==DetId::HGCalHSc)
+                    {
+                        HGCScintillatorDetId cellid(cell);
+                        edm::LogProblem("BadModule")<<"Error: \n Trigger cell "<<cell<<"("<<cellid<<")\n has not been found in \n module "<<HGCScintillatorDetId(id);
+                        std::stringstream output;
+                        output<<" Available trigger cells are:\n";
+                        for(auto cell_geom : triggercells_geom)
+                        {
+                            output<<"     "<<HGCScintillatorDetId(cell_geom)<<"\n";
+                        }
+                        edm::LogProblem("BadModule")<<output.str();
+                        throw cms::Exception("BadGeometry")
+                            << "HGCalTriggerGeometry: Found inconsistency in trigger cell <->  module mapping";
+                    }
+                    else
+                    {
+                        HGCalTriggerDetId cellid(cell);
+                        edm::LogProblem("BadModule")<<"Error: \n Trigger cell "<<cell<<"("<<cellid<<")\n has not been found in \n module "<<HGCalDetId(id);
+                        std::stringstream output;
+                        output<<" Available trigger cells are:\n";
+                        for(auto cell_geom : triggercells_geom)
+                        {
+                            output<<"     "<<HGCalTriggerDetId(cell_geom)<<"\n";
+                        }
+                        edm::LogProblem("BadModule")<<output.str();
+                        throw cms::Exception("BadGeometry")
+                            << "HGCalTriggerGeometry: Found inconsistency in trigger cell <->  module mapping";
+                    }
+                }
+            }
+        }
+        edm::LogPrint("ModuleCheck")<<"Checking cell -> module -> cell consistency";
+        for( const auto& module_cells : modules_to_cells )
+        {
+            DetId id(module_cells.first);
+            // Check consistency of cells included in module
+            HGCalTriggerGeometryBase::geom_set cells_geom = triggerGeometry_->getCellsFromModule(id);
+            const auto& cells = module_cells.second;
+            for(auto cell : cells)
+            {
+                if(cells_geom.find(cell)==cells_geom.end())
+                {
+                    if(id.det()==DetId::HGCalHSc)
+                    {
+                        edm::LogProblem("BadModule")<<"Error: \n Cell "<<cell<<"("<<HGCScintillatorDetId(cell)<<")\n has not been found in \n module "<<HGCScintillatorDetId(id);
+                    }
+                    else
+                    {
+                        edm::LogProblem("BadModule")<<"Error: \n Cell "<<cell<<"("<<HGCSiliconDetId(cell)<<")\n has not been found in \n module "<<HGCalDetId(id);
+                    }
+                    std::stringstream output;
+                    output<<" Available cells are:\n";
+                    for(auto cell_geom : cells_geom)
+                    {
+                        output<<cell_geom<<" ";
+                    }
+                    edm::LogProblem("BadModule")<<output.str();
+                    throw cms::Exception("BadGeometry")
+                        << "HGCalTriggerGeometry: Found inconsistency in cell <->  module mapping";
+                }
+            }
+        }
+    }
+    catch(const cms::Exception& e) {
+        edm::LogWarning("HGCalTriggerGeometryTester") << "Problem with the trigger geometry detected. Only the basic cells tree will be filled\n";
+        edm::LogWarning("HGCalTriggerGeometryTester") << e.message() << "\n";
+        return false;
+    }
+    return true;
+}
+
+
+bool HGCalTriggerGeomTesterV9Imp2::checkNeighborConsistency()
+{
+    try
+    {
+        trigger_map_set triggercells_to_cells;
+
+        // EE
+        for(const auto& id : triggerGeometry_->eeGeometry()->getValidDetIds())
+        {
+            if(!triggerGeometry_->eeTopology().valid(id)) continue;
+            // fill trigger cells
+            // Skip trigger cells in module 0
+            uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+            uint32_t module = triggerGeometry_->getModuleFromTriggerCell(trigger_cell);
+            if(HGCalDetId(module).wafer()==0) continue;
+            auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+            itr_insert.first->second.emplace(id);
+        }
+        // HSi
+        for(const auto& id : triggerGeometry_->hsiGeometry()->getValidDetIds())
+        {
+            if(!triggerGeometry_->hsiTopology().valid(id)) continue;
+            // fill trigger cells
+            // Skip trigger cells in module 0
+            uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+            uint32_t module = triggerGeometry_->getModuleFromTriggerCell(trigger_cell);
+            if(HGCalDetId(module).wafer()==0) continue;
+            auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+            itr_insert.first->second.emplace(id);
+        }
+
+        // HSc
+        for(const auto& id : triggerGeometry_->hscGeometry()->getValidDetIds())
+        {
+            if(!triggerGeometry_->hscTopology().valid(id)) continue;
+            // fill trigger cells
+            // Skip trigger cells in module 0
+            uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+            uint32_t module = triggerGeometry_->getModuleFromTriggerCell(trigger_cell);
+            if(HGCalDetId(module).wafer()==0) continue;
+            auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+            itr_insert.first->second.emplace(id);
+        }
+
+        edm::LogPrint("NeighborCheck")<<"Checking trigger cell neighbor consistency";
+        // Loop over trigger cells
+        for( const auto& triggercell_cells : triggercells_to_cells )
+        {
+            unsigned triggercell_id(triggercell_cells.first);
+            const auto neighbors = triggerGeometry_->getNeighborsFromTriggerCell(triggercell_id);
+            for(const auto neighbor : neighbors)
+            {
+                const auto neighbors_of_neighbor = triggerGeometry_->getNeighborsFromTriggerCell(neighbor);
+                // check if the original cell is included in the neigbors of neighbor
+                if(neighbors_of_neighbor.find(triggercell_id)==neighbors_of_neighbor.end())
+                {
+                    edm::LogProblem("BadNeighbor")<<"Error: \n Trigger cell "<< HGCalDetId(neighbor) << "\n is a neighbor of \n" << HGCalDetId(triggercell_id);
+                    edm::LogProblem("BadNeighbor")<<" But the opposite is not true";
+                    std::stringstream output;
+                    output<<" List of neighbors of neighbor = \n";
+                    for(const auto neighbor_of_neighbor : neighbors_of_neighbor)
+                    {
+                        output<<"  "<< HGCalDetId(neighbor_of_neighbor)<<"\n";
+                    }
+                    edm::LogProblem("BadNeighbor")<<output.str();
+                }
+            }
+        }
+    }
+    catch(const cms::Exception& e) {
+        edm::LogWarning("HGCalTriggerGeometryTester") << "Problem with the trigger neighbors detected. No neighbor information will be filled\n";
+        edm::LogWarning("HGCalTriggerGeometryTester") << e.message() << "\n";
+        return false;
+    }
+    return true;
+}
+
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp2::fillTriggerGeometry()
+/*****************************************************************/
+{
+    trigger_map_set modules;
+    trigger_map_set trigger_cells;
+
+    // Loop over cells
+    edm::LogPrint("TreeFilling")<<"Filling cells tree";
+    // EE
+    std::cout<<"Filling EE geometry\n";
+    for(const auto& id : triggerGeometry_->eeGeometry()->getValidDetIds())
+    {
+        HGCSiliconDetId detid(id); 
+        cellId_         = detid.rawId();
+        cellSide_       = detid.zside();
+        cellSubdet_     = detid.subdet();
+        cellLayer_      = detid.layer();
+        cellWaferU_     = detid.waferU();
+        cellWaferV_     = detid.waferV();
+        cellU_          = detid.cellU();
+        cellV_          = detid.cellV();
+        int type1 = detid.type();
+        int type2 = triggerGeometry_->eeTopology().dddConstants().getTypeHex(cellLayer_, cellWaferU_, cellWaferV_);
+        if(type1!=type2)
+        {
+            std::cout<<"Found incompatible wafer types:\n  "<<detid<<"\n";
+        }
+        //
+        GlobalPoint center = triggerGeometry_->eeGeometry()->getPosition(id);
+        cellX_      = center.x();
+        cellY_      = center.y();
+        cellZ_      = center.z();
+        std::vector<GlobalPoint> corners = triggerGeometry_->eeGeometry()->getCorners(id);
+        cellCornersN_ = corners.size();
+        setTreeCellCornerSize(cellCornersN_);
+        for(unsigned i=0; i<corners.size(); i++)
+        {
+            cellCornersX_.get()[i] = corners[i].x();
+            cellCornersY_.get()[i] = corners[i].y();
+            cellCornersZ_.get()[i] = corners[i].z();
+        }
+        treeCells_->Fill();
+        // fill trigger cells
+        if(!no_trigger_)
+        {
+            uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+            // Skip trigger cells in module 0
+            uint32_t module = triggerGeometry_->getModuleFromTriggerCell(trigger_cell);
+            if(HGCalDetId(module).wafer()==0) continue;
+            auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+            itr_insert.first->second.emplace(id);
+        }
+    }
+    std::cout<<"Filling HSi geometry\n";
+    for(const auto& id : triggerGeometry_->hsiGeometry()->getValidDetIds())
+    {
+        HGCSiliconDetId detid(id); 
+        cellId_         = detid.rawId();
+        cellSide_       = detid.zside();
+        cellSubdet_     = detid.subdet();
+        cellLayer_      = detid.layer();
+        cellWaferU_     = detid.waferU();
+        cellWaferV_     = detid.waferV();
+        cellU_          = detid.cellU();
+        cellV_          = detid.cellV();
+        int type1 = detid.type();
+        int type2 = triggerGeometry_->hsiTopology().dddConstants().getTypeHex(cellLayer_, cellWaferU_, cellWaferV_);
+        if(type1!=type2)
+        {
+            std::cout<<"Found incompatible wafer types:\n  "<<detid<<"\n";
+        }
+        //
+        GlobalPoint center = triggerGeometry_->hsiGeometry()->getPosition(id);
+        cellX_      = center.x();
+        cellY_      = center.y();
+        cellZ_      = center.z();
+        std::vector<GlobalPoint> corners = triggerGeometry_->hsiGeometry()->getCorners(id);
+        cellCornersN_ = corners.size();
+        setTreeCellCornerSize(cellCornersN_);
+        for(unsigned i=0; i<corners.size(); i++)
+        {
+            cellCornersX_.get()[i] = corners[i].x();
+            cellCornersY_.get()[i] = corners[i].y();
+            cellCornersZ_.get()[i] = corners[i].z();
+        }
+        treeCells_->Fill();
+        // fill trigger cells
+        if(!no_trigger_)
+        {
+            uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+            // Skip trigger cells in module 0
+            uint32_t module = triggerGeometry_->getModuleFromTriggerCell(trigger_cell);
+            if(HGCalDetId(module).wafer()==0) continue;
+            auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+            itr_insert.first->second.emplace(id);
+        }
+    }
+    std::cout<<"Filling HSc geometry\n";
+    for(const auto& id : triggerGeometry_->hscGeometry()->getValidDetIds())
+    {
+        HGCScintillatorDetId cellid(id); 
+        cellBHId_ = cellid.rawId();
+        cellBHType_ = cellid.type();
+        cellBHSide_ = cellid.zside();
+        cellBHSubdet_ = cellid.subdet();
+        cellBHLayer_ = cellid.layer();
+        cellBHIEta_ = cellid.ieta();
+        cellBHIPhi_ = cellid.iphi();
+        //
+        GlobalPoint center = triggerGeometry_->hscGeometry()->getPosition(id);
+        cellBHEta_      = center.eta();
+        cellBHPhi_      = center.phi();
+        cellBHX_      = center.x();
+        cellBHY_      = center.y();
+        cellBHZ_      = center.z();
+        auto corners = triggerGeometry_->hscGeometry()->getCorners(id);
+        if(corners.size()>=4)
+        {
+            cellBHX1_      = corners[0].x();
+            cellBHY1_      = corners[0].y();
+            cellBHX2_      = corners[1].x();
+            cellBHY2_      = corners[1].y();
+            cellBHX3_      = corners[2].x();
+            cellBHY3_      = corners[2].y();
+            cellBHX4_      = corners[3].x();
+            cellBHY4_      = corners[3].y();
+        }
+        treeCellsBH_->Fill();
+        // fill trigger cells
+        if(!no_trigger_)
+        {
+            uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+            auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+            itr_insert.first->second.emplace(id);
+        }
+    }
+
+    // if problem detected in the trigger geometry, don't produce trigger trees
+    if(no_trigger_) return;
+
+    // Loop over trigger cells
+    edm::LogPrint("TreeFilling")<<"Filling trigger cells tree";
+    for( const auto& triggercell_cells : trigger_cells )
+    {
+        DetId id(triggercell_cells.first);
+        HGCalTriggerDetId id_trig(triggercell_cells.first);
+        HGCScintillatorDetId id_sc(triggercell_cells.first);
+        GlobalPoint position = triggerGeometry_->getTriggerCellPosition(id);
+        triggerCellId_     = id.rawId();
+        if(id.det()==DetId::HGCalHSc)
+        {
+            triggerCellSide_   = id_sc.zside();
+            triggerCellSubdet_ = id_sc.subdet();
+            triggerCellLayer_  = id_sc.layer();
+            triggerCellIEta_       = id_sc.ietaAbs();
+            triggerCellIPhi_       = id_sc.iphi();
+        }
+        else
+        {
+            triggerCellSide_   = id_trig.zside();
+            triggerCellSubdet_ = id_trig.subdet();
+            triggerCellLayer_  = id_trig.layer();
+            triggerCellWaferU_  = id_trig.waferU();
+            triggerCellWaferV_  = id_trig.waferV();
+            triggerCellU_       = id_trig.triggerCellU();
+            triggerCellV_       = id_trig.triggerCellV();
+        }
+        triggerCellX_      = position.x();
+        triggerCellY_      = position.y();
+        triggerCellZ_      = position.z();
+        triggerCellCell_N_ = triggercell_cells.second.size();
+        //
+        setTreeTriggerCellSize(triggerCellCell_N_);
+        size_t ic = 0;
+        for(const auto& c : triggercell_cells.second)
+        {
+            if(id.det()==DetId::HGCalHSc)
+            {
+                HGCScintillatorDetId cId(c);
+                GlobalPoint cell_position = triggerGeometry_->hscGeometry()->getPosition(cId);
+                triggerCellCell_id_    .get()[ic] = c;
+                triggerCellCell_zside_ .get()[ic] = cId.zside();
+                triggerCellCell_subdet_.get()[ic] = cId.subdetId();
+                triggerCellCell_layer_ .get()[ic] = cId.layer();
+                triggerCellCell_waferU_ .get()[ic] = 0;
+                triggerCellCell_waferV_ .get()[ic] = 0;
+                triggerCellCell_cellU_  .get()[ic] = 0;
+                triggerCellCell_cellV_  .get()[ic] = 0;
+                triggerCellCell_ieta_  .get()[ic] = cId.ietaAbs();
+                triggerCellCell_iphi_  .get()[ic] = cId.iphi();
+                triggerCellCell_x_     .get()[ic] = cell_position.x();
+                triggerCellCell_y_     .get()[ic] = cell_position.y();
+                triggerCellCell_z_     .get()[ic] = cell_position.z();
+            }
+            else
+            {
+                HGCSiliconDetId cId(c);
+                GlobalPoint cell_position = (cId.det()==DetId::HGCalEE ? triggerGeometry_->eeGeometry()->getPosition(cId) :  triggerGeometry_->hsiGeometry()->getPosition(cId));
+                triggerCellCell_id_    .get()[ic] = c;
+                triggerCellCell_zside_ .get()[ic] = cId.zside();
+                triggerCellCell_subdet_.get()[ic] = cId.subdet();
+                triggerCellCell_layer_ .get()[ic] = cId.layer();
+                triggerCellCell_waferU_ .get()[ic] = cId.waferU();
+                triggerCellCell_waferV_ .get()[ic] = cId.waferV();
+                triggerCellCell_cellU_  .get()[ic] = cId.cellU();
+                triggerCellCell_cellV_  .get()[ic] = cId.cellV();
+                triggerCellCell_ieta_  .get()[ic] = 0;
+                triggerCellCell_iphi_  .get()[ic] = 0;
+                triggerCellCell_x_     .get()[ic] = cell_position.x();
+                triggerCellCell_y_     .get()[ic] = cell_position.y();
+                triggerCellCell_z_     .get()[ic] = cell_position.z();
+            }
+            ic++;
+        }
+        
+        treeTriggerCells_->Fill();
+        // fill modules
+        uint32_t module = triggerGeometry_->getModuleFromTriggerCell(id);
+        auto itr_insert = modules.emplace(module, std::unordered_set<uint32_t>());
+        itr_insert.first->second.emplace(id);
+    }
+    // Loop over modules
+    edm::LogPrint("TreeFilling")<<"Filling modules tree";
+    for( const auto& module_triggercells : modules )
+    {
+        DetId id(module_triggercells.first);
+        GlobalPoint position = triggerGeometry_->getModulePosition(id);
+        moduleId_     = id.rawId();
+        moduleX_      = position.x();
+        moduleY_      = position.y();
+        moduleZ_      = position.z();
+        if(id.det()==DetId::HGCalHSc)
+        {
+            HGCScintillatorDetId sc_id(module_triggercells.first);
+            moduleSide_   = sc_id.zside();
+            moduleSubdet_ = ForwardSubdetector::HGCHEB;
+            moduleLayer_  = sc_id.layer();
+            moduleIEta_       = sc_id.ietaAbs();
+            moduleIPhi_       = sc_id.iphi();
+            module_ = 0;
+        }
+        else
+        {
+            HGCalDetId si_id(module_triggercells.first);
+            moduleSide_   = si_id.zside();
+            moduleSubdet_ = si_id.subdetId();
+            moduleLayer_  = si_id.layer();
+            moduleIEta_   = 0;
+            moduleIPhi_   = 0;
+            module_ = si_id.wafer();
+        }
+        moduleTC_N_   = module_triggercells.second.size();
+        //
+        setTreeModuleSize(moduleTC_N_);
+        size_t itc = 0;
+        for(const auto& tc : module_triggercells.second)
+        {
+            moduleTC_id_    .get()[itc] = tc;
+            if(id.det()==DetId::HGCalHSc)
+            {
+                HGCScintillatorDetId tcId(tc);
+                moduleTC_zside_ .get()[itc] = tcId.zside();
+                moduleTC_subdet_.get()[itc] = tcId.subdet();
+                moduleTC_layer_ .get()[itc] = tcId.layer();
+                moduleTC_waferU_ .get()[itc] = 0;
+                moduleTC_waferV_ .get()[itc] = 0;
+                moduleTC_cellU_  .get()[itc] = 0;
+                moduleTC_cellV_  .get()[itc] = 0;
+                moduleTC_ieta_  .get()[itc] = tcId.ietaAbs();
+                moduleTC_iphi_  .get()[itc] = tcId.iphi();
+            }
+            else
+            {
+                HGCalTriggerDetId tcId(tc);
+                moduleTC_zside_ .get()[itc] = tcId.zside();
+                moduleTC_subdet_.get()[itc] = tcId.subdet();
+                moduleTC_layer_ .get()[itc] = tcId.layer();
+                moduleTC_waferU_ .get()[itc] = tcId.waferU();
+                moduleTC_waferV_ .get()[itc] = tcId.waferV();
+                moduleTC_cellU_  .get()[itc] = tcId.triggerCellU();
+                moduleTC_cellV_  .get()[itc] = tcId.triggerCellV();
+                moduleTC_ieta_  .get()[itc] = 0;
+                moduleTC_iphi_  .get()[itc] = 0;
+            }
+            GlobalPoint position = triggerGeometry_->getTriggerCellPosition(tc);
+            moduleTC_x_     .get()[itc] = position.x();
+            moduleTC_y_     .get()[itc] = position.y();
+            moduleTC_z_     .get()[itc] = position.z();
+            itc++;
+        }
+        auto cells_in_module = triggerGeometry_->getCellsFromModule(id);
+        moduleCell_N_   = cells_in_module.size();
+        //
+        setTreeModuleCellSize(moduleCell_N_);
+        size_t ic = 0;
+        for(const auto& c : cells_in_module)
+        {
+            if(id.det()==DetId::HGCalHSc)
+            {
+                HGCScintillatorDetId cId(c);
+                GlobalPoint cell_position = triggerGeometry_->hscGeometry()->getPosition(cId);
+                triggerCellCell_id_    .get()[ic] = c;
+                triggerCellCell_zside_ .get()[ic] = cId.zside();
+                triggerCellCell_subdet_.get()[ic] = cId.subdetId();
+                triggerCellCell_layer_ .get()[ic] = cId.layer();
+                triggerCellCell_waferU_ .get()[ic] = 0;
+                triggerCellCell_waferV_ .get()[ic] = 0;
+                triggerCellCell_cellU_  .get()[ic] = 0;
+                triggerCellCell_cellV_  .get()[ic] = 0;
+                triggerCellCell_ieta_  .get()[ic] = cId.ietaAbs();
+                triggerCellCell_iphi_  .get()[ic] = cId.iphi();
+                triggerCellCell_x_     .get()[ic] = cell_position.x();
+                triggerCellCell_y_     .get()[ic] = cell_position.y();
+                triggerCellCell_z_     .get()[ic] = cell_position.z();
+            }
+            else
+            {
+                HGCSiliconDetId cId(c);
+                const GlobalPoint position = (cId.det()==DetId::HGCalEE ? triggerGeometry_->eeGeometry()->getPosition(cId) :  triggerGeometry_->hsiGeometry()->getPosition(cId));
+                moduleCell_id_    .get()[ic] = c;
+                moduleCell_zside_ .get()[ic] = cId.zside();
+                moduleCell_subdet_.get()[ic] = cId.subdetId();
+                moduleCell_layer_ .get()[ic] = cId.layer();
+                moduleCell_waferU_ .get()[ic] = cId.waferU();
+                moduleCell_waferV_ .get()[ic] = cId.waferV();
+                moduleCell_cellU_  .get()[ic] = cId.cellU();
+                moduleCell_cellV_  .get()[ic] = cId.cellV();
+                moduleCell_x_     .get()[ic] = position.x();
+                moduleCell_y_     .get()[ic] = position.y();
+                moduleCell_z_     .get()[ic] = position.z();
+                ic++;
+            }
+        }
+        //
+        treeModules_->Fill();
+    }
+
+}
+
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp2::analyze(const edm::Event& e, 
+        const edm::EventSetup& es) 
+/*****************************************************************/
+{
+
+}
+
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp2::setTreeModuleSize(const size_t n) 
+/*****************************************************************/
+{
+    moduleTC_id_    .reset(new int[n],   array_deleter<int>());
+    moduleTC_zside_ .reset(new int[n],   array_deleter<int>());
+    moduleTC_subdet_.reset(new int[n],   array_deleter<int>());
+    moduleTC_layer_ .reset(new int[n],   array_deleter<int>());
+    moduleTC_waferU_ .reset(new int[n],   array_deleter<int>());
+    moduleTC_waferV_ .reset(new int[n],   array_deleter<int>());
+    moduleTC_cellU_  .reset(new int[n],   array_deleter<int>());
+    moduleTC_cellV_  .reset(new int[n],   array_deleter<int>());
+    moduleTC_ieta_  .reset(new int[n],   array_deleter<int>());
+    moduleTC_iphi_  .reset(new int[n],   array_deleter<int>());
+    moduleTC_x_     .reset(new float[n], array_deleter<float>());
+    moduleTC_y_     .reset(new float[n], array_deleter<float>());
+    moduleTC_z_     .reset(new float[n], array_deleter<float>());
+
+    treeModules_->GetBranch("tc_id")     ->SetAddress(moduleTC_id_    .get());
+    treeModules_->GetBranch("tc_zside")  ->SetAddress(moduleTC_zside_ .get());
+    treeModules_->GetBranch("tc_subdet") ->SetAddress(moduleTC_subdet_.get());
+    treeModules_->GetBranch("tc_layer")  ->SetAddress(moduleTC_layer_ .get());
+    treeModules_->GetBranch("tc_waferu")  ->SetAddress(moduleTC_waferU_ .get());
+    treeModules_->GetBranch("tc_waferv")  ->SetAddress(moduleTC_waferV_ .get());
+    treeModules_->GetBranch("tc_cellu")   ->SetAddress(moduleTC_cellU_  .get());
+    treeModules_->GetBranch("tc_cellv")   ->SetAddress(moduleTC_cellV_  .get());
+    treeModules_->GetBranch("tc_ieta")   ->SetAddress(moduleTC_ieta_  .get());
+    treeModules_->GetBranch("tc_iphi")   ->SetAddress(moduleTC_iphi_  .get());
+    treeModules_->GetBranch("tc_x")      ->SetAddress(moduleTC_x_     .get());
+    treeModules_->GetBranch("tc_y")      ->SetAddress(moduleTC_y_     .get());
+    treeModules_->GetBranch("tc_z")      ->SetAddress(moduleTC_z_     .get());
+}
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp2::setTreeModuleCellSize(const size_t n) 
+/*****************************************************************/
+{
+    moduleCell_id_    .reset(new int[n],   array_deleter<int>());
+    moduleCell_zside_ .reset(new int[n],   array_deleter<int>());
+    moduleCell_subdet_.reset(new int[n],   array_deleter<int>());
+    moduleCell_layer_ .reset(new int[n],   array_deleter<int>());
+    moduleCell_waferU_ .reset(new int[n],   array_deleter<int>());
+    moduleCell_waferV_ .reset(new int[n],   array_deleter<int>());
+    moduleCell_cellU_  .reset(new int[n],   array_deleter<int>());
+    moduleCell_cellV_  .reset(new int[n],   array_deleter<int>());
+    moduleCell_x_     .reset(new float[n], array_deleter<float>());
+    moduleCell_y_     .reset(new float[n], array_deleter<float>());
+    moduleCell_z_     .reset(new float[n], array_deleter<float>());
+
+    treeModules_->GetBranch("c_id")     ->SetAddress(moduleCell_id_    .get());
+    treeModules_->GetBranch("c_zside")  ->SetAddress(moduleCell_zside_ .get());
+    treeModules_->GetBranch("c_subdet") ->SetAddress(moduleCell_subdet_.get());
+    treeModules_->GetBranch("c_layer")  ->SetAddress(moduleCell_layer_ .get());
+    treeModules_->GetBranch("c_waferu")  ->SetAddress(moduleCell_waferU_ .get());
+    treeModules_->GetBranch("c_waferv")  ->SetAddress(moduleCell_waferV_ .get());
+    treeModules_->GetBranch("c_cellu")   ->SetAddress(moduleCell_cellU_  .get());
+    treeModules_->GetBranch("c_cellv")   ->SetAddress(moduleCell_cellV_  .get());
+    treeModules_->GetBranch("c_x")      ->SetAddress(moduleCell_x_     .get());
+    treeModules_->GetBranch("c_y")      ->SetAddress(moduleCell_y_     .get());
+    treeModules_->GetBranch("c_z")      ->SetAddress(moduleCell_z_     .get());
+}
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp2::setTreeTriggerCellSize(const size_t n) 
+/*****************************************************************/
+{
+    triggerCellCell_id_    .reset(new int[n],   array_deleter<int>());
+    triggerCellCell_zside_ .reset(new int[n],   array_deleter<int>());
+    triggerCellCell_subdet_.reset(new int[n],   array_deleter<int>());
+    triggerCellCell_layer_ .reset(new int[n],   array_deleter<int>());
+    triggerCellCell_waferU_ .reset(new int[n],   array_deleter<int>());
+    triggerCellCell_waferV_ .reset(new int[n],   array_deleter<int>());
+    triggerCellCell_cellU_  .reset(new int[n],   array_deleter<int>());
+    triggerCellCell_cellV_  .reset(new int[n],   array_deleter<int>());
+    triggerCellCell_ieta_  .reset(new int[n],   array_deleter<int>());
+    triggerCellCell_iphi_  .reset(new int[n],   array_deleter<int>());
+    triggerCellCell_x_     .reset(new float[n], array_deleter<float>());
+    triggerCellCell_y_     .reset(new float[n], array_deleter<float>());
+    triggerCellCell_z_     .reset(new float[n], array_deleter<float>());
+
+    treeTriggerCells_->GetBranch("c_id")     ->SetAddress(triggerCellCell_id_    .get());
+    treeTriggerCells_->GetBranch("c_zside")  ->SetAddress(triggerCellCell_zside_ .get());
+    treeTriggerCells_->GetBranch("c_subdet") ->SetAddress(triggerCellCell_subdet_.get());
+    treeTriggerCells_->GetBranch("c_layer")  ->SetAddress(triggerCellCell_layer_ .get());
+    treeTriggerCells_->GetBranch("c_waferu")  ->SetAddress(triggerCellCell_waferU_ .get());
+    treeTriggerCells_->GetBranch("c_waferv")  ->SetAddress(triggerCellCell_waferV_ .get());
+    treeTriggerCells_->GetBranch("c_cellu")   ->SetAddress(triggerCellCell_cellU_  .get());
+    treeTriggerCells_->GetBranch("c_cellv")   ->SetAddress(triggerCellCell_cellV_  .get());
+    treeTriggerCells_->GetBranch("c_ieta")   ->SetAddress(triggerCellCell_ieta_  .get());
+    treeTriggerCells_->GetBranch("c_iphi")   ->SetAddress(triggerCellCell_iphi_  .get());
+    treeTriggerCells_->GetBranch("c_x")      ->SetAddress(triggerCellCell_x_     .get());
+    treeTriggerCells_->GetBranch("c_y")      ->SetAddress(triggerCellCell_y_     .get());
+    treeTriggerCells_->GetBranch("c_z")      ->SetAddress(triggerCellCell_z_     .get());
+}
+
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp2::setTreeCellCornerSize(const size_t n) 
+/*****************************************************************/
+{
+    cellCornersX_.reset(new float[n],   array_deleter<float>());
+    cellCornersY_.reset(new float[n],   array_deleter<float>());
+    cellCornersZ_.reset(new float[n],   array_deleter<float>());
+
+    treeCells_->GetBranch("corner_x")->SetAddress(cellCornersX_.get());
+    treeCells_->GetBranch("corner_y")->SetAddress(cellCornersY_.get());
+    treeCells_->GetBranch("corner_z")->SetAddress(cellCornersZ_.get());
+}
+
+
+
+/*****************************************************************/
+void HGCalTriggerGeomTesterV9Imp2::setTreeTriggerCellNeighborSize(const size_t n) 
+/*****************************************************************/
+{
+    triggerCellNeighbor_id_.reset(new int[n],array_deleter<int>());
+    triggerCellNeighbor_zside_ .reset(new int[n],   array_deleter<int>());
+    triggerCellNeighbor_subdet_.reset(new int[n],   array_deleter<int>());
+    triggerCellNeighbor_layer_ .reset(new int[n],   array_deleter<int>());
+    triggerCellNeighbor_waferU_ .reset(new int[n],   array_deleter<int>());
+    triggerCellNeighbor_waferV_ .reset(new int[n],   array_deleter<int>());
+    triggerCellNeighbor_cellU_  .reset(new int[n],   array_deleter<int>());
+    triggerCellNeighbor_cellV_  .reset(new int[n],   array_deleter<int>());
+    triggerCellNeighbor_distance_  .reset(new float[n],   array_deleter<float>());
+    treeTriggerCells_->GetBranch("neighbor_id")->SetAddress(triggerCellNeighbor_id_.get());
+    treeTriggerCells_->GetBranch("neighbor_zside")  ->SetAddress(triggerCellNeighbor_zside_ .get());
+    treeTriggerCells_->GetBranch("neighbor_subdet") ->SetAddress(triggerCellNeighbor_subdet_.get());
+    treeTriggerCells_->GetBranch("neighbor_layer")  ->SetAddress(triggerCellNeighbor_layer_ .get());
+    treeTriggerCells_->GetBranch("neighbor_waferu")  ->SetAddress(triggerCellNeighbor_waferU_ .get());
+    treeTriggerCells_->GetBranch("neighbor_waferv")  ->SetAddress(triggerCellNeighbor_waferV_ .get());
+    treeTriggerCells_->GetBranch("neighbor_cellu")   ->SetAddress(triggerCellNeighbor_cellU_  .get());
+    treeTriggerCells_->GetBranch("neighbor_cellv")   ->SetAddress(triggerCellNeighbor_cellV_  .get());
+    treeTriggerCells_->GetBranch("neighbor_distance")   ->SetAddress(triggerCellNeighbor_distance_  .get());
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HGCalTriggerGeomTesterV9Imp2);

--- a/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV9Imp2_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV9Imp2_cfg.py
@@ -1,0 +1,122 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process('DIGI',eras.Phase2C4)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2023D28Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D28_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt10_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+
+process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
+    fileName = cms.untracked.string('file:junk.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+# Additional output definition
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string("test_triggergeom.root")
+    )
+
+
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+
+process.generator = cms.EDProducer("FlatRandomPtGunProducer",
+    PGunParameters = cms.PSet(
+        MaxPt = cms.double(10.01),
+        MinPt = cms.double(9.99),
+        PartID = cms.vint32(13),
+        MaxEta = cms.double(2.5),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-2.5),
+        MinPhi = cms.double(-3.14159265359)
+    ),
+    Verbosity = cms.untracked.int32(0),
+    psethack = cms.string('single electron pt 10'),
+    AddAntiParticle = cms.bool(True),
+    firstRun = cms.untracked.uint32(1)
+)
+
+process.mix.digitizers = cms.PSet(process.theDigitizersValid)
+
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.digitisation_step = cms.Path(process.pdigi_valid)
+process.L1simulation_step = cms.Path(process.SimL1Emulator)
+process.digi2raw_step = cms.Path(process.DigiToRaw)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.FEVTDEBUGoutput_step = cms.EndPath(process.FEVTDEBUGoutput)
+
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+# Eventually modify default geometry parameters
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V9
+process = custom_geometry_V9(process, 2)
+
+process.hgcaltriggergeomtester = cms.EDAnalyzer(
+    "HGCalTriggerGeomTesterV9Imp2"
+    )
+process.test_step = cms.Path(process.hgcaltriggergeomtester)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.digitisation_step,process.L1simulation_step,process.digi2raw_step,process.test_step,process.endjob_step,process.FEVTDEBUGoutput_step)
+#process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.digitisation_step,process.L1simulation_step,process.digi2raw_step,process.endjob_step,process.FEVTDEBUGoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+    getattr(process,path)._seq = process.generator * getattr(process,path)._seq
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_RelValV9_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_RelValV9_cfg.py
@@ -1,10 +1,7 @@
 import FWCore.ParameterSet.Config as cms 
 from Configuration.StandardSequences.Eras import eras
-from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 
-# For old samples use the digi converter
-#process = cms.Process('DIGI',eras.Phase2,convertHGCalDigisSim)
-process = cms.Process('DIGI',eras.Phase2)
+process = cms.Process('DIGI',eras.Phase2C4)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -12,8 +9,8 @@ process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
-process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2023D17_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D35Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D35_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
@@ -32,7 +29,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("PoolSource",
-       fileNames = cms.untracked.vstring('/store/relval/CMSSW_10_4_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/103X_upgrade2023_realistic_v2_2023D21noPU-v1/20000/F4344045-AEDE-4240-B7B1-27D2CF96C34E.root'),
+       fileNames = cms.untracked.vstring('/store/relval/CMSSW_10_4_0_pre2/RelValSinglePiFlatPt_0p7to10_pythia8_cfi/GEN-SIM-DIGI-RAW/103X_upgrade2023_realistic_v2_2023D35noPU-v1/10000/CE7F0A8C-F917-F14D-9BC4-CD46CFA8B7FD.root'),
        inputCommands=cms.untracked.vstring(
            'keep *',
            'drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT',
@@ -40,6 +37,11 @@ process.source = cms.Source("PoolSource",
            'drop l1tEMTFHit2016s_simEmtfDigis__HLT',
            'drop l1tEMTFTrack2016Extras_simEmtfDigis__HLT',
            'drop l1tEMTFTrack2016s_simEmtfDigis__HLT',
+           'drop FTLClusteredmNewDetSetVector_mtdClusters_FTLBarrel_RECO',
+           'drop FTLClusteredmNewDetSetVector_mtdClusters_FTLEndcap_RECO',
+           'drop MTDTrackingRecHitedmNewDetSetVector_mtdTrackingRecHits__RECO',
+           'drop BTLDetIdBTLSampleFTLDataFrameTsSorted_mix_FTLBarrel_HLT',
+           'drop ETLDetIdETLSampleFTLDataFrameTsSorted_mix_FTLEndcap_HLT',
            )
        )
 
@@ -67,9 +69,13 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 # load HGCAL TPG simulation
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
-# Change to V7 trigger geometry for older samples
-#  from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_ZoltanSplit_V7
-#  process = custom_geometry_ZoltanSplit_V7(process)
+# To test V9Imp2
+#from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V9
+#process = custom_geometry_V9(process, implementation=2)
+#from L1Trigger.L1THGCal.customClustering import custom_2dclustering_dummy, custom_3dclustering_histoMax
+#process = custom_2dclustering_dummy(process)
+#process = custom_3dclustering_histoMax(process)
+
 
 # load ntuplizer
 process.load('L1Trigger.L1THGCal.hgcalTriggerNtuples_cff')


### PR DESCRIPTION
This PR is equivalent to #25949, where the commit history below has been squashed into a single commit:

Add compatibility with V9 geom detid scheme

Fix trigger layers

Add layers() in trigger tools

Update compatibility of digi ntuplizer with V9 geometry

cleaning

Update compatibility of TC ntuplizer with V9 geometry

Cleaning

Save H/E in the Multicluster to avoid expensive recomputation

Modify relval test file

Fix thicknessIndex for trigger cells

Add v2 implementation of v9 geometry

Add V9 Imp2 geometry tester

Temporarily remove module check

Add scintillator TCs for V9Imp2

Update detid management

Silicon panels implementation in V9 Imp2

add scintillator modules in V9 Imp2

Rename V9 panel mapping

Fix layer in geometry V9 Imp2

Add V9 relval test config

Add isEm/Had in trigger tools

Update geometry README

Cleaning V9Imp2 geometry

Fix triggerTools config in concentrator

Accessor should be float, not bool

Remove data geometry file

Remove multiple if statements in HGCalClusterT

Remove temporaries

Code update has been verified to be identical to the original version.