### PR TITLE
set False as default for bypassVersionCheck

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -28,7 +28,7 @@ def mergeProcess(*inputFiles, **options):
     - output_file : sets the output file name
     - output_lfn : sets the output LFN
     - mergeNANO : to merge NanoAOD
-    - bypassVersionCheck : to bypass version check in case merging happened in lower version of CMSSW (i.e. UL HLT case). This will be TRUE by default.
+    - bypassVersionCheck : to bypass version check in case merging happened in lower version of CMSSW (i.e. UL HLT case). This will be FALSE by default.
 
     """
     #  //
@@ -41,7 +41,7 @@ def mergeProcess(*inputFiles, **options):
     dropDQM = options.get("drop_dqm", False)
     newDQMIO = options.get("newDQMIO", False)
     mergeNANO = options.get("mergeNANO", False)
-    bypassVersionCheck = options.get("bypassVersionCheck", True)
+    bypassVersionCheck = options.get("bypassVersionCheck", False)
     #  //
     # // build process
     #//
@@ -55,7 +55,8 @@ def mergeProcess(*inputFiles, **options):
         process.add_(Service("DQMStore"))
     else:
         process.source = Source("PoolSource")
-        process.source.bypassVersionCheck = CfgTypes.untracked.bool(bypassVersionCheck)
+        if bypassVersionCheck:
+            process.source.bypassVersionCheck = CfgTypes.untracked.bool(True)
         if dropDQM:
             process.source.inputCommands = CfgTypes.untracked.vstring('keep *','drop *_EDMtoMEConverter_*_*')
     process.source.fileNames = CfgTypes.untracked(CfgTypes.vstring())

--- a/Configuration/DataProcessing/test/RunMerge.py
+++ b/Configuration/DataProcessing/test/RunMerge.py
@@ -24,7 +24,7 @@ class RunMerge:
         self.inputFiles = []
         self.newDQMIO = False
         self.mergeNANO = False
-        self.bypassVersionCheck = True
+        self.bypassVersionCheck = False
         
 
     def __call__(self):


### PR DESCRIPTION
#### PR description:

Following the discussion in XC - ULHLT, 
https://indico.cern.ch/event/806058/,
the bypassVersionCheck should turn to False by default, except for 8_0 and 9_4.

This PR is to set the bypassVersionCheck to False by default.

#### PR validation:

`python RunMerge.py --input-files 'a.root' `

> process.source = cms.Source("PoolSource",
>     fileNames = cms.untracked.vstring("[\'a.root\']")
> )

`python RunMerge.py --input-files 'a.root' --bypassVersionCheck`

> process.source = cms.Source("PoolSource",
>     bypassVersionCheck = cms.untracked.bool(True),
>     fileNames = cms.untracked.vstring("[\'a.root\']")
> )

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
