### PR TITLE
PPS pixel detector edges

### DIFF
--- a/Geometry/VeryForwardGeometry/interface/CTPPSPixelSimTopology.h
+++ b/Geometry/VeryForwardGeometry/interface/CTPPSPixelSimTopology.h
@@ -86,7 +86,7 @@ class CTPPSPixelSimTopology : public CTPPSPixelTopology
 
       // columns (y segmentation)
       if( acol == 0 ) {
-        lower_y = 50;
+        lower_y = 0.050;
         higher_y = 0.35;
       }
       else if ( acol <= 50 ) {

--- a/Geometry/VeryForwardGeometry/interface/CTPPSPixelSimTopology.h
+++ b/Geometry/VeryForwardGeometry/interface/CTPPSPixelSimTopology.h
@@ -86,7 +86,7 @@ class CTPPSPixelSimTopology : public CTPPSPixelTopology
 
       // columns (y segmentation)
       if( acol == 0 ) {
-        lower_y = 0.050;
+        lower_y = 0.05;
         higher_y = 0.35;
       }
       else if ( acol <= 50 ) {

--- a/Geometry/VeryForwardGeometry/interface/CTPPSPixelSimTopology.h
+++ b/Geometry/VeryForwardGeometry/interface/CTPPSPixelSimTopology.h
@@ -60,7 +60,7 @@ class CTPPSPixelSimTopology : public CTPPSPixelTopology
 
       // rows (x segmentation)
       if ( arow == 0 ) {
-        lower_x = 0;
+        lower_x = 0.05;
         higher_x = 0.3;
       }
       else if ( arow <= 78 ) {
@@ -81,12 +81,12 @@ class CTPPSPixelSimTopology : public CTPPSPixelTopology
       }
       else if ( arow == 159) {
         lower_x =  0.3 + ( arow+1 )*pitch_simX_;
-        higher_x = 0.3 + ( arow+4 )*pitch_simX_;
+        higher_x = 0.3 + ( arow+2 )*pitch_simX_ + 0.15;
       }
 
       // columns (y segmentation)
       if( acol == 0 ) {
-        lower_y = 0;
+        lower_y = 50;
         higher_y = 0.35;
       }
       else if ( acol <= 50 ) {
@@ -119,7 +119,7 @@ class CTPPSPixelSimTopology : public CTPPSPixelTopology
       }
       else if ( acol == 155 ) {
         lower_y =  0.35 + ( acol+3 )*pitch_simY_;
-        higher_y = 0.35 + ( acol+4 )*pitch_simY_ + 0.2;
+        higher_y = 0.35 + ( acol+4 )*pitch_simY_ + 0.15;
       }
 
       lower_x = lower_x - simX_width_/2.;

--- a/Geometry/VeryForwardGeometry/interface/CTPPSPixelSimTopology.h
+++ b/Geometry/VeryForwardGeometry/interface/CTPPSPixelSimTopology.h
@@ -60,66 +60,66 @@ class CTPPSPixelSimTopology : public CTPPSPixelTopology
 
       // rows (x segmentation)
       if ( arow == 0 ) {
-        lower_x = 0.05;
-        higher_x = 0.3;
+        lower_x = dead_edge_width_ - phys_active_edge_dist_; // 50 um
+        higher_x = dead_edge_width_ + pitch_simX_; // 300 um
       }
       else if ( arow <= 78 ) {
-        lower_x =  0.3 + ( arow-1 )*pitch_simX_;
-        higher_x = 0.3 +   arow    *pitch_simX_;
+        lower_x =  dead_edge_width_ + arow*pitch_simX_;
+        higher_x = dead_edge_width_ +   ( arow+1 )*pitch_simX_;
       }
       else if ( arow == 79 ) {
-        lower_x =  0.3 + ( arow-1 )*pitch_simX_;
-        higher_x = 0.3 + ( arow+1 )*pitch_simX_;
+        lower_x =  dead_edge_width_ + arow*pitch_simX_;
+        higher_x = dead_edge_width_ + ( arow+2 )*pitch_simX_;
       }
       else if ( arow == 80 ) {
-        lower_x =  0.3 +   arow    *pitch_simX_;
-        higher_x = 0.3 + ( arow+2 )*pitch_simX_;
+        lower_x =  dead_edge_width_ + ( arow+1 )*pitch_simX_;
+        higher_x = dead_edge_width_ + ( arow+3 )*pitch_simX_;
       }
       else if ( arow <= 158 ) {
-        lower_x =  0.3 + ( arow+1 )*pitch_simX_;
-        higher_x = 0.3 + ( arow+2 )*pitch_simX_;
+        lower_x =  dead_edge_width_ + ( arow+2 )*pitch_simX_;
+        higher_x = dead_edge_width_ + ( arow+3 )*pitch_simX_;
       }
       else if ( arow == 159) {
-        lower_x =  0.3 + ( arow+1 )*pitch_simX_;
-        higher_x = 0.3 + ( arow+2 )*pitch_simX_ + 0.15;
+        lower_x =  dead_edge_width_ + ( arow+2 )*pitch_simX_;
+        higher_x = dead_edge_width_ + ( arow+3 )*pitch_simX_ + phys_active_edge_dist_ ;
       }
 
       // columns (y segmentation)
       if( acol == 0 ) {
-        lower_y = 0.05;
-        higher_y = 0.35;
+        lower_y = dead_edge_width_ - phys_active_edge_dist_; // 50 um
+        higher_y = dead_edge_width_ + pitch_simY_; // 350 um
       }
       else if ( acol <= 50 ) {
-        lower_y =  0.35 + ( acol-1 )*pitch_simY_;
-        higher_y = 0.35 +   acol    *pitch_simY_;
+        lower_y =  dead_edge_width_ + acol*pitch_simY_;
+        higher_y = dead_edge_width_ +  ( acol+1 )*pitch_simY_;
       }
       else if ( acol == 51 ) {
-        lower_y =  0.35 + ( acol-1 )*pitch_simY_;
-        higher_y = 0.35 + ( acol+1 )*pitch_simY_;
+        lower_y =  dead_edge_width_ + acol*pitch_simY_;
+        higher_y = dead_edge_width_ + ( acol+2 )*pitch_simY_;
       }
       else if ( acol == 52 ) {
-        lower_y =  0.35 +   acol    *pitch_simY_;
-        higher_y = 0.35 + ( acol+2 )*pitch_simY_;
+        lower_y =  dead_edge_width_ + ( acol+1 )*pitch_simY_;
+        higher_y = dead_edge_width_ + ( acol+3 )*pitch_simY_;
       }
       else if ( acol <= 102 ) {
-        lower_y =  0.35 + ( acol+1 )*pitch_simY_;
-        higher_y = 0.35 + ( acol+2 )*pitch_simY_;
+        lower_y =  dead_edge_width_ + ( acol+2 )*pitch_simY_;
+        higher_y = dead_edge_width_ + ( acol+3 )*pitch_simY_;
       }
       else if ( acol == 103 ) {
-        lower_y =  0.35 + ( acol+1 )*pitch_simY_;
-        higher_y = 0.35 + ( acol+3 )*pitch_simY_;
+        lower_y =  dead_edge_width_ + ( acol+2 )*pitch_simY_;
+        higher_y = dead_edge_width_ + ( acol+4 )*pitch_simY_;
       }
       else if ( acol == 104) {
-        lower_y =  0.35 + ( acol+2 )*pitch_simY_;
-        higher_y = 0.35 + ( acol+4 )*pitch_simY_;
+        lower_y =  dead_edge_width_ + ( acol+3 )*pitch_simY_;
+        higher_y = dead_edge_width_ + ( acol+5 )*pitch_simY_;
       }
       else if ( acol <= 154 ) {
-        lower_y =  0.35 + ( acol+3 )*pitch_simY_;
-        higher_y = 0.35 + ( acol+4 )*pitch_simY_;
+        lower_y =  dead_edge_width_ + ( acol+4 )*pitch_simY_;
+        higher_y = dead_edge_width_ + ( acol+5 )*pitch_simY_;
       }
       else if ( acol == 155 ) {
-        lower_y =  0.35 + ( acol+3 )*pitch_simY_;
-        higher_y = 0.35 + ( acol+4 )*pitch_simY_ + 0.15;
+        lower_y =  dead_edge_width_ + ( acol+4 )*pitch_simY_;
+        higher_y = dead_edge_width_ + ( acol+5 )*pitch_simY_ + phys_active_edge_dist_ ;
       }
 
       lower_x = lower_x - simX_width_/2.;

--- a/Geometry/VeryForwardGeometry/interface/CTPPSPixelTopology.h
+++ b/Geometry/VeryForwardGeometry/interface/CTPPSPixelTopology.h
@@ -38,6 +38,24 @@ class CTPPSPixelTopology
     inline double activeEdgeSigma() const { return active_edge_sigma_; }
     inline double physActiveEdgeDist() const { return phys_active_edge_dist_; }
 
+
+    static bool isPixelHit(float xLocalCoordinate, float yLocalCoordinate, bool is3x2 = true)
+    {
+      float tmpXlocalCoordinate = xLocalCoordinate + (79*0.1 + 0.2);
+      float tmpYlocalCoordinate = yLocalCoordinate + (0.15*51 + 0.3*2 + 0.15*25);
+
+      if(tmpXlocalCoordinate<0) return false;
+      if(tmpYlocalCoordinate<0) return false;
+      int xModuleSize = 0.1*79 + 0.2*2 + 0.1*79; // mm - 100 um pitch direction
+      int yModuleSize; // mm - 150 um pitch direction
+      if (is3x2) yModuleSize = 0.15*51 + 0.3*2 + 0.15*50 + 0.3*2 + 0.15*51;
+      else       yModuleSize = 0.15*51 + 0.3*2 + 0.15*51;
+      if(tmpXlocalCoordinate>xModuleSize) return false;
+      if(tmpYlocalCoordinate>yModuleSize) return false;
+      return true;
+    }
+    
+
     CTPPSPixelIndices indices_;
 };
 

--- a/Geometry/VeryForwardGeometry/interface/CTPPSPixelTopology.h
+++ b/Geometry/VeryForwardGeometry/interface/CTPPSPixelTopology.h
@@ -41,21 +41,23 @@ class CTPPSPixelTopology
 
     static bool isPixelHit(float xLocalCoordinate, float yLocalCoordinate, bool is3x2 = true)
     {
-      float tmpXlocalCoordinate = xLocalCoordinate + (79*0.1 + 0.2);
-      float tmpYlocalCoordinate = yLocalCoordinate + (0.15*51 + 0.3*2 + 0.15*25);
-
-      if(tmpXlocalCoordinate<0) return false;
-      if(tmpYlocalCoordinate<0) return false;
-      int xModuleSize = 0.1*79 + 0.2*2 + 0.1*79; // mm - 100 um pitch direction
-      int yModuleSize; // mm - 150 um pitch direction
-      if (is3x2) yModuleSize = 0.15*51 + 0.3*2 + 0.15*50 + 0.3*2 + 0.15*51;
-      else       yModuleSize = 0.15*51 + 0.3*2 + 0.15*51;
-      if(tmpXlocalCoordinate>xModuleSize) return false;
-      if(tmpYlocalCoordinate>yModuleSize) return false;
+// check hit fiducial boundaries
+      double xModuleSize = 2*((no_of_pixels_simX_/2. + 1)*pitch_simX_ + dead_edge_width_);
+      if(xLocalCoordinate < -xModuleSize/2. || xLocalCoordinate > xModuleSize/2.)
+	return false;
+      
+      double yModuleSize = (no_of_pixels_simY_ + 4.)*pitch_simY_ + 2.*dead_edge_width_;
+      double y2x2top = no_of_pixels_simY_/6.*pitch_simY_ + dead_edge_width_;
+      if(is3x2 && (yLocalCoordinate < -yModuleSize/2. || yLocalCoordinate > yModuleSize/2.))
+	return false;
+      
+      if(!is3x2 && (yLocalCoordinate < -yModuleSize/2. || yLocalCoordinate > y2x2top))
+	return false;
+         
       return true;
+      
     }
     
-
     CTPPSPixelIndices indices_;
 };
 


### PR DESCRIPTION
#### PR description:
This PR reduces the sensitive dimension of the pixel detector at the edges by 50um.
It also introduce a bool method (isPixelHit) to check if x,y coordinates belong to the pixel detector area.

#### PR validation:
The new code has been privately tested over a set of ZeroBias events.
Only very minimal changes expected in the output of the reconstruction. 

