### PR TITLE
Close by gun generator

### DIFF
--- a/IOMC/EventVertexGenerators/interface/PassThroughEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/PassThroughEvtVtxGenerator.h
@@ -1,0 +1,44 @@
+#ifndef IOMC_PassThroughEvtVtxGenerator_H
+#define IOMC_PassThroughEvtVtxGenerator_H
+/*
+*/
+
+#include "IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "TMatrixD.h"
+
+namespace HepMC {
+   class FourVector ;
+}
+
+namespace CLHEP {
+   class HepRandomEngine;
+}
+
+namespace edm {
+   class HepMCProduct;
+}
+
+class PassThroughEvtVtxGenerator : public BaseEvtVtxGenerator
+{
+   public:
+
+   // ctor & dtor
+   explicit PassThroughEvtVtxGenerator( const edm::ParameterSet& );
+   ~PassThroughEvtVtxGenerator() override;
+
+   void produce( edm::Event&, const edm::EventSetup&) override;
+
+   virtual HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
+
+   virtual TMatrixD const* GetInvLorentzBoost() const override { return nullptr;};
+
+   private :
+
+   edm::EDGetTokenT<edm::HepMCProduct> sourceToken;
+
+};
+
+#endif

--- a/IOMC/EventVertexGenerators/interface/PassThroughEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/PassThroughEvtVtxGenerator.h
@@ -31,9 +31,9 @@ class PassThroughEvtVtxGenerator : public BaseEvtVtxGenerator
 
    void produce( edm::Event&, const edm::EventSetup&) override;
 
-   virtual HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
+   HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
 
-   virtual TMatrixD const* GetInvLorentzBoost() const override { return nullptr;};
+   TMatrixD const* GetInvLorentzBoost() const override { return nullptr;};
 
    private :
 

--- a/IOMC/EventVertexGenerators/interface/PassThroughEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/PassThroughEvtVtxGenerator.h
@@ -1,5 +1,5 @@
-#ifndef IOMC_PassThroughEvtVtxGenerator_H
-#define IOMC_PassThroughEvtVtxGenerator_H
+#ifndef IOMC_EventVertexGenerators_PassThroughEvtVtxGenerator_H
+#define IOMC_EventVertexGenerators_PassThroughEvtVtxGenerator_H
 /*
 */
 

--- a/IOMC/EventVertexGenerators/src/PassThroughEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/PassThroughEvtVtxGenerator.cc
@@ -1,0 +1,67 @@
+
+/*
+*/
+
+#include "IOMC/EventVertexGenerators/interface/PassThroughEvtVtxGenerator.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "DataFormats/Provenance/interface/Provenance.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+//#include "HepMC/GenEvent.h"
+// #include "CLHEP/Vector/ThreeVector.h"
+// #include "HepMC/SimpleVector.h"
+
+using namespace edm;
+using namespace CLHEP;
+//using namespace HepMC;
+
+
+PassThroughEvtVtxGenerator::PassThroughEvtVtxGenerator( const ParameterSet& pset )
+  : BaseEvtVtxGenerator(pset)
+{
+   Service<RandomNumberGenerator> rng;
+   if ( ! rng.isAvailable()) {
+     throw cms::Exception("Configuration")
+       << "The PassThroughEvtVtxGenerator requires the RandomNumberGeneratorService\n"
+          "which is not present in the configuration file. \n"
+          "You must add the service\n"
+          "in the configuration file or remove the modules that require it.";
+   }
+   sourceToken=consumes<edm::HepMCProduct>(pset.getParameter<edm::InputTag>("src"));
+}
+
+PassThroughEvtVtxGenerator::~PassThroughEvtVtxGenerator()
+{
+}
+
+HepMC::FourVector PassThroughEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine*) const  {
+  return HepMC::FourVector(0.,0.,0.);
+}
+
+void PassThroughEvtVtxGenerator::produce( Event& evt, const EventSetup& )
+{
+   edm::Service<edm::RandomNumberGenerator> rng;
+
+   Handle<HepMCProduct> HepUnsmearedMCEvt ;
+
+   evt.getByToken( sourceToken, HepUnsmearedMCEvt ) ;
+
+   // Copy the HepMC::GenEvent
+   HepMC::GenEvent* genevt = new HepMC::GenEvent(*HepUnsmearedMCEvt->GetEvent());
+   std::unique_ptr<edm::HepMCProduct> HepMCEvt(new edm::HepMCProduct(genevt));
+
+   evt.put(std::move(HepMCEvt)) ;
+
+   return ;
+}

--- a/IOMC/EventVertexGenerators/src/module.cc
+++ b/IOMC/EventVertexGenerators/src/module.cc
@@ -3,6 +3,7 @@
 //#include "IOMC/EventVertexGenerators/interface/VertexGenerator.h"
 
 #include "IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h"
+#include "IOMC/EventVertexGenerators/interface/PassThroughEvtVtxGenerator.h"
 #include "IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h"
 #include "IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h"
 #include "IOMC/EventVertexGenerators/interface/BeamProfileVtxGenerator.h"
@@ -18,6 +19,7 @@
 
 //using edm::VertexGenerator;
 //DEFINE_FWK_MODULE(VertexGenerator) ;
+DEFINE_FWK_MODULE(PassThroughEvtVtxGenerator) ;
 DEFINE_FWK_MODULE(GaussEvtVtxGenerator) ;
 DEFINE_FWK_MODULE(FlatEvtVtxGenerator) ;
 DEFINE_FWK_MODULE(BeamProfileVtxGenerator) ;

--- a/IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h
+++ b/IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h
@@ -21,6 +21,7 @@ namespace edm
 
     // data members
     double fEn,fR,fZ,fDelta;
+    bool fPointing = false;
     std::vector<int> fPartIDs;
   };
 }

--- a/IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h
+++ b/IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h
@@ -1,0 +1,28 @@
+#ifndef CloseByParticleGunProducer_H
+#define CloseByParticleGunProducer_H
+
+#include "IOMC/ParticleGuns/interface/BaseFlatGunProducer.h"
+
+namespace edm
+{
+
+  class CloseByParticleGunProducer : public BaseFlatGunProducer
+  {
+
+  public:
+    CloseByParticleGunProducer(const ParameterSet &);
+    ~CloseByParticleGunProducer() override;
+
+  private:
+
+    void produce(Event & e, const EventSetup& es) override;
+
+  protected :
+
+    // data members
+    double fEn,fR,fZ,fDelta;
+    std::vector<int> fPartIDs;
+  };
+}
+
+#endif

--- a/IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h
+++ b/IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h
@@ -1,5 +1,5 @@
-#ifndef CloseByParticleGunProducer_H
-#define CloseByParticleGunProducer_H
+#ifndef IOMC_ParticleGun_CloseByParticleGunProducer_H
+#define IOMC_ParticleGun_CloseByParticleGunProducer_H
 
 #include "IOMC/ParticleGuns/interface/BaseFlatGunProducer.h"
 

--- a/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
@@ -29,9 +29,9 @@ CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
     pset.getParameter<ParameterSet>("PGunParameters") ;
 
   fEn = pgun_params.getParameter<double>("En");
-  fR = pgun_params.getParameter<double>("R")*cm;
-  fZ = pgun_params.getParameter<double>("Z")*cm;
-  fDelta = pgun_params.getParameter<double>("Delta")*cm;
+  fR = pgun_params.getParameter<double>("R");
+  fZ = pgun_params.getParameter<double>("Z");
+  fDelta = pgun_params.getParameter<double>("Delta");
   fPartIDs = pgun_params.getParameter< vector<int> >("PartID");
   fPointing = pgun_params.getParameter<bool>("Pointing");
 
@@ -84,7 +84,9 @@ void CloseByParticleGunProducer::produce(Event &e, const EventSetup& es)
      // Compute Vertex Position
      double x=fR*cos(phi);
      double y=fR*sin(phi);
-     HepMC::GenVertex* Vtx = new HepMC::GenVertex(HepMC::FourVector(x,y,fZ));
+     constexpr double c= 2.99792458e+1; // cm/ns
+     double timeOffset = sqrt(x*x + y*y + fZ*fZ)/c*ns*c_light;
+     HepMC::GenVertex* Vtx = new HepMC::GenVertex(HepMC::FourVector(x*cm,y*cm,fZ*cm,timeOffset));
 
      HepMC::FourVector p(px,py,pz,energy) ;
      // If we are requested to be pointing to (0,0,0), corect the momentum direction

--- a/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
@@ -11,6 +11,9 @@
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 
 #include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "CLHEP/Random/RandFlat.h"
 
 using namespace edm;
 using namespace std;
@@ -24,9 +27,9 @@ CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
     pset.getParameter<ParameterSet>("PGunParameters") ;
 
   fEn = pgun_params.getParameter<double>("En");
-  fR = pgun_params.getParameter<double>("R");
-  fZ = pgun_params.getParameter<double>("Z");
-  fDelta = pgun_params.getParameter<double>("Delta");
+  fR = pgun_params.getParameter<double>("R")*cm;
+  fZ = pgun_params.getParameter<double>("Z")*cm;
+  fDelta = pgun_params.getParameter<double>("Delta")*cm;
   fPartIDs = pgun_params.getParameter< vector<int> >("PartID");
 
   produces<HepMCProduct>("unsmeared");
@@ -84,8 +87,10 @@ void CloseByParticleGunProducer::produce(Event &e, const EventSetup& es)
      double y=fR*sin(phi);
      HepMC::GenVertex* Vtx = new HepMC::GenVertex(HepMC::FourVector(x,y,fZ));
      Vtx->add_particle_out(Part);
-     if (fVerbosity > 0)
+     if (fVerbosity > 0) {
        Vtx->print();
+       Part->print();
+     }
      fEvt->add_vertex(Vtx) ;
    }
 

--- a/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
@@ -53,17 +53,7 @@ void CloseByParticleGunProducer::produce(Event &e, const EventSetup& es)
      {
        cout << " CloseByParticleGunProducer : Begin New Event Generation" << endl ;
      }
-   // event loop (well, another step in it...)
-
-   // no need to clean up GenEvent memory - done in HepMCProduct
-   //
-
-   // here re-create fEvt (memory)
-   //
    fEvt = new HepMC::GenEvent() ;
-
-   // now actualy, cook up the event from PDGTable and gun parameters
-   //
 
    // loop over particles
    //
@@ -89,7 +79,7 @@ void CloseByParticleGunProducer::produce(Event &e, const EventSetup& es)
      HepMC::GenVertex* Vtx = new HepMC::GenVertex(HepMC::FourVector(x*cm,y*cm,fZ*cm,timeOffset));
 
      HepMC::FourVector p(px,py,pz,energy) ;
-     // If we are requested to be pointing to (0,0,0), corect the momentum direction
+     // If we are requested to be pointing to (0,0,0), correct the momentum direction
      if (fPointing) {
        math::XYZVector direction(x,y,fZ);
        math::XYZVector momentum = direction.unit() * mom;
@@ -98,8 +88,8 @@ void CloseByParticleGunProducer::produce(Event &e, const EventSetup& es)
        p.setZ(momentum.z());
      }
      HepMC::GenParticle* Part = new HepMC::GenParticle(p,PartID,1);
-     Part->suggest_barcode( barcode ) ;
-     barcode++ ;
+     Part->suggest_barcode( barcode );
+     barcode++;
 
      Vtx->add_particle_out(Part);
 
@@ -107,19 +97,19 @@ void CloseByParticleGunProducer::produce(Event &e, const EventSetup& es)
        Vtx->print();
        Part->print();
      }
-     fEvt->add_vertex(Vtx) ;
+     fEvt->add_vertex(Vtx);
    }
 
 
-   fEvt->set_event_number(e.id().event()) ;
-   fEvt->set_signal_process_id(20) ;
+   fEvt->set_event_number(e.id().event());
+   fEvt->set_signal_process_id(20);
 
    if ( fVerbosity > 0 )
    {
-      fEvt->print() ;
+      fEvt->print();
    }
 
-   unique_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
+   unique_ptr<HepMCProduct> BProduct(new HepMCProduct());
    BProduct->addHepMCData( fEvt );
    e.put(std::move(BProduct), "unsmeared");
 

--- a/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
@@ -1,0 +1,113 @@
+#include <ostream>
+
+#include "IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+#include "CLHEP/Random/RandFlat.h"
+
+using namespace edm;
+using namespace std;
+
+CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset) :
+   BaseFlatGunProducer(pset)
+{
+
+  ParameterSet defpset ;
+  ParameterSet pgun_params =
+    pset.getParameter<ParameterSet>("PGunParameters") ;
+
+  fEn = pgun_params.getParameter<double>("En");
+  fR = pgun_params.getParameter<double>("R");
+  fZ = pgun_params.getParameter<double>("Z");
+  fDelta = pgun_params.getParameter<double>("Delta");
+  fPartIDs = pgun_params.getParameter< vector<int> >("PartID");
+
+  produces<HepMCProduct>("unsmeared");
+  produces<GenEventInfoProduct>();
+}
+
+CloseByParticleGunProducer::~CloseByParticleGunProducer()
+{
+   // no need to cleanup GenEvent memory - done in HepMCProduct
+}
+
+void CloseByParticleGunProducer::produce(Event &e, const EventSetup& es)
+{
+   edm::Service<edm::RandomNumberGenerator> rng;
+   CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
+
+   if ( fVerbosity > 0 )
+     {
+       cout << " CloseByParticleGunProducer : Begin New Event Generation" << endl ;
+     }
+   // event loop (well, another step in it...)
+
+   // no need to clean up GenEvent memory - done in HepMCProduct
+   //
+
+   // here re-create fEvt (memory)
+   //
+   fEvt = new HepMC::GenEvent() ;
+
+   // now actualy, cook up the event from PDGTable and gun parameters
+   //
+
+   // loop over particles
+   //
+   int barcode = 1 ;
+   double phi = CLHEP::RandFlat::shoot(engine, -3.14159265358979323846, 3.14159265358979323846);
+   for (unsigned int ip=0; ip<fPartIDs.size(); ++ip, phi += fDelta/fR)
+   {
+
+     int PartID = fPartIDs[ip] ;
+     const HepPDT::ParticleData *PData = fPDGTable->particle(HepPDT::ParticleID(abs(PartID))) ;
+     double mass   = PData->mass().value() ;
+     double mom    = sqrt(fEn*fEn-mass*mass);
+     double px     = 0.;
+     double py     = 0.;
+     double pz     = mom;
+     double energy = fEn;
+
+     HepMC::FourVector p(px,py,pz,energy) ;
+     HepMC::GenParticle* Part = new HepMC::GenParticle(p,PartID,1);
+     Part->suggest_barcode( barcode ) ;
+     barcode++ ;
+
+     double x=fR*cos(phi);
+     double y=fR*sin(phi);
+     HepMC::GenVertex* Vtx = new HepMC::GenVertex(HepMC::FourVector(x,y,fZ));
+     Vtx->add_particle_out(Part);
+     if (fVerbosity > 0)
+       Vtx->print();
+     fEvt->add_vertex(Vtx) ;
+   }
+
+
+   fEvt->set_event_number(e.id().event()) ;
+   fEvt->set_signal_process_id(20) ;
+
+   if ( fVerbosity > 0 )
+   {
+      fEvt->print() ;
+   }
+
+   unique_ptr<HepMCProduct> BProduct(new HepMCProduct()) ;
+   BProduct->addHepMCData( fEvt );
+   e.put(std::move(BProduct), "unsmeared");
+
+   unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
+   e.put(std::move(genEventInfo));
+
+   if ( fVerbosity > 0 )
+     {
+       cout << " CloseByParticleGunProducer : Event Generation Done " << endl;
+     }
+}
+

--- a/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
@@ -11,6 +11,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CLHEP/Random/RandFlat.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
@@ -51,7 +52,7 @@ void CloseByParticleGunProducer::produce(Event &e, const EventSetup& es)
 
    if ( fVerbosity > 0 )
      {
-       cout << " CloseByParticleGunProducer : Begin New Event Generation" << endl ;
+       LogDebug("CloseByParticleGunProducer") << " CloseByParticleGunProducer : Begin New Event Generation" << endl ;
      }
    fEvt = new HepMC::GenEvent() ;
 
@@ -118,7 +119,7 @@ void CloseByParticleGunProducer::produce(Event &e, const EventSetup& es)
 
    if ( fVerbosity > 0 )
      {
-       cout << " CloseByParticleGunProducer : Event Generation Done " << endl;
+       LogDebug("CloseByParticleGunProducer") << " CloseByParticleGunProducer : Event Generation Done " << endl;
      }
 }
 

--- a/IOMC/ParticleGuns/src/SealModule.cc
+++ b/IOMC/ParticleGuns/src/SealModule.cc
@@ -19,12 +19,13 @@
 #include "IOMC/ParticleGuns/interface/RandomtXiGunProducer.h"
 #include "IOMC/ParticleGuns/interface/FlatRandomPtAndDxyGunProducer.h"
 #include "IOMC/ParticleGuns/interface/RandomMultiParticlePGunProducer.h"
+#include "IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h"
 
 
 // particle gun prototypes
 //
-  
-  
+
+
 /*
 using edm::FlatEGunASCIIWriter;
 DEFINE_FWK_MODULE(FlatEGunASCIIWriter);
@@ -58,3 +59,5 @@ using edm::FlatRandomPtAndDxyGunProducer;
 DEFINE_FWK_MODULE(FlatRandomPtAndDxyGunProducer);
 using edm::RandomMultiParticlePGunProducer;
 DEFINE_FWK_MODULE(RandomMultiParticlePGunProducer);
+using edm::CloseByParticleGunProducer;
+DEFINE_FWK_MODULE(CloseByParticleGunProducer);


### PR DESCRIPTION
This PR introduces a new ParticleGunGenerator that is capable of creating several vertices located at the specified (R,Z), with Z fixed and evenly spacing along R all the requested particles.
Particles can be produced parallel to the beamline or pointing towards (0,0,0).
The vertices are assigned the time required to travel from (0,0,0) to the desired location.
An accompanying PassThrough Event Vertex Generator has been added in order to copy-paste everything w/o any additional smearing on any vertex.
This generator has been extremely useful to perform clustering studies for the HGCAL detector (See, e.g. [these slides](https://indico.cern.ch/event/800319/contributions/3325661/attachments/1799403/2935155/20190220_HGCAL_DPG_MR.pdf)