### PR TITLE
[10.6.X][Validation] Fix clang warnings in validation subsystem

### DIFF
--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -600,9 +600,6 @@ void GlobalRecHitsAnalyzer::fillHCal(const edm::Event& iEvent,
     return;
   }
   
-  // iterator to access containers
-  edm::PCaloHitContainer::const_iterator itHit;
-  
   ///////////////////////
   // extract simhit info
   //////////////////////

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -600,7 +600,6 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
     typename edm::SortedCollection<Digi>::const_iterator digiItr;
 
     // ADC2fC
-    HcalCalibrations calibrations;
     CaloSamples tool;
     iEvent.getByToken(tok, digiCollection);
     if (!digiCollection.isValid()) return;
@@ -896,7 +895,6 @@ template<class dataFrameType> void HcalDigisValidation::reco(const edm::Event& i
     
 
     // ADC2fC
-    HcalCalibrations calibrations;
     CaloSamples tool;
     iEvent.getByToken(tok, digiHandle);
     if (!digiHandle.isValid()) return;

--- a/Validation/SiPixelPhase1RecHitsV/src/SiPixelPhase1RecHitsV.cc
+++ b/Validation/SiPixelPhase1RecHitsV/src/SiPixelPhase1RecHitsV.cc
@@ -34,8 +34,6 @@ void SiPixelPhase1RecHitsV::analyze(const edm::Event& iEvent, const edm::EventSe
     auto id = DetId(it->detId());
 
     for(SiPixelRecHit const& rechit : *it) {
-      SiPixelRecHit::ClusterRef const& clust = rechit.cluster();
-
       std::vector<PSimHit> associateSimHit;
       associateSimHit = associate.associateHit(rechit);
       std::vector<PSimHit>::const_iterator closestIt = associateSimHit.begin();


### PR DESCRIPTION
#### PR description:

This fixes clang warnings for all validation subsystem packages. Mostly just removal of unused variables.

#### PR validation:

Local build based on clang IBs shows no more warnings

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
