### PR TITLE
EgammaTools - empty classes to free functions and ConversionInfo to struct

### DIFF
--- a/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
+++ b/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
@@ -5,7 +5,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/ElectronHcalHelper.h"
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
-#include "RecoEgamma/EgammaTools/interface/ConversionFinder.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 #include "JetMETCorrections/Objects/interface/JetCorrectionsRecord.h"

--- a/EgammaAnalysis/ElectronTools/interface/SuperClusterHelper.h
+++ b/EgammaAnalysis/ElectronTools/interface/SuperClusterHelper.h
@@ -6,7 +6,6 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
-#include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
@@ -79,7 +78,6 @@ class SuperClusterHelper {
   const EcalRecHitCollection * rechits_;
   const CaloTopology* topology_;
   const CaloGeometry* geometry_;
-  EcalClusterLocal local_;
   bool barrel_;
 
   

--- a/EgammaAnalysis/ElectronTools/src/SuperClusterHelper.cc
+++ b/EgammaAnalysis/ElectronTools/src/SuperClusterHelper.cc
@@ -1,6 +1,7 @@
 #include "EgammaAnalysis/ElectronTools/interface/SuperClusterHelper.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 #include "FWCore/Utilities/interface/isFinite.h"
+#include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
 
 
 
@@ -129,9 +130,9 @@ void SuperClusterHelper::localCoordinates() {
   if (localCoordinatesComputed_) return;
 
   if (barrel_) {
-    local_.localCoordsEB(*seedCluster_, *geometry_, etaCrySeed_ , phiCrySeed_ ,ietaSeed_ , iphiSeed_ , thetaTilt_ , phiTilt_);
+    egammaTools::localEcalClusterCoordsEB(*seedCluster_, *geometry_, etaCrySeed_ , phiCrySeed_ ,ietaSeed_ , iphiSeed_ , thetaTilt_ , phiTilt_);
   } else {
-    local_.localCoordsEE(*seedCluster_, *geometry_, etaCrySeed_ , phiCrySeed_ ,ietaSeed_ , iphiSeed_ , thetaTilt_ , phiTilt_);
+    egammaTools::localEcalClusterCoordsEE(*seedCluster_, *geometry_, etaCrySeed_ , phiCrySeed_ ,ietaSeed_ , iphiSeed_ , thetaTilt_ , phiTilt_);
   }
     localCoordinatesComputed_ = true;
 }

--- a/ElectroWeakAnalysis/ZEE/src/ZeeCandidateFilter.cc
+++ b/ElectroWeakAnalysis/ZEE/src/ZeeCandidateFilter.cc
@@ -932,8 +932,7 @@ Bool_t ZeeCandidateFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSe
 
         if ( iEvent.getByToken(tracksToken_, ctfTracks) ) {
 
-            ConversionFinder convFinder;
-            ConversionInfo convInfo = convFinder.getConversionInfo(maxETelec1, ctfTracks, bfield);
+            ConversionInfo convInfo = egammaTools::getConversionInfo(maxETelec1, ctfTracks, bfield);
 
             Float_t dist = convInfo.dist();
             Float_t dcot = convInfo.dcot();
@@ -1003,8 +1002,7 @@ Bool_t ZeeCandidateFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSe
 
         if ( iEvent.getByToken(tracksToken_, ctfTracks) ) {
 
-            ConversionFinder convFinder;
-            ConversionInfo convInfo = convFinder.getConversionInfo(maxETelec2, ctfTracks, bfield);
+            ConversionInfo convInfo = egammaTools::getConversionInfo(maxETelec2, ctfTracks, bfield);
 
             Float_t dist = convInfo.dist();
             Float_t dcot = convInfo.dcot();

--- a/ElectroWeakAnalysis/ZEE/src/ZeeCandidateFilter.cc
+++ b/ElectroWeakAnalysis/ZEE/src/ZeeCandidateFilter.cc
@@ -934,8 +934,8 @@ Bool_t ZeeCandidateFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSe
 
             ConversionInfo convInfo = egammaTools::getConversionInfo(maxETelec1, ctfTracks, bfield);
 
-            Float_t dist = convInfo.dist();
-            Float_t dcot = convInfo.dcot();
+            Float_t dist = convInfo.dist;
+            Float_t dcot = convInfo.dcot;
 
             Bool_t isConv = ( ( TMath::Abs(dist) < dist1_ ) && ( TMath::Abs(dcot) < dcot1_ ) ) ;
 
@@ -1004,8 +1004,8 @@ Bool_t ZeeCandidateFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSe
 
             ConversionInfo convInfo = egammaTools::getConversionInfo(maxETelec2, ctfTracks, bfield);
 
-            Float_t dist = convInfo.dist();
-            Float_t dcot = convInfo.dcot();
+            Float_t dist = convInfo.dist;
+            Float_t dcot = convInfo.dcot;
 
             Bool_t isConv = ( ( TMath::Abs(dist) < dist2_ ) && ( TMath::Abs(dcot) < dcot2_ ) ) ;
 

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.h
@@ -43,7 +43,6 @@
 #include "DataFormats/PatCandidates/interface/UserData.h"
 #include "PhysicsTools/PatAlgos/interface/PATUserDataHelper.h"
 
-#include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -132,7 +131,6 @@ namespace pat {
       
       const CaloTopology * ecalTopology_;
       const CaloGeometry * ecalGeometry_;
-      EcalClusterLocal ecl_;
 
       bool saveRegressionData_;
 

--- a/PhysicsTools/TagAndProbe/plugins/ElectronConversionRejectionVars.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ElectronConversionRejectionVars.cc
@@ -97,9 +97,9 @@ ElectronConversionRejectionVars::produce(edm::Event & iEvent, const edm::EventSe
 	    && fabs(eleIt->phi() - probe->phi() ) < 0.01 ){
 	  //we have a match
 	  ConversionInfo convInfo = egammaTools::getConversionInfo(*eleIt, tracks_h, evt_bField);
-	  dist = convInfo.dist();
-	  dcot = convInfo.dcot();
-	  convradius = convInfo.radiusOfConversion();
+	  dist = convInfo.dist;
+	  dcot = convInfo.dcot;
+	  convradius = convInfo.radiusOfConversion;
 	  if( fabs(dist)>0.02 && fabs(dcot)>0.02)  passConvRej = 1.0;
 	  break; //got our guy, so break
 	}

--- a/PhysicsTools/TagAndProbe/plugins/ElectronConversionRejectionVars.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ElectronConversionRejectionVars.cc
@@ -86,7 +86,6 @@ ElectronConversionRejectionVars::produce(edm::Event & iEvent, const edm::EventSe
     double dcot = 0.0;
     double convradius = 0.0;
     double passConvRej = 0.0;
-    ConversionFinder convFinder;
 
     View<reco::Candidate>::const_iterator probe, endprobes = probes->end();
     const reco::GsfElectronCollection* electronCollection = elHandle.product();
@@ -97,7 +96,7 @@ ElectronConversionRejectionVars::produce(edm::Event & iEvent, const edm::EventSe
 	if( fabs(eleIt->et() - probe->et() ) < 0.05 && fabs(eleIt->eta() - probe->eta() ) < 0.01
 	    && fabs(eleIt->phi() - probe->phi() ) < 0.01 ){
 	  //we have a match
-	  ConversionInfo convInfo = convFinder.getConversionInfo(*eleIt, tracks_h, evt_bField);
+	  ConversionInfo convInfo = egammaTools::getConversionInfo(*eleIt, tracks_h, evt_bField);
 	  dist = convInfo.dist();
 	  dcot = convInfo.dcot();
 	  convradius = convInfo.radiusOfConversion();

--- a/PhysicsTools/UtilAlgos/interface/AdHocNTupler.h
+++ b/PhysicsTools/UtilAlgos/interface/AdHocNTupler.h
@@ -733,8 +733,7 @@ class AdHocNTupler : public NTupler {
 	//if(!el->closestCtfTrackRef().isNonnull())
 	//cout<< "Could not find an electron ctf track" << endl;	         
 
-        ConversionFinder convFinder;
-        ConversionInfo convInfo = convFinder.getConversionInfo(*el, tracks_h, evt_bField);
+        ConversionInfo convInfo = egammaTools::getConversionInfo(*el, tracks_h, evt_bField);
    
         (*els_conversion_dist).push_back(convInfo.dist());
         (*els_conversion_dcot).push_back(convInfo.dcot());

--- a/RecoEgamma/EgammaElectronAlgos/interface/RegressionHelper.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/RegressionHelper.h
@@ -20,11 +20,6 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
-#include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
-
-
-
-class EcalClusterLocal;
 
 class RegressionHelper {
   public:
@@ -77,7 +72,6 @@ class RegressionHelper {
   const GBRForest * ecalRegErrorEndcap_ ;  
   const GBRForest * combinationReg_ ;
    
-  EcalClusterLocal ecl_;
 };
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -716,7 +716,6 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection & electrons, El
 
   eventData.retreiveOriginalTrackCollections(electronData.ctfTrackRef,electronData.coreRef->gsfTrack()) ;
 
-  ConversionFinder conversionFinder ;
   double BInTesla = eventSetupData_.magField->inTesla(GlobalPoint(0.,0.,0.)).z() ;
   edm::Handle<reco::TrackCollection> ctfTracks = eventData.originalCtfTracks ;
   if (!ctfTracks.isValid()) { ctfTracks = eventData.currentCtfTracks ; }
@@ -727,7 +726,7 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection & electrons, El
   // 1     : Partner track found in the CTF collection using
   // 2     : Partner track found in the GSF collection using
   // 3     : Partner track found in the GSF collection using the electron's GSF track
-  ConversionInfo conversionInfo = conversionFinder.getConversionInfo
+  ConversionInfo conversionInfo = egammaTools::getConversionInfo
    (*electronData.coreRef,ctfTracks,eventData.originalGsfTracks,BInTesla) ;
 
   reco::GsfElectron::ConversionRejection conversionVars ;

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -720,7 +720,7 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection & electrons, El
   edm::Handle<reco::TrackCollection> ctfTracks = eventData.originalCtfTracks ;
   if (!ctfTracks.isValid()) { ctfTracks = eventData.currentCtfTracks ; }
 
-  // values of conversionInfo.flag()
+  // values of conversionInfo.flag
   // -9999 : Partner track was not found
   // 0     : Partner track found in the CTF collection using
   // 1     : Partner track found in the CTF collection using
@@ -730,14 +730,14 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection & electrons, El
    (*electronData.coreRef,ctfTracks,eventData.originalGsfTracks,BInTesla) ;
 
   reco::GsfElectron::ConversionRejection conversionVars ;
-  conversionVars.flags = conversionInfo.flag()  ;
-  conversionVars.dist = conversionInfo.dist()  ;
-  conversionVars.dcot = conversionInfo.dcot()  ;
-  conversionVars.radius = conversionInfo.radiusOfConversion()  ;
+  conversionVars.flags = conversionInfo.flag  ;
+  conversionVars.dist = conversionInfo.dist  ;
+  conversionVars.dcot = conversionInfo.dcot  ;
+  conversionVars.radius = conversionInfo.radiusOfConversion  ;
   if ((conversionVars.flags==0)or(conversionVars.flags==1))
-    conversionVars.partner = TrackBaseRef(conversionInfo.conversionPartnerCtfTk())  ;
+    conversionVars.partner = TrackBaseRef(conversionInfo.conversionPartnerCtfTk)  ;
   else if ((conversionVars.flags==2)or(conversionVars.flags==3))
-    conversionVars.partner = TrackBaseRef(conversionInfo.conversionPartnerGsfTk())  ;
+    conversionVars.partner = TrackBaseRef(conversionInfo.conversionPartnerGsfTk)  ;
 
 
   //====================================================

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronDetaDphiProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTElectronDetaDphiProducer.cc
@@ -134,11 +134,10 @@ std::pair<float,float> EgammaHLTElectronDetaDphiProducer::calDEtaDPhiSCTrk(reco:
       deltaphi = fabs(scAtVtx.dPhi());
     }
   } else if (useTrackProjectionToEcal_) { 
-    ECALPositionCalculator posCalc;
     const math::XYZPoint vertex(bsPosition.x(),bsPosition.y(),eleref->track()->vz());
     
-    float phi1= posCalc.ecalPhi(magField,trackMom,vertex,1);
-    float phi2= posCalc.ecalPhi(magField,trackMom,vertex,-1);
+    float phi1 = egammaTools::ecalPhi(*magField,trackMom,vertex,1);
+    float phi2 = egammaTools::ecalPhi(*magField,trackMom,vertex,-1);
     
     float deltaphi1=fabs( phi1 - theClus->position().phi() );
     if(deltaphi1>6.283185308) deltaphi1 -= 6.283185308;

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
@@ -20,7 +20,6 @@
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 
 #include "DataFormats/Math/interface/Point3D.h"
-#include "RecoEgamma/EgammaTools/interface/ECALPositionCalculator.h"
 
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"

--- a/RecoEgamma/EgammaTools/interface/BaselinePFSCRegression.h
+++ b/RecoEgamma/EgammaTools/interface/BaselinePFSCRegression.h
@@ -2,7 +2,6 @@
 #define __BASELINEPFSCREGRESSION_H__
 
 #include "RecoEgamma/EgammaTools/interface/SCRegressionCalculator.h"
-#include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
 
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h" 
@@ -38,7 +37,6 @@ class BaselinePFSCRegression {
  private:
   const CaloTopologyRecord* topo_record;
   const CaloGeometryRecord* geom_record;
-  EcalClusterLocal ecl_;
   edm::ESHandle<CaloTopology> calotopo;
   edm::ESHandle<CaloGeometry> calogeom;
   edm::EDGetTokenT<EcalRecHitCollection>          inputTagEBRecHits_;

--- a/RecoEgamma/EgammaTools/interface/ConversionFinder.h
+++ b/RecoEgamma/EgammaTools/interface/ConversionFinder.h
@@ -33,10 +33,7 @@
    radius of conversion for this pair and fill the ConversionInfo
 */
 
-class ConversionFinder {
- public:
-  ConversionFinder();
-  ~ConversionFinder();
+namespace egammaTools {
   //bField has to be supplied in Tesla
 
   //returns a vector of Conversion Infos.
@@ -61,16 +58,6 @@ class ConversionFinder {
 				   const double bFieldAtOrigin,
 				   const double minFracSharedHits = 0.45);
 
-  //used internally, so call this only if you know what you're doing.
-  ConversionInfo getConversionInfo(const reco::Track *el_track,
-				   const reco::Track *candPartnerTk,
-				   const double bFieldAtOrigin);
-
-  const reco::Track* getElectronTrack(const reco::GsfElectron &, const float minFracSharedHits = 0.45);
-
-  const reco::Track* getElectronTrack(const reco::GsfElectronCore &, const float minFracSharedHits = 0.45);
-
-
   //takes in a vector of candidate conversion partners
   //and arbitrates between them returning the one with the
   //smallest R=sqrt(dist*dist + dcot*dcot)
@@ -79,13 +66,6 @@ class ConversionFinder {
 
   //places different cuts on dist, dcot, delmissing hits and arbitration based on R = sqrt(dist*dist + dcot*dcot)
   ConversionInfo findBestConversionMatch(const std::vector<ConversionInfo>& v_convCandidates);
-
-  //function below is only for backwards compatibility
-  static std::pair<double, double> getConversionInfo(math::XYZTLorentzVector trk1_p4,
-						     int trk1_q, float trk1_d0,
-						     math::XYZTLorentzVector trk2_p4,
-						     int trk2_q, float trk2_d0,
-						     float bFieldAtOrigin);
 
   //for backwards compatibility. Does not use the GSF track collection. This function will be
   //deprecated soon
@@ -98,7 +78,5 @@ class ConversionFinder {
   // DEPRECATED
   bool isFromConversion( const ConversionInfo &, double maxAbsDist = 0.02, double maxAbsDcot = 0.02);
 
- private:
-
-};
+}
 #endif

--- a/RecoEgamma/EgammaTools/interface/ConversionInfo.h
+++ b/RecoEgamma/EgammaTools/interface/ConversionInfo.h
@@ -1,86 +1,31 @@
 #ifndef EgammaTools_ConversionInfo_h
 #define EgammaTools_ConversionInfo_h
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-//#include "DataFormats/TrackReco/interface/Track.h"
-//#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/Math/interface/Point3D.h"
 
 
-class ConversionInfo
- {
-  public:
+struct ConversionInfo
+{
+    const double dist;
+    const double dcot;
+    const double radiusOfConversion;
+    const math::XYZPoint pointOfConversion;
+    // if the partner track is found in the  GSF track collection,
+    // this is a ref to the GSF partner track
+    const reco::TrackRef conversionPartnerCtfTk;
+    // if the partner track is found in the  CTF track collection,
+    // this is a ref to the CTF partner track
+    const reco::GsfTrackRef conversionPartnerGsfTk;
+    const int deltaMissingHits;
+    const int flag;
 
-    ConversionInfo()
-     {
-      dist_ = -9999.;
-      dcot_ = -9999.;
-      radiusOfConversion_ = -9999.;
-      pointOfConversion_ = math::XYZPoint(-9999.,-9999.,-9999);
-      conversionPartnerCtfTk_ = reco::TrackRef();
-      conversionPartnerGsfTk_ = reco::GsfTrackRef();
-      deltaMissingHits_ = -9999;
-      flag_ = -9999;
-     }
-    ~ConversionInfo() {}
-    ConversionInfo
-     ( double dist, double dcot,
-       double radiusOfConversion, math::XYZPoint pointOfConversion,
-       reco::TrackRef conversionPartnerCtfTk,
-       reco::GsfTrackRef conversionPartnerGsfTk,
-       int deltaMissingHits,
-       int flag )
-     {
-      dist_ = dist;
-      dcot_ = dcot;
-      radiusOfConversion_ = radiusOfConversion;
-      pointOfConversion_ = pointOfConversion;
-      conversionPartnerCtfTk_ = conversionPartnerCtfTk;
-      conversionPartnerGsfTk_ = conversionPartnerGsfTk;
-      deltaMissingHits_ = deltaMissingHits;
-      flag_ = flag;
-     }
-    double dist() const {return dist_ ; }
-    double dcot() const {return dcot_ ; }
-    double radiusOfConversion() const { return radiusOfConversion_ ; }
-    math::XYZPoint pointOfConversion() const { return pointOfConversion_ ; }
-    reco::TrackRef conversionPartnerCtfTk() const { return conversionPartnerCtfTk_ ; }
-
-    //if the partner track is found in the  GSF track collection,
-    //we return a ref to the GSF partner track
-    reco::GsfTrackRef conversionPartnerGsfTk() const { return conversionPartnerGsfTk_ ; }
-
-    //if the partner track is found in the  CTF track collection,
-    //we return a ref to the CTF partner track
-    int deltaMissingHits() const { return deltaMissingHits_ ; }
-    /*
-      if(flag == 0) //Partner track found in the CTF collection using the electron's CTF track
-      if(flag == 1) //Partner track found in the CTF collection using the electron's GSF track
-      if(flag == 2) //Partner track found in the GSF collection using the electron's CTF track
-      if(flag == 3) //Partner track found in the GSF collection using the electron's GSF track
-     */
-    int flag() const { return flag_ ; }
-
-    reco::TrackRef conversionPartnerTk() const {
-      edm::LogWarning("ConversionInfo") << "The conversionPartnerTk() function is deprecated, but still returns the CTF partner track if found! \n"
-                << "Please use either conversionPartnerCtfTk() and conversionPartnerGsfTk() instead. \n";
-      return conversionPartnerCtfTk_;
-    }
-
-  private:
-
-    double dist_;
-    double dcot_;
-    double radiusOfConversion_;
-    math::XYZPoint pointOfConversion_;
-    reco::TrackRef conversionPartnerCtfTk_;
-    reco::GsfTrackRef conversionPartnerGsfTk_;
-    int deltaMissingHits_;
-    int flag_;
-
- } ;
+    // flag 0: Partner track found in the CTF collection using the electron's CTF track
+    // flag 1: Partner track found in the CTF collection using the electron's GSF track
+    // flag 2: Partner track found in the GSF collection using the electron's CTF track
+    // flag 3: Partner track found in the GSF collection using the electron's GSF track
+};
 
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/ECALPositionCalculator.h
+++ b/RecoEgamma/EgammaTools/interface/ECALPositionCalculator.h
@@ -6,14 +6,10 @@
 
 class MagneticField;
 
-class ECALPositionCalculator
+namespace egammaTools
 {
-   public:
-      ECALPositionCalculator() { };
-      double ecalPhi(const MagneticField *magField, const math::XYZVector &momentum, const math::XYZPoint &vertex, const int charge);
-      double ecalEta(const math::XYZVector &momentum, const math::XYZPoint &vertex);
-   private:
-
+    double ecalPhi(const MagneticField &magField, const math::XYZVector &momentum, const math::XYZPoint &vertex, const int charge);
+    double ecalEta(const math::XYZVector &momentum, const math::XYZPoint &vertex);
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EGEnergyCorrector.h
+++ b/RecoEgamma/EgammaTools/interface/EGEnergyCorrector.h
@@ -14,7 +14,6 @@
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 
 class GBRForest;
@@ -42,8 +41,6 @@ class EGEnergyCorrector {
     Bool_t fIsInitialized;
     Bool_t fOwnsForests;
     Float_t *fVals;
-
-    EcalClusterLocal _ecalLocal;
 
     };
 

--- a/RecoEgamma/EgammaTools/interface/EcalClusterLocal.h
+++ b/RecoEgamma/EgammaTools/interface/EcalClusterLocal.h
@@ -8,22 +8,16 @@
   */
 
 
-//#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 
 class CaloGeometry;
 
-class EcalClusterLocal {
-        public:
-          EcalClusterLocal();
-          ~EcalClusterLocal();
+namespace egammaTools {
 
-          void localCoordsEB( const reco::CaloCluster &bclus, const edm::EventSetup &es, float &etacry, float &phicry, int &ieta, int &iphi, float &thetatilt, float &phitilt) const;
-          void localCoordsEE( const reco::CaloCluster &bclus, const edm::EventSetup &es, float &xcry, float &ycry, int &ix, int &iy, float &thetatilt, float &phitilt) const;
-
-	  void localCoordsEB( const reco::CaloCluster &bclus, const CaloGeometry & geom, float &etacry, float &phicry, int &ieta, int &iphi, float &thetatilt, float &phitilt) const;
-          void localCoordsEE( const reco::CaloCluster &bclus, const CaloGeometry & geom, float &xcry, float &ycry, int &ix, int &iy, float &thetatilt, float &phitilt) const;
+    void localEcalClusterCoordsEB( const reco::CaloCluster &bclus, const CaloGeometry & geom, float &etacry,
+                                   float &phicry, int &ieta, int &iphi, float &thetatilt, float &phitilt);
+    void localEcalClusterCoordsEE( const reco::CaloCluster &bclus, const CaloGeometry & geom, float &xcry,
+                                   float &ycry, int &ix, int &iy, float &thetatilt, float &phitilt);
 
 };
 

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
@@ -10,6 +10,8 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
 #include <vdt/vdtMath.h>
 
@@ -214,11 +216,12 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   int iEta;
   float cryPhi;
   float cryEta;
-  EcalClusterLocal ecalLocal;
+  edm::ESHandle<CaloGeometry> caloGeometry;
+  iSetup_->get<CaloGeometryRecord>().get(caloGeometry); 
   if (ele.isEB())
-    ecalLocal.localCoordsEB(*theseed, *iSetup_, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
+    egammaTools::localEcalClusterCoordsEB(*theseed, *caloGeometry, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
   else
-    ecalLocal.localCoordsEE(*theseed, *iSetup_, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
+    egammaTools::localEcalClusterCoordsEE(*theseed, *caloGeometry, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
 
   if (isEB) {
     eval[29] = cryEta;

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
@@ -8,6 +8,8 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
 #include <vdt/vdtMath.h>
 
@@ -162,13 +164,14 @@ void EGRegressionModifierV2::modifyObject(reco::GsfElectron& ele) const {
   eval[25]  = std::max(0,numberOfClusters);
 
   // calculate coordinate variables
-  EcalClusterLocal ecalLocal;
+  edm::ESHandle<CaloGeometry> caloGeometry;
+  iSetup_->get<CaloGeometryRecord>().get(caloGeometry); 
   if (isEB) {
 
     float dummy;
     int ieta;
     int iphi;
-    ecalLocal.localCoordsEB(*seed, *iSetup_, dummy, dummy, ieta, iphi, dummy, dummy);
+    egammaTools::localEcalClusterCoordsEB(*seed, *caloGeometry, dummy, dummy, ieta, iphi, dummy, dummy);
     eval[26] = ieta;
     eval[27] = iphi;
     int signieta = ieta > 0 ? +1 : -1;
@@ -182,7 +185,7 @@ void EGRegressionModifierV2::modifyObject(reco::GsfElectron& ele) const {
     float dummy;
     int ix;
     int iy;
-    ecalLocal.localCoordsEE(*seed, *iSetup_, dummy, dummy, ix, iy, dummy, dummy);
+    egammaTools::localEcalClusterCoordsEE(*seed, *caloGeometry, dummy, dummy, ix, iy, dummy, dummy);
     eval[26] = ix;
     eval[27] = iy;
     eval[28] = raw_es_energy/rawEnergy;
@@ -354,14 +357,15 @@ void EGRegressionModifierV2::modifyObject(reco::Photon& pho) const {
   eval[25]  = std::max(0,numberOfClusters);
 
   // calculate coordinate variables
-  EcalClusterLocal ecalLocal;
+  edm::ESHandle<CaloGeometry> caloGeometry;
+  iSetup_->get<CaloGeometryRecord>().get(caloGeometry); 
 
   if (isEB) {
 
     float dummy;
     int ieta;
     int iphi;
-    ecalLocal.localCoordsEB(*seed, *iSetup_, dummy, dummy, ieta, iphi, dummy, dummy);
+    egammaTools::localEcalClusterCoordsEB(*seed, *caloGeometry, dummy, dummy, ieta, iphi, dummy, dummy);
     eval[26] = ieta;
     eval[27] = iphi;
     int signieta = ieta > 0 ? +1 : -1;
@@ -375,7 +379,7 @@ void EGRegressionModifierV2::modifyObject(reco::Photon& pho) const {
     float dummy;
     int ix;
     int iy;
-    ecalLocal.localCoordsEE(*seed, *iSetup_, dummy, dummy, ix, iy, dummy, dummy);
+    egammaTools::localEcalClusterCoordsEE(*seed, *caloGeometry, dummy, dummy, ix, iy, dummy, dummy);
     eval[26] = ix;
     eval[27] = iy;
     eval[28] = raw_es_energy/rawEnergy;

--- a/RecoEgamma/EgammaTools/src/ConversionFinder.cc
+++ b/RecoEgamma/EgammaTools/src/ConversionFinder.cc
@@ -5,22 +5,26 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "TMath.h"
 
+namespace egammaTools {
+
 typedef math::XYZTLorentzVector LorentzVector;
 
-bool ConversionFinder::isFromConversion(const ConversionInfo &convInfo,
+ConversionInfo getConversionInfo(const reco::Track *el_track,
+                                 const reco::Track *candPartnerTk,
+                                 const double bFieldAtOrigin);
+
+const reco::Track* getElectronTrack(const reco::GsfElectron &, const float minFracSharedHits = 0.45);
+
+const reco::Track* getElectronTrack(const reco::GsfElectronCore &, const float minFracSharedHits = 0.45);
+
+bool isFromConversion(const ConversionInfo &convInfo,
         double maxAbsDist, double maxAbsDcot)
 {
   return (std::abs(convInfo.dist()) < maxAbsDist) && (std::abs(convInfo.dcot()) < maxAbsDcot);
 }
 
 //-----------------------------------------------------------------------------
-ConversionFinder::ConversionFinder() {}
-
-//-----------------------------------------------------------------------------
-ConversionFinder::~ConversionFinder() {}
-
-//-----------------------------------------------------------------------------
-ConversionInfo ConversionFinder::getConversionInfo(const reco::GsfElectron& gsfElectron,
+ConversionInfo getConversionInfo(const reco::GsfElectron& gsfElectron,
 								const edm::Handle<reco::TrackCollection>& ctftracks_h,
 								const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
 								const double bFieldAtOrigin,
@@ -31,7 +35,7 @@ ConversionInfo ConversionFinder::getConversionInfo(const reco::GsfElectron& gsfE
 
 }
 //-----------------------------------------------------------------------------
-ConversionInfo ConversionFinder::getConversionInfo(const reco::GsfElectronCore& gsfElectron,
+ConversionInfo getConversionInfo(const reco::GsfElectronCore& gsfElectron,
 						    const edm::Handle<reco::TrackCollection>& ctftracks_h,
 						    const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
 						    const double bFieldAtOrigin,
@@ -44,7 +48,7 @@ ConversionInfo ConversionFinder::getConversionInfo(const reco::GsfElectronCore& 
 
 
 //-----------------------------------------------------------------------------
-std::vector<ConversionInfo> ConversionFinder::getConversionInfos(const reco::GsfElectronCore& gsfElectron,
+std::vector<ConversionInfo> getConversionInfos(const reco::GsfElectronCore& gsfElectron,
 								const edm::Handle<reco::TrackCollection>& ctftracks_h,
 								const edm::Handle<reco::GsfTrackCollection>& gsftracks_h,
 								const double bFieldAtOrigin,
@@ -240,7 +244,7 @@ std::vector<ConversionInfo> ConversionFinder::getConversionInfos(const reco::Gsf
 
 
 //-------------------------------------------------------------------------------------
-ConversionInfo ConversionFinder::getConversionInfo(const reco::Track *el_track,
+ConversionInfo getConversionInfo(const reco::Track *el_track,
 						   const reco::Track *candPartnerTk,
 						   const double bFieldAtOrigin) {
 
@@ -288,7 +292,7 @@ ConversionInfo ConversionFinder::getConversionInfo(const reco::Track *el_track,
 }
 
 //-------------------------------------------------------------------------------------
-const reco::Track* ConversionFinder::getElectronTrack(const reco::GsfElectron& electron, const float minFracSharedHits) {
+const reco::Track* getElectronTrack(const reco::GsfElectron& electron, const float minFracSharedHits) {
 
   if(electron.closestCtfTrackRef().isNonnull() &&
      electron.shFracInnerHits() > minFracSharedHits)
@@ -302,7 +306,7 @@ const reco::Track* ConversionFinder::getElectronTrack(const reco::GsfElectron& e
 //takes in a vector of candidate conversion partners
 //and arbitrates between them returning the one with the
 //smallest R=sqrt(dist*dist + dcot*dcot)
-ConversionInfo ConversionFinder::arbitrateConversionPartnersbyR(const std::vector<ConversionInfo>& v_convCandidates) {
+ConversionInfo arbitrateConversionPartnersbyR(const std::vector<ConversionInfo>& v_convCandidates) {
 
   if(v_convCandidates.size() == 1)
     return v_convCandidates.at(0);
@@ -325,7 +329,7 @@ ConversionInfo ConversionFinder::arbitrateConversionPartnersbyR(const std::vecto
  }
 
 //------------------------------------------------------------------------------------
-ConversionInfo ConversionFinder::findBestConversionMatch(const std::vector<ConversionInfo>& v_convCandidates)
+ConversionInfo findBestConversionMatch(const std::vector<ConversionInfo>& v_convCandidates)
  {
   using namespace std;
 
@@ -420,7 +424,7 @@ ConversionInfo ConversionFinder::findBestConversionMatch(const std::vector<Conve
 
 //------------------------------------------------------------------------------------
 // Exists here for backwards compatibility only. Provides only the dist and dcot
-std::pair<double, double> ConversionFinder::getConversionInfo(LorentzVector trk1_p4,
+std::pair<double, double> getConversionInfo(LorentzVector trk1_p4,
 							      int trk1_q, float trk1_d0,
 							      LorentzVector trk2_p4,
 							      int trk2_q, float trk2_d0,
@@ -450,7 +454,7 @@ std::pair<double, double> ConversionFinder::getConversionInfo(LorentzVector trk1
 
 
 //-------------------------------------- Also for backwards compatibility reasons  ---------------------------------------------------------------
-ConversionInfo ConversionFinder::getConversionInfo(const reco::GsfElectron& gsfElectron,
+ConversionInfo getConversionInfo(const reco::GsfElectron& gsfElectron,
 						   const edm::Handle<reco::TrackCollection>& track_h,
 						   const double bFieldAtOrigin,
 						   const double minFracSharedHits) {
@@ -564,5 +568,7 @@ ConversionInfo ConversionFinder::getConversionInfo(const reco::GsfElectron& gsfE
   return ConversionInfo(dist, dcot, rconv, convPoint, candCtfTrackRef, GsfTrackRef(), deltaMissingHits, flag);
 
  }
+
+}
 
 //-------------------------------------------------------------------------------------

--- a/RecoEgamma/EgammaTools/src/ECALPositionCalculator.cc
+++ b/RecoEgamma/EgammaTools/src/ECALPositionCalculator.cc
@@ -7,11 +7,13 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 
-static const float R_ECAL           = 136.5;
-static const float Z_Endcap         = 328.0;
-static const float etaBarrelEndcap  = 1.479;
+static constexpr float R_ECAL           = 136.5;
+static constexpr float Z_Endcap         = 328.0;
+static constexpr float etaBarrelEndcap  = 1.479;
 
-double ECALPositionCalculator::ecalPhi(const MagneticField *magField,const math::XYZVector &momentum, const math::XYZPoint &vertex, int charge)
+namespace egammaTools {
+
+double ecalPhi(const MagneticField &magField,const math::XYZVector &momentum, const math::XYZPoint &vertex, const int charge)
 {
 
    // Get kinematic variables
@@ -27,7 +29,7 @@ double ECALPositionCalculator::ecalPhi(const MagneticField *magField,const math:
    const float ZENDM = 3.186 ;  	// was 3.15 , updated on 16122003
 
    float rbend = RBARM-(vRho/100.0); 	//Assumed vRho in cm
-   float bend  = 0.3 * magField->inTesla(GlobalPoint(0.,0.,0.)).z() * rbend / 2.0; 
+   float bend  = 0.3 * magField.inTesla(GlobalPoint(0.,0.,0.)).z() * rbend / 2.0; 
    float phi = 0.0;
 
    if( fabs(etaParticle) <=  etaBarrelEndcap)
@@ -66,7 +68,7 @@ double ECALPositionCalculator::ecalPhi(const MagneticField *magField,const math:
 
 }
 
-double ECALPositionCalculator::ecalEta(const math::XYZVector &momentum, const math::XYZPoint &vertex)
+double ecalEta(const math::XYZVector &momentum, const math::XYZPoint &vertex)
 {
 
    // Get kinematic variables
@@ -105,3 +107,4 @@ double ECALPositionCalculator::ecalEta(const math::XYZVector &momentum, const ma
 
 }
 
+}

--- a/RecoEgamma/EgammaTools/src/EGEnergyCorrector.cc
+++ b/RecoEgamma/EgammaTools/src/EGEnergyCorrector.cc
@@ -1,4 +1,3 @@
-
 #include <TFile.h>
 #include "RecoEgamma/EgammaTools/interface/EGEnergyCorrector.h"
 #include "CondFormats/EgammaObjects/interface/GBRForest.h"
@@ -9,6 +8,9 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
+#include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
 using namespace reco;
 
@@ -220,7 +222,9 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const Photo
     //seed cluster
     float betacry, bphicry, bthetatilt, bphitilt;
     int bieta, biphi;
-    _ecalLocal.localCoordsEB(*b,es,betacry,bphicry,bieta,biphi,bthetatilt,bphitilt);
+    edm::ESHandle<CaloGeometry> caloGeometry;
+    es.get<CaloGeometryRecord>().get(caloGeometry); 
+    egammaTools::localEcalClusterCoordsEB(*b,*caloGeometry,betacry,bphicry,bieta,biphi,bthetatilt,bphitilt);
 
     fVals[56] = bieta; //crystal ieta
     fVals[57] = biphi; //crystal iphi
@@ -235,7 +239,8 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const Photo
     //2nd cluster (meaningful gap corrections for converted photons)
     float bc2etacry, bc2phicry, bc2thetatilt, bc2phitilt;
     int bc2ieta, bc2iphi;
-    if (hasbc2) _ecalLocal.localCoordsEB(*b2,es,bc2etacry,bc2phicry,bc2ieta,bc2iphi,bc2thetatilt,bc2phitilt);
+    if (hasbc2) egammaTools::localEcalClusterCoordsEB( *b2,*caloGeometry,bc2etacry,bc2phicry,
+                                                       bc2ieta,bc2iphi,bc2thetatilt,bc2phitilt );
 
     fVals[64] = hasbc2 ? bc2ieta : 0.;
     fVals[65] = hasbc2 ? bc2iphi : 0.;
@@ -416,7 +421,9 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const GsfEl
 
     float betacry, bphicry, bthetatilt, bphitilt;
     int bieta, biphi;
-    _ecalLocal.localCoordsEB(*b,es,betacry,bphicry,bieta,biphi,bthetatilt,bphitilt);
+    edm::ESHandle<CaloGeometry> caloGeometry;
+    es.get<CaloGeometryRecord>().get(caloGeometry); 
+    egammaTools::localEcalClusterCoordsEB(*b,*caloGeometry,betacry,bphicry,bieta,biphi,bthetatilt,bphitilt);
 
     fVals[56] = bieta;
     fVals[57] = biphi;
@@ -429,7 +436,8 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithError(const GsfEl
 
     float bc2etacry, bc2phicry, bc2thetatilt, bc2phitilt;
     int bc2ieta, bc2iphi;
-    if (hasbc2) _ecalLocal.localCoordsEB(*b2,es,bc2etacry,bc2phicry,bc2ieta,bc2iphi,bc2thetatilt,bc2phitilt);
+    if (hasbc2) egammaTools::localEcalClusterCoordsEB( *b2,*caloGeometry,bc2etacry,bc2phicry,
+                                                       bc2ieta,bc2iphi,bc2thetatilt,bc2phitilt );
 
     fVals[64] = hasbc2 ? bc2ieta : 0.;
     fVals[65] = hasbc2 ? bc2iphi : 0.;
@@ -540,7 +548,9 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Pho
     //seed cluster
     float betacry, bphicry, bthetatilt, bphitilt;
     int bieta, biphi;
-    _ecalLocal.localCoordsEB(*b,es,betacry,bphicry,bieta,biphi,bthetatilt,bphitilt);
+    edm::ESHandle<CaloGeometry> caloGeometry;
+    es.get<CaloGeometryRecord>().get(caloGeometry); 
+    egammaTools::localEcalClusterCoordsEB(*b,*caloGeometry,betacry,bphicry,bieta,biphi,bthetatilt,bphitilt);
 
     fVals[30] = bieta; //crystal ieta
     fVals[31] = biphi; //crystal iphi
@@ -702,7 +712,9 @@ std::pair<double,double> EGEnergyCorrector::CorrectedEnergyWithErrorV3(const Gsf
     //seed cluster
     float betacry, bphicry, bthetatilt, bphitilt;
     int bieta, biphi;
-    _ecalLocal.localCoordsEB(*b,es,betacry,bphicry,bieta,biphi,bthetatilt,bphitilt);
+    edm::ESHandle<CaloGeometry> caloGeometry;
+    es.get<CaloGeometryRecord>().get(caloGeometry); 
+    egammaTools::localEcalClusterCoordsEB(*b,*caloGeometry,betacry,bphicry,bieta,biphi,bthetatilt,bphitilt);
 
     fVals[30] = bieta; //crystal ieta
     fVals[31] = biphi; //crystal iphi

--- a/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc
+++ b/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc
@@ -1,8 +1,4 @@
 #include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/TruncatedPyramid.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
@@ -13,22 +9,10 @@
 #include "TMath.h"
 #include "TVector2.h"
 
-EcalClusterLocal::EcalClusterLocal()
-{}
+namespace egammaTools {
 
-EcalClusterLocal::~EcalClusterLocal()
-{}
-
-void EcalClusterLocal::localCoordsEB( const reco::CaloCluster &bclus, const edm::EventSetup &es, float &etacry, float &phicry, int &ieta, int &iphi, float &thetatilt, float &phitilt) const {
-  edm::ESHandle<CaloGeometry> pG;
-  es.get<CaloGeometryRecord>().get(pG); 
-  localCoordsEB( bclus, *pG, etacry, phicry, ieta, iphi, thetatilt, phitilt);
-}
-
-
-
- 
-void EcalClusterLocal::localCoordsEB( const reco::CaloCluster &bclus, const CaloGeometry & caloGeometry,  float &etacry, float &phicry, int &ieta, int &iphi, float &thetatilt, float &phitilt) const
+void localEcalClusterCoordsEB( const reco::CaloCluster &bclus, const CaloGeometry & caloGeometry,
+                               float &etacry, float &phicry, int &ieta, int &iphi, float &thetatilt, float &phitilt )
 {
   
   assert(bclus.hitsAndFractions().at(0).first.subdetId()==EcalBarrel);
@@ -96,14 +80,8 @@ void EcalClusterLocal::localCoordsEB( const reco::CaloCluster &bclus, const Calo
 
 }
 
-void EcalClusterLocal::localCoordsEE( const reco::CaloCluster &bclus, const edm::EventSetup &es, float &xcry, float &ycry, int &ix, int &iy, float &thetatilt, float &phitilt) const
-{
-  edm::ESHandle<CaloGeometry> pG;
-  es.get<CaloGeometryRecord>().get(pG); 
-  localCoordsEE( bclus, *pG, xcry, ycry, ix, iy, thetatilt, phitilt);
-}
-
-void EcalClusterLocal::localCoordsEE( const reco::CaloCluster &bclus, const CaloGeometry & caloGeometry, float &xcry, float &ycry, int &ix, int &iy, float &thetatilt, float &phitilt) const
+void localEcalClusterCoordsEE( const reco::CaloCluster &bclus, const CaloGeometry & caloGeometry,
+                               float &xcry, float &ycry, int &ix, int &iy, float &thetatilt, float &phitilt )
 {
     
   assert(bclus.hitsAndFractions().at(0).first.subdetId()==EcalEndcap);
@@ -170,5 +148,7 @@ void EcalClusterLocal::localCoordsEE( const reco::CaloCluster &bclus, const Calo
   ycry = (Y-YCentr)/YWidth;
   
   return;
+
+}
 
 }

--- a/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
+++ b/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
@@ -85,18 +85,11 @@ void EcalRegressionData::fill(const reco::SuperCluster& superClus,
   else if(localCovs[1]>0) sigmaIEtaIPhi_ = 1.;
   else sigmaIEtaIPhi_ = -1.;
   
+  auto localCoordsFunc = isEB() ? egammaTools::localEcalClusterCoordsEB : egammaTools::localEcalClusterCoordsEE;
 
-  EcalClusterLocal ecalClusterLocal; //not clear why this doesnt use static functions
-  float thetaTilt=0,phiTilt=0; //dummy variables that are not used but are required by below function
-  void (EcalClusterLocal::*localCoordFunc)(const reco::CaloCluster &, const CaloGeometry &,
-  					   float &, float &, int &, int &, 
-  					   float &, float &)const;
-  localCoordFunc = &EcalClusterLocal::localCoordsEB;
-  if(!isEB()) localCoordFunc = &EcalClusterLocal::localCoordsEE;
-  (ecalClusterLocal.*localCoordFunc)(*superClus.seed(),*geom,
-				     seedCrysEtaOrX_,seedCrysPhiOrY_,
-				     seedCrysIEtaOrIX_,seedCrysIPhiOrIY_,
-				     thetaTilt,phiTilt);
+  float dummy;
+  localCoordsFunc( *superClus.seed(),*geom, seedCrysEtaOrX_,seedCrysPhiOrY_,
+                   seedCrysIEtaOrIX_,seedCrysIPhiOrIY_, dummy, dummy );
 
   for( auto clus = superClus.clustersBegin()+1;clus != superClus.clustersEnd(); ++clus ) {
     const float dEta = (*clus)->eta() - superClus.seed()->eta();

--- a/RecoEgamma/ElectronIdentification/src/CutBasedElectronID.cc
+++ b/RecoEgamma/ElectronIdentification/src/CutBasedElectronID.cc
@@ -1,7 +1,6 @@
 #include "RecoEgamma/ElectronIdentification/interface/CutBasedElectronID.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
-//#include "RecoEgamma/EgammaTools/interface/ConversionFinder.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
 #include <algorithm>

--- a/RecoEgamma/ElectronIdentification/src/CutBasedElectronID.cc
+++ b/RecoEgamma/ElectronIdentification/src/CutBasedElectronID.cc
@@ -25,7 +25,7 @@ void CutBasedElectronID::setup(const edm::ParameterSet& conf) {
     newCategories_ = conf.getParameter<bool>("additionalCategories");
   }
 
-  if (type_ == "classbased" and (version_ == "V03" or version_ == "V04" or version_ == "V05" or version_ == "")) {
+  if (type_ == "classbased" and (version_ == "V03" or version_ == "V04" or version_ == "V05" or version_.empty())) {
     wantBinning_ = conf.getParameter<bool>("etBinning");
     newCategories_ = conf.getParameter<bool>("additionalCategories");
   }
@@ -328,7 +328,7 @@ double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
     return result;
   }
 
-  if (type_ == "classbased" && (version_ == "V06" || version_ == "")) { 
+  if (type_ == "classbased" && (version_ == "V06" || version_.empty())) { 
     std::vector<double> cutIsoSum      = cuts_.getParameter<std::vector<double> >("cutiso_sum");
     std::vector<double> cutIsoSumCorr  = cuts_.getParameter<std::vector<double> >("cutiso_sumoet");
     std::vector<double> cuthoe         = cuts_.getParameter<std::vector<double> >("cuthoe");


### PR DESCRIPTION
#### PR description:

Another of the occasional quick PRs where the member functions of classes without data members get converted to free functions, so these classes don't have to be instantiated.

Besides, I realized that the ConversionInfo class was basically just an immutable data structure, so this is made explicit by turning it into a struct with const members only, also avoiding some "magic" 9999 literals. I want to showcase that not everything has to be a class, and getters/setters are not always needed:

https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rh-get

#### PR validation:

Local matrix tests pass.