### PR TITLE
Fix GEM eMap and PF calibration in 2017 ideal simulation GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -44,7 +44,7 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v1',
+    'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
     'phase1_2017_realistic'    :  '106X_mc2017_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode


### PR DESCRIPTION
#### PR description:

The PR is to solve the issue [**Failure in wf 10424.0 due to missing GEM record**](https://github.com/cms-sw/cmssw/issues/26317) by fixing the missing new GEM eMap and updating PF calibration in 2017 ideal simulation. 

#### PR validation:

The PR is tested by running the workflow 10424 which was failed due to 2017 ideal simulation GT.
runTheMatrix -l 10424. No failure in each step. 
The different in GT (see [link](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017_design_IdealBS_v1/106X_mc2017_design_IdealBS_v2) ) is to fix the new GEMeMap missing and update PF calibration.

