### PR TITLE
[10.6.X][PAT] Fix for clang warnings: PhysicsTools

### DIFF
--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionRefSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionRefSelector.h
@@ -53,7 +53,7 @@ private:
   container selected_;
   selector select_;
   RefAdder addRef_;
-  friend class reco::modules::SingleElementCollectionRefSelectorEventSetupInit<SingleElementCollectionRefSelector>;
+  friend struct reco::modules::SingleElementCollectionRefSelectorEventSetupInit<SingleElementCollectionRefSelector>;
 };
 
 #include "CommonTools/UtilAlgos/interface/EventSetupInitTrait.h"

--- a/PhysicsTools/CondLiteIO/test/IntProductESSource.cc
+++ b/PhysicsTools/CondLiteIO/test/IntProductESSource.cc
@@ -77,7 +77,7 @@ IntProductESSource::produce(const IntProductRecord&) {
    auto data = std::make_unique<edmtest::IntProduct>();
    data->value = nCalls_;
    ++nCalls_;
-   return std::move(data);
+   return data;
 }
 
 


### PR DESCRIPTION
#### PR description:

This fixes clang warnings generated during compilation of PhysicsTools packages

#### PR validation:

Local build based on clang IBs shows no more warnings

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
