### PR TITLE
Update VtxSmearingScenario for 10_6_X MC production - Flat Optics

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -61,6 +61,8 @@ VtxSmeared = {
     'RealisticPbPbCollision2018' : 'IOMC.EventVertexGenerators.VtxSmearedRealisticPbPbCollision2018_cfi',
     'Run3RoundOptics25ns13TeVLowSigmaZ'  : 'IOMC.EventVertexGenerators.VtxSmearedRun3RoundOptics25ns13TeVLowSigmaZ_cfi',
     'Run3RoundOptics25ns13TeVHighSigmaZ' : 'IOMC.EventVertexGenerators.VtxSmearedRun3RoundOptics25ns13TeVHighSigmaZ_cfi',
+    'Run3FlatOpticsGaussSigmaZ4p2cm'     : 'IOMC.EventVertexGenerators.VtxSmearedRun3FlatOpticsGaussSigmaZ4p2cm_cfi',
+    'Run3FlatOpticsGaussSigmaZ5p3cm'     : 'IOMC.EventVertexGenerators.VtxSmearedRun3FlatOpticsGaussSigmaZ5p3cm_cfi',
 }
 VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
 VtxSmearedHIDefaultKey='RealisticPbPbCollision2018'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -33,6 +33,50 @@ GaussVtxSigmaZ4cmSmearingParameters = cms.PSet(
     SigmaZ = cms.double(4.0),
     TimeOffset = cms.double(0.0)
 )
+# Gaussian smearing
+# Flat optics for Run3 - Low SigmaZ
+# SigmaZ = 4.2 cm
+# SigmaX = 11.8 um
+# SigmaY = 5.5 um
+# BS positions extracted from 2018B 3.8T data, run 316199, fill 6675 (from StreamExpressAlignment, HP BS):
+# X0         =  0.09676  [cm]
+# Y0         = -0.06245  [cm]
+# Z0         = -0.292    [cm]
+# BPIX absolute position (from https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod):
+# X = 0.0859918 cm
+# Y = -0.104172 cm
+# Z = -0.327748 cm
+Run3FlatOpticsGaussVtxSigmaZ4p2cmSmearingParameters = cms.PSet(
+    MeanX = cms.double(0.0107682),
+    MeanY = cms.double(0.041722),
+    MeanZ = cms.double(0.035748),
+    SigmaY = cms.double(0.00055),
+    SigmaX = cms.double(0.00118),
+    SigmaZ = cms.double(4.2),
+    TimeOffset = cms.double(0.0)
+)
+# Gaussian smearing
+# Flat optics for Run3 - High SigmaZ
+# SigmaZ = 5.3 cm
+# SigmaX = 15 um
+# SigmaY = 13 um
+# BS positions extracted from 2018B 3.8T data, run 316199, fill 6675 (from StreamExpressAlignment, HP BS):
+# X0         =  0.09676  [cm]
+# Y0         = -0.06245  [cm]
+# Z0         = -0.292    [cm]
+# BPIX absolute position (from https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod):
+# X = 0.0859918 cm
+# Y = -0.104172 cm
+# Z = -0.327748 cm
+Run3FlatOpticsGaussVtxSigmaZ5p3cmSmearingParameters = cms.PSet(
+    MeanX = cms.double(0.0107682),
+    MeanY = cms.double(0.041722),
+    MeanZ = cms.double(0.035748),
+    SigmaY = cms.double(0.0013),
+    SigmaX = cms.double(0.0015),
+    SigmaZ = cms.double(5.3),
+    TimeOffset = cms.double(0.0)
+)
 
 # Flat Smearing
 # Important note: flat independent distributions in Z and T are not correct for physics production

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRun3FlatOpticsGaussSigmaZ4p2cm_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRun3FlatOpticsGaussSigmaZ4p2cm_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Run3FlatOpticsGaussVtxSigmaZ4p2cmSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("GaussEvtVtxGenerator",
+    Run3FlatOpticsGaussVtxSigmaZ4p2cmSmearingParameters,
+    VtxSmearedCommon
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRun3FlatOpticsGaussSigmaZ5p3cm_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRun3FlatOpticsGaussSigmaZ5p3cm_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Run3FlatOpticsGaussVtxSigmaZ5p3cmSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("GaussEvtVtxGenerator",
+    Run3FlatOpticsGaussVtxSigmaZ5p3cmSmearingParameters,
+    VtxSmearedCommon
+)


### PR DESCRIPTION
Update the VtxSmearingScenario parameters for 10_6_X MC production for Flat Optics.
Two different configurations are created to test the possible beamspot conditions during Run3 using flat optics.
The same BeamSpot (run 316199, fill 6675) and Barycenter (from Payload Inspector https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod ) positions are used in both configurations and are the same as used in https://github.com/cms-sw/cmssw/pull/26140 for consistency.
The BeamSpot widths are taken from https://indico.cern.ch/event/802103/contributions/3334310/attachments/1804615/2944598/RunCoord_LS_2019_01_03_XC.pdf 
The two different scenarios are:

1. LowSigmaZ --> sigmaZ = 4.2 cm, sigmaX = 11.8 micron, sigmaY = 5.5 micron
2. HighSigmaZ --> sigmaZ = 5.3 cm, sigmaX = 15 micon, sigmaY = 13 micron