### PR TITLE
Added std namespace to avoid cxxmodule Ib errors

### DIFF
--- a/DataFormats/FEDRawData/interface/DaqData.h
+++ b/DataFormats/FEDRawData/interface/DaqData.h
@@ -49,6 +49,7 @@
 #include <map>
 #include <string>
 #include <cmath>
+#include <iostream>
    
 template <class Format>
 class DaqData {
@@ -112,8 +113,8 @@ class DaqData {
 
     catch (std::string s){
 
-      cout<<"DaqData - Exception caught: " << s <<endl;
-      cout<<"Object compression failed! No data has been constructed for format: "<< string(typeid(Format).name())<<endl; 
+      std::cout<<"DaqData - Exception caught: " << s <<endl;
+      std::cout<<"Object compression failed! No data has been constructed for format: "<< string(typeid(Format).name())<<endl;
       
     }
 
@@ -136,7 +137,7 @@ class DaqData {
       // cout<<"The buffer will be "<<size_ <<" bytes long"<<endl;      
 
       if ((sizeinbytes*8)%ObjSize != 0) {
-	cout<<"DaqData: there will be  " << (sizeinbytes*8)%ObjSize <<" meaningless bits at the end of the buffer"<<endl;
+	std::cout<<"DaqData: there will be  " << (sizeinbytes*8)%ObjSize <<" meaningless bits at the end of the buffer"<<endl;
       }
 
       //     buffer_ = new char[sizeinbytes];
@@ -237,11 +238,11 @@ class DaqData {
       std::map < int, std::vector<unsigned int> >::const_iterator it = data_.find(indobj);
       if (it != data_.end()) return ((*it).second)[indfield];
       else {
-	cout<<"DaqData - Strange: object should exist but was not found "<<endl;
+	std::cout<<"DaqData - Strange: object should exist but was not found "<<endl;
 	return 0;
       }
     }
-    else  cout<<"DaqData - Non existent field or object"<<endl;
+    else  std::cout<<"DaqData - Non existent field or object"<<endl;
     return 0;
 
   }


### PR DESCRIPTION
#### PR description:

CXXMODULE IBs failed (if module is activated for  DataFormats/FEDRawData package ) due to unknow cout. This PR adds the missing header and namespace. 

Do we really need these `cout` in header file? Should we just remove these?

#### PR validation:

local compilation works

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
