### PR TITLE
Make sure isPixel is always initialized in TestAssociator

### DIFF
--- a/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
@@ -97,7 +97,7 @@ void TestAssociator::printRechitSimhit(const edm::Handle<edmNew::DetSetVector<re
       int i=0;
       hitCounter++;
       cout << hitCounter <<") " << rechitName << " RecHit subDet, DetId " << detid.subdetId() << ", " << myid << " Pos = " << rechit.localPosition() << endl;
-      bool isPixel;
+      bool isPixel=false;
       float mindist = 999999;
       float dist, distx, disty;
       PSimHit closest;


### PR DESCRIPTION

#### PR description:

This fixes a compiler warning from the ASAN build.

#### PR validation:

Compiled using regular gcc 7 build.