### PR TITLE
Removed unnecessary dictionary struct from DataFormats/TrackingRecHit

### DIFF
--- a/DataFormats/TrackingRecHit/src/classes.h
+++ b/DataFormats/TrackingRecHit/src/classes.h
@@ -6,23 +6,3 @@
 #include "DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/RecSegment.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-
-namespace DataFormats_TrackingRecHit {
-  struct dictionary {
-    AlgebraicSymMatrix as;
-
-    std::vector<TrackingRecHit*> v1;
-    TrackingRecHitCollection c1;
-    TrackingRecHitRef r1;
-    InvalidTrackingRecHit i;
-    TrackingRecHitRefProd rp1;
-    TrackingRecHitRefVector rv1;
-    TrackingRecHitRefVector::const_iterator it1;
-    std::pair<edm::OwnVector<TrackingRecHit,
-                             edm::ClonePolicy<TrackingRecHit> >::const_iterator,
-              edm::OwnVector<TrackingRecHit,
-                             edm::ClonePolicy<TrackingRecHit> >::const_iterator> pr1;    
-    std::unique_ptr<TrackingRecHitRef> ap1;
-    edm::Wrapper<TrackingRecHitCollection> w1;
-  };
-}


### PR DESCRIPTION
#### PR description:

ROOT no longer requires explicitly referencing templates in the classes.h file.

#### PR validation:

The code compiles.