### PR TITLE
Adding PF-like GenJet specifics

### DIFF
--- a/DataFormats/HepMCCandidate/interface/GenParticleFwd.h
+++ b/DataFormats/HepMCCandidate/interface/GenParticleFwd.h
@@ -2,6 +2,9 @@
 #define HepMCCandidate_GenParticleFwd_h
 #include <vector>
 #include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/Common/interface/FwdRef.h"
+#include "DataFormats/Common/interface/FwdPtr.h"
 #include "DataFormats/Common/interface/RefProd.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/Association.h"
@@ -12,12 +15,18 @@ namespace reco {
   typedef std::vector<GenParticle> GenParticleCollection;
   /// persistent reference to a GenParticle
   typedef edm::Ref<GenParticleCollection> GenParticleRef;
+  /// persistent reference to a GenParticle
+  typedef edm::Ptr<GenParticle> GenParticlePtr;
+  /// forward persistent reference to a GenParticle
+  typedef edm::FwdPtr<GenParticle> GenParticleFwdPtr;
   /// persistent reference to a GenParticle collection
   typedef edm::RefProd<GenParticleCollection> GenParticleRefProd;
   /// vector of reference to GenParticle in the same collection
   typedef edm::RefVector<GenParticleCollection> GenParticleRefVector;
   /// vector of reference to GenParticle in the same collection
   typedef edm::Association<GenParticleCollection> GenParticleMatch;
+  // vector of forward persistent reference to a GenParticle
+  typedef std::vector<GenParticleFwdPtr> GenParticleFwdPtrVector;
 }
 
 #endif

--- a/DataFormats/JetReco/interface/GenJet.h
+++ b/DataFormats/JetReco/interface/GenJet.h
@@ -11,7 +11,8 @@
  *
  * \author Fedor Ratnikov, UMd
  *
- * \version   Original March 31, 2006 by F.R.
+ * \version   Original March 31, 2006 by F.R. 
+ *            Added GenJet specifics, 2019 by Salvatore Rappoccio
  ************************************************************/
 
 
@@ -26,10 +27,22 @@ public:
   struct Specific {
     Specific () :
       m_EmEnergy (0),
-	 m_HadEnergy (0),
-	 m_InvisibleEnergy (0),
-	 m_AuxiliaryEnergy (0) {}
+      m_HadEnergy (0),
+      m_InvisibleEnergy (0),
+      m_AuxiliaryEnergy (0),
+      mChargedHadronEnergy(0),
+      mNeutralHadronEnergy(0),
+      mChargedEmEnergy(0),
+      mNeutralEmEnergy(0),
+      mMuonEnergy(0),
+      mChargedHadronMultiplicity(0),
+      mNeutralHadronMultiplicity(0),
+      mChargedEmMultiplicity(0),
+      mNeutralEmMultiplicity(0),
+      mMuonMultiplicity(0)
+    {}
 
+    /// Calo-like definitions:
     /// Energy of EM particles
     float m_EmEnergy;
     /// Energy of Hadrons
@@ -38,6 +51,25 @@ public:
     float m_InvisibleEnergy;
     /// Anything else (undecayed Sigmas etc.)
     float m_AuxiliaryEnergy;
+
+    /// PF-like definitions:
+    /// pi+, K+, etc
+    float mChargedHadronEnergy;
+    /// K0, etc
+    float mNeutralHadronEnergy;
+    /// Electrons
+    float mChargedEmEnergy;
+    /// Photons
+    float mNeutralEmEnergy;
+    /// Muons
+    float mMuonEnergy;
+    /// Corresponding multiplicities: 
+    int   mChargedHadronMultiplicity;
+    int   mNeutralHadronMultiplicity;
+    int   mChargedEmMultiplicity;
+    int   mNeutralEmMultiplicity;
+    int   mMuonMultiplicity; 
+    
   };
 
   /** Default constructor*/
@@ -61,6 +93,19 @@ public:
   float invisibleEnergy() const {return m_specific.m_InvisibleEnergy;};
   /** Returns other energy (undecayed Sigmas etc.)*/
   float auxiliaryEnergy() const {return m_specific.m_AuxiliaryEnergy;};
+
+
+  // PF-like definitions
+  float chargedHadronEnergy() const { return m_specific.mChargedHadronEnergy;}
+  float neutralHadronEnergy() const { return m_specific.mNeutralHadronEnergy;}
+  float chargedEmEnergy    () const { return m_specific.mChargedEmEnergy    ;}
+  float neutralEmEnergy    () const { return m_specific.mNeutralEmEnergy    ;}
+  float muonEnergy         () const { return m_specific.mMuonEnergy         ;}
+  int chargedHadronMultiplicity() const { return m_specific.mChargedHadronMultiplicity;}
+  int neutralHadronMultiplicity() const { return m_specific.mNeutralHadronMultiplicity;}
+  int chargedEmMultiplicity    () const { return m_specific.mChargedEmMultiplicity    ;}
+  int neutralEmMultiplicity    () const { return m_specific.mNeutralEmMultiplicity    ;}
+  int muonMultiplicity         () const { return m_specific.mMuonMultiplicity         ;}  
 
   /// Detector Eta (use reference Z and jet kinematics only)
   float detectorEta (float fZVertex) const;

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -93,7 +93,8 @@
    <version ClassVersion="11" checksum="2159688147"/>
    <version ClassVersion="10" checksum="1136403928"/>
   </class>
-  <class name="reco::GenJet::Specific" ClassVersion="10">
+  <class name="reco::GenJet::Specific" ClassVersion="11">
+    <version ClassVersion="11" checksum="1739165020"/>
    <version ClassVersion="10" checksum="3126154868"/>
   </class>
   <class name="std::vector<reco::GenJet>"/>

--- a/RecoJets/JetProducers/src/JetSpecific.cc
+++ b/RecoJets/JetProducers/src/JetSpecific.cc
@@ -385,11 +385,17 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & mcparticles,
       edm::LogWarning("DataNotFound") << " JetSpecific: MC Particle is invalid\n";
       continue;
     }
+
+    
     const Candidate* candidate = itMcParticle->get();
     if (candidate->hasMasterClone()) candidate = candidate->masterClone().get();
     //const GenParticle* genParticle = GenJet::genParticle(candidate);
+
+    
     if (candidate) {
       double e = candidate->energy();
+
+      // Legacy calo-like definitions
       switch (abs (candidate->pdgId ())) {
       case 22: // photon
       case 11: // e
@@ -412,12 +418,46 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & mcparticles,
       default: 
 	genJetSpecific->m_AuxiliaryEnergy += e;
       }
-    }
+
+      // PF-like definitions
+      switch (abs (candidate->pdgId ())) {
+      case 11: //electron
+	genJetSpecific->mChargedEmEnergy += e;
+	++(genJetSpecific->mChargedEmMultiplicity); 
+	break;
+      case 13: // muon
+	genJetSpecific->mMuonEnergy += e;
+	++(genJetSpecific->mMuonEnergy);
+      case 211: //pi+-
+      case 321: //K
+      case 2212: //p
+      case 3222: //Sigma+
+      case 3112: //Sigma-
+      case 3312: //Xi-
+      case 3334: //Omega-
+	genJetSpecific->mChargedHadronEnergy += e;
+	++(genJetSpecific->mChargedHadronMultiplicity);
+	break;
+      case 310: //KS0
+      case 130: //KL0
+      case 3122: //Lambda0
+      case 3212: //Sigma0
+      case 3322: //Xi0
+      case 2112: //n0
+	genJetSpecific->mNeutralHadronEnergy += e;
+	++(genJetSpecific->mNeutralHadronMultiplicity);
+	break;
+      case 22: //photon
+	genJetSpecific->mNeutralEmEnergy += e;
+	++(genJetSpecific->mNeutralEmMultiplicity);
+	break;
+      }	 
+    } // end if found a candidate
     else {
       edm::LogWarning("DataNotFound") <<"reco::makeGenJetSpecific: Referred  GenParticleCandidate "
 				      <<"is not available in the event\n";
     }
-  }
+  }// end for loop over MC particles
   
   return true;
 }


### PR DESCRIPTION
#### PR description:

This PR adds the capability to recorrect AK8 CHS jets. This requires the addition of the jet area and jet correction factors in the user floats for AK8. Requested by several people. Addresses issue [here](https://github.com/cms-sw/cmssw/issues/26104). 

#### PR validation:

Workflows run:
```
135.12_QCD_Pt_80_120_13+QCD_Pt_80_120FS_13+HARVESTUP15FS+MINIAODMCUP15FS/	136.8311_RunJetHT2017F_reminiaod+RunJetHT2017F_reminiaod+REMINIAOD_data2017+HARVEST2017_REMINIAOD_data2017/
25409.18_QCD_FlatPt_15_3000HS_13+FS_QCD_FlatPt_15_3000HS_13_UP18_PU50+HARVESTUP18FS+MINIAODMCUP18FS/
```

Example of output:
```
	ak8PFJetsCHSValueMap:eta -1.5529447794
	ak8PFJetsCHSValueMap:jetArea 2.02458190918
	ak8PFJetsCHSValueMap:mass 61.9588699341
	ak8PFJetsCHSValueMap:phi -1.08592498302
	ak8PFJetsCHSValueMap:pt 476.583618164
	ak8PFJetsCHSValueMap:rawFactor 0.899871528149
```

#### if this PR is a backport please specify the original PR:

Original PR: https://github.com/cms-sw/cmssw/pull/26117