### PR TITLE
DyT algorithm new thresholds parameterization 

### DIFF
--- a/RecoMuon/GlobalMuonProducer/python/tevMuons_cfi.py
+++ b/RecoMuon/GlobalMuonProducer/python/tevMuons_cfi.py
@@ -9,9 +9,9 @@ tevMuons = cms.EDProducer("TevMuonProducer",
     #    InputTag MuonCollectionLabel = standAloneMuons:UpdatedAtVtx
     MuonServiceProxy,
     RefitIndex = cms.vint32(1, 2, 3, 4),
-    Refits = cms.vstring('default', 
-        'firstHit', 
-        'picky', 
+    Refits = cms.vstring('default',
+        'firstHit',
+        'picky',
         'dyt'),
     MuonCollectionLabel = cms.InputTag("globalMuons"),
     RefitterParameters = cms.PSet(
@@ -26,6 +26,3 @@ fastSim.toModify(tevMuons,
                  RefitterParameters = dict(TrackerRecHitBuilder = 'WithoutRefit',
                                            Propagator = "SmartPropagatorAny")
                  )
-
-
-

--- a/RecoMuon/GlobalMuonProducer/python/tevMuons_cfi.py
+++ b/RecoMuon/GlobalMuonProducer/python/tevMuons_cfi.py
@@ -9,9 +9,9 @@ tevMuons = cms.EDProducer("TevMuonProducer",
     #    InputTag MuonCollectionLabel = standAloneMuons:UpdatedAtVtx
     MuonServiceProxy,
     RefitIndex = cms.vint32(1, 2, 3, 4),
-    Refits = cms.vstring('default',
-        'firstHit',
-        'picky',
+    Refits = cms.vstring('default', 
+        'firstHit', 
+        'picky', 
         'dyt'),
     MuonCollectionLabel = cms.InputTag("globalMuons"),
     RefitterParameters = cms.PSet(

--- a/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
+++ b/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
@@ -107,7 +107,6 @@ class DynamicTruncation {
   void                 useSegment(CSCSegment const &, TrajectoryStateOnSurface const &);
   void                 sort(ConstRecHitContainer&);
   void                 setEtaRegion();
-  static edm::ParameterSetDescription fillDefaultThrsParameters();
 
   ConstRecHitContainer result, prelFitMeas;
   bool useAPE;

--- a/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
+++ b/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
@@ -85,8 +85,6 @@ class DynamicTruncation {
     return dytInfo;
   }
 
-  void                 correctThrByPtAndEta();
-
  private:
 
   void                 compatibleDets(TrajectoryStateOnSurface&, std::map<int, std::vector<DetId> >&);
@@ -100,7 +98,7 @@ class DynamicTruncation {
   void                 updateWithDThits(TrajectoryStateOnSurface&, DTRecSegment4D const &);
   void                 updateWithCSChits(TrajectoryStateOnSurface&, CSCSegment const &);
   void                 getThresholdFromDB(double&, DetId const&);
-  void                 correctThrByPtAndEta(double&);
+  void                 correctThrByPAndEta(double&);
   void                 getThresholdFromCFG(double&, DetId const&);
   void                 testDTstation(TrajectoryStateOnSurface&, std::vector<DTRecSegment4D> const &, double&, DTRecSegment4D&, TrajectoryStateOnSurface&);
   void                 testCSCstation(TrajectoryStateOnSurface&, std::vector<CSCSegment> const &, double&, CSCSegment&, TrajectoryStateOnSurface&);

--- a/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
+++ b/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
@@ -107,6 +107,7 @@ class DynamicTruncation {
   void                 useSegment(CSCSegment const &, TrajectoryStateOnSurface const &);
   void                 sort(ConstRecHitContainer&);
   void                 setEtaRegion();
+  static edm::ParameterSetDescription fillDefaultThrsParameters();
 
   ConstRecHitContainer result, prelFitMeas;
   bool useAPE;

--- a/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
+++ b/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
@@ -66,13 +66,10 @@ class DynamicTruncation {
   void setUpdateState(bool);
   void setUseAPE(bool);
   /*---- DyT v2-----*/
-  void setRecoP(double p) {
-    p_reco = p;
-    useParametrizedThr = true;
-   }
+  void setParThrsMode(bool dytParThrsMode) { useParametrizedThr = dytParThrsMode;}
+  void setRecoP(double p) { p_reco = p; }
   void setRecoEta(double eta) {
     eta_reco = eta;
-    useParametrizedThr = true;
     setEtaRegion();
   }
 

--- a/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
+++ b/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
@@ -46,7 +46,7 @@ namespace dyt_utils{
 };
 
 class DynamicTruncation {
-
+  
  public:
 
   typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
@@ -56,7 +56,7 @@ class DynamicTruncation {
 
   ~DynamicTruncation();
 
-  void setProd(const edm::Handle<DTRecSegment4DCollection>& DTSegProd,
+  void setProd(const edm::Handle<DTRecSegment4DCollection>& DTSegProd, 
 	       const edm::Handle<CSCSegmentCollection>& CSCSegProd) {
     getSegs->initCSU(DTSegProd, CSCSegProd);
   }
@@ -77,7 +77,7 @@ class DynamicTruncation {
   // Return the vector with the tracker plus the selected muon hits
   TransientTrackingRecHit::ConstRecHitContainer filter(const Trajectory&);
 
-  // Return the DYTInfo object
+  // Return the DYTInfo object 
   reco::DYTInfo getDYTInfo() {
     dytInfo.setNStUsed(nStationsUsed);
     dytInfo.setDYTEstimators(estimatorMap);

--- a/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
+++ b/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
@@ -52,7 +52,7 @@ class DynamicTruncation {
   typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
   typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
 
-  DynamicTruncation(const edm::Event&, const MuonServiceProxy&, const edm::ParameterSet&);
+  DynamicTruncation(const edm::Event&, const MuonServiceProxy&);
 
   ~DynamicTruncation();
 
@@ -66,6 +66,7 @@ class DynamicTruncation {
   void setUpdateState(bool);
   void setUseAPE(bool);
   /*---- DyT v2-----*/
+  void setThrsMap(const edm::ParameterSet&);
   void setParThrsMode(bool dytParThrsMode) { useParametrizedThr = dytParThrsMode;}
   void setRecoP(double p) { p_reco = p; }
   void setRecoEta(double eta) {

--- a/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
+++ b/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
@@ -45,6 +45,10 @@ class DynamicTruncation {
   
  public:
 
+  /* Variables for v2 */
+  double p_reco;
+  double eta_reco;
+
   typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
   typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
 
@@ -63,7 +67,7 @@ class DynamicTruncation {
   void setUseAPE(bool);
   
   // Return the vector with the tracker plus the selected muon hits
-  TransientTrackingRecHit::ConstRecHitContainer filter(const Trajectory&);
+  TransientTrackingRecHit::ConstRecHitContainer filter(const Trajectory&, double globalMomentum, double globalEta);
 
   // Return the DYTInfo object 
   reco::DYTInfo getDYTInfo() {
@@ -77,7 +81,7 @@ class DynamicTruncation {
  private:
 
   void                 compatibleDets(TrajectoryStateOnSurface&, std::map<int, std::vector<DetId> >&);
-  void                 filteringAlgo();
+  void                 filteringAlgo(double momentum,double eta);
   void                 fillSegmentMaps(std::map<int, std::vector<DetId> >&, std::map<int, std::vector<DTRecSegment4D> >&, std::map<int, std::vector<CSCSegment> >&);
   void                 preliminaryFit(std::map<int, std::vector<DetId> >, std::map<int, std::vector<DTRecSegment4D> >, std::map<int, std::vector<CSCSegment> >);
   bool                 chooseLayers(int&, double const &, DTRecSegment4D const &, TrajectoryStateOnSurface const &, double const &, CSCSegment const &, TrajectoryStateOnSurface const &);

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
@@ -9,7 +9,7 @@
  *  \author C. Liu 		 Purdue University
  *  \author A. Everett 		 Purdue University
  *
- *  \modified by C. Calabria     INFN & Universita  Bari
+ *  \modified by C. Calabria     INFN & Universitaï¿½ Bari
  *  \modified by D. Nash         Northeastern University
  */
 
@@ -67,7 +67,7 @@ class GlobalMuonRefitter {
 
     /// constructor with Parameter Set and MuonServiceProxy
     GlobalMuonRefitter(const edm::ParameterSet&, const MuonServiceProxy*, edm::ConsumesCollector&);
-          
+
     /// destructor
     virtual ~GlobalMuonRefitter();
 
@@ -78,7 +78,7 @@ class GlobalMuonRefitter {
     void setServices(const edm::EventSetup&);
 
     /// build combined trajectory from sta Track and tracker RecHits
-    std::vector<Trajectory> refit(const reco::Track& globalTrack, const int theMuonHitsOption, 
+    std::vector<Trajectory> refit(const reco::Track& globalTrack, const int theMuonHitsOption,
 				  const TrackerTopology *tTopo) const;
 
     /// build combined trajectory from subset of sta Track and tracker RecHits
@@ -92,30 +92,30 @@ class GlobalMuonRefitter {
     std::vector<Trajectory> transform(const reco::Track& newTrack,
                                       const reco::TransientTrack track,
                                       const TransientTrackingRecHit::ConstRecHitContainer& recHitsForReFit) const;
-    
+
     // get rid of selected station RecHits
     ConstRecHitContainer getRidOfSelectStationHits(const ConstRecHitContainer& hits,
 						   const TrackerTopology *tTopo) const;
 
-    // return DYT-related informations           
+    // return DYT-related informations
     const reco::DYTInfo* getDYTInfo() {return dytInfo;}
-    
+
   protected:
 
     enum RefitDirection{insideOut,outsideIn,undetermined};
-    
+
     /// check muon RecHits, calculate chamber occupancy and select hits to be used in the final fit
-    void checkMuonHits(const reco::Track&, ConstRecHitContainer&, 
+    void checkMuonHits(const reco::Track&, ConstRecHitContainer&,
                        std::map<DetId, int> &) const;
 
-    /// get the RecHits in the tracker and the first muon chamber with hits 
-    void getFirstHits(const reco::Track&, ConstRecHitContainer&, 
+    /// get the RecHits in the tracker and the first muon chamber with hits
+    void getFirstHits(const reco::Track&, ConstRecHitContainer&,
                        ConstRecHitContainer&) const;
- 
+
     /// select muon hits compatible with trajectory; check hits in chambers with showers
-    ConstRecHitContainer selectMuonHits(const Trajectory&, 
+    ConstRecHitContainer selectMuonHits(const Trajectory&,
                                         const std::map<DetId, int> &) const;
- 
+
     /// print all RecHits of a trajectory
     void printHits(const ConstRecHitContainer&) const;
 
@@ -129,7 +129,7 @@ class GlobalMuonRefitter {
     float thePtCut;
 
   private:
-  
+
     int   theMuonHitsOption;
     float theProbCut;
     int   theHitThreshold;
@@ -157,10 +157,10 @@ class GlobalMuonRefitter {
     int   theTrackerSkipSystem;
     int   theTrackerSkipSection;
 
-    unsigned long long theCacheId_TRH;        
+    unsigned long long theCacheId_TRH;
 
     std::string thePropagatorName;
-  
+
     bool theRPCInTheFit;
 
     double theRescaleErrorFactor;
@@ -172,14 +172,15 @@ class GlobalMuonRefitter {
     bool theDYTupdator;
     bool theDYTuseAPE;
     reco::DYTInfo *dytInfo;
+    edm::ParameterSet theDYTthrsParameters;
 
     std::string theFitterName;
     std::unique_ptr<TrajectoryFitter> theFitter;
-  
+
     std::string theTrackerRecHitBuilderName;
     edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
     TkClonerImpl hitCloner;
-  
+
     std::string theMuonRecHitBuilderName;
     edm::ESHandle<TransientTrackingRecHitBuilder> theMuonRecHitBuilder;
 

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
@@ -171,8 +171,9 @@ class GlobalMuonRefitter {
     int theDYTselector;
     bool theDYTupdator;
     bool theDYTuseAPE;
-    reco::DYTInfo *dytInfo;
+    bool dytParThrsMode;
     edm::ParameterSet theDYTthrsParameters;
+    reco::DYTInfo *dytInfo;
 
     std::string theFitterName;
     std::unique_ptr<TrajectoryFitter> theFitter;

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
@@ -172,7 +172,7 @@ class GlobalMuonRefitter {
     int theDYTselector;
     bool theDYTupdator;
     bool theDYTuseAPE;
-    bool dytParThrsMode;
+    bool theDYTParThrsMode;
     edm::ParameterSet theDYTthrsParameters;
     reco::DYTInfo *dytInfo;
 

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
@@ -9,8 +9,9 @@
  *  \author C. Liu 		 Purdue University
  *  \author A. Everett 		 Purdue University
  *
- *  \modified by C. Calabria     INFN & Universita� Bari
+ *  \modified by C. Calabria     INFN & Universita Bari
  *  \modified by D. Nash         Northeastern University
+ *  \modified by C. Caputo       UCLouvain
  */
 
 #include "DataFormats/Common/interface/Handle.h"
@@ -67,7 +68,7 @@ class GlobalMuonRefitter {
 
     /// constructor with Parameter Set and MuonServiceProxy
     GlobalMuonRefitter(const edm::ParameterSet&, const MuonServiceProxy*, edm::ConsumesCollector&);
-
+          
     /// destructor
     virtual ~GlobalMuonRefitter();
 
@@ -105,15 +106,15 @@ class GlobalMuonRefitter {
     enum RefitDirection{insideOut,outsideIn,undetermined};
 
     /// check muon RecHits, calculate chamber occupancy and select hits to be used in the final fit
-    void checkMuonHits(const reco::Track&, ConstRecHitContainer&,
+    void checkMuonHits(const reco::Track&, ConstRecHitContainer&, 
                        std::map<DetId, int> &) const;
 
     /// get the RecHits in the tracker and the first muon chamber with hits
-    void getFirstHits(const reco::Track&, ConstRecHitContainer&,
+    void getFirstHits(const reco::Track&, ConstRecHitContainer&, 
                        ConstRecHitContainer&) const;
 
     /// select muon hits compatible with trajectory; check hits in chambers with showers
-    ConstRecHitContainer selectMuonHits(const Trajectory&,
+    ConstRecHitContainer selectMuonHits(const Trajectory&, 
                                         const std::map<DetId, int> &) const;
 
     /// print all RecHits of a trajectory
@@ -129,7 +130,7 @@ class GlobalMuonRefitter {
     float thePtCut;
 
   private:
-
+  
     int   theMuonHitsOption;
     float theProbCut;
     int   theHitThreshold;

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
@@ -358,7 +358,7 @@ void GlobalTrackQualityProducer::fillDescriptions(edm::ConfigurationDescriptions
     descGlbMuonRefitter.add<int>("DYTselector",1);
     descGlbMuonRefitter.add<bool>("DYTupdator", false);
     descGlbMuonRefitter.add<bool>("DYTuseAPE", false );
-    descGlbMuonRefitter.add<bool>("DYTuseThrsParametrization", true);
+    descGlbMuonRefitter.add<bool>("DYTuseThrsParametrization", false);
     {
       edm::ParameterSetDescription descDYTthrs;
       descDYTthrs.add<std::vector<double>>("eta0p8", {1,-0.919853, 0.990742});

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
@@ -311,5 +311,68 @@ GlobalTrackQualityProducer::trackProbability(Trajectory& track) const {
 
 }
 
+void GlobalTrackQualityProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions){
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("InputCollection",edm::InputTag("globalMuons"));
+  desc.add<edm::InputTag>("InputLinksCollection",edm::InputTag("globalMuons"));
+  desc.add<std::string>("BaseLabel","GLB");
+//  edm::ParameterSetDescription descRefitter;
+  {
+    edm::ParameterSetDescription descGlbMuonRefitter;
+    descGlbMuonRefitter.add<edm::InputTag>("DTRecSegmentLabel" , edm::InputTag("dt1DRecHits"));
+    descGlbMuonRefitter.add<edm::InputTag>("CSCRecSegmentLabel" , edm::InputTag("csc2DRecHits"));
+    descGlbMuonRefitter.add<edm::InputTag>("GEMRecHitLabel" , edm::InputTag("gemRecHits"));
+    descGlbMuonRefitter.add<edm::InputTag>("ME0RecHitLabel" , edm::InputTag("me0Segments"));
+    descGlbMuonRefitter.add<edm::InputTag>("RPCRecSegmentLabel" , edm::InputTag("rpcRecHits"));
+
+    descGlbMuonRefitter.add<int>("MuonHitsOption", 1);
+    descGlbMuonRefitter.add<double>("PtCut", 1.0);
+    descGlbMuonRefitter.add<double>("Chi2ProbabilityCut", 30.0);
+    descGlbMuonRefitter.add<double>("Chi2CutCSC", 1.0);
+    descGlbMuonRefitter.add<double>("Chi2CutDT", 30.0);
+    descGlbMuonRefitter.add<double>("Chi2CutGEM", 1.0);
+    descGlbMuonRefitter.add<double>("Chi2CutME0", 1.0);
+    descGlbMuonRefitter.add<double>("Chi2CutRPC", 1.0);
+    descGlbMuonRefitter.add<int>("HitThreshold", 1);
+
+    descGlbMuonRefitter.add<std::string>("Fitter", "KFFitterForRefitInsideOut");
+    descGlbMuonRefitter.add<std::string>("Smoother", "KFSmootherForRefitInsideOut");
+    descGlbMuonRefitter.add<std::string>("Propagator", "SmartPropagatorAnyRK");
+    descGlbMuonRefitter.add<std::string>("TrackerRecHitBuilder", "WithAngleAndTemplate");
+    descGlbMuonRefitter.add<std::string>("MuonRecHitBuilder", "MuonRecHitBuilder");
+    descGlbMuonRefitter.add<bool>("DoPredictionsOnly", false);
+    descGlbMuonRefitter.add<std::string>("RefitDirection", "insideOut");
+    descGlbMuonRefitter.add<bool>("PropDirForCosmics", false);
+    descGlbMuonRefitter.add<bool>("RefitRPCHits", true);
+
+    descGlbMuonRefitter.add<std::vector<int>>("DYTthrs",{10, 10});
+    descGlbMuonRefitter.add<int>("DYTselector",1);
+    descGlbMuonRefitter.add<bool>("DYTupdator", false);
+    descGlbMuonRefitter.add<bool>("DYTuseAPE", false );
+    descGlbMuonRefitter.add<bool>("DYTuseThrsParametrization", true);
+    {
+      edm::ParameterSetDescription descDYTthrs;
+      descDYTthrs.add<std::vector<double>>("eta0p8", {1,-0.919853, 0.990742});
+      descDYTthrs.add<std::vector<double>>("eta1p2", {1,-0.897354, 0.987738});
+      descDYTthrs.add<std::vector<double>>("eta2p0", {1,-0.986855, 0.998516});
+      descDYTthrs.add<std::vector<double>>("eta2p2", {1,-0.940342, 0.992955});
+      descDYTthrs.add<std::vector<double>>("eta2p4", {1,-0.947633, 0.993762});
+      descGlbMuonRefitter.add<edm::ParameterSetDescription>("DYTthrsParameters", descDYTthrs);
+    }
+
+    descGlbMuonRefitter.add<int>("SkipStation", -1);
+    descGlbMuonRefitter.add<int>("TrackerSkipSystem",-1);
+    descGlbMuonRefitter.add<int>("TrackerSkipSection", -1);
+    descGlbMuonRefitter.add<bool>("RefitFlag", true );
+
+    //descRefitter.add<edm::ParameterSetDescription>("GlobalMuonRefitter", descGlbMuonRefitter);
+    desc.add<edm::ParameterSetDescription>("RefitterParameters", descGlbMuonRefitter);
+  }
+  //desc.add<edm::ParameterSetDescription>("RefitterParameters", descRefitter);
+  desc.add<double>("nSigma", 3.0);
+  desc.add<double>("MaxChi2", 100000.0);
+
+  descriptions.add("GlobalTrackQualityProducer", desc);
+}
 //#include "FWCore/Framework/interface/MakerMacros.h"
 //DEFINE_FWK_MODULE(GlobalTrackQualityProducer);

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
@@ -313,10 +313,19 @@ GlobalTrackQualityProducer::trackProbability(Trajectory& track) const {
 
 void GlobalTrackQualityProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions){
   edm::ParameterSetDescription desc;
+  {
+    edm::ParameterSetDescription psd1;
+    psd1.setAllowAnything();
+    desc.add<edm::ParameterSetDescription>("ServiceParameters", psd1);
+  }
+  {
+    edm::ParameterSetDescription psd1;
+    psd1.setAllowAnything();
+    desc.add<edm::ParameterSetDescription>("GlobalMuonTrackMatcher", psd1);
+  }
   desc.add<edm::InputTag>("InputCollection",edm::InputTag("globalMuons"));
   desc.add<edm::InputTag>("InputLinksCollection",edm::InputTag("globalMuons"));
   desc.add<std::string>("BaseLabel","GLB");
-//  edm::ParameterSetDescription descRefitter;
   {
     edm::ParameterSetDescription descGlbMuonRefitter;
     descGlbMuonRefitter.add<edm::InputTag>("DTRecSegmentLabel" , edm::InputTag("dt1DRecHits"));

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
@@ -328,21 +328,12 @@ void GlobalTrackQualityProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<std::string>("BaseLabel","GLB");
   {
     edm::ParameterSetDescription descGlbMuonRefitter;
+    descGlbMuonRefitter.setAllowAnything();
     descGlbMuonRefitter.add<edm::InputTag>("DTRecSegmentLabel" , edm::InputTag("dt1DRecHits"));
     descGlbMuonRefitter.add<edm::InputTag>("CSCRecSegmentLabel" , edm::InputTag("csc2DRecHits"));
     descGlbMuonRefitter.add<edm::InputTag>("GEMRecHitLabel" , edm::InputTag("gemRecHits"));
     descGlbMuonRefitter.add<edm::InputTag>("ME0RecHitLabel" , edm::InputTag("me0Segments"));
     descGlbMuonRefitter.add<edm::InputTag>("RPCRecSegmentLabel" , edm::InputTag("rpcRecHits"));
-
-    descGlbMuonRefitter.add<int>("MuonHitsOption", 1);
-    descGlbMuonRefitter.add<double>("PtCut", 1.0);
-    descGlbMuonRefitter.add<double>("Chi2ProbabilityCut", 30.0);
-    descGlbMuonRefitter.add<double>("Chi2CutCSC", 1.0);
-    descGlbMuonRefitter.add<double>("Chi2CutDT", 30.0);
-    descGlbMuonRefitter.add<double>("Chi2CutGEM", 1.0);
-    descGlbMuonRefitter.add<double>("Chi2CutME0", 1.0);
-    descGlbMuonRefitter.add<double>("Chi2CutRPC", 1.0);
-    descGlbMuonRefitter.add<int>("HitThreshold", 1);
 
     descGlbMuonRefitter.add<std::string>("Fitter", "KFFitterForRefitInsideOut");
     descGlbMuonRefitter.add<std::string>("Smoother", "KFSmootherForRefitInsideOut");
@@ -363,7 +354,7 @@ void GlobalTrackQualityProducer::fillDescriptions(edm::ConfigurationDescriptions
       edm::ParameterSetDescription descDYTthrs;
       descDYTthrs.add<std::vector<double>>("eta0p8", {1,-0.919853, 0.990742});
       descDYTthrs.add<std::vector<double>>("eta1p2", {1,-0.897354, 0.987738});
-      descDYTthrs.add<std::vector<double>>("eta2p0", {1,-0.986855, 0.998516});
+      descDYTthrs.add<std::vector<double>>("eta2p0", {4,-0.986855, 0.998516});
       descDYTthrs.add<std::vector<double>>("eta2p2", {1,-0.940342, 0.992955});
       descDYTthrs.add<std::vector<double>>("eta2p4", {1,-0.947633, 0.993762});
       descGlbMuonRefitter.add<edm::ParameterSetDescription>("DYTthrsParameters", descDYTthrs);
@@ -374,14 +365,12 @@ void GlobalTrackQualityProducer::fillDescriptions(edm::ConfigurationDescriptions
     descGlbMuonRefitter.add<int>("TrackerSkipSection", -1);
     descGlbMuonRefitter.add<bool>("RefitFlag", true );
 
-    //descRefitter.add<edm::ParameterSetDescription>("GlobalMuonRefitter", descGlbMuonRefitter);
     desc.add<edm::ParameterSetDescription>("RefitterParameters", descGlbMuonRefitter);
   }
-  //desc.add<edm::ParameterSetDescription>("RefitterParameters", descRefitter);
   desc.add<double>("nSigma", 3.0);
   desc.add<double>("MaxChi2", 100000.0);
 
-  descriptions.add("GlobalTrackQualityProducer", desc);
+  descriptions.add("globalTrackQualityProducer", desc);
 }
 //#include "FWCore/Framework/interface/MakerMacros.h"
 //DEFINE_FWK_MODULE(GlobalTrackQualityProducer);

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.h
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -30,6 +31,8 @@ class GlobalTrackQualityProducer : public edm::stream::EDProducer<> {
 
   ~GlobalTrackQualityProducer() override; // {}
   
+  // describe the parameters it allows or requires to be in its configuration
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
  private:
   void produce(edm::Event&, const edm::EventSetup&) override;
   virtual std::pair<double,double> kink(Trajectory& muon) const ;

--- a/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
@@ -33,7 +33,7 @@ GlobalMuonRefitter = cms.PSet(
     DYTupdator = cms.bool(True),
     DYTuseAPE = cms.bool(False),
     ## Parameters for DYT threshold parametrization
-    DYTuseThrsParametrization = cms.bool(True),
+    DYTuseThrsParametrization = cms.bool(False),
     DYTthrsParameters = cms.PSet(
                                   eta0p8 = cms.vdouble(1, -0.919853, 0.990742),
                                   eta1p2 = cms.vdouble(1, -0.897354, 0.987738),

--- a/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
@@ -35,12 +35,11 @@ GlobalMuonRefitter = cms.PSet(
     ## Parameters for DYT threshold parametrization
     DYTuseThrsParametrization = cms.bool(True),
     DYTthrsParameters = cms.PSet(
-                                  eta0p8 = cms.vdouble(-0.919853, 0.990742),
-                                  eta1p2 = cms.vdouble(-0.897354, 0.987738),
-                                  eta2p0 = cms.vdouble(-0.986855, 0.998516),
-                                  eta2p2 = cms.vdouble(-0.940342, 0.992955),
-                                  eta2p4 = cms.vdouble(-0.947633, 0.993762),
-                                  thr50  = cms.vdouble(1, 1, 4, 1, 1),
+                                  eta0p8 = cms.vdouble(1, -0.919853, 0.990742),
+                                  eta1p2 = cms.vdouble(1, -0.897354, 0.987738),
+                                  eta2p0 = cms.vdouble(4, -0.986855, 0.998516),
+                                  eta2p2 = cms.vdouble(1, -0.940342, 0.992955),
+                                  eta2p4 = cms.vdouble(1, -0.947633, 0.993762),
                                 ),
     # muon station to be skipped
     SkipStation		= cms.int32(-1),

--- a/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
@@ -26,13 +26,22 @@ GlobalMuonRefitter = cms.PSet(
     RefitDirection = cms.string('insideOut'),
     PropDirForCosmics = cms.bool(False),
     RefitRPCHits = cms.bool(True),
- 
+
     # DYT stuff
     DYTthrs = cms.vint32(10, 10),
     DYTselector = cms.int32(1),
     DYTupdator = cms.bool(True),
     DYTuseAPE = cms.bool(False),
-    
+    ## Parameters for DYT threshold parametrization
+    DYTuseThrsParametrization = cms.bool(True),
+    DYTthrsParameters = cms.PSet(
+                                  eta0p8 = cms.vdouble(-0.919853, 0.990742),
+                                  eta1p2 = cms.vdouble(-0.897354, 0.987738),
+                                  eta2p0 = cms.vdouble(-0.986855, 0.998516),
+                                  eta2p2 = cms.vdouble(-0.940342, 0.992955),
+                                  eta2p4 = cms.vdouble(-0.947633, 0.993762),
+                                  thr50  = cms.vdouble(1, 1, 4, 1, 1),
+                                ),
     # muon station to be skipped
     SkipStation		= cms.int32(-1),
 

--- a/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
@@ -41,7 +41,7 @@ GlobalTrajectoryBuilderCommon = cms.PSet(
         Chi2CutME0 = cms.double(1.0),
         Chi2CutRPC = cms.double(1.0),
         HitThreshold = cms.int32(1),
-        
+
         Fitter = cms.string('GlbMuKFFitter'),
         Propagator = cms.string('SmartPropagatorAnyRK'),
         TrackerRecHitBuilder = cms.string('WithAngleAndTemplate'),
@@ -50,19 +50,29 @@ GlobalTrajectoryBuilderCommon = cms.PSet(
         RefitDirection = cms.string('insideOut'),
         PropDirForCosmics = cms.bool(False),
         RefitRPCHits = cms.bool(True),
-        
+
         # DYT stuff
         DYTthrs = cms.vint32(20, 30),
         DYTselector = cms.int32(1),
         DYTupdator = cms.bool(False),
         DYTuseAPE = cms.bool(False),
+        ## Parameters for DYT threshold parametrization
+        DYTuseThrsParametrization = cms.bool(True),
+        DYTthrsParameters = cms.PSet(
+                                      eta0p8 = cms.vdouble(-0.919853, 0.990742),
+                                      eta1p2 = cms.vdouble(-0.897354, 0.987738),
+                                      eta2p0 = cms.vdouble(-0.986855, 0.998516),
+                                      eta2p2 = cms.vdouble(-0.940342, 0.992955),
+                                      eta2p4 = cms.vdouble(-0.947633, 0.993762),
+                                      thr50  = cms.vdouble(1, 1, 4, 1, 1),
+                                    ),
 
         # muon station to be skipped
         SkipStation		= cms.int32(-1),
-        
+
         # PXB = 1, PXF = 2, TIB = 3, TID = 4, TOB = 5, TEC = 6
         TrackerSkipSystem	= cms.int32(-1),
-        
+
         # layer, wheel, or disk depending on the system
         TrackerSkipSection	= cms.int32(-1),
 

--- a/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
@@ -59,12 +59,11 @@ GlobalTrajectoryBuilderCommon = cms.PSet(
         ## Parameters for DYT threshold parametrization
         DYTuseThrsParametrization = cms.bool(True),
         DYTthrsParameters = cms.PSet(
-                                      eta0p8 = cms.vdouble(-0.919853, 0.990742),
-                                      eta1p2 = cms.vdouble(-0.897354, 0.987738),
-                                      eta2p0 = cms.vdouble(-0.986855, 0.998516),
-                                      eta2p2 = cms.vdouble(-0.940342, 0.992955),
-                                      eta2p4 = cms.vdouble(-0.947633, 0.993762),
-                                      thr50  = cms.vdouble(1, 1, 4, 1, 1),
+                                  eta0p8 = cms.vdouble(1, -0.919853, 0.990742),
+                                  eta1p2 = cms.vdouble(1, -0.897354, 0.987738),
+                                  eta2p0 = cms.vdouble(4, -0.986855, 0.998516),
+                                  eta2p2 = cms.vdouble(1, -0.940342, 0.992955),
+                                  eta2p4 = cms.vdouble(1, -0.947633, 0.993762),
                                     ),
 
         # muon station to be skipped

--- a/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
@@ -57,7 +57,7 @@ GlobalTrajectoryBuilderCommon = cms.PSet(
         DYTupdator = cms.bool(False),
         DYTuseAPE = cms.bool(False),
         ## Parameters for DYT threshold parametrization
-        DYTuseThrsParametrization = cms.bool(True),
+        DYTuseThrsParametrization = cms.bool(False),
         DYTthrsParameters = cms.PSet(
                                   eta0p8 = cms.vdouble(1, -0.919853, 0.990742),
                                   eta1p2 = cms.vdouble(1, -0.897354, 0.987738),

--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -79,7 +79,7 @@ void DynamicTruncation::updateWithDThits(TrajectoryStateOnSurface& tsos, DTRecSe
   ConstRecHitContainer tmprecHits;
   vector<const TrackingRecHit*> DTrh = bestDTSeg.recHits();
   for (vector<const TrackingRecHit*>::iterator it = DTrh.begin(); it != DTrh.end(); it++) {
-    tmprecHits.push_back(theMuonRecHitBuilder->build(*it));
+    tmprecHits.push_back(theMuonRecHitBuilder->build(*it)); 
   }
   sort(tmprecHits);
   for (ConstRecHitContainer::const_iterator it = tmprecHits.begin(); it != tmprecHits.end(); ++it) {
@@ -101,7 +101,7 @@ void DynamicTruncation::updateWithCSChits(TrajectoryStateOnSurface& tsos, CSCSeg
   sort(tmprecHits);
   for (ConstRecHitContainer::const_iterator it = tmprecHits.begin(); it != tmprecHits.end(); ++it) {
     const CSCLayer* cscLayer = cscGeom->layer((*it)->det()->geographicalId());
-    TrajectoryStateOnSurface temp = propagator->propagate(tsos, cscLayer->surface());
+    TrajectoryStateOnSurface temp = propagator->propagate(tsos, cscLayer->surface());  
     if (temp.isValid()) {
       TrajectoryStateOnSurface tempTsos = updatorHandle->update(temp, **it);
       if (tempTsos.isValid() ) tsos = tempTsos;
@@ -199,7 +199,7 @@ void DynamicTruncation::filteringAlgo() {
   compatibleDets(currentState, compatibleIds);
 
   // Fill segment maps
-  fillSegmentMaps(compatibleIds, dtSegMap, cscSegMap);
+  fillSegmentMaps(compatibleIds, dtSegMap, cscSegMap); 
 
   // Do a preliminary fit
   if (useDBforThr) preliminaryFit(compatibleIds, dtSegMap, cscSegMap);
@@ -214,7 +214,7 @@ void DynamicTruncation::filteringAlgo() {
     vector<DTRecSegment4D> dtSegs   = dtSegMap[it->first];
     vector<CSCSegment> cscSegs      = cscSegMap[it->first];
 
-    // DT case: find the most compatible segment
+    // DT case: find the most compatible segment 
     TrajectoryStateOnSurface tsosDTlayer;
     testDTstation(currentState, dtSegs, bestDTEstimator, bestDTSeg, tsosDTlayer);
 
@@ -224,7 +224,7 @@ void DynamicTruncation::filteringAlgo() {
 
     // Decide whether to keep the layer or not
     bool chosenLayer = chooseLayers(incompConLay, bestDTEstimator, bestDTSeg, tsosDTlayer, bestCSCEstimator, bestCSCSeg, tsosCSClayer);
-    fillDYTInfos(stLayer, chosenLayer, incompConLay, bestDTEstimator, bestCSCEstimator, bestDTSeg, bestCSCSeg);
+    fillDYTInfos(stLayer, chosenLayer, incompConLay, bestDTEstimator, bestCSCEstimator, bestDTSeg, bestCSCSeg); 
   }
   //cout << "Number of used stations = " << nStationsUsed << endl;
 }
@@ -245,7 +245,7 @@ int DynamicTruncation::stationfromDet(DetId const& det) {
 
 
 //===> fillDYTInfos
-void DynamicTruncation::fillDYTInfos(int const &st, bool const &chosenLayer, int &incompConLay,
+void DynamicTruncation::fillDYTInfos(int const &st, bool const &chosenLayer, int &incompConLay, 
 				     double const &bestDTEstimator, double const &bestCSCEstimator,
 				     DTRecSegment4D const &bestDTSeg, CSCSegment const &bestCSCSeg) {
   if (chosenLayer) {
@@ -253,7 +253,7 @@ void DynamicTruncation::fillDYTInfos(int const &st, bool const &chosenLayer, int
     incompConLay = 0;
     if (bestDTEstimator <= bestCSCEstimator) {
       estimatorMap[st] = bestDTEstimator;
-      DetId id(bestDTSeg.chamberId());
+      DetId id(bestDTSeg.chamberId()); 
       idChamberMap[st] = id;
     } else {
       DetId id(bestCSCSeg.cscDetId());
@@ -282,7 +282,7 @@ void DynamicTruncation::compatibleDets(TrajectoryStateOnSurface &tsos, map<int, 
 	navLayers[ilayer]->subDetector() != GeomDetEnumerators::CSC) continue;
     ilayerCorrected++;
     vector<DetLayer::DetWithState> comps = navLayers[ilayer]->compatibleDets(currentState, *propagatorCompatibleDet, *theEstimator);
-    //cout << comps.size() << " compatible Dets with " << navLayers[ilayer]->subDetector() << " Layer " << ilayer << " "
+    //cout << comps.size() << " compatible Dets with " << navLayers[ilayer]->subDetector() << " Layer " << ilayer << " " 
     //<< dumper.dumpLayer(navLayers[ilayer]);
     if (!comps.empty()) {
       for ( unsigned int icomp=0; icomp<comps.size(); icomp++ ) {
@@ -318,7 +318,7 @@ void DynamicTruncation::fillSegmentMaps( map<int, vector<DetId> > &compatibleIds
 
 
 //===> testDTstation
-void DynamicTruncation::testDTstation(TrajectoryStateOnSurface &startingState, vector<DTRecSegment4D> const &segments,
+void DynamicTruncation::testDTstation(TrajectoryStateOnSurface &startingState, vector<DTRecSegment4D> const &segments, 
 				      double &bestEstimator, DTRecSegment4D &bestSeg, TrajectoryStateOnSurface &tsosdt) {
   if (segments.empty()) return;
   for (unsigned int iSeg = 0; iSeg < segments.size(); iSeg++) {
@@ -331,7 +331,7 @@ void DynamicTruncation::testDTstation(TrajectoryStateOnSurface &startingState, v
     StateSegmentMatcher estim(tsosdt, segments[iSeg], apeLoc);
     double estimator = estim.value();
     //cout << "estimator DT = " << estimator << endl;
-    if (estimator >= bestEstimator) continue;
+    if (estimator >= bestEstimator) continue; 
     bestEstimator = estimator;
     bestSeg = segments[iSeg];
   }
@@ -339,7 +339,7 @@ void DynamicTruncation::testDTstation(TrajectoryStateOnSurface &startingState, v
 
 
 //===> testCSCstation
-void DynamicTruncation::testCSCstation(TrajectoryStateOnSurface &startingState, vector<CSCSegment> const &segments,
+void DynamicTruncation::testCSCstation(TrajectoryStateOnSurface &startingState, vector<CSCSegment> const &segments, 
 				       double &bestEstimator, CSCSegment &bestSeg, TrajectoryStateOnSurface &tsoscsc) {
   if (segments.empty()) return;
   for (unsigned int iSeg = 0; iSeg < segments.size(); iSeg++) {
@@ -367,7 +367,7 @@ void DynamicTruncation::useSegment(DTRecSegment4D const &bestDTSeg, TrajectorySt
 }
 
 
-//===> useSegment
+//===> useSegment 
 void DynamicTruncation::useSegment(CSCSegment const &bestCSCSeg, TrajectoryStateOnSurface const &tsosCSC) {
   result.push_back(theMuonRecHitBuilder->build(&bestCSCSeg));
   if (doUpdateOfKFStates) updateWithCSChits(currentState, bestCSCSeg);
@@ -423,9 +423,9 @@ void DynamicTruncation::preliminaryFit(map<int, vector<DetId> > compatibleIds, m
   }
   if (!prelFitMeas.empty()) prelFitMeas.pop_back();
   for (auto imrh = prelFitMeas.rbegin(); imrh != prelFitMeas.rend(); ++imrh) {
-    DetId id = (*imrh)->geographicalId();
+    DetId id = (*imrh)->geographicalId(); 
     TrajectoryStateOnSurface tmp = propagatorPF->propagate(prelFitState, theG->idToDet(id)->surface());
-    if (tmp.isValid()) prelFitState = tmp;
+    if (tmp.isValid()) prelFitState = tmp; 
   }
   muonPTest  = prelFitState.globalMomentum().perp();
   muonETAest = prelFitState.globalMomentum().eta();
@@ -433,17 +433,17 @@ void DynamicTruncation::preliminaryFit(map<int, vector<DetId> > compatibleIds, m
 
 
 //===> chooseLayers
-bool DynamicTruncation::chooseLayers(int &incompLayers, double const &bestDTEstimator, DTRecSegment4D const &bestDTSeg, TrajectoryStateOnSurface const &tsosDT,
+bool DynamicTruncation::chooseLayers(int &incompLayers, double const &bestDTEstimator, DTRecSegment4D const &bestDTSeg, TrajectoryStateOnSurface const &tsosDT, 
 				     double const &bestCSCEstimator, CSCSegment const &bestCSCSeg, TrajectoryStateOnSurface const &tsosCSC) {
   double initThr = MAX_THR;
   if (bestDTEstimator == MAX_THR && bestCSCEstimator == MAX_THR) return false;
   if (bestDTEstimator <= bestCSCEstimator) {
     // Get threshold for the chamber
     if (useDBforThr) getThresholdFromDB(initThr, DetId(bestDTSeg.chamberId()));
-    else getThresholdFromCFG(initThr, DetId(bestDTSeg.chamberId()));
+    else getThresholdFromCFG(initThr, DetId(bestDTSeg.chamberId())); 
     if (DYTselector == 0 || (DYTselector == 1 && bestDTEstimator < initThr) ||
 	(DYTselector == 2 && incompLayers < 2 && bestDTEstimator < initThr)) {
-      useSegment(bestDTSeg, tsosDT);
+      useSegment(bestDTSeg, tsosDT); 
       return true;
     }
   } else {

--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -477,31 +477,27 @@ void DynamicTruncation::getThresholdFromDB(double& thr, DetId const& id) {
 //===> correctThrByPAndEta
 void DynamicTruncation::correctThrByPAndEta(double& thr) {
 
-
-
     auto parametricThreshold = [this]{
       double thr50 = this->parameters[this->region].at(0);
       double p0    = this->parameters[this->region].at(1);
       double p1    = this->parameters[this->region].at(2);
-      return thr50 * ( 1 + p0*p_reco + TMath::Power( this->p_reco, p1));
+      return thr50 * ( 1 + p0*p_reco + std::pow( this->p_reco, p1));
     };
 
-    // printf("thr before = %f \n", thr);
-    // printf("Muon with pt equal to = %f  --  eta = %f\n", p_reco, eta_reco );
-    // printf("parametricThreshold(1,%f, %f) = %f \n", this->parameters[this->region].at(0), this->parameters[this->region].at(1), parametricThreshold());
     thr = parametricThreshold();
 }
 
 void DynamicTruncation::setEtaRegion(){
 
+  float absEta = std::abs(eta_reco);
   // Defaul value for muons with abs(eta) > 2.4
   region = dyt_utils::etaRegion::eta2p4;
 
-  if( TMath::Abs(eta_reco) > 0 && TMath::Abs(eta_reco) <= 0.8 ) region = dyt_utils::etaRegion::eta0p8;
-  else if( TMath::Abs(eta_reco) > 0.8 && TMath::Abs(eta_reco) <= 1.2 ) region = dyt_utils::etaRegion::eta1p2;
-  else if( TMath::Abs(eta_reco) > 1.2 && TMath::Abs(eta_reco) <= 2.0 ) region = dyt_utils::etaRegion::eta2p0;
-  else if( TMath::Abs(eta_reco) > 2.0 && TMath::Abs(eta_reco) <= 2.2 ) region = dyt_utils::etaRegion::eta2p2;
-  else if( TMath::Abs(eta_reco) > 2.2 && TMath::Abs(eta_reco) <= 2.4 ) region = dyt_utils::etaRegion::eta2p4;
+  if( absEta <= 0.8 ) region = dyt_utils::etaRegion::eta0p8;
+  else if( absEta <= 1.2 ) region = dyt_utils::etaRegion::eta1p2;
+  else if( absEta <= 2.0 ) region = dyt_utils::etaRegion::eta2p0;
+  else if( absEta <= 2.2 ) region = dyt_utils::etaRegion::eta2p2;
+  else if( absEta <= 2.4 ) region = dyt_utils::etaRegion::eta2p4;
 
 }
 

--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -467,12 +467,12 @@ void DynamicTruncation::getThresholdFromDB(double& thr, DetId const& id) {
       break;
     }
   }
-  if (useParametrizedThr) correctThrByPtAndEta(thr);
+  if (useParametrizedThr) correctThrByPAndEta(thr);
 }
 
 
-//===> correctThrByPtAndEta
-void DynamicTruncation::correctThrByPtAndEta(double& thr) {
+//===> correctThrByPAndEta
+void DynamicTruncation::correctThrByPAndEta(double& thr) {
 
 
 
@@ -509,7 +509,7 @@ void DynamicTruncation::getThresholdFromCFG(double& thr, DetId const& id) {
     thr = Thrs[1];
   }
 
-  if (useParametrizedThr) correctThrByPtAndEta(thr);
+  if (useParametrizedThr) correctThrByPAndEta(thr);
 }
 
 

--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -135,13 +135,16 @@ void DynamicTruncation::setThr(const vector<int>& thr) {
 
 
 //===> filter
-TransientTrackingRecHit::ConstRecHitContainer DynamicTruncation::filter(const Trajectory& traj) {
+TransientTrackingRecHit::ConstRecHitContainer DynamicTruncation::filter(const Trajectory& traj, double globalMomentum, double globalEta) {
   result.clear();
   prelFitMeas.clear();
   
   // Get APE maps 
   dtApeMap = thrManager->GetDTApeMap();
   cscApeMap = thrManager->GetCSCApeMap();
+
+  double momentum = globalMomentum;
+  double eta = globalEta;
 
   // Get Last tracker TSOS (updated)
   vector<TrajectoryMeasurement> muonMeasurements = traj.measurements();
@@ -164,19 +167,22 @@ TransientTrackingRecHit::ConstRecHitContainer DynamicTruncation::filter(const Tr
   prelFitMeas = result;
 
   // Run the DYT
-  filteringAlgo();
+  filteringAlgo(momentum,eta); //filteringAlgo();
   
   return result;
 }
 
 
 //===> filteringAlgo
-void DynamicTruncation::filteringAlgo() {
+void DynamicTruncation::filteringAlgo(double momentum,double eta) {
   map<int, vector<DetId> > compatibleIds;
   map<int, vector<DTRecSegment4D> > dtSegMap;
   map<int, vector<CSCSegment> > cscSegMap;
   int incompConLay = 0;
   nStationsUsed = 0;
+
+  p_reco = momentum;
+  eta_reco = eta;
 
   // Get list of compatible layers
   compatibleDets(currentState, compatibleIds);
@@ -460,10 +466,31 @@ void DynamicTruncation::getThresholdFromDB(double& thr, DetId const& id) {
 //===> correctThrByPtAndEta
 void DynamicTruncation::correctThrByPtAndEta(double& thr) {
 
-  //////////////////////////////////////
-  // This section will be implemented //
-  //    after the release of APEs     //
-  //////////////////////////////////////
+	//double p = p_reco;
+	//double   p08[2] = { -0.919853, 0.990742};
+	//double   p12[4] = { -0.897354, 0.987738};
+	//double   p20[3] = { -0.986855, 0.998516};
+	//double   p22[2] = { -0.940342, 0.992955};
+	//double   p24[2] = { -0.947633, 0.993762};
+	//double thr50[5] = { 1, 1, 4, 1, 1};
+
+	if( TMath::Abs(eta_reco) > 0 && TMath::Abs(eta_reco) <= 0.8 ){
+		thr = 24; //3000-> 26; //400-> 11; //1000-> 19; //2000-> 25;
+		//thr = thr50[0] * ( 1 + p08[0]*p + TMath::Power( p, p08[1])); 	
+	} else if( TMath::Abs(eta_reco) > 0.8 && TMath::Abs(eta_reco) <= 1.2 ){
+		thr = 38; //3000-> 29; //400-> 14; //1000-> 22; //2000-> 27;
+                //thr = thr50[1] * ( 1 + p12[0]*p + TMath::Power( p, p12[1])); 
+        } else if( TMath::Abs(eta_reco) > 1.2 && TMath::Abs(eta_reco) <= 2.0 ){
+		thr = 19; //3000-> 20; //400-> 10; //1000-> 16; //2000-> 19;
+        	//thr = thr50[2] * ( 1 + p20[0]*p + TMath::Power( p, p20[1])); 
+        } else if( TMath::Abs(eta_reco) > 2.0 && TMath::Abs(eta_reco) <= 2.2 ){
+		thr = 16; //3000-> 16; //400-> 8; //1000-> 13; //2000-> 15;
+        	//thr = thr50[3] * ( 1 + p22[0]*p + TMath::Power( p, p22[1]));
+        } else if( TMath::Abs(eta_reco) > 2.2 && TMath::Abs(eta_reco) <= 2.4 ){
+		thr = 14; //3000-> 12; //400-> 8; //1000-> 11; //2000-> 13;
+        	//thr = thr50[4] * ( 1 + p24[0]*p + TMath::Power( p, p24[1]));
+	}
+	//thr = 10;
 
 }
 

--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -44,7 +44,7 @@ namespace dyt_utils{
 
 
 
-DynamicTruncation::DynamicTruncation(const edm::Event& event, const MuonServiceProxy& theService, const edm::ParameterSet& par) {
+DynamicTruncation::DynamicTruncation(const edm::Event& event, const MuonServiceProxy& theService) {
   propagator = theService.propagator("SmartPropagatorAny");
   propagatorPF = theService.propagator("SmartPropagatorAny");
   propagatorCompatibleDet = theService.propagator("SmartPropagatorAny");
@@ -62,9 +62,6 @@ DynamicTruncation::DynamicTruncation(const edm::Event& event, const MuonServiceP
 
   doUpdateOfKFStates = true;
   useParametrizedThr = false;
-  for (auto const& region : dyt_utils::etaRegionStr ){
-      parameters[region.first] = par.getParameter< std::vector<double> >(region.second);
-  }
 }
 
 DynamicTruncation::~DynamicTruncation() {
@@ -141,6 +138,12 @@ void DynamicTruncation::setThr(const vector<int>& thr) {
     return;
   }
   throw cms::Exception("NotAvailable") << "WARNING: wrong size for the threshold vector!\nExpected size: 2\n   Found size: " << thr.size();
+}
+
+void DynamicTruncation::setThrsMap(const edm::ParameterSet& par) {
+  for (auto const& region : dyt_utils::etaRegionStr ){
+      parameters[region.first] = par.getParameter< std::vector<double> >(region.second);
+  }
 }
 /////////////////////////////////
 /////////////////////////////////

--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -474,38 +474,19 @@ void DynamicTruncation::getThresholdFromDB(double& thr, DetId const& id) {
 //===> correctThrByPtAndEta
 void DynamicTruncation::correctThrByPtAndEta(double& thr) {
 
-	//double p = p_reco;
-	//double   p08[2] = { -0.919853, 0.990742};
-	//double   p12[4] = { -0.897354, 0.987738};
-	//double   p20[3] = { -0.986855, 0.998516};
-	//double   p22[2] = { -0.940342, 0.992955};
-	//double   p24[2] = { -0.947633, 0.993762};
-	//double thr50[5] = { 1, 1, 4, 1, 1};
 
-  // auto parametricThreshold = [this](float thr50, float p0, float p1){
-  //   return thr50 * ( 1 + p0*p_reco + TMath::Power( this->p_reco, p1));
-  // };
 
-  // printf("parametricThreshold(1,-0.919853, 0.990742) = %f", parametricThreshold(1,-0.919853, 0.990742));
+    auto parametricThreshold = [this]{
+      double thr50 = this->parameters[this->region].at(0);
+      double p0    = this->parameters[this->region].at(1);
+      double p1    = this->parameters[this->region].at(2);
+      return thr50 * ( 1 + p0*p_reco + TMath::Power( this->p_reco, p1));
+    };
 
-	if( TMath::Abs(eta_reco) > 0 && TMath::Abs(eta_reco) <= 0.8 ){
-		thr = 24; //3000-> 26; //400-> 11; //1000-> 19; //2000-> 25;
-		//thr = thr50[0] * ( 1 + p08[0]*p + TMath::Power( p, p08[1]));
-	} else if( TMath::Abs(eta_reco) > 0.8 && TMath::Abs(eta_reco) <= 1.2 ){
-		thr = 38; //3000-> 29; //400-> 14; //1000-> 22; //2000-> 27;
-                //thr = thr50[1] * ( 1 + p12[0]*p + TMath::Power( p, p12[1]));
-        } else if( TMath::Abs(eta_reco) > 1.2 && TMath::Abs(eta_reco) <= 2.0 ){
-		thr = 19; //3000-> 20; //400-> 10; //1000-> 16; //2000-> 19;
-        	//thr = thr50[2] * ( 1 + p20[0]*p + TMath::Power( p, p20[1]));
-        } else if( TMath::Abs(eta_reco) > 2.0 && TMath::Abs(eta_reco) <= 2.2 ){
-		thr = 16; //3000-> 16; //400-> 8; //1000-> 13; //2000-> 15;
-        	//thr = thr50[3] * ( 1 + p22[0]*p + TMath::Power( p, p22[1]));
-        } else if( TMath::Abs(eta_reco) > 2.2 && TMath::Abs(eta_reco) <= 2.4 ){
-		thr = 14; //3000-> 12; //400-> 8; //1000-> 11; //2000-> 13;
-        	//thr = thr50[4] * ( 1 + p24[0]*p + TMath::Power( p, p24[1]));
-	}
-	//thr = 10;
-
+    // printf("thr before = %f \n", thr);
+    // printf("Muon with pt equal to = %f  --  eta = %f\n", p_reco, eta_reco );
+    // printf("parametricThreshold(1,%f, %f) = %f \n", this->parameters[this->region].at(0), this->parameters[this->region].at(1), parametricThreshold());
+    thr = parametricThreshold();
 }
 
 void DynamicTruncation::setEtaRegion(){
@@ -516,28 +497,6 @@ void DynamicTruncation::setEtaRegion(){
 	else if( TMath::Abs(eta_reco) > 2.0 && TMath::Abs(eta_reco) <= 2.2 ) region = dyt_utils::etaRegion::eta2p2;
 	else if( TMath::Abs(eta_reco) > 2.2 && TMath::Abs(eta_reco) <= 2.4 ) region = dyt_utils::etaRegion::eta2p4;
 
-}
-
-//===> correctThrByPtAndEta
-void DynamicTruncation::correctThrByPtAndEta() {
-
-	//double p = p_reco;
-	//double   p08[2] = { -0.919853, 0.990742};
-	//double   p12[4] = { -0.897354, 0.987738};
-	//double   p20[3] = { -0.986855, 0.998516};
-	//double   p22[2] = { -0.940342, 0.992955};
-	//double   p24[2] = { -0.947633, 0.993762};
-	//double thr50[5] = { 1, 1, 4, 1, 1};
-
-
-  auto parametricThreshold = [this](float thr50){
-    double p0 = this->parameters[this->region].at(0);
-    double p1 = this->parameters[this->region].at(1);
-    return thr50 * ( 1 + p0*p_reco + TMath::Power( this->p_reco, p1));
-  };
-
-  printf("Muon with pt equal to = %f  --  eta = %f\n", p_reco, eta_reco );
-  printf("parametricThreshold(1,%f, %f) = %f \n", this->parameters[this->region].at(0), this->parameters[this->region].at(1), parametricThreshold(1));
 }
 
 

--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -35,7 +35,7 @@ using namespace std;
 using namespace reco;
 
 namespace dyt_utils{
-  std::map<etaRegion, std::string> etaRegionStr { {etaRegion::eta0p8, "eta0p8"},
+  static const std::map<etaRegion, std::string> etaRegionStr { {etaRegion::eta0p8, "eta0p8"},
                                                   {etaRegion::eta1p2, "eta1p2"},
                                                   {etaRegion::eta2p0, "eta2p0"},
                                                   {etaRegion::eta2p2, "eta2p2"},

--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -494,11 +494,14 @@ void DynamicTruncation::correctThrByPAndEta(double& thr) {
 
 void DynamicTruncation::setEtaRegion(){
 
+  // Defaul value for muons with abs(eta) > 2.4
+  region = dyt_utils::etaRegion::eta2p4;
+
   if( TMath::Abs(eta_reco) > 0 && TMath::Abs(eta_reco) <= 0.8 ) region = dyt_utils::etaRegion::eta0p8;
-	else if( TMath::Abs(eta_reco) > 0.8 && TMath::Abs(eta_reco) <= 1.2 ) region = dyt_utils::etaRegion::eta1p2;
-	else if( TMath::Abs(eta_reco) > 1.2 && TMath::Abs(eta_reco) <= 2.0 ) region = dyt_utils::etaRegion::eta2p0;
-	else if( TMath::Abs(eta_reco) > 2.0 && TMath::Abs(eta_reco) <= 2.2 ) region = dyt_utils::etaRegion::eta2p2;
-	else if( TMath::Abs(eta_reco) > 2.2 && TMath::Abs(eta_reco) <= 2.4 ) region = dyt_utils::etaRegion::eta2p4;
+  else if( TMath::Abs(eta_reco) > 0.8 && TMath::Abs(eta_reco) <= 1.2 ) region = dyt_utils::etaRegion::eta1p2;
+  else if( TMath::Abs(eta_reco) > 1.2 && TMath::Abs(eta_reco) <= 2.0 ) region = dyt_utils::etaRegion::eta2p0;
+  else if( TMath::Abs(eta_reco) > 2.0 && TMath::Abs(eta_reco) <= 2.2 ) region = dyt_utils::etaRegion::eta2p2;
+  else if( TMath::Abs(eta_reco) > 2.2 && TMath::Abs(eta_reco) <= 2.4 ) region = dyt_utils::etaRegion::eta2p4;
 
 }
 

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -121,7 +121,7 @@ GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
   theDYTupdator  = par.existsAs<bool>("DYTupdator")?par.getParameter<bool>("DYTupdator"):false;
   theDYTuseAPE   = par.existsAs<bool>("DYTuseAPE")?par.getParameter<bool>("DYTuseAPE"):false;
   dytParThrsMode = par.existsAs<bool>("DYTuseThrsParametrization")?par.getParameter<bool>("DYTuseThrsParametrization"):false;
-  theDYTthrsParameters = par.getParameter< edm::ParameterSet >("DYTthrsParameters");
+  if (dytParThrsMode) theDYTthrsParameters = par.getParameter< edm::ParameterSet >("DYTthrsParameters");
   dytInfo        = new reco::DYTInfo();
 
   if (par.existsAs<double>("RescaleErrorFactor")) {
@@ -273,7 +273,7 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
       //
       // DYT 2.0
       //
-      DynamicTruncation dytRefit(*theEvent,*theService,theDYTthrsParameters);
+      DynamicTruncation dytRefit(*theEvent,*theService);
       dytRefit.setProd(all4DSegments, CSCSegments);
       dytRefit.setSelector(theDYTselector);
       dytRefit.setThr(theDYTthrs);
@@ -281,6 +281,7 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
       dytRefit.setUseAPE(theDYTuseAPE);
       if(dytParThrsMode) {
         dytRefit.setParThrsMode(dytParThrsMode);
+				dytRefit.setThrsMap(theDYTthrsParameters);
         dytRefit.setRecoP(globalTrack.p());
         dytRefit.setRecoEta(globalTrack.eta());
       }

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -121,8 +121,8 @@ GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
   theDYTselector = par.getParameter<int>("DYTselector");
   theDYTupdator  = par.getParameter<bool>("DYTupdator");
   theDYTuseAPE   = par.getParameter<bool>("DYTuseAPE");
-  dytParThrsMode = par.getParameter<bool>("DYTuseThrsParametrization");
-  if (dytParThrsMode) theDYTthrsParameters = par.getParameter< edm::ParameterSet >("DYTthrsParameters");
+  theDYTParThrsMode = par.getParameter<bool>("DYTuseThrsParametrization");
+  if (theDYTParThrsMode) theDYTthrsParameters = par.getParameter< edm::ParameterSet >("DYTthrsParameters");
   dytInfo        = new reco::DYTInfo();
 
   if (par.existsAs<double>("RescaleErrorFactor")) {
@@ -280,8 +280,8 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
       dytRefit.setThr(theDYTthrs);
       dytRefit.setUpdateState(theDYTupdator);
       dytRefit.setUseAPE(theDYTuseAPE);
-      if(dytParThrsMode) {
-        dytRefit.setParThrsMode(dytParThrsMode);
+      if(theDYTParThrsMode) {
+        dytRefit.setParThrsMode(theDYTParThrsMode);
         dytRefit.setThrsMap(theDYTthrsParameters);
         dytRefit.setRecoP(globalTrack.p());
         dytRefit.setRecoEta(globalTrack.eta());

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -118,10 +118,10 @@ GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
   theRPCInTheFit = par.getParameter<bool>("RefitRPCHits");
 
   theDYTthrs     = par.getParameter< std::vector<int> >("DYTthrs");
-  theDYTselector = par.existsAs<int>("DYTselector")?par.getParameter<int>("DYTselector"):1;
-  theDYTupdator  = par.existsAs<bool>("DYTupdator")?par.getParameter<bool>("DYTupdator"):false;
-  theDYTuseAPE   = par.existsAs<bool>("DYTuseAPE")?par.getParameter<bool>("DYTuseAPE"):false;
-  dytParThrsMode = par.existsAs<bool>("DYTuseThrsParametrization")?par.getParameter<bool>("DYTuseThrsParametrization"):false;
+  theDYTselector = par.getParameter<int>("DYTselector");
+  theDYTupdator  = par.getParameter<bool>("DYTupdator");
+  theDYTuseAPE   = par.getParameter<bool>("DYTuseAPE");
+  dytParThrsMode = par.getParameter<bool>("DYTuseThrsParametrization");
   if (dytParThrsMode) theDYTthrsParameters = par.getParameter< edm::ParameterSet >("DYTthrsParameters");
   dytInfo        = new reco::DYTInfo();
 

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -8,8 +8,9 @@
  *  Authors :
  *  P. Traczyk, SINS Warsaw
  *
- *  \modified by C. Calabria, INFN & Universita� Bari
+ *  \modified by C. Calabria, INFN & Universita Bari
  *  \modified by D. Nash, Northeastern University
+ *  \modified by C. Caputo, UCLouvain
  *
  **/
 
@@ -74,7 +75,7 @@ using namespace edm;
 
 GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
 				       const MuonServiceProxy* service,
-				       edm::ConsumesCollector& iC) :
+				       edm::ConsumesCollector& iC) : 
   theCosmicFlag(par.getParameter<bool>("PropDirForCosmics")),
   theDTRecHitLabel(par.getParameter<InputTag>("DTRecSegmentLabel")),
   theCSCRecHitLabel(par.getParameter<InputTag>("CSCRecSegmentLabel")),
@@ -96,15 +97,15 @@ GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
 
   if (refitDirectionName == "insideOut" ) theRefitDirection = insideOut;
   else if (refitDirectionName == "outsideIn" ) theRefitDirection = outsideIn;
-  else
-    throw cms::Exception("TrackTransformer constructor")
+  else 
+    throw cms::Exception("TrackTransformer constructor") 
       <<"Wrong refit direction chosen in TrackTransformer ParameterSet"
       << "\n"
       << "Possible choices are:"
       << "\n"
       << "RefitDirection = insideOut or RefitDirection = outsideIn";
 
-  theFitterName = par.getParameter<string>("Fitter");
+  theFitterName = par.getParameter<string>("Fitter");  
   thePropagatorName = par.getParameter<string>("Propagator");
 
   theSkipStation        = par.getParameter<int>("SkipStation");
@@ -134,7 +135,7 @@ GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
   theCacheId_TRH = 0;
   theDTRecHitToken=iC.consumes<DTRecHitCollection>(theDTRecHitLabel);
   theCSCRecHitToken=iC.consumes<CSCRecHit2DCollection>(theCSCRecHitLabel);
-  theGEMRecHitToken=iC.consumes<GEMRecHitCollection>(theGEMRecHitLabel);
+  theGEMRecHitToken=iC.consumes<GEMRecHitCollection>(theGEMRecHitLabel); 
   theME0RecHitToken=iC.consumes<ME0SegmentCollection>(theME0RecHitLabel);
   CSCSegmentsToken = iC.consumes<CSCSegmentCollection>(InputTag("cscSegments"));
   all4DSegmentsToken=iC.consumes<DTRecSegment4DCollection>(InputTag("dt4DSegments"));
@@ -157,8 +158,8 @@ void GlobalMuonRefitter::setEvent(const edm::Event& event) {
   theEvent = &event;
   event.getByToken(theDTRecHitToken, theDTRecHits);
   event.getByToken(theCSCRecHitToken, theCSCRecHits);
-  event.getByToken(theGEMRecHitToken, theGEMRecHits);
-  event.getByToken(theME0RecHitToken, theME0RecHits);
+  event.getByToken(theGEMRecHitToken, theGEMRecHits);   
+  event.getByToken(theME0RecHitToken, theME0RecHits);   
   event.getByToken(CSCSegmentsToken, CSCSegments);
   event.getByToken(all4DSegmentsToken, all4DSegments);
 }
@@ -204,7 +205,7 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
 	allRecHitsTemp.push_back((**hit).cloneForFit(*tkbuilder->geometry()->idToDet( (**hit).geographicalId() ) ) );
       else if ((*hit)->geographicalId().det() == DetId::Muon) {
 	if ((*hit)->geographicalId().subdetId() == 3 && !theRPCInTheFit) {
-	  LogTrace(theCategory) << "RPC Rec Hit discarged";
+	  LogTrace(theCategory) << "RPC Rec Hit discarged"; 
 	  continue;
 	}
 	allRecHitsTemp.push_back(theMuonRecHitBuilder->build(&**hit));
@@ -241,7 +242,7 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
   LogTrace(theCategory) << " Track momentum before refit: " << globalTrack.pt() << endl;
   LogTrace(theCategory) << " Hits size before : " << allRecHitsTemp.size() << endl;
 
-  allRecHits = getRidOfSelectStationHits(allRecHitsTemp, tTopo);
+  allRecHits = getRidOfSelectStationHits(allRecHitsTemp, tTopo);  
   //    printHits(allRecHits);
   LogTrace(theCategory) << " Hits size: " << allRecHits.size() << endl;
 
@@ -256,7 +257,7 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
       return vector<Trajectory>();
     }
 
-    LogTrace(theCategory) << " Initial trajectory state: "
+    LogTrace(theCategory) << " Initial trajectory state: " 
                           << globalTraj.front().lastMeasurement().updatedState().freeState()->parameters() << endl;
 
     if (theMuonHitsOption == 1 )
@@ -312,7 +313,7 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
 //
 //
 //
-void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
+void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon, 
 				       ConstRecHitContainer& all,
 				       map<DetId, int> &hitMap) const {
 
@@ -498,8 +499,8 @@ void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
 
   } // end of loop over muon rechits
 
-  for (map<DetId,int>::iterator imap=hitMap.begin(); imap!=hitMap.end(); imap++ )
-    LogTrace(theCategory) << " Station " << imap->first.rawId() << ": " << imap->second <<endl;
+  for (map<DetId,int>::iterator imap=hitMap.begin(); imap!=hitMap.end(); imap++ ) 
+    LogTrace(theCategory) << " Station " << imap->first.rawId() << ": " << imap->second <<endl; 
 
   LogTrace(theCategory) << "CheckMuonHits: "<<all.size();
 
@@ -516,7 +517,7 @@ void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
 //
 // Get the hits from the first muon station (containing hits)
 //
-void GlobalMuonRefitter::getFirstHits(const reco::Track& muon,
+void GlobalMuonRefitter::getFirstHits(const reco::Track& muon, 
 				       ConstRecHitContainer& all,
 				       ConstRecHitContainer& first) const {
 
@@ -551,7 +552,7 @@ void GlobalMuonRefitter::getFirstHits(const reco::Track& muon,
   }
 
   if (station_to_keep <= 0 || station_to_keep > 4 || stations.size() != all.size())
-    LogInfo(theCategory) << "failed to getFirstHits (all muon hits are outliers/bad ?)! station_to_keep = "
+    LogInfo(theCategory) << "failed to getFirstHits (all muon hits are outliers/bad ?)! station_to_keep = " 
 			    << station_to_keep << " stations.size " << stations.size() << " all.size " << all.size();
 
   for (unsigned i = 0; i < stations.size(); ++i)
@@ -562,17 +563,17 @@ void GlobalMuonRefitter::getFirstHits(const reco::Track& muon,
 
 
 //
-// select muon hits compatible with trajectory;
+// select muon hits compatible with trajectory; 
 // check hits in chambers with showers
 //
-GlobalMuonRefitter::ConstRecHitContainer
-GlobalMuonRefitter::selectMuonHits(const Trajectory& traj,
+GlobalMuonRefitter::ConstRecHitContainer 
+GlobalMuonRefitter::selectMuonHits(const Trajectory& traj, 
                                    const map<DetId, int> &hitMap) const {
 
   ConstRecHitContainer muonRecHits;
   const double globalChi2Cut = 200.0;
 
-  vector<TrajectoryMeasurement> muonMeasurements = traj.measurements();
+  vector<TrajectoryMeasurement> muonMeasurements = traj.measurements(); 
 
   // loop through all muon hits and skip hits with bad chi2 in chambers with high occupancy
   for (std::vector<TrajectoryMeasurement>::const_iterator im = muonMeasurements.begin(); im != muonMeasurements.end(); im++ ) {
@@ -627,19 +628,19 @@ GlobalMuonRefitter::selectMuonHits(const Trajectory& traj,
     } else
       continue;
 
-    double chi2ndf = (*im).estimate()/(*im).recHit()->dimension();
+    double chi2ndf = (*im).estimate()/(*im).recHit()->dimension();  
 
     bool keep = true;
     map<DetId,int>::const_iterator imap=hitMap.find(chamberId);
-    if ( imap!=hitMap.end() )
+    if ( imap!=hitMap.end() ) 
       if (imap->second>threshold) keep = false;
 
     if ( (keep || (chi2ndf<chi2Cut)) && (chi2ndf<globalChi2Cut) ) {
       muonRecHits.push_back((*im).recHit());
     } else {
       LogTrace(theCategory)
-	<< "Skip hit: " << id.rawId() << " chi2="
-	<< chi2ndf << " ( threshold: " << chi2Cut << ") Det: "
+	<< "Skip hit: " << id.rawId() << " chi2=" 
+	<< chi2ndf << " ( threshold: " << chi2Cut << ") Det: " 
 	<< imap->second << endl;
     }
   }
@@ -659,12 +660,12 @@ void GlobalMuonRefitter::printHits(const ConstRecHitContainer& hits) const {
   for (ConstRecHitContainer::const_iterator ir = hits.begin(); ir != hits.end(); ir++ ) {
     if ( !(*ir)->isValid() ) {
       LogTrace(theCategory) << "invalid RecHit";
-      continue;
+      continue; 
     }
 
     const GlobalPoint& pos = (*ir)->globalPosition();
 
-    LogTrace(theCategory)
+    LogTrace(theCategory) 
       << "r = " << sqrt(pos.x() * pos.x() + pos.y() * pos.y())
       << "  z = " << pos.z()
       << "  dimension = " << (*ir)->dimension()

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -8,7 +8,7 @@
  *  Authors :
  *  P. Traczyk, SINS Warsaw
  *
- *  \modified by C. Calabria, INFN & Universita  Bari
+ *  \modified by C. Calabria, INFN & Universitaï¿½ Bari
  *  \modified by D. Nash, Northeastern University
  *
  **/
@@ -74,7 +74,7 @@ using namespace edm;
 
 GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
 				       const MuonServiceProxy* service,
-				       edm::ConsumesCollector& iC) : 
+				       edm::ConsumesCollector& iC) :
   theCosmicFlag(par.getParameter<bool>("PropDirForCosmics")),
   theDTRecHitLabel(par.getParameter<InputTag>("DTRecSegmentLabel")),
   theCSCRecHitLabel(par.getParameter<InputTag>("CSCRecSegmentLabel")),
@@ -96,15 +96,15 @@ GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
 
   if (refitDirectionName == "insideOut" ) theRefitDirection = insideOut;
   else if (refitDirectionName == "outsideIn" ) theRefitDirection = outsideIn;
-  else 
-    throw cms::Exception("TrackTransformer constructor") 
+  else
+    throw cms::Exception("TrackTransformer constructor")
       <<"Wrong refit direction chosen in TrackTransformer ParameterSet"
       << "\n"
       << "Possible choices are:"
       << "\n"
       << "RefitDirection = insideOut or RefitDirection = outsideIn";
-  
-  theFitterName = par.getParameter<string>("Fitter");  
+
+  theFitterName = par.getParameter<string>("Fitter");
   thePropagatorName = par.getParameter<string>("Propagator");
 
   theSkipStation        = par.getParameter<int>("SkipStation");
@@ -121,6 +121,7 @@ GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
   theDYTupdator = par.existsAs<bool>("DYTupdator")?par.getParameter<bool>("DYTupdator"):false;
   theDYTuseAPE = par.existsAs<bool>("DYTuseAPE")?par.getParameter<bool>("DYTuseAPE"):false;
   dytInfo        = new reco::DYTInfo();
+	theDYTthrsParameters = par.getParameter< edm::ParameterSet >("DYTthrsParameters");
 
   if (par.existsAs<double>("RescaleErrorFactor")) {
     theRescaleErrorFactor = par.getParameter<double>("RescaleErrorFactor");
@@ -133,7 +134,7 @@ GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
   theDTRecHitToken=iC.consumes<DTRecHitCollection>(theDTRecHitLabel);
   theCSCRecHitToken=iC.consumes<CSCRecHit2DCollection>(theCSCRecHitLabel);
   theGEMRecHitToken=iC.consumes<GEMRecHitCollection>(theGEMRecHitLabel);
-  theME0RecHitToken=iC.consumes<ME0SegmentCollection>(theME0RecHitLabel); 
+  theME0RecHitToken=iC.consumes<ME0SegmentCollection>(theME0RecHitLabel);
   CSCSegmentsToken = iC.consumes<CSCSegmentCollection>(InputTag("cscSegments"));
   all4DSegmentsToken=iC.consumes<DTRecSegment4DCollection>(InputTag("dt4DSegments"));
 }
@@ -155,8 +156,8 @@ void GlobalMuonRefitter::setEvent(const edm::Event& event) {
   theEvent = &event;
   event.getByToken(theDTRecHitToken, theDTRecHits);
   event.getByToken(theCSCRecHitToken, theCSCRecHits);
-  event.getByToken(theGEMRecHitToken, theGEMRecHits);   
-  event.getByToken(theME0RecHitToken, theME0RecHits);   
+  event.getByToken(theGEMRecHitToken, theGEMRecHits);
+  event.getByToken(theME0RecHitToken, theME0RecHits);
   event.getByToken(CSCSegmentsToken, CSCSegments);
   event.getByToken(all4DSegmentsToken, all4DSegments);
 }
@@ -167,7 +168,7 @@ void GlobalMuonRefitter::setServices(const EventSetup& setup) {
   edm::ESHandle<TrajectoryFitter> aFitter;
   theService->eventSetup().get<TrajectoryFitter::Record>().get(theFitterName,aFitter);
   theFitter = aFitter->clone();
-  
+
 
   // Transient Rechit Builders
   unsigned long long newCacheId_TRH = setup.get<TransientRecHitRecord>().cacheIdentifier();
@@ -185,15 +186,15 @@ void GlobalMuonRefitter::setServices(const EventSetup& setup) {
 //
 // build a combined tracker-muon trajectory
 //
-vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack, 
+vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
 					     const int theMuonHitsOption,
 					     const TrackerTopology *tTopo) const {
   LogTrace(theCategory) << " *** GlobalMuonRefitter *** option " << theMuonHitsOption << endl;
-    
+
   ConstRecHitContainer allRecHitsTemp; // all muon rechits temp
 
   reco::TransientTrack track(globalTrack,&*(theService->magneticField()),theService->trackingGeometry());
-  
+
   auto tkbuilder = static_cast<TkTransientTrackingRecHitBuilder const *>(theTrackerRecHitBuilder.product());
 
   for (trackingRecHit_iterator hit = track.recHitsBegin(); hit != track.recHitsEnd(); ++hit)
@@ -202,12 +203,12 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
 	allRecHitsTemp.push_back((**hit).cloneForFit(*tkbuilder->geometry()->idToDet( (**hit).geographicalId() ) ) );
       else if ((*hit)->geographicalId().det() == DetId::Muon) {
 	if ((*hit)->geographicalId().subdetId() == 3 && !theRPCInTheFit) {
-	  LogTrace(theCategory) << "RPC Rec Hit discarged"; 
+	  LogTrace(theCategory) << "RPC Rec Hit discarged";
 	  continue;
 	}
 	allRecHitsTemp.push_back(theMuonRecHitBuilder->build(&**hit));
       }
-    }  
+    }
   vector<Trajectory> refitted = refit(globalTrack,track,allRecHitsTemp,theMuonHitsOption, tTopo);
   return refitted;
 }
@@ -239,7 +240,7 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
   LogTrace(theCategory) << " Track momentum before refit: " << globalTrack.pt() << endl;
   LogTrace(theCategory) << " Hits size before : " << allRecHitsTemp.size() << endl;
 
-  allRecHits = getRidOfSelectStationHits(allRecHitsTemp, tTopo);  
+  allRecHits = getRidOfSelectStationHits(allRecHitsTemp, tTopo);
   //    printHits(allRecHits);
   LogTrace(theCategory) << " Hits size: " << allRecHits.size() << endl;
 
@@ -254,32 +255,36 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
       return vector<Trajectory>();
     }
 
-    LogTrace(theCategory) << " Initial trajectory state: " 
+    LogTrace(theCategory) << " Initial trajectory state: "
                           << globalTraj.front().lastMeasurement().updatedState().freeState()->parameters() << endl;
-  
+
     if (theMuonHitsOption == 1 )
       outputTraj.push_back(globalTraj.front());
-    
+
     if (theMuonHitsOption == 3 ) {
       checkMuonHits(globalTrack, allRecHits, hitMap);
       selectedRecHits = selectMuonHits(globalTraj.front(),hitMap);
-      LogTrace(theCategory) << " Selected hits size: " << selectedRecHits.size() << endl;  
+      LogTrace(theCategory) << " Selected hits size: " << selectedRecHits.size() << endl;
       outputTraj = transform(globalTrack, track, selectedRecHits);
-    }     
+    }
 
     if (theMuonHitsOption == 4 ) {
       //
-      // DYT 2.0 
+      // DYT 2.0
       //
+			cout << " New DyT Version !!!!!!!! ----  " << endl;
       double momentum = globalTrack.p();
       double eta = globalTrack.eta();
-      DynamicTruncation dytRefit(*theEvent,*theService);
+      DynamicTruncation dytRefit(*theEvent,*theService,theDYTthrsParameters);
       dytRefit.setProd(all4DSegments, CSCSegments);
       dytRefit.setSelector(theDYTselector);
       dytRefit.setThr(theDYTthrs);
       dytRefit.setUpdateState(theDYTupdator);
       dytRefit.setUseAPE(theDYTuseAPE);
-      DYTRecHits = dytRefit.filter(globalTraj.front() ,momentum, eta);
+			dytRefit.setRecoP(momentum);
+			dytRefit.setRecoEta(eta);
+			dytRefit.correctThrByPtAndEta();
+      DYTRecHits = dytRefit.filter(globalTraj.front());
       dytInfo->CopyFrom(dytRefit.getDYTInfo());
       if ((DYTRecHits.size() > 1) && (DYTRecHits.front()->globalPosition().mag() > DYTRecHits.back()->globalPosition().mag()))
         stable_sort(DYTRecHits.begin(),DYTRecHits.end(),RecHitLessByDet(alongMomentum));
@@ -289,7 +294,7 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
   } else if (theMuonHitsOption == 2 )  {
       getFirstHits(globalTrack, allRecHits, fmsRecHits);
       outputTraj = transform(globalTrack, track, fmsRecHits);
-    } 
+    }
 
 
   if (!outputTraj.empty()) {
@@ -299,14 +304,14 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
     LogTrace(theCategory) << "No refitted Tracks... " << endl;
     return vector<Trajectory>();
   }
-  
+
 }
 
 
 //
 //
 //
-void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon, 
+void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
 				       ConstRecHitContainer& all,
 				       map<DetId, int> &hitMap) const {
 
@@ -316,12 +321,12 @@ void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
 
   // loop through all muon hits and calculate the maximum # of hits in each chamber
   for (ConstRecHitContainer::const_iterator imrh = all.begin(); imrh != all.end(); imrh++ ) {
-        
+
     if ( (*imrh != nullptr ) && !(*imrh)->isValid() ) continue;
-  
+
     int detRecHits = 0;
     MuonRecHitContainer dRecHits;
-      
+
     DetId id = (*imrh)->geographicalId();
     DetId chamberId;
 
@@ -331,7 +336,7 @@ void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
     if ( id.subdetId() == MuonSubdetId::DT ) {
       DTChamberId did(id.rawId());
       chamberId=did;
-      
+
       if ((*imrh)->dimension()>1) {
         std::vector <const TrackingRecHit*> hits2d = (*imrh)->recHits();
         for (std::vector <const TrackingRecHit*>::const_iterator hit2d = hits2d.begin(); hit2d!= hits2d.end(); hit2d++) {
@@ -344,7 +349,7 @@ void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
               DTRecHitCollection::range dRecHits = theDTRecHits->get(lid);
               int layerHits=0;
               for (DTRecHitCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++ ) {
-          	double rhitDistance = fabs(ir->localPosition().x()-(**hit1d).localPosition().x()); 
+          	double rhitDistance = fabs(ir->localPosition().x()-(**hit1d).localPosition().x());
         	if ( rhitDistance < coneSize ) layerHits++;
                 LogTrace(theCategory) << "       " << (ir)->localPosition() << "  " << (**hit1d).localPosition()
                      << " Distance: " << rhitDistance << " recHits: " << layerHits << "  SL: " << lid.superLayer() << endl;
@@ -363,10 +368,10 @@ void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
 	    }
 	  }
         }
-      
+
       } else {
         DTLayerId lid(id.rawId());
-    
+
         // Get the 1d DT RechHits from this layer
         DTRecHitCollection::range dRecHits = theDTRecHits->get(lid);
 
@@ -387,9 +392,9 @@ void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
         for (std::vector <const TrackingRecHit*>::const_iterator hit2d = hits2d.begin(); hit2d!= hits2d.end(); hit2d++) {
           DetId id1 = (*hit2d)->geographicalId();
           CSCDetId lid(id1.rawId());
-          
+
           // Get the CSC Rechits from this layer
-          CSCRecHit2DCollection::range dRecHits = theCSCRecHits->get(lid);      
+          CSCRecHit2DCollection::range dRecHits = theCSCRecHits->get(lid);
           int layerHits=0;
 
           for (CSCRecHit2DCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++ ) {
@@ -402,7 +407,7 @@ void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
         }
       } else {
         // Get the CSC Rechits from this layer
-        CSCRecHit2DCollection::range dRecHits = theCSCRecHits->get(did);      
+        CSCRecHit2DCollection::range dRecHits = theCSCRecHits->get(did);
 
         for (CSCRecHit2DCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++ ) {
   	  double rhitDistance = (ir->localPosition()-(**imrh).localPosition()).mag();
@@ -482,9 +487,9 @@ void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
     } //end of ME0 if
     else {
       if ( id.subdetId() != MuonSubdetId::RPC ) LogError(theCategory)<<" Wrong Hit Type ";
-      continue;      
+      continue;
     }
-      
+
     map<DetId,int>::iterator imap=hitMap.find(chamberId);
     if (imap!=hitMap.end()) {
       if (detRecHits>imap->second) imap->second=detRecHits;
@@ -492,8 +497,8 @@ void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
 
   } // end of loop over muon rechits
 
-  for (map<DetId,int>::iterator imap=hitMap.begin(); imap!=hitMap.end(); imap++ ) 
-    LogTrace(theCategory) << " Station " << imap->first.rawId() << ": " << imap->second <<endl; 
+  for (map<DetId,int>::iterator imap=hitMap.begin(); imap!=hitMap.end(); imap++ )
+    LogTrace(theCategory) << " Station " << imap->first.rawId() << ": " << imap->second <<endl;
 
   LogTrace(theCategory) << "CheckMuonHits: "<<all.size();
 
@@ -510,7 +515,7 @@ void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
 //
 // Get the hits from the first muon station (containing hits)
 //
-void GlobalMuonRefitter::getFirstHits(const reco::Track& muon, 
+void GlobalMuonRefitter::getFirstHits(const reco::Track& muon,
 				       ConstRecHitContainer& all,
 				       ConstRecHitContainer& first) const {
 
@@ -520,7 +525,7 @@ void GlobalMuonRefitter::getFirstHits(const reco::Track& muon,
   int station_to_keep = 999;
   vector<int> stations;
   for (ConstRecHitContainer::const_iterator ihit = all.begin(); ihit != all.end(); ++ihit) {
-  
+
     int station = 0;
     bool use_it = true;
     DetId id = (*ihit)->geographicalId();
@@ -545,7 +550,7 @@ void GlobalMuonRefitter::getFirstHits(const reco::Track& muon,
   }
 
   if (station_to_keep <= 0 || station_to_keep > 4 || stations.size() != all.size())
-    LogInfo(theCategory) << "failed to getFirstHits (all muon hits are outliers/bad ?)! station_to_keep = " 
+    LogInfo(theCategory) << "failed to getFirstHits (all muon hits are outliers/bad ?)! station_to_keep = "
 			    << station_to_keep << " stations.size " << stations.size() << " all.size " << all.size();
 
   for (unsigned i = 0; i < stations.size(); ++i)
@@ -556,19 +561,19 @@ void GlobalMuonRefitter::getFirstHits(const reco::Track& muon,
 
 
 //
-// select muon hits compatible with trajectory; 
+// select muon hits compatible with trajectory;
 // check hits in chambers with showers
 //
-GlobalMuonRefitter::ConstRecHitContainer 
-GlobalMuonRefitter::selectMuonHits(const Trajectory& traj, 
+GlobalMuonRefitter::ConstRecHitContainer
+GlobalMuonRefitter::selectMuonHits(const Trajectory& traj,
                                    const map<DetId, int> &hitMap) const {
 
   ConstRecHitContainer muonRecHits;
   const double globalChi2Cut = 200.0;
 
-  vector<TrajectoryMeasurement> muonMeasurements = traj.measurements(); 
+  vector<TrajectoryMeasurement> muonMeasurements = traj.measurements();
 
-  // loop through all muon hits and skip hits with bad chi2 in chambers with high occupancy      
+  // loop through all muon hits and skip hits with bad chi2 in chambers with high occupancy
   for (std::vector<TrajectoryMeasurement>::const_iterator im = muonMeasurements.begin(); im != muonMeasurements.end(); im++ ) {
 
     if ( !(*im).recHit()->isValid() ) continue;
@@ -576,7 +581,7 @@ GlobalMuonRefitter::selectMuonHits(const Trajectory& traj,
       //      if ( ( chi2ndf < globalChi2Cut ) )
       muonRecHits.push_back((*im).recHit());
       continue;
-    }  
+    }
     const MuonTransientTrackingRecHit* immrh = dynamic_cast<const MuonTransientTrackingRecHit*>((*im).recHit().get());
 
     DetId id = immrh->geographicalId();
@@ -621,23 +626,23 @@ GlobalMuonRefitter::selectMuonHits(const Trajectory& traj,
     } else
       continue;
 
-    double chi2ndf = (*im).estimate()/(*im).recHit()->dimension();  
+    double chi2ndf = (*im).estimate()/(*im).recHit()->dimension();
 
     bool keep = true;
     map<DetId,int>::const_iterator imap=hitMap.find(chamberId);
-    if ( imap!=hitMap.end() ) 
+    if ( imap!=hitMap.end() )
       if (imap->second>threshold) keep = false;
-    
+
     if ( (keep || (chi2ndf<chi2Cut)) && (chi2ndf<globalChi2Cut) ) {
       muonRecHits.push_back((*im).recHit());
     } else {
       LogTrace(theCategory)
-	<< "Skip hit: " << id.rawId() << " chi2=" 
-	<< chi2ndf << " ( threshold: " << chi2Cut << ") Det: " 
+	<< "Skip hit: " << id.rawId() << " chi2="
+	<< chi2ndf << " ( threshold: " << chi2Cut << ") Det: "
 	<< imap->second << endl;
     }
   }
-  
+
   // check order of rechits
   reverse(muonRecHits.begin(),muonRecHits.end());
   return muonRecHits;
@@ -653,12 +658,12 @@ void GlobalMuonRefitter::printHits(const ConstRecHitContainer& hits) const {
   for (ConstRecHitContainer::const_iterator ir = hits.begin(); ir != hits.end(); ir++ ) {
     if ( !(*ir)->isValid() ) {
       LogTrace(theCategory) << "invalid RecHit";
-      continue; 
+      continue;
     }
-    
+
     const GlobalPoint& pos = (*ir)->globalPosition();
-    
-    LogTrace(theCategory) 
+
+    LogTrace(theCategory)
       << "r = " << sqrt(pos.x() * pos.x() + pos.y() * pos.y())
       << "  z = " << pos.z()
       << "  dimension = " << (*ir)->dimension()
@@ -704,7 +709,7 @@ GlobalMuonRefitter::checkRecHitsOrdering(const TransientTrackingRecHit::ConstRec
 vector<Trajectory> GlobalMuonRefitter::transform(const reco::Track& newTrack,
 						 const reco::TransientTrack track,
 						 const TransientTrackingRecHit::ConstRecHitContainer& urecHitsForReFit) const {
-  
+
   TransientTrackingRecHit::ConstRecHitContainer recHitsForReFit = urecHitsForReFit;
   LogTrace(theCategory) << "GlobalMuonRefitter::transform: " << recHitsForReFit.size() << " hits:";
   printHits(recHitsForReFit);
@@ -745,7 +750,7 @@ vector<Trajectory> GlobalMuonRefitter::transform(const reco::Track& newTrack,
     firstTSOS = track.outermostMeasurementState();
     lastTSOS  = track.innermostMeasurementState();
     inner_is_first = false;
-  } 
+  }
 
   LogTrace(theCategory) << "firstTSOS: inner_is_first? " << inner_is_first
 			<< " globalPosition is " << firstTSOS.globalPosition()
@@ -784,7 +789,7 @@ vector<Trajectory> GlobalMuonRefitter::transform(const reco::Track& newTrack,
       if ((*it)->globalPosition().y() > 0) ++y_count;
       else --y_count;
     }
-    
+
     PropagationDirection propDir_ycount = alongMomentum;
     if (y_count > 0) {
       if      (theRefitDirection == insideOut) propDir_ycount = oppositeToMomentum;
@@ -794,12 +799,12 @@ vector<Trajectory> GlobalMuonRefitter::transform(const reco::Track& newTrack,
       if      (theRefitDirection == insideOut) propDir_ycount = alongMomentum;
       else if (theRefitDirection == outsideIn) propDir_ycount = oppositeToMomentum;
     }
-    
+
     LogTrace(theCategory) << "y_count = " << y_count
 			  << "; based on geometrically-outermost TSOS, propDir is " << propDir << ": "
 			  << (propDir == propDir_ycount ? "agrees" : "disagrees")
 			  << " with ycount determination";
-    
+
     if (propDir_first != propDir_last) {
       LogTrace(theCategory) << "since first/last disagreed, using y_count propDir";
       propDir = propDir_ycount;
@@ -819,25 +824,25 @@ vector<Trajectory> GlobalMuonRefitter::transform(const reco::Track& newTrack,
     }
   }
 
-/*  
+/*
   cout << " GlobalMuonRefitter : theFitter " << propDir << endl;
-  cout << "                      First TSOS: " 
+  cout << "                      First TSOS: "
        << firstTSOS.globalPosition() << "  p="
        << firstTSOS.globalMomentum() << " = "
        << firstTSOS.globalMomentum().mag() << endl;
-       
+
   cout << "                      Starting seed: "
        << " nHits= " << seed.nHits()
        << " tsos: "
        << seed.startingState().parameters().position() << "  p="
        << seed.startingState().parameters().momentum() << endl;
-       
+
   cout << "                      RecHits: "
        << recHitsForReFit.size() << endl;
 */
-       
+
   vector<Trajectory> trajectories = theFitter->fit(seed,recHitsForReFit,firstTSOS);
-  
+
   if(trajectories.empty()){
     LogDebug(theCategory) << "No Track refitted!" << endl;
     return vector<Trajectory>();
@@ -868,28 +873,28 @@ GlobalMuonRefitter::ConstRecHitContainer GlobalMuonRefitter::getRidOfSelectStati
 	//                              continue;  //caveat that just removes the whole system from refitting
 
 	if (theTrackerSkipSystem == PXB) {
-	  
+
 	  layer = tTopo->pxbLayer(id);
 	}
 	if (theTrackerSkipSystem == TIB) {
-	  
+
 	  layer = tTopo->tibLayer(id);
 	}
 
 	if (theTrackerSkipSystem == TOB) {
-	  
+
 	  layer = tTopo->tobLayer(id);
 	}
 	if (theTrackerSkipSystem == PXF) {
-	  
+
 	  disk = tTopo->pxfDisk(id);
 	}
 	if (theTrackerSkipSystem == TID) {
-	  
+
 	  wheel = tTopo->tidWheel(id);
 	}
 	if (theTrackerSkipSystem == TEC) {
-	  
+
 	  wheel = tTopo->tecWheel(id);
 	}
 	if (theTrackerSkipSection >= 0 && layer == theTrackerSkipSection) continue;
@@ -924,4 +929,3 @@ GlobalMuonRefitter::ConstRecHitContainer GlobalMuonRefitter::getRidOfSelectStati
   }
   return results;
 }
-

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -282,7 +282,7 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
       dytRefit.setUseAPE(theDYTuseAPE);
       if(dytParThrsMode) {
         dytRefit.setParThrsMode(dytParThrsMode);
-				dytRefit.setThrsMap(theDYTthrsParameters);
+        dytRefit.setThrsMap(theDYTthrsParameters);
         dytRefit.setRecoP(globalTrack.p());
         dytRefit.setRecoEta(globalTrack.eta());
       }
@@ -826,22 +826,21 @@ vector<Trajectory> GlobalMuonRefitter::transform(const reco::Track& newTrack,
     }
   }
 
-/*
-  cout << " GlobalMuonRefitter : theFitter " << propDir << endl;
-  cout << "                      First TSOS: "
+
+  LogDebug(theCategory) << " GlobalMuonRefitter : theFitter " << propDir << endl;
+  LogDebug(theCategory) << "                      First TSOS: "
        << firstTSOS.globalPosition() << "  p="
        << firstTSOS.globalMomentum() << " = "
        << firstTSOS.globalMomentum().mag() << endl;
 
-  cout << "                      Starting seed: "
+  LogDebug(theCategory) << "                      Starting seed: "
        << " nHits= " << seed.nHits()
        << " tsos: "
        << seed.startingState().parameters().position() << "  p="
        << seed.startingState().parameters().momentum() << endl;
 
-  cout << "                      RecHits: "
+  LogDebug(theCategory) << "                      RecHits: "
        << recHitsForReFit.size() << endl;
-*/
 
   vector<Trajectory> trajectories = theFitter->fit(seed,recHitsForReFit,firstTSOS);
 

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -271,13 +271,15 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
       //
       // DYT 2.0 
       //
+      double momentum = globalTrack.p();
+      double eta = globalTrack.eta();
       DynamicTruncation dytRefit(*theEvent,*theService);
       dytRefit.setProd(all4DSegments, CSCSegments);
       dytRefit.setSelector(theDYTselector);
       dytRefit.setThr(theDYTthrs);
       dytRefit.setUpdateState(theDYTupdator);
       dytRefit.setUseAPE(theDYTuseAPE);
-      DYTRecHits = dytRefit.filter(globalTraj.front());
+      DYTRecHits = dytRefit.filter(globalTraj.front() ,momentum, eta);
       dytInfo->CopyFrom(dytRefit.getDYTInfo());
       if ((DYTRecHits.size() > 1) && (DYTRecHits.front()->globalPosition().mag() > DYTRecHits.back()->globalPosition().mag()))
         stable_sort(DYTRecHits.begin(),DYTRecHits.end(),RecHitLessByDet(alongMomentum));

--- a/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
@@ -217,6 +217,19 @@ void L3MuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
         30,
         15,
       });
+      psd1.add<int>("DYTselector",1);
+      psd1.add<bool>("DYTupdator", false);
+      psd1.add<bool>("DYTuseAPE", false );
+      psd1.add<bool>("DYTuseThrsParametrization", false);
+      {
+        edm::ParameterSetDescription psd2;
+        psd2.add<std::vector<double>>("eta0p8", {1,-0.919853, 0.990742});
+        psd2.add<std::vector<double>>("eta1p2", {1,-0.897354, 0.987738});
+        psd2.add<std::vector<double>>("eta2p0", {1,-0.986855, 0.998516});
+        psd2.add<std::vector<double>>("eta2p2", {1,-0.940342, 0.992955});
+        psd2.add<std::vector<double>>("eta2p4", {1,-0.947633, 0.993762});
+        psd1.add<edm::ParameterSetDescription>("DYTthrsParameters", psd2);
+      }
       psd1.add<double>("Chi2CutCSC", 150.0);
       psd1.add<double>("Chi2CutDT", 10.0);
       psd1.add<double>("Chi2CutGEM", 1.0);


### PR DESCRIPTION
#### PR description:
This PR introduces a new threshold parameterization for the DyT algorithm. 
Muon POG presentation [here](https://indico.cern.ch/event/797254/contributions/3323400/attachments/1797744/2931260/19_01_25_DYT.pdf).

modified:   RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
modified:   RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
- new namespace 'dyt_utils' that contains EtaRegion enum
- p_reco and eta_reco private variables
- function to obtain the EtaRegion
- lambda expr for threshold analytic parameterization

modified:   RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
modified:   RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
- add bool for selecting dyt version to use
- add PSet for threshold functions parameters

modified:   RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
- add few lines in dyt block

The bool for selecting the new DyT is set on `False`

#### PR validation:
Validation performed using 
```
runTheMatrix.py --nThreads=4 -l 10809.0
```
with output:
```
10809.0_SingleMuPt1000+SingleMuPt1000_pythia8_2018_GenSimFull+DigiFull_2018+RecoFull_2018+HARVESTFull_2018+ALCAFull_2018+NanoFull_2018 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED Step5-PASSED  - time date Mon Apr  1 17:41:48 2019-date Mon Apr  1 17:17:32 2019; exit: 0 0 0 0 0 0
1 1 1 1 1 1 tests passed, 0 0 0 0 0 0 failed
```
