### PR TITLE
Adapt ETL numbering scheme to new forward volume hierarchy (scenario D41, HGCal v10)

### DIFF
--- a/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
@@ -43,7 +43,12 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   std::string baseName = ringName.substr(ringName.find(":")+1);
   const int ringCopy ( ::atoi( baseName.c_str() + 4 ) );
 
-  const uint32_t sideCopy ( baseNumber.getCopyNumber( 7 ) ) ;
+  // Side choice: up to scenario D38 is given by level 7 (HGCal v9)
+  int nSide(7);
+  const std::string& sideName ( baseNumber.getLevelName( nSide ) ) ;
+  // Side choice: from scenario D41 is given by level 8 (HGCal v10)
+  if ( sideName == "caloBase:CALOECTSFront" ) { nSide = 8 ;}  
+  const uint32_t sideCopy ( baseNumber.getCopyNumber( nSide ) ) ;
   const uint32_t zside ( sideCopy == 1 ? 1 : 0 ) ;
 
 #ifdef EDM_ML_DEBUG


### PR DESCRIPTION
#### PR description:

Phase 2 scenario D41 (with HGCal v10 geometry) changes the hierarchy of volumes, while keeping the overall number of levels constant. The volume from whose copy number the side can be derived is no more the 7th (EREG) but the 8th (CALOEC). The numbering scheme is defining the side in the DetId based on this information, and needs to be adapted accordingly.

#### PR validation:

The Geometry/MTDCommonData test for numbering and position shows that the side is now correctly assigned depending on the CALOEC copy number (and absolute position in the global system of coordinates):

```
 - /cms:OCMS[0]/cms:CMSE[1]/caloBase:CALO[1]/caloBase:CALOEC[1]/caloBase:CALOECTSFront[1]/caloBase:CALOECFront[1]/etl:EndcapTimingLayer[1]/mtd:Disc1[1]/mtd:Ring1Disc1[1]/mtd:EModule1Disc1[1]/mtd:EModule1Disc1Timingwafer[1]/mtd:EModule1Disc1Timingactive[1]
[MTDDetId::print]  0110 0011 0100 0001 0000 0000 1000 0000
 rawId       : 0x63410080
 bits[0:24]  : 01410080
 Detector        : 6
 SubDetector     : 1
 MTD subdetector : 2
 ETL 
 Side        : 1
 Ring        : 1
 Module      : 1
 Module type : 0
```

```
 - /cms:OCMS[0]/cms:CMSE[1]/caloBase:CALO[1]/caloBase:CALOEC[2]/caloBase:CALOECTSFront[1]/caloBase:CALOECFront[1]/etl:EndcapTimingLayer[1]/mtd:Disc1[1]/mtd:Ring1Disc1[1]/mtd:EModule1Disc1[1]/mtd:EModule1Disc1Timingwafer[1]/mtd:EModule1Disc1Timingactive[1]
[MTDDetId::print]  0110 0011 0000 0001 0000 0000 1000 0000
 rawId       : 0x63010080
 bits[0:24]  : 01010080
 Detector        : 6
 SubDetector     : 1
 MTD subdetector : 2
 ETL 
 Side        : 0
 Ring        : 1
 Module      : 1
 Module type : 0
```