### PR TITLE
Provide forward compatibility to HepMC::GenEvent reading

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -72,6 +72,8 @@ namespace SimDataFormats_GeneratorProducts {
 
 //needed for backward compatibility between HepMC 2.06.xx and 2.05.yy
 namespace hepmc_rootio {
+  void add_to_particles_in(HepMC::GenVertex*, HepMC::GenParticle*);
+
   inline void weightcontainer_set_default_names(unsigned int n, std::map<std::string,HepMC::WeightContainer::size_type>& names) {
       std::ostringstream name;
       for ( HepMC::WeightContainer::size_type count = 0; count<n; ++count ) 

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -13,6 +13,11 @@
 		<!-- <field name="itsParticleData" transient="true"/> -->
 		<!-- <field name="itsDecayData" transient="true"/> -->
 	</class>
+        <ioread sourceClass = "HepMC::GenParticle" source="int m_barcode" version="[11]" targetClass="HepMC::GenParticle" target="m_barcode">
+            <![CDATA[m_barcode = onfile.m_barcode;
+                  if(newObj->end_vertex()) { hepmc_rootio::add_to_particles_in(newObj->end_vertex(), newObj); }
+]]> 
+            </ioread>
     <class name="HepMC::GenCrossSection" ClassVersion="10">
      <version ClassVersion="10" checksum="920043842"/>
     </class>

--- a/SimDataFormats/GeneratorProducts/src/hepmc_rootio.cc
+++ b/SimDataFormats/GeneratorProducts/src/hepmc_rootio.cc
@@ -1,0 +1,25 @@
+#include <HepMC/GenParticle.h>
+#include <HepMC/GenVertex.h>
+#include <iostream>
+
+//HACK We need to change the internals of GenVertex when reading
+// back via ROOT. We use the private access of GenEvent to 
+// accomplish it.
+namespace HepMC {
+  class GenEvent {
+  public:
+    static void clear_particles_in(HepMC::GenVertex* iVertex) {
+      iVertex->m_particles_in.clear();
+    }
+    static void add_to_particles_in(HepMC::GenVertex* iVertex, HepMC::GenParticle* iPart) {
+      iVertex->m_particles_in.push_back(iPart);
+    }
+  };
+}
+
+
+namespace hepmc_rootio {                                                                                                                
+  void add_to_particles_in(HepMC::GenVertex* iVertex, HepMC::GenParticle* iPart) {
+    HepMC::GenEvent::add_to_particles_in(iVertex, iPart);
+  }
+}


### PR DESCRIPTION
#### PR description:

Provide a iorule to allow reading data stored in CMSSW_10_6.

#### PR validation:

Tested with job that read a CMSSW_10_6 GENSIM+RAW data file.