### PR TITLE
Run2-hcx192 Changes to DDHCalAngular by removing explicit reference to CLHEP

### DIFF
--- a/DetectorDescription/Core/interface/DDTypes.h
+++ b/DetectorDescription/Core/interface/DDTypes.h
@@ -35,4 +35,8 @@ std::ostream & operator<<(std::ostream & os, const DDStringVectorArguments & t);
 // Formats an angle in radians as a 0-padded string in degrees; e.g. "0001.293900" for 1.2939 degrees.
 std::string formatAsDegrees(double radianVal);
 
+// Formats an angle in radians as a 0-padded string in degrees expressed as integer between 0 and 360; e.g. "090" for -270.001 degrees. 
+std::string formatAsDegreesInInteger(double radianVal);
+
+
 #endif // DDTYPES

--- a/DetectorDescription/Core/src/DDTypes.cc
+++ b/DetectorDescription/Core/src/DDTypes.cc
@@ -81,3 +81,16 @@ std::string formatAsDegrees(double radianVal)
 		return degstr;
 	else return "0000.000000";
 }
+
+// Formats an angle in radians as a 0-padded string in degrees expressed as integer between 0 and 360; e.g. "090" for -270.001 degrees.
+std::string formatAsDegreesInInteger(double radianVal) {
+
+  const unsigned short numlen = 4;
+  char degstr[numlen];
+  int degVal = std::lround(convertRadToDeg( radianVal ));
+  if (degVal < 0) degVal += 360;
+  int retval = snprintf(degstr, numlen, "%0*d", numlen-1, degVal);
+
+  if (retval == numlen - 1) return degstr;
+  else                      return "000";
+}

--- a/Geometry/HcalAlgo/plugins/DDHCalAngular.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalAngular.cc
@@ -72,7 +72,7 @@ void DDHCalAngular::execute(DDCompactView& cpv) {
     DDRotation rotation;
     std::string rotstr("NULL");
  
-    static const int tol = 0.1;
+    static const double tol = 0.1;
     if (std::abs(phix) > tol) {
       rotstr = "R" + formatAsDegreesInInteger(phix);
       rotation = DDRotation(DDName(rotstr, rotns)); 

--- a/Geometry/HcalAlgo/plugins/DDHCalAngular.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalAngular.cc
@@ -7,13 +7,19 @@
 #include <algorithm>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include "DetectorDescription/Core/interface/DDLogicalPart.h"
 #include "DetectorDescription/Core/interface/DDCurrentNamespace.h"
 #include "Geometry/HcalAlgo/plugins/DDHCalAngular.h"
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
+
+//#define EDM_ML_DEBUG                                                         
+using namespace geant_units;
+using namespace geant_units::operators;
 
 DDHCalAngular::DDHCalAngular() {
-  LogDebug("HCalGeom") << "DDHCalAngular test: Creating an instance";
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalAngular: Creating an instance";
+#endif
 }
 
 DDHCalAngular::~DDHCalAngular() {}
@@ -32,37 +38,44 @@ void DDHCalAngular::initialize(const DDNumericArguments & nArgs,
   n           = int (nArgs["n"]);
   startCopyNo = int (nArgs["startCopyNo"]);
   incrCopyNo  = int (nArgs["incrCopyNo"]);
-  LogDebug("HCalGeom") << "DDHCalAngular debug: Parameters for positioning-- "
-		       << n << " copies in " << rangeAngle/CLHEP::deg 
-		       << " from " << startAngle/CLHEP::deg << "\tShifts " 
-		       << shiftX << ", " << shiftY 
-		       << " along x, y axes; \tZoffest " << zoffset
-		       << "\tStart and inremental copy nos " << startCopyNo 
-		       << ", " << incrCopyNo;
-
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalAngular: Parameters for positioning "
+			       << "-- " << n << " copies in " 
+			       << convertRadToDeg(rangeAngle) << " from " 
+			       << convertRadToDeg(startAngle) << "\tShifts " 
+			       << shiftX << ", " << shiftY 
+			       << " along x, y axes; \tZoffest " << zoffset
+			       << "\tStart and inremental copy nos " 
+			       << startCopyNo << ", " << incrCopyNo;
+#endif
   rotns       = sArgs["RotNameSpace"];
   idNameSpace = DDCurrentNamespace::ns();
   childName   = sArgs["ChildName"]; 
+#ifdef EDM_ML_DEBUG
   DDName parentName = parent().name(); 
-  LogDebug("HCalGeom") << "DDHCalAngular debug: Parent " << parentName 
-		       << "\tChild " << childName << "\tNameSpace "
-		       << idNameSpace << "\tRotation Namespace " << rotns;
+  edm::LogVerbatim("HCalGeom") << "DDHCalAngular: Parent " << parentName 
+			       << "\tChild " << childName << "\tNameSpace "
+			       << idNameSpace << "\tRotation Namespace "
+			       << rotns;
+#endif
 }
 
 void DDHCalAngular::execute(DDCompactView& cpv) {
 
   double dphi   = rangeAngle/n;
-  double phi    = startAngle;
+  double phix   = startAngle;
   int    copyNo = startCopyNo;
+  double theta  = 90._deg;
 
   for (int ii=0; ii<n; ii++) {
-
-    double phideg = phi/CLHEP::deg;
-    int    iphi;
-    if (phideg > 0) iphi = int(phideg+0.1);
-    else            iphi = int(phideg-0.1);
-    if (iphi >= 360) iphi   -= 360;
-    phideg = iphi;
+    double phideg = convertRadToDeg(phix);
+    int    iphi   = std::lround(phideg);
+    if (iphi >= 360) {
+      iphi   -= 360;
+      phideg  = iphi;
+      phix    = convertDegToRad(phideg);
+    }
+    double phiy   = phix + 90._deg;
     DDRotation rotation;
     std::string rotstr("NULL");
 
@@ -72,26 +85,30 @@ void DDHCalAngular::execute(DDCompactView& cpv) {
       rotstr = rotstr + std::to_string(phideg);
       rotation = DDRotation(DDName(rotstr, rotns)); 
       if (!rotation) {
-        LogDebug("HCalGeom") << "DDHCalAngular test: Creating a new rotation "
-			     << DDName(rotstr, idNameSpace) << "\t90, " 
-			     << phideg << ", 90, " << (phideg+90) << ", 0, 0";
-        rotation = DDrot(DDName(rotstr, rotns), 90*CLHEP::deg, 
-			 phideg*CLHEP::deg, 90*CLHEP::deg, 
-			 (90+phideg)*CLHEP::deg, 0*CLHEP::deg,  0*CLHEP::deg);
+#ifdef EDM_ML_DEBUG
+        edm::LogVerbatim("HCalGeom") << "DDHCalAngular: Creating a rotation "
+				     << DDName(rotstr, idNameSpace) << "\t90, "
+				     << phideg << ", 90, " << (phideg+90) 
+				     << ", 0, 0";
+#endif
+        rotation = DDrot(DDName(rotstr, rotns), theta, phix, theta, phiy, 0,0);
       } 
     }
     
-    double xpos = shiftX*cos(phi) - shiftY*sin(phi);
-    double ypos = shiftX*sin(phi) + shiftY*cos(phi);
+    double xpos = shiftX*cos(phix) - shiftY*sin(phix);
+    double ypos = shiftX*sin(phix) + shiftY*cos(phix);
     DDTranslation tran(xpos, ypos, zoffset);
   
     DDName parentName = parent().name(); 
-   cpv.position(DDName(childName,idNameSpace), parentName, copyNo, tran, rotation);
-    LogDebug("HCalGeom") << "DDHCalAngular test: " 
-			 << DDName(childName, idNameSpace) << " number " 
-			 << copyNo << " positioned in " << parentName << " at "
-			 << tran << " with " << rotation;
-    phi    += dphi;
+    cpv.position(DDName(childName,idNameSpace),parentName,copyNo,tran,rotation);
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HCalGeom") << "DDHCalAngular: " 
+				 << DDName(childName, idNameSpace) 
+				 << " number " << copyNo << " positioned in "
+				 << parentName << " at " << tran << " with "
+				 << rotation;
+#endif
+    phix   += dphi;
     copyNo += incrCopyNo;
   }
 }

--- a/Geometry/HcalAlgo/plugins/DDHCalAngular.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalAngular.cc
@@ -8,8 +8,9 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Math/interface/GeantUnits.h"
-#include "DetectorDescription/Core/interface/DDLogicalPart.h"
 #include "DetectorDescription/Core/interface/DDCurrentNamespace.h"
+#include "DetectorDescription/Core/interface/DDLogicalPart.h"
+#include "DetectorDescription/Core/interface/DDTypes.h"
 #include "Geometry/HcalAlgo/plugins/DDHCalAngular.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
@@ -71,19 +72,16 @@ void DDHCalAngular::execute(DDCompactView& cpv) {
     DDRotation rotation;
     std::string rotstr("NULL");
  
-    int    phideg = std::lround(convertRadToDeg(phix));
-    if (phideg >= 360) phideg -= 360;
-    if (phideg != 0) {
-      rotstr = "R"; 
-      if (phideg >=0 && phideg < 100) rotstr = "R0"; 
-      rotstr = rotstr + std::to_string(phideg);
+    static const int tol = 0.1;
+    if (std::abs(phix) > tol) {
+      rotstr = "R" + formatAsDegreesInInteger(phix);
       rotation = DDRotation(DDName(rotstr, rotns)); 
       if (!rotation) {
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HCalGeom") << "DDHCalAngular: Creating a rotation "
 				     << DDName(rotstr, idNameSpace) << "\t90, "
-				     << phideg << ", 90, " << (phideg+90) 
-				     << ", 0, 0";
+				     << convertRadToDeg(phi) << ", 90, " 
+				     << (90+convertRadToDeg(phi)) << ", 0, 0";
 #endif
         rotation = DDrot(DDName(rotstr, rotns), theta, phix, theta, phiy, 0,0);
       } 

--- a/Geometry/HcalAlgo/plugins/DDHCalAngular.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalAngular.cc
@@ -11,9 +11,9 @@
 #include "DetectorDescription/Core/interface/DDLogicalPart.h"
 #include "DetectorDescription/Core/interface/DDCurrentNamespace.h"
 #include "Geometry/HcalAlgo/plugins/DDHCalAngular.h"
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
 
 //#define EDM_ML_DEBUG                                                         
-using namespace geant_units;
 using namespace geant_units::operators;
 
 DDHCalAngular::DDHCalAngular() {
@@ -66,20 +66,14 @@ void DDHCalAngular::execute(DDCompactView& cpv) {
   double phix   = startAngle;
   int    copyNo = startCopyNo;
   double theta  = 90._deg;
-
   for (int ii=0; ii<n; ii++) {
-    double phideg = convertRadToDeg(phix);
-    int    iphi   = std::lround(phideg);
-    if (iphi >= 360) {
-      iphi   -= 360;
-      phideg  = iphi;
-      phix    = convertDegToRad(phideg);
-    }
     double phiy   = phix + 90._deg;
     DDRotation rotation;
     std::string rotstr("NULL");
-
-    if (iphi != 0) {
+ 
+    int    phideg = std::lround(convertRadToDeg(phix));
+    if (phideg >= 360) phideg -= 360;
+    if (phideg != 0) {
       rotstr = "R"; 
       if (phideg >=0 && phideg < 100) rotstr = "R0"; 
       rotstr = rotstr + std::to_string(phideg);


### PR DESCRIPTION
#### PR description:

Remove explicit reference to CLHEP from DDHCalAngular and also making changes to debug statements

#### PR validation:

Run the code with debug On which prints out the positioning with translation and rotation in this algorithm for all calls in the new and the older versions and make a diff which results no difference:

diff -bw /build/sunanda/CMSSW_10_6_X_2019-03-26-2300/relval/dump2.log dump.log

1c1
< Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at 27-Mar-2019 18:59:23.481 CET
---
> Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at 27-Mar-2019 19:01:00.661 CET

#### if this PR is a backport please specify the original PR:

Need to go to master and is the first step before translating this for dd4hep