### PR TITLE
retain name of script that is fed to cmsRun in pybind11 interface

### DIFF
--- a/FWCore/PyDevParameterSet/src/PyBind11ProcessDesc.cc
+++ b/FWCore/PyDevParameterSet/src/PyBind11ProcessDesc.cc
@@ -85,13 +85,11 @@ void PyBind11ProcessDesc::read(std::string const& config) {
 }
 
 void PyBind11ProcessDesc::readFile(std::string const& fileName) {
-  std::string initCommand("from FWCore.ParameterSet.Types import makeCppPSet\n"
-                          "exec(open('");
-  initCommand += fileName + "').read())";
-
-  pybind11::exec(initCommand.c_str());
+  std::string initCommand("from FWCore.ParameterSet.Types import makeCppPSet");
+  pybind11::exec(initCommand);
+  pybind11::eval_file(fileName);
   std::string command("process.fillProcessDesc(processPSet)");
-  pybind11::exec(command.c_str());
+  pybind11::exec(command);
 }
 
 void PyBind11ProcessDesc::readString(std::string const& pyConfig) {

--- a/FWCore/PyDevParameterSet/src/PyBind11ProcessDesc.cc
+++ b/FWCore/PyDevParameterSet/src/PyBind11ProcessDesc.cc
@@ -85,8 +85,6 @@ void PyBind11ProcessDesc::read(std::string const& config) {
 }
 
 void PyBind11ProcessDesc::readFile(std::string const& fileName) {
-  std::string initCommand("from FWCore.ParameterSet.Types import makeCppPSet");
-  pybind11::exec(initCommand);
   pybind11::eval_file(fileName);
   std::string command("process.fillProcessDesc(processPSet)");
   pybind11::exec(command);


### PR DESCRIPTION
#### PR description:

retain name of script that is fed to cmsRun in pybind11 interface

#### PR validation:

Fixes unit test failing in DEVEL build in FWCore/Integration package

