### PR TITLE
Removed unnecessary dictionary struct from DataFormats/TrajectorySeed

### DIFF
--- a/DataFormats/TrajectorySeed/src/classes.h
+++ b/DataFormats/TrajectorySeed/src/classes.h
@@ -8,23 +8,3 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/RefHolder.h"
-
-namespace DataFormats_TrajectorySeed {
-  struct dictionary {
-    std::vector<TrajectorySeed> v1;
-    TrajectorySeedCollection c1;
-    edm::Wrapper<TrajectorySeedCollection> w1;
-
-    edm::RefVectorIterator<std::vector<TrajectorySeed>,TrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<TrajectorySeed>,TrajectorySeed> > rfitr1;
-    edm::Ref<TrajectorySeedCollection> s1;
-    edm::RefProd<TrajectorySeedCollection> s2;
-    edm::RefVector<TrajectorySeedCollection> s3;
-
-    edm::RefToBase<TrajectorySeed> sr;  
-    edm::reftobase::IndirectHolder<TrajectorySeed> ihs;
-    edm::reftobase::Holder< TrajectorySeed, edm::Ref<TrajectorySeedCollection> > rbh;
-    edm::reftobase::RefHolder< edm::Ref<TrajectorySeedCollection> > rbrh;
-    edm::reftobase::RefHolder< edm::Ptr<TrajectorySeed> > rhptrts;
-    edm::Ptr<TrajectorySeed> ptrts;
-  };
-}


### PR DESCRIPTION
#### PR description:

ROOT no longer requires explicitly referencing templates in the classes.h file.

#### PR validation:

The code compiles.