### PR TITLE
Add the conversions from lowPtGsfTracks (bparking) to the miniAOD content

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -93,6 +93,7 @@ _bParking_extraCommands = ['keep *_slimmedLowPtElectrons_*_*',
                            'keep floatedmValueMap_lowPtGsfElectronSeedValueMaps_*_*',
                            'keep floatedmValueMap_lowPtGsfElectronID_*_*',
                            'keep *_lowPtGsfLinks_*_*',
+                           'keep *_gsfTracksOpenConversions_*_*', 
                            ]
 bParking.toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _bParking_extraCommands)
 

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -26,6 +26,7 @@ from PhysicsTools.PatAlgos.slimming.MicroEventContent_cff import *
 from RecoEgamma.EgammaPhotonProducers.reducedEgamma_cfi  import *
 from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import bunchSpacingProducer
 from HeavyFlavorAnalysis.Onia2MuMu.OniaPhotonConversionProducer_cfi import PhotonCandidates as oniaPhotonCandidates
+from RecoEgamma.EgammaPhotonProducers.gsfTracksOpenConversionSequence_cff  import  gsfTracksOpenConversions
 
 slimmingTask = cms.Task(
     packedPFCandidatesTask,
@@ -60,3 +61,7 @@ slimmingTask = cms.Task(
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toReplaceWith(slimmingTask, slimmingTask.copyAndExclude([slimmedOOTPhotons]))
+
+from Configuration.Eras.Modifier_bParking_cff import bParking
+_bParking_slimmingTask = cms.Task(slimmingTask.copy(),gsfTracksOpenConversions)
+bParking.toReplaceWith(slimmingTask,_bParking_slimmingTask)

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -26,7 +26,6 @@ from PhysicsTools.PatAlgos.slimming.MicroEventContent_cff import *
 from RecoEgamma.EgammaPhotonProducers.reducedEgamma_cfi  import *
 from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import bunchSpacingProducer
 from HeavyFlavorAnalysis.Onia2MuMu.OniaPhotonConversionProducer_cfi import PhotonCandidates as oniaPhotonCandidates
-from RecoEgamma.EgammaPhotonProducers.gsfTracksOpenConversionSequence_cff  import  gsfTracksOpenConversions
 
 slimmingTask = cms.Task(
     packedPFCandidatesTask,
@@ -62,6 +61,3 @@ slimmingTask = cms.Task(
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toReplaceWith(slimmingTask, slimmingTask.copyAndExclude([slimmedOOTPhotons]))
 
-from Configuration.Eras.Modifier_bParking_cff import bParking
-_bParking_slimmingTask = cms.Task(slimmingTask.copy(),gsfTracksOpenConversions)
-bParking.toReplaceWith(slimmingTask,_bParking_slimmingTask)

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -60,4 +60,3 @@ slimmingTask = cms.Task(
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toReplaceWith(slimmingTask, slimmingTask.copyAndExclude([slimmedOOTPhotons]))
-


### PR DESCRIPTION
This PR touches the package PhysicsTools/PatAlgos. Only two files are updated: python/slimming/slimming_cff.py and python/slimming/MicroEventContent_cff.py 
Conversions from lowPtGsfTracks are saved in the reco data format. Not necessary to put them in pat format. 