### PR TITLE
Bug fix for behavior after exceptions with concurrent lumis

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -222,6 +222,7 @@ namespace edm {
                         edm::WaitingTaskHolder iHolder);
     void continueLumiAsync(edm::WaitingTaskHolder iHolder);
     
+    void handleEndLumiExceptions(std::exception_ptr const* iPtr, WaitingTaskHolder& holder);
     void globalEndLumiAsync(edm::WaitingTaskHolder iTask, std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus);
     void streamEndLumiAsync(edm::WaitingTaskHolder iTask,
                             unsigned int iStreamIndex,
@@ -239,7 +240,7 @@ namespace edm {
 
     void setExceptionMessageFiles(std::string& message);
     void setExceptionMessageRuns(std::string& message);
-    void setExceptionMessageLumis(std::string& message);
+    void setExceptionMessageLumis();
 
     bool setDeferredException(std::exception_ptr);
 
@@ -330,8 +331,7 @@ namespace edm {
     bool                                          fileModeNoMerge_;
     std::string                                   exceptionMessageFiles_;
     std::string                                   exceptionMessageRuns_;
-    std::string                                   exceptionMessageLumis_;
-    std::atomic<bool>                             exceptionMessageLumisIsSet_;
+    std::atomic<bool>                             exceptionMessageLumis_;
     bool                                          forceLooperToEnd_;
     bool                                          looperBeginJobRun_;
     bool                                          forceESCacheClearOnNewRun_;

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -331,6 +331,7 @@ namespace edm {
     std::string                                   exceptionMessageFiles_;
     std::string                                   exceptionMessageRuns_;
     std::string                                   exceptionMessageLumis_;
+    std::atomic<bool>                             exceptionMessageLumisIsSet_;
     bool                                          forceLooperToEnd_;
     bool                                          looperBeginJobRun_;
     bool                                          forceESCacheClearOnNewRun_;

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -243,8 +243,7 @@ namespace edm {
     fileModeNoMerge_(false),
     exceptionMessageFiles_(),
     exceptionMessageRuns_(),
-    exceptionMessageLumis_(),
-    exceptionMessageLumisIsSet_(false),
+    exceptionMessageLumis_(false),
     forceLooperToEnd_(false),
     looperBeginJobRun_(false),
     forceESCacheClearOnNewRun_(false),
@@ -280,8 +279,7 @@ namespace edm {
     fileModeNoMerge_(false),
     exceptionMessageFiles_(),
     exceptionMessageRuns_(),
-    exceptionMessageLumis_(),
-    exceptionMessageLumisIsSet_(false),
+    exceptionMessageLumis_(false),
     forceLooperToEnd_(false),
     looperBeginJobRun_(false),
     forceESCacheClearOnNewRun_(false),
@@ -319,8 +317,7 @@ namespace edm {
     fileModeNoMerge_(false),
     exceptionMessageFiles_(),
     exceptionMessageRuns_(),
-    exceptionMessageLumis_(),
-    exceptionMessageLumisIsSet_(false),
+    exceptionMessageLumis_(false),
     forceLooperToEnd_(false),
     looperBeginJobRun_(false),
     forceESCacheClearOnNewRun_(false),
@@ -757,10 +754,11 @@ namespace edm {
         
       } // Try block
       catch (cms::Exception & e) {
-        if (!exceptionMessageLumis_.empty()) {
-          e.addAdditionalInfo(exceptionMessageLumis_);
+        if (exceptionMessageLumis_) {
+          std::string message("Another exception was caught while trying to clean up lumis after the primary fatal exception.");
+          e.addAdditionalInfo(message);
           if (e.alreadyPrinted()) {
-            LogAbsolute("Additional Exceptions") << exceptionMessageLumis_;
+            LogAbsolute("Additional Exceptions") << message;
           }
         }
         if (!exceptionMessageRuns_.empty()) {
@@ -1244,6 +1242,15 @@ namespace edm {
     }) );
   }
 
+  void EventProcessor::handleEndLumiExceptions(std::exception_ptr const* iPtr, WaitingTaskHolder& holder) {
+    if (setDeferredException(*iPtr)) {
+      WaitingTaskHolder tmp(holder);
+      tmp.doneWaiting(*iPtr);
+    } else {
+      setExceptionMessageLumis();
+    }
+  }
+
   void EventProcessor::globalEndLumiAsync(edm::WaitingTaskHolder iTask,
                                           std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus) {
 
@@ -1259,11 +1266,7 @@ namespace edm {
 
       std::exception_ptr ptr;
       if(iPtr) {
-        ptr = *iPtr;
-        WaitingTaskHolder tmp(iTask);
-        //set the exception early to prevent a beginLumi from running
-        // we use a copy to keep t from resetting on doneWaiting call.
-        tmp.doneWaiting(ptr);
+        handleEndLumiExceptions(iPtr, iTask);
       } else {
         try {
           ServiceRegistry::Operate operate(serviceToken_);
@@ -1272,36 +1275,55 @@ namespace edm {
             auto const& es = esp_->eventSetup();
             looper_->doEndLuminosityBlock(lp, es, &processContext_);
           }
-        }catch(...) {
-          if(not ptr) {
-            ptr = std::current_exception();
-          }
-        }
-      }
-      ServiceRegistry::Operate operate(serviceToken_);
-      try {
-        deleteLumiFromCache(*status);
-        //release our hold on the IOV
-        iovQueue_.resume();
-        status->resumeGlobalLumiQueue();
-      } catch(...) {
-        if( not ptr) {
+        } catch(...) {
           ptr = std::current_exception();
         }
       }
+      ServiceRegistry::Operate operate(serviceToken_);
+
+      // Try hard to clean up resources so the
+      // process can terminate in a controlled
+      // fashion even after exceptions have occurred.
+
       try {
-        status.reset();
+        deleteLumiFromCache(*status);
       } catch(...) {
-        if( not ptr) {
+        if (not ptr) {
           ptr = std::current_exception();
         }
       }
 
-      // This call to doneWaiting must be after the call to status.reset().
-      // Otherwise there will be a data race which could result in
-      // endRun being delayed until it is too late to successfully call
-      // it.
-      iTask.doneWaiting(ptr);
+      try {
+        //release our hold on the IOV
+        iovQueue_.resume();
+      } catch(...) {
+        if (not ptr) {
+          ptr = std::current_exception();
+        }
+      }
+
+      try {
+        status->resumeGlobalLumiQueue();
+      } catch(...) {
+        if (not ptr) {
+          ptr = std::current_exception();
+        }
+      }
+
+      try {
+        // This call to status.reset() must occur before iTask is destroyed.
+        // Otherwise there will be a data race which could result in endRun
+        // being delayed until it is too late to successfully call it.
+        status.reset();
+      } catch(...) {
+        if (not ptr) {
+          ptr = std::current_exception();
+        }
+      }
+
+      if (ptr) {
+        handleEndLumiExceptions(&ptr, iTask);
+      }
     });
 
     auto writeT = edm::make_waiting_task(
@@ -1340,9 +1362,8 @@ namespace edm {
                                           std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus) {
     
     auto t =edm::make_waiting_task(tbb::task::allocate_root(), [this, iStreamIndex, iTask](std::exception_ptr const* iPtr) mutable {
-      std::exception_ptr ptr;
       if(iPtr) {
-        ptr = *iPtr;
+        handleEndLumiExceptions(iPtr, iTask);
       }
       auto status =streamLumiStatus_[iStreamIndex];
       //reset status before releasing queue else get race condtion
@@ -1353,10 +1374,11 @@ namespace edm {
       //are we the last one?
       if( status->streamFinishedLumi()) {
         globalEndLumiAsync(iTask, std::move(status));
+      } else {
+        status.reset();
       }
-      iTask.doneWaiting(ptr);
     });
-    
+
     edm::WaitingTaskHolder lumiDoneTask{t};
     
     iLumiStatus->setEndTime();
@@ -1595,30 +1617,10 @@ namespace edm {
                      // This is the case where the exception in iPtr is the primary
                      // exception and we want to see its message.
                      deferredExceptionPtr_ = *iPtr;
-                     std::exception_ptr excpt = *iPtr;
-                     auto delayError = make_waiting_task(tbb::task::allocate_root(), [this, iTask, excpt](std::exception_ptr const* jPtr) mutable {
-                       if (jPtr) {
-                         std::string message("Another exception was caught while trying to clean up lumis after the primary fatal exception.");
-                         setExceptionMessageLumis(message);
-                       }
-                       iTask.doneWaiting(excpt);
-                     });
-                     WaitingTaskHolder delayErrorHolder(delayError);
-                     streamEndLumiAsync(std::move(delayErrorHolder), iStreamIndex, streamLumiStatus_[iStreamIndex]);
-                   } else {
-                     // Something else already threw and set the deferred exception so
-                     // we simply ignore subsequent exceptions.
-                     std::exception_ptr excpt;
-                     auto ignoreError = make_waiting_task(tbb::task::allocate_root(), [this, iTask, excpt](std::exception_ptr const* jPtr) mutable {
-                       if (jPtr) {
-                         std::string message("Another exception was caught while trying to clean up lumis after the primary fatal exception.");
-                         setExceptionMessageLumis(message);
-                       }
-                       iTask.doneWaiting(excpt);
-                     });
-                     WaitingTaskHolder ignoreErrorHolder(ignoreError);
-                     streamEndLumiAsync(std::move(ignoreErrorHolder), iStreamIndex, streamLumiStatus_[iStreamIndex]);
+                     WaitingTaskHolder tempHolder(iTask);
+                     tempHolder.doneWaiting(*iPtr);
                    }
+                   streamEndLumiAsync(std::move(iTask), iStreamIndex, streamLumiStatus_[iStreamIndex]);
                    //the stream will stop now
                    return;
                  }
@@ -1787,11 +1789,8 @@ namespace edm {
     exceptionMessageRuns_ = message;
   }
 
-  void EventProcessor::setExceptionMessageLumis(std::string& message) {
-    bool expected = false;
-    if (exceptionMessageLumisIsSet_.compare_exchange_strong(expected,true)) {
-      exceptionMessageLumis_ = message;
-    }
+  void EventProcessor::setExceptionMessageLumis() {
+    exceptionMessageLumis_ = true;
   }
 
   bool EventProcessor::setDeferredException(std::exception_ptr iException) {

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -10,6 +10,8 @@
 
 //Transition processing helpers
 
+#include <cassert>
+
 struct FileResources {
   FileResources(EventProcessor& iEP):
   ep_(iEP) {}
@@ -143,6 +145,7 @@ public:
     lumis_.normalEnd();
     if(currentRun_) {
       currentRun_->normalEnd();
+      assert(currentRun_.use_count() == 1);
     }
     currentRun_.reset();
   }

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -102,8 +102,7 @@ public:
       }
     } catch(...) {
       if(not currentRun_->ep_.setDeferredException(std::current_exception())) {
-        std::string message("Another exception was caught while trying to clean up lumis after the primary fatal exception.");
-        currentRun_->ep_.setExceptionMessageLumis(message);
+        currentRun_->ep_.setExceptionMessageLumis();
       }
     }
 

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -368,7 +368,7 @@ namespace edm {
   
   void MockEventProcessor::setExceptionMessageFiles(std::string&) {}
   void MockEventProcessor::setExceptionMessageRuns(std::string&) {}
-  void MockEventProcessor::setExceptionMessageLumis(std::string&) {}
+  void MockEventProcessor::setExceptionMessageLumis() {}
 
   bool MockEventProcessor::setDeferredException(std::exception_ptr) { return true;}
 

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -78,7 +78,7 @@ namespace edm {
 
     void setExceptionMessageFiles(std::string& message);
     void setExceptionMessageRuns(std::string& message);
-    void setExceptionMessageLumis(std::string& message);
+    void setExceptionMessageLumis();
 
 
     bool setDeferredException(std::exception_ptr);

--- a/FWCore/Framework/test/run_cmsRun.sh
+++ b/FWCore/Framework/test/run_cmsRun.sh
@@ -5,4 +5,29 @@ function die { echo $1: status $2 ;  exit $2; }
 
 (cmsRun --help ) || die 'Failure running cmsRun --help' $?
 
+# This test is supposed to throw an exception.
+# We had a bug where EventProcessor went into an
+# infinite wait under the circumstances in this test
+# and after an exception. The conditions were multiple
+# concurrent lumis in flight with an exception on an
+# event in a lumi before the last lumi.
+# This test passes as long as it does not go into
+# an infinite wait.
+F2=${LOCAL_TEST_DIR}/testConcurrentLumiExceptions_cfg.py
+echo $F2 "This test intentionally throws an exception"
+(cmsRun $F2 ) && die "No exception using $F2" $?
 
+# Test maxEvents output parameter
+F3=${LOCAL_TEST_DIR}/testMaxEventsOutput_cfg.py
+echo $F3
+(cmsRun $F3 ) || die "Failure running cmsRun $F3" $?
+# 6th word on the line containing the string "events"
+# output by edmFileUtil
+nEvents=`edmFileUtil file:testMaxEventsOutput.root | grep events | awk ' {print $6; exit} '`
+if [ "$nEvents" -lt 6 ] || [ "$nEvents" -gt 9 ]; then
+echo "maxEvents output test failed, nEvents = " $nEvents
+exit 1
+fi
+echo "number of events written = " $nEvents
+
+exit 0

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -158,17 +158,20 @@ namespace edmtest {
     token_{produces<IntProduct>()},
     value_(p.getParameter<int>("ivalue")),
     iterations_(p.getParameter<unsigned int>("iterations")),
-    pi_(std::acos(-1)){
+    pi_(std::acos(-1)),
+    lumiNumberToThrow_(p.getParameter<unsigned int>("lumiNumberToThrow")) {
     }
 
     void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
-    
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   private:
     const edm::EDPutTokenT<IntProduct> token_;
     const int value_;
     const unsigned int iterations_;
     const double pi_;
-    
+    const unsigned int lumiNumberToThrow_;
   };
   
   void
@@ -181,6 +184,19 @@ namespace edmtest {
     }
     
     e.emplace(token_,value_+sum);
+
+    if (e.luminosityBlock() == lumiNumberToThrow_) {
+      throw cms::Exception("Test");
+    }
+  }
+
+  void
+  BusyWaitIntProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<int>("ivalue");
+    desc.add<unsigned int>("iterations");
+    desc.add<unsigned int>("lumiNumberToThrow", 0);
+    descriptions.addDefault(desc);
   }
 
   //--------------------------------------------------------------------

--- a/FWCore/Framework/test/testConcurrentLumiExceptions_cfg.py
+++ b/FWCore/Framework/test/testConcurrentLumiExceptions_cfg.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(1),
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(1),
+    numberEventsInRun = cms.untracked.uint32(100)
+)
+
+process.maxEvents = cms.untracked.PSet(
+  input = cms.untracked.int32(20)
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(4),
+    numberOfStreams = cms.untracked.uint32(4),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(4)
+)
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",
+                               ivalue = cms.int32(1),
+                               iterations = cms.uint32(10*1000*1000),
+                               lumiNumberToThrow = cms.uint32(7)
+)
+
+process.p1 = cms.Path(process.busy1)

--- a/FWCore/Framework/test/testMaxEventsOutput_cfg.py
+++ b/FWCore/Framework/test/testMaxEventsOutput_cfg.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(1),
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(1),
+    numberEventsInRun = cms.untracked.uint32(100)
+)
+
+# set to 6 output events. Actual number could be
+# anywhere from 6 to 9 because after 6 events written
+# it will finish the other events already running concurrently.
+# In this config there are 3 other streams possible.
+process.maxEvents = cms.untracked.PSet(
+  input = cms.untracked.int32(20),
+  output = cms.untracked.int32(6)
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(4),
+    numberOfStreams = cms.untracked.uint32(4),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(4)
+)
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",
+                               ivalue = cms.int32(1),
+                               iterations = cms.uint32(10*1000*1000),
+                               lumiNumberToThrow = cms.uint32(7)
+)
+
+process.p1 = cms.Path(process.busy1)
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testMaxEventsOutput.root')
+)
+
+process.e = cms.EndPath(process.out)
+

--- a/FWCore/Framework/test/testMaxEventsOutput_cfg.py
+++ b/FWCore/Framework/test/testMaxEventsOutput_cfg.py
@@ -29,7 +29,7 @@ process.options = cms.untracked.PSet(
 process.busy1 = cms.EDProducer("BusyWaitIntProducer",
                                ivalue = cms.int32(1),
                                iterations = cms.uint32(10*1000*1000),
-                               lumiNumberToThrow = cms.uint32(7)
+                               lumiNumberToThrow = cms.uint32(0)
 )
 
 process.p1 = cms.Path(process.busy1)


### PR DESCRIPTION
#### PR description:

This fixes a bug that would be encountered when more than
one lumi is being processed concurrently and there is an
exception. If the exception is associated with a lumi other
than the last one read, an infinite wait will be entered.
The wait is in the processLumis function of the EventProcessor.
It waits on every task in the stream SerialTaskQueues.
In the above situation the serial queue is not resumed
before the wait and there are still tasks in the queues.
There is code that would clean these up in the function
endUnfinishedLumis but that only runs after the wait
is over and processLumis has returned. Too late.

This commit also fixes the maxEvents output parameter which was
broken when more than one lumi is processed concurrently. As far
as I know nothing uses this, but it is an advertised parameter
of the Framework that is supposed to work. One note about
this. If events are running concurrently when the limit is
reached, then all the events already running will complete, so
the job could write more than the requested number of events
to output.

The modified code is not executed if there are no exceptions and
the maxEvents output parameter is not used. Under normal
circumstances this should not have any effect on output or
performance.

#### PR validation:

This adds two new unit tests. One test would fail with an infinite
wait if executed in a release before this commit. It creates the
condition described above. The other tests the maxEvent output
parameter. Plus I added an assert that checks that the reference
count is one in normalEnd when we try to delete RunResources
and get endRun to execute (something to be concerned about in
concurrent lumi mode).

