### PR TITLE
HFStripFilter for Run 2 data

### DIFF
--- a/DataFormats/METReco/interface/HcalPhase1FlagLabels.h
+++ b/DataFormats/METReco/interface/HcalPhase1FlagLabels.h
@@ -20,7 +20,8 @@ namespace HcalPhase1FlagLabels
         /*  0 */ HFLongShort = HcalCaloFlagLabels::HFLongShort,
         /*  3 */ HFS8S1Ratio = HcalCaloFlagLabels::HFS8S1Ratio,
         /*  4 */ HFPET = HcalCaloFlagLabels::HFPET,
-        /*  5 */ HFSignalAsymmetry = 5
+        /*  5 */ HFSignalAsymmetry = 5,
+        /*  6 */ HFAnomalousHit = 6
     };
 
     enum CommonFlag {

--- a/RecoLocalCalo/HcalRecAlgos/BuildFile.xml
+++ b/RecoLocalCalo/HcalRecAlgos/BuildFile.xml
@@ -11,6 +11,7 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>
+<use   name="FWCore/MessageLogger"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="vdt_headers"/>
 <use   name="rootminuit2"/> 

--- a/RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h
@@ -1,0 +1,45 @@
+#ifndef RecoLocalCalo_HcalRecAlgos_HFStripFilter_h_
+#define RecoLocalCalo_HcalRecAlgos_HFStripFilter_h_
+
+#include <memory>
+
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+class HFStripFilter
+{
+public:
+    // Construct this object with all necessary parameters
+    HFStripFilter(double energyMax1, double energyMax2,
+                  double stripThreshold, double maxThreshold,
+                  double timeMax, double maxStripTime,
+                  double wedgeCut, int gap,
+                  int lstrips, int verboseLevel);
+
+    // Destructor
+    ~HFStripFilter();
+
+    // The actual rechit tagging is performed by the following function
+    void runFilter(HFRecHitCollection& rec) const;
+
+    // Parser function to create this object from a parameter set
+    static std::unique_ptr<HFStripFilter> parseParameterSet(
+        const edm::ParameterSet& ps);
+
+    // Standard parameter values
+    static edm::ParameterSetDescription fillDescription();
+
+private:
+    double energyMax1_;
+    double energyMax2_;
+    double stripThreshold_;
+    double maxThreshold_;
+    double timeMax_;
+    double maxStripTime_;
+    double wedgeCut_;
+    int gap_;
+    int lstrips_;
+    int verboseLevel_;
+};
+
+#endif // RecoLocalCalo_HcalRecAlgos_HFStripFilter_h_

--- a/RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h
@@ -6,6 +6,9 @@
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
+class HcalChannelQuality;
+class HcalSeverityLevelComputer;
+
 class HFStripFilter
 {
 public:
@@ -20,7 +23,9 @@ public:
     ~HFStripFilter();
 
     // The actual rechit tagging is performed by the following function
-    void runFilter(HFRecHitCollection& rec) const;
+    void runFilter(HFRecHitCollection& rec,
+                   const HcalChannelQuality* myqual,
+                   const HcalSeverityLevelComputer* mySeverity) const;
 
     // Parser function to create this object from a parameter set
     static std::unique_ptr<HFStripFilter> parseParameterSet(

--- a/RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h
@@ -13,11 +13,11 @@ class HFStripFilter
 {
 public:
     // Construct this object with all necessary parameters
-    HFStripFilter(double energyMax1, double energyMax2,
-                  double stripThreshold, double maxThreshold,
+    HFStripFilter(double stripThreshold, double maxThreshold,
                   double timeMax, double maxStripTime,
                   double wedgeCut, int gap,
-                  int lstrips, int verboseLevel);
+                  int lstrips, int acceptSeverityLevel,
+                  int verboseLevel);
 
     // Destructor
     ~HFStripFilter();
@@ -35,8 +35,6 @@ public:
     static edm::ParameterSetDescription fillDescription();
 
 private:
-    double energyMax1_;
-    double energyMax2_;
     double stripThreshold_;
     double maxThreshold_;
     double timeMax_;
@@ -44,6 +42,7 @@ private:
     double wedgeCut_;
     int gap_;
     int lstrips_;
+    int acceptSeverityLevel_;
     int verboseLevel_;
 };
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h
@@ -12,14 +12,14 @@ public:
     // Construct this object with all necessary parameters
     HFStripFilter(double stripThreshold, double maxThreshold,
                   double timeMax, double maxStripTime,
-                  double wedgeCut, int gap,
-                  int lstrips, int verboseLevel);
+                  double wedgeCut, int seedHitIetaMax, 
+                  int gap, int lstrips, int verboseLevel);
 
     // Destructor
     ~HFStripFilter();
 
     // The actual rechit tagging is performed by the following function
-    void runFilter(HFRecHitCollection& rec) const;
+    void runFilter(HFRecHitCollection& rec, const HcalChannelQuality* myqual) const;
 
     // Parser function to create this object from a parameter set
     static std::unique_ptr<HFStripFilter> parseParameterSet(
@@ -34,6 +34,7 @@ private:
     double timeMax_;
     double maxStripTime_;
     double wedgeCut_;
+    int seedHitIetaMax_;
     int gap_;
     int lstrips_;
     int verboseLevel_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h
@@ -6,9 +6,6 @@
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-class HcalChannelQuality;
-class HcalSeverityLevelComputer;
-
 class HFStripFilter
 {
 public:
@@ -16,16 +13,13 @@ public:
     HFStripFilter(double stripThreshold, double maxThreshold,
                   double timeMax, double maxStripTime,
                   double wedgeCut, int gap,
-                  int lstrips, int acceptSeverityLevel,
-                  int verboseLevel);
+                  int lstrips, int verboseLevel);
 
     // Destructor
     ~HFStripFilter();
 
     // The actual rechit tagging is performed by the following function
-    void runFilter(HFRecHitCollection& rec,
-                   const HcalChannelQuality* myqual,
-                   const HcalSeverityLevelComputer* mySeverity) const;
+    void runFilter(HFRecHitCollection& rec) const;
 
     // Parser function to create this object from a parameter set
     static std::unique_ptr<HFStripFilter> parseParameterSet(
@@ -42,7 +36,6 @@ private:
     double wedgeCut_;
     int gap_;
     int lstrips_;
-    int acceptSeverityLevel_;
     int verboseLevel_;
 };
 

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -31,7 +31,10 @@ from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify(hcalRecAlgos,
     phase = cms.uint32(1),
     SeverityLevels = {
-        2 : dict( RecHitFlags = cms.vstring('HBHEIsolatedNoise') ),
+        2 : dict( RecHitFlags = cms.vstring('HBHEIsolatedNoise',
+                                            'HFAnomalousHit'
+                )
+            ),
         3 : dict( RecHitFlags = cms.vstring('HBHEHpdHitMultiplicity',  
                                             'HBHEFlatNoise', 
                                             'HBHESpikeNoise', 
@@ -40,10 +43,10 @@ run2_HCAL_2017.toModify(hcalRecAlgos,
                                             'HBHEOOTPU'
                 )
             ),
-        4: dict( RecHitFlags = cms.vstring('HFLongShort', 
-                                           'HFS8S1Ratio',  
-                                           'HFPET', 
-                                           'HFSignalAsymmetry'
+        4 : dict( RecHitFlags = cms.vstring('HFLongShort', 
+                                            'HFS8S1Ratio',  
+                                            'HFPET', 
+                                            'HFSignalAsymmetry'
                 )
             ),
     },

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -6,20 +6,19 @@
 
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h"
 
-HFStripFilter::HFStripFilter(const double energyMax1, const double energyMax2,
-                             const double stripThreshold, const double maxThreshold,
+HFStripFilter::HFStripFilter(const double stripThreshold, const double maxThreshold,
                              const double timeMax, const double maxStripTime,
                              const double wedgeCut, const int gap,
-                             const int lstrips, const int verboseLevel)
-    : energyMax1_(energyMax1),
-      energyMax2_(energyMax2),
-      stripThreshold_(stripThreshold),
+                             const int lstrips, const int acceptSeverityLevel,
+                             const int verboseLevel)
+    : stripThreshold_(stripThreshold),
       maxThreshold_(maxThreshold),
       timeMax_(timeMax),
       maxStripTime_(maxStripTime),
       wedgeCut_(wedgeCut),
       gap_(gap),
       lstrips_(lstrips),
+      acceptSeverityLevel_(acceptSeverityLevel),
       verboseLevel_(verboseLevel)
 {
     // For the description of CMSSW message logging, see
@@ -55,8 +54,6 @@ std::unique_ptr<HFStripFilter> HFStripFilter::parseParameterSet(
     const edm::ParameterSet& ps)
 {
     return std::make_unique<HFStripFilter>(
-        ps.getParameter<double>("energyMax1"),
-        ps.getParameter<double>("energyMax2"),
         ps.getParameter<double>("stripThreshold"),
         ps.getParameter<double>("maxThreshold"),
         ps.getParameter<double>("timeMax"),
@@ -64,6 +61,7 @@ std::unique_ptr<HFStripFilter> HFStripFilter::parseParameterSet(
         ps.getParameter<double>("wedgeCut"),
         ps.getParameter<int>("gap"),
         ps.getParameter<int>("lstrips"),
+        ps.getParameter<int>("acceptSeverityLevel"),
         ps.getParameter<int>("verboseLevel")
     );
 }
@@ -72,8 +70,6 @@ edm::ParameterSetDescription HFStripFilter::fillDescription()
 {
     edm::ParameterSetDescription desc;
 
-    desc.add<double>("energyMax1", -10.0);
-    desc.add<double>("energyMax2", -10.0);
     desc.add<double>("stripThreshold", 40.0);
     desc.add<double>("maxThreshold", 100.0);
     desc.add<double>("timeMax", 6.0);
@@ -81,6 +77,7 @@ edm::ParameterSetDescription HFStripFilter::fillDescription()
     desc.add<double>("wedgeCut", 0.05);
     desc.add<int>("gap", 2);
     desc.add<int>("lstrips", 2);
+    desc.add<int>("acceptSeverityLevel", 9);
     desc.add<int>("verboseLevel", 0);
 
     return desc;

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -1,10 +1,10 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 #include "DataFormats/METReco/interface/HcalPhase1FlagLabels.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
 
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h"
-
 
 HFStripFilter::HFStripFilter(const double energyMax1, const double energyMax2,
                              const double stripThreshold, const double maxThreshold,
@@ -34,7 +34,9 @@ HFStripFilter::~HFStripFilter()
         edm::LogInfo("HFStripFilter") << "destructor called";
 }
 
-void HFStripFilter::runFilter(HFRecHitCollection& rec) const
+void HFStripFilter::runFilter(HFRecHitCollection& rec,
+                              const HcalChannelQuality* myqual,
+                              const HcalSeverityLevelComputer* mySeverity) const
 {
     if (verboseLevel_ >= 20)
         edm::LogInfo("HFStripFilter") << "runFilter called";

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -1,0 +1,85 @@
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/METReco/interface/HcalPhase1FlagLabels.h"
+
+#include "RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h"
+
+
+HFStripFilter::HFStripFilter(const double energyMax1, const double energyMax2,
+                             const double stripThreshold, const double maxThreshold,
+                             const double timeMax, const double maxStripTime,
+                             const double wedgeCut, const int gap,
+                             const int lstrips, const int verboseLevel)
+    : energyMax1_(energyMax1),
+      energyMax2_(energyMax2),
+      stripThreshold_(stripThreshold),
+      maxThreshold_(maxThreshold),
+      timeMax_(timeMax),
+      maxStripTime_(maxStripTime),
+      wedgeCut_(wedgeCut),
+      gap_(gap),
+      lstrips_(lstrips),
+      verboseLevel_(verboseLevel)
+{
+    // For the description of CMSSW message logging, see
+    // https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMessageLogger
+    if (verboseLevel_ >= 20)
+        edm::LogInfo("HFStripFilter") << "constructor called";
+}
+
+HFStripFilter::~HFStripFilter()
+{
+    if (verboseLevel_ >= 20)
+        edm::LogInfo("HFStripFilter") << "destructor called";
+}
+
+void HFStripFilter::runFilter(HFRecHitCollection& rec) const
+{
+    if (verboseLevel_ >= 20)
+        edm::LogInfo("HFStripFilter") << "runFilter called";
+
+    // Cycle over the rechit collection
+    for (HFRecHitCollection::iterator it = rec.begin(); it != rec.end(); ++it)
+    {
+        // Figure out which rechits need to be tagged
+
+        // To tag a rechit with the anomalous hit flag, do the following
+        it->setFlagField(1U, HcalPhase1FlagLabels::HFAnomalousHit);
+    }
+}
+
+std::unique_ptr<HFStripFilter> HFStripFilter::parseParameterSet(
+    const edm::ParameterSet& ps)
+{
+    return std::make_unique<HFStripFilter>(
+        ps.getParameter<double>("energyMax1"),
+        ps.getParameter<double>("energyMax2"),
+        ps.getParameter<double>("stripThreshold"),
+        ps.getParameter<double>("maxThreshold"),
+        ps.getParameter<double>("timeMax"),
+        ps.getParameter<double>("maxStripTime"),
+        ps.getParameter<double>("wedgeCut"),
+        ps.getParameter<int>("gap"),
+        ps.getParameter<int>("lstrips"),
+        ps.getParameter<int>("verboseLevel")
+    );
+}
+
+edm::ParameterSetDescription HFStripFilter::fillDescription()
+{
+    edm::ParameterSetDescription desc;
+
+    desc.add<double>("energyMax1", -10.0);
+    desc.add<double>("energyMax2", -10.0);
+    desc.add<double>("stripThreshold", 40.0);
+    desc.add<double>("maxThreshold", 100.0);
+    desc.add<double>("timeMax", 6.0);
+    desc.add<double>("maxStripTime", 10.0);
+    desc.add<double>("wedgeCut", 0.05);
+    desc.add<int>("gap", 2);
+    desc.add<int>("lstrips", 2);
+    desc.add<int>("verboseLevel", 0);
+
+    return desc;
+}

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -39,20 +39,19 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
   
   std::vector<HFRecHit> d1strip;
   std::vector<HFRecHit> d2strip;
-  std::vector<HFRecHit>::const_iterator it1;  
   
   HFRecHit d1max;
   HFRecHit d2max;
   
   d1max.setEnergy(-10);
   // find d1 and d2 seed hits with max energy and time < timeMax_
-  for (HFRecHitCollection::const_iterator it = rec.begin(); it != rec.end(); ++it)
+  for (auto& it : rec)
     {
-      if ((*it).time() > timeMax_ || (*it).time() < 0 || (*it).energy() < stripThreshold_) continue;	
+      if (it.time() > timeMax_ || it.time() < 0 || it.energy() < stripThreshold_) continue;	
       // find HF hit with maximum signal in depth = 1
-      if ((*it).id().depth() == 1) {
-	if ((*it).energy() > d1max.energy() && abs((*it).id().ieta()) < 35) {
-	  d1max = (*it);
+      if (it.id().depth() == 1) {
+	if (it.energy() > d1max.energy() && std::abs(it.id().ieta()) < 35) {
+	  d1max = it;
 	}
       }
     }
@@ -64,24 +63,24 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
   int stripIetaMax = 0;
   
   if (d1max.energy() > 0) {
-    signStripIeta = d1max.id().ieta()/abs(d1max.id().ieta());
+    signStripIeta = d1max.id().ieta()/std::abs(d1max.id().ieta());
     stripIphiMax = d1max.id().iphi();
     stripIetaMax = d1max.id().ieta();
   }
 
   d2max.setEnergy(-10);
-  for (HFRecHitCollection::const_iterator it = rec.begin(); it != rec.end(); ++it)
+  for (auto& it : rec)
     {
-      if ((*it).time() > timeMax_ || (*it).time() < 0 || (*it).energy() < stripThreshold_) continue;	
+      if (it.time() > timeMax_ || it.time() < 0 || it.energy() < stripThreshold_) continue;	
       // find HFhit with maximum signal in depth = 2
-      if ((*it).id().depth() == 2 && (*it).energy() > d2max.energy() && abs((*it).id().ieta()) < 35) {
+      if (it.id().depth() == 2 && it.energy() > d2max.energy() && std::abs(it.id().ieta()) < 35) {
 	if (d1max.energy() > 0) {
-	  int signIeta = (*it).id().ieta()/abs((*it).id().ieta());
-	  if ((*it).id().iphi() == stripIphiMax && signIeta == signStripIeta) {
-	    d2max = (*it);
+	  int signIeta = it.id().ieta()/std::abs(it.id().ieta());
+	  if (it.id().iphi() == stripIphiMax && signIeta == signStripIeta) {
+	    d2max = it;
 	  }
 	} else {
-	  d2max = (*it);
+	  d2max = it;
 	}	  
       }
     }
@@ -92,7 +91,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
   if (d1max.energy() < maxThreshold_ && d2max.energy() < maxThreshold_) return; 
  
   if (stripIphiMax == 0 && d2max.energy() > 0) {
-    signStripIeta = d2max.id().ieta()/abs(d2max.id().ieta());
+    signStripIeta = d2max.id().ieta()/std::abs(d2max.id().ieta());
     stripIphiMax = d2max.id().iphi();
     stripIetaMax = d2max.id().ieta();
   }
@@ -110,31 +109,31 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
 
   // prepare the strips: all hits along given ieta in one wedge (d1strip and d2strip)
   //---------------------------------------------------------------------------------
-  for (HFRecHitCollection::const_iterator it = rec.begin(); it != rec.end(); ++it)
+  for (auto& it : rec)
     {
-      if ((*it).energy() < stripThreshold_) continue;
-      int signIeta = (*it).id().ieta()/abs((*it).id().ieta());
+      if (it.energy() < stripThreshold_) continue;
+      int signIeta = it.id().ieta()/std::abs(it.id().ieta());
       
       if (verboseLevel_ >= 30) {
-	ss << " HF hit: ieta = " << (*it).id().ieta() << "\t iphi = " << (*it).id().iphi()
-	   << "\t depth = " << (*it).id().depth() << "\t time = " << (*it).time() << "\t energy = "
-	   << (*it).energy() << "\t flags = " << (*it).flags() << std::endl;
+	ss << " HF hit: ieta = " << it.id().ieta() << "\t iphi = " << it.id().iphi()
+	   << "\t depth = " << it.id().depth() << "\t time = " << it.time() << "\t energy = "
+	   << it.energy() << "\t flags = " << it.flags() << std::endl;
       }
       
       // collect hits with the same iphi but different ieta into strips
-      if ((*it).id().iphi() == stripIphiMax && signIeta == signStripIeta 
-         && (*it).time() < maxStripTime_) {	  
-	if ((*it).id().depth() == 1) {
+      if (it.id().iphi() == stripIphiMax && signIeta == signStripIeta && 
+          it.time() < maxStripTime_) {	  
+	if (it.id().depth() == 1) {
 	  // check if hit = (*it) is already in d1strip
 	  bool pass = false;
           if (d1strip.empty()) {
-	    if (abs((*it).id().iphi() - stripIetaMax) <= gap_) {
-	      d1strip.push_back((*it));
+	    if (std::abs(it.id().iphi() - stripIetaMax) <= gap_) {
+	      d1strip.push_back(it);
 	      pass = true;
 	    }
 	  } else {
-            for (it1 = d1strip.begin(); it1 < d1strip.end(); it1++) {
- 	      if ((*it).id().ieta() == (*it1).id().ieta() && (*it).energy() == (*it1).energy()) {
+            for (auto& it1 : d1strip) {
+ 	      if (it.id().ieta() == it1.id().ieta() && it.energy() == it1.energy()) {
 	        pass = true;
 	        break;
 	      }
@@ -142,25 +141,25 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
 	  }
           if (pass) continue;
 	  // add hit = (*it) to d1strip if distance to the closest hit in d1strip <= gap_
-	  for (it1 = d1strip.begin(); it1 < d1strip.end(); it1++) {
+	  for (auto& it1 : d1strip) {
 	    // check distance along Ieta to the closest hit 
-	    if (abs((*it1).id().ieta() - (*it).id().ieta()) <= gap_) {
-	      d1strip.push_back((*it));
+	    if (std::abs(it1.id().ieta() - it.id().ieta()) <= gap_) {
+	      d1strip.push_back(it);
 	      break;
 	    }
 	  }
 	}
-	else if ((*it).id().depth() == 2) {
+	else if (it.id().depth() == 2) {
 	  // check if hit = (*it) is already in d2strip
           bool pass= false;
 	  if (d2strip.empty()) {
-	    if (abs((*it).id().ieta() - stripIetaMax) <= gap_) {
-	      d2strip.push_back((*it));
+	    if (std::abs(it.id().ieta() - stripIetaMax) <= gap_) {
+	      d2strip.push_back(it);
 	      pass = true;
 	    }
 	  } else {
-            for (it1 = d2strip.begin(); it1 < d2strip.end(); it1++) {
-              if ((*it).id().ieta() == (*it1).id().ieta() && (*it).energy() == (*it1).energy()) {
+            for (auto& it1 : d2strip) {
+              if (it.id().ieta() == it1.id().ieta() && it.energy() == it1.energy()) {
                 pass = true;
                 break;
               }
@@ -169,10 +168,10 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
           if (pass) continue;
 	  
 	  // add hit = (*it) to d2strip if distance to the closest hit in d1strip <= gap_
-	  for (it1 = d2strip.begin(); it1 < d2strip.end(); it1++) {
+	  for (auto& it1 : d2strip) {
 	    // check distance along Ieta to the closest hit 
-	    if (abs((*it1).id().ieta() - (*it).id().ieta()) <= gap_) {
-	      d2strip.push_back((*it));
+	    if (std::abs(it1.id().ieta() - it.id().ieta()) <= gap_) {
+	      d2strip.push_back(it);
 	      break;
 	    }
 	  }
@@ -183,11 +182,11 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
   if (verboseLevel_ >= 30) {
     ss << " Lstrip1 = " << (int)d1strip.size() << " (iphi = " << stripIphiMax
        << ")  Lstrip2 = " << (int)d2strip.size() << std::endl << " Strip1: ";
-    for (it1 = d1strip.begin(); it1 < d1strip.end(); it1++) {
-      ss << (*it1).energy() << " (" << (*it1).id().ieta() << ") "; }
+    for (auto& it1 : d1strip) {
+      ss << it1.energy() << " (" << it1.id().ieta() << ") "; }
     ss << std::endl << " Strip2: ";
-    for (it1 = d2strip.begin(); it1 < d2strip.end(); it1++) {
-      ss << (*it1).energy() << " (" << (*it1).id().ieta() << ") "; }
+    for (auto& it1 : d2strip) {
+      ss << it1.energy() << " (" << it1.id().ieta() << ") "; }
     ss << std::endl;
   }
   
@@ -202,15 +201,15 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
   // define range of strips in ieta 
   int ietaMin1 = 1000;  // for d1strip
   int ietaMax1 = -1000;
-  for (it1 = d1strip.begin(); it1 < d1strip.end(); ++it1) {
-    if ((*it1).id().ieta() < ietaMin1) ietaMin1 = (*it1).id().ieta();
-    if ((*it1).id().ieta() > ietaMax1) ietaMax1 = (*it1).id().ieta();
+  for (auto& it1 : d1strip) {
+    if (it1.id().ieta() < ietaMin1) ietaMin1 = it1.id().ieta();
+    if (it1.id().ieta() > ietaMax1) ietaMax1 = it1.id().ieta();
   }
   int ietaMin2 = 1000;  // for d2strip
   int ietaMax2 = -1000;
-  for (it1 = d2strip.begin(); it1 < d2strip.end(); ++it1) {
-    if ((*it1).id().ieta() < ietaMin2) ietaMin2 = (*it1).id().ieta();
-    if ((*it1).id().ieta() > ietaMax2) ietaMax2 = (*it1).id().ieta();
+  for (auto& it1 : d2strip) {
+    if (it1.id().ieta() < ietaMin2) ietaMin2 = it1.id().ieta();
+    if (it1.id().ieta() > ietaMax2) ietaMax2 = it1.id().ieta();
   }
   
   // define ietamin and ietamax - common area for d1strip and d2strip
@@ -226,13 +225,13 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
     
   // calculate the total energy in strips
   double eStrip = 0;    
-  for (it1 = d1strip.begin(); it1 < d1strip.end(); ++it1) {   
-    if ((*it1).id().ieta() < ietaMin || (*it1).id().ieta() > ietaMax) continue;
-    eStrip += (*it1).energy();
+  for (auto& it1 : d1strip) {   
+    if (it1.id().ieta() < ietaMin || it1.id().ieta() > ietaMax) continue;
+    eStrip += it1.energy();
   }
-  for (it1 = d2strip.begin(); it1 < d2strip.end(); ++it1) {   
-    if ((*it1).id().ieta() < ietaMin || (*it1).id().ieta() > ietaMax) continue;
-    eStrip += (*it1).energy();
+  for (auto& it1 : d2strip) {   
+    if (it1.id().ieta() < ietaMin || it1.id().ieta() > ietaMax) continue;
+    eStrip += it1.energy();
   }
   
   if (verboseLevel_ >= 30) {
@@ -242,7 +241,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
   }
   
   int phiseg = 2; // 10 degrees segmentation for most of HF (1 iphi unit = 5 degrees)
-  if (abs(d1strip[0].id().ieta()) > 39) phiseg = 4; // 20 degrees segmentation for |ieta| > 39
+  if (std::abs(d1strip[0].id().ieta()) > 39) phiseg = 4; // 20 degrees segmentation for |ieta| > 39
   
   // Check if seed hit has neighbours with (iphi +/- phiseg) and the same ieta    
   int iphi1 = d1strip[0].id().iphi() - phiseg;
@@ -253,12 +252,12 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
   // energies in the neighboring wedges  
   double energyIphi1 = 0;
   double energyIphi2 = 0;
-  for (HFRecHitCollection::const_iterator it = rec.begin(); it != rec.end(); ++it) 
+  for (auto& it : rec)
     {
-      if ((*it).energy() < stripThreshold_) continue;
-      if ((*it).id().ieta() < ietaMin || (*it).id().ieta() > ietaMax) continue;
-      if ((*it).id().iphi() == iphi1) energyIphi1 += (*it).energy();      // iphi1
-      else if ((*it).id().iphi() == iphi2) energyIphi2 += (*it).energy(); // iphi2
+      if (it.energy() < stripThreshold_) continue;
+      if (it.id().ieta() < ietaMin || it.id().ieta() > ietaMax) continue;
+      if (it.id().iphi() == iphi1) energyIphi1 += it.energy();      // iphi1
+      else if (it.id().iphi() == iphi2) energyIphi2 += it.energy(); // iphi2
     }
   
   double ratio1 = eStrip > 0 ? energyIphi1/eStrip : 0;
@@ -280,11 +279,11 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
       ss << "  stripPass = false" << std::endl 
 	 << "  mark hits in strips now " << std::endl;
     }
-    
+   
     // Figure out which rechits need to be tagged (d1.strip)
-    for (it1 = d1strip.begin(); it1 < d1strip.end(); ++it1) {
-      if ((*it1).id().ieta() < ietaMin || (*it1).id().ieta() > ietaMax) continue;
-      HFRecHitCollection::iterator hit = rec.find((*it1).id());
+    for (auto& it1 : d1strip) {
+      if (it1.id().ieta() < ietaMin || it1.id().ieta() > ietaMax) continue;
+      HFRecHitCollection::iterator hit = rec.find(it1.id());
       if (hit != rec.end()) {
 	// tag a rechit with the anomalous hit flag
 	if (verboseLevel_ >= 30) {
@@ -293,10 +292,11 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
 	hit->setFlagField(1U, HcalPhase1FlagLabels::HFAnomalousHit);
       }
     }
+
     // Figure out which rechits need to be tagged (d2.strip)
-    for (it1 = d2strip.begin(); it1 < d2strip.end(); ++it1) {
-      if ((*it1).id().ieta() < ietaMin || (*it1).id().ieta() > ietaMax) continue;
-      HFRecHitCollection::iterator hit = rec.find((*it1).id());
+    for (auto& it1 : d2strip) {
+      if (it1.id().ieta() < ietaMin || it1.id().ieta() > ietaMax) continue;
+      HFRecHitCollection::iterator hit = rec.find(it1.id());
       if (hit != rec.end()) {
 	// tag a rechit with the anomalous hit flag
 	if (verboseLevel_ >= 30) {
@@ -322,14 +322,14 @@ std::unique_ptr<HFStripFilter> HFStripFilter::parseParameterSet(
     const edm::ParameterSet& ps)
 {
     return std::make_unique<HFStripFilter>(
-        ps.getParameter<double>("stripThreshold"),
-        ps.getParameter<double>("maxThreshold"),
-        ps.getParameter<double>("timeMax"),
-        ps.getParameter<double>("maxStripTime"),
-        ps.getParameter<double>("wedgeCut"),
-        ps.getParameter<int>("gap"),
-        ps.getParameter<int>("lstrips"),
-        ps.getParameter<int>("verboseLevel")
+        ps.getUntrackedParameter<double>("stripThreshold"),
+        ps.getUntrackedParameter<double>("maxThreshold"),
+        ps.getUntrackedParameter<double>("timeMax"),
+        ps.getUntrackedParameter<double>("maxStripTime"),
+        ps.getUntrackedParameter<double>("wedgeCut"),
+        ps.getUntrackedParameter<int>("gap"),
+        ps.getUntrackedParameter<int>("lstrips"),
+        ps.getUntrackedParameter<int>("verboseLevel")
     );
 }
 
@@ -337,14 +337,14 @@ edm::ParameterSetDescription HFStripFilter::fillDescription()
 {
     edm::ParameterSetDescription desc;
 
-    desc.add<double>("stripThreshold", 40.0);
-    desc.add<double>("maxThreshold", 100.0);
-    desc.add<double>("timeMax", 6.0);
-    desc.add<double>("maxStripTime", 10.0);
-    desc.add<double>("wedgeCut", 0.05);
-    desc.add<int>("gap", 2);
-    desc.add<int>("lstrips", 2);
-    desc.add<int>("verboseLevel", 0);
+    desc.addUntracked<double>("stripThreshold", 40.0);
+    desc.addUntracked<double>("maxThreshold", 100.0);
+    desc.addUntracked<double>("timeMax", 6.0);
+    desc.addUntracked<double>("maxStripTime", 10.0);
+    desc.addUntracked<double>("wedgeCut", 0.05);
+    desc.addUntracked<int>("gap", 2);
+    desc.addUntracked<int>("lstrips", 2);
+    desc.addUntracked<int>("verboseLevel", 0);
 
     return desc;
 }

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -6,6 +6,8 @@
 
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h"
 
+#include <iostream>
+
 HFStripFilter::HFStripFilter(const double stripThreshold, const double maxThreshold,
                              const double timeMax, const double maxStripTime,
                              const double wedgeCut, const int gap,
@@ -33,22 +35,317 @@ HFStripFilter::~HFStripFilter()
         edm::LogInfo("HFStripFilter") << "destructor called";
 }
 
+
 void HFStripFilter::runFilter(HFRecHitCollection& rec,
                               const HcalChannelQuality* myqual,
                               const HcalSeverityLevelComputer* mySeverity) const
 {
-    if (verboseLevel_ >= 20)
-        edm::LogInfo("HFStripFilter") << "runFilter called";
-
-    // Cycle over the rechit collection
-    for (HFRecHitCollection::iterator it = rec.begin(); it != rec.end(); ++it)
+  if (verboseLevel_ >= 20)
+    edm::LogInfo("HFStripFilter") << "runFilter called";
+  
+  std::vector<HFRecHit> d1strip;
+  std::vector<HFRecHit> d2strip;
+  std::vector<HFRecHit>::const_iterator it1;  
+  
+  HFRecHit d1max;
+  HFRecHit d2max;
+  
+  d1max.setEnergy(-10);
+  // find d1 and d2 seed hits with max energy and time < timeMax_
+  for (HFRecHitCollection::const_iterator it = rec.begin(); it != rec.end(); ++it)
     {
-        // Figure out which rechits need to be tagged
-
-        // To tag a rechit with the anomalous hit flag, do the following
-        it->setFlagField(1U, HcalPhase1FlagLabels::HFAnomalousHit);
+      if ((*it).time() > timeMax_ || (*it).time() < 0 || (*it).energy() < stripThreshold_) continue;	
+      // find HF hit with maximum signal in depth = 1
+      if ((*it).id().depth() == 1) {
+	if ((*it).energy() > d1max.energy() && abs((*it).id().ieta()) < 35) {
+	  d1max = (*it);
+	}
+      }
     }
+
+  if (d1max.energy() > 0) d1strip.push_back(d1max);
+  
+  int signStripIeta = 0;
+  int stripIphiMax = 0;
+  int stripIetaMax = 0;
+  
+  if (d1max.energy() > 0) {
+    signStripIeta = d1max.id().ieta()/fabs(d1max.id().ieta());
+    stripIphiMax = d1max.id().iphi();
+    stripIetaMax = d1max.id().ieta();
+  }
+
+  d2max.setEnergy(-10);
+  for (HFRecHitCollection::const_iterator it = rec.begin(); it != rec.end(); ++it)
+    {
+      if ((*it).time() > timeMax_ || (*it).time() < 0 || (*it).energy() < stripThreshold_) continue;	
+      // find HFhit with maximum signal in depth = 2
+      if ((*it).id().depth() == 2 && (*it).energy() > d2max.energy() && abs((*it).id().ieta()) < 35) {
+	if (d1max.energy() > 0) {
+	  int signIeta = (*it).id().ieta()/fabs((*it).id().ieta());
+	  if ((*it).id().iphi() == stripIphiMax && signIeta == signStripIeta) {
+	    d2max = (*it);
+	  }
+	} else {
+	  d2max = (*it);
+	}	  
+      }
+    }
+
+  if (d2max.energy() > 0) d2strip.push_back(d2max);
+  
+  // check if possible seed hits have energies not too small  
+  if (d1max.energy() < maxThreshold_ && d2max.energy() < maxThreshold_) return; 
+ 
+  if (stripIphiMax == 0 && d2max.energy() > 0) {
+    signStripIeta = d2max.id().ieta()/fabs(d2max.id().ieta());
+    stripIphiMax = d2max.id().iphi();
+    stripIetaMax = d2max.id().ieta();
+  }
+
+  if (verboseLevel_ >= 30) {
+    std::stringstream ss;
+    if (d1max.energy() > 0) {
+      ss << "  MaxHit in Depth 1: ieta = " << d1max.id().ieta() << " iphi = " << stripIphiMax 
+	 << " energy = " << d1max.energy() << " time = " << d1max.time() << std::endl; }
+    if (d2max.energy() > 0) {
+      ss << "  MaxHit in Depth 2: ieta = " << d2max.id().ieta() << " iphi = " << d2max.id().iphi() 
+	 << " energy = " << d2max.energy() << " time = " << d2max.time() << std::endl; } 
+    ss << "  stripThreshold_ = " << stripThreshold_ << std::endl;
+    
+    //edm::LogInfo("HFStripFilter") << ss.str();
+    std::cout << ss.str();
+  }
+
+  // prepare the strips: all hits along given ieta in one wedge (d1strip and d2strip)
+  //---------------------------------------------------------------------------------
+  for (HFRecHitCollection::const_iterator it = rec.begin(); it != rec.end(); ++it)
+    {
+      if ((*it).energy() < stripThreshold_) continue;
+      int signIeta = (*it).id().ieta()/fabs((*it).id().ieta());
+      
+      if (verboseLevel_ >= 30) {
+	std::stringstream ss;
+	ss << " HF hit: ieta = " << (*it).id().ieta() << "\t iphi = " << (*it).id().iphi()
+	   << "\t depth = " << (*it).id().depth() << "\t time = " << (*it).time() << "\t energy = "
+	   << (*it).energy() << "\t flags = " << (*it).flags() << std::endl;
+	//edm::LogInfo("HFStripFilter") << ss.str();
+	std::cout << ss.str();
+      }
+      
+      // collect hits with the same iphi but different ieta into strips
+      if ((*it).id().iphi() == stripIphiMax && signIeta == signStripIeta 
+         && (*it).time() < maxStripTime_) {	  
+	if ((*it).id().depth() == 1) {
+	  // check if hit = (*it) is already in d1strip
+	  bool pass = false;
+          if (d1strip.size() == 0) {
+	    if (abs((*it).id().iphi() - stripIetaMax) <= gap_) {
+	      d1strip.push_back((*it));
+	      pass = true;
+	    }
+	  } else {
+            for (it1 = d1strip.begin(); it1 < d1strip.end(); it1++) {
+ 	      if ((*it).id().ieta() == (*it1).id().ieta() && (*it).energy() == (*it1).energy()) {
+	        pass = true;
+	        break;
+	      }
+	    }
+	  }
+          if (pass) continue;
+	  // add hit = (*it) to d1strip if distance to the closest hit in d1strip <= gap_
+	  for (it1 = d1strip.begin(); it1 < d1strip.end(); it1++) {
+	    // check distance along Ieta to the closest hit 
+	    if (abs((*it1).id().ieta() - (*it).id().ieta()) <= gap_) {
+	      d1strip.push_back((*it));
+	      break;
+	    }
+	  }
+	}
+	else if ((*it).id().depth() == 2) {
+	  // check if hit = (*it) is already in d2strip
+          bool pass= false;
+	  if (d2strip.size() == 0) {
+	    if (abs((*it).id().ieta() - stripIetaMax) <= gap_) {
+	      d2strip.push_back((*it));
+	      pass = true;
+	    }
+	  } else {
+            for (it1 = d2strip.begin(); it1 < d2strip.end(); it1++) {
+              if ((*it).id().ieta() == (*it1).id().ieta() && (*it).energy() == (*it1).energy()) {
+                pass = true;
+                break;
+              }
+            }
+          }
+          if (pass) continue;
+	  
+	  // add hit = (*it) to d2strip if distance to the closest hit in d1strip <= gap_
+	  for (it1 = d2strip.begin(); it1 < d2strip.end(); it1++) {
+	    // check distance along Ieta to the closest hit 
+	    if (abs((*it1).id().ieta() - (*it).id().ieta()) <= gap_) {
+	      d2strip.push_back((*it));
+	      break;
+	    }
+	  }
+	}
+      }
+    }
+  
+  if (verboseLevel_ >= 30) {
+    std::stringstream ss;
+    ss << " Lstrip1 = " << (int)d1strip.size() << " (iphi = " << stripIphiMax
+       << ")  Lstrip2 = " << (int)d2strip.size() << std::endl << " Strip1: ";
+    for (it1 = d1strip.begin(); it1 < d1strip.end(); it1++) {
+      ss << (*it1).energy() << " (" << (*it1).id().ieta() << ") "; }
+    ss << std::endl << " Strip2: ";
+    for (it1 = d2strip.begin(); it1 < d2strip.end(); it1++) {
+      ss << (*it1).energy() << " (" << (*it1).id().ieta() << ") "; }
+    ss << std::endl;
+    
+    //edm::LogInfo("HFStripFilter") << ss.str();
+    std::cout << ss.str();
+  }
+  
+  // check if one of strips in depth1 or depth2 >= lstrips_
+  if ((int)d1strip.size() < lstrips_ && (int)d2strip.size() < lstrips_) return; 
+  
+  // define range of strips in ieta 
+  int ietaMin1 = 1000;  // for d1strip
+  int ietaMax1 = -1000;
+  for (it1 = d1strip.begin(); it1 < d1strip.end(); ++it1) {
+    if ((*it1).id().ieta() < ietaMin1) ietaMin1 = (*it1).id().ieta();
+    if ((*it1).id().ieta() > ietaMax1) ietaMax1 = (*it1).id().ieta();
+  }
+  int ietaMin2 = 1000;  // for d2strip
+  int ietaMax2 = -1000;
+  for (it1 = d2strip.begin(); it1 < d2strip.end(); ++it1) {
+    if ((*it1).id().ieta() < ietaMin2) ietaMin2 = (*it1).id().ieta();
+    if ((*it1).id().ieta() > ietaMax2) ietaMax2 = (*it1).id().ieta();
+  }
+  
+  // define ietamin and ietamax - common area for d1strip and d2strip
+  int ietaMin = ietaMin1;
+  int ietaMax = ietaMax1;
+  
+  if (ietaMin2 >= ietaMin1 && ietaMin2 <= ietaMax1) {
+    if (ietaMax2 > ietaMax1) ietaMax = ietaMax2;
+  } else if (ietaMin2 <= ietaMin1 && ietaMax2 >= ietaMin1) {
+    if (ietaMin2 < ietaMin1) ietaMin = ietaMin2;
+    if (ietaMax2 > ietaMax1) ietaMax = ietaMax2;
+  }
+    
+  // calculate the total energy in strips
+  double eStrip = 0;    
+  for (it1 = d1strip.begin(); it1 < d1strip.end(); ++it1) {   
+    if ((*it1).id().ieta() < ietaMin || (*it1).id().ieta() > ietaMax) continue;
+    eStrip += (*it1).energy();
+  }
+  for (it1 = d2strip.begin(); it1 < d2strip.end(); ++it1) {   
+    if ((*it1).id().ieta() < ietaMin || (*it1).id().ieta() > ietaMax) continue;
+    eStrip += (*it1).energy();
+  }
+  
+  if (verboseLevel_ >= 30) {
+    std::stringstream ss;
+    ss << " ietaMin1 = " << ietaMin1 << "  ietaMax1 = " << ietaMax1 << std::endl
+       << " ietaMin2 = " << ietaMin2 << "  ietaMax2 = " << ietaMax2 << std::endl   
+       << " Common strip:  ietaMin = " << ietaMin << "  ietaMax = " << ietaMax << std::endl; 
+
+    //edm::LogInfo("HFStripFilter") << ss.str();
+    std::cout << ss.str();
+  }
+  
+  int phiseg = 2; // 10 degrees segmentation for most of HF (1 iphi unit = 5 degrees)
+  if (abs(d1strip[0].id().ieta()) > 39) phiseg = 4; // 20 degrees segmentation for |ieta| > 39
+  
+  // Check if seed hit has neighbours with (iphi +/- phiseg) and the same ieta    
+  int iphi1 = d1strip[0].id().iphi() - phiseg;
+  while (iphi1 < 0) iphi1 += 72;
+  int iphi2 = d1strip[0].id().iphi() + phiseg;
+  while (iphi2 > 72) iphi2 -= 72;
+  
+  // energies in the neighboring wedges  
+  double energyIphi1 = 0;
+  double energyIphi2 = 0;
+  for (HFRecHitCollection::const_iterator it = rec.begin(); it != rec.end(); ++it) 
+    {
+      if ((*it).energy() < stripThreshold_) continue;
+      if ((*it).id().ieta() < ietaMin || (*it).id().ieta() > ietaMax) continue;
+      if ((*it).id().iphi() == iphi1) energyIphi1 += (*it).energy();      // iphi1
+      else if ((*it).id().iphi() == iphi2) energyIphi2 += (*it).energy(); // iphi2
+    }
+  
+  double ratio1 = eStrip > 0 ? energyIphi1/eStrip : 0;
+  double ratio2 = eStrip > 0 ? energyIphi2/eStrip : 0;
+    
+  if (verboseLevel_ >= 30) {
+    std::stringstream ss;
+    ss << "  iphi = " << d1strip[0].id().iphi() << "  iphi1 = " << iphi1 << "  iphi2 = " 
+       << iphi2 << std::endl
+       << "  Estrip = " << eStrip << "  EnergyIphi1 = " << energyIphi1
+       << "  Ratio = "	<< ratio1 << std::endl
+       << "                  " << "  EnergyIphi2 = " << energyIphi2
+       << "  Ratio = "	<< ratio2 << std::endl;
+
+    //edm::LogInfo("HFStripFilter") << ss.str();
+    std::cout << ss.str();
+  }
+  
+  // check if our wedge does not have substantial leak into adjacent wedges
+  if (ratio1 < wedgeCut_ && ratio2 < wedgeCut_) { // noise event with strips (d1 and/or d2)
+    
+    if (verboseLevel_ >= 30) {
+      std::stringstream ss;
+      ss << "  stripPass = false" << std::endl 
+	 << "  mark hits in strips now " << std::endl;
+
+      //edm::LogInfo("HFStripFilter") << ss.str();
+      std::cout << ss.str();
+    }
+    
+    // Figure out which rechits need to be tagged (d1.strip)
+    for (it1 = d1strip.begin(); it1 < d1strip.end(); ++it1) {
+      if ((*it1).id().ieta() < ietaMin || (*it1).id().ieta() > ietaMax) continue;
+      HFRecHitCollection::iterator hit = rec.find((*it1).id());
+      if (hit != rec.end()) {
+	// tag a rechit with the anomalous hit flag
+	if (verboseLevel_ >= 30) {
+	  std::stringstream ss;
+	  ss << " d1strip: marked hit = " << (*hit) << std::endl;
+	  //edm::LogInfo("HFStripFilter") << ss.str();
+	  std::cout << ss.str();
+	}
+	hit->setFlagField(1U, HcalPhase1FlagLabels::HFAnomalousHit);
+      }
+    }
+    // Figure out which rechits need to be tagged (d2.strip)
+    for (it1 = d2strip.begin(); it1 < d2strip.end(); ++it1) {
+      if ((*it1).id().ieta() < ietaMin || (*it1).id().ieta() > ietaMax) continue;
+      HFRecHitCollection::iterator hit = rec.find((*it1).id());
+      if (hit != rec.end()) {
+	// tag a rechit with the anomalous hit flag
+	if (verboseLevel_ >= 30) {
+	  std::stringstream ss;
+	  ss << " d2strip: marked hit = " << (*hit) << std::endl;
+	  //edm::LogInfo("HFStripFilter") << ss.str();
+	  std::cout << ss.str();
+	}
+	hit->setFlagField(1U, HcalPhase1FlagLabels::HFAnomalousHit);
+      }
+    }
+  }
+  else {
+    if (verboseLevel_ >= 30) {
+      std::stringstream ss;
+      ss << "  stripPass = true" << std::endl;
+
+      //edm::LogInfo("HFStripFilter") << ss.str();
+      std::cout << ss.str();      
+    }
+  } 
 }
+
 
 std::unique_ptr<HFStripFilter> HFStripFilter::parseParameterSet(
     const edm::ParameterSet& ps)

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -65,11 +65,13 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec,
   int signStripIeta = 0;
   int stripIphiMax = 0;
   int stripIetaMax = 0;
+  int stripDepthMax = 0;
   
   if (d1max.energy() > 0) {
     signStripIeta = std::signbit(d1max.id().ieta());
     stripIphiMax = d1max.id().iphi();
     stripIetaMax = d1max.id().ieta();
+    stripDepthMax = d1max.id().depth();
   }
 
   d2max.setEnergy(-10);
@@ -99,6 +101,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec,
     signStripIeta = std::signbit(d2max.id().ieta());
     stripIphiMax = d2max.id().iphi();
     stripIetaMax = d2max.id().ieta();
+    stripDepthMax = d2max.id().depth();
   }
 
   std::stringstream ss;
@@ -107,7 +110,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec,
       ss << "  MaxHit in Depth 1: ieta = " << d1max.id().ieta() << " iphi = " << stripIphiMax 
 	 << " energy = " << d1max.energy() << " time = " << d1max.time() << std::endl; }
     if (d2max.energy() > 0) {
-      ss << "  MaxHit in Depth 2: ieta = " << d2max.id().ieta() << " iphi = " << d2max.id().iphi() 
+      ss << "  MaxHit in Depth 2: ieta = " << d2max.id().ieta() << " iphi = " << stripIphiMax 
 	 << " energy = " << d2max.energy() << " time = " << d2max.time() << std::endl; } 
     ss << "  stripThreshold_ = " << stripThreshold_ << std::endl;
   }
@@ -257,7 +260,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec,
     {
       if (it.energy() < stripThreshold_) continue;
       if (it.id().ieta() < ietaMin || it.id().ieta() > ietaMax) continue;
-      HcalDetId id(HcalForward, it.id().ieta(), d1strip[0].id().iphi(), d1strip[0].id().depth());
+      HcalDetId id(HcalForward, it.id().ieta(), stripIphiMax, stripDepthMax);
       bool neigh = myqual->topo()->decIPhi(id, neighbour);
       iphi1 = (neigh) ? neighbour.iphi() : 0;
       neigh = myqual->topo()->incIPhi(id, neighbour);
@@ -270,7 +273,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec,
   double ratio2 = eStrip > 0 ? energyIphi2/eStrip : 0;
     
   if (verboseLevel_ >= 30) {
-    ss << "  iphi = " << d1strip[0].id().iphi() << "  iphi1 = " << iphi1 << "  iphi2 = " 
+    ss << "  iphi = " << stripIphiMax << "  iphi1 = " << iphi1 << "  iphi2 = " 
        << iphi2 << std::endl
        << "  Estrip = " << eStrip << "  EnergyIphi1 = " << energyIphi1
        << "  Ratio = "	<< ratio1 << std::endl

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -64,7 +64,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
   int stripIetaMax = 0;
   
   if (d1max.energy() > 0) {
-    signStripIeta = d1max.id().ieta()/fabs(d1max.id().ieta());
+    signStripIeta = d1max.id().ieta()/abs(d1max.id().ieta());
     stripIphiMax = d1max.id().iphi();
     stripIetaMax = d1max.id().ieta();
   }
@@ -76,7 +76,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
       // find HFhit with maximum signal in depth = 2
       if ((*it).id().depth() == 2 && (*it).energy() > d2max.energy() && abs((*it).id().ieta()) < 35) {
 	if (d1max.energy() > 0) {
-	  int signIeta = (*it).id().ieta()/fabs((*it).id().ieta());
+	  int signIeta = (*it).id().ieta()/abs((*it).id().ieta());
 	  if ((*it).id().iphi() == stripIphiMax && signIeta == signStripIeta) {
 	    d2max = (*it);
 	  }
@@ -92,7 +92,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
   if (d1max.energy() < maxThreshold_ && d2max.energy() < maxThreshold_) return; 
  
   if (stripIphiMax == 0 && d2max.energy() > 0) {
-    signStripIeta = d2max.id().ieta()/fabs(d2max.id().ieta());
+    signStripIeta = d2max.id().ieta()/abs(d2max.id().ieta());
     stripIphiMax = d2max.id().iphi();
     stripIetaMax = d2max.id().ieta();
   }
@@ -113,7 +113,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
   for (HFRecHitCollection::const_iterator it = rec.begin(); it != rec.end(); ++it)
     {
       if ((*it).energy() < stripThreshold_) continue;
-      int signIeta = (*it).id().ieta()/fabs((*it).id().ieta());
+      int signIeta = (*it).id().ieta()/abs((*it).id().ieta());
       
       if (verboseLevel_ >= 30) {
 	ss << " HF hit: ieta = " << (*it).id().ieta() << "\t iphi = " << (*it).id().iphi()

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -6,7 +6,7 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 
-#include <math.h>
+#include <cmath>
 
 HFStripFilter::HFStripFilter(const double stripThreshold, const double maxThreshold,
                              const double timeMax, const double maxStripTime,
@@ -67,7 +67,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec,
   int stripIetaMax = 0;
   
   if (d1max.energy() > 0) {
-    signStripIeta = signbit(d1max.id().ieta());
+    signStripIeta = std::signbit(d1max.id().ieta());
     stripIphiMax = d1max.id().iphi();
     stripIetaMax = d1max.id().ieta();
   }
@@ -80,7 +80,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec,
       if (it.id().depth() == 2 && it.energy() > d2max.energy() && std::abs(it.id().ieta()) 
           < seedHitIetaMax_) {
 	if (d1max.energy() > 0) {
-	  int signIeta = signbit(it.id().ieta());
+	  int signIeta = std::signbit(it.id().ieta());
 	  if (it.id().iphi() == stripIphiMax && signIeta == signStripIeta) {
 	    d2max = it;
 	  }
@@ -96,7 +96,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec,
   if (d1max.energy() < maxThreshold_ && d2max.energy() < maxThreshold_) return; 
  
   if (d1max.energy() <= 0 && d2max.energy() > 0) {
-    signStripIeta = signbit(d2max.id().ieta());
+    signStripIeta = std::signbit(d2max.id().ieta());
     stripIphiMax = d2max.id().iphi();
     stripIetaMax = d2max.id().ieta();
   }
@@ -117,7 +117,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec,
   for (auto& it : rec)
     {
       if (it.energy() < stripThreshold_) continue;
-      int signIeta = signbit(it.id().ieta());
+      int signIeta = std::signbit(it.id().ieta());
       
       if (verboseLevel_ >= 30) {
 	ss << " HF hit: ieta = " << it.id().ieta() << "\t iphi = " << it.id().iphi()

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -127,7 +127,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
 	if ((*it).id().depth() == 1) {
 	  // check if hit = (*it) is already in d1strip
 	  bool pass = false;
-          if (d1strip.size() == 0) {
+          if (d1strip.empty()) {
 	    if (abs((*it).id().iphi() - stripIetaMax) <= gap_) {
 	      d1strip.push_back((*it));
 	      pass = true;
@@ -153,7 +153,7 @@ void HFStripFilter::runFilter(HFRecHitCollection& rec) const
 	else if ((*it).id().depth() == 2) {
 	  // check if hit = (*it) is already in d2strip
           bool pass= false;
-	  if (d2strip.size() == 0) {
+	  if (d2strip.empty()) {
 	    if (abs((*it).id().ieta() - stripIetaMax) <= gap_) {
 	      d2strip.push_back((*it));
 	      pass = true;

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -322,13 +322,13 @@ std::unique_ptr<HFStripFilter> HFStripFilter::parseParameterSet(
     const edm::ParameterSet& ps)
 {
     return std::make_unique<HFStripFilter>(
-        ps.getUntrackedParameter<double>("stripThreshold"),
-        ps.getUntrackedParameter<double>("maxThreshold"),
-        ps.getUntrackedParameter<double>("timeMax"),
-        ps.getUntrackedParameter<double>("maxStripTime"),
-        ps.getUntrackedParameter<double>("wedgeCut"),
-        ps.getUntrackedParameter<int>("gap"),
-        ps.getUntrackedParameter<int>("lstrips"),
+        ps.getParameter<double>("stripThreshold"),
+        ps.getParameter<double>("maxThreshold"),
+        ps.getParameter<double>("timeMax"),
+        ps.getParameter<double>("maxStripTime"),
+        ps.getParameter<double>("wedgeCut"),
+        ps.getParameter<int>("gap"),
+        ps.getParameter<int>("lstrips"),
         ps.getUntrackedParameter<int>("verboseLevel")
     );
 }
@@ -337,13 +337,13 @@ edm::ParameterSetDescription HFStripFilter::fillDescription()
 {
     edm::ParameterSetDescription desc;
 
-    desc.addUntracked<double>("stripThreshold", 40.0);
-    desc.addUntracked<double>("maxThreshold", 100.0);
-    desc.addUntracked<double>("timeMax", 6.0);
-    desc.addUntracked<double>("maxStripTime", 10.0);
-    desc.addUntracked<double>("wedgeCut", 0.05);
-    desc.addUntracked<int>("gap", 2);
-    desc.addUntracked<int>("lstrips", 2);
+    desc.add<double>("stripThreshold", 40.0);
+    desc.add<double>("maxThreshold", 100.0);
+    desc.add<double>("timeMax", 6.0);
+    desc.add<double>("maxStripTime", 10.0);
+    desc.add<double>("wedgeCut", 0.05);
+    desc.add<int>("gap", 2);
+    desc.add<int>("lstrips", 2);
     desc.addUntracked<int>("verboseLevel", 0);
 
     return desc;

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -2,7 +2,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/METReco/interface/HcalPhase1FlagLabels.h"
 #include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
 
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h"
 
@@ -11,8 +10,7 @@
 HFStripFilter::HFStripFilter(const double stripThreshold, const double maxThreshold,
                              const double timeMax, const double maxStripTime,
                              const double wedgeCut, const int gap,
-                             const int lstrips, const int acceptSeverityLevel,
-                             const int verboseLevel)
+                             const int lstrips, const int verboseLevel)
     : stripThreshold_(stripThreshold),
       maxThreshold_(maxThreshold),
       timeMax_(timeMax),
@@ -20,7 +18,6 @@ HFStripFilter::HFStripFilter(const double stripThreshold, const double maxThresh
       wedgeCut_(wedgeCut),
       gap_(gap),
       lstrips_(lstrips),
-      acceptSeverityLevel_(acceptSeverityLevel),
       verboseLevel_(verboseLevel)
 {
     // For the description of CMSSW message logging, see
@@ -36,9 +33,7 @@ HFStripFilter::~HFStripFilter()
 }
 
 
-void HFStripFilter::runFilter(HFRecHitCollection& rec,
-                              const HcalChannelQuality* myqual,
-                              const HcalSeverityLevelComputer* mySeverity) const
+void HFStripFilter::runFilter(HFRecHitCollection& rec) const
 {
   if (verboseLevel_ >= 20)
     edm::LogInfo("HFStripFilter") << "runFilter called";
@@ -358,7 +353,6 @@ std::unique_ptr<HFStripFilter> HFStripFilter::parseParameterSet(
         ps.getParameter<double>("wedgeCut"),
         ps.getParameter<int>("gap"),
         ps.getParameter<int>("lstrips"),
-        ps.getParameter<int>("acceptSeverityLevel"),
         ps.getParameter<int>("verboseLevel")
     );
 }
@@ -374,7 +368,6 @@ edm::ParameterSetDescription HFStripFilter::fillDescription()
     desc.add<double>("wedgeCut", 0.05);
     desc.add<int>("gap", 2);
     desc.add<int>("lstrips", 2);
-    desc.add<int>("acceptSeverityLevel", 9);
     desc.add<int>("verboseLevel", 0);
 
     return desc;

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSeverityLevelComputer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSeverityLevelComputer.cc
@@ -52,6 +52,7 @@ bool HcalSeverityLevelComputer::getRecHitFlag(HcalSeverityDefinition& mydef,
         else if (mybit == "HFS8S1Ratio")        setBit(HcalPhase1FlagLabels::HFS8S1Ratio, mydef.HFFlagMask);
         else if (mybit == "HFPET")              setBit(HcalPhase1FlagLabels::HFPET, mydef.HFFlagMask);
         else if (mybit == "HFSignalAsymmetry")  setBit(HcalPhase1FlagLabels::HFSignalAsymmetry, mydef.HFFlagMask);
+        else if (mybit == "HFAnomalousHit")     setBit(HcalPhase1FlagLabels::HFAnomalousHit, mydef.HFFlagMask);
 
         // Common subdetector bits ++++++++++++++++++++++
         else if (mybit == "TimingFromTDC")      setAllRHMasks(HcalPhase1FlagLabels::TimingFromTDC, mydef);

--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -74,6 +74,10 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
     # Turn on/off the noise cleanup algorithms
     setNoiseFlags = cms.bool(True),
 
+    # Run HFStripFilter in the noise cleanup sequence? This switch
+    # is meaningful only if "setNoiseFlags" is set to True.
+    runHFStripFilter = cms.bool(True),
+
     # Parameters for the S9S1 test.
     #
     #   optimumSlopes are slopes for each of the |ieta| values
@@ -190,5 +194,20 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
         short_R_29 = cms.vdouble([0.8]),
         long_R_29  = cms.vdouble([0.8]), # should move from 0.98 to 0.8?
         HcalAcceptSeverityLevel = cms.int32(9), # allow hits with severity up to AND INCLUDING 9
+    ),
+
+    # Parameters for HFStripFilter.
+    # Please add some descriptions of their meaning.
+    HFStripFilter = cms.PSet(
+        energyMax1 = cms.double(-10.0),
+        energyMax2 = cms.double(-10.0),
+        stripThreshold = cms.double(40.0),
+        maxThreshold = cms.double(100.0),
+        timeMax = cms.double(6.0),
+        maxStripTime = cms.double(10.0),
+        wedgeCut = cms.double(0.05),
+        gap = cms.int32(2),
+        lstrips = cms.int32(2),
+        verboseLevel = cms.int32(20)
     )
 )

--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -199,8 +199,6 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
     # Parameters for HFStripFilter.
     # Please add some descriptions of their meaning.
     HFStripFilter = cms.PSet(
-        energyMax1 = cms.double(-10.0),
-        energyMax2 = cms.double(-10.0),
         stripThreshold = cms.double(40.0),
         maxThreshold = cms.double(100.0),
         timeMax = cms.double(6.0),
@@ -208,6 +206,7 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
         wedgeCut = cms.double(0.05),
         gap = cms.int32(2),
         lstrips = cms.int32(2),
+        acceptSeverityLevel = cms.int32(9),
         verboseLevel = cms.int32(20)
     )
 )

--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -206,7 +206,6 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
         wedgeCut = cms.double(0.05),
         gap = cms.int32(2),
         lstrips = cms.int32(2),
-        acceptSeverityLevel = cms.int32(9),
         verboseLevel = cms.int32(20)
     )
 )

--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -199,13 +199,13 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
     # Parameters for HFStripFilter.
     # Please add some descriptions of their meaning.
     HFStripFilter = cms.PSet(
-        stripThreshold = cms.untracked.double(40.0),
-        maxThreshold = cms.untracked.double(100.0),
-        timeMax = cms.untracked.double(6.0),
-        maxStripTime = cms.untracked.double(10.0),
-        wedgeCut = cms.untracked.double(0.05),
-        gap = cms.untracked.int32(2),
-        lstrips = cms.untracked.int32(2),
+        stripThreshold = cms.double(40.0),
+        maxThreshold = cms.double(100.0),
+        timeMax = cms.double(6.0),
+        maxStripTime = cms.double(10.0),
+        wedgeCut = cms.double(0.05),
+        gap = cms.int32(2),
+        lstrips = cms.int32(2),
         verboseLevel = cms.untracked.int32(20)
     )
 )

--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -199,13 +199,13 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
     # Parameters for HFStripFilter.
     # Please add some descriptions of their meaning.
     HFStripFilter = cms.PSet(
-        stripThreshold = cms.double(40.0),
-        maxThreshold = cms.double(100.0),
-        timeMax = cms.double(6.0),
-        maxStripTime = cms.double(10.0),
-        wedgeCut = cms.double(0.05),
-        gap = cms.int32(2),
-        lstrips = cms.int32(2),
-        verboseLevel = cms.int32(20)
+        stripThreshold = cms.untracked.double(40.0),
+        maxThreshold = cms.untracked.double(100.0),
+        timeMax = cms.untracked.double(6.0),
+        maxStripTime = cms.untracked.double(10.0),
+        wedgeCut = cms.untracked.double(0.05),
+        gap = cms.untracked.int32(2),
+        lstrips = cms.untracked.int32(2),
+        verboseLevel = cms.untracked.int32(20)
     )
 )

--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -204,8 +204,9 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
         timeMax = cms.double(6.0),
         maxStripTime = cms.double(10.0),
         wedgeCut = cms.double(0.05),
+        seedHitIetaMax = cms.int32(35),
         gap = cms.int32(2),
         lstrips = cms.int32(2),
-        verboseLevel = cms.untracked.int32(20)
+        verboseLevel = cms.untracked.int32(10)
     )
 )

--- a/RecoLocalCalo/HcalRecProducers/src/HFPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPhase1Reconstructor.cc
@@ -289,7 +289,7 @@ HFPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetup)
 
         // Step 4:  Run HFStripFilter if requested
         if (runHFStripFilter_)
-            hfStripFilter_->runFilter(*rec);
+            hfStripFilter_->runFilter(*rec, myqual, mySeverity);
     }
 
     // Add the output collection to the event record

--- a/RecoLocalCalo/HcalRecProducers/src/HFPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPhase1Reconstructor.cc
@@ -289,7 +289,7 @@ HFPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetup)
 
         // Step 4:  Run HFStripFilter if requested
         if (runHFStripFilter_)
-            hfStripFilter_->runFilter(*rec, myqual, mySeverity);
+            hfStripFilter_->runFilter(*rec);
     }
 
     // Add the output collection to the event record

--- a/RecoLocalCalo/HcalRecProducers/src/HFPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPhase1Reconstructor.cc
@@ -289,7 +289,7 @@ HFPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetup)
 
         // Step 4:  Run HFStripFilter if requested
         if (runHFStripFilter_)
-            hfStripFilter_->runFilter(*rec);
+            hfStripFilter_->runFilter(*rec, myqual);
     }
 
     // Add the output collection to the event record


### PR DESCRIPTION
#### PR description:

This PR is devoted to the development of a new filter HFStripFilter
for HF RecHits. This work was started when the JetMET group found a
lot of FakJets originated in HF. A careful examination revealed that
the high-energy hits from these jets have times ~4-6 ns and Ieta
mostly 29-34. This indicated that these hits could be the residual
tails after TDC cuts with QIE10. In Ieta 29-34 the distribution of
signals in time corresponding to early hits caused by possible PMT
hits are not well separated from the main physical signals and hits
with ~4-6 ns are probably due to tails from PMT hits (See slide 13
in ref. 1).
These early hits may be due to muons passing through "jungle" of
optical fibers coming from the HF absorbers to PMTs. In this case, we
can have a sequence of hits in one HF wedge, which can have signals in
both depths 1 and 2 and have a strip-like structure: sequence of hits
in one wedge and without or with very small signals in adjacent
wedges. Such signals cannot be marked with other HF filters, because
signals basically have comparable hits in both depths 1 and 2 and PET
and S9S1 HF filters work with hits which have very large signal in one
of depths and very small signal or no signal in another depth.
So HFStripFilter is looking for strips in HFRecHitCollection and marks
hits in the strips if they were found with special flag which could be
used for further data processing (See first part of report in ref. 2).

References:
1. https://indico.cern.ch/event/800247/contributions/3325296/attachments/1800754/2937107/HFStripFilter_22Feb2019.pdf
2. https://indico.cern.ch/event/807827/contributions/3362430/attachments/1816769/2969579/HFStripFilter_22Mar2019.pdf

#### PR validation:
The logs produced by "runTheMatrix" script look reasonable. There are few errors in log files, but one error related  to data server  eoscms.cern.ch which appears to be down or unreachable (cmsdev31.cern.ch). Some other workflows with errors have DAS_ERROR status which is also unrelated to this PR.

In attached Screenshots you can see pictures of EvenrDisplay (FireWorks) with HF rechits after reconstruction procedure. In column 'flags' you can see the upper 2 hits in table belonging to strip have values 1048640 (set bits 6, 20). Bit6 is new flag HcalPhase1FlagLabels::HFAnomalousHit). 
<img width="1201" alt="Screenshot 2019-03-25 at 17 21 55" src="https://user-images.githubusercontent.com/7665869/54983371-f8e16100-4fac-11e9-897c-c391d8a166ee.png">
<img width="1200" alt="Screenshot 2019-03-25 at 17 18 58" src="https://user-images.githubusercontent.com/7665869/54983400-04cd2300-4fad-11e9-9bbd-3daa3fc71d45.png">
