### PR TITLE
PFSimParticle: import ParticleFilter setting from pre-defined config rather than re-…

### DIFF
--- a/RecoParticleFlow/PFProducer/python/particleFlowSimParticle_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowSimParticle_cfi.py
@@ -11,7 +11,7 @@ particleFlowSimParticle = cms.EDProducer("PFSimParticleProducer",
     # flags 
     process_RecTracks = cms.untracked.bool(False),
     #
-    ParticleFilter = ParticleFilterBlock.ParticleFilter,
+    ParticleFilter = ParticleFilterBlock.ParticleFilter.clone(chargedPtMin = 0, EMin = 0),
     #
     TTRHBuilder = cms.string('WithTrackAngle'),
     process_Particles = cms.untracked.bool(True),
@@ -31,6 +31,3 @@ particleFlowSimParticle = cms.EDProducer("PFSimParticleProducer",
     fastSimProducer = cms.untracked.InputTag('fastSimProducer','EcalHitsEB')
 )
 
-# Custom setting
-particleFlowSimParticle.ParticleFilter.chargedPtMin = cms.double(0.0)
-particleFlowSimParticle.ParticleFilter.EMin = cms.double(0.0)

--- a/RecoParticleFlow/PFProducer/python/particleFlowSimParticle_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowSimParticle_cfi.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from FastSimulation.Event.ParticleFilter_cfi import ParticleFilterBlock
+
 particleFlowSimParticle = cms.EDProducer("PFSimParticleProducer",
     # verbosity 
     verbose = cms.untracked.bool(False),
@@ -9,9 +11,8 @@ particleFlowSimParticle = cms.EDProducer("PFSimParticleProducer",
     # flags 
     process_RecTracks = cms.untracked.bool(False),
     #
-    # Now import setting from FastSimulation.Event.ParticleFilter_cfi
-    #ParticleFilter = cms.PSet(
-    #),
+    particleFilter =  ParticleFilterBlock.ParticleFilter,
+    #
     TTRHBuilder = cms.string('WithTrackAngle'),
     process_Particles = cms.untracked.bool(True),
     Propagator = cms.string('PropagatorWithMaterial'),
@@ -30,7 +31,6 @@ particleFlowSimParticle = cms.EDProducer("PFSimParticleProducer",
     fastSimProducer = cms.untracked.InputTag('fastSimProducer','EcalHitsEB')
 )
 
-from FastSimulation.Event.ParticleFilter_cfi import ParticleFilterBlock
-particleFlowSimParticle.ParticleFilter = ParticleFilterBlock.ParticleFilter.copy()
+# Custom setting
 particleFlowSimParticle.ParticleFilter.chargedPtMin = cms.double(0.0)
 particleFlowSimParticle.ParticleFilter.EMin = cms.double(0.0)

--- a/RecoParticleFlow/PFProducer/python/particleFlowSimParticle_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowSimParticle_cfi.py
@@ -30,7 +30,7 @@ particleFlowSimParticle = cms.EDProducer("PFSimParticleProducer",
     fastSimProducer = cms.untracked.InputTag('fastSimProducer','EcalHitsEB')
 )
 
-from FastSimulation.Event.ParticleFilter_cfi import  ParticleFilterBlock
+from FastSimulation.Event.ParticleFilter_cfi import ParticleFilterBlock
 particleFlowSimParticle.ParticleFilter = ParticleFilterBlock.ParticleFilter.copy()
 particleFlowSimParticle.ParticleFilter.chargedPtMin = cms.double(0.0)
 particleFlowSimParticle.ParticleFilter.EMin = cms.double(0.0)

--- a/RecoParticleFlow/PFProducer/python/particleFlowSimParticle_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowSimParticle_cfi.py
@@ -8,16 +8,10 @@ particleFlowSimParticle = cms.EDProducer("PFSimParticleProducer",
     # replace ParticleFilter.pTMin = 0.5
     # flags 
     process_RecTracks = cms.untracked.bool(False),
-    ParticleFilter = cms.PSet(
-        EProton = cms.double(5000.0),
-        # Particles with |eta| > etaMax (momentum direction at primary vertex) 
-        # are not simulated 
-        etaMax = cms.double(5.0),
-        # Charged particles with pT < pTMin (GeV/c) are not simulated
-        pTMin = cms.double(0.0),
-        # Particles with energy smaller than EMin (GeV) are not simulated
-        EMin = cms.double(0.0)
-    ),
+    #
+    # Now import setting from FastSimulation.Event.ParticleFilter_cfi
+    #ParticleFilter = cms.PSet(
+    #),
     TTRHBuilder = cms.string('WithTrackAngle'),
     process_Particles = cms.untracked.bool(True),
     Propagator = cms.string('PropagatorWithMaterial'),
@@ -35,3 +29,8 @@ particleFlowSimParticle = cms.EDProducer("PFSimParticleProducer",
     #retrieving fastSim SimHits                                     
     fastSimProducer = cms.untracked.InputTag('fastSimProducer','EcalHitsEB')
 )
+
+from FastSimulation.Event.ParticleFilter_cfi import  ParticleFilterBlock
+particleFlowSimParticle.ParticleFilter = ParticleFilterBlock.ParticleFilter.copy()
+particleFlowSimParticle.ParticleFilter.chargedPtMin = cms.double(0.0)
+particleFlowSimParticle.ParticleFilter.EMin = cms.double(0.0)

--- a/RecoParticleFlow/PFProducer/python/particleFlowSimParticle_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowSimParticle_cfi.py
@@ -11,7 +11,7 @@ particleFlowSimParticle = cms.EDProducer("PFSimParticleProducer",
     # flags 
     process_RecTracks = cms.untracked.bool(False),
     #
-    particleFilter =  ParticleFilterBlock.ParticleFilter,
+    ParticleFilter = ParticleFilterBlock.ParticleFilter,
     #
     TTRHBuilder = cms.string('WithTrackAngle'),
     process_Particles = cms.untracked.bool(True),


### PR DESCRIPTION
…defining it in particleFlowSimParticle

#### PR description:

Fixing RecoParticleFlow/PFProducer/python/particleFlowSimParticle_cfi.py
It now reads ParticleFilter setting from
FastSimulation.Event.ParticleFilter_cfi
rather than re-defining it manually. 

I expect no change in the reconstruction output. It just helps the PF hadron calibration workflow .

#### PR validation:

Made sure that now PF hadron calibration workflow works without over-writing settings for particleFlowSimParticle.

#### if this PR is a backport please specify the original PR:

This is not a backport.

