### PR TITLE
keep hidden valley and dark matter particles in miniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -36,6 +36,10 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
 	"keep abs(pdgId) = 10511 || abs(pdgId) = 10521 || abs(pdgId) = 10513 || abs(pdgId) = 10523 || abs(pdgId) = 20513 || abs(pdgId) = 20523 || abs(pdgId) = 10531 || abs(pdgId) = 10533 || abs(pdgId) = 20533 || abs(pdgId) = 10541 || abs(pdgId) = 10543 || abs(pdgId) = 20543", 
 #keep SUSY particles
 	"keep (1000001 <= abs(pdgId) <= 1000039 ) || ( 2000001 <= abs(pdgId) <= 2000015)",
+# keep hidden valley particles
+    "keep (4900001 <= abs(pdgId) <= 4900991)",
+# keep dark matter particles
+    "keep (51 <= abs(pdgId) <= 53)",
 # keep protons 
         "keep pdgId = 2212",
         "keep status == 3 || ( 21 <= status <= 29) || ( 11 <= status <= 19)",  #keep event summary (status=3 for pythia6, 21 <= status <= 29 for pythia8)


### PR DESCRIPTION
#### PR description:

Store hidden valley and dark matter particles in the miniAOD pruned gen particles collection. These particles only appear in specific signal models, so the change will have no effect on 99% of MC samples.

Hidden valley PDG IDs are described here: http://home.thep.lu.se/Pythia/pythia82php/HiddenValleyProcesses.php

Dark matter PDG IDs are described here (page 3, "special particles"): http://pdg.lbl.gov/2018/reviews/rpp2018-rev-monte-carlo-numbering.pdf

#### PR validation:

Ran matrix workflow 10024.0, which completed successfully.

Re-ran the workflow, substituting a hidden valley fragment (from https://github.com/cms-sw/genproductions/tree/master/python/ThirteenTeV/SemiVisibleJets), and confirmed that the particles were kept in miniAOD by comparing to the RECO file.

This PR will be backported to active miniAOD releases: 9_4_X and 10_2_X.