### PR TITLE
Force-on threaded mode in DQMStore for the DQM step.

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1935,6 +1935,8 @@ class ConfigBuilder(object):
     def prepare_DQM(self, sequence = 'DQMOffline'):
         # this one needs replacement
 
+        # any 'DQM' job should use DQMStore in non-legacy mode (but not HARVESTING)
+        self.loadAndRemember("DQMServices/Core/DQMStoreNonLegacy_cff")
         self.loadDefaultOrSpecifiedCFF(sequence,self.DQMOFFLINEDefaultCFF)
         sequenceList=sequence.split('.')[-1].split('+')
         postSequenceList=sequence.split('.')[-1].split('+')

--- a/DQMServices/Core/python/DQMStoreNonLegacy_cff.py
+++ b/DQMServices/Core/python/DQMStoreNonLegacy_cff.py
@@ -1,0 +1,9 @@
+from DQMServices.Core.DQMStore_cfi import DQMStore
+
+# This flag is turned on automatically when a job runs with more than one stream.
+# However, it changes much more than just thread safety related things, so it is
+# better to turn it on in *any* job that can be run multi-threaded, to get more
+# reliable tests. Running single-threaded with this flag turned on is safe, but
+# some modules (HARVESTING, legacy) will not work with this (and therefore can't
+# run multi-threaded.
+DQMStore.enableMultiThread = True


### PR DESCRIPTION
#### PR description:

DQMStore has 'legacy' and 'threaded' modes, and defaults to 'legacy' unless there is more than one stream. This means that e.g. the PR tests for jobs that would use threaded mode in production still use legacy mode in the tests. That is a problem, since legacy mode uses completely different code paths and therefore makes the tests unreliable.

This PR turns on threaded mod by default in the `DQM` step in `ConfigBuilder`. It should only affect small tests, not the production jobs which use threaded mode anyways.

#### PR validation:

None, this PR is to adjust the tests to what happens in the real world.

This will be included in #26232, this PR is mainly to isolate the effects in a separate test.