### PR TITLE
Fix race condition in EventProcessor

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -52,6 +52,7 @@ namespace edm {
   class ProcessDesc;
   class SubProcess;
   class WaitingTaskHolder;
+  class LuminosityBlockPrincipal;
   class LuminosityBlockProcessingStatus;
   class IOVSyncValue;
   
@@ -231,7 +232,7 @@ namespace edm {
     int readAndMergeLumi(LuminosityBlockProcessingStatus&);
     void writeRunAsync(WaitingTaskHolder, ProcessHistoryID const& phid, RunNumber_t run, MergeableRunProductMetadata const*);
     void deleteRunFromCache(ProcessHistoryID const& phid, RunNumber_t run);
-    void writeLumiAsync(WaitingTaskHolder, std::shared_ptr<LuminosityBlockProcessingStatus> );
+    void writeLumiAsync(WaitingTaskHolder, LuminosityBlockPrincipal& lumiPrincipal);
     void deleteLumiFromCache(LuminosityBlockProcessingStatus&);
 
     bool shouldWeStop() const;


### PR DESCRIPTION
#### PR description:

This fixes the problem from issue #26246. This is related
to a data race condition in EventProcessor. Almost always,
the correct data path wins the race and there are no
problems. In these cases, there should be no differences
in the output with or without this PR. But there are very rare
cases where the wrong code path wins the data race, then
endRun gets called late and this would most likely cause a
seg fault or very bad failure of some unpredictable nature. 

The condition is related to the deletion of the
LuminosityBlockProcessingStatus object. If we want
to call endRun after exiting processLumis, then
this status object must have already been destroyed
because it holds a shared_ptr to the RunResources
object that prevents endRun from running. If it isn't
destroyed then endRun may get called at some random
time much later which causes serious problems.

The writeT task in EventProcessor::globalEndLumiAsync
is the one that caused the failure in the issue. Although
there were several similar issues that this also fixes that could
result in the same problem.

#### PR validation:

It is hard to write a test for this, because it is a rare non reproducible problem. Even without the fix, almost always the right code path wins and there is absolutely no difference in how things execute in that case.

#### if this PR is a backport please specify the original PR:

Potentially I could backport this. These failures are very rare, so it is a judgement call whether it is worth the effort. Probably it was introduced when concurrent lumis were implemented.
