### PR TITLE
Removed unused function getfullpathfromfip_

### DIFF
--- a/GeneratorInterface/ReggeGribovPartonMCInterface/src/fileinpathwrapper.cc
+++ b/GeneratorInterface/ReggeGribovPartonMCInterface/src/fileinpathwrapper.cc
@@ -1,9 +1,0 @@
-#include "FWCore/ParameterSet/interface/FileInPath.h"
-#include <iostream>
-extern "C"{
-  const char* getfullpathfromfip_(char* fipname){
-    //std::cout << "getfullpathfromfip_ " << fipname << std::endl;
-    edm::FileInPath* fip = new edm::FileInPath(fipname); 
-    return fip->fullPath().c_str(); 
-  }
-}  


### PR DESCRIPTION
#### PR description:

In addition to being unused, the function was returning a pointer to already deleted memory. 
This was found by the clang static analyzer.

#### PR validation:

The code compiles. Using `nm` on the resultant library showed that the removed function does not appear as a missing symbol. Doing a `git grep getfullpath` turned up no hits in CMSSW.