### PR TITLE
[PPS] Conditions format update for diamond timing calibration

### DIFF
--- a/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
+++ b/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
@@ -21,7 +21,7 @@ class PPSTimingCalibration
     /// Helper structure for indexing calibration data
     struct Key
     {
-      int key1, key2, key3, key4;
+      int db, sampic, channel, cell;
 
       /// Comparison operator
       bool operator<( const Key& rhs ) const;

--- a/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
+++ b/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
@@ -21,7 +21,7 @@ class PPSTimingCalibration
     /// Helper structure for indexing calibration data
     struct Key
     {
-      int db, sampic, channel, cell;
+      int key1, key2, key3, key4;
 
       /// Comparison operator
       bool operator<( const Key& rhs ) const;
@@ -39,10 +39,10 @@ class PPSTimingCalibration
       formula_( formula ), parameters_( params ), timeInfo_( timeinfo ) {}
     ~PPSTimingCalibration() = default;
 
-    std::vector<double> parameters( int db, int sampic, int channel, int cell ) const;
+    std::vector<double> parameters( int key1, int key2, int key3, int key4 ) const;
     inline const std::string& formula() const { return formula_; }
-    double timeOffset( int db, int sampic, int channel ) const;
-    double timePrecision( int db, int sampic, int channel ) const;
+    double timeOffset( int key1, int key2, int key3, int key4 = -1 ) const;
+    double timePrecision( int key1, int key2, int key3, int key4 = -1 ) const;
 
     friend std::ostream& operator<<( std::ostream& os, const PPSTimingCalibration& data );
 

--- a/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
@@ -72,7 +72,6 @@ PPSTimingCalibrationESSource::PPSTimingCalibrationESSource( const edm::Parameter
 edm::ESProducts<std::unique_ptr<PPSTimingCalibration> >
 PPSTimingCalibrationESSource::produce( const PPSTimingCalibrationRcd& )
 {
-  edm::LogInfo("ddd") << "---> " << (int)subdetector_;
   switch ( subdetector_ ) {
     case Detector::TOTEM_VERTICAL:
       return edm::es::products( parseTotemJsonFile() );

--- a/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
@@ -119,7 +119,7 @@ PPSTimingCalibrationESSource::parseTotemJsonFile() const
       time_info[key] = { timeOffset, timePrecision };
 
       int cell_ct = 0;
-      for ( pt::ptree::value_type &cell : board.second.get_child( "cells" ) ) {
+      for ( pt::ptree::value_type& cell : board.second.get_child( "cells" ) ) {
         std::vector<double> values;
         key.cell = cell_ct;
 
@@ -142,26 +142,28 @@ PPSTimingCalibrationESSource::parsePPSDiamondJsonFile() const
   const std::string formula = node.get<std::string>( "formula" );
   PPSTimingCalibration::ParametersMap params;
   PPSTimingCalibration::TimingMap time_info;
-  edm::LogInfo("cc") << formula << std::endl;
 
   for ( pt::ptree::value_type& par : node.get_child( "Parameters.Sectors" ) ) {
     PPSTimingCalibration::Key key;
     key.db = par.second.get<int>( "sector" );
-    edm::LogInfo("bb") << key.db << std::endl;
 
-    for ( pt::ptree::value_type& pl : par.second.get_child( "Planes" ) ) {
-      key.sampic = pl.second.get<int>( "plane" );
-      for ( pt::ptree::value_type& ch : pl.second.get_child( "Channels" ) ) {
-        key.channel = ch.second.get<int>( "channel" );
-        key.cell = -1;
-        double timeOffset = ch.second.get<double>( "time_offset" );
-        double timePrecision = ch.second.get<double>( "time_precision" );
-        time_info[key] = { timeOffset, timePrecision };
-        std::vector<double> values;
-        for ( pt::ptree::value_type& param : ch.second.get_child( "param" ) )
-          values.emplace_back( std::stod( param.second.data(), nullptr ) );
-        params[key] = values;
-        edm::LogInfo("aa") << key << "|" << values[0];
+    for ( pt::ptree::value_type& st : par.second.get_child( "Stations" ) ) {
+      key.sampic = st.second.get<int>( "station" );
+
+      for ( pt::ptree::value_type& pl : st.second.get_child( "Planes" ) ) {
+        key.channel = pl.second.get<int>( "plane" );
+
+        for ( pt::ptree::value_type& ch : pl.second.get_child( "Channels" ) ) {
+          key.cell = ch.second.get<int>( "channel" );
+          double timeOffset = ch.second.get<double>( "time_offset" );
+          double timePrecision = ch.second.get<double>( "time_precision" );
+          time_info[key] = { timeOffset, timePrecision };
+
+          std::vector<double> values;
+          for ( pt::ptree::value_type& param : ch.second.get_child( "param" ) )
+            values.emplace_back( std::stod( param.second.data(), nullptr ) );
+          params[key] = values;
+        }
       }
     }
   }

--- a/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
@@ -72,6 +72,7 @@ PPSTimingCalibrationESSource::PPSTimingCalibrationESSource( const edm::Parameter
 edm::ESProducts<std::unique_ptr<PPSTimingCalibration> >
 PPSTimingCalibrationESSource::produce( const PPSTimingCalibrationRcd& )
 {
+  edm::LogInfo("ddd") << "---> " << (int)subdetector_;
   switch ( subdetector_ ) {
     case Detector::TOTEM_VERTICAL:
       return edm::es::products( parseTotemJsonFile() );
@@ -141,19 +142,26 @@ PPSTimingCalibrationESSource::parsePPSDiamondJsonFile() const
   const std::string formula = node.get<std::string>( "formula" );
   PPSTimingCalibration::ParametersMap params;
   PPSTimingCalibration::TimingMap time_info;
+  edm::LogInfo("cc") << formula << std::endl;
 
   for ( pt::ptree::value_type& par : node.get_child( "Parameters.Sectors" ) ) {
     PPSTimingCalibration::Key key;
     key.db = par.second.get<int>( "sector" );
+    edm::LogInfo("bb") << key.db << std::endl;
 
     for ( pt::ptree::value_type& pl : par.second.get_child( "Planes" ) ) {
       key.sampic = pl.second.get<int>( "plane" );
       for ( pt::ptree::value_type& ch : pl.second.get_child( "Channels" ) ) {
         key.channel = ch.second.get<int>( "channel" );
+        key.cell = -1;
+        double timeOffset = ch.second.get<double>( "time_offset" );
+        double timePrecision = ch.second.get<double>( "time_precision" );
+        time_info[key] = { timeOffset, timePrecision };
         std::vector<double> values;
         for ( pt::ptree::value_type& param : ch.second.get_child( "param" ) )
           values.emplace_back( std::stod( param.second.data(), nullptr ) );
         params[key] = values;
+        edm::LogInfo("aa") << key << "|" << values[0];
       }
     }
   }

--- a/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
@@ -2,6 +2,7 @@
  *
  * This is a part of CTPPS offline software.
  * Authors:
+ *   Edoardo Bossini
  *   Filip Dej
  *   Laurent Forthomme
  *
@@ -99,14 +100,14 @@ PPSTimingCalibrationESSource::setIntervalFor( const edm::eventsetup::EventSetupR
 std::unique_ptr<PPSTimingCalibration>
 PPSTimingCalibrationESSource::parseTotemUFSDJsonFile() const
 {
-  pt::ptree node;
-  pt::read_json( filename_, node );
+  pt::ptree mother_node;
+  pt::read_json( filename_, mother_node );
 
-  const std::string formula = node.get<std::string>( "formula" );
+  const std::string formula = mother_node.get<std::string>( "formula" );
   PPSTimingCalibration::ParametersMap params;
   PPSTimingCalibration::TimingMap time_info;
 
-  for ( pt::ptree::value_type& par : node.get_child( "parameters" ) ) {
+  for ( pt::ptree::value_type& par : mother_node.get_child( "parameters" ) ) {
     PPSTimingCalibration::Key key;
     key.key1 = (int)strtol( par.first.data(), nullptr, 10 );
 
@@ -136,14 +137,14 @@ PPSTimingCalibrationESSource::parseTotemUFSDJsonFile() const
 std::unique_ptr<PPSTimingCalibration>
 PPSTimingCalibrationESSource::parsePPSDiamondJsonFile() const
 {
-  pt::ptree node;
-  pt::read_json( filename_, node );
+  pt::ptree mother_node;
+  pt::read_json( filename_, mother_node );
 
-  const std::string formula = node.get<std::string>( "formula" );
+  const std::string formula = mother_node.get<std::string>( "formula" );
   PPSTimingCalibration::ParametersMap params;
   PPSTimingCalibration::TimingMap time_info;
 
-  for ( pt::ptree::value_type& par : node.get_child( "Parameters.Sectors" ) ) {
+  for ( pt::ptree::value_type& par : mother_node.get_child( "Parameters.Sectors" ) ) {
     PPSTimingCalibration::Key key;
     key.key1 = par.second.get<int>( "sector" );
 

--- a/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
@@ -109,20 +109,20 @@ PPSTimingCalibrationESSource::parseTotemUFSDJsonFile() const
 
   for ( pt::ptree::value_type& par : mother_node.get_child( "parameters" ) ) {
     PPSTimingCalibration::Key key;
-    key.key1 = (int)strtol( par.first.data(), nullptr, 10 );
+    key.db = (int)strtol( par.first.data(), nullptr, 10 );
 
     for ( pt::ptree::value_type& board : par.second ) {
-      key.key2 = board.second.get<int>( "sampic" );
-      key.key3 = board.second.get<int>( "channel" );
+      key.sampic = board.second.get<int>( "sampic" );
+      key.channel = board.second.get<int>( "channel" );
       double timeOffset = board.second.get<double>( "time_offset" );
       double timePrecision = board.second.get<double>( "time_precision" );
-      key.key4 = -1;
+      key.cell = -1;
       time_info[key] = { timeOffset, timePrecision };
 
       int cell_ct = 0;
       for ( pt::ptree::value_type& cell : board.second.get_child( "cells" ) ) {
         std::vector<double> values;
-        key.key4 = cell_ct;
+        key.cell = cell_ct;
 
         for ( pt::ptree::value_type& param : cell.second )
           values.emplace_back( std::stod( param.second.data(), nullptr ) );
@@ -146,16 +146,16 @@ PPSTimingCalibrationESSource::parsePPSDiamondJsonFile() const
 
   for ( pt::ptree::value_type& par : mother_node.get_child( "Parameters.Sectors" ) ) {
     PPSTimingCalibration::Key key;
-    key.key1 = par.second.get<int>( "sector" );
+    key.db = par.second.get<int>( "sector" );
 
     for ( pt::ptree::value_type& st : par.second.get_child( "Stations" ) ) {
-      key.key2 = st.second.get<int>( "station" );
+      key.sampic = st.second.get<int>( "station" );
 
       for ( pt::ptree::value_type& pl : st.second.get_child( "Planes" ) ) {
-        key.key3 = pl.second.get<int>( "plane" );
+        key.channel = pl.second.get<int>( "plane" );
 
         for ( pt::ptree::value_type& ch : pl.second.get_child( "Channels" ) ) {
-          key.key4 = ch.second.get<int>( "channel" );
+          key.cell = ch.second.get<int>( "channel" );
           double timeOffset = ch.second.get<double>( "time_offset" );
           double timePrecision = ch.second.get<double>( "time_precision" );
           time_info[key] = { timeOffset, timePrecision };

--- a/CondFormats/CTPPSReadoutObjects/python/PPSTimingDetEnum_cff.py
+++ b/CondFormats/CTPPSReadoutObjects/python/PPSTimingDetEnum_cff.py
@@ -1,0 +1,5 @@
+class PPSTimingDetEnum:
+    INVALID     = 0
+    TOTEM_UFSD  = 1
+    PPS_DIAMOND = 2
+

--- a/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
@@ -14,29 +14,29 @@
 bool
 PPSTimingCalibration::Key::operator<( const PPSTimingCalibration::Key& rhs ) const
 {
-  if ( db == rhs.db ) {
-    if ( sampic == rhs.sampic ) {
-      if ( channel == rhs.channel )
-        return cell < rhs.cell;
-      return channel < rhs.channel;
+  if ( key1 == rhs.key1 ) {
+    if ( key2 == rhs.key2 ) {
+      if ( key3 == rhs.key3 )
+        return key4 < rhs.key4;
+      return key3 < rhs.key4;
     }
-    return sampic < rhs.sampic;
+    return key2 < rhs.key2;
   }
-  return db < rhs.db;
+  return key1 < rhs.key1;
 }
 
 std::ostream&
 operator<<( std::ostream& os, const PPSTimingCalibration::Key& key )
 {
-  return os << key.db << " " << key.sampic << " " << key.channel << " " << key.cell;
+  return os << key.key1 << " " << key.key2 << " " << key.key3 << " " << key.key4;
 }
 
 //--------------------------------------------------------------------------
 
 std::vector<double>
-PPSTimingCalibration::parameters( int db, int sampic, int channel, int cell ) const
+PPSTimingCalibration::parameters( int key1, int key2, int key3, int key4 ) const
 {
-  Key key{ db, sampic, channel, cell };
+  Key key{ key1, key2, key3, key4 };
   auto out = parameters_.find( key );
   if ( out == parameters_.end() )
     return {};
@@ -44,9 +44,9 @@ PPSTimingCalibration::parameters( int db, int sampic, int channel, int cell ) co
 }
 
 double
-PPSTimingCalibration::timeOffset( int db, int sampic, int channel ) const
+PPSTimingCalibration::timeOffset( int key1, int key2, int key3, int key4 ) const
 {
-  Key key{ db, sampic, channel, -1 };
+  Key key{ key1, key2, key3, key4 };
   auto out = timeInfo_.find( key );
   if ( out == timeInfo_.end() )
     return 0.;
@@ -54,9 +54,9 @@ PPSTimingCalibration::timeOffset( int db, int sampic, int channel ) const
 }
 
 double
-PPSTimingCalibration::timePrecision( int db, int sampic, int channel ) const
+PPSTimingCalibration::timePrecision( int key1, int key2, int key3, int key4 ) const
 {
-  Key key{ db, sampic, channel, -1 };
+  Key key{ key1, key2, key3, key4 };
   auto out = timeInfo_.find( key );
   if ( out == timeInfo_.end() )
     return 0.;

--- a/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
@@ -71,9 +71,7 @@ operator<<( std::ostream& os, const PPSTimingCalibration& data )
     os << kv.first <<" [";
     for ( size_t i = 0; i < kv.second.size(); ++i )
       os << ( i > 0 ? ", " : "" ) << kv.second.at( i );
-    PPSTimingCalibration::Key k = kv.first;
-    k.cell = -1;
-    const auto& time = data.timeInfo_.at( k );
+    const auto& time = data.timeInfo_.at( kv.first );
     os << "] " << time.first << " " <<  time.second << "\n";
   }
   return os;

--- a/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
@@ -63,6 +63,8 @@ PPSTimingCalibration::timePrecision( int db, int sampic, int channel ) const
   return out->second.second;
 }
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 std::ostream&
 operator<<( std::ostream& os, const PPSTimingCalibration& data )
 {

--- a/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
@@ -14,21 +14,21 @@
 bool
 PPSTimingCalibration::Key::operator<( const PPSTimingCalibration::Key& rhs ) const
 {
-  if ( key1 == rhs.key1 ) {
-    if ( key2 == rhs.key2 ) {
-      if ( key3 == rhs.key3 )
-        return key4 < rhs.key4;
-      return key3 < rhs.key4;
+  if ( db == rhs.db ) {
+    if ( sampic == rhs.sampic ) {
+      if ( channel == rhs.channel )
+        return cell < rhs.cell;
+      return channel < rhs.channel;
     }
-    return key2 < rhs.key2;
+    return sampic < rhs.sampic;
   }
-  return key1 < rhs.key1;
+  return db < rhs.db;
 }
 
 std::ostream&
 operator<<( std::ostream& os, const PPSTimingCalibration::Key& key )
 {
-  return os << key.key1 << " " << key.key2 << " " << key.key3 << " " << key.key4;
+  return os << key.db << " " << key.sampic << " " << key.channel << " " << key.cell;
 }
 
 //--------------------------------------------------------------------------
@@ -72,6 +72,7 @@ operator<<( std::ostream& os, const PPSTimingCalibration& data )
     for ( size_t i = 0; i < kv.second.size(); ++i )
       os << ( i > 0 ? ", " : "" ) << kv.second.at( i );
     PPSTimingCalibration::Key k = kv.first;
+    k.cell = -1;
     const auto& time = data.timeInfo_.at( k );
     os << "] " << time.first << " " <<  time.second << "\n";
   }

--- a/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
@@ -63,8 +63,6 @@ PPSTimingCalibration::timePrecision( int db, int sampic, int channel ) const
   return out->second.second;
 }
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 std::ostream&
 operator<<( std::ostream& os, const PPSTimingCalibration& data )
 {
@@ -74,7 +72,6 @@ operator<<( std::ostream& os, const PPSTimingCalibration& data )
     for ( size_t i = 0; i < kv.second.size(); ++i )
       os << ( i > 0 ? ", " : "" ) << kv.second.at( i );
     PPSTimingCalibration::Key k = kv.first;
-    k.cell = -1;
     const auto& time = data.timeInfo_.at( k );
     os << "] " << time.first << " " <<  time.second << "\n";
   }

--- a/CondTools/CTPPS/test/ppsTimingCalibrationAnalyzer_cfg.py
+++ b/CondTools/CTPPS/test/ppsTimingCalibrationAnalyzer_cfg.py
@@ -20,7 +20,7 @@ process.source = cms.Source('EmptyIOVSource',
 
 # load calibrations from database
 process.load('CondCore.CondDB.CondDB_cfi')
-process.CondDB.connect = 'sqlite_file:totemTiming_calibration.sqlite' # SQLite input
+process.CondDB.connect = 'sqlite_file:ppsDiamondTiming_calibration.sqlite' # SQLite input
 
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     process.CondDB,
@@ -28,7 +28,7 @@ process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     toGet = cms.VPSet(
         cms.PSet(
             record = cms.string('PPSTimingCalibrationRcd'),
-            tag = cms.string('TotemTimingCalibration')
+            tag = cms.string('PPSDiamondTimingCalibration')
         )
     )
 )

--- a/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
+++ b/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
@@ -13,7 +13,7 @@ from CondFormats.CTPPSReadoutObjects.PPSTimingDetEnum_cff import PPSTimingDetEnu
 
 # load calibrations from JSON file
 process.load('CondFormats.CTPPSReadoutObjects.ppsTimingCalibrationESSource_cfi')
-process.ppsTimingCalibrationESSource.calibrationFile = cms.FileInPath('DiamondCalibrationExample.json')
+process.ppsTimingCalibrationESSource.calibrationFile = cms.FileInPath('RecoCTPPS/TotemRPLocal/data/timing_calibration_diamond_2018_mar19.ex.json')
 process.ppsTimingCalibrationESSource.subDetector = PPSTimingDetEnum.PPS_DIAMOND
 
 # output service for database

--- a/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
+++ b/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
@@ -11,15 +11,12 @@ process.source = cms.Source('EmptyIOVSource',
 
 # load calibrations from JSON file
 process.load('CondFormats.CTPPSReadoutObjects.ppsTimingCalibrationESSource_cfi')
-#process.ppsTimingCalibrationESSource.calibrationFile = cms.FileInPath('RecoCTPPS/TotemRPLocal/data/timing_offsets_ufsd_2018.dec18.cal.json')
 process.ppsTimingCalibrationESSource.calibrationFile = cms.FileInPath('DiamondCalibrationExample.json')
 process.ppsTimingCalibrationESSource.subDetector = cms.uint32(2)
 
 # output service for database
 process.load('CondCore.CondDB.CondDB_cfi')
-process.CondDB.connect = 'sqlite_file:totemTiming_calibration.sqlite' # SQLite output
-#process.CondDB.connect = 'oracle://cmsprep/TimingCalibration' # Oracle output
-#process.CondDB.connect = 'frontier://cmsfrontier.cern.ch:8000/FrontierPrep/TimingCalibration' # Frontier output
+process.CondDB.connect = 'sqlite_file:ppsDiamondTiming_calibration.sqlite' # SQLite output
 
 process.PoolDBOutputService = cms.Service('PoolDBOutputService',
     process.CondDB,
@@ -27,7 +24,7 @@ process.PoolDBOutputService = cms.Service('PoolDBOutputService',
     toPut = cms.VPSet(
         cms.PSet(
             record = cms.string('PPSTimingCalibrationRcd'),
-            tag = cms.string('TotemTimingCalibration'),
+            tag = cms.string('PPSDiamondTimingCalibration'),
         )
     )
 )

--- a/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
+++ b/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
@@ -11,7 +11,9 @@ process.source = cms.Source('EmptyIOVSource',
 
 # load calibrations from JSON file
 process.load('CondFormats.CTPPSReadoutObjects.ppsTimingCalibrationESSource_cfi')
-process.ppsTimingCalibrationESSource.calibrationFile = cms.FileInPath('RecoCTPPS/TotemRPLocal/data/timing_offsets_ufsd_2018.dec18.cal.json')
+#process.ppsTimingCalibrationESSource.calibrationFile = cms.FileInPath('RecoCTPPS/TotemRPLocal/data/timing_offsets_ufsd_2018.dec18.cal.json')
+process.ppsTimingCalibrationESSource.calibrationFile = cms.FileInPath('DiamondCalibrationExample.json')
+process.ppsTimingCalibrationESSource.subDetector = cms.uint32(2)
 
 # output service for database
 process.load('CondCore.CondDB.CondDB_cfi')

--- a/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
+++ b/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
@@ -9,10 +9,12 @@ process.source = cms.Source('EmptyIOVSource',
     interval = cms.uint64(1)
 )
 
+from CondFormats.CTPPSReadoutObjects.PPSTimingDetEnum_cff import PPSTimingDetEnum
+
 # load calibrations from JSON file
 process.load('CondFormats.CTPPSReadoutObjects.ppsTimingCalibrationESSource_cfi')
 process.ppsTimingCalibrationESSource.calibrationFile = cms.FileInPath('DiamondCalibrationExample.json')
-process.ppsTimingCalibrationESSource.subDetector = cms.uint32(2)
+process.ppsTimingCalibrationESSource.subDetector = PPSTimingDetEnum.PPS_DIAMOND
 
 # output service for database
 process.load('CondCore.CondDB.CondDB_cfi')


### PR DESCRIPTION
#### PR description:

A new readout mode for timing calibration JSONs is introduced for the `PPSTimingCalibration` `ESProducer`. This allows the rechit-level calibration of diamond detectors to be submitted in a follow-up PR (HPTDC time over threshold calibration conditions produced outside this scope).

#### PR validation:

To be tested along with https://github.com/cms-sw/cmsdist/issues/4785, which enables to parse and produce the payload from an external (example) file through the `CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py` utility.
Local reco branch maintained in parallel, to be submitted when this PR reaches a more mature state. Validation SW tools part of this follow-up PR.

#### if this PR is a backport please specify the original PR: N/A

Before submitting your pull requests, make sure you followed this checklist:

- [x] verify that the PR is really intended for the chosen branch
- [x] verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- [x] verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

cc: @fabferro @jan-kaspar @jjhollar