### PR TITLE
Properly handle a polymorphic exception in DTCCablingMapProducer

### DIFF
--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
@@ -213,7 +213,7 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(std::vector<std::s
 					{
 						detIdRaw = std::stoi( csvColumn[csvFormat_idetid_] );
 					}
-					catch (std::exception e)
+					catch (std::exception const& e)
 					{
 						if (verbosity_ >= 0)
 						{


### PR DESCRIPTION
#### PR description:

Fixes a gcc 8 compiler warning.

#### PR validation:

Compiled under gcc7.