### PR TITLE
Fix types in Merge.py, and RunMerge.py for missing mergeNANO default

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -73,7 +73,7 @@ def mergeProcess(*inputFiles, **options):
         outMod = OutputModule("PoolOutputModule")
 
     # To bypass the version check in the merge process (TRUE by default)
-    process.source.bypassVersionCheck = cms.untracked.bool(bypassVersionCheck)
+    process.source.bypassVersionCheck = CfgTypes.untracked.bool(bypassVersionCheck)
 
     outMod.fileName = CfgTypes.untracked.string(outputFilename)
     if outputLFN != None:

--- a/Configuration/DataProcessing/test/RunMerge.py
+++ b/Configuration/DataProcessing/test/RunMerge.py
@@ -23,6 +23,7 @@ class RunMerge:
         self.outputLFN = None
         self.inputFiles = []
         self.newDQMIO = False
+        self.mergeNANO = False
         self.bypassVersionCheck = True
         
 


### PR DESCRIPTION
#### PR description:

This PR proposes two independent fixes to Configuration/DataProcessing:

- the recent update of Merge.py from #26030 introduces a bug, as bypassVersionCheck should be defined from CfgTypes and not cms (see #26110 by @srimanob);

- while testing it I have realized RunMerge.py fails to build due to the lack of a mergeNano default, now added.

#### PR validation:

```
python RunMerge.py --input-files=a.root 
```
now runs smoothly and produces the desired RunMergeCfg.py output with the bypassVersionCheck option activated by default:

```
process.source = cms.Source("PoolSource",
    bypassVersionCheck = cms.untracked.bool(True),
    fileNames = cms.untracked.vstring("[\'a.root\']")
)
```

