### PR TITLE
Fix a corner case in ClusterTPAssociationProducer

### DIFF
--- a/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
+++ b/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
@@ -31,12 +31,16 @@ public:
   explicit ClusterTPAssociation(const edm::HandleBase& mappedHandle): ClusterTPAssociation(mappedHandle.id()) {}
   explicit ClusterTPAssociation(const edm::ProductID& mappedProductId): mappedProductId_(mappedProductId) {}
 
+  void addKeyID(edm::ProductID id) {
+    auto foundKeyID = std::find(std::begin(keyProductIDs_), std::end(keyProductIDs_), id);
+    if(foundKeyID == std::end(keyProductIDs_)) {
+      keyProductIDs_.emplace_back(id);
+    }
+  }
+
   void emplace_back(const OmniClusterRef& cluster, const TrackingParticleRef& tp) {
     checkMappedProductID(tp);
-    auto foundKeyID = std::find(std::begin(keyProductIDs_), std::end(keyProductIDs_), cluster.id());
-    if(foundKeyID == std::end(keyProductIDs_)) {
-      keyProductIDs_.emplace_back(cluster.id());
-    }
+    checkKeyProductID(cluster.id());
     map_.emplace_back(cluster, tp);
   }
   void sortAndUnique() {

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
@@ -134,6 +134,7 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
 
   if ( foundPixelClusters ) {
     // Pixel Clusters 
+    clusterTPList->addKeyID(pixelClusters.id());
     for (edmNew::DetSetVector<SiPixelCluster>::const_iterator iter  = pixelClusters->begin(); 
                                                             iter != pixelClusters->end(); ++iter) {
       uint32_t detid = iter->id(); 
@@ -168,6 +169,7 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
 
   if ( foundStripClusters ) {
     // Strip Clusters
+    clusterTPList->addKeyID(stripClusters.id());
     for (edmNew::DetSetVector<SiStripCluster>::const_iterator iter  = stripClusters->begin(false), eter = stripClusters->end(false); 
 	 iter != eter; ++iter) {
       if (!(*iter).isValid()) continue;
@@ -202,8 +204,8 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
   }
 
   if ( foundPhase2OTClusters ) {
-
     // Phase2 Clusters
+    clusterTPList->addKeyID(phase2OTClusters.id());
     if(phase2OTClusters.isValid()){
       for (edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator iter  = phase2OTClusters->begin(false), eter = phase2OTClusters->end(false);
                                                                 iter != eter; ++iter) {


### PR DESCRIPTION
#### PR description:

There is a rare case in ClusterTPAssociationProducer that if none of the pixel or strip clusters match to SimTracks, the `ClusterTPAssociation::equal_range()` will throw an exception for such pixel or strip cluster as the ProductID of these (key) clusters has not been recorded. The behavior should have been to return an empty range.

This PR changes the behavior such that the ProductIDs of the cluster collections are always added to the `ClusterTPAssociation`.

Thanks to @slava77 for reporting.

There should be no changes in standard workflows (as the exception has not been observed before).

#### PR validation:

@slava77 said that the problematic event got processed correctly.