### PR TITLE
Revert  PR 25975 "Change devel build to use pybind11 for cmsRun"

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -27,7 +27,7 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/ParameterSetReader"/>
 </bin>
-<bin   name="cmsRun" file="cmsRunPyDev.cpp">
+<bin   name="cmsRun" file="cmsRun.cpp">
   <use   name="tbb"/>
   <use   name="boost"/>
   <use   name="boost_program_options"/>
@@ -41,7 +41,7 @@
   <use   name="FWCore/ServiceRegistry"/>
   <use   name="FWCore/Utilities"/>
   <use   name="FWCore/ParameterSet"/>
-  <use   name="FWCore/PyDevParameterSet"/>
+  <use   name="FWCore/ParameterSetReader"/>
 </bin>
 <bin   name="cmsRunVDT" file="cmsRun.cpp">
   <use   name="vdt"/>


### PR DESCRIPTION
This reverts commit fcf7e7029a1421d4c8e96cea619e0806b22c01e7.

#### PR description:

This PR replaces #26291 , updating in the same spirit 10_6_DEVEL_X to bring it in sync with 10_6_X, before merging #26278 .

#### PR validation:

This revert just make 10_6_X and 10_6_DEVEL_X branches coincide.
