### PR TITLE
Adding emplace_back method to edm::DetSet

### DIFF
--- a/DataFormats/Common/interface/DetSet.h
+++ b/DataFormats/Common/interface/DetSet.h
@@ -66,6 +66,7 @@ namespace edm {
     const_reference operator[](size_type i) const { return data[ i ]; }
     void reserve(size_t s) { data.reserve(s); }
     void push_back(const T & t) { data.push_back(t); }
+    void emplace_back(const T & t) { data.emplace_back(t); }
     void clear() { data.clear(); }
     void swap(DetSet<T> & other) noexcept;
 

--- a/DataFormats/Common/interface/DetSet.h
+++ b/DataFormats/Common/interface/DetSet.h
@@ -67,7 +67,7 @@ namespace edm {
     void reserve(size_t s) { data.reserve(s); }
     void push_back(const T & t) { data.push_back(t); }
     template<class... Args>
-    auto emplace_back(Args&&... args) { return data.emplace_back(std::forward<Args>(args)...); }
+    decltype(auto) emplace_back(Args&&... args) { return data.emplace_back(std::forward<Args>(args)...); }
     void clear() { data.clear(); }
     void swap(DetSet<T> & other) noexcept;
 

--- a/DataFormats/Common/interface/DetSet.h
+++ b/DataFormats/Common/interface/DetSet.h
@@ -66,7 +66,8 @@ namespace edm {
     const_reference operator[](size_type i) const { return data[ i ]; }
     void reserve(size_t s) { data.reserve(s); }
     void push_back(const T & t) { data.push_back(t); }
-    void emplace_back(const T & t) { data.emplace_back(t); }
+    template<class... Args>
+    auto emplace_back(Args&&... args) { return data.emplace_back(std::forward<Args>(args)...); }
     void clear() { data.clear(); }
     void swap(DetSet<T> & other) noexcept;
 


### PR DESCRIPTION
This purely technical PR adds the `emplace_back` method from STL `vector` to `edm::DetSet`'s public interface, thus allowing to drop one copy when a new element is inserted in the collection.