### PR TITLE
change of the argument definition of some reco::Muon functions 

### DIFF
--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -238,7 +238,6 @@ namespace reco {
     /// number of chambers CSC or DT matches only (MuonChamberMatches include RPC rolls)
     int numberOfChambersCSCorDT() const;
     /// get number of chambers with matched segments
-    //int numberOfMatches( unsigned int type = SegmentAndTrackArbitration ) const; 
     int numberOfMatches( ArbitrationType type = SegmentAndTrackArbitration ) const;
     /// get number of stations with matched segments
     /// just adds the bits returned by stationMask
@@ -249,7 +248,6 @@ namespace reco {
     /// get bit map of stations with matched segments
     /// bits 0-1-2-3 = DT stations 1-2-3-4
     /// bits 4-5-6-7 = CSC stations 1-2-3-4
-    /* unsigned int stationMask( unsigned int type = SegmentAndTrackArbitration ) const; */
     unsigned int stationMask( ArbitrationType type = SegmentAndTrackArbitration ) const;
     /// get bit map of stations with tracks within
     /// given distance (in cm) of chamber edges 
@@ -341,15 +339,12 @@ namespace reco {
     /// get vector of muon chambers for given station and detector
     const std::vector<const MuonChamberMatch*> chambers( int station, int muonSubdetId ) const;
     /// get pointers to best segment and corresponding chamber in vector of chambers
-    /* std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> pair( const std::vector<const MuonChamberMatch*> &, */
-    /* 								     unsigned int type = SegmentAndTrackArbitration ) const; */
     std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> pair( const std::vector<const MuonChamberMatch*> &,
 								     ArbitrationType type = SegmentAndTrackArbitration ) const;
     /// selector bitmap
     unsigned int selectors_;
    public:
      /// get number of segments
-     /* int numberOfSegments( int station, int muonSubdetId, unsigned int type = SegmentAndTrackArbitration ) const; */
     int numberOfSegments( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
      /// get deltas between (best) segment and track
      /// If no chamber or no segment returns 999999

--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -238,7 +238,8 @@ namespace reco {
     /// number of chambers CSC or DT matches only (MuonChamberMatches include RPC rolls)
     int numberOfChambersCSCorDT() const;
     /// get number of chambers with matched segments
-    int numberOfMatches( unsigned int type = SegmentAndTrackArbitration ) const;
+    //int numberOfMatches( unsigned int type = SegmentAndTrackArbitration ) const; 
+    int numberOfMatches( ArbitrationType type = SegmentAndTrackArbitration ) const;
     /// get number of stations with matched segments
     /// just adds the bits returned by stationMask
     int numberOfMatchedStations( ArbitrationType type = SegmentAndTrackArbitration ) const;
@@ -248,7 +249,8 @@ namespace reco {
     /// get bit map of stations with matched segments
     /// bits 0-1-2-3 = DT stations 1-2-3-4
     /// bits 4-5-6-7 = CSC stations 1-2-3-4
-    unsigned int stationMask( unsigned int type = SegmentAndTrackArbitration ) const;
+    /* unsigned int stationMask( unsigned int type = SegmentAndTrackArbitration ) const; */
+    unsigned int stationMask( ArbitrationType type = SegmentAndTrackArbitration ) const;
     /// get bit map of stations with tracks within
     /// given distance (in cm) of chamber edges 
     /// bit assignments are same as above
@@ -269,8 +271,10 @@ namespace reco {
     static const unsigned int GEMMuon =  1<<7;
     static const unsigned int ME0Muon =  1<<8;
 
-    void setType( unsigned int type ) { type_ = type; }
-    unsigned int type() const { return type_; }
+    void setType( unsigned int type ) { type_ = type; } 
+    unsigned int type() const { return type_; } 
+
+   
     // override of method in base class reco::Candidate
     bool isMuon() const override { return true; }
     bool isGlobalMuon()     const override { return type_ & GlobalMuon; }
@@ -328,7 +332,7 @@ namespace reco {
 
     /// muon type mask
     unsigned int type_;
-
+    
     //PF muon p4
     reco::Candidate::LorentzVector pfP4_;
 
@@ -337,13 +341,16 @@ namespace reco {
     /// get vector of muon chambers for given station and detector
     const std::vector<const MuonChamberMatch*> chambers( int station, int muonSubdetId ) const;
     /// get pointers to best segment and corresponding chamber in vector of chambers
+    /* std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> pair( const std::vector<const MuonChamberMatch*> &, */
+    /* 								     unsigned int type = SegmentAndTrackArbitration ) const; */
     std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> pair( const std::vector<const MuonChamberMatch*> &,
-								     unsigned int type = SegmentAndTrackArbitration ) const;
+								     ArbitrationType type = SegmentAndTrackArbitration ) const;
     /// selector bitmap
     unsigned int selectors_;
    public:
      /// get number of segments
-     int numberOfSegments( int station, int muonSubdetId, unsigned int type = SegmentAndTrackArbitration ) const;
+     /* int numberOfSegments( int station, int muonSubdetId, unsigned int type = SegmentAndTrackArbitration ) const; */
+    int numberOfSegments( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
      /// get deltas between (best) segment and track
      /// If no chamber or no segment returns 999999
      float dX       ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -60,7 +60,6 @@ int Muon::numberOfChambersCSCorDT() const
   return total;
 }
 
-//int Muon::numberOfMatches( unsigned int type ) const
 int Muon::numberOfMatches( ArbitrationType type ) const
 {
    int matches(0);
@@ -110,11 +109,6 @@ int Muon::numberOfMatches( ArbitrationType type ) const
 	     matches++;
 	     break;
 	   }
-         // if(type > 1<<7)
-         //    if(segmentMatch->isMask(type)) {
-         //       matches++;
-         //       break;
-         //    }
       }
    }
 
@@ -153,7 +147,6 @@ unsigned int Muon::expectedNnumberOfMatchedStations( float minDistanceFromEdge )
   return n;
 }
 
-// unsigned int Muon::stationMask( unsigned int type ) const
 unsigned int Muon::stationMask( ArbitrationType type ) const
 {
    unsigned int totMask(0);
@@ -220,14 +213,6 @@ unsigned int Muon::stationMask( ArbitrationType type ) const
                   totMask += curMask;
                break;
             }
-         // if(type > 1<<7)
-         //    if(segmentMatch->isMask(type)) {
-         //       curMask = 1<<( (chamberMatch->station()-1)+4*(chamberMatch->detector()-1) );
-         //       // do not double count
-         //       if(!(totMask & curMask))
-         //          totMask += curMask;
-         //       break;
-         //    }
       }
    }
 
@@ -349,7 +334,6 @@ unsigned int Muon::stationGapMaskPull( float sigmaCut ) const
    return totMask;
 }
 
-// int Muon::numberOfSegments( int station, int muonSubdetId, unsigned int type ) const
 int Muon::numberOfSegments( int station, int muonSubdetId, ArbitrationType type ) const
 {
    int segments(0);
@@ -385,11 +369,6 @@ int Muon::numberOfSegments( int station, int muonSubdetId, ArbitrationType type 
                segments++;
                break;
             }
-         // if(type > 1<<7)
-         //    if(segmentMatch->isMask(type)) {
-         //       segments++;
-         //       break;
-         //    }
       }
    }
 
@@ -406,8 +385,6 @@ const std::vector<const MuonChamberMatch*> Muon::chambers( int station, int muon
    return chambers;
 }
 
-// std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> Muon::pair( const std::vector<const MuonChamberMatch*> &chambers,
-//      unsigned int type ) const
 std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> Muon::pair( const std::vector<const MuonChamberMatch*> &chambers,
      ArbitrationType type ) const
 {
@@ -438,9 +415,6 @@ std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> Muon::pair( const std
 	          segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR) &&
 	          segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByCleaning))
                return std::make_pair(*chamberMatch, &(*segmentMatch));
-         // if(type > 1<<7)
-         //    if(segmentMatch->isMask(type))
-         //       return std::make_pair(*chamberMatch, &(*segmentMatch));
       }
    }
 

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -60,7 +60,8 @@ int Muon::numberOfChambersCSCorDT() const
   return total;
 }
 
-int Muon::numberOfMatches( unsigned int type ) const
+//int Muon::numberOfMatches( unsigned int type ) const
+int Muon::numberOfMatches( ArbitrationType type ) const
 {
    int matches(0);
    for( std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
@@ -109,11 +110,11 @@ int Muon::numberOfMatches( unsigned int type ) const
 	     matches++;
 	     break;
 	   }
-         if(type > 1<<7)
-            if(segmentMatch->isMask(type)) {
-               matches++;
-               break;
-            }
+         // if(type > 1<<7)
+         //    if(segmentMatch->isMask(type)) {
+         //       matches++;
+         //       break;
+         //    }
       }
    }
 
@@ -152,7 +153,8 @@ unsigned int Muon::expectedNnumberOfMatchedStations( float minDistanceFromEdge )
   return n;
 }
 
-unsigned int Muon::stationMask( unsigned int type ) const
+// unsigned int Muon::stationMask( unsigned int type ) const
+unsigned int Muon::stationMask( ArbitrationType type ) const
 {
    unsigned int totMask(0);
    unsigned int curMask(0);
@@ -218,14 +220,14 @@ unsigned int Muon::stationMask( unsigned int type ) const
                   totMask += curMask;
                break;
             }
-         if(type > 1<<7)
-            if(segmentMatch->isMask(type)) {
-               curMask = 1<<( (chamberMatch->station()-1)+4*(chamberMatch->detector()-1) );
-               // do not double count
-               if(!(totMask & curMask))
-                  totMask += curMask;
-               break;
-            }
+         // if(type > 1<<7)
+         //    if(segmentMatch->isMask(type)) {
+         //       curMask = 1<<( (chamberMatch->station()-1)+4*(chamberMatch->detector()-1) );
+         //       // do not double count
+         //       if(!(totMask & curMask))
+         //          totMask += curMask;
+         //       break;
+         //    }
       }
    }
 
@@ -347,7 +349,8 @@ unsigned int Muon::stationGapMaskPull( float sigmaCut ) const
    return totMask;
 }
 
-int Muon::numberOfSegments( int station, int muonSubdetId, unsigned int type ) const
+// int Muon::numberOfSegments( int station, int muonSubdetId, unsigned int type ) const
+int Muon::numberOfSegments( int station, int muonSubdetId, ArbitrationType type ) const
 {
    int segments(0);
    for( std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
@@ -382,11 +385,11 @@ int Muon::numberOfSegments( int station, int muonSubdetId, unsigned int type ) c
                segments++;
                break;
             }
-         if(type > 1<<7)
-            if(segmentMatch->isMask(type)) {
-               segments++;
-               break;
-            }
+         // if(type > 1<<7)
+         //    if(segmentMatch->isMask(type)) {
+         //       segments++;
+         //       break;
+         //    }
       }
    }
 
@@ -403,8 +406,10 @@ const std::vector<const MuonChamberMatch*> Muon::chambers( int station, int muon
    return chambers;
 }
 
+// std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> Muon::pair( const std::vector<const MuonChamberMatch*> &chambers,
+//      unsigned int type ) const
 std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> Muon::pair( const std::vector<const MuonChamberMatch*> &chambers,
-     unsigned int type ) const
+     ArbitrationType type ) const
 {
    MuonChamberMatch* m = nullptr;
    MuonSegmentMatch* s = nullptr;
@@ -433,9 +438,9 @@ std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> Muon::pair( const std
 	          segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR) &&
 	          segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByCleaning))
                return std::make_pair(*chamberMatch, &(*segmentMatch));
-         if(type > 1<<7)
-            if(segmentMatch->isMask(type))
-               return std::make_pair(*chamberMatch, &(*segmentMatch));
+         // if(type > 1<<7)
+         //    if(segmentMatch->isMask(type))
+         //       return std::make_pair(*chamberMatch, &(*segmentMatch));
       }
    }
 


### PR DESCRIPTION
#### PR description:
This would be a more clean fix to the issue described in this PR
https://github.com/cms-sw/cmssw/issues/23057

#### PR validation:
No changes are expected from this PR. The main check is to be sure that this doesn't break anything. All the integration tests have been successfully done, those failed (which are 25) are failing the step0 (no das input file).

