### PR TITLE
Removed unnecessary dictionary struct from FWCore/MessageLogger

### DIFF
--- a/FWCore/MessageLogger/src/classes.h
+++ b/FWCore/MessageLogger/src/classes.h
@@ -1,8 +1,2 @@
 #include <vector>
 #include "FWCore/MessageLogger/interface/ErrorSummaryEntry.h"
-
-namespace FWCore_MessageLogger {
-  struct dictionary {
-    std::vector<edm::ErrorSummaryEntry> w_v_es;
-  };
-}


### PR DESCRIPTION
#### PR description:

ROOT no longer requires explicitly referencing templates in the classes.h file.

#### PR validation:

The code compiles.