### PR TITLE
add necessary changes to handle dump import and fetch novel TrackerDetToDTCELinkCablingMap and DTCELinkId CondFormats

### DIFF
--- a/CondCore/Utilities/BuildFile.xml
+++ b/CondCore/Utilities/BuildFile.xml
@@ -33,6 +33,7 @@
 <use   name="CondFormats/BTauObjects"/>
 <use   name="CondFormats/MFObjects"/>
 <use   name="CondFormats/PCLConfig"/>
+<use   name="CondFormats/SiPhase2TrackerObjects"/>
 <use   name="CondFormats/CTPPSReadoutObjects"/>
 <use   name="rootgraphics"/>
 <export>

--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -260,6 +260,8 @@ PAYLOAD_2XML_MODULE( pluginUtilities_payload2xml ){
   PAYLOAD_2XML_CLASS( SiStripNoises );
   PAYLOAD_2XML_CLASS( SiStripPedestals );
   PAYLOAD_2XML_CLASS( SiStripThreshold );
+  PAYLOAD_2XML_CLASS( DTCELinkId );
+  PAYLOAD_2XML_CLASS( TrackerDetToDTCELinkCablingMap );
   //PAYLOAD_2XML_CLASS( StorableDoubleMap<AbsOOTPileupCorrection> );
   PAYLOAD_2XML_CLASS( TrackProbabilityCalibration );
   PAYLOAD_2XML_CLASS( cond::BaseKeyed );

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -292,6 +292,8 @@ namespace cond {
       FETCH_PAYLOAD_CASE( SiStripNoises )
       FETCH_PAYLOAD_CASE( SiStripPedestals )
       FETCH_PAYLOAD_CASE( SiStripThreshold )
+      FETCH_PAYLOAD_CASE( DTCELinkId )
+      FETCH_PAYLOAD_CASE( TrackerDetToDTCELinkCablingMap )
       FETCH_PAYLOAD_CASE( TrackProbabilityCalibration )
       FETCH_PAYLOAD_CASE( cond::BaseKeyed )
       FETCH_PAYLOAD_CASE( ESCondObjectContainer<ESChannelStatusCode> )

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -313,6 +313,8 @@ namespace cond {
       IMPORT_PAYLOAD_CASE( SiStripNoises )
       IMPORT_PAYLOAD_CASE( SiStripPedestals )
       IMPORT_PAYLOAD_CASE( SiStripThreshold )
+      IMPORT_PAYLOAD_CASE( DTCELinkId )
+      IMPORT_PAYLOAD_CASE( TrackerDetToDTCELinkCablingMap )
       IMPORT_PAYLOAD_CASE( TrackProbabilityCalibration )
       IMPORT_PAYLOAD_CASE( cond::BaseKeyed )
       IMPORT_PAYLOAD_CASE( ESCondObjectContainer<ESChannelStatusCode> )

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -261,7 +261,8 @@
 #include "CondFormats/BTauObjects/interface/TrackProbabilityCalibration.h"
 #include "CondFormats/MFObjects/interface/MagFieldConfig.h"
 #include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
-
+#include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h"
 #include "CondFormats/Common/interface/BaseKeyed.h"
 
 #include "CondFormats/External/interface/DetID.h"


### PR DESCRIPTION
#### PR description:

As PR https://github.com/cms-sw/cmssw/pull/26268 including the novel `CondFormat`s for the Phase-2 Tracker DTC cabling map has been merged, this pull request adds a commit which was left over from original PR https://github.com/cms-sw/cmssw/pull/26029, allowing the dumping / DB handling of payloads of type `TrackerDetToDTCELinkCablingMap` and `DTCELinkId`

#### PR validation:
Recipe steps to produce a payload of the new format and dump it:
```bash
git cms-addpkg CondTools/SiPhase2Tracker
git cms-addpkg CondFormats/DataRecord
scramv1 b -j 8
cmsenv
cd CondTools/SiPhase2Tracker/test/
cmsRun DTCCablingMapProducer_write.py
conddb --db OuterTrackerDTCCablingMap.db dump e54afaa74e8aff576df16b328b4ef5048004d92f
```

the last command of this recipe won't work without this PR.