### PR TITLE
TkAl AllInOneTool: Moving to absolute imports at the end of presentation.py

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/presentation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/presentation.py
@@ -186,8 +186,8 @@ def plotSortKey(plot):
         return 'chi2b'
     return plot
 
-from . import geometryComparison
-from . import offlineValidation
-from . import trackSplittingValidation
-from . import primaryVertexValidation
-from . import zMuMuValidation
+import Alignment.OfflineValidation.TkAlAllInOneTool.geometryComparison
+import Alignment.OfflineValidation.TkAlAllInOneTool.offlineValidation
+import Alignment.OfflineValidation.TkAlAllInOneTool.trackSplittingValidation
+import Alignment.OfflineValidation.TkAlAllInOneTool.primaryVertexValidation
+import Alignment.OfflineValidation.TkAlAllInOneTool.zMuMuValidation


### PR DESCRIPTION
#### PR description:
Recent changes made to relative imports to be python 3 compliant do not work in python 2 in case of circular imports. In this case it affected the line `from . import offlineValidation` but for consistency I changed all the imports at the end of this file to be absolute. Need to think about if we want to change more towards absolute imports in this package in the future, but at least in the meantime this stops the production of CMSSW releases in which the TkAl AllInOne validation tool is not useable. 
No other packages are affected.

#### PR validation:
Checked that the AllInOne tool runs correctly after this change, not expected to affect any automated tests. 
