### PR TITLE
Update DeepAK8 to 94X training

### DIFF
--- a/RecoBTag/MXNet/plugins/DeepBoostedJetTagsProducer.cc
+++ b/RecoBTag/MXNet/plugins/DeepBoostedJetTagsProducer.cc
@@ -31,8 +31,8 @@ struct MXBlockCache {
 struct PreprocessParams {
   struct VarInfo {
     VarInfo() {}
-    VarInfo(float median, float upper) :
-      center(median), norm_factor(upper==median ? 1 : 1./(upper-median)) {}
+    VarInfo(float median, float norm_factor) :
+      center(median), norm_factor(norm_factor) {}
     float center = 0;
     float norm_factor = 1;
   };
@@ -107,8 +107,8 @@ DeepBoostedJetTagsProducer::DeepBoostedJetTagsProducer(const edm::ParameterSet& 
     for (const auto &var_name : prep_params.var_names){
       const auto &var_pset = var_info_pset.getParameterSet(var_name);
       double median = var_pset.getParameter<double>("median");
-      double upper = var_pset.getParameter<double>("upper");
-      prep_params.var_info_map[var_name] = PreprocessParams::VarInfo(median, upper);
+      double norm_factor = var_pset.getParameter<double>("norm_factor");
+      prep_params.var_info_map[var_name] = PreprocessParams::VarInfo(median, norm_factor);
     }
 
     // create data storage with a fixed size vector initilized w/ 0

--- a/RecoBTag/MXNet/python/pfDeepBoostedJet_cff.py
+++ b/RecoBTag/MXNet/python/pfDeepBoostedJet_cff.py
@@ -3,22 +3,23 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.FeatureTools.pfDeepBoostedJetTagInfos_cfi import pfDeepBoostedJetTagInfos
 from RecoBTag.MXNet.pfDeepBoostedJetTags_cfi import pfDeepBoostedJetTags as _pfDeepBoostedJetTags
 from RecoBTag.MXNet.pfDeepBoostedJetPreprocessParams_cfi import pfDeepBoostedJetPreprocessParams
+from RecoBTag.MXNet.pfMassDecorrelatedDeepBoostedJetPreprocessParams_cfi import pfMassDecorrelatedDeepBoostedJetPreprocessParams
 from RecoBTag.MXNet.pfDeepBoostedDiscriminatorsJetTags_cfi import pfDeepBoostedDiscriminatorsJetTags
 from RecoBTag.MXNet.pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags_cfi import pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags
 
 # nominal DeepAK8
 pfDeepBoostedJetTags = _pfDeepBoostedJetTags.clone(
     preprocessParams = pfDeepBoostedJetPreprocessParams,
-    model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V01/full/resnet-symbol.json',
-    param_path = 'RecoBTag/Combined/data/DeepBoostedJet/V01/full/resnet-0000.params',
+    model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/full/resnet-symbol.json',
+    param_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/full/resnet-0000.params',
     debugMode  = False, # debug
 )
 
 # mass-decorrelated DeepAK8
 pfMassDecorrelatedDeepBoostedJetTags = _pfDeepBoostedJetTags.clone(
-    preprocessParams = pfDeepBoostedJetPreprocessParams,
-    model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V01/decorrelated/resnet-symbol.json',
-    param_path = 'RecoBTag/Combined/data/DeepBoostedJet/V01/decorrelated/resnet-0000.params',
+    preprocessParams = pfMassDecorrelatedDeepBoostedJetPreprocessParams,
+    model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/decorrelated/resnet-symbol.json',
+    param_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/decorrelated/resnet-0000.params',
     debugMode = False, # debug
 )
 

--- a/RecoBTag/MXNet/python/pfMassDecorrelatedDeepBoostedJetPreprocessParams_cfi.py
+++ b/RecoBTag/MXNet/python/pfMassDecorrelatedDeepBoostedJetPreprocessParams_cfi.py
@@ -1,12 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-pfDeepBoostedJetPreprocessParams = cms.PSet(
+pfMassDecorrelatedDeepBoostedJetPreprocessParams = cms.PSet(
     input_names = cms.vstring(
         'pfcand', 
         'sv'
     ),
     pfcand = cms.PSet(
-        input_shape = cms.vuint32(1, 42, 100, 1),
+        input_shape = cms.vuint32(1, 36, 100, 1),
         var_infos = cms.PSet(
             pfcand_VTX_ass = cms.PSet(
                 median = cms.double(7.0),
@@ -124,30 +124,6 @@ pfDeepBoostedJetPreprocessParams = cms.PSet(
                 median = cms.double(-0.00711047858931),
                 norm_factor = cms.double(4.2642743837)
             ),
-            pfcand_hcalFrac = cms.PSet(
-                median = cms.double(0.0),
-                norm_factor = cms.double(1.0)
-            ),
-            pfcand_isChargedHad = cms.PSet(
-                median = cms.double(1.0),
-                norm_factor = cms.double(1.0)
-            ),
-            pfcand_isEl = cms.PSet(
-                median = cms.double(0.0),
-                norm_factor = cms.double(1.0)
-            ),
-            pfcand_isGamma = cms.PSet(
-                median = cms.double(0.0),
-                norm_factor = cms.double(1.0)
-            ),
-            pfcand_isMu = cms.PSet(
-                median = cms.double(0.0),
-                norm_factor = cms.double(1.0)
-            ),
-            pfcand_isNeutralHad = cms.PSet(
-                median = cms.double(0.0),
-                norm_factor = cms.double(1.0)
-            ),
             pfcand_lostInnerHits = cms.PSet(
                 median = cms.double(-1.0),
                 norm_factor = cms.double(1.0)
@@ -191,12 +167,6 @@ pfDeepBoostedJetPreprocessParams = cms.PSet(
             'pfcand_drsubjet1', 
             'pfcand_drsubjet2', 
             'pfcand_charge', 
-            'pfcand_isMu', 
-            'pfcand_isEl', 
-            'pfcand_isChargedHad', 
-            'pfcand_isGamma', 
-            'pfcand_isNeutralHad', 
-            'pfcand_hcalFrac', 
             'pfcand_VTX_ass', 
             'pfcand_lostInnerHits', 
             'pfcand_normchi2', 


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, what changes are expected in the output if any, what other PRs or externals it depends upon if any -->

This PR updates the DeepAK8 tagger to a new training performed with 2017 (94X) samples. Both the full (`pfDeepBoostedJetTags`) and the mass-decorrelated (`pfMassDecorrelatedDeepBoostedJetTags`) taggers are updated. 

Needs https://github.com/cms-data/RecoBTag-Combined/pull/21.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

The update has been presented at the [BTV meeting](https://indico.cern.ch/event/808258/contributions/3366869/attachments/1817445/2971091/DeepAK8_BTV_Presentation_March25_PK.pdf). The new training shows improved performance on Phase1 detector compared to the 2016 training. The new training is also evaluated on 2016 samples and no loss of performance is found compared to the 2016 training. Therefore the updated model is intended for use in UL processing for all three years.

Small improvements have been made to the training afterwards to further reduce the mass sculpting. The performance of the latest version (in this PR) can be found [here](https://www.dropbox.com/s/lhhmjjnhayp29hm/deepAK8_PR_comp_20190329.pdf?dl=0). 

Outputs from CMSSW with this PR have been verified with the training framework.

@gouskos @pkontaxa