### PR TITLE
PPS: alignment from auto GT

### DIFF
--- a/CalibPPS/ESProducers/python/ctppsAlignment_cff.py
+++ b/CalibPPS/ESProducers/python/ctppsAlignment_cff.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi import *
-ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring(
-  "Alignment/CTPPS/data/RPixGeometryCorrections.xml"
-)
+# by default, alignment is now loaded from CondDB using a GT
+
+#from CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi import *
+#ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring(
+#  "Alignment/CTPPS/data/RPixGeometryCorrections.xml"
+#)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,16 +24,16 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '105X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '105X_dataRun2_v8',
+    'run1_data'         :   '106X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '105X_dataRun2_v8',
+    'run2_data'         :   '106X_dataRun2_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '105X_dataRun2_relval_v8',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v1',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '105X_dataRun2_PromptLike_HEfail_v7',
+    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '105X_dataRun2_PromptLike_v8',
-    'run2_data_promptlike_hi' : '105X_dataRun2_PromptLike_HI_v3',
+    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v1',
+    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v8',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/RecoCTPPS/ProtonReconstruction/python/ctppsProtons_cff.py
+++ b/RecoCTPPS/ProtonReconstruction/python/ctppsProtons_cff.py
@@ -3,6 +3,5 @@ import FWCore.ParameterSet.Config as cms
 from RecoCTPPS.ProtonReconstruction.ctppsProtons_cfi import *
 
 # TODO: remove these lines once conditions data are available in DB
-from CalibPPS.ESProducers.ctppsAlignment_cff import *
 from CalibPPS.ESProducers.ctppsOpticalFunctions_cff import *
 ctppsProtons.lhcInfoLabel = ctppsLHCInfoLabel

--- a/Validation/CTPPS/test/year_2016/proton_reconstruction_LHC_data/test_reconstruction_cfg.py
+++ b/Validation/CTPPS/test/year_2016/proton_reconstruction_LHC_data/test_reconstruction_cfg.py
@@ -8,10 +8,6 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, "auto:run2_data")
 
-# TODO: these lines can be useful before all necessary data available in DB with an auto GT
-#process.GlobalTag = GlobalTag(process.GlobalTag, "105X_dataRun2_relval_v2")
-#process.alignmentEsPrefer = cms.ESPrefer("PoolDBESSource", "GlobalTag")
-
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",
   statistics = cms.untracked.vstring(),


### PR DESCRIPTION
#### PR description:

The default source of PPS alignment is changed to CondDB via auto GT.

The only two changes wrt. master are:
  * c3302ac67546d249604fe0aabe23152bfbaf13c7: cherry-pick of @tocheng's 2490f473de6540804b070b5ede3d18757b820b08 where auto GTs are updated
  * 20088375561f68e1849e6461ab65f35ec521cead: update to PPS configuration to use the alignment from DB

This PR is a replacement for the earlier-closed #26243 .

#### PR validation:

Below a comparison of results of 2016 data reconstruction (file /store/data/Run2016C/BTagCSV/AOD/07Aug17-v1/110000/0026FCD2-369A-E711-920C-0025905A607E.root). Blue histogram: master with alignment from XML files, red: this PR. There is perfect agreement.

![cmp](https://user-images.githubusercontent.com/17830858/55324857-947a4200-5483-11e9-9772-bad9d7ece91a.png)

Below a check on pixel reconstruction quality, re-reco performed on file /store/data/Run2017C/ZeroBias/RAW/v1/000/301/283/00000/8ED63519-2282-E711-9073-02163E01A3C6.root. The quality is maintained.

![pixel_quality](https://user-images.githubusercontent.com/17830858/55325028-21bd9680-5484-11e9-9804-cc4dff29fdec.png)


