### PR TITLE
Add small changes in CondCore for PPS proton reco, and serialization …

### DIFF
--- a/CondCore/CTPPSPlugins/src/plugin.cc
+++ b/CondCore/CTPPSPlugins/src/plugin.cc
@@ -13,6 +13,8 @@
 #include "CondFormats/AlignmentRecord/interface/RPMisalignedAlignmentRecord.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h"
 #include "CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h"
+#include "CondFormats/CTPPSReadoutObjects/interface/LHCOpticalFunctionsSetCollection.h"
+#include "CondFormats/DataRecord/interface/CTPPSOpticsRcd.h"
 
 REGISTER_PLUGIN(CTPPSBeamParametersRcd,CTPPSBeamParameters);
 REGISTER_PLUGIN(CTPPSPixelDAQMappingRcd,CTPPSPixelDAQMapping);
@@ -22,4 +24,4 @@ REGISTER_PLUGIN(CTPPSRPAlignmentCorrectionsDataRcd,CTPPSRPAlignmentCorrectionsDa
 REGISTER_PLUGIN(RPRealAlignmentRecord,CTPPSRPAlignmentCorrectionsData);
 REGISTER_PLUGIN(RPMisalignedAlignmentRecord,CTPPSRPAlignmentCorrectionsData);
 REGISTER_PLUGIN(PPSTimingCalibrationRcd,PPSTimingCalibration);
-
+REGISTER_PLUGIN(CTPPSOpticsRcd,LHCOpticalFunctionsSetCollection);

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -53,6 +53,7 @@ namespace cond {
       FETCH_PAYLOAD_CASE( CTPPSPixelAnalysisMask )
       FETCH_PAYLOAD_CASE( CTPPSPixelGainCalibrations )
       FETCH_PAYLOAD_CASE( CTPPSRPAlignmentCorrectionsData )
+      FETCH_PAYLOAD_CASE( LHCOpticalFunctionsSetCollection )
       FETCH_PAYLOAD_CASE( CastorChannelQuality )
       FETCH_PAYLOAD_CASE( CastorElectronicsMap )
       FETCH_PAYLOAD_CASE( CastorGainWidths )

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -68,6 +68,7 @@ namespace cond {
       IMPORT_PAYLOAD_CASE( CTPPSPixelAnalysisMask )
       IMPORT_PAYLOAD_CASE( CTPPSPixelGainCalibrations  )
       IMPORT_PAYLOAD_CASE( CTPPSRPAlignmentCorrectionsData )
+      IMPORT_PAYLOAD_CASE( LHCOpticalFunctionsSetCollection )
       IMPORT_PAYLOAD_CASE( CastorChannelQuality )
       IMPORT_PAYLOAD_CASE( CastorElectronicsMap )
       IMPORT_PAYLOAD_CASE( CastorGainWidths )

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -31,6 +31,7 @@
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSRPAlignmentCorrectionsData.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h"
+#include "CondFormats/CTPPSReadoutObjects/interface/LHCOpticalFunctionsSetCollection.h"
 #include "CondFormats/DTObjects/interface/DTCCBConfig.h"
 #include "CondFormats/DTObjects/interface/DTDeadFlag.h"
 #include "CondFormats/DTObjects/interface/DTHVStatus.h"

--- a/CondFormats/CTPPSReadoutObjects/test/BuildFile.xml
+++ b/CondFormats/CTPPSReadoutObjects/test/BuildFile.xml
@@ -5,3 +5,7 @@
 <bin file="testSerializationBeamParameters.cc">
   <use name="CondFormats/CTPPSReadoutObjects"/>
 </bin>
+
+<bin file="testSerializationLHCOpticalFunctionsSet.cc">
+  <use name="CondFormats/CTPPSReadoutObjects"/>
+</bin>

--- a/CondFormats/CTPPSReadoutObjects/test/testSerializationLHCOpticalFunctionsSet.cc
+++ b/CondFormats/CTPPSReadoutObjects/test/testSerializationLHCOpticalFunctionsSet.cc
@@ -1,0 +1,11 @@
+#include "CondFormats/Serialization/interface/Test.h"
+#include "CondFormats/CTPPSReadoutObjects/interface/LHCOpticalFunctionsSet.h"
+#include "CondFormats/CTPPSReadoutObjects/interface/LHCOpticalFunctionsSetCollection.h"
+
+int main()
+{
+    testSerialization<LHCOpticalFunctionsSet>() ;
+    testSerialization<LHCOpticalFunctionsSetCollection>() ;
+    
+    return 0 ;
+}


### PR DESCRIPTION
…test code for LHCOpticalFunctions

#### PR description:

This PR includes: 

- Minor changes needed for reading(writing) optical functions data from(into) POOL databases, consumed by the proton reconstruction introduced by the recently merged PR #25495. 

- A serialization test code for the condition formats `LHCOpticalFunctionsSet` and `LHCOpticalFunctionsCollection` introduced in #25495.

#### PR validation:

Tests run: just followed https://cms-sw.github.io/PRWorkflow.html.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### Informing: @jan-kaspar @malbouis @clemencia @forthommel 
