### PR TITLE
Fix clang warnings in Calibration

### DIFF
--- a/DataFormats/HcalCalibObjects/interface/HOCalibVariables.h
+++ b/DataFormats/HcalCalibObjects/interface/HOCalibVariables.h
@@ -2,8 +2,8 @@
 #define AlCaHOCalibProducer_HOCalibVariables_h
 #include <vector>
 //April 2015 : Added more variables, e.g., momatho, tkpt03, ecal03, hcal03, inslumi, nprim
-struct HOCalibVariables {
-
+class HOCalibVariables {
+  public:
   int   nmuon; //number of muons in the event
   int   nprim; // number of primary vertices
 


### PR DESCRIPTION
Fixes this: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc700/CMSSW_10_6_CLANG_X_2019-03-05-2300/Calibration/HcalAlCaRecoProducers