### PR TITLE
Activate Simulation of the Pixel Bad Components on the FED channel basis

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -44,29 +44,29 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '105X_mc2017_design_IdealBS_v6',
+    'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '105X_mc2017_realistic_v7',
+    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '105X_mc2017cosmics_realistic_deco_v8',
+    'phase1_2017_cosmics'      :  '106X_mc2017cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '105X_mc2017cosmics_realistic_peak_v8',
+    'phase1_2017_cosmics_peak' :  '106X_mc2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '105X_upgrade2018_design_v5',
+    'phase1_2018_design'       :  '106X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v6',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v4',
+    'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v6',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v7',
+    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v7',
+    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '105X_postLS2_design_v4', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '106X_postLS2_design_v1', # GT containing design conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase1 2019
-    'phase1_2019_realistic'    : '105X_postLS2_realistic_v6', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'    : '106X_postLS2_realistic_v1', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
     'phase2_realistic'         : '105X_upgrade2023_realistic_v5'
 }

--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -36,7 +36,7 @@ def _modifyPixelDigitizerForPhase1Pixel( digitizer ) :
     digitizer.ElectronsPerVcal_Offset    = cms.double(-60)  # L2-4: -60 +- 130
     digitizer.ElectronsPerVcal_L1_Offset = cms.double(-670) # L1:   -670 +- 220
     digitizer.UseReweighting = cms.bool(True)
-    
+    digitizer.KillBadFEDChannels = cms.bool(True)
 
 SiPixelSimBlock = cms.PSet(
     SiPixelQualityLabel = cms.string(''),


### PR DESCRIPTION
#### PR description:
Based on the feedback received so far in https://its.cern.ch/jira/browse/PDMVRELVALS-30, the goal of this PR is to:
   * switch on simulation of the Pixel Bad Components on the FED channel basis (a.k.a. stuck-TBM simulation)
   * supply default payloads for the new record `SiPixelStatusScenarioProbabilityRcd `and `SiPixelStatusScenariosRcd` introduced in PR https://github.com/cms-sw/cmssw/pull/25466/, to all the phase-1 Global Tags.

As the `SiPixelStatusScenario` payload used in all the updated Global Tags contains (still) no bad components and the `SiPixelStatusScenarioProbability` payload defaults this "empty" scenario for all the PU bins, no changes in the physics outcome are expected from this PR, which then can be qualified as technical. 
2017 and 2018 simulation Global Tags will be updated in a later time once appropriate conditions will be available. 

#### PR validation:
The branch was tested via:
```
runTheMatrix.py -l limited -i all -j 8 --ibeos
```
and no failing workflows are observed: 32 31 30 24 12 2 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed.
