### PR TITLE
Run2-alca152 Update the macros used for calibration of HCAL

### DIFF
--- a/Calibration/HcalCalibAlgos/macros/CalibCorr.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibCorr.C
@@ -67,25 +67,69 @@ unsigned int truncateId(unsigned int detId, int truncateFlag, bool debug=false){
 double puFactor(int type, int ieta, double pmom, double eHcal, double ediff) {
 
   double fac(1.0);
-  double frac = (type == 1) ? 0.02 : 0.03;
-  if (pmom > 0 && ediff >  frac*pmom) {
-    double a1(0), a2(0);
-    if (type == 1) {
-      a1 = -0.35; a2 = -0.65;
-      if (std::abs(ieta) == 25) {
-	a2 = -0.30;
-      } else if (std::abs(ieta) > 25) {
-	a1 = -0.45; a2 = -0.10;
+  if (type <=2) {
+    double frac = (type == 1) ? 0.02 : 0.03;
+    if (pmom > 0 && ediff >  frac*pmom) {
+      double a1(0), a2(0);
+      if (type == 1) {
+	a1 = -0.35; a2 = -0.65;
+	if (std::abs(ieta) == 25) {
+	  a2 = -0.30;
+	} else if (std::abs(ieta) > 25) {
+	  a1 = -0.45; a2 = -0.10;
+	}
+      } else {
+	a1 = -0.39; a2 = -0.59;
+	if (std::abs(ieta) >= 25) {
+	  a1 = -0.283; a2 = -0.272;
+	} else if (std::abs(ieta) > 22) {
+	  a1 = -0.238; a2 = -0.241;
+	}
       }
+      fac = (1.0+a1*(eHcal/pmom)*(ediff/pmom)*(1+a2*(ediff/pmom)));
     } else {
-      a1 = -0.39; a2 = -0.59;
-      if (std::abs(ieta) >= 25) {
-	a1 = -0.283; a2 = -0.272;
-      } else if (std::abs(ieta) > 22) {
-	a1 = -0.238; a2 = -0.241;
+      int    jeta = std::abs(ieta);
+      double d2p  = (ediff/pmom);
+      const double DELTA_CUT = 0.03;
+      const int    PU_IETA_3 = 25;
+      if (type == 3) {           // 16pu
+	const double CONST_COR_COEF[4]  = { 0.971, 1.008,  0.985,  1.086 };
+	const double LINEAR_COR_COEF[4] = { 0,    -0.359, -0.251, -0.535 };
+	const double SQUARE_COR_COEF[4] = { 0,     0,      0.048,  0.143 };
+	const int    PU_IETA_1          = 9;
+	const int    PU_IETA_2          = 16;
+	unsigned icor = (unsigned(jeta >= PU_IETA_1) + 
+			 unsigned(jeta >= PU_IETA_2) +
+			 unsigned(jeta >= PU_IETA_3));
+	if (d2p > DELTA_CUT) fac = (CONST_COR_COEF[icor] + 
+				    LINEAR_COR_COEF[icor]*d2p + 
+				    SQUARE_COR_COEF[icor]*d2p*d2p);
+      } else if (type == 4) {    // 17pu
+	const double CONST_COR_COEF[4]  = { 0.974, 1.023,  0.989,  1.077 };
+	const double LINEAR_COR_COEF[4] = { 0,    -0.524, -0.268, -0.584 };
+	const double SQUARE_COR_COEF[4] = { 0,     0,      0.053,  0.170 };
+	const int PU_IETA_1             = 9;
+	const int PU_IETA_2             = 18;
+	unsigned icor = (unsigned(jeta >= PU_IETA_1) + 
+			 unsigned(jeta >= PU_IETA_2) +
+			 unsigned(jeta >= PU_IETA_3));
+	if (d2p > DELTA_CUT) fac = (CONST_COR_COEF[icor] + 
+				    LINEAR_COR_COEF[icor]*d2p + 
+				    SQUARE_COR_COEF[icor]*d2p*d2p);
+      } else {                   // 18pu
+	const double CONST_COR_COEF[4]  = { 0.973, 0.998,  0.992,  0.965 };
+	const double LINEAR_COR_COEF[4] = { 0,    -0.318, -0.261, -0.406 };
+	const double SQUARE_COR_COEF[4] = { 0,     0,      0.047,  0.089 };
+	const int PU_IETA_1      = 7;
+	const int PU_IETA_2      = 16;
+	unsigned icor = (unsigned(jeta >= PU_IETA_1) + 
+			 unsigned(jeta >= PU_IETA_2) +
+			 unsigned(jeta >= PU_IETA_3));
+	if (d2p > DELTA_CUT) fac = (CONST_COR_COEF[icor] + 
+				    LINEAR_COR_COEF[icor]*d2p + 
+				    SQUARE_COR_COEF[icor]*d2p*d2p);
       }
     }
-    fac = (1.0+a1*(eHcal/pmom)*(ediff/pmom)*(1+a2*(ediff/pmom)));
   }
   return fac;
 }

--- a/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
@@ -154,6 +154,8 @@
 #include <fstream>
 #include <cstdlib>
 
+#include "CalibCorr.C"
+
 struct cfactors {
   int    ieta, depth;
   double corrf, dcorr;
@@ -212,25 +214,6 @@ std::pair<double,double> GetWidth(TH1D* hist, double xmin, double xmax) {
     err   = rms/std::sqrt(2*wt);
   }
   return std::pair<double,double>(rms,err);
-}
-
-std::vector <std::string> splitString (const std::string& fLine) {
-  std::vector <std::string> result;
-  int start = 0;
-  bool empty = true;
-  for (unsigned i = 0; i <= fLine.size (); i++) {
-    if (fLine [i] == ' ' || i == fLine.size ()) {
-      if (!empty) {
-	std::string item (fLine, start, i-start);
-	result.push_back (item);
-	empty = true;
-      }
-      start = i+1;
-    } else {
-      if (empty) empty = false;
-    }
-  }
-  return result;
 }
 
 Double_t langaufun(Double_t *x, Double_t *par) {
@@ -371,7 +354,7 @@ results fitTwoGauss (TH1D* hist, bool debug) {
   startvalues[4] =     Fit->Value(1); lowValue[4] = 0.5*startvalues[4]; highValue[4] = 2.*startvalues[4];
   startvalues[5] = 2.0*Fit->Value(2); lowValue[5] = 0.5*startvalues[5]; highValue[5] = 100.*startvalues[5];
 //fitrange[0] = mean - 2.0*rms; fitrange[1] = mean + 2.0*rms;
-  fitrange[0] = Fit->Value(1) - 2.0*Fit->Value(2); fitrange[1] = Fit->Value(1) + 2.0*Fit->Value(2);
+  fitrange[0] = Fit->Value(1) - Fit->Value(2); fitrange[1] = Fit->Value(1) + Fit->Value(2);
   TFitResultPtr Fitfun = functionFit(hist, fitrange, startvalues, lowValue, highValue);
   double wt1    = (Fitfun->Value(0))*(Fitfun->Value(2));
   double value1 = Fitfun->Value(1);
@@ -660,7 +643,7 @@ void FitHistExtended(const char* infile, const char* outfile,std::string prefix,
       }
       if (hist0->GetEntries() > 10) {
 	double rms;
-	results                  meaner0 = fitTwoGauss(hist0, debug);
+	results                  meaner0 = fitOneGauss(hist0,true,debug);
 	std::pair<double,double> meaner1 = GetMean(hist0,0.2,2.0,rms);
 	std::pair<double,double> meaner2 = GetWidth(hist0,0.2,2.0);
 	if (debug) {
@@ -704,7 +687,7 @@ void FitHistExtended(const char* infile, const char* outfile,std::string prefix,
 	      value = meaner.mean;    error = meaner.errmean;
 	      width = meaner.width;   werror= meaner.errwidth;
 	    } else {
-	      results meaner = fitOneGauss(hist,false,debug);
+	      results meaner = fitOneGauss(hist,true,debug);
 	      value = meaner.mean;    error = meaner.errmean;
 	      width = meaner.width;   werror= meaner.errwidth;
 	    }

--- a/Calibration/HcalCalibAlgos/macros/CalibTree.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibTree.C
@@ -551,7 +551,7 @@ Double_t CalibTree::Loop(int loop, TFile *fout, bool useweight, int nMin,
 	  else          isItRBX = !(temp);
 	}
 	++kprint;
-	if (cSelect_ && !(isItRBX)) {
+	if (!(isItRBX)) {
 	  for (unsigned int idet=0; idet<(*t_DetIds).size(); idet++) { 
 	    if (selectPhi((*t_DetIds)[idet])) {
 	      unsigned int detid = truncateId((*t_DetIds)[idet],


### PR DESCRIPTION
#### PR description:

The macros used for calibrating HB/HE energy scale factors using isolated charged particles

#### PR validation:

The code is tested by applying them to extraction of calibration constants for ultra-legacy re-reconstruction 

#### if this PR is a backport please specify the original PR:

No intention of back porting this to earlier CMSSW versions