### PR TITLE
Updates for UL reprocessing test: DataProcessing and CSC missing data format

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -27,6 +27,8 @@ def mergeProcess(*inputFiles, **options):
     - newDQMIO : specifies if the new DQM format should be used to merge the files
     - output_file : sets the output file name
     - output_lfn : sets the output LFN
+    - mergeNANO : to merge NanoAOD
+    - bypassVersionCheck : to bypass version check in case merging happened in lower version of CMSSW (i.e. UL HLT case). This will be TRUE by default.
 
     """
     #  //
@@ -39,6 +41,7 @@ def mergeProcess(*inputFiles, **options):
     dropDQM = options.get("drop_dqm", False)
     newDQMIO = options.get("newDQMIO", False)
     mergeNANO = options.get("mergeNANO", False)
+    bypassVersionCheck = options.get("bypassVersionCheck", True)
     #  //
     # // build process
     #//
@@ -52,6 +55,7 @@ def mergeProcess(*inputFiles, **options):
         process.add_(Service("DQMStore"))
     else:
         process.source = Source("PoolSource")
+        process.source.bypassVersionCheck = CfgTypes.untracked.bool(bypassVersionCheck)
         if dropDQM:
             process.source.inputCommands = CfgTypes.untracked.vstring('keep *','drop *_EDMtoMEConverter_*_*')
     process.source.fileNames = CfgTypes.untracked(CfgTypes.vstring())

--- a/Configuration/DataProcessing/test/RunMerge.py
+++ b/Configuration/DataProcessing/test/RunMerge.py
@@ -22,7 +22,9 @@ class RunMerge:
         self.outputLFN = None
         self.inputFiles = []
         self.newDQMIO = False
-        
+        self.mergeNANO = False
+        self.bypassVersionCheck = True
+
 
     def __call__(self):
         if self.inputFiles == []:
@@ -36,7 +38,8 @@ class RunMerge:
                 output_file = self.outputFile,
                 output_lfn = self.outputLFN,
                 newDQMIO = self.newDQMIO,
-                mergeNANO = self.mergeNANO)
+                mergeNANO = self.mergeNANO,
+                bypassVersionCheck = self.bypassVersionCheck)
         except Exception as ex:
             msg = "Error creating process for Merge:\n"
             msg += str(ex)
@@ -52,7 +55,7 @@ class RunMerge:
 
 
 if __name__ == '__main__':
-    valid = ["input-files=", "output-file=", "output-lfn=", "dqmroot", "mergeNANO" ]
+    valid = ["input-files=", "output-file=", "output-lfn=", "dqmroot", "mergeNANO", "bypassVersionCheck" ]
              
     usage = """RunMerge.py <options>"""
     try:
@@ -76,7 +79,9 @@ if __name__ == '__main__':
             merger.outputLFN = arg
         if opt == "--dqmroot" :
             merger.newDQMIO = True
-        if  opt == "--mergeNANO" :
+        if opt == "--mergeNANO" :
             merger.mergeNANO = True
+        if opt == "--bypassVersionCheck" :
+            merger.bypassVersionCheck = True
 
     merger()

--- a/DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigi.h
@@ -1,0 +1,111 @@
+#ifndef CSCDigi_CSCCLCTPreTriggerDigi_h
+#define CSCDigi_CSCCLCTPreTriggerDigi_h
+
+/**\class CSCCLCTPreTriggerDigi
+ *
+ * Digi for CLCT pre-trigger primitives.
+ *
+ *
+ * \author Tao Huang (TAMU)
+ */
+
+#include <cstdint>
+#include <iosfwd>
+
+class CSCCLCTPreTriggerDigi {
+
+ public:
+
+  /// Constructors
+  CSCCLCTPreTriggerDigi(const int valid, const int quality, const int pattern,
+	      const int striptype, const int bend, const int strip,
+	      const int cfeb, const int bx, const int trknmb = 0, const int fullbx=0);
+  /// default
+  CSCCLCTPreTriggerDigi();
+
+  /// clear this CLCT
+  void clear();
+
+  /// check CLCT validity (1 - valid CLCT)
+  bool isValid()     const {return valid_ ;}
+
+  /// return quality of a pattern (number of layers hit!)
+  int getQuality()   const {return quality_ ;}
+
+  /// return pattern
+  int getPattern()   const {return pattern_ ;}
+
+  /// return striptype
+  int getStripType() const {return striptype_ ;}
+
+  /// return bend
+  int getBend()      const {return bend_ ;}
+
+  /// return halfstrip that goes from 0 to 31
+  int getStrip()     const {return strip_ ;}
+
+  /// return Key CFEB ID
+  int getCFEB()      const {return cfeb_ ;}
+
+  /// return BX
+  int getBX()        const {return bx_ ;}
+
+  /// return track number (1,2)
+  int getTrknmb()    const {return trknmb_ ;}
+
+  /// Convert strip_ and cfeb_ to keyStrip. Each CFEB has up to 16 strips
+  /// (32 halfstrips). There are 5 cfebs.  The "strip_" variable is one
+  /// of 32 halfstrips on the keylayer of a single CFEB, so that
+  /// Distrip   = (cfeb*32 + strip)/4.
+  /// Halfstrip = (cfeb*32 + strip).
+  /// Always return halfstrip number since this is what is stored in
+  /// the correlated LCT digi.  For distrip patterns, the convention is
+  /// the same as for persistent strip numbers: low halfstrip of a distrip.
+  /// SV, June 15th, 2006.
+  int getKeyStrip()  const {
+    int keyStrip = cfeb_ * 32 + strip_;
+    return keyStrip;
+  }
+
+  /// Set track number (1,2) after sorting CLCTs.
+  void setTrknmb(const uint16_t number) {trknmb_ = number;}
+
+  /// return 12-bit full BX.
+  int getFullBX() const {return fullbx_ ;}
+
+  /// Set 12-bit full BX.
+  void setFullBX(const uint16_t fullbx) {fullbx_ = fullbx;}
+
+
+  /// True if the left-hand side has a larger "quality".  Full definition
+  /// of "quality" depends on quality word itself, pattern type, and strip
+  /// number.
+  bool operator >  (const CSCCLCTPreTriggerDigi&) const;
+
+  /// True if the two LCTs have exactly the same members (except the number).
+  bool operator == (const CSCCLCTPreTriggerDigi&) const;
+
+  /// True if the preceding one is false.
+  bool operator != (const CSCCLCTPreTriggerDigi&) const;
+
+  /// Print content of digi.
+  void print() const;
+
+ private:
+
+  uint16_t valid_      ;
+  uint16_t quality_    ;
+  uint16_t pattern_    ;
+  uint16_t striptype_  ; // not used since mid-2008
+  uint16_t bend_       ;
+  uint16_t strip_      ;
+  uint16_t cfeb_       ;
+  uint16_t bx_         ;
+  uint16_t trknmb_     ;
+  uint16_t fullbx_     ;
+
+};
+
+std::ostream & operator<<(std::ostream & o, const CSCCLCTPreTriggerDigi& digi);
+
+#endif

--- a/DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigiCollection.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigiCollection.h
@@ -1,0 +1,10 @@
+#ifndef DataFormats_CSCDigi_CSCCLCTPreTriggerDigiCollection_h
+#define DataFormats_CSCDigi_CSCCLCTPreTriggerDigiCollection_h
+
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigi.h"
+
+typedef MuonDigiCollection<CSCDetId, CSCCLCTPreTriggerDigi> CSCCLCTPreTriggerDigiCollection;
+
+#endif

--- a/DataFormats/CSCDigi/src/CSCCLCTPreTriggerDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTPreTriggerDigi.cc
@@ -1,0 +1,134 @@
+#include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <iomanip>
+#include <iostream>
+
+/// Constructors
+CSCCLCTPreTriggerDigi::CSCCLCTPreTriggerDigi(const int valid, const int quality, const int pattern,
+			 const int striptype, const int bend, const int strip,
+			 const int cfeb, const int bx, const int trknmb, const int fullbx):
+  valid_(valid),
+  quality_(quality),
+  pattern_(pattern),
+  striptype_(striptype),
+  bend_(bend),
+  strip_(strip),
+  cfeb_(cfeb),
+  bx_(bx),
+  trknmb_(trknmb),
+  fullbx_(fullbx)
+{
+}
+
+/// Default
+CSCCLCTPreTriggerDigi::CSCCLCTPreTriggerDigi () :
+  valid_(0),
+  quality_(0),
+  pattern_(0),
+  striptype_(0),
+  bend_(0),
+  strip_(0),
+  cfeb_(0),
+  bx_(0),
+  trknmb_(0),
+  fullbx_(0)
+{
+}
+
+/// Clears this CLCT.
+void CSCCLCTPreTriggerDigi::clear() {
+  valid_     = 0;
+  quality_   = 0;
+  pattern_   = 0;
+  striptype_ = 0;
+  bend_      = 0;
+  strip_     = 0;
+  cfeb_      = 0;
+  bx_        = 0;
+  trknmb_    = 0;
+  fullbx_    = 0;
+}
+
+bool CSCCLCTPreTriggerDigi::operator > (const CSCCLCTPreTriggerDigi& rhs) const {
+  // Several versions of CLCT sorting criteria were used before 2008.
+  // They are available in CMSSW versions prior to 3_1_0; here we only keep
+  // the latest one, used in TMB-07 firmware (w/o distrips).
+  bool returnValue = false;
+
+  int quality1 = getQuality();
+  int quality2 = rhs.getQuality();
+  // The bend-direction bit pid[0] is ignored (left and right bends have
+  // equal quality).
+  int pattern1 = getPattern()     & 14;
+  int pattern2 = rhs.getPattern() & 14;
+
+  // Better-quality CLCTs are preferred.
+  // If two qualities are equal, larger pattern id (i.e., straighter pattern)
+  // is preferred; left- and right-bend patterns are considered to be of
+  // the same quality.
+  // If both qualities and pattern id's are the same, lower keystrip
+  // is preferred.
+  if ((quality1  > quality2) ||
+      (quality1 == quality2 && pattern1 > pattern2) ||
+      (quality1 == quality2 && pattern1 == pattern2 &&
+       getKeyStrip() < rhs.getKeyStrip())) {returnValue = true;}
+
+  return returnValue;
+}
+
+bool CSCCLCTPreTriggerDigi::operator == (const CSCCLCTPreTriggerDigi& rhs) const {
+  // Exact equality.
+  bool returnValue = false;
+  if (isValid()      == rhs.isValid()    && getQuality() == rhs.getQuality() &&
+      getPattern()   == rhs.getPattern() && getKeyStrip()== rhs.getKeyStrip()&&
+      getStripType() == rhs.getStripType() && getBend()  == getBend()        &&
+      getBX()        == rhs.getBX()) {
+    returnValue = true;
+  }
+  return returnValue;
+}
+
+bool CSCCLCTPreTriggerDigi::operator != (const CSCCLCTPreTriggerDigi& rhs) const {
+  // True if == is false.
+  bool returnValue = true;
+  if ((*this) == rhs) returnValue = false;
+  return returnValue;
+}
+
+/// Debug
+void CSCCLCTPreTriggerDigi::print() const {
+  if (isValid()) {
+    char stripType = (getStripType() == 0) ? 'D' : 'H';
+    char bend      = (getBend()      == 0) ? 'L' : 'R';
+
+    edm::LogVerbatim("CSCDigi")
+              << " CSC CLCT #"    << std::setw(1) << getTrknmb()
+	      << ": Valid = "     << std::setw(1) << isValid()
+	      << " Key Strip = "  << std::setw(3) << getKeyStrip()
+	      << " Strip = "      << std::setw(2) << getStrip()
+	      << " Quality = "    << std::setw(1) << getQuality()
+	      << " Pattern = "    << std::setw(1) << getPattern()
+	      << " Bend = "       << std::setw(1) << bend
+	      << " Strip type = " << std::setw(1) << stripType
+	      << " CFEB ID = "    << std::setw(1) << getCFEB()
+	      << " BX = "         << std::setw(1) << getBX()
+              << " Full BX= "     << std::setw(1) << getFullBX();
+  }
+  else {
+    edm::LogVerbatim("CSCDigi") << "Not a valid Cathode LCT.";
+  }
+}
+
+std::ostream & operator<<(std::ostream & o, const CSCCLCTPreTriggerDigi& digi) {
+  return o << "CSC CLCT #"    << digi.getTrknmb()
+           << ": Valid = "    << digi.isValid()
+           << " Quality = "   << digi.getQuality()
+           << " Pattern = "   << digi.getPattern()
+           << " StripType = " << digi.getStripType()
+           << " Bend = "      << digi.getBend()
+           << " Strip = "     << digi.getStrip()
+           << " KeyStrip = "  << digi.getKeyStrip()
+           << " CFEB = "      << digi.getCFEB()
+           << " BX = "        << digi.getBX();
+}

--- a/DataFormats/CSCDigi/src/classes.h
+++ b/DataFormats/CSCDigi/src/classes.h
@@ -27,6 +27,8 @@
 #include "DataFormats/CSCDigi/interface/CSCDCCStatusDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCDCCStatusDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTPreTriggerDigiCollection.h"
 
 // dummy structs to ensure backward compatibility
 struct GEMCSCLCTDigi {};

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -22,6 +22,9 @@
    <class name="CSCCLCTDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="3910057547"/>
    </class>
+   <class name="CSCCLCTPreTriggerDigi" ClassVersion="10">
+    <version ClassVersion="10" checksum="1207676078"/>
+   </class>
    <class name="CSCALCTDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="817473300"/>
    </class>
@@ -54,6 +57,7 @@
    <class name="std::vector<CSCCorrelatedLCTDigi>"/>
    <class name="std::vector<GEMCSCLCTDigi>"/>
    <class name="std::vector<CSCCLCTDigi>"/>
+   <class name="std::vector<CSCCLCTPreTriggerDigi>"/>
    <class name="std::vector<CSCALCTDigi>"/>
    <class name="std::vector<CSCCFEBStatusDigi>"/>
    <class name="std::vector<CSCTMBStatusDigi>"/>
@@ -70,6 +74,7 @@
    <class name="std::map<CSCDetId,std::vector<CSCCorrelatedLCTDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<GEMCSCLCTDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCCLCTDigi> >"/>
+   <class name="std::map<CSCDetId,std::vector<CSCCLCTPreTriggerDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCALCTDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCCFEBStatusDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCTMBStatusDigi> >"/>
@@ -87,6 +92,7 @@
    <class name="std::pair<CSCDetId,std::vector<CSCCorrelatedLCTDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<GEMCSCLCTDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCCLCTDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCCLCTPreTriggerDigi> >"/>  
    <class name="std::pair<CSCDetId,std::vector<CSCALCTDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCCFEBStatusDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCTMBStatusDigi> >"/>
@@ -105,6 +111,7 @@
    <class name="MuonDigiCollection<CSCDetId,CSCCorrelatedLCTDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,GEMCSCLCTDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCCLCTDigi>"/>
+   <class name="MuonDigiCollection<CSCDetId,CSCCLCTPreTriggerDigi>"/> 
    <class name="MuonDigiCollection<CSCDetId,CSCALCTDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCCFEBStatusDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCTMBStatusDigi>"/>
@@ -122,6 +129,7 @@
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCorrelatedLCTDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,GEMCSCLCTDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCLCTDigi> >" splitLevel="0"/>
+   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCLCTPreTriggerDigi> >" splitLevel="0"/>  
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCALCTDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCFEBStatusDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCTMBStatusDigi> >" splitLevel="0"/>


### PR DESCRIPTION
#### PR description:

This PR adds the requested updates to 9_4_MAOD_X (synchronized to 9_4_X) in order to test the workflow chain for the UL reprocessing (after resetting Configuration/DataProcessing to the 9_4_13 status) corresponding to #26045, #26110, #26148 (1sf commit for Configuration/DataProcessing) and #26106 (2nd commit for CSCCLCTPreTriggerDigi backport).

#### PR validation:

For DataProcessing see the discussion of the original PRs (also in master), for CSCCLCTPreTriggerDigi the code compiles, and the event content in tests look unchanged as expected (a new DataFormat is defined, but there is no code to produce and consume it in the release).

#### if this PR is a backport please specify the original PR: #26030, #26120, #26147

