### PR TITLE
Pf gen jet specifics

### DIFF
--- a/DataFormats/HepMCCandidate/interface/GenParticleFwd.h
+++ b/DataFormats/HepMCCandidate/interface/GenParticleFwd.h
@@ -2,6 +2,9 @@
 #define HepMCCandidate_GenParticleFwd_h
 #include <vector>
 #include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/Common/interface/FwdRef.h"
+#include "DataFormats/Common/interface/FwdPtr.h"
 #include "DataFormats/Common/interface/RefProd.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/Association.h"
@@ -12,12 +15,18 @@ namespace reco {
   typedef std::vector<GenParticle> GenParticleCollection;
   /// persistent reference to a GenParticle
   typedef edm::Ref<GenParticleCollection> GenParticleRef;
+  /// persistent reference to a GenParticle
+  typedef edm::Ptr<GenParticle> GenParticlePtr;
+  /// forward persistent reference to a GenParticle
+  typedef edm::FwdPtr<GenParticle> GenParticleFwdPtr;
   /// persistent reference to a GenParticle collection
   typedef edm::RefProd<GenParticleCollection> GenParticleRefProd;
   /// vector of reference to GenParticle in the same collection
   typedef edm::RefVector<GenParticleCollection> GenParticleRefVector;
   /// vector of reference to GenParticle in the same collection
   typedef edm::Association<GenParticleCollection> GenParticleMatch;
+  // vector of forward persistent reference to a GenParticle
+  typedef std::vector<GenParticleFwdPtr> GenParticleFwdPtrVector;
 }
 
 #endif

--- a/DataFormats/JetReco/interface/GenJet.h
+++ b/DataFormats/JetReco/interface/GenJet.h
@@ -30,16 +30,16 @@ public:
       m_HadEnergy (0),
       m_InvisibleEnergy (0),
       m_AuxiliaryEnergy (0),
-      mChargedHadronEnergy(0),
-      mNeutralHadronEnergy(0),
-      mChargedEmEnergy(0),
-      mNeutralEmEnergy(0),
-      mMuonEnergy(0),
-      mChargedHadronMultiplicity(0),
-      mNeutralHadronMultiplicity(0),
-      mChargedEmMultiplicity(0),
-      mNeutralEmMultiplicity(0),
-      mMuonMultiplicity(0)
+      m_ChargedHadronEnergy(0),
+      m_NeutralHadronEnergy(0),
+      m_ChargedEmEnergy(0),
+      m_NeutralEmEnergy(0),
+      m_MuonEnergy(0),
+      m_ChargedHadronMultiplicity(0),
+      m_NeutralHadronMultiplicity(0),
+      m_ChargedEmMultiplicity(0),
+      m_NeutralEmMultiplicity(0),
+      m_MuonMultiplicity(0)
     {}
 
     /// Calo-like definitions:
@@ -54,21 +54,21 @@ public:
 
     /// PF-like definitions:
     /// pi+, K+, etc
-    float mChargedHadronEnergy;
+    float m_ChargedHadronEnergy;
     /// K0, etc
-    float mNeutralHadronEnergy;
+    float m_NeutralHadronEnergy;
     /// Electrons
-    float mChargedEmEnergy;
+    float m_ChargedEmEnergy;
     /// Photons
-    float mNeutralEmEnergy;
+    float m_NeutralEmEnergy;
     /// Muons
-    float mMuonEnergy;
+    float m_MuonEnergy;
     /// Corresponding multiplicities: 
-    int   mChargedHadronMultiplicity;
-    int   mNeutralHadronMultiplicity;
-    int   mChargedEmMultiplicity;
-    int   mNeutralEmMultiplicity;
-    int   mMuonMultiplicity; 
+    int   m_ChargedHadronMultiplicity;
+    int   m_NeutralHadronMultiplicity;
+    int   m_ChargedEmMultiplicity;
+    int   m_NeutralEmMultiplicity;
+    int   m_MuonMultiplicity; 
     
   };
 
@@ -96,16 +96,16 @@ public:
 
 
   // PF-like definitions
-  float chargedHadronEnergy() const { return m_specific.mChargedHadronEnergy;}
-  float neutralHadronEnergy() const { return m_specific.mNeutralHadronEnergy;}
-  float chargedEmEnergy    () const { return m_specific.mChargedEmEnergy    ;}
-  float neutralEmEnergy    () const { return m_specific.mNeutralEmEnergy    ;}
-  float muonEnergy         () const { return m_specific.mMuonEnergy         ;}
-  int chargedHadronMultiplicity() const { return m_specific.mChargedHadronMultiplicity;}
-  int neutralHadronMultiplicity() const { return m_specific.mNeutralHadronMultiplicity;}
-  int chargedEmMultiplicity    () const { return m_specific.mChargedEmMultiplicity    ;}
-  int neutralEmMultiplicity    () const { return m_specific.mNeutralEmMultiplicity    ;}
-  int muonMultiplicity         () const { return m_specific.mMuonMultiplicity         ;}  
+  float chargedHadronEnergy() const { return m_specific.m_ChargedHadronEnergy;}
+  float neutralHadronEnergy() const { return m_specific.m_NeutralHadronEnergy;}
+  float chargedEmEnergy    () const { return m_specific.m_ChargedEmEnergy    ;}
+  float neutralEmEnergy    () const { return m_specific.m_NeutralEmEnergy    ;}
+  float muonEnergy         () const { return m_specific.m_MuonEnergy         ;}
+  int chargedHadronMultiplicity() const { return m_specific.m_ChargedHadronMultiplicity;}
+  int neutralHadronMultiplicity() const { return m_specific.m_NeutralHadronMultiplicity;}
+  int chargedEmMultiplicity    () const { return m_specific.m_ChargedEmMultiplicity    ;}
+  int neutralEmMultiplicity    () const { return m_specific.m_NeutralEmMultiplicity    ;}
+  int muonMultiplicity         () const { return m_specific.m_MuonMultiplicity         ;}  
 
   /// Detector Eta (use reference Z and jet kinematics only)
   float detectorEta (float fZVertex) const;

--- a/DataFormats/JetReco/interface/GenJet.h
+++ b/DataFormats/JetReco/interface/GenJet.h
@@ -11,7 +11,8 @@
  *
  * \author Fedor Ratnikov, UMd
  *
- * \version   Original March 31, 2006 by F.R.
+ * \version   Original March 31, 2006 by F.R. 
+ *            Added GenJet specifics, 2019 by Salvatore Rappoccio
  ************************************************************/
 
 
@@ -26,10 +27,22 @@ public:
   struct Specific {
     Specific () :
       m_EmEnergy (0),
-	 m_HadEnergy (0),
-	 m_InvisibleEnergy (0),
-	 m_AuxiliaryEnergy (0) {}
+      m_HadEnergy (0),
+      m_InvisibleEnergy (0),
+      m_AuxiliaryEnergy (0),
+      mChargedHadronEnergy(0),
+      mNeutralHadronEnergy(0),
+      mChargedEmEnergy(0),
+      mNeutralEmEnergy(0),
+      mMuonEnergy(0),
+      mChargedHadronMultiplicity(0),
+      mNeutralHadronMultiplicity(0),
+      mChargedEmMultiplicity(0),
+      mNeutralEmMultiplicity(0),
+      mMuonMultiplicity(0)
+    {}
 
+    /// Calo-like definitions:
     /// Energy of EM particles
     float m_EmEnergy;
     /// Energy of Hadrons
@@ -38,6 +51,25 @@ public:
     float m_InvisibleEnergy;
     /// Anything else (undecayed Sigmas etc.)
     float m_AuxiliaryEnergy;
+
+    /// PF-like definitions:
+    /// pi+, K+, etc
+    float mChargedHadronEnergy;
+    /// K0, etc
+    float mNeutralHadronEnergy;
+    /// Electrons
+    float mChargedEmEnergy;
+    /// Photons
+    float mNeutralEmEnergy;
+    /// Muons
+    float mMuonEnergy;
+    /// Corresponding multiplicities: 
+    int   mChargedHadronMultiplicity;
+    int   mNeutralHadronMultiplicity;
+    int   mChargedEmMultiplicity;
+    int   mNeutralEmMultiplicity;
+    int   mMuonMultiplicity; 
+    
   };
 
   /** Default constructor*/
@@ -61,6 +93,19 @@ public:
   float invisibleEnergy() const {return m_specific.m_InvisibleEnergy;};
   /** Returns other energy (undecayed Sigmas etc.)*/
   float auxiliaryEnergy() const {return m_specific.m_AuxiliaryEnergy;};
+
+
+  // PF-like definitions
+  float chargedHadronEnergy() const { return m_specific.mChargedHadronEnergy;}
+  float neutralHadronEnergy() const { return m_specific.mNeutralHadronEnergy;}
+  float chargedEmEnergy    () const { return m_specific.mChargedEmEnergy    ;}
+  float neutralEmEnergy    () const { return m_specific.mNeutralEmEnergy    ;}
+  float muonEnergy         () const { return m_specific.mMuonEnergy         ;}
+  int chargedHadronMultiplicity() const { return m_specific.mChargedHadronMultiplicity;}
+  int neutralHadronMultiplicity() const { return m_specific.mNeutralHadronMultiplicity;}
+  int chargedEmMultiplicity    () const { return m_specific.mChargedEmMultiplicity    ;}
+  int neutralEmMultiplicity    () const { return m_specific.mNeutralEmMultiplicity    ;}
+  int muonMultiplicity         () const { return m_specific.mMuonMultiplicity         ;}  
 
   /// Detector Eta (use reference Z and jet kinematics only)
   float detectorEta (float fZVertex) const;

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -93,7 +93,8 @@
    <version ClassVersion="11" checksum="2159688147"/>
    <version ClassVersion="10" checksum="1136403928"/>
   </class>
-  <class name="reco::GenJet::Specific" ClassVersion="10">
+  <class name="reco::GenJet::Specific" ClassVersion="11">
+    <version ClassVersion="11" checksum="1739165020"/>
    <version ClassVersion="10" checksum="3126154868"/>
   </class>
   <class name="std::vector<reco::GenJet>"/>

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -94,7 +94,7 @@
    <version ClassVersion="10" checksum="1136403928"/>
   </class>
   <class name="reco::GenJet::Specific" ClassVersion="11">
-    <version ClassVersion="11" checksum="1739165020"/>
+    <version ClassVersion="11" checksum="1280150924"/>
    <version ClassVersion="10" checksum="3126154868"/>
   </class>
   <class name="std::vector<reco::GenJet>"/>

--- a/RecoJets/JetProducers/src/JetSpecific.cc
+++ b/RecoJets/JetProducers/src/JetSpecific.cc
@@ -26,9 +26,6 @@
 #include <cmath>
 
 
-using namespace std;
-
-
 ////////////////////////////////////////////////////////////////////////////////
 // implementation of global functions
 ////////////////////////////////////////////////////////////////////////////////
@@ -132,7 +129,7 @@ void reco::writeSpecific(reco::PFClusterJet & jet,
 
 
 //______________________________________________________________________________
-bool reco::makeSpecific(vector<reco::CandidatePtr> const & towers,
+bool reco::makeSpecific(std::vector<reco::CandidatePtr> const & towers,
 			const CaloSubdetectorGeometry* towerGeometry,
 			CaloJet::Specific* caloJetSpecific,
 			const HcalTopology &topology)
@@ -142,8 +139,8 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & towers,
   // 1.- Loop over the tower Ids, 
   // 2.- Get the corresponding CaloTower
   // 3.- Calculate the different CaloJet specific quantities
-  vector<double> eECal_i;
-  vector<double> eHCal_i;
+  std::vector<double> eECal_i;
+  std::vector<double> eHCal_i;
   double eInHad = 0.;
   double eInEm = 0.;
   double eInHO = 0.;
@@ -155,7 +152,7 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & towers,
   double eInEE = 0.;
   double jetArea = 0.;
   
-  vector<reco::CandidatePtr>::const_iterator itTower;
+  std::vector<reco::CandidatePtr>::const_iterator itTower;
   for (itTower=towers.begin();itTower!=towers.end();++itTower) {
     if ( itTower->isNull() || !itTower->isAvailable() ) { 
       edm::LogWarning("DataNotFound") << " JetSpecific: Tower is invalid\n";
@@ -225,8 +222,8 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & towers,
   caloJetSpecific->mMaxEInHadTowers = 0;
   
   //Sort the arrays
-  sort(eECal_i.begin(), eECal_i.end(), greater<double>());
-  sort(eHCal_i.begin(), eHCal_i.end(), greater<double>());
+  sort(eECal_i.begin(), eECal_i.end(), std::greater<double>());
+  sort(eHCal_i.begin(), eHCal_i.end(), std::greater<double>());
   
   if (!towers.empty()) {
     //Highest value in the array is the first element of the array
@@ -239,7 +236,7 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & towers,
 
 
 //______________________________________________________________________________
-bool reco::makeSpecific(vector<reco::CandidatePtr> const & particles,	   
+bool reco::makeSpecific(std::vector<reco::CandidatePtr> const & particles,	   
 			PFJet::Specific* pfJetSpecific)
 {
   if (nullptr==pfJetSpecific) return false;
@@ -271,7 +268,7 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & particles,
 
   float HOEnergy=0.;
   
-  vector<reco::CandidatePtr>::const_iterator itParticle;
+  std::vector<reco::CandidatePtr>::const_iterator itParticle;
   for (itParticle=particles.begin();itParticle!=particles.end();++itParticle){
     if ( itParticle->isNull() || !itParticle->isAvailable() ) { 
       edm::LogWarning("DataNotFound") << " JetSpecific: PF Particle is invalid\n";
@@ -374,12 +371,12 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & particles,
 
 
 //______________________________________________________________________________
-bool reco::makeSpecific(vector<reco::CandidatePtr> const & mcparticles, 
+bool reco::makeSpecific(std::vector<reco::CandidatePtr> const & mcparticles, 
 			GenJet::Specific* genJetSpecific)
 {
   if (nullptr==genJetSpecific) return false;
 
-  vector<reco::CandidatePtr>::const_iterator itMcParticle=mcparticles.begin();
+  std::vector<reco::CandidatePtr>::const_iterator itMcParticle=mcparticles.begin();
   for (;itMcParticle!=mcparticles.end();++itMcParticle) {
     if ( itMcParticle->isNull() || !itMcParticle->isAvailable() ) { 
       edm::LogWarning("DataNotFound") << " JetSpecific: MC Particle is invalid\n";
@@ -396,61 +393,60 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & mcparticles,
       double e = candidate->energy();
 
       // Legacy calo-like definitions
-      switch (abs (candidate->pdgId ())) {
-      case 22: // photon
-      case 11: // e
-	genJetSpecific->m_EmEnergy += e;
-	break;
-      case 211: // pi
-      case 321: // K
-      case 130: // KL
-      case 2212: // p
-      case 2112: // n
-	genJetSpecific->m_HadEnergy += e;
-	break;
-      case 13: // muon
-      case 12: // nu_e
-      case 14: // nu_mu
-      case 16: // nu_tau
-	
-	genJetSpecific->m_InvisibleEnergy += e;
-	break;
-      default: 
-	genJetSpecific->m_AuxiliaryEnergy += e;
+      switch (std::abs (candidate->pdgId ())) {
+        case 22: // photon
+        case 11: // e
+	  genJetSpecific->m_EmEnergy += e;
+	  break;
+        case 211: // pi
+        case 321: // K
+        case 130: // KL
+        case 2212: // p
+        case 2112: // n
+	  genJetSpecific->m_HadEnergy += e;
+	  break;
+        case 13: // muon
+        case 12: // nu_e
+        case 14: // nu_mu
+        case 16: // nu_tau	
+	  genJetSpecific->m_InvisibleEnergy += e;
+	  break;
+        default: 
+	  genJetSpecific->m_AuxiliaryEnergy += e;
       }
 
       // PF-like definitions
-      switch (abs (candidate->pdgId ())) {
-      case 11: //electron
-	genJetSpecific->mChargedEmEnergy += e;
-	++(genJetSpecific->mChargedEmMultiplicity); 
-	break;
-      case 13: // muon
-	genJetSpecific->mMuonEnergy += e;
-	++(genJetSpecific->mMuonMultiplicity);
-      case 211: //pi+-
-      case 321: //K
-      case 2212: //p
-      case 3222: //Sigma+
-      case 3112: //Sigma-
-      case 3312: //Xi-
-      case 3334: //Omega-
-	genJetSpecific->mChargedHadronEnergy += e;
-	++(genJetSpecific->mChargedHadronMultiplicity);
-	break;
-      case 310: //KS0
-      case 130: //KL0
-      case 3122: //Lambda0
-      case 3212: //Sigma0
-      case 3322: //Xi0
-      case 2112: //n0
-	genJetSpecific->mNeutralHadronEnergy += e;
-	++(genJetSpecific->mNeutralHadronMultiplicity);
-	break;
-      case 22: //photon
-	genJetSpecific->mNeutralEmEnergy += e;
-	++(genJetSpecific->mNeutralEmMultiplicity);
-	break;
+      switch (std::abs (candidate->pdgId ())) {
+        case 11: //electron
+	  genJetSpecific->m_ChargedEmEnergy += e;
+	  ++(genJetSpecific->m_ChargedEmMultiplicity); 
+	  break;
+        case 13: // muon
+	  genJetSpecific->m_MuonEnergy += e;
+	  ++(genJetSpecific->m_MuonMultiplicity);
+        case 211: //pi+-
+        case 321: //K
+        case 2212: //p
+        case 3222: //Sigma+
+        case 3112: //Sigma-
+        case 3312: //Xi-
+        case 3334: //Omega-
+	  genJetSpecific->m_ChargedHadronEnergy += e;
+	  ++(genJetSpecific->m_ChargedHadronMultiplicity);
+	  break;
+        case 310: //KS0
+        case 130: //KL0
+        case 3122: //Lambda0
+        case 3212: //Sigma0
+        case 3322: //Xi0
+        case 2112: //n0
+	  genJetSpecific->m_NeutralHadronEnergy += e;
+	  ++(genJetSpecific->m_NeutralHadronMultiplicity);
+	  break;
+        case 22: //photon
+	  genJetSpecific->m_NeutralEmEnergy += e;
+	  ++(genJetSpecific->m_NeutralEmMultiplicity);
+	  break;
       }	 
     } // end if found a candidate
     else {

--- a/RecoJets/JetProducers/src/JetSpecific.cc
+++ b/RecoJets/JetProducers/src/JetSpecific.cc
@@ -385,11 +385,17 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & mcparticles,
       edm::LogWarning("DataNotFound") << " JetSpecific: MC Particle is invalid\n";
       continue;
     }
+
+    
     const Candidate* candidate = itMcParticle->get();
     if (candidate->hasMasterClone()) candidate = candidate->masterClone().get();
     //const GenParticle* genParticle = GenJet::genParticle(candidate);
+
+    
     if (candidate) {
       double e = candidate->energy();
+
+      // Legacy calo-like definitions
       switch (abs (candidate->pdgId ())) {
       case 22: // photon
       case 11: // e
@@ -412,12 +418,46 @@ bool reco::makeSpecific(vector<reco::CandidatePtr> const & mcparticles,
       default: 
 	genJetSpecific->m_AuxiliaryEnergy += e;
       }
-    }
+
+      // PF-like definitions
+      switch (abs (candidate->pdgId ())) {
+      case 11: //electron
+	genJetSpecific->mChargedEmEnergy += e;
+	++(genJetSpecific->mChargedEmMultiplicity); 
+	break;
+      case 13: // muon
+	genJetSpecific->mMuonEnergy += e;
+	++(genJetSpecific->mMuonMultiplicity);
+      case 211: //pi+-
+      case 321: //K
+      case 2212: //p
+      case 3222: //Sigma+
+      case 3112: //Sigma-
+      case 3312: //Xi-
+      case 3334: //Omega-
+	genJetSpecific->mChargedHadronEnergy += e;
+	++(genJetSpecific->mChargedHadronMultiplicity);
+	break;
+      case 310: //KS0
+      case 130: //KL0
+      case 3122: //Lambda0
+      case 3212: //Sigma0
+      case 3322: //Xi0
+      case 2112: //n0
+	genJetSpecific->mNeutralHadronEnergy += e;
+	++(genJetSpecific->mNeutralHadronMultiplicity);
+	break;
+      case 22: //photon
+	genJetSpecific->mNeutralEmEnergy += e;
+	++(genJetSpecific->mNeutralEmMultiplicity);
+	break;
+      }	 
+    } // end if found a candidate
     else {
       edm::LogWarning("DataNotFound") <<"reco::makeGenJetSpecific: Referred  GenParticleCandidate "
 				      <<"is not available in the event\n";
     }
-  }
+  }// end for loop over MC particles
   
   return true;
 }


### PR DESCRIPTION
#### PR description:

This PR adds PF-like particle fractions to GenJet, at long last. The long shutdown is a good opportunity. It adds 5 floats and 5 ints to GenJet. 

Addresses [this issue](https://github.com/cms-sw/cmssw/issues/26115)

#### PR validation:

This is gen-only so I used WF 5.1. 

Example of changes:

```
jet   4: pt  41.1, eta +1.13, energies: ch  32.69 nh   9.38 ce   0.00 ne  28.45 mu   0.00, mults: ch   7 nh   2 ce   0 ne  11 mu   0
jet   5: pt  37.4, eta +1.45, energies: ch  43.99 nh  34.36 ce   0.00 ne   6.96 mu   0.00, mults: ch  10 nh   6 ce   0 ne   2 mu   0
jet   6: pt  12.0, eta +2.78, energies: ch  93.68 nh   0.00 ce   0.00 ne   3.35 mu   0.00, mults: ch   4 nh   0 ce   0 ne   2 mu   0
jet   7: pt   9.2, eta +2.42, energies: ch  46.10 nh   6.16 ce   0.00 ne   0.00 mu  43.57, mults: ch   2 nh   1 ce   0 ne   0 mu   1
```

#### if this PR is a backport please specify the original PR:

This is not a backport. 