### PR TITLE
Fix a conflict with UpgradeProperties

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3180,7 +3180,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
     for step in upgradeSteps['ParkingBPH']['steps']:
         stepName = step + upgradeSteps['ParkingBPH']['suffix']
-        if 'Reco' in step and upgradeStepDict[step][k]['--era']=='Run2_2018':
+        if 'Reco' in step and 'Run2_2018' in upgradeStepDict[step][k]['--era']:
             upgradeStepDict[stepName][k] = merge([{'--era': 'Run2_2018,bParking'}, upgradeStepDict[step][k]])
 
     # setup PU


### PR DESCRIPTION
#### PR description:

To avoid the conflict between the code in relval_steps.py and the Era/UpgradeProperties definition in upgradeWorkflowComponents.py. Attaching additional term to the Era definition in UpgradeProperties should not generate an error in the tests with this PR. 