### PR TITLE
ClusterRepair template initialization bugfix

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -508,7 +508,12 @@ void PixelCPEClusterRepair::checkRecommend2D( DetParam const & theDetParam, Clus
     }
     // The 1d pixel template
     SiPixelTemplate templ(thePixelTemp_);
-    templ.interpolate(ID, theClusterParam.cotalpha, theClusterParam.cotbeta, theDetParam.bz, theDetParam.bx);
+    if(!templ.interpolate(ID, theClusterParam.cotalpha, theClusterParam.cotbeta, theDetParam.bz, theDetParam.bx)){
+        //error setting up template, return false
+        theClusterParam.recommended2D_ = false;
+        return;
+    }
+
 
     //length of the cluster taking into account double sized pixels
     float nypix = clusterPayload.mcol;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -508,6 +508,7 @@ void PixelCPEClusterRepair::checkRecommend2D( DetParam const & theDetParam, Clus
     }
     // The 1d pixel template
     SiPixelTemplate templ(thePixelTemp_);
+    templ.interpolate(ID, theClusterParam.cotalpha, theClusterParam.cotbeta, theDetParam.bz, theDetParam.bx);
 
     //length of the cluster taking into account double sized pixels
     float nypix = clusterPayload.mcol;


### PR DESCRIPTION
#### PR description:
This is a bugfix for the ClusterRepair CPE. Previously, one of the objects used to check whether to run 2D reco or not was not fully initialized. This lead to inconsistent behavior due to dependence on un-initialized variables. The ClusterRepair module is still turned off on during standard reconstruction so we expect no change in all of the tests. With ClusterRepair turned on the difference will be more consistent/better hit position estimates. 

#### PR validation:
Standard runTheMatrix tests have been done.
Also hit position residuals with ClusterRepair on have been checked, and the frequency of the usage of the 2d reco matches our expectations and the expected behavior improvement in residuals is seen. 


