### PR TITLE
Tweaked pixel pair MVA selection for pp_on_AA (backport of #26217)

### DIFF
--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -335,7 +335,7 @@ highBetaStar_2018.toModify(pixelPairStep,qualityCuts = [-0.95,0.0,0.3])
 
 trackingPhase1.toModify(pixelPairStep, mva=dict(GBRForestLabel = 'MVASelectorPixelPairStep_Phase1'))
 fastSim.toModify(pixelPairStep, vertices = "firstStepPrimaryVerticesBeforeMixing")
-pp_on_AA_2018.toModify(pixelPairStep, qualityCuts = [-0.2, 0.0, 0.9])
+pp_on_AA_2018.toModify(pixelPairStep, qualityCuts = [-0.2, 0.0, 0.98])
 
 # For LowPU and Phase2PU140
 import RecoTracker.IterativeTracking.LowPtTripletStep_cff


### PR DESCRIPTION
#### PR description:
This is a backport of #26217

This PR tweaks the MVA selection for the pixel pair recovery step in heavy ion collisions.  This step was seen to cause a large fake rate that was problematic for jet reconstruction in central events.  The required MVA value is simply required to be slightly higher to curtail the amount of fake tracks. This change is needed for a reRECO of the jet-triggered data.  

#### PR validation:

More information on the effects of this change can be found in the presentation that was shown at the XEB meeting today:

https://www.dropbox.com/s/j4ej3pc7tdroy4p/HI-PAG_FakeJets_20190318.pptx?dl=0#

#### if this PR is a backport please specify the original PR: #26217

@icali @mandrenguyen @echapon 
