### PR TITLE
Remove unused var in MuonAnalysis/MuonAssociators

### DIFF
--- a/MuonAnalysis/MuonAssociators/plugins/TriggerMatcherToHLTDebug.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/TriggerMatcherToHLTDebug.cc
@@ -245,7 +245,6 @@ void TriggerMatcherToHLTDebug::produce(Event &event, const EventSetup &eventSetu
     double etaTk = stateAtMB2.globalPosition().eta();
     double phiTk = stateAtMB2.globalPosition().phi();
     l1extra::L1MuonParticleCollection::const_iterator it;
-    vector<l1extra::L1MuonParticleRef>::const_iterator itMu3;
     L2MuonTrajectorySeedCollection::const_iterator iSeed;
     L3MuonTrajectorySeedCollection::const_iterator iSeedL3;
     RecoChargedCandidateCollection::const_iterator iL2Muon;


### PR DESCRIPTION
Fixes unused var reported in CLANG IBs 