### PR TITLE
one::OutputModule now supports transition caches

### DIFF
--- a/FWCore/Framework/interface/one/OutputModule.h
+++ b/FWCore/Framework/interface/one/OutputModule.h
@@ -51,6 +51,9 @@ namespace edm {
         return WantsGlobalLuminosityBlockTransitions<T...>::value;
       }
 
+      SerialTaskQueue* globalRunsQueue() final { return globalRunsQueue_.queue();}
+      SerialTaskQueue* globalLuminosityBlocksQueue() final { return globalLuminosityBlocksQueue_.queue();}
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------
@@ -61,6 +64,8 @@ namespace edm {
       const OutputModule& operator=(const OutputModule&) =delete; // stop default
       
       // ---------- member data --------------------------------
+      impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalRunTransitions<T...>::value> globalRunsQueue_;
+      impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalLuminosityBlockTransitions<T...>::value> globalLuminosityBlocksQueue_;
       
     };
   }

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -102,8 +102,8 @@ namespace edm {
       bool wantsStreamRuns() const {return false;}
       bool wantsStreamLuminosityBlocks() const {return false;};
 
-      SerialTaskQueue* globalRunsQueue() { return &runQueue_;}
-      SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_;}
+      virtual SerialTaskQueue* globalRunsQueue() { return nullptr; }
+      virtual SerialTaskQueue* globalLuminosityBlocksQueue() { return nullptr; }
       SharedResourcesAcquirer& sharedResourcesAcquirer() {
         return resourcesAcquirer_;
       }
@@ -128,6 +128,7 @@ namespace edm {
       ParameterSetID selectorConfig() const { return selector_config_id_; }
 
       void doPreallocate(PreallocationConfiguration const&);
+      virtual void preallocLumis(unsigned int) ;
 
       void doBeginJob();
       void doEndJob();

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -205,6 +205,8 @@ namespace edm {
     void OutputModuleBase::doPreallocate(PreallocationConfiguration const& iPC) {
       auto nstreams = iPC.numberOfStreams();
       selectors_.resize(nstreams);
+
+      preallocLumis(iPC.numberOfLuminosityBlocks());
       
       bool seenFirst = false;
       for(auto& s : selectors_) {
@@ -219,6 +221,8 @@ namespace edm {
         }
       }
     }
+
+    void OutputModuleBase::preallocLumis(unsigned int ) {}
 
     void OutputModuleBase::doBeginJob() {
       resourcesAcquirer_ = createAcquirer();

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -43,7 +43,9 @@ class testOneOutputModule: public CppUnit::TestFixture
   
   CPPUNIT_TEST(basicTest);
   CPPUNIT_TEST(runTest);
+  CPPUNIT_TEST(runCacheTest);
   CPPUNIT_TEST(lumiTest);
+  CPPUNIT_TEST(lumiCacheTest);
   CPPUNIT_TEST(fileTest);
   CPPUNIT_TEST(resourceTest);
   
@@ -56,7 +58,9 @@ public:
 
   void basicTest();
   void runTest();
+  void runCacheTest();
   void lumiTest();
+  void lumiCacheTest();
   void fileTest();
   void resourceTest();
 
@@ -143,7 +147,6 @@ private:
     }
   };
 
-
   class LumiOutputModule : public edm::one::OutputModule<edm::one::WatchLuminosityBlocks> {
   public:
     using edm::one::OutputModuleBase::doPreallocate;
@@ -168,6 +171,60 @@ private:
       ++m_count;
     }
   };
+
+  struct DummyCache {};
+  
+  class RunCacheOutputModule : public edm::one::OutputModule<edm::RunCache<DummyCache>> {
+  public:
+    using edm::one::OutputModuleBase::doPreallocate;
+    RunCacheOutputModule(edm::ParameterSet const& iPSet) : edm::one::OutputModuleBase(iPSet), edm::one::OutputModule<edm::RunCache<DummyCache>>(iPSet) {}
+    mutable unsigned int m_count = 0;
+    void write(edm::EventForOutput const&) override {
+      ++m_count;
+    }
+    void writeRun(edm::RunForOutput const&) override {
+      ++m_count;
+    }
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
+      ++m_count;
+    }
+    
+    std::shared_ptr<DummyCache> globalBeginRun(edm::RunForOutput const&) const override {
+      ++m_count;
+      return std::shared_ptr<DummyCache>{};
+    }
+
+    void globalEndRun(edm::RunForOutput const&)  override {
+      ++m_count;
+    }
+  };
+
+  class LumiCacheOutputModule : public edm::one::OutputModule<edm::LuminosityBlockCache<DummyCache>> {
+  public:
+    using edm::one::OutputModuleBase::doPreallocate;
+    LumiCacheOutputModule(edm::ParameterSet const& iPSet) : edm::one::OutputModuleBase(iPSet), edm::one::OutputModule<edm::LuminosityBlockCache<DummyCache>>(iPSet) {}
+    mutable unsigned int m_count = 0;
+    void write(edm::EventForOutput const&) override {
+      ++m_count;
+    }
+    void writeRun(edm::RunForOutput const&) override {
+      ++m_count;
+    }
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
+      ++m_count;
+    }
+    
+    
+    std::shared_ptr<DummyCache> globalBeginLuminosityBlock(edm::LuminosityBlockForOutput const&) const override {
+      ++m_count;
+      return std::shared_ptr<DummyCache>{};
+    }
+    
+    void globalEndLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
+      ++m_count;
+    }
+  };
+
   class FileOutputModule : public edm::one::OutputModule<edm::WatchInputFiles> {
   public:
     using edm::one::OutputModuleBase::doPreallocate;
@@ -412,6 +469,30 @@ void testOneOutputModule::lumiTest()
 
   edm::ParameterSet pset;
   auto testProd = std::make_shared<LumiOutputModule>(pset);
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
+}
+
+void testOneOutputModule::runCacheTest()
+{
+  //make the services available
+  edm::ServiceRegistry::Operate operate(serviceToken_);
+
+  edm::ParameterSet pset;
+  auto testProd = std::make_shared<RunCacheOutputModule>(pset);
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalEndRun});
+}
+
+void testOneOutputModule::lumiCacheTest()
+{
+  //make the services available
+  edm::ServiceRegistry::Operate operate(serviceToken_);
+
+  edm::ParameterSet pset;
+  auto testProd = std::make_shared<LumiCacheOutputModule>(pset);
   
   CPPUNIT_ASSERT(0 == testProd->m_count);
   testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});


### PR DESCRIPTION
#### PR description:

Can now use LuminosityBlockCache and RunCache with one::OutputModule.
When used, the module does not cause a synchronization barrier at those transitions.

#### PR validation:

Framework code compiles. All framework related unit tests pass.