### PR TITLE
Fix Rivet weights

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
@@ -119,18 +119,18 @@ void RivetAnalyzer::analyze(const edm::Event& iEvent,const edm::EventSetup& iSet
 	edm::LogWarning("RivetAnalyzer") << "Original event weight size is " << tmpGenEvtPtr->weights().size() << ". Will change only the first one ";  
       }
     
-      double weightForRivet = 1.;
+      edm::Handle<GenEventInfoProduct> genEventInfoProduct;
+      iEvent.getByToken(_genEventInfoCollection, genEventInfoProduct);
+      double weightForRivet = genEventInfoProduct->weight();
       
       if(_useGENweights){
-	edm::Handle<GenEventInfoProduct> genEventInfoProduct;
-	iEvent.getByToken(_genEventInfoCollection, genEventInfoProduct);
-	weightForRivet *= genEventInfoProduct->weights().at(_GENweightNumber);
+        weightForRivet = genEventInfoProduct->weights().at(_GENweightNumber);
       }
       if(_useLHEweights){
-	edm::Handle<LHEEventProduct> lheEventHandle;
-	iEvent.getByToken(_LHECollection,lheEventHandle);
-	const LHEEventProduct::WGT& wgt = lheEventHandle->weights().at(_LHEweightNumber);
-	weightForRivet *= wgt.wgt;
+        edm::Handle<LHEEventProduct> lheEventHandle;
+        iEvent.getByToken(_LHECollection,lheEventHandle);
+        const LHEEventProduct::WGT& wgt = lheEventHandle->weights().at(_LHEweightNumber)/lheEventHandle->originalXWGTUP();
+        weightForRivet *= wgt.wgt;
       }
       
       tmpGenEvtPtr->weights()[0] = weightForRivet;

--- a/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
@@ -129,8 +129,7 @@ void RivetAnalyzer::analyze(const edm::Event& iEvent,const edm::EventSetup& iSet
       if(_useLHEweights){
         edm::Handle<LHEEventProduct> lheEventHandle;
         iEvent.getByToken(_LHECollection,lheEventHandle);
-        const LHEEventProduct::WGT& wgt = lheEventHandle->weights().at(_LHEweightNumber)/lheEventHandle->originalXWGTUP();
-        weightForRivet *= wgt.wgt;
+        weightForRivet *= lheEventHandle->weights().at(_LHEweightNumber).wgt/lheEventHandle->originalXWGTUP();
       }
       
       tmpGenEvtPtr->weights()[0] = weightForRivet;


### PR DESCRIPTION
#### PR description:

Fix combination of GenEventInfoProduct and LHEEventProduct weights to be passed to Rivet analysis, now agrees with instructions in the twiki: https://twiki.cern.ch/twiki/bin/viewauth/CMS/LHEReaderCMSSW

Thanks to Alexander for spotting the problem: https://hypernews.cern.ch/HyperNews/CMS/get/generators/4273.html

NB: This will require a larger rewrite when Rivet becomes capable of handling multiple weights at once.

#### PR validation:

By mistake, combined PS+LHE weights became positive (blue) also for events that should have a negative overall weight. The fixed version (green) agrees with the default positive/negative ratio (red).
![image](https://user-images.githubusercontent.com/1311783/54034872-4772bb00-41b8-11e9-9856-159fa712b516.png)
