### PR TITLE
[94X] bypassVersionCheck should not apply to DQMRootSource

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -27,6 +27,7 @@ def mergeProcess(*inputFiles, **options):
     - newDQMIO : specifies if the new DQM format should be used to merge the files
     - output_file : sets the output file name
     - output_lfn : sets the output LFN
+    - mergeNANO : to merge NanoAOD
     - bypassVersionCheck : to bypass version check in case merging happened in lower version of CMSSW (i.e. UL HLT case). This will be TRUE by default.
 
     """
@@ -54,6 +55,7 @@ def mergeProcess(*inputFiles, **options):
         process.add_(Service("DQMStore"))
     else:
         process.source = Source("PoolSource")
+        process.source.bypassVersionCheck = CfgTypes.untracked.bool(bypassVersionCheck)
         if dropDQM:
             process.source.inputCommands = CfgTypes.untracked.vstring('keep *','drop *_EDMtoMEConverter_*_*')
     process.source.fileNames = CfgTypes.untracked(CfgTypes.vstring())
@@ -70,9 +72,6 @@ def mergeProcess(*inputFiles, **options):
         outMod = OutputModule("NanoAODOutputModule",Configuration.EventContent.EventContent_cff.NANOAODEventContent.clone())
     else:
         outMod = OutputModule("PoolOutputModule")
-
-    # To bypass the version check in the merge process (TRUE by default)
-    process.source.bypassVersionCheck = CfgTypes.untracked.bool(bypassVersionCheck)
 
     outMod.fileName = CfgTypes.untracked.string(outputFilename)
     if outputLFN != None:


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/26147
This is a bug-fix to not apply bypassVersionCheck to DQM in merge step.
