### PR TITLE
Adding Era dependent  effective area for miniIsolation calculation in muon selectors

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -153,6 +153,7 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavy
 
   //for mini-isolation calculation
   computeMiniIso_ = iConfig.getParameter<bool>("computeMiniIso");
+  activeEra_ = iConfig.getParameter<std::string>("activeEra");
 
   miniIsoParams_ = iConfig.getParameter<std::vector<double> >("miniIsoParams");
   if(computeMiniIso_ && miniIsoParams_.size() != 9){
@@ -650,7 +651,7 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
     double miniIsoValue = -1;
     if (computeMiniIso_){
       // MiniIsolation working points
-      miniIsoValue = getRelMiniIsoPUCorrected(muon,*rho);
+      miniIsoValue = getRelMiniIsoPUCorrected(muon,*rho, activeEra_);
       muon.setSelector(reco::Muon::MiniIsoLoose,     miniIsoValue<0.40);
       muon.setSelector(reco::Muon::MiniIsoMedium,    miniIsoValue<0.20);
       muon.setSelector(reco::Muon::MiniIsoTight,     miniIsoValue<0.10);
@@ -806,13 +807,13 @@ void PATMuonProducer::setMuonMiniIso(Muon& aMuon, const PackedCandidateCollectio
   aMuon.setMiniPFIsolation(miniiso);
 }
 
-double PATMuonProducer::getRelMiniIsoPUCorrected(const pat::Muon& muon, float rho)
+double PATMuonProducer::getRelMiniIsoPUCorrected(const pat::Muon& muon, float rho, std::string era)
 {
   float mindr(miniIsoParams_[0]);
   float maxdr(miniIsoParams_[1]);
   float kt_scale(miniIsoParams_[2]);
   float drcut = pat::miniIsoDr(muon.p4(),mindr,maxdr,kt_scale);
-  return pat::muonRelMiniIsoPUCorrected(muon.miniPFIsolation(), muon.p4(), drcut, rho);
+  return pat::muonRelMiniIsoPUCorrected(muon.miniPFIsolation(), muon.p4(), drcut, rho, era);
 }
 
 // ParameterSet description for module

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -99,8 +99,7 @@ namespace pat {
     template<typename T> void readIsolationLabels( const edm::ParameterSet & iConfig, const char* psetName, IsolationLabels& labels, std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens);
 
     void setMuonMiniIso(pat::Muon& aMuon, const pat::PackedCandidateCollection *pc);
-    double getRelMiniIsoPUCorrected(const pat::Muon& muon, float rho);
-
+    double getRelMiniIsoPUCorrected(const pat::Muon& muon, float rho, std::string era);
     // embed various impact parameters with errors
     // embed high level selection
     void embedHighLevel( pat::Muon & aMuon,
@@ -233,6 +232,12 @@ namespace pat {
     edm::EDGetTokenT<std::vector<pat::TriggerObjectStandAlone>> triggerObjects_;
     edm::EDGetTokenT<edm::TriggerResults> triggerResults_;
     std::vector<std::string> hltCollectionFilters_;
+
+    //figure out active era during run time 
+    std::string activeEra_;
+
+
+
   };
 
 }

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 patMuons = cms.EDProducer("PATMuonProducer",
     # input
@@ -102,6 +103,7 @@ patMuons = cms.EDProducer("PATMuonProducer",
     pfCandsForMiniIso = cms.InputTag("packedPFCandidates"),
     miniIsoParams = cms.vdouble(0.05, 0.2, 10.0, 0.5, 0.0001, 0.01, 0.01, 0.01, 0.0),
 
+    activeEra = cms.string("Run2_2018"),
     # Standard Muon Selectors and Jet-related observables
     # Depends on MiniIsolation, so only works in miniaod
     # Don't forget to set flags properly in miniAOD_tools.py                      
@@ -127,7 +129,6 @@ patMuons = cms.EDProducer("PATMuonProducer",
     triggerResults = cms.InputTag("TriggerResults","","HLT"),
     hltCollectionFilters = cms.vstring('*')
 )
-
 
 
 

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -30,6 +30,7 @@ def miniAOD_customizeCommon(process):
     process.patMuons.computeSoftMuonMVA = cms.bool(True)
 
     process.patMuons.addTriggerMatching = True
+    #process.patMuons.activeEra = "Run2_2018"
 
     #
     # disable embedding of electron and photon associated objects already stored by the ReducedEGProducer
@@ -56,6 +57,11 @@ def miniAOD_customizeCommon(process):
                                     addPFClusterIso = cms.bool(True),
                                     ecalPFClusterIsoMap = cms.InputTag("reducedEgamma", "eleEcalPFClusIso"),
                                     hcalPFClusterIsoMap = cms.InputTag("reducedEgamma", "eleHcalPFClusIso"))
+
+    run2_miniAOD_80XLegacy.toModify(process.patMuons, activeEra=cms.string("run2_miniAOD_80XLegacy"))
+    run2_miniAOD_94XFall17.toModify(process.patMuons, activeEra=cms.string("run2_miniAOD_94XFall17"))
+    
+
 
     #add puppi isolation in miniAOD
     process.patElectrons.addPuppiIsolation = cms.bool(True)

--- a/PhysicsTools/PatUtils/interface/MiniIsolation.h
+++ b/PhysicsTools/PatUtils/interface/MiniIsolation.h
@@ -28,7 +28,8 @@ namespace pat{
   float muonRelMiniIsoPUCorrected(const PFIsolation& iso,
 				  const math::XYZTLorentzVector& p4,
 				  float dr,
-				  float rho);
+				  float rho,
+                                  std::string era);
 }
 
 #endif

--- a/PhysicsTools/PatUtils/src/MiniIsolation.cc
+++ b/PhysicsTools/PatUtils/src/MiniIsolation.cc
@@ -58,16 +58,35 @@ PFIsolation getMiniPFIsolation(const pat::PackedCandidateCollection *pfcands,
   float muonRelMiniIsoPUCorrected(const PFIsolation& iso,
 				  const math::XYZTLorentzVector& p4,
 				  float dr,
-				  float rho)
+				  float rho,
+                                  std::string era)
   {
     double absEta = fabs(p4.eta());
     double ea = 0;
     //Spring15 version
+       if(era=="run2_miniAOD_80XLegacy"){
     if      (absEta<0.800) ea = 0.0735;
     else if (absEta<1.300) ea = 0.0619;
     else if (absEta<2.000) ea = 0.0465;
     else if (absEta<2.200) ea = 0.0433;
     else if (absEta<2.500) ea = 0.0577;
+    }
+    //Fall17 effective area
+    if(era=="run2_miniAOD_94XFall17"){
+    if      (absEta<0.800) ea = 0.0566;
+    else if (absEta<1.300) ea = 0.0562;
+    else if (absEta<2.000) ea = 0.0363;
+    else if (absEta<2.200) ea = 0.0119;
+    else if (absEta<2.500) ea = 0.0064;
+    }
+    //if nothing is mention use 94X areas instead
+    else{
+    if      (absEta<0.800) ea = 0.0566;
+    else if (absEta<1.300) ea = 0.0562;
+    else if (absEta<2.000) ea = 0.0363;
+    else if (absEta<2.200) ea = 0.0119;
+    else if (absEta<2.500) ea = 0.0064;
+    }
     double correction = rho * ea * (dr/0.3) * (dr/0.3);
     double correctedIso = iso.chargedHadronIso() + std::max(0.0, iso.neutralHadronIso()+iso.photonIso() - correction);
     return correctedIso/p4.pt();


### PR DESCRIPTION
- Adding Era dependent effective area for mini isolation calculation 
- The ticket that concerns this is : https://its.cern.ch/jira/browse/CMSMUONS-206
-  The effective areas that are used to calculate the mini Isolation changes with Era
- Currently we have two sets of optimized effective areas are available: https://github.com/bmahakud/cmssw/blob/EraBasedEffectiveAreaforMiniIsolation/PhysicsTools/PatUtils/src/MiniIsolation.cc#L67
