### PR TITLE
RecoParticleFlow/PFProducers - Improve how the PFEGammaFilters and PFMuonAlgo are constructed

### DIFF
--- a/RecoParticleFlow/PFProducer/interface/PFAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFAlgo.h
@@ -60,7 +60,7 @@ class PFAlgo {
   void setAlgo( int algo ) {algo_ = algo;}
   void setPFMuonAlgo(PFMuonAlgo* algo) {pfmu_ =algo;}
   void setMuonHandle(const edm::Handle<reco::MuonCollection>&);
-  void setDebug( bool debug ) {debug_ = debug; connector_.setDebug(debug_); if (pfegamma_) pfegamma_->setDebug(debug); }
+  void setDebug( bool debug ) {debug_ = debug; connector_.setDebug(debug_); }
 
   void setParameters(double nSigmaECAL,
                      double nSigmaHCAL, 
@@ -113,27 +113,7 @@ class PFAlgo {
 			     double sumPtTrackIsoForPhoton,
 			     double sumPtTrackIsoSlopeForPhoton);
 
-  void setEGammaParameters(bool use_EGammaFilters,
-			   std::string ele_iso_path_mvaWeightFile,
-			   double ele_iso_pt,
-			   double ele_iso_mva_barrel,
-			   double ele_iso_mva_endcap,
-			   double ele_iso_combIso_barrel,
-			   double ele_iso_combIso_endcap,
-			   double ele_noniso_mva,
-			   unsigned int ele_missinghits,
-			   double ele_ecalDrivenHademPreselCut,
-			   double ele_maxElePtForOnlyMVAPresel,
-			   bool useProtectionsForJetMET,
-			   const edm::ParameterSet& ele_protectionsForJetMET,
-			   const edm::ParameterSet& ele_protectionsForBadHcal,
-			   double ph_MinEt,
-			   double ph_combIso,
-			   double ph_HoE,
-			   double ph_sietaieta_eb,
-			   double ph_sietaieta_ee,
-			   const edm::ParameterSet& ph_protectionsForJetMET,
-			   const edm::ParameterSet& ph_protectionsForBadHcal);
+  void setEGammaParameters(bool use_EGammaFilters, bool useProtectionsForJetMET);
 
   
   void setEGammaCollections(const edm::View<reco::PFCandidate> & pfEgammaCandidates,
@@ -179,11 +159,11 @@ class PFAlgo {
 
   /// reconstruct particles (full framework case)
   /// will keep track of the block handle to build persistent references,
-  /// and call reconstructParticles( const reco::PFBlockCollection& blocks )
-  void reconstructParticles( const reco::PFBlockHandle& blockHandle );
+  /// and call reconstructParticles( const reco::PFBlockCollection& blocks, PFEGammaFilters const* pfegamma )
+  void reconstructParticles( const reco::PFBlockHandle& blockHandle, PFEGammaFilters const* pfegamma );
 
   /// reconstruct particles 
-  void reconstructParticles( const reco::PFBlockCollection& blocks );
+  void reconstructParticles( const reco::PFBlockCollection& blocks, PFEGammaFilters const* pfegamma );
   
   /// Check HF Cleaning
   void checkCleaning( const reco::PFRecHitCollection& cleanedHF );
@@ -245,7 +225,7 @@ class PFAlgo {
   /// algorithms
   void processBlock( const reco::PFBlockRef& blockref,
                              std::list<reco::PFBlockRef>& hcalBlockRefs, 
-                             std::list<reco::PFBlockRef>& ecalBlockRefs ); 
+                             std::list<reco::PFBlockRef>& ecalBlockRefs, PFEGammaFilters const* pfegamma );
   
   /// Reconstruct a charged particle from a track
   /// Returns the index of the newly created candidate in pfCandidates_
@@ -358,7 +338,6 @@ class PFAlgo {
 
   /// Variables for NEW EGAMMA selection
   bool useEGammaFilters_;
-  PFEGammaFilters *pfegamma_;
   bool useProtectionsForJetMET_;
   const edm::View<reco::PFCandidate> * pfEgammaCandidates_;
   const edm::ValueMap<reco::GsfElectronRef> * valueMapGedElectrons_;

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
@@ -17,71 +17,46 @@ class PFEGammaFilters {
   
  public:
    
-  PFEGammaFilters(float ph_Et,
-		  float ph_combIso,
-		  float ph_loose_hoe,
-		  float ph_sietaieta_eb,
-		  float ph_sietaieta_ee,
-		  const edm::ParameterSet& ph_protectionsForJetMET,
-		  const edm::ParameterSet& ph_protectionsForBadHcal,
-		  float ele_iso_pt,
-		  float ele_iso_mva_eb,
-		  float ele_iso_mva_ee,
-		  float ele_iso_combIso_eb,
-		  float ele_iso_combIso_ee,
-		  float ele_noniso_mva,
-		  unsigned int ele_missinghits,
-		  float ele_ecalDrivenHademPreselCut,
-		  float ele_maxElePtForOnlyMVAPresel,
-		  const std::string& ele_iso_path_mvaWeightFile,
-		  const edm::ParameterSet& ele_protectionsForJetMET,
-		  const edm::ParameterSet& ele_protectionsForBadHcal
-		  );
+  PFEGammaFilters(const edm::ParameterSet& iConfig);
   
-  ~PFEGammaFilters(){};
-  
-  bool passPhotonSelection(const reco::Photon &);
+  bool passPhotonSelection(const reco::Photon &) const;
   bool passElectronSelection(const reco::GsfElectron &, 
 			     const reco::PFCandidate &,
-			     const int & );
-  bool isElectron(const reco::GsfElectron & );
+			     const int & ) const;
+  bool isElectron(const reco::GsfElectron & ) const;
   
   bool isElectronSafeForJetMET(const reco::GsfElectron &, 
 			       const reco::PFCandidate &,
 			       const reco::Vertex &,
-			       bool& lockTracks);
+			       bool& lockTracks) const;
 
   bool isPhotonSafeForJetMET(const reco::Photon &, 
-			     const reco::PFCandidate &);
-
-  void setDebug( bool debug ) { debug_ = debug; }
+			     const reco::PFCandidate &) const;
   
 
  private:
-  bool passGsfElePreSelWithOnlyConeHadem(const reco::GsfElectron &);
+  bool passGsfElePreSelWithOnlyConeHadem(const reco::GsfElectron &) const;
 
 
   // Photon selections
-  float ph_Et_;
-  float ph_combIso_;
-  float ph_loose_hoe_;
-  float ph_sietaieta_eb_;
-  float ph_sietaieta_ee_;
-  //std::vector<double> ph_protectionsForJetMET_; //replacement below
-  float pho_sumPtTrackIso, pho_sumPtTrackIsoSlope;
+  const float ph_Et_;
+  const float ph_combIso_;
+  const float ph_loose_hoe_;
+  const float ph_sietaieta_eb_;
+  const float ph_sietaieta_ee_;
+  const float pho_sumPtTrackIso, pho_sumPtTrackIsoSlope;
 
   // Electron selections 
-  float ele_iso_pt_;
-  float ele_iso_mva_eb_;
-  float ele_iso_mva_ee_;
-  float ele_iso_combIso_eb_;
-  float ele_iso_combIso_ee_;
-  float ele_noniso_mva_;
-  unsigned int ele_missinghits_;
-  float ele_ecalDrivenHademPreselCut_;
-  float ele_maxElePtForOnlyMVAPresel_;
-  //std::vector<double> ele_protectionsForJetMET_; // replacement below
-  float ele_maxNtracks, ele_maxHcalE, ele_maxTrackPOverEele, ele_maxE,
+  const float ele_iso_pt_;
+  const float ele_iso_mva_eb_;
+  const float ele_iso_mva_ee_;
+  const float ele_iso_combIso_eb_;
+  const float ele_iso_combIso_ee_;
+  const float ele_noniso_mva_;
+  const unsigned int ele_missinghits_;
+  const float ele_ecalDrivenHademPreselCut_;
+  const float ele_maxElePtForOnlyMVAPresel_;
+  const float ele_maxNtracks, ele_maxHcalE, ele_maxTrackPOverEele, ele_maxE,
     ele_maxEleHcalEOverEcalE, ele_maxEcalEOverPRes, ele_maxEeleOverPoutRes,
     ele_maxHcalEOverP, ele_maxHcalEOverEcalE, ele_maxEcalEOverP_1,
     ele_maxEcalEOverP_2, ele_maxEeleOverPout, ele_maxDPhiIN;
@@ -91,15 +66,14 @@ class PFEGammaFilters {
   std::array<float,2> badHcal_eInvPInv_;
   std::array<float,2> badHcal_dEta_;
   std::array<float,2> badHcal_dPhi_;
-  bool badHcal_eleEnable_;
-  static void readEBEEParams_(const edm::ParameterSet &pset, const std::string &name, std::array<float,2> & out) ;
+  const bool badHcal_eleEnable_;
 
   // dead hcal selections (photons)
-  float badHcal_phoTrkSolidConeIso_offs_, badHcal_phoTrkSolidConeIso_slope_;
-  bool badHcal_phoEnable_;
+  const float badHcal_phoTrkSolidConeIso_offs_, badHcal_phoTrkSolidConeIso_slope_;
+  const bool badHcal_phoEnable_;
 
   // Event variables 
   
-  bool debug_;
+  const bool debug_ = false;
 };
 #endif

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
@@ -44,7 +44,8 @@ class PFEGammaFilters {
   const float ph_loose_hoe_;
   const float ph_sietaieta_eb_;
   const float ph_sietaieta_ee_;
-  const float pho_sumPtTrackIso, pho_sumPtTrackIsoSlope;
+  float pho_sumPtTrackIso_;
+  float pho_sumPtTrackIsoSlope_;
 
   // Electron selections 
   const float ele_iso_pt_;
@@ -56,24 +57,32 @@ class PFEGammaFilters {
   const unsigned int ele_missinghits_;
   const float ele_ecalDrivenHademPreselCut_;
   const float ele_maxElePtForOnlyMVAPresel_;
-  const float ele_maxNtracks, ele_maxHcalE, ele_maxTrackPOverEele, ele_maxE,
-    ele_maxEleHcalEOverEcalE, ele_maxEcalEOverPRes, ele_maxEeleOverPoutRes,
-    ele_maxHcalEOverP, ele_maxHcalEOverEcalE, ele_maxEcalEOverP_1,
-    ele_maxEcalEOverP_2, ele_maxEeleOverPout, ele_maxDPhiIN;
+  float ele_maxNtracks_;
+  float ele_maxHcalE_;
+  float ele_maxTrackPOverEele_;
+  float ele_maxE_;
+  float ele_maxEleHcalEOverEcalE_;
+  float ele_maxEcalEOverPRes_;
+  float ele_maxEeleOverPoutRes_;
+  float ele_maxHcalEOverP_;
+  float ele_maxHcalEOverEcalE_;
+  float ele_maxEcalEOverP_1_;
+  float ele_maxEcalEOverP_2_;
+  float ele_maxEeleOverPout_;
+  float ele_maxDPhiIN_;
 
   // dead hcal selections (electrons)
   std::array<float,2> badHcal_full5x5_sigmaIetaIeta_;
   std::array<float,2> badHcal_eInvPInv_;
   std::array<float,2> badHcal_dEta_;
   std::array<float,2> badHcal_dPhi_;
-  const bool badHcal_eleEnable_;
+  bool badHcal_eleEnable_;
 
   // dead hcal selections (photons)
-  const float badHcal_phoTrkSolidConeIso_offs_, badHcal_phoTrkSolidConeIso_slope_;
-  const bool badHcal_phoEnable_;
+  float badHcal_phoTrkSolidConeIso_offs_;
+  float badHcal_phoTrkSolidConeIso_slope_;
+  bool badHcal_phoEnable_;
 
-  // Event variables 
-  
   const bool debug_ = false;
 };
 #endif

--- a/RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h
@@ -17,53 +17,26 @@ class PFMuonAlgo {
  public:
 
   /// constructor
-  PFMuonAlgo();
-
-  void setParameters(const edm::ParameterSet&);
-  
-
-
-  /// destructor
-  virtual ~PFMuonAlgo() {;}
+  PFMuonAlgo(edm::ParameterSet const&);
   
   ////STATIC MUON ID METHODS
-
   static bool isMuon( const reco::PFBlockElement& elt );
-
   static bool isLooseMuon( const reco::PFBlockElement& elt );
-
   static bool isGlobalTightMuon( const reco::PFBlockElement& elt );
-
   static bool isGlobalLooseMuon( const reco::PFBlockElement& elt );
-
   static bool isTrackerTightMuon( const reco::PFBlockElement& elt );
-
   static bool isTrackerLooseMuon( const reco::PFBlockElement& elt );
-
   static bool isIsolatedMuon( const reco::PFBlockElement& elt );
-
   static bool isMuon( const reco::MuonRef& muonRef );  
-
   static bool isLooseMuon( const reco::MuonRef& muonRef );
-
   static bool isGlobalTightMuon( const reco::MuonRef& muonRef );
-
   static bool isGlobalLooseMuon( const reco::MuonRef& muonRef );
 
-
-
-
   static bool isTrackerTightMuon( const reco::MuonRef& muonRef );
-  
   static bool isTrackerLooseMuon( const reco::MuonRef& muonRef );
-  
   static bool isIsolatedMuon( const reco::MuonRef& muonRef );
-
   static bool isTightMuonPOG(const reco::MuonRef& muonRef);
-
   static void printMuonProperties( const reco::MuonRef& muonRef );
-
-
 
 
   ////POST CLEANING AND MOMEMNTUM ASSIGNMENT
@@ -156,32 +129,31 @@ class PFMuonAlgo {
 
 
   //Configurables
-  double maxDPtOPt_;
-  int minTrackerHits_;
-  int minPixelHits_;
-  reco::TrackBase::TrackQuality trackQuality_;
-  
-  double errorCompScale_;
-  double eventFractionCleaning_;
-  double sumetPU_;
-  double dzPV_;
-  bool postCleaning_;
-  double minPostCleaningPt_;
-  double eventFactorCosmics_;
-  double metSigForCleaning_;
-  double metSigForRejection_;
-  double metFactorCleaning_;
-  double eventFractionRejection_;
-  double metFactorRejection_;
-  double metFactorHighEta_;
-  double ptFactorHighEta_;
-  double metFactorFake_;
-  double minPunchThroughMomentum_;
-  double minPunchThroughEnergy_;
-  double punchThroughFactor_;
-  double punchThroughMETFactor_;
-  double cosmicRejDistance_;
+  const double maxDPtOPt_;
+  const int minTrackerHits_;
+  const int minPixelHits_;
+  const reco::TrackBase::TrackQuality trackQuality_;
+  const double errorCompScale_;
+  const double eventFractionCleaning_;
+  const double dzPV_;
+  const bool postCleaning_;
+  const double minPostCleaningPt_;
+  const double eventFactorCosmics_;
+  const double metSigForCleaning_;
+  const double metSigForRejection_;
+  const double metFactorCleaning_;
+  const double eventFractionRejection_;
+  const double metFactorRejection_;
+  const double metFactorHighEta_;
+  const double ptFactorHighEta_;
+  const double metFactorFake_;
+  const double minPunchThroughMomentum_;
+  const double minPunchThroughEnergy_;
+  const double punchThroughFactor_;
+  const double punchThroughMETFactor_;
+  const double cosmicRejDistance_;
 
+  double sumetPU_;
   double sumet_;
   double METX_;
   double METY_;

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.h
@@ -25,6 +25,7 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h"
 
 class PFAlgo;
 class PFEnergyCalibrationHF;
@@ -42,7 +43,6 @@ This producer makes use of PFAlgo, the particle flow algorithm.
 class PFProducer : public edm::stream::EDProducer<> {
  public:
   explicit PFProducer(const edm::ParameterSet&);
-  ~PFProducer() override;
   
   void produce(edm::Event&, const edm::EventSetup&) override;
   void beginRun(const edm::Run &, const edm::EventSetup &) override;
@@ -65,6 +65,7 @@ class PFProducer : public edm::stream::EDProducer<> {
   edm::EDGetTokenT<edm::View<reco::PFCandidate> > inputTagPFEGammaCandidates_;
 
   bool use_EGammaFilters_;
+  std::unique_ptr<PFEGammaFilters> pfegamma_ = nullptr;
 
 
   //Use of HO clusters and links in PF Reconstruction

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -22,8 +22,7 @@ public:
     cleanBadConvBrems_(conf.existsAs<bool>("cleanBadConvertedBrems") ? conf.getParameter<bool>("cleanBadConvertedBrems") : false),
     debug_(conf.getUntrackedParameter<bool>("debug",false)) {
     
-    pfmu_ = std::unique_ptr<PFMuonAlgo>(new PFMuonAlgo());
-    pfmu_->setParameters(conf);
+    pfmu_ = std::unique_ptr<PFMuonAlgo>(new PFMuonAlgo(conf));
     
   }
   

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
@@ -23,8 +23,7 @@ public:
     cleanBadConvBrems_(conf.existsAs<bool>("cleanBadConvertedBrems") ? conf.getParameter<bool>("cleanBadConvertedBrems") : false),
     debug_(conf.getUntrackedParameter<bool>("debug",false)) {
     
-    pfmu_ = std::unique_ptr<PFMuonAlgo>(new PFMuonAlgo());
-    pfmu_->setParameters(conf);
+    pfmu_ = std::unique_ptr<PFMuonAlgo>(new PFMuonAlgo(conf));
     
   }
   

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -56,14 +56,12 @@ PFAlgo::PFAlgo()
     debug_(false),
     pfele_(nullptr),
     pfpho_(nullptr),
-    pfegamma_(nullptr),
     useVertices_(false)
 {}
 
 PFAlgo::~PFAlgo() {
   if (usePFElectrons_) delete pfele_;
   if (usePFPhotons_)     delete pfpho_;
-  if (useEGammaFilters_)  delete pfegamma_;
 }
 
 
@@ -201,68 +199,14 @@ PFAlgo::setPFPhotonParameters(bool usePFPhotons,
   return;
 }
 
-void PFAlgo::setEGammaParameters(bool use_EGammaFilters,
-				 std::string ele_iso_path_mvaWeightFile,
-				 double ele_iso_pt,
-				 double ele_iso_mva_barrel,
-				 double ele_iso_mva_endcap,
-				 double ele_iso_combIso_barrel,
-				 double ele_iso_combIso_endcap,
-				 double ele_noniso_mva,
-				 unsigned int ele_missinghits,
-				 double ele_ecalDrivenHademPreselCut,
-				 double ele_maxElePtForOnlyMVAPresel,
-				 bool useProtectionsForJetMET,
-				 const edm::ParameterSet& ele_protectionsForJetMET,
-				 const edm::ParameterSet& ele_protectionsForBadHcal,
-				 double ph_MinEt,
-				 double ph_combIso,
-				 double ph_HoE,
-				 double ph_sietaieta_eb,
-				 double ph_sietaieta_ee,
-				 const edm::ParameterSet& ph_protectionsForJetMET,
-				 const edm::ParameterSet& ph_protectionsForBadHcal
-				 )
+void PFAlgo::setEGammaParameters(bool use_EGammaFilters, bool useProtectionsForJetMET)
 {
 
   useEGammaFilters_ = use_EGammaFilters;
 
   if(!useEGammaFilters_ ) return;
-  FILE * fileEGamma_ele_iso_ID = fopen(ele_iso_path_mvaWeightFile.c_str(), "r");
-  if (fileEGamma_ele_iso_ID) {
-    fclose(fileEGamma_ele_iso_ID);
-  }
-  else {
-    string err = "PFAlgo: cannot open weight file '";
-    err += ele_iso_path_mvaWeightFile;
-    err += "'";
-    throw invalid_argument( err );
-  }
 
-  //  ele_iso_mvaID_ = new ElectronMVAEstimator(ele_iso_path_mvaWeightFile_);
   useProtectionsForJetMET_ = useProtectionsForJetMET;
-
-  pfegamma_ =  new PFEGammaFilters(ph_MinEt,
-				   ph_combIso,
-				   ph_HoE,
-				   ph_sietaieta_eb,
-				   ph_sietaieta_ee,
-				   ph_protectionsForJetMET,
-				   ph_protectionsForBadHcal,
-				   ele_iso_pt,
-				   ele_iso_mva_barrel,
-				   ele_iso_mva_endcap,
-				   ele_iso_combIso_barrel,
-				   ele_iso_combIso_endcap,
-				   ele_noniso_mva,
-				   ele_missinghits,
-				   ele_ecalDrivenHademPreselCut,
-				   ele_maxElePtForOnlyMVAPresel,
-				   ele_iso_path_mvaWeightFile,
-				   ele_protectionsForJetMET,
-				   ele_protectionsForBadHcal);
-
-  return;
 }
 void  PFAlgo::setEGammaCollections(const edm::View<reco::PFCandidate> & pfEgammaCandidates,
 				   const edm::ValueMap<reco::GsfElectronRef> & valueMapGedElectrons,
@@ -405,13 +349,13 @@ PFAlgo::setPFVertexParameters(bool useVertex, reco::VertexCollection const&  pri
   }
 }
 
-void PFAlgo::reconstructParticles( const reco::PFBlockHandle& blockHandle ) {
+void PFAlgo::reconstructParticles( const reco::PFBlockHandle& blockHandle, PFEGammaFilters const* pfegamma ) {
 
   blockHandle_ = blockHandle;
-  reconstructParticles( *blockHandle_ );
+  reconstructParticles( *blockHandle_, pfegamma );
 }
 
-void PFAlgo::reconstructParticles( const reco::PFBlockCollection& blocks ) {
+void PFAlgo::reconstructParticles( const reco::PFBlockCollection& blocks, PFEGammaFilters const* pfegamma ) {
 
   // reset output collection
   if(pfCandidates_.get() )
@@ -495,7 +439,7 @@ void PFAlgo::reconstructParticles( const reco::PFBlockCollection& blocks ) {
   unsigned nblcks = 0;
   for(auto const& other : otherBlockRefs) {
     if ( debug_ ) std::cout << "Block number " << nblcks++ << std::endl;
-    processBlock( other, hcalBlockRefs, ecalBlockRefs );
+    processBlock( other, hcalBlockRefs, ecalBlockRefs, pfegamma );
   }
 
   std::list< reco::PFBlockRef > empty;
@@ -504,14 +448,14 @@ void PFAlgo::reconstructParticles( const reco::PFBlockCollection& blocks ) {
   // process remaining single hcal blocks
   for(auto const& hcal : hcalBlockRefs) {
     if ( debug_ ) std::cout << "HCAL block number " << hblcks++ << std::endl;
-    processBlock( hcal, empty, empty );
+    processBlock( hcal, empty, empty, pfegamma );
   }
 
   unsigned eblcks = 0;
   // process remaining single ecal blocks
   for(auto const& ecal : ecalBlockRefs) {
     if ( debug_ ) std::cout << "ECAL block number " << eblcks++ << std::endl;
-    processBlock( ecal, empty, empty );
+    processBlock( ecal, empty, empty, pfegamma );
   }
 
   // Post HF Cleaning
@@ -528,7 +472,7 @@ void PFAlgo::reconstructParticles( const reco::PFBlockCollection& blocks ) {
 
 void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
                            std::list<reco::PFBlockRef>& hcalBlockRefs,
-                           std::list<reco::PFBlockRef>& ecalBlockRefs ) {
+                           std::list<reco::PFBlockRef>& ecalBlockRefs, PFEGammaFilters const* pfegamma  ) {
 
   // debug_ = false;
   assert(!blockref.isNull() );
@@ -645,8 +589,8 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 
 	  reco::GsfElectronRef gedEleRef = (*valueMapGedElectrons_)[pfEgmRef];
 	  if(gedEleRef.isNonnull()) {
-	    isGoodElectron = pfegamma_->passElectronSelection(*gedEleRef,*pfEgmRef,nVtx_);
-	    isPrimaryElectron = pfegamma_->isElectron(*gedEleRef);
+	    isGoodElectron = pfegamma->passElectronSelection(*gedEleRef,*pfEgmRef,nVtx_);
+	    isPrimaryElectron = pfegamma->isElectron(*gedEleRef);
 	    if(egmLocalDebug){
 	      if(isGoodElectron)
 		cout << "** Good Electron, pt " << gedEleRef->pt()
@@ -666,7 +610,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 
 	  reco::PhotonRef gedPhoRef = (*valueMapGedPhotons_)[pfEgmRef];
 	  if(gedPhoRef.isNonnull()) {
-	    isGoodPhoton =  pfegamma_->passPhotonSelection(*gedPhoRef);
+	    isGoodPhoton =  pfegamma->passPhotonSelection(*gedPhoRef);
 	    if(egmLocalDebug) {
 	      if(isGoodPhoton)
 		cout << "** Good Photon, pt " << gedPhoRef->pt()
@@ -692,7 +636,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	bool isSafe = true;
 	if( useProtectionsForJetMET_) {
 	  lockTracks = true;
-	  isSafe = pfegamma_->isElectronSafeForJetMET(*gedEleRef,myPFElectron,primaryVertex_,lockTracks);
+	  isSafe = pfegamma->isElectronSafeForJetMET(*gedEleRef,myPFElectron,primaryVertex_,lockTracks);
 	}
 
 	if(isSafe) {
@@ -745,7 +689,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	reco::PFCandidate myPFPhoton = *pfEgmRef;
 	bool isSafe = true;
 	if( useProtectionsForJetMET_) {
-	  isSafe = pfegamma_->isPhotonSafeForJetMET(*gedPhoRef,myPFPhoton);
+	  isSafe = pfegamma->isPhotonSafeForJetMET(*gedPhoRef,myPFPhoton);
 	}
 
 

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -234,8 +234,7 @@ void PFAlgo::setPFPhotonRegWeights(
 void
 PFAlgo::setPFMuonAndFakeParameters(const edm::ParameterSet& pset)
 {
-  pfmu_ = new PFMuonAlgo();
-  pfmu_->setParameters(pset);
+  pfmu_ = new PFMuonAlgo(pset);
 
   // Muon parameters
   muonHCAL_= pset.getParameter<std::vector<double> >("muon_HCAL");

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -23,22 +23,6 @@ namespace {
     out[1] = vals[1]; 
   }
 
-  auto eleJetMetProt(const edm::ParameterSet& cfg) {
-      return cfg.getParameter<edm::ParameterSet>("electron_protectionsForJetMET");
-  }
-
-  auto phJetMetProt(const edm::ParameterSet& cfg) {
-      return cfg.getParameter<edm::ParameterSet>("photon_protectionsForJetMET");
-  }
-
-  auto eleHcalProt(const edm::ParameterSet& cfg) {
-      return cfg.getParameter<edm::ParameterSet>("electron_protectionsForBadHcal");
-  }
-
-  auto phHcalProt(const edm::ParameterSet& cfg) {
-      return cfg.getParameter<edm::ParameterSet>("photon_protectionsForBadHcal");
-  }
-
 }
  
 
@@ -48,8 +32,6 @@ PFEGammaFilters::PFEGammaFilters(const edm::ParameterSet& cfg) :
   ph_loose_hoe_(cfg.getParameter<double>("photon_HoE")),
   ph_sietaieta_eb_(cfg.getParameter<double>("photon_SigmaiEtaiEta_barrel")),
   ph_sietaieta_ee_(cfg.getParameter<double>("photon_SigmaiEtaiEta_endcap")),
-  pho_sumPtTrackIso(phJetMetProt(cfg).getParameter<double>("sumPtTrackIso")), 
-  pho_sumPtTrackIsoSlope(phJetMetProt(cfg).getParameter<double>("sumPtTrackIsoSlope")),
   ele_iso_pt_(cfg.getParameter<double>("electron_iso_pt")),
   ele_iso_mva_eb_(cfg.getParameter<double>("electron_iso_mva_barrel")),
   ele_iso_mva_ee_(cfg.getParameter<double>("electron_iso_mva_endcap")),
@@ -58,31 +40,39 @@ PFEGammaFilters::PFEGammaFilters(const edm::ParameterSet& cfg) :
   ele_noniso_mva_(cfg.getParameter<double>("electron_noniso_mvaCut")),
   ele_missinghits_(cfg.getParameter<unsigned int>("electron_missinghits")),
   ele_ecalDrivenHademPreselCut_(cfg.getParameter<double>("electron_ecalDrivenHademPreselCut")),
-  ele_maxElePtForOnlyMVAPresel_(cfg.getParameter<double>("electron_maxElePtForOnlyMVAPresel")),
-  ele_maxNtracks(eleJetMetProt(cfg).getParameter<double>("maxNtracks")), 
-  ele_maxHcalE(eleJetMetProt(cfg).getParameter<double>("maxHcalE")), 
-  ele_maxTrackPOverEele(eleJetMetProt(cfg).getParameter<double>("maxTrackPOverEele")), 
-  ele_maxE(eleJetMetProt(cfg).getParameter<double>("maxE")),
-  ele_maxEleHcalEOverEcalE(eleJetMetProt(cfg).getParameter<double>("maxEleHcalEOverEcalE")),
-  ele_maxEcalEOverPRes(eleJetMetProt(cfg).getParameter<double>("maxEcalEOverPRes")), 
-  ele_maxEeleOverPoutRes(eleJetMetProt(cfg).getParameter<double>("maxEeleOverPoutRes")),
-  ele_maxHcalEOverP(eleJetMetProt(cfg).getParameter<double>("maxHcalEOverP")), 
-  ele_maxHcalEOverEcalE(eleJetMetProt(cfg).getParameter<double>("maxHcalEOverEcalE")), 
-  ele_maxEcalEOverP_1(eleJetMetProt(cfg).getParameter<double>("maxEcalEOverP_1")),
-  ele_maxEcalEOverP_2(eleJetMetProt(cfg).getParameter<double>("maxEcalEOverP_2")), 
-  ele_maxEeleOverPout(eleJetMetProt(cfg).getParameter<double>("maxEeleOverPout")), 
-  ele_maxDPhiIN(eleJetMetProt(cfg).getParameter<double>("maxDPhiIN")),
-  badHcal_eleEnable_(eleHcalProt(cfg).getParameter<bool>("enableProtections")),
-  badHcal_phoTrkSolidConeIso_offs_(phHcalProt(cfg).getParameter<double>("solidConeTrkIsoOffset")),
-  badHcal_phoTrkSolidConeIso_slope_(phHcalProt(cfg).getParameter<double>("solidConeTrkIsoSlope")),
-  badHcal_phoEnable_(phHcalProt(cfg).getParameter<bool>("enableProtections")),
-  debug_(cfg.getUntrackedParameter<bool>("debug",false))
+  ele_maxElePtForOnlyMVAPresel_(cfg.getParameter<double>("electron_maxElePtForOnlyMVAPresel"))
 {
     auto const& eleProtectionsForBadHcal = cfg.getParameter<edm::ParameterSet>("electron_protectionsForBadHcal");
+    auto const& eleProtectionsForJetMET = cfg.getParameter<edm::ParameterSet>("electron_protectionsForJetMET");
+    auto const& phoProtectionsForBadHcal = cfg.getParameter<edm::ParameterSet>("photon_protectionsForBadHcal");
+    auto const& phoProtectionsForJetMET = cfg.getParameter<edm::ParameterSet>("photon_protectionsForJetMET");
+
+    pho_sumPtTrackIso_ = phoProtectionsForJetMET.getParameter<double>("sumPtTrackIso");
+    pho_sumPtTrackIsoSlope_ = phoProtectionsForJetMET.getParameter<double>("sumPtTrackIsoSlope");
+
+    ele_maxNtracks_ = eleProtectionsForJetMET.getParameter<double>("maxNtracks");
+    ele_maxHcalE_ = eleProtectionsForJetMET.getParameter<double>("maxHcalE");
+    ele_maxTrackPOverEele_ = eleProtectionsForJetMET.getParameter<double>("maxTrackPOverEele");
+    ele_maxE_ = eleProtectionsForJetMET.getParameter<double>("maxE");
+    ele_maxEleHcalEOverEcalE_ = eleProtectionsForJetMET.getParameter<double>("maxEleHcalEOverEcalE");
+    ele_maxEcalEOverPRes_ = eleProtectionsForJetMET.getParameter<double>("maxEcalEOverPRes");
+    ele_maxEeleOverPoutRes_ = eleProtectionsForJetMET.getParameter<double>("maxEeleOverPoutRes");
+    ele_maxHcalEOverP_ = eleProtectionsForJetMET.getParameter<double>("maxHcalEOverP");
+    ele_maxHcalEOverEcalE_ = eleProtectionsForJetMET.getParameter<double>("maxHcalEOverEcalE");
+    ele_maxEcalEOverP_1_ = eleProtectionsForJetMET.getParameter<double>("maxEcalEOverP_1");
+    ele_maxEcalEOverP_2_ = eleProtectionsForJetMET.getParameter<double>("maxEcalEOverP_2");
+    ele_maxEeleOverPout_ = eleProtectionsForJetMET.getParameter<double>("maxEeleOverPout");
+    ele_maxDPhiIN_ = eleProtectionsForJetMET.getParameter<double>("maxDPhiIN");
+
     readEBEEParams_(eleProtectionsForBadHcal, "full5x5_sigmaIetaIeta", badHcal_full5x5_sigmaIetaIeta_);
     readEBEEParams_(eleProtectionsForBadHcal, "eInvPInv", badHcal_eInvPInv_);
     readEBEEParams_(eleProtectionsForBadHcal, "dEta", badHcal_dEta_);
     readEBEEParams_(eleProtectionsForBadHcal, "dPhi", badHcal_dPhi_);
+
+    badHcal_eleEnable_ = eleProtectionsForBadHcal.getParameter<bool>("enableProtections");
+    badHcal_phoTrkSolidConeIso_offs_ = phoProtectionsForBadHcal.getParameter<double>("solidConeTrkIsoOffset");
+    badHcal_phoTrkSolidConeIso_slope_ = phoProtectionsForBadHcal.getParameter<double>("solidConeTrkIsoSlope");
+    badHcal_phoEnable_ = phoProtectionsForBadHcal.getParameter<bool>("enableProtections");
 }
 
 
@@ -204,19 +194,19 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
   bool debugSafeForJetMET = false;
   bool isSafeForJetMET = true;
 
-//   cout << " ele_maxNtracks " <<  ele_maxNtracks << endl
-//        << " ele_maxHcalE " << ele_maxHcalE << endl
-//        << " ele_maxTrackPOverEele " << ele_maxTrackPOverEele << endl
-//        << " ele_maxE " << ele_maxE << endl
-//        << " ele_maxEleHcalEOverEcalE "<< ele_maxEleHcalEOverEcalE << endl
-//        << " ele_maxEcalEOverPRes " << ele_maxEcalEOverPRes << endl
-//        << " ele_maxEeleOverPoutRes "  << ele_maxEeleOverPoutRes << endl
-//        << " ele_maxHcalEOverP " << ele_maxHcalEOverP << endl
-//        << " ele_maxHcalEOverEcalE " << ele_maxHcalEOverEcalE << endl
-//        << " ele_maxEcalEOverP_1 " << ele_maxEcalEOverP_1 << endl
-//        << " ele_maxEcalEOverP_2 " << ele_maxEcalEOverP_2 << endl
-//        << " ele_maxEeleOverPout "  << ele_maxEeleOverPout << endl
-//        << " ele_maxDPhiIN " << ele_maxDPhiIN << endl;
+//   cout << " ele_maxNtracks_ " <<  ele_maxNtracks_ << endl
+//        << " ele_maxHcalE_ " << ele_maxHcalE_ << endl
+//        << " ele_maxTrackPOverEele_ " << ele_maxTrackPOverEele_ << endl
+//        << " ele_maxE_ " << ele_maxE_ << endl
+//        << " ele_maxEleHcalEOverEcalE_ "<< ele_maxEleHcalEOverEcalE_ << endl
+//        << " ele_maxEcalEOverPRes_ " << ele_maxEcalEOverPRes_ << endl
+//        << " ele_maxEeleOverPoutRes_ "  << ele_maxEeleOverPoutRes_ << endl
+//        << " ele_maxHcalEOverP_ " << ele_maxHcalEOverP_ << endl
+//        << " ele_maxHcalEOverEcalE_ " << ele_maxHcalEOverEcalE_ << endl
+//        << " ele_maxEcalEOverP_1_ " << ele_maxEcalEOverP_1_ << endl
+//        << " ele_maxEcalEOverP_2_ " << ele_maxEcalEOverP_2_ << endl
+//        << " ele_maxEeleOverPout_ "  << ele_maxEeleOverPout_ << endl
+//        << " ele_maxDPhiIN_ " << ele_maxDPhiIN_ << endl;
     
   // loop on the extra-tracks associated to the electron
   PFCandidateEGammaExtraRef pfcandextra = pfcand.egammaExtraRef();
@@ -308,8 +298,8 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
     }
   }
   if( iextratrack > 0) {
-    if(iextratrack > ele_maxNtracks || Ene_hcalgsf > ele_maxHcalE || (SumExtraKfP/Ene_ecalgsf) > ele_maxTrackPOverEele 
-       || (ETtotal > ele_maxE && iextratrack > 1 && (Ene_hcalgsf/Ene_ecalgsf) > ele_maxEleHcalEOverEcalE) ) {
+    if(iextratrack > ele_maxNtracks_ || Ene_hcalgsf > ele_maxHcalE_ || (SumExtraKfP/Ene_ecalgsf) > ele_maxTrackPOverEele_ 
+       || (ETtotal > ele_maxE_ && iextratrack > 1 && (Ene_hcalgsf/Ene_ecalgsf) > ele_maxEleHcalEOverEcalE_) ) {
       if(debugSafeForJetMET) 
 	cout << " *****This electron candidate is discarded: Non isolated  # tracks "		
 	     << iextratrack << " HOverHE " << HOverHE 
@@ -323,9 +313,9 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
       isSafeForJetMET = false;
     }
     // the electron is retained and the kf tracks are not locked
-    if( (fabs(1.-EtotPinMode) < ele_maxEcalEOverPRes && (fabs(electron.eta()) < 1.0 || fabs(electron.eta()) > 2.0)) ||
+    if( (fabs(1.-EtotPinMode) < ele_maxEcalEOverPRes_ && (fabs(electron.eta()) < 1.0 || fabs(electron.eta()) > 2.0)) ||
 	((EtotPinMode < 1.1 && EtotPinMode > 0.6) && (fabs(electron.eta()) >= 1.0 && fabs(electron.eta()) <= 2.0))) {
-      if( fabs(1.-EGsfPoutMode) < ele_maxEeleOverPoutRes && 
+      if( fabs(1.-EGsfPoutMode) < ele_maxEeleOverPoutRes_ && 
 	  (itrackHcalLinked == iextratrack)) {
 
 	lockTracks = false;
@@ -340,7 +330,7 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
     }
   }
 
-  if (HOverPin > ele_maxHcalEOverP && HOverHE > ele_maxHcalEOverEcalE && EtotPinMode < ele_maxEcalEOverP_1) {
+  if (HOverPin > ele_maxHcalEOverP_ && HOverHE > ele_maxHcalEOverEcalE_ && EtotPinMode < ele_maxEcalEOverP_1_) {
     if(debugSafeForJetMET) 
       cout << " *****This electron candidate is discarded  HCAL ENERGY "	
 	   << " HOverPin " << HOverPin << " HOverHE " << HOverHE  << " EtotPinMode" << EtotPinMode << endl;
@@ -350,7 +340,7 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
   // Reject Crazy E/p values... to be understood in the future how to train a 
   // BDT in order to avoid to select this bad electron candidates. 
   
-  if( EtotPinMode < ele_maxEcalEOverP_2 && EGsfPoutMode < ele_maxEeleOverPout ) {
+  if( EtotPinMode < ele_maxEcalEOverP_2_ && EGsfPoutMode < ele_maxEeleOverPout_ ) {
     if(debugSafeForJetMET) 
       cout << " *****This electron candidate is discarded  Low ETOTPIN "
 	   << " EtotPinMode " << EtotPinMode << " EGsfPoutMode " << EGsfPoutMode << endl;
@@ -358,7 +348,7 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
   }
   
   // For not-preselected Gsf Tracks ET > 50 GeV, apply dphi preselection
-  if(ETtotal > ele_maxE && fabs(dphi_normalsc) > ele_maxDPhiIN ) {
+  if(ETtotal > ele_maxE_ && fabs(dphi_normalsc) > ele_maxDPhiIN_ ) {
     if(debugSafeForJetMET) 
       cout << " *****This electron candidate is discarded  Large ANGLE "
 	   << " ETtotal " << ETtotal << " EGsfPoutMode " << dphi_normalsc << endl;
@@ -374,8 +364,8 @@ bool PFEGammaFilters::isPhotonSafeForJetMET(const reco::Photon & photon, const r
   bool isSafeForJetMET = true;
   bool debugSafeForJetMET = false;
 
-//   cout << " pho_sumPtTrackIsoForPhoton " << pho_sumPtTrackIso
-//        << " pho_sumPtTrackIsoSlopeForPhoton " << pho_sumPtTrackIsoSlope <<  endl;
+//   cout << " pho_sumPtTrackIso_ForPhoton " << pho_sumPtTrackIso_
+//        << " pho_sumPtTrackIsoSlope_ForPhoton " << pho_sumPtTrackIsoSlope_ <<  endl;
 
   float sum_track_pt = 0.;
 
@@ -422,7 +412,7 @@ bool PFEGammaFilters::isPhotonSafeForJetMET(const reco::Photon & photon, const r
   if(debugSafeForJetMET)
     cout << " PFEGammaFilters::isPhotonSafeForJetMET: SumPt " << sum_track_pt << endl;
 
-  if(sum_track_pt>(pho_sumPtTrackIso + pho_sumPtTrackIsoSlope * photon.pt())) {
+  if(sum_track_pt>(pho_sumPtTrackIso_ + pho_sumPtTrackIsoSlope_ * photon.pt())) {
     isSafeForJetMET = false;
     if(debugSafeForJetMET)
       cout << "************************************!!!! PFEGammaFilters::isPhotonSafeForJetMET: Photon Discaded !!! " << endl;


### PR DESCRIPTION
#### PR description:

Proposes to construct the `PFEGammaFilters` directly from a ParameterSet instead of passing around the individual configuration variables 2 times, which cleans up a bit the code for the PFProducer and the PFAlgo.

Also declares all member function of `PFEGammaFilters` as `const`.

#### PR validation:

Local matrix tests pass.