### PR TITLE
Update VtxSmearingScenario for 10_6_X MC production - Round Optics

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -59,6 +59,8 @@ VtxSmeared = {
     'Realistic25ns13TeVEarly2017Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVEarly2017Collision_cfi',
     'Realistic25ns13TeVEarly2018Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVEarly2018Collision_cfi',
     'RealisticPbPbCollision2018' : 'IOMC.EventVertexGenerators.VtxSmearedRealisticPbPbCollision2018_cfi',
+    'Run3RoundOptics25ns13TeVLowSigmaZ'  : 'IOMC.EventVertexGenerators.VtxSmearedRun3RoundOptics25ns13TeVLowSigmaZ_cfi',
+    'Run3RoundOptics25ns13TeVHighSigmaZ' : 'IOMC.EventVertexGenerators.VtxSmearedRun3RoundOptics25ns13TeVHighSigmaZ_cfi',
 }
 VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
 VtxSmearedHIDefaultKey='RealisticPbPbCollision2018'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -622,6 +622,74 @@ Realistic25ns13TeVEarly2018CollisionVtxSmearingParameters = cms.PSet(
     Z0 = cms.double(0.035748 )
 )
 
+# Run3 possible beam parameters
+# Round optics - Low SigmaZ = 3.4 cm
+# From 2018B 3.8T data
+# BS parameters extracted from run 316199, fill 6675 (from StreamExpressAlignment, HP BS):
+# X0         =  0.09676  [cm]
+# Y0         = -0.06245  [cm]
+# Z0         = -0.292    [cm]
+# sigmaZ0    =  3.2676   [cm]
+# BeamWidthX 0.0008050
+# BeamWidthY 0.0006238
+#
+# set SigmaZ0 = 3.4 [cm]
+# set BeamWidthX = BeamWidthY = 11.5 [um]
+# set beta* = 28 cm
+# energy = 13 TeV
+# From LHC calculator, emittance is 4.762e-8 cm
+# https://lpc.web.cern.ch/lpc/lumi2.html
+#
+# BPIX absolute position (from https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod):
+# X = 0.0859918 cm
+# Y = -0.104172 cm
+# Z = -0.327748 cm
+Run3RoundOptics25ns13TeVLowSigmaZVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(28.0),
+    Emittance = cms.double(4.762e-8),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(3.4),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.0107682),
+    Y0 = cms.double(0.041722 ),
+    Z0 = cms.double(0.035748 )
+)
+
+# Run3 possible beam parameters
+# Round optics - High SigmaZ = 5.7 cm
+# From 2018B 3.8T data
+# BS parameters extracted from run 316199, fill 6675 (from StreamExpressAlignment, HP BS):
+# X0         =  0.09676  [cm]
+# Y0         = -0.06245  [cm]
+# Z0         = -0.292    [cm]
+# sigmaZ0    =  3.2676   [cm]
+# BeamWidthX 0.0008050
+# BeamWidthY 0.0006238
+#
+# set SigmaZ0 = 5.7 [cm]
+# set BeamWidthX = BeamWidthY = 11.5 [um]
+# set beta* = 28 cm
+# energy = 13 TeV
+# From LHC calculator, emittance is 4.762e-8 cm
+# https://lpc.web.cern.ch/lpc/lumi2.html
+#
+# BPIX absolute position (from https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod):
+# X = 0.0859918 cm
+# Y = -0.104172 cm
+# Z = -0.327748 cm
+Run3RoundOptics25ns13TeVHighSigmaZVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(28.0),
+    Emittance = cms.double(4.762e-8),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(5.7),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.0107682),
+    Y0 = cms.double(0.041722 ),
+    Z0 = cms.double(0.035748 )
+)
+
 # Test HF offset
 ShiftedCollision2015VtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRun3RoundOptics25ns13TeVHighSigmaZ_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRun3RoundOptics25ns13TeVHighSigmaZ_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Run3RoundOptics25ns13TeVHighSigmaZVtxSmearingParameters,
+    VtxSmearedCommon
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRun3RoundOptics25ns13TeVLowSigmaZ_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRun3RoundOptics25ns13TeVLowSigmaZ_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Run3RoundOptics25ns13TeVLowSigmaZVtxSmearingParameters,
+    VtxSmearedCommon
+)


### PR DESCRIPTION
Update the VtxSmearingScenario parameters for 10_6_X MC production.
Two different configurations are created to test the possible beamspot conditions during Run3 using round optics.
The same BeamSpot (run 316199, fill 6675) and Barycenter (from Payload Inspector https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod ) positions are used in both configurations.
The two configurations only differ by the sigmaZ:
1) LowSigmaZ --> sigmaZ = 3.4 cm
2) HighSigmaZ --> sigma> = 5.7 cm