### PR TITLE
[10.6.X] Duplicate dictionaries cleanup

### DIFF
--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -1,5 +1,4 @@
 <lcgdict>
-  <class name="Ref_Phase2TrackerDigi_" />
   <class name="std::vector<Ref_Phase2TrackerDigi_>" />
   <class name="TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >" />
   <class name="TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >" />

--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -82,9 +82,6 @@
   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Track> >,edm::RefProd<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> > > >" />
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<std::vector<reco::Track>,edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,unsigned int> > >" />
 
-  <class name="edm::Wrapper<reco::SimToRecoCollection>" />
-  <class name="edm::Wrapper<reco::RecoToSimCollection>" />
-
   <class name="reco::SimToRecoCollection" >
    <field name="transientMap_" transient="true"/>
   </class>


### PR DESCRIPTION
#### PR description:

Cleanup duplicate dictionaries caused by cleanup done in #26116
```
Warning in <TInterpreter::ReadRootmapFile>: class  edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > found in libDataFormatsL1TrackTrigger.so  is already in libDataFormatsPhase2TrackerDigi.so 
Warning in <TInterpreter::ReadRootmapFile>: class  edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQualityGeneric<edm::View<reco::Track>,vector<TrackingParticle>,double,unsigned int,edm::RefToBaseProd<reco::Track>,edm::RefProd<vector<TrackingParticle> >,edm::RefToBase<reco::Track>,edm::Ref<vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<vector<TrackingParticle>,TrackingParticle> > > > > found in libDataFormatsRecoCandidate.so  is already in libSimDataFormatsTrackingAnalysis.so 
Warning in <TInterpreter::ReadRootmapFile>: class  edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQualityGeneric<vector<TrackingParticle>,edm::View<reco::Track>,double,unsigned int,edm::RefProd<vector<TrackingParticle> >,edm::RefToBaseProd<reco::Track>,edm::Ref<vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<vector<TrackingParticle>,TrackingParticle> >,edm::RefToBase<reco::Track> > > > found in libDataFormatsRecoCandidate.so  is already in libSimDataFormatsTrackingAnalysis.so 
```

#### PR validation:

Compiled and run unit tests

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
