### PR TITLE
[HGCal] Modify MultiTrackValidator plotting for easier browsing of HGCal plots

### DIFF
--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -418,6 +418,12 @@ class Page(object):
             '  </table>',
         ])
 
+        if len(fileTable):
+            first_row = fileTable[0]
+            self._content.extend([
+              '  <a href="%s">Browse Folder</a>' % (first_row[1][0:first_row[1].rfind('/')])
+            ])
+
     def _appendColumnHeader(self, header):
         leg = ""
         if header in self._columnHeadersIndex:

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -534,7 +534,7 @@ def _findBoundsY(th1s, ylog, ymin=None, ymax=None, coverage=None, coverageRange=
     ymin -- Minimum y value; if None, take the minimum of TH1s
     ymax -- Maximum y value; if None, take the maximum of TH1s
     coverage -- If set, use only values within the 'coverage' part around the median are used for min/max (useful for ratio)
-    coverageRange -- If coverage and this are set, use only the x axis specified by an (xmin,xmax) pair for the coverage 
+    coverageRange -- If coverage and this are set, use only the x axis specified by an (xmin,xmax) pair for the coverage
     """
     if coverage is not None or isinstance(th1s[0], ROOT.TH2):
         # the only use case for coverage for now is ratio, for which
@@ -2533,6 +2533,7 @@ class PlotOnSideGroup(PlotGroup):
     def draw(self, *args, **kwargs):
         kargs = copy.copy(kwargs)
         kargs["ratio"] = False
+        kargs["separate"] = False
         return super(PlotOnSideGroup, self).draw(*args, **kargs)
 
 class PlotFolder:
@@ -2673,7 +2674,7 @@ class PlotFolder:
         """Return True if this subfolder should be processed
 
         Arguments:
-        limitOnlyTo            -- List/set/similar containing the translatedDqmSubFolder 
+        limitOnlyTo            -- List/set/similar containing the translatedDqmSubFolder
         translatedDqmSubFolder -- Return value of translateSubFolder
         """
         return translatedDqmSubFolder in limitOnlyTo

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -32,6 +32,7 @@ def _setStyle():
         statSize = 0.025
 
     ROOT.gROOT.SetStyle("Plain")
+    ROOT.gStyle.SetOptStat("ksiourmen");
     ROOT.gStyle.SetPadRightMargin(0.07)
     ROOT.gStyle.SetPadLeftMargin(0.13)
     ROOT.gStyle.SetTitleFont(font, "XYZ")
@@ -1964,7 +1965,7 @@ class Plot:
             st.SetX1NDC(startingX)
             st.SetX2NDC(startingX+0.3)
             st.SetY1NDC(startingY+dy)
-            st.SetY2NDC(startingY+dy+0.15)
+            st.SetY2NDC(startingY+dy+0.25)
             st.SetTextColor(col)
 
         dy = 0.0

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -32,7 +32,6 @@ def _setStyle():
         statSize = 0.025
 
     ROOT.gROOT.SetStyle("Plain")
-    ROOT.gStyle.SetOptStat("ksiourmen");
     ROOT.gStyle.SetPadRightMargin(0.07)
     ROOT.gStyle.SetPadLeftMargin(0.13)
     ROOT.gStyle.SetTitleFont(font, "XYZ")

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -1964,7 +1964,7 @@ class Plot:
             st.SetX1NDC(startingX)
             st.SetX2NDC(startingX+0.3)
             st.SetY1NDC(startingY+dy)
-            st.SetY2NDC(startingY+dy+0.25)
+            st.SetY2NDC(startingY+dy+0.15)
             st.SetTextColor(col)
 
         dy = 0.0

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -1915,3 +1915,4 @@ tpPlotter.append("tp", [
 ], PlotFolder(
     _tplifetime,
 ))
+

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -1915,4 +1915,3 @@ tpPlotter.append("tp", [
 ], PlotFolder(
     _tplifetime,
 ))
-

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -735,7 +735,7 @@ class Validation:
         if not os.path.exists(certfile):
             print("Private key file {keyfile} does not exist, unable to download RelVal files from {url}".format(keyfile=keyfile, url=relvalUrl))
             sys.exit(1)
-        
+
         # curl --cert-type PEM --cert $HOME/.globus/usercert.pem --key $HOME/.globus/userkey.pem -k -O <url> -O <url>
         cmd = ["curl", "--cert-type", "PEM", "--cert", certfile, "--key", keyfile, "-k"]
         for u in urls:
@@ -1292,6 +1292,15 @@ class SimpleValidation:
             print("Plotter produced multiple files with names", ", ".join(dups))
             print("Typically this is a naming problem in the plotter configuration")
             sys.exit(1)
+
+        if (self._plotterDrawArgs.get("separate", False) == True):
+            if not os.path.exists("%s/res"%newdir):
+              os.makedirs("%s/res"%newdir)
+            downloadables = ["index.php", "res/jquery-ui.js", "res/jquery.js", "res/style.css", "res/style.js", "res/theme.css"]
+            for d in downloadables:
+                if not os.path.exists("%s/%s" % (newdir,d)):
+                    import urllib
+                    urllib.urlretrieve("https://raw.githubusercontent.com/musella/php-plots/master/%s"%d, "%s/%s"%(newdir,d))
 
         print("Created plots in %s" % newdir)
         return map(lambda n: n.replace(newdir, newsubdir), fileList)

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -5,6 +5,7 @@ import re
 import sys
 import shutil
 import subprocess
+import urllib
 
 import ROOT
 ROOT.gROOT.SetBatch(True)
@@ -1293,13 +1294,12 @@ class SimpleValidation:
             print("Typically this is a naming problem in the plotter configuration")
             sys.exit(1)
 
-        if (self._plotterDrawArgs.get("separate", False) == True):
+        if self._plotterDrawArgs.get("separate", False):
             if not os.path.exists("%s/res"%newdir):
               os.makedirs("%s/res"%newdir)
             downloadables = ["index.php", "res/jquery-ui.js", "res/jquery.js", "res/style.css", "res/style.js", "res/theme.css"]
             for d in downloadables:
                 if not os.path.exists("%s/%s" % (newdir,d)):
-                    import urllib
                     urllib.urlretrieve("https://raw.githubusercontent.com/musella/php-plots/master/%s"%d, "%s/%s"%(newdir,d))
 
         print("Created plots in %s" % newdir)


### PR DESCRIPTION
#### PR description:

For the plotting part of the HGCalValidator package we take advantage of the tools already created by the MultiTrackValidator. 
However, one option was added that when set to true it will produce a webpage with all plots to be able to 
visualize all images at a glance. 

#### PR validation:

This PR depends on PR #26099. So, after the harvesting step, you can run the makeHGCalValidationPlots.py script with the new separate option e.g: 

```
python Validation/HGCalValidation/python/makeHGCalValidationPlots.py DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root --outputDir HGCValid --no-ratio --png --separate --html-sample Samplename --html-validation-name hgcalLayerClusters --subdirprefix test1
```

@felicepantaleo @rovere @cseez @malgeri 

@makortel Could you please comment?

