### PR TITLE
HBHE: Mahi arrival time

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -103,7 +103,7 @@ class MahiFit
 
   void setParameters(bool iDynamicPed, double iTS4Thresh, double chiSqSwitch, 
 		     bool iApplyTimeSlew, HcalTimeSlew::BiasSetting slewFlavor,
-		     double iMeanTime, double iTimeSigmaHPD, double iTimeSigmaSiPM, 
+		     bool iCalculateArrivalTime, double iMeanTime, double iTimeSigmaHPD, double iTimeSigmaSiPM,
 		     const std::vector <int> &iActiveBXs, int iNMaxItersMin, int iNMaxItersNNLS,
 		     double iDeltaChiSqThresh, double iNnlsThresh);
 
@@ -165,6 +165,7 @@ class MahiFit
   HcalTimeSlew::BiasSetting slewFlavor_;
   float tsDelay1GeV_=0.f;
 
+  bool calculateArrivalTime_;
   float meanTime_;
   float timeSigmaHPD_; 
   float timeSigmaSiPM_;

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -8,7 +8,7 @@ MahiFit::MahiFit() :
 
 void MahiFit::setParameters(bool iDynamicPed, double iTS4Thresh, double chiSqSwitch, 
 			    bool iApplyTimeSlew, HcalTimeSlew::BiasSetting slewFlavor,
-			    double iMeanTime, double iTimeSigmaHPD, double iTimeSigmaSiPM, 
+			    bool iCalculateArrivalTime, double iMeanTime, double iTimeSigmaHPD, double iTimeSigmaSiPM,
 			    const std::vector <int> &iActiveBXs, int iNMaxItersMin, int iNMaxItersNNLS,
 			    double iDeltaChiSqThresh, double iNnlsThresh) {
 
@@ -20,6 +20,7 @@ void MahiFit::setParameters(bool iDynamicPed, double iTS4Thresh, double chiSqSwi
   applyTimeSlew_ = iApplyTimeSlew;
   slewFlavor_    = slewFlavor;
 
+  calculateArrivalTime_ = iCalculateArrivalTime;
   meanTime_      = iMeanTime;
   timeSigmaHPD_  = iTimeSigmaHPD;
   timeSigmaSiPM_ = iTimeSigmaSiPM;
@@ -197,7 +198,9 @@ void MahiFit::doFit(std::array<float,3> &correctedOutput, int nbx) const {
   if (foundintime) {
     correctedOutput.at(0) = nnlsWork_.ampVec.coeff(ipulseintime); //charge
     if (correctedOutput.at(0)!=0) {
-	float arrivalTime = calculateArrivalTime();
+      // fixME store the timeslew
+	float arrivalTime = 0.;
+	if(calculateArrivalTime_) arrivalTime = calculateArrivalTime();
 	correctedOutput.at(1) = arrivalTime; //time
     }
     else correctedOutput.at(1) = -9999;//time

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -282,7 +282,7 @@ void MahiFit::updatePulseShape(double itQ, FullSampleVector &pulseShape, FullSam
   //with previous SOI=TS4 case assumed by psfPtr_->getPulseShape()
   int delta =  4 - nnlsWork_. tsOffset;
 
-  auto invDt = 0.25 / nnlsWork_.dt;
+  auto invDt = 0.5 / nnlsWork_.dt;
 
   for (unsigned int iTS=0; iTS<nnlsWork_.tsSize; ++iTS) {
 
@@ -336,11 +336,13 @@ float MahiFit::calculateArrivalTime() const {
   for (unsigned int iBX=0; iBX<nnlsWork_.nPulseTot; ++iBX) {
     int offset=nnlsWork_.bxs.coeff(iBX);
     if (offset==0) itIndex=iBX;
+    nnlsWork_.pulseDerivMat.col(iBX) *= nnlsWork_.ampVec.coeff(iBX);
+
   }
 
-  PulseVector residuals = nnlsWork_.pulseMat*nnlsWork_.ampVec - nnlsWork_.amplitudes;
+  SampleVector residuals = nnlsWork_.pulseMat*nnlsWork_.ampVec - nnlsWork_.amplitudes;
   PulseVector solution = nnlsWork_.pulseDerivMat.colPivHouseholderQr().solve(residuals);
-  float t = solution.coeff(itIndex)/nnlsWork_.ampVec.coeff(itIndex);
+  float t = solution.coeff(itIndex);
   t = (t>timeLimit_) ?  timeLimit_ : 
     ((t<-timeLimit_) ? -timeLimit_ : t);
 

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
@@ -20,6 +20,7 @@ parseHBHEMahiDescription(const edm::ParameterSet& conf)
 
   const bool iApplyTimeSlew   = conf.getParameter<bool>   ("applyTimeSlew");
 
+  const bool iCalculateArrivalTime   = conf.getParameter<bool>   ("calculateArrivalTime");
   const double iMeanTime      = conf.getParameter<double> ("meanTime");
   const double iTimeSigmaHPD  = conf.getParameter<double> ("timeSigmaHPD");
   const double iTimeSigmaSiPM = conf.getParameter<double> ("timeSigmaSiPM");
@@ -33,7 +34,7 @@ parseHBHEMahiDescription(const edm::ParameterSet& conf)
   std::unique_ptr<MahiFit> corr = std::make_unique<MahiFit>();
 
   corr->setParameters(iDynamicPed, iTS4Thresh, chiSqSwitch, iApplyTimeSlew, HcalTimeSlew::Medium,
-		      iMeanTime, iTimeSigmaHPD, iTimeSigmaSiPM,
+		      iCalculateArrivalTime, iMeanTime, iTimeSigmaHPD, iTimeSigmaSiPM,
 		      iActiveBXs, iNMaxItersMin, iNMaxItersNNLS,
 		      iDeltaChiSqThresh, iNnlsThresh);
 
@@ -149,6 +150,7 @@ edm::ParameterSetDescription fillDescriptionForParseHBHEPhase1Algo()
     desc.add<double>("tdcTimeShift", 0.0);
     desc.add<bool>("correctForPhaseContainment", true);
     desc.add<bool>("applyLegacyHBMCorrection", true);
+    desc.add<bool>("calculateArrivalTime", true);
 
     return desc;
 }

--- a/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
@@ -98,6 +98,7 @@ class MahiDebugger : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
   HcalTimeSlew::BiasSetting slewFlavor_;
   double tsDelay1GeV_=0;
 
+  bool calculateArrivalTime_;
   float meanTime_;
   float timeSigmaHPD_; 
   float timeSigmaSiPM_;
@@ -180,6 +181,7 @@ MahiDebugger::MahiDebugger(const edm::ParameterSet& iConfig)
     ts4Thresh_(iConfig.getParameter<double> ("ts4Thresh")), 
     chiSqSwitch_(iConfig.getParameter<double> ("chiSqSwitch")),
     applyTimeSlew_(iConfig.getParameter<bool> ("applyTimeSlew")),
+    calculateArrivalTime_(iConfig.getParameter<bool> ("calculateArrivalTime")),
     meanTime_(iConfig.getParameter<double> ("meanTime")),
     timeSigmaHPD_(iConfig.getParameter<double> ("timeSigmaHPD")),
     timeSigmaSiPM_(iConfig.getParameter<double> ("timeSigmaSiPM")),
@@ -195,7 +197,7 @@ MahiDebugger::MahiDebugger(const edm::ParameterSet& iConfig)
   mahi_ = std::make_unique<MahiFit>();
 
   mahi_ -> setParameters(dynamicPed_, ts4Thresh_, chiSqSwitch_, applyTimeSlew_, HcalTimeSlew::Medium,
-			 meanTime_, timeSigmaHPD_, timeSigmaSiPM_,
+			 calculateArrivalTime_, meanTime_, timeSigmaHPD_, timeSigmaSiPM_,
 			 activeBXs_, nMaxItersMin_, nMaxItersNNLS_,
 			 deltaChiSqThresh_, nnlsThresh_);
 

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEMahiParameters_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEMahiParameters_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # Configuration parameters for Mahi
 mahiParameters = cms.PSet(
 
+    calculateArrivalTime  = cms.bool(True),
     dynamicPed        = cms.bool(False),
     ts4Thresh         = cms.double(0.0),
     chiSqSwitch       = cms.double(15.0),


### PR DESCRIPTION
This PR fix a few bugs found in the computation of the arrival time
(as follow up of https://github.com/cms-sw/cmssw/issues/25526)

See more description for the mahi-arrival time here
https://indico.cern.ch/event/803700/contributions/3347234/attachments/1808485/2952580/PSG_0308.pdf

Also a configurable has been added to switch off the computation of the pulse arrival time.
The arrival time is not used at HLT and it use 10% of the cpu, cpu time that can be saved for Run3.