### PR TITLE
Adding PUPPI combined isolation Working Points in miniAOD muon selector

### DIFF
--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -216,7 +216,10 @@ namespace reco {
       InTimeMuon             = 1UL<<23,   
       PFIsoVeryVeryTight     = 1UL<<24,  // reliso<0.05
       MultiIsoLoose          = 1UL<<25,  // miniIso with ptRatio and ptRel 
-      MultiIsoMedium         = 1UL<<26   // miniIso with ptRatio and ptRel 
+      MultiIsoMedium         = 1UL<<26,   // miniIso with ptRatio and ptRel 
+      PuppiIsoLoose          = 1UL<<27,
+      PuppiIsoMedium         = 1UL<<28,
+      PuppiIsoTight          = 1UL<<29
     };
     
     bool passed( unsigned int selection ) const { return (selectors_ & selection)==selection; }

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -883,28 +883,15 @@ double PATMuonProducer::puppiCombinedIsolation(const pat::Muon& muon, const pat:
 }
 
 bool PATMuonProducer::isNeutralHadron( long pdgid ){
-  const long id = abs( pdgid );
-  if( id == 111 ) return true ;
-  if( id == 130 ) return true ;
-  if( id == 310 ) return true ;
-  if( id == 2112 ) return true ;
-  return false;
-
+ return std::abs(pdgid) == 130;
 }
 
 bool PATMuonProducer::isChargedHadron( long pdgid ){
-  const long id = abs( pdgid );
-  if( id == 211    ) return true ;
-  if( id == 321    ) return true ;
-  if( id == 999211 ) return true ;
-  if( id == 2212   ) return true ;
-  return false;
+ return std::abs(pdgid) == 211;
 }
 
 bool PATMuonProducer::isPhoton( long pdgid ){
-  const long id = abs( pdgid );
-  if( id == 22 ) return true ;
-  return false;
+ return pdgid==22;
 }
 
 // ParameterSet description for module

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -154,11 +154,13 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavy
   //for mini-isolation calculation
   computeMiniIso_ = iConfig.getParameter<bool>("computeMiniIso");
 
+  computePuppiCombinedIso_ = iConfig.getParameter<bool>("computePuppiCombinedIso");
+
   miniIsoParams_ = iConfig.getParameter<std::vector<double> >("miniIsoParams");
   if(computeMiniIso_ && miniIsoParams_.size() != 9){
       throw cms::Exception("ParameterError") << "miniIsoParams must have exactly 9 elements.\n";
   }
-  if(computeMiniIso_)
+  if(computeMiniIso_ || computePuppiCombinedIso_)
       pcToken_ = consumes<pat::PackedCandidateCollection >(iConfig.getParameter<edm::InputTag>("pfCandsForMiniIso"));
 
   // standard selectors
@@ -302,7 +304,7 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 
   
   edm::Handle<pat::PackedCandidateCollection> pc;
-  if(computeMiniIso_)
+  if(computeMiniIso_ || computePuppiCombinedIso_)
       iEvent.getByToken(pcToken_, pc);
 
   // get the ESHandle for the transient track builder,
@@ -650,12 +652,24 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
     double miniIsoValue = -1;
     if (computeMiniIso_){
       // MiniIsolation working points
+
       miniIsoValue = getRelMiniIsoPUCorrected(muon,*rho);
+
       muon.setSelector(reco::Muon::MiniIsoLoose,     miniIsoValue<0.40);
       muon.setSelector(reco::Muon::MiniIsoMedium,    miniIsoValue<0.20);
       muon.setSelector(reco::Muon::MiniIsoTight,     miniIsoValue<0.10);
       muon.setSelector(reco::Muon::MiniIsoVeryTight, miniIsoValue<0.05);
     }
+
+    double puppiCombinedIsolationPAT = -1;
+    if(computePuppiCombinedIso_){
+
+      puppiCombinedIsolationPAT=puppiCombinedIsolation(muon, pc.product());
+      muon.setSelector(reco::Muon::PuppiIsoLoose, puppiCombinedIsolationPAT<0.27);
+      muon.setSelector(reco::Muon::PuppiIsoMedium, puppiCombinedIsolationPAT<0.22);
+      muon.setSelector(reco::Muon::PuppiIsoTight, puppiCombinedIsolationPAT<0.12);
+    }
+
     float jetPtRatio = 0.0;
     float jetPtRel = 0.0;
     float mva = 0.0;
@@ -681,6 +695,8 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 
       // multi-isolation
       if (computeMiniIso_){
+
+
 	muon.setSelector(reco::Muon::MultiIsoLoose,  miniIsoValue<0.40 && (muon.jetPtRatio() > 0.80 || muon.jetPtRel() > 7.2) );
 	muon.setSelector(reco::Muon::MultiIsoMedium, miniIsoValue<0.16 && (muon.jetPtRatio() > 0.76 || muon.jetPtRel() > 7.2) );
       }
@@ -815,6 +831,82 @@ double PATMuonProducer::getRelMiniIsoPUCorrected(const pat::Muon& muon, float rh
   return pat::muonRelMiniIsoPUCorrected(muon.miniPFIsolation(), muon.p4(), drcut, rho);
 }
 
+
+double PATMuonProducer::puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection *pc)
+{
+  double dR_threshold = 0.4;
+  double dR2_threshold = dR_threshold * dR_threshold;
+  double mix_fraction = 0.5;
+  enum particleType{
+      CH = 0,
+      NH = 1,
+      PH = 2,
+      OTHER = 100000
+    };
+  double val_PuppiWithLep = 0.0;
+  double val_PuppiWithoutLep = 0.0;  
+
+  for(const auto & cand : *pc){//pat::pat::PackedCandidate loop start
+
+     const particleType pType =
+        isChargedHadron( cand.pdgId() ) ? CH :
+        isNeutralHadron( cand.pdgId() ) ? NH :
+        isPhoton( cand.pdgId() ) ? PH : OTHER;
+     if( pType == OTHER ){
+        if( cand.pdgId() != 1 && cand.pdgId() != 2
+        && abs( cand.pdgId() ) != 11
+        && abs( cand.pdgId() ) != 13){
+        LogTrace("PATMuonProducer") <<"candidate with PDGID = " << cand.pdgId() << " is not CH/NH/PH/e/mu or 1/2 (and this is removed from isolation calculation)" << std::endl;
+       }
+       continue;
+     }
+     double d_eta = std::abs( cand.eta() - muon.eta() );
+     if( d_eta > dR_threshold ) continue;
+
+     double d_phi = std::abs(reco::deltaPhi(cand.phi(),muon.phi()));
+     if( d_phi > dR_threshold ) continue ;
+
+     double dR2=reco::deltaR2(cand, muon);
+     if( dR2  > dR2_threshold ) continue;
+     if( pType == CH && dR2 < 0.0001*0.0001 ) continue;
+     if( pType == NH && dR2 < 0.01  *0.01   ) continue;
+     if( pType == PH && dR2 < 0.01  *0.01   ) continue;
+     val_PuppiWithLep += cand.pt() * cand.puppiWeight();
+     val_PuppiWithoutLep += cand.pt() * cand.puppiWeightNoLep();
+
+  }//pat::pat::PackedCandidate loop end
+
+  double reliso_Puppi_withLep    = val_PuppiWithLep/muon.pt();
+  double reliso_Puppi_withoutlep = val_PuppiWithoutLep/muon.pt();
+  double reliso_Puppi_combined = mix_fraction * reliso_Puppi_withLep + ( 1.0 - mix_fraction) * reliso_Puppi_withoutlep;
+  return reliso_Puppi_combined;
+}
+
+bool PATMuonProducer::isNeutralHadron( long pdgid ){
+  const long id = abs( pdgid );
+  if( id == 111 ) return true ;
+  if( id == 130 ) return true ;
+  if( id == 310 ) return true ;
+  if( id == 2112 ) return true ;
+  return false;
+
+}
+
+bool PATMuonProducer::isChargedHadron( long pdgid ){
+  const long id = abs( pdgid );
+  if( id == 211    ) return true ;
+  if( id == 321    ) return true ;
+  if( id == 999211 ) return true ;
+  if( id == 2212   ) return true ;
+  return false;
+}
+
+bool PATMuonProducer::isPhoton( long pdgid ){
+  const long id = abs( pdgid );
+  if( id == 22 ) return true ;
+  return false;
+}
+
 // ParameterSet description for module
 void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
 {
@@ -857,6 +949,8 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
 
   // mini-iso
   iDesc.add<bool>("computeMiniIso", false)->setComment("whether or not to compute and store electron mini-isolation");
+  iDesc.add<bool>("computePuppiCombinedIso",false)->setComment("whether or not to compute and store puppi combined isolation");
+
   iDesc.add<edm::InputTag>("pfCandsForMiniIso", edm::InputTag("packedPFCandidates"))->setComment("collection to use to compute mini-iso");
   iDesc.add<std::vector<double> >("miniIsoParams", std::vector<double>())->setComment("mini-iso parameters to use for muons");
 

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -101,6 +101,14 @@ namespace pat {
     void setMuonMiniIso(pat::Muon& aMuon, const pat::PackedCandidateCollection *pc);
     double getRelMiniIsoPUCorrected(const pat::Muon& muon, float rho);
 
+    double puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection *pc);
+    bool isNeutralHadron( long pdgid );
+    bool isChargedHadron( long pdgid );
+    bool isPhoton( long pdgid );
+
+
+
+
     // embed various impact parameters with errors
     // embed high level selection
     void embedHighLevel( pat::Muon & aMuon,
@@ -130,6 +138,7 @@ namespace pat {
     // for mini-iso calculation
     edm::EDGetTokenT<pat::PackedCandidateCollection > pcToken_;
     bool computeMiniIso_;
+    bool computePuppiCombinedIso_;
     std::vector<double> miniIsoParams_;
     double relMiniIsoPUCorrected_;
 

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -102,6 +102,7 @@ patMuons = cms.EDProducer("PATMuonProducer",
     pfCandsForMiniIso = cms.InputTag("packedPFCandidates"),
     miniIsoParams = cms.vdouble(0.05, 0.2, 10.0, 0.5, 0.0001, 0.01, 0.01, 0.01, 0.0),
 
+    computePuppiCombinedIso = cms.bool(False),
     # Standard Muon Selectors and Jet-related observables
     # Depends on MiniIsolation, so only works in miniaod
     # Don't forget to set flags properly in miniAOD_tools.py                      

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -25,12 +25,13 @@ def miniAOD_customizeCommon(process):
     process.patMuons.puppiNoLeptonsIsolationNeutralHadrons = cms.InputTag("muonPUPPINoLeptonsIsolation","h0-DR040-ThresholdVeto000-ConeVeto001")
     process.patMuons.puppiNoLeptonsIsolationPhotons        = cms.InputTag("muonPUPPINoLeptonsIsolation","gamma-DR040-ThresholdVeto000-ConeVeto001")
 
-    process.patMuons.computeMiniIso = cms.bool(True)
-    process.patMuons.computeMuonMVA = cms.bool(True)
-    process.patMuons.computeSoftMuonMVA = cms.bool(True)
+    process.patMuons.computeMiniIso = True
+    process.patMuons.computeMuonMVA = True
+    process.patMuons.computeSoftMuonMVA = True
 
     process.patMuons.addTriggerMatching = True
 
+    process.patMuons.computePuppiCombinedIso = True
     #
     # disable embedding of electron and photon associated objects already stored by the ReducedEGProducer
     process.patElectrons.embedGsfElectronCore = False  ## process.patElectrons.embed in AOD externally stored gsf electron core


### PR DESCRIPTION
#### PR description:
- New PR made after closing #26076
- Adding puppi combined isolation working points in muon selectors
- 3 working points added: Loose, Medium and Tight 
- No year dependence 
- All studies and discussion could be found in the ticket: https://its.cern.ch/jira/browse/CMSMUONS-128