### PR TITLE
First attempt of premixing for MTD

### DIFF
--- a/DataFormats/FTLDigi/interface/PMTDSimAccumulator.h
+++ b/DataFormats/FTLDigi/interface/PMTDSimAccumulator.h
@@ -1,0 +1,164 @@
+#ifndef DataFormats_FTLDigi_PMTDSimAccumulator_h
+#define DataFormats_FTLDigi_PMTDSimAccumulator_h
+
+#include "DataFormats/DetId/interface/DetId.h"
+
+#include <vector>
+#include <cassert>
+
+class PMTDSimAccumulator {
+public:
+  // These two structs are public only because of dictionary generation
+  class DetIdSize {
+  public:
+    DetIdSize() {}
+    DetIdSize(unsigned int detId, unsigned char row, unsigned char col):
+      detId_(detId), row_(row), column_(col)
+    {}
+
+    void increaseSize() {
+      ++size_;
+    }
+
+    unsigned int detId() const { return detId_; }
+    unsigned char row() const { return row_; }
+    unsigned char column() const { return column_; }
+    unsigned int size() const { return size_; }
+
+  private:
+    unsigned int detId_ = 0;
+    unsigned char row_ = 0;
+    unsigned char column_ = 0;
+    unsigned char size_ = 0;
+  };
+  class Data {
+  public:
+    constexpr static unsigned energyOffset = 15;
+    constexpr static unsigned energyMask = 0x1;
+    constexpr static unsigned sampleOffset = 11;
+    constexpr static unsigned sampleMask = 0xf;
+    constexpr static unsigned dataOffset = 0;
+    constexpr static unsigned dataMask = 0x7ff;
+
+    Data(): data_(0) {}
+    Data(unsigned short ei, unsigned short si, unsigned short d):
+      data_((ei << energyOffset) | (si << sampleOffset) | d)
+    {}
+
+    unsigned int energyIndex() const { return data_ >> energyOffset; }
+    unsigned int sampleIndex() const { return (data_ >> sampleOffset) & sampleMask; }
+    unsigned int data() const { return data_ & dataMask; }
+
+  private:
+    unsigned short data_;
+  };
+
+  PMTDSimAccumulator() = default;
+  ~PMTDSimAccumulator() = default;
+
+  void reserve(size_t size) {
+    detIdSize_.reserve(size);
+    data_.reserve(size);
+  }
+
+  void shrink_to_fit() {
+    detIdSize_.shrink_to_fit();
+    data_.shrink_to_fit();
+  }
+
+  /**
+   * Adds data for a given detId, energyIndex, and sampleIndex.
+   *
+   * It is the caller's responsibility to ensure that energyIndex,
+   * sampleIndex, and data fit in the space reserved for them in the
+   * Data bitfield above.
+   */
+  void emplace_back(unsigned int detId, unsigned char row, unsigned char column, unsigned short energyIndex, unsigned short sampleIndex, unsigned short data) {
+    if(detIdSize_.empty() || detIdSize_.back().detId() != detId || detIdSize_.back().row() != row || detIdSize_.back().column() != column) {
+      detIdSize_.emplace_back(detId, row, column);
+    }
+    data_.emplace_back(energyIndex, sampleIndex, data);
+    detIdSize_.back().increaseSize();
+  }
+
+  class TmpElem {
+  public:
+    TmpElem(unsigned int detId, unsigned char row, unsigned char column, Data data):
+      detId_(detId), data_(data), row_(row), column_(column)
+    {}
+
+    unsigned int detId() const { return detId_; }
+    unsigned char row() const { return row_; }
+    unsigned char column() const { return column_; }
+    unsigned short energyIndex() const { return data_.energyIndex(); }
+    unsigned short sampleIndex() const { return data_.sampleIndex(); }
+    unsigned short data() const { return data_.data(); }
+  private:
+    unsigned int detId_;
+    Data data_;
+    unsigned char row_;
+    unsigned char column_;
+  };
+
+  class const_iterator {
+  public:
+    // begin
+    const_iterator(const PMTDSimAccumulator *acc):
+      acc_(acc), iDet_(0), iData_(0),
+      endData_(acc->detIdSize_.empty() ? 0 : acc->detIdSize_.front().size())
+    {}
+
+    // end
+    const_iterator(const PMTDSimAccumulator *acc, unsigned int detSize, unsigned int dataSize):
+      acc_(acc), iDet_(detSize), iData_(dataSize), endData_(0)
+    {}
+
+    bool operator==(const const_iterator& other) const {
+      return iDet_ == other.iDet_ && iData_ == other.iData_;
+    }
+    bool operator!=(const const_iterator& other) const {
+      return !operator==(other);
+    }
+    const_iterator& operator++() {
+      ++iData_;
+      if(iData_ == endData_) {
+        ++iDet_;
+        endData_ += (iDet_ == acc_->detIdSize_.size()) ? 0 : acc_->detIdSize_[iDet_].size();
+      }
+      return *this;
+    }
+    const_iterator operator++(int) {
+      auto tmp = *this;
+      ++(*this);
+      return tmp;
+    }
+    TmpElem operator*() {
+      const auto& id = acc_->detIdSize_[iDet_];
+      return TmpElem(id.detId(), id.row(), id.column(),
+                     acc_->data_[iData_]);
+    }
+
+  private:
+    const PMTDSimAccumulator *acc_;
+    unsigned int iDet_;
+    unsigned int iData_;
+    unsigned int endData_;
+  };
+
+  TmpElem back() const {
+    const auto& id = detIdSize_.back();
+    return TmpElem(id.detId(), id.row(), id.column(),
+                   data_.back());
+  }
+
+  const_iterator cbegin() const { return const_iterator(this); }
+  const_iterator begin() const { return cbegin(); }
+  const_iterator cend() const { return const_iterator(this, detIdSize_.size(), data_.size()); }
+  const_iterator end() const { return cend(); }
+
+private:
+  std::vector<DetIdSize> detIdSize_;
+  std::vector<Data> data_;
+};
+
+#endif

--- a/DataFormats/FTLDigi/src/classes.h
+++ b/DataFormats/FTLDigi/src/classes.h
@@ -1,3 +1,4 @@
 #include <vector>
 #include "DataFormats/FTLDigi/interface/FTLDigiCollections.h"
+#include "DataFormats/FTLDigi/interface/PMTDSimAccumulator.h"
 

--- a/DataFormats/FTLDigi/src/classes_def.xml
+++ b/DataFormats/FTLDigi/src/classes_def.xml
@@ -17,4 +17,11 @@
    <class name="std::vector<ETLDataFrame>"/>
    <class name="ETLDigiCollection"/>
    <class name="edm::Wrapper<ETLDigiCollection>"/>   
+
+   <class name="PMTDSimAccumulator"/>
+   <class name="PMTDSimAccumulator::Data"/>
+   <class name="PMTDSimAccumulator::DetIdSize"/>
+   <class name="std::vector<PMTDSimAccumulator::Data>"/>
+   <class name="std::vector<PMTDSimAccumulator::DetIdSize>"/>
+   <class name="edm::Wrapper<PMTDSimAccumulator>"/>
 </lcgdict>

--- a/RecoLocalFastTime/FTLRecProducers/python/mtdUncalibratedRecHits_cfi.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/mtdUncalibratedRecHits_cfi.py
@@ -34,3 +34,9 @@ mtdUncalibratedRecHits = cms.EDProducer(
     BarrelHitsName = cms.string('FTLBarrel'),
     EndcapHitsName = cms.string('FTLEndcap')
 )
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(mtdUncalibratedRecHits,
+    barrelDigis = 'mixData:FTLBarrel',
+    endcapDigis = 'mixData:FTLEndcap',
+)

--- a/SimFastTiming/Configuration/python/SimFastTiming_EventContent_cff.py
+++ b/SimFastTiming/Configuration/python/SimFastTiming_EventContent_cff.py
@@ -20,8 +20,17 @@ SimFastTimingPREMIX = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
 
-_phase2_timing_extraCommands = [ 'keep *_mix_FTLBarrel_*','keep *_mix_FTLEndcap_*','keep *_mix_InitialVertices_*' ]
+_phase2_timing_extraCommands = cms.PSet( # using PSet in order to customize with Modifier
+    value = cms.vstring( 'keep *_mix_FTLBarrel_*','keep *_mix_FTLEndcap_*','keep *_mix_InitialVertices_*' )
+)
+# For premixing switch the sim digi collections to the ones including pileup
+# Unsure what to do with InitialVertices, they don't seem to be consumed downstream?
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(_phase2_timing_extraCommands,
+    value = [ 'keep *_mixData_FTLBarrel_*','keep *_mixData_FTLEndcap_*','keep *_mix_InitialVertices_*' ]
+)
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
-phase2_timing.toModify( SimFastTimingRAW, outputCommands = SimFastTimingRAW.outputCommands + _phase2_timing_extraCommands )
-phase2_timing.toModify( SimFastTimingFEVTDEBUG, outputCommands = SimFastTimingFEVTDEBUG.outputCommands + _phase2_timing_extraCommands )
-phase2_timing.toModify( SimFastTimingRECO, outputCommands = SimFastTimingRECO.outputCommands + _phase2_timing_extraCommands )
+phase2_timing.toModify( SimFastTimingRAW, outputCommands = SimFastTimingRAW.outputCommands + _phase2_timing_extraCommands.value )
+phase2_timing.toModify( SimFastTimingFEVTDEBUG, outputCommands = SimFastTimingFEVTDEBUG.outputCommands + _phase2_timing_extraCommands.value )
+phase2_timing.toModify( SimFastTimingRECO, outputCommands = SimFastTimingRECO.outputCommands + _phase2_timing_extraCommands.value )
+phase2_timing.toModify( SimFastTimingPREMIX, outputCommands = SimFastTimingRECO.outputCommands + _phase2_timing_extraCommands.value )

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
@@ -23,6 +23,8 @@
 
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
+#include "DataFormats/Math/interface/liblogintpack.h"
+
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
@@ -47,6 +49,73 @@ namespace mtd_digitizer {
       if(time_a<time_b) return true;
       
       return false;
+    }
+  }
+
+  inline
+  void saveSimHitAccumulator(PMTDSimAccumulator& simResult, const MTDSimHitDataAccumulator&  simData, const float minCharge, const float maxCharge) {
+    constexpr auto nEnergies = std::tuple_size<decltype(MTDCellInfo().hit_info)>::value;
+    static_assert(nEnergies <= PMTDSimAccumulator::Data::energyMask+1, "PMTDSimAccumulator bit pattern needs to updated");
+    static_assert(nSamples <= PMTDSimAccumulator::Data::sampleMask+1, "PMTDSimAccumulator bit pattern needs to updated");
+
+    const float minPackChargeLog = minCharge > 0.f ? std::log(minCharge) : -2;
+    const float maxPackChargeLog = std::log(maxCharge);
+    constexpr uint16_t base = 1<<PMTDSimAccumulator::Data::sampleOffset;
+
+    simResult.reserve(simData.size());
+    // mimicing the digitization
+    for(const auto& elem: simData) {
+      // store only non-zero
+      for(size_t iEn = 0; iEn < nEnergies; ++iEn) {
+        const auto& samples = elem.second.hit_info[iEn];
+        for(size_t iSample = 0; iSample < nSamples; ++iSample) {
+          if(samples[iSample] > minCharge) {
+            unsigned short packed;
+            if(iEn == 1) {
+              // assuming linear range for tof of 0..26
+              packed = samples[iSample]/PREMIX_MAX_TOF * base;
+            }
+            else {
+              packed = logintpack::pack16log(samples[iSample], minPackChargeLog, maxPackChargeLog, base);
+            }
+            simResult.emplace_back(elem.first.detid_, elem.first.row_, elem.first.column_,
+                                   iEn, iSample, packed);
+          }
+        }
+      }
+    }
+  }
+
+  inline
+  void loadSimHitAccumulator(MTDSimHitDataAccumulator& simData, const PMTDSimAccumulator& simAccumulator, const float minCharge, const float maxCharge) {
+    const float minPackChargeLog = minCharge > 0.f ? std::log(minCharge) : -2;
+    const float maxPackChargeLog = std::log(maxCharge);
+    constexpr uint16_t base = 1<<PMTDSimAccumulator::Data::sampleOffset;
+
+    for(const auto& detIdIndexHitInfo: simAccumulator) {
+      auto foo = simData.emplace(MTDCellId(detIdIndexHitInfo.detId(), detIdIndexHitInfo.row(), detIdIndexHitInfo.column()),
+                                 MTDCellInfo());
+      auto simIt = foo.first;
+      auto& hit_info = simIt->second.hit_info;
+
+      size_t iEn = detIdIndexHitInfo.energyIndex();
+      size_t iSample = detIdIndexHitInfo.sampleIndex();
+
+      float value;
+      if(iEn == 1) {
+        value = static_cast<float>(detIdIndexHitInfo.data())/base*PREMIX_MAX_TOF;
+      }
+      else {
+        value = logintpack::unpack16log(detIdIndexHitInfo.data(), minPackChargeLog, maxPackChargeLog, base);
+      }
+
+      if(iEn == 0) {
+        hit_info[iEn][iSample] += value;
+      }
+      else if(hit_info[iEn][iSample] == 0) {
+        // For iEn==1 the digitizers just set the TOF of the first SimHit
+        hit_info[iEn][iSample] = value;
+      }
     }
   }
 
@@ -76,7 +145,9 @@ namespace mtd_digitizer {
     void accumulate(edm::Event const& e, edm::EventSetup const& c, CLHEP::HepRandomEngine* hre) override;
     void accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& c, CLHEP::HepRandomEngine* hre) override;
     void accumulate(edm::Handle<edm::PSimHitContainer> const &hits, int bxCrossing, CLHEP::HepRandomEngine* hre) override;
-    
+    // for premixing
+    void accumulate(const PMTDSimAccumulator& simAccumulator) override;
+
     /**
        @short actions at the start/end of event
     */
@@ -156,20 +227,33 @@ namespace mtd_digitizer {
     hitRefs.clear();
 
   }
+
+  template<class Traits>
+  void MTDDigitizer<Traits>::accumulate(const PMTDSimAccumulator& simAccumulator) {
+    loadSimHitAccumulator(simHitAccumulator_, simAccumulator, premixStage1MinCharge_, premixStage1MaxCharge_);
+  }
   
   template<class Traits>
   void MTDDigitizer<Traits>::initializeEvent(edm::Event const& e, edm::EventSetup const& c) {
     deviceSim_.getEvent(e);
-    electronicsSim_.getEvent(e);
+    if(not premixStage1_) {
+      electronicsSim_.getEvent(e);
+    }
   }
   
   template<class Traits>
   void MTDDigitizer<Traits>::finalizeEvent(edm::Event& e, edm::EventSetup const& c, 
 					   CLHEP::HepRandomEngine* hre) {
-    
-    auto digiCollection = std::make_unique<DigiCollection>();
-    electronicsSim_.run(simHitAccumulator_,*digiCollection, hre);
-    e.put(std::move(digiCollection),digiCollection_);
+    if(premixStage1_) {
+      auto simResult = std::make_unique<PMTDSimAccumulator>();
+      saveSimHitAccumulator(*simResult, simHitAccumulator_, premixStage1MinCharge_, premixStage1MaxCharge_); // FIXME
+      e.put(std::move(simResult), digiCollection_);
+    }
+    else {
+      auto digiCollection = std::make_unique<DigiCollection>();
+      electronicsSim_.run(simHitAccumulator_,*digiCollection, hre);
+      e.put(std::move(digiCollection),digiCollection_);
+    }
     
     //release memory for next event
     resetSimHitDataAccumulator();
@@ -184,7 +268,9 @@ namespace mtd_digitizer {
     geom_ = geom.product();
 
     deviceSim_.getEventSetup(es);
-    electronicsSim_.getEventSetup(es);
+    if(not premixStage1_) {
+      electronicsSim_.getEventSetup(es);
+    }
 
   }
 }

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
@@ -246,7 +246,7 @@ namespace mtd_digitizer {
 					   CLHEP::HepRandomEngine* hre) {
     if(premixStage1_) {
       auto simResult = std::make_unique<PMTDSimAccumulator>();
-      saveSimHitAccumulator(*simResult, simHitAccumulator_, premixStage1MinCharge_, premixStage1MaxCharge_); // FIXME
+      saveSimHitAccumulator(*simResult, simHitAccumulator_, premixStage1MinCharge_, premixStage1MaxCharge_);
       e.put(std::move(simResult), digiCollection_);
     }
     else {

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
@@ -19,6 +19,9 @@ namespace mtd_digitizer {
     std::array<MTDSimHitData,2> hit_info;
   };
 
+  // Maximum value of time-of-flight for premixing packing
+  constexpr float PREMIX_MAX_TOF = 26.0f;
+
   struct MTDCellId {
     MTDCellId() : detid_(0), row_(0), column_(0) {}
     const uint32_t detid_;

--- a/SimFastTiming/FastTimingCommon/plugins/BuildFile.xml
+++ b/SimFastTiming/FastTimingCommon/plugins/BuildFile.xml
@@ -11,6 +11,7 @@
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/HepMCCandidate"/>
 <use name="SimGeneral/MixingModule"/>
+<use name="SimGeneral/PreMixingModule"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="SimFastTiming/FastTimingCommon"/>
 <use name="Geometry/HGCalCommonData"/>

--- a/SimFastTiming/FastTimingCommon/plugins/PreMixingMTDWorker.cc
+++ b/SimFastTiming/FastTimingCommon/plugins/PreMixingMTDWorker.cc
@@ -1,0 +1,74 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/FTLDigi/interface/PMTDSimAccumulator.h"
+#include "SimFastTiming/FastTimingCommon/interface/MTDDigitizerBase.h"
+
+#include "SimGeneral/PreMixingModule/interface/PreMixingWorker.h"
+#include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
+
+class PreMixingMTDWorker: public PreMixingWorker {
+public:
+  PreMixingMTDWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
+  ~PreMixingMTDWorker() override = default;
+
+  PreMixingMTDWorker(const PreMixingMTDWorker&) = delete;
+  PreMixingMTDWorker& operator=(const PreMixingMTDWorker&) = delete;
+
+  void beginRun(const edm::Run& run, const edm::EventSetup& ES) override;
+  void endRun() override;
+  void initializeEvent(const edm::Event &e, const edm::EventSetup& ES) override {}
+  void addSignals(const edm::Event &e, const edm::EventSetup& ES) override;
+  void addPileups(const PileUpEventPrincipal&, const edm::EventSetup& ES) override;
+  void put(edm::Event &e,const edm::EventSetup& ES, std::vector<PileupSummaryInfo> const& ps, int bs) override;
+
+private:
+  edm::EDGetTokenT<PMTDSimAccumulator> signalToken_;
+
+  edm::InputTag pileInputTag_;
+
+  std::unique_ptr<MTDDigitizerBase> digitizer_;
+};
+
+PreMixingMTDWorker::PreMixingMTDWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC):
+  signalToken_(iC.consumes<PMTDSimAccumulator>(ps.getParameter<edm::InputTag>("digiTagSig"))),
+  pileInputTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
+  digitizer_(MTDDigitizerFactory::get()->create(ps.getParameter<std::string>("digitizerName"),
+                                                ps,iC,producer))
+{}
+
+void PreMixingMTDWorker::beginRun(const edm::Run& run, const edm::EventSetup& ES) {
+  digitizer_->beginRun(ES);
+}
+
+void PreMixingMTDWorker::endRun() {
+  digitizer_->endRun();
+}
+
+void PreMixingMTDWorker::addSignals(const edm::Event &e,const edm::EventSetup& ES) {
+  edm::Handle<PMTDSimAccumulator> handle;
+  e.getByToken(signalToken_, handle);
+  digitizer_->accumulate(*handle);
+}
+
+void PreMixingMTDWorker::addPileups(const PileUpEventPrincipal& pep, const edm::EventSetup& ES) {
+  edm::Handle<PMTDSimAccumulator> handle;
+  pep.getByLabel(pileInputTag_, handle);
+  digitizer_->accumulate(*handle);
+}
+
+void PreMixingMTDWorker::put(edm::Event &e,const edm::EventSetup& ES, std::vector<PileupSummaryInfo> const& ps, int bs) {
+  edm::Service<edm::RandomNumberGenerator> rng;
+  digitizer_->finalizeEvent(e, ES, &rng->getEngine(e.streamID()));
+}
+
+DEFINE_PREMIXING_WORKER(PreMixingMTDWorker);

--- a/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
+++ b/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
@@ -5,6 +5,9 @@ _barrel_tile_MTDDigitizer = cms.PSet(
     inputSimHits      = cms.InputTag("g4SimHits:FastTimerHitsBarrel"),
     digiCollectionTag = cms.string("FTLBarrel"),
     maxSimHitsAccTime = cms.uint32(100),
+    premixStage1      = cms.bool(False),
+    premixStage1MinCharge = cms.double(1e-4), # These give relative precision of 1.1 %,
+    premixStage1MaxCharge = cms.double(1e6),  # can the range be squeezed?
     DeviceSimulation = cms.PSet(
         bxTime                   = cms.double(25),      # [ns] 
         LightYield               = cms.double(40000.),  # [photons/MeV]
@@ -51,6 +54,9 @@ _barrel_bar_MTDDigitizer = cms.PSet(
     inputSimHits      = cms.InputTag("g4SimHits:FastTimerHitsBarrel"),
     digiCollectionTag = cms.string("FTLBarrel"),
     maxSimHitsAccTime = cms.uint32(100),
+    premixStage1      = cms.bool(False),
+    premixStage1MinCharge = cms.double(1e-4),
+    premixStage1MaxCharge = cms.double(1e6),
     DeviceSimulation = cms.PSet(
         bxTime                   = cms.double(25),      # [ns]
         LightYield               = cms.double(40000.),  # [photons/MeV]
@@ -68,6 +74,9 @@ _endcap_MTDDigitizer = cms.PSet(
     inputSimHits      = cms.InputTag("g4SimHits:FastTimerHitsEndcap"),
     digiCollectionTag = cms.string("FTLEndcap"),
     maxSimHitsAccTime = cms.uint32(100),
+    premixStage1      = cms.bool(False),
+    premixStage1MinCharge = cms.double(1e-4),
+    premixStage1MaxCharge = cms.double(1e6),
     DeviceSimulation  = cms.PSet(
         bxTime            = cms.double(25),
         tofDelay          = cms.double(1),
@@ -88,6 +97,10 @@ _endcap_MTDDigitizer = cms.PSet(
         toaLSB_ns          = cms.double(0.013),
         )
 )
+
+from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
+for _m in [_barrel_tile_MTDDigitizer, _barrel_bar_MTDDigitizer, _endcap_MTDDigitizer]:
+    premix_stage1.toModify(_m, premixStage1 = True)
 
 # Fast Timing
 mtdDigitizer = cms.PSet( 

--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -98,6 +98,12 @@ premix_stage2.toModify(theDigitizers,
 (premix_stage2 & phase2_hfnose).toModify(theDigitizers,
     hfnoseDigitizer = dict(premixStage1 = True),
 )
+(premix_stage2 & (phase2_timing_layer_tile | phase2_timing_layer_bar)).toModify(theDigitizers,
+    fastTimingLayer = dict(
+        barrelDigitizer = dict(premixStage1 = True),
+        endcapDigitizer = dict(premixStage1 = True)
+    )
+)
 
 theDigitizersValid = cms.PSet(theDigitizers)
 theDigitizers.mergedtruth.select.signalOnlyTP = True

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -13,6 +13,7 @@ from SimGeneral.MixingModule.SiPixelSimParameters_cfi import SiPixelSimBlock
 from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import phase2TrackerDigitizer, _premixStage1ModifyDict as _phase2TrackerPremixStage1ModifyDict
 from SimGeneral.MixingModule.ecalDigitizer_cfi import ecalDigitizer
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchebackDigitizer, hgchefrontDigitizer, hfnoseDigitizer
+from SimFastTiming.FastTimingCommon.mtdDigitizer_cfi import mtdDigitizer
 
 hcalSimBlock.HcalPreMixStage2 = cms.bool(True)
 
@@ -201,6 +202,8 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+from Configuration.Eras.Modifier_phase2_timing_layer_tile_cff import phase2_timing_layer_tile
+from Configuration.Eras.Modifier_phase2_timing_layer_bar_cff import phase2_timing_layer_bar
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
@@ -237,6 +240,23 @@ phase2_tracker.toModify(mixData,
     ),
 )
 
+# MTD
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toModify(mixData,
+    workers = dict(
+        mtdBarrel = cms.PSet(
+            mtdDigitizer.barrelDigitizer,
+            workerType = cms.string("PreMixingMTDWorker"),
+            digiTagSig = cms.InputTag("mix", "FTLBarrel"),
+            pileInputTag = cms.InputTag("mix", "FTLBarrel"),
+        ),
+        mtdEndcap = cms.PSet(
+            mtdDigitizer.endcapDigitizer,
+            workerType = cms.string("PreMixingMTDWorker"),
+            digiTagSig = cms.InputTag("mix", "FTLEndcap"),
+            pileInputTag = cms.InputTag("mix", "FTLEndcap"),
+        ),
+    )
+)
 # ECAL
 phase2_common.toModify (mixData, workers=dict(ecal=dict(doES=False)))
 phase2_hgcal.toModify(mixData, workers=dict(ecal=dict(doEE=False)))


### PR DESCRIPTION
#### PR description:

This PR makes the first attempt to implement premixing for MTD. As the SimHit accumulation approach is similar to HGCal, the premixing approach is as well similar. A few details are different-enough though so that no code can be easily re-used (e.g. "MTD cell" indexing uses row and column indices in addition to DetId, and the exact way to fill `MTDCellInfo` differs from `HGCCellInfo`).

Basically in stage1 `MTDSimHitDataAccumulator` is converted to `PMTDSimAccumulator` by packing each "non-zero" element `MTDCellInfo` to 11 bits.

Elements of `MTDCellInfo[0]`(energy) are packed with `logintpack::pack16log()` to the range 1e-4..1e6 yielding ~1.3 % precision. I found this range by printing out values on 200 PU, so likely there is room for further tuning (from printouts I noticed that especially on the higher side the values seem to be quantized with much larger steps than 1.3 %).

Elements of `MTDCellInfo[1]` (time of flight) appeared to be limited roughly to the range of 0-26, so those values are packed linearly on that range.

#### PR validation:

Tested in 10_4_0_mtd5 (and then rebased on 10_6_0_pre3, compiled, and limited matrix runs). I have here comparison of 4D-vertices validation on 10 ttbar+PU35 events 
http://mkdev7.cern.ch:8081/dqm/relval/start?runnr=1;dataset=/RelValTTbar_14/CMSSW_10_4_0_mtd5-PU35_2023d35_10ev_classical_v1-v1/DQMIO;sampletype=offline_relval;filter=all;referencepos=ratiooverlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A%3A/RelValTTbar_14/CMSSW_10_4_0_mtd5-PU35_2023d35_10ev_premixing_v2-v1/DQMIO%3A%3A;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=Vertexing/PrimaryVertexV/offlinePrimaryVertices4D;focus=Vertexing/PrimaryVertexV/offlinePrimaryVertices4D/RecoAllAssoc2GenMatched_PullY;zoom=no;
and (e.g. reco-only) distributions look reasonable
![image](https://user-images.githubusercontent.com/33993/55462818-f065d780-55f7-11e9-82d3-98542716455e.png)
![image](https://user-images.githubusercontent.com/33993/55462846-ff4c8a00-55f7-11e9-815e-770340c19e98.png)

Further testing (larger statistics, lower-level variables) would be useful, 

@kpedro88 @mdhildreth @fabiocos 
