### PR TITLE
Remove FWCore/Framework dependency from AssociativeIterator

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
@@ -276,7 +276,8 @@ void PATTriggerEventProducer::produce( Event& iEvent, const EventSetup& iSetup )
         LogError( "triggerMatchValid" ) << "pat::TriggerObjectStandAloneMatch product with InputTag '" << labelTriggerObjectMatcher << "' not in event";
         continue;
       }
-      AssociativeIterator< reco::CandidateBaseRef, TriggerObjectStandAloneMatch > it( *handleTriggerObjectStandAloneMatch, EdmEventItemGetter< reco::CandidateBaseRef >( iEvent ) ), itEnd( it.end() );
+      auto it = makeAssociativeIterator< reco::CandidateBaseRef>( *handleTriggerObjectStandAloneMatch, iEvent );
+      auto itEnd =  it.end();
       Handle< reco::CandidateView > handleCands;
       if ( it != itEnd ) iEvent.get( it->first.id(), handleCands );
       std::vector< int > indices;

--- a/PhysicsTools/PatUtils/src/TriggerHelper.cc
+++ b/PhysicsTools/PatUtils/src/TriggerHelper.cc
@@ -21,7 +21,8 @@ using namespace pat::helper;
 TriggerObjectRef TriggerMatchHelper::triggerMatchObject( const reco::CandidateBaseRef & candRef, const TriggerObjectMatch * matchResult, const edm::Event & event, const TriggerEvent & triggerEvent ) const
 {
   if ( matchResult ) {
-    edm::AssociativeIterator< reco::CandidateBaseRef, TriggerObjectMatch > it( *matchResult, edm::EdmEventItemGetter< reco::CandidateBaseRef >( event ) ), itEnd( it.end() );
+    auto it = edm::makeAssociativeIterator< reco::CandidateBaseRef>( *matchResult, event  );
+    auto itEnd =  it.end() ;
     while ( it != itEnd ) {
       if ( it->first.isNonnull() && it->second.isNonnull() && it->second.isAvailable() ) {
         if ( it->first.id() == candRef.id() && it->first.key() == candRef.key() ) {
@@ -60,7 +61,8 @@ reco::CandidateBaseRefVector TriggerMatchHelper::triggerMatchCandidates( const T
 {
   reco::CandidateBaseRefVector theCands;
   if ( matchResult ) {
-    edm::AssociativeIterator< reco::CandidateBaseRef, TriggerObjectMatch > it( *matchResult, edm::EdmEventItemGetter< reco::CandidateBaseRef >( event ) ), itEnd( it.end() );
+    auto it = edm::makeAssociativeIterator< reco::CandidateBaseRef>( *matchResult, event );
+    auto itEnd = it.end() ;
     while ( it != itEnd ) {
       if ( it->first.isNonnull() && it->second.isNonnull() && it->second.isAvailable() ) {
         if ( it->second == objectRef ) {


### PR DESCRIPTION
#### PR description:

DataFormats/Common should not depend on FWCore/Framework, even just via a header file. Changed the direct dependency to instead be a template parameter. This also allows fwlite::Event to work with the class.
Created makeAssociativeIterator to make it easy to deduce the necessary template arguments for the class.

#### PR validation:

The code compiles.
