### PR TITLE
Initialize pointer in MCMatchCandRefSelector constructor

### DIFF
--- a/PhysicsTools/HepMCCandAlgos/plugins/MCMatchCandRefSelector.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/MCMatchCandRefSelector.cc
@@ -24,7 +24,7 @@ namespace reco {
       bool operator()(const CandidateBaseRef &) const;
     private:
       EDGetTokenT<GenParticleMatch> srcToken_;
-      const GenParticleMatch * match_;
+      const GenParticleMatch * match_ = nullptr;
     };
 
     void MCMatchCandRefSelector::newEvent(const Event& evt, const EventSetup&) {


### PR DESCRIPTION
#### PR description:

All member data are not set at constructor.
#### PR validation:

Compiled using CMSSW_10_6_ASAN_X_2019-03-15-2300 and the warning went away.
