### PR TITLE
Adjust a few reco tau config

### DIFF
--- a/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
+++ b/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
@@ -29,7 +29,7 @@ for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
     e.toModify(recoTauAK4PFJets08Region, minJetPt = 999999.0)
 
 # Reconstruct the pi zeros in our pre-selected jets.
-from RecoTauTag.RecoTau.RecoTauPiZeroProducer_cfi import ak4PFJetsLegacyHPSPiZeros
+from RecoTauTag.RecoTau.RecoTauPiZeroProducer_cff import ak4PFJetsLegacyHPSPiZeros
 ak4PFJetsLegacyHPSPiZeros = ak4PFJetsLegacyHPSPiZeros.clone()
 ak4PFJetsLegacyHPSPiZeros.jetSrc = PFRecoTauPFJetInputs.inputJetCollection
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauProducer.cc
@@ -189,7 +189,7 @@ PFRecoTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<double>("smearedPVsigmaZ", 0.005);
   desc.add<double>("MatchingConeSize_max", 0.6);
   desc.add<double>("HCALIsolConeSize_min", 0.0);
-  descriptions.add("pfRecoTauProducer", desc);
+  descriptions.add("pfRecoTauProducerDef", desc);
 }
 
 DEFINE_FWK_MODULE(PFRecoTauProducer);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauProducer.cc
@@ -189,7 +189,7 @@ PFRecoTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<double>("smearedPVsigmaZ", 0.005);
   desc.add<double>("MatchingConeSize_max", 0.6);
   desc.add<double>("HCALIsolConeSize_min", 0.0);
-  descriptions.add("pfRecoTauProducerDef", desc);
+  descriptions.add("PFRecoTauProducerDef", desc);
 }
 
 DEFINE_FWK_MODULE(PFRecoTauProducer);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauProducer.cc
@@ -189,7 +189,7 @@ PFRecoTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<double>("smearedPVsigmaZ", 0.005);
   desc.add<double>("MatchingConeSize_max", 0.6);
   desc.add<double>("HCALIsolConeSize_min", 0.0);
-  descriptions.add("PFRecoTauProducerDef", desc);
+  descriptions.add("pfRecoTauProducerDef", desc);
 }
 
 DEFINE_FWK_MODULE(PFRecoTauProducer);

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -319,135 +319,6 @@ RecoTauPiZeroProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
   pset_builders.addParameter<int>("verbosity",0);
 
   {
-    // ak4PFJetsLegacyTaNCPiZeros
-    edm::ParameterSetDescription desc;
-    desc.add<double>("massHypothesis", 0.136);
-    desc.addVPSet("ranking", desc_ranking, vpsd_ranking);
-    desc.add<int>("verbosity", 0);
-    desc.add<double>("maxJetAbsEta", 2.5);
-    desc.add<std::string>("outputSelection", "pt > 1.5");
-    desc.add<double>("minJetPt", 14.0);
-    desc.add<edm::InputTag>("jetSrc", edm::InputTag("ak4PFJets"));
-
-    {
-      edm::ParameterSetDescription desc_builders;
-      desc_builders.setAllowAnything();  
-      desc_builders.add<edm::ParameterSetDescription>("qualityCuts", desc_qualityCuts);
-      desc_builders.add<std::string>("name", "1");
-      desc_builders.add<std::string>("plugin", "RecoTauPiZeroTrivialPlugin");
-      desc_builders.add<int>("verbosity", 0);
-
-      desc_builders.addOptional<bool>("makeCombinatoricStrips");
-      desc_builders.addOptional<int>("maxStripBuildIterations");
-      desc_builders.addOptional<double>("minGammaEtStripAdd");
-      desc_builders.addOptional<double>("minGammaEtStripSeed");
-      desc_builders.addOptional<double>("minStripEt");
-      desc_builders.addOptional<std::vector<int>>("stripCandidatesParticleIds");
-      desc_builders.addOptional<bool>("updateStripAfterEachDaughter");
-      desc_builders.addOptional<bool>("applyElecTrackQcuts");
-
-      std::vector<edm::ParameterSet> vpsd_builders;
-      vpsd_builders.push_back(pset_builders);
-      desc.addVPSet("builders", desc_builders, vpsd_builders);
-    }
-
-    descriptions.add("ak4PFJetsLegacyTaNCPiZerosDefault", desc);
-  }
-
-  {
-    // ak4PFJetsRecoTauGreedyPiZeros
-    edm::ParameterSetDescription desc;
-    desc.add<double>("massHypothesis", 0.136);
-    desc.addVPSet("ranking", desc_ranking, vpsd_ranking);
-    desc.add<int>("verbosity", 0);
-    desc.add<double>("maxJetAbsEta", 2.5);
-    desc.add<std::string>("outputSelection", "pt > 1.5");
-    desc.add<double>("minJetPt", 14.0);
-    desc.add<edm::InputTag>("jetSrc", edm::InputTag("ak4PFJets"));
-    {
-      edm::ParameterSetDescription desc_builders;
-      desc_builders.setAllowAnything();
-      desc_builders.add<edm::ParameterSetDescription>("qualityCuts", desc_qualityCuts);
-      desc_builders.add<int>("maxInputStrips", 5);
-      desc_builders.add<std::string>("name", "cs");
-      desc_builders.add<std::string>("plugin", "RecoTauPiZeroStripPlugin");
-      desc_builders.add<double>("stripMassWhenCombining", 0.0);
-      desc_builders.add<double>("stripPhiAssociationDistance", 0.2);
-      desc_builders.add<double>("stripEtaAssociationDistance", 0.05);
-      desc_builders.add<int>("verbosity", 0);
-
-      desc_builders.addOptional<bool>("makeCombinatoricStrips");
-      desc_builders.addOptional<int>("maxStripBuildIterations");
-      desc_builders.addOptional<double>("minGammaEtStripAdd");
-      desc_builders.addOptional<double>("minGammaEtStripSeed");
-      desc_builders.addOptional<double>("minStripEt");
-      desc_builders.addOptional<std::vector<int>>("stripCandidatesParticleIds");
-      desc_builders.addOptional<bool>("updateStripAfterEachDaughter");
-      desc_builders.addOptional<bool>("applyElecTrackQcuts");
-
-      std::vector<edm::ParameterSet> vpsd_builders;
-      vpsd_builders.push_back(pset_builders); 
-      desc.addVPSet("builders", desc_builders, vpsd_builders);
-    }
-    descriptions.add("ak4PFJetsRecoTauGreedyPiZerosDefault", desc);
-  }
-
-  {
-    // ak4PFJetsRecoTauPiZeros
-    edm::ParameterSetDescription desc;
-    desc.add<double>("massHypothesis", 0.136);
-    desc.addVPSet("ranking", desc_ranking, vpsd_ranking);
-    desc.add<int>("verbosity", 0);
-    desc.add<double>("maxJetAbsEta", 2.5);
-    desc.add<std::string>("outputSelection", "pt > 1.5");
-    desc.add<double>("minJetPt", 14.0);
-    desc.add<edm::InputTag>("jetSrc", edm::InputTag("ak4PFJets"));
-    {
-      edm::ParameterSetDescription desc_builders;
-      desc_builders.setAllowAnything();
-      desc_builders.add<edm::ParameterSetDescription>("qualityCuts", desc_qualityCuts);
-      desc_builders.add<std::string>("name", "2");
-      desc_builders.add<std::string>("plugin", "RecoTauPiZeroCombinatoricPlugin");
-      desc_builders.add<double>("maxMass", -1.0);
-      desc_builders.add<double>("minMass", 0.0);
-      desc_builders.add<unsigned int>("choose", 2);
-      desc_builders.addOptional<unsigned int>("maxInputGammas");
-      desc_builders.add<int>("verbosity", 0);
-
-      desc_builders.addOptional<bool>("makeCombinatoricStrips");
-      desc_builders.addOptional<int>("maxStripBuildIterations");
-      desc_builders.addOptional<double>("minGammaEtStripAdd");
-      desc_builders.addOptional<double>("minGammaEtStripSeed");
-      desc_builders.addOptional<double>("minStripEt");
-      desc_builders.addOptional<std::vector<int>>("stripCandidatesParticleIds");
-      desc_builders.addOptional<bool>("updateStripAfterEachDaughter");
-      desc_builders.addOptional<bool>("applyElecTrackQcuts");
-      {
-       	edm::ParameterSetDescription psd0;
-        psd0.addOptional<std::string>("function", "TMath::Min(0.3, TMath::Max(0.05, [0]*TMath::Power(pT, -[1])))");
-        psd0.addOptional<double>("par1", 0.707716);
-        psd0.addOptional<double>("par0", 0.352476);
-        desc_builders.addOptional<edm::ParameterSetDescription>("stripPhiAssociationDistanceFunc", psd0);
-      }
-      {
-       	edm::ParameterSetDescription psd0;
-        psd0.addOptional<std::string>("function", "TMath::Min(0.15, TMath::Max(0.05, [0]*TMath::Power(pT, -[1])))");
-        psd0.addOptional<double>("par1", 0.658701);
-        psd0.addOptional<double>("par0", 0.197077);
-        desc_builders.addOptional<edm::ParameterSetDescription>("stripEtaAssociationDistanceFunc", psd0);
-      }
-
-      //     vpsd_builders.addOptional<edm::ParameterSetDescription>("stripPhiAssociationDistanceFunc");
-      //     vpsd_builders.addOptional<edm::ParameterSetDescription>("stripEtaAssociationDistanceFunc");
-      std::vector<edm::ParameterSet> vpsd_builders;
-      vpsd_builders.push_back(pset_builders);
-      desc.addVPSet("builders", desc_builders, vpsd_builders);
-    }
-
-    descriptions.add("ak4PFJetsRecoTauPiZerosDefault", desc);
-  }
-
-  {
     // ak4PFJetsLegacyHPSPiZeros
     edm::ParameterSetDescription desc;
     desc.add<double>("massHypothesis", 0.136);
@@ -498,9 +369,8 @@ RecoTauPiZeroProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
       desc.addVPSet("builders", desc_builders, vpsd_builders);
     }
 
-    descriptions.add("ak4PFJetsLegacyHPSPiZerosDefault", desc);
-    descriptions.add("ak4PFJetsLegacyHPSPiZerosBoostedDefault", desc); // this one is generated in configs with a strange procedure
-    descriptions.add("pfJetsLegacyHPSPiZerosDefault", desc);
+    descriptions.add("recoTauPiZeroProducer", desc);
+    //    descriptions.add("ak4PFJetsLegacyHPSPiZerosBoostedDefault", desc); // this one is generated in configs with a strange procedure
     // RecoTauTag/Configuration/python/boostedHPSPFTaus_cfi.py
     //    process.PATTauSequenceBoosted = cloneProcessingSnippet(process,process.PATTauSequence, "Boosted", addToTask = True)
   }

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -319,7 +319,7 @@ RecoTauPiZeroProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
   pset_builders.addParameter<int>("verbosity",0);
 
   {
-    // ak4PFJetsLegacyHPSPiZeros
+    // Tailored on ak4PFJetsLegacyHPSPiZeros
     edm::ParameterSetDescription desc;
     desc.add<double>("massHypothesis", 0.136);
     desc.addVPSet("ranking", desc_ranking, vpsd_ranking);
@@ -328,51 +328,46 @@ RecoTauPiZeroProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
     desc.add<std::string>("outputSelection", "pt > 0");
     desc.add<double>("minJetPt", 14.0);
     desc.add<edm::InputTag>("jetSrc", edm::InputTag("ak4PFJets"));
+
     edm::ParameterSetDescription desc_builders;
-    desc_builders.setAllowAnything();
     {
-      // both of the following uncommented version need to be accepted.
-      {
-        edm::ParameterSetDescription psd0;
-        psd0.add<std::string>("function", "TMath::Min(0.3, TMath::Max(0.05, [0]*TMath::Power(pT, -[1])))");
-        psd0.add<double>("par1", 0.707716);
-        psd0.add<double>("par0", 0.352476);
-        desc_builders.addOptional<edm::ParameterSetDescription>("stripPhiAssociationDistanceFunc", psd0);
-      }
-      {
-        edm::ParameterSetDescription psd0;
-        psd0.add<std::string>("function", "TMath::Min(0.15, TMath::Max(0.05, [0]*TMath::Power(pT, -[1])))");
-        psd0.add<double>("par1", 0.658701);
-        psd0.add<double>("par0", 0.197077);
-        desc_builders.addOptional<edm::ParameterSetDescription>("stripEtaAssociationDistanceFunc", psd0);
-      }
-      desc_builders.addOptional<double>("stripEtaAssociationDistance", 0.05);
-      desc_builders.addOptional<double>("stripPhiAssociationDistance", 0.2);
-
-      desc_builders.add<edm::ParameterSetDescription>("qualityCuts", desc_qualityCuts);
-
-      desc_builders.add<std::string>("name");
-      desc_builders.add<std::string>("plugin");
-      desc_builders.add<int>("verbosity", 0);
-
-      desc_builders.addOptional<bool>("makeCombinatoricStrips");
-      desc_builders.addOptional<int>("maxStripBuildIterations");
-      desc_builders.addOptional<double>("minGammaEtStripAdd");
-      desc_builders.addOptional<double>("minGammaEtStripSeed");
-      desc_builders.addOptional<double>("minStripEt");
-      desc_builders.addOptional<std::vector<int>>("stripCandidatesParticleIds");
-      desc_builders.addOptional<bool>("updateStripAfterEachDaughter");
-      desc_builders.addOptional<bool>("applyElecTrackQcuts");
-
-      std::vector<edm::ParameterSet> vpsd_builders;
-      vpsd_builders.push_back(pset_builders);
-      desc.addVPSet("builders", desc_builders, vpsd_builders);
+      edm::ParameterSetDescription psd0;
+      psd0.add<std::string>("function", "TMath::Min(0.3, TMath::Max(0.05, [0]*TMath::Power(pT, -[1])))");
+      psd0.add<double>("par1", 0.707716);
+      psd0.add<double>("par0", 0.352476);
+      desc_builders.addOptional<edm::ParameterSetDescription>("stripPhiAssociationDistanceFunc", psd0);
     }
+    {
+      edm::ParameterSetDescription psd0;
+      psd0.add<std::string>("function", "TMath::Min(0.15, TMath::Max(0.05, [0]*TMath::Power(pT, -[1])))");
+      psd0.add<double>("par1", 0.658701);
+      psd0.add<double>("par0", 0.197077);
+      desc_builders.addOptional<edm::ParameterSetDescription>("stripEtaAssociationDistanceFunc", psd0);
+    }
+    desc_builders.addOptional<double>("stripEtaAssociationDistance", 0.05);
+    desc_builders.addOptional<double>("stripPhiAssociationDistance", 0.2);
+    
+    desc_builders.add<edm::ParameterSetDescription>("qualityCuts", desc_qualityCuts);
+    
+    desc_builders.add<std::string>("name");
+    desc_builders.add<std::string>("plugin");
+    desc_builders.add<int>("verbosity", 0);
+    
+    desc_builders.addOptional<bool>("makeCombinatoricStrips");
+    desc_builders.addOptional<int>("maxStripBuildIterations");
+    desc_builders.addOptional<double>("minGammaEtStripAdd");
+    desc_builders.addOptional<double>("minGammaEtStripSeed");
+    desc_builders.addOptional<double>("minStripEt");
+    desc_builders.addOptional<std::vector<int>>("stripCandidatesParticleIds");
+    desc_builders.addOptional<bool>("updateStripAfterEachDaughter");
+    desc_builders.addOptional<bool>("applyElecTrackQcuts");
+
+    std::vector<edm::ParameterSet> vpsd_builders;
+    vpsd_builders.push_back(pset_builders);
+    desc.addVPSet("builders", desc_builders, vpsd_builders);
 
     descriptions.add("recoTauPiZeroProducer", desc);
-    //    descriptions.add("ak4PFJetsLegacyHPSPiZerosBoostedDefault", desc); // this one is generated in configs with a strange procedure
-    // RecoTauTag/Configuration/python/boostedHPSPFTaus_cfi.py
-    //    process.PATTauSequenceBoosted = cloneProcessingSnippet(process,process.PATTauSequence, "Boosted", addToTask = True)
+
   }
 
 }

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -313,9 +313,10 @@ RecoTauPiZeroProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc_qualityCuts.add<bool>("recoverLeadingTrk", false);
 
   edm::ParameterSet pset_builders;
-  //pset_builders.addParameter<edm::ParameterSet>("qualityCuts");
   pset_builders.addParameter<std::string>("name","");
   pset_builders.addParameter<std::string>("plugin","");
+  edm::ParameterSet qualityCuts;
+  pset_builders.addParameter<edm::ParameterSet>("qualityCuts",qualityCuts);
   pset_builders.addParameter<int>("verbosity",0);
 
   {

--- a/RecoTauTag/RecoTau/python/PFRecoTauProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauProducer_cfi.py
@@ -1,0 +1,4 @@
+from RecoTauTag.RecoTau.PFRecoTauProducerDef_cfi import PFRecoTauProducerDef
+
+pfRecoTauProducer = PFRecoTauProducerDef.clone()
+

--- a/RecoTauTag/RecoTau/python/PFRecoTauProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauProducer_cfi.py
@@ -1,4 +1,4 @@
-from RecoTauTag.RecoTau.PFRecoTauProducerDef_cfi import PFRecoTauProducerDef
+from RecoTauTag.RecoTau.pfRecoTauProducerDef_cfi import pfRecoTauProducerDef
 
-pfRecoTauProducer = PFRecoTauProducerDef.clone()
+pfRecoTauProducer = pfRecoTauProducerDef.clone()
 

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroBuilderPlugins_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroBuilderPlugins_cfi.py
@@ -39,17 +39,15 @@ strips = cms.PSet(
     stripCandidatesParticleIds  = cms.vint32(2, 4),
     stripEtaAssociationDistance = cms.double(0.05),
     stripPhiAssociationDistance = cms.double(0.2),
-    makeCombinatoricStrips = cms.bool(False)
+    makeCombinatoricStrips = cms.bool(False),
+    verbosity = cms.int32(0)
 )
 
-comboStrips = cms.PSet(
+comboStrips = strips.clone(
     name = cms.string("cs"),
     plugin = cms.string("RecoTauPiZeroStripPlugin"),
-    qualityCuts = PFTauQualityCuts,
     # Clusterize photons and electrons (PF numbering)
     stripCandidatesParticleIds  = cms.vint32(2, 4),
-    stripEtaAssociationDistance = cms.double(0.05),
-    stripPhiAssociationDistance = cms.double(0.2),
     makeCombinatoricStrips = cms.bool(True),
     maxInputStrips = cms.int32(5),
     stripMassWhenCombining = cms.double(0.0), # assume photon like
@@ -65,15 +63,13 @@ modStrips = strips.clone(
     minStripEt = cms.double(1.0),
     updateStripAfterEachDaughter = cms.bool(False),
     maxStripBuildIterations = cms.int32(-1),
-    verbosity = cms.int32(0)
 )
 
 # Produce a "strips" of photons
 # with no track quality cuts applied to PFElectrons
 # and eta x phi size of strip increasing for low pT photons
 
-modStrips2 = cms.PSet(
-    name = cms.string("s"),
+modStrips2 = strips.clone(
     plugin = cms.string('RecoTauPiZeroStripPlugin3'),
     applyElecTrackQcuts = cms.bool(False),
     # Clusterize photons and electrons (PF numbering)
@@ -96,5 +92,4 @@ modStrips2 = cms.PSet(
     #     chosen to contain 95% of photons from tau decays
     updateStripAfterEachDaughter = cms.bool(False),
     maxStripBuildIterations = cms.int32(-1),
-    verbosity = cms.int32(0)
 )

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroBuilderPlugins_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroBuilderPlugins_cfi.py
@@ -46,8 +46,6 @@ strips = cms.PSet(
 comboStrips = strips.clone(
     name = cms.string("cs"),
     plugin = cms.string("RecoTauPiZeroStripPlugin"),
-    # Clusterize photons and electrons (PF numbering)
-    stripCandidatesParticleIds  = cms.vint32(2, 4),
     makeCombinatoricStrips = cms.bool(True),
     maxInputStrips = cms.int32(5),
     stripMassWhenCombining = cms.double(0.0), # assume photon like
@@ -72,8 +70,6 @@ modStrips = strips.clone(
 modStrips2 = strips.clone(
     plugin = cms.string('RecoTauPiZeroStripPlugin3'),
     applyElecTrackQcuts = cms.bool(False),
-    # Clusterize photons and electrons (PF numbering)
-    stripCandidatesParticleIds  = cms.vint32(2, 4),
     stripEtaAssociationDistanceFunc = cms.PSet(
         function = cms.string("TMath::Min(0.15, TMath::Max(0.05, [0]*TMath::Power(pT, -[1])))"),
         par0 = cms.double(1.97077e-01),

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cff.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cff.py
@@ -13,8 +13,6 @@ ak4PFJetsLegacyHPSPiZeros = recoTauPiZeroProducer.clone(
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
     builders = cms.VPSet(
-        #builders.strips
-        #builders.modStrips
         builders.modStrips2
     ),
     ranking = cms.VPSet(
@@ -29,7 +27,6 @@ ak4PFJetsRecoTauGreedyPiZeros = recoTauPiZeroProducer.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
-    massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 1.5'),
     builders = cms.VPSet(
         builders.comboStrips
@@ -44,12 +41,9 @@ ak4PFJetsRecoTauPiZeros = recoTauPiZeroProducer.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
-    massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 1.5'),
     builders = cms.VPSet(
         builders.combinatoricPhotonPairs,
-        #builders.strips
-        #builders.modStrips
         builders.modStrips2
     ),
     ranking = cms.VPSet(
@@ -64,7 +58,6 @@ ak4PFJetsLegacyTaNCPiZeros = recoTauPiZeroProducer.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
-    massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 1.5'),
     builders = cms.VPSet(
         builders.allSinglePhotons,

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cff.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cff.py
@@ -3,11 +3,12 @@ import FWCore.ParameterSet.Config as cms
 import RecoTauTag.RecoTau.RecoTauPiZeroBuilderPlugins_cfi as builders
 import RecoTauTag.RecoTau.RecoTauPiZeroQualityPlugins_cfi as ranking
 from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
+from RecoTauTag.RecoTau.RecoTauPiZeroProducer_cfi import RecoTauPiZeroProducer
+
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 
 
-from RecoTauTag.RecoTau.ak4PFJetsLegacyHPSPiZerosDefault_cfi import ak4PFJetsLegacyHPSPiZerosDefault
-ak4PFJetsLegacyHPSPiZeros = ak4PFJetsLegacyHPSPiZerosDefault.clone(
+ak4PFJetsLegacyHPSPiZeros = RecoTauPiZeroProducer.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
@@ -23,9 +24,8 @@ ak4PFJetsLegacyHPSPiZeros = ak4PFJetsLegacyHPSPiZerosDefault.clone(
 phase2_common.toModify(ak4PFJetsLegacyHPSPiZeros, 
                        builders = cms.VPSet(builders.modStrips) )
 
-from RecoTauTag.RecoTau.ak4PFJetsRecoTauGreedyPiZerosDefault_cfi import ak4PFJetsRecoTauGreedyPiZerosDefault
-#ak4PFJetsRecoTauGreedyPiZeros = ak4PFJetsLegacyHPSPiZerosDefault.clone(
-ak4PFJetsRecoTauGreedyPiZeros = ak4PFJetsRecoTauGreedyPiZerosDefault.clone( 
+
+ak4PFJetsRecoTauGreedyPiZeros = RecoTauPiZeroProducer.clone( 
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
@@ -39,9 +39,8 @@ ak4PFJetsRecoTauGreedyPiZeros = ak4PFJetsRecoTauGreedyPiZerosDefault.clone(
     ),
 )
 
-from RecoTauTag.RecoTau.ak4PFJetsRecoTauPiZerosDefault_cfi import ak4PFJetsRecoTauPiZerosDefault
-#ak4PFJetsRecoTauPiZeros = ak4PFJetsLegacyHPSPiZerosDefault.clone(
-ak4PFJetsRecoTauPiZeros = ak4PFJetsRecoTauPiZerosDefault.clone(
+
+ak4PFJetsRecoTauPiZeros = RecoTauPiZeroProducer.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
@@ -60,12 +59,12 @@ ak4PFJetsRecoTauPiZeros = ak4PFJetsRecoTauPiZerosDefault.clone(
     ),
 )
 
-from RecoTauTag.RecoTau.ak4PFJetsLegacyTaNCPiZerosDefault_cfi import ak4PFJetsLegacyTaNCPiZerosDefault
-# ak4PFJetsLegacyTaNCPiZeros = ak4PFJetsLegacyHPSPiZerosDefault.clone(
-ak4PFJetsLegacyTaNCPiZeros = ak4PFJetsLegacyTaNCPiZerosDefault.clone(
+
+ak4PFJetsLegacyTaNCPiZeros = RecoTauPiZeroProducer.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
+    massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 1.5'),
     builders = cms.VPSet(
         builders.allSinglePhotons,

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cff.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cff.py
@@ -3,12 +3,12 @@ import FWCore.ParameterSet.Config as cms
 import RecoTauTag.RecoTau.RecoTauPiZeroBuilderPlugins_cfi as builders
 import RecoTauTag.RecoTau.RecoTauPiZeroQualityPlugins_cfi as ranking
 from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
-from RecoTauTag.RecoTau.RecoTauPiZeroProducer_cfi import RecoTauPiZeroProducer
+from RecoTauTag.RecoTau.recoTauPiZeroProducer_cfi import recoTauPiZeroProducer
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 
 
-ak4PFJetsLegacyHPSPiZeros = RecoTauPiZeroProducer.clone(
+ak4PFJetsLegacyHPSPiZeros = recoTauPiZeroProducer.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
@@ -25,7 +25,7 @@ phase2_common.toModify(ak4PFJetsLegacyHPSPiZeros,
                        builders = cms.VPSet(builders.modStrips) )
 
 
-ak4PFJetsRecoTauGreedyPiZeros = RecoTauPiZeroProducer.clone( 
+ak4PFJetsRecoTauGreedyPiZeros = recoTauPiZeroProducer.clone( 
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
@@ -40,7 +40,7 @@ ak4PFJetsRecoTauGreedyPiZeros = RecoTauPiZeroProducer.clone(
 )
 
 
-ak4PFJetsRecoTauPiZeros = RecoTauPiZeroProducer.clone(
+ak4PFJetsRecoTauPiZeros = recoTauPiZeroProducer.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
@@ -60,7 +60,7 @@ ak4PFJetsRecoTauPiZeros = RecoTauPiZeroProducer.clone(
 )
 
 
-ak4PFJetsLegacyTaNCPiZeros = RecoTauPiZeroProducer.clone(
+ak4PFJetsLegacyTaNCPiZeros = recoTauPiZeroProducer.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,

--- a/RecoTauTag/TauTagTools/test/training/skimming/buildBackgroundDataSet_cfg.py
+++ b/RecoTauTag/TauTagTools/test/training/skimming/buildBackgroundDataSet_cfg.py
@@ -309,7 +309,7 @@ process.preselectedBackgroundJets = cms.EDProducer(
 )
 
 # Build pizeros for our final jet collection
-import RecoTauTag.RecoTau.RecoTauPiZeroProducer_cfi as PiZeroProd
+import RecoTauTag.RecoTau.RecoTauPiZeroProducer_cff as PiZeroProd
 process.backgroundJetsRecoTauPiZeros = PiZeroProd.ak5PFJetsRecoTauPiZeros.clone(
     jetSrc = cms.InputTag("preselectedBackgroundJets")
 )

--- a/RecoTauTag/TauTagTools/test/training/skimming/buildSignalDataSet_cfg.py
+++ b/RecoTauTag/TauTagTools/test/training/skimming/buildSignalDataSet_cfg.py
@@ -199,7 +199,7 @@ process.plotPreselectedSignalJets = cms.EDAnalyzer(
 )
 
 # Produce and save PiZeros for the signal jets
-import RecoTauTag.RecoTau.RecoTauPiZeroProducer_cfi as PiZeroProd
+import RecoTauTag.RecoTau.RecoTauPiZeroProducer_cff as PiZeroProd
 process.signalJetsRecoTauPiZeros = PiZeroProd.ak5PFJetsRecoTauPiZeros.clone(
     jetSrc = cms.InputTag("preselectedSignalJets")
 )


### PR DESCRIPTION
#### PR description:

Bug fix of #26254: restored the file RecoTauTag/RecoTau/python/PFRecoTauProducer_cfi.py which is  imported in a module config, (which is not currently used in the standard sequences, so that "bug" did not harm standard workflows anyhow)

In addition, a few adjustments and cleanings  to the RecoTauPiZeroProducer class and module configs are also integrated:
- Renamed more conveniently RecoTauPiZeroProducer_cfi.py as RecoTauPiZeroProducer_cff.py
- Now the recoTauPiZeroProducer_cfi (as created by the fillDescriptions method) is the only cfi which defines an instance of the RecoTauPiZeroProducer (and as such it  may avoid confusing the HLT parser, for instance)
- All the instances of RecoTauPiZeroProducer defined in RecoTauPiZeroProducer_cff.py are now cloned from that single producer base configuration
- The fillDescription method in the RecoTauPiZeroProducer class does not needlessly define multiple configurations: only one, while the customizations for the different instances are granted by setting as optional some parameter,
- Removed the (now) useless setAllowAnything in the fillDescriptions of RecoTauPiZeroProducer

Since the bug fix applies to a module not currently used in standard reco/pat sequences, and all the rest being just code and config cleaning, no changes are expected in outputs

@swozniewski @mbluj please have a look.


#### PR validation:

PhysicsTools/PatAlgos/test/patTuple_PATandPF2PAT_cfg.py tested successfully
Short matrix tests also succeed