### PR TITLE
Phase2-hgx181 First step of making v10 HGCal geometry

### DIFF
--- a/Geometry/CMSCommonData/data/caloBase/2023/v2/caloBase.xml
+++ b/Geometry/CMSCommonData/data/caloBase/2023/v2/caloBase.xml
@@ -1,0 +1,307 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<ConstantsSection label="caloBase.xml" eval="true">
+ <Constant name="Rmin00"     value="243.0*mm"/>
+ <Constant name="Rmax00"     value="1243.7*mm"/>
+ <Constant name="Zpos00"     value="2965.0*mm"/>
+ <Constant name="Rmin01"     value="1364.7*mm"/>
+ <Constant name="Rmax01"     value="1589.4*mm"/>
+ <Constant name="Zpos01"     value="3185.0*mm"/>
+ <Constant name="slope1"     value="([Rmin01]-[Rmax00])/([Zpos01]-[Zpos00])"/>
+ <Constant name="Rmax02"     value="1816.0*mm"/>
+ <Constant name="Zpos02"     value="3837.0*mm"/>
+ <Constant name="slope2"     value="([Rmax02]-[Rmax01])/([Zpos02]-[Zpos01])"/>
+ <Constant name="Rmin03"     value="[Rmin00]"/>
+ <Constant name="Zpos03"     value="4173.6*mm"/>
+ <Constant name="Rmin04"     value="269.7*mm"/>
+ <Constant name="Zpos04"     value="4416.6*mm"/>
+ <Constant name="Rmax05"     value="2725.0*mm"/>
+ <Constant name="Zpos05"     value="4522.0*mm"/>
+ <Constant name="slope3"     value="([Rmax05]-[Rmax02])/([Zpos05]-[Zpos02])"/>
+ <Constant name="Rmax03"     value="([Rmax02]+[slope3]*([Zpos03]-[Zpos02]))"/>
+ <Constant name="Rmax04"     value="([Rmax02]+[slope3]*([Zpos04]-[Zpos02]))"/>
+ <Constant name="Rmin05"     value="385.3*mm"/>
+ <Constant name="Zpos06"     value="[cms:CalorBeamZ4]"/>
+ <Constant name="Rmin06"     value="[cms:CalorMuonR3]"/>
+ <Constant name="Zpos07"     value="[cms:CalorBeamZ3]"/>
+ <Constant name="ZposV0"     value="3205.0*mm"/>
+ <Constant name="RposV0"     value="1569.1*mm"/>
+ <Constant name="ZposV1"     value="3849.4*mm"/>
+ <Constant name="RposV1"     value="1792.2*mm"/>
+ <Constant name="ZposV2"     value="4524.5*mm"/>
+ <Constant name="RposV2"     value="2684.6*mm"/>
+ <Constant name="slope20"    value="([RposV1]-[RposV0])/([ZposV1]-[ZposV0])"/>
+ <Constant name="slope30"    value="([RposV2]-[RposV1])/([ZposV2]-[ZposV1])"/>
+ <Constant name="cslope2"    value="sqrt([slope20]*[slope20]+1.0)"/>
+ <Constant name="cslope3"    value="sqrt([slope30]*[slope30]+1.0)"/>
+ <Constant name="Zpos10"     value="2966.0*mm"/>
+ <Constant name="Rmax10"     value="([Rmax00]+[slope1]*([Zpos10]-[Zpos00]))"/>
+ <Constant name="Zpos11"     value="3084.0*mm"/>
+ <Constant name="Rmax11"     value="([Rmax00]+[slope1]*([Zpos11]-[Zpos00]))"/>
+ <Constant name="Rmin100"    value="263.0*mm"/>
+ <Constant name="Zpos100"    value="2986.0*mm"/>
+ <Constant name="Rmax100"    value="([Rmax00]+[slope1]*([Zpos100]-[Zpos00]))"/>
+ <Constant name="Zpos110"    value="3063.0*mm"/>
+ <Constant name="Rmax110"    value="([Rmax00]+[slope1]*([Zpos110]-[Zpos00]))"/>
+ <Constant name="Zpos20"     value="[Zpos11]"/>
+ <Constant name="Rmax20"     value="([Rmax00]+[slope1]*([Zpos20]-[Zpos00]))"/>
+ <Constant name="Zpos21"     value="3185.0*mm"/>
+ <Constant name="Rmax21"     value="([Rmax00]+[slope1]*([Zpos21]-[Zpos00]))"/>
+ <Constant name="Zpos23"     value="[ZposV0]"/>
+ <Constant name="Rmin23"     value="1569.1*mm"/>
+ <Constant name="dShield1"   value="20.0*mm"/>
+ <Constant name="Rmax23"     value="([Rmin23]+[cslope2]*[dShield1])"/>
+ <Constant name="Rmax22"     value="([Rmax23]+[slope20]*([Zpos21]-[Zpos23]))"/>
+ <Constant name="Rmin210"    value="278.0*mm"/>
+ <Constant name="Rmax210"    value="1279.0*mm"/>
+ <Constant name="Rmax211"    value="([Rmax210]+[slope1]*([Zpos23]-[Zpos20]))"/>
+ <Constant name="Rmin211"    value="([Rmax210]-[dShield1])"/>
+ <Constant name="Zpos30"     value="[ZposV0]"/>
+ <Constant name="Zpos31"     value="[ZposV1]"/>
+ <Constant name="Zpos32"     value="[Zpos03]"/>
+ <Constant name="Zpos33"     value="[Zpos04]"/>
+ <Constant name="Zpos35"     value="[Zpos06]"/>
+ <Constant name="Zpos36"     value="[Zpos07]"/>
+ <Constant name="Zpos310"    value="3665.1*mm"/>
+ <Constant name="Zpos340"    value="4103.1*mm"/>
+ <Constant name="Zpos360"    value="4352.1*mm"/>
+ <Constant name="Zpos380"    value="[ZposV2]"/>
+ <Constant name="Zpos390"    value="5185.0*mm"/>
+ <Constant name="Zpos40"     value="5234.5*mm"/>
+ <Constant name="Rmin30"     value="263.0*mm"/>
+ <Constant name="Rmin31"     value="297.9*mm"/>
+ <Constant name="Rmin33"     value="349.7*mm"/>
+ <Constant name="Rmin34"     value="465.3*mm"/>
+ <Constant name="Rmin36"     value="930.0*mm"/>
+ <Constant name="Rmax30"     value="([RposV0]+[cslope2]*[dShield1])"/>
+ <Constant name="Rmax31"     value="([Rmax30]+[slope20]*([Zpos31]-[Zpos30]))"/>
+ <Constant name="Rmax32"     value="([Rmax31]+[slope30]*([Zpos32]-[Zpos31]))"/>
+ <Constant name="Rmax33"     value="([Rmax31]+[slope30]*([Zpos33]-[Zpos31]))"/>
+ <Constant name="Rmax34"     value="2714.6*mm"/>
+ <Constant name="Zpos34"     value="([Zpos31]+([Rmax34]-[Rmax31])/[slope30])"/>
+ <Constant name="Rmax300"    value="[RposV0]"/>
+ <Constant name="Rmax310"    value="([RposV0]+[slope20]*([Zpos310]-[Zpos30]))"/>
+ <Constant name="Rmax330"    value="[RposV1]"/>
+ <Constant name="Rmax340"    value="([RposV1]+[slope30]*([Zpos340]-[ZposV1]))"/>
+ <Constant name="Rmax360"    value="([RposV1]+[slope30]*([Zpos360]-[ZposV1]))"/>
+</ConstantsSection>
+
+<MaterialSection label="caloBase.xml">
+  <CompositeMaterial name="CEService" density="0.4819*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.0242">
+      <rMaterial name="materials:Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.1171">
+      <rMaterial name="materials:Insulation"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0104">
+      <rMaterial name="materials:Connector"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0068">
+      <rMaterial name="materials:StainlessSteel"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.8415">
+      <rMaterial name="materials:Air"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CEThermalScreen" density="1.772*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0853">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0064">
+    <rMaterial name="materials:Foam"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.8546">
+    <rMaterial name="materials:Insulation"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0537">
+    <rMaterial name="materials:G10"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+</MaterialSection>
+
+<SolidSection label="caloBase.xml">
+  <Polycone name="CALO" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="-[cms:CalorBeamZ2]" rMin="[cms:CalorMuonR2]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="-[cms:CalorBeamZ3]" rMin="[cms:CalorMuonR2]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="-[cms:CalorBeamZ3]" rMin="[cms:CalorMuonR3]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="-[cms:CalorBeamZ4]" rMin="[cms:CalorMuonR3]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="-[cms:CalorBeamZ4]" rMin="[cms:CalorBeamR2]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="-[cms:CalorBeamZ1]" rMin="[cms:CalorBeamR1]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="-[cms:TrackBeamZ2]" rMin="[cms:TrackBeamR2]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="-[cms:TrackBeamZ2]" rMin="[cms:TrackCalorR]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="[cms:TrackBeamZ2]"  rMin="[cms:TrackCalorR]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="[cms:TrackBeamZ2]"  rMin="[cms:TrackBeamR2]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="[cms:CalorBeamZ1]"  rMin="[cms:CalorBeamR1]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="[cms:CalorBeamZ4]"  rMin="[cms:CalorBeamR2]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="[cms:CalorBeamZ4]"  rMin="[cms:CalorMuonR3]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="[cms:CalorBeamZ3]"  rMin="[cms:CalorMuonR3]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="[cms:CalorBeamZ3]"  rMin="[cms:CalorMuonR2]" rMax="[cms:CalorMuonR]"/>
+    <ZSection z="[cms:CalorBeamZ2]"  rMin="[cms:CalorMuonR2]" rMax="[cms:CalorMuonR]"/>
+  </Polycone>
+  <Polycone name="CALOEC" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[Zpos00]" rMin="[Rmin00]" rMax="[Rmax00]"/>
+    <ZSection z="[Zpos01]" rMin="[Rmin00]" rMax="[Rmin01]"/>
+    <ZSection z="[Zpos01]" rMin="[Rmin00]" rMax="[Rmax01]"/>
+    <ZSection z="[Zpos02]" rMin="[Rmin00]" rMax="[Rmax02]"/>
+    <ZSection z="[Zpos03]" rMin="[Rmin00]" rMax="[Rmax03]"/>
+    <ZSection z="[Zpos03]" rMin="[Rmin04]" rMax="[Rmax03]"/>
+    <ZSection z="[Zpos04]" rMin="[Rmin04]" rMax="[Rmax04]"/>
+    <ZSection z="[Zpos04]" rMin="[Rmin05]" rMax="[Rmax04]"/>
+    <ZSection z="[Zpos05]" rMin="[Rmin05]" rMax="[Rmax05]"/>
+    <ZSection z="[Zpos06]" rMin="[Rmin05]" rMax="[Rmax05]"/>
+    <ZSection z="[Zpos06]" rMin="[Rmin06]" rMax="[Rmax05]"/>
+    <ZSection z="[Zpos07]" rMin="[Rmin06]" rMax="[Rmax05]"/>
+  </Polycone>
+  <Polycone name="CALOECTSFront" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[Zpos10]" rMin="[Rmin00]" rMax="[Rmax10]"/>
+    <ZSection z="[Zpos11]" rMin="[Rmin00]" rMax="[Rmax11]"/>
+  </Polycone>
+  <Polycone name="CALOECFront" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[Zpos100]" rMin="[Rmin100]" rMax="[Rmax100]"/>
+    <ZSection z="[Zpos110]" rMin="[Rmin100]" rMax="[Rmax110]"/>
+  </Polycone>
+  <Polycone name="CALOECTSMiddle" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[Zpos20]" rMin="[Rmin00]" rMax="[Rmax20]"/>
+    <ZSection z="[Zpos21]" rMin="[Rmin00]" rMax="[Rmax21]"/>
+    <ZSection z="[Zpos21]" rMin="[Rmin00]" rMax="[Rmax22]"/>
+    <ZSection z="[Zpos23]" rMin="[Rmin00]" rMax="[Rmax23]"/>
+  </Polycone>
+  <Polycone name="CALOECMiddle" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[Zpos20]" rMin="[Rmin210]" rMax="[Rmax210]"/>
+    <ZSection z="[Zpos23]" rMin="[Rmin210]" rMax="[Rmax211]"/>
+  </Polycone>
+  <Polycone name="CALOECTSMiddle2" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[Zpos20]" rMin="[Rmin211]" rMax="[Rmax210]"/>
+    <ZSection z="[Zpos23]" rMin="[Rmin211]" rMax="[Rmax210]"/>
+  </Polycone>
+  <Polycone name="CALOECModerator" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[Zpos20]" rMin="[Rmin210]" rMax="[Rmin211]"/>
+    <ZSection z="[Zpos23]" rMin="[Rmin210]" rMax="[Rmin211]"/>
+  </Polycone>
+  <Polycone name="CALOECTSRear" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[Zpos30]" rMin="[Rmin00]" rMax="[Rmax30]"/>
+    <ZSection z="[Zpos31]" rMin="[Rmin00]" rMax="[Rmax31]"/>
+    <ZSection z="[Zpos32]" rMin="[Rmin00]" rMax="[Rmax32]"/>
+    <ZSection z="[Zpos32]" rMin="[Rmin04]" rMax="[Rmax32]"/>
+    <ZSection z="[Zpos33]" rMin="[Rmin04]" rMax="[Rmax33]"/>
+    <ZSection z="[Zpos33]" rMin="[Rmin05]" rMax="[Rmax33]"/>
+    <ZSection z="[Zpos34]" rMin="[Rmin05]" rMax="[Rmax34]"/>
+    <ZSection z="[Zpos35]" rMin="[Rmin05]" rMax="[Rmax34]"/>
+    <ZSection z="[Zpos35]" rMin="[Rmin06]" rMax="[Rmax34]"/>
+    <ZSection z="[Zpos36]" rMin="[Rmin06]" rMax="[Rmax34]"/>
+  </Polycone>
+  <Polycone name="CALOECRear" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[Zpos30]"  rMin="[Rmin30]" rMax="[Rmax30]"/>
+    <ZSection z="[Zpos310]" rMin="[Rmin30]" rMax="[Rmax310]"/>
+    <ZSection z="[Zpos310]" rMin="[Rmin31]" rMax="[Rmax310]"/>
+    <ZSection z="[ZposV1]"  rMin="[Rmin31]" rMax="[RposV1]"/>
+    <ZSection z="[Zpos340]" rMin="[Rmin31]" rMax="[Rmax340]"/>
+    <ZSection z="[Zpos340]" rMin="[Rmin33]" rMax="[Rmax340]"/>
+    <ZSection z="[Zpos360]" rMin="[Rmin33]" rMax="[Rmax360]"/>
+    <ZSection z="[Zpos360]" rMin="[Rmin34]" rMax="[Rmax360]"/>
+    <ZSection z="[ZposV2]"  rMin="[Rmin34]" rMax="[RposV2]"/>
+    <ZSection z="[Zpos390]" rMin="[Rmin34]" rMax="[RposV2]"/>
+    <ZSection z="[Zpos390]" rMin="[Rmin36]" rMax="[RposV2]"/>
+    <ZSection z="[Zpos40]"  rMin="[Rmin36]" rMax="[RposV2]"/>
+  </Polycone>
+</SolidSection>
+
+<LogicalPartSection label="caloBase.xml">
+  <LogicalPart name="CALO" category="unspecified">
+    <rSolid name="CALO"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="CALOEC" category="unspecified">
+    <rSolid name="CALOEC"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="CALOECTSFront" category="unspecified">
+    <rSolid name="CALOECTSFront"/>
+    <rMaterial name="caloBase:CEThermalScreen"/>
+  </LogicalPart>
+  <LogicalPart name="CALOECFront" category="unspecified">
+    <rSolid name="CALOECFront"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="CALOECTSMiddle" category="unspecified">
+    <rSolid name="CALOECTSMiddle"/>
+    <rMaterial name="caloBase:CEThermalScreen"/>
+  </LogicalPart>
+  <LogicalPart name="CALOECMiddle" category="unspecified">
+    <rSolid name="CALOECMiddle"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="CALOECTSMiddle2" category="unspecified">
+    <rSolid name="CALOECTSMiddle2"/>
+    <rMaterial name="caloBase:CEThermalScreen"/>
+  </LogicalPart>
+  <LogicalPart name="CALOECModerator" category="unspecified">
+    <rSolid name="CALOECModerator"/>
+    <rMaterial name="materials:E_Polythene"/>
+  </LogicalPart>
+  <LogicalPart name="CALOECTSRear" category="unspecified">
+    <rSolid name="CALOECTSRear"/>
+    <rMaterial name="caloBase:CEThermalScreen"/>
+  </LogicalPart>
+  <LogicalPart name="CALOECRear" category="unspecified">
+    <rSolid name="CALOECRear"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="caloBase.xml">
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALO"/>
+    <rChild name="caloBase:CALOEC"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="caloBase:CALO"/>
+    <rChild name="caloBase:CALOEC"/>
+    <rRotation name="rotations:180D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALOEC"/>
+    <rChild name="caloBase:CALOECTSFront"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALOECTSFront"/>
+    <rChild name="caloBase:CALOECFront"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALOEC"/>
+    <rChild name="caloBase:CALOECTSMiddle"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALOECTSMiddle"/>
+    <rChild name="caloBase:CALOECMiddle"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALOECMiddle"/>
+    <rChild name="caloBase:CALOECTSMiddle2"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALOECMiddle"/>
+    <rChild name="caloBase:CALOECModerator"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALOEC"/>
+    <rChild name="caloBase:CALOECTSRear"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALOECTSRear"/>
+    <rChild name="caloBase:CALOECRear"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+</PosPartSection>
+
+</DDDefinition>

--- a/Geometry/CMSCommonData/data/cms/2023/v2/cms.xml
+++ b/Geometry/CMSCommonData/data/cms/2023/v2/cms.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<ConstantsSection label="cms.xml" eval="true">
+ <Constant name="Rmin"         value="[cmsextent:Rmin]"/>
+ <Constant name="Zmin"         value="[cmsextent:Zmin]"/>
+ <Constant name="HallZ"        value="[cmsextent:HallZ]"/>
+ <Constant name="HallR"        value="[cmsextent:HallR]"/>
+ <Constant name="HallRMax"     value="[cmsextent:HallRMax]"/>
+ <Constant name="CMSR1"        value="[cmsextent:CMSR1]"/>
+ <Constant name="CMSR2"        value="[cmsextent:CMSR2]"/>
+ <Constant name="CMSR3"        value="[cavernData:CMSR3]"/>
+ <Constant name="CMSR4"        value="[cavernData:CMSR4]"/>
+ <Constant name="CMSZ1"        value="[cmsextent:CMSZ1]"/>
+ <Constant name="CMSZ2"        value="[cmsextent:CMSZ2]"/>
+ <Constant name="HFRiseZ1"     value="[cavernData:HFRiseZ1]"/>
+ <Constant name="HFRiseZ2"     value="[cavernData:HFRiseZ2]"/>
+ <Constant name="ShaftY"       value="[cavernData:ShaftY]"/>
+ <Constant name="ShaftZ"       value="[cavernData:ShaftZ]"/>
+ <Constant name="CMSZ2"        value="[cmsextent:CMSZ2]"/>
+ <Constant name="TrackCalorR"  value="1.233*m"/>
+ <Constant name="CalorMuonR"   value="2.950*m"/>
+ <Constant name="CalorMuonR2"  value="2.810*m"/>
+ <Constant name="CalorMuonR3"  value="0.900*m"/>
+ <Constant name="TrackBeamZ1"  value="1.948*m"/>
+ <Constant name="TrackBeamZ2"  value="2.935*m"/>
+ <Constant name="TrackBeamSupZ1"  value="1.630*m-.6*cm"/>
+ <Constant name="TrackBeamSupZ2"  value="1.630*m+.6*cm"/>
+ <Constant name="TrackBeamR1"  value="2.50*cm"/> <!-- 3.10*cm -->
+ <Constant name="TrackBeamR2"  value="7.40*cm"/>
+ <Constant name="TrackLumiZ1"  value="1.722*m"/>
+ <Constant name="TrackLumiZ2"  value="1.800*m"/>
+ <Constant name="TrackLumiR1"  value="7.70*cm"/>
+ <Constant name="TrackLumiR1Min" value="3.170*cm"/>
+ <Constant name="TrackLumiR2Min" value="3.3*cm"/>
+ <Constant name="CalorBeamZ1"  value="3.180*m"/>
+ <Constant name="CalorBeamZ2"  value="5.541*m"/>
+ <Constant name="CalorBeamZ3"  value="5.245*m"/>
+ <Constant name="CalorBeamZ4"  value="5.215*m"/>
+ <Constant name="CalorBeamR1"  value="8.00*cm"/>
+ <Constant name="CalorBeamR2"  value="8.93*cm"/>
+ <Constant name="MuonBeamZ0"   value="6.50*m"/>
+ <Constant name="MuonBeamZ1"   value="7.499*m"/>
+ <Constant name="MuonBeamZ2"   value="10.86*m"/>
+ <Constant name="MuonBeamR0"   value="10.50*cm"/>
+ <Constant name="MuonBeamR1"   value="11.785*cm"/>
+ <Constant name="MuonBeamR2"   value="76.80*cm"/>
+ <Constant name="TotemMuonZ1"  value="10.165*m"/>
+ <Constant name="TotemMuonZ2"  value="10.50*m"/>
+ <Constant name="TotemMuonR1"  value="1.0411*m"/>
+ <Constant name="TotemMuonR2"  value="1.1300*m"/>
+ <Constant name="TotemBeamZ1"  value="7.9500*m"/>
+ <Constant name="TotemBeamZ2"  value="13.381*m"/>
+ <Constant name="TotemBeamZ3"  value="13.439*m"/>
+ <Constant name="TotemBeamZ4"  value="13.465*m"/>
+ <Constant name="TotemBeamR1"  value="[MuonBeamR1]"/>
+ <Constant name="TotemBeamR2"  value="12.15*cm"/>
+ <Constant name="TotemBeamR3"  value="12.20*cm"/>
+ <Constant name="TotemBeamR4"  value="3.675*cm"/>
+ <Constant name="TotemBeamR5"  value="3.575*cm"/>
+ <Constant name="ForwdBeamZ1"  value="10.539*m"/>
+ <Constant name="ForwdBeamZ2"  value="13.109*m"/>
+ <Constant name="ForwdBeamZ3"  value="13.290*m"/>
+ <Constant name="ForwdBeamZ4"  value="16.0305*m"/>
+ <Constant name="ForwdBeamZ5"  value="16.424*m"/>
+ <Constant name="ForwdBeamZ6"  value="17.058*m"/>
+ <Constant name="ForwdBeamZ7"  value="17.920*m"/>
+ <Constant name="ForwdBeamZ8"  value="18.562*m"/>
+ <Constant name="ForwdBeamZ9"  value="18.905*m"/>
+ <Constant name="ForwdBeamR0"  value="15.95*cm"/>
+ <Constant name="ForwdBeamR1"  value="12.495*cm"/>
+ <Constant name="ForwdBeamR2"  value="12.50*cm"/>
+ <Constant name="ForwdBeamR3"  value="25.0*cm"/>
+ <Constant name="ForwdBeamR4"  value="2.85*cm+0.65*cm"/> <!-- Post LS2 beam-pipe -->
+ <Constant name="ForwdBeamR5"  value="7.50*cm"/>
+ <Constant name="ForwdBeamR6"  value="20.5*cm"/>
+ <Constant name="ForwdBeamR7"  value="4.00*cm"/>
+ <Constant name="ForwdBeamR8"  value="2.15*cm"/>
+ <Constant name="ForwdVcalZ1"  value="11.1495*m"/>
+ <Constant name="ForwdVcalZ2"  value="12.8005*m"/>
+ <Constant name="ForwdVcalR1"  value="1.595*m"/>
+ <Constant name="ForwdDetsZ1"  value="16.0065*m"/>
+ <Constant name="ForwdDetsZ2"  value="16.0065*m-1.6165*m"/>
+ <Constant name="ForwdDetsR1"  value="33.00*cm"/>
+ <Constant name="MBarRmin"     value="3.80*m"/>
+ <Constant name="MBarRmax"     value="[cms:CMSR4]"/>
+ <Constant name="MBarZ"        value="6.61*m"/>
+ <Constant name="MBRingZ"      value="1.268*m"/>
+ <Constant name="MBRing1Zpos"  value="2.686*m"/>
+ <Constant name="MBRing2Zpos"  value="5.342*m"/>
+ <Constant name="MEndcapZ0"    value="6.59*m"/>
+ <Constant name="MEndcapZ1"    value="6.835*m"/>
+ <Constant name="MERmin0"      value="66.569*cm"/>
+ <Constant name="MERmin1"      value="67.50*cm"/>
+ <Constant name="MERmin2"      value="70.00*cm"/>
+ <Constant name="MERmin3"      value="108.60*cm"/>
+</ConstantsSection>
+
+<SolidSection label="cms.xml">
+ <Polycone name="OCMS" startPhi="0*deg" deltaPhi="360*deg" >
+  <ZSection z="-[CMSZ1]"  rMin="[Rmin]"  rMax="[CMSR2]" />
+  <ZSection z="-[HallZ]"  rMin="[Rmin]"  rMax="[CMSR2]" /> 
+  <ZSection z="-[HallZ]"  rMin="[Rmin]"  rMax="[ShaftY]+1*m"/>
+  <ZSection z="-[ShaftZ]" rMin="[Rmin]"  rMax="[ShaftY]+1*m"/>
+  <ZSection z="-[ShaftZ]" rMin="[Rmin]"  rMax="[HallRMax]+360*cm"/>
+  <ZSection z="[HallZ]"   rMin="[Rmin]"  rMax="[HallRMax]+360*cm"/>
+  <ZSection z="[HallZ]"   rMin="[Rmin]"  rMax="[CMSR2]" />
+  <ZSection z="[CMSZ1]"   rMin="[Rmin]"  rMax="[CMSR2]" />
+ </Polycone> 
+ <Polycone name="CMSEp" startPhi="0*deg" deltaPhi="360*deg" >
+  <ZSection z="-[CMSZ1]"  rMin="[Rmin]"  rMax="[CMSR2]"/>
+  <ZSection z="-[CMSZ2]"  rMin="[Rmin]"  rMax="[CMSR2]"/> 
+  <ZSection z="-[CMSZ2]"  rMin="[Rmin]"  rMax="[CMSR4]"/>
+  <ZSection z="-[HFRiseZ1]" rMin="[Rmin]" rMax="[CMSR4]"/>
+  <ZSection z="-[HFRiseZ1]" rMin="[Rmin]" rMax="[CMSR3]"/>
+  <ZSection z="-[HFRiseZ2]" rMin="[Rmin]" rMax="[CMSR3]"/>
+  <ZSection z="-[HFRiseZ2]" rMin="[Rmin]" rMax="[CMSR4]"/>
+  <ZSection z="[HFRiseZ2]" rMin="[Rmin]" rMax="[CMSR4]"/>
+  <ZSection z="[HFRiseZ2]" rMin="[Rmin]" rMax="[CMSR3]"/>
+  <ZSection z="[HFRiseZ1]" rMin="[Rmin]" rMax="[CMSR3]"/>
+  <ZSection z="[HFRiseZ1]" rMin="[Rmin]" rMax="[CMSR4]"/>
+  <ZSection z="[CMSZ2]"   rMin="[Rmin]"  rMax="[CMSR4]"/>
+  <ZSection z="[CMSZ2]"   rMin="[Rmin]"  rMax="[CMSR2]"/>
+  <ZSection z="[CMSZ1]"   rMin="[Rmin]"  rMax="[CMSR2]"/>
+ </Polycone> 
+ <Box name="YBFeetBox" dx="505*cm" dy="280*cm" dz="670*cm"/>
+ <UnionSolid name="CMSE">
+   <rSolid name="CMSEp"/>
+   <rSolid name="YBFeetBox"/>
+   <Translation x="0*fm" y="-880*cm+280*cm" z="0*fm"/>
+ </UnionSolid>
+</SolidSection>
+<LogicalPartSection label="cms.xml">
+  <LogicalPart name="World" category="unspecified">
+    <rSolid name="OCMS"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="OCMS" category="unspecified">
+    <rSolid name="OCMS"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="MCMS" category="unspecified">
+    <rSolid name="OCMS"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="CMSE" category="unspecified">
+    <rSolid name="CMSE"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+</LogicalPartSection>
+
+</DDDefinition>

--- a/Geometry/EcalCommonData/data/PhaseII/v2/ectkcable.xml
+++ b/Geometry/EcalCommonData/data/PhaseII/v2/ectkcable.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<ConstantsSection label="ectkcable.xml" eval="true">
+  <Constant name="z0CabEC"  value="2.70888*m"/>
+  <Constant name="z1CabEC"  value="2.78000*m"/>
+  <Constant name="z2CabEC"  value="3.05756*m"/>
+  <Constant name="z3CabEC"  value="[eregalgo:z3CabEC]"/>
+  <Constant name="z4CabEC"  value="[eregalgo:z4CabEC]"/>
+  <Constant name="rMin0Cab" value="1.40500*m"/>
+  <Constant name="rMin1Cab" value="1.42000*m"/>
+  <Constant name="rMin2Cab" value="[eregalgo:rMin2Cab]"/>
+  <Constant name="rMax0Cab" value="1.28300*m"/>
+  <Constant name="rMax1Cab" value="1.42445*m"/>
+</ConstantsSection>
+
+<SolidSection label="ectkcable.xml">
+  <!-- Tracking support and cables -->
+  <Polycone name="ETCS" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[z0CabEC]" rMin="[eregalgo:EBRMin]" rMax="[eregalgo:EBRMin]"/>
+    <ZSection z="[z1CabEC]" rMin="[eregalgo:EBRMin]" rMax="[rMax0Cab]"/>
+    <ZSection z="[z2CabEC]" rMin="[rMin0Cab]"     rMax="[rMax1Cab]"/>
+    <ZSection z="[z2CabEC]" rMin="[rMin0Cab]"     rMax="[eregalgo:EBRMax]"/>
+    <ZSection z="[z3CabEC]" rMin="[rMin1Cab]"     rMax="[eregalgo:EBRMax]"/>
+    <ZSection z="[z3CabEC]" rMin="[rMin2Cab]"     rMax="[eregalgo:EBRMax]"/>
+    <ZSection z="[z4CabEC]" rMin="[rMin2Cab]"     rMax="[eregalgo:EBRMax]"/>
+  </Polycone>
+  <Polycone name="ETCS_1" startPhi="10*deg" deltaPhi="160*deg">
+    <ZSection z="[z0CabEC]" rMin="[eregalgo:EBRMin]" rMax="[eregalgo:EBRMin]"/>
+    <ZSection z="[z1CabEC]" rMin="[eregalgo:EBRMin]" rMax="[rMax0Cab]"/>
+    <ZSection z="[z2CabEC]" rMin="[rMin0Cab]"     rMax="[rMax1Cab]"/>
+    <ZSection z="[z2CabEC]" rMin="[rMin0Cab]"     rMax="[eregalgo:EBRMax]"/>
+    <ZSection z="[z3CabEC]" rMin="[rMin1Cab]"     rMax="[eregalgo:EBRMax]"/>
+  </Polycone>
+  <Polycone name="ETCS_2" startPhi="10*deg" deltaPhi="160*deg">
+    <ZSection z="[z3CabEC]" rMin="[rMin2Cab]"     rMax="[eregalgo:EBRMax]"/>
+    <ZSection z="[z4CabEC]" rMin="[rMin2Cab]"     rMax="[eregalgo:EBRMax]"/>
+  </Polycone>
+  <Polycone name="ETSU" startPhi="-5*deg" deltaPhi="10*deg">
+    <ZSection z="[z0CabEC]" rMin="[eregalgo:EBRMin]" rMax="[eregalgo:EBRMin]"/>
+    <ZSection z="[z1CabEC]" rMin="[eregalgo:EBRMin]" rMax="[rMax0Cab]"/>
+    <ZSection z="[z2CabEC]" rMin="[rMin0Cab]"     rMax="[rMax1Cab]"/>
+    <ZSection z="[z2CabEC]" rMin="[rMin0Cab]"     rMax="[eregalgo:EBRMax]"/>
+    <ZSection z="[z3CabEC]" rMin="[rMin1Cab]"     rMax="[eregalgo:EBRMax]"/>
+    <ZSection z="[z3CabEC]" rMin="[rMin2Cab]"     rMax="[eregalgo:EBRMax]"/>
+    <ZSection z="[z4CabEC]" rMin="[rMin2Cab]"     rMax="[eregalgo:EBRMax]"/>
+  </Polycone>
+</SolidSection>
+
+<LogicalPartSection label="ectkcable.xml">
+  <LogicalPart name="ETCA" category="unspecified">
+    <rSolid name="ETCS"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="Tracker_PP1_Cables" category="unspecified">
+    <rSolid name="ETCS_1"/>
+    <rMaterial name="ectkcablemat:Tk_Cables_PP1"/>
+  </LogicalPart>
+  <LogicalPart name="Tracker_PP1_Connectors" category="unspecified">
+    <rSolid name="ETCS_2"/>
+    <rMaterial name="ectkcablemat:Tk_Connectors_PP1"/>
+  </LogicalPart>
+  <LogicalPart name="ETSU" category="unspecified">
+    <rSolid name="ETSU"/>
+    <rMaterial name="materials:Aluminium"/>
+  </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="ectkcable.xml">
+  <!-- Tracker Support and Cables -->
+  <PosPart copyNumber="1">
+    <rParent name="eregalgo:ECAL"/>
+    <rChild name="ectkcable:ETCA"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="eregalgo:ECAL"/>
+    <rChild name="ectkcable:ETCA"/>
+    <rRotation name="rotations:180D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="ectkcable:ETCA"/>
+    <rChild name="ectkcable:ETSU"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="ectkcable:ETCA"/>
+    <rChild name="ectkcable:ETSU"/>
+    <rRotation name="rotations:R180"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="ectkcable:ETCA"/>
+    <rChild name="ectkcable:Tracker_PP1_Cables"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="ectkcable:ETCA"/>
+    <rChild name="ectkcable:Tracker_PP1_Cables"/>
+    <rRotation name="rotations:R180"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="ectkcable:ETCA"/>
+    <rChild name="ectkcable:Tracker_PP1_Connectors"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="ectkcable:ETCA"/>
+    <rChild name="ectkcable:Tracker_PP1_Connectors"/>
+    <rRotation name="rotations:R180"/>
+  </PosPart>
+</PosPartSection>
+</DDDefinition>

--- a/Geometry/EcalCommonData/data/PhaseII/v2/ectkcablemat.xml
+++ b/Geometry/EcalCommonData/data/PhaseII/v2/ectkcablemat.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<MaterialSection label="ectkcablematerial.xml">
+  <CompositeMaterial name="TS_PowerCable" density="4.02080*g/cm3" method="mixture by weight" symbol=" ">
+    <MaterialFraction fraction="0.10028">
+      <rMaterial name="materials:Copper" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.89972">
+      <rMaterial name="materials:Polyethylene" />
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="TS_SignalCable" density="3.13035*g/cm3" method="mixture by weight" symbol=" ">
+    <MaterialFraction fraction="0.10018">
+      <rMaterial name="materials:Copper" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.89982">
+      <rMaterial name="materials:Polyethylene" />
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CAB_Al60" density="1.37448*g/cm3" method="mixture by weight" symbol=" ">
+    <MaterialFraction fraction="0.29872">
+      <rMaterial name="materials:Copper" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.35518">
+      <rMaterial name="materials:Aluminium" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.2691">
+      <rMaterial name="materials:Polyethylene" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.02224">
+      <rMaterial name="materials:T_Kapton" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.05475">
+      <rMaterial name="materials:Silver" />
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CAB_Al48" density="1.14748*g/cm3" method="mixture by weight" symbol=" ">
+    <MaterialFraction fraction="0.31894">
+      <rMaterial name="materials:Copper" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.32994">
+      <rMaterial name="materials:Aluminium" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.28131">
+      <rMaterial name="materials:Polyethylene" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.02411">
+      <rMaterial name="materials:T_Kapton" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0457">
+      <rMaterial name="materials:Silver" />
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CAB_Al36" density="1.06783*g/cm3" method="mixture by weight" symbol=" ">
+    <MaterialFraction fraction="0.32521">
+      <rMaterial name="materials:Copper" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.31456">
+      <rMaterial name="materials:Aluminium" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.29435">
+      <rMaterial name="materials:Polyethylene" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.02564">
+      <rMaterial name="materials:T_Kapton" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.04024">
+      <rMaterial name="materials:Silver" />
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_C6F14_F2_-30C" density="1.87917*g/cm3" method="mixture by weight" symbol=" ">
+    <MaterialFraction fraction="1.00000000">
+      <rMaterial name="materials:C6F14" />
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_RuggRibbon" density="0.83457*g/cm3" method="mixture by weight" symbol=" ">
+    <MaterialFraction fraction="0.67776">
+      <rMaterial name="materials:Polyethylene" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.13932">
+      <rMaterial name="materials:Kevlar" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.06569">
+      <rMaterial name="materials:Acrylate" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.04524">
+      <rMaterial name="materials:Silica" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.07199">
+      <rMaterial name="materials:Acrylate" />
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_Cables_PP1" density="2.07590*g/cm3" method="mixture by weight" symbol=" ">
+    <MaterialFraction fraction="0.00998">
+      <rMaterial name="ectkcablemat:TS_PowerCable" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.06704">
+      <rMaterial name="materials:Steel-008" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0">
+      <rMaterial name="materials:C6F14_3M_-15C" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.22783">
+      <rMaterial name="ectkcablemat:CAB_Al60" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01863">
+      <rMaterial name="materials:Polyethylene" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.13358">
+      <rMaterial name="ectkcablemat:T_C6F14_F2_-30C" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.10686">
+      <rMaterial name="materials:Copper" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.08857">
+      <rMaterial name="ectkcablemat:T_RuggRibbon" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.12643">
+      <rMaterial name="ectkcablemat:CAB_Al48" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.21136">
+      <rMaterial name="ectkcablemat:CAB_Al36" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00972">
+      <rMaterial name="ectkcablemat:TS_SignalCable" />
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_Connectors_PP1" density="0.30245*g/cm3" method="mixture by weight" symbol=" ">
+    <MaterialFraction fraction="0.22194">
+      <rMaterial name="ectkcablemat:CAB_Al36" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.08451">
+      <rMaterial name="ectkcablemat:CAB_Al48" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.27443">
+      <rMaterial name="ectkcablemat:CAB_Al60" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.13535">
+      <rMaterial name="ectkcablemat:T_RuggRibbon" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01331">
+      <rMaterial name="ectkcablemat:T_RuggRibbon" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01320">
+      <rMaterial name="materials:Copper" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.22420">
+      <rMaterial name="ectkcablemat:T_C6F14_F2_-30C" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01676">
+      <rMaterial name="ectkcablemat:TS_PowerCable" />
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01631">
+      <rMaterial name="ectkcablemat:TS_SignalCable" />
+    </MaterialFraction>
+  </CompositeMaterial>
+</MaterialSection>
+
+</DDDefinition>

--- a/Geometry/EcalCommonData/data/PhaseII/v2/eregalgo.xml
+++ b/Geometry/EcalCommonData/data/PhaseII/v2/eregalgo.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<ConstantsSection label="eregalgo.xml" eval="true">
+  <Constant name="z3CabEC"             value="3.10606*m"/>
+  <Constant name="z4CabEC"             value="3.28850*m"/>
+  <Constant name="rMin2Cab"            value="1.72150*m"/>
+  <Constant name="ESFrontZ"            value="2955*mm"/>
+  <Constant name="ESRearZ"             value="3170*mm"/>
+  <Constant name="ESMidZ"              value="[z3CabEC]"/>
+  <Constant name="R_MIN"               value="1365*mm"/>
+  <Constant name="R_MAX"               value="1510*mm"/>
+  <Constant name="EBRMin"              value="1238.0*mm"/>
+  <Constant name="EBRMax"              value="1775.0*mm"/>
+  <Constant name="EEIRECR"             value="115*mm"/>
+</ConstantsSection>
+  
+<SolidSection label="eregalgo.xml">
+  <Polycone name="ECAL" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="-[z4CabEC]"     rMin="[rMin2Cab]"         rMax="[EBRMax]"/>
+    <ZSection z="-[ESRearZ]"     rMin="[rMin2Cab]"         rMax="[EBRMax]"/>
+    <ZSection z="-[ESRearZ]"     rMin="[R_MIN]"            rMax="[EBRMax]"/>
+    <ZSection z="-[ESFrontZ]"    rMin="[EBRMin]"           rMax="[EBRMax]"/>
+    <ZSection z=" [ESFrontZ]"    rMin="[EBRMin]"           rMax="[EBRMax]"/>
+    <ZSection z=" [ESRearZ]"     rMin="[R_MIN]"            rMax="[EBRMax]"/>
+    <ZSection z=" [ESRearZ]"     rMin="[rMin2Cab]"         rMax="[EBRMax]"/>
+    <ZSection z=" [z4CabEC]"     rMin="[rMin2Cab]"         rMax="[EBRMax]"/>
+  </Polycone>
+</SolidSection>
+
+<LogicalPartSection label="eregalgo.xml">
+  <LogicalPart name="ECAL" category="unspecified">
+    <rSolid name="ECAL"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="eregalgo.xml">
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALO"/>
+    <rChild name="eregalgo:ECAL"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+</PosPartSection>
+
+</DDDefinition>

--- a/Geometry/HGCalCommonData/data/hgcal/v10/hgcal.xml
+++ b/Geometry/HGCalCommonData/data/hgcal/v10/hgcal.xml
@@ -1,0 +1,287 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<ConstantsSection label="hgcal.xml" eval="true">
+  <Constant name="WaferSize"             value="167.4408*mm"/>
+  <Constant name="WaferThickness"        value="0.31*mm"/>
+  <Constant name="SensorSeparation"      value="1.00*mm"/>
+  <Constant name="MouseBite"             value="5.00*mm"/>
+  <Constant name="CellThicknessFine"     value="0.12*mm"/>
+  <Constant name="CellThicknessCoarse1"  value="0.20*mm"/>
+  <Constant name="CellThicknessCoarse2"  value="0.30*mm"/>
+  <Constant name="ScintillatorThickness" value="3.88*mm"/>
+  <Constant name="NumberOfCellsFine"     value="12"/>
+  <Constant name="NumberOfCellsCoarse"   value="8"/>
+  <Constant name="FirstMixedLayer"       value="9"/>
+  <Constant name="rad100200P0"           value="-2.152079E-05"/>
+  <Constant name="rad100200P1"           value="3.040344E-02"/>
+  <Constant name="rad100200P2"           value="-1.610902E+01"/>
+  <Constant name="rad100200P3"           value="3.793400E+03"/>
+  <Constant name="rad100200P4"           value="-3.348690E+05"/>
+  <Constant name="rad200300P0"           value="-5.18494E-07"/>
+  <Constant name="rad200300P1"           value="8.93133E-04"/>
+  <Constant name="rad200300P2"           value="-5.70664E-01"/>
+  <Constant name="rad200300P3"           value="1.59796E+02"/>
+  <Constant name="rad200300P4"           value="-1.64217E+04"/>
+  <Constant name="zMinForRadPar"         value="330.0*cm"/>
+  <Constant name="ChoiceType"            value="0"/>
+  <Constant name="NCornerCut"            value="2"/>
+  <Constant name="FracAreaMin"           value="0.2"/>
+  <Constant name="radMixL0"              value="1448.0*mm"/>
+  <Constant name="radMixL1"              value="1448.0*mm"/>
+  <Constant name="radMixL2"              value="1448.0*mm"/>
+  <Constant name="radMixL3"              value="1448.0*mm"/>
+  <Constant name="radMixL4"              value="1304.0*mm"/>
+  <Constant name="radMixL5"              value="1172.0*mm"/>
+  <Constant name="radMixL6"              value="1172.0*mm"/>
+  <Constant name="radMixL7"              value="1005.0*mm"/>
+  <Constant name="radMixL8"              value="1005.0*mm"/>
+  <Constant name="radMixL9"              value="1005.0*mm"/>
+  <Constant name="radMixL10"             value="1005.0*mm"/>
+  <Constant name="radMixL11"             value="1005.0*mm"/>
+  <Constant name="radMixL12"             value="1005.0*mm"/>
+  <Constant name="radMixL13"             value="1005.0*mm"/>
+  <Constant name="slope1"                value="[etaMax:slope]"/>
+  <Constant name="slope2"                value="[caloBase:slope20]"/>
+  <Constant name="slope3"                value="[caloBase:slope30]"/>
+  <Constant name="zHGCal0"               value="[caloBase:ZposV0]"/>
+  <Constant name="zHGCal1"               value="3210.5*mm"/>
+  <Constant name="zHGCal2"               value="3625.1*mm"/>
+  <Constant name="zHGCal3"               value="[caloBase:Zpos310]"/>
+  <Constant name="zHGCal4"               value="3893.4*mm"/>
+  <Constant name="zHGCal5"               value="4066.1*mm"/>
+  <Constant name="zHGCal6"               value="[caloBase:Zpos340]"/>
+  <Constant name="zHGCal7"               value="[caloBase:Zpos360]"/>
+  <Constant name="zHGCal8"               value="4562.0*mm"/>
+  <Constant name="zHGCal9"               value="5051.8*mm"/>
+  <Constant name="zHGCal10"              value="5139.1*mm"/>
+  <Constant name="zHGCal11"              value="[caloBase:Zpos390]"/>
+  <Constant name="zHGCal12"              value="[caloBase:Zpos40]"/>
+  <Constant name="rMinHGCal1"            value="[caloBase:Rmin30]"/>
+  <Constant name="rMinHGCal2"            value="[caloBase:Rmin31]"/> 
+  <Constant name="rMinHGCal3"            value="[caloBase:Rmin33]"/>    
+  <Constant name="rMinHGCal4"            value="[caloBase:Rmin34]"/>
+  <Constant name="rMinHGCal5"            value="[caloBase:Rmin36]"/>
+  <Constant name="rMaxHGCal1"            value="1523.3*mm"/>
+  <Constant name="rMaxHGCal2"            value="([rMaxHGCal1]+[slope2]*
+						([zHGCal2]-[zHGCal1]))"/>
+  <Constant name="rMaxHGCal3"            value="([rMaxHGCal1]+[slope2]*
+						([zHGCal3]-[zHGCal1]))"/>
+  <Constant name="rMaxHGCal4"            value="([rMaxHGCal1]+[slope2]*
+						([zHGCal4]-[zHGCal1]))"/>
+  <Constant name="rMaxHGCal8"            value="2624.6*mm"/>
+  <Constant name="rMaxHGCal40"           value="([rMaxHGCal8]+[slope3]*
+						([zHGCal4]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCal5"            value="([rMaxHGCal8]+[slope3]*
+						([zHGCal5]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCal6"            value="([rMaxHGCal8]+[slope3]*
+						([zHGCal6]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCal7"            value="([rMaxHGCal8]+[slope3]*
+						([zHGCal7]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCal9"            value="2484.9*mm"/>
+  <Constant name="zHGCalEE1"             value="[zHGCal1]"/>
+  <Constant name="zHGCalEE2"             value="[zHGCal2]"/>
+  <Constant name="rMinHGCalEE1"          value="287.5*mm"/>
+  <Constant name="rMaxHGCalEE1"          value="[rMaxHGCal1]"/>
+  <Constant name="rMaxHGCalEE2"          value="[rMaxHGCal2]"/>
+  <Constant name="zHGCalHEsil1"          value="[zHGCal2]"/>
+  <Constant name="zHGCalHEsil2"          value="[zHGCal4]"/>
+  <Constant name="zHGCalHEsil3"          value="[zHGCal5]"/>
+  <Constant name="rMinHGCalHEsil1"       value="334.9*mm"/>
+  <Constant name="rMaxHGCalHEsil1"       value="[rMaxHGCal2]"/>
+  <Constant name="rMaxHGCalHEsil2"       value="[rMaxHGCal4]"/>
+  <Constant name="rMaxHGCalHEsil3"       value="[rMaxHGCal40]"/>
+  <Constant name="rMaxHGCalHEsil4"       value="([rMaxHGCal8]+[slope3]*
+						([zHGCalHEsil3]-[zHGCal8]))"/>
+  <Constant name="zHGCalHEmix1"          value="[zHGCal5]"/>
+  <Constant name="zHGCalHEmix2"          value="[zHGCal6]"/>
+  <Constant name="zHGCalHEmix3"          value="[zHGCal7]"/>
+  <Constant name="zHGCalHEmix4"          value="[zHGCal8]"/>
+  <Constant name="zHGCalHEmix5"          value="[zHGCal9]"/>
+  <Constant name="zHGCalHEmix6"          value="[zHGCal10]"/>
+  <Constant name="rMinHGCalHEmix1"       value="386.7*mm"/>
+  <Constant name="rMinHGCalHEmix2"       value="502.3*mm"/>
+  <Constant name="rMaxHGCalHEmix1"       value="([rMaxHGCal8]+[slope3]*
+						([zHGCalHEmix1]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCalHEmix2"       value="([rMaxHGCal8]+[slope3]*
+						([zHGCalHEmix2]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCalHEmix3"       value="([rMaxHGCal8]+[slope3]*
+						([zHGCalHEmix3]-[zHGCal8]))"/>
+  <Constant name="rMaxHGCalHEmix4"       value="[rMaxHGCal8]"/>
+  <Constant name="rMaxHGCalHEmix5"       value="[rMaxHGCal9]"/>
+</ConstantsSection>
+
+<SolidSection label="hgcal.xml">
+  <Polycone name="HGCalService" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[caloBase:Zpos30]"  rMin="[caloBase:Rmin30]" rMax="[caloBase:Rmax30]"/>
+    <ZSection z="[caloBase:Zpos310]" rMin="[caloBase:Rmin30]" rMax="[caloBase:Rmax310]"/>
+    <ZSection z="[caloBase:Zpos310]" rMin="[caloBase:Rmin31]" rMax="[caloBase:Rmax310]"/>
+    <ZSection z="[caloBase:ZposV1]"  rMin="[caloBase:Rmin31]" rMax="[caloBase:RposV1]"/>
+    <ZSection z="[caloBase:Zpos340]" rMin="[caloBase:Rmin31]" rMax="[caloBase:Rmax340]"/>
+    <ZSection z="[caloBase:Zpos340]" rMin="[caloBase:Rmin33]" rMax="[caloBase:Rmax340]"/>
+    <ZSection z="[caloBase:Zpos360]" rMin="[caloBase:Rmin33]" rMax="[caloBase:Rmax360]"/>
+    <ZSection z="[caloBase:Zpos360]" rMin="[caloBase:Rmin34]" rMax="[caloBase:Rmax360]"/>
+    <ZSection z="[caloBase:ZposV2]"  rMin="[caloBase:Rmin34]" rMax="[caloBase:RposV2]"/>
+    <ZSection z="[caloBase:Zpos390]" rMin="[caloBase:Rmin34]" rMax="[caloBase:RposV2]"/>
+    <ZSection z="[caloBase:Zpos390]" rMin="[caloBase:Rmin36]" rMax="[caloBase:RposV2]"/>
+    <ZSection z="[caloBase:Zpos40]"  rMin="[caloBase:Rmin36]" rMax="[caloBase:RposV2]"/>
+  </Polycone>
+  <Polycone name="HGCal" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal0]"   rMin="[rMinHGCal1]"   rMax="[rMaxHGCal1]"/>
+    <ZSection z="[zHGCal1]"   rMin="[rMinHGCal1]"   rMax="[rMaxHGCal1]"/>
+    <ZSection z="[zHGCal3]"   rMin="[rMinHGCal1]"   rMax="[rMaxHGCal3]"/>
+    <ZSection z="[zHGCal3]"   rMin="[rMinHGCal2]"   rMax="[rMaxHGCal3]"/>
+    <ZSection z="[zHGCal4]"   rMin="[rMinHGCal2]"   rMax="[rMaxHGCal4]"/>
+    <ZSection z="[zHGCal5]"   rMin="[rMinHGCal2]"   rMax="[rMaxHGCal5]"/>
+    <ZSection z="[zHGCal5]"   rMin="[rMinHGCal3]"   rMax="[rMaxHGCal5]"/>
+    <ZSection z="[zHGCal7]"   rMin="[rMinHGCal3]"   rMax="[rMaxHGCal7]"/>
+    <ZSection z="[zHGCal7]"   rMin="[rMinHGCal4]"   rMax="[rMaxHGCal7]"/>
+    <ZSection z="[zHGCal8]"   rMin="[rMinHGCal4]"   rMax="[rMaxHGCal8]"/>
+    <ZSection z="[zHGCal9]"   rMin="[rMinHGCal4]"   rMax="[rMaxHGCal8]"/>
+    <ZSection z="[zHGCal9]"   rMin="[rMinHGCal4]"   rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal11]"  rMin="[rMinHGCal4]"   rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal11]"  rMin="[rMinHGCal5]"   rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal12]"  rMin="[rMinHGCal5]"   rMax="[rMaxHGCal9]"/>
+  </Polycone>
+  <Polycone name="HGCalEE" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCalEE1]" rMin="[rMinHGCalEE1]"  rMax="[rMaxHGCalEE1]"/>
+    <ZSection z="[zHGCalEE2]" rMin="[rMinHGCalEE1]"  rMax="[rMaxHGCalEE2]"/>
+  </Polycone>
+  <Polycone name="HGCalEEsup" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCalEE1]" rMin="[rMinHGCal1]"  rMax="[rMinHGCalEE1]"/>
+    <ZSection z="[zHGCalEE2]" rMin="[rMinHGCal1]"  rMax="[rMinHGCalEE1]"/>
+  </Polycone>
+  <Polycone name="HGCalHEsil" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCalHEsil1]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEsil1]"/>
+    <ZSection z="[zHGCalHEsil2]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEsil2]"/>
+    <ZSection z="[zHGCalHEsil3]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEsil4]"/>
+  </Polycone>
+  <Polycone name="HGCalHEmix" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCalHEmix1]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEmix1]"/>
+    <ZSection z="[zHGCalHEmix2]" rMin="[rMinHGCalHEsil1]" rMax="[rMaxHGCalHEmix2]"/>
+    <ZSection z="[zHGCalHEmix2]" rMin="[rMinHGCalHEmix1]" rMax="[rMaxHGCalHEmix2]"/>
+    <ZSection z="[zHGCalHEmix3]" rMin="[rMinHGCalHEmix1]" rMax="[rMaxHGCalHEmix3]"/>
+    <ZSection z="[zHGCalHEmix3]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix3]"/>
+    <ZSection z="[zHGCalHEmix4]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix4]"/>
+    <ZSection z="[zHGCalHEmix5]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix4]"/>
+    <ZSection z="[zHGCalHEmix5]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix5]"/>
+    <ZSection z="[zHGCalHEmix6]" rMin="[rMinHGCalHEmix2]" rMax="[rMaxHGCalHEmix5]"/>
+  </Polycone>
+  <Polycone name="HGCalHEsup1" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal2]"   rMin="[rMinHGCal1]" rMax="[rMinHGCalHEsil1]"/>
+    <ZSection z="[zHGCal3]"   rMin="[rMinHGCal1]" rMax="[rMinHGCalHEsil1]"/>
+    <ZSection z="[zHGCal3]"   rMin="[rMinHGCal2]" rMax="[rMinHGCalHEsil1]"/>
+    <ZSection z="[zHGCal5]"   rMin="[rMinHGCal2]" rMax="[rMinHGCalHEsil1]"/>
+  </Polycone>
+  <Polycone name="HGCalHEsup2" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal5]"   rMin="[rMinHGCal3]" rMax="[rMinHGCalHEmix1]"/>
+    <ZSection z="[zHGCal7]"   rMin="[rMinHGCal3]" rMax="[rMinHGCalHEmix1]"/>
+  </Polycone>
+  <Polycone name="HGCalHEsup3" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal7]"   rMin="[rMinHGCal4]" rMax="[rMinHGCalHEmix2]"/>
+    <ZSection z="[zHGCal10]"  rMin="[rMinHGCal4]" rMax="[rMinHGCalHEmix2]"/>
+  </Polycone>
+  <Polycone name="HGCalBackPlate" startPhi="0*deg" deltaPhi="360*deg">
+    <ZSection z="[zHGCal10]"  rMin="[rMinHGCal4]" rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal11]"  rMin="[rMinHGCal4]" rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal11]"  rMin="[rMinHGCal5]" rMax="[rMaxHGCal9]"/>
+    <ZSection z="[zHGCal12]"  rMin="[rMinHGCal5]" rMax="[rMaxHGCal9]"/>
+  </Polycone>
+</SolidSection>
+
+<LogicalPartSection label="hgcal.xml">
+  <LogicalPart name="HGCalService" category="unspecified">
+    <rSolid name="HGCalService"/>
+    <rMaterial name="caloBase:CEService"/>
+  </LogicalPart>
+  <LogicalPart name="HGCal" category="unspecified">
+    <rSolid name="HGCal"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalEE" category="unspecified">
+    <rSolid name="HGCalEE"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEsil" category="unspecified">
+    <rSolid name="HGCalHEsil"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEmix" category="unspecified">
+    <rSolid name="HGCalHEmix"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalEEsup" category="unspecified">
+    <rSolid name="HGCalEEsup"/>
+    <rMaterial name="materials:Aluminium"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEsup1" category="unspecified">
+    <rSolid name="HGCalHEsup1"/>
+    <rMaterial name="materials:StainlessSteel"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEsup2" category="unspecified">
+    <rSolid name="HGCalHEsup2"/>
+    <rMaterial name="materials:StainlessSteel"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalHEsup3" category="unspecified">
+    <rSolid name="HGCalHEsup3"/>
+    <rMaterial name="materials:StainlessSteel"/>
+  </LogicalPart>
+  <LogicalPart name="HGCalBackPlate" category="unspecified">
+    <rSolid name="HGCalBackPlate"/>
+    <rMaterial name="materials:StainlessSteel"/>
+  </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="hgcal.xml">
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALOECRear"/>
+    <rChild name="hgcal:HGCalService"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalEE"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCalService"/>
+    <rChild name="hgcal:HGCal"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEsil"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEmix"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalEEsup"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEsup1"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEsup2"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalHEsup3"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hgcal:HGCal"/>
+    <rChild name="hgcal:HGCalBackPlate"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+</PosPartSection>
+</DDDefinition>

--- a/Geometry/HGCalCommonData/data/hgcalCons/v10/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/hgcalCons/v10/hgcalCons.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<ConstantsSection label="hgcalCons.xml" eval="true">
+   <Constant name="MinimumTileSize"        value="10.0*mm"/>
+   <Vector name="RadiusMixBoundary" type="numeric" nEntries="14">
+     [hgcal:radMixL0], [hgcal:radMixL1], [hgcal:radMixL2], [hgcal:radMixL3],
+     [hgcal:radMixL4], [hgcal:radMixL5], [hgcal:radMixL6], [hgcal:radMixL7],
+     [hgcal:radMixL8], [hgcal:radMixL9], [hgcal:radMixL10],[hgcal:radMixL11],
+     [hgcal:radMixL12],[hgcal:radMixL13]
+   </Vector>
+   <Vector name="ZRanges" type="numeric" nEntries="4">
+     [hgcal:zHGCalEE1], [hgcal:zHGCalHEsil1], [hgcal:zHGCalHEmix1], 
+     [hgcal:zHGCalHEmix5]</Vector>
+ </ConstantsSection>
+
+<SpecParSection label="hgcalCons.xml" eval="true">
+  <SpecPar name="HGCalEE">
+    <PartSelector path="//HGCalEESensitive.*"/>    
+    <Parameter name="Volume" value="HGCalEESensitive" eval="false"/>
+    <Parameter name="GeometryMode" value="HGCalGeometryMode::Hexagon8Full" eval="false"/>
+    <Parameter name="LevelZSide"          value="3"/>
+    <Parameter name="LevelTop"            value="9"/>
+    <Parameter name="LevelTop"            value="9"/>
+    <Parameter name="CellThickness"       value="[hgcal:CellThicknessFine]"/>
+    <Parameter name="CellThickness"       value="[hgcal:CellThicknessCoarse1]"/>
+    <Parameter name="CellThickness"       value="[hgcal:CellThicknessCoarse2]"/>
+    <Parameter name="FirstMixedLayer"     value="-1"/>
+    <Parameter name="DetectorType"        value="1"/>
+    <Parameter name="Radius100to200"      value="[hgcal:rad100200P0]"/>
+    <Parameter name="Radius100to200"      value="[hgcal:rad100200P1]"/>
+    <Parameter name="Radius100to200"      value="[hgcal:rad100200P2]"/>
+    <Parameter name="Radius100to200"      value="[hgcal:rad100200P3]"/> 
+    <Parameter name="Radius100to200"      value="[hgcal:rad100200P4]"/>
+    <Parameter name="Radius200to300"      value="[hgcal:rad200300P0]"/>
+    <Parameter name="Radius200to300"      value="[hgcal:rad200300P1]"/>
+    <Parameter name="Radius200to300"      value="[hgcal:rad200300P2]"/>
+    <Parameter name="Radius200to300"      value="[hgcal:rad200300P3]"/>
+    <Parameter name="Radius200to300"      value="[hgcal:rad200300P4]"/>
+    <Parameter name="RadiusCuts"          value="[hgcal:ChoiceType]"/>
+    <Parameter name="RadiusCuts"          value="[hgcal:NCornerCut]"/>
+    <Parameter name="RadiusCuts"          value="[hgcal:FracAreaMin]"/>
+    <Parameter name="RadiusCuts"          value="[hgcal:zMinForRadPar]"/>
+    <Parameter name="SlopeBottom"         value="0"/>
+    <Parameter name="SlopeBottom"         value="0"/>
+    <Parameter name="SlopeBottom"         value="0"/>
+    <Parameter name="SlopeBottom"         value="0"/>
+    <Parameter name="ZFrontBottom"        value="[hgcal:zHGCal1]"/>
+    <Parameter name="ZFrontBottom"        value="[hgcal:zHGCal2]"/>
+    <Parameter name="ZFrontBottom"        value="[hgcal:zHGCal6]"/>
+    <Parameter name="ZFrontBottom"        value="[hgcal:zHGCal7]"/>
+    <Parameter name="RMinFront"           value="[hgcal:rMinHGCalEE1]"/>
+    <Parameter name="RMinFront"           value="[hgcal:rMinHGCalHEsil1]"/>
+    <Parameter name="RMinFront"           value="[hgcal:rMinHGCalHEmix1]"/>
+    <Parameter name="RMinFront"           value="[hgcal:rMinHGCalHEmix2]"/>
+    <Parameter name="SlopeTop"            value="[hgcal:slope2]"/>
+    <Parameter name="SlopeTop"            value="[hgcal:slope3]"/>
+    <Parameter name="SlopeTop"            value="0"/>
+    <Parameter name="SlopeTop"            value="0"/>
+    <Parameter name="ZFrontTop"           value="[hgcal:zHGCal1]"/>
+    <Parameter name="ZFrontTop"           value="[hgcal:zHGCal4]"/>
+    <Parameter name="ZFrontTop"           value="[hgcal:zHGCal8]"/> 
+    <Parameter name="ZFrontTop"           value="[hgcal:zHGCal9]"/>
+    <Parameter name="RMaxFront"           value="[hgcal:rMaxHGCal1]"/>
+    <Parameter name="RMaxFront"           value="[hgcal:rMaxHGCal4]"/>
+    <Parameter name="RMaxFront"           value="[hgcal:rMaxHGCal8]"/>
+    <Parameter name="RMaxFront"           value="[hgcal:rMaxHGCal9]"/>
+  </SpecPar>
+  <SpecPar name="HGCalHEsil">
+    <PartSelector path="//HGCalHESiliconSensitive.*"/>
+    <Parameter name="Volume" value="HGCalHESiliconSensitive" eval="false"/>
+    <Parameter name="GeometryMode" value="HGCalGeometryMode::Hexagon8Full" eval="false"/>
+    <Parameter name="LevelZSide"          value="3"/>
+    <Parameter name="LevelTop"            value="9"/>
+    <Parameter name="LevelTop"            value="11"/>
+    <Parameter name="CellThickness"       value="[hgcal:CellThicknessFine]"/>
+    <Parameter name="CellThickness"       value="[hgcal:CellThicknessCoarse1]"/>
+    <Parameter name="CellThickness"       value="[hgcal:CellThicknessCoarse2]"/>
+    <Parameter name="FirstMixedLayer"     value="[hgcal:FirstMixedLayer]"/>
+    <Parameter name="DetectorType"        value="2"/>
+    <Parameter name="Radius100to200"      value="[hgcal:rad100200P0]"/>
+    <Parameter name="Radius100to200"      value="[hgcal:rad100200P1]"/>
+    <Parameter name="Radius100to200"      value="[hgcal:rad100200P2]"/>
+    <Parameter name="Radius100to200"      value="[hgcal:rad100200P3]"/> 
+    <Parameter name="Radius100to200"      value="[hgcal:rad100200P4]"/>
+    <Parameter name="Radius200to300"      value="[hgcal:rad200300P0]"/>
+    <Parameter name="Radius200to300"      value="[hgcal:rad200300P1]"/>
+    <Parameter name="Radius200to300"      value="[hgcal:rad200300P2]"/>
+    <Parameter name="Radius200to300"      value="[hgcal:rad200300P3]"/>
+    <Parameter name="Radius200to300"      value="[hgcal:rad200300P4]"/>
+    <Parameter name="RadiusCuts"          value="[hgcal:ChoiceType]"/>
+    <Parameter name="RadiusCuts"          value="[hgcal:NCornerCut]"/>
+    <Parameter name="RadiusCuts"          value="[hgcal:FracAreaMin]"/>
+    <Parameter name="RadiusCuts"          value="[hgcal:zMinForRadPar]"/>
+    <Parameter name="SlopeBottom"         value="0"/>
+    <Parameter name="SlopeBottom"         value="0"/>
+    <Parameter name="SlopeBottom"         value="0"/>
+    <Parameter name="SlopeBottom"         value="0"/>
+    <Parameter name="ZFrontBottom"        value="[hgcal:zHGCal1]"/>
+    <Parameter name="ZFrontBottom"        value="[hgcal:zHGCal2]"/>
+    <Parameter name="ZFrontBottom"        value="[hgcal:zHGCal6]"/>
+    <Parameter name="ZFrontBottom"        value="[hgcal:zHGCal7]"/>
+    <Parameter name="RMinFront"           value="[hgcal:rMinHGCalEE1]"/>
+    <Parameter name="RMinFront"           value="[hgcal:rMinHGCalHEsil1]"/>
+    <Parameter name="RMinFront"           value="[hgcal:rMinHGCalHEmix1]"/>
+    <Parameter name="RMinFront"           value="[hgcal:rMinHGCalHEmix2]"/>
+    <Parameter name="SlopeTop"            value="[hgcal:slope2]"/>
+    <Parameter name="SlopeTop"            value="[hgcal:slope3]"/>
+    <Parameter name="SlopeTop"            value="0"/>
+    <Parameter name="SlopeTop"            value="0"/>
+    <Parameter name="ZFrontTop"           value="[hgcal:zHGCal1]"/>
+    <Parameter name="ZFrontTop"           value="[hgcal:zHGCal4]"/>
+    <Parameter name="ZFrontTop"           value="[hgcal:zHGCal8]"/> 
+    <Parameter name="ZFrontTop"           value="[hgcal:zHGCal9]"/>
+    <Parameter name="RMaxFront"           value="[hgcal:rMaxHGCal1]"/>
+    <Parameter name="RMaxFront"           value="[hgcal:rMaxHGCal4]"/>
+    <Parameter name="RMaxFront"           value="[hgcal:rMaxHGCal8]"/>
+    <Parameter name="RMaxFront"           value="[hgcal:rMaxHGCal9]"/>
+  </SpecPar>
+  <SpecPar name="HGCalHEsci">
+    <PartSelector path="//HGCalHEScintillatorSensitive.*"/>
+    <Parameter name="Volume" value="HGCalHEScintillatorSensitive" eval="false"/>
+    <Parameter name="GeometryMode" value="HGCalGeometryMode::Trapezoid" eval="false"/>
+    <Parameter name="LevelZSide"          value="3"/>
+    <Parameter name="LevelTop"            value="11"/>
+    <Parameter name="LevelTop"            value="11"/>
+    <Parameter name="FirstLayer"          value="[hgcal:FirstMixedLayer]"/>
+    <Parameter name="FirstMixedLayer"     value="[hgcal:FirstMixedLayer]"/>
+    <Parameter name="DetectorType"        value="3"/>
+    <Parameter name="WaferThickness"      value="[hgcal:ScintillatorThickness]"/>
+    <Parameter name="MinimumTileSize"     value="[MinimumTileSize]"/>
+    <Parameter name="NPhiBinBH"           value="360"/>
+    <Parameter name="NPhiBinBH"           value="288"/>
+    <Parameter name="LayerFrontBH"        value="[hgcal:FirstMixedLayer]"/>
+    <Parameter name="LayerFrontBH"        value="([hgcal:FirstMixedLayer]+4)"/>
+    <Parameter name="RMinLayerBH"         value="[hgcal:radMixL3]"/>
+    <Parameter name="RMinLayerBH"         value="[hgcal:radMixL13]"/>
+    <Parameter name="SlopeBottom"         value="0"/>
+    <Parameter name="SlopeBottom"         value="0"/>
+    <Parameter name="SlopeBottom"         value="0"/>
+    <Parameter name="SlopeBottom"         value="0"/>
+    <Parameter name="ZFrontBottom"        value="[hgcal:zHGCal1]"/>
+    <Parameter name="ZFrontBottom"        value="[hgcal:zHGCal2]"/>
+    <Parameter name="ZFrontBottom"        value="[hgcal:zHGCal6]"/>
+    <Parameter name="ZFrontBottom"        value="[hgcal:zHGCal7]"/>
+    <Parameter name="RMinFront"           value="[hgcal:rMinHGCalEE1]"/>
+    <Parameter name="RMinFront"           value="[hgcal:rMinHGCalHEsil1]"/>
+    <Parameter name="RMinFront"           value="[hgcal:rMinHGCalHEmix1]"/>
+    <Parameter name="RMinFront"           value="[hgcal:rMinHGCalHEmix2]"/>
+    <Parameter name="SlopeTop"            value="[hgcal:slope2]"/>
+    <Parameter name="SlopeTop"            value="[hgcal:slope3]"/>
+    <Parameter name="SlopeTop"            value="0"/>
+    <Parameter name="SlopeTop"            value="0"/>
+    <Parameter name="ZFrontTop"           value="[hgcal:zHGCal1]"/>
+    <Parameter name="ZFrontTop"           value="[hgcal:zHGCal4]"/>
+    <Parameter name="ZFrontTop"           value="[hgcal:zHGCal8]"/> 
+    <Parameter name="ZFrontTop"           value="[hgcal:zHGCal9]"/>
+    <Parameter name="RMaxFront"           value="[hgcal:rMaxHGCal1]"/>
+    <Parameter name="RMaxFront"           value="[hgcal:rMaxHGCal4]"/>
+    <Parameter name="RMaxFront"           value="[hgcal:rMaxHGCal8]"/>
+    <Parameter name="RMaxFront"           value="[hgcal:rMaxHGCal9]"/>
+  </SpecPar>
+  <SpecPar name="HGCalWafer">
+    <PartSelector path="//HGCalEECell.*"/>
+    <PartSelector path="//HGCalHECell.*"/>
+    <Parameter name="OnlyForHGCalNumbering" value="HGCal" eval="false"/>
+    <Parameter name="WaferMode" value="HGCalGeometryMode::ExtrudedPolygon" eval="false"/>
+    <Parameter name="WaferSize"           value="[hgcal:WaferSize]"/>
+    <Parameter name="WaferThickness"      value="[hgcal:WaferThickness]"/>
+    <Parameter name="SensorSeparation"    value="[hgcal:SensorSeparation]"/>
+    <Parameter name="MouseBite"           value="[hgcal:MouseBite]"/>
+    <Parameter name="NumberOfCellsFine"   value="[hgcal:NumberOfCellsFine]"/>
+    <Parameter name="NumberOfCellsCoarse" value="[hgcal:NumberOfCellsCoarse]"/>
+  </SpecPar>
+</SpecParSection>
+
+</DDDefinition>

--- a/Geometry/HGCalCommonData/data/hgcalEE/v10/hgcalEE.xml
+++ b/Geometry/HGCalCommonData/data/hgcalEE/v10/hgcalEE.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<PosPartSection label="hgcalHEsil.xml">
+  <Algorithm name="hgcal:DDHGCalEEAlgo">
+    <rParent name="hgcal:HGCalEE"/>
+    <Vector name="WaferNames" type="string" nEntries="6">
+      hgcalwafer:HGCalEEWafer0Fine,    hgcalwafer:HGCalEEWafer0Coarse1,
+      hgcalwafer:HGCalEEWafer0Coarse2, hgcalwafer:HGCalEEWafer1Fine,
+      hgcalwafer:HGCalEEWafer1Coarse1, hgcalwafer:HGCalEEWafer1Coarse2</Vector>
+    <Vector name="MaterialNames" type="string" nEntries="16">
+      materials:Air, materials:Copper, materials:StainlessSteel, 
+      materials:Epoxy, materials:Lead, materials:Epoxy, materials:Lead,    
+      hgcalMaterial:HGC_G10-FR4, materials:Air, hgcalMaterial:HGC_G10-FR4, 
+      materials:Epoxy, materials:Kapton, materials:Silicon,
+      hgcalMaterial:WCu, materials:Copper, materials:Copper</Vector>
+    <Vector name="VolumeNames" type="string" nEntries="16">
+      HGCalEEHardPointGap, HGCalEEAbsorberCopper, HGCalEEAbsorberStainlessSteel, 
+      HGCalEEAbsorberEpoxy1, HGCalEEAbsorberLead1, HGCalEEAbsorberEpoxy2, 
+      HGCalEEAbsorberLead2, HGCalEEMotherBoard, HGCalEEAirGap, HGCalEEPCB,  
+      HGCalEEEpoxy, HGCalEEKapton, HGCalEESensitive, HGCalEEBasePlate, 
+      HGCalEECoolingPlate, HGCalEECopperCover</Vector>
+    <Vector name="Thickness" type="numeric" nEntries="16">
+      0.1*mm, 0.1*mm, 0.3*mm,  0.075*mm, 4.25*mm, 0.0875*mm, 2.125*mm, 1.85*mm,
+      3.25*mm, 1.76*mm, 0.0675*mm, 0.105*mm, 0.31*mm, 1.45*mm,
+      6.1*mm, 1.0*mm </Vector>
+    <Vector name="Layers" type="numeric" nEntries="14"> 
+      31, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 33</Vector>
+    <Vector name="LayerThick" type="numeric" nEntries="14"> 
+      27.5*mm, 29.7*mm, 29.7*mm, 29.7*mm, 29.7*mm, 29.7*mm, 29.7*mm,
+      29.7*mm, 29.7*mm, 29.7*mm, 29.7*mm, 29.7*mm, 29.7*mm, 30.7*mm </Vector>
+    <Vector name="LayerType" type="numeric" nEntries="448"> 
+      0, 2, 5, 6, 5, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0,      
+      0, 1, 2, 3, 4, 3, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0,
+      0, 1, 2, 3, 4, 3, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0,
+      0, 1, 2, 3, 4, 3, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0,
+      0, 1, 2, 3, 4, 3, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0,
+      0, 1, 2, 3, 4, 3, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0,
+      0, 1, 2, 3, 4, 3, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0,
+      0, 1, 2, 3, 4, 3, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0,
+      0, 1, 2, 3, 4, 3, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0,
+      0, 1, 2, 3, 4, 3, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0,
+      0, 1, 2, 3, 4, 3, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0,
+      0, 1, 2, 3, 4, 3, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0,
+      0, 1, 2, 3, 4, 3, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0,     
+      0, 1, 2, 3, 4, 3, 2, 1, 7, 8, 9, 10, 11, 10, 11, 10, 12, 10, 13, 14, 13, 10, 12, 10, 11, 10, 11, 10, 9, 8, 7, 0, 15     
+    </Vector>
+    <Vector name="LayerSense" type="numeric" nEntries="448">
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    </Vector>
+    <Numeric name="FirstLayer"       value="1"/>
+    <Numeric name="AbsorberMode"     value="0"/>
+    <Numeric name="zMinBlock"        value="[hgcal:zHGCalEE1]"/>
+    <Vector name="rad100to200" type="numeric" nEntries="5">
+      [hgcal:rad100200P0], [hgcal:rad100200P1], [hgcal:rad100200P2],
+      [hgcal:rad100200P3], [hgcal:rad100200P4]</Vector>
+    <Vector name="rad200to300" type="numeric" nEntries="5">
+      [hgcal:rad200300P0], [hgcal:rad200300P1], [hgcal:rad200300P2],
+      [hgcal:rad200300P3], [hgcal:rad200300P4]</Vector>
+    <Numeric name="zMinForRadPar"    value="[hgcal:zMinForRadPar]"/>
+    <Numeric name="choiceType"       value="[hgcal:ChoiceType]"/>
+    <Numeric name="nCornerCut"       value="[hgcal:NCornerCut]"/>
+    <Numeric name="fracAreaMin"      value="[hgcal:FracAreaMin]"/>
+    <Numeric name="waferSize"        value="[hgcal:WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[hgcal:SensorSeparation]"/>
+    <Numeric name="Sectors"          value="36"/>
+    <Vector name="SlopeBottom" type="numeric" nEntries="4">
+      0, 0, 0, 0</Vector>
+    <Vector name="ZFrontBottom" type="numeric" nEntries="4">
+      [hgcal:zHGCal1], [hgcal:zHGCal2], [hgcal:zHGCal6], 
+      [hgcal:zHGCal7]</Vector>
+    <Vector name="RMinFront" type="numeric" nEntries="4">
+      [hgcal:rMinHGCalEE1],    [hgcal:rMinHGCalHEsil1], 
+      [hgcal:rMinHGCalHEmix1], [hgcal:rMinHGCalHEmix2]</Vector>
+    <Vector name="SlopeTop" type="numeric" nEntries="4">
+      [hgcal:slope2], [hgcal:slope3], 0, 0</Vector>
+    <Vector name="ZFrontTop" type="numeric" nEntries="4">
+      [hgcal:zHGCal1], [hgcal:zHGCal4], [hgcal:zHGCal8], 
+      [hgcal:zHGCal9]</Vector>
+    <Vector name="RMaxFront" type="numeric" nEntries="4">
+      [hgcal:rMaxHGCal1], [hgcal:rMaxHGCal4], [hgcal:rMaxHGCal8], 
+      [hgcal:rMaxHGCal9]</Vector>
+    <String name="RotNameSpace" value="hgcalmodule"/>
+  </Algorithm>
+</PosPartSection> 
+
+</DDDefinition>

--- a/Geometry/HGCalCommonData/data/hgcalEE/v9/hgcalEE.xml
+++ b/Geometry/HGCalCommonData/data/hgcalEE/v9/hgcalEE.xml
@@ -57,6 +57,7 @@
       0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0
     </Vector>
     <Numeric name="FirstLayer"       value="1"/>
+    <Numeric name="AbsorberMode"     value="0"/>
     <Numeric name="zMinBlock"        value="[hgcal:zMinEE]"/>
     <Vector name="rad100to200" type="numeric" nEntries="5">
       [hgcal:rad100200P0], [hgcal:rad100200P1], [hgcal:rad100200P2],

--- a/Geometry/HGCalCommonData/data/hgcalEE/v9a/hgcalEE.xml
+++ b/Geometry/HGCalCommonData/data/hgcalEE/v9a/hgcalEE.xml
@@ -57,6 +57,7 @@
       0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0
     </Vector>
     <Numeric name="FirstLayer"       value="1"/>
+    <Numeric name="AbsorberMode"     value="0"/>
     <Numeric name="zMinBlock"        value="[hgcal:zMinEE]"/>
     <Vector name="rad100to200" type="numeric" nEntries="5">
       [hgcal:rad100200P0], [hgcal:rad100200P1], [hgcal:rad100200P2],

--- a/Geometry/HGCalCommonData/data/hgcalHEmix/v10/hgcalHEmix.xml
+++ b/Geometry/HGCalCommonData/data/hgcalHEmix/v10/hgcalHEmix.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<PosPartSection label="hgcalHEmix.xml">
+  <Algorithm name="hgcal:DDHGCalHEAlgo">
+    <rParent name="hgcal:HGCalHEmix"/>
+    <Vector name="WaferNames" type="string" nEntries="6">
+      hgcalwafer:HGCalHEWafer0Fine,    hgcalwafer:HGCalHEWafer0Coarse1,
+      hgcalwafer:HGCalHEWafer0Coarse2, hgcalwafer:HGCalHEWafer1Fine,
+      hgcalwafer:HGCalHEWafer1Coarse1, hgcalwafer:HGCalHEWafer1Coarse2</Vector>
+    <Vector name="MaterialNames" type="string" nEntries="6">
+      materials:StainlessSteel, materials:StainlessSteel, materials:Air,
+      materials:Copper, materials:Air, materials:Copper</Vector>
+    <Vector name="VolumeNames" type="string" nEntries="6">
+      HGCalHEAbsorber1, HGCalHEAbsorber2, HGCalHEAirGap1, HGCalHECopperCover, 
+      HGCalHEMix, HGCalHECoolingPlate</Vector>
+    <Vector name="Thickness" type="numeric" nEntries="6">
+      35.0*mm, 66.0*mm,  3.7*mm,  1.1*mm, 8.6*mm, 6.1*mm</Vector>
+    <Vector name="Layers" type="numeric" nEntries="14"> 
+      5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5</Vector>
+    <Vector name="LayerThick" type="numeric" nEntries="14">  <!-- mod -->
+      54.5*mm, 54.5*mm, 54.5*mm, 54.5*mm, 85.5*mm, 85.5*mm,
+      85.5*mm, 85.5*mm, 85.5*mm, 85.5*mm, 85.5*mm, 85.5*mm,  
+      85.5*mm, 85.5*mm</Vector>
+    <Vector name="LayerRmix" type="numeric" nEntries="14"> 
+      [hgcal:radMixL0],  [hgcal:radMixL1],  [hgcal:radMixL2],
+      [hgcal:radMixL3],  [hgcal:radMixL4],  [hgcal:radMixL5],
+      [hgcal:radMixL6],  [hgcal:radMixL7],  [hgcal:radMixL8],
+      [hgcal:radMixL9],  [hgcal:radMixL10], [hgcal:radMixL11],
+      [hgcal:radMixL12], [hgcal:radMixL13]</Vector>
+    <Vector name="LayerType" type="numeric" nEntries="70">
+      0, 2, 3, 4, 5,  0, 2, 3, 4, 5,  0, 2, 3, 4, 5,
+      0, 2, 3, 4, 5,  1, 2, 3, 4, 5,  1, 2, 3, 4, 5,
+      1, 2, 3, 4, 5,  1, 2, 3, 4, 5,  1, 2, 3, 4, 5,
+      1, 2, 3, 4, 5,  1, 2, 3, 4, 5,  1, 2, 3, 4, 5,
+      1, 2, 3, 4, 5,  1, 2, 3, 4, 5</Vector>
+    <Vector name="LayerSense" type="numeric" nEntries="70">
+      0, 0, 0, 1, 0,  0, 0, 0, 1, 0,  0, 0, 0, 1, 0,
+      0, 0, 0, 1, 0,  0, 0, 0, 1, 0,  0, 0, 0, 1, 0,
+      0, 0, 0, 1, 0,  0, 0, 0, 1, 0,  0, 0, 0, 1, 0,
+      0, 0, 0, 1, 0,  0, 0, 0, 1, 0,  0, 0, 0, 1, 0,
+      0, 0, 0, 1, 0,  0, 0, 0, 1, 0</Vector>
+    <Numeric name="FirstLayer"       value="[hgcal:FirstMixedLayer]"/>
+    <Numeric name="AbsorberMode"     value="1"/>
+    <Vector name="TopMaterialNames" type="string" nEntries="6">
+      materials:Air, materials:Cables, materials:Air,
+      materials:H_Scintillator, materials:Epoxy,
+      hgcalMaterial:HGC_G10-FR4</Vector>
+    <Vector name="TopVolumeNames" type="string" nEntries="6"> 
+      HGCalAirGap1, HGCalCableConnector, HGCalAirGap2, 
+      HGCalHEScintillatorSensitive, HGCalScintillatorEpoxy,
+      HGCalTileBoard</Vector>
+    <Vector name="TopLayerThickness" type="numeric" nEntries="6">
+      0.87*mm, 1.04*mm, 1.245*mm, [hgcal:ScintillatorThickness], 0.075*mm,
+      1.49*mm</Vector>   <!-- scintillator module -->
+    <Vector name="TopLayerType" type="numeric" nEntries="6"> 
+      0, 1, 2, 3, 4, 5</Vector>
+    <Vector name="BottomMaterialNames" type="string" nEntries="7">
+      hgcalMaterial:HGC_G10-FR4, materials:Air, hgcalMaterial:HGC_G10-FR4, 
+      materials:Epoxy, materials:Kapton,
+      materials:Silicon, hgcalMaterial:HGC_G10-FR4</Vector>
+    <Vector name="BottomVolumeNames" type="string" nEntries="7">
+      HGCalMotherBoardPCB, HGCalAirGap3, HGCalModulePCB, HGCalHEEpoxy,
+      HGCalHEKapton, HGCalHESiliconSensitive, HGCalBaseplate</Vector>
+    <Vector name="BottomLayerThickness" type="numeric" nEntries="7">
+      1.85*mm, 3.25*mm,  1.76*mm, 0.075*mm, 0.105*mm, 0.31*mm, 1.1*mm</Vector>
+    <Vector name="BottomLayerType" type="numeric" nEntries="9"> 
+      0, 1, 2, 3, 5, 3, 4, 3, 6</Vector>
+    <Vector name="BottomLayerSense" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 1, 0, 0, 0, 0</Vector>
+    <Numeric name="zMinBlock"        value="[hgcal:zHGCalHEmix1]"/>
+    <Vector name="rad100to200" type="numeric" nEntries="5">
+      [hgcal:rad100200P0], [hgcal:rad100200P1], [hgcal:rad100200P2],
+      [hgcal:rad100200P3], [hgcal:rad100200P4]</Vector>
+    <Vector name="rad200to300" type="numeric" nEntries="5">
+      [hgcal:rad200300P0], [hgcal:rad200300P1], [hgcal:rad200300P2],
+      [hgcal:rad200300P3], [hgcal:rad200300P4]</Vector>
+    <Numeric name="zMinForRadPar"    value="[hgcal:zMinForRadPar]"/>
+    <Numeric name="choiceType"       value="[hgcal:ChoiceType]"/>
+    <Numeric name="nCornerCut"       value="[hgcal:NCornerCut]"/>
+    <Numeric name="fracAreaMin"      value="[hgcal:FracAreaMin]"/>
+    <Numeric name="waferSize"        value="[hgcal:WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[hgcal:SensorSeparation]"/>
+    <Numeric name="Sectors"          value="36"/>
+    <Vector name="SlopeBottom" type="numeric" nEntries="4">
+      0, 0, 0, 0</Vector>
+    <Vector name="ZFrontBottom" type="numeric" nEntries="4">
+      [hgcal:zHGCal1], [hgcal:zHGCal2], [hgcal:zHGCal6], 
+      [hgcal:zHGCal7]</Vector>
+    <Vector name="RMinFront" type="numeric" nEntries="4">
+      [hgcal:rMinHGCalEE1],    [hgcal:rMinHGCalHEsil1], 
+      [hgcal:rMinHGCalHEmix1], [hgcal:rMinHGCalHEmix2]</Vector>
+    <Vector name="SlopeTop" type="numeric" nEntries="4">
+      [hgcal:slope2], [hgcal:slope3], 0, 0</Vector>
+    <Vector name="ZFrontTop" type="numeric" nEntries="4">
+      [hgcal:zHGCal1], [hgcal:zHGCal4], [hgcal:zHGCal8], 
+      [hgcal:zHGCal9]</Vector>
+    <Vector name="RMaxFront" type="numeric" nEntries="4">
+      [hgcal:rMaxHGCal1], [hgcal:rMaxHGCal4], [hgcal:rMaxHGCal8], 
+      [hgcal:rMaxHGCal9]</Vector>
+    <String name="RotNameSpace" value="hgcalmodule"/>
+  </Algorithm>
+</PosPartSection> 
+
+</DDDefinition>

--- a/Geometry/HGCalCommonData/data/hgcalHEmix/v9/hgcalHEmix.xml
+++ b/Geometry/HGCalCommonData/data/hgcalHEmix/v9/hgcalHEmix.xml
@@ -44,6 +44,7 @@
       0, 0, 0, 1, 0,  0, 0, 0, 1, 0,  0, 0, 0, 1, 0,
       0, 0, 0, 1, 0 </Vector>
     <Numeric name="FirstLayer"       value="[hgcal:FirstMixedLayer]"/>
+    <Numeric name="AbsorberMode"     value="0"/>
     <Vector name="TopMaterialNames" type="string" nEntries="3">
       materials:Cables, materials:H_Scintillator, 
       hgcalMaterial:HGC_G10-FR4</Vector>

--- a/Geometry/HGCalCommonData/data/hgcalHEmix/v9a/hgcalHEmix.xml
+++ b/Geometry/HGCalCommonData/data/hgcalHEmix/v9a/hgcalHEmix.xml
@@ -65,6 +65,7 @@
     <Vector name="BottomLayerSense" type="numeric" nEntries="6"> 
       0, 0, 0, 0, 1, 0</Vector>
     <Numeric name="FirstLayer"       value="[hgcal:FirstMixedLayer]"/>
+    <Numeric name="AbsorberMode"     value="0"/>
     <Numeric name="zMinBlock"        value="[hgcal:zMinHEmix]"/>
     <Vector name="rad100to200" type="numeric" nEntries="5">
       [hgcal:rad100200P0], [hgcal:rad100200P1], [hgcal:rad100200P2],

--- a/Geometry/HGCalCommonData/data/hgcalHEsil/v10/hgcalHEsil.xml
+++ b/Geometry/HGCalCommonData/data/hgcalHEsil/v10/hgcalHEsil.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<PosPartSection label="hgcalHEsil.xml">
+  <Algorithm name="hgcal:DDHGCalEEAlgo">
+    <rParent name="hgcal:HGCalHEsil"/>
+    <Vector name="WaferNames" type="string" nEntries="6">
+      hgcalwafer:HGCalHEWafer0Fine,    hgcalwafer:HGCalHEWafer0Coarse1,
+      hgcalwafer:HGCalHEWafer0Coarse2, hgcalwafer:HGCalHEWafer1Fine,
+      hgcalwafer:HGCalHEWafer1Coarse1, hgcalwafer:HGCalHEWafer1Coarse2</Vector>
+    <Vector name="MaterialNames" type="string" nEntries="12"> 
+      materials:StainlessSteel, materials:StainlessSteel, materials:Air,   
+      materials:Copper,  hgcalMaterial:HGC_G10-FR4, materials:Air, 
+      hgcalMaterial:HGC_G10-FR4, materials:Silicon, materials:Epoxy, 
+      materials:Kapton, hgcalMaterial:HGC_G10-FR4, materials:Copper</Vector>
+    <Vector name="VolumeNames" type="string" nEntries="12">
+      HGCalHEAbsorber1, HGCalHEAbsorber2, HGCalHEAirGap1, HGCalHECopperCover, 
+      HGCalHEMotherBoard, HGCalHEAirGap2, HGCalHEPCB, HGCalHESiliconSensitive,
+      HGCALHEsilEpoxy, HGCALHEsilKapton, HGCalHEBaseplate, 
+      HGCalHECoolingPlate</Vector>
+    <Vector name="Thickness" type="numeric" nEntries="12">
+      40.0*mm, 35.0*mm,  3.7*mm,  1.1*mm, 1.85*mm,  3.25*mm, 1.76*mm, 0.31*mm,
+      0.075*mm, 0.105*mm, 1.1*mm, 6.1*mm</Vector>
+    <Vector name="Layers" type="numeric" nEntries="8"> 
+      13, 13, 13, 13, 13, 13, 13, 13</Vector>
+    <Vector name="LayerThick" type="numeric" nEntries="8">
+      59.5*mm, 54.5*mm, 54.5*mm, 54.5*mm, 54.5*mm, 54.5*mm, 54.5*mm,
+      54.5*mm</Vector>
+    <Vector name="LayerType" type="numeric" nEntries="104">
+      0, 2, 3, 4, 5, 6, 8, 7, 8, 9, 8, 10, 11,
+      1, 2, 3, 4, 5, 6, 8, 7, 8, 9, 8, 10, 11,
+      1, 2, 3, 4, 5, 6, 8, 7, 8, 9, 8, 10, 11,
+      1, 2, 3, 4, 5, 6, 8, 7, 8, 9, 8, 10, 11,
+      1, 2, 3, 4, 5, 6, 8, 7, 8, 9, 8, 10, 11,
+      1, 2, 3, 4, 5, 6, 8, 7, 8, 9, 8, 10, 11,
+      1, 2, 3, 4, 5, 6, 8, 7, 8, 9, 8, 10, 11,
+      1, 2, 3, 4, 5, 6, 8, 7, 8, 9, 8, 10, 11 </Vector>
+    <Vector name="LayerSense" type="numeric" nEntries="104">
+      0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0</Vector>
+    <Numeric name="FirstLayer"       value="1"/>
+    <Numeric name="AbsorberMode"     value="1"/>
+    <Numeric name="zMinBlock"        value="[hgcal:zHGCalHEsil1]"/>
+    <Vector name="rad100to200" type="numeric" nEntries="5">
+      [hgcal:rad100200P0], [hgcal:rad100200P1], [hgcal:rad100200P2],
+      [hgcal:rad100200P3], [hgcal:rad100200P4]</Vector>
+    <Vector name="rad200to300" type="numeric" nEntries="5">
+      [hgcal:rad200300P0], [hgcal:rad200300P1], [hgcal:rad200300P2],
+      [hgcal:rad200300P3], [hgcal:rad200300P4]</Vector>
+    <Numeric name="zMinForRadPar"    value="[hgcal:zMinForRadPar]"/>
+    <Numeric name="choiceType"       value="[hgcal:ChoiceType]"/>
+    <Numeric name="nCornerCut"       value="[hgcal:NCornerCut]"/>
+    <Numeric name="fracAreaMin"      value="[hgcal:FracAreaMin]"/>
+    <Numeric name="waferSize"        value="[hgcal:WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[hgcal:SensorSeparation]"/>
+    <Numeric name="Sectors"          value="36"/>
+    <Vector name="SlopeBottom" type="numeric" nEntries="4">
+      0, 0, 0, 0</Vector>
+    <Vector name="ZFrontBottom" type="numeric" nEntries="4">
+      [hgcal:zHGCal1], [hgcal:zHGCal2], [hgcal:zHGCal6], 
+      [hgcal:zHGCal7]</Vector>
+    <Vector name="RMinFront" type="numeric" nEntries="4">
+      [hgcal:rMinHGCalEE1],    [hgcal:rMinHGCalHEsil1], 
+      [hgcal:rMinHGCalHEmix1], [hgcal:rMinHGCalHEmix2]</Vector>
+    <Vector name="SlopeTop" type="numeric" nEntries="4">
+      [hgcal:slope2], [hgcal:slope3], 0, 0</Vector>
+    <Vector name="ZFrontTop" type="numeric" nEntries="4">
+      [hgcal:zHGCal1], [hgcal:zHGCal4], [hgcal:zHGCal8], 
+      [hgcal:zHGCal9]</Vector>
+    <Vector name="RMaxFront" type="numeric" nEntries="4">
+      [hgcal:rMaxHGCal1], [hgcal:rMaxHGCal4], [hgcal:rMaxHGCal8], 
+      [hgcal:rMaxHGCal9]</Vector>
+    <String name="RotNameSpace" value="hgcalmodule"/>
+  </Algorithm>
+</PosPartSection> 
+
+</DDDefinition>

--- a/Geometry/HGCalCommonData/data/hgcalHEsil/v9/hgcalHEsil.xml
+++ b/Geometry/HGCalCommonData/data/hgcalHEsil/v9/hgcalHEsil.xml
@@ -43,6 +43,7 @@
       0, 0, 0, 0, 0, 0, 1, 0, 0,
       0, 0, 0, 0, 0, 0, 1, 0, 0 </Vector>
     <Numeric name="FirstLayer"       value="1"/>
+    <Numeric name="AbsorberMode"     value="0"/>
     <Numeric name="zMinBlock"        value="[hgcal:zMinHEsil]"/>
     <Vector name="rad100to200" type="numeric" nEntries="5">
       [hgcal:rad100200P0], [hgcal:rad100200P1], [hgcal:rad100200P2],

--- a/Geometry/HGCalCommonData/data/hgcalHEsil/v9a/hgcalHEsil.xml
+++ b/Geometry/HGCalCommonData/data/hgcalHEsil/v9a/hgcalHEsil.xml
@@ -43,6 +43,7 @@
       0, 0, 0, 0, 0, 0, 1, 0, 0,
       0, 0, 0, 0, 0, 0, 1, 0, 0 </Vector>
     <Numeric name="FirstLayer"       value="1"/>
+    <Numeric name="AbsorberMode"     value="0"/>
     <Numeric name="zMinBlock"        value="[hgcal:zMinHEsil]"/>
     <Vector name="rad100to200" type="numeric" nEntries="5">
       [hgcal:rad100200P0], [hgcal:rad100200P1], [hgcal:rad100200P2],

--- a/Geometry/HGCalCommonData/interface/HGCalGeomTools.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeomTools.h
@@ -16,6 +16,9 @@ public:
   static double radius(double z, int layer0, int layerf,
 		       std::vector<double> const& zFront,
 		       std::vector<double> const& rFront);
+  static std::pair<double,double> zradius(double z1, double z2,
+					  std::vector<double> const& zFront,
+					  std::vector<double> const& rFront);
   static std::pair<int32_t,int32_t> waferCorner(double xpos, double ypos,
 						double r, double R, 
 						double rMin, double rMax,

--- a/Geometry/HGCalCommonData/plugins/DDHGCalEEAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalEEAlgo.cc
@@ -65,9 +65,14 @@ void DDHGCalEEAlgo::initialize(const DDNumericArguments & nArgs,
   layerType_    = dbl_to_int(vArgs["LayerType"]);
   layerSense_   = dbl_to_int(vArgs["LayerSense"]);
   firstLayer_   = (int)(nArgs["FirstLayer"]);
+  absorbMode_   = (int)(nArgs["AbsorberMode"]);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "First Layere " << firstLayer_ << " and "
+				<< "Absober mode " << absorbMode_;
+#endif
   if (firstLayer_ > 0) {
     for (unsigned int i=0; i<layerType_.size(); ++i) {
-      if (layerSense_[i] != 0) {
+      if (layerSense_[i] > 0) {
 	int ii = layerType_[i];
 	copyNumber_[ii] = firstLayer_;
 #ifdef EDM_ML_DEBUG
@@ -177,7 +182,6 @@ void DDHGCalEEAlgo::constructLayers(const DDLogicalPart& module,
     int     laymax = laymin+layers_[i];
     double  zz     = zi;
     double  thickTot(0);
-    std::vector<double> pgonZ(2), pgonRin(2), pgonRout(2);
     for (int ly=laymin; ly<laymax; ++ly) {
       int     ii     = layerType_[ly];
       int     copy   = copyNumber_[ii];
@@ -198,8 +202,10 @@ void DDHGCalEEAlgo::constructLayers(const DDLogicalPart& module,
 		     DDSplit(materials_[ii]).second);
       DDMaterial matter(matName);
       DDLogicalPart glog;
-      if (layerSense_[ly] == 0) {
+      if (layerSense_[ly] < 1) {
 	double alpha = CLHEP::pi/sectors_;
+	int    nsec  = (layerSense_[ly] == 0 || absorbMode_ == 0) ? 2 : 2;
+	std::vector<double> pgonZ(nsec), pgonRin(nsec), pgonRout(nsec);
 	double rmax  = routF*cos(alpha) - tol;
 	pgonZ[0]    =-hthick;  pgonZ[1]    = hthick;
 	pgonRin[0]  = rinB;    pgonRin[1]  = rinB;   

--- a/Geometry/HGCalCommonData/plugins/DDHGCalEEAlgo.h
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalEEAlgo.h
@@ -47,6 +47,7 @@ private:
   std::vector<int>         layerType_;    //Type of the layer
   std::vector<int>         layerSense_;   //Content of a layer (sensitive?)
   int                      firstLayer_;   //Copy # of the first sensitive layer
+  int                      absorbMode_;   //Absorber mode
   double                   zMinBlock_;    //Starting z-value of the block
   std::vector<double>      rad100to200_;  //Parameters for 120-200mum trans.
   std::vector<double>      rad200to300_;  //Parameters for 200-300mum trans.

--- a/Geometry/HGCalCommonData/plugins/DDHGCalHEAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalHEAlgo.cc
@@ -65,9 +65,14 @@ void DDHGCalHEAlgo::initialize(const DDNumericArguments & nArgs,
   layerType_    = dbl_to_int(vArgs["LayerType"]);
   layerSense_   = dbl_to_int(vArgs["LayerSense"]);
   firstLayer_   = (int)(nArgs["FirstLayer"]);
+  absorbMode_   = (int)(nArgs["AbsorberMode"]);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "First Layere " << firstLayer_ << " and "
+				<< "Absober mode " << absorbMode_;
+#endif
   if (firstLayer_ > 0) {
     for (unsigned int i=0; i<layerType_.size(); ++i) {
-      if (layerSense_[i] != 0) {
+      if (layerSense_[i] > 0) {
 	int ii = layerType_[i];
 	copyNumber_[ii] = firstLayer_;
 #ifdef EDM_ML_DEBUG
@@ -221,7 +226,6 @@ void DDHGCalHEAlgo::constructLayers(const DDLogicalPart& module,
     int     laymax = laymin+layers_[i];
     double  zz     = zi;
     double  thickTot(0);
-    std::vector<double> pgonZ(2), pgonRin(2), pgonRout(2);
     for (int ly=laymin; ly<laymax; ++ly) {
       int     ii     = layerType_[ly];
       int     copy   = copyNumber_[ii];
@@ -242,11 +246,13 @@ void DDHGCalHEAlgo::constructLayers(const DDLogicalPart& module,
 		     DDSplit(materials_[ii]).second);
       DDMaterial matter(matName);
       DDLogicalPart glog;
-      if (layerSense_[ly] == 0) {
+      if (layerSense_[ly] < 1) {
 	double alpha = CLHEP::pi/sectors_;
+	int    nsec  = (layerSense_[ly] == 0 || absorbMode_ == 0) ? 2 : 2;
+	std::vector<double> pgonZ(nsec), pgonRin(nsec), pgonRout(nsec);
 	double rmax  = routF*cos(alpha) - tol;
-	pgonZ[0]    =-hthick;  pgonZ[1]   = hthick;
-	pgonRin[0]  = rinB;    pgonRin[1] = rinB;   
+	pgonZ[0]    =-hthick;  pgonZ[1]    = hthick;
+	pgonRin[0]  = rinB;    pgonRin[1]  = rinB;   
 	pgonRout[0] = rmax;    pgonRout[1] = rmax;   
 	DDSolid solid = DDSolidFactory::polyhedra(DDName(name, nameSpace_),
 						  sectors_,-alpha,CLHEP::twopi,

--- a/Geometry/HGCalCommonData/plugins/DDHGCalHEAlgo.h
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalHEAlgo.h
@@ -53,6 +53,7 @@ private:
   std::vector<int>         layerType_;     //Type of the layer
   std::vector<int>         layerSense_;    //Content of a layer (sensitive?)
   int                      firstLayer_;    //Copy # of the first sensitive layer
+  int                      absorbMode_;    //Absorber mode
   std::vector<std::string> materialsTop_;  //Materials of top layers
   std::vector<std::string> namesTop_;      //Names of top layers
   std::vector<double>      layerThickTop_; //Thickness of the top sections

--- a/Geometry/HGCalCommonData/python/testHGCV10XML_cfi.py
+++ b/Geometry/HGCalCommonData/python/testHGCV10XML_cfi.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+# This config was generated automatically using generate2023Geometry.py
+# If you notice a mistake, please update the generating script, not just this config
+
+XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
+    geomXMLFiles = cms.vstring(
+        'Geometry/CMSCommonData/data/materials.xml',
+        'Geometry/CMSCommonData/data/rotations.xml',
+        'Geometry/CMSCommonData/data/extend/cmsextent.xml',
+        'Geometry/CMSCommonData/data/cms/2023/v2/cms.xml',
+        'Geometry/CMSCommonData/data/eta3/etaMax.xml',
+        'Geometry/CMSCommonData/data/cmsMother.xml',
+        'Geometry/CMSCommonData/data/caloBase/2023/v2/caloBase.xml',
+        'Geometry/CMSCommonData/data/cmsCalo.xml',
+        'Geometry/CMSCommonData/data/beampipe/2023/v1/beampipe.xml',
+        'Geometry/CMSCommonData/data/cmsBeam/2023/v1/cmsBeam.xml',
+        'Geometry/CMSCommonData/data/cavernData/2017/v1/cavernData.xml',
+        'Geometry/EcalCommonData/data/PhaseII/v2/eregalgo.xml',
+        'Geometry/EcalCommonData/data/PhaseII/v2/ectkcable.xml',
+        'Geometry/EcalCommonData/data/PhaseII/v2/ectkcablemat.xml',
+        'Geometry/EcalCommonData/data/ebalgo.xml',
+        'Geometry/EcalCommonData/data/ebcon.xml',
+        'Geometry/EcalCommonData/data/ebrot.xml',
+        'Geometry/HcalCommonData/data/hcalrotations.xml',
+        'Geometry/HcalCommonData/data/hcal/v2/hcalalgo.xml',
+        'Geometry/HcalCommonData/data/hcalbarrelalgo.xml',
+        'Geometry/HcalCommonData/data/hcalcablealgo/v2/hcalcablealgo.xml',
+        'Geometry/HcalCommonData/data/hcalforwardalgo.xml',
+        'Geometry/HcalCommonData/data/average/hcalforwardmaterial.xml',
+        'Geometry/HGCalCommonData/data/hgcalMaterial/v1/hgcalMaterial.xml',
+        'Geometry/HGCalCommonData/data/hgcal/v10/hgcal.xml',
+        'Geometry/HGCalCommonData/data/hgcalEE/v10/hgcalEE.xml',
+        'Geometry/HGCalCommonData/data/hgcalHEsil/v10/hgcalHEsil.xml',
+        'Geometry/HGCalCommonData/data/hgcalHEmix/v10/hgcalHEmix.xml',
+        'Geometry/HGCalCommonData/data/hgcalwafer/v9/hgcalwafer.xml',
+        'Geometry/HGCalCommonData/data/hgcalcell/v9/hgcalcell.xml',
+        'Geometry/HGCalCommonData/data/hgcalCons/v10/hgcalCons.xml',
+    )+
+    cms.vstring(
+        'Geometry/CMSCommonData/data/FieldParameters.xml',
+    ),
+    rootNodeName = cms.string('cms:OCMS')
+)

--- a/Geometry/HGCalCommonData/python/testHGCalV10XML_cfi.py
+++ b/Geometry/HGCalCommonData/python/testHGCalV10XML_cfi.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+# This config was generated automatically using generate2023Geometry.py
+# If you notice a mistake, please update the generating script, not just this config
+
+XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
+    geomXMLFiles = cms.vstring(
+        'Geometry/CMSCommonData/data/materials.xml',
+        'Geometry/CMSCommonData/data/rotations.xml',
+        'Geometry/CMSCommonData/data/extend/cmsextent.xml',
+        'Geometry/CMSCommonData/data/cms/2023/v2/cms.xml',
+        'Geometry/CMSCommonData/data/eta3/etaMax.xml',
+        'Geometry/CMSCommonData/data/cmsMother.xml',
+        'Geometry/CMSCommonData/data/caloBase/2023/v2/caloBase.xml',
+        'Geometry/CMSCommonData/data/cmsCalo.xml',
+        'Geometry/CMSCommonData/data/beampipe/2023/v1/beampipe.xml',
+        'Geometry/CMSCommonData/data/cmsBeam/2023/v1/cmsBeam.xml',
+        'Geometry/CMSCommonData/data/cavernData/2017/v1/cavernData.xml',
+        'Geometry/EcalCommonData/data/PhaseII/v2/eregalgo.xml',
+        'Geometry/EcalCommonData/data/PhaseII/v2/ectkcable.xml',
+        'Geometry/EcalCommonData/data/PhaseII/v2/ectkcablemat.xml',
+        'Geometry/HcalCommonData/data/hcalrotations.xml',
+        'Geometry/HcalCommonData/data/hcal/v2/hcalalgo.xml',
+        'Geometry/HcalCommonData/data/hcalbarrelalgo.xml',
+        'Geometry/HcalCommonData/data/hcalcablealgo/v2/hcalcablealgo.xml',
+        'Geometry/HGCalCommonData/data/hgcalMaterial/v1/hgcalMaterial.xml',
+        'Geometry/HGCalCommonData/data/hgcal/v10/hgcal.xml',
+        'Geometry/HGCalCommonData/data/hgcalEE/v10/hgcalEE.xml',
+        'Geometry/HGCalCommonData/data/hgcalHEsil/v10/hgcalHEsil.xml',
+        'Geometry/HGCalCommonData/data/hgcalHEmix/v10/hgcalHEmix.xml',
+        'Geometry/HGCalCommonData/data/hgcalwafer/v9/hgcalwafer.xml',
+        'Geometry/HGCalCommonData/data/hgcalcell/v9/hgcalcell.xml',
+        'Geometry/HGCalCommonData/data/hgcalCons/v10/hgcalCons.xml',
+    )+
+    cms.vstring(
+        'Geometry/CMSCommonData/data/FieldParameters.xml',
+    ),
+    rootNodeName = cms.string('cms:OCMS')
+)

--- a/Geometry/HGCalCommonData/src/HGCalGeomTools.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomTools.cc
@@ -53,6 +53,19 @@ double HGCalGeomTools::radius(double z, int layer0, int layerf,
   return r;
 }
 
+std::pair<double,double> HGCalGeomTools::zradius(double z1, double z2,
+						 std::vector<double> const& zF,
+						 std::vector<double> const& rF) {
+
+  double z(-1), r(-1);
+  for (unsigned int k=0; k<rF.size(); ++k) {
+    if ((z1 > zF[k]-tol) && (z2 < zF[k]+tol)) {
+      z = zF[k]; r = rF[k]; break;
+    }
+  }
+  return std::make_pair(z,r);
+}
+  
 std::pair<int32_t,int32_t> HGCalGeomTools::waferCorner(double xpos, 
 						       double ypos,
 						       double r, double R, 

--- a/Geometry/HGCalCommonData/test/dumpHGCalGeometry_cfg.py
+++ b/Geometry/HGCalCommonData/test/dumpHGCalGeometry_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("DUMP")
-process.load("Geometry.HGCalCommonData.testHGCXML_cfi")
+process.load("Geometry.HGCalCommonData.testHGCV10XML_cfi")
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 if 'MessageLogger' in process.__dict__:

--- a/Geometry/HcalCommonData/data/hcal/v2/hcalalgo.xml
+++ b/Geometry/HcalCommonData/data/hcal/v2/hcalalgo.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<ConstantsSection label="hcalalgo.xml" eval="true">
+  <Constant name="z3HB"   value="343.640*cm"/>
+  <Constant name="z4HB"   value="381.602*cm"/>
+  <Constant name="z5HB"   value="449.347*cm"/>
+  <Constant name="z6HB"   value="[cms:CalorBeamZ2]"/>
+  <Constant name="rMin1"  value="177.500*cm"/>
+  <Constant name="rMin4"  value="183.88*cm"/>
+  <Constant name="rMin5"  value="281.342*cm"/>
+  <Constant name="rOutHB" value="287.65*cm"/>
+</ConstantsSection>
+
+<SolidSection label="hcalalgo.xml">
+  <Polyhedra name="HCal" numSide="18" startPhi="350*deg" deltaPhi="360*deg">
+    <ZSection z="-[z6HB]" rMin="[rMin5]" rMax="[rOutHB]"/>
+    <ZSection z="-[z5HB]" rMin="[rMin5]" rMax="[rOutHB]"/>
+    <ZSection z="-[z4HB]" rMin="[rMin4]" rMax="[rOutHB]"/>
+    <ZSection z="-[z3HB]" rMin="[rMin4]" rMax="[rOutHB]"/>
+    <ZSection z="-[z3HB]" rMin="[rMin1]" rMax="[rOutHB]"/>
+    <ZSection z="[z3HB]"  rMin="[rMin1]" rMax="[rOutHB]"/>
+    <ZSection z="[z3HB]"  rMin="[rMin4]" rMax="[rOutHB]"/>
+    <ZSection z="[z4HB]"  rMin="[rMin4]" rMax="[rOutHB]"/>
+    <ZSection z="[z5HB]"  rMin="[rMin5]" rMax="[rOutHB]"/>
+    <ZSection z="[z6HB]"  rMin="[rMin5]" rMax="[rOutHB]"/>
+  </Polyhedra>
+</SolidSection>
+
+<LogicalPartSection label="hcalalgo.xml">
+  <LogicalPart name="HCal" category="unspecified">
+    <rSolid name="HCal"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="hcalalgo.xml">
+  <PosPart copyNumber="1">
+    <rParent name="caloBase:CALO"/>
+    <rChild name="hcalalgo:HCal"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+</PosPartSection>
+</DDDefinition>

--- a/Geometry/HcalCommonData/data/hcalcablealgo/v1/hcalcablealgo.xml
+++ b/Geometry/HcalCommonData/data/hcalcablealgo/v1/hcalcablealgo.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<ConstantsSection label="hcalcablealgo.xml" eval="true">
+  <Constant name="Z0HBHE" value="389.550*cm"/>
+  <Constant name="Z0HE"   value="398.250*cm"/>
+  <Constant name="Z1HB"   value="324.200*cm"/>
+  <Constant name="z2HB"   value="370.460*cm"/>
+  <Constant name="z3HB"   value="375.022*cm"/>
+  <Constant name="z4HB"   value="446.079*cm"/>
+  <Constant name="z5HB"   value="449.127*cm"/>
+  <Constant name="z6HB"   value="[cms:CalorBeamZ2]"/>
+  <Constant name="zRat"   value="([Z0HE]-[z6HB])/([cms:CalorBeamZ1]-[z6HB])"/>
+  <Constant name="rMin1"  value="177.500*cm"/>
+  <Constant name="rMin3"  value="171.200*cm"/>
+  <Constant name="rMin4"  value="277.071*cm"/>
+  <Constant name="rMin5"  value="281.342*cm"/>
+  <Constant name="rMin2"  value="[cms:CalorBeamR2]+[zRat]*
+                                ([cms:CalorBeamR1]-[cms:CalorBeamR2])"/>
+  <Constant name="rMax1"  value="186.650*cm"/>
+  <Constant name="rMax3"  value="192.703*cm"/>
+  <Constant name="rMax4"  value="287.000*cm"/>
+  <Constant name="rOutHB" value="287.65*cm"/>
+</ConstantsSection>
+
+<SolidSection label="hcalcablealgo.xml">
+  <Polyhedra name="HRCF" numSide="18" startPhi="350*deg" deltaPhi="360*deg">
+    <ZSection z="[Z1HB]" rMin="[rMin1]" rMax="[rMax1]"/>
+    <ZSection z="[z2HB]" rMin="[rMin1]" rMax="[rMax1]"/>
+    <ZSection z="[z3HB]" rMin="[rMin1]" rMax="[rMax3]"/>
+    <ZSection z="[z4HB]" rMin="[rMin4]" rMax="[rMax4]"/>
+    <ZSection z="[z5HB]" rMin="[rMin5]" rMax="[rMax4]"/>
+    <ZSection z="[z6HB]" rMin="[rMin5]" rMax="[rMax4]"/>
+  </Polyhedra>
+  <Polyhedra name="HEC1" numSide="1" startPhi="350*deg" deltaPhi="20*deg">
+    <ZSection z="[Z1HB]" rMin="[rMin1]" rMax="[rMax1]"/>
+    <ZSection z="[z2HB]" rMin="[rMin1]" rMax="[rMax1]"/>
+    <ZSection z="[z3HB]" rMin="[rMin1]" rMax="[rMax3]"/>
+    <ZSection z="[z4HB]" rMin="[rMin4]" rMax="[rMax4]"/>
+    <ZSection z="[z5HB]" rMin="[rMin5]" rMax="[rMax4]"/>
+    <ZSection z="[z6HB]" rMin="[rMin5]" rMax="[rMax4]"/>
+  </Polyhedra>
+  <Polyhedra name="HHC1" numSide="1" startPhi="352.5*deg" deltaPhi="15*deg">
+    <ZSection z="[Z1HB]" rMin="[rMin1]" rMax="[rMax1]"/>
+    <ZSection z="[z2HB]" rMin="[rMin1]" rMax="[rMax1]"/>
+    <ZSection z="[z3HB]" rMin="[rMin1]" rMax="[rMax3]"/>
+    <ZSection z="[z4HB]" rMin="[rMin4]" rMax="[rMax4]"/>
+    <ZSection z="[z5HB]" rMin="[rMin5]" rMax="[rMax4]"/>
+    <ZSection z="[z6HB]" rMin="[rMin5]" rMax="[rMax4]"/>
+  </Polyhedra>
+  <Polyhedra name="HTC1" numSide="1" startPhi="356*deg" deltaPhi="8*deg">
+    <ZSection z="[Z1HB]" rMin="[rMin1]" rMax="[rMax1]"/>
+    <ZSection z="[z2HB]" rMin="[rMin1]" rMax="[rMax1]"/>
+    <ZSection z="[z3HB]" rMin="[rMin1]" rMax="[rMax3]"/>
+    <ZSection z="[z4HB]" rMin="[rMin4]" rMax="[rMax4]"/>
+    <ZSection z="[z5HB]" rMin="[rMin5]" rMax="[rMax4]"/>
+    <ZSection z="[z6HB]" rMin="[rMin5]" rMax="[rMax4]"/>
+  </Polyhedra>
+</SolidSection>
+
+<LogicalPartSection label="hcalcablealgo.xml">
+  <LogicalPart name="HRCF" category="unspecified">
+    <rSolid name="HRCF"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HEC1" category="unspecified">
+    <rSolid name="HEC1"/>
+    <rMaterial name="materials:Ec_Cable_1"/>
+  </LogicalPart>
+  <LogicalPart name="HHC1" category="unspecified">
+    <rSolid name="HHC1"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HTC1" category="unspecified">
+    <rSolid name="HTC1"/>
+    <rMaterial name="materials:Tk_square_bundles"/>
+  </LogicalPart>
+  <LogicalPart name="HEC2" category="unspecified">
+    <rSolid name="HEC1"/>
+    <rMaterial name="materials:Ec_Cable_1"/>
+  </LogicalPart>
+  <LogicalPart name="HHC2" category="unspecified">
+    <rSolid name="HHC1"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="hcalcablealgo.xml">
+  <PosPart copyNumber="1">
+    <rParent name="hcalalgo:HCal"/>
+    <rChild name="hcalcablealgo:HRCF"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="hcalalgo:HCal"/>
+    <rChild name="hcalcablealgo:HRCF"/>
+    <rRotation name="rotations:180D"/>
+  </PosPart>
+  <!-- There are some subtle differences on the 0 degree and 180 degree
+       segments so that is why only the 16 can be made with the algorithm -->
+  <!-- 16 sub-sections for the cabling ??? -->
+  <Algorithm name="global:DDAngular">
+    <rParent name="hcalcablealgo:HRCF"/>
+    <String name="ChildName" value="hcalcablealgo:HEC1"/>
+    <Numeric name="N" value="8"/>
+    <Numeric name="StartCopyNo" value="0"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="140*deg"/>
+    <Numeric name="StartAngle" value="20*deg"/>
+    <Numeric name="Radius" value="0"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0 </Vector>
+    <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 0.*deg </Vector>
+  </Algorithm>
+  <Algorithm name="global:DDAngular">
+    <rParent name="hcalcablealgo:HRCF"/>
+    <String name="ChildName" value="hcalcablealgo:HEC1"/>
+    <Numeric name="N" value="8"/>
+    <Numeric name="StartCopyNo" value="8"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="140*deg"/>
+    <Numeric name="StartAngle" value="200*deg"/>
+    <Numeric name="Radius" value="0"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0 </Vector>
+    <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 0.*deg </Vector>
+  </Algorithm>
+  <PosPart copyNumber="1">
+    <rParent name="hcalcablealgo:HEC1"/>
+    <rChild name="hcalcablealgo:HHC1"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hcalcablealgo:HHC1"/>
+    <rChild name="hcalcablealgo:HTC1"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hcalcablealgo:HRCF"/>
+    <rChild name="hcalcablealgo:HEC2"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="hcalcablealgo:HRCF"/>
+    <rChild name="hcalcablealgo:HEC2"/>
+    <rRotation name="rotations:R180"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hcalcablealgo:HEC2"/>
+    <rChild name="hcalcablealgo:HHC2"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+</PosPartSection>
+</DDDefinition>

--- a/Geometry/HcalCommonData/data/hcalcablealgo/v2/hcalcablealgo.xml
+++ b/Geometry/HcalCommonData/data/hcalcablealgo/v2/hcalcablealgo.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<ConstantsSection label="hcalcablealgo.xml" eval="true">
+  <Constant name="z0HB"   value="324.200*cm"/>
+  <Constant name="z1HB"   value="334.780*cm"/>
+  <Constant name="z2HB"   value="377.042*cm"/>
+  <Constant name="z3HB"   value="[hcalalgo:z3HB]"/>
+  <Constant name="z4HB"   value="[hcalalgo:z4HB]"/>
+  <Constant name="z4HBP"  value="446.299*cm"/>
+  <Constant name="z5HB"   value="[hcalalgo:z5HB]"/>
+  <Constant name="z6HB"   value="[cms:CalorBeamZ2]"/>
+  <Constant name="rMin1"  value="[hcalalgo:rMin1]"/>
+  <Constant name="rMin4"  value="[hcalalgo:rMin4]"/>
+  <Constant name="rMin4P" value="277.07*cm"/>
+  <Constant name="rMin5"  value="[hcalalgo:rMin5]"/>
+  <Constant name="rMax1"  value="186.650*cm"/>
+  <Constant name="rMax3"  value="192.740*cm"/>
+  <Constant name="rMax4"  value="198.789*cm"/>
+  <Constant name="rMax5"  value="[hcalalgo:rOutHB]"/>
+</ConstantsSection>
+
+<SolidSection label="hcalcablealgo.xml">
+  <Polyhedra name="HRCF" numSide="18" startPhi="350*deg" deltaPhi="360*deg">
+    <ZSection z="[z0HB]"  rMin="[rMin1]"  rMax="[rMax1]"/>
+    <ZSection z="[z1HB]"  rMin="[rMin1]"  rMax="[rMax1]"/>
+    <ZSection z="[z1HB]"  rMin="[rMin1]"  rMax="[rMax3]"/>
+    <ZSection z="[z3HB]"  rMin="[rMin1]"  rMax="[rMax3]"/>
+    <ZSection z="[z3HB]"  rMin="[rMin4]"  rMax="[rMax3]"/>
+    <ZSection z="[z2HB]"  rMin="[rMin4]"  rMax="[rMax3]"/>
+    <ZSection z="[z4HB]"  rMin="[rMin4]"  rMax="[rMax4]"/>
+    <ZSection z="[z4HBP]" rMin="[rMin4P]" rMax="[rMax5]"/>
+    <ZSection z="[z5HB]"  rMin="[rMin5]"  rMax="[rMax5]"/>
+    <ZSection z="[z6HB]"  rMin="[rMin5]"  rMax="[rMax5]"/>
+  </Polyhedra>
+  <Polyhedra name="HEC1" numSide="1" startPhi="350*deg" deltaPhi="20*deg">
+    <ZSection z="[z0HB]"  rMin="[rMin1]"  rMax="[rMax1]"/>
+    <ZSection z="[z1HB]"  rMin="[rMin1]"  rMax="[rMax1]"/>
+    <ZSection z="[z1HB]"  rMin="[rMin1]"  rMax="[rMax3]"/>
+    <ZSection z="[z3HB]"  rMin="[rMin1]"  rMax="[rMax3]"/>
+    <ZSection z="[z3HB]"  rMin="[rMin4]"  rMax="[rMax3]"/>
+    <ZSection z="[z2HB]"  rMin="[rMin4]"  rMax="[rMax3]"/>
+    <ZSection z="[z4HB]"  rMin="[rMin4]"  rMax="[rMax4]"/>
+    <ZSection z="[z4HBP]" rMin="[rMin4P]" rMax="[rMax5]"/>
+    <ZSection z="[z5HB]"  rMin="[rMin5]"  rMax="[rMax5]"/>
+    <ZSection z="[z6HB]"  rMin="[rMin5]"  rMax="[rMax5]"/>
+  </Polyhedra>
+  <Polyhedra name="HHC1" numSide="1" startPhi="352.5*deg" deltaPhi="15*deg">
+    <ZSection z="[z0HB]"  rMin="[rMin1]"  rMax="[rMax1]"/>
+    <ZSection z="[z1HB]"  rMin="[rMin1]"  rMax="[rMax1]"/>
+    <ZSection z="[z1HB]"  rMin="[rMin1]"  rMax="[rMax3]"/>
+    <ZSection z="[z3HB]"  rMin="[rMin1]"  rMax="[rMax3]"/>
+    <ZSection z="[z3HB]"  rMin="[rMin4]"  rMax="[rMax3]"/>
+    <ZSection z="[z2HB]"  rMin="[rMin4]"  rMax="[rMax3]"/>
+    <ZSection z="[z4HB]"  rMin="[rMin4]"  rMax="[rMax4]"/>
+    <ZSection z="[z4HBP]" rMin="[rMin4P]" rMax="[rMax5]"/>
+    <ZSection z="[z5HB]"  rMin="[rMin5]"  rMax="[rMax5]"/>
+    <ZSection z="[z6HB]"  rMin="[rMin5]"  rMax="[rMax5]"/>
+  </Polyhedra>
+  <Polyhedra name="HTC1" numSide="1" startPhi="356*deg" deltaPhi="8*deg">
+    <ZSection z="[z0HB]"  rMin="[rMin1]"  rMax="[rMax1]"/>
+    <ZSection z="[z1HB]"  rMin="[rMin1]"  rMax="[rMax1]"/>
+    <ZSection z="[z1HB]"  rMin="[rMin1]"  rMax="[rMax3]"/>
+    <ZSection z="[z3HB]"  rMin="[rMin1]"  rMax="[rMax3]"/>
+    <ZSection z="[z3HB]"  rMin="[rMin4]"  rMax="[rMax3]"/>
+    <ZSection z="[z2HB]"  rMin="[rMin4]"  rMax="[rMax3]"/>
+    <ZSection z="[z4HB]"  rMin="[rMin4]"  rMax="[rMax4]"/>
+    <ZSection z="[z4HBP]" rMin="[rMin4P]" rMax="[rMax5]"/>
+    <ZSection z="[z5HB]"  rMin="[rMin5]"  rMax="[rMax5]"/>
+    <ZSection z="[z6HB]"  rMin="[rMin5]"  rMax="[rMax5]"/>
+  </Polyhedra>
+</SolidSection>
+
+<LogicalPartSection label="hcalcablealgo.xml">
+  <LogicalPart name="HRCF" category="unspecified">
+    <rSolid name="HRCF"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HEC1" category="unspecified">
+    <rSolid name="HEC1"/>
+    <rMaterial name="materials:Ec_Cable_1"/>
+  </LogicalPart>
+  <LogicalPart name="HHC1" category="unspecified">
+    <rSolid name="HHC1"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="HTC1" category="unspecified">
+    <rSolid name="HTC1"/>
+    <rMaterial name="materials:Tk_square_bundles"/>
+  </LogicalPart>
+  <LogicalPart name="HEC2" category="unspecified">
+    <rSolid name="HEC1"/>
+    <rMaterial name="materials:Ec_Cable_1"/>
+  </LogicalPart>
+  <LogicalPart name="HHC2" category="unspecified">
+    <rSolid name="HHC1"/>
+    <rMaterial name="materials:Air"/>
+  </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="hcalcablealgo.xml">
+  <PosPart copyNumber="1">
+    <rParent name="hcalalgo:HCal"/>
+    <rChild name="hcalcablealgo:HRCF"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="hcalalgo:HCal"/>
+    <rChild name="hcalcablealgo:HRCF"/>
+    <rRotation name="rotations:180D"/>
+  </PosPart>
+  <!-- There are some subtle differences on the 0 degree and 180 degree
+       segments so that is why only the 16 can be made with the algorithm -->
+  <!-- 16 sub-sections for the cabling ??? -->
+  <Algorithm name="global:DDAngular">
+    <rParent name="hcalcablealgo:HRCF"/>
+    <String name="ChildName" value="hcalcablealgo:HEC1"/>
+    <Numeric name="N" value="8"/>
+    <Numeric name="StartCopyNo" value="0"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="140*deg"/>
+    <Numeric name="StartAngle" value="20*deg"/>
+    <Numeric name="Radius" value="0"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0 </Vector>
+    <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 0.*deg </Vector>
+  </Algorithm>
+  <Algorithm name="global:DDAngular">
+    <rParent name="hcalcablealgo:HRCF"/>
+    <String name="ChildName" value="hcalcablealgo:HEC1"/>
+    <Numeric name="N" value="8"/>
+    <Numeric name="StartCopyNo" value="8"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="140*deg"/>
+    <Numeric name="StartAngle" value="200*deg"/>
+    <Numeric name="Radius" value="0"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0 </Vector>
+    <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 0.*deg </Vector>
+  </Algorithm>
+  <PosPart copyNumber="1">
+    <rParent name="hcalcablealgo:HEC1"/>
+    <rChild name="hcalcablealgo:HHC1"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hcalcablealgo:HHC1"/>
+    <rChild name="hcalcablealgo:HTC1"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hcalcablealgo:HRCF"/>
+    <rChild name="hcalcablealgo:HEC2"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+    <rParent name="hcalcablealgo:HRCF"/>
+    <rChild name="hcalcablealgo:HEC2"/>
+    <rRotation name="rotations:R180"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="hcalcablealgo:HEC2"/>
+    <rChild name="hcalcablealgo:HHC2"/>
+    <rRotation name="rotations:000D"/>
+  </PosPart>
+</PosPartSection>
+</DDDefinition>

--- a/SimG4CMS/Calo/test/python/runHGC4_cfg.py
+++ b/SimG4CMS/Calo/test/python/runHGC4_cfg.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("PROD")
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load("IOMC.EventVertexGenerators.VtxSmearedGauss_cfi")
-process.load("Configuration.Geometry.GeometryExtended2023D28_cff")
+#process.load("Configuration.Geometry.GeometryExtended2023D28_cff")
+process.load("Geometry.HGCalCommonData.testHGCV10XML_cfi")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.EventContent.EventContent_cff")
 process.load('Configuration.StandardSequences.Generator_cff')
@@ -16,6 +17,7 @@ process.GlobalTag.globaltag = autoCond['phase2_realistic']
 if hasattr(process,'MessageLogger'):
     process.MessageLogger.categories.append('HGCalGeom')
     process.MessageLogger.categories.append('HGCSim')
+    process.MessageLogger.categories.append('SimG4CoreGeometry')
 
 process.load("IOMC.RandomEngine.IOMC_cff")
 process.RandomNumberGeneratorService.generator.initialSeed = 456789


### PR DESCRIPTION
This is the post TDR geometry with reduced thickness (in cm as well as in lambda) of HGCal. Also the current partition between barrel and endcap is taken care of, the position of neutron moderator. Current ETL geometry cannot be combined with this - it will be changed soon. 