### PR TITLE
Phase2 tracker dtc cabling map (squashed version)

### DIFF
--- a/CondCore/SiPhase2TrackerPlugins/BuildFile.xml
+++ b/CondCore/SiPhase2TrackerPlugins/BuildFile.xml
@@ -1,0 +1,6 @@
+<use name="CondCore/ESSources"/>
+<use name="CondFormats/DataRecord"/>
+<use name="CondFormats/Serialization"/>
+<use name="CondFormats/SiPhase2TrackerObjects"/>
+<use name="rootrflx"/>
+<flags EDM_PLUGIN="1"/>

--- a/CondCore/SiPhase2TrackerPlugins/src/plugin.cc
+++ b/CondCore/SiPhase2TrackerPlugins/src/plugin.cc
@@ -1,0 +1,6 @@
+#include "CondCore/PluginSystem/interface/registration_macros.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
+#include "CondFormats/DataRecord/interface/TrackerDetToDTCELinkCablingMapRcd.h"
+
+REGISTER_PLUGIN(TrackerDetToDTCELinkCablingMapRcd,TrackerDetToDTCELinkCablingMap);
+

--- a/CondFormats/DataRecord/BuildFile.xml
+++ b/CondFormats/DataRecord/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="FWCore/Framework"/>
 <use   name="Geometry/Records"/>
-<use   name="boost"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/DataRecord/interface/TrackerDetToDTCELinkCablingMapRcd.h
+++ b/CondFormats/DataRecord/interface/TrackerDetToDTCELinkCablingMapRcd.h
@@ -1,0 +1,25 @@
+#ifndef CondFormats_DataRecord_TrackerDetToDTCELinkCablingMapRcd_h
+#define CondFormats_DataRecord_TrackerDetToDTCELinkCablingMapRcd_h
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     TrackerDetToDTCELinkCablingMapRcd
+// 
+/**\class TrackerDetToDTCELinkCablingMapRcd TrackerDetToDTCELinkCablingMapRcd.h CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMapRcd.h
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Luigi Calligaris, SPRACE, Sao Paulo, BR
+// Created        :  Wed, 27 Feb 2019 21:41:13 GMT
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class TrackerDetToDTCELinkCablingMapRcd : public edm::eventsetup::EventSetupRecordImplementation<TrackerDetToDTCELinkCablingMapRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/TrackerDetToDTCELinkCablingMapRcd.cc
+++ b/CondFormats/DataRecord/src/TrackerDetToDTCELinkCablingMapRcd.cc
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     TrackerDetToDTCELinkCablingMapRcd
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Luigi Calligaris, SPRACE, Sao Paulo, BR
+// Created        :  Wed, 27 Feb 2019 21:41:13 GMT
+
+#include "CondFormats/DataRecord/interface/TrackerDetToDTCELinkCablingMapRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(TrackerDetToDTCELinkCablingMapRcd);

--- a/CondFormats/SiPhase2TrackerObjects/BuildFile.xml
+++ b/CondFormats/SiPhase2TrackerObjects/BuildFile.xml
@@ -1,0 +1,9 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/Utilities"/>
+<use name="CondFormats/Serialization"/>
+<use name="DataFormats/DetId"/>
+<use name="rootrflx"/>
+<flags GENREFLEX_ARGS="--"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h
+++ b/CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h
@@ -1,0 +1,79 @@
+#ifndef CondFormats_Phase2TrackerDTC_DTCELinkId_h
+#define CondFormats_Phase2TrackerDTC_DTCELinkId_h
+
+// -*- C++ -*-
+//
+// Package:    CondFormats/Phase2TrackerDTC
+// Class:      DTCELinkId
+// 
+/**\class DTCELinkId DTCELinkId.cc CondFormats/Phase2TrackerDTC/src/DTCELinkId.cc
+
+Description: DTCELinkId identifies a specific eLink in the interface of a specific GBT link instance in the firmware of a specific DTC of the tracker back-end.
+
+Implementation:
+		[Notes on implementation]
+*/
+//
+// Original Author:  Luigi Calligaris, SPRACE, Sao Paulo, BR
+// Created        :  Wed, 27 Feb 2019 21:41:13 GMT
+//
+//
+
+#include <cstdint>
+#include <limits>
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+class DTCELinkId
+{
+public:
+	DTCELinkId() noexcept;
+	DTCELinkId(DTCELinkId const&) noexcept;
+	DTCELinkId(DTCELinkId&&) noexcept;
+	DTCELinkId& operator=(DTCELinkId const&) noexcept;
+	DTCELinkId& operator=(DTCELinkId&&) noexcept;
+	~DTCELinkId() noexcept;
+	
+	// Constructs a DTCELinkId addressed by (dtc_id, gbtlink_id, elink_id)
+	DTCELinkId(uint16_t,uint8_t,uint8_t) noexcept;
+	
+	inline auto elink_id()   const noexcept {return elink_id_  ;}
+	inline auto gbtlink_id() const noexcept {return gbtlink_id_;}
+	inline auto dtc_id()     const noexcept {return dtc_id_    ;}
+	
+private:
+	// In order to keep the payload small, we use the C standard integers, optimizing them for size.
+	// The lpGBT has at most 7 ePorts, therefore they can be addressed by an 8-bit number.
+	// The DTC should host at most 72 GBT links, therefore an 8-bit number should be enough to address it.
+	// The C++ memory alignment and padding rules impose that this class will have at least 32 bits size,
+	// i.e. 8+8+8 bits and 8+8+16 would be the same, so we choose the latter.
+	uint8_t  elink_id_  ;
+	uint8_t  gbtlink_id_;
+	uint16_t dtc_id_    ;
+	
+	COND_SERIALIZABLE;
+};
+
+namespace std
+{
+	template <>
+	struct hash<DTCELinkId>
+	{
+		size_t operator()(const DTCELinkId& k) const noexcept
+		{
+			// With 
+			constexpr const size_t shift_gbtlink_id =  numeric_limits< decltype( k.elink_id()   ) >::max() + 1u;
+			constexpr const size_t shift_dtc_id     = (numeric_limits< decltype( k.gbtlink_id() ) >::max() + 1u) * shift_gbtlink_id;
+			
+			return k.elink_id() + k.gbtlink_id() * shift_gbtlink_id + k.dtc_id() * shift_dtc_id;
+		}
+	};
+}
+
+inline bool operator< (DTCELinkId const& lhs, DTCELinkId const& rhs) {return lhs.dtc_id() <  rhs.dtc_id() || (lhs.dtc_id() == rhs.dtc_id() && lhs.gbtlink_id() <  rhs.gbtlink_id()) || (lhs.dtc_id() == rhs.dtc_id() && lhs.gbtlink_id() == rhs.gbtlink_id() && lhs.elink_id() <  rhs.elink_id());}
+inline bool operator> (DTCELinkId const& lhs, DTCELinkId const& rhs) {return lhs.dtc_id() >  rhs.dtc_id() || (lhs.dtc_id() == rhs.dtc_id() && lhs.gbtlink_id() >  rhs.gbtlink_id()) || (lhs.dtc_id() == rhs.dtc_id() && lhs.gbtlink_id() == rhs.gbtlink_id() && lhs.elink_id() >  rhs.elink_id());}
+inline bool operator==(DTCELinkId const& lhs, DTCELinkId const& rhs) {return lhs.dtc_id() == rhs.dtc_id() && lhs.gbtlink_id() == rhs.gbtlink_id() && lhs.elink_id() == rhs.elink_id();}
+inline bool operator!=(DTCELinkId const& lhs, DTCELinkId const& rhs) {return lhs.dtc_id() != rhs.dtc_id() || lhs.gbtlink_id() != rhs.gbtlink_id() || lhs.elink_id() != rhs.elink_id();}
+
+
+#endif // end DataFormats_Phase2TrackerDTC_DTCELinkId_h

--- a/CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h
+++ b/CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h
@@ -1,0 +1,72 @@
+#ifndef CondFormats_Phase2TrackerDTC_TrackerDetToDTCELinkCablingMap_h
+#define CondFormats_Phase2TrackerDTC_TrackerDetToDTCELinkCablingMap_h
+
+// -*- C++ -*-
+//
+// Package:    CondFormats/Phase2TrackerDTC
+// Class:      TrackerDetToDTCELinkCablingMap
+// 
+/**\class TrackerDetToDTCELinkCablingMap TrackerDetToDTCELinkCablingMap.cc CondFormats/Phase2TrackerDTC/src/TrackerDetToDTCELinkCablingMap.cc
+
+Description: Map associating DTCELinkId of Phase2 tracker DTCs to DetId of the sensors connected to each of them.
+
+Implementation:
+		[Notes on implementation]
+*/
+//
+// Original Author:  Luigi Calligaris, SPRACE, Sao Paulo, BR
+// Created        :  Wed, 27 Feb 2019 21:41:13 GMT
+//
+//
+
+#include <vector>
+#include <unordered_map>
+#include <cstdint>
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h"
+
+class TrackerDetToDTCELinkCablingMap
+{
+	public:
+		TrackerDetToDTCELinkCablingMap();
+		virtual ~TrackerDetToDTCELinkCablingMap();
+		
+		/// Resolves the raw DetId of the detector connected to the eLink identified by a DTCELinkId
+		std::unordered_map<DTCELinkId, uint32_t>::const_iterator  dtcELinkIdToDetId(DTCELinkId const&) const;
+		
+		/// Resolves one or more DTCELinkId of eLinks which are connected to the detector identified by the given raw DetId
+		std::pair< std::unordered_multimap<uint32_t, DTCELinkId>::const_iterator, std::unordered_multimap<uint32_t, DTCELinkId>::const_iterator >  detIdToDTCELinkId(uint32_t const) const;
+		
+		/// Returns true if the cabling map has a record corresponding to a detector identified by the given raw DetId
+		bool knowsDTCELinkId(DTCELinkId const&) const;
+		
+		/// Returns true if the cabling map has a record corresponding to an eLink identified by the given DTCELinkId
+		bool knowsDetId(uint32_t) const;
+		
+		// IMPORTANT: The following information is not stored, to preserve space in memory.
+		// As these vectors are generated each time the functions are called, you are encouraged to 
+		// either cache the results or avoid calling them in hot loops.
+		// NOTE: This vectors are unsorted
+		
+		/// Returns a vector containing all elink DTCELinkId nown to the map
+		std::vector<DTCELinkId> getKnownDTCELinkIds() const;
+		
+		/// Returns a vector containing all detector DetId known to the map
+		std::vector<uint32_t>   getKnownDetIds() const;
+		
+		
+		/// Inserts in the cabling map a record corresponding to the connection of an eLink identified by the given DTCELinkId to a detector identified by the given raw DetId
+		void insert(DTCELinkId const&, uint32_t const);
+		
+		/// Clears the map
+		void clear();
+		
+	private:
+		std::unordered_multimap <uint32_t, DTCELinkId> cablingMapDetIdToDTCELinkId_;
+		std::unordered_map      <DTCELinkId, uint32_t> cablingMapDTCELinkIdToDetId_;
+		
+		COND_SERIALIZABLE;
+};
+
+#endif // end CondFormats_Phase2TrackerDTC_TrackerDetToDTCELinkCablingMap_h

--- a/CondFormats/SiPhase2TrackerObjects/src/DTCELinkId.cc
+++ b/CondFormats/SiPhase2TrackerObjects/src/DTCELinkId.cc
@@ -1,0 +1,50 @@
+#include "CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h"
+
+#include <string>
+#include <functional>
+#include <limits>
+
+DTCELinkId::DTCELinkId() noexcept : 
+	elink_id_  (std::numeric_limits< decltype( elink_id()   ) >::max()),
+	gbtlink_id_(std::numeric_limits< decltype( gbtlink_id() ) >::max()),
+	dtc_id_    (std::numeric_limits< decltype( dtc_id()     ) >::max())
+{
+	
+}
+
+DTCELinkId::DTCELinkId(DTCELinkId const& rhs) noexcept : 
+	elink_id_  (rhs.elink_id_  ),
+	gbtlink_id_(rhs.gbtlink_id_),
+	dtc_id_    (rhs.dtc_id_    ) {}
+
+DTCELinkId::DTCELinkId(DTCELinkId&& rhs) noexcept : 
+	elink_id_  (rhs.elink_id_  ),
+	gbtlink_id_(rhs.gbtlink_id_),
+	dtc_id_    (rhs.dtc_id_    ) {}
+
+DTCELinkId& DTCELinkId::operator=(DTCELinkId const& rhs) noexcept
+{
+	elink_id_   = rhs.elink_id_  ;
+	gbtlink_id_ = rhs.gbtlink_id_;
+	dtc_id_     = rhs.dtc_id_    ;
+	
+	return *this;
+}
+
+DTCELinkId& DTCELinkId::operator=(DTCELinkId&& rhs) noexcept
+{
+	elink_id_   = rhs.elink_id_  ;
+	gbtlink_id_ = rhs.gbtlink_id_;
+	dtc_id_     = rhs.dtc_id_    ;
+	
+	return *this;
+}
+
+DTCELinkId::~DTCELinkId() noexcept {}
+
+DTCELinkId::DTCELinkId(uint16_t dtc_id, uint8_t gbtlink_id, uint8_t elink_id) noexcept : 
+	elink_id_  (elink_id  ),
+	gbtlink_id_(gbtlink_id),
+	dtc_id_    (dtc_id    )
+{
+}

--- a/CondFormats/SiPhase2TrackerObjects/src/T_EventSetup_TrackerDetToDTCELinkCablingMap.cc
+++ b/CondFormats/SiPhase2TrackerObjects/src/T_EventSetup_TrackerDetToDTCELinkCablingMap.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(TrackerDetToDTCELinkCablingMap);

--- a/CondFormats/SiPhase2TrackerObjects/src/TrackerDetToDTCELinkCablingMap.cc
+++ b/CondFormats/SiPhase2TrackerObjects/src/TrackerDetToDTCELinkCablingMap.cc
@@ -1,0 +1,103 @@
+#include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <utility>
+#include <algorithm>
+#include <iostream>
+
+TrackerDetToDTCELinkCablingMap::TrackerDetToDTCELinkCablingMap()
+{
+	
+}
+
+TrackerDetToDTCELinkCablingMap::~TrackerDetToDTCELinkCablingMap()
+{
+	
+}
+
+
+std::unordered_map<DTCELinkId, uint32_t>::const_iterator  TrackerDetToDTCELinkCablingMap::dtcELinkIdToDetId(DTCELinkId const& key) const
+{
+	if (cablingMapDTCELinkIdToDetId_.find(key) == cablingMapDTCELinkIdToDetId_.end())
+	{
+		throw cms::Exception("TrackerDetToDTCELinkCablingMap has been asked to return a DetId associated to a DTCELinkId, but the latter is unknown to the map. ")<<" (DTC, GBT, Elink) numbers = (" << key.dtc_id() << "," << key.gbtlink_id() << "," << key.elink_id() << ")" << std::endl;
+	}
+	
+	return cablingMapDTCELinkIdToDetId_.find(key);
+}
+
+
+std::pair<std::unordered_multimap<uint32_t, DTCELinkId>::const_iterator, std::unordered_multimap<uint32_t, DTCELinkId>::const_iterator>  TrackerDetToDTCELinkCablingMap::detIdToDTCELinkId(uint32_t const key) const
+{
+	auto const DTCELinkId_itpair = cablingMapDetIdToDTCELinkId_.equal_range(key);
+	
+	if (DTCELinkId_itpair.first == cablingMapDetIdToDTCELinkId_.end())
+	{
+		throw cms::Exception("TrackerDetToDTCELinkCablingMap has been asked to return a DTCELinkId associated to a DetId, but the latter is unknown to the map. ")<<" DetId = " << key << std::endl;
+	}
+	
+	return DTCELinkId_itpair;
+}
+
+
+bool TrackerDetToDTCELinkCablingMap::knowsDTCELinkId(DTCELinkId const& key) const
+{
+	return cablingMapDTCELinkIdToDetId_.find(key) != cablingMapDTCELinkIdToDetId_.end();
+}
+
+bool TrackerDetToDTCELinkCablingMap::knowsDetId(uint32_t key) const
+{
+	return cablingMapDetIdToDTCELinkId_.find(key) != cablingMapDetIdToDTCELinkId_.end();
+}
+
+
+std::vector<DTCELinkId> TrackerDetToDTCELinkCablingMap::getKnownDTCELinkIds() const
+{
+	std::vector<DTCELinkId> knownDTCELinkIds(cablingMapDTCELinkIdToDetId_.size());
+	
+	// Unzip the map into a vector of DTCELinkId, discarding the DetIds
+	std::transform(cablingMapDTCELinkIdToDetId_.begin(), cablingMapDTCELinkIdToDetId_.end(), knownDTCELinkIds.begin(), [=](auto pair){return pair.first;});
+	
+	return knownDTCELinkIds;
+}
+
+
+std::vector<uint32_t> TrackerDetToDTCELinkCablingMap::getKnownDetIds() const
+{
+	std::vector<uint32_t> knownDetId;
+	
+	// To get the list of unique DetIds we need to iterate over the various equal_ranges 
+	// in the map associated to each unique key, and count them only once.
+	
+	for (auto allpairs_it = cablingMapDetIdToDTCELinkId_.begin(), allpairs_end = cablingMapDetIdToDTCELinkId_.end(); allpairs_it != allpairs_end; )
+	{
+		// ***Store the first instance of the key***
+		knownDetId.push_back(uint32_t(allpairs_it->first));
+		
+		// *** Skip to the end of the equal range ***
+		// The following is just explicative, the bottom expression is equivalent
+		//auto const current_key             = allpairs_it->first;
+		//auto const current_key_equal_range = cablingMapDetIdToDTCELinkId_.equal_range(current_key);
+		//auto const current_key_range_end   = current_key_equal_range.second;
+		auto const current_key_range_end = cablingMapDetIdToDTCELinkId_.equal_range(allpairs_it->first).second;
+		
+		while (allpairs_it != current_key_range_end)
+			++allpairs_it;
+	}
+	
+	return knownDetId;
+}
+
+
+void TrackerDetToDTCELinkCablingMap::insert(DTCELinkId const& dtcELinkId, uint32_t const detId)
+{
+	cablingMapDTCELinkIdToDetId_.insert(std::make_pair(DTCELinkId(dtcELinkId), uint32_t(detId)));
+	cablingMapDetIdToDTCELinkId_.insert(std::make_pair(uint32_t(detId), DTCELinkId(dtcELinkId)));
+}
+
+
+void TrackerDetToDTCELinkCablingMap::clear()
+{
+	cablingMapDTCELinkIdToDetId_.clear();
+	cablingMapDetIdToDTCELinkId_.clear();
+}

--- a/CondFormats/SiPhase2TrackerObjects/src/classes.h
+++ b/CondFormats/SiPhase2TrackerObjects/src/classes.h
@@ -1,0 +1,19 @@
+#include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h"
+#include "DataFormats/DetId/interface/DetId.h"
+
+namespace
+{
+	struct dictionary
+	{
+		TrackerDetToDTCELinkCablingMap cabmap;
+		
+		DTCELinkId dtcelinkid;
+		
+		std::unordered_map     <unsigned int, DTCELinkId> unorderedMapUIntToDTC;
+		std::unordered_multimap<DTCELinkId, unsigned int> unorderedMapDTCToUInt;
+		
+		std::pair<unsigned int, DTCELinkId> unorderedMapUIntToDTC_data = std::make_pair<unsigned int, DTCELinkId>(0,DTCELinkId());
+		std::pair<DTCELinkId, unsigned int> unorderedMapDTCToUInt_data = std::make_pair<DTCELinkId, unsigned int>(DTCELinkId(),0);
+	};
+}

--- a/CondFormats/SiPhase2TrackerObjects/src/classes_def.xml
+++ b/CondFormats/SiPhase2TrackerObjects/src/classes_def.xml
@@ -1,0 +1,8 @@
+<lcgdict>
+	<class name="TrackerDetToDTCELinkCablingMap" class_version="0">
+		<field name="cablingMapDetIdToDTCELinkId_" mapping="blob" />
+		<field name="cablingMapDTCELinkIdToDetId_" mapping="blob" />
+	</class>
+	<class name="DTCELinkId" class_version="0">
+	</class>
+</lcgdict>

--- a/CondFormats/SiPhase2TrackerObjects/src/headers.h
+++ b/CondFormats/SiPhase2TrackerObjects/src/headers.h
@@ -1,0 +1,2 @@
+#include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h"

--- a/CondTools/SiPhase2Tracker/BuildFile.xml
+++ b/CondTools/SiPhase2Tracker/BuildFile.xml
@@ -1,0 +1,8 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/ServiceRegistry"/>
+<use name="FWCore/MessageLogger"/>
+<use name="CondCore/DBOutputService"/>
+<use name="CondFormats/Common"/>
+<use name="CondFormats/DataRecord"/>
+<use name="CondFormats/SiPhase2TrackerObjects"/>

--- a/CondTools/SiPhase2Tracker/plugins/BuildFile.xml
+++ b/CondTools/SiPhase2Tracker/plugins/BuildFile.xml
@@ -1,0 +1,9 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/ServiceRegistry"/>
+<use name="FWCore/MessageLogger"/>
+<use name="CondCore/DBOutputService"/>
+<use name="CondFormats/Common"/>
+<use name="CondFormats/DataRecord"/>
+<use name="CondFormats/SiPhase2TrackerObjects"/>
+<flags EDM_PLUGIN="1"/>

--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
@@ -1,0 +1,313 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/SiPhase2Tracker
+// Class:      DTCCablingMapProducer
+// 
+/**\class DTCCablingMapProducer DTCCablingMapProducer.cc CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
+
+Description: [one line class summary]
+
+Implementation:
+		[Notes on implementation]
+*/
+//
+// Original Author:  Luigi Calligaris, SPRACE, São Paulo, BR
+// Created        :  Wed, 27 Feb 2019 21:41:13 GMT
+//
+//
+
+#include <memory>
+#include <cstdint>
+#include <unordered_map>
+#include <utility>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+// #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+
+#include "CondFormats/Common/interface/Time.h"
+#include "CondFormats/DataRecord/interface/TrackerDetToDTCELinkCablingMapRcd.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h"
+
+
+//
+// CONSTANTS
+//
+
+static constexpr const unsigned int gbt_id_minvalue   = 0;
+static constexpr const unsigned int gbt_id_maxvalue   = 72;
+static constexpr const unsigned int elink_id_minvalue = 0;
+static constexpr const unsigned int elink_id_maxvalue = 7;
+
+
+//
+// SOME HELPER FUNCTIONS
+//
+
+
+
+
+// trim from start (in place)
+static inline void ltrim(std::string &s)
+{
+	s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch)
+	{
+		return !std::isspace(ch);
+	}));
+}
+
+// trim from end (in place)
+static inline void rtrim(std::string &s)
+{
+	s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch)
+	{
+		return !std::isspace(ch);
+	}).base(), s.end());
+}
+
+// trim from both ends (in place)
+static inline void trim(std::string &s)
+{
+	ltrim(s);
+	rtrim(s);
+}
+
+
+
+class DTCCablingMapProducer : public edm::one::EDAnalyzer<>
+{
+	public:
+		explicit DTCCablingMapProducer(const edm::ParameterSet&);
+		~DTCCablingMapProducer() override;
+		
+		static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+		
+	private:
+		void beginJob() override;
+		void analyze(const edm::Event&, const edm::EventSetup&) override;
+		void endJob() override;
+		
+		virtual void LoadModulesToDTCCablingMapFromCSV(std::vector<std::string> const&);
+		
+	private:
+		bool                                            generate_fake_valid_gbtlink_and_elinkid_;
+		int                                             verbosity_                              ;
+		unsigned                                        csvFormat_ncolumns_                     ;
+		unsigned                                        csvFormat_idetid_                       ;
+		unsigned                                        csvFormat_idtcid_                       ;
+		unsigned                                        csvFormat_igbtlinkid_                   ;
+		unsigned                                        csvFormat_ielinkid_                     ;
+		cond::Time_t                                    iovBeginTime_                           ;
+		std::unique_ptr<TrackerDetToDTCELinkCablingMap> pCablingMap_                            ;
+		std::string                                     record_                                 ;
+};
+
+
+void DTCCablingMapProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+	edm::ParameterSetDescription desc;
+	desc.setComment("Stores a TrackerDetToDTCELinkCablingMap object into the database from a CSV file.");
+	desc.add<bool>("generate_fake_valid_gbtlink_and_elinkid", false);
+	desc.add<int>("verbosity", 0);
+	desc.add<unsigned>("csvFormat_idetid"           ,  0);
+	desc.add<unsigned>("csvFormat_ncolumns"         , 15);
+	desc.add<unsigned>("csvFormat_idtcid"           , 10);
+	desc.add<unsigned>("csvFormat_igbtlinkid"       , 11);
+	desc.add<unsigned>("csvFormat_ielinkid"         , 12);
+	desc.add<long long unsigned int>("iovBeginTime" ,  1);
+	desc.add<std::string>("record","TrackerDTCCablingMapRcd");
+	desc.add<std::vector<std::string>>("modulesToDTCCablingCSVFileNames",std::vector<std::string>());
+	descriptions.add("DTCCablingMapProducer", desc);
+}
+
+DTCCablingMapProducer::DTCCablingMapProducer(const edm::ParameterSet& iConfig):
+	generate_fake_valid_gbtlink_and_elinkid_ (iConfig.getParameter<bool>("generate_fake_valid_gbtlink_and_elinkid")),
+	verbosity_                               (iConfig.getParameter<int>("verbosity")),
+	csvFormat_ncolumns_                      (iConfig.getParameter<unsigned>("csvFormat_ncolumns")),
+	csvFormat_idetid_                        (iConfig.getParameter<unsigned>("csvFormat_idetid"  )),
+	csvFormat_idtcid_                        (iConfig.getParameter<unsigned>("csvFormat_idtcid"  )),
+	iovBeginTime_                            (iConfig.getParameter<long long unsigned int>("iovBeginTime")),
+	pCablingMap_                             (std::make_unique<TrackerDetToDTCELinkCablingMap>()),
+	record_                                  (iConfig.getParameter<std::string>("record"))
+{
+	LoadModulesToDTCCablingMapFromCSV(iConfig.getParameter<std::vector<std::string>>("modulesToDTCCablingCSVFileNames"));
+}
+
+void DTCCablingMapProducer::beginJob()
+{
+	
+}
+
+void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(std::vector<std::string> const& modulesToDTCCablingCSVFileNames)
+{
+	using namespace std;
+	
+	for (std::string const& csvFileName : modulesToDTCCablingCSVFileNames)
+	{
+		edm::FileInPath csvFilePath(csvFileName);
+		
+		ifstream csvFile;
+		csvFile.open(csvFilePath.fullPath().c_str());
+		
+		if (csvFile.is_open())
+		{
+			string csvLine;
+			
+			unsigned lineNumber = 0;
+			
+			while (std::getline(csvFile, csvLine))
+			{
+				if (verbosity_ >= 1)
+				{
+					edm::LogInfo("CSVParser") << "Reading CSV file line: " << ++lineNumber << ": \"" << csvLine << "\"" << endl;
+				}
+				
+				istringstream csvStream(csvLine);
+				vector<string> csvColumn;
+				string csvElement;
+				
+				while (std::getline(csvStream, csvElement, ','))
+				{
+					trim(csvElement);
+					csvColumn.push_back(csvElement);
+				}
+				
+				if (verbosity_ >= 2)
+				{
+					ostringstream splitted_line_info;
+					
+					splitted_line_info << "-- split line is: [";
+					
+					for (string const& s : csvColumn)
+						splitted_line_info << "\"" << s << "\", ";
+					
+					splitted_line_info << "]" << endl;
+					
+					edm::LogInfo("CSVParser") << splitted_line_info.str();
+				}
+				
+				if (csvColumn.size() == csvFormat_ncolumns_)
+				{
+					// Skip the legend lines
+					if (0 == csvColumn[0].compare(std::string("Module DetId/U")))
+					{
+						if (verbosity_ >= 1)
+						{
+							edm::LogInfo("CSVParser") << "-- skipping legend line" << endl;
+						}
+						continue;
+					}
+					
+					uint32_t detIdRaw;
+					
+					try
+					{
+						detIdRaw = std::stoi( csvColumn[csvFormat_idetid_] );
+					}
+					catch (std::exception e)
+					{
+						if (verbosity_ >= 0)
+						{
+							edm::LogError("CSVParser") << "-- malformed DetId string in CSV file: \"" << csvLine << "\"" << endl;
+						}
+						throw e;
+					}
+					
+					unsigned const dtc_id = strtoul(csvColumn[csvFormat_idtcid_].c_str(), nullptr, 10);
+					unsigned gbt_id;
+					unsigned elink_id;
+					
+					
+					if (generate_fake_valid_gbtlink_and_elinkid_)
+					{
+						for (gbt_id = gbt_id_minvalue; gbt_id < gbt_id_maxvalue + 1u; ++gbt_id)
+						{
+							for  (elink_id = elink_id_minvalue; elink_id < elink_id_maxvalue + 1u; ++elink_id)
+							{
+								if ( !(pCablingMap_->knowsDTCELinkId( DTCELinkId(dtc_id, gbt_id, elink_id) )) )
+									goto gbtlink_and_elinkid_generator_end; //break out of this double loop
+							}
+						}
+						gbtlink_and_elinkid_generator_end:
+						((void)0); // This is a NOP, it's here just to have a valid (although dummy) instruction after the goto tag
+					}
+					else
+					{
+						gbt_id   = strtoul(csvColumn[csvFormat_igbtlinkid_].c_str(), nullptr, 10);
+						elink_id = strtoul(csvColumn[csvFormat_ielinkid_  ].c_str(), nullptr, 10);
+					}
+					
+					
+					DTCELinkId dtcELinkId( dtc_id, gbt_id, elink_id );
+					
+					if (verbosity_ >= 3)
+					{
+						edm::LogInfo("CSVParser") << "-- DetId = " << detIdRaw << " (dtc_id, gbt_id, elink_id) = (" << dtc_id << "," << gbt_id << "," << elink_id << ")" << endl;
+					}
+					
+					if (pCablingMap_->knowsDTCELinkId(dtcELinkId))
+					{
+						ostringstream message;
+						message << "Reading CSV file: CRITICAL ERROR, duplicated dtcELinkId entry about (dtc_id, gbt_id, elink_id) = (" << dtc_id << "," << gbt_id << "," << elink_id << ")";
+						
+						throw cms::Exception(message.str());
+					}
+					
+					pCablingMap_->insert(dtcELinkId, detIdRaw);
+				}
+				else
+				{
+					if (verbosity_ >= 3)
+					{
+						edm::LogInfo("CSVParser") << "Reading CSV file: Skipped a short line: \"" << csvLine << "\"" << endl;
+					}
+				}
+			}
+		}
+		else
+		{
+			throw cms::Exception("DTCCablingMapProducer: Unable to open input CSV file") << csvFilePath << endl;
+		}
+		
+		csvFile.close();
+	}
+}
+
+void DTCCablingMapProducer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+	
+}
+
+void DTCCablingMapProducer::endJob() 
+{
+// 	using namespace edm;
+	using namespace std;
+	
+	edm::Service<cond::service::PoolDBOutputService> poolDbService;
+	
+	if( poolDbService.isAvailable() )
+	{
+		poolDbService->writeOne( pCablingMap_.release(), iovBeginTime_, record_ );
+	}
+	else
+	{
+		throw cms::Exception("PoolDBService required.");
+	}
+}
+
+DTCCablingMapProducer::~DTCCablingMapProducer()
+{
+	
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(DTCCablingMapProducer);

--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapTestProducer.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapTestProducer.cc
@@ -1,0 +1,109 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/SiPhase2Tracker
+// Class:      DTCCablingMapTestProducer
+// 
+/**\class DTCCablingMapTestProducer DTCCablingMapTestProducer.cc CondTools/SiPhase2Tracker/plugins/DTCCablingMapTestProducer.cc
+
+Description: [one line class summary]
+
+Implementation:
+		[Notes on implementation]
+*/
+//
+// Original Author:  Luigi Calligaris, SPRACE, São Paulo, BR
+// Created        :  Wed, 27 Feb 2019 21:41:13 GMT
+//
+//
+
+#include <memory>
+
+#include <unordered_map>
+#include <utility>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+
+#include "CondFormats/Common/interface/Time.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h"
+#include "CondFormats/DataRecord/interface/TrackerDetToDTCELinkCablingMapRcd.h"
+
+
+class DTCCablingMapTestProducer : public edm::one::EDAnalyzer<>
+{
+	public:
+		explicit DTCCablingMapTestProducer(const edm::ParameterSet&);
+		~DTCCablingMapTestProducer() override;
+		
+		static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+		
+	private:
+		void beginJob() override;
+		void analyze(const edm::Event&, const edm::EventSetup&) override;
+		void endJob() override;
+private:
+		cond::Time_t                                    iovBeginTime_;
+		std::unique_ptr<TrackerDetToDTCELinkCablingMap> pCablingMap_ ;
+		std::string                                     recordName_  ;
+};
+
+void DTCCablingMapTestProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+	edm::ParameterSetDescription desc;
+	desc.setComment("Stores a dummy TrackerDetToDTCELinkCablingMap database object from a CSV file.");
+	desc.add<long long unsigned int>("iovBeginTime", 1);
+	desc.add<std::string>("record","TrackerDetToDTCELinkCablingMap");
+	descriptions.add("DTCCablingMapTestProducer", desc);
+}
+
+DTCCablingMapTestProducer::DTCCablingMapTestProducer(const edm::ParameterSet& iConfig):
+	iovBeginTime_(iConfig.getParameter<long long unsigned int>("iovBeginTime")),
+	pCablingMap_ (std::make_unique<TrackerDetToDTCELinkCablingMap>()),
+	recordName_  (iConfig.getParameter<std::string>("record"))
+{
+	
+}
+
+void DTCCablingMapTestProducer::beginJob()
+{
+	using namespace edm;
+	using namespace std;
+	
+	pCablingMap_->insert(DTCELinkId(101u,1u,2u), 11111111);
+	pCablingMap_->insert(DTCELinkId(102u,2u,2u), 22222222);
+	pCablingMap_->insert(DTCELinkId(103u,3u,3u), 33333333);
+	pCablingMap_->insert(DTCELinkId(104u,4u,4u), 44444444);
+	
+	edm::Service<cond::service::PoolDBOutputService> poolDbService;
+	
+	if( poolDbService.isAvailable() )
+		poolDbService->writeOne( pCablingMap_.release(), iovBeginTime_, recordName_ );
+	else
+		throw std::runtime_error("PoolDBService required.");
+}
+
+
+void DTCCablingMapTestProducer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+	
+}
+
+void DTCCablingMapTestProducer::endJob()
+{
+	
+}
+
+DTCCablingMapTestProducer::~DTCCablingMapTestProducer()
+{
+	
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(DTCCablingMapTestProducer);

--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapTestReader.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapTestReader.cc
@@ -1,0 +1,147 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/SiPhase2Tracker
+// Class:      DTCCablingMapTestReader
+// 
+/**\class DTCCablingMapTestReader DTCCablingMapTestReader.cc CondTools/SiPhase2Tracker/plugins/DTCCablingMapTestReader.cc
+
+Description: [one line class summary]
+
+Implementation:
+		[Notes on implementation]
+*/
+//
+// Original Author:  Luigi Calligaris, SPRACE, São Paulo, BR
+// Created        :  Wed, 27 Feb 2019 21:41:13 GMT
+//
+//
+
+#include <memory>
+#include <utility>
+#include <unordered_map>
+
+#include <string>
+#include <iostream>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+
+#include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h"
+#include "CondFormats/DataRecord/interface/TrackerDetToDTCELinkCablingMapRcd.h"
+
+
+class DTCCablingMapTestReader : public edm::one::EDAnalyzer<>
+{
+	public:
+			explicit DTCCablingMapTestReader(const edm::ParameterSet&);
+			~DTCCablingMapTestReader() override;
+			
+			static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+			
+			
+	private:
+			void beginJob() override;
+			void analyze(const edm::Event&, const edm::EventSetup&) override;
+			void endJob() override;
+			
+};
+
+
+void DTCCablingMapTestReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+	//The following says we do not know what parameters are allowed so do no validation
+	// Please change this to state exactly what you do use, even if it is no parameters
+	edm::ParameterSetDescription desc;
+	desc.setUnknown();
+	descriptions.add("DTCCablingMapTestReader", desc);
+}
+
+
+DTCCablingMapTestReader::DTCCablingMapTestReader(const edm::ParameterSet& iConfig)
+{
+	
+}
+
+
+DTCCablingMapTestReader::~DTCCablingMapTestReader()
+{
+	
+}
+
+
+void DTCCablingMapTestReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+	using namespace edm;
+	using namespace std;
+	
+	edm::ESHandle<TrackerDetToDTCELinkCablingMap> cablingMapHandle;
+	iSetup.get<TrackerDetToDTCELinkCablingMapRcd>().get( cablingMapHandle );
+	TrackerDetToDTCELinkCablingMap const* p_cablingMap = cablingMapHandle.product();
+	
+	{
+		ostringstream dump_DetToElink;
+		
+		dump_DetToElink << "Det To DTC ELink map elements dump (Python-style):" << endl;
+		std::vector<uint32_t> const knownDetIds = p_cablingMap->getKnownDetIds();
+		
+		dump_DetToElink << "{";
+		for (uint32_t detId : knownDetIds)
+		{
+			
+			dump_DetToElink << "(" << detId << " : [";
+			auto equal_range = p_cablingMap->detIdToDTCELinkId(detId);
+			
+			for (auto it = equal_range.first; it != equal_range.second; ++it)
+				dump_DetToElink << "(" << unsigned(it->second.dtc_id()) << ", " << unsigned(it->second.gbtlink_id()) << ", " << unsigned(it->second.elink_id()) << "), ";
+			
+			dump_DetToElink << "], ";
+		}
+		dump_DetToElink << "}" << endl;
+		
+		edm::LogInfo("DetToElinkCablingMapDump") << dump_DetToElink.str();
+	}
+	
+	{
+		ostringstream dump_ElinkToDet;
+		
+		dump_ElinkToDet << "DTC Elink To Det map elements dump (Python-style):" << endl;
+		std::vector<DTCELinkId> const knownDTCELinkIds = p_cablingMap->getKnownDTCELinkIds();
+		
+		dump_ElinkToDet << "{";
+		for (DTCELinkId const& currentELink : knownDTCELinkIds)
+		{
+			dump_ElinkToDet << "(" << unsigned(currentELink.dtc_id()) << ", " << unsigned(currentELink.gbtlink_id()) << ", " << unsigned(currentELink.elink_id()) << ") " << " : ";
+			auto detId_it = p_cablingMap->dtcELinkIdToDetId(currentELink);
+			
+			dump_ElinkToDet << detId_it->second << ", ";
+		}
+		dump_ElinkToDet << "}" << endl;
+		
+		edm::LogInfo("DetToElinkCablingMapDump") << dump_ElinkToDet.str();
+	}
+}
+
+
+void DTCCablingMapTestReader::beginJob()
+{
+	
+}
+
+
+void DTCCablingMapTestReader::endJob() 
+{
+	
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(DTCCablingMapTestReader);

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_dump.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_dump.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DTCCablingMapPayloadDumpTest")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger = cms.Service("MessageLogger",
+	destinations = cms.untracked.vstring(
+		'cerr',
+		'cout'
+	),
+	cerr = cms.untracked.PSet(
+		threshold  = cms.untracked.string('INFO')
+	),
+	cout = cms.untracked.PSet(
+		threshold  = cms.untracked.string('INFO')
+	),
+)
+
+# Load CondDB service
+process.load("CondCore.CondDB.CondDB_cfi")
+
+# input database (in this case the local sqlite files)
+process.CondDB.connect = 'sqlite_file:OuterTrackerDTCCablingMap.db'
+
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    process.CondDB,
+    DumpStat=cms.untracked.bool(True),
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
+        tag = cms.string("DTCCablingMapProducerUserRun")
+    )),
+)
+
+# A data source must always be defined. We don't need it, so here's a dummy one.
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+process.otdtccablingmap_producer = cms.EDAnalyzer("DTCCablingMapTestReader",)
+
+process.path = cms.Path(process.otdtccablingmap_producer)

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_retrieve.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_retrieve.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DTCCablingMapPayloadRetrieveTest")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+process.load("CondCore.CondDB.CondDB_cfi")
+# input database (in this case the local sqlite file)
+process.CondDB.connect = 'sqlite_file:OuterTrackerDTCCablingMap.db'
+
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    process.CondDB,
+    DumpStat=cms.untracked.bool(True),
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
+        tag = cms.string("DTCCablingMapProducerUserRun")
+    )),
+)
+
+process.get = cms.EDAnalyzer("EventSetupRecordDataGetter",
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
+        data = cms.vstring('TrackerDetToDTCELinkCablingMap')
+    )),
+    verbose = cms.untracked.bool(True)
+)
+
+# A data source must always be defined. We don't need it, so here's a dummy one.
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+process.path = cms.Path(process.get)

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DTCCablingMapProducer")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+# Load CondDB service
+process.load("CondCore.CondDB.CondDB_cfi")
+
+# output database (in this case local sqlite file)
+process.CondDB.connect = 'sqlite_file:OuterTrackerDTCCablingMap.db'
+
+# A data source must always be defined. We don't need it, so here's a dummy one.
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+# We define the output service.
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    process.CondDB,
+    timetype = cms.untracked.string('runnumber'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
+        tag = cms.string('DTCCablingMapProducerUserRun')
+    ))
+)
+
+process.otdtccablingmap_producer = cms.EDAnalyzer("DTCCablingMapProducer",
+    record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
+    generate_fake_valid_gbtlink_and_elinkid = cms.bool(True),
+    modulesToDTCCablingCSVFileNames = cms.vstring(
+      "CondTools/SiPhase2Tracker/data/TrackerModuleToDTCCablingMap__OT616_200_IT613__T14__OTOnly.csv"
+    ),
+    csvFormat_ncolumns = cms.uint32( 2),
+    csvFormat_idetid   = cms.uint32( 0),
+    csvFormat_idtcid   = cms.uint32( 1),
+    verbosity = cms.int32(0),
+    #loggingOn= cms.untracked.bool(True),
+    #SinceAppendMode=cms.bool(True),
+    #Source=cms.PSet(
+        #IOVRun=cms.untracked.uint32(1)
+    #)
+)
+
+process.path = cms.Path(process.otdtccablingmap_producer)

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapTestProducer_dump.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapTestProducer_dump.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DTCCablingMapPayloadDumpTest")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger = cms.Service("MessageLogger",
+	destinations = cms.untracked.vstring(
+		'cerr',
+		'cout'
+	),
+	cerr = cms.untracked.PSet(
+		threshold  = cms.untracked.string('INFO') 
+	),
+	cout = cms.untracked.PSet(
+		threshold  = cms.untracked.string('INFO') 
+	),
+)
+
+# Load CondDB service
+process.load("CondCore.CondDB.CondDB_cfi")
+
+# input database (in this case the local sqlite files)
+process.CondDB.connect = 'sqlite_file:OuterTrackerDTCCablingMap_dummytest.db'
+
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    process.CondDB,
+    DumpStat=cms.untracked.bool(True),
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
+        tag = cms.string("DTCCablingMapProducerUserRun")
+    )),
+)
+
+# A data source must always be defined. We don't need it, so here's a dummy one.
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+## We define the output service.
+#process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    #process.CondDB,
+    #timetype = cms.untracked.string('runnumber'),
+    #toPut = cms.VPSet(cms.PSet(
+        #record = cms.string('OuterTrackerDTCCablingMapRcd'),
+        #tag = cms.string('DTCCablingMapProducer_test')
+    #))
+#)
+
+process.otdtccablingmap_producer = cms.EDAnalyzer("DTCCablingMapTestReader",)
+
+process.path = cms.Path(process.otdtccablingmap_producer)

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapTestProducer_retrieve.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapTestProducer_retrieve.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DTCCablingMapPayloadRetrieveTest")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+process.load("CondCore.CondDB.CondDB_cfi")
+# input database (in this case the local sqlite file)
+process.CondDB.connect = 'sqlite_file:OuterTrackerDTCCablingMap_dummytest.db'
+
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    process.CondDB,
+    DumpStat=cms.untracked.bool(True),
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
+        tag = cms.string("DTCCablingMapProducerUserRun")
+    )),
+)
+
+process.get = cms.EDAnalyzer("EventSetupRecordDataGetter",
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
+        data = cms.vstring('TrackerDetToDTCELinkCablingMap')
+    )),
+    verbose = cms.untracked.bool(True)
+)
+
+# A data source must always be defined. We don't need it, so here's a dummy one.
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+process.path = cms.Path(process.get)

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapTestProducer_write.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapTestProducer_write.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DTCCablingMapProducer")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+# Load CondDB service
+process.load("CondCore.CondDB.CondDB_cfi")
+
+# output database (in this case local sqlite file)
+process.CondDB.connect = 'sqlite_file:OuterTrackerDTCCablingMap_dummytest.db'
+
+# A data source must always be defined. We don't need it, so here's a dummy one.
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+# We define the output service.
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    process.CondDB,
+    timetype = cms.untracked.string('runnumber'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string('OuterTrackerDTCCablingMapRcd'),
+        tag = cms.string('DTCCablingMapProducerUserRun')
+    ))
+)
+
+process.otdtccablingmap_producer = cms.EDAnalyzer("DTCCablingMapTestProducer",
+    record = cms.string('OuterTrackerDTCCablingMapRcd'),
+    #loggingOn= cms.untracked.bool(True),
+    #SinceAppendMode=cms.bool(True),
+    #Source=cms.PSet(
+        #IOVRun=cms.untracked.uint32(1)
+    #)
+)
+
+process.path = cms.Path(process.otdtccablingmap_producer)


### PR DESCRIPTION
#### PR description:

Squashed version of #26029 : Database payload object used to associate an eLink inside a GBT link in a specific DTC to a tacker FE module identified by a DetId, and viceversa (the set of eLinks associated to a FE detector).  

The small new package CondCore/SiPhase2TrackerPlugins is added for the time being, postponing a reorganization of that area to a further PR.

See the review of #26029 for further details. It includes the following commits:

commit 04e265b1fccd65b7459910df529c5782b29d0a4f
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Sat Mar 23 16:46:55 2019 -0300

    Specify the correct CSV filename in the cabling map producer

commit 1e15dc6a9cfae1f7bf2ce229fd9bb7bd68ab2ff0
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Mon Mar 18 14:45:03 2019 -0300

    Bugfix: change addDefault(char const*, ConfigurationDescriptions const&) to add(char const*, ConfigurationDescriptions const&) in plugins constructor, since the former call is not supported

commit cc2a34bac9d1392db71013def7668c58018fb143
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Mon Mar 18 13:51:05 2019 -0300

    Add string in DTCCablingMapTestProducer to automatically generate the CFI file

commit 9c59f77b51ddc3104dfc05bff215ff29cc9b063d
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Mon Mar 18 13:47:44 2019 -0300

    Remove redundant Cfi file for DTCCablingMapProducer

commit a2cf9af5e0c3b773909b86fc0556cf544ce90b35
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Fri Mar 15 18:40:22 2019 -0300

    Clean up Buildfile dependencies, move gbt_id and elink_id ranges from being a hardcoded number to a constexpr at the top of the source in the cabling map producer

commit caa1a0b3d8184c0ece3a00e1c0ae9d6aab958b5d
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Thu Mar 14 18:04:52 2019 -0300

    Fix indentation in DTCCablingMapTestProducer, remove redundant bracket in DTCCablingMapProducer

commit baf86486a92d2930448cffef8392584363254f3c
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Fri Mar 8 20:59:43 2019 -0300

    Move headers.h, which was causing problems to git for unknown reasons

commit 54f1cc9e4aa6996bfab976a0721d0cedb74c5c4e
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Fri Mar 8 20:56:52 2019 -0300

    Rename package directories: part 1 (due to git misbehaviour)

commit 6020571d6aed0a0772775d07b9611c6b1647312b
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Fri Mar 8 19:55:31 2019 -0300

    Remove all references to the old SLHCUpgradeSimulations/Phase2TrackerDTC path for the cabling map producer package

commit a884b8721b0c005988e0dd1b2119208329e95235
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Fri Mar 8 19:15:29 2019 -0300

    Rename SLHCUpgradeSimulations/Phase2TrackerDTCCablingMap to CondTools/SiPhase2Tracker

commit ca7e4c94435542f3e42c32e2ef292f8ceda428b2
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Fri Mar 8 19:01:18 2019 -0300

    Remove three string trimming helper functions, which were not being used

commit 76cdbe6fb2285ef31239a0a4a720b54f751d0b46
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Fri Mar 8 14:30:36 2019 -0300

    Remove references to the geometry in the test psets, as it is not used anymore

commit ec15e77a3b40eba3fb590ad3444b6986f8ae24bf
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Fri Mar 8 14:29:48 2019 -0300

    Remove the move operator in the cabling map insertion, which is not needed

commit 254dd82828e6ebaf5469836d9ae75589076f9d7a
Author: Luigi <luigi.calligaris@cern.ch>
Date:   Thu Feb 28 21:10:47 2019 -0300

    Tracker FE to DTC cabling map, after preliminary review (squashed commits)



#### PR validation:

Obtained in CMSSW_10_6_X_2019-03-26-2300 as:
```
git cms-rebase-topic 26029
git checkout -b fc-squash26029
git reset --hard HEAD~14
git merge --squash "HEAD@{1}"
git commit
```

The output of the comparison ```git diff pull/26029..fc-squash26029``` is empty. The original PR has been fully approved already.

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
