### PR TITLE
Do not pass nullptr to strcmp in CZString

### DIFF
--- a/EventFilter/Utilities/src/json_value.cpp
+++ b/EventFilter/Utilities/src/json_value.cpp
@@ -219,7 +219,7 @@ Value::CZString::operator =( const CZString &other )
 bool 
 Value::CZString::operator<( const CZString &other ) const 
 {
-   if ( cstr_ )
+   if ( cstr_ and other.cstr_)
       return strcmp( cstr_, other.cstr_ ) < 0;
    return index_ < other.index_;
 }
@@ -227,7 +227,7 @@ Value::CZString::operator<( const CZString &other ) const
 bool 
 Value::CZString::operator==( const CZString &other ) const 
 {
-   if ( cstr_ )
+   if ( cstr_ and other.cstr_)
       return strcmp( cstr_, other.cstr_ ) == 0;
    return index_ == other.index_;
 }


### PR DESCRIPTION
#### PR description:

Avoid the possibility of passing a nullptr to strcmp.
This potential problem was found by the clang static analyzer.

#### PR validation:

The code compiles.
