### PR TITLE
cleanup dependency: DataFormats/Provenance does not depend on MessageLogger

### DIFF
--- a/DataFormats/Provenance/BuildFile.xml
+++ b/DataFormats/Provenance/BuildFile.xml
@@ -2,7 +2,6 @@
 <use   name="boost"/>
 <use   name="rootcore"/>
 <use   name="tbb"/>
-<use   name="FWCore/MessageLogger"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
#### PR description:

Cleanup dependency: DataFormats/Provenance does not depend on FWCore/MessageLogger. 

#### PR validation:

Local compilation does not show any build errors

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
