### PR TITLE
MTD validation package

### DIFF
--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -11,10 +11,11 @@ autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLite
                    'standardValidation' : ['prevalidation','validation','validationHarvesting'],
                    'standardValidationNoHLT' : ['prevalidationNoHLT','validationNoHLT','validationHarvestingNoHLT'],
                    'HGCalValidation' : ['', 'globalValidationHGCal', 'hgcalValidatorPostProcessor'],
+                   'MTDValidation' : ['', 'globalValidationMTD', ''],
                    'OuterTrackerValidation' : ['', 'globalValidationOuterTracker', 'postValidationOuterTracker'],
                  }
 
-_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation','bTagOnlyValidation','hcalOnlyValidation', 'HGCalValidation', 'OuterTrackerValidation']
+_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation','bTagOnlyValidation','hcalOnlyValidation', 'HGCalValidation', 'MTDValidation', 'OuterTrackerValidation']
 autoValidation['phase2Validation'] = ['','','']
 for i in range(0,3):
     autoValidation['phase2Validation'][i] = '+'.join([_f for _f in [autoValidation[m][i] for m in _phase2_allowed] if _f])

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -161,7 +161,7 @@ globalValidationHCAL = cms.Sequence(
 
 globalValidationHGCal = cms.Sequence(hgcalValidation)
 
-globalValidationMTD = cms.Sequence(mtdSimValid+mtdDigiValid+mtdRecoValid)
+globalValidationMTD = cms.Sequence()
 
 globalValidationOuterTracker = cms.Sequence(OuterTrackerSourceV)
 
@@ -200,3 +200,6 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( globalValidation, _phase2_globalValidation )
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toReplaceWith(globalValidation, globalValidation.copyAndExclude([pfTauRunDQMValidation]))
+from Configuration.Eras.Modifier_phase2_timing_layer_bar_cff import phase2_timing_layer_bar
+from Configuration.Eras.Modifier_phase2_timing_layer_tile_cff import phase2_timing_layer_tile
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toReplaceWith(globalValidationMTD, cms.Sequence(mtdSimValid+mtdDigiValid+mtdRecoValid))

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -41,6 +41,7 @@ from Validation.SiPixelPhase1ConfigV.SiPixelPhase1OfflineDQM_sourceV_cff import 
 from DQMOffline.RecoB.dqmAnalyzer_cff import *
 from Validation.RecoB.BDHadronTrackValidation_cff import *
 from Validation.Configuration.hgcalSimValid_cff import *
+from Validation.Configuration.mtdSimValid_cff import *
 from Validation.SiOuterTrackerV.OuterTrackerSourceConfigV_cff import *
 
 
@@ -159,6 +160,8 @@ globalValidationHCAL = cms.Sequence(
 )
 
 globalValidationHGCal = cms.Sequence(hgcalValidation)
+
+globalValidationMTD = cms.Sequence(mtdSimValid+mtdDigiValid+mtdRecoValid)
 
 globalValidationOuterTracker = cms.Sequence(OuterTrackerSourceV)
 

--- a/Validation/Configuration/python/mtdSimValid_cff.py
+++ b/Validation/Configuration/python/mtdSimValid_cff.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+# MTD validation sequences
+from Validation.MtdValidation.btlSimHits_cfi import btlSimHits 
+from Validation.MtdValidation.btlDigiHits_cfi import btlDigiHits 
+from Validation.MtdValidation.btlRecHits_cfi import btlRecHits 
+from Validation.MtdValidation.etlSimHits_cfi import etlSimHits
+from Validation.MtdValidation.etlDigiHits_cfi import etlDigiHits
+from Validation.MtdValidation.etlRecHits_cfi import etlRecHits
+
+mtdSimValid  = cms.Sequence(btlSimHits  + etlSimHits )
+mtdDigiValid = cms.Sequence(btlDigiHits + etlDigiHits)
+mtdRecoValid = cms.Sequence(btlRecHits  + etlRecHits )

--- a/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
@@ -243,9 +243,9 @@ void BtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitTvsEta_[1] = ibook.bookProfile(
       "BtlHitTvsEtaR", "BTL DIGI ToA vs #eta (R);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, -1.55, 1.55, 0., 1024.);
   meHitTvsZ_[0] = ibook.bookProfile(
-      "BtlHitTvsZL", "BTL SIM ToA vs Z (L);Z_{DIGI} [cm];ToA_{DIGI} [TDC counts]", 50, -260., 260., 0., 1024.);
+      "BtlHitTvsZL", "BTL DIGI ToA vs Z (L);Z_{DIGI} [cm];ToA_{DIGI} [TDC counts]", 50, -260., 260., 0., 1024.);
   meHitTvsZ_[1] = ibook.bookProfile(
-      "BtlHitTvsZR", "BTL SIM ToA vs Z (R);Z_{DIGI} [cm];ToA_{DIGI} [TDC counts]", 50, -260., 260., 0., 1024.);
+      "BtlHitTvsZR", "BTL DIGI ToA vs Z (R);Z_{DIGI} [cm];ToA_{DIGI} [TDC counts]", 50, -260., 260., 0., 1024.);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
@@ -33,20 +33,15 @@
 #include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
 #include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
 
-
 class BtlDigiHitsValidation : public DQMEDAnalyzer {
-
 public:
   explicit BtlDigiHitsValidation(const edm::ParameterSet&);
   ~BtlDigiHitsValidation() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-
 private:
-  void bookHistograms(DQMStore::IBooker &,
-		      edm::Run const&,
-		      edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
@@ -78,25 +73,18 @@ private:
   MonitorElement* meHitTvsPhi_[2];
   MonitorElement* meHitTvsEta_[2];
   MonitorElement* meHitTvsZ_[2];
-
 };
 
-
 // ------------ constructor and destructor --------------
-BtlDigiHitsValidation::BtlDigiHitsValidation(const edm::ParameterSet& iConfig):
-  folder_(iConfig.getParameter<std::string>("folder")) {
-
+BtlDigiHitsValidation::BtlDigiHitsValidation(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")) {
   btlDigiHitsToken_ = consumes<BTLDigiCollection>(iConfig.getParameter<edm::InputTag>("inputTag"));
-
 }
 
-BtlDigiHitsValidation::~BtlDigiHitsValidation() {
-}
-
+BtlDigiHitsValidation::~BtlDigiHitsValidation() {}
 
 // ------------ method called for each event  ------------
 void BtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   using namespace edm;
 
   edm::ESHandle<MTDGeometry> geometryHandle;
@@ -111,38 +99,36 @@ void BtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 
   // --- Loop over the BLT DIGI hits
 
-  unsigned int n_digi_btl[2] = {0,0};
+  unsigned int n_digi_btl[2] = {0, 0};
 
-  for (const auto& dataFrame: *btlDigiHitsHandle) {
-
+  for (const auto& dataFrame : *btlDigiHitsHandle) {
     BTLDetId detId = dataFrame.id();
-    DetId geoId = detId.geographicalId( static_cast<BTLDetId::CrysLayout>(topology->getMTDTopologyMode()) );
+    DetId geoId = detId.geographicalId(static_cast<BTLDetId::CrysLayout>(topology->getMTDTopologyMode()));
     const MTDGeomDet* thedet = geom->idToDet(geoId);
-    if( thedet == nullptr )
-      throw cms::Exception("BtlDigiHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
-						    << " (" << detId.rawId()<< ") is invalid!" << std::dec
-						    << std::endl;
+    if (thedet == nullptr)
+      throw cms::Exception("BtlDigiHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
+                                                    << detId.rawId() << ") is invalid!" << std::dec << std::endl;
     const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
     const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
-    Local3DPoint local_point(0.,0.,0.);
-    local_point = topo.pixelToModuleLocalPoint(local_point,detId.row(topo.nrows()),detId.column(topo.nrows()));
+    Local3DPoint local_point(0., 0., 0.);
+    local_point = topo.pixelToModuleLocalPoint(local_point, detId.row(topo.nrows()), detId.column(topo.nrows()));
     const auto& global_point = thedet->toGlobal(local_point);
 
     const auto& sample_L = dataFrame.sample(0);
     const auto& sample_R = dataFrame.sample(1);
 
     uint32_t adc[2] = {sample_L.data(), sample_R.data()};
-    uint32_t tdc[2] = {sample_L.toa(),  sample_R.toa() };
+    uint32_t tdc[2] = {sample_L.toa(), sample_R.toa()};
 
-    for (int iside=0; iside<2; ++iside) {
-    
-      if ( adc[iside] == 0 ) continue;
+    for (int iside = 0; iside < 2; ++iside) {
+      if (adc[iside] == 0)
+        continue;
 
-      meHitCharge_[iside]->Fill(adc[iside]); 
+      meHitCharge_[iside]->Fill(adc[iside]);
       meHitTime_[iside]->Fill(tdc[iside]);
 
-      meOccupancy_[iside]->Fill(global_point.z(),global_point.phi());
+      meOccupancy_[iside]->Fill(global_point.z(), global_point.phi());
 
       meHitX_[iside]->Fill(global_point.x());
       meHitY_[iside]->Fill(global_point.y());
@@ -150,106 +136,126 @@ void BtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
       meHitPhi_[iside]->Fill(global_point.phi());
       meHitEta_[iside]->Fill(global_point.eta());
 
-      meHitTvsQ_[iside]->Fill(adc[iside],tdc[iside]);
-      meHitQvsPhi_[iside]->Fill(global_point.phi(),adc[iside]);
-      meHitQvsEta_[iside]->Fill(global_point.eta(),adc[iside]);
-      meHitQvsZ_[iside]->Fill(global_point.z(),adc[iside]);
-      meHitTvsPhi_[iside]->Fill(global_point.phi(),tdc[iside]);
-      meHitTvsEta_[iside]->Fill(global_point.eta(),tdc[iside]);
-      meHitTvsZ_[iside]->Fill(global_point.z(),tdc[iside]);
+      meHitTvsQ_[iside]->Fill(adc[iside], tdc[iside]);
+      meHitQvsPhi_[iside]->Fill(global_point.phi(), adc[iside]);
+      meHitQvsEta_[iside]->Fill(global_point.eta(), adc[iside]);
+      meHitQvsZ_[iside]->Fill(global_point.z(), adc[iside]);
+      meHitTvsPhi_[iside]->Fill(global_point.phi(), tdc[iside]);
+      meHitTvsEta_[iside]->Fill(global_point.eta(), tdc[iside]);
+      meHitTvsZ_[iside]->Fill(global_point.z(), tdc[iside]);
 
       n_digi_btl[iside]++;
 
-    } // iside loop
+    }  // iside loop
 
-  } // dataFrame loop
-  
+  }  // dataFrame loop
+
   meNhits_[0]->Fill(n_digi_btl[0]);
   meNhits_[1]->Fill(n_digi_btl[1]);
-
 }
 
-
 // ------------ method for histogram booking ------------
-void BtlDigiHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
-                               edm::Run const& run,
-                               edm::EventSetup const & iSetup) {
-
+void BtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
+                                           edm::Run const& run,
+                                           edm::EventSetup const& iSetup) {
   ibook.setCurrentFolder(folder_);
 
   // --- histograms booking
 
-  meNhits_[0]     = ibook.book1D("BtlNhitsL", "Number of BTL DIGI hits (L);N_{DIGI}", 100, 0., 5000.);
-  meNhits_[1]     = ibook.book1D("BtlNhitsR", "Number of BTL DIGI hits (R);N_{DIGI}", 100, 0., 5000.);
+  meNhits_[0] = ibook.book1D("BtlNhitsL", "Number of BTL DIGI hits (L);N_{DIGI}", 100, 0., 5000.);
+  meNhits_[1] = ibook.book1D("BtlNhitsR", "Number of BTL DIGI hits (R);N_{DIGI}", 100, 0., 5000.);
 
-  meHitCharge_[0] = ibook.book1D("BtlHitChargeL", "BTL DIGI hits charge (L);Q_{DIGI} [ADC counts]",
-				 100, 0., 1024.);
-  meHitCharge_[1] = ibook.book1D("BtlHitChargeR", "BTL DIGI hits charge (R);Q_{DIGI} [ADC counts]",
-				 100, 0., 1024.);
-  meHitTime_[0]   = ibook.book1D("BtlHitTimeL", "BTL DIGI hits ToA (L);ToA_{DIGI} [TDC counts]", 
-				 100, 0., 1024.);
-  meHitTime_[1]   = ibook.book1D("BtlHitTimeR", "BTL DIGI hits ToA (R);ToA_{DIGI} [TDC counts]", 
-				 100, 0., 1024.);
+  meHitCharge_[0] = ibook.book1D("BtlHitChargeL", "BTL DIGI hits charge (L);Q_{DIGI} [ADC counts]", 100, 0., 1024.);
+  meHitCharge_[1] = ibook.book1D("BtlHitChargeR", "BTL DIGI hits charge (R);Q_{DIGI} [ADC counts]", 100, 0., 1024.);
+  meHitTime_[0] = ibook.book1D("BtlHitTimeL", "BTL DIGI hits ToA (L);ToA_{DIGI} [TDC counts]", 100, 0., 1024.);
+  meHitTime_[1] = ibook.book1D("BtlHitTimeR", "BTL DIGI hits ToA (R);ToA_{DIGI} [TDC counts]", 100, 0., 1024.);
 
-  meOccupancy_[0] = ibook.book2D("BtlOccupancyL","BTL DIGI hits occupancy (L);Z_{DIGI} [cm]; #phi_{DIGI} [rad]",
-				 65, -260., 260., 126, -3.15, 3.15 );
-  meOccupancy_[1] = ibook.book2D("BtlOccupancyR","BTL DIGI hits occupancy (R);Z_{DIGI} [cm]; #phi_{DIGI} [rad]",
-				 65, -260., 260., 126, -3.15, 3.15 );
+  meOccupancy_[0] = ibook.book2D("BtlOccupancyL",
+                                 "BTL DIGI hits occupancy (L);Z_{DIGI} [cm]; #phi_{DIGI} [rad]",
+                                 65,
+                                 -260.,
+                                 260.,
+                                 126,
+                                 -3.15,
+                                 3.15);
+  meOccupancy_[1] = ibook.book2D("BtlOccupancyR",
+                                 "BTL DIGI hits occupancy (R);Z_{DIGI} [cm]; #phi_{DIGI} [rad]",
+                                 65,
+                                 -260.,
+                                 260.,
+                                 126,
+                                 -3.15,
+                                 3.15);
 
-  meHitX_[0]      = ibook.book1D("BtlHitXL", "BTL DIGI hits X (L);X_{DIGI} [cm]", 60, -120., 120.);
-  meHitX_[1]      = ibook.book1D("BtlHitXR", "BTL DIGI hits X (R);X_{DIGI} [cm]", 60, -120., 120.);
-  meHitY_[0]      = ibook.book1D("BtlHitYL", "BTL DIGI hits Y (L);Y_{DIGI} [cm]", 60, -120., 120.);
-  meHitY_[1]      = ibook.book1D("BtlHitYR", "BTL DIGI hits Y (R);Y_{DIGI} [cm]", 60, -120., 120.);
-  meHitZ_[0]      = ibook.book1D("BtlHitZL", "BTL DIGI hits Z (L);Z_{DIGI} [cm]", 100, -260., 260.);
-  meHitZ_[1]      = ibook.book1D("BtlHitZR", "BTL DIGI hits Z (R);Z_{DIGI} [cm]", 100, -260., 260.);
-  meHitPhi_[0]    = ibook.book1D("BtlHitPhiL", "BTL DIGI hits #phi (L);#phi_{DIGI} [rad]", 126, -3.15, 3.15);
-  meHitPhi_[1]    = ibook.book1D("BtlHitPhiR", "BTL DIGI hits #phi (R);#phi_{DIGI} [rad]", 126, -3.15, 3.15);
-  meHitEta_[0]    = ibook.book1D("BtlHitEtaL", "BTL DIGI hits #eta (L);#eta_{DIGI}", 100, -1.55, 1.55);
-  meHitEta_[1]    = ibook.book1D("BtlHitEtaR", "BTL DIGI hits #eta (R);#eta_{DIGI}", 100, -1.55, 1.55);
+  meHitX_[0] = ibook.book1D("BtlHitXL", "BTL DIGI hits X (L);X_{DIGI} [cm]", 60, -120., 120.);
+  meHitX_[1] = ibook.book1D("BtlHitXR", "BTL DIGI hits X (R);X_{DIGI} [cm]", 60, -120., 120.);
+  meHitY_[0] = ibook.book1D("BtlHitYL", "BTL DIGI hits Y (L);Y_{DIGI} [cm]", 60, -120., 120.);
+  meHitY_[1] = ibook.book1D("BtlHitYR", "BTL DIGI hits Y (R);Y_{DIGI} [cm]", 60, -120., 120.);
+  meHitZ_[0] = ibook.book1D("BtlHitZL", "BTL DIGI hits Z (L);Z_{DIGI} [cm]", 100, -260., 260.);
+  meHitZ_[1] = ibook.book1D("BtlHitZR", "BTL DIGI hits Z (R);Z_{DIGI} [cm]", 100, -260., 260.);
+  meHitPhi_[0] = ibook.book1D("BtlHitPhiL", "BTL DIGI hits #phi (L);#phi_{DIGI} [rad]", 126, -3.15, 3.15);
+  meHitPhi_[1] = ibook.book1D("BtlHitPhiR", "BTL DIGI hits #phi (R);#phi_{DIGI} [rad]", 126, -3.15, 3.15);
+  meHitEta_[0] = ibook.book1D("BtlHitEtaL", "BTL DIGI hits #eta (L);#eta_{DIGI}", 100, -1.55, 1.55);
+  meHitEta_[1] = ibook.book1D("BtlHitEtaR", "BTL DIGI hits #eta (R);#eta_{DIGI}", 100, -1.55, 1.55);
 
-
-  meHitTvsQ_[0]   = ibook.bookProfile("BtlHitTvsQL", "BTL DIGI ToA vs charge (L);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
-				       50, 0., 1024., 0., 1024.);
-  meHitTvsQ_[1]   = ibook.bookProfile("BtlHitTvsQR", "BTL DIGI ToA vs charge (R);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
-				       50, 0., 1024., 0., 1024.);
-  meHitQvsPhi_[0] = ibook.bookProfile("BtlHitQvsPhiL", "BTL DIGI charge vs #phi (L);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
-				      50, -3.15, 3.15, 0., 1024.);
-  meHitQvsPhi_[1] = ibook.bookProfile("BtlHitQvsPhiR", "BTL DIGI charge vs #phi (R);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
-				      50, -3.15, 3.15, 0., 1024.);
-  meHitQvsEta_[0] = ibook.bookProfile("BtlHitQvsEtaL","BTL DIGI charge vs #eta (L);#eta_{DIGI};Q_{DIGI} [ADC counts]",
-				      50, -1.55, 1.55, 0., 1024.);
-  meHitQvsEta_[1] = ibook.bookProfile("BtlHitQvsEtaR","BTL DIGI charge vs #eta (R);#eta_{DIGI};Q_{DIGI} [ADC counts]",
-				      50, -1.55, 1.55, 0., 1024.);
-  meHitQvsZ_[0]   = ibook.bookProfile("BtlHitQvsZL","BTL DIGI charge vs Z (L);Z_{DIGI} [cm];Q_{DIGI} [ADC counts]",
-				      50, -260., 260., 0., 1024.);
-  meHitQvsZ_[1]   = ibook.bookProfile("BtlHitQvsZR","BTL DIGI charge vs Z (R);Z_{DIGI} [cm];Q_{DIGI} [ADC counts]",
-				      50, -260., 260., 0., 1024.);
-  meHitTvsPhi_[0] = ibook.bookProfile("BtlHitTvsPhiL", "BTL DIGI ToA vs #phi (L);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
-				      50, -3.15, 3.15, 0., 1024.);
-  meHitTvsPhi_[1] = ibook.bookProfile("BtlHitTvsPhiR", "BTL DIGI ToA vs #phi (R);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
-				      50, -3.15, 3.15, 0., 1024.);
-  meHitTvsEta_[0] = ibook.bookProfile("BtlHitTvsEtaL","BTL DIGI ToA vs #eta (L);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
-				      50, -1.55, 1.55, 0., 1024.);
-  meHitTvsEta_[1] = ibook.bookProfile("BtlHitTvsEtaR","BTL DIGI ToA vs #eta (R);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
-				      50, -1.55, 1.55, 0., 1024.);
-  meHitTvsZ_[0]   = ibook.bookProfile("BtlHitTvsZL","BTL SIM ToA vs Z (L);Z_{DIGI} [cm];ToA_{DIGI} [TDC counts]",
-				      50, -260., 260., 0., 1024.);
-  meHitTvsZ_[1]   = ibook.bookProfile("BtlHitTvsZR","BTL SIM ToA vs Z (R);Z_{DIGI} [cm];ToA_{DIGI} [TDC counts]",
-				      50, -260., 260., 0., 1024.);
-
+  meHitTvsQ_[0] = ibook.bookProfile("BtlHitTvsQL",
+                                    "BTL DIGI ToA vs charge (L);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+                                    50,
+                                    0.,
+                                    1024.,
+                                    0.,
+                                    1024.);
+  meHitTvsQ_[1] = ibook.bookProfile("BtlHitTvsQR",
+                                    "BTL DIGI ToA vs charge (R);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+                                    50,
+                                    0.,
+                                    1024.,
+                                    0.,
+                                    1024.);
+  meHitQvsPhi_[0] = ibook.bookProfile("BtlHitQvsPhiL",
+                                      "BTL DIGI charge vs #phi (L);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      1024.);
+  meHitQvsPhi_[1] = ibook.bookProfile("BtlHitQvsPhiR",
+                                      "BTL DIGI charge vs #phi (R);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      1024.);
+  meHitQvsEta_[0] = ibook.bookProfile(
+      "BtlHitQvsEtaL", "BTL DIGI charge vs #eta (L);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, -1.55, 1.55, 0., 1024.);
+  meHitQvsEta_[1] = ibook.bookProfile(
+      "BtlHitQvsEtaR", "BTL DIGI charge vs #eta (R);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, -1.55, 1.55, 0., 1024.);
+  meHitQvsZ_[0] = ibook.bookProfile(
+      "BtlHitQvsZL", "BTL DIGI charge vs Z (L);Z_{DIGI} [cm];Q_{DIGI} [ADC counts]", 50, -260., 260., 0., 1024.);
+  meHitQvsZ_[1] = ibook.bookProfile(
+      "BtlHitQvsZR", "BTL DIGI charge vs Z (R);Z_{DIGI} [cm];Q_{DIGI} [ADC counts]", 50, -260., 260., 0., 1024.);
+  meHitTvsPhi_[0] = ibook.bookProfile(
+      "BtlHitTvsPhiL", "BTL DIGI ToA vs #phi (L);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]", 50, -3.15, 3.15, 0., 1024.);
+  meHitTvsPhi_[1] = ibook.bookProfile(
+      "BtlHitTvsPhiR", "BTL DIGI ToA vs #phi (R);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]", 50, -3.15, 3.15, 0., 1024.);
+  meHitTvsEta_[0] = ibook.bookProfile(
+      "BtlHitTvsEtaL", "BTL DIGI ToA vs #eta (L);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, -1.55, 1.55, 0., 1024.);
+  meHitTvsEta_[1] = ibook.bookProfile(
+      "BtlHitTvsEtaR", "BTL DIGI ToA vs #eta (R);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, -1.55, 1.55, 0., 1024.);
+  meHitTvsZ_[0] = ibook.bookProfile(
+      "BtlHitTvsZL", "BTL SIM ToA vs Z (L);Z_{DIGI} [cm];ToA_{DIGI} [TDC counts]", 50, -260., 260., 0., 1024.);
+  meHitTvsZ_[1] = ibook.bookProfile(
+      "BtlHitTvsZR", "BTL SIM ToA vs Z (R);Z_{DIGI} [cm];ToA_{DIGI} [TDC counts]", 50, -260., 260., 0., 1024.);
 }
-
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void BtlDigiHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/BTL/DigiHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "FTLBarrel"));
 
   descriptions.add("btlDigiHitsDefault", desc);
-
 }
 
 DEFINE_FWK_MODULE(BtlDigiHitsValidation);

--- a/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
@@ -202,63 +202,63 @@ void BtlDigiHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
 
   // --- histograms booking
 
-  meNhits_[0]     = ibook.book1D("BtlNhitsL", "Number of BTL DIGI hits (L);N_{DIGI}", 250, 0., 5000.);
-  meNhits_[1]     = ibook.book1D("BtlNhitsR", "Number of BTL DIGI hits (R);N_{DIGI}", 250, 0., 5000.);
+  meNhits_[0]     = ibook.book1D("BtlNhitsL", "Number of BTL DIGI hits (L);N_{DIGI}", 100, 0., 5000.);
+  meNhits_[1]     = ibook.book1D("BtlNhitsR", "Number of BTL DIGI hits (R);N_{DIGI}", 100, 0., 5000.);
 
   meHitCharge_[0] = ibook.book1D("BtlHitChargeL", "BTL DIGI hits charge (L);Q_{DIGI} [ADC counts]",
-				 1024, 0., 1024.);
+				 100, 0., 1024.);
   meHitCharge_[1] = ibook.book1D("BtlHitChargeR", "BTL DIGI hits charge (R);Q_{DIGI} [ADC counts]",
-				 1024, 0., 1024.);
+				 100, 0., 1024.);
   meHitTime_[0]   = ibook.book1D("BtlHitTimeL", "BTL DIGI hits ToA (L);ToA_{DIGI} [TDC counts]", 
-				 1024, 0., 1024.);
+				 100, 0., 1024.);
   meHitTime_[1]   = ibook.book1D("BtlHitTimeR", "BTL DIGI hits ToA (R);ToA_{DIGI} [TDC counts]", 
-				 1024, 0., 1024.);
+				 100, 0., 1024.);
 
   meOccupancy_[0] = ibook.book2D("BtlOccupancyL","BTL DIGI hits occupancy (L);Z_{DIGI} [cm]; #phi_{DIGI} [rad]",
-				 65, -260., 260., 315, -3.15, 3.15 );
+				 65, -260., 260., 126, -3.15, 3.15 );
   meOccupancy_[1] = ibook.book2D("BtlOccupancyR","BTL DIGI hits occupancy (R);Z_{DIGI} [cm]; #phi_{DIGI} [rad]",
-				 65, -260., 260., 315, -3.15, 3.15 );
+				 65, -260., 260., 126, -3.15, 3.15 );
 
-  meHitX_[0]      = ibook.book1D("BtlHitXL", "BTL DIGI hits X (L);X_{DIGI} [cm]", 135, -135., 135.);
-  meHitX_[1]      = ibook.book1D("BtlHitXR", "BTL DIGI hits X (R);X_{DIGI} [cm]", 135, -135., 135.);
-  meHitY_[0]      = ibook.book1D("BtlHitYL", "BTL DIGI hits Y (L);Y_{DIGI} [cm]", 135, -135., 135.);
-  meHitY_[1]      = ibook.book1D("BtlHitYR", "BTL DIGI hits Y (R);Y_{DIGI} [cm]", 135, -135., 135.);
-  meHitZ_[0]      = ibook.book1D("BtlHitZL", "BTL DIGI hits Z (L);Z_{DIGI} [cm]", 520, -260., 260.);
-  meHitZ_[1]      = ibook.book1D("BtlHitZR", "BTL DIGI hits Z (R);Z_{DIGI} [cm]", 520, -260., 260.);
-  meHitPhi_[0]    = ibook.book1D("BtlHitPhiL", "BTL DIGI hits #phi (L);#phi_{DIGI} [rad]", 315, -3.15, 3.15);
-  meHitPhi_[1]    = ibook.book1D("BtlHitPhiR", "BTL DIGI hits #phi (R);#phi_{DIGI} [rad]", 315, -3.15, 3.15);
-  meHitEta_[0]    = ibook.book1D("BtlHitEtaL", "BTL DIGI hits #eta (L);#eta_{DIGI}", 200, -1.6, 1.6);
-  meHitEta_[1]    = ibook.book1D("BtlHitEtaR", "BTL DIGI hits #eta (R);#eta_{DIGI}", 200, -1.6, 1.6);
+  meHitX_[0]      = ibook.book1D("BtlHitXL", "BTL DIGI hits X (L);X_{DIGI} [cm]", 60, -120., 120.);
+  meHitX_[1]      = ibook.book1D("BtlHitXR", "BTL DIGI hits X (R);X_{DIGI} [cm]", 60, -120., 120.);
+  meHitY_[0]      = ibook.book1D("BtlHitYL", "BTL DIGI hits Y (L);Y_{DIGI} [cm]", 60, -120., 120.);
+  meHitY_[1]      = ibook.book1D("BtlHitYR", "BTL DIGI hits Y (R);Y_{DIGI} [cm]", 60, -120., 120.);
+  meHitZ_[0]      = ibook.book1D("BtlHitZL", "BTL DIGI hits Z (L);Z_{DIGI} [cm]", 100, -260., 260.);
+  meHitZ_[1]      = ibook.book1D("BtlHitZR", "BTL DIGI hits Z (R);Z_{DIGI} [cm]", 100, -260., 260.);
+  meHitPhi_[0]    = ibook.book1D("BtlHitPhiL", "BTL DIGI hits #phi (L);#phi_{DIGI} [rad]", 126, -3.15, 3.15);
+  meHitPhi_[1]    = ibook.book1D("BtlHitPhiR", "BTL DIGI hits #phi (R);#phi_{DIGI} [rad]", 126, -3.15, 3.15);
+  meHitEta_[0]    = ibook.book1D("BtlHitEtaL", "BTL DIGI hits #eta (L);#eta_{DIGI}", 100, -1.55, 1.55);
+  meHitEta_[1]    = ibook.book1D("BtlHitEtaR", "BTL DIGI hits #eta (R);#eta_{DIGI}", 100, -1.55, 1.55);
 
 
   meHitTvsQ_[0]   = ibook.bookProfile("BtlHitTvsQL", "BTL DIGI ToA vs charge (L);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
-				       1024, 0., 1024., 0., 1024.);
+				       50, 0., 1024., 0., 1024.);
   meHitTvsQ_[1]   = ibook.bookProfile("BtlHitTvsQR", "BTL DIGI ToA vs charge (R);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
-				       1024, 0., 1024., 0., 1024.);
+				       50, 0., 1024., 0., 1024.);
   meHitQvsPhi_[0] = ibook.bookProfile("BtlHitQvsPhiL", "BTL DIGI charge vs #phi (L);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
-				      100, -3.15, 3.15, 0., 1024.);
+				      50, -3.15, 3.15, 0., 1024.);
   meHitQvsPhi_[1] = ibook.bookProfile("BtlHitQvsPhiR", "BTL DIGI charge vs #phi (R);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
-				      100, -3.15, 3.15, 0., 1024.);
+				      50, -3.15, 3.15, 0., 1024.);
   meHitQvsEta_[0] = ibook.bookProfile("BtlHitQvsEtaL","BTL DIGI charge vs #eta (L);#eta_{DIGI};Q_{DIGI} [ADC counts]",
-				      200, -1.6, 1.6, 0., 1024.);
+				      50, -1.55, 1.55, 0., 1024.);
   meHitQvsEta_[1] = ibook.bookProfile("BtlHitQvsEtaR","BTL DIGI charge vs #eta (R);#eta_{DIGI};Q_{DIGI} [ADC counts]",
-				      200, -1.6, 1.6, 0., 1024.);
+				      50, -1.55, 1.55, 0., 1024.);
   meHitQvsZ_[0]   = ibook.bookProfile("BtlHitQvsZL","BTL DIGI charge vs Z (L);Z_{DIGI} [cm];Q_{DIGI} [ADC counts]",
-				      520, -260., 260., 0., 1024.);
+				      50, -260., 260., 0., 1024.);
   meHitQvsZ_[1]   = ibook.bookProfile("BtlHitQvsZR","BTL DIGI charge vs Z (R);Z_{DIGI} [cm];Q_{DIGI} [ADC counts]",
-				      520, -260., 260., 0., 1024.);
+				      50, -260., 260., 0., 1024.);
   meHitTvsPhi_[0] = ibook.bookProfile("BtlHitTvsPhiL", "BTL DIGI ToA vs #phi (L);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
-				      100, -3.15, 3.15, 0., 1024.);
+				      50, -3.15, 3.15, 0., 1024.);
   meHitTvsPhi_[1] = ibook.bookProfile("BtlHitTvsPhiR", "BTL DIGI ToA vs #phi (R);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
-				      100, -3.15, 3.15, 0., 1024.);
+				      50, -3.15, 3.15, 0., 1024.);
   meHitTvsEta_[0] = ibook.bookProfile("BtlHitTvsEtaL","BTL DIGI ToA vs #eta (L);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
-				      200, -1.6, 1.6, 0., 1024.);
+				      50, -1.55, 1.55, 0., 1024.);
   meHitTvsEta_[1] = ibook.bookProfile("BtlHitTvsEtaR","BTL DIGI ToA vs #eta (R);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
-				      200, -1.6, 1.6, 0., 1024.);
+				      50, -1.55, 1.55, 0., 1024.);
   meHitTvsZ_[0]   = ibook.bookProfile("BtlHitTvsZL","BTL SIM ToA vs Z (L);Z_{DIGI} [cm];ToA_{DIGI} [TDC counts]",
-				      520, -260., 260., 0., 1024.);
+				      50, -260., 260., 0., 1024.);
   meHitTvsZ_[1]   = ibook.bookProfile("BtlHitTvsZR","BTL SIM ToA vs Z (R);Z_{DIGI} [cm];ToA_{DIGI} [TDC counts]",
-				      520, -260., 260., 0., 1024.);
+				      50, -260., 260., 0., 1024.);
 
 }
 

--- a/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
@@ -1,0 +1,211 @@
+// -*- C++ -*-
+//
+// Package:    Validation/MtdValidation
+// Class:      BtlDigiHitsValidation
+//
+/**\class BtlDigiHitsValidation BtlDigiHitsValidation.cc Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
+
+ Description: BTL DIGI hits validation
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Massimo Casarsa
+//         Created:  Mon, 11 Mar 2019 14:12:22 GMT
+//
+//
+
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "DataFormats/FTLDigi/interface/FTLDigiCollections.h"
+
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+
+#include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
+#include "Geometry/Records/interface/MTDTopologyRcd.h"
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
+#include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
+
+#include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
+#include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
+
+
+//
+// class declaration
+//
+
+
+class BtlDigiHitsValidation : public DQMEDAnalyzer {
+
+public:
+  explicit BtlDigiHitsValidation(const edm::ParameterSet&);
+  ~BtlDigiHitsValidation() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+private:
+  void bookHistograms(DQMStore::IBooker &,
+		      edm::Run const&,
+		      edm::EventSetup const&) override;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  // ------------ member data ------------
+
+  const MTDGeometry* geom_;
+  const MTDTopology* topo_;
+
+  const std::string folder_;
+  const std::string infoLabel_;
+  const std::string btlDigisCollection_;
+
+  int eventCount_;
+
+  edm::EDGetTokenT<BTLDigiCollection> btlDigiHitsToken_;
+
+  MonitorElement* meHitCharge_[2];
+  MonitorElement* meHitTime1_[2];
+  MonitorElement* meHitTime2_[2];
+
+  MonitorElement* meOccupancy_[2];
+
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+BtlDigiHitsValidation::BtlDigiHitsValidation(const edm::ParameterSet& iConfig):
+  geom_(nullptr),
+  topo_(nullptr),
+  folder_(iConfig.getParameter<std::string>("folder")),
+  infoLabel_(iConfig.getParameter<std::string>("moduleLabel")),
+  btlDigisCollection_(iConfig.getParameter<std::string>("btlDigiHitsCollection")),
+  eventCount_(0) {
+
+  btlDigiHitsToken_ = consumes <BTLDigiCollection> (edm::InputTag(std::string(infoLabel_),
+								  std::string(btlDigisCollection_)));
+
+}
+
+
+BtlDigiHitsValidation::~BtlDigiHitsValidation() {
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void BtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  using namespace edm;
+
+  edm::LogInfo("EventInfo") << " Run = " << iEvent.id().run() << " Event = " << iEvent.id().event();
+
+  edm::ESHandle<MTDGeometry> geometryHandle;
+  iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);
+  geom_ = geometryHandle.product();
+
+  edm::ESHandle<MTDTopology> topologyHandle;
+  iSetup.get<MTDTopologyRcd>().get(topologyHandle);
+  topo_ = topologyHandle.product();
+
+  edm::Handle<BTLDigiCollection> btlDigiHitsHandle;
+  iEvent.getByToken(btlDigiHitsToken_, btlDigiHitsHandle);
+
+  if( ! btlDigiHitsHandle.isValid() ) return;
+
+  eventCount_++;
+  
+  // --- Loop over the BLT DIGI hits
+  for (const auto& dataFrame: *btlDigiHitsHandle) {
+
+    //DetId id =  dataFrame.id();
+      
+    const auto& sample_L = dataFrame.sample(0);
+    const auto& sample_R = dataFrame.sample(1);
+
+    uint32_t adcL  = sample_L.data();
+    uint32_t adcR  = sample_R.data();
+    uint32_t tdc1L = sample_L.toa();
+    uint32_t tdc1R = sample_R.toa();
+    uint32_t tdc2L = sample_L.toa2();
+    uint32_t tdc2R = sample_R.toa2();
+
+    meHitCharge_[0]->Fill(adcL); 
+    meHitCharge_[1]->Fill(adcR); 
+    meHitTime1_[0]->Fill(tdc1L);
+    meHitTime1_[1]->Fill(tdc1R);
+    meHitTime2_[0]->Fill(tdc2L);
+    meHitTime2_[1]->Fill(tdc2R);
+
+  } // dataFrame loop
+
+
+
+}
+
+void BtlDigiHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
+                               edm::Run const& run,
+                               edm::EventSetup const & iSetup) {
+
+  ibook.setCurrentFolder(folder_);
+
+  meHitCharge_[0] = ibook.book1D("BtlHitChargeL", "BTL DIGI hits charge (L);amplitude [ADC counts]",
+				 1024, 0., 1024.);
+  meHitCharge_[1] = ibook.book1D("BtlHitChargeR", "BTL DIGI hits charge (R);amplitude [ADC counts]",
+				 1024, 0., 1024.);
+  meHitTime1_[0]  = ibook.book1D("BtlHitTime1L", "BTL DIGI hits ToA1 (L);ToA [TDC counts]", 
+				 1024, 0., 1024.);
+  meHitTime1_[1]  = ibook.book1D("BtlHitTime1R", "BTL DIGI hits ToA1 (R);ToA [TDC counts]", 
+				 1024, 0., 1024.);
+  meHitTime2_[0]  = ibook.book1D("BtlHitTime2L", "BTL DIGI hits ToA2 (L);ToA [TDC counts]", 
+				 1024, 0., 1024.);
+  meHitTime2_[1]  = ibook.book1D("BtlHitTime2R", "BTL DIGI hits ToA2 (R);ToA [TDC counts]", 
+				 1024, 0., 1024.);
+  meOccupancy_[0] = ibook.book2D("BtlOccupancyL","BTL DIGI hits occupancy (L);z [cm]; #phi [rad]",
+				 65, -260., 260., 315, -3.15, 3.15 );
+  meOccupancy_[1] = ibook.book2D("BtlOccupancyR","BTL DIGI hits occupancy (R);z [cm]; #phi [rad]",
+				 65, -260., 260., 315, -3.15, 3.15 );
+
+}
+
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void BtlDigiHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // The following says we do not know what parameters are allowed so do no
+  // validation
+  // Please change this to state exactly what you do use, even if it is no
+  // parameters
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("folder", "MTD/BTL/DigiHits");
+  desc.add<std::string>("moduleLabel","mix");
+  desc.add<std::string>("btlDigiHitsCollection","FTLBarrel");
+  descriptions.add("btlDigiHits", desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BtlDigiHitsValidation);

--- a/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
@@ -65,10 +65,26 @@ private:
 
   // --- histograms declaration
 
+  MonitorElement* meNhits_;
+
   MonitorElement* meHitEnergy_;
   MonitorElement* meHitTime_;
 
   MonitorElement* meOccupancy_;
+
+  MonitorElement* meHitX_;
+  MonitorElement* meHitY_;
+  MonitorElement* meHitZ_;
+  MonitorElement* meHitPhi_;
+  MonitorElement* meHitEta_;
+
+  MonitorElement* meHitTvsE_;
+  MonitorElement* meHitEvsPhi_;
+  MonitorElement* meHitEvsEta_;
+  MonitorElement* meHitEvsZ_;
+  MonitorElement* meHitTvsPhi_;
+  MonitorElement* meHitTvsEta_;
+  MonitorElement* meHitTvsZ_;
 
 };
 
@@ -117,6 +133,9 @@ void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   eventCount_++;
 
   // --- Loop over the BLT RECO hits
+
+  unsigned int n_reco_btl = 0;
+
   for (const auto& recHit: *btlRecHitsHandle) {
 
     BTLDetId detId = recHit.id();
@@ -138,7 +157,25 @@ void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
     meOccupancy_->Fill(global_point.z(),global_point.phi());
 
+    meHitX_->Fill(global_point.x());
+    meHitY_->Fill(global_point.y());
+    meHitZ_->Fill(global_point.z());
+    meHitPhi_->Fill(global_point.phi());
+    meHitEta_->Fill(global_point.eta());
+
+    meHitTvsE_->Fill(recHit.energy(),recHit.time());
+    meHitEvsPhi_->Fill(global_point.phi(),recHit.energy());
+    meHitEvsEta_->Fill(global_point.eta(),recHit.energy());
+    meHitEvsZ_->Fill(global_point.z(),recHit.energy());
+    meHitTvsPhi_->Fill(global_point.phi(),recHit.time());
+    meHitTvsEta_->Fill(global_point.eta(),recHit.time());
+    meHitTvsZ_->Fill(global_point.z(),recHit.time());
+
+    n_reco_btl++;
+
   } // recHit loop
+
+  meNhits_->Fill(n_reco_btl);
 
 }
 
@@ -152,11 +189,35 @@ void BtlRecHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
 
   // --- histograms booking
 
-  meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL RECO hits energy;energy [MeV]", 200, 0., 20.);
-  meHitTime_ = ibook.book1D("BtlHitTime", "BTL RECO hits ToA;ToA [ns]", 250, 0., 25.);
+  meNhits_     = ibook.book1D("BtlNhits", "Number of BTL RECO hits;N_{RECO}", 250, 0., 5000.);
 
-  meOccupancy_ = ibook.book2D("BtlOccupancy","BTL RECO hits occupancy;z [cm]; #phi [rad]",
+  meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL RECO hits energy;E_{RECO} [MeV]", 200, 0., 20.);
+  meHitTime_   = ibook.book1D("BtlHitTime", "BTL RECO hits ToA;ToA_{RECO} [ns]", 250, 0., 25.);
+
+  meOccupancy_ = ibook.book2D("BtlOccupancy","BTL RECO hits occupancy;Z_{RECO} [cm]; #phi_{RECO} [rad]",
 			      65, -260., 260., 315, -3.15, 3.15 );
+
+  meHitX_      = ibook.book1D("BtlHitX", "BTL RECO hits X;X_{RECO} [cm]", 135, -135., 135.);
+  meHitY_      = ibook.book1D("BtlHitY", "BTL RECO hits Y;Y_{RECO} [cm]", 135, -135., 135.);
+  meHitZ_      = ibook.book1D("BtlHitZ", "BTL RECO hits Z;Z_{RECO} [cm]", 520, -260., 260.);
+  meHitPhi_    = ibook.book1D("BtlHitPhi", "BTL RECO hits #phi;#phi_{RECO} [rad]", 315, -3.15, 3.15);
+  meHitEta_    = ibook.book1D("BtlHitEta", "BTL RECO hits #eta;#eta_{RECO}", 200, -1.6, 1.6);
+
+  meHitTvsE_   = ibook.bookProfile("BtlHitTvsE", "BTL RECO ToA vs energy;E_{RECO} [MeV];ToA_{RECO} [ns]",
+				   100, 0., 20., 0., 100.);
+  meHitEvsPhi_ = ibook.bookProfile("BtlHitEvsPhi", "BTL RECO energy vs #phi;#phi_{RECO} [rad];E_{RECO} [MeV]",
+				   100, -3.15, 3.15, 0., 100.);
+  meHitEvsEta_ = ibook.bookProfile("BtlHitEvsEta","BTL RECO energy vs #eta;#eta_{RECO};E_{RECO} [MeV]",
+				   200, -1.6, 1.6, 0., 100.);
+  meHitEvsZ_   = ibook.bookProfile("BtlHitEvsZ","BTL RECO energy vs Z;Z_{RECO} [cm];E_{RECO} [MeV]",
+				   520, -260., 260., 0., 100.);
+  meHitTvsPhi_ = ibook.bookProfile("BtlHitTvsPhi", "BTL RECO ToA vs #phi;#phi_{RECO} [rad];ToA_{RECO} [ns]",
+				   100, -3.15, 3.15, 0., 100.);
+  meHitTvsEta_ = ibook.bookProfile("BtlHitTvsEta","BTL RECO ToA vs #eta;#eta_{RECO};ToA_{RECO} [ns]",
+				   200, -1.6, 1.6, 0., 100.);
+  meHitTvsZ_   = ibook.bookProfile("BtlHitTvsZ","BTL RECO ToA vs Z;Z_{RECO} [cm];ToA_{RECO} [ns]",
+				   520, -260., 260., 0., 100.);
+
 
 }
 

--- a/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
@@ -78,9 +78,6 @@ private:
 // ------------ constructor and destructor --------------
 BtlRecHitsValidation::BtlRecHitsValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")) {
-  const std::string infoLabel = iConfig.getParameter<std::string>("moduleLabel");
-  const std::string btlRecHitsCollection = iConfig.getParameter<std::string>("btlRecHitsCollection");
-
   btlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("inputTag"));
 }
 

--- a/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
@@ -189,34 +189,34 @@ void BtlRecHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
 
   // --- histograms booking
 
-  meNhits_     = ibook.book1D("BtlNhits", "Number of BTL RECO hits;N_{RECO}", 250, 0., 5000.);
+  meNhits_     = ibook.book1D("BtlNhits", "Number of BTL RECO hits;N_{RECO}", 100, 0., 5000.);
 
-  meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL RECO hits energy;E_{RECO} [MeV]", 200, 0., 20.);
-  meHitTime_   = ibook.book1D("BtlHitTime", "BTL RECO hits ToA;ToA_{RECO} [ns]", 250, 0., 25.);
+  meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL RECO hits energy;E_{RECO} [MeV]", 100, 0., 20.);
+  meHitTime_   = ibook.book1D("BtlHitTime", "BTL RECO hits ToA;ToA_{RECO} [ns]", 100, 0., 25.);
 
   meOccupancy_ = ibook.book2D("BtlOccupancy","BTL RECO hits occupancy;Z_{RECO} [cm]; #phi_{RECO} [rad]",
-			      65, -260., 260., 315, -3.15, 3.15 );
+			      65, -260., 260., 126, -3.15, 3.15 );
 
-  meHitX_      = ibook.book1D("BtlHitX", "BTL RECO hits X;X_{RECO} [cm]", 135, -135., 135.);
-  meHitY_      = ibook.book1D("BtlHitY", "BTL RECO hits Y;Y_{RECO} [cm]", 135, -135., 135.);
-  meHitZ_      = ibook.book1D("BtlHitZ", "BTL RECO hits Z;Z_{RECO} [cm]", 520, -260., 260.);
-  meHitPhi_    = ibook.book1D("BtlHitPhi", "BTL RECO hits #phi;#phi_{RECO} [rad]", 315, -3.15, 3.15);
-  meHitEta_    = ibook.book1D("BtlHitEta", "BTL RECO hits #eta;#eta_{RECO}", 200, -1.6, 1.6);
+  meHitX_      = ibook.book1D("BtlHitX", "BTL RECO hits X;X_{RECO} [cm]", 60, -120., 120.);
+  meHitY_      = ibook.book1D("BtlHitY", "BTL RECO hits Y;Y_{RECO} [cm]", 60, -120., 120.);
+  meHitZ_      = ibook.book1D("BtlHitZ", "BTL RECO hits Z;Z_{RECO} [cm]", 100, -260., 260.);
+  meHitPhi_    = ibook.book1D("BtlHitPhi", "BTL RECO hits #phi;#phi_{RECO} [rad]", 126, -3.15, 3.15);
+  meHitEta_    = ibook.book1D("BtlHitEta", "BTL RECO hits #eta;#eta_{RECO}", 100, -1.55, 1.55);
 
   meHitTvsE_   = ibook.bookProfile("BtlHitTvsE", "BTL RECO ToA vs energy;E_{RECO} [MeV];ToA_{RECO} [ns]",
-				   100, 0., 20., 0., 100.);
+				   50, 0., 20., 0., 100.);
   meHitEvsPhi_ = ibook.bookProfile("BtlHitEvsPhi", "BTL RECO energy vs #phi;#phi_{RECO} [rad];E_{RECO} [MeV]",
-				   100, -3.15, 3.15, 0., 100.);
+				   50, -3.15, 3.15, 0., 100.);
   meHitEvsEta_ = ibook.bookProfile("BtlHitEvsEta","BTL RECO energy vs #eta;#eta_{RECO};E_{RECO} [MeV]",
-				   200, -1.6, 1.6, 0., 100.);
+				   50, -1.55, 1.55, 0., 100.);
   meHitEvsZ_   = ibook.bookProfile("BtlHitEvsZ","BTL RECO energy vs Z;Z_{RECO} [cm];E_{RECO} [MeV]",
-				   520, -260., 260., 0., 100.);
+				   50, -260., 260., 0., 100.);
   meHitTvsPhi_ = ibook.bookProfile("BtlHitTvsPhi", "BTL RECO ToA vs #phi;#phi_{RECO} [rad];ToA_{RECO} [ns]",
-				   100, -3.15, 3.15, 0., 100.);
+				   50, -3.15, 3.15, 0., 100.);
   meHitTvsEta_ = ibook.bookProfile("BtlHitTvsEta","BTL RECO ToA vs #eta;#eta_{RECO};ToA_{RECO} [ns]",
-				   200, -1.6, 1.6, 0., 100.);
+				   50, -1.6, 1.6, 0., 100.);
   meHitTvsZ_   = ibook.bookProfile("BtlHitTvsZ","BTL RECO ToA vs Z;Z_{RECO} [cm];ToA_{RECO} [ns]",
-				   520, -260., 260., 0., 100.);
+				   50, -260., 260., 0., 100.);
 
 
 }

--- a/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
@@ -1,0 +1,178 @@
+// -*- C++ -*-
+//
+// Package:    Validation/MtdValidation
+// Class:      BtlRecHitsValidation
+//
+/**\class BtlRecHitsValidation BtlRecHitsValidation.cc Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
+
+ Description: BTL RECO hits validation
+
+ Implementation:
+     [Notes on implementation]
+*/
+
+#include <string>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "DataFormats/FTLRecHit/interface/FTLRecHitCollections.h"
+
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+
+#include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
+#include "Geometry/Records/interface/MTDTopologyRcd.h"
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
+#include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
+
+#include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
+#include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
+
+
+class BtlRecHitsValidation : public DQMEDAnalyzer {
+
+public:
+  explicit BtlRecHitsValidation(const edm::ParameterSet&);
+  ~BtlRecHitsValidation() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+private:
+  void bookHistograms(DQMStore::IBooker &,
+		      edm::Run const&,
+		      edm::EventSetup const&) override;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  // ------------ member data ------------
+
+  const MTDGeometry* geom_;
+  const MTDTopology* topo_;
+
+  const std::string folder_;
+  const std::string infoLabel_;
+  const std::string btlRecHitsCollection_;
+
+  int eventCount_;
+
+  edm::EDGetTokenT<FTLRecHitCollection> btlRecHitsToken_;
+
+  // --- histograms declaration
+
+  MonitorElement* meHitEnergy_;
+  MonitorElement* meHitTime_;
+
+  MonitorElement* meOccupancy_;
+
+};
+
+
+// ------------ constructor and destructor --------------
+BtlRecHitsValidation::BtlRecHitsValidation(const edm::ParameterSet& iConfig):
+  geom_(nullptr),
+  topo_(nullptr),
+  folder_(iConfig.getParameter<std::string>("folder")),
+  infoLabel_(iConfig.getParameter<std::string>("moduleLabel")),
+  btlRecHitsCollection_(iConfig.getParameter<std::string>("btlRecHitsCollection")),
+  eventCount_(0) {
+
+  btlRecHitsToken_ = consumes <FTLRecHitCollection> (edm::InputTag(std::string(infoLabel_),
+								   std::string(btlRecHitsCollection_)));
+
+}
+
+BtlRecHitsValidation::~BtlRecHitsValidation() {
+}
+
+
+// ------------ method called for each event  ------------
+void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  using namespace edm;
+
+  edm::LogInfo("EventInfo") << " Run = " << iEvent.id().run() << " Event = " << iEvent.id().event();
+
+  edm::ESHandle<MTDGeometry> geometryHandle;
+  iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);
+  geom_ = geometryHandle.product();
+
+  edm::ESHandle<MTDTopology> topologyHandle;
+  iSetup.get<MTDTopologyRcd>().get(topologyHandle);
+  topo_ = topologyHandle.product();
+
+  edm::Handle<FTLRecHitCollection> btlRecHitsHandle;
+  iEvent.getByToken(btlRecHitsToken_, btlRecHitsHandle);
+
+  if( ! btlRecHitsHandle.isValid() ) {
+    edm::LogWarning("DataNotFound") << "No BTL RecHits found";
+    return;
+  }
+
+  eventCount_++;
+
+  // --- Loop over the BLT RECO hits
+  for (const auto& recHit: *btlRecHitsHandle) {
+
+    BTLDetId detId = recHit.id();
+    DetId geoId = detId.geographicalId( static_cast<BTLDetId::CrysLayout>(topo_->getMTDTopologyMode()) );
+    const MTDGeomDet* thedet = geom_->idToDet(geoId);
+    if( thedet == nullptr )
+      throw cms::Exception("BtlRecHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
+						   << " (" << detId.rawId()<< ") is invalid!" << std::dec
+						   << std::endl;
+    const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
+    const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
+
+    Local3DPoint local_point(0.,0.,0.);
+    local_point = topo.pixelToModuleLocalPoint(local_point,detId.row(topo.nrows()),detId.column(topo.nrows()));
+    const auto& global_point = thedet->toGlobal(local_point);
+
+    meHitEnergy_->Fill(recHit.energy());
+    meHitTime_->Fill(recHit.time());
+
+    meOccupancy_->Fill(global_point.z(),global_point.phi());
+
+  } // recHit loop
+
+}
+
+
+// ------------ method for histogram booking ------------
+void BtlRecHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
+                               edm::Run const& run,
+                               edm::EventSetup const & iSetup) {
+
+  ibook.setCurrentFolder(folder_);
+
+  // --- histograms booking
+
+  meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL RECO hits energy;energy [MeV]", 200, 0., 20.);
+  meHitTime_ = ibook.book1D("BtlHitTime", "BTL RECO hits ToA;ToA [ns]", 250, 0., 25.);
+
+  meOccupancy_ = ibook.book2D("BtlOccupancy","BTL RECO hits occupancy;z [cm]; #phi [rad]",
+			      65, -260., 260., 315, -3.15, 3.15 );
+
+}
+
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void BtlRecHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+
+  edm::ParameterSetDescription desc;
+
+  desc.add<std::string>("folder", "MTD/BTL/RecHits");
+  desc.add<std::string>("moduleLabel","mtdRecHits");
+  desc.add<std::string>("btlRecHitsCollection","FTLBarrel");
+
+  descriptions.add("btlRecHits", desc);
+
+}
+
+DEFINE_FWK_MODULE(BtlRecHitsValidation);

--- a/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
@@ -21,9 +21,10 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
+#include "DataFormats/Common/interface/ValidHandle.h"
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
 #include "DataFormats/FTLRecHit/interface/FTLRecHitCollections.h"
 
-#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/Records/interface/MTDTopologyRcd.h"
@@ -89,8 +90,7 @@ BtlRecHitsValidation::BtlRecHitsValidation(const edm::ParameterSet& iConfig):
   const std::string infoLabel = iConfig.getParameter<std::string>("moduleLabel");
   const std::string btlRecHitsCollection = iConfig.getParameter<std::string>("btlRecHitsCollection");
 
-  btlRecHitsToken_ = consumes <FTLRecHitCollection> (edm::InputTag(std::string(infoLabel),
-								   std::string(btlRecHitsCollection)));
+  btlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("inputTag"));
 
 }
 
@@ -111,14 +111,7 @@ void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   iSetup.get<MTDTopologyRcd>().get(topologyHandle);
   const MTDTopology* topology = topologyHandle.product();
 
-  edm::Handle<FTLRecHitCollection> btlRecHitsHandle;
-  iEvent.getByToken(btlRecHitsToken_, btlRecHitsHandle);
-
-  if( ! btlRecHitsHandle.isValid() ) {
-    edm::LogWarning("DataNotFound") << "No BTL RecHits found";
-    return;
-  }
-
+  auto btlRecHitsHandle = makeValid(iEvent.getHandle(btlRecHitsToken_));
 
   // --- Loop over the BLT RECO hits
 
@@ -217,8 +210,7 @@ void BtlRecHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/BTL/RecHits");
-  desc.add<std::string>("moduleLabel","mtdRecHits");
-  desc.add<std::string>("btlRecHitsCollection","FTLBarrel");
+  desc.add<edm::InputTag>("inputTag", edm::InputTag("mtdRecHits", "FTLBarrel"));
 
   descriptions.add("btlRecHits", desc);
 

--- a/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
@@ -25,7 +25,6 @@
 #include "DataFormats/ForwardDetId/interface/BTLDetId.h"
 #include "DataFormats/FTLRecHit/interface/FTLRecHitCollections.h"
 
-
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/Records/interface/MTDTopologyRcd.h"
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
@@ -34,20 +33,15 @@
 #include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
 #include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
 
-
 class BtlRecHitsValidation : public DQMEDAnalyzer {
-
 public:
   explicit BtlRecHitsValidation(const edm::ParameterSet&);
   ~BtlRecHitsValidation() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-
 private:
-  void bookHistograms(DQMStore::IBooker &,
-		      edm::Run const&,
-		      edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
@@ -79,28 +73,21 @@ private:
   MonitorElement* meHitTvsPhi_;
   MonitorElement* meHitTvsEta_;
   MonitorElement* meHitTvsZ_;
-
 };
 
-
 // ------------ constructor and destructor --------------
-BtlRecHitsValidation::BtlRecHitsValidation(const edm::ParameterSet& iConfig):
-  folder_(iConfig.getParameter<std::string>("folder")) {
-
+BtlRecHitsValidation::BtlRecHitsValidation(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")) {
   const std::string infoLabel = iConfig.getParameter<std::string>("moduleLabel");
   const std::string btlRecHitsCollection = iConfig.getParameter<std::string>("btlRecHitsCollection");
 
   btlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("inputTag"));
-
 }
 
-BtlRecHitsValidation::~BtlRecHitsValidation() {
-}
-
+BtlRecHitsValidation::~BtlRecHitsValidation() {}
 
 // ------------ method called for each event  ------------
 void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   using namespace edm;
 
   edm::ESHandle<MTDGeometry> geometryHandle;
@@ -117,26 +104,24 @@ void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
   unsigned int n_reco_btl = 0;
 
-  for (const auto& recHit: *btlRecHitsHandle) {
-
+  for (const auto& recHit : *btlRecHitsHandle) {
     BTLDetId detId = recHit.id();
-    DetId geoId = detId.geographicalId( static_cast<BTLDetId::CrysLayout>(topology->getMTDTopologyMode()) );
+    DetId geoId = detId.geographicalId(static_cast<BTLDetId::CrysLayout>(topology->getMTDTopologyMode()));
     const MTDGeomDet* thedet = geom->idToDet(geoId);
-    if( thedet == nullptr )
-      throw cms::Exception("BtlRecHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
-						   << " (" << detId.rawId()<< ") is invalid!" << std::dec
-						   << std::endl;
+    if (thedet == nullptr)
+      throw cms::Exception("BtlRecHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
+                                                   << detId.rawId() << ") is invalid!" << std::dec << std::endl;
     const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
     const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
-    Local3DPoint local_point(0.,0.,0.);
-    local_point = topo.pixelToModuleLocalPoint(local_point,detId.row(topo.nrows()),detId.column(topo.nrows()));
+    Local3DPoint local_point(0., 0., 0.);
+    local_point = topo.pixelToModuleLocalPoint(local_point, detId.row(topo.nrows()), detId.column(topo.nrows()));
     const auto& global_point = thedet->toGlobal(local_point);
 
     meHitEnergy_->Fill(recHit.energy());
     meHitTime_->Fill(recHit.time());
 
-    meOccupancy_->Fill(global_point.z(),global_point.phi());
+    meOccupancy_->Fill(global_point.z(), global_point.phi());
 
     meHitX_->Fill(global_point.x());
     meHitY_->Fill(global_point.y());
@@ -144,76 +129,67 @@ void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     meHitPhi_->Fill(global_point.phi());
     meHitEta_->Fill(global_point.eta());
 
-    meHitTvsE_->Fill(recHit.energy(),recHit.time());
-    meHitEvsPhi_->Fill(global_point.phi(),recHit.energy());
-    meHitEvsEta_->Fill(global_point.eta(),recHit.energy());
-    meHitEvsZ_->Fill(global_point.z(),recHit.energy());
-    meHitTvsPhi_->Fill(global_point.phi(),recHit.time());
-    meHitTvsEta_->Fill(global_point.eta(),recHit.time());
-    meHitTvsZ_->Fill(global_point.z(),recHit.time());
+    meHitTvsE_->Fill(recHit.energy(), recHit.time());
+    meHitEvsPhi_->Fill(global_point.phi(), recHit.energy());
+    meHitEvsEta_->Fill(global_point.eta(), recHit.energy());
+    meHitEvsZ_->Fill(global_point.z(), recHit.energy());
+    meHitTvsPhi_->Fill(global_point.phi(), recHit.time());
+    meHitTvsEta_->Fill(global_point.eta(), recHit.time());
+    meHitTvsZ_->Fill(global_point.z(), recHit.time());
 
     n_reco_btl++;
 
-  } // recHit loop
+  }  // recHit loop
 
   meNhits_->Fill(n_reco_btl);
-
 }
 
-
 // ------------ method for histogram booking ------------
-void BtlRecHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
-                               edm::Run const& run,
-                               edm::EventSetup const & iSetup) {
-
+void BtlRecHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
+                                          edm::Run const& run,
+                                          edm::EventSetup const& iSetup) {
   ibook.setCurrentFolder(folder_);
 
   // --- histograms booking
 
-  meNhits_     = ibook.book1D("BtlNhits", "Number of BTL RECO hits;N_{RECO}", 100, 0., 5000.);
+  meNhits_ = ibook.book1D("BtlNhits", "Number of BTL RECO hits;N_{RECO}", 100, 0., 5000.);
 
   meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL RECO hits energy;E_{RECO} [MeV]", 100, 0., 20.);
-  meHitTime_   = ibook.book1D("BtlHitTime", "BTL RECO hits ToA;ToA_{RECO} [ns]", 100, 0., 25.);
+  meHitTime_ = ibook.book1D("BtlHitTime", "BTL RECO hits ToA;ToA_{RECO} [ns]", 100, 0., 25.);
 
-  meOccupancy_ = ibook.book2D("BtlOccupancy","BTL RECO hits occupancy;Z_{RECO} [cm]; #phi_{RECO} [rad]",
-			      65, -260., 260., 126, -3.15, 3.15 );
+  meOccupancy_ = ibook.book2D(
+      "BtlOccupancy", "BTL RECO hits occupancy;Z_{RECO} [cm]; #phi_{RECO} [rad]", 65, -260., 260., 126, -3.15, 3.15);
 
-  meHitX_      = ibook.book1D("BtlHitX", "BTL RECO hits X;X_{RECO} [cm]", 60, -120., 120.);
-  meHitY_      = ibook.book1D("BtlHitY", "BTL RECO hits Y;Y_{RECO} [cm]", 60, -120., 120.);
-  meHitZ_      = ibook.book1D("BtlHitZ", "BTL RECO hits Z;Z_{RECO} [cm]", 100, -260., 260.);
-  meHitPhi_    = ibook.book1D("BtlHitPhi", "BTL RECO hits #phi;#phi_{RECO} [rad]", 126, -3.15, 3.15);
-  meHitEta_    = ibook.book1D("BtlHitEta", "BTL RECO hits #eta;#eta_{RECO}", 100, -1.55, 1.55);
+  meHitX_ = ibook.book1D("BtlHitX", "BTL RECO hits X;X_{RECO} [cm]", 60, -120., 120.);
+  meHitY_ = ibook.book1D("BtlHitY", "BTL RECO hits Y;Y_{RECO} [cm]", 60, -120., 120.);
+  meHitZ_ = ibook.book1D("BtlHitZ", "BTL RECO hits Z;Z_{RECO} [cm]", 100, -260., 260.);
+  meHitPhi_ = ibook.book1D("BtlHitPhi", "BTL RECO hits #phi;#phi_{RECO} [rad]", 126, -3.15, 3.15);
+  meHitEta_ = ibook.book1D("BtlHitEta", "BTL RECO hits #eta;#eta_{RECO}", 100, -1.55, 1.55);
 
-  meHitTvsE_   = ibook.bookProfile("BtlHitTvsE", "BTL RECO ToA vs energy;E_{RECO} [MeV];ToA_{RECO} [ns]",
-				   50, 0., 20., 0., 100.);
-  meHitEvsPhi_ = ibook.bookProfile("BtlHitEvsPhi", "BTL RECO energy vs #phi;#phi_{RECO} [rad];E_{RECO} [MeV]",
-				   50, -3.15, 3.15, 0., 100.);
-  meHitEvsEta_ = ibook.bookProfile("BtlHitEvsEta","BTL RECO energy vs #eta;#eta_{RECO};E_{RECO} [MeV]",
-				   50, -1.55, 1.55, 0., 100.);
-  meHitEvsZ_   = ibook.bookProfile("BtlHitEvsZ","BTL RECO energy vs Z;Z_{RECO} [cm];E_{RECO} [MeV]",
-				   50, -260., 260., 0., 100.);
-  meHitTvsPhi_ = ibook.bookProfile("BtlHitTvsPhi", "BTL RECO ToA vs #phi;#phi_{RECO} [rad];ToA_{RECO} [ns]",
-				   50, -3.15, 3.15, 0., 100.);
-  meHitTvsEta_ = ibook.bookProfile("BtlHitTvsEta","BTL RECO ToA vs #eta;#eta_{RECO};ToA_{RECO} [ns]",
-				   50, -1.6, 1.6, 0., 100.);
-  meHitTvsZ_   = ibook.bookProfile("BtlHitTvsZ","BTL RECO ToA vs Z;Z_{RECO} [cm];ToA_{RECO} [ns]",
-				   50, -260., 260., 0., 100.);
-
-
+  meHitTvsE_ =
+      ibook.bookProfile("BtlHitTvsE", "BTL RECO ToA vs energy;E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 20., 0., 100.);
+  meHitEvsPhi_ = ibook.bookProfile(
+      "BtlHitEvsPhi", "BTL RECO energy vs #phi;#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.15, 3.15, 0., 100.);
+  meHitEvsEta_ = ibook.bookProfile(
+      "BtlHitEvsEta", "BTL RECO energy vs #eta;#eta_{RECO};E_{RECO} [MeV]", 50, -1.55, 1.55, 0., 100.);
+  meHitEvsZ_ =
+      ibook.bookProfile("BtlHitEvsZ", "BTL RECO energy vs Z;Z_{RECO} [cm];E_{RECO} [MeV]", 50, -260., 260., 0., 100.);
+  meHitTvsPhi_ = ibook.bookProfile(
+      "BtlHitTvsPhi", "BTL RECO ToA vs #phi;#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.15, 3.15, 0., 100.);
+  meHitTvsEta_ =
+      ibook.bookProfile("BtlHitTvsEta", "BTL RECO ToA vs #eta;#eta_{RECO};ToA_{RECO} [ns]", 50, -1.6, 1.6, 0., 100.);
+  meHitTvsZ_ =
+      ibook.bookProfile("BtlHitTvsZ", "BTL RECO ToA vs Z;Z_{RECO} [cm];ToA_{RECO} [ns]", 50, -260., 260., 0., 100.);
 }
-
-
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void BtlRecHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/BTL/RecHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mtdRecHits", "FTLBarrel"));
 
   descriptions.add("btlRecHits", desc);
-
 }
 
 DEFINE_FWK_MODULE(BtlRecHitsValidation);

--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -35,7 +35,6 @@
 #include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
 #include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
 
-
 struct MTDHit {
   float energy;
   float time;
@@ -44,20 +43,15 @@ struct MTDHit {
   float z;
 };
 
-
 class BtlSimHitsValidation : public DQMEDAnalyzer {
-
 public:
   explicit BtlSimHitsValidation(const edm::ParameterSet&);
   ~BtlSimHitsValidation() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-
 private:
-  void bookHistograms(DQMStore::IBooker &,
-		      edm::Run const&,
-		      edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
@@ -96,26 +90,19 @@ private:
   MonitorElement* meHitTvsPhi_;
   MonitorElement* meHitTvsEta_;
   MonitorElement* meHitTvsZ_;
-
 };
 
-
 // ------------ constructor and destructor --------------
-BtlSimHitsValidation::BtlSimHitsValidation(const edm::ParameterSet& iConfig):
-  folder_(iConfig.getParameter<std::string>("folder")),
-  hitMinEnergy_( iConfig.getParameter<double>("hitMinimumEnergy") ) {
-
+BtlSimHitsValidation::BtlSimHitsValidation(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")),
+      hitMinEnergy_(iConfig.getParameter<double>("hitMinimumEnergy")) {
   btlSimHitsToken_ = consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("inputTag"));
-
 }
 
-BtlSimHitsValidation::~BtlSimHitsValidation() {
-}
-
+BtlSimHitsValidation::~BtlSimHitsValidation() {}
 
 // ------------ method called for each event  ------------
 void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   using namespace edm;
   using namespace geant_units::operators;
 
@@ -133,34 +120,31 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   std::unordered_map<uint32_t, std::set<int> > m_btlTrkPerCell;
 
   // --- Loop over the BLT SIM hits
-  for (auto const& simHit: *btlSimHitsHandle) {
-
+  for (auto const& simHit : *btlSimHitsHandle) {
     // --- Use only hits compatible with the in-time bunch-crossing
-    if ( simHit.tof() < 0 || simHit.tof() > 25. ) continue;
+    if (simHit.tof() < 0 || simHit.tof() > 25.)
+      continue;
 
     DetId id = simHit.detUnitId();
 
     m_btlTrkPerCell[id.rawId()].insert(simHit.trackId());
 
-    auto simHitIt = m_btlHits.emplace(id.rawId(),MTDHit()).first;
+    auto simHitIt = m_btlHits.emplace(id.rawId(), MTDHit()).first;
 
     // --- Accumulate the energy (in MeV) of SIM hits in the same detector cell
     (simHitIt->second).energy += convertUnitsTo(0.001_MeV, simHit.energyLoss());
 
     // --- Get the time of the first SIM hit in the cell
-    if( (simHitIt->second).time==0 || simHit.tof()<(simHitIt->second).time ) {
-
+    if ((simHitIt->second).time == 0 || simHit.tof() < (simHitIt->second).time) {
       (simHitIt->second).time = simHit.tof();
 
       auto hit_pos = simHit.entryPoint();
       (simHitIt->second).x = hit_pos.x();
       (simHitIt->second).y = hit_pos.y();
       (simHitIt->second).z = hit_pos.z();
-
     }
 
-  } // simHit loop
-
+  }  // simHit loop
 
   // ==============================================================================
   //  Histogram filling
@@ -168,28 +152,27 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
   meNhits_->Fill(m_btlHits.size());
 
-  for (auto const& hit: m_btlTrkPerCell)
+  for (auto const& hit : m_btlTrkPerCell)
     meNtrkPerCell_->Fill((hit.second).size());
 
-
-  for (auto const& hit: m_btlHits) {
-
-    if ( (hit.second).energy < hitMinEnergy_ ) continue;
+  for (auto const& hit : m_btlHits) {
+    if ((hit.second).energy < hitMinEnergy_)
+      continue;
 
     // --- Get the SIM hit global position
-    BTLDetId detId(hit.first); 
-    DetId geoId = detId.geographicalId( static_cast<BTLDetId::CrysLayout>(topology->getMTDTopologyMode()) );
+    BTLDetId detId(hit.first);
+    DetId geoId = detId.geographicalId(static_cast<BTLDetId::CrysLayout>(topology->getMTDTopologyMode()));
     const MTDGeomDet* thedet = geom->idToDet(geoId);
-    if( thedet == nullptr )
-      throw cms::Exception("BtlSimHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
-						   << " (" << detId.rawId()<< ") is invalid!" << std::dec
-						   << std::endl;
+    if (thedet == nullptr)
+      throw cms::Exception("BtlSimHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
+                                                   << detId.rawId() << ") is invalid!" << std::dec << std::endl;
     const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
     const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
-    Local3DPoint local_point(convertMmToCm((hit.second).x),convertMmToCm((hit.second).y),convertMmToCm((hit.second).z));
+    Local3DPoint local_point(
+        convertMmToCm((hit.second).x), convertMmToCm((hit.second).y), convertMmToCm((hit.second).z));
 
-    local_point = topo.pixelToModuleLocalPoint(local_point,detId.row(topo.nrows()),detId.column(topo.nrows()));
+    local_point = topo.pixelToModuleLocalPoint(local_point, detId.row(topo.nrows()), detId.column(topo.nrows()));
     const auto& global_point = thedet->toGlobal(local_point);
 
     // --- Fill the histograms
@@ -200,84 +183,77 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     meHitYlocal_->Fill((hit.second).y);
     meHitZlocal_->Fill((hit.second).z);
 
-    meOccupancy_->Fill(global_point.z(),global_point.phi());
+    meOccupancy_->Fill(global_point.z(), global_point.phi());
 
-    meHitX_->Fill(global_point.x()); 
-    meHitY_->Fill(global_point.y()); 
-    meHitZ_->Fill(global_point.z()); 
-    meHitPhi_->Fill(global_point.phi()); 
-    meHitEta_->Fill(global_point.eta()); 
+    meHitX_->Fill(global_point.x());
+    meHitY_->Fill(global_point.y());
+    meHitZ_->Fill(global_point.z());
+    meHitPhi_->Fill(global_point.phi());
+    meHitEta_->Fill(global_point.eta());
 
-    meHitTvsE_->Fill((hit.second).energy,(hit.second).time);  
-    meHitEvsPhi_->Fill(global_point.phi(),(hit.second).energy);
-    meHitEvsEta_->Fill(global_point.eta(),(hit.second).energy);
-    meHitEvsZ_->Fill(global_point.z(),(hit.second).energy);
-    meHitTvsPhi_->Fill(global_point.phi(),(hit.second).time);
-    meHitTvsEta_->Fill(global_point.eta(),(hit.second).time);
-    meHitTvsZ_->Fill(global_point.z(),(hit.second).time);
+    meHitTvsE_->Fill((hit.second).energy, (hit.second).time);
+    meHitEvsPhi_->Fill(global_point.phi(), (hit.second).energy);
+    meHitEvsEta_->Fill(global_point.eta(), (hit.second).energy);
+    meHitEvsZ_->Fill(global_point.z(), (hit.second).energy);
+    meHitTvsPhi_->Fill(global_point.phi(), (hit.second).time);
+    meHitTvsEta_->Fill(global_point.eta(), (hit.second).time);
+    meHitTvsZ_->Fill(global_point.z(), (hit.second).time);
 
-  } // hit loop
-
+  }  // hit loop
 }
 
-
 // ------------ method for histogram booking ------------
-void BtlSimHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
-					  edm::Run const& run,
-					  edm::EventSetup const & iSetup) {
-
+void BtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
+                                          edm::Run const& run,
+                                          edm::EventSetup const& iSetup) {
   ibook.setCurrentFolder(folder_);
 
   // --- histograms booking
 
-  meNhits_       = ibook.book1D("BtlNhits", "Number of BTL cells with SIM hits;N_{BTL cells}", 100, 0., 5000.);
+  meNhits_ = ibook.book1D("BtlNhits", "Number of BTL cells with SIM hits;N_{BTL cells}", 100, 0., 5000.);
   meNtrkPerCell_ = ibook.book1D("BtlNtrkPerCell", "Number of tracks per BTL cell;N_{trk}", 10, 0., 10.);
 
-  meHitEnergy_   = ibook.book1D("BtlHitEnergy", "BTL SIM hits energy;E_{SIM} [MeV]", 100, 0., 20.);
-  meHitTime_     = ibook.book1D("BtlHitTime", "BTL SIM hits ToA;ToA_{SIM} [ns]", 100, 0., 25.);
+  meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL SIM hits energy;E_{SIM} [MeV]", 100, 0., 20.);
+  meHitTime_ = ibook.book1D("BtlHitTime", "BTL SIM hits ToA;ToA_{SIM} [ns]", 100, 0., 25.);
 
-  meHitXlocal_   = ibook.book1D("BtlHitXlocal", "BTL SIM local X;X_{SIM}^{LOC} [mm]", 100, -1.65, 1.65);
-  meHitYlocal_   = ibook.book1D("BtlHitYlocal", "BTL SIM local Y;Y_{SIM}^{LOC} [mm]", 100, -30., 30.);
-  meHitZlocal_   = ibook.book1D("BtlHitZlocal", "BTL SIM local z;z_{SIM}^{LOC} [mm]", 100, -2., 2.);
+  meHitXlocal_ = ibook.book1D("BtlHitXlocal", "BTL SIM local X;X_{SIM}^{LOC} [mm]", 100, -1.65, 1.65);
+  meHitYlocal_ = ibook.book1D("BtlHitYlocal", "BTL SIM local Y;Y_{SIM}^{LOC} [mm]", 100, -30., 30.);
+  meHitZlocal_ = ibook.book1D("BtlHitZlocal", "BTL SIM local z;z_{SIM}^{LOC} [mm]", 100, -2., 2.);
 
-  meOccupancy_   = ibook.book2D("BtlOccupancy","BTL SIM hits occupancy;z_{SIM} [cm];#phi_{SIM} [rad]",
-				130, -260., 260., 200, -3.15, 3.15 );
+  meOccupancy_ = ibook.book2D(
+      "BtlOccupancy", "BTL SIM hits occupancy;z_{SIM} [cm];#phi_{SIM} [rad]", 130, -260., 260., 200, -3.15, 3.15);
 
-  meHitX_        = ibook.book1D("BtlHitX", "BTL SIM hits X;X_{SIM} [cm]", 100, -120., 120.);
-  meHitY_        = ibook.book1D("BtlHitY", "BTL SIM hits Y;Y_{SIM} [cm]", 100, -120., 120.);
-  meHitZ_        = ibook.book1D("BtlHitZ", "BTL SIM hits Z;Z_{SIM} [cm]", 100, -260., 260.);
-  meHitPhi_      = ibook.book1D("BtlHitPhi", "BTL SIM hits #phi;#phi_{SIM} [rad]", 200, -3.15, 3.15);
-  meHitEta_      = ibook.book1D("BtlHitEta", "BTL SIM hits #eta;#eta_{SIM}", 100, -1.55, 1.55);
+  meHitX_ = ibook.book1D("BtlHitX", "BTL SIM hits X;X_{SIM} [cm]", 100, -120., 120.);
+  meHitY_ = ibook.book1D("BtlHitY", "BTL SIM hits Y;Y_{SIM} [cm]", 100, -120., 120.);
+  meHitZ_ = ibook.book1D("BtlHitZ", "BTL SIM hits Z;Z_{SIM} [cm]", 100, -260., 260.);
+  meHitPhi_ = ibook.book1D("BtlHitPhi", "BTL SIM hits #phi;#phi_{SIM} [rad]", 200, -3.15, 3.15);
+  meHitEta_ = ibook.book1D("BtlHitEta", "BTL SIM hits #eta;#eta_{SIM}", 100, -1.55, 1.55);
 
-  meHitTvsE_     = ibook.bookProfile("BtlHitTvsE", "BTL SIM time vs energy;E_{SIM} [MeV];T_{SIM} [ns]",
-				     50, 0., 20., 0., 100.);
-  meHitEvsPhi_   = ibook.bookProfile("BtlHitEvsPhi", "BTL SIM energy vs #phi;#phi_{SIM} [rad];E_{SIM} [MeV]",
-				     50, -3.15, 3.15, 0., 100.);
-  meHitEvsEta_   = ibook.bookProfile("BtlHitEvsEta","BTL SIM energy vs #eta;#eta_{SIM};E_{SIM} [MeV]",
-				     50, -1.55, 1.55, 0., 100.);
-  meHitEvsZ_     = ibook.bookProfile("BtlHitEvsZ","BTL SIM energy vs Z;Z_{SIM} [cm];E_{SIM} [MeV]",
-				     50, -260., 260., 0., 100.);
-  meHitTvsPhi_   = ibook.bookProfile("BtlHitTvsPhi", "BTL SIM time vs #phi;#phi_{SIM} [rad];T_{SIM} [ns]",
-				     50, -3.15, 3.15, 0., 100.);
-  meHitTvsEta_   = ibook.bookProfile("BtlHitTvsEta","BTL SIM time vs #eta;#eta_{SIM};T_{SIM} [ns]",
-				     50, -1.55, 1.55, 0., 100.);
-  meHitTvsZ_     = ibook.bookProfile("BtlHitTvsZ","BTL SIM time vs Z;Z_{SIM} [cm];T_{SIM} [ns]",
-				     50, -260., 260., 0., 100.);
-
+  meHitTvsE_ =
+      ibook.bookProfile("BtlHitTvsE", "BTL SIM time vs energy;E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 20., 0., 100.);
+  meHitEvsPhi_ = ibook.bookProfile(
+      "BtlHitEvsPhi", "BTL SIM energy vs #phi;#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
+  meHitEvsEta_ =
+      ibook.bookProfile("BtlHitEvsEta", "BTL SIM energy vs #eta;#eta_{SIM};E_{SIM} [MeV]", 50, -1.55, 1.55, 0., 100.);
+  meHitEvsZ_ =
+      ibook.bookProfile("BtlHitEvsZ", "BTL SIM energy vs Z;Z_{SIM} [cm];E_{SIM} [MeV]", 50, -260., 260., 0., 100.);
+  meHitTvsPhi_ = ibook.bookProfile(
+      "BtlHitTvsPhi", "BTL SIM time vs #phi;#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
+  meHitTvsEta_ =
+      ibook.bookProfile("BtlHitTvsEta", "BTL SIM time vs #eta;#eta_{SIM};T_{SIM} [ns]", 50, -1.55, 1.55, 0., 100.);
+  meHitTvsZ_ =
+      ibook.bookProfile("BtlHitTvsZ", "BTL SIM time vs Z;Z_{SIM} [cm];T_{SIM} [ns]", 50, -260., 260., 0., 100.);
 }
-
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void BtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/BTL/SimHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("g4SimHits", "FastTimerHitsBarrel"));
-  desc.add<double>("hitMinimumEnergy",1.); // [MeV]
+  desc.add<double>("hitMinimumEnergy", 1.);  // [MeV]
 
   descriptions.add("btlSimHits", desc);
-
 }
 
 DEFINE_FWK_MODULE(BtlSimHitsValidation);

--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -1,0 +1,246 @@
+// -*- C++ -*-
+//
+// Package:    Validation/MtdValidation
+// Class:      BtlSimHitsValidation
+//
+/**\class BtlSimHitsValidation BtlSimHitsValidation.cc Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+
+ Description: BTL SIM hits validation
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Massimo Casarsa
+//         Created:  Fri, 08 Mar 2019 14:04:22 GMT
+//
+//
+
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+
+#include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
+#include "Geometry/Records/interface/MTDTopologyRcd.h"
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
+#include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
+
+#include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
+#include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
+
+
+//
+// class declaration
+//
+
+
+class BtlSimHitsValidation : public DQMEDAnalyzer {
+
+public:
+  explicit BtlSimHitsValidation(const edm::ParameterSet&);
+  ~BtlSimHitsValidation() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+private:
+  void bookHistograms(DQMStore::IBooker &,
+		      edm::Run const&,
+		      edm::EventSetup const&) override;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+// ------------ member data ------------
+
+  const MTDGeometry* geom_;
+  const MTDTopology* topo_;
+
+  const std::string folder_;
+  const std::string g4InfoLabel_;
+  const std::string btlHitsCollection_;
+
+  const float hitMinEnergy_;
+
+  int eventCount_;
+
+  edm::EDGetTokenT<edm::PSimHitContainer> btlSimHitsToken_;
+
+  MonitorElement* meHitEnergy_;
+  MonitorElement* meHitTime_;
+
+  MonitorElement* meOccupancy_;
+
+};
+
+//
+// constants, enums and typedefs
+//
+
+struct MTDHit {
+  float energy;
+  float time;
+  float x;
+  float y;
+  float z;
+};
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+BtlSimHitsValidation::BtlSimHitsValidation(const edm::ParameterSet& iConfig):
+  geom_(nullptr),
+  topo_(nullptr),
+  folder_(iConfig.getParameter<std::string>("folder")),
+  g4InfoLabel_(iConfig.getParameter<std::string>("moduleLabelG4")),
+  btlHitsCollection_(iConfig.getParameter<std::string>("btlSimHitsCollection")),
+  hitMinEnergy_( iConfig.getParameter<double>("hitMinimumEnergy") ),
+  eventCount_(0) {
+
+  btlSimHitsToken_ = consumes <edm::PSimHitContainer> (edm::InputTag(std::string(g4InfoLabel_),
+								     std::string(btlHitsCollection_)));
+
+}
+
+
+BtlSimHitsValidation::~BtlSimHitsValidation() {
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  using namespace edm;
+
+  edm::LogInfo("EventInfo") << " Run = " << iEvent.id().run() << " Event = " << iEvent.id().event();
+
+  edm::ESHandle<MTDGeometry> geometryHandle;
+  iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);
+  geom_ = geometryHandle.product();
+
+  edm::ESHandle<MTDTopology> topologyHandle;
+  iSetup.get<MTDTopologyRcd>().get(topologyHandle);
+  topo_ = topologyHandle.product();
+
+  edm::Handle<edm::PSimHitContainer> btlSimHitsHandle;
+  iEvent.getByToken(btlSimHitsToken_, btlSimHitsHandle);
+
+  if( ! btlSimHitsHandle.isValid() ) return;
+
+  eventCount_++;
+  
+  std::map<uint32_t, MTDHit> m_btlHits;
+
+  // --- Loop over the BLT SIM hits
+  for (auto const& simHit: *btlSimHitsHandle) {
+
+    // --- Only hits compatible with the in-time bunch-crossing
+    if ( simHit.tof() < 0 || simHit.tof() > 25. ) continue;
+
+    DetId id = simHit.detUnitId();
+
+    auto simHitIt = m_btlHits.emplace(id.rawId(),MTDHit()).first;
+
+    // --- Accumulate the energy (in MeV) of SIM hits in the same detector cell
+    (simHitIt->second).energy += 1000.*simHit.energyLoss();
+
+    // --- Get the time of the first SIM hit in the cell
+    if( (simHitIt->second).time==0 || simHit.tof()<(simHitIt->second).time ) {
+
+      (simHitIt->second).time = simHit.tof();
+
+      auto hit_pos = simHit.entryPoint();
+      (simHitIt->second).x = hit_pos.x();
+      (simHitIt->second).y = hit_pos.y();
+      (simHitIt->second).z = hit_pos.z();
+
+    }
+
+  } // simHit loop
+
+
+  // ==============================================================================
+  //  Histogram filling
+  // ==============================================================================
+
+  for (auto const& hit: m_btlHits) {
+
+    if ( (hit.second).energy < hitMinEnergy_ ) continue;
+
+    // --- Get the SIM hit global position
+    BTLDetId detId(hit.first); 
+    DetId geoId = detId.geographicalId( static_cast<BTLDetId::CrysLayout>(topo_->getMTDTopologyMode()) );
+    const MTDGeomDet* thedet = geom_->idToDet(geoId);
+    if( thedet == nullptr )
+      throw cms::Exception("BtlSimHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
+						   << " (" << detId.rawId()<< ") is invalid!" << std::dec
+						   << std::endl;
+    const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
+    const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
+
+    Local3DPoint local_point(0.1*(hit.second).x,0.1*(hit.second).y,0.1*(hit.second).z);
+    local_point = topo.pixelToModuleLocalPoint(local_point,detId.row(topo.nrows()),detId.column(topo.nrows()));
+    const auto& global_point = thedet->toGlobal(local_point);
+
+    // --- Fill the histograms
+    meHitEnergy_->Fill((hit.second).energy);
+    meHitTime_->Fill((hit.second).time);
+    meOccupancy_->Fill(global_point.z(),global_point.phi());
+
+  } // hit loop
+
+}
+
+void BtlSimHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
+                               edm::Run const& run,
+                               edm::EventSetup const & iSetup) {
+
+  ibook.setCurrentFolder(folder_);
+
+  meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL SIM hits energy;E_{SIM} [MeV]", 200, 0., 20.);
+  meHitTime_   = ibook.book1D("BtlHitTime", "BTL SIM hits ToA;ToA_{SIM} [ns]", 250, 0., 25.);
+
+  meOccupancy_ = ibook.book2D("BtlOccupancy","BTL SIM hits occupancy;z_{SIM} [cm];#phi_{SIM} [rad]",
+			      520, -260., 260., 315, -3.15, 3.15 );
+
+}
+
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void BtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // The following says we do not know what parameters are allowed so do no
+  // validation
+  // Please change this to state exactly what you do use, even if it is no
+  // parameters
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("folder", "MTD/BTL/SimHits");
+  desc.add<std::string>("moduleLabelG4","g4SimHits");
+  desc.add<std::string>("btlSimHitsCollection","FastTimerHitsBarrel");
+  desc.add<double>("hitMinimumEnergy",1.); // [MeV]
+  descriptions.add("btlSimHits", desc);
+
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BtlSimHitsValidation);

--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -1,3 +1,4 @@
+
 // -*- C++ -*-
 //
 // Package:    Validation/MtdValidation
@@ -216,8 +217,8 @@ void BtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL SIM hits energy;E_{SIM} [MeV]", 100, 0., 20.);
   meHitTime_ = ibook.book1D("BtlHitTime", "BTL SIM hits ToA;ToA_{SIM} [ns]", 100, 0., 25.);
 
-  meHitXlocal_ = ibook.book1D("BtlHitXlocal", "BTL SIM local X;X_{SIM}^{LOC} [mm]", 100, -1.65, 1.65);
-  meHitYlocal_ = ibook.book1D("BtlHitYlocal", "BTL SIM local Y;Y_{SIM}^{LOC} [mm]", 100, -30., 30.);
+  meHitXlocal_ = ibook.book1D("BtlHitXlocal", "BTL SIM local X;X_{SIM}^{LOC} [mm]", 100, -30., 30.);
+  meHitYlocal_ = ibook.book1D("BtlHitYlocal", "BTL SIM local Y;Y_{SIM}^{LOC} [mm]", 100, -1.65, 1.65);
   meHitZlocal_ = ibook.book1D("BtlHitZlocal", "BTL SIM local z;z_{SIM}^{LOC} [mm]", 100, -2., 2.);
 
   meOccupancy_ = ibook.book2D(

--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -249,39 +249,39 @@ void BtlSimHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
 
   // --- histograms booking
 
-  meNhits_       = ibook.book1D("BtlNhits", "Number of BTL cells with SIM hits;N_{BTL cells}", 250, 0., 5000.);
+  meNhits_       = ibook.book1D("BtlNhits", "Number of BTL cells with SIM hits;N_{BTL cells}", 100, 0., 5000.);
   meNtrkPerCell_ = ibook.book1D("BtlNtrkPerCell", "Number of tracks per BTL cell;N_{trk}", 10, 0., 10.);
 
-  meHitEnergy_   = ibook.book1D("BtlHitEnergy", "BTL SIM hits energy;E_{SIM} [MeV]", 200, 0., 20.);
-  meHitTime_     = ibook.book1D("BtlHitTime", "BTL SIM hits ToA;ToA_{SIM} [ns]", 250, 0., 25.);
+  meHitEnergy_   = ibook.book1D("BtlHitEnergy", "BTL SIM hits energy;E_{SIM} [MeV]", 100, 0., 20.);
+  meHitTime_     = ibook.book1D("BtlHitTime", "BTL SIM hits ToA;ToA_{SIM} [ns]", 100, 0., 25.);
 
-  meHitXlocal_   = ibook.book1D("BtlHitXlocal", "BTL SIM local X;X_{SIM}^{LOC} [mm]", 400, -2., 2.);
-  meHitYlocal_   = ibook.book1D("BtlHitYlocal", "BTL SIM local Y;Y_{SIM}^{LOC} [mm]", 600, -30., 30.);
-  meHitZlocal_   = ibook.book1D("BtlHitZlocal", "BTL SIM local z;z_{SIM}^{LOC} [mm]", 400, -2., 2.);
+  meHitXlocal_   = ibook.book1D("BtlHitXlocal", "BTL SIM local X;X_{SIM}^{LOC} [mm]", 100, -1.65, 1.65);
+  meHitYlocal_   = ibook.book1D("BtlHitYlocal", "BTL SIM local Y;Y_{SIM}^{LOC} [mm]", 100, -30., 30.);
+  meHitZlocal_   = ibook.book1D("BtlHitZlocal", "BTL SIM local z;z_{SIM}^{LOC} [mm]", 100, -2., 2.);
 
   meOccupancy_   = ibook.book2D("BtlOccupancy","BTL SIM hits occupancy;z_{SIM} [cm];#phi_{SIM} [rad]",
-				520, -260., 260., 315, -3.15, 3.15 );
+				130, -260., 260., 200, -3.15, 3.15 );
 
-  meHitX_        = ibook.book1D("BtlHitX", "BTL SIM hits X;X_{SIM} [cm]", 135, -135., 135.);
-  meHitY_        = ibook.book1D("BtlHitY", "BTL SIM hits Y;Y_{SIM} [cm]", 135, -135., 135.);
-  meHitZ_        = ibook.book1D("BtlHitZ", "BTL SIM hits Z;Z_{SIM} [cm]", 520, -260., 260.);
-  meHitPhi_      = ibook.book1D("BtlHitPhi", "BTL SIM hits #phi;#phi_{SIM} [rad]", 315, -3.15, 3.15);
-  meHitEta_      = ibook.book1D("BtlHitEta", "BTL SIM hits #eta;#eta_{SIM}", 200, -1.6, 1.6);
+  meHitX_        = ibook.book1D("BtlHitX", "BTL SIM hits X;X_{SIM} [cm]", 100, -120., 120.);
+  meHitY_        = ibook.book1D("BtlHitY", "BTL SIM hits Y;Y_{SIM} [cm]", 100, -120., 120.);
+  meHitZ_        = ibook.book1D("BtlHitZ", "BTL SIM hits Z;Z_{SIM} [cm]", 100, -260., 260.);
+  meHitPhi_      = ibook.book1D("BtlHitPhi", "BTL SIM hits #phi;#phi_{SIM} [rad]", 200, -3.15, 3.15);
+  meHitEta_      = ibook.book1D("BtlHitEta", "BTL SIM hits #eta;#eta_{SIM}", 100, -1.55, 1.55);
 
   meHitTvsE_     = ibook.bookProfile("BtlHitTvsE", "BTL SIM time vs energy;E_{SIM} [MeV];T_{SIM} [ns]",
-				     100, 0., 20., 0., 100.);
+				     50, 0., 20., 0., 100.);
   meHitEvsPhi_   = ibook.bookProfile("BtlHitEvsPhi", "BTL SIM energy vs #phi;#phi_{SIM} [rad];E_{SIM} [MeV]",
-				     100, -3.15, 3.15, 0., 100.);
+				     50, -3.15, 3.15, 0., 100.);
   meHitEvsEta_   = ibook.bookProfile("BtlHitEvsEta","BTL SIM energy vs #eta;#eta_{SIM};E_{SIM} [MeV]",
-				     200, -1.6, 1.6, 0., 100.);
+				     50, -1.55, 1.55, 0., 100.);
   meHitEvsZ_     = ibook.bookProfile("BtlHitEvsZ","BTL SIM energy vs Z;Z_{SIM} [cm];E_{SIM} [MeV]",
-				     520, -260., 260., 0., 100.);
+				     50, -260., 260., 0., 100.);
   meHitTvsPhi_   = ibook.bookProfile("BtlHitTvsPhi", "BTL SIM time vs #phi;#phi_{SIM} [rad];T_{SIM} [ns]",
-				     100, -3.15, 3.15, 0., 100.);
+				     50, -3.15, 3.15, 0., 100.);
   meHitTvsEta_   = ibook.bookProfile("BtlHitTvsEta","BTL SIM time vs #eta;#eta_{SIM};T_{SIM} [ns]",
-				     200, -1.6, 1.6, 0., 100.);
+				     50, -1.55, 1.55, 0., 100.);
   meHitTvsZ_     = ibook.bookProfile("BtlHitTvsZ","BTL SIM time vs Z;Z_{SIM} [cm];T_{SIM} [ns]",
-				     520, -260., 260., 0., 100.);
+				     50, -260., 260., 0., 100.);
 
 }
 

--- a/Validation/MtdValidation/plugins/BuildFile.xml
+++ b/Validation/MtdValidation/plugins/BuildFile.xml
@@ -1,0 +1,7 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/PluginManager"/>
+<use name="FWCore/ParameterSet"/>
+<use name="Geometry/Records"/>
+<use name="Geometry/MTDGeometryBuilder"/>
+<use name="DQMServices/Core"/>
+<flags EDM_PLUGIN="1"/>

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -29,20 +29,15 @@
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 
-
 class EtlDigiHitsValidation : public DQMEDAnalyzer {
-
 public:
   explicit EtlDigiHitsValidation(const edm::ParameterSet&);
   ~EtlDigiHitsValidation() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-
 private:
-  void bookHistograms(DQMStore::IBooker &,
-		      edm::Run const&,
-		      edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
@@ -72,25 +67,18 @@ private:
   MonitorElement* meHitQvsEta_[2];
   MonitorElement* meHitTvsPhi_[2];
   MonitorElement* meHitTvsEta_[2];
-
 };
 
-
 // ------------ constructor and destructor --------------
-EtlDigiHitsValidation::EtlDigiHitsValidation(const edm::ParameterSet& iConfig):
-  folder_(iConfig.getParameter<std::string>("folder")) {
-
+EtlDigiHitsValidation::EtlDigiHitsValidation(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")) {
   etlDigiHitsToken_ = consumes<ETLDigiCollection>(iConfig.getParameter<edm::InputTag>("inputTag"));
-
 }
 
-EtlDigiHitsValidation::~EtlDigiHitsValidation() {
-}
-
+EtlDigiHitsValidation::~EtlDigiHitsValidation() {}
 
 // ------------ method called for each event  ------------
 void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   using namespace edm;
 
   edm::ESHandle<MTDGeometry> geometryHandle;
@@ -101,10 +89,9 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 
   // --- Loop over the ELT DIGI hits
 
-  unsigned int n_digi_etl[2] = {0,0};
+  unsigned int n_digi_etl[2] = {0, 0};
 
-  for (const auto& dataFrame: *etlDigiHitsHandle) {
-
+  for (const auto& dataFrame : *etlDigiHitsHandle) {
     // --- Get the on-time sample
     int isample = 2;
 
@@ -115,119 +102,147 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
     DetId geoId = detId.geographicalId();
 
     const MTDGeomDet* thedet = geom->idToDet(geoId);
-    if( thedet == nullptr )
-      throw cms::Exception("EtlDigiHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
-						    << " (" << detId.rawId()<< ") is invalid!" << std::dec
-						    << std::endl;
+    if (thedet == nullptr)
+      throw cms::Exception("EtlDigiHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
+                                                    << detId.rawId() << ") is invalid!" << std::dec << std::endl;
     const PixelTopology& topo = static_cast<const PixelTopology&>(thedet->topology());
 
-    Local3DPoint local_point(topo.localX(sample.row()),topo.localY(sample.column()),0.);
+    Local3DPoint local_point(topo.localX(sample.row()), topo.localY(sample.column()), 0.);
     const auto& global_point = thedet->toGlobal(local_point);
 
     // --- Fill the histograms
 
-    int idet = (detId.zside()+1)/2;
+    int idet = (detId.zside() + 1) / 2;
 
     meHitCharge_[idet]->Fill(sample.data());
     meHitTime_[idet]->Fill(sample.toa());
-    meOccupancy_[idet]->Fill(global_point.x(),global_point.y());
+    meOccupancy_[idet]->Fill(global_point.x(), global_point.y());
 
-    
     meHitX_[idet]->Fill(global_point.x());
     meHitY_[idet]->Fill(global_point.y());
     meHitZ_[idet]->Fill(global_point.z());
     meHitPhi_[idet]->Fill(global_point.phi());
     meHitEta_[idet]->Fill(global_point.eta());
 
-    meHitTvsQ_[idet]->Fill(sample.data(),sample.toa());
-    meHitQvsPhi_[idet]->Fill(global_point.phi(),sample.data());
-    meHitQvsEta_[idet]->Fill(global_point.eta(),sample.data());
-    meHitTvsPhi_[idet]->Fill(global_point.phi(),sample.toa());
-    meHitTvsEta_[idet]->Fill(global_point.eta(),sample.toa());
+    meHitTvsQ_[idet]->Fill(sample.data(), sample.toa());
+    meHitQvsPhi_[idet]->Fill(global_point.phi(), sample.data());
+    meHitQvsEta_[idet]->Fill(global_point.eta(), sample.data());
+    meHitTvsPhi_[idet]->Fill(global_point.phi(), sample.toa());
+    meHitTvsEta_[idet]->Fill(global_point.eta(), sample.toa());
 
     n_digi_etl[idet]++;
 
-  } // dataFrame loop
+  }  // dataFrame loop
 
   meNhits_[0]->Fill(n_digi_etl[0]);
   meNhits_[1]->Fill(n_digi_etl[1]);
-
 }
 
-
 // ------------ method for histogram booking ------------
-void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
-                               edm::Run const& run,
-                               edm::EventSetup const & iSetup) {
-
+void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
+                                           edm::Run const& run,
+                                           edm::EventSetup const& iSetup) {
   ibook.setCurrentFolder(folder_);
 
   // --- histograms booking
 
-  meNhits_[0]     = ibook.book1D("EtlNhitsZneg", "Number of ETL DIGI hits (-Z);N_{DIGI}", 100, 0., 5000.);
-  meNhits_[1]     = ibook.book1D("EtlNhitsZpos", "Number of ETL DIGI hits (+Z);N_{DIGI}", 100, 0., 5000.);
+  meNhits_[0] = ibook.book1D("EtlNhitsZneg", "Number of ETL DIGI hits (-Z);N_{DIGI}", 100, 0., 5000.);
+  meNhits_[1] = ibook.book1D("EtlNhitsZpos", "Number of ETL DIGI hits (+Z);N_{DIGI}", 100, 0., 5000.);
 
-  meHitCharge_[0] = ibook.book1D("EtlHitChargeZneg", "ETL DIGI hits charge (-Z);Q_{DIGI} [ADC counts]",
-				 100, 0., 256.);
-  meHitCharge_[1] = ibook.book1D("EtlHitChargeZpos", "ETL DIGI hits charge (+Z);Q_{DIGI} [ADC counts]",
-				 100, 0., 256.);
-  meHitTime_[0]   = ibook.book1D("EtlHitTimeZneg", "ETL DIGI hits ToA (-Z);ToA_{DIGI} [TDC counts]", 
-				 100, 0., 2000.);
-  meHitTime_[1]   = ibook.book1D("EtlHitTimeZpos", "ETL DIGI hits ToA (+Z);ToA_{DIGI} [TDC counts]", 
-				 100, 0., 2000.);
+  meHitCharge_[0] = ibook.book1D("EtlHitChargeZneg", "ETL DIGI hits charge (-Z);Q_{DIGI} [ADC counts]", 100, 0., 256.);
+  meHitCharge_[1] = ibook.book1D("EtlHitChargeZpos", "ETL DIGI hits charge (+Z);Q_{DIGI} [ADC counts]", 100, 0., 256.);
+  meHitTime_[0] = ibook.book1D("EtlHitTimeZneg", "ETL DIGI hits ToA (-Z);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
+  meHitTime_[1] = ibook.book1D("EtlHitTimeZpos", "ETL DIGI hits ToA (+Z);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
 
-  meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg","ETL DIGI hits occupancy (-Z);X_{DIGI} [cm];Y_{DIGI} [cm]",
-				 135, -135., 135., 135, -135., 135.);
-  meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos","ETL DIGI hits occupancy (+Z);X_{DIGI} [cm];Y_{DIGI} [cm]",
-				 135, -135., 135., 135, -135., 135.);
+  meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg",
+                                 "ETL DIGI hits occupancy (-Z);X_{DIGI} [cm];Y_{DIGI} [cm]",
+                                 135,
+                                 -135.,
+                                 135.,
+                                 135,
+                                 -135.,
+                                 135.);
+  meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos",
+                                 "ETL DIGI hits occupancy (+Z);X_{DIGI} [cm];Y_{DIGI} [cm]",
+                                 135,
+                                 -135.,
+                                 135.,
+                                 135,
+                                 -135.,
+                                 135.);
 
-  meHitX_[0]      = ibook.book1D("EtlHitXZneg", "ETL DIGI hits X (-Z);X_{DIGI} [cm]", 100, -130., 130.);
-  meHitX_[1]      = ibook.book1D("EtlHitXZpos", "ETL DIGI hits X (+Z);X_{DIGI} [cm]", 100, -130., 130.);
-  meHitY_[0]      = ibook.book1D("EtlHitYZneg", "ETL DIGI hits Y (-Z);Y_{DIGI} [cm]", 100, -130., 130.);
-  meHitY_[1]      = ibook.book1D("EtlHitYZpos", "ETL DIGI hits Y (+Z);Y_{DIGI} [cm]", 100, -130., 130.);
-  meHitZ_[0]      = ibook.book1D("EtlHitZZneg", "ETL DIGI hits Z (-Z);Z_{DIGI} [cm]", 100, -304.2, -303.4);
-  meHitZ_[1]      = ibook.book1D("EtlHitZZpos", "ETL DIGI hits Z (+Z);Z_{DIGI} [cm]", 100,  303.4,  304.2);
+  meHitX_[0] = ibook.book1D("EtlHitXZneg", "ETL DIGI hits X (-Z);X_{DIGI} [cm]", 100, -130., 130.);
+  meHitX_[1] = ibook.book1D("EtlHitXZpos", "ETL DIGI hits X (+Z);X_{DIGI} [cm]", 100, -130., 130.);
+  meHitY_[0] = ibook.book1D("EtlHitYZneg", "ETL DIGI hits Y (-Z);Y_{DIGI} [cm]", 100, -130., 130.);
+  meHitY_[1] = ibook.book1D("EtlHitYZpos", "ETL DIGI hits Y (+Z);Y_{DIGI} [cm]", 100, -130., 130.);
+  meHitZ_[0] = ibook.book1D("EtlHitZZneg", "ETL DIGI hits Z (-Z);Z_{DIGI} [cm]", 100, -304.2, -303.4);
+  meHitZ_[1] = ibook.book1D("EtlHitZZpos", "ETL DIGI hits Z (+Z);Z_{DIGI} [cm]", 100, 303.4, 304.2);
 
-  meHitPhi_[0]    = ibook.book1D("EtlHitPhiZneg", "ETL DIGI hits #phi (-Z);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
-  meHitPhi_[1]    = ibook.book1D("EtlHitPhiZpos", "ETL DIGI hits #phi (+Z);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
-  meHitEta_[0]    = ibook.book1D("EtlHitEtaZneg", "ETL DIGI hits #eta (-Z);#eta_{DIGI}", 100, -3., -1.56);
-  meHitEta_[1]    = ibook.book1D("EtlHitEtaZpos", "ETL DIGI hits #eta (+Z);#eta_{DIGI}", 100,  1.56,  3.);
+  meHitPhi_[0] = ibook.book1D("EtlHitPhiZneg", "ETL DIGI hits #phi (-Z);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[1] = ibook.book1D("EtlHitPhiZpos", "ETL DIGI hits #phi (+Z);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
+  meHitEta_[0] = ibook.book1D("EtlHitEtaZneg", "ETL DIGI hits #eta (-Z);#eta_{DIGI}", 100, -3., -1.56);
+  meHitEta_[1] = ibook.book1D("EtlHitEtaZpos", "ETL DIGI hits #eta (+Z);#eta_{DIGI}", 100, 1.56, 3.);
 
-
-  meHitTvsQ_[0]   = ibook.bookProfile("EtlHitTvsQZneg", "ETL DIGI ToA vs charge (-Z);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
-				      50, 0., 256., 0., 1024.);
-  meHitTvsQ_[1]   = ibook.bookProfile("EtlHitTvsQZpos", "ETL DIGI ToA vs charge (+Z);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
-				      50, 0., 256., 0., 1024.);
-  meHitQvsPhi_[0] = ibook.bookProfile("EtlHitQvsPhiZneg", "ETL DIGI charge vs #phi (-Z);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
-				      50, -3.15, 3.15, 0., 1024.);
-  meHitQvsPhi_[1] = ibook.bookProfile("EtlHitQvsPhiZpos", "ETL DIGI charge vs #phi (+Z);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
-				      50, -3.15, 3.15, 0., 1024.);
-  meHitQvsEta_[0] = ibook.bookProfile("EtlHitQvsEtaZneg","ETL DIGI charge vs #eta (-Z);#eta_{DIGI};Q_{DIGI} [ADC counts]",
-				      50, -3., -1.56, 0., 1024.);
-  meHitQvsEta_[1] = ibook.bookProfile("EtlHitQvsEtaZpos","ETL DIGI charge vs #eta (+Z);#eta_{DIGI};Q_{DIGI} [ADC counts]",
-				      50, 1.56,  3., 0., 1024.);
-  meHitTvsPhi_[0] = ibook.bookProfile("EtlHitTvsPhiZneg", "ETL DIGI ToA vs #phi (-Z);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
-				      50, -3.15, 3.15, 0., 1024.);
-  meHitTvsPhi_[1] = ibook.bookProfile("EtlHitTvsPhiZpos", "ETL DIGI ToA vs #phi (+Z);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
-				      50, -3.15, 3.15, 0., 1024.);
-  meHitTvsEta_[0] = ibook.bookProfile("EtlHitTvsEtaZneg","ETL DIGI ToA vs #eta (-Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
-				      50, -3., -1.56, 0., 1024.);
-  meHitTvsEta_[1] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL DIGI ToA vs #eta (+Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
-				      50, 1.56,  3., 0., 1024.);
-
+  meHitTvsQ_[0] = ibook.bookProfile("EtlHitTvsQZneg",
+                                    "ETL DIGI ToA vs charge (-Z);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+                                    50,
+                                    0.,
+                                    256.,
+                                    0.,
+                                    1024.);
+  meHitTvsQ_[1] = ibook.bookProfile("EtlHitTvsQZpos",
+                                    "ETL DIGI ToA vs charge (+Z);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+                                    50,
+                                    0.,
+                                    256.,
+                                    0.,
+                                    1024.);
+  meHitQvsPhi_[0] = ibook.bookProfile("EtlHitQvsPhiZneg",
+                                      "ETL DIGI charge vs #phi (-Z);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      1024.);
+  meHitQvsPhi_[1] = ibook.bookProfile("EtlHitQvsPhiZpos",
+                                      "ETL DIGI charge vs #phi (+Z);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      1024.);
+  meHitQvsEta_[0] = ibook.bookProfile(
+      "EtlHitQvsEtaZneg", "ETL DIGI charge vs #eta (-Z);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, -3., -1.56, 0., 1024.);
+  meHitQvsEta_[1] = ibook.bookProfile(
+      "EtlHitQvsEtaZpos", "ETL DIGI charge vs #eta (+Z);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, 1.56, 3., 0., 1024.);
+  meHitTvsPhi_[0] = ibook.bookProfile("EtlHitTvsPhiZneg",
+                                      "ETL DIGI ToA vs #phi (-Z);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      1024.);
+  meHitTvsPhi_[1] = ibook.bookProfile("EtlHitTvsPhiZpos",
+                                      "ETL DIGI ToA vs #phi (+Z);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      1024.);
+  meHitTvsEta_[0] = ibook.bookProfile(
+      "EtlHitTvsEtaZneg", "ETL DIGI ToA vs #eta (-Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, -3., -1.56, 0., 1024.);
+  meHitTvsEta_[1] = ibook.bookProfile(
+      "EtlHitTvsEtaZpos", "ETL DIGI ToA vs #eta (+Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, 1.56, 3., 0., 1024.);
 }
-
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void EtlDigiHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/ETL/DigiHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "FTLEndcap"));
 
   descriptions.add("etlDigiHitsDefault", desc);
-
 }
 
 DEFINE_FWK_MODULE(EtlDigiHitsValidation);

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -180,8 +180,8 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   meHitPhi_[0] = ibook.book1D("EtlHitPhiZneg", "ETL DIGI hits #phi (-Z);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
   meHitPhi_[1] = ibook.book1D("EtlHitPhiZpos", "ETL DIGI hits #phi (+Z);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
-  meHitEta_[0] = ibook.book1D("EtlHitEtaZneg", "ETL DIGI hits #eta (-Z);#eta_{DIGI}", 100, -3., -1.56);
-  meHitEta_[1] = ibook.book1D("EtlHitEtaZpos", "ETL DIGI hits #eta (+Z);#eta_{DIGI}", 100, 1.56, 3.);
+  meHitEta_[0] = ibook.book1D("EtlHitEtaZneg", "ETL DIGI hits #eta (-Z);#eta_{DIGI}", 100, -3.2, -1.56);
+  meHitEta_[1] = ibook.book1D("EtlHitEtaZpos", "ETL DIGI hits #eta (+Z);#eta_{DIGI}", 100, 1.56, 3.2);
 
   meHitTvsQ_[0] = ibook.bookProfile("EtlHitTvsQZneg",
                                     "ETL DIGI ToA vs charge (-Z);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
@@ -212,9 +212,9 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                       0.,
                                       1024.);
   meHitQvsEta_[0] = ibook.bookProfile(
-      "EtlHitQvsEtaZneg", "ETL DIGI charge vs #eta (-Z);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, -3., -1.56, 0., 1024.);
+      "EtlHitQvsEtaZneg", "ETL DIGI charge vs #eta (-Z);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, -3.2, -1.56, 0., 1024.);
   meHitQvsEta_[1] = ibook.bookProfile(
-      "EtlHitQvsEtaZpos", "ETL DIGI charge vs #eta (+Z);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, 1.56, 3., 0., 1024.);
+      "EtlHitQvsEtaZpos", "ETL DIGI charge vs #eta (+Z);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, 1.56, 3.2, 0., 1024.);
   meHitTvsPhi_[0] = ibook.bookProfile("EtlHitTvsPhiZneg",
                                       "ETL DIGI ToA vs #phi (-Z);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
                                       50,
@@ -230,9 +230,9 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                       0.,
                                       1024.);
   meHitTvsEta_[0] = ibook.bookProfile(
-      "EtlHitTvsEtaZneg", "ETL DIGI ToA vs #eta (-Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, -3., -1.56, 0., 1024.);
+      "EtlHitTvsEtaZneg", "ETL DIGI ToA vs #eta (-Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, -3.2, -1.56, 0., 1024.);
   meHitTvsEta_[1] = ibook.bookProfile(
-      "EtlHitTvsEtaZpos", "ETL DIGI ToA vs #eta (+Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, 1.56, 3., 0., 1024.);
+      "EtlHitTvsEtaZpos", "ETL DIGI ToA vs #eta (+Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, 1.56, 3.2, 0., 1024.);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -27,6 +27,7 @@
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
 
 
 class EtlDigiHitsValidation : public DQMEDAnalyzer {
@@ -139,8 +140,9 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
       throw cms::Exception("EtlDigiHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
 						    << " (" << detId.rawId()<< ") is invalid!" << std::dec
 						    << std::endl;
-    
-    Local3DPoint local_point(0.,0.,0.);
+    const PixelTopology& topo = static_cast<const PixelTopology&>(thedet->topology());
+
+    Local3DPoint local_point(topo.localX(sample.row()),topo.localY(sample.column()),0.);
     const auto& global_point = thedet->toGlobal(local_point);
 
     // --- Fill the histograms
@@ -183,56 +185,56 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
 
   // --- histograms booking
 
-  meNhits_[0]     = ibook.book1D("EtlNhitsZneg", "Number of ETL DIGI hits (-Z);N_{DIGI}", 250, 0., 5000.);
-  meNhits_[1]     = ibook.book1D("EtlNhitsZpos", "Number of ETL DIGI hits (+Z);N_{DIGI}", 250, 0., 5000.);
+  meNhits_[0]     = ibook.book1D("EtlNhitsZneg", "Number of ETL DIGI hits (-Z);N_{DIGI}", 100, 0., 5000.);
+  meNhits_[1]     = ibook.book1D("EtlNhitsZpos", "Number of ETL DIGI hits (+Z);N_{DIGI}", 100, 0., 5000.);
 
   meHitCharge_[0] = ibook.book1D("EtlHitChargeZneg", "ETL DIGI hits charge (-Z);Q_{DIGI} [ADC counts]",
-				 256, 0., 256.);
+				 100, 0., 256.);
   meHitCharge_[1] = ibook.book1D("EtlHitChargeZpos", "ETL DIGI hits charge (+Z);Q_{DIGI} [ADC counts]",
-				 256, 0., 256.);
+				 100, 0., 256.);
   meHitTime_[0]   = ibook.book1D("EtlHitTimeZneg", "ETL DIGI hits ToA (-Z);ToA_{DIGI} [TDC counts]", 
-				 1000, 0., 2000.);
+				 100, 0., 2000.);
   meHitTime_[1]   = ibook.book1D("EtlHitTimeZpos", "ETL DIGI hits ToA (+Z);ToA_{DIGI} [TDC counts]", 
-				 1000, 0., 2000.);
+				 100, 0., 2000.);
 
   meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg","ETL DIGI hits occupancy (-Z);X_{DIGI} [cm];Y_{DIGI} [cm]",
-				 135, -135., 135.,  135, -135., 135.);
+				 135, -135., 135., 135, -135., 135.);
   meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos","ETL DIGI hits occupancy (+Z);X_{DIGI} [cm];Y_{DIGI} [cm]",
-				 135, -135., 135.,  135, -135., 135.);
+				 135, -135., 135., 135, -135., 135.);
 
-  meHitX_[0]      = ibook.book1D("EtlHitXZneg", "ETL DIGI hits X (-Z);X_{DIGI} [cm]", 135, -135., 135.);
-  meHitX_[1]      = ibook.book1D("EtlHitXZpos", "ETL DIGI hits X (+Z);X_{DIGI} [cm]", 135, -135., 135.);
-  meHitY_[0]      = ibook.book1D("EtlHitYZneg", "ETL DIGI hits Y (-Z);Y_{DIGI} [cm]", 135, -135., 135.);
-  meHitY_[1]      = ibook.book1D("EtlHitYZpos", "ETL DIGI hits Y (+Z);Y_{DIGI} [cm]", 135, -135., 135.);
-  meHitZ_[0]      = ibook.book1D("EtlHitZZneg", "ETL DIGI hits Z (-Z);Z_{DIGI} [cm]", 100, -304.5, -303.);
-  meHitZ_[1]      = ibook.book1D("EtlHitZZpos", "ETL DIGI hits Z (+Z);Z_{DIGI} [cm]", 100,  303.,  304.5);
+  meHitX_[0]      = ibook.book1D("EtlHitXZneg", "ETL DIGI hits X (-Z);X_{DIGI} [cm]", 100, -130., 130.);
+  meHitX_[1]      = ibook.book1D("EtlHitXZpos", "ETL DIGI hits X (+Z);X_{DIGI} [cm]", 100, -130., 130.);
+  meHitY_[0]      = ibook.book1D("EtlHitYZneg", "ETL DIGI hits Y (-Z);Y_{DIGI} [cm]", 100, -130., 130.);
+  meHitY_[1]      = ibook.book1D("EtlHitYZpos", "ETL DIGI hits Y (+Z);Y_{DIGI} [cm]", 100, -130., 130.);
+  meHitZ_[0]      = ibook.book1D("EtlHitZZneg", "ETL DIGI hits Z (-Z);Z_{DIGI} [cm]", 100, -304.2, -303.4);
+  meHitZ_[1]      = ibook.book1D("EtlHitZZpos", "ETL DIGI hits Z (+Z);Z_{DIGI} [cm]", 100,  303.4,  304.2);
 
-  meHitPhi_[0]    = ibook.book1D("EtlHitPhiZneg", "ETL DIGI hits #phi (-Z);#phi_{DIGI} [rad]", 315, -3.15, 3.15);
-  meHitPhi_[1]    = ibook.book1D("EtlHitPhiZpos", "ETL DIGI hits #phi (+Z);#phi_{DIGI} [rad]", 315, -3.15, 3.15);
-  meHitEta_[0]    = ibook.book1D("EtlHitEtaZneg", "ETL DIGI hits #eta (-Z);#eta_{DIGI}", 200,  1.55,  3.05);
-  meHitEta_[1]    = ibook.book1D("EtlHitEtaZpos", "ETL DIGI hits #eta (+Z);#eta_{DIGI}", 200, -3.05, -1.55);
+  meHitPhi_[0]    = ibook.book1D("EtlHitPhiZneg", "ETL DIGI hits #phi (-Z);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[1]    = ibook.book1D("EtlHitPhiZpos", "ETL DIGI hits #phi (+Z);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
+  meHitEta_[0]    = ibook.book1D("EtlHitEtaZneg", "ETL DIGI hits #eta (-Z);#eta_{DIGI}", 100, -2.96, -1.56);
+  meHitEta_[1]    = ibook.book1D("EtlHitEtaZpos", "ETL DIGI hits #eta (+Z);#eta_{DIGI}", 100,  1.56,  2.96);
 
 
   meHitTvsQ_[0]   = ibook.bookProfile("EtlHitTvsQZneg", "ETL DIGI ToA vs charge (-Z);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
-				       256, 0., 256., 0., 1024.);
+				      50, 0., 256., 0., 1024.);
   meHitTvsQ_[1]   = ibook.bookProfile("EtlHitTvsQZpos", "ETL DIGI ToA vs charge (+Z);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
-				       256, 0., 256., 0., 1024.);
+				      50, 0., 256., 0., 1024.);
   meHitQvsPhi_[0] = ibook.bookProfile("EtlHitQvsPhiZneg", "ETL DIGI charge vs #phi (-Z);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
-				      100, -3.15, 3.15, 0., 1024.);
+				      50, -3.15, 3.15, 0., 1024.);
   meHitQvsPhi_[1] = ibook.bookProfile("EtlHitQvsPhiZpos", "ETL DIGI charge vs #phi (+Z);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
-				      100, -3.15, 3.15, 0., 1024.);
+				      50, -3.15, 3.15, 0., 1024.);
   meHitQvsEta_[0] = ibook.bookProfile("EtlHitQvsEtaZneg","ETL DIGI charge vs #eta (-Z);#eta_{DIGI};Q_{DIGI} [ADC counts]",
-				      100, -3.05, -1.55, 0., 1024.);
+				      50, -2.96, -1.56, 0., 1024.);
   meHitQvsEta_[1] = ibook.bookProfile("EtlHitQvsEtaZpos","ETL DIGI charge vs #eta (+Z);#eta_{DIGI};Q_{DIGI} [ADC counts]",
-				      100, 1.55,  3.05, 0., 1024.);
+				      50, 1.56,  2.96, 0., 1024.);
   meHitTvsPhi_[0] = ibook.bookProfile("EtlHitTvsPhiZneg", "ETL DIGI ToA vs #phi (-Z);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
-				      100, -3.15, 3.15, 0., 1024.);
+				      50, -3.15, 3.15, 0., 1024.);
   meHitTvsPhi_[1] = ibook.bookProfile("EtlHitTvsPhiZpos", "ETL DIGI ToA vs #phi (+Z);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
-				      100, -3.15, 3.15, 0., 1024.);
+				      50, -3.15, 3.15, 0., 1024.);
   meHitTvsEta_[0] = ibook.bookProfile("EtlHitTvsEtaZneg","ETL DIGI ToA vs #eta (-Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
-				      100, -3.05, -1.55, 0., 1024.);
+				      50, -2.96, -1.56, 0., 1024.);
   meHitTvsEta_[1] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL DIGI ToA vs #eta (+Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
-				      100, 1.55,  3.05, 0., 1024.);
+				      50, 1.56,  2.96, 0., 1024.);
 
 }
 

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -59,10 +59,24 @@ private:
 
   // --- histograms declaration
 
+  MonitorElement* meNhits_[2];
+
   MonitorElement* meHitCharge_[2];
   MonitorElement* meHitTime_[2];
 
   MonitorElement* meOccupancy_[2];
+
+  MonitorElement* meHitX_[2];
+  MonitorElement* meHitY_[2];
+  MonitorElement* meHitZ_[2];
+  MonitorElement* meHitPhi_[2];
+  MonitorElement* meHitEta_[2];
+
+  MonitorElement* meHitTvsQ_[2];
+  MonitorElement* meHitQvsPhi_[2];
+  MonitorElement* meHitQvsEta_[2];
+  MonitorElement* meHitTvsPhi_[2];
+  MonitorElement* meHitTvsEta_[2];
 
 };
 
@@ -106,6 +120,9 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
   eventCount_++;
   
   // --- Loop over the ELT DIGI hits
+
+  unsigned int n_digi_etl[2] = {0,0};
+
   for (const auto& dataFrame: *etlDigiHitsHandle) {
 
     // --- Get the on-time sample
@@ -134,7 +151,25 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
     meHitTime_[idet]->Fill(sample.toa());
     meOccupancy_[idet]->Fill(global_point.x(),global_point.y());
 
+    
+    meHitX_[idet]->Fill(global_point.x());
+    meHitY_[idet]->Fill(global_point.y());
+    meHitZ_[idet]->Fill(global_point.z());
+    meHitPhi_[idet]->Fill(global_point.phi());
+    meHitEta_[idet]->Fill(global_point.eta());
+
+    meHitTvsQ_[idet]->Fill(sample.data(),sample.toa());
+    meHitQvsPhi_[idet]->Fill(global_point.phi(),sample.data());
+    meHitQvsEta_[idet]->Fill(global_point.eta(),sample.data());
+    meHitTvsPhi_[idet]->Fill(global_point.phi(),sample.toa());
+    meHitTvsEta_[idet]->Fill(global_point.eta(),sample.toa());
+
+    n_digi_etl[idet]++;
+
   } // dataFrame loop
+
+  meNhits_[0]->Fill(n_digi_etl[0]);
+  meNhits_[1]->Fill(n_digi_etl[1]);
 
 }
 
@@ -148,20 +183,56 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
 
   // --- histograms booking
 
-  meHitCharge_[0] = ibook.book1D("EtlHitChargeZneg", "ETL DIGI hits charge (-Z);amplitude [ADC counts]",
-				 256, 0., 256.);
-  meHitCharge_[1] = ibook.book1D("EtlHitChargeZpos", "ETL DIGI hits charge (+Z);amplitude [ADC counts]",
-				 256, 0., 256.);
+  meNhits_[0]     = ibook.book1D("EtlNhitsZneg", "Number of ETL DIGI hits (-Z);N_{DIGI}", 250, 0., 5000.);
+  meNhits_[1]     = ibook.book1D("EtlNhitsZpos", "Number of ETL DIGI hits (+Z);N_{DIGI}", 250, 0., 5000.);
 
-  meHitTime_[0]   = ibook.book1D("EtlHitTimeZneg", "ETL DIGI hits ToA (-Z);ToA [TDC counts]", 
+  meHitCharge_[0] = ibook.book1D("EtlHitChargeZneg", "ETL DIGI hits charge (-Z);Q_{DIGI} [ADC counts]",
+				 256, 0., 256.);
+  meHitCharge_[1] = ibook.book1D("EtlHitChargeZpos", "ETL DIGI hits charge (+Z);Q_{DIGI} [ADC counts]",
+				 256, 0., 256.);
+  meHitTime_[0]   = ibook.book1D("EtlHitTimeZneg", "ETL DIGI hits ToA (-Z);ToA_{DIGI} [TDC counts]", 
 				 1000, 0., 2000.);
-  meHitTime_[1]   = ibook.book1D("EtlHitTimeZpos", "ETL DIGI hits ToA (+Z);ToA [TDC counts]", 
+  meHitTime_[1]   = ibook.book1D("EtlHitTimeZpos", "ETL DIGI hits ToA (+Z);ToA_{DIGI} [TDC counts]", 
 				 1000, 0., 2000.);
 
-  meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg","ETL DIGI hits occupancy (-Z);x [cm];y [cm]",
+  meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg","ETL DIGI hits occupancy (-Z);X_{DIGI} [cm];Y_{DIGI} [cm]",
 				 135, -135., 135.,  135, -135., 135.);
-  meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos","ETL DIGI hits occupancy (+Z);x [cm];y [cm]",
+  meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos","ETL DIGI hits occupancy (+Z);X_{DIGI} [cm];Y_{DIGI} [cm]",
 				 135, -135., 135.,  135, -135., 135.);
+
+  meHitX_[0]      = ibook.book1D("EtlHitXZneg", "ETL DIGI hits X (-Z);X_{DIGI} [cm]", 135, -135., 135.);
+  meHitX_[1]      = ibook.book1D("EtlHitXZpos", "ETL DIGI hits X (+Z);X_{DIGI} [cm]", 135, -135., 135.);
+  meHitY_[0]      = ibook.book1D("EtlHitYZneg", "ETL DIGI hits Y (-Z);Y_{DIGI} [cm]", 135, -135., 135.);
+  meHitY_[1]      = ibook.book1D("EtlHitYZpos", "ETL DIGI hits Y (+Z);Y_{DIGI} [cm]", 135, -135., 135.);
+  meHitZ_[0]      = ibook.book1D("EtlHitZZneg", "ETL DIGI hits Z (-Z);Z_{DIGI} [cm]", 100, -304.5, -303.);
+  meHitZ_[1]      = ibook.book1D("EtlHitZZpos", "ETL DIGI hits Z (+Z);Z_{DIGI} [cm]", 100,  303.,  304.5);
+
+  meHitPhi_[0]    = ibook.book1D("EtlHitPhiZneg", "ETL DIGI hits #phi (-Z);#phi_{DIGI} [rad]", 315, -3.15, 3.15);
+  meHitPhi_[1]    = ibook.book1D("EtlHitPhiZpos", "ETL DIGI hits #phi (+Z);#phi_{DIGI} [rad]", 315, -3.15, 3.15);
+  meHitEta_[0]    = ibook.book1D("EtlHitEtaZneg", "ETL DIGI hits #eta (-Z);#eta_{DIGI}", 200,  1.55,  3.05);
+  meHitEta_[1]    = ibook.book1D("EtlHitEtaZpos", "ETL DIGI hits #eta (+Z);#eta_{DIGI}", 200, -3.05, -1.55);
+
+
+  meHitTvsQ_[0]   = ibook.bookProfile("EtlHitTvsQZneg", "ETL DIGI ToA vs charge (-Z);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+				       256, 0., 256., 0., 1024.);
+  meHitTvsQ_[1]   = ibook.bookProfile("EtlHitTvsQZpos", "ETL DIGI ToA vs charge (+Z);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+				       256, 0., 256., 0., 1024.);
+  meHitQvsPhi_[0] = ibook.bookProfile("EtlHitQvsPhiZneg", "ETL DIGI charge vs #phi (-Z);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+				      100, -3.15, 3.15, 0., 1024.);
+  meHitQvsPhi_[1] = ibook.bookProfile("EtlHitQvsPhiZpos", "ETL DIGI charge vs #phi (+Z);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+				      100, -3.15, 3.15, 0., 1024.);
+  meHitQvsEta_[0] = ibook.bookProfile("EtlHitQvsEtaZneg","ETL DIGI charge vs #eta (-Z);#eta_{DIGI};Q_{DIGI} [ADC counts]",
+				      100, -3.05, -1.55, 0., 1024.);
+  meHitQvsEta_[1] = ibook.bookProfile("EtlHitQvsEtaZpos","ETL DIGI charge vs #eta (+Z);#eta_{DIGI};Q_{DIGI} [ADC counts]",
+				      100, 1.55,  3.05, 0., 1024.);
+  meHitTvsPhi_[0] = ibook.bookProfile("EtlHitTvsPhiZneg", "ETL DIGI ToA vs #phi (-Z);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
+				      100, -3.15, 3.15, 0., 1024.);
+  meHitTvsPhi_[1] = ibook.bookProfile("EtlHitTvsPhiZpos", "ETL DIGI ToA vs #phi (+Z);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
+				      100, -3.15, 3.15, 0., 1024.);
+  meHitTvsEta_[0] = ibook.bookProfile("EtlHitTvsEtaZneg","ETL DIGI ToA vs #eta (-Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
+				      100, -3.05, -1.55, 0., 1024.);
+  meHitTvsEta_[1] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL DIGI ToA vs #eta (+Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
+				      100, 1.55,  3.05, 0., 1024.);
 
 }
 

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -1,0 +1,210 @@
+// -*- C++ -*-
+//
+// Package:    Validation/MtdValidation
+// Class:      EtlDigiHitsValidation
+//
+/**\class EtlDigiHitsValidation EtlDigiHitsValidation.cc Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+
+ Description: ETL DIGI hits validation
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Massimo Casarsa
+//         Created:  Mon, 11 Mar 2019 14:30:22 GMT
+//
+//
+
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "DataFormats/FTLDigi/interface/FTLDigiCollections.h"
+
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+
+#include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
+
+
+//
+// class declaration
+//
+
+
+class EtlDigiHitsValidation : public DQMEDAnalyzer {
+
+public:
+  explicit EtlDigiHitsValidation(const edm::ParameterSet&);
+  ~EtlDigiHitsValidation() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+private:
+  void bookHistograms(DQMStore::IBooker &,
+		      edm::Run const&,
+		      edm::EventSetup const&) override;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  // ------------ member data ------------
+
+  const MTDGeometry* geom_;
+
+  const std::string folder_;
+  const std::string infoLabel_;
+  const std::string etlDigisCollection_;
+
+  int eventCount_;
+
+  edm::EDGetTokenT<ETLDigiCollection> etlDigiHitsToken_;
+
+  MonitorElement* meHitCharge_[2];
+  MonitorElement* meHitTime_[2];
+
+  MonitorElement* meOccupancy_[2];
+
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+EtlDigiHitsValidation::EtlDigiHitsValidation(const edm::ParameterSet& iConfig):
+  geom_(nullptr),
+  folder_(iConfig.getParameter<std::string>("folder")),
+  infoLabel_(iConfig.getParameter<std::string>("moduleLabel")),
+  etlDigisCollection_(iConfig.getParameter<std::string>("etlDigiHitsCollection")),
+  eventCount_(0) {
+
+  etlDigiHitsToken_ = consumes <ETLDigiCollection> (edm::InputTag(std::string(infoLabel_),
+								  std::string(etlDigisCollection_)));
+
+}
+
+
+EtlDigiHitsValidation::~EtlDigiHitsValidation() {
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  using namespace edm;
+
+  edm::LogInfo("EventInfo") << " Run = " << iEvent.id().run() << " Event = " << iEvent.id().event();
+
+  edm::ESHandle<MTDGeometry> geometryHandle;
+  iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);
+  geom_ = geometryHandle.product();
+
+  edm::Handle<ETLDigiCollection> etlDigiHitsHandle;
+  iEvent.getByToken(etlDigiHitsToken_, etlDigiHitsHandle);
+
+  if( ! etlDigiHitsHandle.isValid() ) return;
+
+  eventCount_++;
+  
+  // --- Loop over the ELT DIGI hits
+  for (const auto& dataFrame: *etlDigiHitsHandle) {
+
+    // --- Get the on-time sample
+    int isample = 2;
+
+    const auto& sample = dataFrame.sample(isample);
+
+    ETLDetId detId = dataFrame.id();
+
+    DetId geoId = detId.geographicalId();
+
+    const MTDGeomDet* thedet = geom_->idToDet(geoId);
+    if( thedet == nullptr )
+      throw cms::Exception("EtlSimHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
+						     << " (" << detId.rawId()<< ") is invalid!" << std::dec
+						     << std::endl;
+    
+    Local3DPoint local_point(0.,0.,0.);
+    const auto& global_point = thedet->toGlobal(local_point);
+
+    // --- Fill the histograms
+    if ( detId.zside()>0. ){
+
+      meHitCharge_[0]->Fill(sample.data());
+      meHitTime_[0]->Fill(sample.toa());
+      meOccupancy_[0]->Fill(global_point.x(),global_point.y());
+
+    }
+    else {
+
+      meHitCharge_[1]->Fill(sample.data());
+      meHitTime_[1]->Fill(sample.toa());
+      meOccupancy_[1]->Fill(global_point.x(),global_point.y());
+
+    }
+
+  } // dataFrame loop
+
+}
+
+void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
+                               edm::Run const& run,
+                               edm::EventSetup const & iSetup) {
+
+  ibook.setCurrentFolder(folder_);
+
+  meHitCharge_[0] = ibook.book1D("EtlHitChargeZpos", "ETL DIGI hits charge (+Z);amplitude [ADC counts]",
+				 256, 0., 256.);
+  meHitCharge_[1] = ibook.book1D("EtlHitChargeZneg", "ETL DIGI hits charge (-Z);amplitude [ADC counts]",
+				 256, 0., 256.);
+
+  meHitTime_[0]   = ibook.book1D("EtlHitTimeZpos", "ETL DIGI hits ToA (+Z);ToA [TDC counts]", 
+				 1000, 0., 2000.);
+  meHitTime_[1]   = ibook.book1D("EtlHitTimeZneg", "ETL DIGI hits ToA (-Z);ToA [TDC counts]", 
+				 1000, 0., 2000.);
+
+  meOccupancy_[0] = ibook.book2D("EtlOccupancyZpos","ETL DIGI hits occupancy (+Z);x [cm];y [cm]",
+				 135, -135., 135.,  135, -135., 135.);
+  meOccupancy_[1] = ibook.book2D("EtlOccupancyZneg","ETL DIGI hits occupancy (-Z);x [cm];y [cm]",
+				 135, -135., 135.,  135, -135., 135.);
+
+}
+
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void EtlDigiHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // The following says we do not know what parameters are allowed so do no
+  // validation
+  // Please change this to state exactly what you do use, even if it is no
+  // parameters
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("folder", "MTD/ETL/DigiHits");
+  desc.add<std::string>("moduleLabel","mix");
+  desc.add<std::string>("etlDigiHitsCollection","FTLEndcap");
+  descriptions.add("etlDigiHits", desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(EtlDigiHitsValidation);

--- a/Validation/MtdValidation/plugins/EtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlRecHitsValidation.cc
@@ -59,10 +59,24 @@ private:
 
   // --- histograms declaration
 
+  MonitorElement* meNhits_[2];
+
   MonitorElement* meHitEnergy_[2];
   MonitorElement* meHitTime_[2];
 
   MonitorElement* meOccupancy_[2];
+
+  MonitorElement* meHitX_[2];
+  MonitorElement* meHitY_[2];
+  MonitorElement* meHitZ_[2];
+  MonitorElement* meHitPhi_[2];
+  MonitorElement* meHitEta_[2];
+
+  MonitorElement* meHitTvsE_[2];
+  MonitorElement* meHitEvsPhi_[2];
+  MonitorElement* meHitEvsEta_[2];
+  MonitorElement* meHitTvsPhi_[2];
+  MonitorElement* meHitTvsEta_[2];
 
 };
 
@@ -106,6 +120,9 @@ void EtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   eventCount_++;
 
   // --- Loop over the ELT RECO hits
+
+  unsigned int n_reco_etl[2] = {0,0};
+
   for (const auto& recHit: *etlRecHitsHandle) {
 
     ETLDetId detId = recHit.id();
@@ -128,7 +145,24 @@ void EtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
     meOccupancy_[idet]->Fill(global_point.x(),global_point.y());
 
+    meHitX_[idet]->Fill(global_point.x());
+    meHitY_[idet]->Fill(global_point.y());
+    meHitZ_[idet]->Fill(global_point.z());
+    meHitPhi_[idet]->Fill(global_point.phi());
+    meHitEta_[idet]->Fill(global_point.eta());
+
+    meHitTvsE_[idet]->Fill(recHit.energy(),recHit.time());
+    meHitEvsPhi_[idet]->Fill(global_point.phi(),recHit.energy());
+    meHitEvsEta_[idet]->Fill(global_point.eta(),recHit.energy());
+    meHitTvsPhi_[idet]->Fill(global_point.phi(),recHit.time());
+    meHitTvsEta_[idet]->Fill(global_point.eta(),recHit.time());
+
+    n_reco_etl[idet]++;
+
   } // recHit loop
+
+  meNhits_[0]->Fill(n_reco_etl[0]);
+  meNhits_[1]->Fill(n_reco_etl[1]);
 
 }
 
@@ -142,16 +176,52 @@ void EtlRecHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
 
   // --- histograms booking
 
-  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZneg", "ETL RECO hits energy (-Z);energy [MeV]", 150, 0., 3.);
-  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZpos", "ETL RECO hits energy (+Z);energy [MeV]", 150, 0., 3.);
+  meNhits_[0]     = ibook.book1D("EtlNhitsZneg", "Number of ETL RECO hits (-Z);N_{RECO}", 250, 0., 5000.);
+  meNhits_[1]     = ibook.book1D("EtlNhitsZpos", "Number of ETL RECO hits (+Z);N_{RECO}", 250, 0., 5000.);
 
-  meHitTime_[0] = ibook.book1D("EtlHitTimeZneg", "ETL RECO hits ToA (-Z);ToA [ns]", 250, 0., 25.);
-  meHitTime_[1] = ibook.book1D("EtlHitTimeZpos", "ETL RECO hits ToA (+Z);ToA [ns]", 250, 0., 25.);
+  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZneg", "ETL RECO hits energy (-Z);E_{RECO} [MeV]", 150, 0., 3.);
+  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZpos", "ETL RECO hits energy (+Z);E_{RECO} [MeV]", 150, 0., 3.);
 
-  meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg","ETL RECO hits occupancy (-Z);x [cm];y [cm]",
+  meHitTime_[0] = ibook.book1D("EtlHitTimeZneg", "ETL RECO hits ToA (-Z);ToA_{RECO} [ns]", 250, 0., 25.);
+  meHitTime_[1] = ibook.book1D("EtlHitTimeZpos", "ETL RECO hits ToA (+Z);ToA_{RECO} [ns]", 250, 0., 25.);
+
+  meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg","ETL RECO hits occupancy (-Z);X_{RECO} [cm];Y_{RECO} [cm]",
 				 59, -130., 130.,  59, -130., 130.);
-  meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos","ETL DIGI hits occupancy (+Z);x [cm];y [cm]",
+  meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos","ETL DIGI hits occupancy (+Z);X_{RECO} [cm];Y_{RECO} [cm]",
 				 59, -130., 130.,  59, -130., 130.);
+
+  meHitX_[1]      = ibook.book1D("EtlHitXZpos", "ETL RECO hits X (+Z);X_{RECO} [cm]", 135, -135., 135.);
+  meHitX_[0]      = ibook.book1D("EtlHitXZneg", "ETL RECO hits X (-Z);X_{RECO} [cm]", 135, -135., 135.);
+  meHitY_[1]      = ibook.book1D("EtlHitYZpos", "ETL RECO hits Y (+Z);Y_{RECO} [cm]", 135, -135., 135.);
+  meHitY_[0]      = ibook.book1D("EtlHitYZneg", "ETL RECO hits Y (-Z);Y_{RECO} [cm]", 135, -135., 135.);
+  meHitZ_[1]      = ibook.book1D("EtlHitZZpos", "ETL RECO hits Z (+Z);Z_{RECO} [cm]", 100,  303.,  304.5);
+  meHitZ_[0]      = ibook.book1D("EtlHitZZneg", "ETL RECO hits Z (-Z);Z_{RECO} [cm]", 100, -304.5, -303.);
+
+  meHitPhi_[1]    = ibook.book1D("EtlHitPhiZpos", "ETL RECO hits #phi (+Z);#phi_{RECO} [rad]", 315, -3.15, 3.15);
+  meHitPhi_[0]    = ibook.book1D("EtlHitPhiZneg", "ETL RECO hits #phi (-Z);#phi_{RECO} [rad]", 315, -3.15, 3.15);
+  meHitEta_[1]    = ibook.book1D("EtlHitEtaZpos", "ETL RECO hits #eta (+Z);#eta_{RECO}", 200,  1.55,  3.05);
+  meHitEta_[0]    = ibook.book1D("EtlHitEtaZneg", "ETL RECO hits #eta (-Z);#eta_{RECO}", 200, -3.05, -1.55);
+
+  meHitTvsE_[1]    = ibook.bookProfile("EtlHitTvsEZpos", "ETL RECO time vs energy (+Z);E_{RECO} [MeV];ToA_{RECO} [ns]",
+				       100, 0., 2., 0., 100.);
+  meHitTvsE_[0]    = ibook.bookProfile("EtlHitTvsEZneg", "ETL RECO time vs energy (-Z);E_{RECO} [MeV];ToA_{RECO} [ns]",
+				       100, 0., 2., 0., 100.);
+  meHitEvsPhi_[1]  = ibook.bookProfile("EtlHitEvsPhiZpos", "ETL RECO energy vs #phi (+Z);#phi_{RECO} [rad];E_{RECO} [MeV]",
+				       100, -3.15, 3.15, 0., 100.);
+  meHitEvsPhi_[0]  = ibook.bookProfile("EtlHitEvsPhiZneg", "ETL RECO energy vs #phi (-Z);#phi_{RECO} [rad];E_{RECO} [MeV]",
+				       100, -3.15, 3.15, 0., 100.);
+  meHitEvsEta_[1]  = ibook.bookProfile("EtlHitEvsEtaZpos","ETL RECO energy vs #eta (+Z);#eta_{RECO};E_{RECO} [MeV]",
+				       200, 1.55, 3.05, 0., 100.);
+  meHitEvsEta_[0]  = ibook.bookProfile("EtlHitEvsEtaZneg","ETL RECO energy vs #eta (-Z);#eta_{RECO};E_{RECO} [MeV]",
+				       200, -3.05, -1.55, 0., 100.);
+  meHitTvsPhi_[1]  = ibook.bookProfile("EtlHitTvsPhiZpos", "ETL RECO time vs #phi (+Z);#phi_{RECO} [rad];ToA_{RECO} [ns]",
+				       100, -3.15, 3.15, 0., 100.);
+  meHitTvsPhi_[0]  = ibook.bookProfile("EtlHitTvsPhiZneg", "ETL RECO time vs #phi (-Z);#phi_{RECO} [rad];ToA_{RECO} [ns]",
+				       100, -3.15, 3.15, 0., 100.);
+  meHitTvsEta_[1] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL RECO time vs #eta (+Z);#eta_{RECO};ToA_{RECO} [ns]",
+				       200, 1.55, 3.05, 0., 100.);
+  meHitTvsEta_[0] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL RECO time vs #eta (-Z);#eta_{RECO};ToA_{RECO} [ns]",
+				       200, -3.05, -1.55, 0., 100.);
 
 }
 

--- a/Validation/MtdValidation/plugins/EtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlRecHitsValidation.cc
@@ -1,0 +1,172 @@
+// -*- C++ -*-
+//
+// Package:    Validation/MtdValidation
+// Class:      EtlRecHitsValidation
+//
+/**\class EtlRecHitsValidation EtlRecHitsValidation.cc Validation/MtdValidation/plugins/EtlRecHitsValidation.cc
+
+ Description: ETL RECO hits validation
+
+ Implementation:
+     [Notes on implementation]
+*/
+
+#include <string>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "DataFormats/FTLRecHit/interface/FTLRecHitCollections.h"
+
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+
+#include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
+
+
+class EtlRecHitsValidation : public DQMEDAnalyzer {
+
+public:
+  explicit EtlRecHitsValidation(const edm::ParameterSet&);
+  ~EtlRecHitsValidation() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+private:
+  void bookHistograms(DQMStore::IBooker &,
+		      edm::Run const&,
+		      edm::EventSetup const&) override;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  // ------------ member data ------------
+
+  const MTDGeometry* geom_;
+
+  const std::string folder_;
+  const std::string infoLabel_;
+  const std::string etlRecHitsCollection_;
+
+  int eventCount_;
+
+  edm::EDGetTokenT<FTLRecHitCollection> etlRecHitsToken_;
+
+  // --- histograms declaration
+
+  MonitorElement* meHitEnergy_[2];
+  MonitorElement* meHitTime_[2];
+
+  MonitorElement* meOccupancy_[2];
+
+};
+
+
+// ------------ constructor and destructor --------------
+EtlRecHitsValidation::EtlRecHitsValidation(const edm::ParameterSet& iConfig):
+  geom_(nullptr),
+  folder_(iConfig.getParameter<std::string>("folder")),
+  infoLabel_(iConfig.getParameter<std::string>("moduleLabel")),
+  etlRecHitsCollection_(iConfig.getParameter<std::string>("etlRecHitsCollection")),
+  eventCount_(0) {
+
+  etlRecHitsToken_ = consumes <FTLRecHitCollection> (edm::InputTag(std::string(infoLabel_),
+								   std::string(etlRecHitsCollection_)));
+
+}
+
+EtlRecHitsValidation::~EtlRecHitsValidation() {
+}
+
+
+// ------------ method called for each event  ------------
+void EtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  using namespace edm;
+
+  edm::LogInfo("EventInfo") << " Run = " << iEvent.id().run() << " Event = " << iEvent.id().event();
+
+  edm::ESHandle<MTDGeometry> geometryHandle;
+  iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);
+  geom_ = geometryHandle.product();
+
+  edm::Handle<FTLRecHitCollection> etlRecHitsHandle;
+  iEvent.getByToken(etlRecHitsToken_, etlRecHitsHandle);
+
+  if( ! etlRecHitsHandle.isValid() ) {
+    edm::LogWarning("DataNotFound") << "No ETL RecHits found";
+    return;
+  }
+
+  eventCount_++;
+
+  // --- Loop over the ELT RECO hits
+  for (const auto& recHit: *etlRecHitsHandle) {
+
+    ETLDetId detId = recHit.id();
+
+    DetId geoId = detId.geographicalId();
+    const MTDGeomDet* thedet = geom_->idToDet(geoId);
+    if( thedet == nullptr )
+      throw cms::Exception("EtlRecHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
+						   << " (" << detId.rawId()<< ") is invalid!" << std::dec
+						   << std::endl;
+
+    const auto& global_point = thedet->toGlobal(Local3DPoint(0.,0.,0.));
+
+    // --- Fill the histograms
+
+    int idet = (detId.zside()+1)/2;
+
+    meHitEnergy_[idet]->Fill(recHit.energy());
+    meHitTime_[idet]->Fill(recHit.time());
+
+    meOccupancy_[idet]->Fill(global_point.x(),global_point.y());
+
+  } // recHit loop
+
+}
+
+
+// ------------ method for histogram booking ------------
+void EtlRecHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
+                               edm::Run const& run,
+                               edm::EventSetup const & iSetup) {
+
+  ibook.setCurrentFolder(folder_);
+
+  // --- histograms booking
+
+  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZneg", "ETL RECO hits energy (-Z);energy [MeV]", 150, 0., 3.);
+  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZpos", "ETL RECO hits energy (+Z);energy [MeV]", 150, 0., 3.);
+
+  meHitTime_[0] = ibook.book1D("EtlHitTimeZneg", "ETL RECO hits ToA (-Z);ToA [ns]", 250, 0., 25.);
+  meHitTime_[1] = ibook.book1D("EtlHitTimeZpos", "ETL RECO hits ToA (+Z);ToA [ns]", 250, 0., 25.);
+
+  meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg","ETL RECO hits occupancy (-Z);x [cm];y [cm]",
+				 59, -130., 130.,  59, -130., 130.);
+  meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos","ETL DIGI hits occupancy (+Z);x [cm];y [cm]",
+				 59, -130., 130.,  59, -130., 130.);
+
+}
+
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void EtlRecHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<std::string>("folder", "MTD/ETL/RecHits");
+  desc.add<std::string>("moduleLabel","mtdRecHits");
+  desc.add<std::string>("etlRecHitsCollection","FTLEndcap");
+
+  descriptions.add("etlRecHits", desc);
+
+}
+
+DEFINE_FWK_MODULE(EtlRecHitsValidation);

--- a/Validation/MtdValidation/plugins/EtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlRecHitsValidation.cc
@@ -176,8 +176,8 @@ void EtlRecHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   meHitPhi_[1] = ibook.book1D("EtlHitPhiZpos", "ETL RECO hits #phi (+Z);#phi_{RECO} [rad]", 100, -3.15, 3.15);
   meHitPhi_[0] = ibook.book1D("EtlHitPhiZneg", "ETL RECO hits #phi (-Z);#phi_{RECO} [rad]", 100, -3.15, 3.15);
-  meHitEta_[1] = ibook.book1D("EtlHitEtaZpos", "ETL RECO hits #eta (+Z);#eta_{RECO}", 100, 1.56, 3.);
-  meHitEta_[0] = ibook.book1D("EtlHitEtaZneg", "ETL RECO hits #eta (-Z);#eta_{RECO}", 100, -3., -1.56);
+  meHitEta_[1] = ibook.book1D("EtlHitEtaZpos", "ETL RECO hits #eta (+Z);#eta_{RECO}", 100, 1.56, 3.2);
+  meHitEta_[0] = ibook.book1D("EtlHitEtaZneg", "ETL RECO hits #eta (-Z);#eta_{RECO}", 100, -3.2, -1.56);
 
   meHitTvsE_[1] = ibook.bookProfile(
       "EtlHitTvsEZpos", "ETL RECO time vs energy (+Z);E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 2., 0., 100.);
@@ -188,17 +188,17 @@ void EtlRecHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitEvsPhi_[0] = ibook.bookProfile(
       "EtlHitEvsPhiZneg", "ETL RECO energy vs #phi (-Z);#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.15, 3.15, 0., 100.);
   meHitEvsEta_[1] = ibook.bookProfile(
-      "EtlHitEvsEtaZpos", "ETL RECO energy vs #eta (+Z);#eta_{RECO};E_{RECO} [MeV]", 50, 1.56, 3., 0., 100.);
+      "EtlHitEvsEtaZpos", "ETL RECO energy vs #eta (+Z);#eta_{RECO};E_{RECO} [MeV]", 50, 1.56, 3.2, 0., 100.);
   meHitEvsEta_[0] = ibook.bookProfile(
-      "EtlHitEvsEtaZneg", "ETL RECO energy vs #eta (-Z);#eta_{RECO};E_{RECO} [MeV]", 50, -3., -1.56, 0., 100.);
+      "EtlHitEvsEtaZneg", "ETL RECO energy vs #eta (-Z);#eta_{RECO};E_{RECO} [MeV]", 50, -3.2, -1.56, 0., 100.);
   meHitTvsPhi_[1] = ibook.bookProfile(
       "EtlHitTvsPhiZpos", "ETL RECO time vs #phi (+Z);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.15, 3.15, 0., 100.);
   meHitTvsPhi_[0] = ibook.bookProfile(
       "EtlHitTvsPhiZneg", "ETL RECO time vs #phi (-Z);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.15, 3.15, 0., 100.);
   meHitTvsEta_[1] = ibook.bookProfile(
-      "EtlHitTvsEtaZpos", "ETL RECO time vs #eta (+Z);#eta_{RECO};ToA_{RECO} [ns]", 50, 1.56, 3., 0., 100.);
+      "EtlHitTvsEtaZpos", "ETL RECO time vs #eta (+Z);#eta_{RECO};ToA_{RECO} [ns]", 50, 1.56, 3.2, 0., 100.);
   meHitTvsEta_[0] = ibook.bookProfile(
-      "EtlHitTvsEtaZpos", "ETL RECO time vs #eta (-Z);#eta_{RECO};ToA_{RECO} [ns]", 50, -3., -1.56, 0., 100.);
+      "EtlHitTvsEtaZneg", "ETL RECO time vs #eta (-Z);#eta_{RECO};ToA_{RECO} [ns]", 50, -3.2, -1.56, 0., 100.);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/Validation/MtdValidation/plugins/EtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlRecHitsValidation.cc
@@ -27,6 +27,7 @@
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
 
 
 class EtlRecHitsValidation : public DQMEDAnalyzer {
@@ -133,8 +134,10 @@ void EtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
       throw cms::Exception("EtlRecHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
 						   << " (" << detId.rawId()<< ") is invalid!" << std::dec
 						   << std::endl;
+    const PixelTopology& topo = static_cast<const PixelTopology&>(thedet->topology());
 
-    const auto& global_point = thedet->toGlobal(Local3DPoint(0.,0.,0.));
+    Local3DPoint local_point(topo.localX(recHit.row()),topo.localY(recHit.column()),0.);
+    const auto& global_point = thedet->toGlobal(local_point);
 
     // --- Fill the histograms
 
@@ -176,52 +179,52 @@ void EtlRecHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
 
   // --- histograms booking
 
-  meNhits_[0]     = ibook.book1D("EtlNhitsZneg", "Number of ETL RECO hits (-Z);N_{RECO}", 250, 0., 5000.);
-  meNhits_[1]     = ibook.book1D("EtlNhitsZpos", "Number of ETL RECO hits (+Z);N_{RECO}", 250, 0., 5000.);
+  meNhits_[0]     = ibook.book1D("EtlNhitsZneg", "Number of ETL RECO hits (-Z);N_{RECO}", 100, 0., 5000.);
+  meNhits_[1]     = ibook.book1D("EtlNhitsZpos", "Number of ETL RECO hits (+Z);N_{RECO}", 100, 0., 5000.);
 
-  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZneg", "ETL RECO hits energy (-Z);E_{RECO} [MeV]", 150, 0., 3.);
-  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZpos", "ETL RECO hits energy (+Z);E_{RECO} [MeV]", 150, 0., 3.);
+  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZneg", "ETL RECO hits energy (-Z);E_{RECO} [MeV]", 100, 0., 3.);
+  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZpos", "ETL RECO hits energy (+Z);E_{RECO} [MeV]", 100, 0., 3.);
 
-  meHitTime_[0] = ibook.book1D("EtlHitTimeZneg", "ETL RECO hits ToA (-Z);ToA_{RECO} [ns]", 250, 0., 25.);
-  meHitTime_[1] = ibook.book1D("EtlHitTimeZpos", "ETL RECO hits ToA (+Z);ToA_{RECO} [ns]", 250, 0., 25.);
+  meHitTime_[0] = ibook.book1D("EtlHitTimeZneg", "ETL RECO hits ToA (-Z);ToA_{RECO} [ns]", 100, 0., 25.);
+  meHitTime_[1] = ibook.book1D("EtlHitTimeZpos", "ETL RECO hits ToA (+Z);ToA_{RECO} [ns]", 100, 0., 25.);
 
   meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg","ETL RECO hits occupancy (-Z);X_{RECO} [cm];Y_{RECO} [cm]",
-				 59, -130., 130.,  59, -130., 130.);
+				 135, -135., 135., 135, -135., 135.);
   meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos","ETL DIGI hits occupancy (+Z);X_{RECO} [cm];Y_{RECO} [cm]",
-				 59, -130., 130.,  59, -130., 130.);
+				 135, -135., 135., 135, -135., 135.);
 
-  meHitX_[1]      = ibook.book1D("EtlHitXZpos", "ETL RECO hits X (+Z);X_{RECO} [cm]", 135, -135., 135.);
-  meHitX_[0]      = ibook.book1D("EtlHitXZneg", "ETL RECO hits X (-Z);X_{RECO} [cm]", 135, -135., 135.);
-  meHitY_[1]      = ibook.book1D("EtlHitYZpos", "ETL RECO hits Y (+Z);Y_{RECO} [cm]", 135, -135., 135.);
-  meHitY_[0]      = ibook.book1D("EtlHitYZneg", "ETL RECO hits Y (-Z);Y_{RECO} [cm]", 135, -135., 135.);
-  meHitZ_[1]      = ibook.book1D("EtlHitZZpos", "ETL RECO hits Z (+Z);Z_{RECO} [cm]", 100,  303.,  304.5);
-  meHitZ_[0]      = ibook.book1D("EtlHitZZneg", "ETL RECO hits Z (-Z);Z_{RECO} [cm]", 100, -304.5, -303.);
+  meHitX_[1]      = ibook.book1D("EtlHitXZpos", "ETL RECO hits X (+Z);X_{RECO} [cm]", 100, -130., 130.);
+  meHitX_[0]      = ibook.book1D("EtlHitXZneg", "ETL RECO hits X (-Z);X_{RECO} [cm]", 100, -130., 130.);
+  meHitY_[1]      = ibook.book1D("EtlHitYZpos", "ETL RECO hits Y (+Z);Y_{RECO} [cm]", 100, -130., 130.);
+  meHitY_[0]      = ibook.book1D("EtlHitYZneg", "ETL RECO hits Y (-Z);Y_{RECO} [cm]", 100, -130., 130.);
+  meHitZ_[1]      = ibook.book1D("EtlHitZZpos", "ETL RECO hits Z (+Z);Z_{RECO} [cm]", 100,  303.4,  304.2);
+  meHitZ_[0]      = ibook.book1D("EtlHitZZneg", "ETL RECO hits Z (-Z);Z_{RECO} [cm]", 100, -304.2, -303.4);
 
-  meHitPhi_[1]    = ibook.book1D("EtlHitPhiZpos", "ETL RECO hits #phi (+Z);#phi_{RECO} [rad]", 315, -3.15, 3.15);
-  meHitPhi_[0]    = ibook.book1D("EtlHitPhiZneg", "ETL RECO hits #phi (-Z);#phi_{RECO} [rad]", 315, -3.15, 3.15);
-  meHitEta_[1]    = ibook.book1D("EtlHitEtaZpos", "ETL RECO hits #eta (+Z);#eta_{RECO}", 200,  1.55,  3.05);
-  meHitEta_[0]    = ibook.book1D("EtlHitEtaZneg", "ETL RECO hits #eta (-Z);#eta_{RECO}", 200, -3.05, -1.55);
+  meHitPhi_[1]    = ibook.book1D("EtlHitPhiZpos", "ETL RECO hits #phi (+Z);#phi_{RECO} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[0]    = ibook.book1D("EtlHitPhiZneg", "ETL RECO hits #phi (-Z);#phi_{RECO} [rad]", 100, -3.15, 3.15);
+  meHitEta_[1]    = ibook.book1D("EtlHitEtaZpos", "ETL RECO hits #eta (+Z);#eta_{RECO}", 100,  1.56,  2.96);
+  meHitEta_[0]    = ibook.book1D("EtlHitEtaZneg", "ETL RECO hits #eta (-Z);#eta_{RECO}", 100, -2.96, -1.56);
 
   meHitTvsE_[1]    = ibook.bookProfile("EtlHitTvsEZpos", "ETL RECO time vs energy (+Z);E_{RECO} [MeV];ToA_{RECO} [ns]",
-				       100, 0., 2., 0., 100.);
+				       50, 0., 2., 0., 100.);
   meHitTvsE_[0]    = ibook.bookProfile("EtlHitTvsEZneg", "ETL RECO time vs energy (-Z);E_{RECO} [MeV];ToA_{RECO} [ns]",
-				       100, 0., 2., 0., 100.);
+				       50, 0., 2., 0., 100.);
   meHitEvsPhi_[1]  = ibook.bookProfile("EtlHitEvsPhiZpos", "ETL RECO energy vs #phi (+Z);#phi_{RECO} [rad];E_{RECO} [MeV]",
-				       100, -3.15, 3.15, 0., 100.);
+				       50, -3.15, 3.15, 0., 100.);
   meHitEvsPhi_[0]  = ibook.bookProfile("EtlHitEvsPhiZneg", "ETL RECO energy vs #phi (-Z);#phi_{RECO} [rad];E_{RECO} [MeV]",
-				       100, -3.15, 3.15, 0., 100.);
+				       50, -3.15, 3.15, 0., 100.);
   meHitEvsEta_[1]  = ibook.bookProfile("EtlHitEvsEtaZpos","ETL RECO energy vs #eta (+Z);#eta_{RECO};E_{RECO} [MeV]",
-				       200, 1.55, 3.05, 0., 100.);
+				       50, 1.56, 2.96, 0., 100.);
   meHitEvsEta_[0]  = ibook.bookProfile("EtlHitEvsEtaZneg","ETL RECO energy vs #eta (-Z);#eta_{RECO};E_{RECO} [MeV]",
-				       200, -3.05, -1.55, 0., 100.);
+				       50, -2.96, -1.56, 0., 100.);
   meHitTvsPhi_[1]  = ibook.bookProfile("EtlHitTvsPhiZpos", "ETL RECO time vs #phi (+Z);#phi_{RECO} [rad];ToA_{RECO} [ns]",
-				       100, -3.15, 3.15, 0., 100.);
+				       50, -3.15, 3.15, 0., 100.);
   meHitTvsPhi_[0]  = ibook.bookProfile("EtlHitTvsPhiZneg", "ETL RECO time vs #phi (-Z);#phi_{RECO} [rad];ToA_{RECO} [ns]",
-				       100, -3.15, 3.15, 0., 100.);
+				       50, -3.15, 3.15, 0., 100.);
   meHitTvsEta_[1] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL RECO time vs #eta (+Z);#eta_{RECO};ToA_{RECO} [ns]",
-				       200, 1.55, 3.05, 0., 100.);
+				       50, 1.56, 2.96, 0., 100.);
   meHitTvsEta_[0] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL RECO time vs #eta (-Z);#eta_{RECO};ToA_{RECO} [ns]",
-				       200, -3.05, -1.55, 0., 100.);
+				       50, -2.96, -1.56, 0., 100.);
 
 }
 

--- a/Validation/MtdValidation/plugins/EtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlRecHitsValidation.cc
@@ -29,20 +29,15 @@
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 
-
 class EtlRecHitsValidation : public DQMEDAnalyzer {
-
 public:
   explicit EtlRecHitsValidation(const edm::ParameterSet&);
   ~EtlRecHitsValidation() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-
 private:
-  void bookHistograms(DQMStore::IBooker &,
-		      edm::Run const&,
-		      edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
@@ -72,25 +67,18 @@ private:
   MonitorElement* meHitEvsEta_[2];
   MonitorElement* meHitTvsPhi_[2];
   MonitorElement* meHitTvsEta_[2];
-
 };
 
-
 // ------------ constructor and destructor --------------
-EtlRecHitsValidation::EtlRecHitsValidation(const edm::ParameterSet& iConfig):
-  folder_(iConfig.getParameter<std::string>("folder")) {
-
+EtlRecHitsValidation::EtlRecHitsValidation(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")) {
   etlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("inputTag"));
-
 }
 
-EtlRecHitsValidation::~EtlRecHitsValidation() {
-}
-
+EtlRecHitsValidation::~EtlRecHitsValidation() {}
 
 // ------------ method called for each event  ------------
 void EtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   using namespace edm;
 
   edm::ESHandle<MTDGeometry> geometryHandle;
@@ -101,31 +89,29 @@ void EtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
   // --- Loop over the ELT RECO hits
 
-  unsigned int n_reco_etl[2] = {0,0};
+  unsigned int n_reco_etl[2] = {0, 0};
 
-  for (const auto& recHit: *etlRecHitsHandle) {
-
+  for (const auto& recHit : *etlRecHitsHandle) {
     ETLDetId detId = recHit.id();
 
     DetId geoId = detId.geographicalId();
     const MTDGeomDet* thedet = geom->idToDet(geoId);
-    if( thedet == nullptr )
-      throw cms::Exception("EtlRecHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
-						   << " (" << detId.rawId()<< ") is invalid!" << std::dec
-						   << std::endl;
+    if (thedet == nullptr)
+      throw cms::Exception("EtlRecHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
+                                                   << detId.rawId() << ") is invalid!" << std::dec << std::endl;
     const PixelTopology& topo = static_cast<const PixelTopology&>(thedet->topology());
 
-    Local3DPoint local_point(topo.localX(recHit.row()),topo.localY(recHit.column()),0.);
+    Local3DPoint local_point(topo.localX(recHit.row()), topo.localY(recHit.column()), 0.);
     const auto& global_point = thedet->toGlobal(local_point);
 
     // --- Fill the histograms
 
-    int idet = (detId.zside()+1)/2;
+    int idet = (detId.zside() + 1) / 2;
 
     meHitEnergy_[idet]->Fill(recHit.energy());
     meHitTime_[idet]->Fill(recHit.time());
 
-    meOccupancy_[idet]->Fill(global_point.x(),global_point.y());
+    meOccupancy_[idet]->Fill(global_point.x(), global_point.y());
 
     meHitX_[idet]->Fill(global_point.x());
     meHitY_[idet]->Fill(global_point.y());
@@ -133,33 +119,30 @@ void EtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     meHitPhi_[idet]->Fill(global_point.phi());
     meHitEta_[idet]->Fill(global_point.eta());
 
-    meHitTvsE_[idet]->Fill(recHit.energy(),recHit.time());
-    meHitEvsPhi_[idet]->Fill(global_point.phi(),recHit.energy());
-    meHitEvsEta_[idet]->Fill(global_point.eta(),recHit.energy());
-    meHitTvsPhi_[idet]->Fill(global_point.phi(),recHit.time());
-    meHitTvsEta_[idet]->Fill(global_point.eta(),recHit.time());
+    meHitTvsE_[idet]->Fill(recHit.energy(), recHit.time());
+    meHitEvsPhi_[idet]->Fill(global_point.phi(), recHit.energy());
+    meHitEvsEta_[idet]->Fill(global_point.eta(), recHit.energy());
+    meHitTvsPhi_[idet]->Fill(global_point.phi(), recHit.time());
+    meHitTvsEta_[idet]->Fill(global_point.eta(), recHit.time());
 
     n_reco_etl[idet]++;
 
-  } // recHit loop
+  }  // recHit loop
 
   meNhits_[0]->Fill(n_reco_etl[0]);
   meNhits_[1]->Fill(n_reco_etl[1]);
-
 }
 
-
 // ------------ method for histogram booking ------------
-void EtlRecHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
-                               edm::Run const& run,
-                               edm::EventSetup const & iSetup) {
-
+void EtlRecHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
+                                          edm::Run const& run,
+                                          edm::EventSetup const& iSetup) {
   ibook.setCurrentFolder(folder_);
 
   // --- histograms booking
 
-  meNhits_[0]     = ibook.book1D("EtlNhitsZneg", "Number of ETL RECO hits (-Z);N_{RECO}", 100, 0., 5000.);
-  meNhits_[1]     = ibook.book1D("EtlNhitsZpos", "Number of ETL RECO hits (+Z);N_{RECO}", 100, 0., 5000.);
+  meNhits_[0] = ibook.book1D("EtlNhitsZneg", "Number of ETL RECO hits (-Z);N_{RECO}", 100, 0., 5000.);
+  meNhits_[1] = ibook.book1D("EtlNhitsZpos", "Number of ETL RECO hits (+Z);N_{RECO}", 100, 0., 5000.);
 
   meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZneg", "ETL RECO hits energy (-Z);E_{RECO} [MeV]", 100, 0., 3.);
   meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZpos", "ETL RECO hits energy (+Z);E_{RECO} [MeV]", 100, 0., 3.);
@@ -167,47 +150,56 @@ void EtlRecHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
   meHitTime_[0] = ibook.book1D("EtlHitTimeZneg", "ETL RECO hits ToA (-Z);ToA_{RECO} [ns]", 100, 0., 25.);
   meHitTime_[1] = ibook.book1D("EtlHitTimeZpos", "ETL RECO hits ToA (+Z);ToA_{RECO} [ns]", 100, 0., 25.);
 
-  meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg","ETL RECO hits occupancy (-Z);X_{RECO} [cm];Y_{RECO} [cm]",
-				 135, -135., 135., 135, -135., 135.);
-  meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos","ETL DIGI hits occupancy (+Z);X_{RECO} [cm];Y_{RECO} [cm]",
-				 135, -135., 135., 135, -135., 135.);
+  meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg",
+                                 "ETL RECO hits occupancy (-Z);X_{RECO} [cm];Y_{RECO} [cm]",
+                                 135,
+                                 -135.,
+                                 135.,
+                                 135,
+                                 -135.,
+                                 135.);
+  meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos",
+                                 "ETL DIGI hits occupancy (+Z);X_{RECO} [cm];Y_{RECO} [cm]",
+                                 135,
+                                 -135.,
+                                 135.,
+                                 135,
+                                 -135.,
+                                 135.);
 
-  meHitX_[1]      = ibook.book1D("EtlHitXZpos", "ETL RECO hits X (+Z);X_{RECO} [cm]", 100, -130., 130.);
-  meHitX_[0]      = ibook.book1D("EtlHitXZneg", "ETL RECO hits X (-Z);X_{RECO} [cm]", 100, -130., 130.);
-  meHitY_[1]      = ibook.book1D("EtlHitYZpos", "ETL RECO hits Y (+Z);Y_{RECO} [cm]", 100, -130., 130.);
-  meHitY_[0]      = ibook.book1D("EtlHitYZneg", "ETL RECO hits Y (-Z);Y_{RECO} [cm]", 100, -130., 130.);
-  meHitZ_[1]      = ibook.book1D("EtlHitZZpos", "ETL RECO hits Z (+Z);Z_{RECO} [cm]", 100,  303.4,  304.2);
-  meHitZ_[0]      = ibook.book1D("EtlHitZZneg", "ETL RECO hits Z (-Z);Z_{RECO} [cm]", 100, -304.2, -303.4);
+  meHitX_[1] = ibook.book1D("EtlHitXZpos", "ETL RECO hits X (+Z);X_{RECO} [cm]", 100, -130., 130.);
+  meHitX_[0] = ibook.book1D("EtlHitXZneg", "ETL RECO hits X (-Z);X_{RECO} [cm]", 100, -130., 130.);
+  meHitY_[1] = ibook.book1D("EtlHitYZpos", "ETL RECO hits Y (+Z);Y_{RECO} [cm]", 100, -130., 130.);
+  meHitY_[0] = ibook.book1D("EtlHitYZneg", "ETL RECO hits Y (-Z);Y_{RECO} [cm]", 100, -130., 130.);
+  meHitZ_[1] = ibook.book1D("EtlHitZZpos", "ETL RECO hits Z (+Z);Z_{RECO} [cm]", 100, 303.4, 304.2);
+  meHitZ_[0] = ibook.book1D("EtlHitZZneg", "ETL RECO hits Z (-Z);Z_{RECO} [cm]", 100, -304.2, -303.4);
 
-  meHitPhi_[1]    = ibook.book1D("EtlHitPhiZpos", "ETL RECO hits #phi (+Z);#phi_{RECO} [rad]", 100, -3.15, 3.15);
-  meHitPhi_[0]    = ibook.book1D("EtlHitPhiZneg", "ETL RECO hits #phi (-Z);#phi_{RECO} [rad]", 100, -3.15, 3.15);
-  meHitEta_[1]    = ibook.book1D("EtlHitEtaZpos", "ETL RECO hits #eta (+Z);#eta_{RECO}", 100,  1.56,  3.);
-  meHitEta_[0]    = ibook.book1D("EtlHitEtaZneg", "ETL RECO hits #eta (-Z);#eta_{RECO}", 100, -3., -1.56);
+  meHitPhi_[1] = ibook.book1D("EtlHitPhiZpos", "ETL RECO hits #phi (+Z);#phi_{RECO} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[0] = ibook.book1D("EtlHitPhiZneg", "ETL RECO hits #phi (-Z);#phi_{RECO} [rad]", 100, -3.15, 3.15);
+  meHitEta_[1] = ibook.book1D("EtlHitEtaZpos", "ETL RECO hits #eta (+Z);#eta_{RECO}", 100, 1.56, 3.);
+  meHitEta_[0] = ibook.book1D("EtlHitEtaZneg", "ETL RECO hits #eta (-Z);#eta_{RECO}", 100, -3., -1.56);
 
-  meHitTvsE_[1]    = ibook.bookProfile("EtlHitTvsEZpos", "ETL RECO time vs energy (+Z);E_{RECO} [MeV];ToA_{RECO} [ns]",
-				       50, 0., 2., 0., 100.);
-  meHitTvsE_[0]    = ibook.bookProfile("EtlHitTvsEZneg", "ETL RECO time vs energy (-Z);E_{RECO} [MeV];ToA_{RECO} [ns]",
-				       50, 0., 2., 0., 100.);
-  meHitEvsPhi_[1]  = ibook.bookProfile("EtlHitEvsPhiZpos", "ETL RECO energy vs #phi (+Z);#phi_{RECO} [rad];E_{RECO} [MeV]",
-				       50, -3.15, 3.15, 0., 100.);
-  meHitEvsPhi_[0]  = ibook.bookProfile("EtlHitEvsPhiZneg", "ETL RECO energy vs #phi (-Z);#phi_{RECO} [rad];E_{RECO} [MeV]",
-				       50, -3.15, 3.15, 0., 100.);
-  meHitEvsEta_[1]  = ibook.bookProfile("EtlHitEvsEtaZpos","ETL RECO energy vs #eta (+Z);#eta_{RECO};E_{RECO} [MeV]",
-				       50, 1.56, 3., 0., 100.);
-  meHitEvsEta_[0]  = ibook.bookProfile("EtlHitEvsEtaZneg","ETL RECO energy vs #eta (-Z);#eta_{RECO};E_{RECO} [MeV]",
-				       50, -3., -1.56, 0., 100.);
-  meHitTvsPhi_[1]  = ibook.bookProfile("EtlHitTvsPhiZpos", "ETL RECO time vs #phi (+Z);#phi_{RECO} [rad];ToA_{RECO} [ns]",
-				       50, -3.15, 3.15, 0., 100.);
-  meHitTvsPhi_[0]  = ibook.bookProfile("EtlHitTvsPhiZneg", "ETL RECO time vs #phi (-Z);#phi_{RECO} [rad];ToA_{RECO} [ns]",
-				       50, -3.15, 3.15, 0., 100.);
-  meHitTvsEta_[1] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL RECO time vs #eta (+Z);#eta_{RECO};ToA_{RECO} [ns]",
-				       50, 1.56, 3., 0., 100.);
-  meHitTvsEta_[0] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL RECO time vs #eta (-Z);#eta_{RECO};ToA_{RECO} [ns]",
-				       50, -3., -1.56, 0., 100.);
-
+  meHitTvsE_[1] = ibook.bookProfile(
+      "EtlHitTvsEZpos", "ETL RECO time vs energy (+Z);E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 2., 0., 100.);
+  meHitTvsE_[0] = ibook.bookProfile(
+      "EtlHitTvsEZneg", "ETL RECO time vs energy (-Z);E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 2., 0., 100.);
+  meHitEvsPhi_[1] = ibook.bookProfile(
+      "EtlHitEvsPhiZpos", "ETL RECO energy vs #phi (+Z);#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.15, 3.15, 0., 100.);
+  meHitEvsPhi_[0] = ibook.bookProfile(
+      "EtlHitEvsPhiZneg", "ETL RECO energy vs #phi (-Z);#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.15, 3.15, 0., 100.);
+  meHitEvsEta_[1] = ibook.bookProfile(
+      "EtlHitEvsEtaZpos", "ETL RECO energy vs #eta (+Z);#eta_{RECO};E_{RECO} [MeV]", 50, 1.56, 3., 0., 100.);
+  meHitEvsEta_[0] = ibook.bookProfile(
+      "EtlHitEvsEtaZneg", "ETL RECO energy vs #eta (-Z);#eta_{RECO};E_{RECO} [MeV]", 50, -3., -1.56, 0., 100.);
+  meHitTvsPhi_[1] = ibook.bookProfile(
+      "EtlHitTvsPhiZpos", "ETL RECO time vs #phi (+Z);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.15, 3.15, 0., 100.);
+  meHitTvsPhi_[0] = ibook.bookProfile(
+      "EtlHitTvsPhiZneg", "ETL RECO time vs #phi (-Z);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.15, 3.15, 0., 100.);
+  meHitTvsEta_[1] = ibook.bookProfile(
+      "EtlHitTvsEtaZpos", "ETL RECO time vs #eta (+Z);#eta_{RECO};ToA_{RECO} [ns]", 50, 1.56, 3., 0., 100.);
+  meHitTvsEta_[0] = ibook.bookProfile(
+      "EtlHitTvsEtaZpos", "ETL RECO time vs #eta (-Z);#eta_{RECO};ToA_{RECO} [ns]", 50, -3., -1.56, 0., 100.);
 }
-
-
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void EtlRecHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -217,7 +209,6 @@ void EtlRecHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mtdRecHits", "FTLEndcap"));
 
   descriptions.add("etlRecHits", desc);
-
 }
 
 DEFINE_FWK_MODULE(EtlRecHitsValidation);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -1,0 +1,251 @@
+// -*- C++ -*-
+//
+// Package:    Validation/MtdValidation
+// Class:      EtlSimHitsValidation
+//
+/**\class EtlSimHitsValidation EtlSimHitsValidation.cc Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+
+ Description: ETL SIM hits validation
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Massimo Casarsa
+//         Created:  Mon, 11 Mar 2019 13:56:22 GMT
+//
+//
+
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+
+#include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
+
+
+//
+// class declaration
+//
+
+
+class EtlSimHitsValidation : public DQMEDAnalyzer {
+
+public:
+  explicit EtlSimHitsValidation(const edm::ParameterSet&);
+  ~EtlSimHitsValidation() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+private:
+  void bookHistograms(DQMStore::IBooker &,
+		      edm::Run const&,
+		      edm::EventSetup const&) override;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+// ------------ member data ------------
+
+  const MTDGeometry* geom_;
+
+  const std::string folder_;
+  const std::string g4InfoLabel_;
+  const std::string etlHitsCollection_;
+
+  const float hitMinEnergy_;
+
+  int eventCount_;
+
+  edm::EDGetTokenT<edm::PSimHitContainer> etlSimHitsToken_;
+
+  MonitorElement* meHitEnergyZpos_;
+  MonitorElement* meHitEnergyZneg_;
+  MonitorElement* meHitTimeZpos_;
+  MonitorElement* meHitTimeZneg_;
+
+  MonitorElement* meOccupancyZpos_;
+  MonitorElement* meOccupancyZneg_;
+
+};
+
+//
+// constants, enums and typedefs
+//
+
+struct MTDHit {
+  float energy;
+  float time;
+  float x;
+  float y;
+  float z;
+};
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+EtlSimHitsValidation::EtlSimHitsValidation(const edm::ParameterSet& iConfig):
+  geom_(nullptr),
+  folder_(iConfig.getParameter<std::string>("folder")),
+  g4InfoLabel_(iConfig.getParameter<std::string>("moduleLabelG4")),
+  etlHitsCollection_(iConfig.getParameter<std::string>("etlSimHitsCollection")),
+  hitMinEnergy_( iConfig.getParameter<double>("hitMinimumEnergy") ),
+  eventCount_(0) {
+  
+  etlSimHitsToken_ = consumes <edm::PSimHitContainer> (edm::InputTag(std::string(g4InfoLabel_),
+								     std::string(etlHitsCollection_)));
+
+}
+
+
+EtlSimHitsValidation::~EtlSimHitsValidation() {
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  using namespace edm;
+
+  edm::LogInfo("EventInfo") << " Run = " << iEvent.id().run() << " Event = " << iEvent.id().event();
+
+  edm::ESHandle<MTDGeometry> geometryHandle;
+  iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);
+  geom_ = geometryHandle.product();
+
+  edm::Handle<edm::PSimHitContainer> etlSimHitsHandle;
+  iEvent.getByToken(etlSimHitsToken_, etlSimHitsHandle);
+
+  if( ! etlSimHitsHandle.isValid() ) return;
+
+  eventCount_++;
+  
+  std::map<uint32_t, MTDHit> m_etlHits;
+
+  // --- Loop over the BLT SIM hits
+  for (auto const& simHit: *etlSimHitsHandle) {
+
+    // --- Only hits compatible with the in-time bunch-crossing
+    if ( simHit.tof() < 0 || simHit.tof() > 25. ) continue;
+
+    DetId id = simHit.detUnitId();
+
+    auto simHitIt = m_etlHits.emplace(id.rawId(),MTDHit()).first;
+
+    // --- Accumulate the energy (in MeV) of SIM hits in the same detector cell
+    (simHitIt->second).energy += 1000.*simHit.energyLoss();
+
+    // --- Get the time of the first SIM hit in the cell
+    if( (simHitIt->second).time==0 || simHit.tof()<(simHitIt->second).time ) {
+
+      (simHitIt->second).time = simHit.tof();
+
+      auto hit_pos = simHit.entryPoint();
+      (simHitIt->second).x = hit_pos.x();
+      (simHitIt->second).y = hit_pos.y();
+      (simHitIt->second).z = hit_pos.z();
+
+    }
+
+  } // simHit loop
+
+
+  // ==============================================================================
+  //  Histogram filling
+  // ==============================================================================
+
+  for (auto const& hit: m_etlHits) {
+
+    if ( (hit.second).energy < hitMinEnergy_ ) continue;
+
+    // --- Get the SIM hit global position
+    ETLDetId detId(hit.first); 
+
+    DetId geoId = detId.geographicalId();
+    const MTDGeomDet* thedet = geom_->idToDet(geoId);
+    if( thedet == nullptr )
+      throw cms::Exception("EtlSimHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
+						   << " (" << detId.rawId()<< ") is invalid!" << std::dec
+						   << std::endl;
+
+    Local3DPoint local_point(0.1*(hit.second).x,0.1*(hit.second).y,0.1*(hit.second).z);
+    const auto& global_point = thedet->toGlobal(local_point);
+
+    // --- Fill the histograms
+    if ( detId.zside()>0. ){
+
+      meHitEnergyZpos_->Fill((hit.second).energy);
+      meHitTimeZpos_->Fill((hit.second).time);
+      meOccupancyZpos_->Fill(global_point.x(),global_point.y());
+
+    }
+    else {
+
+      meHitEnergyZneg_->Fill((hit.second).energy);
+      meHitTimeZneg_->Fill((hit.second).time);
+      meOccupancyZneg_->Fill(global_point.x(),global_point.y());
+
+    }
+
+  } // hit loop
+
+}
+
+void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
+                               edm::Run const& run,
+                               edm::EventSetup const & iSetup) {
+
+  ibook.setCurrentFolder(folder_);
+
+  meHitEnergyZpos_ = ibook.book1D("EtlHitEnergyZpos", "ETL SIM hits energy (+Z);E_{SIM} [MeV]", 200, 0., 2.);
+  meHitEnergyZneg_ = ibook.book1D("EtlHitEnergyZneg", "ETL SIM hits energy (-Z);E_{SIM} [MeV]", 200, 0., 2.);
+  meHitTimeZpos_   = ibook.book1D("EtlHitTimeZpos", "ETL SIM hits ToA (+Z);ToA_{SIM} [ns]", 250, 0., 25.);
+  meHitTimeZneg_   = ibook.book1D("EtlHitTimeZneg", "ETL SIM hits ToA (-Z);ToA_{SIM} [ns]", 250, 0., 25.);
+
+  meOccupancyZpos_ = ibook.book2D("EtlOccupancyZpos", "ETL SIM hits occupancy (+Z);x_{SIM} [cm];y_{SIM} [cm]",
+				  135, -135., 135.,  135, -135., 135.);
+  meOccupancyZneg_ = ibook.book2D("EtlOccupancyZneg", "ETL SIM hits occupancy (-Z);x_{SIM} [cm];y_{SIM} [cm]",
+				  135, -135., 135.,  135, -135., 135.);
+
+}
+
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void EtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // The following says we do not know what parameters are allowed so do no
+  // validation
+  // Please change this to state exactly what you do use, even if it is no
+  // parameters
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("folder", "MTD/ETL/SimHits");
+  desc.add<std::string>("moduleLabelG4","g4SimHits");
+  desc.add<std::string>("etlSimHitsCollection","FastTimerHitsEndcap");
+  desc.add<double>("hitMinimumEnergy",0.1); // [MeV]
+  descriptions.add("etlSimHits", desc);
+
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(EtlSimHitsValidation);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -231,8 +231,8 @@ void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   meHitPhi_[1] = ibook.book1D("EtlHitPhiZpos", "ETL SIM hits #phi (+Z);#phi_{SIM} [rad]", 100, -3.15, 3.15);
   meHitPhi_[0] = ibook.book1D("EtlHitPhiZneg", "ETL SIM hits #phi (-Z);#phi_{SIM} [rad]", 100, -3.15, 3.15);
-  meHitEta_[1] = ibook.book1D("EtlHitEtaZpos", "ETL SIM hits #eta (+Z);#eta_{SIM}", 100, 1.56, 3.);
-  meHitEta_[0] = ibook.book1D("EtlHitEtaZneg", "ETL SIM hits #eta (-Z);#eta_{SIM}", 100, 3., -1.56);
+  meHitEta_[1] = ibook.book1D("EtlHitEtaZpos", "ETL SIM hits #eta (+Z);#eta_{SIM}", 100, 1.56, 3.2);
+  meHitEta_[0] = ibook.book1D("EtlHitEtaZneg", "ETL SIM hits #eta (-Z);#eta_{SIM}", 100, -3.2, -1.56);
 
   meHitTvsE_[1] = ibook.bookProfile(
       "EtlHitTvsEZpos", "ETL SIM time vs energy (+Z);E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 2., 0., 100.);
@@ -243,17 +243,17 @@ void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitEvsPhi_[0] = ibook.bookProfile(
       "EtlHitEvsPhiZneg", "ETL SIM energy vs #phi (-Z);#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
   meHitEvsEta_[1] = ibook.bookProfile(
-      "EtlHitEvsEtaZpos", "ETL SIM energy vs #eta (+Z);#eta_{SIM};E_{SIM} [MeV]", 50, 1.56, 3., 0., 100.);
+      "EtlHitEvsEtaZpos", "ETL SIM energy vs #eta (+Z);#eta_{SIM};E_{SIM} [MeV]", 50, 1.56, 3.2, 0., 100.);
   meHitEvsEta_[0] = ibook.bookProfile(
-      "EtlHitEvsEtaZneg", "ETL SIM energy vs #eta (-Z);#eta_{SIM};E_{SIM} [MeV]", 50, 3., -1.56, 0., 100.);
+      "EtlHitEvsEtaZneg", "ETL SIM energy vs #eta (-Z);#eta_{SIM};E_{SIM} [MeV]", 50, -3.2, -1.56, 0., 100.);
   meHitTvsPhi_[1] = ibook.bookProfile(
       "EtlHitTvsPhiZpos", "ETL SIM time vs #phi (+Z);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
   meHitTvsPhi_[0] = ibook.bookProfile(
       "EtlHitTvsPhiZneg", "ETL SIM time vs #phi (-Z);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
   meHitTvsEta_[1] = ibook.bookProfile(
-      "EtlHitTvsEtaZpos", "ETL SIM time vs #eta (+Z);#eta_{SIM};T_{SIM} [ns]", 50, 1.56, 3., 0., 100.);
+      "EtlHitTvsEtaZpos", "ETL SIM time vs #eta (+Z);#eta_{SIM};T_{SIM} [ns]", 50, 1.56, 3.2, 0., 100.);
   meHitTvsEta_[0] = ibook.bookProfile(
-      "EtlHitTvsEtaZpos", "ETL SIM time vs #eta (-Z);#eta_{SIM};T_{SIM} [ns]", 50, 3., -1.56, 0., 100.);
+      "EtlHitTvsEtaZneg", "ETL SIM time vs #eta (-Z);#eta_{SIM};T_{SIM} [ns]", 50, -3.2, -1.56, 0., 100.);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -70,13 +70,29 @@ private:
 
   // --- histograms declaration
 
-  MonitorElement* meHitEnergyZpos_;
-  MonitorElement* meHitEnergyZneg_;
-  MonitorElement* meHitTimeZpos_;
-  MonitorElement* meHitTimeZneg_;
+  MonitorElement* meNhits_[2];
+  MonitorElement* meNtrkPerCell_[2];
 
-  MonitorElement* meOccupancyZpos_;
-  MonitorElement* meOccupancyZneg_;
+  MonitorElement* meHitEnergy_[2];
+  MonitorElement* meHitTime_[2];
+
+  MonitorElement* meHitXlocal_[2];
+  MonitorElement* meHitYlocal_[2];
+  MonitorElement* meHitZlocal_[2];
+
+  MonitorElement* meOccupancy_[2];
+
+  MonitorElement* meHitX_[2];
+  MonitorElement* meHitY_[2];
+  MonitorElement* meHitZ_[2];
+  MonitorElement* meHitPhi_[2];
+  MonitorElement* meHitEta_[2];
+
+  MonitorElement* meHitTvsE_[2];
+  MonitorElement* meHitEvsPhi_[2];
+  MonitorElement* meHitEvsEta_[2];
+  MonitorElement* meHitTvsPhi_[2];
+  MonitorElement* meHitTvsEta_[2];
 
 };
 
@@ -120,7 +136,8 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
   eventCount_++;
   
-  std::map<uint32_t, MTDHit> m_etlHits;
+  std::unordered_map<uint32_t, MTDHit> m_etlHits[2];
+  std::unordered_map<uint32_t, std::set<int> > m_etlTrkPerCell[2];
 
   // --- Loop over the BLT SIM hits
   for (auto const& simHit: *etlSimHitsHandle) {
@@ -128,9 +145,13 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     // --- Use only hits compatible with the in-time bunch-crossing
     if ( simHit.tof() < 0 || simHit.tof() > 25. ) continue;
 
-    DetId id = simHit.detUnitId();
+    ETLDetId id = simHit.detUnitId();
 
-    auto simHitIt = m_etlHits.emplace(id.rawId(),MTDHit()).first;
+    int idet = (id.zside()+1)/2;
+
+    m_etlTrkPerCell[idet][id.rawId()].insert(simHit.trackId());
+
+    auto simHitIt = m_etlHits[idet].emplace(id.rawId(),MTDHit()).first;
 
     // --- Accumulate the energy (in MeV) of SIM hits in the same detector cell
     (simHitIt->second).energy += 1000.*simHit.energyLoss();
@@ -154,40 +175,58 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   //  Histogram filling
   // ==============================================================================
 
-  for (auto const& hit: m_etlHits) {
+  for (int idet=0; idet<2; ++idet){
 
-    if ( (hit.second).energy < hitMinEnergy_ ) continue;
+    meNhits_[idet]->Fill(m_etlHits[idet].size());
 
-    // --- Get the SIM hit global position
-    ETLDetId detId(hit.first); 
+    for (auto const& hit: m_etlTrkPerCell[idet])
+      meNtrkPerCell_[idet]->Fill((hit.second).size());
 
-    DetId geoId = detId.geographicalId();
-    const MTDGeomDet* thedet = geom_->idToDet(geoId);
-    if( thedet == nullptr )
-      throw cms::Exception("EtlSimHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
-						   << " (" << detId.rawId()<< ") is invalid!" << std::dec
-						   << std::endl;
 
-    Local3DPoint local_point(0.1*(hit.second).x,0.1*(hit.second).y,0.1*(hit.second).z);
-    const auto& global_point = thedet->toGlobal(local_point);
+    for (auto const& hit: m_etlHits[idet]) {
 
-    // --- Fill the histograms
-    if ( detId.zside()>0. ){
+      if ( (hit.second).energy < hitMinEnergy_ ) continue;
 
-      meHitEnergyZpos_->Fill((hit.second).energy);
-      meHitTimeZpos_->Fill((hit.second).time);
-      meOccupancyZpos_->Fill(global_point.x(),global_point.y());
+      // --- Get the SIM hit global position
+      ETLDetId detId(hit.first); 
 
-    }
-    else {
+      DetId geoId = detId.geographicalId();
+      const MTDGeomDet* thedet = geom_->idToDet(geoId);
+      if( thedet == nullptr )
+	throw cms::Exception("EtlSimHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
+						     << " (" << detId.rawId()<< ") is invalid!" << std::dec
+						     << std::endl;
 
-      meHitEnergyZneg_->Fill((hit.second).energy);
-      meHitTimeZneg_->Fill((hit.second).time);
-      meOccupancyZneg_->Fill(global_point.x(),global_point.y());
+      Local3DPoint local_point(0.1*(hit.second).x,0.1*(hit.second).y,0.1*(hit.second).z);
+      const auto& global_point = thedet->toGlobal(local_point);
 
-    }
+      // --- Fill the histograms
 
-  } // hit loop
+      meHitEnergy_[idet]->Fill((hit.second).energy);
+      meHitTime_[idet]->Fill((hit.second).time);
+
+      meHitXlocal_[idet]->Fill((hit.second).x);
+      meHitYlocal_[idet]->Fill((hit.second).y);
+      meHitZlocal_[idet]->Fill((hit.second).z);
+
+      meOccupancy_[idet]->Fill(global_point.x(),global_point.y());
+
+      meHitX_[idet]->Fill(global_point.x()); 
+      meHitY_[idet]->Fill(global_point.y()); 
+      meHitZ_[idet]->Fill(global_point.z()); 
+      meHitPhi_[idet]->Fill(global_point.phi()); 
+      meHitEta_[idet]->Fill(global_point.eta()); 
+
+      meHitTvsE_[idet]->Fill((hit.second).energy,(hit.second).time);  
+      meHitEvsPhi_[idet]->Fill(global_point.phi(),(hit.second).energy);
+      meHitEvsEta_[idet]->Fill(global_point.eta(),(hit.second).energy);
+      meHitTvsPhi_[idet]->Fill(global_point.phi(),(hit.second).time);
+      meHitTvsEta_[idet]->Fill(global_point.eta(),(hit.second).time);
+
+
+    } // hit loop
+
+  } // idet loop
 
 }
 
@@ -201,15 +240,60 @@ void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
 
   // --- histograms booking
 
-  meHitEnergyZpos_ = ibook.book1D("EtlHitEnergyZpos", "ETL SIM hits energy (+Z);E_{SIM} [MeV]", 200, 0., 2.);
-  meHitEnergyZneg_ = ibook.book1D("EtlHitEnergyZneg", "ETL SIM hits energy (-Z);E_{SIM} [MeV]", 200, 0., 2.);
-  meHitTimeZpos_   = ibook.book1D("EtlHitTimeZpos", "ETL SIM hits ToA (+Z);ToA_{SIM} [ns]", 250, 0., 25.);
-  meHitTimeZneg_   = ibook.book1D("EtlHitTimeZneg", "ETL SIM hits ToA (-Z);ToA_{SIM} [ns]", 250, 0., 25.);
+  meNhits_[1]     = ibook.book1D("EtlNhitsZpos", "Number of ETL cells with SIM hits (+Z);N_{ETL cells}", 250, 0., 5000.);
+  meNhits_[0]     = ibook.book1D("EtlNhitsZneg", "Number of ETL cells with SIM hits (-Z);N_{ETL cells}", 250, 0., 5000.);
+  meNtrkPerCell_[1] = ibook.book1D("EtlNtrkPerCellZpos", "Number of tracks per ETL sensor (+Z);N_{trk}", 10, 0., 10.);
+  meNtrkPerCell_[0] = ibook.book1D("EtlNtrkPerCellZneg", "Number of tracks per ETL sensor (-Z);N_{trk}", 10, 0., 10.);
 
-  meOccupancyZpos_ = ibook.book2D("EtlOccupancyZpos", "ETL SIM hits occupancy (+Z);x_{SIM} [cm];y_{SIM} [cm]",
+  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZpos", "ETL SIM hits energy (+Z);E_{SIM} [MeV]", 200, 0., 2.);
+  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZneg", "ETL SIM hits energy (-Z);E_{SIM} [MeV]", 200, 0., 2.);
+  meHitTime_[1]   = ibook.book1D("EtlHitTimeZpos", "ETL SIM hits ToA (+Z);ToA_{SIM} [ns]", 250, 0., 25.);
+  meHitTime_[0]   = ibook.book1D("EtlHitTimeZneg", "ETL SIM hits ToA (-Z);ToA_{SIM} [ns]", 250, 0., 25.);
+
+  meHitXlocal_[1] = ibook.book1D("EtlHitXlocalZpos", "ETL SIM local X (+Z);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
+  meHitXlocal_[0] = ibook.book1D("EtlHitXlocalZneg", "ETL SIM local X (-Z);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
+  meHitYlocal_[1] = ibook.book1D("EtlHitYlocalZpos", "ETL SIM local Y (+Z);Y_{SIM}^{LOC} [mm]", 200, -50., 50.);
+  meHitYlocal_[0] = ibook.book1D("EtlHitYlocalZneg", "ETL SIM local Y (-Z);Y_{SIM}^{LOC} [mm]", 200, -50., 50.);
+  meHitZlocal_[1] = ibook.book1D("EtlHitZlocalZpos", "ETL SIM local Z (+Z);Z_{SIM}^{LOC} [mm]", 80, -0.2, 0.2);
+  meHitZlocal_[0] = ibook.book1D("EtlHitZlocalZneg", "ETL SIM local Z (-Z);Z_{SIM}^{LOC} [mm]", 80, -0.2, 0.2);
+
+  meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos", "ETL SIM hits occupancy (+Z);X_{SIM} [cm];Y_{SIM} [cm]",
 				  135, -135., 135.,  135, -135., 135.);
-  meOccupancyZneg_ = ibook.book2D("EtlOccupancyZneg", "ETL SIM hits occupancy (-Z);x_{SIM} [cm];y_{SIM} [cm]",
+  meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg", "ETL SIM hits occupancy (-Z);X_{SIM} [cm];Y_{SIM} [cm]",
 				  135, -135., 135.,  135, -135., 135.);
+
+  meHitX_[1]      = ibook.book1D("EtlHitXZpos", "ETL SIM hits X (+Z);X_{SIM} [cm]", 135, -135., 135.);
+  meHitX_[0]      = ibook.book1D("EtlHitXZneg", "ETL SIM hits X (-Z);X_{SIM} [cm]", 135, -135., 135.);
+  meHitY_[1]      = ibook.book1D("EtlHitYZpos", "ETL SIM hits Y (+Z);Y_{SIM} [cm]", 135, -135., 135.);
+  meHitY_[0]      = ibook.book1D("EtlHitYZneg", "ETL SIM hits Y (-Z);Y_{SIM} [cm]", 135, -135., 135.);
+  meHitZ_[1]      = ibook.book1D("EtlHitZZpos", "ETL SIM hits Z (+Z);Z_{SIM} [cm]", 100,  303.,  304.5);
+  meHitZ_[0]      = ibook.book1D("EtlHitZZneg", "ETL SIM hits Z (-Z);Z_{SIM} [cm]", 100, -304.5, -303.);
+
+  meHitPhi_[1]    = ibook.book1D("EtlHitPhiZpos", "ETL SIM hits #phi (+Z);#phi_{SIM} [rad]", 315, -3.15, 3.15);
+  meHitPhi_[0]    = ibook.book1D("EtlHitPhiZneg", "ETL SIM hits #phi (-Z);#phi_{SIM} [rad]", 315, -3.15, 3.15);
+  meHitEta_[1]    = ibook.book1D("EtlHitEtaZpos", "ETL SIM hits #eta (+Z);#eta_{SIM}", 200,  1.55,  3.05);
+  meHitEta_[0]    = ibook.book1D("EtlHitEtaZneg", "ETL SIM hits #eta (-Z);#eta_{SIM}", 200, -3.05, -1.55);
+
+  meHitTvsE_[1]    = ibook.bookProfile("EtlHitTvsEZpos", "ETL SIM time vs energy (+Z);E_{SIM} [MeV];T_{SIM} [ns]",
+				       100, 0., 2., 0., 100.);
+  meHitTvsE_[0]    = ibook.bookProfile("EtlHitTvsEZneg", "ETL SIM time vs energy (-Z);E_{SIM} [MeV];T_{SIM} [ns]",
+				       100, 0., 2., 0., 100.);
+  meHitEvsPhi_[1]  = ibook.bookProfile("EtlHitEvsPhiZpos", "ETL SIM energy vs #phi (+Z);#phi_{SIM} [rad];E_{SIM} [MeV]",
+				       100, -3.15, 3.15, 0., 100.);
+  meHitEvsPhi_[0]  = ibook.bookProfile("EtlHitEvsPhiZneg", "ETL SIM energy vs #phi (-Z);#phi_{SIM} [rad];E_{SIM} [MeV]",
+				       100, -3.15, 3.15, 0., 100.);
+  meHitEvsEta_[1]  = ibook.bookProfile("EtlHitEvsEtaZpos","ETL SIM energy vs #eta (+Z);#eta_{SIM};E_{SIM} [MeV]",
+				       200, 1.55, 3.05, 0., 100.);
+  meHitEvsEta_[0]  = ibook.bookProfile("EtlHitEvsEtaZneg","ETL SIM energy vs #eta (-Z);#eta_{SIM};E_{SIM} [MeV]",
+				       200, -3.05, -1.55, 0., 100.);
+  meHitTvsPhi_[1]  = ibook.bookProfile("EtlHitTvsPhiZpos", "ETL SIM time vs #phi (+Z);#phi_{SIM} [rad];T_{SIM} [ns]",
+				       100, -3.15, 3.15, 0., 100.);
+  meHitTvsPhi_[0]  = ibook.bookProfile("EtlHitTvsPhiZneg", "ETL SIM time vs #phi (-Z);#phi_{SIM} [rad];T_{SIM} [ns]",
+				       100, -3.15, 3.15, 0., 100.);
+  meHitTvsEta_[1] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL SIM time vs #eta (+Z);#eta_{SIM};T_{SIM} [ns]",
+				       200, 1.55, 3.05, 0., 100.);
+  meHitTvsEta_[0] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL SIM time vs #eta (-Z);#eta_{SIM};T_{SIM} [ns]",
+				       200, -3.05, -1.55, 0., 100.);
 
 }
 

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -30,7 +30,6 @@
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
 
-
 struct MTDHit {
   float energy;
   float time;
@@ -39,20 +38,15 @@ struct MTDHit {
   float z;
 };
 
-
 class EtlSimHitsValidation : public DQMEDAnalyzer {
-
 public:
   explicit EtlSimHitsValidation(const edm::ParameterSet&);
   ~EtlSimHitsValidation() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-
 private:
-  void bookHistograms(DQMStore::IBooker &,
-		      edm::Run const&,
-		      edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
@@ -89,26 +83,19 @@ private:
   MonitorElement* meHitEvsEta_[2];
   MonitorElement* meHitTvsPhi_[2];
   MonitorElement* meHitTvsEta_[2];
-
 };
 
-
 // ------------ constructor and destructor --------------
-EtlSimHitsValidation::EtlSimHitsValidation(const edm::ParameterSet& iConfig):
-  folder_(iConfig.getParameter<std::string>("folder")),
-  hitMinEnergy_( iConfig.getParameter<double>("hitMinimumEnergy") ) {
-  
+EtlSimHitsValidation::EtlSimHitsValidation(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")),
+      hitMinEnergy_(iConfig.getParameter<double>("hitMinimumEnergy")) {
   etlSimHitsToken_ = consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("inputTag"));
-
 }
 
-EtlSimHitsValidation::~EtlSimHitsValidation() {
-}
-
+EtlSimHitsValidation::~EtlSimHitsValidation() {}
 
 // ------------ method called for each event  ------------
 void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   using namespace edm;
   using namespace geant_units::operators;
 
@@ -122,64 +109,59 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   std::unordered_map<uint32_t, std::set<int> > m_etlTrkPerCell[2];
 
   // --- Loop over the BLT SIM hits
-  for (auto const& simHit: *etlSimHitsHandle) {
-
+  for (auto const& simHit : *etlSimHitsHandle) {
     // --- Use only hits compatible with the in-time bunch-crossing
-    if ( simHit.tof() < 0 || simHit.tof() > 25. ) continue;
+    if (simHit.tof() < 0 || simHit.tof() > 25.)
+      continue;
 
     ETLDetId id = simHit.detUnitId();
 
-    int idet = (id.zside()+1)/2;
+    int idet = (id.zside() + 1) / 2;
 
     m_etlTrkPerCell[idet][id.rawId()].insert(simHit.trackId());
 
-    auto simHitIt = m_etlHits[idet].emplace(id.rawId(),MTDHit()).first;
+    auto simHitIt = m_etlHits[idet].emplace(id.rawId(), MTDHit()).first;
 
     // --- Accumulate the energy (in MeV) of SIM hits in the same detector cell
     (simHitIt->second).energy += convertUnitsTo(0.001_MeV, simHit.energyLoss());
 
     // --- Get the time of the first SIM hit in the cell
-    if( (simHitIt->second).time==0 || simHit.tof()<(simHitIt->second).time ) {
-
+    if ((simHitIt->second).time == 0 || simHit.tof() < (simHitIt->second).time) {
       (simHitIt->second).time = simHit.tof();
 
       auto hit_pos = simHit.entryPoint();
       (simHitIt->second).x = hit_pos.x();
       (simHitIt->second).y = hit_pos.y();
       (simHitIt->second).z = hit_pos.z();
-
     }
 
-  } // simHit loop
-
+  }  // simHit loop
 
   // ==============================================================================
   //  Histogram filling
   // ==============================================================================
 
-  for (int idet=0; idet<2; ++idet){
-
+  for (int idet = 0; idet < 2; ++idet) {
     meNhits_[idet]->Fill(m_etlHits[idet].size());
 
-    for (auto const& hit: m_etlTrkPerCell[idet])
+    for (auto const& hit : m_etlTrkPerCell[idet])
       meNtrkPerCell_[idet]->Fill((hit.second).size());
 
-
-    for (auto const& hit: m_etlHits[idet]) {
-
-      if ( (hit.second).energy < hitMinEnergy_ ) continue;
+    for (auto const& hit : m_etlHits[idet]) {
+      if ((hit.second).energy < hitMinEnergy_)
+        continue;
 
       // --- Get the SIM hit global position
-      ETLDetId detId(hit.first); 
+      ETLDetId detId(hit.first);
 
       DetId geoId = detId.geographicalId();
       const MTDGeomDet* thedet = geom->idToDet(geoId);
-      if( thedet == nullptr )
-	throw cms::Exception("EtlSimHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId()
-						     << " (" << detId.rawId()<< ") is invalid!" << std::dec
-						     << std::endl;
+      if (thedet == nullptr)
+        throw cms::Exception("EtlSimHitsValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
+                                                     << detId.rawId() << ") is invalid!" << std::dec << std::endl;
 
-      Local3DPoint local_point(convertMmToCm((hit.second).x),convertMmToCm((hit.second).y),convertMmToCm((hit.second).z));
+      Local3DPoint local_point(
+          convertMmToCm((hit.second).x), convertMmToCm((hit.second).y), convertMmToCm((hit.second).z));
       const auto& global_point = thedet->toGlobal(local_point);
 
       // --- Fill the histograms
@@ -191,46 +173,42 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
       meHitYlocal_[idet]->Fill((hit.second).y);
       meHitZlocal_[idet]->Fill((hit.second).z);
 
-      meOccupancy_[idet]->Fill(global_point.x(),global_point.y());
+      meOccupancy_[idet]->Fill(global_point.x(), global_point.y());
 
-      meHitX_[idet]->Fill(global_point.x()); 
-      meHitY_[idet]->Fill(global_point.y()); 
-      meHitZ_[idet]->Fill(global_point.z()); 
-      meHitPhi_[idet]->Fill(global_point.phi()); 
-      meHitEta_[idet]->Fill(global_point.eta()); 
+      meHitX_[idet]->Fill(global_point.x());
+      meHitY_[idet]->Fill(global_point.y());
+      meHitZ_[idet]->Fill(global_point.z());
+      meHitPhi_[idet]->Fill(global_point.phi());
+      meHitEta_[idet]->Fill(global_point.eta());
 
-      meHitTvsE_[idet]->Fill((hit.second).energy,(hit.second).time);  
-      meHitEvsPhi_[idet]->Fill(global_point.phi(),(hit.second).energy);
-      meHitEvsEta_[idet]->Fill(global_point.eta(),(hit.second).energy);
-      meHitTvsPhi_[idet]->Fill(global_point.phi(),(hit.second).time);
-      meHitTvsEta_[idet]->Fill(global_point.eta(),(hit.second).time);
+      meHitTvsE_[idet]->Fill((hit.second).energy, (hit.second).time);
+      meHitEvsPhi_[idet]->Fill(global_point.phi(), (hit.second).energy);
+      meHitEvsEta_[idet]->Fill(global_point.eta(), (hit.second).energy);
+      meHitTvsPhi_[idet]->Fill(global_point.phi(), (hit.second).time);
+      meHitTvsEta_[idet]->Fill(global_point.eta(), (hit.second).time);
 
+    }  // hit loop
 
-    } // hit loop
-
-  } // idet loop
-
+  }  // idet loop
 }
 
-
 // ------------ method for histogram booking ------------
-void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
-                               edm::Run const& run,
-                               edm::EventSetup const & iSetup) {
-
+void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
+                                          edm::Run const& run,
+                                          edm::EventSetup const& iSetup) {
   ibook.setCurrentFolder(folder_);
 
   // --- histograms booking
 
-  meNhits_[1]     = ibook.book1D("EtlNhitsZpos", "Number of ETL cells with SIM hits (+Z);N_{ETL cells}", 100, 0., 5000.);
-  meNhits_[0]     = ibook.book1D("EtlNhitsZneg", "Number of ETL cells with SIM hits (-Z);N_{ETL cells}", 100, 0., 5000.);
+  meNhits_[1] = ibook.book1D("EtlNhitsZpos", "Number of ETL cells with SIM hits (+Z);N_{ETL cells}", 100, 0., 5000.);
+  meNhits_[0] = ibook.book1D("EtlNhitsZneg", "Number of ETL cells with SIM hits (-Z);N_{ETL cells}", 100, 0., 5000.);
   meNtrkPerCell_[1] = ibook.book1D("EtlNtrkPerCellZpos", "Number of tracks per ETL sensor (+Z);N_{trk}", 10, 0., 10.);
   meNtrkPerCell_[0] = ibook.book1D("EtlNtrkPerCellZneg", "Number of tracks per ETL sensor (-Z);N_{trk}", 10, 0., 10.);
 
   meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZpos", "ETL SIM hits energy (+Z);E_{SIM} [MeV]", 100, 0., 3.);
   meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZneg", "ETL SIM hits energy (-Z);E_{SIM} [MeV]", 100, 0., 3.);
-  meHitTime_[1]   = ibook.book1D("EtlHitTimeZpos", "ETL SIM hits ToA (+Z);ToA_{SIM} [ns]", 100, 0., 25.);
-  meHitTime_[0]   = ibook.book1D("EtlHitTimeZneg", "ETL SIM hits ToA (-Z);ToA_{SIM} [ns]", 100, 0., 25.);
+  meHitTime_[1] = ibook.book1D("EtlHitTimeZpos", "ETL SIM hits ToA (+Z);ToA_{SIM} [ns]", 100, 0., 25.);
+  meHitTime_[0] = ibook.book1D("EtlHitTimeZneg", "ETL SIM hits ToA (-Z);ToA_{SIM} [ns]", 100, 0., 25.);
 
   meHitXlocal_[1] = ibook.book1D("EtlHitXlocalZpos", "ETL SIM local X (+Z);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
   meHitXlocal_[0] = ibook.book1D("EtlHitXlocalZneg", "ETL SIM local X (-Z);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
@@ -239,58 +217,54 @@ void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
   meHitZlocal_[1] = ibook.book1D("EtlHitZlocalZpos", "ETL SIM local Z (+Z);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
   meHitZlocal_[0] = ibook.book1D("EtlHitZlocalZneg", "ETL SIM local Z (-Z);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
 
-  meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos", "ETL SIM hits occupancy (+Z);X_{SIM} [cm];Y_{SIM} [cm]",
-				  135, -135., 135.,  135, -135., 135.);
-  meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg", "ETL SIM hits occupancy (-Z);X_{SIM} [cm];Y_{SIM} [cm]",
-				  135, -135., 135.,  135, -135., 135.);
+  meOccupancy_[1] = ibook.book2D(
+      "EtlOccupancyZpos", "ETL SIM hits occupancy (+Z);X_{SIM} [cm];Y_{SIM} [cm]", 135, -135., 135., 135, -135., 135.);
+  meOccupancy_[0] = ibook.book2D(
+      "EtlOccupancyZneg", "ETL SIM hits occupancy (-Z);X_{SIM} [cm];Y_{SIM} [cm]", 135, -135., 135., 135, -135., 135.);
 
-  meHitX_[1]      = ibook.book1D("EtlHitXZpos", "ETL SIM hits X (+Z);X_{SIM} [cm]", 100, -130., 130.);
-  meHitX_[0]      = ibook.book1D("EtlHitXZneg", "ETL SIM hits X (-Z);X_{SIM} [cm]", 100, -130., 130.);
-  meHitY_[1]      = ibook.book1D("EtlHitYZpos", "ETL SIM hits Y (+Z);Y_{SIM} [cm]", 100, -130., 130.);
-  meHitY_[0]      = ibook.book1D("EtlHitYZneg", "ETL SIM hits Y (-Z);Y_{SIM} [cm]", 100, -130., 130.);
-  meHitZ_[1]      = ibook.book1D("EtlHitZZpos", "ETL SIM hits Z (+Z);Z_{SIM} [cm]", 100,  303.4,  304.2);
-  meHitZ_[0]      = ibook.book1D("EtlHitZZneg", "ETL SIM hits Z (-Z);Z_{SIM} [cm]", 100, -304.2, -303.4);
+  meHitX_[1] = ibook.book1D("EtlHitXZpos", "ETL SIM hits X (+Z);X_{SIM} [cm]", 100, -130., 130.);
+  meHitX_[0] = ibook.book1D("EtlHitXZneg", "ETL SIM hits X (-Z);X_{SIM} [cm]", 100, -130., 130.);
+  meHitY_[1] = ibook.book1D("EtlHitYZpos", "ETL SIM hits Y (+Z);Y_{SIM} [cm]", 100, -130., 130.);
+  meHitY_[0] = ibook.book1D("EtlHitYZneg", "ETL SIM hits Y (-Z);Y_{SIM} [cm]", 100, -130., 130.);
+  meHitZ_[1] = ibook.book1D("EtlHitZZpos", "ETL SIM hits Z (+Z);Z_{SIM} [cm]", 100, 303.4, 304.2);
+  meHitZ_[0] = ibook.book1D("EtlHitZZneg", "ETL SIM hits Z (-Z);Z_{SIM} [cm]", 100, -304.2, -303.4);
 
-  meHitPhi_[1]    = ibook.book1D("EtlHitPhiZpos", "ETL SIM hits #phi (+Z);#phi_{SIM} [rad]", 100, -3.15, 3.15);
-  meHitPhi_[0]    = ibook.book1D("EtlHitPhiZneg", "ETL SIM hits #phi (-Z);#phi_{SIM} [rad]", 100, -3.15, 3.15);
-  meHitEta_[1]    = ibook.book1D("EtlHitEtaZpos", "ETL SIM hits #eta (+Z);#eta_{SIM}", 100,  1.56,  3.);
-  meHitEta_[0]    = ibook.book1D("EtlHitEtaZneg", "ETL SIM hits #eta (-Z);#eta_{SIM}", 100, 3., -1.56);
+  meHitPhi_[1] = ibook.book1D("EtlHitPhiZpos", "ETL SIM hits #phi (+Z);#phi_{SIM} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[0] = ibook.book1D("EtlHitPhiZneg", "ETL SIM hits #phi (-Z);#phi_{SIM} [rad]", 100, -3.15, 3.15);
+  meHitEta_[1] = ibook.book1D("EtlHitEtaZpos", "ETL SIM hits #eta (+Z);#eta_{SIM}", 100, 1.56, 3.);
+  meHitEta_[0] = ibook.book1D("EtlHitEtaZneg", "ETL SIM hits #eta (-Z);#eta_{SIM}", 100, 3., -1.56);
 
-  meHitTvsE_[1]    = ibook.bookProfile("EtlHitTvsEZpos", "ETL SIM time vs energy (+Z);E_{SIM} [MeV];T_{SIM} [ns]",
-				       50, 0., 2., 0., 100.);
-  meHitTvsE_[0]    = ibook.bookProfile("EtlHitTvsEZneg", "ETL SIM time vs energy (-Z);E_{SIM} [MeV];T_{SIM} [ns]",
-				       50, 0., 2., 0., 100.);
-  meHitEvsPhi_[1]  = ibook.bookProfile("EtlHitEvsPhiZpos", "ETL SIM energy vs #phi (+Z);#phi_{SIM} [rad];E_{SIM} [MeV]",
-				       50, -3.15, 3.15, 0., 100.);
-  meHitEvsPhi_[0]  = ibook.bookProfile("EtlHitEvsPhiZneg", "ETL SIM energy vs #phi (-Z);#phi_{SIM} [rad];E_{SIM} [MeV]",
-				       50, -3.15, 3.15, 0., 100.);
-  meHitEvsEta_[1]  = ibook.bookProfile("EtlHitEvsEtaZpos","ETL SIM energy vs #eta (+Z);#eta_{SIM};E_{SIM} [MeV]",
-				       50, 1.56, 3., 0., 100.);
-  meHitEvsEta_[0]  = ibook.bookProfile("EtlHitEvsEtaZneg","ETL SIM energy vs #eta (-Z);#eta_{SIM};E_{SIM} [MeV]",
-				       50, 3., -1.56, 0., 100.);
-  meHitTvsPhi_[1]  = ibook.bookProfile("EtlHitTvsPhiZpos", "ETL SIM time vs #phi (+Z);#phi_{SIM} [rad];T_{SIM} [ns]",
-				       50, -3.15, 3.15, 0., 100.);
-  meHitTvsPhi_[0]  = ibook.bookProfile("EtlHitTvsPhiZneg", "ETL SIM time vs #phi (-Z);#phi_{SIM} [rad];T_{SIM} [ns]",
-				       50, -3.15, 3.15, 0., 100.);
-  meHitTvsEta_[1] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL SIM time vs #eta (+Z);#eta_{SIM};T_{SIM} [ns]",
-				       50, 1.56, 3., 0., 100.);
-  meHitTvsEta_[0] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL SIM time vs #eta (-Z);#eta_{SIM};T_{SIM} [ns]",
-				       50, 3., -1.56, 0., 100.);
-
+  meHitTvsE_[1] = ibook.bookProfile(
+      "EtlHitTvsEZpos", "ETL SIM time vs energy (+Z);E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 2., 0., 100.);
+  meHitTvsE_[0] = ibook.bookProfile(
+      "EtlHitTvsEZneg", "ETL SIM time vs energy (-Z);E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 2., 0., 100.);
+  meHitEvsPhi_[1] = ibook.bookProfile(
+      "EtlHitEvsPhiZpos", "ETL SIM energy vs #phi (+Z);#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
+  meHitEvsPhi_[0] = ibook.bookProfile(
+      "EtlHitEvsPhiZneg", "ETL SIM energy vs #phi (-Z);#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
+  meHitEvsEta_[1] = ibook.bookProfile(
+      "EtlHitEvsEtaZpos", "ETL SIM energy vs #eta (+Z);#eta_{SIM};E_{SIM} [MeV]", 50, 1.56, 3., 0., 100.);
+  meHitEvsEta_[0] = ibook.bookProfile(
+      "EtlHitEvsEtaZneg", "ETL SIM energy vs #eta (-Z);#eta_{SIM};E_{SIM} [MeV]", 50, 3., -1.56, 0., 100.);
+  meHitTvsPhi_[1] = ibook.bookProfile(
+      "EtlHitTvsPhiZpos", "ETL SIM time vs #phi (+Z);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
+  meHitTvsPhi_[0] = ibook.bookProfile(
+      "EtlHitTvsPhiZneg", "ETL SIM time vs #phi (-Z);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
+  meHitTvsEta_[1] = ibook.bookProfile(
+      "EtlHitTvsEtaZpos", "ETL SIM time vs #eta (+Z);#eta_{SIM};T_{SIM} [ns]", 50, 1.56, 3., 0., 100.);
+  meHitTvsEta_[0] = ibook.bookProfile(
+      "EtlHitTvsEtaZpos", "ETL SIM time vs #eta (-Z);#eta_{SIM};T_{SIM} [ns]", 50, 3., -1.56, 0., 100.);
 }
-
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void EtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/ETL/SimHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("g4SimHits", "FastTimerHitsEndcap"));
-  desc.add<double>("hitMinimumEnergy",0.1); // [MeV]
+  desc.add<double>("hitMinimumEnergy", 0.1);  // [MeV]
 
   descriptions.add("etlSimHits", desc);
-
 }
 
 DEFINE_FWK_MODULE(EtlSimHitsValidation);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -240,60 +240,60 @@ void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker & ibook,
 
   // --- histograms booking
 
-  meNhits_[1]     = ibook.book1D("EtlNhitsZpos", "Number of ETL cells with SIM hits (+Z);N_{ETL cells}", 250, 0., 5000.);
-  meNhits_[0]     = ibook.book1D("EtlNhitsZneg", "Number of ETL cells with SIM hits (-Z);N_{ETL cells}", 250, 0., 5000.);
+  meNhits_[1]     = ibook.book1D("EtlNhitsZpos", "Number of ETL cells with SIM hits (+Z);N_{ETL cells}", 100, 0., 5000.);
+  meNhits_[0]     = ibook.book1D("EtlNhitsZneg", "Number of ETL cells with SIM hits (-Z);N_{ETL cells}", 100, 0., 5000.);
   meNtrkPerCell_[1] = ibook.book1D("EtlNtrkPerCellZpos", "Number of tracks per ETL sensor (+Z);N_{trk}", 10, 0., 10.);
   meNtrkPerCell_[0] = ibook.book1D("EtlNtrkPerCellZneg", "Number of tracks per ETL sensor (-Z);N_{trk}", 10, 0., 10.);
 
-  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZpos", "ETL SIM hits energy (+Z);E_{SIM} [MeV]", 200, 0., 2.);
-  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZneg", "ETL SIM hits energy (-Z);E_{SIM} [MeV]", 200, 0., 2.);
-  meHitTime_[1]   = ibook.book1D("EtlHitTimeZpos", "ETL SIM hits ToA (+Z);ToA_{SIM} [ns]", 250, 0., 25.);
-  meHitTime_[0]   = ibook.book1D("EtlHitTimeZneg", "ETL SIM hits ToA (-Z);ToA_{SIM} [ns]", 250, 0., 25.);
+  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZpos", "ETL SIM hits energy (+Z);E_{SIM} [MeV]", 100, 0., 3.);
+  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZneg", "ETL SIM hits energy (-Z);E_{SIM} [MeV]", 100, 0., 3.);
+  meHitTime_[1]   = ibook.book1D("EtlHitTimeZpos", "ETL SIM hits ToA (+Z);ToA_{SIM} [ns]", 100, 0., 25.);
+  meHitTime_[0]   = ibook.book1D("EtlHitTimeZneg", "ETL SIM hits ToA (-Z);ToA_{SIM} [ns]", 100, 0., 25.);
 
   meHitXlocal_[1] = ibook.book1D("EtlHitXlocalZpos", "ETL SIM local X (+Z);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
   meHitXlocal_[0] = ibook.book1D("EtlHitXlocalZneg", "ETL SIM local X (-Z);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
-  meHitYlocal_[1] = ibook.book1D("EtlHitYlocalZpos", "ETL SIM local Y (+Z);Y_{SIM}^{LOC} [mm]", 200, -50., 50.);
-  meHitYlocal_[0] = ibook.book1D("EtlHitYlocalZneg", "ETL SIM local Y (-Z);Y_{SIM}^{LOC} [mm]", 200, -50., 50.);
-  meHitZlocal_[1] = ibook.book1D("EtlHitZlocalZpos", "ETL SIM local Z (+Z);Z_{SIM}^{LOC} [mm]", 80, -0.2, 0.2);
-  meHitZlocal_[0] = ibook.book1D("EtlHitZlocalZneg", "ETL SIM local Z (-Z);Z_{SIM}^{LOC} [mm]", 80, -0.2, 0.2);
+  meHitYlocal_[1] = ibook.book1D("EtlHitYlocalZpos", "ETL SIM local Y (+Z);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
+  meHitYlocal_[0] = ibook.book1D("EtlHitYlocalZneg", "ETL SIM local Y (-Z);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
+  meHitZlocal_[1] = ibook.book1D("EtlHitZlocalZpos", "ETL SIM local Z (+Z);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
+  meHitZlocal_[0] = ibook.book1D("EtlHitZlocalZneg", "ETL SIM local Z (-Z);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
 
   meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos", "ETL SIM hits occupancy (+Z);X_{SIM} [cm];Y_{SIM} [cm]",
 				  135, -135., 135.,  135, -135., 135.);
   meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg", "ETL SIM hits occupancy (-Z);X_{SIM} [cm];Y_{SIM} [cm]",
 				  135, -135., 135.,  135, -135., 135.);
 
-  meHitX_[1]      = ibook.book1D("EtlHitXZpos", "ETL SIM hits X (+Z);X_{SIM} [cm]", 135, -135., 135.);
-  meHitX_[0]      = ibook.book1D("EtlHitXZneg", "ETL SIM hits X (-Z);X_{SIM} [cm]", 135, -135., 135.);
-  meHitY_[1]      = ibook.book1D("EtlHitYZpos", "ETL SIM hits Y (+Z);Y_{SIM} [cm]", 135, -135., 135.);
-  meHitY_[0]      = ibook.book1D("EtlHitYZneg", "ETL SIM hits Y (-Z);Y_{SIM} [cm]", 135, -135., 135.);
-  meHitZ_[1]      = ibook.book1D("EtlHitZZpos", "ETL SIM hits Z (+Z);Z_{SIM} [cm]", 100,  303.,  304.5);
-  meHitZ_[0]      = ibook.book1D("EtlHitZZneg", "ETL SIM hits Z (-Z);Z_{SIM} [cm]", 100, -304.5, -303.);
+  meHitX_[1]      = ibook.book1D("EtlHitXZpos", "ETL SIM hits X (+Z);X_{SIM} [cm]", 100, -130., 130.);
+  meHitX_[0]      = ibook.book1D("EtlHitXZneg", "ETL SIM hits X (-Z);X_{SIM} [cm]", 100, -130., 130.);
+  meHitY_[1]      = ibook.book1D("EtlHitYZpos", "ETL SIM hits Y (+Z);Y_{SIM} [cm]", 100, -130., 130.);
+  meHitY_[0]      = ibook.book1D("EtlHitYZneg", "ETL SIM hits Y (-Z);Y_{SIM} [cm]", 100, -130., 130.);
+  meHitZ_[1]      = ibook.book1D("EtlHitZZpos", "ETL SIM hits Z (+Z);Z_{SIM} [cm]", 100,  303.4,  304.2);
+  meHitZ_[0]      = ibook.book1D("EtlHitZZneg", "ETL SIM hits Z (-Z);Z_{SIM} [cm]", 100, -304.2, -303.4);
 
-  meHitPhi_[1]    = ibook.book1D("EtlHitPhiZpos", "ETL SIM hits #phi (+Z);#phi_{SIM} [rad]", 315, -3.15, 3.15);
-  meHitPhi_[0]    = ibook.book1D("EtlHitPhiZneg", "ETL SIM hits #phi (-Z);#phi_{SIM} [rad]", 315, -3.15, 3.15);
-  meHitEta_[1]    = ibook.book1D("EtlHitEtaZpos", "ETL SIM hits #eta (+Z);#eta_{SIM}", 200,  1.55,  3.05);
-  meHitEta_[0]    = ibook.book1D("EtlHitEtaZneg", "ETL SIM hits #eta (-Z);#eta_{SIM}", 200, -3.05, -1.55);
+  meHitPhi_[1]    = ibook.book1D("EtlHitPhiZpos", "ETL SIM hits #phi (+Z);#phi_{SIM} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[0]    = ibook.book1D("EtlHitPhiZneg", "ETL SIM hits #phi (-Z);#phi_{SIM} [rad]", 100, -3.15, 3.15);
+  meHitEta_[1]    = ibook.book1D("EtlHitEtaZpos", "ETL SIM hits #eta (+Z);#eta_{SIM}", 100,  1.56,  2.96);
+  meHitEta_[0]    = ibook.book1D("EtlHitEtaZneg", "ETL SIM hits #eta (-Z);#eta_{SIM}", 100, -2.96, -1.56);
 
   meHitTvsE_[1]    = ibook.bookProfile("EtlHitTvsEZpos", "ETL SIM time vs energy (+Z);E_{SIM} [MeV];T_{SIM} [ns]",
-				       100, 0., 2., 0., 100.);
+				       50, 0., 2., 0., 100.);
   meHitTvsE_[0]    = ibook.bookProfile("EtlHitTvsEZneg", "ETL SIM time vs energy (-Z);E_{SIM} [MeV];T_{SIM} [ns]",
-				       100, 0., 2., 0., 100.);
+				       50, 0., 2., 0., 100.);
   meHitEvsPhi_[1]  = ibook.bookProfile("EtlHitEvsPhiZpos", "ETL SIM energy vs #phi (+Z);#phi_{SIM} [rad];E_{SIM} [MeV]",
-				       100, -3.15, 3.15, 0., 100.);
+				       50, -3.15, 3.15, 0., 100.);
   meHitEvsPhi_[0]  = ibook.bookProfile("EtlHitEvsPhiZneg", "ETL SIM energy vs #phi (-Z);#phi_{SIM} [rad];E_{SIM} [MeV]",
-				       100, -3.15, 3.15, 0., 100.);
+				       50, -3.15, 3.15, 0., 100.);
   meHitEvsEta_[1]  = ibook.bookProfile("EtlHitEvsEtaZpos","ETL SIM energy vs #eta (+Z);#eta_{SIM};E_{SIM} [MeV]",
-				       200, 1.55, 3.05, 0., 100.);
+				       50, 1.56, 2.96, 0., 100.);
   meHitEvsEta_[0]  = ibook.bookProfile("EtlHitEvsEtaZneg","ETL SIM energy vs #eta (-Z);#eta_{SIM};E_{SIM} [MeV]",
-				       200, -3.05, -1.55, 0., 100.);
+				       50, -2.96, -1.56, 0., 100.);
   meHitTvsPhi_[1]  = ibook.bookProfile("EtlHitTvsPhiZpos", "ETL SIM time vs #phi (+Z);#phi_{SIM} [rad];T_{SIM} [ns]",
-				       100, -3.15, 3.15, 0., 100.);
+				       50, -3.15, 3.15, 0., 100.);
   meHitTvsPhi_[0]  = ibook.bookProfile("EtlHitTvsPhiZneg", "ETL SIM time vs #phi (-Z);#phi_{SIM} [rad];T_{SIM} [ns]",
-				       100, -3.15, 3.15, 0., 100.);
+				       50, -3.15, 3.15, 0., 100.);
   meHitTvsEta_[1] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL SIM time vs #eta (+Z);#eta_{SIM};T_{SIM} [ns]",
-				       200, 1.55, 3.05, 0., 100.);
+				       50, 1.56, 2.96, 0., 100.);
   meHitTvsEta_[0] = ibook.bookProfile("EtlHitTvsEtaZpos","ETL SIM time vs #eta (-Z);#eta_{SIM};T_{SIM} [ns]",
-				       200, -3.05, -1.55, 0., 100.);
+				       50, -2.96, -1.56, 0., 100.);
 
 }
 

--- a/Validation/MtdValidation/python/btlDigiHits_cfi.py
+++ b/Validation/MtdValidation/python/btlDigiHits_cfi.py
@@ -3,4 +3,4 @@ from Validation.MtdValidation.btlDigiHitsDefault_cfi import btlDigiHitsDefault a
 btlDigiHits = _btlDigiHitsDefault.clone()
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(btlDigiHits, moduleLabel = "mixData")
+premix_stage2.toModify(btlDigiHits, inputTag = cms.InputTag("mixData","FTLBarrel"))

--- a/Validation/MtdValidation/python/btlDigiHits_cfi.py
+++ b/Validation/MtdValidation/python/btlDigiHits_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+from Validation.MtdValidation.btlDigiHitsDefault_cfi import btlDigiHitsDefault as _btlDigiHitsDefault
+btlDigiHits = _btlDigiHitsDefault.clone()
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(btlDigiHits, moduleLabel = "mixData")

--- a/Validation/MtdValidation/python/etlDigiHits_cfi.py
+++ b/Validation/MtdValidation/python/etlDigiHits_cfi.py
@@ -3,4 +3,4 @@ from Validation.MtdValidation.etlDigiHitsDefault_cfi import etlDigiHitsDefault a
 etlDigiHits = _etlDigiHitsDefault.clone()
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(etlDigiHits, moduleLabel = "mixData")
+premix_stage2.toModify(etlDigiHits, inputTag = cms.InputTag("mixData","FTLEndcap"))

--- a/Validation/MtdValidation/python/etlDigiHits_cfi.py
+++ b/Validation/MtdValidation/python/etlDigiHits_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+from Validation.MtdValidation.etlDigiHitsDefault_cfi import etlDigiHitsDefault as _etlDigiHitsDefault
+etlDigiHits = _etlDigiHitsDefault.clone()
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(etlDigiHits, moduleLabel = "mixData")

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("mtdSimHitsValidation")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.load("Configuration.Geometry.GeometryExtended2023D38_cff")
+
+process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi")
+process.load("Geometry.MTDNumberingBuilder.mtdTopology_cfi")
+process.load("Geometry.MTDGeometryBuilder.mtdGeometry_cfi")
+process.load("Geometry.MTDGeometryBuilder.mtdParameters_cfi")
+
+process.mtdGeometry = cms.ESProducer("MTDDigiGeometryESModule",
+    alignmentsLabel = cms.string(''),
+    appendToDataLabel = cms.string(''),
+    applyAlignment = cms.bool(False),
+    fromDDD = cms.bool(True)
+)
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+process.MessageLogger.cerr.FwkReport  = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32(100),
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:step3.root'
+    )
+)
+
+# --- BTL Validation
+process.load("Validation.MtdValidation.btlSimHits_cfi")
+process.load("Validation.MtdValidation.btlDigiHits_cfi")
+btlValidation = cms.Sequence(process.btlSimHits + process.btlDigiHits)
+
+# --- ETL Validation
+process.load("Validation.MtdValidation.etlSimHits_cfi")
+process.load("Validation.MtdValidation.etlDigiHits_cfi")
+etlValidation = cms.Sequence(process.etlSimHits + process.etlDigiHits)
+
+process.DQMStore = cms.Service("DQMStore")
+
+process.load("DQMServices.FileIO.DQMFileSaverOnline_cfi")
+
+process.p = cms.Path( btlValidation + etlValidation + process.dqmSaver )

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -33,12 +33,14 @@ process.source = cms.Source("PoolSource",
 # --- BTL Validation
 process.load("Validation.MtdValidation.btlSimHits_cfi")
 process.load("Validation.MtdValidation.btlDigiHits_cfi")
-btlValidation = cms.Sequence(process.btlSimHits + process.btlDigiHits)
+process.load("Validation.MtdValidation.btlRecHits_cfi")
+btlValidation = cms.Sequence(process.btlSimHits + process.btlDigiHits + process.btlRecHits)
 
 # --- ETL Validation
 process.load("Validation.MtdValidation.etlSimHits_cfi")
 process.load("Validation.MtdValidation.etlDigiHits_cfi")
-etlValidation = cms.Sequence(process.etlSimHits + process.etlDigiHits)
+process.load("Validation.MtdValidation.etlRecHits_cfi")
+etlValidation = cms.Sequence(process.etlSimHits + process.etlDigiHits + process.etlRecHits)
 
 process.DQMStore = cms.Service("DQMStore")
 


### PR DESCRIPTION
This is the first implementation of a DQM/validation package for the MTD system:
       Validation/MtdValidation
It is based on the DQMEDAnalyzer, it fills histograms for both the BTL and the ETL detectors at SIM, DIGI, and RECO steps.

This package has been tested with the TTbar 2023D41 workflow. 
It adds ~700 kB of data to the DQM output file:
    475.40 KiB       MTD/ETL
    231.58 KiB       MTD/BTL