### PR TITLE
bypassVersionCheck should not apply to DQMRootSource

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -27,6 +27,7 @@ def mergeProcess(*inputFiles, **options):
     - newDQMIO : specifies if the new DQM format should be used to merge the files
     - output_file : sets the output file name
     - output_lfn : sets the output LFN
+    - mergeNANO : to merge NanoAOD
     - bypassVersionCheck : to bypass version check in case merging happened in lower version of CMSSW (i.e. UL HLT case). This will be TRUE by default.
 
     """
@@ -54,6 +55,7 @@ def mergeProcess(*inputFiles, **options):
         process.add_(Service("DQMStore"))
     else:
         process.source = Source("PoolSource")
+        process.source.bypassVersionCheck = CfgTypes.untracked.bool(bypassVersionCheck)
         if dropDQM:
             process.source.inputCommands = CfgTypes.untracked.vstring('keep *','drop *_EDMtoMEConverter_*_*')
     process.source.fileNames = CfgTypes.untracked(CfgTypes.vstring())
@@ -71,9 +73,6 @@ def mergeProcess(*inputFiles, **options):
         process.add_(Service("InitRootHandlers", EnableIMT = CfgTypes.untracked.bool(False)))
     else:
         outMod = OutputModule("PoolOutputModule")
-
-    # To bypass the version check in the merge process (TRUE by default)
-    process.source.bypassVersionCheck = CfgTypes.untracked.bool(bypassVersionCheck)
 
     outMod.fileName = CfgTypes.untracked.string(outputFilename)
     if outputLFN != None:


### PR DESCRIPTION
This is a PR to fix again bypassVersion check which should not apply to DQMRootSource

Try with

> python RunMerge.py --input-files 'file:step3_inDQM.root','file:step3_inDQM_2.root' --dqmroot

The merge config file is dumped properly
> process.source = cms.Source("DQMRootSource",
>     fileNames = cms.untracked.vstring("[\'file:step3_inDQM.root\', \'file:step3_inDQM_2.root\']")
> )
> process.Merged = cms.OutputModule("DQMRootOutputModule",
>     fileName = cms.untracked.string('Merged.root')
> )

@prebello @pgunnell @zhenhu @franzoni 