### PR TITLE
Fix HGCalValidator configuration for premixing

### DIFF
--- a/Validation/HGCalValidation/python/HGCalValidator_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalValidator_cfi.py
@@ -46,3 +46,8 @@ hgcalValidator = cms.EDAnalyzer(
 
 )
 
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(hgcalValidator,
+    label_cp_effic = "mixData:MergedCaloTruth",
+    label_cp_fake = "mixData:MergedCaloTruth"
+)


### PR DESCRIPTION
#### PR description:

This PR addresses the problem described in #26284, after the integration of the HGCalValidator #26099 into the standard sequence. The class is configured to use CaloParticles from "mix", while for premixing they are from "mixData". See also #26001 . Here a simple addition of a modifier is proposed to circumvent the failure observed in the CMSSW_10_6_X_2019-03-27-2300 IB for workflow 20234.99 step4.

#### PR validation:

Both phase2 wf 29024.0 (D41 no PU) and 20234.99 (D17 Premixing) run smoothly.
