### PR TITLE
DD4hep-based Geometry Description to G4 Geometry Converter

### DIFF
--- a/DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml
+++ b/DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml
@@ -6,9 +6,9 @@
     <debug_rotations/>
     <debug_includes/>
     <debug_volumes/>
-    <debug_constants/>
+    <debug_constants/-->
     <debug_materials/>
-    <debug_namespaces/>
+    <!--debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
     <debug_materials/>
@@ -30,7 +30,7 @@
   </ConstantsSection>
 
   <IncludeSection>
-    <Include ref='Geometry/CMSCommonData/data/materials.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/materials/2019/v1/materials.xml'/>
     <Include ref='Geometry/CMSCommonData/data/rotations.xml'/>
     <Include ref='Geometry/CMSCommonData/data/extend/cmsextent.xml'/>
     <Include ref='Geometry/CMSCommonData/data/cms.xml'/>

--- a/Geometry/CMSCommonData/data/materials/2019/v1/materials.xml
+++ b/Geometry/CMSCommonData/data/materials/2019/v1/materials.xml
@@ -1,0 +1,4709 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <MaterialSection label="materials.xml">
+  <ElementaryMaterial name="Aluminium" density="2.7*g/cm3" symbol=" " atomicWeight="26.98*g/mole" atomicNumber="13"/>
+ <ElementaryMaterial name="TD_Aluminium" density="8.1*g/cm3" symbol=" " atomicWeight="26.98*g/mole" atomicNumber="13"/>
+  <ElementaryMaterial name="Antimony" density="6.679*g/cm3" symbol=" " atomicWeight="121.75*g/mole" atomicNumber="51"/>
+  <ElementaryMaterial name="Argon" density="1.639*mg/cm3" symbol=" " atomicWeight="39.948*g/mole" atomicNumber="18"/>
+  <ElementaryMaterial name="Arsenic" density="5.72*g/cm3" symbol=" " atomicWeight="74.922*g/mole" atomicNumber="33"/>
+  <ElementaryMaterial name="Barium" density="3.5*g/cm3" symbol=" " atomicWeight="137.33*g/mole" atomicNumber="56"/>
+  <ElementaryMaterial name="Beryllium" density="1.848*g/cm3" symbol=" " atomicWeight="9.0122*g/mole" atomicNumber="4"/>
+  <ElementaryMaterial name="Bismuth" density="9.37*g/cm3" symbol=" " atomicWeight="208.98*g/mole" atomicNumber="83"/>
+  <ElementaryMaterial name="Bor 10" density="2.34*g/cm3" symbol=" " atomicWeight="10*g/mole" atomicNumber="5"/>
+  <ElementaryMaterial name="Bor 11" density="2.34*g/cm3" symbol=" " atomicWeight="11*g/mole" atomicNumber="5"/>
+  <ElementaryMaterial name="Bromine" density="3.11*g/cm3" symbol=" " atomicWeight="79.904*g/mole" atomicNumber="35"/>
+  <ElementaryMaterial name="Cadmium" density="8.63*g/cm3" symbol=" " atomicWeight="112.41*g/mole" atomicNumber="48"/>
+  <ElementaryMaterial name="Calcium" density="1.55*g/cm3" symbol=" " atomicWeight="40.078*g/mole" atomicNumber="20"/>
+  <ElementaryMaterial name="Carbon" density="2.265*g/cm3" symbol=" " atomicWeight="12.011*g/mole" atomicNumber="6"/>
+  <ElementaryMaterial name="Cerium" density="6.637*g/cm3" symbol=" " atomicWeight="140.12*g/mole" atomicNumber="58"/>
+  <ElementaryMaterial name="Cesium" density="1.87*g/cm3" symbol=" " atomicWeight="132.9054*g/mole" atomicNumber="55"/>
+  <ElementaryMaterial name="Chlorine" density="1.56*g/cm3" symbol=" " atomicWeight="35.45*g/mole" atomicNumber="17"/>
+  <ElementaryMaterial name="Chromium" density="7.18*g/cm3" symbol=" " atomicWeight="51.996*g/mole" atomicNumber="24"/>
+  <ElementaryMaterial name="Cobalt" density="8.9*g/cm3" symbol=" " atomicWeight="58.933*g/mole" atomicNumber="27"/>
+  <ElementaryMaterial name="Copper" density="8.96*g/cm3" symbol=" " atomicWeight="63.546*g/mole" atomicNumber="29"/>
+  <ElementaryMaterial name="Deuterium" density="162*mg/cm3" symbol=" " atomicWeight="2.01*g/mole" atomicNumber="1"/>
+  <ElementaryMaterial name="Fluorine" density="1.108*g/cm3" symbol=" " atomicWeight="18.998*g/mole" atomicNumber="9"/>
+  <ElementaryMaterial name="Gallium" density="5.877*g/cm3" symbol=" " atomicWeight="69.723*g/mole" atomicNumber="31"/>
+  <ElementaryMaterial name="Germanium" density="5.323*g/cm3" symbol=" " atomicWeight="72.61*g/mole" atomicNumber="32"/>
+  <ElementaryMaterial name="Gold" density="18.85*g/cm3" symbol=" " atomicWeight="196.97*g/mole" atomicNumber="79"/>
+  <ElementaryMaterial name="Helium" density="125*mg/cm3" symbol=" " atomicWeight="4.0026*g/mole" atomicNumber="2"/>
+  <ElementaryMaterial name="Hydrogen" density="70.8*mg/cm3" symbol=" " atomicWeight="1.00794*g/mole" atomicNumber="1"/>
+  <ElementaryMaterial name="Indium" density="7.3*g/cm3" symbol=" " atomicWeight="114.82*g/mole" atomicNumber="49"/>
+  <ElementaryMaterial name="Iodine" density="7.3*g/cm3" symbol=" " atomicWeight="114.82*g/mole" atomicNumber="53"/>
+  <ElementaryMaterial name="Iron" density="7.87*g/cm3" symbol=" " atomicWeight="55.85*g/mole" atomicNumber="26"/>
+  <ElementaryMaterial name="Krypton" density="2.6*g/cm3" symbol=" " atomicWeight="83.8*g/mole" atomicNumber="36"/>
+  <ElementaryMaterial name="Lanthanum" density="6.127*g/cm3" symbol=" " atomicWeight="138.9055*g/mole" atomicNumber="57"/>
+  <ElementaryMaterial name="Lead" density="11.35*g/cm3" symbol=" " atomicWeight="207.19*g/mole" atomicNumber="82"/>
+  <ElementaryMaterial name="Lithium" density="534*mg/cm3" symbol=" " atomicWeight="6.941*g/mole" atomicNumber="3"/>
+   <ElementaryMaterial name="Lutecium" density="9.841*g/cm3" symbol=" " atomicWeight="174.96*g/mole" atomicNumber="71"/>
+  <ElementaryMaterial name="Magnesium" density="1.735*g/cm3" symbol=" " atomicWeight="24.305*g/mole" atomicNumber="12"/>
+  <ElementaryMaterial name="Manganese" density="7.43*g/cm3" symbol=" " atomicWeight="54.938*g/mole" atomicNumber="25"/>
+  <ElementaryMaterial name="Molybdenum" density="10.2*g/cm3" symbol=" " atomicWeight="95.94*g/mole" atomicNumber="42"/>
+  <ElementaryMaterial name="Neodymium" density="1e-22*mg/cm3" symbol=" " atomicWeight="144.24*g/mole" atomicNumber="60"/>
+  <ElementaryMaterial name="Neon" density="1.207*g/cm3" symbol=" " atomicWeight="20.18*g/mole" atomicNumber="10"/>
+  <ElementaryMaterial name="Nickel" density="8.876*g/cm3" symbol=" " atomicWeight="58.693*g/mole" atomicNumber="28"/>
+  <ElementaryMaterial name="Niobium" density="8.55*g/cm3" symbol=" " atomicWeight="92.906*g/mole" atomicNumber="41"/>
+  <ElementaryMaterial name="Nitrogen" density="808*mg/cm3" symbol=" " atomicWeight="14.007*g/mole" atomicNumber="7"/>
+  <ElementaryMaterial name="Oxygen" density="1.43*mg/cm3" symbol=" " atomicWeight="15.999*g/mole" atomicNumber="8"/>
+  <ElementaryMaterial name="Palladium" density="12*g/cm3" symbol=" " atomicWeight="106.42*g/mole" atomicNumber="46"/>
+  <ElementaryMaterial name="Phosphor" density="1.82*g/cm3" symbol=" " atomicWeight="30.974*g/mole" atomicNumber="15"/>
+  <ElementaryMaterial name="Potassium" density="860*mg/cm3" symbol=" " atomicWeight="39.098*g/mole" atomicNumber="19"/>
+  <ElementaryMaterial name="Praseodymium" density="1e-22*mg/cm3" symbol=" " atomicWeight="140.9077*g/mole" atomicNumber="59"/>
+  <ElementaryMaterial name="Rhodium" density="12.39*g/cm3" symbol=" " atomicWeight="102.9055*g/mole" atomicNumber="45"/>
+  <ElementaryMaterial name="Rubidium" density="1.529*g/cm3" symbol=" " atomicWeight="85.4678*g/mole" atomicNumber="37"/>
+  <ElementaryMaterial name="Ruthenium" density="12.39*g/cm3" symbol=" " atomicWeight="101.07*g/mole" atomicNumber="44"/>
+  <ElementaryMaterial name="Scandium" density="2.98*g/cm3" symbol=" " atomicWeight="44.956*g/mole" atomicNumber="21"/>
+  <ElementaryMaterial name="Selenium" density="4.78*g/cm3" symbol=" " atomicWeight="78.96*g/mole" atomicNumber="34"/>
+  <ElementaryMaterial name="Silicon" density="2.33*g/cm3" symbol=" " atomicWeight="28.09*g/mole" atomicNumber="14"/>
+  <ElementaryMaterial name="Silver" density="10.48*g/cm3" symbol=" " atomicWeight="107.87*g/mole" atomicNumber="47"/>
+  <ElementaryMaterial name="Sodium" density="969*mg/cm3" symbol=" " atomicWeight="22.99*g/mole" atomicNumber="11"/>
+  <ElementaryMaterial name="Strontium" density="2.54*g/cm3" symbol=" " atomicWeight="87.62*g/mole" atomicNumber="38"/>
+  <ElementaryMaterial name="Sulfur" density="2.07*g/cm3" symbol=" " atomicWeight="32.066*g/mole" atomicNumber="16"/>
+  <ElementaryMaterial name="Tantalum" density="16.65*g/cm3" symbol=" " atomicWeight="180.9479*g/mole" atomicNumber="73"/>
+  <ElementaryMaterial name="Technetium" density="11.48*g/cm3" symbol=" " atomicWeight="98*g/mole" atomicNumber="43"/>
+  <ElementaryMaterial name="Tellurium" density="6.23*g/cm3" symbol=" " atomicWeight="127.6*g/mole" atomicNumber="52"/>
+  <ElementaryMaterial name="Tin" density="7.31*g/cm3" symbol=" " atomicWeight="118.69*g/mole" atomicNumber="50"/>
+  <ElementaryMaterial name="Titanium" density="4.53*g/cm3" symbol=" " atomicWeight="47.88*g/mole" atomicNumber="22"/>
+  <ElementaryMaterial name="Tungsten" density="19.3*g/cm3" symbol=" " atomicWeight="183.85*g/mole" atomicNumber="74"/>
+  <ElementaryMaterial name="Uranium" density="18.95*g/cm3" symbol=" " atomicWeight="238.03*g/mole" atomicNumber="92"/>
+  <!--ElementaryMaterial name="Vacuum" density="1e-13*mg/cm3" symbol=" " atomicWeight="1*g/mole" atomicNumber="1"/-->
+  
+  <ElementaryMaterial name="Vanadium" density="6.1*g/cm3" symbol=" " atomicWeight="50.941*g/mole" atomicNumber="23"/>
+  <ElementaryMaterial name="Xenon" density="3.057*g/cm3" symbol=" " atomicWeight="131.29*g/mole" atomicNumber="54"/>
+  <ElementaryMaterial name="Yttrium" density="4.456*g/cm3" symbol=" " atomicWeight="88.9059*g/mole" atomicNumber="39"/>
+  <ElementaryMaterial name="Zinc" density="7.112*g/cm3" symbol=" " atomicWeight="65.39*g/mole" atomicNumber="30"/>
+  <ElementaryMaterial name="Zirconium" density="6.494*g/cm3" symbol=" " atomicWeight="91.22*g/mole" atomicNumber="40"/>
+  <CompositeMaterial name="Vacuum" density="1e-10*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_Thermflow" density="0.7625*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.3787448">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.21575329">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3239468">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.08155498">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_TPG" density="2.47*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin" density="3.43511*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_OuterOuterRing" density="2.2677*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_OuterInnerRing" density="1.000035*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_InnerOuterRing" density="1.77*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_InnerInnerRing" density="1.1744*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_OuterOuterRing" density="1.612*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_OuterInnerRing" density="1.745*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_InnerOuterRing" density="1.944*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_InnerInnerRing" density="1.566*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="80pct Argon plus 20pct CO_2" density="1.675*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.78405896">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.058934941">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1570061">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AISI-1006-Steel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0045">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9938">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AISI-1018-Steel" density="7.83*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0018">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0001">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0025">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9854">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Steel_Upgrade" density="0.4915*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:AISI-1018-Steel"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  <CompositeMaterial name="AISI-1045-Steel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.005">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.009">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9851">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bpix_Pipe_Steel" density="8.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.7195">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  <CompositeMaterial name="AQBB borated concre" density="2.135*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.032142361">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47563465">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20400656">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.051371319">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20008524">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0048537181">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02135636">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010549802">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001119">
+    <rMaterial name="materials:Water"/>
+   </MaterialFraction>   
+  </CompositeMaterial>
+  <CompositeMaterial name="Heavy Boron concrete" density="3.574*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5203954">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34702">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0080099">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0296094">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0684299">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.006620977">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.008010562">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004774732">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004804022">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.000555229">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001653212">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.000118189">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>   
+  </CompositeMaterial>
+  <CompositeMaterial name="Air" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al support" density="254*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al-MMC" density="1.84*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al-silicate plus Zi" density="3.3196*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.34196227">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11867705">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43936068">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al_2 O_3" density="3.91*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.52924272">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47075728">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium 2219" density="2.84*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9168">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.068">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.003">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.002">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Vanadium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0025">
+    <rMaterial name="materials:Zirconium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium 2219 light" density="1.42*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Aluminium 2219"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium 2219 very light" density="0.067558*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.065">
+    <rMaterial name="materials:Aluminium 2219"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.935">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Alumina" density="3.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.52924272">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47075728">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium Pix_b" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium honeycomb" density="0.0511415*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.97670111">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017460186">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0055195064">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00030055565">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.863911e-05">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium silicate" density="3.156*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.37995808">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13186339">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.48817853">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminized Mylar" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45014471">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.030220222">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.23984232">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27979275">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar 50pct plus CO_2 50pct" density="1.729*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.475815">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14306133">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38112367">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar 40pct plus Ethane 60pct " density="1.4692*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46968659">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.42365618">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10665723">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Cu mixt. for Cors" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.032220584">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.93514796">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.018242877">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0021475706">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0056206649">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0048079473">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010151454">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00079724857">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Cu mixture for EM" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.30224783">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.4919464">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17112881">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0020145463">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012041684">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017214762">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.002658102">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00074786557">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Cu mixture for HD" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.032220584">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.93514796">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.018242877">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0021475706">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0056206649">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0048079473">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010151454">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00079724857">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Pb mixture for EM" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.26749417">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.54605374">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15145173">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017829057">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010657083">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015235339">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0023524628">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.000661873">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0043106974">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="WCu" density="14.979*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.75">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/W Catcher section" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="9.6146597e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99990385">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/W Hadron section" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="9.6146597e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99990385">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/W mixt. for E.M." density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="9.6146597e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99990385">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Argon 50pct CF_4 CO_2" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.39336475">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11827135">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29931485">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18904904">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Argon CF_4 CO_2" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="BET2a concrete plus Poly" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.75468049">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.070780535">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0095602944">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.079376542">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035227691">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040083658">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0057520693">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00084050447">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0036982197">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="BET2b concrete plus Poly" density="1.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.86250534">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080265403">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0031685162">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.026156529">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011497209">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013100008">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017629095">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00028594245">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0012581468">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="B_2 O_3" density="2.34*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.057473742">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25288446">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68964179">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ba O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.89565575">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10434425">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bakelite" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.074565894">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77748634">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14794776">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Barite" density="3.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.003866475">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31286387">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0055278003">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0036870588">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042359836">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017690768">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00036536456">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.49076686">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11459208">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015333135">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0067465796">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Barium sulfate" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5884092">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13739117">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27419963">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Beryllia" density="2.63*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.36032657">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.63967343">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bi_4 Ge_3 O_12" density="7.1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.67102392">
+    <rMaterial name="materials:Bismuth"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1748602">
+    <rMaterial name="materials:Germanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15411587">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Borated Polyethyl." density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.116">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.612">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.222">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron" density="2.34*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18518519">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.81481481">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron-Barite" density="3.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0067292668">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34051688">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013925946">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0080541549">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013576194">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.044652146">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0011660794">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00088239182">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.8572377e-05">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0023924499">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01052678">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.45198295">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10553619">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron_frits-Lumnite" density="3.1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.006189139">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33104107">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054553968">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016633648">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.029078398">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020734192">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00052224672">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00060798896">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00045402481">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015404679">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0067780588">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012029137">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.46123883">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1076974">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C F_4" density="3.7037*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.13648398">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.86351602">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C O_2" density="1.8182*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27292145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.72707855">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C6F14" density="1.76*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.21318905">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.78681095">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CF_4 CO_2 50:50" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18196831">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.57564464">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24238706">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CO2Ar Freon" density="2.04*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017209441">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25354028">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.030543441">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016368527">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68233831">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CSC Electronics" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00046948789">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00014841431">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="8.081657e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.0118803e-07">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32063924">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.39047805">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28825623">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CT Al cable" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.67273024">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31187538">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015319366">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.5010078e-05">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CT Cu cable" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.87214714">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12183881">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0059847409">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="2.9303816e-05">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_New Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ca C O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.40043563">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47955758">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12000679">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ca O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.71469586">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28530414">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_0" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.47272949">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16266859">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041785423">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.23271447">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.143868e-05">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.039129523">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.050901068">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_MSGC_2" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.3625772">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12348903">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.036468221">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30679798">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="3.0189302e-05">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.074162202">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.096475172">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_MSGC_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.37934415">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12285748">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035749337">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29734771">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="2.9095785e-05">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.071569642">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.093102596">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_Si_1" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.61618264">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.082694045">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.044364552">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2563757">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00037658981">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="6.4825308e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Carbon fib.str." density="1.45*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6470534">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3529466">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Carbon fibre str." density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Carbon_fibre_str_Upgrade2" density="0.845*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  <CompositeMaterial name="Carbon fibre st_b" density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Carbon fibre str."/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Phase1 BPIX CFStrip material as defined by W. Bertl-->
+  <CompositeMaterial name="CFK" density="1.575*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Phase1 BPIX micro-twisted pairs signal cables material as defined by W. Bertl -->
+  <CompositeMaterial name="micro_twisted_signal_cable" density="4.09*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.476683">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.274139">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1494102">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02006116">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.07960754">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Phase1 BPIX micro-twisted pairs power cables material as defined by W. Bertl -->
+  <CompositeMaterial name="micro_twisted_power_cable" density="3.42*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.751011">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138483">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066287">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0089008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0353182">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+  <!--OUTDATED Phase1 BPIX micro-twisted pairs boundle material as defined by W. Bertl, effective density defined to matcht the measured weigth (0.0071+0.0208 g/cm) in a single 1.5mm diam. boundle-->
+  <CompositeMaterial name="micro_twisted_boundle" density="1.585*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7455">
+    <rMaterial name="materials:micro_twisted_power_cable"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2545">
+    <rMaterial name="materials:micro_twisted_signal_cable"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+  <!--Phase1 BPIX micro-twisted pairs boundle material as defined by L. Caminada-->
+  <CompositeMaterial name="micro_twisted_power_cable" density="3.639*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.36933">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.63067">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="micro_twisted_boundle_1" density="2.93382*g/cm3" symbol=" " method="mixture by weight"> <!--for L1-->
+   <MaterialFraction fraction="0.04631">
+    <rMaterial name="trackermaterial:T_Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.95369">
+    <rMaterial name="materials:micro_twisted_power_cable"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="micro_twisted_boundle_2" density="2.91735*g/cm3" symbol=" " method="mixture by weight"> <!--for L2,3,4-->
+   <MaterialFraction fraction="0.04964">
+    <rMaterial name="trackermaterial:T_Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.95036">
+    <rMaterial name="materials:micro_twisted_power_cable"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Carbon_fibre_str_Upgrade" density="0.293*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Carbon fibre str."/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ce F_3" density="6.16*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.71085768">
+    <rMaterial name="materials:Cerium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28914232">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ceramic" density="3.96525*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.52924272">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47075728">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Coil average" density="5.10794*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98933034">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010669663">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Colmanite Barite" density="3.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0033244208">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32054568">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.019644903">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00631619">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.021681066">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.024762714">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00091831559">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0071874954">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00057930956">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="8.1400861e-05">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0019024847">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0083709328">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47400649">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1106786">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Connector" density="1.119*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.12175975">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.029972928">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.075860931">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77184835">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00054859821">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.4434439e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Coolant" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012092387">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063980691">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24016253">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68376439">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Thick_Copper" density="8.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Crack average" density="1.85*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.1922">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0242">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2836">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cu/Quartz" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0081131524">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0092418886">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0011862487">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00011002641">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.98134868">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cu/Sci spaghetti mix" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012637483">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017671321">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00040177288">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00010044322">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0022298395">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.98286333">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cu/Scintillator/PolB" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.013621137">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0018577191">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.98179207">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00040133497">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00010033374">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0022274091">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DTBX gas" density="1.695*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.049996061">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25927645">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.69072749">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Dead_Argon CF_4 CO_2" density="2.14154*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Doped Quartz" density="2.5*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.28638718">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32623058">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38738224">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Double-sided MSGC el" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.15487536">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0062815446">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.062222733">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30743601">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12068891">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30724234">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041253098">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Double-sided MSGCsub" density="2.207*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.20936607">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36666251">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01999014">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36881246">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035168818">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Double-sided Si elec" density="2.392*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.25534309">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013472574">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.058711815">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1751292">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.023514409">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24970935">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22411956">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DropsPolyethylene" density="450*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="EAPD_Silicon" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Aluminium" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP1" density="1.6*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP2" density="700*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP3" density="400*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP4" density="300*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Cables" density="2.68*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DD_E_Cables" density="5.36*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+   <CompositeMaterial name="E_Carbon Fibre" density="1.45*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.65">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Copper" density="8.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Epoxy" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.53539691">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13179314">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33280996">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_G10" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.2198829">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.41718655">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26819334">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066018389">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028718811">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Iron" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Lead" density="11.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_PbWO4" density="8.28*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45532661">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.40403397">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14063942">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Polythene" density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Rohacell" density="71*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Silicon" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Water" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.11190083">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.88809917">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ec_Cable_1" density="2.12*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="EE_Aveolar" density="0.94*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.65">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Epoxy" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.53539691">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13179314">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33280996">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ethane" density="1.356*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.79887887">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20112113">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Fe_2 O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.69944958">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30055042">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Fibre_connector" density="1.05917*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.33154227">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38182349">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.064261825">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16677931">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.052722204">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028709009">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Flushing gas" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0010671918">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00033736021">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.8370396e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.1392493e-06">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99857594">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Foam" density="100*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Freon-12" density="4.93*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.099340816">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.58640112">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31425807">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FrontEnd Electronics" density="1.03441*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00065963049">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002085221">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.1354728e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.0416919e-07">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.45049813">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.54862165">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="G10" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.13232243">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032572448">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.48316123">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35194389">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="G_conntr" density="2.007*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.36065118">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38351407">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.051494019">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20434074">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Gas" density="1.9573*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.49078595">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.50287777">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0063362788">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Glass" density="2.23*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.36611059">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53173295">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.007820091">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0344084">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.059927964">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Graph.Epoxy Sup." density="138.3*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.80947966">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.073636829">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11688351">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Graphite Epoxy suprt" density="1.383*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.80947966">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.073636829">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11688351">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HFE" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012092387">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063980691">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24016253">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68376439">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HV Light Guides" density="1.32*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46726616">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53238309">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00034445206">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.9293189e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="3.677097e-07">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Aluminium" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Brass" density="8.53*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Iron" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Polystyrene" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Scintillator" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hcal average" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98854345">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="2.2305277e-06">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.0511343e-07">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="3.8395793e-08">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00034716943">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011106403">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hcal sci" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.92257895">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.07742105">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hexel for CSC" density="165*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0002303291">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.046295939">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35049864">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47901437">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11791403">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0060466926">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="High Tension cables" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45726783">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.44778783">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.070543148">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.024401185">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Honeycomb" density="280*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hybrids" density="1.785*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6459597">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.21237145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028514885">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11315397">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="ICB" density="2.309*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.26383847">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.097410682">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.023978583">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35568471">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25908755">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Insulation" density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.008091404">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043705226">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0029341267">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.023286651">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10908214">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.81290046">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Isobutane" density="2.67*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.82658619">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17341381">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="K_2 O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.83015022">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16984978">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kapton" density="1.11*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kr/Cu mixture for HD" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.054145746">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017829582">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0020989171">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054933281">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0046990226">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00099214713">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0007791868">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.91396207">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kr/Pb mixture for EM" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.38570939">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.45792903">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12700974">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001495172">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0089371927">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012776589">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0019728114">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00055505683">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0036150168">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kr/Pb mixture for HD" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.043537564">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.93041049">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014336428">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0016876993">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0044170805">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0037783947">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00079776662">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00062652927">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00040805081">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="LeadBPolymer" density="3.53*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.023">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0037037037">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016296296">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.114">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.102">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.088">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.022">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.618">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="LeadLoadedPolymerCon" density="3.53*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.023512713">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041643122">
+    <rMaterial name="materials:Lithium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11416406">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10198306">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.087818747">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01869691">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028328615">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013031207">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.59631732">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Limonite" density="2.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0097839501">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36018046">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012566469">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.008172324">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.57297034">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035392035">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00093441511">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Limonite Iron" density="4.16*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0077950891">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25025334">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035888928">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020743458">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.61983399">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.062339683">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0020806726">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010648449">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Limonite magetite" density="3.41*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0046317534">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33176807">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010582504">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.006612936">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.61641603">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.029106142">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00088255997">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Ar Detector" density="1.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Argon" density="1.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Kr Detector" density="2.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Krypton" density="2.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Lithium Polyethyl." density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.113">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.596">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.075">
+    <rMaterial name="materials:Lithium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.216">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron Polyethyl." density="1.02*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.81347018">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1365297">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0092592584">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040740732">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron PolyethylHD" density="1.40*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.81347018">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1365297">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0092592584">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040740732">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AntiLead" density="11.16*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.96">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04">
+    <rMaterial name="materials:Antimony"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Low Tension cables" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98029046">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016876977">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028325668">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Lucite" density="1.16*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="ME_free_space" density="0.254467*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.003218">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.157312">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.5388547e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020068">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.249899">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013999">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.555499">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MSGC cooling pipe" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.30132877">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.053356059">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.42345953">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22185565">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MSGC-Average" density="7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0016109746">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11608918">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.87746662">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004833228">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Al36" density="1.403*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.379586">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27524785">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26823734">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.045019923">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03190889">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Al48" density="1.373*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.40684004">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25552552">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26144891">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043880579">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032304952">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Al60" density="971*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.43940244">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22781143">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25517545">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042827665">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.034783015">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Al_cable" density="1.95062*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.69471035">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2614148">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043874854">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Cu_cable" density="9.4537*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91351941">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.074051989">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012428601">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_cntr" density="2.049*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27792206">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36612478">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.21351888">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028668949">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11376533">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Aluminium" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Argon 50pct CF_4 CO_2" density="2.1057*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.39336475">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11827135">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29931485">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18904904">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Argon CF_4 CO_2" density="2.1416*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_B_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Cables" density="2.68*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="NEMA G10 plate" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.2198829">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.41718655">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26819334">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066018389">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028718811">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Copper" density="8.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Thick_Steel-008" density="7.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00089992039">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015987127">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042943177">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017903506">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012830888">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5139401e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00029757275">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069973892">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99180725">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_DTBX Gas" density="1.695*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.049996061">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25927645">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.69072749">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Electronics averag" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.074565894">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77748634">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14794776">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_F_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_NEMA FR4 plate" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18077359">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.4056325">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27804208">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.068442752">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.067109079">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_RPC_Bakelite" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.074565894">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77748634">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14794776">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_RPC_Gas" density="1.87685*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017572792">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2588934">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.031188319">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016714124">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.67563137">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Steel-008" density="7.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00089992039">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015987127">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042943177">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017903506">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012830888">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5139401e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00029757275">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069973892">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99180725">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_YokeSteel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9825">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_honeycomb" density=" 0.0511415*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.97670111">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017460186">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0055195064">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00030055565">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.863911e-05">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cables" density="2.68*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Magetite" density="3.12*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0068217712">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34582528">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011586696">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0079728988">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.59461377">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032281783">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00089780071">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Magnet Conductor" density="3.157*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.097336411">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014292995">
+    <rMaterial name="materials:Niobium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017134031">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054482651">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.75894659">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10684171">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MagnetiteBoron" density="3.637*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.007">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0026">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0104">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.027">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.55">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MagnetiteConc" density="3.65*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0035">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0026">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0104">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3512">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0131">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0271">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5519">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Thick_MagnetiteConc" density="3.65*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0035">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0026">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0104">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3512">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0131">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0271">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5519">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Marble" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46021905">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53804265">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017382968">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Methane" density="0.717*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.74868663">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25131337">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mg O" density="3.58*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.60304188">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.39695812">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mg-MMC" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mn O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.77446185">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22553815">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Muon Al" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Muon average" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0012744281">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001149531">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002893993">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99728664">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mylar" density="1.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.62502108">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041960452">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33301847">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="NEMA FR4 plate" density="1.025*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18077359">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.4056325">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27804208">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.068442752">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.067109079">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_NEMA G10 plate" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.2198829">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.41718655">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26819334">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066018389">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028718811">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Na_2 O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.74186418">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25813582">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ne30_DME70" density="1.7*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.15805943">
+    <rMaterial name="materials:Neon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43902091">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29239429">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11052537">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ni_2 O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.70978275">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29021725">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Nomex" density="32*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.027815941">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31653768">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00047881724">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.077581544">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.57758601">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Nomex for CSC" density="28.9*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Noryl" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="O_Hybrid" density="2.838*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.17862818">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0038859926">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012801535">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11166264">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13680825">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.096505544">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.238333">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.027828501">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17363266">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.019913693">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Optical fibre" density="1.05*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Outer_pipes" density="2.533*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.49604605">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.006094006">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032243322">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12103086">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34458577">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="P_pipes" density="2.3285*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.32927494">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0007222183">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0019399576">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="8.087907e-05">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.7963526e-05">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="4.2979215e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00013442846">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00031610699">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.44804883">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.044156804">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17522489">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pb W O_4" density="8.28*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45532661">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.40403397">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14063942">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pb/Sci spaghetti mix" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.018845478">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017479474">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.97940657">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Peek" density="1.32*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.53539691">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13179314">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33280996">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="PhotoCathode" density="1.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Cesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pigtails" density="3.145*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.65753522">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20542786">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.027582577">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10945434">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pipe with Water" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.092022289">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.082576264">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29261257">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53278887">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pipe with gas" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18514234">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13149061">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24084727">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24888489">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1936349">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Plexiglas" density="1.18*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polycarbonate" density="7*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polyethylene" density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DD_Polyethylene" density="2*950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polymer Concrete" density="450*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.23789097">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43443755">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26294502">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.064726463">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polystyrene" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polyvinylchloride" density="1.38*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.38437771">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.048384356">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.56723794">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Px_cool_pipe" density="2.72629*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.54838378">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054611179">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028894718">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1084613">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30879909">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Quartz" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Quartz support" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="QuartzBundle" density="1.30515*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.41130114">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.46868914">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.056403482">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0052320714">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.057839878">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00052523876">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.0413398e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="QuartzFibers" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="RPC Gas" density="1.87685*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017572792">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2588934">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.031188319">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016714124">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.67563137">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Rohacell" density="0.052*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.60">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.08">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="SITRA-Average" density="7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="SMD_metal" density="10.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.045444306">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.80484958">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14970612">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="S_2 O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.57194838">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.42805162">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Scintillator" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Serpentine - Iron" density="3.765*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0089840293">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31549151">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11229814">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017986016">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0023751734">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.40725359">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.049064913">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.085014416">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015322121">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Serpentine 2" density="2.01*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017056138">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.52511018">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22286408">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028434767">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.055055747">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.048338182">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.095947828">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010639801">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042627075">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0018663973">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Si O_2" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Si cooling pipe" density="1.921*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.56814774">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19928206">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.026024798">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2065454">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Silica" density="2.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Silicon Detector" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Siliecal" density="1.0859*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.87264263">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12735737">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Single-sided MSGC el" density="2.44*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.30413689">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0014717137">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.058467105">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36931633">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15011919">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10269944">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013789342">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Single-sided MSGCsub" density="2.3258*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.33240081">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43382861">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017726182">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19998078">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016063621">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Single-sided Si elec" density="2.392*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.31484492">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014476209">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.050561611">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.114528">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015377551">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2652606">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22495111">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="StainlessSteel" density="8.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6996">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Stand.Concrete" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.006">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Thick_Stand.Concrete" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.006">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Standard Serpentine" density="2.302*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0096577278">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.52863475">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32556232">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.054746312">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.022623255">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028372381">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0012881659">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00095487516">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01557902">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012581187">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Steel-008" density="7.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00089992039">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015987127">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042943177">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017903506">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012830888">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5139401e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00029757275">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069973892">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99180725">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Steel-light" density="520*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6996">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Super Conductor" density="4.94*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.81579799">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.077846795">
+    <rMaterial name="materials:Niobium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.096238669">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010116543">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Brass" density="8.5*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.63">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.37">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="BGA" density="8.82*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.62">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Air" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Argon CF_4 CO_2" density="2.1416*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Bronze" density="8.89*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.94059406">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.059405941">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Carbon fibre str." density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Foam" density="100*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Kapton" density="1.4*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_MSGC-Average" density="230*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.8">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_OPC" density="1.05917*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.33154227">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38182349">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.064261825">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16677931">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.052722204">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028709009">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_OP_cable" density="601.463*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0086851733">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10083068">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.51167977">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.086185453">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28766708">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0049518353">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Bar_Det" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Bar_Hybrid" density="3.918*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.12227401">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020384302">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.23710889">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24417229">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17802235">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19803815">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Bar_Readout" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Fwd_Det" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Fwd_Readout" density="2.17525*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84842968">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063360581">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015596821">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.039385794">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.033227128">
+    <rMaterial name="materials:Indium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Silicon" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Silicon Detector" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Teflon" density="2.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.24018637">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.75981363">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ti_2 O_3" density="4.6*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.66612408">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33387592">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_Cable_1" density="942.8*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.4364364">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19550706">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.031331664">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.060965631">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043156039">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041667015">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15813109">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032805106">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_square_bundles" density="971*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45591441">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20422984">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032729696">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063679098">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.045081214">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043521896">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12057473">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03426911">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_support" density="5.25617*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="V_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="V_Iron" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="V_Quartz" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Vcal C4H10" density="2.67*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.82658619">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17341381">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Vcal CO2" density="1.98*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27292145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.72707855">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Vcal average" density="7.55*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0012701968">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015979957">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042923919">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017895477">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012825134">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5096736e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002974393">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069942512">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99136248">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.7766882e-05">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="W/Sci spaghetti mix" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0059212984">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00082799058">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00018825087">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="4.7062717e-05">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010447923">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99197061">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Water" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.11190083">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.88809917">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Wood" density="500*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.11684213">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.88315787">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="YokeSteel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9825">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="active_screen" density="11.197*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.025418913">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.085235146">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.50483588">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38451007">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="c_Peek" density="1.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45427914">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11182521">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36306779">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.070827858">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HV_Cu/QFib_mx." density="7.30515*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0247913">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00471238  ">
+    <rMaterial name="materials:Polystyrene"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04296 ">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.927536">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Borosilicate_Glass" density="2.51*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.303594">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0452533">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0556199">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0449903">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0222285">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0245335">
+    <rMaterial name="materials:Boron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0239803">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00459437">
+    <rMaterial name="materials:Antimony"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00001">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.475195">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Silicone_Gel" density="0.965*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.3866">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0973">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3616">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1545">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Barium_Titanate" density="6.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5889">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2053">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2058">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_PolyGrains" density="589*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CuNi" density="8.94*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Acrylate" density="1170*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.55814">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.06977">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.37209">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Inconel600" density="8.47*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7200">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0285">
+    <rMaterial name="materials:Cobalt"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1500">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0800">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0100">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0050">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0050">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kevlar" density="1.44*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.71180785">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11852895">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12699531">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04266788">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Tracker Cooling Fluids INIT -->
+  <!-- 3M type is the old one used for Thermal Screen only -->
+  <CompositeMaterial name="C6F14_3M_-15C" density="1.80340*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- F2 type is the new one used for subdetectors and preshower -->
+  <CompositeMaterial name="C6F14_F2_-30C" density="1.87917*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C6F14_F2_-20C" density="1.84675*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C6F14_F2_-10C" density="1.82033*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CO2_Upgrade" density="0.2033*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Vcal CO2"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bpix_CO2_-20C" density="1.0327*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27292145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.72707855">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  <!-- Tracker Cooling Fluids END -->
+  <!-- CASTOR materials -->
+  <CompositeMaterial name="Castor_QuartzFibers/Air_mx" density="2.1743080*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9999233027749">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0000766972251">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle6_QF/Air_mx" density="0.4808336*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99800842127">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00199157873">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle5_QF/Air_mx" density="0.5726188*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99841066074">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00158933926">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle4_QF/Air_mx" density="0.7092276*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99881654262">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00118345738">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle3_QF/Air_mx" density="1.1048788*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99942577695">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00057422305">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle2_QF/Air_mx" density="1.5612536*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99974500842">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00025499158">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle1_QF/Air_mx" density="2.2522530*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99998212349">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00001787651">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_LMixer_QF/Air_mx" density="2.2834241*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99998943692">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00001056308">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Electronics averag" density="1.4881*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.000560">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.999440">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Paper" density="1.55*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.448">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.056">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.496">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Coolant" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012092387">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063980691">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24016253">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68376439">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AlBeMet" density="2.071*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.380">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.615">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0045">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Rdout_Brd" density="1.79*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98667">
+    <rMaterial name="materials:G10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01333">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Kapton_Cu" density="1.24*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9836">
+    <rMaterial name="materials:Kapton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0164">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_GEM_Gas" density="1.8*mg/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.60">
+    <rMaterial name="materials:Argon"/>
+    </MaterialFraction>
+   <MaterialFraction fraction="0.083">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.145">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.172">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_GEM_Foil" density="1.74*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6565">
+    <rMaterial name="materials:Kapton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1013">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2422">
+    <rMaterial name="materials:M_GEM_Gas"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Diamond" density="3.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>   
+  <!--Materials added for BHM-->
+    <CompositeMaterial name="BorosilicateGlass" density="2.23*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.377220">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028191">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.003321">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.539562">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011644">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040064">
+    <rMaterial name="materials:Boron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bialkali" density="4.28*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.133">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.452">
+    <rMaterial name="materials:Cesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.415">
+    <rMaterial name="materials:Antimony"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="RTV" density="1.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0811">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3790">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3241">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2158">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="LYSO" density="7.11*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7145">
+    <rMaterial name="materials:Lutecium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0403">
+    <rMaterial name="materials:Yttrium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0637">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1815">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+ </MaterialSection>
+</DDDefinition>

--- a/SimG4Core/DD4hepGeometry/BuildFile.xml
+++ b/SimG4Core/DD4hepGeometry/BuildFile.xml
@@ -1,0 +1,10 @@
+<use   name="dd4hep"/>
+<use   name="geant4core"/>
+<use   name="Geometry/Records"/>
+<use   name="FWCore/MessageLogger"/>
+<use   name="FWCore/Utilities"/>
+<use   name="rootgeom"/>
+<use   name="rootmath"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/SimG4Core/DD4hepGeometry/interface/DD4hep_DDDWorld.h
+++ b/SimG4Core/DD4hepGeometry/interface/DD4hep_DDDWorld.h
@@ -1,0 +1,30 @@
+#ifndef SIMG4CORE_DD4HEP_DDDWORLD_H
+#define SIMG4CORE_DD4HEP_DDDWORLD_H
+
+#include "G4VPhysicalVolume.hh"
+
+namespace cms {
+
+  class DDDetector;
+  
+  class DDDWorld {
+
+  public:
+    DDDWorld(const cms::DDDetector*);
+    ~DDDWorld();
+    static void SetAsWorld(G4VPhysicalVolume* pv);
+    static void WorkerSetAsWorld(G4VPhysicalVolume* pv);
+    const G4VPhysicalVolume* GetWorldVolume() const { return m_world; }
+    
+    // In order to share the world volume with the worker threads, we
+    // need a non-const pointer. Thread-safety is handled inside Geant4
+    // with TLS. Should we consider a friend declaration here in order
+    // to avoid misuse?
+    G4VPhysicalVolume* GetWorldVolumeForWorker() const { return m_world; }
+
+  private:
+    G4VPhysicalVolume* m_world;
+  };
+}
+
+#endif

--- a/SimG4Core/DD4hepGeometry/interface/Geant4AssemblyVolume.h
+++ b/SimG4Core/DD4hepGeometry/interface/Geant4AssemblyVolume.h
@@ -1,0 +1,80 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Disable diagnostics for ROOT dictionaries
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
+
+#define private public
+#include "G4AssemblyVolume.hh"
+#undef private
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim {
+
+    /// Hack! Wrapper around G4AssemblyVolume to access protected members.
+    /**
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    class Geant4AssemblyVolume : public G4AssemblyVolume {
+      
+    public:
+
+      std::vector<const TGeoNode*> m_entries;
+      typedef std::vector<const TGeoNode*> Chain;
+
+      /// Default constructor with initialization
+      Geant4AssemblyVolume() {
+      }
+
+      /// Default destructor
+      virtual ~Geant4AssemblyVolume() {
+      }
+
+      //std::vector<G4AssemblyTriplet>& triplets()  { return fTriplets; }
+      long placeVolume(const TGeoNode* n, G4LogicalVolume* pPlacedVolume, G4Transform3D& transformation) {
+        size_t id = fTriplets.size();
+        m_entries.push_back(n);
+        this->AddPlacedVolume(pPlacedVolume, transformation);
+        return (long)id;
+      }
+
+      long placeAssembly(const TGeoNode* n, Geant4AssemblyVolume* pPlacedVolume, G4Transform3D& transformation) {
+        size_t id = fTriplets.size();
+        m_entries.push_back(n);
+        this->AddPlacedAssembly(pPlacedVolume, transformation);
+        return (long)id;
+      }
+
+      void imprint(Geant4GeometryInfo& info,
+                   const TGeoNode* n,
+                   Chain chain,
+                   Geant4AssemblyVolume* pAssembly,
+                   G4LogicalVolume*  pMotherLV,
+                   G4Transform3D&    transformation,
+                   G4int copyNumBase,
+                   G4bool surfCheck );
+    };
+  }
+}

--- a/SimG4Core/DD4hepGeometry/interface/Geant4Converter.h
+++ b/SimG4Core/DD4hepGeometry/interface/Geant4Converter.h
@@ -1,0 +1,126 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+#ifndef DD4HEP_GEANT4CONVERTER_H
+#define DD4HEP_GEANT4CONVERTER_H
+
+// Framework include files
+#include "DD4hep/Printout.h"
+//FIXME: #include "DDG4/Geant4Mapping.h"
+#include "SimG4Core/DD4hepGeometry/interface/Geant4Mapping.h"
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim {
+
+    /// Geometry converter from dd4hep to Geant 4.
+    /**
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    class Geant4Converter : public detail::GeoHandler, public Geant4Mapping {
+    public:
+      /// Property: Flag to debug materials during conversion mechanism
+      bool debugMaterials  = false;
+      /// Property: Flag to debug elements during conversion mechanism
+      bool debugElements   = false;
+      /// Property: Flag to debug shapes during conversion mechanism
+      bool debugShapes     = false;
+      /// Property: Flag to debug volumes during conversion mechanism
+      bool debugVolumes    = false;
+      /// Property: Flag to debug placements during conversion mechanism
+      bool debugPlacements = false;
+      /// Property: Flag to debug regions during conversion mechanism
+      bool debugRegions    = false;
+      /// Property: Flag to debug surfaces during conversion mechanism
+      bool debugSurfaces   = false;
+
+      /// Property: Flag to dump all placements after the conversion procedure
+      bool printPlacements = false;
+      /// Property: Flag to dump all sensitives after the conversion procedure
+      bool printSensitives = false;
+
+      /// Property: Check geometrical overlaps for volume placements and G4 imprints 
+      bool       checkOverlaps;
+      /// Property: Output level for debug printing
+      PrintLevel outputLevel;
+
+      /// Initializing Constructor
+      Geant4Converter(const Detector& description);
+
+      /// Initializing Constructor
+      Geant4Converter(Detector& description, PrintLevel level);
+
+      /// Standard destructor
+      virtual ~Geant4Converter();
+
+      /// Create geometry conversion
+      Geant4Converter& create(DetElement top);
+
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
+      /// Convert the geometry type material into the corresponding Geant4 object(s).
+      virtual void* handleMaterialProperties(TObject* matrix) const;
+
+      /// Convert the optical surface to Geant4
+      void* handleOpticalSurface(TObject* surface) const;
+
+      /// Convert the skin surface to Geant4
+      void* handleSkinSurface(TObject* surface) const;
+
+      /// Convert the border surface to Geant4
+      void* handleBorderSurface(TObject* surface) const;
+#endif
+      /// Convert the geometry type material into the corresponding Geant4 object(s).
+      virtual void* handleMaterial(const std::string& name, Material medium) const;
+
+      /// Convert the geometry type element into the corresponding Geant4 object(s).
+      virtual void* handleElement(const std::string& name, Atom element) const;
+
+      /// Convert the geometry type solid into the corresponding Geant4 object(s).
+      virtual void* handleSolid(const std::string& name, const TGeoShape* volume) const;
+
+      /// Convert the geometry type logical volume into the corresponding Geant4 object(s).
+      virtual void* handleVolume(const std::string& name, const TGeoVolume* volume) const;
+      virtual void* collectVolume(const std::string& name, const TGeoVolume* volume) const;
+
+      /// Convert the geometry type volume placement into the corresponding Geant4 object(s).
+      virtual void* handlePlacement(const std::string& name, const TGeoNode* node) const;
+      virtual void* handleAssembly(const std::string& name, const TGeoNode* node) const;
+
+      /// Convert the geometry type field into the corresponding Geant4 object(s).
+      ///virtual void* handleField(const std::string& name, Ref_t field) const;
+
+      /// Convert the geometry type region into the corresponding Geant4 object(s).
+      virtual void* handleRegion(Region region, const std::set<const TGeoVolume*>& volumes) const;
+
+      /// Convert the geometry visualisation attributes to the corresponding Geant4 object(s).
+      virtual void* handleVis(const std::string& name, VisAttr vis) const;
+
+      /// Convert the geometry type LimitSet into the corresponding Geant4 object(s).
+      virtual void* handleLimitSet(LimitSet limitset, const std::set<const TGeoVolume*>& volumes) const;
+
+      /// Handle the geant 4 specific properties
+      void handleProperties(Detector::Properties& prp) const;
+
+      /// Print the geometry type SensitiveDetector
+      virtual void printSensitive(SensitiveDetector sens_det, const std::set<const TGeoVolume*>& volumes) const;
+
+      /// Print Geant4 placement
+      virtual void* printPlacement(const std::string& name, const TGeoNode* node) const;
+    };
+  }    // End namespace sim
+}      // End namespace dd4hep
+
+#endif // DD4HEP_GEANT4CONVERTER_H

--- a/SimG4Core/DD4hepGeometry/interface/Geant4GeometryInfo.h
+++ b/SimG4Core/DD4hepGeometry/interface/Geant4GeometryInfo.h
@@ -1,0 +1,144 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+#ifndef DD4HEP_DDG4_GEANT4GEOMETRYINFO_H
+#define DD4HEP_DDG4_GEANT4GEOMETRYINFO_H
+
+// Framework include files
+#include "DD4hep/Objects.h"
+#include "DD4hep/Printout.h"
+#include "DD4hep/GeoHandler.h"
+//#include "DD4hep/PropertyTable.h"
+//FIXME: #include "DDG4/Geant4Primitives.h"
+#include "DD4hep/Primitives.h" //???
+
+// C/C++ include files
+#include <map>
+#include <vector>
+
+// Forward declarations (TGeo)
+class TGeoElement;
+class TGeoMedium;
+class TGeoVolume;
+class TGeoShape;
+class TGeoNode;
+// Forward declarations (Geant4)
+class G4Element;
+class G4Material;
+class G4VSolid;
+class G4LogicalVolume;
+class G4Region;
+class G4UserLimits;
+class G4VisAttributes;
+class G4VPhysicalVolume;
+class G4OpticalSurface;
+class G4LogicalSkinSurface;
+class G4LogicalBorderSurface;
+class G4AssemblyVolume;
+class G4VSensitiveDetector;
+class G4PhysicsOrderedFreeVector;
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim {
+
+    // Forward declarations
+    class Geant4Mapping;
+    class Geant4AssemblyVolume;
+
+    /// Helper namespace defining data types for the relation information between geant4 objects and dd4hep objects.
+    /**
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    namespace Geant4GeometryMaps  {
+      //typedef std::vector<const G4VPhysicalVolume*>           Geant4PlacementPath;
+      typedef std::map<Atom, G4Element*>                      ElementMap;
+      typedef std::map<Material, G4Material*>                 MaterialMap;
+      //typedef std::map<LimitSet, G4UserLimits*>               LimitMap;
+      typedef std::map<PlacedVolume, G4VPhysicalVolume*>      PlacementMap;
+      //typedef std::map<Region, G4Region*>                     RegionMap;
+      typedef std::map<Volume, G4LogicalVolume*>              VolumeMap;
+      typedef std::map<PlacedVolume, Geant4AssemblyVolume*>   AssemblyMap;
+
+      typedef std::vector<const TGeoNode*>                    VolumeChain;
+      typedef std::pair<VolumeChain,const G4VPhysicalVolume*> ImprintEntry;
+      typedef std::vector<ImprintEntry>                       Imprints;
+      typedef std::map<Volume,Imprints>                       VolumeImprintMap;
+      typedef std::map<const TGeoShape*, G4VSolid*>           SolidMap;
+      //typedef std::map<VisAttr, G4VisAttributes*>             VisMap;
+      //typedef std::map<Geant4PlacementPath, VolumeID>         Geant4PathMap;
+    }
+
+    /// Concreate class holding the relation information between geant4 objects and dd4hep objects.
+    /**
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    class Geant4GeometryInfo : public TNamed, public detail::GeoHandlerTypes::GeometryInfo {
+    public:
+      typedef std::vector<const G4VPhysicalVolume*>           Geant4PlacementPath;
+      TGeoManager*                         manager = 0;
+      Geant4GeometryMaps::ElementMap       g4Elements;
+      Geant4GeometryMaps::MaterialMap      g4Materials;
+      Geant4GeometryMaps::SolidMap         g4Solids;
+      Geant4GeometryMaps::VolumeMap        g4Volumes;
+      Geant4GeometryMaps::PlacementMap     g4Placements;
+      Geant4GeometryMaps::AssemblyMap      g4AssemblyVolumes;
+      Geant4GeometryMaps::VolumeImprintMap g4VolumeImprints;
+      struct PropertyVector  {
+        std::vector<double> bins;
+        std::vector<double> values;
+        std::string name, title;
+        PropertyVector() = default;
+        ~PropertyVector() = default;
+      };
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
+      std::map<PropertyTable,  PropertyVector*>                g4OpticalProperties;
+      std::map<OpticalSurface, G4OpticalSurface*>              g4OpticalSurfaces;
+      std::map<SkinSurface,    G4LogicalSkinSurface*>          g4SkinSurfaces;
+      std::map<BorderSurface,  G4LogicalBorderSurface*>        g4BorderSurfaces;
+#endif
+      std::map<Region, G4Region*>                              g4Regions;
+      std::map<VisAttr, G4VisAttributes*>                      g4Vis;
+      std::map<LimitSet, G4UserLimits*>                        g4Limits;
+      std::map<Geant4PlacementPath, VolumeID>                  g4Paths;
+      std::map<SensitiveDetector,std::set<const TGeoVolume*> > sensitives;
+      std::map<Region,           std::set<const TGeoVolume*> > regions;
+      std::map<LimitSet,         std::set<const TGeoVolume*> > limits;
+      G4VPhysicalVolume*                                       m_world;
+      PrintLevel                                               printLevel;
+      bool                                                     valid;
+    private:
+      friend class Geant4Mapping;
+      /// Default constructor
+      Geant4GeometryInfo();
+      /// Default destructor
+      virtual ~Geant4GeometryInfo();
+    public:
+      /// The world placement
+      G4VPhysicalVolume* world() const;
+      /// Set the world volume
+      void setWorld(const TGeoNode* node);
+      /// Assemble Geant4 volume path
+      static std::string placementPath(const Geant4PlacementPath& path, bool reverse=true);
+    };
+
+  }    // End namespace sim
+}      // End namespace dd4hep
+
+#endif // DD4HEP_DDG4_GEANT4GEOMETRYINFO_H

--- a/SimG4Core/DD4hepGeometry/interface/Geant4Mapping.h
+++ b/SimG4Core/DD4hepGeometry/interface/Geant4Mapping.h
@@ -1,0 +1,86 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+#ifndef DD4HEP_DDG4_GEANT4MAPPING_H
+#define DD4HEP_DDG4_GEANT4MAPPING_H
+
+// Framework include files
+#include "DD4hep/Detector.h"
+#include "DD4hep/Volumes.h"
+#include "DD4hep/GeoHandler.h"
+//FIXME: #include "DDG4/Geant4GeometryInfo.h"
+#include "SimG4Core/DD4hepGeometry/interface/Geant4GeometryInfo.h"
+//FIXME: #include "DDG4/Geant4VolumeManager.h"
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim {
+
+    /// Geometry mapping from dd4hep to Geant 4.
+    /**
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    class Geant4Mapping: public detail::GeoHandlerTypes {
+    protected:
+      const Detector& m_detDesc;
+      Geant4GeometryInfo* m_dataPtr;
+
+      /// When resolving pointers, we must check for the validity of the data block
+      void checkValidity() const;
+    public:
+      /// Initializing Constructor
+      Geant4Mapping(const Detector& description);
+
+      /// Standard destructor
+      virtual ~Geant4Mapping();
+
+      /// Possibility to define a singleton instance
+      static Geant4Mapping& instance();
+
+      /// Accesor to the Detector instance
+      const Detector& detectorDescription() const {
+        return m_detDesc;
+      }
+
+      /// Access to the data pointer
+      Geant4GeometryInfo& data() const {
+        return *m_dataPtr;
+      }
+
+      /// Access to the data pointer
+      Geant4GeometryInfo* ptr() const {
+        return m_dataPtr;
+      }
+
+      /// Create and attach new data block. Delete old data block if present.
+      Geant4GeometryInfo& init();
+
+      /// Release data and pass over the ownership
+      Geant4GeometryInfo* detach();
+
+      /// Set a new data block
+      void attach(Geant4GeometryInfo* data);
+
+      /// Access the volume manager
+      //Geant4VolumeManager volumeManager() const;
+
+      /// Accessor to resolve geometry placements
+      PlacedVolume placement(const G4VPhysicalVolume* node) const;
+    };
+  }    // End namespace sim
+}      // End namespace dd4hep
+
+#endif // DD4HEP_DDG4_GEANT4MAPPING_H

--- a/SimG4Core/DD4hepGeometry/interface/Geant4Particle.h
+++ b/SimG4Core/DD4hepGeometry/interface/Geant4Particle.h
@@ -1,0 +1,355 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+#ifndef DD4HEP_GEANT4PARTICLE_H
+#define DD4HEP_GEANT4PARTICLE_H
+
+// Framework include files
+#include "DD4hep/Memory.h"
+
+// ROOT includes
+#include "Math/Vector4D.h"
+
+// Geant4 forward declarations
+class G4ParticleDefinition;
+class G4VProcess;
+
+// C/C++ include files
+#include <set>
+#include <map>
+#include <vector>
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim {
+
+    // Forward declarations
+    class Geant4Particle;
+
+    /// Base class to extend the basic particle class used by DDG4 with user information
+    /**
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    class ParticleExtension  {
+    public:
+      /// Default constructor
+      ParticleExtension() {}
+      /// Default destructor
+      virtual ~ParticleExtension();
+    };
+
+    /// Track properties
+    enum Geant4ParticleProperties {
+      G4PARTICLE_CREATED_HIT = 1<<1,
+      G4PARTICLE_PRIMARY = 1<<2,
+      G4PARTICLE_HAS_SECONDARIES = 1<<3,
+      G4PARTICLE_ABOVE_ENERGY_THRESHOLD = 1<<4,
+      G4PARTICLE_KEEP_PROCESS = 1<<5,
+      G4PARTICLE_KEEP_PARENT = 1<<6,
+      G4PARTICLE_CREATED_CALORIMETER_HIT = 1<<7,
+      G4PARTICLE_CREATED_TRACKER_HIT = 1<<8,
+      G4PARTICLE_KEEP_USER = 1<<9,
+      G4PARTICLE_KEEP_ALWAYS = 1<<10,
+      G4PARTICLE_FORCE_KILL = 1<<11,
+
+      // Generator status for a given particles: bit 0...4, agreed by many formats (HepMC, LCIO, ....):
+      G4PARTICLE_GEN_EMPTY           = 1<<0,  // Empty line
+      G4PARTICLE_GEN_STABLE          = 1<<1,  // undecayed particle, stable in the generator
+      G4PARTICLE_GEN_DECAYED         = 1<<2,  // particle decayed in the generator
+      G4PARTICLE_GEN_DOCUMENTATION   = 1<<3,  // documentation line
+      G4PARTICLE_GEN_BEAM            = 1<<4,  // beam particle
+
+      G4PARTICLE_GEN_OTHER           = 1<<9,  // any other generator status
+
+      G4PARTICLE_GEN_GENERATOR       =        // Particle comes from generator
+      (  G4PARTICLE_GEN_EMPTY+G4PARTICLE_GEN_STABLE+
+         G4PARTICLE_GEN_DECAYED+G4PARTICLE_GEN_DOCUMENTATION+
+         G4PARTICLE_GEN_BEAM+G4PARTICLE_GEN_OTHER),
+      G4PARTICLE_GEN_STATUS          = 0x3FF, // Mask for generator status (bit 0...9)
+      G4PARTICLE_GEN_STATUS_MASK     = 0xFFFF,// Mask for the raw generator status (max 65k values)
+      // Simulation status of a given particle
+      G4PARTICLE_SIM_CREATED         = 1<<10, // True if the particle has been created by the simulation program (rather than the generator)
+      G4PARTICLE_SIM_BACKSCATTER     = 1<<11, // True if the particle is the result of a backscatter from a calorimeter shower.
+      G4PARTICLE_SIM_DECAY_CALO      = 1<<12, // True if the particle has interacted in a calorimeter region.
+      G4PARTICLE_SIM_DECAY_TRACKER   = 1<<13, // True if the particle has interacted in a tracking region.
+      G4PARTICLE_SIM_STOPPED         = 1<<14, // True if the particle has been stopped by the simulation program.
+      G4PARTICLE_SIM_LEFT_DETECTOR   = 1<<15, // True if the particle has left the world volume undecayed.
+      G4PARTICLE_SIM_PARENT_RADIATED = 1<<16, // True if the particle's vertex is not the endpoint of the  parent particle.
+      G4PARTICLE_SIM_OVERLAY         = 1<<17, // True if the particle has been overlayed by the simulation (or digitization)  program.
+
+      G4PARTICLE_LAST_NOTHING = 1<<31
+    };
+
+
+
+    /// Data structure to store the MC particle information
+    /**
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    class Geant4Particle {
+    public:
+      typedef std::set<int> Particles;
+      /// Reference counter
+      int ref = 0;           //! not persistent
+      int id  = 0;
+      int originalG4ID = 0;  //! not persistent
+      int g4Parent = 0, reason = 0, mask = 0;
+      int steps  = 0, secondaries = 0, pdgID = 0;
+      int status = 0, colorFlow[2] {0,0};
+      unsigned short genStatus= 0;
+      char  charge = 0;
+      char  _spare[1] {0};
+      float spin[3] {0E0,0E0,0E0};
+      // 12 ints + 4 bytes + 3 floats should be aligned to 8 bytes....
+      double vsx  = 0E0, vsy  = 0E0, vsz = 0E0;
+      double vex  = 0E0, vey  = 0E0, vez = 0E0;
+      double psx  = 0E0, psy  = 0E0, psz = 0E0;
+      double pex  = 0E0, pey  = 0E0, pez = 0E0;
+      double mass = 0E0, time = 0E0, properTime = 0E0;
+      /// The list of daughters of this MC particle
+      Particles parents;
+      Particles daughters;
+
+      /// User data extension if required
+#ifdef DD4HEP_DD4HEP_PTR_AUTO
+      dd4hep_ptr<ParticleExtension> extension;
+#else
+      dd4hep_ptr<ParticleExtension> extension;   //! not persisten. ROOT cannot handle
+#endif
+      const G4VProcess *process = 0;             //! not persistent
+      /// Default constructor
+      Geant4Particle();
+      /// Constructor with ID initialization
+      Geant4Particle(int part_id);
+      /// NO copy constructor
+      Geant4Particle(const Geant4Particle& copy) = delete;
+      /// Default destructor
+      virtual ~Geant4Particle();
+      /// NO assignment operation
+      Geant4Particle& operator=(const Geant4Particle& copy) = delete;
+      /// Increase reference count
+      Geant4Particle* addRef()  {
+        ++ref;
+        return this;
+      }
+      /// Decrease reference count. Deletes object if NULL
+      void release();
+      /// Assignment operator
+      Geant4Particle& get_data(Geant4Particle& c);
+      /// Remove daughter from set
+      void removeDaughter(int id_daughter);
+      /// Charge accessor (for python etc.)
+      int charge3() const  {  return charge; }
+    };
+
+#ifndef __DDG4_STANDALONE_DICTIONARIES__
+
+    /// Data structure to access derived MC particle information
+    /**
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    class Geant4ParticleHandle {
+    public:
+      typedef ROOT::Math::PxPyPzM4D<double> FourVector;
+      typedef ROOT::Math::Cartesian3D<double> ThreeVector;
+    protected:
+      /// Particle pointer
+      Geant4Particle* particle;
+    public:
+      /// Default constructor
+      Geant4ParticleHandle(Geant4Particle* part);
+      /// Initializing constructor
+      Geant4ParticleHandle(const Geant4ParticleHandle& h);
+      /// Assignment operator
+      Geant4ParticleHandle& operator=(Geant4Particle* part);
+      /// Overloaded -> operator to access particle details
+      Geant4Particle* operator->() const;
+      /// Conversion  operator to pointer
+      operator Geant4Particle*() const;
+      /// Accessor to the number of particle parents
+      size_t numParent() const;
+      /// Accessor to the number of particle daughters
+      size_t numDaughter() const;
+      /// Scalar particle momentum squared
+      double momentum2() const;
+      /// Scalar particle energy
+      double energy() const;
+      /// Scalar particle momentum
+      double momentum() const   {  return std::sqrt(momentum2());  }
+      /// Geant4 charge of the particle
+      double charge()  const    { return double(particle->charge); }
+      /// Geant4 mass of the particle
+      double mass() const       { return particle->mass;           }
+      /// Geant4 time of the particle
+      double time() const       { return particle->time;           }
+      /// Access to the Geant4 particle name
+      std::string particleName() const;
+      /// Access to the Geant4 particle type
+      std::string particleType() const;
+      /// Access to the creator process name
+      std::string processName() const;
+      /// Access to the creator process type name
+      std::string processTypeName() const;
+      /// Access patricle momentum, energy as 4 vector
+      FourVector pxPyPzM() const;
+      /// Access patricle momentum, energy as 4 vector
+      ThreeVector startVertex() const;
+      /// Access patricle momentum, energy as 4 vector
+      ThreeVector endVertex()  const;
+      /// Access the Geant4 particle definition object (expensive!)
+      const G4ParticleDefinition *definition() const;
+
+      /// Various output formats:
+
+      /// Output type 1:+++ "tag"   10 def:0xde4eaa8 [gamma     ,   gamma] reason:      20 E:+1.017927e+03  \#Par:  1/4    \#Dau:  2
+      void dump1(int level, const std::string& src, const char* tag) const;
+      /// Output type 2:+++ "tag"   20 G4:   7 def:0xde4eaa8 [gamma     ,   gamma] reason:      20 E:+3.304035e+01 in record:YES  \#Par:  1/18   \#Dau:  0
+      void dump2(int level, const std::string& src, const char* tag, int g4id, bool inrec) const;
+      /// Output type 3:+++ "tag" ID:  0 e-           status:00000014 type:       11 Vertex:(+0.00e+00,+0.00e+00,+0.00e+00) [mm] time: +0.00e+00 [ns] \#Par:  0 \#Dau:  4
+      void dumpWithVertex(int level, const std::string& src, const char* tag) const;
+      void dumpWithMomentum(int level, const std::string& src, const char* tag) const;
+      void dumpWithMomentumAndVertex(int level, const std::string& src, const char* tag) const;
+      static void header4(int level, const std::string& src, const char* tag);
+      void dump4(int level, const std::string& src, const char* tag) const;
+
+      /// Handlers
+
+      /// Offset all particle identifiers (id, parents, daughters) by a constant number
+      void offset(int off)  const;
+
+      /// Access Geant4 particle definitions by regular expression
+      static std::vector<G4ParticleDefinition*> g4DefinitionsRegEx(const std::string& expression);
+      /// Access Geant4 particle definitions by exact match
+      static G4ParticleDefinition* g4DefinitionsExact(const std::string& expression);
+    };
+
+    inline Geant4ParticleHandle::Geant4ParticleHandle(const Geant4ParticleHandle& c)
+      : particle(c.particle) {
+    }
+
+    /// Initializing constructor
+    inline Geant4ParticleHandle::Geant4ParticleHandle(Geant4Particle* p)
+      : particle(p)  {
+    }
+
+    /// Overloaded -> operator to access particle details
+    inline Geant4Particle* Geant4ParticleHandle::operator->() const  {
+      return particle;
+    }
+    /// Assignment operator
+    inline Geant4ParticleHandle& Geant4ParticleHandle::operator=(Geant4Particle* part) {
+      particle = part;
+      return *this;
+    }
+    /// Conversion  operator to pointer
+    inline Geant4ParticleHandle::operator Geant4Particle*() const  {
+      return particle;
+    }
+    /// Accessor to the number of particle parents
+    inline size_t Geant4ParticleHandle::numParent() const   {
+      return particle->parents.size();
+    }
+    /// Accessor to the number of particle daughters
+    inline size_t Geant4ParticleHandle::numDaughter() const   {
+      return particle->daughters.size();
+    }
+    /// Access patricle momentum, energy as 4 vector
+    inline ROOT::Math::PxPyPzM4D<double> Geant4ParticleHandle::pxPyPzM() const {
+      const Geant4Particle* p = particle;
+      return ROOT::Math::PxPyPzM4D<double>(p->psx,p->psy,p->psz,p->mass);
+    }
+
+    /// Access patricle momentum, energy as 4 vector
+    inline ROOT::Math::Cartesian3D<double> Geant4ParticleHandle::startVertex() const {
+      const Geant4Particle* p = particle;
+      return ROOT::Math::Cartesian3D<double>(p->vsx,p->vsy,p->vsz);
+    }
+
+    /// Access patricle momentum, energy as 4 vector
+    inline ROOT::Math::Cartesian3D<double> Geant4ParticleHandle::endVertex()  const {
+      const Geant4Particle* p = particle;
+      return ROOT::Math::Cartesian3D<double>(p->vex,p->vey,p->vez);
+    }
+
+    /// Scalar particle energy
+    inline double Geant4ParticleHandle::energy() const {
+      const Geant4Particle* p = particle;
+      ROOT::Math::PxPyPzM4D<double> v(p->psx,p->psy,p->psz,p->mass);
+      return v.E();
+    }
+
+    /// Scalar particle momentum squared
+    inline double Geant4ParticleHandle::momentum2() const  {
+      const Geant4Particle* p = particle;
+      return (p->psx*p->psx + p->psy*p->psy + p->psz*p->psz);
+    }
+
+    /// Data structure to map particles produced during the generation and the simulation
+    /**
+     *  This data structure is added to the Geant4Event data extensions
+     *  by the Geant4GenerationInit action.
+     *  Particles are added:
+     *  - During the generation if the required modules are activated
+     *  - At the end of the handling of the MC truth are particles to be kept
+     *    are inserted if the required modules are activated such as the
+     *    Geant4ParticleHandler.
+     *
+     *  Note: This object takes OWNERSHIP of the inserted particles!
+     *        beware of double deletion of objects!
+     *
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    class Geant4ParticleMap  {
+    public:
+      typedef Geant4Particle          Particle;
+      typedef std::map<int,Particle*> ParticleMap;
+      typedef std::map<int,int>       TrackEquivalents;
+      /// Mapping of particles of this event
+      ParticleMap particleMap; //! not persistent
+      /// Map associating the G4Track identifiers with identifiers of existing MCParticles
+      TrackEquivalents equivalentTracks;
+
+      /// Default constructor
+      Geant4ParticleMap() {}
+      /// Default destructor
+      virtual ~Geant4ParticleMap();
+      /// Check if the particle map was ever filled (ie. some particle handler was present)
+      bool isValid() const;
+      /// Dump content
+      void dump()  const;
+      /// Clear particle maps
+      void clear();
+      /// Adopt particle maps
+      void adopt(ParticleMap& pm, TrackEquivalents& equiv);
+      /// Access the particle map
+      const ParticleMap& particles() const  {  return particleMap; }
+      /// Access the map of track equivalents
+      const TrackEquivalents& equivalents() const  {  return equivalentTracks;  }
+      /// Access the equivalent track id (shortcut to the usage of TrackEquivalents)
+      int particleID(int track, bool throw_if_not_found=true) const;
+    };
+#endif
+
+  }    // End namespace sim
+}      // End namespace dd4hep
+#endif // DD4HEP_GEANT4PARTICLE_H

--- a/SimG4Core/DD4hepGeometry/interface/Geant4UserLimits.h
+++ b/SimG4Core/DD4hepGeometry/interface/Geant4UserLimits.h
@@ -1,0 +1,103 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+#ifndef DD4HEP_DDG4_GEANT4USERLIMITS_H
+#define DD4HEP_DDG4_GEANT4USERLIMITS_H
+
+// Framework include files
+#include "DD4hep/Objects.h"
+
+// Geant 4 include files
+#include "G4UserLimits.hh"
+
+// Forward declarations
+class G4ParticleDefinition;
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim {
+
+    /// Helper to dump Geant4 volume hierarchy
+    /**
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    class Geant4UserLimits : public  G4UserLimits {
+    public:
+      /// Helper class to one limit type
+      /**
+       *  \author  M.Frank
+       *  \version 1.0
+       *  \ingroup DD4HEP_SIMULATION
+       */
+      struct Handler  {
+      public:
+        /// Default value (either from base class or value if Limit.particles='*')
+        double                defaultValue = 0.0;
+        /// Handler particle ids for the limit (pdgID)
+        std::map<const G4ParticleDefinition*, double> particleLimits;
+      public:
+        /// Default constructor
+        Handler() = default;
+        /// Set the handler value(s)
+        void set(const std::string& particles, double val);
+        /// Access value according to track
+        double value(const G4Track& track) const;
+      };
+      /// Handle to the limitset to be applied.
+      LimitSet  limits;
+      /// Handler map for MaxStepLength limit
+      Handler   maxStepLength;
+      /// Handler map for MaxTrackLength limit
+      Handler   maxTrackLength;
+      /// Handler map for MaxTime limit
+      Handler   maxTime;
+      /// Handler map for MinEKine limit
+      Handler   minEKine;
+      /// Handler map for MinRange limit
+      Handler   minRange;
+
+    public:
+      /// Initializing Constructor
+      Geant4UserLimits(LimitSet ls);
+      /// Standard destructor
+      virtual ~Geant4UserLimits();
+      /// Access the user tracklength for a G4 track object
+      virtual G4double GetMaxAllowedStep(const G4Track& track)
+      {  return maxStepLength.value(track);    }
+      /// Access the user tracklength for a G4 track object
+      virtual G4double GetUserMaxTrackLength(const G4Track& track)
+      {  return maxTrackLength.value(track);   }
+      /// Access the proper time cut for a G4 track object
+      virtual G4double GetUserMaxTime (const G4Track& track)
+      {  return maxTime.value(track);          }
+      /// Access the kinetic energy cut for a G4 track object
+      virtual G4double GetUserMinEkine(const G4Track& track)
+      {  return minEKine.value(track);         }
+      /// Access the range cut for a G4 track object
+      virtual G4double GetUserMinRange(const G4Track& track)
+      {  return minRange.value(track);         }
+      /// Setters may not be called!
+      virtual void SetMaxAllowedStep(G4double ustepMax);    
+      virtual void SetUserMaxTrackLength(G4double utrakMax);
+      virtual void SetUserMaxTime(G4double utimeMax);
+      virtual void SetUserMinEkine(G4double uekinMin);
+      virtual void SetUserMinRange(G4double urangMin);
+    };
+  }
+}
+
+#endif  // DD4HEP_DDG4_GEANT4USERLIMITS_H

--- a/SimG4Core/DD4hepGeometry/plugins/BuildFile.xml
+++ b/SimG4Core/DD4hepGeometry/plugins/BuildFile.xml
@@ -1,0 +1,21 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/PluginManager"/>
+<use name="FWCore/ParameterSet"/>
+<use name="dd4hep"/>
+<use name="DetectorDescription/DDCMS"/>
+
+<library name="DD4hepGeometryPlugins" file="*.cc">
+  <use name="DataFormats/GeometryVector"/>
+  <use name="SimG4Core/Notification"/>
+  <use name="SimG4Core/Watcher"/>
+  <use name="SimG4Core/DD4hepGeometry"/>
+  <use name="SimG4Core/SensitiveDetector"/>
+  <use name="SimG4Core/MagneticField"/>
+  <use name="MagneticField/Engine"/>
+  <use name="MagneticField/Records"/>
+  <use name="geant4core"/>
+  <use name="Geometry/Records"/>
+  <lib name="Geom"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
+

--- a/SimG4Core/DD4hepGeometry/plugins/DD4hep_DDTestG4Geometry.cc
+++ b/SimG4Core/DD4hepGeometry/plugins/DD4hep_DDTestG4Geometry.cc
@@ -1,0 +1,65 @@
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DetectorDescription/DDCMS/interface/DetectorDescriptionRcd.h"
+#include "DetectorDescription/DDCMS/interface/DDDetector.h"
+#include "DetectorDescription/DDCMS/interface/DDVectorRegistryRcd.h"
+#include "DetectorDescription/DDCMS/interface/DDVectorRegistry.h"
+#include "SimG4Core/DD4hepGeometry/interface/Geant4Converter.h"
+#include "DD4hep/Detector.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace cms;
+using namespace edm;
+using namespace dd4hep;
+
+class DDTestG4Geometry : public one::EDAnalyzer<> {
+public:
+  explicit DDTestG4Geometry(const ParameterSet&);
+
+  void beginJob() override {}
+  void analyze(Event const& iEvent, EventSetup const&) override;
+  void endJob() override {}
+
+private:  
+  const ESInputTag m_tag;
+  const string m_detElementPath;
+  const string m_placedVolPath;
+
+};
+
+DDTestG4Geometry::DDTestG4Geometry(const ParameterSet& iConfig)
+  : m_tag(iConfig.getParameter<ESInputTag>("DDDetector"))
+{}
+
+void
+DDTestG4Geometry::analyze(const Event&, const EventSetup& iEventSetup)
+{
+  LogVerbatim("Geometry") << "\nDDTestG4Geometry::analyze: " << m_tag;
+
+  const DDVectorRegistryRcd& regRecord = iEventSetup.get<DDVectorRegistryRcd>();
+  ESTransientHandle<DDVectorRegistry> reg;
+  regRecord.get(m_tag.module(), reg);
+
+  const DetectorDescriptionRcd& ddRecord = iEventSetup.get<DetectorDescriptionRcd>();
+  ESTransientHandle<DDDetector> ddd;
+  ddRecord.get(m_tag.module(), ddd);
+    
+  const dd4hep::Detector& detector = *ddd->description();
+  dd4hep::sim::Geant4Converter g4Geo = dd4hep::sim::Geant4Converter(detector);
+  g4Geo.debugMaterials = true;
+  g4Geo.debugElements = true;
+  g4Geo.debugShapes = true;
+  g4Geo.debugVolumes = true;
+  g4Geo.debugPlacements = true;
+  g4Geo.create(detector.world());
+  
+  LogVerbatim("Geometry") << "Done.";
+}
+
+DEFINE_FWK_MODULE(DDTestG4Geometry);

--- a/SimG4Core/DD4hepGeometry/plugins/DD4hep_GeometryESProducer.cc
+++ b/SimG4Core/DD4hepGeometry/plugins/DD4hep_GeometryESProducer.cc
@@ -1,0 +1,221 @@
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "SimG4Core/Notification/interface/SimActivityRegistry.h"
+#include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h"
+#include "SimG4Core/Watcher/interface/SimProducer.h"
+#include "SimG4Core/Watcher/interface/SimWatcherFactory.h"
+#include "SimG4Core/Geometry/interface/DDDWorld.h"
+#include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
+#include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
+#include "SimG4Core/MagneticField/interface/FieldBuilder.h"
+#include "SimG4Core/MagneticField/interface/CMSFieldManager.h"
+#include "SimG4Core/MagneticField/interface/Field.h"
+#include "SimG4Core/Notification/interface/SimTrackManager.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+
+#include "G4RunManagerKernel.hh"
+#include "G4TransportationManager.hh"
+
+#include <iostream>
+
+#include <memory>
+
+namespace sim { class FieldBuilder; }
+
+class SimWatcher;
+class SimProducer;
+class DDDWorld;
+class G4RunManagerKernel;
+class SimTrackManager;
+
+using namespace edm;
+using namespace std;
+using namespace cms;
+
+static
+void createWatchers(const ParameterSet& iP, SimActivityRegistry& iReg,
+		    vector<shared_ptr<SimWatcher>>& oWatchers,
+		    vector<shared_ptr<SimProducer>>& oProds)
+{
+  using Exception = cms::Exception;
+  vector<ParameterSet> watchers;
+  try { watchers = iP.getParameter<vector<ParameterSet> >("Watchers"); } 
+  catch(Exception const&) {}
+  
+  for(vector<ParameterSet>::iterator itWatcher = watchers.begin();
+      itWatcher != watchers.end(); ++itWatcher) {
+    unique_ptr<SimWatcherMakerBase> 
+      maker(SimWatcherFactory::get()->create(itWatcher->getParameter<std::string> ("type")));
+    if(maker.get() == nullptr) { 
+      throw Exception("SimG4CoreG4GeometryESProducer", 
+		      " createWatchers: Unable to find the requested Watcher");
+    }
+      
+    shared_ptr<SimWatcher> watcherTemp;
+    shared_ptr<SimProducer> producerTemp;
+    maker->make(*itWatcher,iReg,watcherTemp,producerTemp);
+    oWatchers.push_back(watcherTemp);
+    if(producerTemp) oProds.push_back(producerTemp);
+  }
+}
+
+namespace cms {
+  
+class G4GeometryESProducer : public one::EDProducer<one::SharedResources, one::WatchRuns>
+{
+public:
+  using Producers = vector<shared_ptr<SimProducer>>;
+ 
+  explicit G4GeometryESProducer(ParameterSet const&);
+  ~G4GeometryESProducer() override;
+  void beginRun(const Run&, const EventSetup&) override;
+  void endRun(const Run&, const EventSetup&) override;
+  void produce(Event&, const EventSetup&) override;
+  void beginLuminosityBlock(LuminosityBlock&, EventSetup const&);
+  
+  vector<shared_ptr<SimProducer>> producers() const {
+    return m_producers;
+  }
+  vector<SensitiveTkDetector*>& sensTkDetectors() { return m_sensTkDets; }
+  vector<SensitiveCaloDetector*>& sensCaloDetectors() { return m_sensCaloDets; }
+  
+private:
+
+  void updateMagneticField(EventSetup const&);
+  
+  G4RunManagerKernel* m_kernel;
+  bool m_pUseMagneticField;
+  ParameterSet m_pField;
+  bool m_pUseSensitiveDetectors;
+  SimActivityRegistry m_registry;
+  vector<shared_ptr<SimWatcher>> m_watchers;
+  vector<shared_ptr<SimProducer>> m_producers;
+  unique_ptr<sim::FieldBuilder> m_fieldBuilder;
+  unique_ptr<SimTrackManager> m_trackManager;
+  AttachSD * m_attach;
+  vector<SensitiveTkDetector*> m_sensTkDets;
+  vector<SensitiveCaloDetector*> m_sensCaloDets;
+  ParameterSet m_p;
+  bool m_firstRun;
+};
+}
+
+G4GeometryESProducer::G4GeometryESProducer(ParameterSet const& p) :
+    m_kernel(nullptr),
+    m_pUseMagneticField(p.getParameter<bool>("UseMagneticField")),
+    m_pField(p.getParameter<ParameterSet>("MagneticField")), 
+    m_pUseSensitiveDetectors(p.getParameter<bool>("UseSensitiveDetectors")),
+    m_attach(nullptr), m_p(p), m_firstRun(true)
+{
+    //Look for an outside SimActivityRegistry
+    //this is used by the visualization code
+    Service<SimActivityRegistry> otherRegistry;
+    if(otherRegistry) m_registry.connect(*otherRegistry);
+    createWatchers(m_p, m_registry, m_watchers, m_producers);
+    produces<int>();
+}
+
+G4GeometryESProducer::~G4GeometryESProducer() 
+{
+  delete m_attach;
+  delete m_kernel; 
+}
+
+void G4GeometryESProducer::updateMagneticField(EventSetup const& es) {
+  if(m_pUseMagneticField) {
+    // setup the magnetic field
+    ESHandle<MagneticField> pMF;
+    es.get<IdealMagneticFieldRecord>().get(pMF);
+    const GlobalPoint g(0.,0.,0.);
+    LogInfo("G4GeometryESProducer") << "B-field(T) at (0,0,0)(cm): " << pMF->inTesla(g);
+
+    sim::FieldBuilder fieldBuilder(pMF.product(), m_pField);
+    CMSFieldManager* fieldManager = new CMSFieldManager();
+    G4TransportationManager * tM = G4TransportationManager::GetTransportationManager();
+    tM->SetFieldManager(fieldManager);
+    fieldBuilder.build( fieldManager, tM->GetPropagatorInField());
+    LogInfo("G4GeometryESProducer") << "Magentic field is built";
+  }
+}
+
+void G4GeometryESProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&) 
+{
+  // mag field cannot be change in new lumi section - this is commented out
+  //     updateMagneticField( es );
+}
+
+void G4GeometryESProducer::beginRun(const edm::Run &, const edm::EventSetup&)
+{}
+
+void G4GeometryESProducer::endRun(const edm::Run &,const edm::EventSetup&)
+{}
+
+void G4GeometryESProducer::produce(edm::Event & e, const edm::EventSetup & es)
+{
+  if(!m_firstRun) return;
+  m_firstRun = false;
+  
+  LogInfo("G4GeometryESProducer") << "Producing G4 Geom";   
+
+  m_kernel = G4RunManagerKernel::GetRunManagerKernel();   
+  if(m_kernel == nullptr) m_kernel = new G4RunManagerKernel();
+  LogInfo("G4GeometryESProducer") << " G4GeometryESProducer initializing ";
+  // DDDWorld: get the DDCV from the ES and use it to build the World
+  ESTransientHandle<DDCompactView> pDD;
+  es.get<IdealGeometryRecord>().get(pDD);
+  //  m_detDesc->apply("DD4hep_XMLLoader", 1, &arg);
+  G4LogicalVolumeToDDLogicalPartMap map;
+  SensitiveDetectorCatalog catalog;
+  const DDDWorld * world = new DDDWorld(&(*pDD), map, catalog, false);
+  m_registry.dddWorldSignal_(world);
+  //FIXME:??? m_registry.watchDDDWorld(world);
+
+  updateMagneticField(es);
+  
+  if(m_pUseSensitiveDetectors) {
+    LogInfo("G4GeometryESProducer") << " instantiating sensitive detectors ";
+    // instantiate and attach the sensitive detectors
+    m_trackManager = unique_ptr<SimTrackManager>(new SimTrackManager);
+    if(m_attach == nullptr) m_attach = new AttachSD;
+    {
+      pair<vector<SensitiveTkDetector*>,
+	   vector<SensitiveCaloDetector*>> 
+	sensDets = m_attach->create((*pDD), catalog, m_p, m_trackManager.get(), m_registry);
+      
+      m_sensTkDets.swap(sensDets.first);
+      m_sensCaloDets.swap(sensDets.second);
+    }
+
+    LogInfo("G4GeometryESProducer") << " Sensitive Detector building finished; found " 
+				<< m_sensTkDets.size()
+				<< " Tk type Producers, and " << m_sensCaloDets.size() 
+				<< " Calo type producers ";
+  }
+
+  for(Producers::iterator itProd = m_producers.begin();itProd != m_producers.end();
+      ++itProd) { 
+    (*itProd)->produce(e,es); 
+  }
+}
+
+DEFINE_FWK_MODULE(G4GeometryESProducer);
+

--- a/SimG4Core/DD4hepGeometry/src/DD4hep_DDDWorld.cc
+++ b/SimG4Core/DD4hepGeometry/src/DD4hep_DDDWorld.cc
@@ -1,0 +1,50 @@
+#include "SimG4Core/DD4hepGeometry/interface/DD4hep_DDDWorld.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DetectorDescription/DDCMS/interface/DDDetector.h"
+#include "SimG4Core/DD4hepGeometry/interface/Geant4Converter.h"
+#include "SimG4Core/DD4hepGeometry/interface/Geant4GeometryInfo.h"
+#include "DD4hep/Detector.h"
+
+#include "G4RunManagerKernel.hh"
+#include "G4PVPlacement.hh"
+#include "G4TransportationManager.hh"
+ 
+using namespace edm;
+using namespace cms;
+
+DDDWorld::DDDWorld(const DDDetector* ddd) {
+  
+  dd4hep::DetElement world = ddd->description()->world();
+  const dd4hep::Detector& detector = *ddd->description();
+  dd4hep::sim::Geant4Converter g4Geo(detector);
+  dd4hep::sim::Geant4GeometryInfo* geometry = g4Geo.create(world).detach();
+ 
+  m_world = geometry->world();
+
+  SetAsWorld(m_world);
+}
+
+DDDWorld::~DDDWorld() {}
+
+void
+DDDWorld::SetAsWorld(G4VPhysicalVolume * pv) {
+  G4RunManagerKernel* kernel = G4RunManagerKernel::GetRunManagerKernel();
+  if(kernel) kernel->DefineWorldVolume(pv);
+  else edm::LogError("SimG4CoreGeometry") << "No G4RunManagerKernel?";
+  edm::LogInfo("SimG4CoreGeometry") << " World volume defined ";
+}
+
+void
+DDDWorld::WorkerSetAsWorld(G4VPhysicalVolume * pv) {
+  G4RunManagerKernel* kernel = G4RunManagerKernel::GetRunManagerKernel();
+  if(kernel) {
+    kernel->WorkerDefineWorldVolume(pv);
+    // The following does not get done in WorkerDefineWorldVolume()
+    // because we don't use G4MTRunManager
+    G4TransportationManager* transM = G4TransportationManager::GetTransportationManager();
+    transM->SetWorldForTracking(pv);
+  }
+  else edm::LogError("SimG4CoreGeometry") << "No G4RunManagerKernel?";
+  edm::LogInfo("SimG4CoreGeometry") << " World volume defined (for worker) ";
+}
+

--- a/SimG4Core/DD4hepGeometry/src/Geant4Converter.cc
+++ b/SimG4Core/DD4hepGeometry/src/Geant4Converter.cc
@@ -1,0 +1,1414 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Framework include files
+#include "DD4hep/Detector.h"
+#include "DD4hep/Plugins.h"
+#include "DD4hep/Volumes.h"
+#include "DD4hep/Printout.h"
+#include "DD4hep/DD4hepUnits.h"
+//#include "DD4hep/PropertyTable.h"
+#include "DD4hep/detail/ObjectsInterna.h"
+#include "DD4hep/detail/DetectorInterna.h"
+
+//#include "DDG4/Geant4Field.h"
+//FIXME: #include "DDG4/Geant4Converter.h"
+#include "SimG4Core/DD4hepGeometry/interface/Geant4Converter.h"
+//FIXME: #include "DDG4/Geant4UserLimits.h"
+#include "SimG4Core/DD4hepGeometry/interface/Geant4UserLimits.h"
+//#include "DDG4/Geant4SensitiveDetector.h"
+#include <G4VSensitiveDetector.hh>
+
+// ROOT includes
+#include "TROOT.h"
+#include "TColor.h"
+#include "TGeoNode.h"
+#include "TGeoShape.h"
+#include "TGeoCone.h"
+#include "TGeoHype.h"
+#include "TGeoPcon.h"
+#include "TGeoEltu.h"
+#include "TGeoPgon.h"
+#include "TGeoSphere.h"
+#include "TGeoTorus.h"
+#include "TGeoTrd1.h"
+#include "TGeoTrd2.h"
+#include "TGeoTube.h"
+#include "TGeoArb8.h"
+#include "TGeoMatrix.h"
+#include "TGeoBoolNode.h"
+#include "TGeoParaboloid.h"
+#include "TGeoCompositeShape.h"
+#include "TGeoShapeAssembly.h"
+#include "TGeoScaledShape.h"
+#include "TGeoManager.h"
+#include "TClass.h"
+#include "TMath.h"
+
+// Geant4 include files
+#include "G4VisAttributes.hh"
+#include "G4ProductionCuts.hh"
+#include "G4VUserRegionInformation.hh"
+
+#include "G4Element.hh"
+#include "G4Box.hh"
+#include "G4Trd.hh"
+#include "G4Tubs.hh"
+#include "G4Trap.hh"
+#include "G4Cons.hh"
+#include "G4Hype.hh"
+#include "G4Torus.hh"
+#include "G4Sphere.hh"
+#include "G4Polycone.hh"
+#include "G4Polyhedra.hh"
+#include "G4UnionSolid.hh"
+#include "G4Paraboloid.hh"
+#include "G4Ellipsoid.hh"
+#include "G4GenericTrap.hh"
+#include "G4ExtrudedSolid.hh"
+#include "G4EllipticalTube.hh"
+#include "G4SubtractionSolid.hh"
+#include "G4IntersectionSolid.hh"
+#include "G4Region.hh"
+#include "G4UserLimits.hh"
+#include "G4LogicalVolume.hh"
+#include "G4Material.hh"
+#include "G4Element.hh"
+#include "G4Isotope.hh"
+#include "G4Transform3D.hh"
+#include "G4ThreeVector.hh"
+#include "G4PVPlacement.hh"
+#include "G4ElectroMagneticField.hh"
+#include "G4FieldManager.hh"
+#include "G4ReflectionFactory.hh"
+#include "G4OpticalSurface.hh"
+#include "G4LogicalSkinSurface.hh"
+#include "G4LogicalBorderSurface.hh"
+#include "G4MaterialPropertiesTable.hh"
+#include "CLHEP/Units/SystemOfUnits.h"
+
+// C/C++ include files
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+
+namespace units = dd4hep;
+using namespace dd4hep::detail;
+using namespace dd4hep::sim;
+using namespace dd4hep;
+using namespace std;
+
+//FIXME:#include "DDG4/Geant4AssemblyVolume.h"
+#include "SimG4Core/DD4hepGeometry/interface/Geant4AssemblyVolume.h"
+#include "DD4hep/DetectorTools.h"
+#include "G4RotationMatrix.hh"
+#include "G4AffineTransform.hh"
+#include "G4LogicalVolume.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4ReflectionFactory.hh"
+
+void Geant4AssemblyVolume::imprint(Geant4GeometryInfo& info,
+                                   const TGeoNode*   parent,
+                                   Chain chain,
+                                   Geant4AssemblyVolume* pAssembly,
+                                   G4LogicalVolume*  pMotherLV,
+                                   G4Transform3D&    transformation,
+                                   G4int copyNumBase,
+                                   G4bool surfCheck )
+{
+  TGeoVolume* vol = parent->GetVolume();
+  static int level=0;
+  ++level;
+
+
+  unsigned int  numberOfDaughters;
+
+  if( copyNumBase == 0 )
+  {
+    numberOfDaughters = pMotherLV->GetNoDaughters();
+  }
+  else
+  {
+    numberOfDaughters = copyNumBase;
+  }
+
+  // We start from the first available index
+  //
+  numberOfDaughters++;
+
+  ImprintsCountPlus();
+
+  vector<G4AssemblyTriplet> triplets = pAssembly->fTriplets;
+  //cout << " Assembly:" << detail::tools::placementPath(chain) << endl;
+
+  for( unsigned int i = 0; i < triplets.size(); i++ )  {
+    const TGeoNode* node = pAssembly->m_entries[i];
+    Chain new_chain = chain;
+    new_chain.push_back(node);
+    //cout << " Assembly: Entry: " << detail::tools::placementPath(new_chain) << endl;
+
+    G4Transform3D Ta( *(triplets[i].GetRotation()),
+                      triplets[i].GetTranslation() );
+    if ( triplets[i].IsReflection() )  { Ta = Ta * G4ReflectZ3D(); }
+
+    G4Transform3D Tfinal = transformation * Ta;
+
+    if ( triplets[i].GetVolume() )
+    {
+      // Generate the unique name for the next PV instance
+      // The name has format:
+      //
+      // av_WWW_impr_XXX_YYY_ZZZ
+      // where the fields mean:
+      // WWW - assembly volume instance number
+      // XXX - assembly volume imprint number
+      // YYY - the name of a log. volume we want to make a placement of
+      // ZZZ - the log. volume index inside the assembly volume
+      //
+      stringstream pvName;
+      pvName << "av_"
+             << GetAssemblyID()
+             << "_impr_"
+             << GetImprintsCount()
+             << "_"
+             << triplets[i].GetVolume()->GetName().c_str()
+             << "_pv_"
+             << i
+             << ends;
+
+      // Generate a new physical volume instance inside a mother
+      // (as we allow 3D transformation use G4ReflectionFactory to
+      //  take into account eventual reflection)
+      //
+      G4PhysicalVolumesPair pvPlaced
+        = G4ReflectionFactory::Instance()->Place( Tfinal,
+                                                  pvName.str().c_str(),
+                                                  triplets[i].GetVolume(),
+                                                  pMotherLV,
+                                                  false,
+                                                  numberOfDaughters + i,
+                                                  surfCheck );
+
+      // Register the physical volume created by us so we can delete it later
+      //
+      fPVStore.push_back( pvPlaced.first );
+      info.g4VolumeImprints[vol].push_back(make_pair(new_chain,pvPlaced.first));
+#if 0
+      cout << " Assembly:Parent:" << parent->GetName() << " " << node->GetName()
+           << " " <<  (void*)node << " G4:" << pvName.str() << " Daughter:"
+           << detail::tools::placementPath(new_chain) << endl;
+      cout << endl;
+#endif
+
+      if ( pvPlaced.second )  {
+        G4Exception("G4AssemblyVolume::MakeImprint(..)", "GeomVol0003", FatalException,
+                    "Fancy construct popping new mother from the stack!");
+        //fPVStore.push_back( pvPlaced.second );
+      }
+    }
+    else if ( triplets[i].GetAssembly() )  {
+      // Place volumes in this assembly with composed transformation
+      imprint(info, parent, new_chain, (Geant4AssemblyVolume*)triplets[i].GetAssembly(), pMotherLV, Tfinal, i*100+copyNumBase, surfCheck );
+    }
+    else   {
+      --level;
+      G4Exception("G4AssemblyVolume::MakeImprint(..)",
+                  "GeomVol0003", FatalException,
+                  "Triplet has no volume and no assembly");
+    }
+  }
+  //cout << "Imprinted assembly level:" << level << " in mother:" << pMotherLV->GetName() << endl;
+  --level;
+}
+
+namespace {
+  static string indent = "";
+  static Double_t s_identity_rot[] = { 1., 0., 0., 0., 1., 0., 0., 0., 1. };
+  struct MyTransform3D : public G4Transform3D {
+    MyTransform3D(double XX, double XY, double XZ, double DX, double YX, double YY, double YZ, double DY, double ZX, double ZY,
+                  double ZZ, double DZ)
+      : G4Transform3D(XX, XY, XZ, DX, YX, YY, YZ, DY, ZX, ZY, ZZ, DZ) {
+    }
+    MyTransform3D(const double* t, const double* r = s_identity_rot)
+      : G4Transform3D(r[0],r[1],r[2],t[0]*CM_2_MM,r[3],r[4],r[5],t[1]*CM_2_MM,r[6],r[7],r[8],t[2]*CM_2_MM)  {
+    }
+  };
+
+#if 0  // warning: unused function 'handleName' [-Wunused-function]
+  void handleName(const TGeoNode* n) {
+    TGeoVolume* v = n->GetVolume();
+    TGeoMedium* m = v->GetMedium();
+    TGeoShape* s = v->GetShape();
+    string nam;
+    printout(DEBUG, "G4", "TGeoNode:'%s' Vol:'%s' Shape:'%s' Medium:'%s'", n->GetName(), v->GetName(), s->GetName(),
+             m->GetName());
+  }
+#endif
+
+  class G4UserRegionInformation : public G4VUserRegionInformation {
+  public:
+    Region region;
+    double threshold;
+    bool storeSecondaries;
+    G4UserRegionInformation()
+      : threshold(0.0), storeSecondaries(false) {
+    }
+    virtual ~G4UserRegionInformation() {
+    }
+    virtual void Print() const {
+      if (region.isValid())
+        printout(DEBUG, "Region", "Name:%s", region.name());
+    }
+  };
+}
+
+/// Initializing Constructor
+Geant4Converter::Geant4Converter(const Detector& description_ref)
+  : Geant4Mapping(description_ref), checkOverlaps(true) {
+  this->Geant4Mapping::init();
+  m_propagateRegions = true;
+  outputLevel = PrintLevel(printLevel() - 1);
+}
+
+/// Initializing Constructor
+Geant4Converter::Geant4Converter(Detector& description_ref, PrintLevel level)
+  : Geant4Mapping(description_ref), checkOverlaps(true) {
+  this->Geant4Mapping::init();
+  m_propagateRegions = true;
+  outputLevel = level;
+}
+
+/// Standard destructor
+Geant4Converter::~Geant4Converter() {
+}
+
+/// Dump element in GDML format to output stream
+void* Geant4Converter::handleElement(const string& name, const Atom element) const {
+  G4Element* g4e = data().g4Elements[element];
+  if (!g4e) {
+    g4e = G4Element::GetElement(name, false);
+    if (!g4e) {
+      PrintLevel lvl = debugElements ? ALWAYS : outputLevel;
+      double a_conv = (CLHEP::g / CLHEP::mole);
+      if (element->GetNisotopes() > 0) {
+        g4e = new G4Element(name, element->GetTitle(), element->GetNisotopes());
+        for (int i = 0, n = element->GetNisotopes(); i < n; ++i) {
+          TGeoIsotope* iso = element->GetIsotope(i);
+          G4Isotope* g4iso = G4Isotope::GetIsotope(iso->GetName(), false);
+          if (!g4iso) {
+            g4iso = new G4Isotope(iso->GetName(), iso->GetZ(), iso->GetN(), iso->GetA()*a_conv);
+            printout(lvl, "Geant4Converter", "++ Created G4 Isotope %s from data: Z=%d N=%d A=%.3f [g/mole]",
+                     iso->GetName(), iso->GetZ(), iso->GetN(), iso->GetA());
+          }
+          else  {
+            printout(lvl, "Geant4Converter", "++ Re-used G4 Isotope %s from data: Z=%d N=%d A=%.3f [g/mole]",
+                     iso->GetName(), iso->GetZ(), iso->GetN(), iso->GetA());
+          }
+          g4e->AddIsotope(g4iso, element->GetRelativeAbundance(i));
+        }
+      }
+      else {
+        // This adds in Geant4 the natural isotopes, which we normally do not want. We want to steer it outselves.
+        g4e = new G4Element(element->GetTitle(), name, element->Z(), element->A()*a_conv);
+        printout(lvl, "Geant4Converter", "++ Created G4 Isotope %s from data: Z=%d N=%d A=%.3f [g/mole]",
+                 element->GetName(), element->Z(), element->N(), element->A());
+#if 0  // Disabled for now!
+        g4e = new G4Element(name, element->GetTitle(), 1);
+        G4Isotope* g4iso = G4Isotope::GetIsotope(name, false);
+        if (!g4iso) {
+          g4iso = new G4Isotope(name, element->Z(), element->N(), element->A()*a_conv);
+          printout(lvl, "Geant4Converter", "++ Created G4 Isotope %s from data: Z=%d N=%d A=%.3f [g/mole]",
+                   element->GetName(), element->Z(), element->N(), element->A());
+        }
+        else  {
+          printout(lvl, "Geant4Converter", "++ Re-used G4 Isotope %s from data: Z=%d N=%d A=%.3f [g/mole]",
+                   element->GetName(), element->Z(), element->N(), element->A());
+        }
+        g4e->AddIsotope(g4iso, 1.0);
+#endif
+      }
+      stringstream str;
+      str << (*g4e);
+      printout(lvl, "Geant4Converter", "++ Created G4 %s No.Isotopes:%d",
+               str.str().c_str(),element->GetNisotopes());
+    }
+    data().g4Elements[element] = g4e;
+  }
+  return g4e;
+}
+
+/// Dump material in GDML format to output stream
+void* Geant4Converter::handleMaterial(const string& name, Material medium) const {
+  Geant4GeometryInfo& info = data();
+  G4Material* mat = info.g4Materials[medium];
+  if (!mat) {
+    PrintLevel lvl = debugMaterials ? ALWAYS : outputLevel;
+    mat = G4Material::GetMaterial(name, false);
+    if (!mat) {
+      TGeoMaterial* material = medium->GetMaterial();
+      G4State state   = kStateUndefined;
+      double  density = material->GetDensity() * (CLHEP::gram / CLHEP::cm3);
+      if (density < 1e-25)
+        density = 1e-25;
+      switch (material->GetState()) {
+      case TGeoMaterial::kMatStateSolid:
+        state = kStateSolid;
+        break;
+      case TGeoMaterial::kMatStateLiquid:
+        state = kStateLiquid;
+        break;
+      case TGeoMaterial::kMatStateGas:
+        state = kStateGas;
+        break;
+      default:
+      case TGeoMaterial::kMatStateUndefined:
+        state = kStateUndefined;
+        break;
+      }
+      if (material->IsMixture()) {
+        double A_total = 0.0;
+        double W_total = 0.0;
+        TGeoMixture* mix = (TGeoMixture*) material;
+        int nElements = mix->GetNelements();
+        mat = new G4Material(name, density, nElements, state, 
+                             material->GetTemperature(), material->GetPressure());
+        for (int i = 0; i < nElements; ++i)  {
+          A_total += (mix->GetAmixt())[i];
+          W_total += (mix->GetWmixt())[i];
+        }
+        for (int i = 0; i < nElements; ++i) {
+          TGeoElement* e = mix->GetElement(i);
+          G4Element* g4e = (G4Element*) handleElement(e->GetName(), Atom(e));
+          if (!g4e) {
+            printout(ERROR, "Material", 
+                     "Missing component %s for material %s. A=%f W=%f", 
+                     e->GetName(), mix->GetName(), A_total, W_total);
+          }
+          //mat->AddElement(g4e, (mix->GetAmixt())[i] / A_total);
+          mat->AddElement(g4e, (mix->GetWmixt())[i] / W_total);
+        }
+      }
+      else {
+        double z = material->GetZ(), a = material->GetA();
+        if ( z < 1.0000001 ) z = 1.0;
+        if ( a < 0.5000001 ) a = 1.0;
+        mat = new G4Material(name, z, a, density, state, 
+                             material->GetTemperature(), material->GetPressure());
+      }
+      stringstream str;
+      str << (*mat);
+      printout(lvl, "Geant4Converter", "++ Created G4 %s", str.str().c_str());
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
+      /// Attach the material properties if any
+      G4MaterialPropertiesTable* tab = 0;
+      TListIter propIt(&material->GetProperties());
+      for(TObject* obj=propIt.Next(); obj; obj = propIt.Next())  {
+        TNamed*      n = (TNamed*)obj;
+        TGDMLMatrix* matrix = info.manager->GetGDMLMatrix(n->GetTitle());
+        Geant4GeometryInfo::PropertyVector* v =
+          (Geant4GeometryInfo::PropertyVector*)handleMaterialProperties(matrix);
+        if ( 0 == v )   {
+          except("Geant4Converter", "++ FAILED to create G4 material %s [Cannot convert property:%s]",
+                 material->GetName(), n->GetName());
+        }
+        if ( 0 == tab )  {
+          tab = new G4MaterialPropertiesTable();
+          mat->SetMaterialPropertiesTable(tab);
+        }
+        G4MaterialPropertyVector* vec =
+          new G4MaterialPropertyVector(&v->bins[0], &v->values[0], v->bins.size());
+        printout(lvl, "Geant4Converter", "++      Property: %-20s [%ld x %ld] -> %s ",
+                 n->GetName(), matrix->GetRows(), matrix->GetCols(), n->GetTitle());
+        tab->AddProperty(n->GetName(), vec);
+      }
+#endif
+    }
+    info.g4Materials[medium] = mat;
+  }
+  return mat;
+}
+
+/// Dump solid in GDML format to output stream
+void* Geant4Converter::handleSolid(const string& name, const TGeoShape* shape) const {
+  G4VSolid* solid = 0;
+  if (shape) {
+    PrintLevel lvl = debugShapes ? ALWAYS : outputLevel;
+    if (0 != (solid = data().g4Solids[shape])) {
+      return solid;
+    }
+    else if (shape->IsA() == TGeoShapeAssembly::Class()) {
+      // Assemblies have no corresponding 'shape' in Geant4. Ignore the shape translation.
+      // It does not harm, since this 'shape' is never accessed afterwards.
+      data().g4Solids[shape] = solid;
+      return solid;
+    }
+    else if (shape->IsA() == TGeoBBox::Class()) {
+      const TGeoBBox* sh = (const TGeoBBox*) shape;
+      solid = new G4Box(name, sh->GetDX() * CM_2_MM, sh->GetDY() * CM_2_MM, sh->GetDZ() * CM_2_MM);
+    }
+    else if (shape->IsA() == TGeoTube::Class()) {
+      const TGeoTube* sh = (const TGeoTube*) shape;
+      solid = new G4Tubs(name, sh->GetRmin() * CM_2_MM, sh->GetRmax() * CM_2_MM, sh->GetDz() * CM_2_MM, 0, 2. * M_PI);
+    }
+    else if (shape->IsA() == TGeoTubeSeg::Class()) {
+      const TGeoTubeSeg* sh = (const TGeoTubeSeg*) shape;
+      solid = new G4Tubs(name, sh->GetRmin() * CM_2_MM, sh->GetRmax() * CM_2_MM, sh->GetDz() * CM_2_MM,
+                         sh->GetPhi1() * DEGREE_2_RAD, (sh->GetPhi2()-sh->GetPhi1()) * DEGREE_2_RAD);
+    }
+    else if (shape->IsA() == TGeoEltu::Class()) {
+      const TGeoEltu* sh = (const TGeoEltu*) shape;
+      solid = new G4EllipticalTube(name,sh->GetA() * CM_2_MM, sh->GetB() * CM_2_MM, sh->GetDz() * CM_2_MM);
+    }
+    else if (shape->IsA() == TGeoTrd1::Class()) {
+      const TGeoTrd1* sh = (const TGeoTrd1*) shape;
+      solid = new G4Trd(name, sh->GetDx1() * CM_2_MM, sh->GetDx2() * CM_2_MM, sh->GetDy() * CM_2_MM, sh->GetDy() * CM_2_MM,
+                        sh->GetDz() * CM_2_MM);
+    }
+    else if (shape->IsA() == TGeoTrd2::Class()) {
+      const TGeoTrd2* sh = (const TGeoTrd2*) shape;
+      solid = new G4Trd(name, sh->GetDx1() * CM_2_MM, sh->GetDx2() * CM_2_MM, sh->GetDy1() * CM_2_MM, sh->GetDy2() * CM_2_MM,
+                        sh->GetDz() * CM_2_MM);
+    }
+    else if (shape->IsA() == TGeoHype::Class()) {
+      const TGeoHype* sh = (const TGeoHype*) shape;
+      solid = new G4Hype(name, sh->GetRmin() * CM_2_MM, sh->GetRmax() * CM_2_MM,
+                         sh->GetStIn() * DEGREE_2_RAD, sh->GetStOut() * DEGREE_2_RAD,
+                         sh->GetDz() * CM_2_MM);
+    }
+    else if (shape->IsA() == TGeoXtru::Class()) {
+      const TGeoXtru* sh = (const TGeoXtru*) shape;
+      size_t nz = sh->GetNz();
+      vector<G4ExtrudedSolid::ZSection> z;
+      vector<G4TwoVector> polygon;
+      z.reserve(nz);
+      polygon.reserve(nz);
+      for(size_t i=0; i<nz; ++i)   {
+        z.push_back(G4ExtrudedSolid::ZSection(sh->GetZ(i) * CM_2_MM,
+                                              {sh->GetXOffset(i), sh->GetYOffset(i)},
+                                              sh->GetScale(i)));
+        polygon.push_back(G4TwoVector(sh->GetX(i) * CM_2_MM,sh->GetY(i) * CM_2_MM));
+      }
+      solid = new G4ExtrudedSolid(name, polygon, z);
+    }
+    else if (shape->IsA() == TGeoPgon::Class()) {
+      const TGeoPgon* sh = (const TGeoPgon*) shape;
+      double phi_start = sh->GetPhi1() * DEGREE_2_RAD;
+      double phi_total = (sh->GetDphi() + sh->GetPhi1()) * DEGREE_2_RAD;
+      vector<double> rmin, rmax, z;
+      for (Int_t i = 0; i < sh->GetNz(); ++i) {
+        rmin.push_back(sh->GetRmin(i) * CM_2_MM);
+        rmax.push_back(sh->GetRmax(i) * CM_2_MM);
+        z.push_back(sh->GetZ(i) * CM_2_MM);
+      }
+      solid = new G4Polyhedra(name, phi_start, phi_total, sh->GetNedges(), sh->GetNz(), &z[0], &rmin[0], &rmax[0]);
+    }
+    else if (shape->IsA() == TGeoPcon::Class()) {
+      const TGeoPcon* sh = (const TGeoPcon*) shape;
+      double phi_start = sh->GetPhi1() * DEGREE_2_RAD;
+      double phi_total = (sh->GetDphi() + sh->GetPhi1()) * DEGREE_2_RAD;
+      vector<double> rmin, rmax, z;
+      for (Int_t i = 0; i < sh->GetNz(); ++i) {
+        rmin.push_back(sh->GetRmin(i) * CM_2_MM);
+        rmax.push_back(sh->GetRmax(i) * CM_2_MM);
+        z.push_back(sh->GetZ(i) * CM_2_MM);
+      }
+      solid = new G4Polycone(name, phi_start, phi_total, sh->GetNz(), &z[0], &rmin[0], &rmax[0]);
+    }
+    else if (shape->IsA() == TGeoCone::Class()) {
+      const TGeoCone* sh = (const TGeoCone*) shape;
+      solid = new G4Cons(name, sh->GetRmin1() * CM_2_MM, sh->GetRmax1() * CM_2_MM, sh->GetRmin2() * CM_2_MM,
+                         sh->GetRmax2() * CM_2_MM, sh->GetDz() * CM_2_MM, 0.0, 2.*M_PI);
+    }
+    else if (shape->IsA() == TGeoConeSeg::Class()) {
+      const TGeoConeSeg* sh = (const TGeoConeSeg*) shape;
+      solid = new G4Cons(name, sh->GetRmin1() * CM_2_MM, sh->GetRmax1() * CM_2_MM,
+                         sh->GetRmin2() * CM_2_MM, sh->GetRmax2() * CM_2_MM,
+                         sh->GetDz() * CM_2_MM,
+                         sh->GetPhi1() * DEGREE_2_RAD, (sh->GetPhi2()-sh->GetPhi1()) * DEGREE_2_RAD);
+    }
+    else if (shape->IsA() == TGeoParaboloid::Class()) {
+      const TGeoParaboloid* sh = (const TGeoParaboloid*) shape;
+      solid = new G4Paraboloid(name, sh->GetDz() * CM_2_MM, sh->GetRlo() * CM_2_MM, sh->GetRhi() * CM_2_MM);
+    }
+#if 0  /* Not existent */
+    else if (shape->IsA() == TGeoEllisoid::Class()) {
+      const TGeoParaboloid* sh = (const TGeoParaboloid*) shape;
+      solid = new G4Paraboloid(name, sh->GetDz() * CM_2_MM, sh->GetRlo() * CM_2_MM, sh->GetRhi() * CM_2_MM);
+    }
+#endif
+    else if (shape->IsA() == TGeoSphere::Class()) {
+      const TGeoSphere* sh = (const TGeoSphere*) shape;
+      solid = new G4Sphere(name, sh->GetRmin() * CM_2_MM, sh->GetRmax() * CM_2_MM, sh->GetPhi1() * DEGREE_2_RAD,
+                           sh->GetPhi2() * DEGREE_2_RAD, sh->GetTheta1() * DEGREE_2_RAD, sh->GetTheta2() * DEGREE_2_RAD);
+    }
+    else if (shape->IsA() == TGeoTorus::Class()) {
+      const TGeoTorus* sh = (const TGeoTorus*) shape;
+      solid = new G4Torus(name, sh->GetRmin() * CM_2_MM, sh->GetRmax() * CM_2_MM, sh->GetR() * CM_2_MM,
+                          sh->GetPhi1() * DEGREE_2_RAD, sh->GetDphi() * DEGREE_2_RAD);
+    }
+    else if (shape->IsA() == TGeoTrap::Class()) {
+      const TGeoTrap* sh = (const TGeoTrap*) shape;
+      solid = new G4Trap(name, sh->GetDz() * CM_2_MM, sh->GetTheta(), sh->GetPhi(),
+                         sh->GetH1() * CM_2_MM, sh->GetBl1() * CM_2_MM, sh->GetTl1() * CM_2_MM, sh->GetAlpha1() * DEGREE_2_RAD,
+                         sh->GetH2() * CM_2_MM, sh->GetBl2() * CM_2_MM, sh->GetTl2() * CM_2_MM, sh->GetAlpha2() * DEGREE_2_RAD);
+    }
+    else if (shape->IsA() == TGeoArb8::Class())  {
+      vector<G4TwoVector> vertices;
+      TGeoTrap* sh = (TGeoTrap*) shape;
+      Double_t* vtx_xy = sh->GetVertices();
+      for ( size_t i=0; i<8; ++i, vtx_xy +=2 )
+        vertices.push_back(G4TwoVector(vtx_xy[0] * CM_2_MM,vtx_xy[1] * CM_2_MM));
+      solid = new G4GenericTrap(name, sh->GetDz() * CM_2_MM, vertices);
+    }
+    else if (shape->IsA() == TGeoCompositeShape::Class()) {
+      const TGeoCompositeShape* sh = (const TGeoCompositeShape*) shape;
+      const TGeoBoolNode* boolean = sh->GetBoolNode();
+      TGeoBoolNode::EGeoBoolType oper = boolean->GetBooleanOperator();
+      TGeoMatrix* matrix = boolean->GetRightMatrix();
+      G4VSolid* left  = (G4VSolid*) handleSolid(name + "_left", boolean->GetLeftShape());
+      G4VSolid* right = (G4VSolid*) handleSolid(name + "_right", boolean->GetRightShape());
+
+      if (!left) {
+        throw runtime_error("G4Converter: No left Geant4 Solid present for composite shape:" + name);
+      }
+      if (!right) {
+        throw runtime_error("G4Converter: No right Geant4 Solid present for composite shape:" + name);
+      }
+
+      //specific case!
+      //Ellipsoid tag preparing
+      //if left == TGeoScaledShape AND right  == TGeoBBox
+      //   AND if TGeoScaledShape->GetShape == TGeoSphere
+      TGeoShape* ls = boolean->GetLeftShape();
+      TGeoShape* rs = boolean->GetRightShape();
+      if (strcmp(ls->ClassName(), "TGeoScaledShape") == 0 &&
+          strcmp(rs->ClassName(), "TGeoBBox") == 0) {
+        if (strcmp(((TGeoScaledShape *)ls)->GetShape()->ClassName(), "TGeoSphere") == 0) {
+          if (oper == TGeoBoolNode::kGeoIntersection) {
+            TGeoScaledShape* lls = (TGeoScaledShape *)ls;
+            TGeoBBox* rrs = (TGeoBBox*)rs;
+            double sx     = lls->GetScale()->GetScale()[0];
+            double sy     = lls->GetScale()->GetScale()[1];
+            double radius = ((TGeoSphere *)lls->GetShape())->GetRmax();
+            double dz     = rrs->GetDZ();
+            double zorig  = rrs->GetOrigin()[2];
+            double zcut2  = dz + zorig;
+            double zcut1  = 2 * zorig - zcut2;
+            solid = new G4Ellipsoid(name,
+                                    sx * radius * CM_2_MM,
+                                    sy * radius * CM_2_MM,
+                                    radius * CM_2_MM,
+                                    zcut1 * CM_2_MM,
+                                    zcut2 * CM_2_MM);
+            data().g4Solids[shape] = solid;
+            return solid;
+          }
+        }
+      }
+
+      if (matrix->IsRotation()) {
+        MyTransform3D transform(matrix->GetTranslation(),matrix->GetRotationMatrix());
+        if (oper == TGeoBoolNode::kGeoSubtraction)
+          solid = new G4SubtractionSolid(name, left, right, transform);
+        else if (oper == TGeoBoolNode::kGeoUnion)
+          solid = new G4UnionSolid(name, left, right, transform);
+        else if (oper == TGeoBoolNode::kGeoIntersection)
+          solid = new G4IntersectionSolid(name, left, right, transform);
+      }
+      else {
+        const Double_t *t = matrix->GetTranslation();
+        G4ThreeVector transform(t[0] * CM_2_MM, t[1] * CM_2_MM, t[2] * CM_2_MM);
+        if (oper == TGeoBoolNode::kGeoSubtraction)
+          solid = new G4SubtractionSolid(name, left, right, 0, transform);
+        else if (oper == TGeoBoolNode::kGeoUnion)
+          solid = new G4UnionSolid(name, left, right, 0, transform);
+        else if (oper == TGeoBoolNode::kGeoIntersection)
+          solid = new G4IntersectionSolid(name, left, right, 0, transform);
+      }
+    }
+
+    if (!solid) {
+      string err = "Failed to handle unknown solid shape:" + name + " of type " + string(shape->IsA()->GetName());
+      throw runtime_error(err);
+    }
+    else  {
+      printout(lvl,"Geant4Converter","++ Successessfully converted shape [%p] of type:%s to %s.",
+               solid,shape->IsA()->GetName(),typeName(typeid(*solid)).c_str());
+    }
+    data().g4Solids[shape] = solid;
+  }
+  return solid;
+}
+
+/// Dump logical volume in GDML format to output stream
+void* Geant4Converter::handleVolume(const string& name, const TGeoVolume* volume) const {
+  Geant4GeometryInfo& info = data();
+  PrintLevel lvl = debugVolumes ? ALWAYS : outputLevel;
+  Geant4GeometryMaps::VolumeMap::const_iterator volIt = info.g4Volumes.find(volume);
+  Volume     _v(volume);
+  if ( _v.testFlagBit(Volume::VETO_SIMU) )  {
+    printout(lvl, "Geant4Converter", "++ Volume %s not converted [Veto'ed for simulation]",volume->GetName());
+    return 0;
+  }
+  else if (volIt == info.g4Volumes.end() ) {
+    const TGeoVolume* v = volume;
+    string      n   = v->GetName();
+    TGeoMedium* med = v->GetMedium();
+    TGeoShape* sh   = v->GetShape();
+    G4VSolid* solid = (G4VSolid*) handleSolid(sh->GetName(), sh);
+    G4Material* medium = 0;
+    bool assembly = sh->IsA() == TGeoShapeAssembly::Class() || v->IsA() == TGeoVolumeAssembly::Class();
+
+    LimitSet lim = _v.limitSet();
+    G4UserLimits* user_limits = 0;
+    if (lim.isValid()) {
+      user_limits = info.g4Limits[lim];
+      if (!user_limits) {
+        throw runtime_error("G4Cnv::volume[" + name + "]:    + FATAL Failed to "
+                            "access Geant4 user limits.");
+      }
+    }
+    VisAttr vis = _v.visAttributes();
+    G4VisAttributes* vis_attr = 0;
+    if (vis.isValid()) {
+      vis_attr = (G4VisAttributes*)handleVis(vis.name(), vis);
+    }
+    Region reg = _v.region();
+    G4Region* region = 0;
+    if (reg.isValid()) {
+      region = info.g4Regions[reg];
+      if (!region) {
+        throw runtime_error("G4Cnv::volume[" + name + "]:    + FATAL Failed to "
+                            "access Geant4 region.");
+      }
+    }
+    printout(lvl, "Geant4Converter", "++ Convert Volume %-32s: %p %s/%s assembly:%s",
+             n.c_str(), v, sh->IsA()->GetName(), v->IsA()->GetName(), yes_no(assembly));
+
+    if (assembly) {
+      //info.g4AssemblyVolumes[v] = new Geant4AssemblyVolume();
+      return 0;
+    }
+    medium = (G4Material*) handleMaterial(med->GetName(), Material(med));
+    if (!solid) {
+      throw runtime_error("G4Converter: No Geant4 Solid present for volume:" + n);
+    }
+    if (!medium) {
+      throw runtime_error("G4Converter: No Geant4 material present for volume:" + n);
+    }
+    if (user_limits) {
+      printout(lvl, "Geant4Converter", "++ Volume     + Apply LIMITS settings:%-24s to volume %s.",
+               lim.name(), _v.name());
+    }
+    G4LogicalVolume* vol = new G4LogicalVolume(solid, medium, n, 0, 0, user_limits);
+    if (region) {
+      printout(lvl, "Geant4Converter", "++ Volume     + Apply REGION settings: %s to volume %s.",
+               reg.name(), _v.name());
+      vol->SetRegion(region);
+      region->AddRootLogicalVolume(vol);
+    }
+    if (vis_attr) {
+      vol->SetVisAttributes(vis_attr);
+    }
+    info.g4Volumes[v] = vol;
+    printout(lvl, "Geant4Converter", "++ Volume     + %s converted: %p ---> G4: %p", n.c_str(), v, vol);
+  }
+  return 0;
+}
+
+/// Dump logical volume in GDML format to output stream
+void* Geant4Converter::collectVolume(const string& /* name */, const TGeoVolume* volume) const {
+  Geant4GeometryInfo& info = data();
+  const TGeoVolume* v = volume;
+  Volume _v(v);
+  Region reg = _v.region();
+  LimitSet lim = _v.limitSet();
+  SensitiveDetector det = _v.sensitiveDetector();
+
+  if (lim.isValid())
+    info.limits[lim].insert(v);
+  if (reg.isValid())
+    info.regions[reg].insert(v);
+  if (det.isValid())
+    info.sensitives[det].insert(v);
+  return (void*) v;
+}
+
+/// Dump volume placement in GDML format to output stream
+void* Geant4Converter::handleAssembly(const string& name, const TGeoNode* node) const {
+  TGeoVolume* mot_vol = node->GetVolume();
+  PrintLevel lvl = debugVolumes ? ALWAYS : outputLevel;
+  if ( mot_vol->IsA() != TGeoVolumeAssembly::Class() )    {
+    return 0;
+  }
+  Volume _v(mot_vol);
+  if ( _v.testFlagBit(Volume::VETO_SIMU) )  {
+    printout(lvl, "Geant4Converter", "++ AssemblyNode %s not converted [Veto'ed for simulation]",node->GetName());
+    return 0;
+  }
+  Geant4GeometryInfo& info = data();
+  Geant4AssemblyVolume* g4 = info.g4AssemblyVolumes[node];
+
+  if ( !g4 )  {
+    g4 = new Geant4AssemblyVolume();
+    for(Int_t i=0; i < mot_vol->GetNdaughters(); ++i)   {
+      TGeoNode*   d = mot_vol->GetNode(i);
+      TGeoVolume* dau_vol = d->GetVolume();
+      TGeoMatrix* tr = d->GetMatrix();
+      MyTransform3D transform(tr->GetTranslation(),tr->IsRotation() ? tr->GetRotationMatrix() : s_identity_rot);
+      if ( dau_vol->IsA() == TGeoVolumeAssembly::Class() )  {
+        Geant4GeometryMaps::AssemblyMap::iterator assIt = info.g4AssemblyVolumes.find(d);
+        if ( assIt == info.g4AssemblyVolumes.end() )  {
+          printout(FATAL, "Geant4Converter", "+++ Invalid child assembly at %s : %d  parent: %s child:%s",
+                   __FILE__, __LINE__, name.c_str(), d->GetName());
+          return 0;
+        }
+        g4->placeAssembly(d,(*assIt).second,transform);
+        printout(lvl, "Geant4Converter", "+++ Assembly: AddPlacedAssembly : dau:%s "
+                 "to mother %s Tr:x=%8.3f y=%8.3f z=%8.3f",
+                 dau_vol->GetName(), mot_vol->GetName(),
+                 transform.dx(), transform.dy(), transform.dz());
+      }
+      else   {
+        Geant4GeometryMaps::VolumeMap::iterator volIt = info.g4Volumes.find(dau_vol);
+        if ( volIt == info.g4Volumes.end() )  {
+          printout(FATAL,"Geant4Converter", "+++ Invalid child volume at %s : %d  parent: %s child:%s",
+                   __FILE__, __LINE__, name.c_str(), d->GetName());
+          except("Geant4Converter", "+++ Invalid child volume at %s : %d  parent: %s child:%s",
+                 __FILE__, __LINE__, name.c_str(), d->GetName());
+        }
+        g4->placeVolume(d,(*volIt).second, transform);
+        printout(lvl, "Geant4Converter", "+++ Assembly: AddPlacedVolume : dau:%s "
+                 "to mother %s Tr:x=%8.3f y=%8.3f z=%8.3f",
+                 dau_vol->GetName(), mot_vol->GetName(),
+                 transform.dx(), transform.dy(), transform.dz());
+      }
+    }
+    info.g4AssemblyVolumes[node] = g4;
+  }
+  return g4;
+}
+
+/// Dump volume placement in GDML format to output stream
+void* Geant4Converter::handlePlacement(const string& name, const TGeoNode* node) const {
+  Geant4GeometryInfo& info = data();
+  PrintLevel lvl = debugPlacements ? ALWAYS : outputLevel;
+  Geant4GeometryMaps::PlacementMap::const_iterator g4it = info.g4Placements.find(node);
+  G4VPhysicalVolume* g4 = (g4it == info.g4Placements.end()) ? 0 : (*g4it).second;
+  TGeoVolume* vol = node->GetVolume();
+  Volume _v(vol);
+  if ( _v.testFlagBit(Volume::VETO_SIMU) )  {
+    printout(lvl, "Geant4Converter", "++ Placement %s not converted [Veto'ed for simulation]",node->GetName());
+    return 0;
+  }
+  if (!g4) {
+    TGeoVolume* mot_vol = node->GetMotherVolume();
+    TGeoMatrix* tr = node->GetMatrix();
+    if (!tr) {
+      except("Geant4Converter", "++ Attempt to handle placement without transformation:%p %s of type %s vol:%p", node,
+             node->GetName(), node->IsA()->GetName(), vol);
+    }
+    else if (0 == vol) {
+      except("Geant4Converter", "++ Unknown G4 volume:%p %s of type %s ptr:%p", node, node->GetName(),
+             node->IsA()->GetName(), vol);
+    }
+    else {
+      int copy = node->GetNumber();
+      bool node_is_assembly = vol->IsA() == TGeoVolumeAssembly::Class();
+      bool mother_is_assembly = mot_vol ? mot_vol->IsA() == TGeoVolumeAssembly::Class() : false;
+      MyTransform3D transform(tr->GetTranslation(),tr->IsRotation() ? tr->GetRotationMatrix() : s_identity_rot);
+      Geant4GeometryMaps::VolumeMap::const_iterator volIt = info.g4Volumes.find(mot_vol);
+
+      if ( mother_is_assembly )   {
+        //
+        // Mother is an assembly:
+        // Nothing to do here, because:
+        // -- placed volumes were already added before in "handleAssembly"
+        // -- imprint cannot be made, because this requires a logical volume as a mother
+        //
+        printout(lvl, "Geant4Converter", "+++ Assembly: **** : dau:%s "
+                 "to mother %s Tr:x=%8.3f y=%8.3f z=%8.3f",
+                 vol->GetName(), mot_vol->GetName(),
+                 transform.dx(), transform.dy(), transform.dz());
+        return 0;
+      }
+      else if ( node_is_assembly )   {
+        //
+        // Node is an assembly:
+        // Imprint the assembly. The mother MUST already be transformed.
+        //
+        printout(lvl, "Geant4Converter", "+++ Assembly: makeImprint: dau:%s in mother %s "
+                 "Tr:x=%8.3f y=%8.3f z=%8.3f",
+                 node->GetName(), mot_vol ? mot_vol->GetName() : "<unknown>",
+                 transform.dx(), transform.dy(), transform.dz());
+        Geant4AssemblyVolume* ass = (Geant4AssemblyVolume*)info.g4AssemblyVolumes[node];
+        Geant4AssemblyVolume::Chain chain;
+        chain.push_back(node);
+        ass->imprint(info,node,chain,ass,(*volIt).second, transform, copy, checkOverlaps);
+        return 0;
+      }
+      else if ( node != info.manager->GetTopNode() && volIt == info.g4Volumes.end() )  {
+        throw logic_error("Geant4Converter: Invalid mother volume found!");
+      }
+      G4LogicalVolume* g4vol = info.g4Volumes[vol];
+      G4LogicalVolume* g4mot = info.g4Volumes[mot_vol];
+      g4 = new G4PVPlacement(transform,   // no rotation
+                             g4vol,     // its logical volume
+                             name,      // its name
+                             g4mot,     // its mother (logical) volume
+                             false,     // no boolean operations
+                             copy,      // its copy number
+                             checkOverlaps);
+    }
+    info.g4Placements[node] = g4;
+  }
+  else {
+    printout(ERROR, "Geant4Converter", "++ Attempt to DOUBLE-place physical volume: %s No:%d", name.c_str(), node->GetNumber());
+  }
+  return g4;
+}
+
+/// Convert the geometry type region into the corresponding Geant4 object(s).
+void* Geant4Converter::handleRegion(Region region, const set<const TGeoVolume*>& /* volumes */) const {
+  G4Region* g4 = data().g4Regions[region];
+  if (!g4) {
+    PrintLevel lvl = debugRegions ? ALWAYS : outputLevel;
+    Region r = region;
+    g4 = new G4Region(r.name());
+
+    // create region info with storeSecondaries flag
+    if( not r.wasThresholdSet() and r.storeSecondaries() ) {
+      throw runtime_error("G4Region: StoreSecondaries is True, but no explicit threshold set:");
+    }
+    printout(lvl, "Geant4Converter", "++ Setting up region: %s", r.name());
+    G4UserRegionInformation* info = new G4UserRegionInformation();
+    info->region = r;
+    info->threshold = r.threshold()*CLHEP::MeV/units::MeV;
+    info->storeSecondaries = r.storeSecondaries();
+    g4->SetUserInformation(info);
+
+    printout(lvl, "Geant4Converter", "++ Converted region settings of:%s.", r.name());
+    vector < string > &limits = r.limits();
+    G4ProductionCuts* cuts = 0;
+    // set production cut
+    if( not r.useDefaultCut() ) {
+      cuts = new G4ProductionCuts();
+      cuts->SetProductionCut(r.cut()*CLHEP::mm/units::mm);
+      printout(lvl, "Geant4Converter", "++ %s: Using default cut: %f [mm]",
+               r.name(), r.cut()*CLHEP::mm/units::mm);
+    }
+    for (const auto& nam : limits )  {
+      LimitSet ls = m_detDesc.limitSet(nam);
+      if (ls.isValid()) {
+        const LimitSet::Set& cts = ls.cuts();
+        for (const auto& c : cts )   {
+          int pid = 0;
+          if ( c.particles == "*" ) pid = -1;
+          else if ( c.particles == "e-"     ) pid = idxG4ElectronCut;
+          else if ( c.particles == "e+"     ) pid = idxG4PositronCut;
+          else if ( c.particles == "e[+-]"  ) pid = -idxG4PositronCut-idxG4ElectronCut;
+          else if ( c.particles == "e[-+]"  ) pid = -idxG4PositronCut-idxG4ElectronCut;
+          else if ( c.particles == "gamma"  ) pid = idxG4GammaCut;
+          else if ( c.particles == "proton" ) pid = idxG4ProtonCut;
+          else throw runtime_error("G4Region: Invalid production cut particle-type:" + c.particles);
+          if ( !cuts ) cuts = new G4ProductionCuts();
+          if ( pid == -(idxG4PositronCut+idxG4ElectronCut) )  {
+            cuts->SetProductionCut(c.value*CLHEP::mm/units::mm, idxG4PositronCut);
+            cuts->SetProductionCut(c.value*CLHEP::mm/units::mm, idxG4ElectronCut);
+          }
+          else  {
+            cuts->SetProductionCut(c.value*CLHEP::mm/units::mm, pid);
+          }
+          printout(lvl, "Geant4Converter", "++ %s: Set cut  [%s/%d] = %f [mm]",
+                   r.name(), c.particles.c_str(), pid, c.value*CLHEP::mm/units::mm);
+        }
+        bool found = false;
+        const auto& lm = data().g4Limits;
+        for (const auto& j : lm )   {
+          if (nam == j.first->GetName()) {
+            g4->SetUserLimits(j.second);
+            printout(lvl, "Geant4Converter", "++ %s: Set limits %s to region type %s",
+                     r.name(), nam.c_str(), j.second->GetType().c_str());
+            found = true;
+            break;
+          }
+        }
+        if ( found )   {
+          continue;
+        }
+      }
+      throw runtime_error("G4Region: Failed to resolve user limitset:" + nam);
+    }
+    /// Assign cuts to region if they were created
+    if ( cuts ) g4->SetProductionCuts(cuts);
+    data().g4Regions[region] = g4;
+  }
+  return g4;
+}
+
+/// Convert the geometry type LimitSet into the corresponding Geant4 object(s).
+void* Geant4Converter::handleLimitSet(LimitSet limitset, const set<const TGeoVolume*>& /* volumes */) const {
+  G4UserLimits* g4 = data().g4Limits[limitset];
+  if (!g4) {
+    struct LimitPrint  {
+      const LimitSet& ls;
+      LimitPrint(const LimitSet& lset) : ls(lset) {}
+      const LimitPrint& operator()(const std::string& pref, const Geant4UserLimits::Handler& h)  const {
+        if ( !h.particleLimits.empty() )  {
+          printout(ALWAYS,"Geant4Converter",
+                   "+++ LimitSet: Limit %s.%s applied for particles:",ls.name(), pref.c_str());
+          for(const auto& p : h.particleLimits)
+            printout(ALWAYS,"Geant4Converter","+++ LimitSet:    Particle type: %-18s PDG: %-6d : %f",
+                     p.first->GetParticleName().c_str(), p.first->GetPDGEncoding(), p.second);
+        }
+        else  {
+          printout(ALWAYS,"Geant4Converter",
+                   "+++ LimitSet: Limit %s.%s NOT APPLIED.",ls.name(), pref.c_str());
+        }
+        return *this;
+      }
+    };
+    Geant4UserLimits* limits = new Geant4UserLimits(limitset);
+    g4 = limits;
+    if ( debugRegions )    {
+      LimitPrint print(limitset);
+      print("maxTime",    limits->maxTime)
+        ("minEKine",      limits->minEKine)
+        ("minRange",      limits->minRange)
+        ("maxStepLength", limits->maxStepLength)
+        ("maxTrackLength",limits->maxTrackLength);
+    }
+    data().g4Limits[limitset] = g4;
+  }
+  return g4;
+}
+
+/// Convert the geometry visualisation attributes to the corresponding Geant4 object(s).
+void* Geant4Converter::handleVis(const string& /* name */, VisAttr attr) const {
+  Geant4GeometryInfo& info = data();
+  G4VisAttributes* g4 = info.g4Vis[attr];
+  if (!g4) {
+    float red = 0, green = 0, blue = 0;
+    int style = attr.lineStyle();
+    attr.rgb(red, green, blue);
+    g4 = new G4VisAttributes(attr.visible(), G4Colour(red, green, blue, attr.alpha()));
+    //g4->SetLineWidth(attr->GetLineWidth());
+    g4->SetDaughtersInvisible(!attr.showDaughters());
+    if (style == VisAttr::SOLID) {
+      g4->SetLineStyle(G4VisAttributes::unbroken);
+      g4->SetForceWireframe(false);
+      g4->SetForceSolid(true);
+    }
+    else if (style == VisAttr::WIREFRAME || style == VisAttr::DASHED) {
+      g4->SetLineStyle(G4VisAttributes::dashed);
+      g4->SetForceSolid(false);
+      g4->SetForceWireframe(true);
+    }
+    info.g4Vis[attr] = g4;
+  }
+  return g4;
+}
+
+/// Handle the geant 4 specific properties
+void Geant4Converter::handleProperties(Detector::Properties& prp) const {
+  map < string, string > processors;
+  static int s_idd = 9999999;
+  string id;
+  for (Detector::Properties::const_iterator i = prp.begin(); i != prp.end(); ++i) {
+    const string& nam = (*i).first;
+    const Detector::PropertyValues& vals = (*i).second;
+    if (nam.substr(0, 6) == "geant4") {
+      Detector::PropertyValues::const_iterator id_it = vals.find("id");
+      if (id_it != vals.end()) {
+        id = (*id_it).second;
+      }
+      else {
+        char txt[32];
+        ::snprintf(txt, sizeof(txt), "%d", ++s_idd);
+        id = txt;
+      }
+      processors.insert(make_pair(id, nam));
+    }
+  }
+  for (map<string, string>::const_iterator i = processors.begin(); i != processors.end(); ++i) {
+    const GeoHandler* hdlr = this;
+    string nam = (*i).second;
+    const Detector::PropertyValues& vals = prp[nam];
+    string type = vals.find("type")->second;
+    string tag = type + "_Geant4_action";
+    long result = PluginService::Create<long>(tag, &m_detDesc, hdlr, &vals);
+    if (0 == result) {
+      throw runtime_error("Failed to locate plugin to interprete files of type"
+                          " \"" + tag + "\" - no factory:" + type);
+    }
+    result = *(long*) result;
+    if (result != 1) {
+      throw runtime_error("Failed to invoke the plugin " + tag + " of type " + type);
+    }
+    printout(outputLevel, "Geant4Converter", "+++++ Executed Successfully Geant4 setup module *%s*.", type.c_str());
+  }
+}
+
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
+/// Convert the geometry type material into the corresponding Geant4 object(s).
+void* Geant4Converter::handleMaterialProperties(TObject* matrix) const    {
+  TGDMLMatrix* m = (TGDMLMatrix*)matrix;
+  Geant4GeometryInfo& info = data();
+  Geant4GeometryInfo::PropertyVector* g4 = info.g4OpticalProperties[m];
+  if (!g4) {
+    PrintLevel lvl = debugMaterials ? ALWAYS : outputLevel;
+    g4 = new Geant4GeometryInfo::PropertyVector();
+    size_t rows = m->GetRows();
+    g4->name    = m->GetName();
+    g4->title   = m->GetTitle();
+    g4->bins.reserve(rows);
+    g4->values.reserve(rows);
+    for(size_t i=0; i<rows; ++i)  {
+      g4->bins.push_back(m->Get(i,0)  /*   *CLHEP::eV/units::eV   */);
+      g4->values.push_back(m->Get(i,1));
+    }
+    printout(lvl, "Geant4Converter", "++ Successfully converted material property:%s : %s [%ld rows]",
+             m->GetName(), m->GetTitle(), rows);
+    info.g4OpticalProperties[m] = g4;
+  }
+  return g4;
+}
+
+static G4OpticalSurfaceFinish geant4_surface_finish(TGeoOpticalSurface::ESurfaceFinish f)   {
+#define TO_G4_FINISH(x)  case TGeoOpticalSurface::kF##x : return x;
+  switch(f)   {
+    TO_G4_FINISH(polished);              // smooth perfectly polished surface
+    TO_G4_FINISH(polishedfrontpainted);  // smooth top-layer (front) paint
+    TO_G4_FINISH(polishedbackpainted);   // same is 'polished' but with a back-paint
+ 
+    TO_G4_FINISH(ground);                // rough surface
+    TO_G4_FINISH(groundfrontpainted);    // rough top-layer (front) paint
+    TO_G4_FINISH(groundbackpainted);     // same as 'ground' but with a back-paint
+
+    TO_G4_FINISH(polishedlumirrorair);   // mechanically polished surface, with lumirror
+    TO_G4_FINISH(polishedlumirrorglue);  // mechanically polished surface, with lumirror & meltmount
+    TO_G4_FINISH(polishedair);           // mechanically polished surface
+    TO_G4_FINISH(polishedteflonair);     // mechanically polished surface, with teflon
+    TO_G4_FINISH(polishedtioair);        // mechanically polished surface, with tio paint
+    TO_G4_FINISH(polishedtyvekair);      // mechanically polished surface, with tyvek
+    TO_G4_FINISH(polishedvm2000air);     // mechanically polished surface, with esr film
+    TO_G4_FINISH(polishedvm2000glue);    // mechanically polished surface, with esr film & meltmount
+
+    TO_G4_FINISH(etchedlumirrorair);     // chemically etched surface, with lumirror
+    TO_G4_FINISH(etchedlumirrorglue);    // chemically etched surface, with lumirror & meltmount
+    TO_G4_FINISH(etchedair);             // chemically etched surface
+    TO_G4_FINISH(etchedteflonair);       // chemically etched surface, with teflon
+    TO_G4_FINISH(etchedtioair);          // chemically etched surface, with tio paint
+    TO_G4_FINISH(etchedtyvekair);        // chemically etched surface, with tyvek
+    TO_G4_FINISH(etchedvm2000air);       // chemically etched surface, with esr film
+    TO_G4_FINISH(etchedvm2000glue);      // chemically etched surface, with esr film & meltmount
+
+    TO_G4_FINISH(groundlumirrorair);     // rough-cut surface, with lumirror
+    TO_G4_FINISH(groundlumirrorglue);    // rough-cut surface, with lumirror & meltmount
+    TO_G4_FINISH(groundair);             // rough-cut surface
+    TO_G4_FINISH(groundteflonair);       // rough-cut surface, with teflon
+    TO_G4_FINISH(groundtioair);          // rough-cut surface, with tio paint
+    TO_G4_FINISH(groundtyvekair);        // rough-cut surface, with tyvek
+    TO_G4_FINISH(groundvm2000air);       // rough-cut surface, with esr film
+    TO_G4_FINISH(groundvm2000glue);      // rough-cut surface, with esr film & meltmount
+
+    // for DAVIS model
+    TO_G4_FINISH(Rough_LUT);             // rough surface
+    TO_G4_FINISH(RoughTeflon_LUT);       // rough surface wrapped in Teflon tape
+    TO_G4_FINISH(RoughESR_LUT);          // rough surface wrapped with ESR
+    TO_G4_FINISH(RoughESRGrease_LUT);    // rough surface wrapped with ESR and coupled with opical grease
+    TO_G4_FINISH(Polished_LUT);          // polished surface
+    TO_G4_FINISH(PolishedTeflon_LUT);    // polished surface wrapped in Teflon tape
+    TO_G4_FINISH(PolishedESR_LUT);       // polished surface wrapped with ESR
+    TO_G4_FINISH(PolishedESRGrease_LUT); // polished surface wrapped with ESR and coupled with opical grease
+    TO_G4_FINISH(Detector_LUT);          // polished surface with optical grease
+  default:
+    printout(ERROR,"Geant4Surfaces","++ Unknown finish style: %d [%s]. Assume polished!",
+             int(f), TGeoOpticalSurface::FinishToString(f));
+    return polished;
+  }
+#undef TO_G4_FINISH
+}
+
+static G4SurfaceType geant4_surface_type(TGeoOpticalSurface::ESurfaceType t)   {
+#define TO_G4_TYPE(x)  case TGeoOpticalSurface::kT##x : return x;
+  switch(t)   {
+    TO_G4_TYPE(dielectric_metal);      // dielectric-metal interface
+    TO_G4_TYPE(dielectric_dielectric); // dielectric-dielectric interface
+    TO_G4_TYPE(dielectric_LUT);        // dielectric-Look-Up-Table interface
+    TO_G4_TYPE(dielectric_LUTDAVIS);   // dielectric-Look-Up-Table DAVIS interface
+    TO_G4_TYPE(dielectric_dichroic);   // dichroic filter interface
+    TO_G4_TYPE(firsov);                // for Firsov Process
+    TO_G4_TYPE(x_ray);                  // for x-ray mirror process
+  default:
+    printout(ERROR,"Geant4Surfaces","++ Unknown surface type: %d [%s]. Assume dielectric_metal!",
+             int(t), TGeoOpticalSurface::TypeToString(t));
+    return dielectric_metal;
+  }
+#undef TO_G4_TYPE
+}
+
+static G4OpticalSurfaceModel geant4_surface_model(TGeoOpticalSurface::ESurfaceModel m)   {
+#define TO_G4_MODEL(x)  case TGeoOpticalSurface::kM##x : return x;
+  switch(m)   {
+    TO_G4_MODEL(glisur);   // original GEANT3 model
+    TO_G4_MODEL(unified);  // UNIFIED model
+    TO_G4_MODEL(LUT);      // Look-Up-Table model
+    TO_G4_MODEL(DAVIS);    // DAVIS model
+    TO_G4_MODEL(dichroic); // dichroic filter
+  default:
+    printout(ERROR,"Geant4Surfaces","++ Unknown surface model: %d [%s]. Assume glisur!",
+             int(m), TGeoOpticalSurface::ModelToString(m));
+    return glisur;
+  }
+#undef TO_G4_MODEL
+}
+
+/// Convert the optical surface to Geant4
+void* Geant4Converter::handleOpticalSurface(TObject* surface) const    {
+  TGeoOpticalSurface* s    = (TGeoOpticalSurface*)surface;
+  Geant4GeometryInfo& info = data();
+  G4OpticalSurface*   g4   = info.g4OpticalSurfaces[s];
+  if (!g4) {
+    G4SurfaceType          type   = geant4_surface_type(s->GetType());
+    G4OpticalSurfaceModel  model  = geant4_surface_model(s->GetModel());
+    G4OpticalSurfaceFinish finish = geant4_surface_finish(s->GetFinish());
+    g4 = new G4OpticalSurface(s->GetName(), model, finish, type, s->GetValue());
+    g4->SetSigmaAlpha(s->GetSigmaAlpha());
+    // not implemented: g4->SetPolish(s->GetPolish());
+    printout(debugSurfaces ? ALWAYS : DEBUG, "Geant4Converter",
+             "++ Created OpticalSurface: %-18s type:%s model:%s finish:%s",
+             s->GetName(),
+             TGeoOpticalSurface::TypeToString(s->GetType()),
+             TGeoOpticalSurface::ModelToString(s->GetModel()),
+             TGeoOpticalSurface::FinishToString(s->GetFinish()));
+    G4MaterialPropertiesTable* tab = 0;
+    TListIter it(&s->GetProperties());
+    for(TObject* obj = it.Next(); obj; obj = it.Next())  {
+      TNamed* n = (TNamed*)obj;
+      TGDMLMatrix *matrix = info.manager->GetGDMLMatrix(n->GetTitle());
+      if ( 0 == tab )  {
+        tab = new G4MaterialPropertiesTable();
+        g4->SetMaterialPropertiesTable(tab);
+      }
+      Geant4GeometryInfo::PropertyVector* v =
+        (Geant4GeometryInfo::PropertyVector*)handleMaterialProperties(matrix);
+      if ( !v )  {  // Error!
+        except("Geant4OpticalSurface","++ Failed to convert opt.surface %s. Property table %s is not defined!",
+               s->GetName(), n->GetTitle());
+      }
+      G4MaterialPropertyVector* vec =
+        new G4MaterialPropertyVector(&v->bins[0], &v->values[0], v->bins.size());
+      tab->AddProperty(n->GetName(), vec);
+      printout(debugSurfaces ? ALWAYS : DEBUG, "Geant4Converter",
+               "++       Property: %-20s [%ld x %ld] -->  %s",
+               n->GetName(), matrix->GetRows(), matrix->GetCols(), n->GetTitle());
+    }
+    info.g4OpticalSurfaces[s] = g4;
+  }
+  return g4;
+}
+
+/// Convert the skin surface to Geant4
+void* Geant4Converter::handleSkinSurface(TObject* surface) const   {
+  TGeoSkinSurface*    surf = (TGeoSkinSurface*)surface;
+  Geant4GeometryInfo& info = data();
+  G4LogicalSkinSurface* g4 = info.g4SkinSurfaces[surf];
+  if (!g4) {
+    G4OpticalSurface* s  = info.g4OpticalSurfaces[OpticalSurface(surf->GetSurface())];
+    G4LogicalVolume*  v = info.g4Volumes[surf->GetVolume()];
+    g4 = new G4LogicalSkinSurface(surf->GetName(), v, s);
+    printout(debugSurfaces ? ALWAYS : DEBUG, "Geant4Converter",
+             "++ Created SkinSurface: %-18s  optical:%s",
+             surf->GetName(), surf->GetSurface()->GetName());
+    info.g4SkinSurfaces[surf] = g4;
+  }
+  return g4;
+}
+
+/// Convert the border surface to Geant4
+void* Geant4Converter::handleBorderSurface(TObject* surface) const   {
+  TGeoBorderSurface*    surf = (TGeoBorderSurface*)surface;
+  Geant4GeometryInfo&   info = data();
+  G4LogicalBorderSurface* g4 = info.g4BorderSurfaces[surf];
+  if (!g4) {
+    G4OpticalSurface*  s  = info.g4OpticalSurfaces[OpticalSurface(surf->GetSurface())];
+    G4VPhysicalVolume* n1 = info.g4Placements[surf->GetNode1()];
+    G4VPhysicalVolume* n2 = info.g4Placements[surf->GetNode2()];
+    g4 = new G4LogicalBorderSurface(surf->GetName(), n1, n2, s);
+    printout(debugSurfaces ? ALWAYS : DEBUG, "Geant4Converter",
+             "++ Created BorderSurface: %-18s  optical:%s",
+             surf->GetName(), surf->GetSurface()->GetName());
+    info.g4BorderSurfaces[surf] = g4;
+  }
+  return g4;
+}
+#endif
+
+/// Convert the geometry type SensitiveDetector into the corresponding Geant4 object(s).
+void Geant4Converter::printSensitive(SensitiveDetector sens_det, const set<const TGeoVolume*>& /* volumes */) const {
+  Geant4GeometryInfo&     info = data();
+  set<const TGeoVolume*>& volset = info.sensitives[sens_det];
+  SensitiveDetector       sd = sens_det;
+  stringstream str;
+
+  printout(INFO, "Geant4Converter", "++ SensitiveDetector: %-18s %-20s Hits:%-16s", sd.name(), ("[" + sd.type() + "]").c_str(),
+           sd.hitsCollection().c_str());
+  str << "                    | " << "Cutoff:" << setw(6) << left << sd.energyCutoff() << setw(5) << right << volset.size()
+      << " volumes ";
+  if (sd.region().isValid())
+    str << " Region:" << setw(12) << left << sd.region().name();
+  if (sd.limits().isValid())
+    str << " Limits:" << setw(12) << left << sd.limits().name();
+  str << ".";
+  printout(INFO, "Geant4Converter", str.str().c_str());
+
+  for (const auto i : volset )  {
+    map<Volume, G4LogicalVolume*>::iterator v = info.g4Volumes.find(i);
+    G4LogicalVolume* vol = (*v).second;
+    str.str("");
+    str << "                                   | " << "Volume:" << setw(24) << left << vol->GetName() << " "
+        << vol->GetNoDaughters() << " daughters.";
+    printout(INFO, "Geant4Converter", str.str().c_str());
+  }
+}
+
+string printSolid(G4VSolid* sol) {
+  stringstream str;
+  if (typeid(*sol) == typeid(G4Box)) {
+    const G4Box* b = (G4Box*) sol;
+    str << "++ Box: x=" << b->GetXHalfLength() << " y=" << b->GetYHalfLength() << " z=" << b->GetZHalfLength();
+  }
+  else if (typeid(*sol) == typeid(G4Tubs)) {
+    const G4Tubs* t = (const G4Tubs*) sol;
+    str << " Tubs: Ri=" << t->GetInnerRadius() << " Ra=" << t->GetOuterRadius() << " z/2=" << t->GetZHalfLength() << " Phi="
+        << t->GetStartPhiAngle() << "..." << t->GetDeltaPhiAngle();
+  }
+  return str.str();
+}
+
+/// Print G4 placement
+void* Geant4Converter::printPlacement(const string& name, const TGeoNode* node) const {
+  Geant4GeometryInfo& info = data();
+  G4VPhysicalVolume* g4 = info.g4Placements[node];
+  G4LogicalVolume* vol = info.g4Volumes[node->GetVolume()];
+  G4LogicalVolume* mot = info.g4Volumes[node->GetMotherVolume()];
+  G4VSolid* sol = vol->GetSolid();
+  G4ThreeVector tr = g4->GetObjectTranslation();
+
+  G4VSensitiveDetector* sd = vol->GetSensitiveDetector();
+  if (!sd)  {
+    return g4;
+  }
+  stringstream str;
+  str << "G4Cnv::placement: + " << name << " No:" << node->GetNumber() << " Vol:" << vol->GetName() << " Solid:"
+      << sol->GetName();
+  printout(outputLevel, "G4Placement", str.str().c_str());
+  str.str("");
+  str << "                  |" << " Loc: x=" << tr.x() << " y=" << tr.y() << " z=" << tr.z();
+  printout(outputLevel, "G4Placement", str.str().c_str());
+  printout(outputLevel, "G4Placement", printSolid(sol).c_str());
+  str.str("");
+  str << "                  |" << " Ndau:" << vol->GetNoDaughters() << " physvols." << " Mat:" << vol->GetMaterial()->GetName()
+      << " Mother:" << (char*) (mot ? mot->GetName().c_str() : "---");
+  printout(outputLevel, "G4Placement", str.str().c_str());
+  str.str("");
+  str << "                  |" << " SD:" << sd->GetName();
+  printout(outputLevel, "G4Placement", str.str().c_str());
+  return g4;
+}
+
+template <typename O, typename C, typename F> void handleRefs(const O* o, const C& c, F pmf) {
+  for (typename C::const_iterator i = c.begin(); i != c.end(); ++i) {
+    //(o->*pmf)((*i)->GetName(), *i);
+    (o->*pmf)("", *i);
+  }
+}
+
+template <typename O, typename C, typename F> void handle(const O* o, const C& c, F pmf) {
+  for (typename C::const_iterator i = c.begin(); i != c.end(); ++i) {
+    (o->*pmf)((*i)->GetName(), *i);
+  }
+}
+
+template <typename O, typename F> void handleArray(const O* o, const TObjArray* c, F pmf) {
+  TObjArrayIter arr(c);
+  for(TObject* i = arr.Next(); i; i=arr.Next())
+    (o->*pmf)(i);
+}
+
+template <typename O, typename C, typename F> void handleMap(const O* o, const C& c, F pmf) {
+  for (typename C::const_iterator i = c.begin(); i != c.end(); ++i)
+    (o->*pmf)((*i).first, (*i).second);
+}
+
+template <typename O, typename C, typename F> void handleRMap(const O* o, const C& c, F pmf) {
+  for (typename C::const_reverse_iterator i = c.rbegin(); i != c.rend(); ++i)  {
+    //cout << "Handle RMAP [ " << (*i).first << " ]" << endl;
+    handle(o, (*i).second, pmf);
+  }
+}
+
+/// Create geometry conversion
+Geant4Converter& Geant4Converter::create(DetElement top) {
+  Geant4GeometryInfo& geo = this->init();
+  World wrld = top.world();
+  m_data->clear();
+  geo.manager = &wrld.detectorDescription().manager();
+  collect(top, geo);
+  checkOverlaps = false;
+  // We do not have to handle defines etc.
+  // All positions and the like are not really named.
+  // Hence, start creating the G4 objects for materials, solids and log volumes.
+
+  //outputLevel = WARNING;
+  //setPrintLevel(VERBOSE);
+
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
+  handleArray(this, geo.manager->GetListOfGDMLMatrices(), &Geant4Converter::handleMaterialProperties);
+  handleArray(this, geo.manager->GetListOfOpticalSurfaces(), &Geant4Converter::handleOpticalSurface);
+#endif
+  
+  handle(this,     geo.volumes, &Geant4Converter::collectVolume);
+  handle(this,     geo.solids,  &Geant4Converter::handleSolid);
+  printout(outputLevel, "Geant4Converter", "++ Handled %ld solids.", geo.solids.size());
+  handleRefs(this, geo.vis,     &Geant4Converter::handleVis);
+  printout(outputLevel, "Geant4Converter", "++ Handled %ld visualization attributes.", geo.vis.size());
+  handleMap(this,  geo.limits,  &Geant4Converter::handleLimitSet);
+  printout(outputLevel, "Geant4Converter", "++ Handled %ld limit sets.", geo.limits.size());
+  handleMap(this,  geo.regions, &Geant4Converter::handleRegion);
+  printout(outputLevel, "Geant4Converter", "++ Handled %ld regions.", geo.regions.size());
+  handle(this,     geo.volumes, &Geant4Converter::handleVolume);
+  printout(outputLevel, "Geant4Converter", "++ Handled %ld volumes.", geo.volumes.size());
+  handleRMap(this, *m_data,     &Geant4Converter::handleAssembly);
+  // Now place all this stuff appropriately
+  handleRMap(this, *m_data,     &Geant4Converter::handlePlacement);
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
+  /// Handle concrete surfaces
+  handleArray(this, geo.manager->GetListOfSkinSurfaces(),   &Geant4Converter::handleSkinSurface);
+  handleArray(this, geo.manager->GetListOfBorderSurfaces(), &Geant4Converter::handleBorderSurface);
+#endif
+  //==================== Fields
+  handleProperties(m_detDesc.properties());
+  if ( printSensitives )  {
+    handleMap(this, geo.sensitives, &Geant4Converter::printSensitive);
+  }
+  if ( printPlacements )  {
+    handleRMap(this, *m_data, &Geant4Converter::printPlacement);
+  }
+
+  geo.setWorld(top.placement().ptr());
+  geo.valid = true;
+  printout(INFO, "Geant4Converter", "+++  Successfully converted geometry to Geant4.");
+  return *this;
+}

--- a/SimG4Core/DD4hepGeometry/src/Geant4GeometryInfo.cc
+++ b/SimG4Core/DD4hepGeometry/src/Geant4GeometryInfo.cc
@@ -1,0 +1,66 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Framework include files
+//FIXME: #include "DDG4/Geant4GeometryInfo.h"
+#include "SimG4Core/DD4hepGeometry/interface/Geant4GeometryInfo.h"
+
+// Geant4 include files
+#include "G4VPhysicalVolume.hh"
+
+// C/C++ include files
+#include <stdexcept>
+
+using namespace std;
+using namespace dd4hep::sim;
+
+
+string Geant4GeometryInfo::placementPath(const Geant4PlacementPath& path, bool reverse)   {
+  string s;
+  if ( reverse )  {
+    for (Geant4PlacementPath::const_reverse_iterator pIt = path.rbegin(); pIt != path.rend(); ++pIt) {
+      s += "/"; s += (*pIt)->GetName();
+    }
+  }
+  else  {
+    for (Geant4PlacementPath::const_iterator pIt = path.begin(); pIt != path.end(); ++pIt) {
+      s += "/"; s += (*pIt)->GetName();
+    }
+  }
+  return s;
+}
+
+/// Default constructor
+Geant4GeometryInfo::Geant4GeometryInfo()
+  : TNamed("Geant4GeometryInfo", "Geant4GeometryInfo"), m_world(0), printLevel(DEBUG), valid(false) {
+}
+
+/// Default destructor
+Geant4GeometryInfo::~Geant4GeometryInfo() {
+}
+
+/// The world placement
+G4VPhysicalVolume* Geant4GeometryInfo::world() const   {
+  if ( m_world ) return m_world;
+  throw runtime_error("Geant4GeometryInfo: Attempt to access invalid world placement");
+}
+
+/// Set the world placement
+void Geant4GeometryInfo::setWorld(const TGeoNode* node)    {
+  Geant4GeometryMaps::PlacementMap::const_iterator g4it = g4Placements.find(node);
+  G4VPhysicalVolume* g4 = (g4it == g4Placements.end()) ? 0 : (*g4it).second;
+  if (!g4) {
+    throw runtime_error("Geant4GeometryInfo: Attempt to SET invalid world placement");
+  }
+  m_world = g4;
+}

--- a/SimG4Core/DD4hepGeometry/src/Geant4Mapping.cc
+++ b/SimG4Core/DD4hepGeometry/src/Geant4Mapping.cc
@@ -1,0 +1,93 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Framework include files
+//FIXME: #include "DDG4/Geant4Mapping.h"
+#include "SimG4Core/DD4hepGeometry/interface/Geant4Mapping.h"
+
+#include "DD4hep/Printout.h"
+#include "DD4hep/VolumeManager.h"
+#include "G4PVPlacement.hh"
+#include <stdexcept>
+
+using namespace dd4hep::sim;
+using namespace dd4hep;
+using namespace std;
+
+/// Initializing Constructor
+Geant4Mapping::Geant4Mapping(const Detector& description_ref)
+  : m_detDesc(description_ref), m_dataPtr(0) {
+}
+
+/// Standard destructor
+Geant4Mapping::~Geant4Mapping() {
+  if (m_dataPtr)
+    delete m_dataPtr;
+  m_dataPtr = 0;
+}
+
+/// Possibility to define a singleton instance
+Geant4Mapping& Geant4Mapping::instance() {
+  static Geant4Mapping inst(Detector::getInstance());
+  return inst;
+}
+
+/// When resolving pointers, we must check for the validity of the data block
+void Geant4Mapping::checkValidity() const {
+  if (m_dataPtr)
+    return;
+  throw runtime_error("Geant4Mapping: Attempt to access an invalid data block!");
+}
+
+/// Create new data block. Delete old data block if present.
+Geant4GeometryInfo& Geant4Mapping::init() {
+  Geant4GeometryInfo* p = detach();
+  if (p)
+    delete p;
+  attach(new Geant4GeometryInfo());
+  return data();
+}
+
+/// Release data and pass over the ownership
+Geant4GeometryInfo* Geant4Mapping::detach() {
+  Geant4GeometryInfo* p = m_dataPtr;
+  m_dataPtr = 0;
+  return p;
+}
+
+/// Set a new data block
+void Geant4Mapping::attach(Geant4GeometryInfo* data_ptr) {
+  m_dataPtr = data_ptr;
+}
+
+/// Access the volume manager
+//FIXME: Geant4VolumeManager Geant4Mapping::volumeManager() const {
+//   if ( m_dataPtr ) {
+//     if ( m_dataPtr->g4Paths.empty() ) {
+//       VolumeManager::getVolumeManager(m_detDesc);
+//       return Geant4VolumeManager(m_detDesc, m_dataPtr);
+//     }
+//     return Geant4VolumeManager(Handle < Geant4GeometryInfo > (m_dataPtr));
+//   }
+//   throw runtime_error(format("Geant4Mapping", "Cannot create volume manager without Geant4 geometry info [Invalid-Info]"));
+// }
+
+/// Accessor to resolve geometry placements
+PlacedVolume Geant4Mapping::placement(const G4VPhysicalVolume* node) const {
+  checkValidity();
+  const Geant4GeometryMaps::PlacementMap& m = m_dataPtr->g4Placements;
+  for (Geant4GeometryMaps::PlacementMap::const_iterator i = m.begin(); i != m.end(); ++i)
+    if ((*i).second == node)
+      return PlacedVolume((*i).first);
+  return PlacedVolume(0);
+}

--- a/SimG4Core/DD4hepGeometry/src/Geant4Particle.cc
+++ b/SimG4Core/DD4hepGeometry/src/Geant4Particle.cc
@@ -1,0 +1,521 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Framework include files
+#include "DD4hep/Printout.h"
+#include "DD4hep/Primitives.h"
+#include "DD4hep/InstanceCount.h"
+//FIXME: #include "DDG4/Geant4Particle.h"
+#include "SimG4Core/DD4hepGeometry/interface/Geant4Particle.h"
+#include "TDatabasePDG.h"
+#include "TParticlePDG.h"
+#include "G4ParticleTable.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4VProcess.hh"
+#include "G4ChargedGeantino.hh"
+#include "G4Geantino.hh"
+
+#include <sstream>
+#include <iostream>
+#include <regex.h>
+
+using namespace dd4hep;
+using namespace dd4hep::sim;
+typedef detail::ReferenceBitMask<int> PropertyMask;
+
+/// Default destructor
+ParticleExtension::~ParticleExtension() {
+}
+
+/// Default constructor
+Geant4Particle::Geant4Particle() : ref(1)
+{
+  InstanceCount::increment(this);
+}
+
+/// Constructor with ID initialization
+Geant4Particle::Geant4Particle(int part_id) : ref(1), id(part_id), originalG4ID(part_id)
+{
+  InstanceCount::increment(this);
+}
+
+/// Default destructor
+Geant4Particle::~Geant4Particle()  {
+  InstanceCount::decrement(this);
+  //::printf("************ Delete Geant4Particle[%p]: ID:%d pdgID %d ref:%d\n",(void*)this,id,pdgID,ref);
+}
+
+void Geant4Particle::release()  {
+  //::printf("************ Release Geant4Particle[%p]: ID:%d pdgID %d ref:%d\n",(void*)this,id,pdgID,ref-1);
+  if ( --ref <= 0 )  {
+    delete this;
+  }
+}
+
+/// Assignment operator
+Geant4Particle& Geant4Particle::get_data(Geant4Particle& c)   {
+  if ( this != &c )  {
+    id = c.id;
+    originalG4ID = c.originalG4ID;
+    g4Parent    = c.g4Parent;
+    reason      = c.reason;
+    mask        = c.mask;
+    status      = c.status;
+    genStatus   = c.genStatus;
+    charge      = c.charge;
+    steps       = c.steps;
+    secondaries = c.secondaries;
+    pdgID       = c.pdgID;
+    vsx         = c.vsx;
+    vsy         = c.vsy;
+    vsz         = c.vsz;
+    vex         = c.vex;
+    vey         = c.vey;
+    vez         = c.vez;
+    psx         = c.psx;
+    psy         = c.psy;
+    psz         = c.psz;
+    pex         = c.pex;
+    pey         = c.pey;
+    pez         = c.pez;
+    mass        = c.mass;
+    time        = c.time;
+    properTime  = c.properTime;
+    process     = c.process;
+    //definition  = c.definition;
+    daughters   = c.daughters;
+    parents     = c.parents;
+#if __cplusplus >= 201103L
+    extension.swap(c.extension);
+#else
+    extension   = c.extension;
+#endif
+    //DD4hep_ptr<ParticleExtension>(c.extension.release());
+  }
+  return *this;
+}
+
+/// Remove daughter from set
+void Geant4Particle::removeDaughter(int id_daughter)  {
+  std::set<int>::iterator j = daughters.find(id_daughter);
+  if ( j != daughters.end() ) daughters.erase(j);
+}
+
+/// Access the Geant4 particle definition object (expensive!)
+const G4ParticleDefinition* Geant4ParticleHandle::definition() const   {
+  G4ParticleTable*      tab = G4ParticleTable::GetParticleTable();
+  G4ParticleDefinition* def = tab->FindParticle(particle->pdgID);
+  if ( 0 == def && 0 == particle->pdgID )   {
+    if ( 0 == particle->charge )
+      return G4Geantino::Definition();
+    return G4ChargedGeantino::Definition();
+  }
+  return def;
+}
+
+/// Access to the Geant4 particle name
+std::string Geant4ParticleHandle::particleName() const   {
+  const G4ParticleDefinition* def = definition();
+  if ( def )   {
+    //particle->definition = def;
+    return def->GetParticleName();
+  }
+#if 0
+  TDatabasePDG* db = TDatabasePDG::Instance();
+  TParticlePDG* pdef = db->GetParticle(particle->pdgID);
+  if ( pdef ) return pdef->GetName();
+#endif
+  char text[32];
+  ::snprintf(text,sizeof(text),"PDG:%d",particle->pdgID);
+  return text;
+}
+
+/// Access to the Geant4 particle type
+std::string Geant4ParticleHandle::particleType() const   {
+  const G4ParticleDefinition* def = definition();
+  if ( def )   {
+    //particle->definition = def;
+    return def->GetParticleType();
+  }
+#if 0
+  TDatabasePDG* db = TDatabasePDG::Instance();
+  TParticlePDG* pdef = db->GetParticle(particle->pdgID);
+  if ( pdef ) return pdef->ParticleClass();
+#endif
+  char text[32];
+  ::snprintf(text,sizeof(text),"PDG:%d",particle->pdgID);
+  return text;
+}
+
+/// Access Geant4 particle definitions by regular expression
+std::vector<G4ParticleDefinition*> Geant4ParticleHandle::g4DefinitionsRegEx(const std::string& expression)   {
+  std::vector<G4ParticleDefinition*> results;
+  std::string exp = expression;   //'^'+expression+"$";
+  G4ParticleTable* pt = G4ParticleTable::GetParticleTable();
+  G4ParticleTable::G4PTblDicIterator* iter = pt->GetIterator();
+  char msgbuf[128];
+  regex_t reg;
+  int ret = ::regcomp(&reg, exp.c_str(), 0);
+  if (ret) {
+    throw std::runtime_error(format("Geant4ParticleHandle", "REGEX: Failed to compile particle name %s", exp.c_str()));
+  }
+  results.clear();
+  iter->reset();
+  while ((*iter)()) {
+    G4ParticleDefinition* p = iter->value();
+    ret = ::regexec(&reg, p->GetParticleName().c_str(), 0, NULL, 0);
+    if (!ret)
+      results.push_back(p);
+    else if (ret == REG_NOMATCH)
+      continue;
+    else {
+      ::regerror(ret, &reg, msgbuf, sizeof(msgbuf));
+      ::regfree(&reg);
+      throw std::runtime_error(format("Geant4ParticleHandle", "REGEX: Failed to match particle name %s err=%s", exp.c_str(), msgbuf));
+    }
+  }
+  ::regfree(&reg);
+  return results;
+}
+
+/// Access Geant4 particle definitions by exact match
+G4ParticleDefinition* Geant4ParticleHandle::g4DefinitionsExact(const std::string& expression)   {
+  G4ParticleTable*      tab = G4ParticleTable::GetParticleTable();
+  G4ParticleDefinition* def = tab->FindParticle(expression);
+  return def;
+}
+
+/// Access to the creator process name
+std::string Geant4ParticleHandle::processName() const   {
+  if ( particle->process ) return particle->process->GetProcessName();
+  else if ( particle->reason&G4PARTICLE_PRIMARY ) return "Primary";
+  else if ( particle->status&G4PARTICLE_GEN_EMPTY ) return "Gen.Empty";
+  else if ( particle->status&G4PARTICLE_GEN_STABLE ) return "Gen.Stable";
+  else if ( particle->status&G4PARTICLE_GEN_DECAYED ) return "Gen.Decay";
+  else if ( particle->status&G4PARTICLE_GEN_DOCUMENTATION ) return "Gen.DOC";
+  else if ( particle->status&G4PARTICLE_GEN_BEAM ) return "Gen.Beam";
+  else if ( particle->status&G4PARTICLE_GEN_OTHER ) return "Gen.Other";
+  return "???";
+}
+
+/// Access to the creator process type name
+std::string Geant4ParticleHandle::processTypeName() const   {
+  if ( particle->process )   {
+    return G4VProcess::GetProcessTypeName(particle->process->GetProcessType());
+  }
+  return "";
+}
+
+/// Offset all particle identifiers (id, parents, daughters) by a constant number
+void Geant4ParticleHandle::offset(int off)  const   {
+  std::set<int> temp;
+  Geant4Particle* p = particle;
+  p->id += off;
+
+  temp = p->daughters;
+  p->daughters.clear();
+  for(std::set<int>::iterator i=temp.begin(); i != temp.end(); ++i)
+    p->daughters.insert((*i)+off);
+
+  temp = p->parents;
+  p->parents.clear();
+  for(std::set<int>::iterator i=temp.begin(); i != temp.end(); ++i)
+    p->parents.insert((*i)+off);
+}
+
+/// Output type 1:+++ <tag>   10 def:0xde4eaa8 [gamma     ,   gamma] reason:      20 E:+1.017927e+03  \#Par:  1/4    \#Dau:  2
+void Geant4ParticleHandle::dump1(int level, const std::string& src, const char* tag) const   {
+  char text[256];
+  Geant4ParticleHandle p(*this);
+  text[0]=0;
+  if ( p->parents.size() == 1 )
+    ::snprintf(text,sizeof(text),"/%d",*(p->parents.begin()));
+  else if ( p->parents.size() >  1 )   {
+    text[0]='/';text[1]=0;
+    for(std::set<int>::const_iterator i=p->parents.begin(); i!=p->parents.end(); ++i)
+      ::snprintf(text+strlen(text),sizeof(text)-strlen(text),"%d ",*i);
+  }
+  printout((dd4hep::PrintLevel)level,src,
+           "+++ %s %4d def [%-11s,%8s] reason:%8d E:%+.2e %3s #Dau:%3d #Par:%3d%-5s",
+           tag, p->id,
+           p.particleName().c_str(),
+           p.particleType().c_str(),
+           p->reason,
+           p.energy(),
+           p->g4Parent>0 ? "Sim" : "Gen",
+           int(p->daughters.size()),
+           int(p->parents.size()),text);
+}
+
+/// Output type 2:+++ <tag>   20 G4:   7 def:0xde4eaa8 [gamma     ,   gamma] reason:      20 E:+3.304035e+01 in record:YES  \#Par:  1/18   \#Dau:  0
+void Geant4ParticleHandle::dump2(int level, const std::string& src, const char* tag, int g4id, bool inrec) const   {
+  char text[32];
+  Geant4ParticleHandle p(*this);
+  if ( p->parents.size() == 0 ) text[0]=0;
+  else if ( p->parents.size() == 1 ) ::snprintf(text,sizeof(text),"/%d",*(p->parents.begin()));
+  else if ( p->parents.size() >  1 ) ::snprintf(text,sizeof(text),"/%d..",*(p->parents.begin()));
+  printout((dd4hep::PrintLevel)level,src,
+           "+++ %s %4d G4:%4d [%-12s,%8s] reason:%8d "
+           "E:%+.2e in record:%s  #Par:%3d%-5s #Dau:%3d",
+           tag, p->id, g4id,
+           p.particleName().c_str(),
+           p.particleType().c_str(),
+           p->reason,
+           p.energy(),
+           yes_no(inrec),
+           int(p->parents.size()),text,
+           int(p->daughters.size()));
+}
+
+/// Output type 3:+++ <tag> ID:  0 e-           status:00000014 type:       11 Vertex:(+0.00e+00,+0.00e+00,+0.00e+00) [mm] time: +0.00e+00 [ns] \#Par:  0 \#Dau:  4
+void Geant4ParticleHandle::dumpWithVertex(int level, const std::string& src, const char* tag) const  {
+  char text[256];
+  Geant4ParticleHandle p(*this);
+  text[0]=0;
+  if ( p->parents.size() == 1 )
+    ::snprintf(text,sizeof(text),"/%d",*(p->parents.begin()));
+  else if ( p->parents.size() >  1 )   {
+    text[0]='/';text[1]=0;
+    for(std::set<int>::const_iterator i=p->parents.begin(); i!=p->parents.end(); ++i)
+      ::snprintf(text+strlen(text),sizeof(text)-strlen(text),"%d ",*i);
+  }
+  printout((dd4hep::PrintLevel)level,src,
+           "+++ %s ID:%3d %-12s status:%08X PDG:%6d Vtx:(%+.2e,%+.2e,%+.2e)[mm] "
+           "time: %+.2e [ns] #Dau:%3d #Par:%1d%-6s",
+           tag,p->id,p.particleName().c_str(),p->status,p->pdgID,
+           p->vsx/CLHEP::mm,p->vsy/CLHEP::mm,p->vsz/CLHEP::mm,p->time/CLHEP::ns,
+           p->daughters.size(),
+           p->parents.size(),
+           text);
+}
+
+
+/// Output type 3:+++ <tag> ID:  0 e-           status:00000014 type:       11 Vertex:(+0.00e+00,+0.00e+00,+0.00e+00) [mm] time: +0.00e+00 [ns] \#Par:  0 \#Dau:  4
+void Geant4ParticleHandle::dumpWithMomentum(int level, const std::string& src, const char* tag) const  {
+  char text[256];
+  Geant4ParticleHandle p(*this);
+  text[0]=0;
+  if ( p->parents.size() == 1 )
+    ::snprintf(text,sizeof(text),"/%d",*(p->parents.begin()));
+  else if ( p->parents.size() >  1 )   {
+    text[0]='/';text[1]=0;
+    for(std::set<int>::const_iterator i=p->parents.begin(); i!=p->parents.end(); ++i)
+      ::snprintf(text+strlen(text),sizeof(text)-strlen(text),"%d ",*i);
+  }
+  printout((dd4hep::PrintLevel)level,src,
+           "+++%s ID:%3d %-12s stat:%08X PDG:%6d Mom:(%+.2e,%+.2e,%+.2e)[MeV] "
+           "time: %+.2e [ns] #Dau:%3d #Par:%1d%-6s",
+           tag,p->id,p.particleName().c_str(),p->status,p->pdgID,
+           p->psx/CLHEP::MeV,p->psy/CLHEP::MeV,p->psz/CLHEP::MeV,p->time/CLHEP::ns,
+           int(p->daughters.size()),
+           int(p->parents.size()),
+           text);
+}
+
+/// Output type 3:+++ <tag> ID:  0 e-           status:00000014 type:       11 Vertex:(+0.00e+00,+0.00e+00,+0.00e+00) [mm] time: +0.00e+00 [ns] \#Par:  0 \#Dau:  4
+void Geant4ParticleHandle::dumpWithMomentumAndVertex(int level, const std::string& src, const char* tag) const  {
+  char text[256];
+  Geant4ParticleHandle p(*this);
+  text[0]=0;
+  if ( p->parents.size() == 1 )
+    ::snprintf(text,sizeof(text),"/%d",*(p->parents.begin()));
+  else if ( p->parents.size() >  1 )   {
+    text[0]='/';text[1]=0;
+    for(std::set<int>::const_iterator i=p->parents.begin(); i!=p->parents.end(); ++i)
+      ::snprintf(text+strlen(text),sizeof(text)-strlen(text),"%d ",*i);
+  }
+  printout((dd4hep::PrintLevel)level,src,
+           "+++%s %3d %-12s stat:%08X PDG:%6d Mom:(%+.2e,%+.2e,%+.2e)[MeV] "
+           "Vtx:(%+.2e,%+.2e,%+.2e)[mm] #Dau:%3d #Par:%1d%-6s",
+           tag,p->id,p.particleName().c_str(),p->status,p->pdgID,
+           p->psx/CLHEP::MeV,p->psy/CLHEP::MeV,p->psz/CLHEP::MeV,
+           p->vsx/CLHEP::mm,p->vsy/CLHEP::mm,p->vsz/CLHEP::mm,
+           int(p->daughters.size()),
+           int(p->parents.size()),
+           text);
+}
+
+void Geant4ParticleHandle::header4(int level, const std::string& src, const char* tag)  {
+  printout((dd4hep::PrintLevel)level,src,
+           "+++ %s %10s/%-7s %12s/%-10s %6s/%-6s %4s %4s "
+           "%-4s %-3s %-3s %-10s "
+           "%-5s %-6s %-3s %-3s  %-20s %s",
+           tag,"ID", "G4-ID", "Part-Name","PDG", "Parent","G4-ID", "#Par","#Dau",
+           "Prim","Sec",">E","Energy",
+           "EMPTY","STAB","DEC","DOC", 
+           "Process", "Processing Flags");
+}
+
+void Geant4ParticleHandle::dump4(int level, const std::string& src, const char* tag) const  {
+  Geant4ParticleHandle p(*this);
+  //char equiv[32];
+  PropertyMask mask(p->reason);
+  PropertyMask status(p->status);
+  std::string proc_name = p.processName();
+  std::string proc_type = p.processTypeName();
+  std::string proc = '['+proc_name+(p->process ? "/" : "")+proc_type+']';
+  int parent_id = p->parents.empty() ? -1 : *(p->parents.begin());
+
+  //equiv[0] = 0;
+  //if ( p->parents.end() == p->parents.find(p->g4Parent) )  {
+  //  ::snprintf(equiv,sizeof(equiv),"/%d",p->g4Parent);
+  //}
+  std::stringstream str;
+  str << "Parents: ";
+  for( const auto i : p->parents )
+    str << i << " ";
+  str << " Daughters: ";
+  for( const auto i : p->daughters )
+    str << i << " ";
+  printout((dd4hep::PrintLevel)level,src,
+           "+++ %s ID:%7d/%-7d %12s/%-10d %6d/%-6d %4d %4d %-4s %-3s %-3s %+.3e  "
+           "%-5s %-4s %-3s %-3s  %-20s %c%c%c%c -- %c%c%c%c%c%c%c%c%c  %s",
+           tag,
+           p->id,p->originalG4ID,
+           p.particleName().c_str(),
+           p->pdgID,
+           parent_id,p->g4Parent,
+           p.numParent(),
+           int(p->daughters.size()),
+           yes_no(mask.isSet(G4PARTICLE_PRIMARY)),
+           yes_no(mask.isSet(G4PARTICLE_HAS_SECONDARIES)),
+           yes_no(mask.isSet(G4PARTICLE_ABOVE_ENERGY_THRESHOLD)),
+           p.energy(),
+           //
+           yes_no(mask.isSet(G4PARTICLE_CREATED_CALORIMETER_HIT)),
+           yes_no(mask.isSet(G4PARTICLE_CREATED_TRACKER_HIT)),
+           yes_no(mask.isSet(G4PARTICLE_KEEP_PROCESS)),
+           mask.isSet(G4PARTICLE_KEEP_PARENT) ? "YES" : "",
+           proc.c_str(),
+           // 13 flags in total
+           status.isSet(G4PARTICLE_GEN_EMPTY) ? 'E' : '.',               // 1
+           status.isSet(G4PARTICLE_GEN_STABLE) ? 'S' : '.',
+           status.isSet(G4PARTICLE_GEN_DECAYED) ? 'D' : '.',
+           status.isSet(G4PARTICLE_GEN_DOCUMENTATION) ? 'd' : '.',
+           status.isSet(G4PARTICLE_GEN_BEAM) ? 'B' : '.',                // 5
+           status.isSet(G4PARTICLE_GEN_OTHER) ? 'o' : '.',
+           status.isSet(G4PARTICLE_SIM_CREATED) ? 's' : '.',
+           status.isSet(G4PARTICLE_SIM_BACKSCATTER) ? 'b' : '.',
+           status.isSet(G4PARTICLE_SIM_PARENT_RADIATED) ? 'v' : '.',
+           status.isSet(G4PARTICLE_SIM_DECAY_TRACKER) ? 't' : '.',       // 10
+           status.isSet(G4PARTICLE_SIM_DECAY_CALO) ? 'c' : '.',
+           status.isSet(G4PARTICLE_SIM_LEFT_DETECTOR) ? 'l' : '.',
+           status.isSet(G4PARTICLE_SIM_STOPPED) ? 's' : '.',
+           str.str().c_str()
+           );
+#if 0
+  printout((dd4hep::PrintLevel)level,src,
+           "+++ %s ID:%7d %12s %6d%-7s %7s %3s %5d %3s %+.3e  %-4s %-7s %-3s %-3s %2d  [%s%s%s] %c%c%c%c -- %c%c%c%c%c%c%c",
+           tag,
+           p->id,
+           p.particleName().c_str(),
+           parent_id,equiv,
+           yes_no(mask.isSet(G4PARTICLE_PRIMARY)),
+           yes_no(mask.isSet(G4PARTICLE_HAS_SECONDARIES)),
+           int(p->daughters.size()),
+           yes_no(mask.isSet(G4PARTICLE_ABOVE_ENERGY_THRESHOLD)),
+           p.energy(),
+           yes_no(mask.isSet(G4PARTICLE_CREATED_CALORIMETER_HIT)),
+           yes_no(mask.isSet(G4PARTICLE_CREATED_TRACKER_HIT)),
+           yes_no(mask.isSet(G4PARTICLE_KEEP_PROCESS)),
+           mask.isSet(G4PARTICLE_KEEP_PARENT) ? "YES" : "",
+           p.numParent(),
+           proc_name.c_str(),
+           p->process ? "/" : "",
+           proc_type.c_str(),
+           status.isSet(G4PARTICLE_GEN_EMPTY) ? 'E' : '.',
+           status.isSet(G4PARTICLE_GEN_STABLE) ? 'S' : '.',
+           status.isSet(G4PARTICLE_GEN_DECAYED) ? 'D' : '.',
+           status.isSet(G4PARTICLE_GEN_DOCUMENTATION) ? 'd' : '.',
+           status.isSet(G4PARTICLE_GEN_BEAM) ? 'B' : '.',
+           status.isSet(G4PARTICLE_GEN_OTHER) ? 'o' : '.',
+
+           status.isSet(G4PARTICLE_SIM_CREATED) ? 's' : '.',
+           status.isSet(G4PARTICLE_SIM_BACKSCATTER) ? 'b' : '.',
+           status.isSet(G4PARTICLE_SIM_PARENT_RADIATED) ? 'v' : '.',
+           status.isSet(G4PARTICLE_SIM_DECAY_TRACKER) ? 't' : '.',
+           status.isSet(G4PARTICLE_SIM_DECAY_CALO) ? 'c' : '.',
+           status.isSet(G4PARTICLE_SIM_LEFT_DETECTOR) ? 'l' : '.',
+           status.isSet(G4PARTICLE_SIM_STOPPED) ? 's' : '.'
+           );
+#endif
+}
+
+/// Default destructor
+Geant4ParticleMap::~Geant4ParticleMap()    {
+  clear();
+}
+
+/// Clear particle maps
+void Geant4ParticleMap::clear()    {
+  detail::releaseObjects(particleMap);
+  particleMap.clear();
+  equivalentTracks.clear();
+}
+
+/// Dump content
+void Geant4ParticleMap::dump()  const  {
+  int cnt;
+  char text[64];
+  using namespace std;
+  const Geant4ParticleMap* m = this;
+
+  cnt = 0;
+  cout << "Particle map:" << endl;
+  for(Geant4ParticleMap::ParticleMap::const_iterator i=m->particleMap.begin(); i!=m->particleMap.end();++i)  {
+    ::snprintf(text,sizeof(text)," [%-4d:%p]",(*i).second->id,(void*)(*i).second);
+    cout << text;
+    if ( ++cnt == 8 ) {
+      cout << endl;
+      cnt = 0;
+    }
+  }
+  cout << endl;
+
+  cnt = 0;
+  cout << "Equivalents:" << endl;
+  for(Geant4ParticleMap::TrackEquivalents::const_iterator i=m->equivalentTracks.begin(); i!=m->equivalentTracks.end();++i)  {
+    ::snprintf(text,sizeof(text)," [%-5d : %-5d]",(*i).first,(*i).second);
+    cout << text;
+    if ( ++cnt == 8 ) {
+      cout << endl;
+      cnt = 0;
+    }
+  }
+  cout << endl;
+}
+
+/// Adopt particle maps
+void Geant4ParticleMap::adopt(ParticleMap& pm, TrackEquivalents& equiv)    {
+  clear();
+  particleMap = pm;
+  equivalentTracks = equiv;
+  pm.clear();
+  equiv.clear();
+  //dump();
+}
+
+/// Check if the particle map was ever filled (ie. some particle handler was present)
+  bool Geant4ParticleMap::isValid() const   {
+  return !equivalentTracks.empty();
+}
+
+/// Access the equivalent track id (shortcut to the usage of TrackEquivalents)
+int Geant4ParticleMap::particleID(int g4_id, bool) const   {
+  TrackEquivalents::const_iterator iequiv = equivalentTracks.find(g4_id);
+  if ( iequiv != equivalentTracks.end() ) return (*iequiv).second;
+  printout(ERROR,"Geant4ParticleMap","+++ No Equivalent particle for track:%d."
+           " Monte Carlo truth record looks broken!",g4_id);
+  dump();
+  return -1;
+}

--- a/SimG4Core/DD4hepGeometry/src/Geant4UserLimits.cc
+++ b/SimG4Core/DD4hepGeometry/src/Geant4UserLimits.cc
@@ -1,0 +1,109 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Framework include files
+//FIXME: #include "DDG4/Geant4UserLimits.h"
+#include "SimG4Core/DD4hepGeometry/interface/Geant4UserLimits.h"
+//FIXME: #include "DDG4/Geant4Particle.h"
+#include "SimG4Core/DD4hepGeometry/interface/Geant4Particle.h"
+#include "DD4hep/InstanceCount.h"
+#include "DD4hep/DD4hepUnits.h"
+#include "DD4hep/Primitives.h"
+
+// Geant 4 include files
+#include "G4Track.hh"
+#include "CLHEP/Units/SystemOfUnits.h"
+
+// C/C++ include files
+#include <stdexcept>
+
+using namespace std;
+using namespace dd4hep::sim;
+
+/// Access value according to track
+double Geant4UserLimits::Handler::value(const G4Track& track) const    {
+  if ( !particleLimits.empty() )  {
+    auto i = particleLimits.find(track.GetDefinition());
+    if ( i != particleLimits.end() )  {
+      return (*i).second;
+    }
+  }
+  return defaultValue;
+}
+
+/// Set the handler value(s)
+void Geant4UserLimits::Handler::set(const string& particles, double val)   {
+  if ( particles == "*" )   {
+    defaultValue = val;
+    return;
+  }
+  auto defs = Geant4ParticleHandle::g4DefinitionsRegEx(particles);
+  for(auto* d : defs)
+    particleLimits[d] = val;
+}
+
+/// Initializing Constructor
+Geant4UserLimits::Geant4UserLimits(LimitSet ls)
+  : G4UserLimits(ls.name()), limits(ls)
+{
+  const auto& lim = limits.limits();
+  InstanceCount::increment(this);
+  /// Set defaults
+  maxStepLength.defaultValue  = fMaxStep;
+  maxTrackLength.defaultValue = fMaxTrack;
+  maxTime.defaultValue        = fMaxTime;
+  minEKine.defaultValue       = fMinEkine;
+  minRange.defaultValue       = fMinRange;
+  /// Overwrite with values if present:
+  for(const Limit& l : lim)   {
+    if (l.name == "step_length_max")
+      maxStepLength.set(l.particles, l.value*CLHEP::mm/dd4hep::mm);
+    else if (l.name == "track_length_max")
+      maxTrackLength.set(l.particles, l.value*CLHEP::mm/dd4hep::mm);
+    else if (l.name == "time_max")
+      maxTime.set(l.particles, l.value*CLHEP::ns/dd4hep::ns);
+    else if (l.name == "ekin_min")
+      minEKine.set(l.particles, l.value*CLHEP::MeV/dd4hep::MeV);
+    else if (l.name == "range_min")
+      minRange.set(l.particles, l.value);
+    else
+      throw runtime_error("Unknown Geant4 user limit: " + l.toString());
+  }
+}
+
+/// Standard destructor
+Geant4UserLimits::~Geant4UserLimits()  {
+  InstanceCount::decrement(this);
+}
+
+/// Setters may not be called!
+void Geant4UserLimits::SetMaxAllowedStep(G4double /* ustepMax */)  {
+  dd4hep::notImplemented(string(__PRETTY_FUNCTION__)+" May not be called!");
+}
+
+void Geant4UserLimits::SetUserMaxTrackLength(G4double /* utrakMax */)  {
+  dd4hep::notImplemented(string(__PRETTY_FUNCTION__)+" May not be called!");
+}
+
+void Geant4UserLimits::SetUserMaxTime(G4double /* utimeMax */)  {
+  dd4hep::notImplemented(string(__PRETTY_FUNCTION__)+" May not be called!");
+}
+
+void Geant4UserLimits::SetUserMinEkine(G4double /* uekinMin */)  {
+  dd4hep::notImplemented(string(__PRETTY_FUNCTION__)+" May not be called!");
+}
+
+void Geant4UserLimits::SetUserMinRange(G4double /* urangMin */)  {
+  dd4hep::notImplemented(string(__PRETTY_FUNCTION__)+" May not be called!");
+}
+

--- a/SimG4Core/DD4hepGeometry/test/python/testG4Geometry.py
+++ b/SimG4Core/DD4hepGeometry/test/python/testG4Geometry.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("G4GeometryTest")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.MessageLogger = cms.Service(
+    "MessageLogger",
+    statistics = cms.untracked.vstring('cout', 'g4Geometry'),
+    categories = cms.untracked.vstring('Geometry'),
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING'),
+        noLineBreaks = cms.untracked.bool(True)
+        ),
+    g4Geometry = cms.untracked.PSet(
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        noLineBreaks = cms.untracked.bool(True),
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        WARNING = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        ERROR = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        threshold = cms.untracked.string('INFO'),
+        Geometry = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            )
+        ),
+    destinations = cms.untracked.vstring('cout',
+                                         'g4Geometry')
+    )
+
+process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml'),
+                                            appendToDataLabel = cms.string('MUON')
+                                            )
+process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
+                                                    appendToDataLabel = cms.string('MUON'))
+
+process.test = cms.EDAnalyzer("DDTestG4Geometry",
+                              DDDetector = cms.ESInputTag('MUON')
+                              )
+
+process.p = cms.Path(process.test)


### PR DESCRIPTION
#### PR description:

This PR is intended for discussion only. It does not need to be merged in IBs. @mrodozov is working on adding DDG4 static library, so eventually this code will be picked up from an external. These are DD4hep classes needed to convert a DD geometry description to a G4 geometry.

* DD4hep geometry to G4 geometry converter
* Added a test and its configuration

**There is one issue:** the converter does not like our _material:Vacuum_ definition:

```
<ElementaryMaterial name="Vacuum" density="1e-13*mg/cm3" symbol=" " atomicWeight="1*g/mole" atomicNumber="1"/>
```
as it passes it to G4 the latter throws:
```
-------- EEEE ------- G4Exception-START -------- EEEE -------

*** ExceptionHandler is not defined ***
*** G4Exception : mat012
      issued by : G4Element::G4Element()
Fail to create G4Element CMS element with Z= 2  N= 1   N < Z is not allowed

*** Fatal Exception ***
-------- EEEE -------- G4Exception-END --------- EEEE -------
```

Instead, the following Vacuum definition as a thin Air works fine:
```
<CompositeMaterial name="Vacuum" density="1e-10*mg/cm3" symbol=" " method="mixture by weight">
   <MaterialFraction fraction="0.7494">
    <rMaterial name="materials:Nitrogen"/>
   </MaterialFraction>
   <MaterialFraction fraction="0.2369">
    <rMaterial name="materials:Oxygen"/>
   </MaterialFraction>
   <MaterialFraction fraction="0.0129">
    <rMaterial name="materials:Argon"/>
   </MaterialFraction>
   <MaterialFraction fraction="0.0008">
    <rMaterial name="materials:Hydrogen"/>
   </MaterialFraction>
  </CompositeMaterial>
```
which creates:
```
Geant4Converter        ++ Created G4  Material: materials:Vacuum    density:  0.000 mg/cm3  RadL: 5864694.266 km   Nucl.Int.Length: 13694660.844 km 
                       Imean:  85.538 eV   temperature: 273.15 K  pressure:   1.00 atm
```

#### PR validation:

```
cmsRun SimG4Core/DD4hepGeometry/test/python/testG4Geometry.py
```

#### if this PR is a backport please specify the original PR:

no back port is needed
