### PR TITLE
Removed inclusion of Transform3DPJ from HGCalTriggerNtupleGen

### DIFF
--- a/L1Trigger/L1THGCal/plugins/BuildFile.xml
+++ b/L1Trigger/L1THGCal/plugins/BuildFile.xml
@@ -39,7 +39,6 @@
   <use   name="SimDataFormats/GeneratorProducts"/>
   <use   name="TrackPropagation/RungeKutta"/>
   <use   name="FastSimulation/Event"/>
-  <use   name="FastSimulation/CaloGeometryTools"/>
   <use   name="MagneticField/Engine"/>
   <use   name="MagneticField/Records"/>
   <use name="heppdt"/>

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleGen.cc
@@ -14,7 +14,6 @@
 #include "TrackPropagation/RungeKutta/interface/RKPropagatorInS.h"
 #include "FastSimulation/Event/interface/FSimEvent.h"
 #include "FastSimulation/Particle/interface/ParticleTable.h"
-#include "FastSimulation/CaloGeometryTools/interface/Transform3DPJ.h"
 #include "SimGeneral/HepPDTRecord/interface/PDTRecord.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -119,9 +118,6 @@ class HGCalTriggerNtupleGen : public HGCalTriggerNtupleBase
 
         void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
         void fill(const edm::Event&, const edm::EventSetup& ) final;
-
-        typedef ROOT::Math::Transform3DPJ Transform3D;
-        typedef ROOT::Math::Transform3DPJ::Point Point;
 
         enum ReachHGCal {
           notReach = 0,
@@ -316,7 +312,6 @@ fill(const edm::Event& iEvent, const edm::EventSetup& es)
     vtx_x_ = primaryVertex->position().x() * mm2cm;  // to put in official units
     vtx_y_ = primaryVertex->position().y() * mm2cm;
     vtx_z_ = primaryVertex->position().z() * mm2cm;
-    Point sim_pv(vtx_x_, vtx_y_, vtx_z_);
 
 
     HGCal_helpers::SimpleTrackPropagator toHGCalPropagator(aField_);


### PR DESCRIPTION
Transform3DPJ had no functional use in the code. This removes an unnecessary dependency on FastSimulation.