### PR TITLE
Added missing skipEvents to LHESource

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -205,6 +205,7 @@ LHESource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("A source which reads LHE files.");
   edm::ProducerSourceFromFiles::fillDescription(desc);
+  desc.addUntracked<unsigned int>("skipEvents", 0U)->setComment("Skip the first 'skipEvents' events.");
   descriptions.add("source", desc);
 }
 


### PR DESCRIPTION
#### PR description:

When the LHESource gained a fillDescriptions validator, that function did not include 'skipEvents' as an allowed parameter.

#### PR validation:

The code was tested by running a configuration which was previously failing do to the validation problem. After the code change, the configuration runs.