### PR TITLE
Fixed pt shift in the muon validation plots

### DIFF
--- a/Validation/RecoMuon/test/macro/new_PlotHelpers.C
+++ b/Validation/RecoMuon/test/macro/new_PlotHelpers.C
@@ -754,13 +754,18 @@ TH1* AddOverflow(TH1* h) {
   ++overflowCounter;
 
   TString  name = h->GetName();
-  Int_t    nx   = h->GetNbinsX()+1;
-  Double_t bw   = h->GetBinWidth(nx);
+  const Int_t nx = h->GetNbinsX();
   Double_t x1   = h->GetBinLowEdge(1);
-  Double_t x2   = h->GetBinLowEdge(nx) + bw;
-  
-  // Book a new histogram having an extra bin for overflows
-  TH1F* htmp = new TH1F(Form(name + "_overflow_%d", overflowCounter), "", nx, x1, x2);
+
+  Double_t xbins[nx+1];
+
+  //Loop necessary since some histograms are TH1 while some are TProfile and do not allow us to use the clone function (SetBinContent do not exists for TProfiles)
+  for (Int_t ibin=1; ibin<=nx+1; ibin++) {
+    Float_t xmin = h->GetBinLowEdge(ibin);
+    xbins[ibin-1] = xmin;
+  }
+
+  TH1F* htmp = new TH1F(Form(name + "_overflow_%d", overflowCounter), "", nx, xbins);
 
   // Fill the new histogram including the extra bin for overflows
   for (Int_t i=1; i<=nx; i++) {

--- a/Validation/RecoMuon/test/macro/new_TrackValHistoPublisher.C
+++ b/Validation/RecoMuon/test/macro/new_TrackValHistoPublisher.C
@@ -177,9 +177,9 @@ void new_TrackValHistoPublisher(const char* newFile="NEW_FILE",const char* refFi
     miny[3]=-0.0001;
     
     maxy[0]=1.09;
-    maxy[1]=0.;
+    maxy[1]=1.09;
     maxy[2]=1.09;
-    maxy[3]=0.;
+    maxy[3]=1.09;
     
     Plot4Histograms(newDir + "/eff_eta_phi",
 		    rdir, sdir, 
@@ -218,7 +218,7 @@ void new_TrackValHistoPublisher(const char* newFile="NEW_FILE",const char* refFi
     miny[3]= 0.;
 
     maxy[0]= 1.09;
-    maxy[1]= 0.;
+    maxy[1]= 1.09;
     maxy[2]= 0.;
     maxy[3]= 0.;
 

--- a/Validation/RecoMuon/test/new_userparams.py
+++ b/Validation/RecoMuon/test/new_userparams.py
@@ -23,8 +23,8 @@ Publish_rootfile=False
 # + Location of the AFS place where to put the PDFs
 WebRepository = '/eos/user/c/cmsmupog/www/Validation/'
 
-# User enabled to write in the afs area
-User='giovanni'
+# User enabled to write in the official repository
+User='cprieels'
 
 #
 # Information about the new release
@@ -34,28 +34,24 @@ NewParams = dict(
     Type='New',
     
     # Releases to compare
-    Release='CMSSW_10_1_0_pre1',
+    Release='CMSSW_10_5_0_pre2',
 
     # Conditions of the sample
-    #
-    #    FullSim in CMSSW_10_1_0_pre1 
-    Condition='100X_upgrade2018_realistic_v10',
-    #
-    #    FastSim in CMSSW_10_1_0_pre1
+    Condition='105X_upgrade2018_realistic_v2',
     #Condition='100X_mcRun2_asymptotic_v2',
 
     # 'no' if no pileup, otherwise set BX spacing
-    PileUp='25ns',
+    PileUp='no',
+    #PileUp='25ns',
     #PileUp='',      # for HeavyIons
-    #PileUp='no',
 
     Version='v1',
 
     Format='DQMIO',
 
     # If True use Fastsim, else use Fullsim
+    #FastSim=False,
     FastSim=False,
-    #FastSim=True,
 
     # for HeavyIons samples (few folders are not there) 
     HeavyIons=False,
@@ -91,7 +87,7 @@ RefParams = dict(
     # Type of parameters
     Type='Ref',
 
-    Release='CMSSW_10_0_0',
+    Release='CMSSW_10_5_0_pre1',
 
     # Conditions for Special RelVals in CMSSW_10_0_0
     #
@@ -100,8 +96,9 @@ RefParams = dict(
     #Condition='100X_upgrade2018_realistic_v6_mahiON', #standard RelVals (v1 and v2)
     #
     #    FullSim PU25ns in CMSSW_10_0_0
-    Condition='100X_upgrade2018_realistic_v6_muVal_resubwith4cores',
+    Condition='103X_upgrade2018_realistic_v8',
     #
+
     #    FastSim in CMSSW_10_0_0
     #Condition='100X_mcRun2_asymptotic_v2_muVal',
     #Condition='100X_mcRun2_asymptotic_v2', #standard RelVals (v1)
@@ -132,6 +129,7 @@ ValidateDQM  = True
 
 # For FullSim PU 25ns
 samples = ['RelValZMM_13', 'RelValTTbar_13']
+#samples = ['RelValTTbar_13']
 
 # For HeavyIons FullSim
 #samples = ['RelValZEEMM_13_HI']


### PR DESCRIPTION
#### PR description:

Fixed an issue where the x-axis values appeared shifted in some specific cases. Configuration file updated to match the latest validation performed (CMSSW_10_5_0_pre2).

#### PR validation:

Test validation ran with the new usersparam configuration file to make sure everything looks fine.