### PR TITLE
DD4hep: Drop Namespace in Geometry Definition

### DIFF
--- a/DetectorDescription/DDCMS/data/cms-tracker.xml
+++ b/DetectorDescription/DDCMS/data/cms-tracker.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <DDDefinition>
-  <debug>
-<!-- 
+  <debug> 
     <debug_rotations/>
     <debug_materials/>
 
@@ -13,7 +12,6 @@
     <debug_placements/>
     <debug_algorithms/>
     <debug_visattr/>
--->
   </debug>
   <open_geometry/>
   <close_geometry/>

--- a/DetectorDescription/DDCMS/interface/DDFilteredView.h
+++ b/DetectorDescription/DDCMS/interface/DDFilteredView.h
@@ -97,7 +97,7 @@ namespace cms {
   private:
     
     bool accept(std::string_view);
-    bool addPath(std::string_view, Node* const);
+    bool addPath(Node* const);
     bool addNode(Node* const);
     
     ExpandedNodes nodes_;

--- a/DetectorDescription/DDCMS/interface/Filter.h
+++ b/DetectorDescription/DDCMS/interface/Filter.h
@@ -35,9 +35,6 @@ namespace cms {
     bool isRegex(std::string_view);
     bool compareEqual(std::string_view, std::string_view);
     std::string_view realTopName(std::string_view input);
-    std::string_view noCopyNo(std::string_view input);
-    int copyNo(std::string_view input);
-    std::string_view noNamespace(std::string_view input);
     std::vector<std::string_view> split(std::string_view, const char*);
   }
 }

--- a/DetectorDescription/DDCMS/plugins/DDTECModuleAlgo.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTECModuleAlgo.cc
@@ -213,7 +213,7 @@ static long algorithm(Detector& /* description */,
   if (isStereo) tag = "Stereo";
   //usefull constants
   const double topFrameEndZ = 0.5 * (-waferPosition + fullHeight) + pitchHeight + hybridHeight - topFrameHeight;
-  string idName     = ns.prepend(ns.objName(mother.name()));
+  string idName     = ns.prepend(ns.realName(mother.name()));
   LogDebug("TECGeom") << "idName: " << idName << " parent " << mother.name() << " namespace " << ns.name();
   Solid solid;
   

--- a/DetectorDescription/DDCMS/plugins/DDTECPhiAltAlgo.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTECPhiAltAlgo.cc
@@ -35,7 +35,7 @@ static long algorithm(Detector& /* description */,
   LogDebug("TECGeom") << "debug: Parent " << mother.name() 
 		      << "\tChild " << child.name() << " NameSpace " 
 		      << ns.name();
-
+  
   if (number > 0) {
     double theta  = 90._deg;
     int    copyNo = startCopyNo;

--- a/DetectorDescription/DDCMS/src/DDNamespace.cc
+++ b/DetectorDescription/DDCMS/src/DDNamespace.cc
@@ -181,7 +181,6 @@ DDNamespace::addVolume( dd4hep::Volume vol ) const
   string   n = prepend(vol.name());
   dd4hep::Solid    s = vol.solid();
   dd4hep::Material m = vol.material();
-  vol->SetName(n.c_str());
   m_context->volumes[n] = vol;
   dd4hep::printout( m_context->debug_volumes ? dd4hep::ALWAYS : dd4hep::DEBUG, "DD4CMS",
            "+++ Add volume:%-38s Solid:%-26s[%-16s] Material:%s",

--- a/DetectorDescription/DDCMS/src/DDNamespace.cc
+++ b/DetectorDescription/DDCMS/src/DDNamespace.cc
@@ -181,6 +181,7 @@ DDNamespace::addVolume( dd4hep::Volume vol ) const
   string   n = prepend(vol.name());
   dd4hep::Solid    s = vol.solid();
   dd4hep::Material m = vol.material();
+  //vol->SetName(n.c_str());
   m_context->volumes[n] = vol;
   dd4hep::printout( m_context->debug_volumes ? dd4hep::ALWAYS : dd4hep::DEBUG, "DD4CMS",
            "+++ Add volume:%-38s Solid:%-26s[%-16s] Material:%s",
@@ -215,7 +216,7 @@ DDNamespace::addSolidNS( const string& name, dd4hep::Solid solid ) const
   dd4hep::printout( m_context->debug_shapes ? dd4hep::ALWAYS : dd4hep::DEBUG, "DD4CMS",
            "+++ Add shape of type %s : %s", solid->IsA()->GetName(), name.c_str());
 
-  m_context->shapes.emplace( name,  solid.setName( name ));
+  m_context->shapes.emplace( name,  solid.setName(name));
 
   return solid;
 }

--- a/DetectorDescription/DDCMS/src/Filter.cc
+++ b/DetectorDescription/DDCMS/src/Filter.cc
@@ -12,6 +12,8 @@ namespace cms {
       if(!isRegex(name)) {
     	return (name == node);
       } else {
+	if(name.front() != node.front())
+	  return false;
     	regex pattern({name.data(), name.size()});
     	return regex_match(begin(node), end(node), pattern);
       }
@@ -34,35 +36,13 @@ namespace cms {
 
     bool isRegex(string_view input) {
       return ((contains(input, "*") != -1) ||
-	      (contains(input, ".") != -1));
+      	      (contains(input, ".") != -1));
     }
 
     string_view realTopName(string_view input) {
       string_view v = input;
       auto first = v.find_first_of("//");
       v.remove_prefix(min(first+2, v.size()));
-      return v;
-    }
-    
-    string_view noCopyNo(string_view input) {
-      string_view v = input;
-      auto last = v.find_last_of("_");
-      v.remove_suffix(v.size() - min(last, v.size()));
-      return v;
-    }
-    
-    int copyNo(string_view input) {
-      string_view v = input;
-      auto last = v.find_last_of("_");
-      v.remove_prefix(min(last+1, v.size()));
-    
-      return stoi({v.data(), v.size()});
-    }
-    
-    string_view noNamespace(string_view input) {
-      string_view v = input;
-      auto first = v.find_first_of(":");
-      v.remove_prefix(min(first+1, v.size()));
       return v;
     }
     

--- a/DetectorDescription/DDCMS/test/python/testDDDetectorESProducer.py
+++ b/DetectorDescription/DDCMS/test/python/testDDDetectorESProducer.py
@@ -50,7 +50,7 @@ process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer"
 process.test = cms.EDAnalyzer("DDTestNavigateGeometry",
                               DDDetector = cms.ESInputTag('MUON'),
                               detElementPath = cms.string(''),
-                              placedVolumePath = cms.string('/world_volume_1/cms:OCMS_1/cms:CMSE_1/muonBase:MUON_1')
+                              placedVolumePath = cms.string('/world_volume_1/OCMS_1/CMSE_1/MUON_1')
                               )
 
 process.p = cms.Path(process.test)


### PR DESCRIPTION
#### PR description:

Drop a namespace when building a Geometry description. This allows to drop string manipulations to retrieve copy numbers, names, etc. This gives a gain of additional 0.2 sec

#### PR validation:

Unit tests and integration tests run automatically.

#### if this PR is a backport please specify the original PR:
no back port is needed 