### PR TITLE
Pythia filter to focus on the probe side of B decays (backport)

### DIFF
--- a/GeneratorInterface/GenFilters/interface/PythiaProbeFilter.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaProbeFilter.h
@@ -1,0 +1,73 @@
+#ifndef PYTHIAPROBEFILTER_h
+#define PYTHIAPROBEFILTER_h
+// -*- C++ -*-
+//
+// Package:    PythiaProbeFilter
+// Class:      PythiaProbeFilter
+// 
+/**\class PythiaProbeFilter PythiaProbeFilter.cc 
+
+ Description: Filter to exclude selected particles from passing pT,eta cuts etc. Usefull when we are interested in a decay that its daughters should not pass any cuts, but another particle of the same flavour should e.g B+B- production with B+->K+mumu forcing (probe side) and we want mu to come from B- (tag side)
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Georgios Karathanasis
+//         Created:  Mar 14 2019
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "Pythia8/Pythia.h"
+
+//
+// class decleration
+//
+namespace edm {
+  class HepMCProduct;
+}
+
+class PythiaProbeFilter : public edm::global::EDFilter<> {
+   public:
+      explicit PythiaProbeFilter(const edm::ParameterSet&);
+      ~PythiaProbeFilter() override;
+
+
+      bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+      bool AlreadyExcludedCheck(std::vector<unsigned int> excludedList, unsigned int current_part) const;
+   private:
+      // ----------memeber function----------------------
+
+      // ----------member data ---------------------------
+      
+       const edm::EDGetTokenT<edm::HepMCProduct> token_;
+       std::vector<int> exclsisIDs;
+       std::vector<int> exclauntIDs;
+       const int particleID;
+       const int MomID;
+       const int GrandMomID;
+       const bool chargeconju; 
+       const  int nsisters;
+       const  int naunts;
+       const double minptcut;
+       const double maxptcut;
+       const double minetacut;
+       const double maxetacut;
+       const bool countQEDCorPhotons;
+       bool identicalParticle;
+       std::unique_ptr<Pythia8::Pythia> fLookupGen; // this instance is for accessing particleData information
+};
+#endif

--- a/GeneratorInterface/GenFilters/src/PythiaProbeFilter.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaProbeFilter.cc
@@ -1,0 +1,181 @@
+
+#include "GeneratorInterface/GenFilters/interface/PythiaProbeFilter.h"
+
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include <iostream>
+
+using namespace edm;
+using namespace std;
+using namespace Pythia8;
+
+
+PythiaProbeFilter::PythiaProbeFilter(const edm::ParameterSet& iConfig) :
+token_(consumes<edm::HepMCProduct>(edm::InputTag(iConfig.getUntrackedParameter("moduleLabel",std::string("generator")),"unsmeared"))),
+particleID(iConfig.getUntrackedParameter("ParticleID", 0)),
+MomID(iConfig.getUntrackedParameter("MomID", 0)),
+GrandMomID(iConfig.getUntrackedParameter("GrandMomID", 0)),
+chargeconju(iConfig.getUntrackedParameter("ChargeConjugation", true)),
+nsisters(iConfig.getUntrackedParameter("NumberOfSisters", 0)),
+naunts(iConfig.getUntrackedParameter("NumberOfAunts", 0)),
+minptcut(iConfig.getUntrackedParameter("MinPt", 0.)),
+maxptcut(iConfig.getUntrackedParameter("MaxPt", 14000.)),
+minetacut(iConfig.getUntrackedParameter("MinEta", -10.)),
+maxetacut(iConfig.getUntrackedParameter("MaxEta", 10.)),
+countQEDCorPhotons(iConfig.getUntrackedParameter("countQEDCorPhotons", false))
+{
+   //now do what ever initialization is needed
+   vector<int> defID;
+   defID.push_back(0);
+   exclsisIDs = iConfig.getUntrackedParameter< vector<int> >("SisterIDs",defID);
+   exclauntIDs = iConfig.getUntrackedParameter< vector<int> >("AuntIDs",defID);
+   identicalParticle=false;
+   for( unsigned int ilist=0; ilist< exclsisIDs.size(); ++ilist) {
+     if (fabs(exclsisIDs[ilist])==fabs(particleID))
+         identicalParticle=true;
+   }
+ // create pythia8 instance to access particle data
+   edm::LogInfo("PythiaProbeFilter::PythiaProbeFilter") << "Creating pythia8 instance for particle properties" << endl;
+   if(!fLookupGen.get()) fLookupGen.reset(new Pythia());
+}
+
+
+PythiaProbeFilter::~PythiaProbeFilter()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+bool PythiaProbeFilter::AlreadyExcludedCheck(std::vector<unsigned int> excludedList, unsigned int current_part) const
+{
+  bool result=false;
+  for (unsigned int checkNow: excludedList ){
+    if (current_part!=checkNow) continue;
+    result=true; break;
+  }
+  return result;
+}
+//
+// member functions
+//
+// ------------ method called to produce the data  ------------
+bool PythiaProbeFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
+{
+   using namespace edm;
+   bool accepted = false;
+   Handle<HepMCProduct> evt;
+   iEvent.getByToken(token_, evt);  
+
+   const HepMC::GenEvent * myGenEvent = evt->GetEvent();
+
+   //access particles
+   for ( HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin(); p != myGenEvent->particles_end(); ++p ) {     
+     //select tag particle
+     if (fabs((*p)->pdg_id()) == fabs(particleID))
+     if( (*p)->pdg_id() != particleID && !chargeconju ) continue;
+    
+     if( fabs((*p)->pdg_id()) != fabs(particleID) && chargeconju ) continue;
+     //kinematic properties of tag
+     if ((*p)->momentum().perp()< minptcut || (*p)->momentum().perp()>maxptcut )
+       continue;
+     if ((*p)->momentum().eta()< minetacut || (*p)->momentum().eta()>maxetacut )       continue;
+     //remove probe side particles
+     bool excludeTagParticle=false;
+     if (naunts==0){
+      if ( (*p)->production_vertex()) {
+        for ( HepMC::GenVertex::particle_iterator  anc=(*p)->production_vertex()->particles_begin(HepMC::parents); anc != (*p)->production_vertex()->particles_end(HepMC::parents); ++anc ) {         
+         if (fabs((*anc)->pdg_id())!=fabs(MomID) && chargeconju) continue;
+         else if ((*anc)->pdg_id()!=MomID && !chargeconju) continue;
+         int nsis=0; int exclsis=0; std::vector<unsigned int> checklistSis;
+         if ((*anc)->end_vertex()){
+           for ( HepMC::GenVertex::particle_iterator sis=(*anc)->end_vertex()->particles_begin(HepMC::children); sis != (*anc)->end_vertex()->particles_end(HepMC::children); ++sis ) {
+             //identify the tag particle in the decay
+             if ((*p)->pdg_id()==(*sis)->pdg_id() && (identicalParticle || !chargeconju)) continue;
+             if (fabs((*p)->pdg_id())==fabs((*sis)->pdg_id()) && !identicalParticle && chargeconju) continue;
+             //remove QED photons
+             if ((*sis)->pdg_id()==22 && !countQEDCorPhotons) continue;
+             nsis++;
+             //check if this sis is excluded already
+             for( unsigned int ilist=0; ilist< exclsisIDs.size(); ++ilist) {
+               if(AlreadyExcludedCheck(checklistSis,ilist)){
+                 continue;}
+               if (fabs(exclsisIDs[ilist])==fabs((*sis)->pdg_id()) && chargeconju){ 
+                  exclsis++; checklistSis.push_back(ilist);
+               }
+               if (exclsisIDs[ilist]==(*sis)->pdg_id() && !chargeconju){ 
+                  exclsis++; checklistSis.push_back(ilist);
+                  }
+		}
+	     }
+	   }
+         if (nsis==exclsis && nsis==nsisters) {
+            excludeTagParticle=true; break;}
+        }
+      }     
+     }
+   else if (naunts>0){
+    //now take into account that we have up 2 generations in the decay
+    if ( (*p)->production_vertex() ) {
+      for ( HepMC::GenVertex::particle_iterator  anc=(*p)->production_vertex()->particles_begin(HepMC::parents); anc != (*p)->production_vertex()->particles_end(HepMC::parents); ++anc ) {
+        if (fabs((*anc)->pdg_id())!=fabs(MomID) && chargeconju) continue;
+        else if ((*anc)->pdg_id()!=MomID && !chargeconju) continue;
+        int nsis=0; int exclsis=0; std::vector<unsigned int> checklistSis;
+        int naunt=0; int exclaunt=0; std::vector<unsigned int> checklistAunt;
+        if ((*anc)->end_vertex()){
+          for ( HepMC::GenVertex::particle_iterator sis=(*anc)->end_vertex()->particles_begin(HepMC::children); sis != (*anc)->end_vertex()->particles_end(HepMC::children); ++sis ) {
+            //identify the particle under study in the decay
+            if ((*p)->pdg_id()==(*sis)->pdg_id() && (identicalParticle || !chargeconju)) continue;
+            if (fabs((*p)->pdg_id())==fabs((*sis)->pdg_id()) && !identicalParticle && chargeconju) continue;
+            //remove QED photons
+            if ((*sis)->pdg_id()==22 && !countQEDCorPhotons) continue;
+            nsis++;
+            for( unsigned int ilist=0; ilist< exclsisIDs.size(); ++ilist) {
+              if(AlreadyExcludedCheck(checklistSis,ilist)) continue;
+              if (fabs(exclsisIDs[ilist])==fabs((*sis)->pdg_id()) && chargeconju){ 
+                 exclsis++; checklistSis.push_back(ilist);}
+              if (exclsisIDs[ilist]==(*sis)->pdg_id() && !chargeconju){ 
+                  exclsis++; checklistSis.push_back(ilist);  } 
+		 }
+	  }
+	}
+        //check sisters
+        if (nsis!=exclsis || nsis!=nsisters) break;
+        if ( (*anc)->production_vertex() ) {
+	  for ( HepMC::GenVertex::particle_iterator  granc=(*anc)->production_vertex()->particles_begin(HepMC::parents); granc != (*anc)->production_vertex()->particles_end(HepMC::parents); ++granc ) {
+             if (fabs((*granc)->pdg_id())!=fabs(GrandMomID) && chargeconju)
+                continue;
+             else if ((*granc)->pdg_id()!=GrandMomID && !chargeconju) 
+                continue;
+             for ( HepMC::GenVertex::particle_iterator aunt=(*granc)->end_vertex()->particles_begin(HepMC::children); aunt != (*granc)->end_vertex()->particles_end(HepMC::children); ++aunt ) {
+               if ((*aunt)->pdg_id()==(*anc)->pdg_id()) continue;
+               if ((*aunt)->pdg_id()==22 && !countQEDCorPhotons) continue;
+               naunt++;      
+               for( unsigned int ilist=0; ilist< exclauntIDs.size(); ++ilist) {
+                 if(AlreadyExcludedCheck(checklistAunt,ilist)) continue;
+                 if (fabs(exclauntIDs[ilist])==fabs((*aunt)->pdg_id()) && chargeconju){ 
+                   exclaunt++;  checklistAunt.push_back(ilist); }
+                 if (exclauntIDs[ilist]==(*aunt)->pdg_id() && !chargeconju){ 
+                   exclaunt++;  checklistAunt.push_back(ilist); }    
+	       }
+	     }
+	  }
+	}        
+        //check aunts
+        if (naunt==exclaunt && naunt==naunts) {
+              excludeTagParticle=true; break;} 
+      }
+    }	   
+   }
+    if (excludeTagParticle) continue;
+    accepted = true;      
+    break;           
+   }
+
+ if (accepted){
+    return true;  }
+ else      {
+    return false;}
+       
+} 

--- a/GeneratorInterface/GenFilters/src/SealModule.cc
+++ b/GeneratorInterface/GenFilters/src/SealModule.cc
@@ -4,6 +4,7 @@
 #include "GeneratorInterface/GenFilters/interface/PythiaFilterHT.h"
 #include "GeneratorInterface/GenFilters/interface/PythiaFilterMultiMother.h"
 #include "GeneratorInterface/GenFilters/interface/PythiaDauFilter.h"
+#include "GeneratorInterface/GenFilters/interface/PythiaProbeFilter.h"
 #include "GeneratorInterface/GenFilters/interface/PythiaFilterGammaJet.h"
 #include "GeneratorInterface/GenFilters/interface/PythiaFilterGammaGamma.h"
 #include "GeneratorInterface/GenFilters/interface/PythiaFilterZJet.h"
@@ -56,6 +57,7 @@
   DEFINE_FWK_MODULE(PythiaFilterHT);
   DEFINE_FWK_MODULE(PythiaFilterMultiMother);
   DEFINE_FWK_MODULE(PythiaDauFilter);
+  DEFINE_FWK_MODULE(PythiaProbeFilter);
   DEFINE_FWK_MODULE(PythiaFilterGammaJet);
   DEFINE_FWK_MODULE(PythiaFilterGammaGamma);
   DEFINE_FWK_MODULE(PythiaFilterZJet);


### PR DESCRIPTION
#### PR description:

Its a dedicated filter to simulate the effect of probe side kinematics for B decays. By probe side we mean that the muons of B should be excluded from the filter, while the filter must be passed by another muon of the event (eg B+->mu1mu2K, B- ->mu3X; we want only the mu3 to be filtered). This filter helps to save valuable events that were going to be wasted by using the "standard" filters.

#### PR validation:
This is a backport of https://github.com/cms-sw/cmssw/pull/26286 . There I have uploaded validation and performance plots. Also that PR passed all the tests.

#### if this PR is a backport please specify the original PR:

This PR is backport of #26286 
