### PR TITLE
Masking legacy HB- energy correction for Run 3

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/SimpleHBHEPhase1Algo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/SimpleHBHEPhase1Algo.h
@@ -45,6 +45,7 @@ public:
                          float phaseNS,
                          float timeShift,
                          bool correctForPhaseContainment,
+                         bool applyLegacyHBMCorrection,
                          std::unique_ptr<PulseShapeFitOOTPileupCorrection> m2,
                          std::unique_ptr<HcalDeterministicFit> detFit,
 			 std::unique_ptr<MahiFit> mahi);
@@ -98,6 +99,7 @@ private:
     float timeShift_;
     int runnum_;
     bool corrFPC_;
+    bool applyLegacyHBMCorrection_;
 
     // "Metod 2" algorithm
     std::unique_ptr<PulseShapeFitOOTPileupCorrection> psFitOOTpuCorr_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/parseHBHEPhase1AlgoDescription.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/parseHBHEPhase1AlgoDescription.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include "RecoLocalCalo/HcalRecAlgos/interface/AbsHBHEPhase1Algo.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 namespace edm {
     class ParameterSet;
@@ -17,5 +18,12 @@ namespace edm {
 //
 std::unique_ptr<AbsHBHEPhase1Algo>
 parseHBHEPhase1AlgoDescription(const edm::ParameterSet& ps);
+
+//
+// Parameter descriptions for "parseHBHEPhase1AlgoDescription".
+// Keep implementation of this function is sync with
+// "parseHBHEPhase1AlgoDescription".
+//
+edm::ParameterSetDescription fillDescriptionForParseHBHEPhase1Algo();
 
 #endif // RecoLocalCalo_HcalRecAlgos_parseHBHEPhase1AlgoDescription_h

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
@@ -139,6 +139,15 @@ edm::ParameterSetDescription fillDescriptionForParseHBHEPhase1Algo()
     edm::ParameterSetDescription desc;
 
     desc.setAllowAnything();
+    desc.add<std::string>("Class", "SimpleHBHEPhase1Algo");
+    desc.add<bool>("useM2", false);
+    desc.add<bool>("useM3", true);
+    desc.add<bool>("useMahi", true);
+    desc.add<int>("firstSampleShift", 0);
+    desc.add<int>("samplesToAdd", 2);
+    desc.add<double>("correctionPhaseNS", 6.0);
+    desc.add<double>("tdcTimeShift", 0.0);
+    desc.add<bool>("correctForPhaseContainment", true);
     desc.add<bool>("applyLegacyHBMCorrection", true);
 
     return desc;

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
@@ -125,9 +125,21 @@ parseHBHEPhase1AlgoDescription(const edm::ParameterSet& ps)
                                      ps.getParameter<double>("correctionPhaseNS"),
                                      ps.getParameter<double>("tdcTimeShift"),
                                      ps.getParameter<bool>  ("correctForPhaseContainment"),
+                                     ps.getParameter<bool>  ("applyLegacyHBMCorrection"),
                                      std::move(m2), std::move(detFit), std::move(mahi))
             );
     }
 
     return algo;
+}
+
+
+edm::ParameterSetDescription fillDescriptionForParseHBHEPhase1Algo()
+{
+    edm::ParameterSetDescription desc;
+
+    desc.setAllowAnything();
+    desc.add<bool>("applyLegacyHBMCorrection", true);
+
+    return desc;
 }

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
@@ -75,7 +75,10 @@ hbheprereco = cms.EDProducer(
         useM3 = cms.bool(True),
 
         # Use Mahi?
-        useMahi = cms.bool(True)
+        useMahi = cms.bool(True),
+
+        # Apply legacy HB- energy correction?
+        applyLegacyHBMCorrection = cms.bool(True)
     ),
 
     # Reconstruction algorithm configuration data to fetch from DB, if any
@@ -108,3 +111,6 @@ hbheprereco.pulseShapeParametersQIE8.TrianglePeakTS = cms.uint32(10000)
 
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 run2_HE_2017.toModify(hbheprereco, saveEffectivePedestal = cms.bool(True))
+
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toModify(hbheprereco, algorithm = dict(applyLegacyHBMCorrection = cms.bool(False)))

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -788,7 +788,7 @@ HBHEPhase1Reconstructor::fillDescriptions(edm::ConfigurationDescriptions& descri
     desc.add<bool>("setLegacyFlagsQIE8");
     desc.add<bool>("setLegacyFlagsQIE11");
 
-    add_param_set(algorithm);
+    desc.add<edm::ParameterSetDescription>("algorithm", fillDescriptionForParseHBHEPhase1Algo());
     add_param_set(flagParametersQIE8);
     add_param_set(flagParametersQIE11);
     add_param_set(pulseShapeParametersQIE8);


### PR DESCRIPTION
#### PR description:

Adding an era-dependent mask so that legacy hardwired HB- energy corrections are not applied for Run 3. These corrections mitigate a hardware defect in the laser calibration system (in the light attenuation filter). They are applied only for data, as this defect is not modelled in the MC. The hardware will be fixed later this year, so these corrections are not needed in the future.

Also, very minor optimizations are made to the M0 rechit time code (no changes to the algorithm).

This is a pure maintenance PR. It is not supposed to modify any relval results.

#### PR validation:

"runTheMatrix" script was run and the results appear to be normal.
