### PR TITLE
Switching HCAL Run3 MC to DB conditions

### DIFF
--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -220,6 +220,8 @@ from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
 from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 
 run2_HCAL_2017.toModify( es_hardcode, useLayer0Weight = cms.bool(True), useIeta18depth1 = cms.bool(False) )
 run2_HF_2017.toModify( es_hardcode, useHFUpgrade = cms.bool(True) )
@@ -228,9 +230,6 @@ run2_HEPlan1_2017.toModify( es_hardcode, testHEPlan1 = cms.bool(True), useHEUpgr
 
 run2_HCAL_2018.toModify( es_hardcode, useLayer0Weight = cms.bool(True), useIeta18depth1 = cms.bool(False) )
 run3_HB.toModify( es_hardcode, useHBUpgrade = cms.bool(True), HBreCalibCutoff = cms.double(100.0) )
-# now that we have an emap
-run3_HB.toModify( es_hardcode, toGet = cms.untracked.vstring(_toGet_noEmap),  )
 
-from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+phase2_hcal.toModify( es_hardcode, toGet = cms.untracked.vstring(_toGet_noEmap)) 
 phase2_hgcal.toModify( es_hardcode, killHE = cms.bool(True) )
-                            

--- a/Configuration/Eras/python/Era_Phase2_cff.py
+++ b/Configuration/Eras/python/Era_Phase2_cff.py
@@ -10,5 +10,7 @@ from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
 
-Phase2 = cms.ModifierChain(Run3.copyAndExclude([phase1Pixel,trackingPhase1]), phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon)
+
+Phase2 = cms.ModifierChain(Run3.copyAndExclude([phase1Pixel,trackingPhase1]), phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon, hcalHardcodeConditions)

--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -5,7 +5,6 @@ from Configuration.Eras.Modifier_run3_common_cff import run3_common
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
-from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
 
-Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB, hcalHardcodeConditions)
+Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB)
 


### PR DESCRIPTION
#### PR description:

Switching from hardcode HCAL Run3 MC conditions to updated DB conditions available since 10_6_0_pre1 from  PR https://github.com/cms-sw/cmssw/pull/26049

Namely: 
'phase1_2019_design' : '105X_postLS2_design_v4'
'phase1_2019_realistic' : '105X_postLS2_realistic_v6'
with updated 2019 HCAL tags:
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4089.html
-> 
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/105X_postLS2_realistic_v6 

#### PR validation:

(1) Regulal runTheMatrix tests are OK in CMSSW_10_6_X_2019-03-10-2300

(2) Private Run3 single-pion gun test with DB conditions (wrt 2018) looks OK,
with expected difference in HB (Run3 Phase1 vs 2018 Phase0) to be calibrated out with IsoTrack samples in the near future
https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/10_X/10_5_0_pre1_2019_newGT_vs_10_5_0_pre1_2018_SinglePi/
