### PR TITLE
[10.2.X] Additional GBRForest parser without TMVA for LowPtGsfElectrons

### DIFF
--- a/CommonTools/MVAUtils/BuildFile.xml
+++ b/CommonTools/MVAUtils/BuildFile.xml
@@ -1,0 +1,11 @@
+<use   name="CommonTools/Utils"/>
+<use   name="CondFormats/EgammaObjects"/>
+<use   name="FWCore/ParameterSet"/>
+<use   name="FWCore/Utilities"/>
+<use   name="CondFormats/DataRecord"/>
+<use   name="roottmva"/>
+<use   name="tinyxml2"/>
+
+<export>
+  <lib   name="1"/>
+</export>

--- a/CommonTools/MVAUtils/interface/GBRForestTools.h
+++ b/CommonTools/MVAUtils/interface/GBRForestTools.h
@@ -1,0 +1,27 @@
+#ifndef CommonTools_MVAUtils_GBRForestTools_h
+#define CommonTools_MVAUtils_GBRForestTools_h
+
+//--------------------------------------------------------------------------------------------------
+//
+// GRBForestToolsTinyXML
+//
+// Utility to parse an XML weights files specifying an ensemble of decision trees into a GRBForest.
+//
+// Author: Jonas Rembser
+//--------------------------------------------------------------------------------------------------
+
+
+#include "CondFormats/EgammaObjects/interface/GBRForest.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
+#include <memory>
+
+// Create a GBRForest from an XML weight file
+std::unique_ptr<const GBRForest> createGBRForest(const std::string     &weightsFile);
+std::unique_ptr<const GBRForest> createGBRForest(const edm::FileInPath &weightsFile);
+
+// Overloaded versions which are taking string vectors by reference to strore the variable names in
+std::unique_ptr<const GBRForest> createGBRForest(const std::string     &weightsFile, std::vector<std::string> &varNames);
+std::unique_ptr<const GBRForest> createGBRForest(const edm::FileInPath &weightsFile, std::vector<std::string> &varNames);
+
+#endif

--- a/CommonTools/MVAUtils/src/GBRForestTools.cc
+++ b/CommonTools/MVAUtils/src/GBRForestTools.cc
@@ -1,0 +1,304 @@
+#include "CommonTools/MVAUtils/interface/GBRForestTools.h"
+#include "CommonTools/Utils/interface/TMVAZipReader.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <RVersion.h>
+#include <cmath>
+#include <tinyxml2.h>
+
+namespace {
+
+    size_t readVariables(tinyxml2::XMLElement* root, const char * key, std::vector<std::string>& names)
+    {
+      size_t n = 0;
+      names.clear();
+
+      if (root != nullptr) {
+          for(tinyxml2::XMLElement* e = root->FirstChildElement(key);
+                  e != nullptr; e = e->NextSiblingElement(key))
+          {
+              names.push_back(e->Attribute("Expression"));
+              ++n;
+          }
+      }
+
+      return n;
+    }
+
+    bool isTerminal(tinyxml2::XMLElement* node)
+    {
+      bool is = true;
+      for(tinyxml2::XMLElement* e = node->FirstChildElement("Node");
+              e != nullptr; e = e->NextSiblingElement("Node")) {
+          is = false;
+      }
+      return is;
+    }
+
+    unsigned int countIntermediateNodes(tinyxml2::XMLElement* node)
+    {
+
+      unsigned int count = 0;
+      for(tinyxml2::XMLElement* e = node->FirstChildElement("Node");
+              e != nullptr; e = e->NextSiblingElement("Node")) {
+          count += countIntermediateNodes(e);
+      }
+      return count > 0 ? count + 1 : 0;
+      
+    }
+
+    unsigned int countTerminalNodes(tinyxml2::XMLElement* node)
+    {
+      
+      unsigned int count = 0;
+      for(tinyxml2::XMLElement* e = node->FirstChildElement("Node");
+              e != nullptr; e = e->NextSiblingElement("Node")) {
+          count += countTerminalNodes(e);
+      }
+      return count > 0 ? count : 1;
+      
+    }
+
+    void addNode(GBRTree& tree, tinyxml2::XMLElement* node,
+            double scale, bool isRegression, bool useYesNoLeaf,
+            bool adjustboundary, bool isAdaClassifier)
+    {
+
+      bool nodeIsTerminal = isTerminal(node);
+      if (nodeIsTerminal) {
+        double response = 0.;
+        if (isRegression) {
+          node->QueryDoubleAttribute("res", &response);
+        }
+        else {
+          if (useYesNoLeaf) {
+            node->QueryDoubleAttribute("nType", &response);
+          }
+          else {
+            if (isAdaClassifier) {
+                node->QueryDoubleAttribute("purity", &response);
+            } else {
+                node->QueryDoubleAttribute("res", &response);
+            }
+          }
+        }
+        response *= scale;
+        tree.Responses().push_back(response);
+      }
+      else {    
+
+        int thisidx = tree.CutIndices().size(); 
+        
+        int selector; 
+        float cutval; 
+        bool ctype; 
+
+        node->QueryIntAttribute("IVar", &selector);
+        node->QueryFloatAttribute("Cut", &cutval);
+        node->QueryBoolAttribute("cType", &ctype);
+
+        tree.CutIndices().push_back(static_cast<unsigned char>(selector)); 
+
+        //newer tmva versions use >= instead of > in decision tree splits, so adjust cut value
+        //to reproduce the correct behaviour
+        if (adjustboundary) {
+          cutval = std::nextafter(cutval,std::numeric_limits<float>::lowest());
+        }
+        tree.CutVals().push_back(cutval);
+        tree.LeftIndices().push_back(0);   
+        tree.RightIndices().push_back(0);
+        
+        tinyxml2::XMLElement* left = nullptr;
+        tinyxml2::XMLElement* right = nullptr;
+        for(tinyxml2::XMLElement* e = node->FirstChildElement("Node");
+                e != nullptr; e = e->NextSiblingElement("Node")) {
+            if (*(e->Attribute("pos")) == 'l') left = e;
+            else if (*(e->Attribute("pos")) == 'r') right = e;
+        }
+        if (!ctype) {
+          std::swap(left, right);
+        }
+
+        tree.LeftIndices()[thisidx] = isTerminal(left) ? -tree.Responses().size() : tree.CutIndices().size() ;
+        addNode(tree, left, scale, isRegression, useYesNoLeaf, adjustboundary,isAdaClassifier);
+        
+        tree.RightIndices()[thisidx] = isTerminal(right) ? -tree.Responses().size() : tree.CutIndices().size() ;
+        addNode(tree, right, scale, isRegression, useYesNoLeaf, adjustboundary,isAdaClassifier);
+        
+      }
+  
+    }
+
+    std::unique_ptr<GBRForest> init(const std::string& weightsFileFullPath,
+                                    std::vector<std::string>& varNames)
+    {
+
+      //
+      // Load weights file, for gzipped or raw xml file
+      //
+      tinyxml2::XMLDocument xmlDoc;
+
+      using namespace reco::details;
+
+      if (hasEnding(weightsFileFullPath, ".xml")) {
+          xmlDoc.LoadFile(weightsFileFullPath.c_str());
+      } else if (hasEnding(weightsFileFullPath, ".gz") ||
+                 hasEnding(weightsFileFullPath, ".gzip")) {
+          char * buffer = readGzipFile(weightsFileFullPath);
+          xmlDoc.Parse(buffer);
+          free(buffer);
+      }
+
+      tinyxml2::XMLElement* root = xmlDoc.FirstChildElement("MethodSetup");
+      readVariables(root->FirstChildElement("Variables"), "Variable", varNames);
+
+      // Read in the TMVA general info
+      std::map <std::string, std::string> info; 
+      tinyxml2::XMLElement* infoElem = xmlDoc.FirstChildElement("MethodSetup")->FirstChildElement("GeneralInfo");
+      if (infoElem == nullptr) {
+          throw cms::Exception("XMLError")
+              << "No GeneralInfo found in " << weightsFileFullPath << " !!\n";
+      }
+      for(tinyxml2::XMLElement* e = infoElem->FirstChildElement("Info");
+              e != nullptr; e = e->NextSiblingElement("Info"))
+      {
+          const char * name;
+          const char * value;
+          e->QueryStringAttribute("name",  &name);
+          e->QueryStringAttribute("value", &value);
+          info[name] = value;
+      }
+
+      // Read in the TMVA options
+      std::map <std::string, std::string> options; 
+      tinyxml2::XMLElement* optionsElem = xmlDoc.FirstChildElement("MethodSetup")->FirstChildElement("Options");
+      if (optionsElem == nullptr) {
+          throw cms::Exception("XMLError")
+              << "No Options found in " << weightsFileFullPath << " !!\n";
+      }
+      for(tinyxml2::XMLElement* e = optionsElem->FirstChildElement("Option");
+              e != nullptr; e = e->NextSiblingElement("Option"))
+      {
+          const char * name;
+          e->QueryStringAttribute("name",  &name);
+          options[name] = e->GetText();
+      }
+
+      // Get root version number if available
+      int rootTrainingVersion(0);
+      if (info.find("ROOT Release") != info.end()) {
+        std::string s = info["ROOT Release"];
+        rootTrainingVersion = std::stoi(s.substr(s.find("[")+1,s.find("]")-s.find("[")-1));
+      }
+
+      // Get the boosting weights
+      std::vector<double> boostWeights;
+      tinyxml2::XMLElement* weightsElem = xmlDoc.FirstChildElement("MethodSetup")->FirstChildElement("Weights");
+      if (weightsElem == nullptr) {
+          throw cms::Exception("XMLError")
+              << "No Weights found in " << weightsFileFullPath << " !!\n";
+      }
+      bool hasTrees = false;
+      for(tinyxml2::XMLElement* e = weightsElem->FirstChildElement("BinaryTree");
+              e != nullptr; e = e->NextSiblingElement("BinaryTree"))
+      {
+          hasTrees = true;
+          double w;
+          e->QueryDoubleAttribute("boostWeight", &w);
+          boostWeights.push_back(w);
+      }
+      if (!hasTrees) {
+          throw cms::Exception("XMLError")
+              << "No BinaryTrees found in " << weightsFileFullPath << " !!\n";
+      }
+
+      bool isRegression = info["AnalysisType"] == "Regression";
+
+      //special handling for non-gradient-boosted (ie ADABoost) classifiers, where tree responses
+      //need to be renormalized after the training for evaluation purposes
+      bool isAdaClassifier = !isRegression && options["BoostType"] != "Grad";
+      bool useYesNoLeaf = isAdaClassifier && options["UseYesNoLeaf"] == "True";
+
+      //newer tmva versions use >= instead of > in decision tree splits, so adjust cut value
+      //to reproduce the correct behaviour  
+      bool adjustBoundaries = (rootTrainingVersion>=ROOT_VERSION(5,34,20) &&
+              rootTrainingVersion<ROOT_VERSION(6,0,0)) || rootTrainingVersion>=ROOT_VERSION(6,2,0);
+        
+      auto forest = std::make_unique<GBRForest>();
+      forest->SetInitialResponse(isRegression ? boostWeights[0] : 0.);
+      
+      double norm = 0;
+      if (isAdaClassifier) {
+        for (double w : boostWeights) {
+          norm += w;
+        }
+      }
+
+      forest->Trees().reserve(boostWeights.size());
+      size_t itree = 0;
+      // Loop over tree estimators
+      for(tinyxml2::XMLElement* e = weightsElem->FirstChildElement("BinaryTree");
+              e != nullptr; e = e->NextSiblingElement("BinaryTree")) {
+        double scale = isAdaClassifier ? boostWeights[itree]/norm : 1.0;
+
+        tinyxml2::XMLElement* root = e->FirstChildElement("Node");
+        forest->Trees().push_back(GBRTree(countIntermediateNodes(root), countTerminalNodes(root)));
+        auto & tree = forest->Trees().back();
+
+        addNode(tree, root, scale, isRegression, useYesNoLeaf, adjustBoundaries, isAdaClassifier);
+
+        //special case, root node is terminal, create fake intermediate node at root
+        if (tree.CutIndices().empty()) {
+          tree.CutIndices().push_back(0);
+          tree.CutVals().push_back(0);
+          tree.LeftIndices().push_back(0);
+          tree.RightIndices().push_back(0);
+        }
+
+        ++itree;
+      }
+
+      return forest;
+    }
+
+}
+
+// Create a GBRForest from an XML weight file
+std::unique_ptr<const GBRForest>
+createGBRForest(const std::string &weightsFile)
+{
+    std::vector<std::string> varNames;
+    return createGBRForest(weightsFile, varNames);
+}
+
+std::unique_ptr<const GBRForest>
+createGBRForest(const edm::FileInPath &weightsFile)
+{
+    std::vector<std::string> varNames;
+    return createGBRForest(weightsFile.fullPath(), varNames);
+}
+
+// Overloaded versions which are taking string vectors by reference to store the variable names in
+std::unique_ptr<const GBRForest>
+createGBRForest(const std::string &weightsFile, std::vector<std::string> &varNames)
+{
+    std::unique_ptr<GBRForest> gbrForest;
+
+    if(weightsFile[0] == '/') {
+        gbrForest = init(weightsFile, varNames);
+    }
+    else {
+        edm::FileInPath weightsFileEdm(weightsFile);
+        gbrForest = init( weightsFileEdm.fullPath(), varNames);
+    }
+    return gbrForest;
+}
+
+std::unique_ptr<const GBRForest>
+createGBRForest(const edm::FileInPath &weightsFile, std::vector<std::string> &varNames)
+{
+    return createGBRForest(weightsFile.fullPath(), varNames);
+}

--- a/CondFormats/EgammaObjects/interface/GBRTree.h
+++ b/CondFormats/EgammaObjects/interface/GBRTree.h
@@ -39,6 +39,7 @@
 
        GBRTree();
        explicit GBRTree(const TMVA::DecisionTree *tree, double scale, bool useyesnoleaf, bool adjustboundary);
+       explicit GBRTree(int nIntermediate, int nTerminal);
        virtual ~GBRTree();
        
        double GetResponse(const float* vector) const;

--- a/CondFormats/EgammaObjects/src/GBRTree.cxx
+++ b/CondFormats/EgammaObjects/src/GBRTree.cxx
@@ -13,6 +13,21 @@ GBRTree::GBRTree()
 }
 
 //_______________________________________________________________________
+GBRTree::GBRTree(int nIntermediate, int nTerminal)
+{
+
+  //special case, root node is terminal
+  if (nIntermediate==0) nIntermediate = 1;
+  
+  fCutIndices.reserve(nIntermediate);
+  fCutVals.reserve(nIntermediate);
+  fLeftIndices.reserve(nIntermediate);
+  fRightIndices.reserve(nIntermediate);
+  fResponses.reserve(nTerminal);
+
+}
+
+//_______________________________________________________________________
 GBRTree::GBRTree(const TMVA::DecisionTree *tree, double scale, bool useyesnoleaf, bool adjustboundary)
 {
   

--- a/RecoEgamma/EgammaElectronProducers/BuildFile.xml
+++ b/RecoEgamma/EgammaElectronProducers/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="CommonTools/MVAUtils"/>
 <use name="CondFormats/EgammaObjects"/>
 <use name="DataFormats/BeamSpot"/>
 <use name="DataFormats/EgammaCandidates"/>

--- a/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronIDHeavyObjectCache.cc
+++ b/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronIDHeavyObjectCache.cc
@@ -1,3 +1,4 @@
+#include "CommonTools/MVAUtils/interface/GBRForestTools.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
@@ -7,7 +8,6 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "RecoEgamma/EgammaElectronProducers/interface/LowPtGsfElectronIDHeavyObjectCache.h"
-#include "RecoEgamma/EgammaTools/interface/GBRForestTools.h"
 #include <string>
 
 namespace lowptgsfeleid {
@@ -112,7 +112,7 @@ namespace lowptgsfeleid {
       }
     for ( auto& weights : conf.getParameter< std::vector<std::string> >("ModelWeights") ) 
       {
-	models_.push_back(GBRForestTools::createGBRForest(edm::FileInPath(weights)));
+	models_.push_back(createGBRForest(edm::FileInPath(weights)));
       }
     for ( auto& thresh : conf.getParameter< std::vector<double> >("ModelThresholds") )
       {

--- a/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronSeedHeavyObjectCache.cc
+++ b/RecoEgamma/EgammaElectronProducers/src/LowPtGsfElectronSeedHeavyObjectCache.cc
@@ -1,3 +1,4 @@
+#include "CommonTools/MVAUtils/interface/GBRForestTools.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
@@ -6,9 +7,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "RecoEgamma/EgammaElectronProducers/interface/LowPtGsfElectronSeedHeavyObjectCache.h"
-#include "RecoEgamma/EgammaTools/interface/GBRForestTools.h"
-#include "TMVA/MethodBDT.h"
-#include "TMVA/Reader.h"
+
 #include <string>
 
 namespace lowptgsfeleseed {
@@ -119,7 +118,7 @@ namespace lowptgsfeleseed {
       }
     for ( auto& weights : conf.getParameter< std::vector<std::string> >("ModelWeights") ) 
       {
-	models_.push_back(GBRForestTools::createGBRForest(edm::FileInPath(weights)));
+	models_.push_back(createGBRForest(edm::FileInPath(weights)));
       }
     for ( auto& thresh : conf.getParameter< std::vector<double> >("ModelThresholds") )
       {


### PR DESCRIPTION
#### PR description:

* Brings the __CommonTools/MVAUtils__ package from master to 10_2_X to parse XML weights files to GBRForests without TMVA and therefore solve issue https://github.com/cms-sw/cmssw/issues/26154.
* Make the low pt electron reconstruction use the new parser
* Use the new parser in RecoParticleFlow, such that we can keep using the same external PR as in https://github.com/cms-sw/cmssw/pull/26170
* Alternative to https://github.com/cms-sw/cmssw/pull/26170

Depends on external https://github.com/cms-sw/cmsdist/pull/4777.

#### PR validation:

Code compiles and local matrix tests pass.

If you want to test the PR locally as well, there are some extra steps needed besides the usual `git cms-merge-topic` or `git cms-rebase-topic`:
1. Get tinyxml2 [1] and put tinyxml2.h and tinyxml2.cc into CommonTools/MVAUtils/src/
2. Go into `RecoParticleFlow/PFProducer`, clone https://github.com/cms-data/RecoParticleFlow-PFProducer and rename the cloned repository to `data`. Remove the existing data directory if there is already one.

[1] https://github.com/leethomason/tinyxml2
[2] https://github.com/cms-sw/cmssw/blob/master/CommonTools/MVAUtils/src/GBRForestTools.cc#L10