### PR TITLE
Revert "Change devel build to use pybind11 for cmsRun"

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -27,7 +27,7 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/ParameterSetReader"/>
 </bin>
-<bin   name="cmsRun" file="cmsRunPyDev.cpp">
+<bin   name="cmsRun" file="cmsRun.cpp">
   <use   name="tbb"/>
   <use   name="boost"/>
   <use   name="boost_program_options"/>
@@ -41,7 +41,7 @@
   <use   name="FWCore/ServiceRegistry"/>
   <use   name="FWCore/Utilities"/>
   <use   name="FWCore/ParameterSet"/>
-  <use   name="FWCore/PyDevParameterSet"/>
+  <use   name="FWCore/ParameterSetReader"/>
 </bin>
 <bin   name="cmsRunVDT" file="cmsRun.cpp">
   <use   name="vdt"/>


### PR DESCRIPTION
Reverts devel build only change that is now obsolete.

Replaced by #26278 
