### PR TITLE
Phase2-hgx191 Fix the scintillator cell size for V10

### DIFF
--- a/Geometry/HGCalCommonData/data/hgcalCons/v10/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/hgcalCons/v10/hgcalCons.xml
@@ -129,7 +129,7 @@
     <Parameter name="DetectorType"        value="3"/>
     <Parameter name="WaferThickness"      value="[hgcal:ScintillatorThickness]"/>
     <Parameter name="MinimumTileSize"     value="[MinimumTileSize]"/>
-    <Parameter name="NPhiBinBH"           value="360"/>
+    <Parameter name="NPhiBinBH"           value="288"/>
     <Parameter name="NPhiBinBH"           value="288"/>
     <Parameter name="LayerFrontBH"        value="[hgcal:FirstMixedLayer]"/>
     <Parameter name="LayerFrontBH"        value="([hgcal:FirstMixedLayer]+4)"/>


### PR DESCRIPTION
#### PR description:

Scintillators in the fine and thick absorber regions having same tile size

#### PR validation:

Works with workflow 29034.0

#### if this PR is a backport please specify the original PR:

To be included before the next pre-release