### PR TITLE
Run2-hcx194 Changes to some of the algorithms used for TB application by removing explicit reference to CLHEP

### DIFF
--- a/Geometry/HcalAlgo/plugins/DDHCalTBCableAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalTBCableAlgo.cc
@@ -160,21 +160,17 @@ void DDHCalTBCableAlgo::execute(DDCompactView& cpv) {
   
   for (int ii=0; ii<nsectortot; ii++) {
     double phi    = ii*2*alpha;
-    double phideg = convertRadToDeg(phi);
-    
     DDRotation rotation;
     std::string rotstr("NULL");
-    if (phideg != 0) {
-      rotstr = "R"; 
-      if (phideg < 100)	rotstr = "R0"; 
-      rotstr = rotstr + std::to_string(phideg);
+    if (phi != 0) {
+      rotstr = "R" + formatAsDegreesInInteger(phi);
       rotation = DDRotation(DDName(rotstr, rotns)); 
       if (!rotation) {
 #ifdef EDM_ML_DEBUG
 	edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Creating a new "
 				     << "rotation " << rotstr << "\t90," 
-				     << phideg << ", 90, " << (phideg+90) 
-				     << ", 0, 0";
+                                     << convertRadToDeg(phi) << ",90,"
+                                     << (90+convertRadToDeg(phi)) << ", 0, 0";
 #endif
 	rotation = DDrot(DDName(rotstr, idNameSpace), 90._deg, phi, 90._deg, 
 			 (90._deg+phi), 0,  0);

--- a/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.cc
@@ -6,17 +6,20 @@
 #include <cmath>
 #include <algorithm>
 
-namespace std{} using namespace std;
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include "DetectorDescription/Core/interface/DDLogicalPart.h"
 #include "DetectorDescription/Core/interface/DDCurrentNamespace.h"
 #include "DetectorDescription/Core/interface/DDSplit.h"
 #include "Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.h"
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
+
+//#define EDM_ML_DEBUG
+using namespace geant_units::operators;
 
 DDHCalTBZposAlgo::DDHCalTBZposAlgo() {
-  LogDebug("HCalGeom") << "DDHCalTBZposAlgo test: Creating an instance";
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: Creating an instance";
+#endif
 }
 
 DDHCalTBZposAlgo::~DDHCalTBZposAlgo() {}
@@ -35,19 +38,22 @@ void DDHCalTBZposAlgo::initialize(const DDNumericArguments & nArgs,
   dist       = nArgs["Distance"];
   tilt       = nArgs["TiltAngle"];
   copyNumber = int (nArgs["Number"]);
-  LogDebug("HCalGeom") << "DDHCalTBZposAlgo debug: Parameters for position"
-		       << "ing--" << " Eta " << eta << "\tTheta " 
-		       << theta/CLHEP::deg << "\tShifts " << shiftX << ", " 
-		       << shiftY  << " along x, y axes; \tZoffest " << zoffset
-		       << "\tRadial Distance " << dist << "\tTilt angle "
-		       << tilt/CLHEP::deg << "\tcopyNumber " << copyNumber;
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: Parameters for position"
+			       << "ing--" << " Eta " << eta << "\tTheta " 
+			       << convertRadToDeg(theta) << "\tShifts " 
+			       << shiftX << ", " << shiftY  << " along x, y "
+			       << "axes; \tZoffest " << zoffset
+			       << "\tRadial Distance " << dist 
+			       << "\tTilt angle " << convertRadToDeg(tilt)
+			       << "\tcopyNumber " << copyNumber;
 
   idNameSpace = DDCurrentNamespace::ns();
   childName   = sArgs["ChildName"]; 
-  DDName parentName = parent().name(); 
-  LogDebug("HCalGeom") << "DDHCalTBZposAlgo debug: Parent " << parentName
-		       << "\tChild " << childName << " NameSpace "
-		       << idNameSpace;
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: Parent " <<parent().name()
+			       << "\tChild " << childName << " NameSpace "
+			       << idNameSpace;
+#endif
 }
 
 void DDHCalTBZposAlgo::execute(DDCompactView& cpv) {
@@ -55,13 +61,13 @@ void DDHCalTBZposAlgo::execute(DDCompactView& cpv) {
   DDName mother = parent().name();
   DDName child(DDSplit(childName).first, DDSplit(childName).second);
  
-  double thetax = 90.*CLHEP::deg - theta;
+  double thetax = 90._deg - theta;
   double z      = zoffset + dist*tan(thetax);
   double x      = shiftX - shiftY*sin(tilt);
   double y      = shiftY*cos(tilt);
   DDTranslation tran(x,y,z);
   DDRotation rot;
-  double tiltdeg = tilt/CLHEP::deg;
+  double tiltdeg = convertRadToDeg(tilt);
   int    itilt   = int(tiltdeg+0.1);
   if (itilt != 0) {
     std::string rotstr = "R";
@@ -69,15 +75,20 @@ void DDHCalTBZposAlgo::execute(DDCompactView& cpv) {
     rotstr = rotstr + std::to_string(tiltdeg);
     rot    = DDRotation(DDName(rotstr, idNameSpace)); 
     if (!rot) {
-      LogDebug("HCalGeom") << "DDHCalAngular test: Creating a new rotation "
-			   << DDName(rotstr,idNameSpace) << "\t90, " << tiltdeg
-			   << ", 90, " << (tiltdeg+90) << ", 0, 0";
-      rot = DDrot(DDName(rotstr, idNameSpace), 90*CLHEP::deg, tilt, 
-		  90*CLHEP::deg, (90*CLHEP::deg+tilt), 0.0,  0.0);
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("HCalGeom") << "DDHCalZposAlgo: Creating a rotation "
+				   << DDName(rotstr,idNameSpace) << "\t90, "
+				   << tiltdeg  << ", 90, " << (tiltdeg+90)
+				   << ", 0, 0";
+#endif
+      rot = DDrot(DDName(rotstr, idNameSpace), 90._deg, tilt, 
+		  90._deg, (90._deg+tilt), 0.0,  0.0);
     }
   }
- cpv.position(child, mother, copyNumber, tran, rot);
-  LogDebug("HCalGeom") << "DDHCalTBZposAlgo test: " << child << " number " 
-		       << copyNumber << " positioned in " << mother
-		       << " at " << tran << " with " << rot;
+  cpv.position(child, mother, copyNumber, tran, rot);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: " << child << " number " 
+			       << copyNumber << " positioned in " << mother
+			       << " at " << tran << " with " << rot;
+#endif
 }

--- a/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.cc
@@ -67,9 +67,8 @@ void DDHCalTBZposAlgo::execute(DDCompactView& cpv) {
   double y      = shiftY*cos(tilt);
   DDTranslation tran(x,y,z);
   DDRotation rot;
-  double tiltdeg = convertRadToDeg(tilt);
-  int    itilt   = int(tiltdeg+0.1);
-  if (itilt != 0) {
+  if (tilt != 0) {
+    int  tiltdeg = std::lround(convertRadToDeg(tilt));
     std::string rotstr = "R";
     if (tiltdeg < 100) rotstr = "R0"; 
     rotstr = rotstr + std::to_string(tiltdeg);

--- a/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.cc
@@ -68,17 +68,14 @@ void DDHCalTBZposAlgo::execute(DDCompactView& cpv) {
   DDTranslation tran(x,y,z);
   DDRotation rot;
   if (tilt != 0) {
-    int  tiltdeg = std::lround(convertRadToDeg(tilt));
-    std::string rotstr = "R";
-    if (tiltdeg < 100) rotstr = "R0"; 
-    rotstr = rotstr + std::to_string(tiltdeg);
+    std::string rotstr = "R" + formatAsDegrees(tilt);
     rot    = DDRotation(DDName(rotstr, idNameSpace)); 
     if (!rot) {
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HCalGeom") << "DDHCalZposAlgo: Creating a rotation "
 				   << DDName(rotstr,idNameSpace) << "\t90, "
-				   << tiltdeg  << ", 90, " << (tiltdeg+90)
-				   << ", 0, 0";
+				   << convertRadToDeg(tilt) << ",90,"
+				   << (90+convertRadToDeg(tilt)) << ", 0, 0";
 #endif
       rot = DDrot(DDName(rotstr, idNameSpace), 90._deg, tilt, 
 		  90._deg, (90._deg+tilt), 0.0,  0.0);

--- a/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.cc
@@ -59,8 +59,8 @@ void DDHCalTestBeamAlgo::execute(DDCompactView& cpv) {
 
   double thetax = 90._deg + theta;
   double sthx   = sin(thetax);
-  if (abs(sthx)>1.e-12) sthx = 1./sthx;
-  else                  sthx = 1.;
+  if (std::abs(sthx)>1.e-12) sthx = 1./sthx;
+  else                       sthx = 1.;
   double phix   = atan2(sthx*cos(theta)*sin(phi),sthx*cos(theta)*cos(phi));
   double thetay = 90._deg;
   double phiy   = 90._deg + phi;

--- a/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.cc
@@ -6,15 +6,19 @@
 #include <cmath>
 #include <algorithm>
 
-namespace std{} using namespace std;
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include "DetectorDescription/Core/interface/DDLogicalPart.h"
 #include "DetectorDescription/Core/interface/DDCurrentNamespace.h"
 #include "Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.h"
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
+
+//#define EDM_ML_DEBUG
+using namespace geant_units::operators;
 
 DDHCalTestBeamAlgo::DDHCalTestBeamAlgo() {
-  LogDebug("HCalGeom") << "DDHCalTestBeamAlgo test: Creating an instance";
+#ifdef  EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalTestBeamAlgo: Creating an instance";
+#endif
 }
 
 DDHCalTestBeamAlgo::~DDHCalTestBeamAlgo() {}
@@ -33,39 +37,47 @@ void DDHCalTestBeamAlgo::initialize(const DDNumericArguments & nArgs,
   dz         = nArgs["Dz"];
   copyNumber = int (nArgs["Number"]);
   dist       = (distance+distanceZ/sin(theta));
-  LogDebug("HCalGeom") << "DDHCalTestBeamAlgo debug: Parameters for position"
-		       << "ing--" << " Eta " << eta << "\tPhi " 
-		       << phi/CLHEP::deg << "\tTheta " << theta/CLHEP::deg 
-		       << "\tDistance " << distance << "/" << distanceZ << "/"
-		       << dist <<"\tDz " << dz <<"\tcopyNumber " << copyNumber;
-
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalTestBeamAlgo: Parameters for position"
+			       << "ing--" << " Eta " << eta << "\tPhi " 
+			       << convertRadToDeg(phi) << "\tTheta " 
+			       << convertRadToDeg(theta) << "\tDistance "
+			       << distance << "/" << distanceZ << "/"
+			       << dist <<"\tDz " << dz <<"\tcopyNumber "
+			       << copyNumber;
+#endif
   idNameSpace = DDCurrentNamespace::ns();
   childName   = sArgs["ChildName"]; 
-  DDName parentName = parent().name(); 
-  LogDebug("HCalGeom") << "DDHCalTestBeamAlgo debug: Parent " << parentName
-		       << "\tChild " << childName << " NameSpace "
-		       << idNameSpace;
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalTestBeamAlgo:Parent " 
+			       << parent().name() << "\tChild " << childName 
+			       << " NameSpace " << idNameSpace;
+#endif
 }
 
 void DDHCalTestBeamAlgo::execute(DDCompactView& cpv) {
 
-  double thetax = 90.*CLHEP::deg + theta;
+  double thetax = 90._deg + theta;
   double sthx   = sin(thetax);
   if (abs(sthx)>1.e-12) sthx = 1./sthx;
   else                  sthx = 1.;
   double phix   = atan2(sthx*cos(theta)*sin(phi),sthx*cos(theta)*cos(phi));
-  double thetay = 90.*CLHEP::deg;
-  double phiy   = 90.*CLHEP::deg + phi;
+  double thetay = 90._deg;
+  double phiy   = 90._deg + phi;
   double thetaz = theta;
   double phiz   = phi;
   
   DDRotation rotation;
-  string rotstr = childName;
-  LogDebug("HCalGeom") << "DDHCalTestBeamAlgo test: Creating a new rotation "
-		       << rotstr << "\t" << thetax/CLHEP::deg << "," 
-		       << phix/CLHEP::deg << "," << thetay/CLHEP::deg << "," 
-		       << phiy/CLHEP::deg << "," << thetaz/CLHEP::deg <<"," 
-		       << phiz/CLHEP::deg;
+  std::string rotstr = childName;
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalTestBeamAlgo: Creating a rotation "
+			       << rotstr << "\t" << convertRadToDeg(thetax)
+			       << "," << convertRadToDeg(phix) << "," 
+			       << convertRadToDeg(thetay) << "," 
+			       << convertRadToDeg(phiy) << "," 
+			       << convertRadToDeg(thetaz) <<"," 
+			       << convertRadToDeg(phiz);
+#endif
   rotation = DDrot(DDName(rotstr, idNameSpace), thetax, phix, thetay, phiy,
 		   thetaz, phiz);
 	
@@ -76,11 +88,13 @@ void DDHCalTestBeamAlgo::execute(DDCompactView& cpv) {
   DDTranslation tran(xpos, ypos, zpos);
   
   DDName parentName = parent().name(); 
- cpv.position(DDName(childName,idNameSpace), parentName,copyNumber, tran,rotation);
-  LogDebug("HCalGeom") << "DDHCalTestBeamAlgo test: " 
-		       << DDName(childName, idNameSpace) << " number " 
-		       << copyNumber << " positioned in " << parentName 
-		       << " at " << tran << " with " << rotation;
+  cpv.position(DDName(childName,idNameSpace), parentName, copyNumber, tran,
+	       rotation);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalTestBeamAlgo: " 
+			       << DDName(childName, idNameSpace) << " number " 
+			       << copyNumber << " positioned in " << parentName
+			       << " at " << tran << " with " << rotation;
 
   xpos = (dist-dz)*sin(theta)*cos(phi);
   ypos = (dist-dz)*sin(theta)*sin(phi);
@@ -90,4 +104,5 @@ void DDHCalTestBeamAlgo::execute(DDCompactView& cpv) {
 			   << "(" << xpos << ", " << ypos << ", " << zpos 
 			   << ") and (dist, eta, phi) = (" << (dist-dz) << ", "
 			   << eta << ", " << phi << ")";
+#endif
 }

--- a/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.cc
@@ -83,7 +83,7 @@ void DDHCalXtalAlgo::execute(DDCompactView& cpv) {
     DDTranslation tran(pos[0], pos[1], pos[2]);
     DDName parentName = parent().name(); 
 
-    static const int tol = 0.000174523292; // 0.01 degree
+    static const double tol = 0.000174523292; // 0.01 degree
     if (std::abs(angle) > tol) {
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo: Creating a rotation " 

--- a/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.cc
@@ -6,15 +6,20 @@
 #include <cmath>
 #include <algorithm>
 
-namespace std{} using namespace std;
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include "DetectorDescription/Core/interface/DDLogicalPart.h"
 #include "DetectorDescription/Core/interface/DDCurrentNamespace.h"
 #include "Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
+//#define EDM_ML_DEBUG
+using namespace geant_units::operators;
+
 DDHCalXtalAlgo::DDHCalXtalAlgo() {
-  LogDebug("HCalGeom") << "DDHCalXtalAlgo info: Creating an instance";
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo info: Creating an instance";
+#endif
 }
 
 DDHCalXtalAlgo::~DDHCalXtalAlgo() {}
@@ -33,60 +38,71 @@ void DDHCalXtalAlgo::initialize(const DDNumericArguments & nArgs,
   iaxis      = int (nArgs["Axis"]);
   names      = vsArgs["Names"];
 
-  LogDebug("HCalGeom") << "DDHCalXtalAlgo debug: Parameters for positioning:: "
-		       << "Axis " << iaxis << "\tRadius " << radius 
-		       << "\tOffset " << offset << "\tDx " << dx << "\tDz " 
-		       << dz << "\tAngWidth " << angwidth/CLHEP::deg 
-		       << "\tNumbers " << names.size();
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo::Parameters for positioning:"
+			       << " Axis " << iaxis << "\tRadius " << radius 
+			       << "\tOffset " << offset << "\tDx " << dx
+			       << "\tDz " << dz << "\tAngWidth " 
+			       << convertRadToDeg(angwidth) << "\tNumbers "
+			       << names.size();
   for (unsigned int i = 0; i < names.size(); i++)
-    LogDebug("HCalGeom") << "\tnames[" << i << "] = " << names[i];
-
+    edm::LogVerbatim("HCalGeom") << "\tnames[" << i << "] = " << names[i];
+#endif
   idNameSpace = DDCurrentNamespace::ns();
   idName      = sArgs["ChildName"]; 
-  DDName parentName = parent().name(); 
-  LogDebug("HCalGeom") << "DDHCalXtalAlgo debug: Parent " << parentName 
-		       << "\tChild " << idName << " NameSpace " << idNameSpace;
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo: Parent " << parent().name()
+			       << "\tChild " << idName << " NameSpace "
+			       << idNameSpace;
+#endif
 }
 
 void DDHCalXtalAlgo::execute(DDCompactView& cpv) {
 
   double theta[3], phi[3], pos[3];
   phi[0] = 0;
-  phi[1] = 90*CLHEP::deg;
-  theta[1-iaxis] = 90*CLHEP::deg;
+  phi[1] = 90._deg;
+  theta[1-iaxis] = 90._deg;
   pos[1-iaxis]   = 0;
   int number = (int)(names.size());
   for (int i=0; i<number; i++) {
     double angle = 0.5*angwidth*(2*i+1-number);
-    theta[iaxis] = 90*CLHEP::deg + angle;
+    theta[iaxis] = 90._deg + angle;
     if (angle>0) {
       theta[2]   = angle;
-      phi[2]     = 90*iaxis*CLHEP::deg;
+      phi[2]     = iaxis*90._deg;
     } else {
       theta[2]   =-angle;
-      phi[2]     = 90*(2-3*iaxis)*CLHEP::deg;
+      phi[2]     = (2-3*iaxis)*90._deg;
     }
     pos[iaxis]   = angle*(dz+radius);
     pos[2]       = dx*abs(sin(angle)) + offset;
   
     DDRotation rotation;
-    string rotstr = names[i];
+    std::string rotstr = names[i];
     DDTranslation tran(pos[0], pos[1], pos[2]);
     DDName parentName = parent().name(); 
 
-    if (abs(angle) > 0.01*CLHEP::deg) {
-      LogDebug("HCalGeom") << "DDHCalXtalAlgo test: Creating a new rotation " 
-			   << rotstr << "\t" << theta[0]/CLHEP::deg << "," 
-			   << phi[0]/CLHEP::deg << "," << theta[1]/CLHEP::deg 
-			   << "," << phi[1]/CLHEP::deg << "," 
-			   << theta[2]/CLHEP::deg << ","  << phi[2]/CLHEP::deg;
+    if (std::lround(100.0*convertRadToDeg(angle)) != 0) {
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo: Creating a rotation " 
+				   << rotstr << "\t" 
+				   << convertRadToDeg(theta[0]) << "," 
+				   << convertRadToDeg(phi[0]) << "," 
+				   << convertRadToDeg(theta[1]) << "," 
+				   << convertRadToDeg(phi[1]) << "," 
+				   << convertRadToDeg(theta[2]) << ","
+				   << convertRadToDeg(phi[2]);
+#endif
       rotation = DDrot(DDName(rotstr, idNameSpace), theta[0], phi[0], theta[1],
 		       phi[1], theta[2], phi[2]);
     }
     cpv.position(DDName(idName, idNameSpace), parentName, i+1, tran, rotation);
-    LogDebug("HCalGeom") << "DDHCalXtalAlgo test: "
-			 << DDName(idName,idNameSpace) << " number " << i+1 
-			 << " positioned in " << parentName << " at " << tran
-			 << " with " << rotation;
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo: "
+				 << DDName(idName,idNameSpace) << " number "
+				 << i+1 << " positioned in " << parentName
+				 << " at " << tran << " with " << rotation;
+#endif
   }
 }

--- a/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.cc
@@ -76,14 +76,15 @@ void DDHCalXtalAlgo::execute(DDCompactView& cpv) {
       phi[2]     = (2-3*iaxis)*90._deg;
     }
     pos[iaxis]   = angle*(dz+radius);
-    pos[2]       = dx*abs(sin(angle)) + offset;
+    pos[2]       = dx*std::abs(sin(angle)) + offset;
   
     DDRotation rotation;
     std::string rotstr = names[i];
     DDTranslation tran(pos[0], pos[1], pos[2]);
     DDName parentName = parent().name(); 
 
-    if (std::lround(100.0*convertRadToDeg(angle)) != 0) {
+    static const int tol = 0.000174523292; // 0.01 degree
+    if (std::abs(angle) > tol) {
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo: Creating a rotation " 
 				   << rotstr << "\t" 

--- a/SimG4CMS/HcalTestBeam/python/TB2007GeometryNoESXML_cfi.py
+++ b/SimG4CMS/HcalTestBeam/python/TB2007GeometryNoESXML_cfi.py
@@ -18,6 +18,8 @@ XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
         'Geometry/HcalTestBeamData/data/TBHcal07HcalOuter.xml', 
         'Geometry/HcalTestBeamData/data/TBHcal07Sens.xml', 
         'Geometry/HcalTestBeamData/data/TBHcal07eeSens.xml', 
+        'Geometry/HcalTestBeamData/data/TBHcal06SimNumbering.xml', 
+        'Geometry/HcalCommonData/data/hcalRecNumbering.xml',
         'Geometry/HcalTestBeamData/data/TBHcal06ProdCuts.xml', 
         'Geometry/HcalTestBeamData/data/TBHcal06Util.xml'),
     rootNodeName = cms.string('TBHcal:OTBHCal')

--- a/SimG4CMS/HcalTestBeam/python/TB2007GeometryNoEcalXML_cfi.py
+++ b/SimG4CMS/HcalTestBeam/python/TB2007GeometryNoEcalXML_cfi.py
@@ -11,6 +11,8 @@ XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
         'Geometry/HcalTestBeamData/data/TBHcalEndcap.xml', 
         'Geometry/HcalTestBeamData/data/TBHcal07HcalOuter.xml', 
         'Geometry/HcalTestBeamData/data/TBHcal07Sens.xml', 
+        'Geometry/HcalTestBeamData/data/TBHcal06SimNumbering.xml', 
+        'Geometry/HcalCommonData/data/hcalRecNumbering.xml',
         'Geometry/HcalTestBeamData/data/TBHcal06ProdCuts.xml', 
         'Geometry/HcalTestBeamData/data/TBHcal06Util.xml'),
     rootNodeName = cms.string('TBHcal:OTBHCal')

--- a/SimG4CMS/HcalTestBeam/python/TB2007GeometryXML_cfi.py
+++ b/SimG4CMS/HcalTestBeam/python/TB2007GeometryXML_cfi.py
@@ -20,6 +20,8 @@ XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
         'Geometry/HcalTestBeamData/data/TBHcal07Sens.xml', 
         'Geometry/HcalTestBeamData/data/TBHcal07eeSens.xml', 
         'Geometry/HcalTestBeamData/data/TBHcal07esSens.xml', 
+        'Geometry/HcalTestBeamData/data/TBHcal06SimNumbering.xml', 
+        'Geometry/HcalCommonData/data/hcalRecNumbering.xml',
         'Geometry/HcalTestBeamData/data/TBHcal06ProdCuts.xml', 
         'Geometry/HcalTestBeamData/data/TBHcal06Util.xml'),
     rootNodeName = cms.string('TBHcal:OTBHCal')

--- a/SimG4CMS/HcalTestBeam/test/python/run2006_33_cfg.py
+++ b/SimG4CMS/HcalTestBeam/test/python/run2006_33_cfg.py
@@ -2,53 +2,25 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PROD")
 
-process.load("SimGeneral.HepPDTESSource.pdt_cfi")
+process.load('SimG4CMS.HcalTestBeam.TB2006Geometry33XML_cfi')
+process.load('SimGeneral.HepPDTESSource.pdt_cfi')
 process.load('Configuration.StandardSequences.Services_cff')
-process.load("SimG4CMS.HcalTestBeam.TB2006Geometry33XML_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
-process.load("Configuration.EventContent.EventContent_cff")
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Geometry.HcalCommonData.hcalParameters_cfi')
+process.load('Geometry.HcalCommonData.hcalDDDSimConstants_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
 process.load('IOMC.EventVertexGenerators.VtxSmearedFlat_cfi')
 process.load('GeneratorInterface.Core.generatorSmeared_cfi')
 process.load('SimG4Core.Application.g4SimHits_cfi')
 process.load('IOMC.RandomEngine.IOMC_cff')
 
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.categories.append('HCalGeom')
+    process.MessageLogger.categories.append('HcalSim')
+
 process.TFileService = cms.Service("TFileService",
                                    fileName = cms.string('hcaltb06_33.root')
                                    )
-
-process.MessageLogger = cms.Service("MessageLogger",
-                                    destinations = cms.untracked.vstring('cout'),
-                                    categories = cms.untracked.vstring('CaloSim', 
-                                                                       'HCalGeom', 
-                                                                       'HcalSim', 
-                                                                       'HcalTBSim', 
-                                                                       'SimHCalData'),
-                                    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        INFO = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-            ),
-        DEBUG = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        CaloSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        HCalGeom = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        HcalSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        HcalTBSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        SimHCalData = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            )
-        )
-                                    )
 
 process.RandomNumberGeneratorService.generator.initialSeed = 456789
 process.RandomNumberGeneratorService.g4SimHits.initialSeed = 9876
@@ -118,6 +90,7 @@ process.testbeam = cms.EDAnalyzer("HcalTB06Analysis",
         HcalWidth  = cms.double(0.640),
         EcalFactor = cms.double(1.0),
         HcalFactor = cms.double(100.0),
+        MIP        = cms.double(0.8),
         Verbose    = cms.untracked.bool(True),
         MakeTree   = cms.untracked.bool(True)
         )

--- a/SimG4CMS/HcalTestBeam/test/python/run2006_37_cfg.py
+++ b/SimG4CMS/HcalTestBeam/test/python/run2006_37_cfg.py
@@ -2,53 +2,25 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PROD")
 
-process.load("SimGeneral.HepPDTESSource.pdt_cfi")
+process.load('SimG4CMS.HcalTestBeam.TB2006Geometry37XML_cfi')
+process.load('SimGeneral.HepPDTESSource.pdt_cfi')
 process.load('Configuration.StandardSequences.Services_cff')
-process.load("SimG4CMS.HcalTestBeam.TB2006Geometry37XML_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
-process.load("Configuration.EventContent.EventContent_cff")
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Geometry.HcalCommonData.hcalParameters_cfi')
+process.load('Geometry.HcalCommonData.hcalDDDSimConstants_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
 process.load('IOMC.EventVertexGenerators.VtxSmearedFlat_cfi')
 process.load('GeneratorInterface.Core.generatorSmeared_cfi')
 process.load('SimG4Core.Application.g4SimHits_cfi')
 process.load('IOMC.RandomEngine.IOMC_cff')
 
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.categories.append('HCalGeom')
+    process.MessageLogger.categories.append('HcalSim')
+
 process.TFileService = cms.Service("TFileService",
                                    fileName = cms.string('hcaltb06_37.root')
                                    )
-
-process.MessageLogger = cms.Service("MessageLogger",
-                                    destinations = cms.untracked.vstring('cout'),
-                                    categories = cms.untracked.vstring('CaloSim', 
-                                                                       'HCalGeom', 
-                                                                       'HcalSim', 
-                                                                       'HcalTBSim', 
-                                                                       'SimHCalData'),
-                                    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        INFO = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-            ),
-        DEBUG = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        CaloSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        HCalGeom = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        HcalSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        HcalTBSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        SimHCalData = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            )
-        )
-                                    )
 
 process.RandomNumberGeneratorService.generator.initialSeed = 456789
 process.RandomNumberGeneratorService.g4SimHits.initialSeed = 9876
@@ -118,6 +90,7 @@ process.testbeam = cms.EDAnalyzer("HcalTB06Analysis",
         HcalWidth  = cms.double(0.640),
         EcalFactor = cms.double(1.0),
         HcalFactor = cms.double(100.0),
+        MIP        = cms.double(0.8),
         Verbose    = cms.untracked.bool(True),
         MakeTree   = cms.untracked.bool(True)
         )

--- a/SimG4CMS/HcalTestBeam/test/python/run2006_77_cfg.py
+++ b/SimG4CMS/HcalTestBeam/test/python/run2006_77_cfg.py
@@ -2,53 +2,25 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PROD")
 
-process.load("SimGeneral.HepPDTESSource.pdt_cfi")
+process.load('SimG4CMS.HcalTestBeam.TB2006Geometry77XML_cfi')
+process.load('SimGeneral.HepPDTESSource.pdt_cfi')
 process.load('Configuration.StandardSequences.Services_cff')
-process.load("SimG4CMS.HcalTestBeam.TB2006Geometry77XML_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
-process.load("Configuration.EventContent.EventContent_cff")
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Geometry.HcalCommonData.hcalParameters_cfi')
+process.load('Geometry.HcalCommonData.hcalDDDSimConstants_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
 process.load('IOMC.EventVertexGenerators.VtxSmearedFlat_cfi')
 process.load('GeneratorInterface.Core.generatorSmeared_cfi')
 process.load('SimG4Core.Application.g4SimHits_cfi')
 process.load('IOMC.RandomEngine.IOMC_cff')
 
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.categories.append('HCalGeom')
+    process.MessageLogger.categories.append('HcalSim')
+
 process.TFileService = cms.Service("TFileService",
                                    fileName = cms.string('hcaltb06_77.root')
                                    )
-
-process.MessageLogger = cms.Service("MessageLogger",
-                                    destinations = cms.untracked.vstring('cout'),
-                                    categories = cms.untracked.vstring('CaloSim', 
-                                                                       'HCalGeom', 
-                                                                       'HcalSim', 
-                                                                       'HcalTBSim', 
-                                                                       'SimHCalData'),
-                                    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        INFO = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-            ),
-        DEBUG = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        CaloSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        HCalGeom = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        HcalSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        HcalTBSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        SimHCalData = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            )
-        )
-                                    )
 
 process.RandomNumberGeneratorService.generator.initialSeed = 456789
 process.RandomNumberGeneratorService.g4SimHits.initialSeed = 9876
@@ -118,6 +90,7 @@ process.testbeam = cms.EDAnalyzer("HcalTB06Analysis",
         HcalWidth  = cms.double(0.640),
         EcalFactor = cms.double(1.0),
         HcalFactor = cms.double(100.0),
+        MIP        = cms.double(0.8),
         Verbose    = cms.untracked.bool(True),
         MakeTree   = cms.untracked.bool(True)
         )

--- a/SimG4CMS/HcalTestBeam/test/python/run2006_cfg.py
+++ b/SimG4CMS/HcalTestBeam/test/python/run2006_cfg.py
@@ -2,71 +2,25 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PROD")
 
-process.load("SimGeneral.HepPDTESSource.pdt_cfi")
+process.load('SimG4CMS.HcalTestBeam.TB2006GeometryXML_cfi')
+process.load('SimGeneral.HepPDTESSource.pdt_cfi')
 process.load('Configuration.StandardSequences.Services_cff')
-process.load("SimG4CMS.HcalTestBeam.TB2006GeometryXML_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
-process.load("Configuration.EventContent.EventContent_cff")
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Geometry.HcalCommonData.hcalParameters_cfi')
+process.load('Geometry.HcalCommonData.hcalDDDSimConstants_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
 process.load('IOMC.EventVertexGenerators.VtxSmearedFlat_cfi')
 process.load('GeneratorInterface.Core.generatorSmeared_cfi')
 process.load('SimG4Core.Application.g4SimHits_cfi')
 process.load('IOMC.RandomEngine.IOMC_cff')
 
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.categories.append('HCalGeom')
+    process.MessageLogger.categories.append('HcalSim')
+
 process.TFileService = cms.Service("TFileService",
                                    fileName = cms.string('hcaltb06.root')
                                    )
-
-process.MessageLogger = cms.Service("MessageLogger",
-                                    destinations = cms.untracked.vstring('cout'),
-                                    debugModules = cms.untracked.vstring('*'),
-                                    categories = cms.untracked.vstring('CaloSim', 
-                                                                       'EcalGeom', 
-                                                                       'EcalSim', 
-                                                                       'HCalGeom', 
-                                                                       'HcalSim', 
-                                                                       'HcalTBSim', 
-                                                                       'SimHCalData', 
-                                                                       'SimG4CoreGeometry', 
-                                                                       'SimG4CoreApplication', 
-                                                                       'VertexGenerator'),
-                                    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        INFO = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-            ),
-        DEBUG = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        VertexGenerator = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-            ),
-        SimG4CoreApplication = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        SimG4CoreGeometry = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        EcalGeom = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        CaloSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        HCalGeom = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        HcalSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        HcalTBSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            ),
-        SimHCalData = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-            )
-        )
-                                    )
 
 process.RandomNumberGeneratorService.generator.initialSeed = 456789
 process.RandomNumberGeneratorService.g4SimHits.initialSeed = 9876
@@ -142,6 +96,7 @@ process.testbeam = cms.EDAnalyzer("HcalTB06Analysis",
         HcalWidth  = cms.double(0.640),
         EcalFactor = cms.double(1.0),
         HcalFactor = cms.double(100.0),
+        MIP        = cms.double(0.8),
         Verbose    = cms.untracked.bool(True),
         MakeTree   = cms.untracked.bool(True)
         )

--- a/SimG4CMS/HcalTestBeam/test/python/run2010_cfg.py
+++ b/SimG4CMS/HcalTestBeam/test/python/run2010_cfg.py
@@ -2,49 +2,24 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PROD")
 
-process.load("SimGeneral.HepPDTESSource.pdt_cfi")
-process.load("SimG4CMS.HcalTestBeam.TB2010GeometryXML_cfi")
-process.load("Geometry.HcalCommonData.hcalParameters_cfi")
-process.load("Geometry.HcalCommonData.hcalDDDSimConstants_cfi")
-process.load("Configuration.EventContent.EventContent_cff")
-process.load("SimG4Core.Application.g4SimHits_cfi")
+process.load('SimG4CMS.HcalTestBeam.TB2010GeometryXML_cfi')
+process.load('SimGeneral.HepPDTESSource.pdt_cfi')
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Geometry.HcalCommonData.hcalParameters_cfi')
+process.load('Geometry.HcalCommonData.hcalDDDSimConstants_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedFlat_cfi')
+process.load('GeneratorInterface.Core.generatorSmeared_cfi')
+process.load('SimG4Core.Application.g4SimHits_cfi')
+process.load('IOMC.RandomEngine.IOMC_cff')
+
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.categories.append('HCalGeom')
+    process.MessageLogger.categories.append('HcalSim')
 
 process.TFileService = cms.Service("TFileService",
     fileName = cms.string('ehcaltb10.root')
-)
-
-process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout'),
-    debugModules = cms.untracked.vstring('*'),
-    categories = cms.untracked.vstring('CaloSim', 
-        'EcalSim', 
-        'HcalSim', 
-        'HcalTBSim', 
-        'EcalGeom'),
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        INFO = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-        ),
-        DEBUG = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        CaloSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        EcalSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        HcalSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        HcalTBSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        EcalGeom = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-        )
-    )
 )
 
 process.load("IOMC.RandomEngine.IOMC_cff")
@@ -53,6 +28,9 @@ process.RandomNumberGeneratorService.g4SimHits.initialSeed = 9876
 process.RandomNumberGeneratorService.VtxSmeared.initialSeed = 123456789
 
 process.common_beam_direction_parameters = cms.PSet(
+    MinE         = cms.double(50.0),
+    MaxE         = cms.double(50.0),
+    PartID       = cms.vint32(-211),
     MinEta       = cms.double(0.2175),
     MaxEta       = cms.double(0.2175),
     MinPhi       = cms.double(-0.1309),
@@ -66,15 +44,12 @@ process.source = cms.Source("EmptySource",
 )
 
 process.generator = cms.EDProducer("FlatRandomEGunProducer",
-    PGunParameters = cms.PSet(
-        process.common_beam_direction_parameters,
-        MinE   = cms.double(50.0),
-        MaxE   = cms.double(50.0),
-        PartID = cms.vint32(-211)
-    ),
-    Verbosity       = cms.untracked.int32(0),
-    AddAntiParticle = cms.bool(False)
-)
+                                   PGunParameters = cms.PSet(
+                                       process.common_beam_direction_parameters,
+                                   ),
+                                   Verbosity       = cms.untracked.int32(0),
+                                   AddAntiParticle = cms.bool(False)
+                               )
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(100)
@@ -110,13 +85,34 @@ process.VtxSmeared = cms.EDProducer("BeamProfileVtxGenerator",
     TimeOffset      = cms.double(0.)
 )
 
-process.p1 = cms.Path(process.generator*process.VtxSmeared*process.g4SimHits)
+process.testbeam = cms.EDAnalyzer("HcalTB06Analysis",
+                                  process.common_beam_direction_parameters,
+                                  ECAL = cms.bool(True),
+                                  TestBeamAnalysis = cms.PSet(
+        EHCalMax   = cms.untracked.double(50.0),
+        ETtotMax   = cms.untracked.double(400.0),
+        beamEnergy = cms.untracked.double(50.),
+        TimeLimit  = cms.double(180.0),
+        EcalWidth  = cms.double(0.362),
+        HcalWidth  = cms.double(0.640),
+        EcalFactor = cms.double(1.0),
+        HcalFactor = cms.double(100.0),
+        MIP        = cms.double(0.8),
+        Verbose    = cms.untracked.bool(True),
+        MakeTree   = cms.untracked.bool(True)
+        )
+                                  )
+
+process.p1 = cms.Path(process.generator*process.VtxSmeared*process.generatorSmeared*process.g4SimHits*process.testbeam)
 process.outpath = cms.EndPath(process.o1)
 
 process.common_maximum_timex = cms.PSet(
     MaxTrackTime  = cms.double(1000.0),
     MaxTimeNames  = cms.vstring(),
-    MaxTrackTimes = cms.vdouble()
+    MaxTrackTimes = cms.vdouble(),
+    DeadRegions   = cms.vstring(),
+    CriticalEnergyForVacuum = cms.double(2.0),
+    CriticalDensity         = cms.double(1e-15)
 )
 process.g4SimHits.NonBeamEvent = True
 process.g4SimHits.UseMagneticField = False
@@ -142,32 +138,46 @@ process.g4SimHits.HCalSD.ForTBH2 = True
 process.g4SimHits.StackingAction = cms.PSet(
     process.common_heavy_suppression1,
     process.common_maximum_timex,
-    TrackNeutrino = cms.bool(False),
     KillDeltaRay  = cms.bool(False),
+    TrackNeutrino = cms.bool(False),
     KillHeavy     = cms.bool(False),
+    KillGamma     = cms.bool(True),
+    GammaThreshold = cms.double(0.0001), ## (MeV)
     SaveFirstLevelSecondary = cms.untracked.bool(False),
     SavePrimaryDecayProductsAndConversionsInTracker = cms.untracked.bool(False),
     SavePrimaryDecayProductsAndConversionsInCalo = cms.untracked.bool(False),
     SavePrimaryDecayProductsAndConversionsInMuon = cms.untracked.bool(False),
-    RusRoEcalNeutron         = cms.double(1.0),
-    RusRoEcalNeutronLimit    = cms.double(0.0),
-    RusRoHcalNeutron         = cms.double(1.0),
-    RusRoHcalNeutronLimit    = cms.double(0.0),
-    RusRoEcalProton      = cms.double(1.0),
-    RusRoEcalProtonLimit = cms.double(0.0),
-    RusRoHcalProton      = cms.double(1.0),
-    RusRoHcalProtonLimit = cms.double(0.0)
-)
+    SaveAllPrimaryDecayProductsAndConversions = cms.untracked.bool(True),
+    RusRoGammaEnergyLimit  = cms.double(5.0), ## (MeV)
+    RusRoEcalGamma         = cms.double(0.3),
+    RusRoHcalGamma         = cms.double(0.3),
+    RusRoMuonIronGamma     = cms.double(0.3),
+    RusRoPreShowerGamma    = cms.double(0.3),
+    RusRoCastorGamma       = cms.double(0.3),
+    RusRoWorldGamma        = cms.double(0.3),
+    RusRoNeutronEnergyLimit  = cms.double(10.0), ## (MeV)
+    RusRoEcalNeutron         = cms.double(0.1),
+    RusRoHcalNeutron         = cms.double(0.1),
+    RusRoMuonIronNeutron     = cms.double(0.1),
+    RusRoPreShowerNeutron    = cms.double(0.1),
+    RusRoCastorNeutron       = cms.double(0.1),
+    RusRoWorldNeutron        = cms.double(0.1),
+    RusRoProtonEnergyLimit  = cms.double(0.0),
+    RusRoEcalProton         = cms.double(1.0),
+    RusRoHcalProton         = cms.double(1.0),
+    RusRoMuonIronProton     = cms.double(1.0),
+    RusRoPreShowerProton    = cms.double(1.0),
+    RusRoCastorProton       = cms.double(1.0),
+    RusRoWorldProton        = cms.double(1.0)
+    )
+
 process.g4SimHits.SteppingAction = cms.PSet(
     process.common_maximum_timex,
-    KillBeamPipe            = cms.bool(True),
-    CriticalEnergyForVacuum = cms.double(2.0),
-    CriticalDensity         = cms.double(1e-15),
     EkinNames               = cms.vstring(),
     EkinThresholds          = cms.vdouble(),
-    EkinParticles           = cms.vstring(),
-    Verbosity = cms.untracked.int32(0)
-)
+    EkinParticles           = cms.vstring()
+    )
+
 process.g4SimHits.CaloSD = cms.PSet(
     process.common_beam_direction_parameters,
     process.common_heavy_suppression1,
@@ -185,16 +195,5 @@ process.g4SimHits.CaloSD = cms.PSet(
     DetailedTiming = cms.untracked.bool(False),
     CorrectTOFBeam = cms.bool(False)
 )
+
 process.g4SimHits.CaloTrkProcessing.TestBeam = True
-process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
-    HcalTB06Analysis = cms.PSet(
-        process.common_beam_direction_parameters,
-        Names    = cms.vstring('HcalHits', 'EcalHitsEB'),
-        EHCalMax = cms.untracked.double(10.0),
-        ETtotMax = cms.untracked.double(500.0),
-        Verbose  = cms.untracked.bool(True)
-    ),
-    type = cms.string('HcalTB06Analysis')
-))
-
-


### PR DESCRIPTION
#### PR description:

Three algorithms used in describing the geometry of ECAL+HCAL Test Beam setups are modified to avoid explicit calls to CLHEP. The scripts for TB simulation are updated

#### PR validation:

Some of the TB applications are run and tested

#### if this PR is a backport please specify the original PR:

This is not for back porting
