### PR TITLE
Fix v12 IO rule for HitPattern

### DIFF
--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -445,6 +445,14 @@ public:
     int numberOfDTStationsWithRZView() const;
     int numberOfDTStationsWithBothViews() const;
 
+  //only used by ROOT IO rule to read v12 HitPatterns
+  static bool fillNewHitPatternWithOldHitPattern_v12(const uint16_t oldHitPattern[], 
+                                                     uint8_t hitCount,
+                                                     uint8_t beginTrackHits, uint8_t endTrackHits,
+                                                     uint8_t beginInner, uint8_t endInner,
+                                                     uint8_t beginOuter, uint8_t endOuter,
+                                                     reco::HitPattern* newObj);
+
 private:
 
     // 3 bits for hit type

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -29,80 +29,17 @@
   </class>
  <ioread
     sourceClass="reco::HitPattern"
-      source="uint16_t hitPattern[50]"
+      source="uint16_t hitPattern[50]; uint8_t hitCount; uint8_t beginTrackHits; uint8_t endTrackHits;uint8_t beginInner; uint8_t endInner; uint8_t beginOuter; uint8_t endOuter;"
       targetClass="reco::HitPattern"
-      target="hitPattern"
+      target=""
       version="[12]"
-      include="utility"
       >
    <![CDATA[
-            using namespace reco;
-
-            const unsigned short HitSize = 11;
-            const unsigned short PatternSize = 50;
-            const int MaxHits = (PatternSize * sizeof(uint16_t) * 8) / HitSize;
-
-            auto getHitFromOldHitPattern = [](const uint16_t hitPattern[], const int position) {
-                uint16_t bitEndOffset = (position + 1) * HitSize;
-                uint8_t secondWord   = (bitEndOffset >> 4);
-                uint8_t secondWordBits = bitEndOffset & (16 - 1); // that is, bitEndOffset % 32
-                if (secondWordBits >= HitSize) {
-                    // full block is in this word
-                    uint8_t lowBitsToTrash = secondWordBits - HitSize;
-                    return (hitPattern[secondWord] >> lowBitsToTrash) & ((1 << HitSize) - 1);
-                } else {
-                    uint8_t  firstWordBits   = HitSize - secondWordBits;
-                    uint16_t firstWordBlock  = hitPattern[secondWord - 1] >> (16 - firstWordBits);
-                    uint16_t secondWordBlock = hitPattern[secondWord] & ((1 << secondWordBits) - 1);
-                    return firstWordBlock + (secondWordBlock << firstWordBits);
-                }
-            };
-
-            auto appendOldHitPattern = [&](const uint16_t pattern) {
-                // for this version we just have to add a 0 bit to the top of the pattern
-                const static unsigned short HitTypeMask = 0x3;
-                const static unsigned short HitTypeOffset = 0;                
-
-                const uint16_t VALID_CONST = (uint16_t) TrackingRecHit::valid;
-                const uint16_t MISSING_CONST = (uint16_t) TrackingRecHit::missing;
-                const uint16_t INACTIVE_CONST = (uint16_t) TrackingRecHit::inactive;
-                const uint16_t BAD_CONST = (uint16_t) TrackingRecHit::bad;
-
-                uint16_t rawHitType = (pattern >> HitTypeOffset) & HitTypeMask;                
-
-                TrackingRecHit::Type hitType = TrackingRecHit::valid;
-                switch (rawHitType) {
-                case VALID_CONST:
-                    hitType = TrackingRecHit::valid;
-                    break;
-                case MISSING_CONST:
-                    hitType = TrackingRecHit::missing;
-                    break;
-                case INACTIVE_CONST:
-                    hitType = TrackingRecHit::inactive;
-                    break;
-                case BAD_CONST:
-                    hitType = TrackingRecHit::bad;
-                    break;
-                }                
-                return newObj->appendHit(pattern,hitType);                
-            };
-
-            auto fillNewHitPatternWithOldHitPattern = [&](const uint16_t oldHitPattern[]) {
-                newObj->clear();
-                for (int i = 0; i < MaxHits; i++) {
-                    uint16_t pattern = getHitFromOldHitPattern(oldHitPattern, i);
-                    if (pattern == 0) {
-                        break;
-                    }
-                    if(!appendOldHitPattern(pattern)) {
-                        return false;
-                    }
-                }
-                return true;
-            };
-
-            fillNewHitPatternWithOldHitPattern(onfile.hitPattern);
+            (void) reco::HitPattern::fillNewHitPatternWithOldHitPattern_v12(onfile.hitPattern, *onfile.hitCount,
+                    *onfile.beginTrackHits, *onfile.endTrackHits,
+                    *onfile.beginInner,  *onfile.endInner,
+                    *onfile.beginOuter, *onfile.endOuter,
+                    newObj);
       ]]>
  </ioread>
  <ioread

--- a/DataFormats/TrackReco/src/rootio_HitPattern.cc
+++ b/DataFormats/TrackReco/src/rootio_HitPattern.cc
@@ -9,7 +9,7 @@ using namespace reco;
 namespace {
   constexpr unsigned short HitSize = 11;
   constexpr unsigned short PatternSize = 50;
-  constexpr int MaxHits = (PatternSize * sizeof(uint16_t) * 8) / HitSize;
+  constexpr int MaxHitsV12 = (PatternSize * sizeof(uint16_t) * 8) / HitSize;
   
   auto getHitFromOldHitPattern(const uint16_t hitPattern[], const int position) {
     const uint16_t bitEndOffset = (position + 1) * HitSize;
@@ -66,7 +66,7 @@ reco::HitPattern::fillNewHitPatternWithOldHitPattern_v12(const uint16_t oldHitPa
                                                          HitPattern* newObj) {
   newObj->clear();
   bool ret = true;
-  for (int i = 0; i < MaxHits; i++) {
+  for (int i = 0; i < MaxHitsV12; i++) {
     uint16_t pattern = getHitFromOldHitPattern(oldHitPattern, i);
     //if (pattern == 0) {
     //  break;

--- a/DataFormats/TrackReco/src/rootio_HitPattern.cc
+++ b/DataFormats/TrackReco/src/rootio_HitPattern.cc
@@ -68,9 +68,9 @@ reco::HitPattern::fillNewHitPatternWithOldHitPattern_v12(const uint16_t oldHitPa
   bool ret = true;
   for (int i = 0; i < MaxHitsV12; i++) {
     uint16_t pattern = getHitFromOldHitPattern(oldHitPattern, i);
-    //if (pattern == 0) {
-    //  break;
-    //}
+    if (pattern == 0) {
+      break;
+    }
     if(! newObj->appendHit(pattern, hitTypeFromOldHitPattern(pattern)) ) {
       ret = false;
       break;

--- a/DataFormats/TrackReco/src/rootio_HitPattern.cc
+++ b/DataFormats/TrackReco/src/rootio_HitPattern.cc
@@ -1,0 +1,87 @@
+#include "DataFormats/TrackReco/interface/HitPattern.h"
+
+/* This file contains the function used to read back v12 versions of HitPatterns from a ROOT file.
+   The function is called by a ROOT IO rule.
+ */
+
+using namespace reco;
+
+namespace {
+  constexpr unsigned short HitSize = 11;
+  constexpr unsigned short PatternSize = 50;
+  constexpr int MaxHits = (PatternSize * sizeof(uint16_t) * 8) / HitSize;
+  
+  auto getHitFromOldHitPattern(const uint16_t hitPattern[], const int position) {
+    const uint16_t bitEndOffset = (position + 1) * HitSize;
+    const uint8_t secondWord   = (bitEndOffset >> 4);
+    const uint8_t secondWordBits = bitEndOffset & (16 - 1); // that is, bitEndOffset % 32
+    if (secondWordBits >= HitSize) {
+      // full block is in this word
+     const  uint8_t lowBitsToTrash = secondWordBits - HitSize;
+      return (hitPattern[secondWord] >> lowBitsToTrash) & ((1 << HitSize) - 1);
+    }
+    const uint8_t  firstWordBits   = HitSize - secondWordBits;
+    const uint16_t firstWordBlock  = hitPattern[secondWord - 1] >> (16 - firstWordBits);
+    const uint16_t secondWordBlock = hitPattern[secondWord] & ((1 << secondWordBits) - 1);
+    return firstWordBlock + (secondWordBlock << firstWordBits);
+  }
+
+  auto hitTypeFromOldHitPattern(const uint16_t pattern) {
+    // for this version we just have to add a 0 bit to the top of the pattern
+    constexpr unsigned short HitTypeMask = 0x3;
+    constexpr unsigned short HitTypeOffset = 0;                
+    
+    constexpr uint16_t VALID_CONST = (uint16_t) TrackingRecHit::valid;
+    constexpr uint16_t MISSING_CONST = (uint16_t) TrackingRecHit::missing;
+    constexpr uint16_t INACTIVE_CONST = (uint16_t) TrackingRecHit::inactive;
+    constexpr  uint16_t BAD_CONST = (uint16_t) TrackingRecHit::bad;
+    
+    const uint16_t rawHitType = (pattern >> HitTypeOffset) & HitTypeMask;                
+    
+    TrackingRecHit::Type hitType = TrackingRecHit::valid;
+    switch (rawHitType) {
+    case VALID_CONST:
+      hitType = TrackingRecHit::valid;
+      break;
+    case MISSING_CONST:
+      hitType = TrackingRecHit::missing;
+      break;
+    case INACTIVE_CONST:
+      hitType = TrackingRecHit::inactive;
+      break;
+    case BAD_CONST:
+      hitType = TrackingRecHit::bad;
+      break;
+    }
+    return hitType;
+  };
+}
+
+bool 
+reco::HitPattern::fillNewHitPatternWithOldHitPattern_v12(const uint16_t oldHitPattern[], 
+                                                         uint8_t hitCount,
+                                                         uint8_t beginTrackHits, uint8_t endTrackHits,
+                                                         uint8_t beginInner, uint8_t endInner,
+                                                         uint8_t beginOuter, uint8_t endOuter,
+                                                         HitPattern* newObj) {
+  newObj->clear();
+  bool ret = true;
+  for (int i = 0; i < MaxHits; i++) {
+    uint16_t pattern = getHitFromOldHitPattern(oldHitPattern, i);
+    //if (pattern == 0) {
+    //  break;
+    //}
+    if(! newObj->appendHit(pattern, hitTypeFromOldHitPattern(pattern)) ) {
+      ret = false;
+      break;
+    }
+  }
+  newObj->hitCount = hitCount;
+  newObj->beginTrackHits =beginTrackHits;
+  newObj->endTrackHits = endTrackHits;
+  newObj->beginInner = beginInner;
+  newObj->endInner = endInner;
+  newObj->beginOuter = beginOuter;
+  newObj->endOuter = endOuter;
+  return ret;
+}

--- a/DataFormats/TrackReco/test/testHitPattern.cpp
+++ b/DataFormats/TrackReco/test/testHitPattern.cpp
@@ -60,6 +60,107 @@ namespace test {
        assert(hp.numberOfValidTimingHits() == 1);
     }
     
+    {
+      uint16_t oldHitPattern[50]  = {20113,
+                                     44149,
+                                     2321,
+                                     19529,
+                                     37506,
+                                     34993,
+                                     11429,
+                                     12644,
+                                     23051,
+                                     13124,
+                                     26,
+                                     0};
+
+
+      uint8_t hitCount = 15;
+      uint8_t beginTrackHits = 3;
+      uint8_t endTrackHits = 15;
+      uint8_t beginInner = 0;
+      uint8_t endInner = 0;
+      uint8_t beginOuter = 0;
+      uint8_t endOuter = 3;
+      
+      HitPattern hp;
+      HitPattern::fillNewHitPatternWithOldHitPattern_v12(oldHitPattern, hitCount,
+                                                         beginTrackHits, endTrackHits,
+                                                         beginInner, endInner,
+                                                         beginOuter, endOuter,
+                                                         &hp);
+
+      assert(hp.numberOfValidTrackerHits() ==12 );                         
+      assert(hp.numberOfValidPixelHits() == 4);                           
+      assert(hp.numberOfValidPixelBarrelHits() == 4 );                     
+      assert(hp.numberOfValidPixelEndcapHits() == 0);                     
+      assert(hp.numberOfValidStripHits() == 8 );                           
+      assert(hp.numberOfValidStripTIBHits() == 6);                        
+      assert(hp.numberOfValidStripTIDHits() == 0);                        
+      assert(hp.numberOfValidStripTOBHits() == 2);                        
+      assert(hp.numberOfValidStripTECHits() == 0);                        
+
+      assert(hp.numberOfTimingHits() == 0);         
+      assert(hp.numberOfValidTimingHits() ==  0);    
+      assert(hp.numberOfValidTimingBTLHits() == 0 );       
+      assert(hp.numberOfValidTimingETLHits() == 0);       
+
+      assert(hp.numberOfLostTimingHits() == 0 );     
+      assert(hp.numberOfLostTimingBTLHits() == 0);  
+      assert(hp.numberOfLostTimingETLHits() == 0 );  
+    
+      assert(hp.numberOfMuonHits() == 0);             
+      assert(hp.numberOfValidMuonHits() == 0);        
+      assert(hp.numberOfValidMuonDTHits() == 0);      
+      assert(hp.numberOfValidMuonCSCHits() == 0); //20     
+      assert(hp.numberOfValidMuonRPCHits() == 0);     
+      assert(hp.numberOfValidMuonGEMHits() == 0);     
+      assert(hp.numberOfValidMuonME0Hits() == 0);     
+
+      assert(hp.numberOfLostMuonHits() == 0);         
+      assert(hp.numberOfLostMuonDTHits() == 0);       
+      assert(hp.numberOfLostMuonCSCHits() == 0);      
+      assert(hp.numberOfLostMuonRPCHits() == 0);      
+      assert(hp.numberOfLostMuonGEMHits() == 0);      
+      assert(hp.numberOfLostMuonME0Hits() == 0);      
+
+      assert(hp.numberOfBadHits() == 0); // 30             
+      assert(hp.numberOfBadMuonHits() == 0);          
+      assert(hp.numberOfBadMuonDTHits() == 0);        
+      assert(hp.numberOfBadMuonCSCHits() == 0);       
+      assert(hp.numberOfBadMuonRPCHits() == 0);       
+      assert(hp.numberOfBadMuonGEMHits() == 0);       
+      assert(hp.numberOfBadMuonME0Hits() == 0);       
+
+      assert(hp.numberOfInactiveHits() == 0);         
+      assert(hp.numberOfInactiveTrackerHits() == 0);  
+      //assert(hp.numberOfInactiveTimingHits() );   
+
+      assert(hp.numberOfValidStripLayersWithMonoAndStereo() == 3);
+
+      assert(hp.trackerLayersWithMeasurementOld() == 9); //40        
+      assert(hp.trackerLayersWithMeasurement() == 9 );        
+      assert(hp.pixelLayersWithMeasurementOld() == 4);          
+      assert(hp.pixelLayersWithMeasurement() == 4);          
+      assert(hp.stripLayersWithMeasurement() == 5);          
+      assert(hp.pixelBarrelLayersWithMeasurement() == 4);    
+      assert(hp.pixelEndcapLayersWithMeasurement() == 0 );    
+      assert(hp.stripTIBLayersWithMeasurement() == 4);       
+      assert(hp.stripTIDLayersWithMeasurement() == 0 );       
+      assert(hp.stripTOBLayersWithMeasurement() == 1);       
+      assert(hp.stripTECLayersWithMeasurement() == 0); //50       
+
+      assert(hp.trackerLayersNull() ==20);                   
+      assert(hp.pixelLayersNull() == 3);                     
+      assert(hp.stripLayersNull() == 17);                     
+      assert(hp.pixelBarrelLayersNull() == 0);               
+      assert(hp.pixelEndcapLayersNull() == 3);               
+      assert(hp.stripTIBLayersNull() == 0);                  
+      assert(hp.stripTIDLayersNull() == 3);                  
+      assert(hp.stripTOBLayersNull() == 5);                  
+      assert(hp.stripTECLayersNull() == 9);                  
+
+    }
     
     
         HitPattern hp1;


### PR DESCRIPTION
#### PR description:

The original rule depended on the exact order in which the different member data were filled by ROOT. The new rule explicitly tells ROOT about the dependencies between member data.

#### PR validation:

Compared reading a file containing a v12 version of HitPattern in both ROOT 6.12 and ROOT 6.14 versions of CMSSW_10_6. Dumped the values of the various functions of HitPattern and compared the results from both versions of ROOT. With this change, the values are identical.

Added a unit test which uses values from one of the previously failing v12 data objects.
