### PR TITLE
Adding CHS area

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -229,7 +229,7 @@ def applySubstructure( process, postfix="" ) :
                                                 'userFloat("NjettinessAK8'+postfix+':tau2")',
                                                 'userFloat("NjettinessAK8'+postfix+':tau3")',
                                                 'userFloat("NjettinessAK8'+postfix+':tau4")',
-                                                'pt','eta','phi','mass'
+                                                'pt','eta','phi','mass', 'jetArea', 'jecFactor(0)'
                                             ]),
                                             valueLabels = cms.vstring( [
                                                 'ak8PFJetsCHSPrunedMass',
@@ -238,7 +238,7 @@ def applySubstructure( process, postfix="" ) :
                                                 'NjettinessAK8CHSTau2',
                                                 'NjettinessAK8CHSTau3',
                                                 'NjettinessAK8CHSTau4',
-                                                'pt','eta','phi','mass'
+                                                'pt','eta','phi','mass', 'jetArea', 'rawFactor'
                                             ]) ),
                         process, task)
 
@@ -255,6 +255,8 @@ def applySubstructure( process, postfix="" ) :
                                                    cms.InputTag('ak8PFJetsCHSValueMap'+postfix,'eta'),
                                                    cms.InputTag('ak8PFJetsCHSValueMap'+postfix,'phi'),
                                                    cms.InputTag('ak8PFJetsCHSValueMap'+postfix,'mass'),
+                                                   cms.InputTag('ak8PFJetsCHSValueMap'+postfix,'jetArea'),
+                                                   cms.InputTag('ak8PFJetsCHSValueMap'+postfix,'rawFactor'),
                                                    ]
 
     


### PR DESCRIPTION
#### PR description:

This PR adds the capability to recorrect AK8 CHS jets. This requires the addition of the jet area and jet correction factors in the user floats for AK8. Requested by several people. Addresses issue [here](https://github.com/cms-sw/cmssw/issues/26104). 

#### PR validation:

Workflows run:
```
135.12_QCD_Pt_80_120_13+QCD_Pt_80_120FS_13+HARVESTUP15FS+MINIAODMCUP15FS/	136.8311_RunJetHT2017F_reminiaod+RunJetHT2017F_reminiaod+REMINIAOD_data2017+HARVEST2017_REMINIAOD_data2017/
25409.18_QCD_FlatPt_15_3000HS_13+FS_QCD_FlatPt_15_3000HS_13_UP18_PU50+HARVESTUP18FS+MINIAODMCUP18FS/
```

Example of output:
```
	ak8PFJetsCHSValueMap:eta -1.5529447794
	ak8PFJetsCHSValueMap:jetArea 2.02458190918
	ak8PFJetsCHSValueMap:mass 61.9588699341
	ak8PFJetsCHSValueMap:phi -1.08592498302
	ak8PFJetsCHSValueMap:pt 476.583618164
	ak8PFJetsCHSValueMap:rawFactor 0.899871528149
```

#### if this PR is a backport please specify the original PR:

This is not a backport. 