### PR TITLE
bug fix on Merge.py for 80X

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -69,7 +69,7 @@ def mergeProcess(*inputFiles, **options):
         outMod = OutputModule("PoolOutputModule")
  
     # To bypass the version check in the merge process (TRUE by default)
-    process.source.bypassVersionCheck = cms.untracked.bool(bypassVersionCheck)
+    process.source.bypassVersionCheck = CfgTypes.untracked.bool(bypassVersionCheck)
 
     outMod.fileName = CfgTypes.untracked.string(outputFilename)
     if outputLFN != None:


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/26110
No update on RunMerge.py, as mergeNANO does not exist in 8_0 release.

Test seem to run fine, bypassVersionCheck is dumped properly

> process.source = cms.Source("PoolSource",
>     bypassVersionCheck = cms.untracked.bool(True),
>     fileNames = cms.untracked.vstring("[\'a.root\']")
> )