### PR TITLE
Save DQM output per lumisection for UL rereco

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1935,6 +1935,8 @@ class ConfigBuilder(object):
     def prepare_DQM(self, sequence = 'DQMOffline'):
         # this one needs replacement
 
+        # any 'DQM' job should use DQMStore in non-legacy mode (but not HARVESTING)
+        self.loadAndRemember("DQMServices/Core/DQMStoreNonLegacy_cff")
         self.loadDefaultOrSpecifiedCFF(sequence,self.DQMOFFLINEDefaultCFF)
         sequenceList=sequence.split('.')[-1].split('+')
         postSequenceList=sequence.split('.')[-1].split('+')

--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -52,7 +52,7 @@ def mergeProcess(*inputFiles, **options):
     #//
     if newDQMIO:
         process.source = Source("DQMRootSource")
-        process.add_(Service("DQMStore"))
+        process.add_(Service("DQMStore", forceResetOnBeginLumi = CfgTypes.untracked.bool(True)))
     else:
         process.source = Source("PoolSource")
         if bypassVersionCheck:

--- a/DQM/EcalMonitorClient/interface/DQWorkerClient.h
+++ b/DQM/EcalMonitorClient/interface/DQWorkerClient.h
@@ -20,7 +20,7 @@ namespace ecaldqm
     };
 
     DQWorkerClient();
-    virtual ~DQWorkerClient() {}
+    ~DQWorkerClient() override {}
 
     static void fillDescriptions(edm::ParameterSetDescription&);
 

--- a/DQM/EcalMonitorClient/interface/DQWorkerClient.h
+++ b/DQM/EcalMonitorClient/interface/DQWorkerClient.h
@@ -25,6 +25,7 @@ namespace ecaldqm
     static void fillDescriptions(edm::ParameterSetDescription&);
 
     void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+    void resetPerLumi();
 
     void bookMEs(DQMStore::IBooker&) override;
     void releaseMEs() override;

--- a/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
+++ b/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
@@ -102,6 +102,11 @@ EcalDQMonitorClient::dqmEndLuminosityBlock(DQMStore::IBooker& _ibooker, DQMStore
   ecaldqmEndLuminosityBlock(_lumi, _es);
 
   runWorkers(_igetter, ecaldqm::DQWorkerClient::kLumi);
+
+  executeOnWorkers_([](ecaldqm::DQWorker* worker){
+    ecaldqm::DQWorkerClient* client(static_cast<ecaldqm::DQWorkerClient*>(worker));
+    client->resetPerLumi();
+  }, "dqmEndLuminosityBlock", "Reset per-lumi MEs");
 }
 
 void

--- a/DQM/EcalMonitorClient/src/DQWorkerClient.cc
+++ b/DQM/EcalMonitorClient/src/DQWorkerClient.cc
@@ -169,6 +169,23 @@ namespace ecaldqm
     }
   }    
 
+  void 
+  DQWorkerClient::resetPerLumi()
+  {
+    for (auto const& meset : MEs_) {
+      int i = 0;
+      while (auto me = meset.second->getME(i)) {
+        if (me->getLumiFlag()) {
+          std::cout << "+++ reset " << me->getFullname() << "\n";
+          // reset per-lumi histograms in offline harvesting so that they only show
+          // data of the current lumisection.
+          me->Reset();
+        }
+        i++;
+      }
+    }
+  }
+
   void
   DQWorkerClient::towerAverage_(MESet& _target, MESet const& _source, float _threshold)
   {

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -224,6 +224,8 @@ namespace hcaldqm
 
 		//	push all the flags for all FEDs for this LS
 		_vflagsLS.push_back(lssum);
+		cDigiSize_Crate.reset();
+		cOccupancy_depth.reset();
 	}
 
 	/*

--- a/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
@@ -363,6 +363,17 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker & ibooker, DQM
     }
   }
 
+  // After harvesting, all per-lumi MEs are reset, to make sure we only get
+  // events of the new lumisection next time.
+  for (std::map<std::string, TrackingMEs>::iterator it = TrackingMEsMap.begin();
+       it != TrackingMEsMap.end(); it++) {
+    std::string localMEdirpath = it->second.HistoDir;
+    std::vector<MonitorElement*> tmpMEvec = igetter.getContents(ibooker.pwd()+"/"+localMEdirpath);
+    for ( auto ime : tmpMEvec ) {
+      ime->Reset();
+    }
+  }
+
   if (verbose_) std::cout << "[TrackingQualityChecker::fillTrackingStatus] gstatus: " << gstatus << std::endl;  
   size_t nQT = TrackingMEsMap.size();
   if (gstatus < 1.) gstatus = -1.;

--- a/DQMOffline/EGamma/interface/ElectronDqmAnalyzerBase.h
+++ b/DQMOffline/EGamma/interface/ElectronDqmAnalyzerBase.h
@@ -19,7 +19,7 @@ class MonitorElement ;
 namespace edab {
   struct Empty {};
 }
-class ElectronDqmAnalyzerBase : public one::DQMEDAnalyzer<edm::LuminosityBlockCache<edab::Empty>>
+class ElectronDqmAnalyzerBase : public DQMEDAnalyzer
  {
 
   protected:
@@ -28,17 +28,12 @@ class ElectronDqmAnalyzerBase : public one::DQMEDAnalyzer<edm::LuminosityBlockCa
     ~ElectronDqmAnalyzerBase() override ;
 
     // specific implementation of EDAnalyzer
-    void endRun( edm::Run const &, edm::EventSetup const & )  override;
-    std::shared_ptr<edab::Empty> globalBeginLuminosityBlock( edm::LuminosityBlock const &, edm::EventSetup const & ) const final ;
-    void globalEndLuminosityBlock( edm::LuminosityBlock const &, edm::EventSetup const & ) final ;
-    void dqmBeginRun( edm::Run const & , edm::EventSetup const & )  override;
     void bookHistograms( DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
     // interface to implement in derived classes
     void analyze( const edm::Event & e, const edm::EventSetup & c ) override {}
 
     // utility methods
-    bool finalStepDone() { return finalDone_ ; }
     int verbosity() { return verbosity_ ; }
 
     void setBookPrefix( const std::string & ) ;
@@ -101,7 +96,6 @@ class ElectronDqmAnalyzerBase : public one::DQMEDAnalyzer<edm::LuminosityBlockCa
     std::string outputFile_ ;
     std::string inputInternalPath_ ;
     std::string outputInternalPath_ ;
-    bool finalDone_ ;
 
     // utility methods
     std::string newName( const std::string & name ) ;

--- a/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
+++ b/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
@@ -17,7 +17,7 @@
 #include <sstream>
 
 ElectronDqmAnalyzerBase::ElectronDqmAnalyzerBase( const edm::ParameterSet& conf )
- : bookPrefix_("ele"), bookIndex_(0), histoNamesReady(false), finalDone_(false)
+ : bookPrefix_("ele"), bookIndex_(0), histoNamesReady(false)
  {
   verbosity_ = conf.getUntrackedParameter<int>("Verbosity") ;
   finalStep_ = conf.getParameter<std::string>("FinalStep") ;
@@ -55,39 +55,6 @@ std::string ElectronDqmAnalyzerBase::newName( const std::string & name )
   return oss.str() ;
  }
 
-void ElectronDqmAnalyzerBase::dqmBeginRun( edm::Run const & , edm::EventSetup const & ) 
- {
- }
-
-void ElectronDqmAnalyzerBase::endRun( edm::Run const &, edm::EventSetup const & )
- {
-  if (finalStep_=="AtRunEnd")
-   {
-    if (finalDone_)
-     { edm::LogWarning("ElectronDqmAnalyzerBase::endRun")<<"finalize() already called" ; }
-    finalDone_ = true ;
-
-    // --- transfert from endJob()
-    if (!outputFile_.empty())
-     { 
-//     edm::LogWarning("ElectronDqmAnalyzerBase::endRun")<<"finalize() already called" ;
-	 } /**/
-   }
- }
-
-std::shared_ptr<edab::Empty> 
-ElectronDqmAnalyzerBase::globalBeginLuminosityBlock( edm::LuminosityBlock const &, edm::EventSetup const & ) const {
-  return std::shared_ptr<edab::Empty>();
-}
-void ElectronDqmAnalyzerBase::globalEndLuminosityBlock( edm::LuminosityBlock const &, edm::EventSetup const & )
- {
-  if (finalStep_=="AtLumiEnd")
-   {
-    if (finalDone_)
-     { edm::LogWarning("ElectronDqmAnalyzerBase::endLuminosityBlock")<<"finalize() already called" ; }
-    finalDone_ = true ;
-   }
- } /**/
 
 void ElectronDqmAnalyzerBase::bookHistograms( DQMStore::IBooker & ibooker_, edm::Run const &, edm::EventSetup const &) 
 {

--- a/DQMServices/Components/plugins/DQMDcsInfoClient.cc
+++ b/DQMServices/Components/plugins/DQMDcsInfoClient.cc
@@ -90,7 +90,7 @@ DQMDcsInfoClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& igett
 
   reportSummaryMap_ = ibooker.book2D("reportSummaryMap",
                      "HV and GT vs Lumi", nlsmax, 0., nlsmax, 25, 0., 25.);
-  if (processedLS_.size() < 1) return;
+  if (processedLS_.empty()) return;
   unsigned int lastProcessedLS = *(--processedLS_.end());
   meProcessedLS_ = ibooker.book1D("ProcessedLS",
                                   "Processed Lumisections",

--- a/DQMServices/Components/plugins/DQMDcsInfoClient.cc
+++ b/DQMServices/Components/plugins/DQMDcsInfoClient.cc
@@ -2,7 +2,7 @@
 /*
  * \file DQMDcsInfoClient.cc
  * \author Andreas Meyer
- * Last Update:
+ * Last Update: 2019-03-26 Migrate to DQMEDHarvester
  *
 */
 
@@ -17,8 +17,6 @@ DQMDcsInfoClient::DQMDcsInfoClient( const edm::ParameterSet& ps ) {
 
   parameters_ = ps;
 
-  dbe_ = edm::Service<DQMStore>().operator->();
-
   subsystemname_ = parameters_.getUntrackedParameter<std::string>("subSystemFolder", "Info") ;
   dcsinfofolder_ = parameters_.getUntrackedParameter<std::string>("dcsInfoFolder", "DcsInfo") ;
 
@@ -30,31 +28,14 @@ DQMDcsInfoClient::~DQMDcsInfoClient() = default;
 void 
 DQMDcsInfoClient::beginRun(const edm::Run& r, const edm::EventSetup& c) 
 {
-  // Fetch GlobalTag information and fill the string/ME.
-  dbe_->cd();  
-  dbe_->setCurrentFolder(subsystemname_ +"/CMSSWInfo/");
-  const edm::ParameterSet &globalTagPSet =
-    edm::getProcessParameterSetContainingModule(moduleDescription())
-    .getParameterSet("PoolDBESSource@GlobalTag");
-
-  dbe_->bookString("globalTag_Harvesting", globalTagPSet.getParameter<std::string>("globaltag"));
-
   DCS.clear();
   DCS.resize(10);  // start with 10 LS, resize later
   processedLS_.clear();
 }
 
 void 
-DQMDcsInfoClient::analyze(const edm::Event& e, const edm::EventSetup& c)
+DQMDcsInfoClient::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter, const edm::LuminosityBlock& l, const edm::EventSetup& c)
 {
-  return;
-}
-
-void 
-DQMDcsInfoClient::endLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c)
-{
-  if (!dbe_) return;
-
   unsigned int nlumi = l.id().luminosityBlock() ;
   processedLS_.insert(nlumi);
   // cout << " in lumi section " << nlumi << endl;
@@ -64,7 +45,7 @@ DQMDcsInfoClient::endLuminosityBlock(const edm::LuminosityBlock& l, const edm::E
   // cout << "DCS size: " << DCS.size() << endl;     
 
   MonitorElement* DCSbyLS_ = 
-            dbe_->get(subsystemname_ + "/" + dcsinfofolder_ + "/DCSbyLS" ); 
+            igetter.get(subsystemname_ + "/" + dcsinfofolder_ + "/DCSbyLS" ); 
 
   if ( DCSbyLS_ ) 
   {
@@ -86,27 +67,35 @@ DQMDcsInfoClient::endLuminosityBlock(const edm::LuminosityBlock& l, const edm::E
 }
 
 void 
-DQMDcsInfoClient::endRun(const edm::Run& r, const edm::EventSetup& c) 
+DQMDcsInfoClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter)
 {
+  // Fetch GlobalTag information and fill the string/ME.
+  ibooker.cd();  
+  ibooker.setCurrentFolder(subsystemname_ +"/CMSSWInfo/");
+  const edm::ParameterSet &globalTagPSet =
+    edm::getProcessParameterSetContainingModule(moduleDescription())
+    .getParameterSet("PoolDBESSource@GlobalTag");
 
-  // book 
-  dbe_->cd();  
-  dbe_->setCurrentFolder(subsystemname_ +"/EventInfo/");
+  ibooker.bookString("globalTag_Harvesting", globalTagPSet.getParameter<std::string>("globaltag"));
+
+  ibooker.cd();  
+  ibooker.setCurrentFolder(subsystemname_ +"/EventInfo/");
 
   unsigned int nlsmax = DCS.size();
-  reportSummary_=dbe_->bookFloat("reportSummary");
+  reportSummary_=ibooker.bookFloat("reportSummary");
   reportSummary_->Fill(1.);
   
-  reportSummaryMap_ = dbe_->get(subsystemname_ +"/EventInfo/reportSummaryMap");
-  if (reportSummaryMap_) dbe_->removeElement(reportSummaryMap_->getName());
+  reportSummaryMap_ = igetter.get(subsystemname_ +"/EventInfo/reportSummaryMap");
+  assert(!reportSummaryMap_); // this would be a configuration problem
 
-  reportSummaryMap_ = dbe_->book2D("reportSummaryMap",
+  reportSummaryMap_ = ibooker.book2D("reportSummaryMap",
                      "HV and GT vs Lumi", nlsmax, 0., nlsmax, 25, 0., 25.);
+  if (processedLS_.size() < 1) return;
   unsigned int lastProcessedLS = *(--processedLS_.end());
-  meProcessedLS_ = dbe_->book1D("ProcessedLS",
-				"Processed Lumisections",
-				lastProcessedLS+1,
-				0.,lastProcessedLS+1);
+  meProcessedLS_ = ibooker.book1D("ProcessedLS",
+                                  "Processed Lumisections",
+                                  lastProcessedLS+1,
+                                  0.,lastProcessedLS+1);
   reportSummaryMap_->setBinLabel( 1, "CSC+"    , 2);
   reportSummaryMap_->setBinLabel( 2, "CSC-"    , 2);
   reportSummaryMap_->setBinLabel( 3, "DT0"     , 2);
@@ -146,22 +135,18 @@ DQMDcsInfoClient::endRun(const edm::Run& r, const edm::EventSetup& c)
     }
   }
 
-  std::set<unsigned int>::iterator it,ite;
-  it  = processedLS_.begin();
-  ite = processedLS_.end();
   unsigned int lastAccessed = 0;
   
-  for (; it!=ite; it++)
+  for (auto ls : processedLS_)
   {
-    while (lastAccessed < (*it))
+    while (lastAccessed < ls)
     {
       //      std::cout << "Filling " << lastAccessed << " with -1" << std::endl; 
       meProcessedLS_->Fill(lastAccessed, -1.);
       lastAccessed++;
     }
     //    std::cout << "Filling " << *it << " with 1" << std::endl; 
-    meProcessedLS_->Fill(*it);
-    lastAccessed = (*it)+1;
+    meProcessedLS_->Fill(ls);
+    lastAccessed = ls+1;
   }
-  
 }

--- a/DQMServices/Components/plugins/DQMDcsInfoClient.h
+++ b/DQMServices/Components/plugins/DQMDcsInfoClient.h
@@ -15,14 +15,14 @@
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <FWCore/ServiceRegistry/interface/Service.h>
 
-#include <DQMServices/Core/interface/DQMStore.h>
+#include <DQMServices/Core/interface/DQMEDHarvester.h>
 #include <DQMServices/Core/interface/MonitorElement.h>
 
 //
 // class declaration
 //
 
-class DQMDcsInfoClient : public edm::EDAnalyzer {
+class DQMDcsInfoClient : public DQMEDHarvester {
 public:
   DQMDcsInfoClient( const edm::ParameterSet& ps);
   ~DQMDcsInfoClient() override;
@@ -30,9 +30,8 @@ public:
 protected:
 
   void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
-  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-  void endLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c) override;
-  void endRun(const edm::Run& r, const edm::EventSetup& c) override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker&, DQMStore::IGetter&, const edm::LuminosityBlock& l, const edm::EventSetup& c) override;
+  void dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
 
 private:
 
@@ -40,7 +39,6 @@ private:
   std::string subsystemname_;
   std::string dcsinfofolder_;
 
-  DQMStore * dbe_;
 
   std::vector<int> DCS;
   std::set<unsigned int> processedLS_;

--- a/DQMServices/Components/python/DQMDcsInfoClient_cfi.py
+++ b/DQMServices/Components/python/DQMDcsInfoClient_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester 
 
-
-dqmDcsInfoClient = cms.EDAnalyzer("DQMDcsInfoClient",
+dqmDcsInfoClient = DQMEDHarvester("DQMDcsInfoClient",
     subSystemFolder = cms.untracked.string('Info'),
     dcsInfoFolder = cms.untracked.string('DcsInfo')
 )

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -240,13 +240,14 @@ public:
   // into the DQMStore via a public API. The central mutex is acquired
   // *before* invoking and automatically released upon returns.
   template <typename iFunc>
-  void bookTransaction(iFunc f, uint32_t run, uint32_t moduleId)
+  void bookTransaction(iFunc f, uint32_t run, uint32_t moduleId, bool canSaveByLumi)
   {
     std::lock_guard<std::mutex> guard(book_mutex_);
     /* Set the run number and module id only if multithreading is enabled */
     if (enableMultiThread_) {
       run_ = run;
       moduleId_ = moduleId;
+      canSaveByLumi_ = canSaveByLumi;
     }
     IBooker booker{this};
     f(booker);
@@ -255,6 +256,7 @@ public:
     if (enableMultiThread_) {
       run_ = 0;
       moduleId_ = 0;
+      canSaveByLumi_ = false;
     }
   }
 
@@ -638,6 +640,10 @@ private:
   std::string readSelectedDirectory_{};
   uint32_t run_{};
   uint32_t moduleId_{};
+  // set to true in the transaction if module supports per-lumi saving.
+  bool canSaveByLumi_{false};
+  // set to true in configuration if per-lumi saving is requested.
+  bool doSaveByLumi_{false};
   std::unique_ptr<std::ostream> stream_{nullptr};
 
   std::string pwd_{};

--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -144,7 +144,7 @@ public:
 
   /// true if ME is meant to be stored for each luminosity section
   bool getLumiFlag() const
-    { return data_.flags & DQMNet::DQM_PROP_LUMI; }
+    { return true; }
 
   /// this ME is meant to be stored for each luminosity section
   void setLumiFlag()

--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -144,7 +144,7 @@ public:
 
   /// true if ME is meant to be stored for each luminosity section
   bool getLumiFlag() const
-    { return true; }
+    { return data_.flags & DQMNet::DQM_PROP_LUMI; }
 
   /// this ME is meant to be stored for each luminosity section
   void setLumiFlag()

--- a/DQMServices/Core/interface/oneDQMEDAnalyzer.h
+++ b/DQMServices/Core/interface/oneDQMEDAnalyzer.h
@@ -101,7 +101,7 @@ public:
 
 template <typename... T> class DQMBaseClass;
 
-template<> class DQMBaseClass<> : public DQMRunEDProducer<> {};
+template<> class DQMBaseClass<> : public DQMLumisEDProducer {};
 template<> class DQMBaseClass<DQMLuminosityBlockElements> : public DQMLumisEDProducer {};
 template<> class DQMBaseClass<edm::one::WatchLuminosityBlocks> : public DQMRunEDProducer<edm::one::WatchLuminosityBlocks> {};
 template<typename T> class DQMBaseClass<edm::LuminosityBlockCache<T>> : public DQMRunEDProducer<edm::LuminosityBlockCache<T>>{};

--- a/DQMServices/Core/interface/oneDQMEDAnalyzer.h
+++ b/DQMServices/Core/interface/oneDQMEDAnalyzer.h
@@ -51,7 +51,8 @@ public:
       this->bookHistograms(booker, run, setup);
     },
     run.run(),
-    this->moduleDescription().id());
+    this->moduleDescription().id(),
+    this->getCanSaveByLumi());
   }
 
   void endRun(edm::Run const& run, edm::EventSetup const& setup) override {}
@@ -70,6 +71,8 @@ public:
   void accumulate(edm::Event const& ev, edm::EventSetup const& es) final {
     analyze(ev,es);
   }
+
+  virtual bool getCanSaveByLumi() { return false; }
 private:
   edm::EDPutTokenT<DQMToken> runToken_;
 
@@ -101,7 +104,9 @@ public:
 
 template <typename... T> class DQMBaseClass;
 
-template<> class DQMBaseClass<> : public DQMLumisEDProducer {};
+template<> class DQMBaseClass<> : public DQMLumisEDProducer {
+  bool getCanSaveByLumi() override { return true; }
+};
 template<> class DQMBaseClass<DQMLuminosityBlockElements> : public DQMLumisEDProducer {};
 template<> class DQMBaseClass<edm::one::WatchLuminosityBlocks> : public DQMRunEDProducer<edm::one::WatchLuminosityBlocks> {};
 template<typename T> class DQMBaseClass<edm::LuminosityBlockCache<T>> : public DQMRunEDProducer<edm::LuminosityBlockCache<T>>{};

--- a/DQMServices/Core/python/DQMStoreNonLegacy_cff.py
+++ b/DQMServices/Core/python/DQMStoreNonLegacy_cff.py
@@ -1,0 +1,9 @@
+from DQMServices.Core.DQMStore_cfi import DQMStore
+
+# This flag is turned on automatically when a job runs with more than one stream.
+# However, it changes much more than just thread safety related things, so it is
+# better to turn it on in *any* job that can be run multi-threaded, to get more
+# reliable tests. Running single-threaded with this flag turned on is safe, but
+# some modules (HARVESTING, legacy) will not work with this (and therefore can't
+# run multi-threaded.
+DQMStore.enableMultiThread = True

--- a/DQMServices/Core/python/DQMStore_cfi.py
+++ b/DQMServices/Core/python/DQMStore_cfi.py
@@ -10,5 +10,8 @@ DQMStore = cms.Service("DQMStore",
     #MEs are flagged to be LS based.
     LSbasedMode = cms.untracked.bool(False),
     #this is bound to the enableMultiThread flag.
-    forceResetOnBeginLumi = cms.untracked.bool(False)
+    forceResetOnBeginLumi = cms.untracked.bool(False),
+    # similar to LSBasedMode but for offline. Explicitly sets LumiFLag on all
+    # MEs/modules that allow it (canSaveByLumi)
+    saveByLumi = cms.untracked.bool(True),
 )

--- a/DQMServices/Core/python/DQMStore_cfi.py
+++ b/DQMServices/Core/python/DQMStore_cfi.py
@@ -13,5 +13,5 @@ DQMStore = cms.Service("DQMStore",
     forceResetOnBeginLumi = cms.untracked.bool(False),
     # similar to LSBasedMode but for offline. Explicitly sets LumiFLag on all
     # MEs/modules that allow it (canSaveByLumi)
-    saveByLumi = cms.untracked.bool(True),
+    saveByLumi = cms.untracked.bool(False),
 )

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -423,6 +423,10 @@ DQMStore::initializeFrom(edm::ParameterSet const& pset)
   if (LSbasedMode_)
     std::cout << "DQMStore: LSbasedMode option is enabled\n";
 
+  doSaveByLumi_ = pset.getUntrackedParameter<bool>("saveByLumi", false);
+  if (doSaveByLumi_)
+    std::cout << "DQMStore: saveByLumi option is enabled\n";
+
   std::string ref = pset.getUntrackedParameter<std::string>("referenceFileName", "");
   if (! ref.empty()) {
     std::cout << "DQMStore: using reference file '" << ref << "'\n";
@@ -934,9 +938,9 @@ DQMStore::book_(std::string const& dir,
     // Create and initialise core object.
     assert(dirs_.count(dir));
     MonitorElement proto(&*dirs_.find(dir), name, run_, moduleId_);
-    if (run_ != 0 && moduleId_ != 0) {
+    if (doSaveByLumi_ && canSaveByLumi_) {
       proto.setLumiFlag(); // default to per-lumi mode for all non-legacy MEs.
-      // for legacy (moduleId_ == 0) this is not always safe.
+      // for legacy (not DQMEDAnalyzer) this is not save.
     }
     me = const_cast<MonitorElement&>(*data_.insert(std::move(proto)).first)
       .initialise((MonitorElement::Kind)kind, h);
@@ -996,9 +1000,9 @@ DQMStore::book_(std::string const& dir,
     // Create it and return for initialisation.
     assert(dirs_.count(dir));
     MonitorElement proto(&*dirs_.find(dir), name, run_, moduleId_);
-    if (run_ != 0 && moduleId_ != 0) {
+    if (doSaveByLumi_ && canSaveByLumi_) {
       proto.setLumiFlag(); // default to per-lumi mode for all non-legacy MEs.
-      // for legacy (moduleId_ == 0) this is not always safe.
+      // for legacy (not DQMEDAnalyzer) this is not save.
     }
     return &const_cast<MonitorElement&>(*data_.insert(std::move(proto)).first);
   }

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -939,8 +939,8 @@ DQMStore::book_(std::string const& dir,
     assert(dirs_.count(dir));
     MonitorElement proto(&*dirs_.find(dir), name, run_, moduleId_);
     if (doSaveByLumi_ && canSaveByLumi_) {
-      proto.setLumiFlag(); // default to per-lumi mode for all non-legacy MEs.
       // for legacy (not DQMEDAnalyzer) this is not save.
+      proto.setLumiFlag(); // default to per-lumi mode for all non-legacy MEs.
     }
     me = const_cast<MonitorElement&>(*data_.insert(std::move(proto)).first)
       .initialise((MonitorElement::Kind)kind, h);
@@ -1000,10 +1000,8 @@ DQMStore::book_(std::string const& dir,
     // Create it and return for initialisation.
     assert(dirs_.count(dir));
     MonitorElement proto(&*dirs_.find(dir), name, run_, moduleId_);
-    if (doSaveByLumi_ && canSaveByLumi_) {
-      proto.setLumiFlag(); // default to per-lumi mode for all non-legacy MEs.
-      // for legacy (not DQMEDAnalyzer) this is not save.
-    }
+    // this is used only for Int/String/Float. We don't save these by lumi by
+    // default, since we can't merge them properly.
     return &const_cast<MonitorElement&>(*data_.insert(std::move(proto)).first);
   }
 }

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -934,6 +934,10 @@ DQMStore::book_(std::string const& dir,
     // Create and initialise core object.
     assert(dirs_.count(dir));
     MonitorElement proto(&*dirs_.find(dir), name, run_, moduleId_);
+    if (run_ != 0 && moduleId_ != 0) {
+      proto.setLumiFlag(); // default to per-lumi mode for all non-legacy MEs.
+      // for legacy (moduleId_ == 0) this is not always safe.
+    }
     me = const_cast<MonitorElement&>(*data_.insert(std::move(proto)).first)
       .initialise((MonitorElement::Kind)kind, h);
 
@@ -992,6 +996,10 @@ DQMStore::book_(std::string const& dir,
     // Create it and return for initialisation.
     assert(dirs_.count(dir));
     MonitorElement proto(&*dirs_.find(dir), name, run_, moduleId_);
+    if (run_ != 0 && moduleId_ != 0) {
+      proto.setLumiFlag(); // default to per-lumi mode for all non-legacy MEs.
+      // for legacy (moduleId_ == 0) this is not always safe.
+    }
     return &const_cast<MonitorElement&>(*data_.insert(std::move(proto)).first);
   }
 }

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -376,8 +376,10 @@ DQMStore::DQMStore(edm::ParameterSet const& pset, edm::ActivityRegistry& ar)
     ar.watchPostSourceRun([this](edm::RunIndex){ forceReset(); });
   }
   if(pset.getUntrackedParameter<bool>("forceResetOnBeginLumi",false) && enableMultiThread_ == false) {
+#if !WITHOUT_CMS_FRAMEWORK
     forceResetOnBeginLumi_ = true;
     ar.watchPreSourceLumi([this](edm::LuminosityBlockIndex){ forceReset(); });
+#endif
   }
   ar.watchPostGlobalBeginLumi(this, &DQMStore::postGlobalBeginLumi);
 }

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -377,7 +377,7 @@ DQMStore::DQMStore(edm::ParameterSet const& pset, edm::ActivityRegistry& ar)
   }
   if(pset.getUntrackedParameter<bool>("forceResetOnBeginLumi",false) && enableMultiThread_ == false) {
     forceResetOnBeginLumi_ = true;
-    ar.watchPostSourceLumi([this](edm::LuminosityBlockIndex){ forceReset(); });
+    ar.watchPreSourceLumi([this](edm::LuminosityBlockIndex){ forceReset(); });
   }
   ar.watchPostGlobalBeginLumi(this, &DQMStore::postGlobalBeginLumi);
 }

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -1933,7 +1933,12 @@ DQMStore::cloneLumiHistograms(uint32_t const run, uint32_t const lumi, uint32_t 
   std::string null_str("");
   auto i = data_.lower_bound(MonitorElement(&null_str, null_str, run, moduleId));
   auto e = data_.lower_bound(MonitorElement(&null_str, null_str, run, moduleId + 1));
+  // we will later modify data_, so better do two passes.
+  auto tobehandled = std::vector<MonitorElement const*>();
   for (; i != e; ++i) {
+    tobehandled.push_back(&*i);
+  }
+  for (auto i : tobehandled) {
     // handle only lumisection-based histograms
     if (not LSbasedMode_ and not i->getLumiFlag())
       continue;
@@ -1970,7 +1975,12 @@ DQMStore::cloneRunHistograms(uint32_t const run, uint32_t const moduleId)
   std::string null_str("");
   auto i = data_.lower_bound(MonitorElement(&null_str, null_str, run, moduleId));
   auto e = data_.lower_bound(MonitorElement(&null_str, null_str, run, moduleId + 1));
+  // we will later modify data_, so better do two passes.
+  auto tobehandled = std::vector<MonitorElement const*>();
   for (; i != e; ++i) {
+    tobehandled.push_back(&*i);
+  }
+  for (auto i : tobehandled) {
     // handle only non lumisection-based histograms
     if (LSbasedMode_ or i->getLumiFlag())
       continue;

--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -627,12 +627,12 @@ DQMRootSource::readLuminosityBlock_( edm::LuminosityBlockPrincipal& lbCache)
     
     edm::Service<DQMStore> store;
     std::vector<MonitorElement*> allMEs = (*store).getAllContents("");
-    for(auto const& ME : allMEs) {
-      // We do not want to reset Run Products here!
-      if (ME->getLumiFlag()) {
-	ME->Reset();
-      }
-    }
+    //for(auto const& ME : allMEs) {
+    //  // We do not want to reset Run Products here!
+    //  if (ME->getLumiFlag()) {
+    //    ME->Reset();
+    //  }
+    //}
     m_lastSeenReducedPHID2 = m_reducedHistoryIDs.at(runLumiRange.m_historyIDIndex);
     m_lastSeenRun2 = runLumiRange.m_run;
     m_lastSeenLumi2 = runLumiRange.m_lumi;

--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -585,9 +585,6 @@ DQMRootSource::readRun_(edm::RunPrincipal& rpCache)
       edm::Service<DQMStore> store;
       std::vector<MonitorElement*> allMEs = (*store).getAllContents("");
       for(auto const& ME : allMEs) {
-        // We do not want to reset here Lumi products, since a dedicated
-        // resetting is done at every lumi transition.
-        if (ME->getLumiFlag()) continue;
 	if ( !(*store).isCollate() )
 	  ME->Reset();
       }

--- a/DQMServices/FwkIO/test/copy_file_multi_types_cfg.py
+++ b/DQMServices/FwkIO/test/copy_file_multi_types_cfg.py
@@ -9,6 +9,6 @@ process.out = cms.OutputModule("DQMRootOutputModule",
                                fileName = cms.untracked.string("dqm_copy_multi_types.root"))
 process.e = cms.EndPath(process.out)
 
-process.add_(cms.Service("DQMStore"))
+process.add_(cms.Service("DQMStore", forceResetOnBeginLumi = cms.untracked.bool(True)))
 #process.add_(cms.Service("Tracer"))
 

--- a/DQMServices/FwkIO/test/create_run_lumi_file_cfg.py
+++ b/DQMServices/FwkIO/test/create_run_lumi_file_cfg.py
@@ -26,5 +26,6 @@ process.o = cms.EndPath(process.out)
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
-process.add_(cms.Service("DQMStore",forceResetOnBeginRun = cms.untracked.bool(True)))
+process.add_(cms.Service("DQMStore",forceResetOnBeginRun = cms.untracked.bool(True), verbose = cms.untracked.int32(10)))
+process.add_(cms.Service("Tracer"))
 

--- a/DQMServices/FwkIO/test/merge_file1_file2_cfg.py
+++ b/DQMServices/FwkIO/test/merge_file1_file2_cfg.py
@@ -9,6 +9,6 @@ process.out = cms.OutputModule("DQMRootOutputModule",
                                fileName = cms.untracked.string("dqm_merged_file1_file2.root"))
 process.e = cms.EndPath(process.out)
 
-process.add_(cms.Service("DQMStore"))
+process.add_(cms.Service("DQMStore", forceResetOnBeginLumi = cms.untracked.bool(True)))
 #process.add_(cms.Service("Tracer"))
 

--- a/DQMServices/FwkIO/test/merge_file1_file3_file2_cfg.py
+++ b/DQMServices/FwkIO/test/merge_file1_file3_file2_cfg.py
@@ -11,6 +11,6 @@ process.out = cms.OutputModule("DQMRootOutputModule",
                                fileName = cms.untracked.string("dqm_merged_file1_file3_file2.root"))
 process.e = cms.EndPath(process.out)
 
-process.add_(cms.Service("DQMStore"))
+process.add_(cms.Service("DQMStore", forceResetOnBeginLumi = cms.untracked.bool(True)))
 #process.add_(cms.Service("Tracer"))
 

--- a/DQMServices/FwkIO/test/merge_file1_file3_file2_filterOnRun1_cfg.py
+++ b/DQMServices/FwkIO/test/merge_file1_file3_file2_filterOnRun1_cfg.py
@@ -13,6 +13,6 @@ process.out = cms.OutputModule("DQMRootOutputModule",
                                filterOnRun = cms.untracked.uint32(1))
 process.e = cms.EndPath(process.out)
 
-process.add_(cms.Service("DQMStore"))
+process.add_(cms.Service("DQMStore", forceResetOnBeginLumi = cms.untracked.bool(True)))
 #process.add_(cms.Service("Tracer"))
 

--- a/DQMServices/FwkIO/test/merge_file1_file3_file4_cfg.py
+++ b/DQMServices/FwkIO/test/merge_file1_file3_file4_cfg.py
@@ -9,6 +9,6 @@ process.out = cms.OutputModule("DQMRootOutputModule",
                                fileName = cms.untracked.string("dqm_merged_file1_file3_file4.root"))
 process.e = cms.EndPath(process.out)
 
-process.add_(cms.Service("DQMStore"))
+process.add_(cms.Service("DQMStore", forceResetOnBeginLumi = cms.untracked.bool(True)))
 #process.add_(cms.Service("Tracer"))
 

--- a/DQMServices/FwkIO/test/read_file1_file2_cfg.py
+++ b/DQMServices/FwkIO/test/read_file1_file2_cfg.py
@@ -40,6 +40,6 @@ process.reader = cms.EDAnalyzer("DummyReadDQMStore",
 
 process.e = cms.EndPath(process.check+process.reader)
 
-process.add_(cms.Service("DQMStore"))
+process.add_(cms.Service("DQMStore", forceResetOnBeginLumi = cms.untracked.bool(True)))
 #process.add_(cms.Service("Tracer"))
 

--- a/DQMServices/FwkIO/test/read_file1_file3_cfg.py
+++ b/DQMServices/FwkIO/test/read_file1_file3_cfg.py
@@ -41,6 +41,6 @@ process.reader = cms.EDAnalyzer("DummyReadDQMStore",
 
 process.e = cms.EndPath(process.check+process.reader)
 
-process.add_(cms.Service("DQMStore"))
+process.add_(cms.Service("DQMStore", forceResetOnBeginLumi = cms.untracked.bool(True)))
 #process.add_(cms.Service("Tracer"))
 

--- a/DQMServices/FwkIO/test/read_lumi_only_file_cfg.py
+++ b/DQMServices/FwkIO/test/read_lumi_only_file_cfg.py
@@ -22,6 +22,6 @@ process.check = cms.EDAnalyzer("RunLumiEventChecker",
 
 process.e = cms.EndPath(process.check)
 
-process.add_(cms.Service("DQMStore"))
+process.add_(cms.Service("DQMStore", forceResetOnBeginLumi = cms.untracked.bool(True)))
 #process.add_(cms.Service("Tracer"))
 

--- a/DQMServices/FwkIO/test/read_merged_file1_file2_cfg.py
+++ b/DQMServices/FwkIO/test/read_merged_file1_file2_cfg.py
@@ -41,6 +41,6 @@ process.reader = cms.EDAnalyzer("DummyReadDQMStore",
 
 process.e = cms.EndPath(process.check+process.reader)
 
-process.add_(cms.Service("DQMStore"))
+process.add_(cms.Service("DQMStore", forceResetOnBeginLumi = cms.untracked.bool(True)))
 #process.add_(cms.Service("Tracer"))
 

--- a/DQMServices/FwkIO/test/read_merged_file1_file3_file2_cfg.py
+++ b/DQMServices/FwkIO/test/read_merged_file1_file3_file2_cfg.py
@@ -42,6 +42,6 @@ process.reader = cms.EDAnalyzer("DummyReadDQMStore",
 
 process.e = cms.EndPath(process.check+process.reader)
 
-process.add_(cms.Service("DQMStore"))
+process.add_(cms.Service("DQMStore", forceResetOnBeginLumi = cms.untracked.bool(True)))
 #process.add_(cms.Service("Tracer"))
 

--- a/DQMServices/FwkIO/test/read_merged_file1_file3_file4_cfg.py
+++ b/DQMServices/FwkIO/test/read_merged_file1_file3_file4_cfg.py
@@ -62,6 +62,6 @@ process.reader = cms.EDAnalyzer("DummyReadDQMStore",
 
 process.e = cms.EndPath(process.check+process.reader)
 
-process.add_(cms.Service("DQMStore"))
+process.add_(cms.Service("DQMStore", forceResetOnBeginLumi = cms.untracked.bool(True)))
 #process.add_(cms.Service("Tracer"))
 

--- a/DQMServices/FwkIO/test/read_write_merged_file1_file3_file2_filterOnRun1_cfg.py
+++ b/DQMServices/FwkIO/test/read_write_merged_file1_file3_file2_filterOnRun1_cfg.py
@@ -11,5 +11,5 @@ process.out = cms.OutputModule("DQMRootOutputModule",
 
 process.e = cms.EndPath(process.out)
 
-process.add_(cms.Service("DQMStore"))
+process.add_(cms.Service("DQMStore", forceResetOnBeginLumi = cms.untracked.bool(True)))
 


### PR DESCRIPTION
#### PR description:

This PR enables per-lumisection saving of *all* DQM output for the UL rereco. This wish came up for machine learning studies targeting per-LS data certification or online monitoring.

In prompt reco, we have per-LS DQM output available due to how Tier0 processes only ~1 LS per job, and the per-job DQMIO output files are available. It would be very nice to have the same granularity of data preserved for the UL rereco, which in addition provides the full run2 dataset processed using the same software.

This is safe to do for most of DQM, since HARVESTING will re-generate per run/job statistics from the per-lumisection snapshots. It is not save for legacy modules that modify MEs at non-standard times or that do not support merging correctly; none of these should exist in RECO/DQM step since the threaded migration, but since there are still a few, I apply the change only to the non-legacy MEs.

#### PR validation:

Validated on a modified `136.85` that crosses a lumi boundary: `runTheMatrix.py -l 136.85 --command '--customise_commands "if process.process == \"reHLT\": process.source.skipEvents=cms.untracked.uint32(3800)\n"' --ibeos -t 8`. Will need some special attention during relval since the DQMIO output file size will increase.

Known problems:
- Various "known unstable" plots change behaviour. These change behaviour on trivial changes such as adding debug output, and might be caused by race conditions.
- The behaviour of per-lumi plots in harvesting changes. This can lead to "double counting" in the existing offline per-lumi harvesting code, and cause subtly incorrect results. Since there is very little such code, I manually adapted the places I could find; however, due to the freedom that harvesting code has, I can not guarantee that these are all cases.