### PR TITLE
fix module name: avoid space characters in module name

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/IsFromLostTrackMapProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/IsFromLostTrackMapProducer.cc
@@ -123,7 +123,7 @@ void IsFromLostTrackMapProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<edm::InputTag>("lostTracks")->setComment("lost tracks collection");
 
   std::string modname;
-  modname="isFromLostTrack map producer";
+  modname="isFromLostTrackMapProducer";
   descriptions.add(modname,desc);
 
 }


### PR DESCRIPTION
#### PR description:

Modulename should not have space characters in them. This PR fixes the error we get at build time
```
/usr/bin/cp: cannot stat 'tmp/slc7_amd64_gcc700/src/PhysicsTools/NanoAOD/plugins/PhysicsToolsNanoAODPlugins/edm_write_config/isFromLostTrack': No such file or directory
/usr/bin/cp: cannot stat 'tmp/slc7_amd64_gcc700/src/PhysicsTools/NanoAOD/plugins/PhysicsToolsNanoAODPlugins/edm_write_config/map': No such file or directory
/usr/bin/cp: cannot stat 'tmp/slc7_amd64_gcc700/src/PhysicsTools/NanoAOD/plugins/PhysicsToolsNanoAODPlugins/edm_write_config/producer_cfi.py': No such file or directory
--- Registered EDM Plugin: PhysicsToolsNanoAODPlugins
```

#### PR validation:

Local build ran fine. As this module was never registered properly so there are no tests to run. 
```
@@@@ Running edmWriteConfigs for PhysicsToolsNanoAODPlugins
....
L1TriggerResultsConverter
isFromLostTrackMapProducer
....
--- Registered EDM Plugin: PhysicsToolsNanoAODPlugins
```

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
