### PR TITLE
Added missing include of memory to Herwig6Instance

### DIFF
--- a/GeneratorInterface/Herwig6Interface/interface/Herwig6Instance.h
+++ b/GeneratorInterface/Herwig6Interface/interface/Herwig6Instance.h
@@ -2,6 +2,7 @@
 #define gen_Herwig6Instance_h
 
 #include "GeneratorInterface/Core/interface/FortranInstance.h"
+#include <memory>
 
 namespace CLHEP {
     class HepRandomEngine;


### PR DESCRIPTION
#### PR description:
This fixes a 'check headers' error.

#### PR validation:
The code compiles.
