### PR TITLE
Replaced DQM histogram booking macro to regular methods inside IBooker

### DIFF
--- a/DQM/Physics/src/FSQDQM.cc
+++ b/DQM/Physics/src/FSQDQM.cc
@@ -143,12 +143,12 @@ FSQDQM::~FSQDQM()
    h_ntracks_transverse      = bei.book1D("h_ntracks_transverse",";h_ntracks_transverse",50,-0.5,49.5);
    h_ntracks_away      = bei.book1D("h_ntracks_away",";h_ntracks_away",50,-0.5,49.5);
    
-   h_leadingtrkpt_ntrk_away =bei.bookProfile("h_leadingtrkpt_ntrk_away","h_leadingtrkpt_ntrk_away",50,0,50,0,30," ");
-   h_leadingtrkpt_ntrk_towards =bei.bookProfile("h_leadingtrkpt_ntrk_towards","h_leadingtrkpt_ntrk_towards",50,0,50,0,30," ");
-   h_leadingtrkpt_ntrk_transverse =bei.bookProfile("h_leadingtrkpt_ntrk_transverse","h_leadingtrkpt_ntrk_transverse",50,0,50,0,30," ");
-   h_leadingtrkpt_ptsum_away =bei.bookProfile("h_leadingtrkpt_ptsum_away","h_leadingtrkpt_ptsum_away",50,0,50,0,30," ");
-   h_leadingtrkpt_ptsum_towards =bei.bookProfile("h_leadingtrkpt_ptsum_towards","h_leadingtrkpt_ptsum_towards",50,0,50,0,30," ");
-   h_leadingtrkpt_ptsum_transverse =bei.bookProfile("h_leadingtrkpt_ptsum_transverse","h_leadingtrkpt_ptsum_transverse",50,0,50,0,30," ");
+   h_leadingtrkpt_ntrk_away =bei.bookProfile("h_leadingtrkpt_ntrk_away","h_leadingtrkpt_ntrk_away",50,0.0,50,0,30," ");
+   h_leadingtrkpt_ntrk_towards =bei.bookProfile("h_leadingtrkpt_ntrk_towards","h_leadingtrkpt_ntrk_towards",50,0.0,50,0,30," ");
+   h_leadingtrkpt_ntrk_transverse =bei.bookProfile("h_leadingtrkpt_ntrk_transverse","h_leadingtrkpt_ntrk_transverse",50,0.0,50,0,30," ");
+   h_leadingtrkpt_ptsum_away =bei.bookProfile("h_leadingtrkpt_ptsum_away","h_leadingtrkpt_ptsum_away",50,0.0,50,0,30," ");
+   h_leadingtrkpt_ptsum_towards =bei.bookProfile("h_leadingtrkpt_ptsum_towards","h_leadingtrkpt_ptsum_towards",50,0.0,50,0,30," ");
+   h_leadingtrkpt_ptsum_transverse =bei.bookProfile("h_leadingtrkpt_ptsum_transverse","h_leadingtrkpt_ptsum_transverse",50,0.0,50,0,30," ");
      
  }
 

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -201,8 +201,8 @@ void SiPixelPhase1Summary::bookTrendPlots(DQMStore::IBooker & iBooker){
     }
   }
   else {
-    deadROCTrends_[offline] = iBooker.bookProfile("deadRocTotal","N dead ROCs",6,0,6,0.,8192,"");
-    ineffROCTrends_[offline] = iBooker.bookProfile("ineffRocTotal","N inefficient ROCs",6,0,6,0.,8192,""); 
+    deadROCTrends_[offline] = iBooker.bookProfile("deadRocTotal","N dead ROCs",6,0.,6,0.,8192,"");
+    ineffROCTrends_[offline] = iBooker.bookProfile("ineffRocTotal","N inefficient ROCs",6,0.,6,0.,8192,"");
     deadROCTrends_[offline]->setAxisTitle("Subdetector",1);
     ineffROCTrends_[offline]->setAxisTitle("Subdetector",1);
     for (unsigned int i = 1; i <= binAxisLabels.size(); i++){

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -1533,7 +1533,7 @@ void TrackAnalyzer::bookHistosForState(std::string sname, DQMStore::IBooker & ib
     tkmes.Chi2oNDFVsPt->setAxisTitle("Track #chi^{2}/ndf",2);
 
     histname = "Chi2oNDFVsNHits_" + histTag;
-    tkmes.Chi2oNDFVsNHits   = ibooker.bookProfile(histname, histname, 50, 0, 50, Chi2NDFMin, Chi2NDFMax,"");
+    tkmes.Chi2oNDFVsNHits   = ibooker.bookProfile(histname, histname, 50, 0., 50, Chi2NDFMin, Chi2NDFMax,"");
     tkmes.Chi2oNDFVsNHits->setAxisTitle("Track NHits", 1);
     tkmes.Chi2oNDFVsNHits->setAxisTitle("Track #chi^{2}/ndf",2);
 

--- a/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
+++ b/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
@@ -206,7 +206,7 @@ void StandaloneTrackMonitor::bookHistograms(DQMStore::IBooker &iBook, edm::Run c
 						  TrackPtHistoPar.getParameter<double>("Xmin"),
 						  TrackPtHistoPar.getParameter<double>("Xmax"),0.0,0.0,"g");
   if (!nHitsVsnVtxH_) 
-    nHitsVsnVtxH_ = iBook.bookProfile("nHitsVsnVtx", "Number of Hits Vs Number of Vertex", 100,0,50,0.0,0.0,"g");
+    nHitsVsnVtxH_ = iBook.bookProfile("nHitsVsnVtx", "Number of Hits Vs Number of Vertex", 100,0.0,50,0.0,0.0,"g");
   if (!nHitsVsEtaH_) 
     nHitsVsEtaH_ = iBook.bookProfile("nHitsVsEta", "Number of Hits Vs Eta", 
 						    TrackEtaHistoPar.getParameter<int32_t>("Xbins"),

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -96,10 +96,8 @@ public:
     MonitorElement* book1D(TString const& name, TString const& title, int nchX, float const* xbinsize);
     MonitorElement* book1D(TString const& name, TH1F* object);
     MonitorElement* book1S(TString const& name, TString const& title, int nchX, double lowX, double highX);
-    // MonitorElement* book1S(TString const& name, TString const& title, int nchX, float const* xbinsize);
     MonitorElement* book1S(TString const& name, TH1S* object);
     MonitorElement* book1DD(TString const& name, TString const& title, int nchX, double lowX, double highX);
-    // MonitorElement* book1DD(TString const& name, TString const& title, int nchX, float const* xbinsize);
     MonitorElement* book1DD(TString const& name, TH1D* object);
     MonitorElement* book2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY);
     MonitorElement* book2D(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize);
@@ -108,7 +106,6 @@ public:
     MonitorElement* book2S(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize);
     MonitorElement* book2S(TString const& name, TH2S* object);
     MonitorElement* book2DD(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY);
-    // MonitorElement* book2DD(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize);
     MonitorElement* book2DD(TString const& name, TH2D* object);
     MonitorElement* book3D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ);
     MonitorElement* book3D(TString const& name, TH3F* object);
@@ -155,10 +152,8 @@ public:
     ConcurrentMonitorElement book1D(TString const& name, TString const& title, int nchX, float const* xbinsize);
     ConcurrentMonitorElement book1D(TString const& name, TH1F* object);
     ConcurrentMonitorElement book1S(TString const& name, TString const& title, int nchX, double lowX, double highX);
-    // ConcurrentMonitorElement book1S(TString const& name, TString const& title, int nchX, float const* xbinsize);
     ConcurrentMonitorElement book1S(TString const& name, TH1S* object);
     ConcurrentMonitorElement book1DD(TString const& name, TString const& title, int nchX, double lowX, double highX);
-    // ConcurrentMonitorElement book1DD(TString const& name, TString const& title, int nchX, float const* xbinsize);
     ConcurrentMonitorElement book1DD(TString const& name, TH1D* object);
     ConcurrentMonitorElement book2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY);
     ConcurrentMonitorElement book2D(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize);
@@ -167,7 +162,6 @@ public:
     ConcurrentMonitorElement book2S(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize);
     ConcurrentMonitorElement book2S(TString const& name, TH2S* object);
     ConcurrentMonitorElement book2DD(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY);
-    // ConcurrentMonitorElement book2DD(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize);
     ConcurrentMonitorElement book2DD(TString const& name, TH2D* object);
     ConcurrentMonitorElement book3D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ);
     ConcurrentMonitorElement book3D(TString const& name, TH3F* object);
@@ -350,16 +344,10 @@ public:
   MonitorElement* book1S(char_string const& name,
                          char_string const& title,
                          int nchX, double lowX, double highX);
-  // MonitorElement* book1S(char_string const& name,
-  //                        char_string const& title,
-  //                        int nchX, float const* xbinsize);
   MonitorElement* book1S(char_string const& name, TH1S* h);
   MonitorElement* book1DD(char_string const& name,
                           char_string const& title,
                           int nchX, double lowX, double highX);
-  // MonitorElement* book1DD(char_string const& name,
-  //                         char_string const& title,
-  //                         int nchX, float const* xbinsize);
   MonitorElement* book1DD(char_string const& name, TH1D* h);
   MonitorElement* book2D(char_string const& name,
                          char_string const& title,
@@ -383,10 +371,6 @@ public:
                           char_string const& title,
                           int nchX, double lowX, double highX,
                           int nchY, double lowY, double highY);
-  // MonitorElement* book2DD(char_string const& name,
-  //                         char_string const& title,
-  //                         int nchX, float const* xbinsize,
-  //                         int nchY, float const* ybinsize);
   MonitorElement* book2DD(char_string const& name, TH2D* h);
   MonitorElement* book3D(char_string const& name,
                          char_string const& title,

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -89,31 +89,160 @@ public:
   public:
     friend class DQMStore;
 
-#define IBOOKER_FUNCTION_WITH_SUFFIX(suffix)                            \
-    template <typename... Args>                                         \
-    MonitorElement* book##suffix(Args&&... args)                        \
-    {                                                                   \
-      return owner_->book##suffix(std::forward<Args>(args)...);         \
-    }
+    MonitorElement* bookInt(TString const& name)
+    {
+      return owner_->bookInt(name);
+    };
 
-    // For the supported interface, see the DQMStore function that
-    // starts with "book" and ends with the supplied suffix.  For
-    // example, giving an argument of "String" generates a function
-    // that interfaces with DQMStore::bookString.
-    IBOOKER_FUNCTION_WITH_SUFFIX(String);
-    IBOOKER_FUNCTION_WITH_SUFFIX(Int);
-    IBOOKER_FUNCTION_WITH_SUFFIX(Float);
-    IBOOKER_FUNCTION_WITH_SUFFIX(1D);
-    IBOOKER_FUNCTION_WITH_SUFFIX(1S);
-    IBOOKER_FUNCTION_WITH_SUFFIX(1DD);
-    IBOOKER_FUNCTION_WITH_SUFFIX(2D);
-    IBOOKER_FUNCTION_WITH_SUFFIX(2S);
-    IBOOKER_FUNCTION_WITH_SUFFIX(2DD);
-    IBOOKER_FUNCTION_WITH_SUFFIX(3D);
-    IBOOKER_FUNCTION_WITH_SUFFIX(Profile);
-    IBOOKER_FUNCTION_WITH_SUFFIX(Profile2D);
+    MonitorElement* bookFloat(TString const& name)
+    {
+      return owner_->bookFloat(name);
+    };
 
-#undef IBOOKER_FUNCTION_WITH_SUFFIX
+    MonitorElement* bookString(TString const& name, TString const& value)
+    {
+      return owner_->bookString(name, value);
+    };
+
+    MonitorElement* book1D(TString const& name, TString const& title, int const nchX, double const lowX, double const highX)
+    {
+      return owner_->book1D(name, title, nchX, lowX, highX);
+    };
+
+    MonitorElement* book1D(TString const& name, TString const& title, int nchX, float const* xbinsize)
+    {
+      return owner_->book1D(name, title, nchX, xbinsize);
+    };
+                        
+    MonitorElement* book1D(TString const& name, TH1F* object)
+    {
+      return owner_->book1D(name, object);
+    };
+
+    MonitorElement* book1S(TString const& name, TString const& title, int nchX, double lowX, double highX)
+    {
+      return owner_->book1S(name, title, nchX, lowX, highX);
+    };
+
+    MonitorElement* book1S(TString const& name, TString const& title, int nchX, float const* xbinsize)
+    {
+      return owner_->book1S(name, title, nchX, xbinsize);
+    };
+
+    MonitorElement* book1S(TString const& name, TH1S* object)
+    {
+      return owner_->book1S(name, object);
+    };
+
+    MonitorElement* book1DD(TString const& name, TString const& title, int nchX, double lowX, double highX)
+    {
+      return owner_->book1DD(name, title, nchX, lowX, highX);
+    };
+
+    MonitorElement* book1DD(TString const& name, TString const& title, int nchX, float const* xbinsize)
+    {
+      return owner_->book1DD(name, title, nchX, xbinsize);
+    };
+
+    MonitorElement* book1DD(TString const& name, TH1D* object)
+    {
+      return owner_->book1DD(name, object);
+    };
+
+    MonitorElement* book2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY)
+    {
+      return owner_->book2D(name, title, nchX, lowX, highX, nchY, lowY, highY);
+    };
+
+    MonitorElement* book2D(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
+    {
+      return owner_->book2D(name, title, nchX, xbinsize, nchY, ybinsize);
+    };
+
+    MonitorElement* book2D(TString const& name, TH2F* object)
+    {
+      return owner_->book2D(name, object);
+    };
+
+    MonitorElement* book2S(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY)
+    {
+      return owner_->book2S(name, title, nchX, lowX, highX, nchY, lowY, highY);
+    };
+
+    MonitorElement* book2S(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
+    {
+      return owner_->book2S(name, title, nchX, xbinsize, nchY, ybinsize);
+    };
+
+    MonitorElement* book2S(TString const& name, TH2S* object)
+    {
+      return owner_->book2S(name, object);
+    };
+
+    MonitorElement* book2DD(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY)
+    {
+      return owner_->book2DD(name, title, nchX, lowX, highX, nchY, lowY, highY);
+    };
+
+    MonitorElement* book2DD(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
+    {
+      return owner_->book2DD(name, title, nchX, xbinsize, nchY, ybinsize);
+    };
+
+    MonitorElement* book2DD(TString const& name, TH2D* object)
+    {
+      return owner_->book2DD(name, object);
+    };
+
+    MonitorElement* book3D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ)
+    {
+      return owner_->book3D(name, title, nchX, lowX, highX, nchY, lowY, highY, nchZ, lowZ, highZ);
+    };
+
+    MonitorElement* book3D(TString const& name, TH3F* object)
+    {
+      return owner_->book3D(name, object);
+    };
+
+    MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, char const* option = "s")
+    {
+      return owner_->bookProfile(name, title, nchX, lowX, highX, nchY, lowY, highY, option); // 9
+    };
+
+    DQM_DEPRECATED MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, /*double*/ int lowX, double highX, double lowY, double highY, char const* option = "s")
+    {
+      return owner_->bookProfile(name, title, nchX, lowX, highX, lowY, highY, option); // 8
+    };
+
+    DQM_DEPRECATED MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, int nchY, double lowY, double highY, char const* option = "s")
+    {
+      return owner_->bookProfile(name, title, nchX, xbinsize, nchY, lowY, highY, option); // 8
+    };
+
+    MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, double lowY, double highY, char const* option = "s")
+    {
+      return owner_->bookProfile(name, title, nchX, xbinsize, lowY, highY, option); // 7
+    };
+
+    MonitorElement* bookProfile(TString const& name, TProfile* object)
+    {
+      return owner_->bookProfile(name, object);
+    };
+
+    MonitorElement* bookProfile2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, double lowZ, double highZ, char const* option = "s")
+    {
+      return owner_->bookProfile2D(name, title, nchX, lowX, highX, nchY, lowY, highY, lowZ, highZ, option);
+    };
+
+    MonitorElement* bookProfile2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ, char const* option = "s")
+    {
+      return owner_->bookProfile2D(name, title, nchX, lowX, highX, nchY, lowY, highY, nchZ, lowZ, highZ, option);
+    };
+
+    MonitorElement* bookProfile2D(TString const& name, TProfile2D* object)
+    {
+      return owner_->bookProfile2D(name, object);
+    };
 
     void cd();
     void cd(std::string const& dir);

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -206,22 +206,22 @@ public:
 
     MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, char const* option = "s")
     {
-      return owner_->bookProfile(name, title, nchX, lowX, highX, nchY, lowY, highY, option); // 9
+      return owner_->bookProfile(name, title, nchX, lowX, highX, nchY, lowY, highY, option);
     };
 
-    DQM_DEPRECATED MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, /*double*/ int lowX, double highX, double lowY, double highY, char const* option = "s")
+    MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double lowX, double highX, double lowY, double highY, char const* option = "s")
     {
-      return owner_->bookProfile(name, title, nchX, lowX, highX, lowY, highY, option); // 8
+      return owner_->bookProfile(name, title, nchX, lowX, highX, lowY, highY, option);
     };
 
-    DQM_DEPRECATED MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, int nchY, double lowY, double highY, char const* option = "s")
+    MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, int nchY, double lowY, double highY, char const* option = "s")
     {
-      return owner_->bookProfile(name, title, nchX, xbinsize, nchY, lowY, highY, option); // 8
+      return owner_->bookProfile(name, title, nchX, xbinsize, nchY, lowY, highY, option);
     };
 
     MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, double lowY, double highY, char const* option = "s")
     {
-      return owner_->bookProfile(name, title, nchX, xbinsize, lowY, highY, option); // 7
+      return owner_->bookProfile(name, title, nchX, xbinsize, lowY, highY, option);
     };
 
     MonitorElement* bookProfile(TString const& name, TProfile* object)

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -89,160 +89,37 @@ public:
   public:
     friend class DQMStore;
 
-    MonitorElement* bookInt(TString const& name)
-    {
-      return owner_->bookInt(name);
-    };
-
-    MonitorElement* bookFloat(TString const& name)
-    {
-      return owner_->bookFloat(name);
-    };
-
-    MonitorElement* bookString(TString const& name, TString const& value)
-    {
-      return owner_->bookString(name, value);
-    };
-
-    MonitorElement* book1D(TString const& name, TString const& title, int const nchX, double const lowX, double const highX)
-    {
-      return owner_->book1D(name, title, nchX, lowX, highX);
-    };
-
-    MonitorElement* book1D(TString const& name, TString const& title, int nchX, float const* xbinsize)
-    {
-      return owner_->book1D(name, title, nchX, xbinsize);
-    };
-                        
-    MonitorElement* book1D(TString const& name, TH1F* object)
-    {
-      return owner_->book1D(name, object);
-    };
-
-    MonitorElement* book1S(TString const& name, TString const& title, int nchX, double lowX, double highX)
-    {
-      return owner_->book1S(name, title, nchX, lowX, highX);
-    };
-
-    MonitorElement* book1S(TString const& name, TString const& title, int nchX, float const* xbinsize)
-    {
-      return owner_->book1S(name, title, nchX, xbinsize);
-    };
-
-    MonitorElement* book1S(TString const& name, TH1S* object)
-    {
-      return owner_->book1S(name, object);
-    };
-
-    MonitorElement* book1DD(TString const& name, TString const& title, int nchX, double lowX, double highX)
-    {
-      return owner_->book1DD(name, title, nchX, lowX, highX);
-    };
-
-    MonitorElement* book1DD(TString const& name, TString const& title, int nchX, float const* xbinsize)
-    {
-      return owner_->book1DD(name, title, nchX, xbinsize);
-    };
-
-    MonitorElement* book1DD(TString const& name, TH1D* object)
-    {
-      return owner_->book1DD(name, object);
-    };
-
-    MonitorElement* book2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY)
-    {
-      return owner_->book2D(name, title, nchX, lowX, highX, nchY, lowY, highY);
-    };
-
-    MonitorElement* book2D(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
-    {
-      return owner_->book2D(name, title, nchX, xbinsize, nchY, ybinsize);
-    };
-
-    MonitorElement* book2D(TString const& name, TH2F* object)
-    {
-      return owner_->book2D(name, object);
-    };
-
-    MonitorElement* book2S(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY)
-    {
-      return owner_->book2S(name, title, nchX, lowX, highX, nchY, lowY, highY);
-    };
-
-    MonitorElement* book2S(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
-    {
-      return owner_->book2S(name, title, nchX, xbinsize, nchY, ybinsize);
-    };
-
-    MonitorElement* book2S(TString const& name, TH2S* object)
-    {
-      return owner_->book2S(name, object);
-    };
-
-    MonitorElement* book2DD(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY)
-    {
-      return owner_->book2DD(name, title, nchX, lowX, highX, nchY, lowY, highY);
-    };
-
-    MonitorElement* book2DD(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
-    {
-      return owner_->book2DD(name, title, nchX, xbinsize, nchY, ybinsize);
-    };
-
-    MonitorElement* book2DD(TString const& name, TH2D* object)
-    {
-      return owner_->book2DD(name, object);
-    };
-
-    MonitorElement* book3D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ)
-    {
-      return owner_->book3D(name, title, nchX, lowX, highX, nchY, lowY, highY, nchZ, lowZ, highZ);
-    };
-
-    MonitorElement* book3D(TString const& name, TH3F* object)
-    {
-      return owner_->book3D(name, object);
-    };
-
-    MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, char const* option = "s")
-    {
-      return owner_->bookProfile(name, title, nchX, lowX, highX, nchY, lowY, highY, option);
-    };
-
-    MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double lowX, double highX, double lowY, double highY, char const* option = "s")
-    {
-      return owner_->bookProfile(name, title, nchX, lowX, highX, lowY, highY, option);
-    };
-
-    MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, int nchY, double lowY, double highY, char const* option = "s")
-    {
-      return owner_->bookProfile(name, title, nchX, xbinsize, nchY, lowY, highY, option);
-    };
-
-    MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, double lowY, double highY, char const* option = "s")
-    {
-      return owner_->bookProfile(name, title, nchX, xbinsize, lowY, highY, option);
-    };
-
-    MonitorElement* bookProfile(TString const& name, TProfile* object)
-    {
-      return owner_->bookProfile(name, object);
-    };
-
-    MonitorElement* bookProfile2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, double lowZ, double highZ, char const* option = "s")
-    {
-      return owner_->bookProfile2D(name, title, nchX, lowX, highX, nchY, lowY, highY, lowZ, highZ, option);
-    };
-
-    MonitorElement* bookProfile2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ, char const* option = "s")
-    {
-      return owner_->bookProfile2D(name, title, nchX, lowX, highX, nchY, lowY, highY, nchZ, lowZ, highZ, option);
-    };
-
-    MonitorElement* bookProfile2D(TString const& name, TProfile2D* object)
-    {
-      return owner_->bookProfile2D(name, object);
-    };
+    MonitorElement* bookInt(TString const& name);
+    MonitorElement* bookFloat(TString const& name);
+    MonitorElement* bookString(TString const& name, TString const& value);
+    MonitorElement* book1D(TString const& name, TString const& title, int const nchX, double const lowX, double const highX);
+    MonitorElement* book1D(TString const& name, TString const& title, int nchX, float const* xbinsize);
+    MonitorElement* book1D(TString const& name, TH1F* object);
+    MonitorElement* book1S(TString const& name, TString const& title, int nchX, double lowX, double highX);
+    // MonitorElement* book1S(TString const& name, TString const& title, int nchX, float const* xbinsize);
+    MonitorElement* book1S(TString const& name, TH1S* object);
+    MonitorElement* book1DD(TString const& name, TString const& title, int nchX, double lowX, double highX);
+    // MonitorElement* book1DD(TString const& name, TString const& title, int nchX, float const* xbinsize);
+    MonitorElement* book1DD(TString const& name, TH1D* object);
+    MonitorElement* book2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY);
+    MonitorElement* book2D(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize);
+    MonitorElement* book2D(TString const& name, TH2F* object);
+    MonitorElement* book2S(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY);
+    MonitorElement* book2S(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize);
+    MonitorElement* book2S(TString const& name, TH2S* object);
+    MonitorElement* book2DD(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY);
+    // MonitorElement* book2DD(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize);
+    MonitorElement* book2DD(TString const& name, TH2D* object);
+    MonitorElement* book3D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ);
+    MonitorElement* book3D(TString const& name, TH3F* object);
+    MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, char const* option = "s");
+    MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double lowX, double highX, double lowY, double highY, char const* option = "s");
+    MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, int nchY, double lowY, double highY, char const* option = "s");
+    MonitorElement* bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, double lowY, double highY, char const* option = "s");
+    MonitorElement* bookProfile(TString const& name, TProfile* object);
+    MonitorElement* bookProfile2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, double lowZ, double highZ, char const* option = "s");
+    MonitorElement* bookProfile2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ, char const* option = "s");
+    MonitorElement* bookProfile2D(TString const& name, TProfile2D* object);
 
     void cd();
     void cd(std::string const& dir);
@@ -271,32 +148,37 @@ public:
   public:
     friend class DQMStore;
 
-#define CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(suffix)                   \
-    template <typename... Args>                                         \
-    ConcurrentMonitorElement book##suffix(Args&&... args)               \
-    {                                                                   \
-      MonitorElement* me = IBooker::book##suffix(std::forward<Args>(args)...); \
-      return ConcurrentMonitorElement(me);                              \
-    }
-
-    // For the supported interface, see the DQMStore function that
-    // starts with "book" and ends with the supplied suffix.  For
-    // example, giving an argument of "String" generates a function
-    // that interfaces with DQMStore::bookString.
-    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(String);
-    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(Int);
-    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(Float);
-    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(1D);
-    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(1S);
-    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(1DD);
-    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(2D);
-    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(2S);
-    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(2DD);
-    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(3D);
-    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(Profile);
-    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(Profile2D);
-
-#undef CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX
+    ConcurrentMonitorElement bookInt(TString const& name);
+    ConcurrentMonitorElement bookFloat(TString const& name);
+    ConcurrentMonitorElement bookString(TString const& name, TString const& value);
+    ConcurrentMonitorElement book1D(TString const& name, TString const& title, int const nchX, double const lowX, double const highX);
+    ConcurrentMonitorElement book1D(TString const& name, TString const& title, int nchX, float const* xbinsize);
+    ConcurrentMonitorElement book1D(TString const& name, TH1F* object);
+    ConcurrentMonitorElement book1S(TString const& name, TString const& title, int nchX, double lowX, double highX);
+    // ConcurrentMonitorElement book1S(TString const& name, TString const& title, int nchX, float const* xbinsize);
+    ConcurrentMonitorElement book1S(TString const& name, TH1S* object);
+    ConcurrentMonitorElement book1DD(TString const& name, TString const& title, int nchX, double lowX, double highX);
+    // ConcurrentMonitorElement book1DD(TString const& name, TString const& title, int nchX, float const* xbinsize);
+    ConcurrentMonitorElement book1DD(TString const& name, TH1D* object);
+    ConcurrentMonitorElement book2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY);
+    ConcurrentMonitorElement book2D(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize);
+    ConcurrentMonitorElement book2D(TString const& name, TH2F* object);
+    ConcurrentMonitorElement book2S(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY);
+    ConcurrentMonitorElement book2S(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize);
+    ConcurrentMonitorElement book2S(TString const& name, TH2S* object);
+    ConcurrentMonitorElement book2DD(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY);
+    // ConcurrentMonitorElement book2DD(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize);
+    ConcurrentMonitorElement book2DD(TString const& name, TH2D* object);
+    ConcurrentMonitorElement book3D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ);
+    ConcurrentMonitorElement book3D(TString const& name, TH3F* object);
+    ConcurrentMonitorElement bookProfile(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, char const* option = "s");
+    ConcurrentMonitorElement bookProfile(TString const& name, TString const& title, int nchX, double lowX, double highX, double lowY, double highY, char const* option = "s");
+    ConcurrentMonitorElement bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, int nchY, double lowY, double highY, char const* option = "s");
+    ConcurrentMonitorElement bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, double lowY, double highY, char const* option = "s");
+    ConcurrentMonitorElement bookProfile(TString const& name, TProfile* object);
+    ConcurrentMonitorElement bookProfile2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, double lowZ, double highZ, char const* option = "s");
+    ConcurrentMonitorElement bookProfile2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ, char const* option = "s");
+    ConcurrentMonitorElement bookProfile2D(TString const& name, TProfile2D* object);
 
     ConcurrentBooker() = delete;
     ConcurrentBooker(ConcurrentBooker const&) = delete;
@@ -468,16 +350,16 @@ public:
   MonitorElement* book1S(char_string const& name,
                          char_string const& title,
                          int nchX, double lowX, double highX);
-  MonitorElement* book1S(char_string const& name,
-                         char_string const& title,
-                         int nchX, float const* xbinsize);
+  // MonitorElement* book1S(char_string const& name,
+  //                        char_string const& title,
+  //                        int nchX, float const* xbinsize);
   MonitorElement* book1S(char_string const& name, TH1S* h);
   MonitorElement* book1DD(char_string const& name,
                           char_string const& title,
                           int nchX, double lowX, double highX);
-  MonitorElement* book1DD(char_string const& name,
-                          char_string const& title,
-                          int nchX, float const* xbinsize);
+  // MonitorElement* book1DD(char_string const& name,
+  //                         char_string const& title,
+  //                         int nchX, float const* xbinsize);
   MonitorElement* book1DD(char_string const& name, TH1D* h);
   MonitorElement* book2D(char_string const& name,
                          char_string const& title,
@@ -501,10 +383,10 @@ public:
                           char_string const& title,
                           int nchX, double lowX, double highX,
                           int nchY, double lowY, double highY);
-  MonitorElement* book2DD(char_string const& name,
-                          char_string const& title,
-                          int nchX, float const* xbinsize,
-                          int nchY, float const* ybinsize);
+  // MonitorElement* book2DD(char_string const& name,
+  //                         char_string const& title,
+  //                         int nchX, float const* xbinsize,
+  //                         int nchY, float const* ybinsize);
   MonitorElement* book2DD(char_string const& name, TH2D* h);
   MonitorElement* book3D(char_string const& name,
                          char_string const& title,

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -290,11 +290,6 @@ MonitorElement* DQMStore::IBooker::book1S(TString const& name, TString const& ti
   return owner_->book1S(name, title, nchX, lowX, highX);
 }
 
-// MonitorElement* DQMStore::IBooker::book1S(TString const& name, TString const& title, int nchX, float const* xbinsize)
-// {
-//   return owner_->book1S(name, title, nchX, xbinsize);
-// }
-
 MonitorElement* DQMStore::IBooker::book1S(TString const& name, TH1S* object)
 {
   return owner_->book1S(name, object);
@@ -304,11 +299,6 @@ MonitorElement* DQMStore::IBooker::book1DD(TString const& name, TString const& t
 {
   return owner_->book1DD(name, title, nchX, lowX, highX);
 }
-
-// MonitorElement* DQMStore::IBooker::book1DD(TString const& name, TString const& title, int nchX, float const* xbinsize)
-// {
-//   return owner_->book1DD(name, title, nchX, xbinsize);
-// }
 
 MonitorElement* DQMStore::IBooker::book1DD(TString const& name, TH1D* object)
 {
@@ -349,11 +339,6 @@ MonitorElement* DQMStore::IBooker::book2DD(TString const& name, TString const& t
 {
   return owner_->book2DD(name, title, nchX, lowX, highX, nchY, lowY, highY);
 }
-
-// MonitorElement* DQMStore::IBooker::book2DD(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
-// {
-//   return owner_->book2DD(name, title, nchX, xbinsize, nchY, ybinsize);
-// }
 
 MonitorElement* DQMStore::IBooker::book2DD(TString const& name, TH2D* object)
 {
@@ -561,12 +546,6 @@ ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1S(TString const& name,
   return ConcurrentMonitorElement(me);
 }
 
-// ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1S(TString const& name, TString const& title, int nchX, float const* xbinsize)
-// {
-//   MonitorElement* me = IBooker::book1S(name, title, nchX, xbinsize);
-//   return ConcurrentMonitorElement(me);
-// }
-
 ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1S(TString const& name, TH1S* object)
 {
   MonitorElement* me = IBooker::book1S(name, object);
@@ -578,12 +557,6 @@ ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1DD(TString const& name
   MonitorElement* me = IBooker::book1DD(name, title, nchX, lowX, highX);
   return ConcurrentMonitorElement(me);
 }
-
-// ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1DD(TString const& name, TString const& title, int nchX, float const* xbinsize)
-// {
-//   MonitorElement* me = IBooker::book1DD(name, title, nchX, xbinsize);
-//   return ConcurrentMonitorElement(me);
-// }
 
 ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1DD(TString const& name, TH1D* object)
 {
@@ -632,12 +605,6 @@ ConcurrentMonitorElement DQMStore::ConcurrentBooker::book2DD(TString const& name
   MonitorElement* me = IBooker::book2DD(name, title, nchX, lowX, highX, nchY, lowY, highY);
   return ConcurrentMonitorElement(me);
 }
-
-// ConcurrentMonitorElement DQMStore::ConcurrentBooker::book2DD(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
-// {
-//   MonitorElement* me = IBooker::book2DD(name, title, nchX, xbinsize, nchY, ybinsize);
-//   return ConcurrentMonitorElement(me);
-// }
 
 ConcurrentMonitorElement DQMStore::ConcurrentBooker::book2DD(TString const& name, TH2D* object)
 {

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -255,6 +255,161 @@ bool fastmatch::match(std::string const& s) const
 }
 
 //IBooker methods
+MonitorElement* DQMStore::IBooker::bookInt(TString const& name)
+{
+  return owner_->bookInt(name);
+}
+
+MonitorElement* DQMStore::IBooker::bookFloat(TString const& name)
+{
+  return owner_->bookFloat(name);
+}
+
+MonitorElement* DQMStore::IBooker::bookString(TString const& name, TString const& value)
+{
+  return owner_->bookString(name, value);
+}
+
+MonitorElement* DQMStore::IBooker::book1D(TString const& name, TString const& title, int const nchX, double const lowX, double const highX)
+{
+  return owner_->book1D(name, title, nchX, lowX, highX);
+}
+
+MonitorElement* DQMStore::IBooker::book1D(TString const& name, TString const& title, int nchX, float const* xbinsize)
+{
+  return owner_->book1D(name, title, nchX, xbinsize);
+};
+
+MonitorElement* DQMStore::IBooker::book1D(TString const& name, TH1F* object)
+{
+  return owner_->book1D(name, object);
+}
+
+MonitorElement* DQMStore::IBooker::book1S(TString const& name, TString const& title, int nchX, double lowX, double highX)
+{
+  return owner_->book1S(name, title, nchX, lowX, highX);
+}
+
+// MonitorElement* DQMStore::IBooker::book1S(TString const& name, TString const& title, int nchX, float const* xbinsize)
+// {
+//   return owner_->book1S(name, title, nchX, xbinsize);
+// }
+
+MonitorElement* DQMStore::IBooker::book1S(TString const& name, TH1S* object)
+{
+  return owner_->book1S(name, object);
+}
+
+MonitorElement* DQMStore::IBooker::book1DD(TString const& name, TString const& title, int nchX, double lowX, double highX)
+{
+  return owner_->book1DD(name, title, nchX, lowX, highX);
+}
+
+// MonitorElement* DQMStore::IBooker::book1DD(TString const& name, TString const& title, int nchX, float const* xbinsize)
+// {
+//   return owner_->book1DD(name, title, nchX, xbinsize);
+// }
+
+MonitorElement* DQMStore::IBooker::book1DD(TString const& name, TH1D* object)
+{
+  return owner_->book1DD(name, object);
+}
+
+MonitorElement* DQMStore::IBooker::book2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY)
+{
+  return owner_->book2D(name, title, nchX, lowX, highX, nchY, lowY, highY);
+}
+
+MonitorElement* DQMStore::IBooker::book2D(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
+{
+  return owner_->book2D(name, title, nchX, xbinsize, nchY, ybinsize);
+}
+
+MonitorElement* DQMStore::IBooker::book2D(TString const& name, TH2F* object)
+{
+  return owner_->book2D(name, object);
+}
+
+MonitorElement* DQMStore::IBooker::book2S(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY)
+{
+  return owner_->book2S(name, title, nchX, lowX, highX, nchY, lowY, highY);
+}
+
+MonitorElement* DQMStore::IBooker::book2S(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
+{
+  return owner_->book2S(name, title, nchX, xbinsize, nchY, ybinsize);
+}
+
+MonitorElement* DQMStore::IBooker::book2S(TString const& name, TH2S* object)
+{
+  return owner_->book2S(name, object);
+}
+
+MonitorElement* DQMStore::IBooker::book2DD(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY)
+{
+  return owner_->book2DD(name, title, nchX, lowX, highX, nchY, lowY, highY);
+}
+
+// MonitorElement* DQMStore::IBooker::book2DD(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
+// {
+//   return owner_->book2DD(name, title, nchX, xbinsize, nchY, ybinsize);
+// }
+
+MonitorElement* DQMStore::IBooker::book2DD(TString const& name, TH2D* object)
+{
+  return owner_->book2DD(name, object);
+}
+
+MonitorElement* DQMStore::IBooker::book3D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ)
+{
+  return owner_->book3D(name, title, nchX, lowX, highX, nchY, lowY, highY, nchZ, lowZ, highZ);
+}
+
+MonitorElement* DQMStore::IBooker::book3D(TString const& name, TH3F* object)
+{
+  return owner_->book3D(name, object);
+}
+
+MonitorElement* DQMStore::IBooker::bookProfile(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, char const* option)
+{
+  return owner_->bookProfile(name, title, nchX, lowX, highX, nchY, lowY, highY, option);
+}
+
+MonitorElement* DQMStore::IBooker::bookProfile(TString const& name, TString const& title, int nchX, double lowX, double highX, double lowY, double highY, char const* option)
+{
+  return owner_->bookProfile(name, title, nchX, lowX, highX, lowY, highY, option);
+}
+
+MonitorElement* DQMStore::IBooker::bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, int nchY, double lowY, double highY, char const* option)
+{
+  return owner_->bookProfile(name, title, nchX, xbinsize, nchY, lowY, highY, option);
+}
+
+MonitorElement* DQMStore::IBooker::bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, double lowY, double highY, char const* option)
+{
+  return owner_->bookProfile(name, title, nchX, xbinsize, lowY, highY, option);
+}
+
+MonitorElement* DQMStore::IBooker::bookProfile(TString const& name, TProfile* object)
+{
+  return owner_->bookProfile(name, object);
+}
+
+MonitorElement* DQMStore::IBooker::bookProfile2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, double lowZ, double highZ, char const* option)
+{
+  return owner_->bookProfile2D(name, title, nchX, lowX, highX, nchY, lowY, highY, lowZ, highZ, option);
+}
+
+MonitorElement* DQMStore::IBooker::bookProfile2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ, char const* option)
+{
+  return owner_->bookProfile2D(name, title, nchX, lowX, highX, nchY, lowY, highY, nchZ, lowZ, highZ, option);
+}
+
+MonitorElement* DQMStore::IBooker::bookProfile2D(TString const& name, TProfile2D* object)
+{
+  return owner_->bookProfile2D(name, object);
+}
+
 void DQMStore::IBooker::cd()
 {
   owner_->cd();
@@ -361,6 +516,187 @@ void
 DQMStore::IGetter::setCurrentFolder(std::string const& fullpath)
 {
   owner_->setCurrentFolder(fullpath);
+}
+
+// ConcurrentBooker methods
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::bookInt(TString const& name)
+{
+  MonitorElement* me = IBooker::bookInt(name);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::bookFloat(TString const& name)
+{
+  MonitorElement* me = IBooker::bookFloat(name);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::bookString(TString const& name, TString const& value)
+{
+  MonitorElement* me = IBooker::bookString(name, value);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1D(TString const& name, TString const& title, int const nchX, double const lowX, double const highX)
+{
+  MonitorElement* me = IBooker::book1D(name, title, nchX, lowX, highX);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1D(TString const& name, TString const& title, int nchX, float const* xbinsize)
+{
+  MonitorElement* me = IBooker::book1D(name, title, nchX, xbinsize);
+  return ConcurrentMonitorElement(me);
+};
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1D(TString const& name, TH1F* object)
+{
+  MonitorElement* me = IBooker::book1D(name, object);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1S(TString const& name, TString const& title, int nchX, double lowX, double highX)
+{
+  MonitorElement* me = IBooker::book1S(name, title, nchX, lowX, highX);
+  return ConcurrentMonitorElement(me);
+}
+
+// ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1S(TString const& name, TString const& title, int nchX, float const* xbinsize)
+// {
+//   MonitorElement* me = IBooker::book1S(name, title, nchX, xbinsize);
+//   return ConcurrentMonitorElement(me);
+// }
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1S(TString const& name, TH1S* object)
+{
+  MonitorElement* me = IBooker::book1S(name, object);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1DD(TString const& name, TString const& title, int nchX, double lowX, double highX)
+{
+  MonitorElement* me = IBooker::book1DD(name, title, nchX, lowX, highX);
+  return ConcurrentMonitorElement(me);
+}
+
+// ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1DD(TString const& name, TString const& title, int nchX, float const* xbinsize)
+// {
+//   MonitorElement* me = IBooker::book1DD(name, title, nchX, xbinsize);
+//   return ConcurrentMonitorElement(me);
+// }
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book1DD(TString const& name, TH1D* object)
+{
+  MonitorElement* me = IBooker::book1DD(name, object);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY)
+{
+  MonitorElement* me = IBooker::book2D(name, title, nchX, lowX, highX, nchY, lowY, highY);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book2D(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
+{
+  MonitorElement* me = IBooker::book2D(name, title, nchX, xbinsize, nchY, ybinsize);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book2D(TString const& name, TH2F* object)
+{
+  MonitorElement* me = IBooker::book2D(name, object);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book2S(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY)
+{
+  MonitorElement* me = IBooker::book2S(name, title, nchX, lowX, highX, nchY, lowY, highY);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book2S(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
+{
+  MonitorElement* me = IBooker::book2S(name, title, nchX, xbinsize, nchY, ybinsize);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book2S(TString const& name, TH2S* object)
+{
+  MonitorElement* me = IBooker::book2S(name, object);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book2DD(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY)
+{
+  MonitorElement* me = IBooker::book2DD(name, title, nchX, lowX, highX, nchY, lowY, highY);
+  return ConcurrentMonitorElement(me);
+}
+
+// ConcurrentMonitorElement DQMStore::ConcurrentBooker::book2DD(TString const& name, TString const& title, int nchX, float const* xbinsize, int nchY, float const* ybinsize)
+// {
+//   MonitorElement* me = IBooker::book2DD(name, title, nchX, xbinsize, nchY, ybinsize);
+//   return ConcurrentMonitorElement(me);
+// }
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book2DD(TString const& name, TH2D* object)
+{
+  MonitorElement* me = IBooker::book2DD(name, object);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book3D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ)
+{
+  MonitorElement* me = IBooker::book3D(name, title, nchX, lowX, highX, nchY, lowY, highY, nchZ, lowZ, highZ);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::book3D(TString const& name, TH3F* object)
+{
+  MonitorElement* me = IBooker::book3D(name, object);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::bookProfile(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, char const* option)
+{
+  MonitorElement* me = IBooker::bookProfile(name, title, nchX, lowX, highX, nchY, lowY, highY, option);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::bookProfile(TString const& name, TString const& title, int nchX, double lowX, double highX, double lowY, double highY, char const* option)
+{
+  MonitorElement* me = IBooker::bookProfile(name, title, nchX, (double)lowX, highX, lowY, highY, option);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, int nchY, double lowY, double highY, char const* option)
+{
+  MonitorElement* me = IBooker::bookProfile(name, title, nchX, xbinsize, nchY, lowY, highY, option);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::bookProfile(TString const& name, TString const& title, int nchX, double const* xbinsize, double lowY, double highY, char const* option)
+{
+  MonitorElement* me = IBooker::bookProfile(name, title, nchX, xbinsize, lowY, highY, option);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::bookProfile(TString const& name, TProfile* object)
+{
+  MonitorElement* me = IBooker::bookProfile(name, object);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::bookProfile2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, double lowZ, double highZ, char const* option)
+{
+  MonitorElement* me = IBooker::bookProfile2D(name, title, nchX, lowX, highX, nchY, lowY, highY, lowZ, highZ, option);
+  return ConcurrentMonitorElement(me);
+}
+
+ConcurrentMonitorElement DQMStore::ConcurrentBooker::bookProfile2D(TString const& name, TString const& title, int nchX, double lowX, double highX, int nchY, double lowY, double highY, int nchZ, double lowZ, double highZ, char const* option)
+{
+  MonitorElement* me = IBooker::bookProfile2D(name, title, nchX, lowX, highX, nchY, lowY, highY, nchZ, lowZ, highZ, option);
+  return ConcurrentMonitorElement(me);
 }
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#### PR description:

Changed a macro that would generate histogram booking calls to regular methods inside `IBooker`.

Previous implementation was using a macro to generate a facade monitor element booking methods for DQMStore. Such approach saves some lines of code but code navigation becomes impossible and readability decreases. 

Due to the fact that argument forwarding (`std::forward<Args>(args)...`) somehow caries out the type information of literal value arguments, different overloads are chosen after the update. Such cases were identified and fixed in this PR.

The problematic methods are [these two](https://github.com/cms-sw/cmssw/blob/cca5eecc3fa46fcae943c7dad1a2c37668261579/DQMServices/Core/interface/DQMStore.h#L212-L220). When `0` literal value is passed to the fourth argument, the pointer overload is (incorrectly) selected because of two reasons:

- `0` is a valid null pointer literal value, and
- it takes an implicit conversion (from int to double) for a double overload to be called

Previously the double version of the overload would be selected and the new behaviour is incorrect. 

The fix is simple: finding all the cases where one of these two overloads are called and replacing zero literal values (i.e. `0`) with double literal values (i.e. `0.0` or '0.').

#### PR validation:

The calls mentioned above were found by temporarily changing the type of first overload from `double` to `int` and compiling with `-k` (keep going in case of errors) option. This resulted in an ambiguity (compiler error with a corresponding message) because `0` literal value could be used for both methods without any implicit conversions. 
