### PR TITLE
Use also the fourth hit of pixel track in SeedGeneratorFromProtoTracksEDProducer

### DIFF
--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -143,7 +143,9 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
 	edm::ParameterSet seedCreatorPSet = theConfig.getParameter<edm::ParameterSet>("SeedCreatorPSet");
 	SeedFromConsecutiveHitsCreator seedCreator(seedCreatorPSet);
 	seedCreator.init(region, es, nullptr);
-	seedCreator.makeSeed(*result, SeedingHitSet(hits[0], hits[1], hits.size() >2 ? hits[2] : SeedingHitSet::nullPtr() ));
+	seedCreator.makeSeed(*result, SeedingHitSet(hits[0], hits[1],
+                                                    hits.size() >2 ? hits[2] : SeedingHitSet::nullPtr(),
+                                                    hits.size() >3 ? hits[3] : SeedingHitSet::nullPtr() ));
       }
     }
   } 


### PR DESCRIPTION
#### PR description:

I noticed that `SeedGeneratorFromProtoTracksEDProducer` does not include the possible fourth hit of a pixel tracks when creating `TrajectorySeed`s from pixel tracks (when `useProtoTrackKinematics == False`). This PR adds also the fourth hit.

In addition of affecting HLT with phase1 pixel, also phase0 HI tracking is affected, as `TrackCleaner` is used there for pixel tracks and the cleaner merges tracks.

#### PR validation:

I have here MTV plots (done in `10_4_0_patch1` with ttbar+PU 50 events on 2018 realistic conditions) comparing the effect with both the "offline MTV cuts" and "online MTV cuts"
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_10_4_0_patch1_hlt/
The main effects seem to be
- iter0 efficiency increases and iter1 decreases (fakes and duplicates stay as they are)
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_10_4_0_patch1_hlt/plots_hlt_hltIter0PFlowTrackSelectionHighPurity/effandfakePtEtaPhi.pdf
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_10_4_0_patch1_hlt/plots_hlt_hltIter1PFlowTrackSelectionHighPurity/effandfakePtEtaPhi.pdf
- iter1Merged efficiency stays roughly the same, but duplicate rate increases
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_10_4_0_patch1_hlt/plots_hlt_hltIter1Merged/effandfakePtEtaPhi.pdf
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_10_4_0_patch1_hlt/plots_hlt_hltIter1Merged/dupandfakePtEtaPhi.pdf
- `hltMerged` efficiency stays roughly the same, but duplicate rate increases
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_10_4_0_patch1_hlt/plots_hlt_hltMerged/effandfakePtEtaPhi.pdf
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_10_4_0_patch1_hlt/plots_hlt_hltMerged/dupandfakePtEtaPhi.pdf
- iter0 produces more tracks with 4 pixel layers
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_10_4_0_patch1_hlt/plots_hlt_hltIter0PFlowTrackSelectionHighPurity/distHitsLayers.pdf
which is probably the reason why the mean number of pixel hits decreases
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_10_4_0_patch1_hlt/plots_hlt_hltIter0PFlowTrackSelectionHighPurity/hitsLayers.pdf

@mtosi @JanFSchulte 
