### PR TITLE
Fixing MultiIso in muon Selector: Removing the double declaration of the variable "miniIsoValue "

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -650,7 +650,7 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
     double miniIsoValue = -1;
     if (computeMiniIso_){
       // MiniIsolation working points
-      double miniIsoValue = getRelMiniIsoPUCorrected(muon,*rho);
+      miniIsoValue = getRelMiniIsoPUCorrected(muon,*rho);
       muon.setSelector(reco::Muon::MiniIsoLoose,     miniIsoValue<0.40);
       muon.setSelector(reco::Muon::MiniIsoMedium,    miniIsoValue<0.20);
       muon.setSelector(reco::Muon::MiniIsoTight,     miniIsoValue<0.10);


### PR DESCRIPTION
MultiIso is based on the values of three variables i.e. 
1.) miniIsoValue
2.) muon.jetPtRatio and 
3.) muon.jetPtRel() . 
If you print values of miniIsoValue at this line

https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc#L684  it always gives -1. 
This is because it has been declared twice 
https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc#L650-L653

So the current mutiIso values that you get in miniAOD is just based on the two variables . 2.) muon.jetPtRatio and 3.) muon.jetPtRel() 
So with this bug , the desired performance of MultiIso is not expected at mini AOD. 
Fixing this, desired performance will be achieved.



