### PR TITLE
PPS: proton reconstruction, algorithm update

### DIFF
--- a/CalibPPS/ESProducers/plugins/CTPPSInterpolatedOpticalFunctionsESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSInterpolatedOpticalFunctionsESSource.cc
@@ -159,16 +159,22 @@ std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> CTPPSInterpolatedO
       const auto rpId = rp_p.first;
       const auto &rp_it2 = ofs2.find(rpId);
       if (rp_it2 == ofs2.end())
-        throw cms::Exception("CTPPSInterpolatedOpticalFunctionsESSource") << "Mismatch between ofs1 and ofs2.";
+        throw cms::Exception("CTPPSInterpolatedOpticalFunctionsESSource") << "RP mismatch between ofs1 and ofs2.";
 
       const auto &of1 = rp_p.second;
       const auto &of2 = rp_it2->second;
 
+      const size_t num_xi_vals1 = of1.getXiValues().size();
+      const size_t num_xi_vals2 = of2.getXiValues().size();
+
+      if (num_xi_vals1 != num_xi_vals2)
+        throw cms::Exception("CTPPSInterpolatedOpticalFunctionsESSource") << "Size mismatch between ofs1 and ofs2.";
+
+      const size_t num_xi_vals = num_xi_vals1;
+
       LHCInterpolatedOpticalFunctionsSet iof;
       iof.m_z = of1.getScoringPlaneZ();
-
-      const size_t num_xi_vals = of1.getXiValues().size();
-
+      iof.m_fcn_values.resize(LHCInterpolatedOpticalFunctionsSet::nFunctions);
       iof.m_xi_values.resize(num_xi_vals);
 
       for (size_t fi = 0; fi < of1.getFcnValues().size(); ++fi)

--- a/CalibPPS/ESProducers/plugins/CTPPSLHCInfoESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSLHCInfoESSource.cc
@@ -54,11 +54,11 @@ void CTPPSLHCInfoESSource::setIntervalFor(const edm::eventsetup::EventSetupRecor
   const edm::IOVSyncValue& iosv, edm::ValidityInterval& oValidity)
 {
   // TODO: the IOV specified in config is temporarily replaced with a hardcoded one
-  m_insideValidityRange = true;
-
   edm::IOVSyncValue beg(edm::EventID(270293, 0, 0), edm::Timestamp(1461016800ULL << 32));
   edm::IOVSyncValue end(edm::EventID(290872, 0, 0), edm::Timestamp(1483138800ULL << 32));
   oValidity = edm::ValidityInterval(beg, end);
+
+  m_insideValidityRange = (beg < iosv && iosv < end);
 
   /*
   if (edm::contains(m_validityRange, iosv.eventID()))

--- a/CalibPPS/ESProducers/plugins/CTPPSOpticalFunctionsESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSOpticalFunctionsESSource.cc
@@ -6,7 +6,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
-#include "FWCore/Framework/interface/ESProducts.h"
 
 #include "CondFormats/CTPPSReadoutObjects/interface/LHCOpticalFunctionsSetCollection.h"
 #include "CondFormats/DataRecord/interface/CTPPSOpticsRcd.h"
@@ -22,51 +21,67 @@ class CTPPSOpticalFunctionsESSource: public edm::ESProducer, public edm::EventSe
     CTPPSOpticalFunctionsESSource(const edm::ParameterSet &);
     ~CTPPSOpticalFunctionsESSource() override = default;
 
-    edm::ESProducts<std::unique_ptr<LHCOpticalFunctionsSetCollection>> produce(const CTPPSOpticsRcd &);
+    std::unique_ptr<LHCOpticalFunctionsSetCollection> produce(const CTPPSOpticsRcd &);
     static void fillDescriptions(edm::ConfigurationDescriptions&);
 
   private:
     void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue&, edm::ValidityInterval&) override;
 
-    edm::EventRange m_validityRange;
-    bool m_insideValidityRange;
-
     struct FileInfo
     {
-      double xangle;
-      std::string fileName;
+      double m_xangle;
+      std::string m_fileName;
     };
-    std::vector<FileInfo> m_fileInfo;
 
     struct RPInfo
     {
-      std::string dirName;
-      double scoringPlaneZ;
+      std::string m_dirName;
+      double m_scoringPlaneZ;
     };
-    std::unordered_map<unsigned int, RPInfo> m_rpInfo;
+
+    struct Entry
+    {
+      edm::EventRange m_validityRange;
+      std::vector<FileInfo> m_fileInfo;
+      std::unordered_map<unsigned int, RPInfo> m_rpInfo;
+    };
+
+    std::vector<Entry> m_entries;
+
+    bool m_currentEntryValid;
+    unsigned int m_currentEntry;
 };
 
 //----------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------
 
 CTPPSOpticalFunctionsESSource::CTPPSOpticalFunctionsESSource(const edm::ParameterSet& conf) :
-  m_validityRange(conf.getParameter<edm::EventRange>("validityRange")),
-  m_insideValidityRange(false)
+  m_currentEntryValid(false),
+  m_currentEntry(0)
 {
-  for (const auto &pset : conf.getParameter<std::vector<edm::ParameterSet>>("opticalFunctions"))
+  for (const auto &entry_pset : conf.getParameter<std::vector<edm::ParameterSet>>("configuration"))
   {
-    const double &xangle = pset.getParameter<double>("xangle");
-    const std::string &fileName = pset.getParameter<edm::FileInPath>("fileName").fullPath();
-    m_fileInfo.push_back({xangle, fileName});
-  }
+    edm::EventRange validityRange = entry_pset.getParameter<edm::EventRange>("validityRange");
 
-  for (const auto &pset : conf.getParameter<std::vector<edm::ParameterSet>>("scoringPlanes"))
-  {
-    const unsigned int rpId = pset.getParameter<unsigned int>("rpId");
-    const std::string dirName = pset.getParameter<std::string>("dirName");
-    const double z = pset.getParameter<double>("z");
-    const RPInfo entry = {dirName, z};
-    m_rpInfo.emplace(rpId, entry);
+    std::vector<FileInfo> fileInfo;
+    for (const auto &pset : entry_pset.getParameter<std::vector<edm::ParameterSet>>("opticalFunctions"))
+    {
+      const double &xangle = pset.getParameter<double>("xangle");
+      const std::string &fileName = pset.getParameter<edm::FileInPath>("fileName").fullPath();
+      fileInfo.push_back({xangle, fileName});
+    }
+
+    std::unordered_map<unsigned int, RPInfo> rpInfo;
+    for (const auto &pset : entry_pset.getParameter<std::vector<edm::ParameterSet>>("scoringPlanes"))
+    {
+      const unsigned int rpId = pset.getParameter<unsigned int>("rpId");
+      const std::string dirName = pset.getParameter<std::string>("dirName");
+      const double z = pset.getParameter<double>("z");
+      const RPInfo entry = {dirName, z};
+      rpInfo.emplace(rpId, entry);
+    }
+
+    m_entries.push_back({validityRange, fileInfo, rpInfo});
   }
 
   setWhatProduced(this);
@@ -78,56 +93,60 @@ CTPPSOpticalFunctionsESSource::CTPPSOpticalFunctionsESSource(const edm::Paramete
 void CTPPSOpticalFunctionsESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &key,
   const edm::IOVSyncValue& iosv, edm::ValidityInterval& oValidity)
 {
-  if (edm::contains(m_validityRange, iosv.eventID()))
+  for (unsigned int idx = 0; idx < m_entries.size(); ++idx)
   {
-    m_insideValidityRange = true;
-    oValidity = edm::ValidityInterval(edm::IOVSyncValue(m_validityRange.startEventID()), edm::IOVSyncValue(m_validityRange.endEventID()));
-  } else {
-    m_insideValidityRange = false;
+    const auto &entry = m_entries[idx];
 
-    if (iosv.eventID() < m_validityRange.startEventID())
+    // is within an entry ?
+    if (edm::contains(entry.m_validityRange, iosv.eventID()))
     {
-      edm::RunNumber_t run = m_validityRange.startEventID().run();
-      edm::LuminosityBlockNumber_t lb = m_validityRange.startEventID().luminosityBlock();
-      edm::EventID endEvent = (lb > 1) ? edm::EventID(run, lb-1, 0) : edm::EventID(run-1, edm::EventID::maxLuminosityBlockNumber(), 0);
-
-      oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue(endEvent));
-    } else {
-      edm::RunNumber_t run = m_validityRange.startEventID().run();
-      edm::LuminosityBlockNumber_t lb = m_validityRange.startEventID().luminosityBlock();
-      edm::EventID beginEvent = (lb < edm::EventID::maxLuminosityBlockNumber()-1) ? edm::EventID(run, lb+1, 0) : edm::EventID(run+1, 0, 0);
-
-      oValidity = edm::ValidityInterval(edm::IOVSyncValue(beginEvent), edm::IOVSyncValue::endOfTime());
+      m_currentEntryValid = true;
+      m_currentEntry = idx;
+      oValidity = edm::ValidityInterval(edm::IOVSyncValue(entry.m_validityRange.startEventID()), edm::IOVSyncValue(entry.m_validityRange.endEventID()));
+      return;
     }
   }
+
+  // not within any entry
+  m_currentEntryValid = true;
+  m_currentEntry = 0;
+
+  edm::LogInfo("") << "No configuration entry found for event " << iosv.eventID() << ", no optical functions will be available.";
+
+  const edm::EventID start(iosv.eventID().run(), iosv.eventID().luminosityBlock(), iosv.eventID().event());
+  const edm::EventID end(iosv.eventID().run(), iosv.eventID().luminosityBlock(), iosv.eventID().event());
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue(start), edm::IOVSyncValue(end));
 }
 
 //----------------------------------------------------------------------------------------------------
 
-edm::ESProducts<std::unique_ptr<LHCOpticalFunctionsSetCollection> >
+std::unique_ptr<LHCOpticalFunctionsSetCollection>
 CTPPSOpticalFunctionsESSource::produce(const CTPPSOpticsRcd &)
 {
-  // fill the output
+  // prepare output, empty by default
   auto output = std::make_unique<LHCOpticalFunctionsSetCollection>();
 
-  if (m_insideValidityRange)
+  // fill the output
+  if (m_currentEntryValid)
   {
-    for (const auto &fi : m_fileInfo)
+    const auto &entry = m_entries[m_currentEntry];
+
+    for (const auto &fi : entry.m_fileInfo)
     {
       std::unordered_map<unsigned int, LHCOpticalFunctionsSet> xa_data;
 
-      for (const auto &rpi : m_rpInfo)
+      for (const auto &rpi : entry.m_rpInfo)
       {
-        LHCOpticalFunctionsSet fcn(fi.fileName, rpi.second.dirName, rpi.second.scoringPlaneZ);
+        LHCOpticalFunctionsSet fcn(fi.m_fileName, rpi.second.m_dirName, rpi.second.m_scoringPlaneZ);
         xa_data.emplace(rpi.first, std::move(fcn));
       }
 
-      output->emplace(fi.xangle, xa_data);
+      output->emplace(fi.m_xangle, xa_data);
     }
   }
 
   // commit the output
-  return edm::es::products(std::move(output));
+  return output;
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -137,20 +156,25 @@ CTPPSOpticalFunctionsESSource::fillDescriptions(edm::ConfigurationDescriptions& 
 {
   edm::ParameterSetDescription desc;
 
-  desc.add<edm::EventRange>("validityRange", edm::EventRange())->setComment("interval of validity");
+  edm::ParameterSetDescription config_desc;
+
+  config_desc.add<edm::EventRange>("validityRange", edm::EventRange())->setComment("interval of validity");
 
   edm::ParameterSetDescription of_desc;
   of_desc.add<double>("xangle")->setComment("half crossing angle value in urad");
   of_desc.add<edm::FileInPath>("fileName")->setComment("ROOT file with optical functions");
   std::vector<edm::ParameterSet> of;
-  desc.addVPSet("opticalFunctions", of_desc, of)->setComment("list of optical functions at different crossing angles");
+  config_desc.addVPSet("opticalFunctions", of_desc, of)->setComment("list of optical functions at different crossing angles");
 
   edm::ParameterSetDescription sp_desc;
   sp_desc.add<unsigned int>("rpId")->setComment("associated detector DetId");
   sp_desc.add<std::string>("dirName")->setComment("associated path to the optical functions file");
   sp_desc.add<double>("z")->setComment("longitudinal position at scoring plane/detector");
   std::vector<edm::ParameterSet> sp;
-  desc.addVPSet("scoringPlanes", sp_desc, sp)->setComment("list of sensitive planes/detectors stations");
+  config_desc.addVPSet("scoringPlanes", sp_desc, sp)->setComment("list of sensitive planes/detectors stations");
+
+  std::vector<edm::ParameterSet> config;
+  desc.addVPSet("configuration", config_desc, sp)->setComment("list of configuration blocks");
 
   descriptions.add("ctppsOpticalFunctionsESSource", desc);
 }

--- a/CalibPPS/ESProducers/plugins/CTPPSOpticalFunctionsESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSOpticalFunctionsESSource.cc
@@ -108,7 +108,7 @@ void CTPPSOpticalFunctionsESSource::setIntervalFor(const edm::eventsetup::EventS
   }
 
   // not within any entry
-  m_currentEntryValid = true;
+  m_currentEntryValid = false;
   m_currentEntry = 0;
 
   edm::LogInfo("") << "No configuration entry found for event " << iosv.eventID() << ", no optical functions will be available.";

--- a/CalibPPS/ESProducers/python/ctppsOpticalFunctions_cff.py
+++ b/CalibPPS/ESProducers/python/ctppsOpticalFunctions_cff.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from CalibPPS.ESProducers.ctppsLHCInfo_cff import *
 
-from CalibPPS.ESProducers.ctppsOpticalFunctionsESSource_cfi import ctppsOpticalFunctionsESSource as _optics_tmp
+from CalibPPS.ESProducers.ctppsOpticalFunctionsESSource_cfi import *
 
-# optical functions for 2016 data
-ctppsOpticalFunctionsESSource_2016 = _optics_tmp.clone(
-  validityRange = cms.EventRange("270293:min - 290872:max"),
+# add 2016 pre-TS2 configuration
+config_2016_preTS2 = cms.PSet(
+  validityRange = cms.EventRange("273725:min - 280385:max"),
 
   opticalFunctions = cms.VPSet(
       cms.PSet( xangle = cms.double(185), fileName = cms.FileInPath("CalibPPS/ESProducers/data/optical_functions_2016.root") )
@@ -14,12 +14,14 @@ ctppsOpticalFunctionsESSource_2016 = _optics_tmp.clone(
 
   scoringPlanes = cms.VPSet(
       # z in cm
-      cms.PSet( rpId = cms.uint32(0x76100000), dirName = cms.string("XRPH_C6L5_B2"), z = cms.double(-20382.6) ),  # RP 002
-      cms.PSet( rpId = cms.uint32(0x76180000), dirName = cms.string("XRPH_D6L5_B2"), z = cms.double(-21255.1) ),  # RP 003
-      cms.PSet( rpId = cms.uint32(0x77100000), dirName = cms.string("XRPH_C6R5_B1"), z = cms.double(+20382.6) ),  # RP 102
-      cms.PSet( rpId = cms.uint32(0x77180000), dirName = cms.string("XRPH_D6R5_B1"), z = cms.double(+21255.1) ),  # RP 103
+      cms.PSet( rpId = cms.uint32(0x76100000), dirName = cms.string("XRPH_C6L5_B2"), z = cms.double(-20382.6) ),  # RP 002, strip
+      cms.PSet( rpId = cms.uint32(0x76180000), dirName = cms.string("XRPH_D6L5_B2"), z = cms.double(-21255.1) ),  # RP 003, strip
+      cms.PSet( rpId = cms.uint32(0x77100000), dirName = cms.string("XRPH_C6R5_B1"), z = cms.double(+20382.6) ),  # RP 102, strip
+      cms.PSet( rpId = cms.uint32(0x77180000), dirName = cms.string("XRPH_D6R5_B1"), z = cms.double(+21255.1) ),  # RP 103, strip
   )
 )
+
+ctppsOpticalFunctionsESSource.configuration.append(config_2016_preTS2)
 
 # optics interpolation between crossing angles
 from CalibPPS.ESProducers.ctppsInterpolatedOpticalFunctionsESSource_cfi import *

--- a/DataFormats/ProtonReco/interface/ForwardProton.h
+++ b/DataFormats/ProtonReco/interface/ForwardProton.h
@@ -38,8 +38,9 @@ namespace reco
       ForwardProton();
       /// constructor from refit parameters, fitted vertex and momentum, and longitudinal fractional momentum loss
       ForwardProton( double chi2, double ndof, const Point& vtx, const Vector& momentum, float xi,
-                     const CovarianceMatrix& cov, ReconstructionMethod method,
-                     const CTPPSLocalTrackLiteRefVector& local_tracks, bool valid );
+                      const CovarianceMatrix& cov, ReconstructionMethod method,
+                      const CTPPSLocalTrackLiteRefVector& local_tracks, bool valid,
+                      const float time=0., const float time_err=0. );
 
       /// fitted vertex position
       const Point& vertex() const { return vertex_; }
@@ -107,8 +108,11 @@ namespace reco
 
       /// time of proton arrival at forward stations
       float time() const { return time_; }
+      void setTime(float time) { time_ = time; }
+
       /// uncertainty on time of proton arrival at forward stations
       float timeError() const { return time_err_; }
+      void setTimeError(float time_err) { time_err_ = time_err; }
 
       /// set the flag for the fit validity
       void setValidFit( bool valid = true ) { valid_fit_ = valid; }

--- a/DataFormats/ProtonReco/src/ForwardProton.cc
+++ b/DataFormats/ProtonReco/src/ForwardProton.cc
@@ -17,9 +17,10 @@ ForwardProton::ForwardProton() :
 
 ForwardProton::ForwardProton( double chi2, double ndof, const Point& vtx, const Vector& momentum, float xi,
                               const CovarianceMatrix& cov, ReconstructionMethod method,
-                              const CTPPSLocalTrackLiteRefVector& local_tracks, bool valid ) :
+                              const CTPPSLocalTrackLiteRefVector& local_tracks, bool valid,
+                              const float time, const float time_err ) :
   vertex_( vtx ), momentum_( momentum ),
-  time_( 0. ), time_err_( 0. ), xi_( xi ),
+  time_( time ), time_err_( time_err ), xi_( xi ),
   covariance_( cov ), chi2_( chi2 ), ndof_( ndof ),
   valid_fit_( valid ), method_( method ), contributing_local_tracks_( local_tracks )
 {}

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -514,9 +514,11 @@ def miniAOD_customizeData(process):
     runOnData( process, outputModules = [] )
     process.load("RecoCTPPS.TotemRPLocal.ctppsLocalTrackLiteProducer_cff")
     process.load("RecoCTPPS.ProtonReconstruction.ctppsProtons_cff")
+    process.load("Geometry.VeryForwardGeometry.geometryRPFromDB_cfi")
     task = getPatAlgosToolsTask(process)
-    task.add(process.ctppsLocalTrackLiteProducer)
-    task.add(process.ctppsProtons)
+    from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+    ctpps_2016.toModify(task, func=lambda t: t.add(process.ctppsLocalTrackLiteProducer))
+    ctpps_2016.toModify(task, func=lambda t: t.add(process.ctppsProtons))
 
 def miniAOD_customizeAllData(process):
     miniAOD_customizeCommon(process)

--- a/RecoCTPPS/ProtonReconstruction/BuildFile.xml
+++ b/RecoCTPPS/ProtonReconstruction/BuildFile.xml
@@ -8,6 +8,10 @@
 
 <use name="CondFormats/RunInfo"/>
 <use name="CondFormats/CTPPSReadoutObjects"/>
+<use name="CondFormats/DataRecord"/>
+
+<use name="Geometry/Records"/>
+<use name="Geometry/VeryForwardGeometryBuilder"/>
 
 <export>
   <lib name="1"/>

--- a/RecoCTPPS/ProtonReconstruction/interface/ProtonReconstructionAlgorithm.h
+++ b/RecoCTPPS/ProtonReconstruction/interface/ProtonReconstructionAlgorithm.h
@@ -33,13 +33,11 @@ class ProtonReconstructionAlgorithm
     void release();
 
     /// run proton reconstruction using single-RP strategy
-    void reconstructFromSingleRP(const CTPPSLocalTrackLiteRefVector& input,
-      reco::ForwardProtonCollection& output,
+    reco::ForwardProton reconstructFromSingleRP(const CTPPSLocalTrackLiteRef &track,
       const LHCInfo& lhcInfo, std::ostream& os) const;
 
     /// run proton reconstruction using multiple-RP strategy
-    void reconstructFromMultiRP(const CTPPSLocalTrackLiteRefVector& input,
-      reco::ForwardProtonCollection& output,
+    reco::ForwardProton reconstructFromMultiRP(const CTPPSLocalTrackLiteRefVector &tracks,
       const LHCInfo& lhcInfo, std::ostream& os) const;
 
   private:

--- a/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
+++ b/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
@@ -27,6 +27,9 @@
 #include "CondFormats/DataRecord/interface/CTPPSInterpolatedOpticsRcd.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/LHCInterpolatedOpticalFunctionsSetCollection.h"
 
+#include "Geometry/Records/interface/VeryForwardRealGeometryRecord.h"
+#include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
+
 //----------------------------------------------------------------------------------------------------
 
 class CTPPSProtonProducer : public edm::stream::EDProducer<>
@@ -52,6 +55,24 @@ class CTPPSProtonProducer : public edm::stream::EDProducer<>
     std::string singleRPReconstructionLabel_;
     std::string multiRPReconstructionLabel_;
 
+    double localAngleXMin_, localAngleXMax_, localAngleYMin_, localAngleYMax_;
+
+    struct AssociationCuts
+    {
+      bool x_cut_apply;
+      double x_cut_value;
+      bool y_cut_apply;
+      double y_cut_value;
+      bool xi_cut_apply;
+      double xi_cut_value;
+      bool th_y_cut_apply;
+      double th_y_cut_value;
+    };
+
+    std::map<unsigned int, AssociationCuts> association_cuts_;  // map: arm -> AssociationCuts
+
+    unsigned int max_n_timing_tracks_;
+
     ProtonReconstructionAlgorithm algorithm_;
 
     bool opticsValid_;
@@ -68,10 +89,32 @@ CTPPSProtonProducer::CTPPSProtonProducer(const edm::ParameterSet& iConfig) :
   doMultiRPReconstruction_    (iConfig.getParameter<bool>("doMultiRPReconstruction")),
   singleRPReconstructionLabel_(iConfig.getParameter<std::string>("singleRPReconstructionLabel")),
   multiRPReconstructionLabel_ (iConfig.getParameter<std::string>("multiRPReconstructionLabel")),
+
+  localAngleXMin_             (iConfig.getParameter<double>("localAngleXMin")),
+  localAngleXMax_             (iConfig.getParameter<double>("localAngleXMax")),
+  localAngleYMin_             (iConfig.getParameter<double>("localAngleYMin")),
+  localAngleYMax_             (iConfig.getParameter<double>("localAngleYMax")),
+
+  max_n_timing_tracks_        (iConfig.getParameter<unsigned int>("max_n_timing_tracks")),
+
   algorithm_                  (iConfig.getParameter<bool>("fitVtxY"), iConfig.getParameter<bool>("useImprovedInitialEstimate"), verbosity_),
   opticsValid_(false),
   currentCrossingAngle_(-1.)
 {
+  for (const std::string &sector : { "45", "56" })
+  {
+    const unsigned int arm = (sector == "45") ? 0 : 1;
+
+    association_cuts_[arm].x_cut_apply    = iConfig.getParameter<bool>  ("association_" + sector + "_x_cut_apply");
+    association_cuts_[arm].x_cut_value    = iConfig.getParameter<double>("association_" + sector + "_x_cut_value");
+    association_cuts_[arm].y_cut_apply    = iConfig.getParameter<bool>  ("association_" + sector + "_y_cut_apply");
+    association_cuts_[arm].y_cut_value    = iConfig.getParameter<double>("association_" + sector + "_y_cut_value");
+    association_cuts_[arm].xi_cut_apply   = iConfig.getParameter<bool>  ("association_" + sector + "_xi_cut_apply");
+    association_cuts_[arm].xi_cut_value   = iConfig.getParameter<double>("association_" + sector + "_xi_cut_value");
+    association_cuts_[arm].th_y_cut_apply = iConfig.getParameter<bool>  ("association_" + sector + "_th_y_cut_apply");
+    association_cuts_[arm].th_y_cut_value = iConfig.getParameter<double>("association_" + sector + "_th_y_cut_value");
+  }
+
   if (doSingleRPReconstruction_)
     produces<reco::ForwardProtonCollection>(singleRPReconstructionLabel_);
 
@@ -105,6 +148,31 @@ void CTPPSProtonProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<std::string>("multiRPReconstructionLabel", "multiRP")
     ->setComment("output label for multi-RP reconstruction products");
 
+  desc.add<double>("localAngleXMin", -0.03)->setComment("minimal accepted value of local horizontal angle (rad)");
+  desc.add<double>("localAngleXMax", +0.03)->setComment("maximal accepted value of local horizontal angle (rad)");
+  desc.add<double>("localAngleYMin", -0.04)->setComment("minimal accepted value of local vertical angle (rad)");
+  desc.add<double>("localAngleYMax", +0.04)->setComment("maximal accepted value of local vertical angle (rad)");
+
+  desc.add<bool>("association_45_x_cut_apply", false)->setComment("whether to apply track-association cut in x, sector 45");
+  desc.add<double>("association_45_x_cut_value", 800E-6)->setComment("threshold of track-association cut in x, mm, sector 45");
+  desc.add<bool>("association_45_y_cut_apply", false)->setComment("whether to apply track-association cut in y, sector 45");
+  desc.add<double>("association_45_y_cut_value", 600E-6)->setComment("threshold of track-association cut in y, mm, sector 45");
+  desc.add<bool>("association_45_xi_cut_apply", true)->setComment("whether to apply track-association cut in xi, sector 45");
+  desc.add<double>("association_45_xi_cut_value", 0.013)->setComment("threshold of track-association cut in xi, sector 45");
+  desc.add<bool>("association_45_th_y_cut_apply", true)->setComment("whether to apply track-association cut in th_y, sector 45");
+  desc.add<double>("association_45_th_y_cut_value", 20E-6)->setComment("threshold of track-association cut in th_y, rad, sector 45");
+
+  desc.add<bool>("association_56_x_cut_apply", false)->setComment("whether to apply track-association cut in x, sector 56");
+  desc.add<double>("association_56_x_cut_value", 800E-6)->setComment("threshold of track-association cut in x, mm, sector 56");
+  desc.add<bool>("association_56_y_cut_apply", false)->setComment("whether to apply track-association cut in y, sector 56");
+  desc.add<double>("association_56_y_cut_value", 600E-6)->setComment("threshold of track-association cut in y, mm, sector 56");
+  desc.add<bool>("association_56_xi_cut_apply", true)->setComment("whether to apply track-association cut in xi, sector 56");
+  desc.add<double>("association_56_xi_cut_value", 0.013)->setComment("threshold of track-association cut in xi, sector 56");
+  desc.add<bool>("association_56_th_y_cut_apply", true)->setComment("whether to apply track-association cut in th_y, sector 56");
+  desc.add<double>("association_56_th_y_cut_value", 20E-6)->setComment("threshold of track-association cut in th_y, rad, sector 56");
+
+  desc.add<unsigned int>("max_n_timing_tracks", 5)->setComment("maximum number of timing tracks per RP");
+
   desc.add<bool>("fitVtxY", true)
     ->setComment("for multi-RP reconstruction, flag whether y* should be free fit parameter");
 
@@ -124,6 +192,9 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
   edm::ESHandle<LHCInterpolatedOpticalFunctionsSetCollection> hOpticalFunctions;
   iSetup.get<CTPPSInterpolatedOpticsRcd>().get(hOpticalFunctions);
+
+  edm::ESHandle<CTPPSGeometry> hGeometry;
+  iSetup.get<VeryForwardRealGeometryRecord>().get(hGeometry);
 
   // re-initialise algorithm upon crossing-angle change
   if (hLHCInfo->crossingAngle() != currentCrossingAngle_) {
@@ -150,60 +221,230 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     // prepare log
     std::ostringstream ssLog;
     if (verbosity_)
-      ssLog << "input tracks:";
+      ssLog << "* input tracks:" << std::endl;
 
     // get input
     edm::Handle<CTPPSLocalTrackLiteCollection> hTracks;
     iEvent.getByToken(tracksToken_, hTracks);
 
-    // keep only tracks from tracker RPs, split them by LHC sector
-    CTPPSLocalTrackLiteRefVector tracks_45, tracks_56;
-    std::map<CTPPSDetId, unsigned int> nTracksPerRP;
-    for (unsigned int idx = 0; idx < hTracks->size(); ++idx) {
+    // select tracks with small local angles, split them by LHC sector and tracker/timing RPs
+    std::map<unsigned int, std::vector<unsigned int>> trackingSelection, timingSelection;
+
+    for (unsigned int idx = 0; idx < hTracks->size(); ++idx)
+    {
       const auto& tr = hTracks->at(idx);
-      const CTPPSDetId rpId(tr.getRPId());
-      if (rpId.subdetId() != CTPPSDetId::sdTrackingStrip && rpId.subdetId() != CTPPSDetId::sdTrackingPixel)
+
+      if (tr.getTx() < localAngleXMin_ || tr.getTx() > localAngleXMax_
+          || tr.getTy() < localAngleYMin_ || tr.getTy() > localAngleYMax_)
         continue;
 
+      const CTPPSDetId rpId(tr.getRPId());
+
       if (verbosity_)
-        ssLog << "\n\t"
+        ssLog << "\t"
+          << "[" << idx << "] "
           << tr.getRPId() << " (" << (rpId.arm()*100 + rpId.station()*10 + rpId.rp()) << "): "
           << "x=" << tr.getX() << " +- " << tr.getXUnc() << " mm, "
-          << "y=" << tr.getY() << " +- " << tr.getYUnc() << " mm";
+          << "y=" << tr.getY() << " +- " << tr.getYUnc() << " mm" << std::endl;
 
-      CTPPSLocalTrackLiteRef r_track(hTracks, idx);
-      if (rpId.arm() == 0)
-        tracks_45.push_back(r_track);
-      if (rpId.arm() == 1)
-        tracks_56.push_back(r_track);
+      const bool trackerRP = (rpId.subdetId() == CTPPSDetId::sdTrackingStrip || rpId.subdetId() == CTPPSDetId::sdTrackingPixel);
 
-      nTracksPerRP[rpId]++;
+      if (trackerRP)
+        trackingSelection[rpId.arm()].push_back(idx);
+      else
+        timingSelection[rpId.arm()].push_back(idx);
     }
 
-    // for the moment: check whether there is no more than 1 track in each arm
-    bool singleTrack_45 = true, singleTrack_56 = true;
-    for (const auto& detid_num : nTracksPerRP) {
-      if (detid_num.second > 1) {
-        const CTPPSDetId& rpId = detid_num.first;
-        if (rpId.arm() == 0)
-          singleTrack_45 = false;
-        if (rpId.arm() == 1)
-          singleTrack_56 = false;
+    // process each arm
+    for (const auto &arm_it : trackingSelection)
+    {
+      const auto &indeces = arm_it.second;
+
+      const auto &ac = association_cuts_[arm_it.first];
+
+      // do single-RP reco if needed
+      std::map<unsigned int, reco::ForwardProton> singleRPResultsIndexed;
+      if (doSingleRPReconstruction_ || ac.xi_cut_apply || ac.th_y_cut_apply)
+      {
+        for (const auto &idx : indeces)
+        {
+          if (verbosity_)
+            ssLog << std::endl << "* reconstruction from track " << idx << std::endl;
+
+          singleRPResultsIndexed[idx] = algorithm_.reconstructFromSingleRP(CTPPSLocalTrackLiteRef(hTracks, idx), *hLHCInfo, ssLog);
+        }
       }
-    }
 
-    // single-RP reconstruction
-    if (doSingleRPReconstruction_) {
-      algorithm_.reconstructFromSingleRP(tracks_45, *pOutSingleRP, *hLHCInfo, ssLog);
-      algorithm_.reconstructFromSingleRP(tracks_56, *pOutSingleRP, *hLHCInfo, ssLog);
-    }
+      // do multi-RP reco if chosen
+      if (doMultiRPReconstruction_)
+      {
+        // check that exactly two tracking RPs are involved
+        //    - 1 is insufficient for multi-RP reconstruction
+        //    - PPS did not use more than 2 tracking RPs per arm -> algorithms are tuned to this
+        std::set<unsigned int> rpIds;
+        for (const auto &idx : indeces)
+          rpIds.insert(hTracks->at(idx).getRPId());
+        if (rpIds.size() != 2)
+          continue;
 
-    // multi-RP reconstruction
-    if (doMultiRPReconstruction_) {
-      if (singleTrack_45)
-        algorithm_.reconstructFromMultiRP(tracks_45, *pOutMultiRP, *hLHCInfo, ssLog);
-      if (singleTrack_56)
-        algorithm_.reconstructFromMultiRP(tracks_56, *pOutMultiRP, *hLHCInfo, ssLog);
+        // find matching track pairs from different tracking RPs
+        std::vector<std::pair<unsigned int, unsigned int>> idx_pairs;
+        std::map<unsigned int, unsigned int> idx_pair_multiplicity;
+        for (const auto &i : indeces)
+        {
+          for (const auto &j : indeces)
+          {
+            if (j <= i)
+              continue;
+
+            const auto &tr_i = hTracks->at(i);
+            const auto &tr_j = hTracks->at(j);
+
+            const auto &pr_i = singleRPResultsIndexed[i];
+            const auto &pr_j = singleRPResultsIndexed[j];
+
+            if (tr_i.getRPId() == tr_j.getRPId())
+              continue;
+
+            bool matching = true;
+
+            if (ac.x_cut_apply && fabs(tr_i.getX() - tr_j.getX()) > ac.x_cut_value)
+              matching = false;
+            if (ac.y_cut_apply && fabs(tr_i.getY() - tr_j.getY()) > ac.y_cut_value)
+              matching = false;
+            if (ac.xi_cut_apply && fabs(pr_i.xi() - pr_j.xi()) > ac.xi_cut_value)
+              matching = false;
+            if (ac.th_y_cut_apply && fabs(pr_i.thetaY() - pr_j.thetaY()) > ac.th_y_cut_value)
+              matching = false;
+
+            if (!matching)
+              continue;
+
+            idx_pairs.emplace_back(i, j);
+            idx_pair_multiplicity[i]++;
+            idx_pair_multiplicity[j]++;
+          }
+        }
+
+        // evaluate track multiplicity in each timing RP
+        std::map<unsigned int, unsigned int> timing_RP_track_multiplicity;
+        for (const auto &ti : timingSelection[arm_it.first])
+        {
+          const auto &tr = hTracks->at(ti);
+          timing_RP_track_multiplicity[tr.getRPId()]++;
+        }
+
+        // associate tracking-RP pairs with timing-RP tracks
+        std::map<unsigned int, std::vector<unsigned int>> mached_timing_track_indeces;
+        std::map<unsigned int, unsigned int> matched_timing_track_multiplicity;
+        for (unsigned int pr_idx = 0; pr_idx < idx_pairs.size(); ++pr_idx)
+        {
+          const auto &i = idx_pairs[pr_idx].first;
+          const auto &j = idx_pairs[pr_idx].second;
+
+          // skip non-unique associations
+          if (idx_pair_multiplicity[i] > 1 || idx_pair_multiplicity[j] > 1)
+            continue;
+
+          const auto &tr_i = hTracks->at(i);
+          const auto &tr_j = hTracks->at(j);
+
+          const double z_i = hGeometry->getRPTranslation(tr_i.getRPId()).z();
+          const double z_j = hGeometry->getRPTranslation(tr_j.getRPId()).z();
+
+          for (const auto &ti : timingSelection[arm_it.first])
+          {
+            const auto &tr_ti = hTracks->at(ti);
+
+            // skip if timing RP saturated (high track multiplicity)
+            if (timing_RP_track_multiplicity[tr_ti.getRPId()] > max_n_timing_tracks_)
+              continue;
+
+            // interpolation from tracking RPs
+            const double z_ti = - hGeometry->getRPTranslation(tr_ti.getRPId()).z(); // the minus sign fixes a bug in the diamond geometry
+            const double f_i = (z_ti - z_j) / (z_i - z_j), f_j = (z_i - z_ti) / (z_i - z_j);
+            const double x_inter = f_i * tr_i.getX() + f_j * tr_j.getX();
+            const double x_inter_unc_sq = f_i*f_i * tr_i.getXUnc()*tr_i.getXUnc() + f_j*f_j * tr_j.getXUnc()*tr_j.getXUnc();
+
+            const double de_x = tr_ti.getX() - x_inter;
+            const double de_x_unc = sqrt(tr_ti.getXUnc()*tr_ti.getXUnc() + x_inter_unc_sq);
+
+            const bool matching = (fabs(de_x) <= de_x_unc);
+
+            ssLog << "ti=" << ti << ", i=" << i << ", j=" << j
+              << " | z_ti=" << z_ti << ", z_i=" << z_i << ", z_j=" << z_j
+              << " | x_ti=" << tr_ti.getX() << ", x_inter=" << x_inter << ", de_x=" << de_x << ", de_x_unc=" << de_x_unc
+              << ", matching=" << matching << std::endl;
+
+            if (!matching)
+              continue;
+
+            mached_timing_track_indeces[pr_idx].push_back(ti);
+            matched_timing_track_multiplicity[ti]++;
+          }
+        }
+
+        // process associated tracks
+        for (unsigned int pr_idx = 0; pr_idx < idx_pairs.size(); ++pr_idx)
+        {
+          const auto &i = idx_pairs[pr_idx].first;
+          const auto &j = idx_pairs[pr_idx].second;
+
+          // skip non-unique associations of tracking-RP tracks
+          if (idx_pair_multiplicity[i] > 1 || idx_pair_multiplicity[j] > 1)
+            continue;
+
+          if (verbosity_)
+            ssLog << std::endl << "* reconstruction from tracking-RP tracks: " << i << ", " << j << " and timing-RP tracks: ";
+
+          // process tracking-RP data
+          CTPPSLocalTrackLiteRefVector sel_tracks;
+          sel_tracks.push_back(CTPPSLocalTrackLiteRef(hTracks, i));
+          sel_tracks.push_back(CTPPSLocalTrackLiteRef(hTracks, j));
+          reco::ForwardProton proton = algorithm_.reconstructFromMultiRP(sel_tracks, *hLHCInfo, ssLog);
+
+          // process timing-RP data
+          double Sw=0., Swt=0.;
+          for (const auto &ti : mached_timing_track_indeces[pr_idx])
+          {
+            // skip non-unique associations of timing-RP tracks
+            if (matched_timing_track_multiplicity[ti] > 1)
+              continue;
+
+            sel_tracks.push_back(CTPPSLocalTrackLiteRef(hTracks, ti));
+
+            if (verbosity_)
+              ssLog << ti << ", ";
+
+            const auto &tr = hTracks->at(ti);
+            const double t_unc = tr.getTimeUnc();
+            const double w = (t_unc > 0.) ? 1./t_unc/t_unc : 1.;
+            Sw += w;
+            Swt += w * tr.getTime();
+          }
+
+          float time = 0., time_unc = 0.;
+          if (Sw > 0.)
+          {
+            time = Swt / Sw;
+            time_unc = 1. / sqrt(Sw);
+          }
+
+          if (verbosity_)
+            ssLog << std::endl << "    time = " << time << " +- " << time_unc << std::endl;
+
+          // save combined output
+          proton.setContributingLocalTracks(sel_tracks);
+          proton.setTime(time);
+          proton.setTimeError(time_unc);
+
+          pOutMultiRP->emplace_back(proton);
+        }
+      }
+
+      // save single-RP results (un-indexed)
+      for (const auto &p : singleRPResultsIndexed)
+        pOutSingleRP->emplace_back(std::move(p.second));
     }
 
     // dump log

--- a/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
+++ b/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
@@ -141,17 +141,9 @@ double ProtonReconstructionAlgorithm::ChiSquareCalculator::operator() (const dou
 
 //----------------------------------------------------------------------------------------------------
 
-void ProtonReconstructionAlgorithm::reconstructFromMultiRP(const CTPPSLocalTrackLiteRefVector& tracks,
-                                                           reco::ForwardProtonCollection& output,
-                                                           const LHCInfo& lhcInfo, std::ostream& os) const
+reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const CTPPSLocalTrackLiteRefVector& tracks,
+                                                            const LHCInfo& lhcInfo, std::ostream& os) const
 {
-  if (!initialized_)
-    return;
-
-  // need at least two tracks
-  if (tracks.size() < 2)
-    return;
-
   // make sure optics is available for all tracks
   for (const auto &it : tracks) {
     auto oit = m_rp_optics_.find(it->getRPId());
@@ -223,10 +215,10 @@ void ProtonReconstructionAlgorithm::reconstructFromMultiRP(const CTPPSLocalTrack
   unsigned int armId = CTPPSDetId((*tracks.begin())->getRPId()).arm();
 
   if (verbosity_)
-    os << "\n"
+    os
       << "ProtonReconstructionAlgorithm::reconstructFromMultiRP(" << armId << ")" << std::endl
       << "    initial estimate: xi_init = " << xi_init << ", th_x_init = " << th_x_init
-      << ", th_y_init = " << th_y_init << ", vtx_y_init = " << vtx_y_init << ".";
+      << ", th_y_init = " << th_y_init << ", vtx_y_init = " << vtx_y_init << "." << std::endl;
 
   // minimisation
   fitter_->Config().ParSettings(0).Set("xi", xi_init, 0.005);
@@ -248,12 +240,12 @@ void ProtonReconstructionAlgorithm::reconstructFromMultiRP(const CTPPSLocalTrack
   const double *params = result.GetParams();
 
   if (verbosity_)
-    os << "\n"
-      << "xi=" << params[0] << " +- " << result.Error(0)
+    os
+      << "    xi=" << params[0] << " +- " << result.Error(0)
       << ", th_x=" << params[1] << " +-" << result.Error(1)
       << ", th_y=" << params[2] << " +-" << result.Error(2)
       << ", vtx_y=" << params[3] << " +-" << result.Error(3)
-      << ", chiSq = " << result.Chi2();
+      << ", chiSq = " << result.Chi2() << std::endl;
 
   // save reco candidate
   using FP = reco::ForwardProton;
@@ -291,67 +283,59 @@ void ProtonReconstructionAlgorithm::reconstructFromMultiRP(const CTPPSLocalTrack
     }
   }
 
-  output.emplace_back(result.Chi2(), ndf, vertex, momentum, xi, cm, FP::ReconstructionMethod::multiRP, tracks, result.IsValid());
+  return reco::ForwardProton(result.Chi2(), ndf, vertex, momentum, xi, cm,
+    FP::ReconstructionMethod::multiRP, tracks, result.IsValid());
 }
 
 //----------------------------------------------------------------------------------------------------
 
-void ProtonReconstructionAlgorithm::reconstructFromSingleRP(const CTPPSLocalTrackLiteRefVector& tracks,
-                                                            reco::ForwardProtonCollection& output,
+reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromSingleRP(const CTPPSLocalTrackLiteRef &track,
                                                             const LHCInfo& lhcInfo, std::ostream& os) const
 {
-  if (!initialized_)
-    return;
+  CTPPSDetId rpId(track->getRPId());
 
-  // make sure optics is available for all tracks
-  for (const auto &it : tracks) {
-    auto oit = m_rp_optics_.find(it->getRPId());
-    if (oit == m_rp_optics_.end())
-      throw cms::Exception("ProtonReconstructionAlgorithm") << "Optics data not available for RP " << it->getRPId()
-        << ", i.e. " << CTPPSDetId(it->getRPId()) << ".";
-  }
+  if (verbosity_)
+    os << "reconstructFromSingleRP(" << rpId.arm()*100 + rpId.station()*10 + rpId.rp() << ")" << std::endl;
+
+  // make sure optics is available for the track
+  auto oit = m_rp_optics_.find(track->getRPId());
+  if (oit == m_rp_optics_.end())
+    throw cms::Exception("ProtonReconstructionAlgorithm") << "Optics data not available for RP " << track->getRPId()
+      << ", i.e. " << rpId << ".";
 
   // rough estimate of xi and th_y from each track
-  for (const auto &track : tracks) {
-    CTPPSDetId rpId(track->getRPId());
+  const double x_full = track->getX()*1E-1 + oit->second.x0; // conversion mm --> cm
+  const double xi = oit->second.s_xi_vs_x_d->Eval(x_full);
+  const double L_y = oit->second.s_L_y_vs_xi->Eval(xi);
+  const double th_y = track->getY()*1E-1 / L_y; // conversion mm --> cm
 
-    if (verbosity_)
-      os << "\nreconstructFromSingleRP(" << rpId.arm()*100 + rpId.station()*10 + rpId.rp() << ")";
+  const double ep_x = 1E-6;
+  const double dxi_dx = (oit->second.s_xi_vs_x_d->Eval(x_full + ep_x) - xi) / ep_x;
+  const double xi_unc = abs(dxi_dx) * track->getXUnc() * 1E-1; // conversion mm --> cm
 
-    auto oit = m_rp_optics_.find(track->getRPId());
-    const double x_full = track->getX()*1E-1 + oit->second.x0; // conversion mm --> cm
-    const double xi = oit->second.s_xi_vs_x_d->Eval(x_full);
-    const double L_y = oit->second.s_L_y_vs_xi->Eval(xi);
-    const double th_y = track->getY()*1E-1 / L_y; // conversion mm --> cm
+  const double ep_xi = 1E-4;
+  const double dL_y_dxi = ( oit->second.s_L_y_vs_xi->Eval(xi + ep_xi) - L_y ) / ep_xi;
+  const double th_y_unc = th_y * sqrt( pow(track->getYUnc() / track->getY(), 2.) + pow(dL_y_dxi * xi_unc / L_y, 2.) );
 
-    const double ep_x = 1E-6;
-    const double dxi_dx = (oit->second.s_xi_vs_x_d->Eval(x_full + ep_x) - xi) / ep_x;
-    const double xi_unc = abs(dxi_dx) * track->getXUnc() * 1E-1; // conversion mm --> cm
+  if (verbosity_)
+    os << "    xi = " << xi << " +- " << xi_unc << ", th_y = " << th_y << " +- " << th_y_unc << "." << std::endl;
 
-    const double ep_xi = 1E-4;
-    const double dL_y_dxi = ( oit->second.s_L_y_vs_xi->Eval(xi + ep_xi) - L_y ) / ep_xi;
-    const double th_y_unc = th_y * sqrt( pow(track->getYUnc() / track->getY(), 2.) + pow(dL_y_dxi * xi_unc / L_y, 2.) );
+  using FP = reco::ForwardProton;
 
-    if (verbosity_)
-      os << "\n    xi = " << xi << " +- " << xi_unc << ", th_y = " << th_y << " +- " << th_y_unc << ".";
+  // save proton candidate
+  const double sign_z = (CTPPSDetId(track->getRPId()).arm() == 0) ? +1. : -1.;  // CMS convention
+  const FP::Point vertex(0., 0., 0.);
+  const double cos_th = sqrt(1. - th_y*th_y);
+  const double p = lhcInfo.energy() * (1. - xi);
+  const FP::Vector momentum(0., p * th_y, sign_z * p * cos_th);
 
-    using FP = reco::ForwardProton;
+  FP::CovarianceMatrix cm;
+  cm((int)FP::Index::xi, (int)FP::Index::xi) = xi_unc * xi_unc;
+  cm((int)FP::Index::th_y, (int)FP::Index::th_y) = th_y_unc * th_y_unc;
 
-    // save proton candidate
+  CTPPSLocalTrackLiteRefVector trk;
+  trk.push_back( track );
 
-    const double sign_z = (CTPPSDetId(track->getRPId()).arm() == 0) ? +1. : -1.;  // CMS convention
-    const FP::Point vertex(0., 0., 0.);
-    const double cos_th = sqrt(1. - th_y*th_y);
-    const double p = lhcInfo.energy() * (1. - xi);
-    const FP::Vector momentum(0., p * th_y, sign_z * p * cos_th);
-
-    FP::CovarianceMatrix cm;
-    cm((int)FP::Index::xi, (int)FP::Index::xi) = xi_unc * xi_unc;
-    cm((int)FP::Index::th_y, (int)FP::Index::th_y) = th_y_unc * th_y_unc;
-
-    CTPPSLocalTrackLiteRefVector trk;
-    trk.push_back( track );
-    output.emplace_back(0., 0, vertex, momentum, xi, cm, FP::ReconstructionMethod::singleRP, trk, true);
-  }
+  return reco::ForwardProton(0., 0, vertex, momentum, xi, cm, FP::ReconstructionMethod::singleRP, trk, true);
 }
 

--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
@@ -76,9 +76,9 @@ class CTPPSProtonReconstructionPlotter : public edm::one::EDAnalyzer<>
       std::unique_ptr<TProfile> p_th_y_vs_xi;
 
       SingleRPPlots() :
-        h_xi(new TH1D("", ";#xi", 100, 0., 0.25)),
-        h2_th_y_vs_xi(new TH2D("", ";#xi;#theta_{y}   (rad)", 100, 0., 0.25, 100, -500E-6, +500E-6)),
-        p_th_y_vs_xi(new TProfile("", ";#xi;#theta_{y}   (rad)", 100, 0., 0.25))
+        h_xi(new TH1D("", ";#xi", 100, 0., 0.3)),
+        h2_th_y_vs_xi(new TH2D("", ";#xi;#theta_{y}   (rad)", 100, 0., 0.3, 100, -500E-6, +500E-6)),
+        p_th_y_vs_xi(new TProfile("", ";#xi;#theta_{y}   (rad)", 100, 0., 0.3))
       {}
 
       void fill(const reco::ForwardProton &p)
@@ -105,24 +105,27 @@ class CTPPSProtonReconstructionPlotter : public edm::one::EDAnalyzer<>
 
     struct MultiRPPlots
     {
-      std::unique_ptr<TH1D> h_xi, h_th_x, h_th_y, h_vtx_y, h_t, h_chi_sq, h_chi_sq_norm;
+      std::unique_ptr<TH1D> h_xi, h_th_x, h_th_y, h_vtx_y, h_t_unif, h_t, h_chi_sq, h_chi_sq_norm;
       std::unique_ptr<TH1D> h_t_xi_range1, h_t_xi_range2, h_t_xi_range3;
+      std::unique_ptr<TH1D> h_n_tracking_RPs, h_n_timing_RPs;
       std::unique_ptr<TH2D> h2_th_x_vs_xi, h2_th_y_vs_xi, h2_vtx_y_vs_xi, h2_t_vs_xi;
       std::unique_ptr<TProfile> p_th_x_vs_xi, p_th_y_vs_xi, p_vtx_y_vs_xi;
 
       MultiRPPlots() :
-        h_xi(new TH1D("", ";#xi", 100, 0., 0.25)),
+        h_xi(new TH1D("", ";#xi", 100, 0., 0.3)),
         h_th_x(new TH1D("", ";#theta_{x}   (rad)", 100, -500E-6, +500E-6)),
         h_th_y(new TH1D("", ";#theta_{y}   (rad)", 100, -500E-6, +500E-6)),
         h_vtx_y(new TH1D("", ";vtx_{y}   (cm)", 100, -2., +2.)),
         h_chi_sq(new TH1D("", ";#chi^{2}", 100, 0., 0.)),
         h_chi_sq_norm(new TH1D("", ";#chi^{2}/ndf", 100, 0., 5.)),
-        h2_th_x_vs_xi(new TH2D("", ";#xi;#theta_{x}   (rad)", 100, 0., 0.25, 100, -500E-6, +500E-6)),
-        h2_th_y_vs_xi(new TH2D("", ";#xi;#theta_{y}   (rad)", 100, 0., 0.25, 100, -500E-6, +500E-6)),
-        h2_vtx_y_vs_xi(new TH2D("", ";#xi;vtx_{y}   (cm)", 100, 0., 0.25, 100, -500E-3, +500E-3)),
-        p_th_x_vs_xi(new TProfile("", ";#xi;#theta_{x}   (rad)", 100, 0., 0.25)),
-        p_th_y_vs_xi(new TProfile("", ";#xi;#theta_{y}   (rad)", 100, 0., 0.25)),
-        p_vtx_y_vs_xi(new TProfile("", ";#xi;vtx_{y}   (cm)", 100, 0., 0.25))
+        h_n_tracking_RPs(new TH1D("", ";n of tracking RPs", 4, -0.5, +3.5)),
+        h_n_timing_RPs(new TH1D("", ";n of timing RPs", 4, -0.5, +3.5)),
+        h2_th_x_vs_xi(new TH2D("", ";#xi;#theta_{x}   (rad)", 100, 0., 0.3, 100, -500E-6, +500E-6)),
+        h2_th_y_vs_xi(new TH2D("", ";#xi;#theta_{y}   (rad)", 100, 0., 0.3, 100, -500E-6, +500E-6)),
+        h2_vtx_y_vs_xi(new TH2D("", ";#xi;vtx_{y}   (cm)", 100, 0., 0.3, 100, -500E-3, +500E-3)),
+        p_th_x_vs_xi(new TProfile("", ";#xi;#theta_{x}   (rad)", 100, 0., 0.3)),
+        p_th_y_vs_xi(new TProfile("", ";#xi;#theta_{y}   (rad)", 100, 0., 0.3)),
+        p_vtx_y_vs_xi(new TProfile("", ";#xi;vtx_{y}   (cm)", 100, 0., 0.3))
       {
         std::vector<double> v_t_bin_edges;
         for (double t = 0; t <= 5.; ) {
@@ -130,17 +133,28 @@ class CTPPSProtonReconstructionPlotter : public edm::one::EDAnalyzer<>
           const double de_t = 0.05 + 0.09 * t + 0.02 * t*t;
           t += de_t;
         }
+        h_t_unif.reset(new TH1D("", ";|t|   (GeV^2)", 100, 0., 5.));
         h_t.reset(new TH1D("", ";|t|   (GeV^2)", v_t_bin_edges.size() - 1, v_t_bin_edges.data()));
         h_t_xi_range1.reset(new TH1D("", ";|t|   (GeV^2)", v_t_bin_edges.size() - 1, v_t_bin_edges.data()));
         h_t_xi_range2.reset(new TH1D("", ";|t|   (GeV^2)", v_t_bin_edges.size() - 1, v_t_bin_edges.data()));
         h_t_xi_range3.reset(new TH1D("", ";|t|   (GeV^2)", v_t_bin_edges.size() - 1, v_t_bin_edges.data()));
-        h2_t_vs_xi.reset(new TH2D("", ";#xi;|t|   (GeV^2)", 100, 0., 0.25, v_t_bin_edges.size() - 1, v_t_bin_edges.data()));
+        h2_t_vs_xi.reset(new TH2D("", ";#xi;|t|   (GeV^2)", 100, 0., 0.3, v_t_bin_edges.size() - 1, v_t_bin_edges.data()));
       }
 
       void fill(const reco::ForwardProton &p)
       {
         if (!p.validFit())
           return;
+
+        unsigned int n_tracking_RPs=0, n_timing_RPs=0;
+        for (const auto &tr : p.contributingLocalTracks())
+        {
+          CTPPSDetId detId(tr->getRPId());
+          if (detId.subdetId() == CTPPSDetId::sdTrackingStrip || detId.subdetId() == CTPPSDetId::sdTrackingPixel)
+            n_tracking_RPs++;
+          if (detId.subdetId() == CTPPSDetId::sdTimingDiamond || detId.subdetId() == CTPPSDetId::sdTimingFastSilicon)
+            n_timing_RPs++;
+        }
 
         const double th_x = p.thetaX();
         const double th_y = p.thetaY();
@@ -150,6 +164,9 @@ class CTPPSProtonReconstructionPlotter : public edm::one::EDAnalyzer<>
         if (p.ndof() > 0)
           h_chi_sq_norm->Fill(p.normalizedChi2());
 
+        h_n_tracking_RPs->Fill(n_tracking_RPs);
+        h_n_timing_RPs->Fill(n_timing_RPs);
+
         h_xi->Fill(p.xi());
 
         h_th_x->Fill(th_x);
@@ -157,6 +174,7 @@ class CTPPSProtonReconstructionPlotter : public edm::one::EDAnalyzer<>
 
         h_vtx_y->Fill(p.vertex().y());
 
+        h_t_unif->Fill(mt);
         h_t->Fill(mt);
         if (p.xi() > 0.04 && p.xi() < 0.07) h_t_xi_range1->Fill(mt);
         if (p.xi() > 0.07 && p.xi() < 0.10) h_t_xi_range2->Fill(mt);
@@ -176,6 +194,9 @@ class CTPPSProtonReconstructionPlotter : public edm::one::EDAnalyzer<>
       {
         h_chi_sq->Write("h_chi_sq");
         h_chi_sq_norm->Write("h_chi_sq_norm");
+
+        h_n_tracking_RPs->Write("h_n_tracking_RPs");
+        h_n_timing_RPs->Write("h_n_timing_RPs");
 
         h_xi->Write("h_xi");
 
@@ -200,6 +221,9 @@ class CTPPSProtonReconstructionPlotter : public edm::one::EDAnalyzer<>
         profileToRMSGraph(p_vtx_y_vs_xi.get(), g_vtx_y_RMS_vs_xi.get());
         g_vtx_y_RMS_vs_xi->Write("g_vtx_y_RMS_vs_xi");
 
+        h_t->Scale(1., "width");
+
+        h_t_unif->Write("h_t_unif");
         h_t->Write("h_t");
         h_t_xi_range1->Write("h_t_xi_range1");
         h_t_xi_range2->Write("h_t_xi_range2");
@@ -222,11 +246,11 @@ class CTPPSProtonReconstructionPlotter : public edm::one::EDAnalyzer<>
       std::unique_ptr<TH2D> h2_th_y_mu_vs_th_y_si;
 
       SingleMultiCorrelationPlots() :
-        h2_xi_mu_vs_xi_si(new TH2D("", ";#xi_{single};#xi_{multi}", 100, 0., 0.25, 100, 0., 0.25)),
+        h2_xi_mu_vs_xi_si(new TH2D("", ";#xi_{single};#xi_{multi}", 100, 0., 0.3, 100, 0., 0.3)),
         h_xi_diff_mu_si(new TH1D("", ";#xi_{multi} - #xi_{single}", 100, -0.1, +0.1)),
         h_xi_diff_si_mu(new TH1D("", ";#xi_{single} - #xi_{multi}", 100, -0.1, +0.1)),
-        h2_xi_diff_si_mu_vs_xi_mu(new TH2D("", ";#xi_{multi};#xi_{single} - #xi_{multi}", 100, 0., 0.25, 100, -0.10, 0.10)),
-        p_xi_diff_si_mu_vs_xi_mu(new TProfile("", ";#xi_{multi};#xi_{single} - #xi_{multi}", 100, 0., 0.25)),
+        h2_xi_diff_si_mu_vs_xi_mu(new TH2D("", ";#xi_{multi};#xi_{single} - #xi_{multi}", 100, 0., 0.3, 100, -0.10, 0.10)),
+        p_xi_diff_si_mu_vs_xi_mu(new TProfile("", ";#xi_{multi};#xi_{single} - #xi_{multi}", 100, 0., 0.3)),
         h2_th_y_mu_vs_th_y_si(new TH2D("", ";#theta^{*}_{y,si};#theta^{*}_{y,mu}", 100, -500E-6, +500E-6, 100, -500E-6, +500E-6))
       {}
 
@@ -272,9 +296,9 @@ class CTPPSProtonReconstructionPlotter : public edm::one::EDAnalyzer<>
 
       ArmCorrelationPlots() :
         h_xi_si_diffNF(new TH1D("", ";#xi_{sF} - #xi_{sN}", 100, -0.02, +0.02)),
-        p_xi_si_diffNF_vs_xi_mu(new TProfile("", ";#xi_{m};#xi_{sF} - #xi_{sN}", 100, 0., 0.25)),
+        p_xi_si_diffNF_vs_xi_mu(new TProfile("", ";#xi_{m};#xi_{sF} - #xi_{sN}", 100, 0., 0.3)),
         h_th_y_si_diffNF(new TH1D("", ";#theta_{y,sF} - #theta_{y,sN}", 100, -100E-6, +100E-6)),
-        p_th_y_si_diffNF_vs_xi_mu(new TProfile("", ";#xi_{m};#theta_{y,sF} - #theta_{y,sN}", 100, 0., 0.25))
+        p_th_y_si_diffNF_vs_xi_mu(new TProfile("", ";#xi_{m};#theta_{y,sF} - #theta_{y,sN}", 100, 0., 0.3))
       {}
 
       void fill(const reco::ForwardProton &p_s_N, const reco::ForwardProton &p_s_F, const reco::ForwardProton &p_m)


### PR DESCRIPTION
#### PR description:

This PR updates the PPS proton reconstruction code with minimal changes to the configuration. It contains several bugfixes and small improvements of the existing code. Mainly, it brings new algorithms:
  * Local tracks (input to proton reconstruction) with large angles are discarded (they cannot be coming from IP).
  * Local tracks in different RPs of the same arm are associated according to optics-driven correlations. On one side, this prevents spurious track combinations (backround). On the other, it allows to perform proton reconstruction even if multiple tracks are present.
  * Local tracks from timing RPs are associated with tracks from tracking RPs. This allows to append timing information to the reconstructed-proton candidates.

This PR is essential for the UL re-reco.

#### PR validation:

Below a comparison test of re-running the full PPS reco chain on 
`/store/data/Run2016B/DoubleEG/RAW/v2/000/275/371/00000/FE9F0F13-9436-E611-8F39-02163E012B47.root`. Red histograms are obtained with #26305, the blue ones with this PR. The differences are very small. The seemingly big difference in the xi plots is due to different binnings. In the other histograms (where the same binning is used), blue curves are never above the red ones. This is expected since in 2016, the (strip) detectors could not resolve more than 1 local track. Thus the only effect of this PR is the removal of spurious/doubtful local-track combinations.

![cmp_45](https://user-images.githubusercontent.com/17830858/55482558-1190ed00-5625-11e9-81fc-93bcb42ece2b.png)

![cmp_56](https://user-images.githubusercontent.com/17830858/55482559-1190ed00-5625-11e9-8260-aa3e2597209e.png)

