### PR TITLE
BTagCalibration: Added protection against -ve eta values for SFs calculated on abs(eta)

### DIFF
--- a/CondTools/BTau/src/BTagCalibrationReader.cc
+++ b/CondTools/BTau/src/BTagCalibrationReader.cc
@@ -163,6 +163,11 @@ double BTagCalibrationReader::BTagCalibrationReaderImpl::eval_auto_bounds(
   bool eta_is_out_of_bounds = false;
 
   if (sf_bounds_eta.first < 0) sf_bounds_eta.first = -sf_bounds_eta.second;   
+
+  if (useAbsEta_[jf] && eta < 0) {
+    eta = -eta;
+  }
+
   if (eta <= sf_bounds_eta.first || eta > sf_bounds_eta.second ) {
     eta_is_out_of_bounds = true;
   }

--- a/CondTools/BTau/test/BTagCalibrationStandalone.cpp
+++ b/CondTools/BTau/test/BTagCalibrationStandalone.cpp
@@ -528,7 +528,12 @@ double BTagCalibrationReader::BTagCalibrationReaderImpl::eval_auto_bounds(
   auto sf_bounds_eta = min_max_eta(jf, discr);
   bool eta_is_out_of_bounds = false;
 
-  if (sf_bounds_eta.first < 0) sf_bounds_eta.first = -sf_bounds_eta.second;   
+  if (sf_bounds_eta.first < 0) sf_bounds_eta.first = -sf_bounds_eta.second;  
+
+  if (useAbsEta_[jf] && eta < 0) {
+      eta = -eta;
+  } 
+ 
   if (eta <= sf_bounds_eta.first || eta > sf_bounds_eta.second ) {
     eta_is_out_of_bounds = true;
   }


### PR DESCRIPTION
This PR is aimed at fixing the issue titled ["Issue with BTV SF in NanoAOD"](https://github.com/cms-nanoAOD/nanoAOD-tools/issues/129). A simple fix has been applied to the BTagCalibration framework (for both the CMSSW and Standalone versions) that adds an additional protection against negative eta values for taggers whose SF values are stored as a function of abs(eta).

The NanoAOD production tests have been run after performing this fix and the new SF values for jets with -ve eta values have been seen to be as expected.

