### PR TITLE
Fix config in Merge.py

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -72,7 +72,7 @@ def mergeProcess(*inputFiles, **options):
         outMod = OutputModule("PoolOutputModule")
 
     # To bypass the version check in the merge process (TRUE by default)
-    process.source.bypassVersionCheck = cms.untracked.bool(bypassVersionCheck)
+    process.source.bypassVersionCheck = CfgTypes.untracked.bool(bypassVersionCheck)
 
     outMod.fileName = CfgTypes.untracked.string(outputFilename)
     if outputLFN != None:

--- a/Configuration/DataProcessing/test/RunMerge.py
+++ b/Configuration/DataProcessing/test/RunMerge.py
@@ -22,6 +22,7 @@ class RunMerge:
         self.outputLFN = None
         self.inputFiles = []
         self.newDQMIO = False
+        self.mergeNANO = False
         self.bypassVersionCheck = True
 
 


### PR DESCRIPTION
Another fix on Merge.py to bypass the version check on production side.
Fix also RunMerge.py that self.mergeNANO is missing.

Validated by using
`python RunMerge.py --input-files=a.root`

output file seems to be OK. bypassVersionCheck appears correctly.

`import FWCore.ParameterSet.Config as cms

process = cms.Process("Merge")

process.source = cms.Source("PoolSource",
    bypassVersionCheck = cms.untracked.bool(True),
    fileNames = cms.untracked.vstring("[\'a.root\']")
)
process.Merged = cms.OutputModule("PoolOutputModule",
    fileName = cms.untracked.string('Merged.root')
)


process.outputPath = cms.EndPath(process.Merged)`