### PR TITLE
move PythonFramework to PyDevParameterSet

### DIFF
--- a/FWCore/PyDevParameterSet/interface/PyBind11ProcessDesc.h
+++ b/FWCore/PyDevParameterSet/interface/PyBind11ProcessDesc.h
@@ -50,7 +50,7 @@ private:
 
   Python11ParameterSet theProcessPSet;
   pybind11::object theMainModule;
-  //  pybind11::object theMainNamespace;
+  bool theOwnsInterpreter;
 };
 
 #endif

--- a/FWCore/PyDevParameterSet/src/PyBind11Module.h
+++ b/FWCore/PyDevParameterSet/src/PyBind11Module.h
@@ -34,8 +34,13 @@
 
 PYBIND11_MODULE(libFWCorePyDevParameterSet,m) 
 {
-
-  //  pybind11::register_exception_translator<cms::Exception>(translatorlibFWCorePythonParameterSet);
+  pybind11::register_exception_translator([](std::exception_ptr p) {
+      try {
+        if (p) std::rethrow_exception(p);
+      } catch (const cms::Exception &e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    });
 
   pybind11::class_<edm::InputTag>(m,"InputTag")
     .def(pybind11::init<>())

--- a/FWCore/PyDevParameterSet/src/PyBind11ProcessDesc.cc
+++ b/FWCore/PyDevParameterSet/src/PyBind11ProcessDesc.cc
@@ -11,14 +11,15 @@
 
 PyBind11ProcessDesc::PyBind11ProcessDesc() :
    theProcessPSet(),
-   theMainModule()
+   theMainModule(),
+   theOwnsInterpreter(false)
 {
-  pybind11::initialize_interpreter();
 }
 
 PyBind11ProcessDesc::PyBind11ProcessDesc(std::string const& config) :
    theProcessPSet(),
-   theMainModule()
+   theMainModule(),
+   theOwnsInterpreter(true)
 {
   pybind11::initialize_interpreter();
   edm::python::initializePyBind11Module();
@@ -29,7 +30,9 @@ PyBind11ProcessDesc::PyBind11ProcessDesc(std::string const& config) :
 
 PyBind11ProcessDesc::PyBind11ProcessDesc(std::string const& config, int argc, char* argv[]) :
    theProcessPSet(),
-   theMainModule()
+   theMainModule(),
+   theOwnsInterpreter(true)
+
 {
   pybind11::initialize_interpreter();
   edm::python::initializePyBind11Module();
@@ -58,9 +61,10 @@ PyBind11ProcessDesc::PyBind11ProcessDesc(std::string const& config, int argc, ch
 
 
 PyBind11ProcessDesc::~PyBind11ProcessDesc() {
-  theMainModule=pybind11::object();
-  pybind11::finalize_interpreter();
-
+  if ( theOwnsInterpreter ) {
+    theMainModule=pybind11::object();
+    pybind11::finalize_interpreter();
+  }
 }
 
 void PyBind11ProcessDesc::prepareToRead() {

--- a/FWCore/PythonFramework/BuildFile.xml
+++ b/FWCore/PythonFramework/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="FWCore/Framework"/>
-<use   name="FWCore/PythonParameterSet"/>
+<use   name="FWCore/PyDevParameterSet"/>
 <use   name="boost"/>
-<use   name="boost_python"/>
+<use   name="py2-pybind11"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/FWCore/PythonFramework/interface/PythonEventProcessor.h
+++ b/FWCore/PythonFramework/interface/PythonEventProcessor.h
@@ -20,6 +20,7 @@
 
 // system include files
 #include "FWCore/Framework/interface/EventProcessor.h"
+#include "FWCore/PyDevParameterSet/interface/PyBind11ProcessDesc.h"
 
 // user include files
 
@@ -30,7 +31,7 @@ class PythonEventProcessor
 {
 
    public:
-      PythonEventProcessor(PythonProcessDesc const&);
+      PythonEventProcessor(PyBind11ProcessDesc const&);
       ~PythonEventProcessor();
       // ---------- const member functions ---------------------
       /// Return the number of events this EventProcessor has tried to process

--- a/FWCore/PythonFramework/python/CmsRun.py
+++ b/FWCore/PythonFramework/python/CmsRun.py
@@ -1,5 +1,5 @@
 import libFWCorePythonFramework as _pf
-import libFWCorePythonParameterSet as _pp
+import libFWCorePyDevParameterSet as _pp
 
 class CmsRun(object):
   def __init__(self,process):
@@ -8,6 +8,7 @@ class CmsRun(object):
     procDesc = _pp.ProcessDesc()
     process.fillProcessDesc(procDesc.pset())
     self._cppProcessor = _pf.PythonEventProcessor(procDesc)
+
   def run(self):
     """Process all the events
     """

--- a/FWCore/PythonFramework/src/PythonEventProcessor.cc
+++ b/FWCore/PythonFramework/src/PythonEventProcessor.cc
@@ -15,7 +15,7 @@
 
 // user include files
 #include "FWCore/PythonFramework/interface/PythonEventProcessor.h"
-#include "FWCore/PythonParameterSet/interface/PythonProcessDesc.h"
+#include "FWCore/PyDevParameterSet/interface/PyBind11ProcessDesc.h"
 
 #include "FWCore/Framework/interface/defaultCmsRunServices.h"
 #include "FWCore/ParameterSet/interface/ProcessDesc.h"
@@ -58,7 +58,7 @@ namespace {
 //
 // constructors and destructor
 //
-PythonEventProcessor::PythonEventProcessor(PythonProcessDesc const& iDesc)
+PythonEventProcessor::PythonEventProcessor(PyBind11ProcessDesc const& iDesc)
 : forcePluginSetupFirst_(setupPluginSystem())
   ,processor_(addDefaultServicesToProcessDesc(iDesc.processDesc()),createJobReport(),edm::serviceregistry::kOverlapIsError)
 {

--- a/FWCore/PythonFramework/src/PythonModule.cc
+++ b/FWCore/PythonFramework/src/PythonModule.cc
@@ -1,11 +1,13 @@
 #ifndef FWCore_PythonFramework_PythonModule_h
 #define FWCore_PythonFramework_PythonModule_h
 
-#include "FWCore/PythonParameterSet/interface/BoostPython.h"
-#include "FWCore/PythonParameterSet/interface/PythonProcessDesc.h"
+
+#include "FWCore/PyDevParameterSet/interface/PyBind11ProcessDesc.h"
 
 #include "FWCore/PythonFramework/interface/PythonEventProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
+
+#include <pybind11/pybind11.h>
 
 // This is to give some special handling to cms::Exceptions thrown
 // in C++ code called by python. Only at the very top level do
@@ -16,21 +18,23 @@
 // improve these messages even more by adding something in the python
 // to add module type and label context to the messages being caught
 // here. At this point we did not think it worth the time to implement.
-namespace {
-  void translator(cms::Exception const& ex) {
-    PyErr_SetString(PyExc_RuntimeError, ex.message().c_str());
-  }
-}
 
-BOOST_PYTHON_MODULE(libFWCorePythonFramework)
+PYBIND11_MODULE(libFWCorePythonFramework,m)
 {
-  boost::python::register_exception_translator<cms::Exception>(translator);
+  pybind11::register_exception_translator([](std::exception_ptr p) {
+      try {
+        if (p) std::rethrow_exception(p);
+      } catch (const cms::Exception &e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    });
 
-  boost::python::class_<PythonEventProcessor, boost::noncopyable>("PythonEventProcessor", boost::python::init<PythonProcessDesc const&>())
+  pybind11::class_<PythonEventProcessor>(m,"PythonEventProcessor")
+    .def(pybind11::init<PyBind11ProcessDesc const&>())
     .def("run", &PythonEventProcessor::run)
     .def("totalEvents", &PythonEventProcessor::totalEvents)
     .def("totalEventsPassed", &PythonEventProcessor::totalEventsPassed)
-    .def("totalEventsFailed", &PythonEventProcessor::totalEventsFailed)
-  ;
+    .def("totalEventsFailed", &PythonEventProcessor::totalEventsFailed);
+  
 }
 #endif


### PR DESCRIPTION
#### PR description:

move python framework to pybind11 interface to parameter sets. I had to teach the pybind11 process description class that it does not always own the python process.

#### PR validation:

compiles/unit tests ok 
