### PR TITLE
Ban DQMReferenceHistogramRootFileEventSetupAnalyzer from Production DQM sequences.

### DIFF
--- a/DQMOffline/Configuration/python/DQMOfflineCosmics_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineCosmics_SecondStep_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from CondTools.DQM.DQMReferenceHistogramRootFileEventSetupAnalyzer_cfi import *
 from DQMServices.Components.DQMMessageLoggerClient_cff import *
 from DQMServices.Components.DQMDcsInfoClient_cfi import *
 from DQMServices.Components.DQMFastTimerServiceClient_cfi import *
@@ -27,7 +26,7 @@ DQMOfflineCosmics_SecondStep_PreDPG = cms.Sequence( dqmDcsInfoClient *
                                                     dqmFEDIntegrityClient )
 
 
-DQMOfflineCosmics_SecondStepDPG = cms.Sequence( dqmRefHistoRootFileGetter *
+DQMOfflineCosmics_SecondStepDPG = cms.Sequence(
                                                 DQMOfflineCosmics_SecondStep_PreDPG *
                                                 DQMMessageLoggerClientSeq )
 
@@ -49,12 +48,12 @@ DQMOfflineCosmics_SecondStep_PrePOG = cms.Sequence( TrackingCosmicDQMClient *
                                                     SusyPostProcessorSequence )
  
 DQMOfflineCosmics_SecondStep_PrePOG.remove(fsqClient)
-DQMOfflineCosmics_SecondStepPOG = cms.Sequence( dqmRefHistoRootFileGetter *
+DQMOfflineCosmics_SecondStepPOG = cms.Sequence(
                                                 DQMOfflineCosmics_SecondStep_PrePOG *
                                                 DQMMessageLoggerClientSeq *
                                                 dqmFastTimerServiceClient)
 
-DQMOfflineCosmics_SecondStep = cms.Sequence( dqmRefHistoRootFileGetter *
+DQMOfflineCosmics_SecondStep = cms.Sequence( 
                                              DQMOfflineCosmics_SecondStep_PreDPG *
                                              DQMOfflineCosmics_SecondStep_PrePOG *
                                              DQMMessageLoggerClientSeq )

--- a/DQMOffline/Configuration/python/DQMOfflineHeavyIons_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineHeavyIons_SecondStep_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from CondTools.DQM.DQMReferenceHistogramRootFileEventSetupAnalyzer_cfi import *
 from DQMServices.Components.DQMMessageLoggerClient_cff import *
 from DQMServices.Components.DQMDcsInfoClient_cfi import *
 from DQMServices.Components.DQMFastTimerServiceClient_cfi import *
@@ -27,7 +26,7 @@ DQMOfflineHeavyIons_SecondStep_PreDPG = cms.Sequence( dqmDcsInfoClient *
                                                       es_dqm_client_offline *
                                                       dqmFEDIntegrityClient )
 
-DQMOfflineHeavyIons_SecondStepDPG = cms.Sequence( dqmRefHistoRootFileGetter *
+DQMOfflineHeavyIons_SecondStepDPG = cms.Sequence(
                                          DQMOfflineHeavyIons_SecondStep_PreDPG *
                                          DQMMessageLoggerClientSeq )
 
@@ -46,12 +45,12 @@ DQMOfflineHeavyIons_SecondStep_PrePOG = cms.Sequence( muonQualityTests
                                                       * hiTrackingDqmClientHeavyIons
                                                       )
 
-DQMOfflineHeavyIons_SecondStepPOG = cms.Sequence( dqmRefHistoRootFileGetter *
+DQMOfflineHeavyIons_SecondStepPOG = cms.Sequence(
                                                   DQMOfflineHeavyIons_SecondStep_PrePOG *
                                                   DQMMessageLoggerClientSeq *
                                                   dqmFastTimerServiceClient)
 
-DQMOfflineHeavyIons_SecondStep = cms.Sequence( dqmRefHistoRootFileGetter *
+DQMOfflineHeavyIons_SecondStep = cms.Sequence(
                                                DQMOfflineHeavyIons_SecondStep_PreDPG *
                                                DQMOfflineHeavyIons_SecondStep_PrePOG *
                                                DQMMessageLoggerClientSeq )

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from CondTools.DQM.DQMReferenceHistogramRootFileEventSetupAnalyzer_cfi import *
 from DQMServices.Components.DQMMessageLoggerClient_cff import *
 from DQMServices.Components.DQMDcsInfoClient_cfi import *
 from DQMServices.Components.DQMFastTimerServiceClient_cfi import *
@@ -33,7 +32,7 @@ DQMOffline_SecondStep_PreDPG = cms.Sequence( dqmDcsInfoClient *
                                              dqmFEDIntegrityClient *
                                              l1TriggerDqmOfflineClient )
 
-DQMOffline_SecondStepDPG = cms.Sequence( dqmRefHistoRootFileGetter *
+DQMOffline_SecondStepDPG = cms.Sequence(
                                          DQMOffline_SecondStep_PreDPG *
                                          DQMMessageLoggerClientSeq )
 
@@ -59,14 +58,14 @@ DQMOffline_SecondStep_PrePOG = cms.Sequence( TrackingOfflineDQMClient *
                                              runTauEff)
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
-DQMOffline_SecondStepPOG = cms.Sequence( dqmRefHistoRootFileGetter *
+DQMOffline_SecondStepPOG = cms.Sequence(
                                          DQMOffline_SecondStep_PrePOG *
                                          DQMMessageLoggerClientSeq )
 
 
 HLTMonitoringClient = cms.Sequence(trackingMonitorClientHLT * trackingForDisplacedJetMonitorClientHLT)
 HLTMonitoringClientPA= cms.Sequence(trackingMonitorClientHLT * PAtrackingMonitorClientHLT)
-DQMOffline_SecondStep = cms.Sequence( dqmRefHistoRootFileGetter *
+DQMOffline_SecondStep = cms.Sequence(
                                       DQMOffline_SecondStep_PreDPG *
                                       DQMOffline_SecondStep_PrePOG *
                                       HLTMonitoringClient *
@@ -82,11 +81,11 @@ DQMOffline_SecondStep_FakeHLT.remove( HLTMonitoringClient )
 
 DQMOffline_SecondStep_PrePOGMC = cms.Sequence( bTagCollectorSequenceDATA )
 
-DQMOffline_SecondStepPOGMC = cms.Sequence( dqmRefHistoRootFileGetter *
+DQMOffline_SecondStepPOGMC = cms.Sequence(
                                            DQMOffline_SecondStep_PrePOGMC *
                                            DQMMessageLoggerClientSeq )
 
-DQMHarvestCommon = cms.Sequence( dqmRefHistoRootFileGetter *
+DQMHarvestCommon = cms.Sequence(
                                  DQMMessageLoggerClientSeq *
                                  dqmDcsInfoClient *
                                  SiStripOfflineDQMClient *
@@ -99,7 +98,7 @@ DQMHarvestCommon = cms.Sequence( dqmRefHistoRootFileGetter *
                                  runTauEff *
                                  dqmFastTimerServiceClient
                                 )
-DQMHarvestCommonSiStripZeroBias = cms.Sequence(dqmRefHistoRootFileGetter *
+DQMHarvestCommonSiStripZeroBias = cms.Sequence(
                                                DQMMessageLoggerClientSeq *
                                                dqmDcsInfoClient *
                                                SiStripOfflineDQMClient *
@@ -119,7 +118,7 @@ DQMHarvestTracking = cms.Sequence( TrackingOfflineDQMClient *
 
 DQMHarvestPixelTracking = cms.Sequence( pixelTrackingEffFromHitPattern )
 
-DQMHarvestOuterTracker = cms.Sequence( dqmRefHistoRootFileGetter *
+DQMHarvestOuterTracker = cms.Sequence(
                                  dqmDcsInfoClient *
                                  OuterTrackerClient *
                                  dqmFEDIntegrityClient *


### PR DESCRIPTION
#### PR description:

The references that it loads seem to be deeply outdated, and it is a highly dangerous legacy module.

This was found as collateral damage in #26232.

#### PR validation:

Manual inspection of the histogram names in the old reference shows names that have not been used since 2013 (like `TEC/side1`, which was renamed to `TEC/MINUS` many years ago. Actually, I did not find any name in the reference that is still used.
