### PR TITLE
Remove direct dependency on PythonParameterSet from FWCore/SerivceRegistry

### DIFF
--- a/CondCore/Utilities/BuildFile.xml
+++ b/CondCore/Utilities/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/Concurrency"/>
 <use   name="boost"/>
+<use   name="boost_python"/>
 <use   name="boost_program_options"/>
 <use   name="CondCore/CondDB"/>
 <use   name="CondFormats/HLTObjects"/>

--- a/DetectorDescription/Parser/test/BuildFile.xml
+++ b/DetectorDescription/Parser/test/BuildFile.xml
@@ -6,9 +6,8 @@
 <bin name="testmat" file="testmat.cpp">
  <use name="DetectorDescription/Parser"/>
  <use name="FWCore/MessageLogger"/>
- <use name="FWCore/ParameterSet"/>
+ <use name="FWCore/ParameterSetReader"/>
  <use name="FWCore/PluginManager"/>
- <use name="FWCore/PythonParameterSet"/>
  <use name="FWCore/ServiceRegistry"/>
  <use name="FWCore/Utilities"/>
 </bin>

--- a/DetectorDescription/Parser/test/testmat.cpp
+++ b/DetectorDescription/Parser/test/testmat.cpp
@@ -7,6 +7,7 @@
 #include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "DetectorDescription/Parser/interface/DDLElementRegistry.h"
 #include "DetectorDescription/Parser/src/DDLElementaryMaterial.h"
+#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 #include "FWCore/PluginManager/interface/PresenceFactory.h"
 #include "FWCore/PluginManager/interface/ProblemTracker.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
@@ -55,7 +56,10 @@ int main(int argc, char *argv[])
       "process.e = cms.EndPath(process.out)\n";
 
     // D.  Create the services.
-    edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(config));
+    std::unique_ptr<edm::ParameterSet> params;
+    edm::makeParameterSets(config, params);
+    edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
+
 
 
     // E.  Make the services available.

--- a/DetectorDescription/RegressionTest/test/BuildFile.xml
+++ b/DetectorDescription/RegressionTest/test/BuildFile.xml
@@ -3,9 +3,8 @@
   <use name="DetectorDescription/Parser"/>
   <use name="DetectorDescription/RegressionTest"/>
   <use name="FWCore/MessageLogger"/>
-  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ParameterSetReader"/>
   <use name="FWCore/PluginManager"/>
-  <use name="FWCore/PythonParameterSet"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Utilities"/>
 </bin>
@@ -14,9 +13,8 @@
   <use name="DetectorDescription/Parser"/>
   <use name="DetectorDescription/RegressionTest"/>
   <use name="FWCore/MessageLogger"/>
-  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ParameterSetReader"/>
   <use name="FWCore/PluginManager"/>
-  <use name="FWCore/PythonParameterSet"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Utilities"/>
   <use name="Utilities/Xerces"/>
@@ -26,9 +24,8 @@
   <use name="DetectorDescription/Parser"/>
   <use name="DetectorDescription/RegressionTest"/>
   <use name="FWCore/MessageLogger"/>
-  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ParameterSetReader"/>
   <use name="FWCore/PluginManager"/>
-  <use name="FWCore/PythonParameterSet"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Utilities"/>
 </bin>
@@ -42,9 +39,8 @@
   <use name="DetectorDescription/Parser"/>
   <use name="DetectorDescription/RegressionTest"/>
   <use name="FWCore/MessageLogger"/>
-  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ParameterSetReader"/>
   <use name="FWCore/PluginManager"/>
-  <use name="FWCore/PythonParameterSet"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Utilities"/>
 </bin>
@@ -129,8 +125,6 @@
  <use name="FWCore/Framework"/>
  <use name="FWCore/Utilities"/>
  <use name="FWCore/PluginManager"/>
- <use name="FWCore/ParameterSet"/>
- <use name="FWCore/PythonParameterSet"/>
  <use name="FWCore/ServiceRegistry"/>
  <use name="FWCore/MessageLogger"/>
 </bin>

--- a/DetectorDescription/RegressionTest/test/dumpDDCompactView.cpp
+++ b/DetectorDescription/RegressionTest/test/dumpDDCompactView.cpp
@@ -13,6 +13,7 @@
 #include "DetectorDescription/Core/src/Material.h"
 #include "DetectorDescription/Parser/interface/DDLParser.h"
 #include "DetectorDescription/Parser/interface/FIPConfiguration.h"
+#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 #include "FWCore/PluginManager/interface/PresenceFactory.h"
 #include "FWCore/PluginManager/interface/ProblemTracker.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
@@ -63,7 +64,10 @@ int main(int argc, char *argv[])
       "process.e = cms.EndPath(process.out)\n";
 
     // D.  Create the services.
-    edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(config));
+    std::unique_ptr<edm::ParameterSet> params;
+    edm::makeParameterSets(config, params);
+    edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
+
 
     // E.  Make the services available.
     edm::ServiceRegistry::Operate operate(tempToken);

--- a/DetectorDescription/RegressionTest/test/dumpDDExpandedView.cpp
+++ b/DetectorDescription/RegressionTest/test/dumpDDExpandedView.cpp
@@ -10,6 +10,7 @@
 #include "DetectorDescription/Core/src/Material.h"
 #include "DetectorDescription/Parser/interface/DDLParser.h"
 #include "DetectorDescription/Parser/interface/FIPConfiguration.h"
+#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 #include "FWCore/PluginManager/interface/PresenceFactory.h"
 #include "FWCore/PluginManager/interface/ProblemTracker.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
@@ -59,7 +60,9 @@ int main(int argc, char *argv[])
       "process.e = cms.EndPath(process.out)\n";
 
     // D.  Create the services.
-    edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(config));
+    std::unique_ptr<edm::ParameterSet> params;
+    edm::makeParameterSets(config, params);
+    edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
 
     // E.  Make the services available.
     edm::ServiceRegistry::Operate operate(tempToken);

--- a/DetectorDescription/RegressionTest/test/testDDCompactView.cpp
+++ b/DetectorDescription/RegressionTest/test/testDDCompactView.cpp
@@ -11,6 +11,7 @@
 #include "DetectorDescription/RegressionTest/src/DDCheck.h"
 #include "DetectorDescription/Parser/interface/DDLParser.h"
 #include "DetectorDescription/Parser/interface/FIPConfiguration.h"
+#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 #include "FWCore/PluginManager/interface/PresenceFactory.h"
 #include "FWCore/PluginManager/interface/ProblemTracker.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
@@ -59,7 +60,9 @@ int main(int argc, char *argv[])
       "process.e = cms.EndPath(process.out)\n";
 
     // D.  Create the services.
-    edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(config));
+    std::unique_ptr<edm::ParameterSet> params;
+    edm::makeParameterSets(config, params);
+    edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
 
     // E.  Make the services available.
     edm::ServiceRegistry::Operate operate(tempToken);

--- a/FWCore/Catalog/test/BuildFile.xml
+++ b/FWCore/Catalog/test/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="FWCore/Catalog"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ServiceRegistry"/>
+<use   name="FWCore/ParameterSetReader"/>
 <bin   name="edmCatalogFileLocator_t" file="FileLocator_t.cpp">
 </bin>

--- a/FWCore/Catalog/test/FileLocator_t.cpp
+++ b/FWCore/Catalog/test/FileLocator_t.cpp
@@ -3,6 +3,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 #include <boost/filesystem.hpp>
 #include <iostream>
 
@@ -18,7 +19,9 @@ int main() {
       "process.SiteLocalConfigService = cms.Service('SiteLocalConfigService')\n";
 
     //create the services
-    edm::ServiceToken tempToken = edm::ServiceRegistry::createServicesFromConfig(config);
+    std::unique_ptr<edm::ParameterSet> params;
+    edm::makeParameterSets(config, params);
+    edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
 
     //make the services available
     edm::ServiceRegistry::Operate operate(tempToken);

--- a/FWCore/MessageService/bin/BuildFile.xml
+++ b/FWCore/MessageService/bin/BuildFile.xml
@@ -2,7 +2,7 @@
   <use   name="boost"/>
   <use   name="boost_program_options"/>
   <use   name="FWCore/MessageLogger"/>
-  <use   name="FWCore/PythonParameterSet"/>
+  <use   name="FWCore/ParameterSetReader"/>
   <use   name="FWCore/PluginManager"/>
   <use   name="FWCore/ServiceRegistry"/>
   <use   name="FWCore/Utilities"/>

--- a/FWCore/MessageService/bin/Standalone.cpp
+++ b/FWCore/MessageService/bin/Standalone.cpp
@@ -18,6 +18,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/PluginManager/interface/ProblemTracker.h"
 #include "FWCore/Utilities/interface/Presence.h"
+#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 #include "FWCore/PluginManager/interface/PresenceFactory.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
@@ -101,7 +102,10 @@ int main(int, char* argv[]) {
       "}";
 
 // D.  Create the services.
-    edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(config));
+    std::unique_ptr<edm::ParameterSet> params;
+    edm::makeParameterSets(config, params);
+    edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
+    
 
 // E.  Make the services available.
     edm::ServiceRegistry::Operate operate(tempToken);

--- a/FWCore/PythonFramework/test/BuildFile.xml
+++ b/FWCore/PythonFramework/test/BuildFile.xml
@@ -7,5 +7,6 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/Framework"/>
   <use name="boost"/>
+  <use   name="boost_python"/>
 </library>
 

--- a/FWCore/ServiceRegistry/BuildFile.xml
+++ b/FWCore/ServiceRegistry/BuildFile.xml
@@ -1,7 +1,6 @@
 <use   name="DataFormats/Provenance"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PluginManager"/>
-<use   name="FWCore/ParameterSetReader"/>
 <use   name="FWCore/Utilities"/>
 <export>
   <lib   name="1"/>

--- a/FWCore/ServiceRegistry/interface/ServiceRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ServiceRegistry.h
@@ -87,7 +87,7 @@ namespace edm {
 
       // ---------- member functions ---------------------------
 
-      static ServiceToken createServicesFromConfig(std::string const& config);
+      static ServiceToken createServicesFromConfig(std::unique_ptr<ParameterSet> params);
 
    public: // Made public (temporarily) at the request of Emilio Meschi.
       static ServiceToken createSet(std::vector<ParameterSet>&);

--- a/FWCore/ServiceRegistry/src/ServiceRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ServiceRegistry.cc
@@ -12,7 +12,6 @@
 
 // user include files
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
-#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 
 // system include files
 
@@ -77,9 +76,7 @@ namespace edm {
    //
 
    ServiceToken
-   ServiceRegistry::createServicesFromConfig(std::string const& config) {
-      std::unique_ptr<ParameterSet> params;
-      makeParameterSets(config, params);
+   ServiceRegistry::createServicesFromConfig(std::unique_ptr<ParameterSet> params) {
 
       auto serviceSets = params->popVParameterSet(std::string("services"));
       //create the services

--- a/Fireworks/FWInterface/BuildFile.xml
+++ b/Fireworks/FWInterface/BuildFile.xml
@@ -15,8 +15,8 @@
 <lib name="RGL"/>
 <lib name="GuiHtml"/>
 <lib name="GX11"/>
-<lib name="boost_python"/>
-<lib name="FWCore/PythonParameterSet"/>
+<use name="boost_python"/>
+<use name="FWCore/PythonParameterSet"/>
 <export>
 <lib name="1"/>
 </export>

--- a/Fireworks/FWInterface/BuildFile.xml
+++ b/Fireworks/FWInterface/BuildFile.xml
@@ -15,6 +15,8 @@
 <lib name="RGL"/>
 <lib name="GuiHtml"/>
 <lib name="GX11"/>
+<lib name="boost_python"/>
+<lib name="FWCore/PythonParameterSet"/>
 <export>
 <lib name="1"/>
 </export>

--- a/PhysicsTools/UtilAlgos/bin/BuildFile.xml
+++ b/PhysicsTools/UtilAlgos/bin/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="boost_program_options"/>
 <use   name="PhysicsTools/FWLite"/>
 <use   name="PhysicsTools/UtilAlgos"/>
+<use   name="FWCore/ParameterSetReader"/>
 
 <environment>
   <bin   file="FWLiteWithBasicAnalyzer.cc"></bin>


### PR DESCRIPTION
#### PR description:

Remove direct dependency on PythonParameterSet from FWCore/SerivceRegistry
(affects tests/binaries only - but cascades into build files)

Motivation is to remove libFWCoreParameterSetReader dependency from libFWCoreServiceRegistry

#### PR validation:

compiles ok - just code rearrangement.

