### PR TITLE
Turning on ClusterRepair for edge hits only 

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '105X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v1',
+    'run1_data'         :   '106X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v1',
+    'run2_data'         :   '106X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v1',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -76,6 +76,7 @@ public:
       float lorentzShiftInCmX;   // a FULL shift, in cm
       float lorentzShiftInCmY;   // a FULL shift, in cm
       int   detTemplateId;       // det if for templates & generic errors
+      int   detTemplateId2D;       // det if for 2D templates
    };
    
    struct ClusterParam

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
@@ -87,6 +87,8 @@ private:
 			SiPixelTemplateReco::ClusMatrix & clusterPayload,
 			int ID) const;
 
+   //Fill IDs for 2D template
+   void fill2DTemplIDs();
 
 
    
@@ -103,6 +105,8 @@ private:
    int barrelTemplateID_ ;
    int forwardTemplateID_ ;
    std::string templateDir_ ;
+
+   const SiPixel2DTemplateDBObject * templateDBobject2D_;
 
    // Configure 2D reco.
    float minChargeRatio_;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
@@ -110,7 +110,32 @@ private:
    
    //bool DoCosmics_;
    //bool LoadTemplatesFromDB_;
-   
+
+   // read sub-detectors to recommend 2D
+   class Rule {
+   public:
+     // parse a rule from a string
+     Rule(const std::string &str) ;
+     // check this DetId to recommend 2D or not (default false)
+     bool recommend(DetId detid, const TrackerTopology &tTopo) const {
+       // check detector
+       if (detid.subdetId() == subdet_) {
+	 // check layer
+	 if ( (layer_ == 0) || (layer_ == int(tTopo.layer(detid))) ) {
+	   return true;
+	 }
+	 else return false;
+       }
+       else return false;
+     }
+   private:
+     int  subdet_;
+     int  layer_;
+   };
+   std::vector<Rule> Recommend2D_;
+
+   // run on damaged hits or not
+   bool RunDamagedClusters_;
 };
 
 #endif

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
@@ -136,10 +136,10 @@ private:
      int  subdet_;
      int  layer_;
    };
-   std::vector<Rule> Recommend2D_;
+   std::vector<Rule> recommend2D_;
 
    // run on damaged hits or not
-   bool RunDamagedClusters_;
+   bool runDamagedClusters_;
 };
 
 #endif

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepairESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepairESProducer.h
@@ -3,6 +3,8 @@
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
 #include <memory>
@@ -11,6 +13,7 @@ class  PixelCPEClusterRepairESProducer: public edm::ESProducer{
  public:
   PixelCPEClusterRepairESProducer(const edm::ParameterSet & p);
   ~PixelCPEClusterRepairESProducer() override; 
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   std::unique_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
  private:
   edm::ParameterSet pset_;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
@@ -37,6 +37,28 @@ PixelCPEClusterRepairESProducer::PixelCPEClusterRepairESProducer(const edm::Para
 
 PixelCPEClusterRepairESProducer::~PixelCPEClusterRepairESProducer() {}
 
+void PixelCPEClusterRepairESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // templates2
+  edm::ParameterSetDescription desc;
+  desc.add<bool>("DoLorentz", true);
+  desc.add<bool>("DoCosmics", false);
+  desc.add<bool>("LoadTemplatesFromDB", true);
+  desc.add<bool>("RunDamagedClusters", false);
+  desc.add<std::string>("ComponentName", "PixelCPEClusterRepair");
+  desc.add<double>("MinChargeRatio", 0.8);
+  desc.add<double>("MaxSizeMismatchInY", 0.3);
+  desc.add<bool>("Alpha2Order", true);
+  desc.add<std::vector<std::string>>("Recommend2D", {
+      "PXB 2",
+        "PXB 3",
+        "PXB 4",
+        });
+  desc.add<int>("ClusterProbComputationFlag", 0);
+  desc.add<int>("speed", -2);
+  desc.add<bool>("UseClusterSplitter", false);
+  descriptions.add("templates2", desc);
+}
+
 std::unique_ptr<PixelClusterParameterEstimator> 
 PixelCPEClusterRepairESProducer::produce(const TkPixelCPERecord & iRecord){ 
 

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
@@ -12,6 +12,11 @@ templates2 = cms.ESProducer("PixelCPEClusterRepairESProducer",
     MaxSizeMismatchInY = cms.double(0.3),
     MinChargeRatio = cms.double(0.8),
     
+    # layers to run on: (only PXB 2,PXB 3,PXB 4 for now)
+    Recommend2D = cms.vstring("PXB 2","PXB 3","PXB 4"),
+
+    # to run on damaged clusterss or not (default=no)
+    RunDamagedClusters = cms.bool(False),
 
     # petar, for clusterProbability() from TTRHs
     ClusterProbComputationFlag = cms.int32(0),

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -105,7 +105,7 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const & conf,
    }
 
    // run CR on damaged clusters (and not only on edge hits)
-   runDamagedClusters_ = conf.existsAs<bool>("RunDamagedClusters")?conf.getParameter<bool>("RunDamagedClusters"):false;
+   runDamagedClusters_ = conf.getParameter<bool>("RunDamagedClusters");
 }
 
 //-----------------------------------------------------------------------------

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -138,7 +138,7 @@ void PixelCPEClusterRepair::fill2DTemplIDs()
 
       p.detTemplateId2D = templateDBobject2D_->getTemplateID(p.theDet->geographicalId());
       if(p.detTemplateId != p.detTemplateId2D && !printed_info){
-          edm::LogInfo("PixelCPEClusterRepair") << "different template ID between 1D and 2D " << p.detTemplateId << " " << p.detTemplateId2D << endl;
+          edm::LogWarning("PixelCPEClusterRepair") << "different template ID between 1D and 2D " << p.detTemplateId << " " << p.detTemplateId2D << endl;
           printed_info = true;
       }
    }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -100,8 +100,8 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const & conf,
    //     XYZ n (XYZ as above, n = layer, wheel or disk = 1 .. 6 ;)
    std::vector<std::string> str_recommend2D = conf.getParameter<std::vector<std::string> >("Recommend2D");
    recommend2D_.reserve(str_recommend2D.size());
-   for (unsigned int i=0; i<str_recommend2D.size();++i){
-     recommend2D_.push_back(Rule(str_recommend2D.at(i)));
+   for (auto & str: str_recommend2D){
+     recommend2D_.push_back(str);
    }
 
    // run CR on damaged clusters (and not only on edge hits)
@@ -545,9 +545,9 @@ void PixelCPEClusterRepair::checkRecommend2D( DetParam const & theDetParam, Clus
     DetId id = (theDetParam.theDet->geographicalId());
 
     bool recommend = false;
-    for (unsigned int i=0; i<recommend2D_.size(); i++){
-        recommend = recommend2D_.at(i).recommend(id, ttopo_);
-	if(recommend) break;
+    for (auto & rec: recommend2D_){
+        recommend = rec.recommend(id, ttopo_);
+        if(recommend) break;
     }
 
     // only run on those layers recommended by configuration

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -541,7 +541,9 @@ void PixelCPEClusterRepair::checkRecommend2D( DetParam const & theDetParam, Clus
 			SiPixelTemplateReco::ClusMatrix & clusterPayload, int ID ) const
 
 {
-
+    // recommend2D is false by default
+    theClusterParam.recommended2D_  = false;
+  
     DetId id = (theDetParam.theDet->geographicalId());
 
     bool recommend = false;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -94,18 +94,18 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const & conf,
    maxSizeMismatchInY_ = conf.getParameter<double>("MaxSizeMismatchInY");
    minChargeRatio_ = conf.getParameter<double>("MinChargeRatio");
 
-   // read sub-detectors to recommend 2D
+   // read sub-detectors and apply rule to recommend 2D 
    // can be: 
    //     XYX (XYZ = PXB, PXE)
    //     XYZ n (XYZ as above, n = layer, wheel or disk = 1 .. 6 ;)
-   std::vector<std::string> str_Recommend2D = conf.getParameter<std::vector<std::string> >("Recommend2D");
-   Recommend2D_.reserve(str_Recommend2D.size());
-   for (std::vector<std::string>::const_iterator it = str_Recommend2D.begin(), ed = str_Recommend2D.end(); it != ed; ++it) {
-     Recommend2D_.push_back(Rule(*it));
+   std::vector<std::string> str_recommend2D = conf.getParameter<std::vector<std::string> >("Recommend2D");
+   recommend2D_.reserve(str_recommend2D.size());
+   for (unsigned int i=0; i<str_recommend2D.size();++i){
+     recommend2D_.push_back(Rule(str_recommend2D.at(i)));
    }
 
    // run CR on damaged clusters (and not only on edge hits)
-   RunDamagedClusters_ = conf.existsAs<bool>("RunDamagedClusters")?conf.getParameter<bool>("RunDamagedClusters"):false;
+   runDamagedClusters_ = conf.existsAs<bool>("RunDamagedClusters")?conf.getParameter<bool>("RunDamagedClusters"):false;
 }
 
 //-----------------------------------------------------------------------------
@@ -193,7 +193,6 @@ PixelCPEClusterRepair::localPosition(DetParam const & theDetParam, ClusterParam 
       else
 	ID1 = ID2 = forwardTemplateID_ ; // forward
    }
-   //cout << "PixelCPEClusterRepair : ID1 = " << ID1 << endl;
 
    // &&& PM, note for later: PixelCPEBase calculates minInX,Y, and maxInX,Y
    //     Why can't we simply use that and save time with row_offset, col_offset
@@ -546,8 +545,8 @@ void PixelCPEClusterRepair::checkRecommend2D( DetParam const & theDetParam, Clus
     DetId id = (theDetParam.theDet->geographicalId());
 
     bool recommend = false;
-    for (std::vector<Rule>::const_iterator itr = Recommend2D_.begin(), edr = Recommend2D_.end(); itr != edr; ++itr) {
-        recommend = itr->recommend(id, ttopo_);
+    for (unsigned int i=0; i<recommend2D_.size(); i++){
+        recommend = recommend2D_.at(i).recommend(id, ttopo_);
 	if(recommend) break;
     }
 
@@ -592,7 +591,7 @@ void PixelCPEClusterRepair::checkRecommend2D( DetParam const & theDetParam, Clus
         theClusterParam.hasBadPixels_ = true;
 
 	// if not RunDamagedClusters flag, don't try to fix any clusters
-	if(!RunDamagedClusters_) {
+	if(!runDamagedClusters_) {
 	    theClusterParam.recommended2D_ = false;
 	}
 

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -12,6 +12,6 @@ from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU
 trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, Phase2StripCPE = cms.string('Phase2StripCPE'))
 
 # uncomment these two lines to turn on Cluster Repair CPE
-# from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-# phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = cms.string('PixelCPEClusterRepair'))
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = cms.string('PixelCPEClusterRepair'))
 


### PR DESCRIPTION
#### PR description:

This PR turns ON ClusterRepair CPE for edge hits only. 
It adds an option to the configuration file so that is possible to choose which pixel sub-detectors/layers to run on. By default this option is: "PXB 2","PXB 3","PXB 4" which refers to layers 2,3 and 4 of PixelBarrel.
The PR further adds a flag to turn on/off CR for truncated clusters - this flag is false by default.

The PR follows from the discussion on the DPG meeting https://indico.cern.ch/event/787658/?showDate=all&showSession=6

The following are updated tags for autoCond:

### **Update pixel local reco conditions** in the offline GTs

### **Data**
New offline GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/106X_dataRun2_v4
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v4/106X_dataRun2_v1
New offline relval GT is
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/106X_dataRun2_relval_v2
Diff
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v2/106X_dataRun2_relval_1

Only 2017 conditions are updated in GenErr, Lorentz angle and 1D template.
2D template changes in 2016 and 2017, but it was not consumed in the past till this PR.

- GenErr 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/tags/SiPixelGenErrorDBObject_38T_forPR26263/SiPixelGenErrorDBObject_38T_v8_offline
- Lorentz angle 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/tags/SiPixelLorentzAngle_38T_forPR26263/SiPixelLorentzAngle_v10_offline
- 1D template
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/tags/SiPixelTemplateDBObject_38T_forPR26263/SiPixelTemplateDBObject_38T_v13_offline
- 2D template 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/tags/SiPixel2DTemplateDBObject_38T_v2_offline/SiPixel2DTemplateDBObject_38T_v1_offline

#### PR validation:

It has been tested locally on data - using cmsDriver step3 - (on JetHT and on a run for which a 2D template exists) and verified by printouts that is called only for the layers that are defined in the configuration file.
It has also been tested using standard runTheMatrix tests using 105X_dataRun2_Candidate_2019_04_03_13_37_01 GT and checking step3 independently for runs corresponding to each 2017 IOV.