### PR TITLE
pr106x Fix bug memory over-read in OMTF Producer

### DIFF
--- a/L1Trigger/L1TMuonOverlap/src/GhostBusterPreferRefDt.cc
+++ b/L1Trigger/L1TMuonOverlap/src/GhostBusterPreferRefDt.cc
@@ -20,6 +20,9 @@ std::vector<AlgoMuon> GhostBusterPreferRefDt::select(std::vector<AlgoMuon> muons
 
   // sorting within GB.
   auto customLess = [&](const AlgoMuon& a, const AlgoMuon& b)->bool {
+    // protect against access violation
+    if(a.getRefLayer() == -1 || b.getRefLayer() == -1)
+      return false;
     int aRefLayerLogicNum = omtfConfig->getRefToLogicNumber()[a.getRefLayer()];
     int bRefLayerLogicNum = omtfConfig->getRefToLogicNumber()[b.getRefLayer()];
     if(a.getQ() > b.getQ())


### PR DESCRIPTION
10_6_X

This PR is a fix for the problem of memory over-read in the OMTF Producer,  mentioned in the issue https://github.com/cms-sw/cmssw/issues/25785




