### PR TITLE
[10.6.X] Use cmssdt.cern.ch/lxr instead of cmslxr.fnal.gov

### DIFF
--- a/Utilities/ReleaseScripts/python/cmsCodeRules/showPage.py
+++ b/Utilities/ReleaseScripts/python/cmsCodeRules/showPage.py
@@ -152,7 +152,7 @@ def createLogFiles(rulesResult, logsDir, ib):
                 for path, lineNumbers in packageResult:
                     for line in lineNumbers:
                         directory = join(package, path)
-                        file.write('<a href="http://cmslxr.fnal.gov/lxr/source/%s?v=%s#%s">%s:%s</a>\n'%(directory, ib, numberConverter(line), directory, line))
+                        file.write('<a href="https://cmssdt.cern.ch/lxr/source/%s?v=%s#%s">%s:%s</a>\n'%(directory, ib, numberConverter(line), directory, line))
                         file.write("<br/>")
                 file.write('\n')
                 file.close()


### PR DESCRIPTION
#### PR description:

Fix LXR link. cmslxr.fnal.gov is not available.

#### PR validation:

This code is not directly used by cmssw so no testing was done.

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
