### PR TITLE
Let DummyLHEAnalyzer test run out of the box

### DIFF
--- a/GeneratorInterface/LHEInterface/test/DummyLHEAnalyzer.cc
+++ b/GeneratorInterface/LHEInterface/test/DummyLHEAnalyzer.cc
@@ -23,7 +23,6 @@ private:
 public:
   explicit DummyLHEAnalyzer( const ParameterSet & cfg ) :
     dumpHeader_( cfg.getUntrackedParameter<bool>("dumpHeader",false) ),
-    src_( cfg.getParameter<InputTag>( "src" ) ),
     tokenLHERunInfo_(consumes<LHERunInfoProduct,edm::InRun>(cfg.getUntrackedParameter<edm::InputTag>("moduleLabel", std::string("source")) ) ),
     tokenLHEEvent_(consumes<LHEEventProduct>(cfg.getUntrackedParameter<edm::InputTag>("moduleLabel", std::string("source")) ) )
   {
@@ -32,7 +31,6 @@ private:
   void analyze( const Event & iEvent, const EventSetup & iSetup ) override {
 
     edm::Handle<LHEEventProduct> evt;
-    //iEvent.getByLabel(src_, evt);
     iEvent.getByToken(tokenLHEEvent_, evt);
 
     const lhef::HEPEUP hepeup_ = evt->hepeup();
@@ -119,7 +117,6 @@ private:
 
   }
 
-  InputTag src_;
   edm::EDGetTokenT<LHERunInfoProduct> tokenLHERunInfo_;
   edm::EDGetTokenT<LHEEventProduct> tokenLHEEvent_;
 

--- a/GeneratorInterface/LHEInterface/test/dumpLHE_cfg.py
+++ b/GeneratorInterface/LHEInterface/test/dumpLHE_cfg.py
@@ -11,7 +11,8 @@ process.source = cms.Source("PoolSource",
 )
 
 process.dummy = cms.EDAnalyzer("DummyLHEAnalyzer",
-    src = cms.InputTag("source")
+    moduleLabel = cms.untracked.InputTag("externalLHEProducer"),
+    dumpHeader = cms.untracked.bool(True)
 )
 
 process.p = cms.Path(process.dummy)


### PR DESCRIPTION
#### PR description:

Cleaning of GeneratorInterface/LHEInterface/test/DummyLHEAnalyzer.cc and of the test configuration provided so as it may run out of the box on modern output files.

#### PR validation:

Run dump_cfg.py on the output of test workflow 521.0 (linked to lhe.root)