### PR TITLE
Initialize useTriple in MahiFit::phase1Apply so that it is never returned as undefined

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -96,10 +96,8 @@ void MahiFit::phase1Apply(const HBHEChannelInfo& channelData,
     }
   }
 
+  useTriple=false;
   if(tstrig >= ts4Thresh_ && tsTOT > 0) {
-
-    useTriple=false;
-
     // only do pre-fit with 1 pulse if chiSq threshold is positive
     if (chiSqSwitch_>0) {
       doFit(reconstructedVals,1);


### PR DESCRIPTION
#### PR description:

The static analyzer reports about the possibility of returning undefined bools from ```MahiFit::phase1Apply(...)``` in some pathological situation.

By initializing ```useTriple=false``` that bool is never returned with an undefined state, even when the fit is not performed

#### PR validation:

The change is quite trivial
I'd ask however HCAL contacts to bless it, before signing for reco: @igv4321 + Salavat (I can't find the github nick, sorry...)
