### PR TITLE
MTD Geometry: avoid dependence on namespace in volume name string 

### DIFF
--- a/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
@@ -47,7 +47,7 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   int nSide(7);
   const std::string& sideName ( baseNumber.getLevelName( nSide ) ) ;
   // Side choice: from scenario D41 is given by level 8 (HGCal v10)
-  if ( sideName == "caloBase:CALOECTSFront" ) { nSide = 8 ;}  
+  if ( sideName.find("CALOECTSFront") != std::string::npos ) { nSide = 8 ;}
   const uint32_t sideCopy ( baseNumber.getCopyNumber( nSide ) ) ;
   const uint32_t zside ( sideCopy == 1 ? 1 : 0 ) ;
 


### PR DESCRIPTION
#### PR description:

Follow-up of #26307 : the DetId for ETL negative size is correctly reconstructed in the geometry test, but within Geant4 the namespace of the volume is not present in the string list used to build the basename. This is now fixed. 

#### PR validation:

The residual issue was detected with the MTD validation package under preparation (PR to arrive independently). Enabling detailed verbosity within step1 of test workflows shows now that ETDetIds are correctly generated:

```
%MSG-d TimingSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3 TimingSD.cc:139
TimingSD:
 Global entry point: (-742.526,-533.83,-3031)
 Global exit  point: (-742.603,-533.88,-3031.3)
 Global step length: 0.313607
 Local  entry point: (20.7802,17.6108,0.15)
 Local  exit  point: (20.7776,17.5195,-0.15)
 Local  step length: 0.313607
%MSG
%MSG-i MtdSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
MtdSD::getBaseNumber(): Adding level 0: EModule8Disc1Timingactive[1]
%MSG
%MSG-i MtdSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
MtdSD::getBaseNumber(): Adding level 1: EModule8Disc1Timingwafer[1]
%MSG
%MSG-i MtdSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
MtdSD::getBaseNumber(): Adding level 2: EModule8Disc1[124]
%MSG
%MSG-i MtdSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
MtdSD::getBaseNumber(): Adding level 3: Ring8Disc1[1]
%MSG
%MSG-i MtdSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
MtdSD::getBaseNumber(): Adding level 4: Disc1[1]
%MSG
%MSG-i MtdSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
MtdSD::getBaseNumber(): Adding level 5: EndcapTimingLayer[1]
%MSG
%MSG-i MtdSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
MtdSD::getBaseNumber(): Adding level 6: CALOECFront[1]
%MSG
%MSG-i MtdSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
MtdSD::getBaseNumber(): Adding level 7: CALOECTSFront[1]
%MSG
%MSG-i MtdSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
MtdSD::getBaseNumber(): Adding level 8: CALOEC[2]
%MSG
%MSG-i MtdSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
MtdSD::getBaseNumber(): Adding level 9: CALO[1]
%MSG
%MSG-i MtdSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
MtdSD::getBaseNumber(): Adding level 10: CMSE[1]
%MSG
%MSG-i MtdSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
MtdSD::getBaseNumber(): Adding level 11: DDDWorld[0]
%MSG
%MSG-i MTDGeom:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
ETLNumberingScheme geometry levels = 12
%MSG
%MSG-i MTDGeom:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
EModule8Disc1Timingactive, EModule8Disc1Timingwafer, EModule8Disc1, Ring8Disc1, Disc1, EndcapTimingLayer, CALOECFront, CALOECTSFront, CALOEC, CALO, CMSE, DDDWorld
%MSG
%MSG-i MTDGeom:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
ETL Numbering scheme:  ring = 8 zside = 0 module = 124 modtyp = 0 Raw Id = 1661484544[MTDDetId::print]  0110 0011 0000 1000 0011 1110 0000 0000
 rawId       : 0x63083e00
 bits[0:24]  : 01083e00
 Detector        : 6
 SubDetector     : 1
 MTD subdetector : 2
 ETL 
 Side        : 0
 Ring        : 8
 Module      : 124
 Module type : 0

%MSG
TimingSD CreateNewHit for FastTimerHitsEndcap PV EModule8Disc1Timingactive PVid = 1 Unit 1661484544
 primary 1 Tof(ns)= 10.2171 time slice 1021 E(GeV)= 34070.9 trackID 1 mu+ parentID 0
 is primary particle
updateHit: FastTimerHitsEndcap add eloss(GeV) 8.66007e-05CurrentHit=0x7f7433b36140, PostStepPoint= (-742.603,-533.88,-3031.3)
%MSG-d TimingSim:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3 TimingSD.cc:139
TimingSD:
 Global entry point: (-743.986,-534.771,-3036.7)
 Global exit  point: (-744.063,-534.82,-3037)
 Global step length: 0.313626
 Local  entry point: (21.5955,15.8952,-0.15)
 Local  exit  point: (21.6023,15.804,0.15)
 Local  step length: 0.313626
%MSG
%MSG-i MTDGeom:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
ETLNumberingScheme geometry levels = 12
%MSG
%MSG-i MTDGeom:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
EModule8Disc1Timingactive, EModule8Disc1Timingwafer, EModule8Disc1, Ring8Disc1, Disc1, EndcapTimingLayer, CALOECFront, CALOECTSFront, CALOEC, CALO, CMSE, DDDWorld
%MSG
%MSG-i MTDGeom:  OscarMTProducer:g4SimHits 03-Apr-2019 16:51:49 CEST  Run: 1 Event: 3
ETL Numbering scheme:  ring = 8 zside = 0 module = 123 modtyp = 0 Raw Id = 1661484416[MTDDetId::print]  0110 0011 0000 1000 0011 1101 1000 0000
 rawId       : 0x63083d80
 bits[0:24]  : 01083d80
 Detector        : 6
 SubDetector     : 1
 MTD subdetector : 2
 ETL 
 Side        : 0
 Ring        : 8
 Module      : 123
 Module type : 0

%MSG
TimingSD CreateNewHit for FastTimerHitsEndcap PV EModule8Disc1Timingactive PVid = 1 Unit 1661484416
 primary 1 Tof(ns)= 10.237 time slice 1023 E(GeV)= 34069.1 trackID 1 mu+ parentID 0
 is primary particle
```

SimHits are now visible in the test https://github.com/casarsa/cmssw/blob/mc-valMTD-devel-new/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc as can be seen by the produced plots:

[SimHitNeg.pdf](https://github.com/cms-sw/cmssw/files/3039609/SimHitNeg.pdf)
[SimHitPos.pdf](https://github.com/cms-sw/cmssw/files/3039610/SimHitPos.pdf)
