### PR TITLE
Backport : Update GT for ultra legacy - MC ECAL, GEM eMap

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,38 +2,38 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '105X_mcRun1_design_v1',
+    'run1_design'       :   '103X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '105X_mcRun1_realistic_v1',
+    'run1_mc'           :   '103X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '105X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '103X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '105X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '103X_mcRun1_pA_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '105X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '103X_mcRun2_startup_v3',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '105X_mcRun2_asymptotic_l1stage1_v1',
+    'run2_mc_l1stage1'  :   '103X_mcRun2_asymptotic_l1stage1_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '105X_mcRun2_design_v2',
+    'run2_design'       :   '105X_mcRun2_design_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '105X_mcRun2_asymptotic_v3',
+    'run2_mc'           :   '105X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '105X_mcRun2cosmics_startup_deco_v3',
+    'run2_mc_cosmics'   :   '105X_mcRun2cosmics_startup_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '105X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'        :   '103X_mcRun2_HeavyIon_v3',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '105X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '103X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '105X_dataRun2_v7',
+    'run1_data'         :   '105X_dataRun2_v6',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '105X_dataRun2_v7',
+    'run2_data'         :   '105X_dataRun2_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '105X_dataRun2_relval_v7',
+    'run2_data_relval'  :   '105X_dataRun2_relval_v6',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v6',
+    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v5',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v7',
-    'run2_data_promptlike_hi' : '105X_dataRun2_PromptLike_HI_v2',
+    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v6',
+    'run2_data_promptlike_hi' : '105X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -44,31 +44,31 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v5',
+    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v6',
+    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v7',
+    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v7',
+    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '105X_upgrade2018_design_v4',
+    'phase1_2018_design'       :  '105X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v5',
+    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v3',
+    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v6',
+    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v6',
+    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v6',
+    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '105X_postLS2_design_v3', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '105X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase1 2019
-    'phase1_2019_realistic'    : '105X_postLS2_realistic_v5', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'    : '105X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '105X_upgrade2023_realistic_v4'
+    'phase2_realistic'         : '105X_upgrade2023_realistic_v3'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,9 +16,9 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '105X_mcRun2_design_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '105X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '105X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '105X_mcRun2cosmics_startup_deco_v1',
+    'run2_mc_cosmics'   :   '105X_mcRun2cosmics_startup_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '103X_mcRun2_HeavyIon_v3',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
@@ -54,15 +54,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '105X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v3',
+    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v1',
+    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v4',
+    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v4',
+    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v4',
+    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '105X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase1 2019

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,7 +33,7 @@ autoCond = {
     'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v5',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v6',
-    'run2_data_promptlike_hi' : '103X_dataRun2_PromptLike_HI_v2',
+    'run2_data_promptlike_hi' : '105X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -44,31 +44,31 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v3',
+    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v4',
+    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v4',
+    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v5',
+    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '105X_upgrade2018_design_v2',
+    'phase1_2018_design'       :  '105X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v2',
+    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '103X_upgrade2018_realistic_HI_v12',
+    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v3',
+    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v3',
+    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v3',
+    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '105X_postLS2_design_v1', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '105X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase1 2019
-    'phase1_2019_realistic'    : '105X_postLS2_realistic_v3', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'    : '105X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '105X_upgrade2023_realistic_v2'
+    'phase2_realistic'         : '105X_upgrade2023_realistic_3'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,38 +2,38 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '103X_mcRun1_design_v1',
+    'run1_design'       :   '105X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '103X_mcRun1_realistic_v1',
+    'run1_mc'           :   '105X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '103X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '105X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '103X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '105X_mcRun1_pA_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '103X_mcRun2_startup_v3',
+    'run2_mc_50ns'      :   '105X_mcRun2_startup_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '103X_mcRun2_asymptotic_l1stage1_v1',
+    'run2_mc_l1stage1'  :   '105X_mcRun2_asymptotic_l1stage1_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '105X_mcRun2_design_v1',
+    'run2_design'       :   '105X_mcRun2_design_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '105X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '105X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '105X_mcRun2cosmics_startup_deco_v2',
+    'run2_mc_cosmics'   :   '105X_mcRun2cosmics_startup_deco_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '103X_mcRun2_HeavyIon_v3',
+    'run2_mc_hi'        :   '105X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '103X_mcRun2_pA_v3',
+    'run2_mc_pa'        :   '105X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '105X_dataRun2_v6',
+    'run1_data'         :   '105X_dataRun2_v7',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '105X_dataRun2_v6',
+    'run2_data'         :   '105X_dataRun2_v7',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '105X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '105X_dataRun2_relval_v7',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v5',
+    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v6',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v6',
-    'run2_data_promptlike_hi' : '105X_dataRun2_PromptLike_HI_v1',
+    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v7',
+    'run2_data_promptlike_hi' : '105X_dataRun2_PromptLike_HI_v2',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -44,31 +44,31 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v4',
+    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v5',
+    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v6',
+    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v7',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v6',
+    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '105X_upgrade2018_design_v3',
+    'phase1_2018_design'       :  '105X_upgrade2018_design_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v4',
+    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v2',
+    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v5',
+    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v5',
+    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v5',
+    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '105X_postLS2_design_v2', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '105X_postLS2_design_v3', # GT containing design conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase1 2019
-    'phase1_2019_realistic'    : '105X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'    : '105X_postLS2_realistic_v5', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '105X_upgrade2023_realistic_v3'
+    'phase2_realistic'         : '105X_upgrade2023_realistic_v4'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,7 +68,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2019
     'phase1_2019_realistic'    : '105X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '105X_upgrade2023_realistic_3'
+    'phase2_realistic'         : '105X_upgrade2023_realistic_v3'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -48,7 +48,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
     'phase1_2017_realistic'    :  '105X_mc2017_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v5',
+    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)


### PR DESCRIPTION
Backport of PR #26049 

Revert the PF calibration as we agree that the new PF calibration will only enter CMSSW_10_6_X release