### PR TITLE
move to pybind11 parameteset reader as default. fix some buildfiles

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -70,7 +70,7 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/ParameterSetReader"/>
 </bin>
-<bin   name="cmsRunPyDev" file="cmsRunPyDev.cpp">
+<bin   name="cmsRunBoostPython" file="cmsRunBoostPython.cpp">
   <use   name="tbb"/>
   <use   name="boost"/>
   <use   name="boost_program_options"/>
@@ -84,5 +84,6 @@
   <use   name="FWCore/ServiceRegistry"/>
   <use   name="FWCore/Utilities"/>
   <use   name="FWCore/ParameterSet"/>
-  <use   name="FWCore/PyDevParameterSet"/>
+  <use   name="FWCore/PythonParameterSet"/>
+  <use   name="boost_python"/>
 </bin>

--- a/FWCore/Framework/bin/cmsRunBoostPython.cpp
+++ b/FWCore/Framework/bin/cmsRunBoostPython.cpp
@@ -24,7 +24,7 @@ PSet script.   See notes in EventProcessor.cpp for details about it.
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Presence.h"
 #include "FWCore/Utilities/interface/TimingServiceBase.h"
-#include "FWCore/PyDevParameterSet/interface/MakePyBind11ParameterSets.h"
+#include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
 #include "TError.h"
 
 #include "boost/program_options.hpp"
@@ -277,7 +277,7 @@ int main(int argc, char* argv[]) {
       context += fileName;
       std::shared_ptr<edm::ProcessDesc> processDesc;
       try {
-        std::unique_ptr<edm::ParameterSet> parameterSet = edm::cmspybind11::readConfig(fileName, argc, argv);
+        std::unique_ptr<edm::ParameterSet> parameterSet = edm::boost_python::readConfig(fileName, argc, argv);
         processDesc.reset(new edm::ProcessDesc(std::move(parameterSet)));
       }
       catch(cms::Exception& iException) {

--- a/FWCore/Framework/test/eventprocessor_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor_t.cppunit.cc
@@ -39,9 +39,9 @@ class testeventprocessor: public CppUnit::TestFixture {
   CPPUNIT_TEST(beginEndTest);
   CPPUNIT_TEST(cleanupJobTest);
   CPPUNIT_TEST(activityRegistryTest);
-  CPPUNIT_TEST(moduleFailureTest);
   CPPUNIT_TEST(endpathTest);
   CPPUNIT_TEST(serviceConfigSaveTest);
+  CPPUNIT_TEST(moduleFailureTest);
   CPPUNIT_TEST_SUITE_END();
 
  public:

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -139,6 +139,7 @@
   <bin   file="SwitchProducer_t.cpp">
     <use   name="FWCore/Framework"/>
     <use   name="FWCore/ParameterSet"/>
+    <use   name="FWCore/PythonParameterSet"/>
     <use   name="FWCore/TestProcessor"/>
     <use   name="DataFormats/Provenance"/>
     <use   name="catch2"/>

--- a/FWCore/ParameterSetReader/BuildFile.xml
+++ b/FWCore/ParameterSetReader/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="FWCore/ParameterSet"/>
-<use   name="FWCore/PythonParameterSet"/>
+<use   name="FWCore/PyDevParameterSet"/>
 <export>
-  <use   name="boost_python"/> 
   <lib   name="1"/>
+  <use  name="py2-pybind11"/>
 </export>

--- a/FWCore/ParameterSetReader/interface/ProcessDescImpl.h
+++ b/FWCore/ParameterSetReader/interface/ProcessDescImpl.h
@@ -1,9 +1,9 @@
 #ifndef FWCore_Framework_ProcessDescImpl_h
 #define FWCore_Framework_ProcessDescImpl_h
 
-#include "FWCore/PythonParameterSet/interface/PythonProcessDesc.h"
+#include "FWCore/PyDevParameterSet/interface/PyBind11ProcessDesc.h"
 
-using ProcessDescImpl = PythonProcessDesc; 
+using ProcessDescImpl = PyBind11ProcessDesc; 
 
 #endif
 

--- a/FWCore/ParameterSetReader/src/ParameterSetReader.cc
+++ b/FWCore/ParameterSetReader/src/ParameterSetReader.cc
@@ -1,27 +1,27 @@
 #include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
-#include "FWCore/PythonParameterSet/interface/PythonProcessDesc.h"
-#include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
+#include "FWCore/PyDevParameterSet/interface/PyBind11ProcessDesc.h"
+#include "FWCore/PyDevParameterSet/interface/MakePyBind11ParameterSets.h"
 
 std::unique_ptr<edm::ParameterSet> edm::getPSetFromConfig(const std::string &config) {
-  return PythonProcessDesc(config).parameterSet();
+  return PyBind11ProcessDesc(config).parameterSet();
 }
 
 
 //its really the stuff in MakePythonParameterSets that should be in the different namespace
 //I'll do that if this setup is ok
 std::unique_ptr<edm::ParameterSet> edm::readConfig(std::string const& config, int argc, char* argv[]) {
-  return edm::boost_python::readConfig(config,argc,argv);
+  return edm::cmspybind11::readConfig(config,argc,argv);
 }
 
 std::unique_ptr<edm::ParameterSet> edm::readConfig(std::string const& config) {
-  return edm::boost_python::readConfig(config);
+  return edm::cmspybind11::readConfig(config);
 }
 
 void edm::makeParameterSets(std::string const& configtext,
 			    std::unique_ptr<ParameterSet> & main) {
-  edm::boost_python::makeParameterSets(configtext,main);
+  edm::cmspybind11::makeParameterSets(configtext,main);
 }
 
 std::unique_ptr<edm::ParameterSet> edm::readPSetsFrom(std::string const& fileOrString) {
-  return edm::boost_python::readPSetsFrom(fileOrString);
+  return edm::cmspybind11::readPSetsFrom(fileOrString);
 }

--- a/FWCore/TestProcessor/BuildFile.xml
+++ b/FWCore/TestProcessor/BuildFile.xml
@@ -1,7 +1,6 @@
 <use   name="FWCore/Framework"/>
-<use   name="FWCore/PythonParameterSet"/>
+<use   name="FWCore/ParameterSetReader"/>
 <use   name="boost"/>
-<use   name="boost_python"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
#### PR description:

This exchanges the boost_python parameterset reader for one based on pybind11 for cmsRun and other users of FWCore/ParameterSetReader package.

A subsequent step will be to remove the boost_python version.

#### PR validation:

Similar implementation is running in DEVEL build (but this PR will be a better check of the output consistency). Unit tests of affected packages pass. runTheMatrix tests that i did were also ok.

