### PR TITLE
Added plots to monitor pixel clusterrepair algorithm (backport)

### DIFF
--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1RecHits.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1RecHits.cc
@@ -32,7 +32,9 @@ class SiPixelPhase1RecHits final : public SiPixelPhase1Base {
     ERROR_X,
     ERROR_Y,
     POS,
-    CLUSTER_PROB
+    CLUSTER_PROB,
+    NONEDGE,
+    NOTHERBAD
   };
 
   public:
@@ -142,6 +144,8 @@ void SiPixelPhase1RecHits::analyze(const edm::Event& iEvent, const edm::EventSet
       float lerr_y = sqrt(lerr.yy());
 
       histo[NRECHITS].fill(id, &iEvent, col, row); //in general a inclusive counter of missing/valid/inactive hits
+      if(prechit->isOnEdge()) histo[NONEDGE].fill(id, &iEvent, col, row);
+      if(prechit->hasBadPixels()) histo[NOTHERBAD].fill(id, &iEvent, col, row);
 
       if (isHitValid){
 	histo[CLUST_X].fill(sizeX, id, &iEvent, col, row);

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1RecHits_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1RecHits_cfi.py
@@ -108,6 +108,100 @@ SiPixelPhase1RecHitsProb = DefaultHistoTrack.clone(
   )
 )
 
+SiPixelPhase1RecHitsOnEdge = DefaultHistoTrack.clone(
+  name = "onedge",
+  title = "OnEdge",
+  range_min = 0, range_max = 30, range_nbins = 30,
+  xlabel = "onedge",
+  dimensions = 0,
+  specs = VPSet(
+
+   StandardSpecificationTrend_Num,
+   StandardSpecificationOccupancy,
+   Specification().groupBy("PXBarrel/PXLayer/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/PXLayer/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer","EXTEND_X")
+                   .save(),
+   Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/PXDisk/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk","EXTEND_X")
+                   .save(),
+   Specification().groupBy("PXBarrel/PXLayer/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/PXLayer/")
+                   .save(nbins=100, xmin=0, xmax=1000),
+   Specification().groupBy("PXBarrel/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel")
+                   .save(nbins=100, xmin=0, xmax=1000),
+
+    Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/PXDisk/")
+                   .save(nbins=100, xmin=0, xmax=1000),
+    Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward")
+                   .save(nbins=100, xmin=0, xmax=1000),
+
+    Specification().groupBy("PXAll/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXAll")
+                   .save(nbins=100, xmin=0, xmax=1000)
+
+  )
+)
+
+SiPixelPhase1RecHitsOtherBad = DefaultHistoTrack.clone(
+  name = "otherbad",
+  title = "OtherBad",
+  range_min = 0, range_max = 30, range_nbins = 30,
+  xlabel = "otherbad",
+  dimensions = 0,
+  specs = VPSet(
+
+   StandardSpecificationTrend_Num,
+   StandardSpecificationOccupancy,
+   Specification().groupBy("PXBarrel/PXLayer/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/PXLayer/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer","EXTEND_X")
+                   .save(),
+   Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/PXDisk/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk","EXTEND_X")
+                   .save(),
+   Specification().groupBy("PXBarrel/PXLayer/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/PXLayer/")
+                   .save(nbins=100, xmin=0, xmax=1000),
+   Specification().groupBy("PXBarrel/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel")
+                   .save(nbins=100, xmin=0, xmax=1000),
+
+    Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/PXDisk/")
+                   .save(nbins=100, xmin=0, xmax=1000),
+    Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward")
+                   .save(nbins=100, xmin=0, xmax=1000),
+
+    Specification().groupBy("PXAll/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXAll")
+                   .save(nbins=100, xmin=0, xmax=1000)
+  )
+)
 
 SiPixelPhase1RecHitsConf = cms.VPSet(
   SiPixelPhase1RecHitsNRecHits,
@@ -117,6 +211,8 @@ SiPixelPhase1RecHitsConf = cms.VPSet(
   SiPixelPhase1RecHitsErrorY,
   SiPixelPhase1RecHitsPosition,
   SiPixelPhase1RecHitsProb,
+  SiPixelPhase1RecHitsOnEdge,
+  SiPixelPhase1RecHitsOtherBad,
 )
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer


### PR DESCRIPTION
#### PR description:

Some PixelPhase1 DQM plots added in order to monitor the performances of the Pixel Cluster Repair algorithm.

#### PR validation:

Code as been tested on MC ttbar data.

#### if this PR is a backport please specify the original PR:

#26324 
