### PR TITLE
[HGCal]  dEdx weights and thickness correction factors for V10 (D41)

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -114,7 +114,63 @@ dEdX_weights_v9 = cms.vdouble(0.0,      # there is no layer zero
 
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
-phase2_hgcalV9.toModify( dEdX, weights = dEdX_weights_v9 ) 
+phase2_hgcalV9.toModify( dEdX, weights = dEdX_weights_v9 )
+
+dEdX_weights_v10 = cms.vdouble(0.0,      # there is no layer zero
+                               8.894541,  # Mev
+                               10.937907,
+                               10.937907,
+                               10.937907,
+                               10.937907,
+                               10.937907,
+                               10.937907,
+                               10.937907,
+                               10.937907,
+                               10.932882,
+                               10.932882,
+                               10.937907,
+                               10.937907,
+                               10.938169,
+                               10.938169,
+                               10.938169,
+                               10.938169,
+                               10.938169,
+                               10.938169,
+                               10.938169,
+                               10.938169,
+                               10.938169,
+                               10.938169,
+                               10.938169,
+                               10.938169,
+                               10.938169,
+                               10.938169,
+                               32.332097,
+                               51.574301,
+                               51.444192,
+                               51.444192,
+                               51.444192,
+                               51.444192,
+                               51.444192,
+                               51.444192,
+                               51.444192,
+                               51.444192,
+                               51.444192,
+                               51.444192,
+                               69.513118,
+                               87.582044,
+                               87.582044,
+                               87.582044,
+                               87.582044,
+                               87.582044,
+                               87.214571,
+                               86.888309,
+                               86.929520,
+                               86.929520,
+                               86.929520)
+
+
+from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
+phase2_hgcalV10.toModify( dEdX, weights = dEdX_weights_v10 )
 
 # HGCAL rechit producer
 HGCalRecHit = cms.EDProducer(
@@ -155,3 +211,4 @@ HGCalRecHit = cms.EDProducer(
     )
 
 phase2_hgcalV9.toModify( HGCalRecHit , thicknessCorrection = cms.vdouble(0.759,0.760,0.773) ) #120um, 200um, 300um
+phase2_hgcalV10.toModify( HGCalRecHit , thicknessCorrection = cms.vdouble(0.781,0.775,0.769) ) #120um, 200um, 300um

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -210,5 +210,5 @@ HGCalRecHit = cms.EDProducer(
 
     )
 
-phase2_hgcalV9.toModify( HGCalRecHit , thicknessCorrection = cms.vdouble(0.759,0.760,0.773) ) #120um, 200um, 300um
-phase2_hgcalV10.toModify( HGCalRecHit , thicknessCorrection = cms.vdouble(0.781,0.775,0.769) ) #120um, 200um, 300um
+phase2_hgcalV9.toModify( HGCalRecHit , thicknessCorrection = [0.759,0.760,0.773] ) #120um, 200um, 300um
+phase2_hgcalV10.toModify( HGCalRecHit , thicknessCorrection = [0.781,0.775,0.769] ) #120um, 200um, 300um

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
@@ -4,7 +4,7 @@ from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, 
 
 fCPerMIP_v9 = cms.vdouble(2.06,3.43,5.15) #120um, 200um, 300um
 
-fCPerMIP_v10 = cms.vdouble(2.06,3.43,5.15) #120um, 200um, 300um
+fCPerMIP_v10 = fCPerMIP_v9
 
 # HGCAL producer of rechits starting from digis
 HGCalUncalibRecHit = cms.EDProducer(

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
@@ -4,6 +4,8 @@ from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, 
 
 fCPerMIP_v9 = cms.vdouble(2.06,3.43,5.15) #120um, 200um, 300um
 
+fCPerMIP_v10 = cms.vdouble(2.06,3.43,5.15) #120um, 200um, 300um
+
 # HGCAL producer of rechits starting from digis
 HGCalUncalibRecHit = cms.EDProducer(
     "HGCalUncalibRecHitProducer",
@@ -52,4 +54,11 @@ HGCalUncalibRecHit = cms.EDProducer(
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 phase2_hgcalV9.toModify( HGCalUncalibRecHit.HGCEEConfig , fCPerMIP = fCPerMIP_v9 ) 
-phase2_hgcalV9.toModify( HGCalUncalibRecHit.HGCHEFConfig , fCPerMIP = fCPerMIP_v9 ) 
+phase2_hgcalV9.toModify( HGCalUncalibRecHit.HGCHEFConfig , fCPerMIP = fCPerMIP_v9 )
+
+from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
+phase2_hgcalV10.toModify( HGCalUncalibRecHit.HGCEEConfig , fCPerMIP = fCPerMIP_v10 ) 
+phase2_hgcalV10.toModify( HGCalUncalibRecHit.HGCHEFConfig , fCPerMIP = fCPerMIP_v10 )
+
+
+


### PR DESCRIPTION
#### PR description:

This PR is (re)based on top of #26301 . 

It includes the work done with @rovere, @felicepantaleo, @amartelli, @clelange on the dEdX weights and thickness correction factors for the V10 (D41) geometry. 

#### PR validation:

The slides describing the calculation were presented in the HGCal DPG and can be seen in this [link](https://indico.cern.ch/event/810242/contributions/3377477/attachments/1823243/2982972/dEdxWeightsandHitCalib_03April2018.pdf). 

#### if this PR is a backport please specify the original PR:

It is based on a new set of Era's and it is not a back porting. 

@felicepantaleo @rovere @amartelli @clelange @cseez @bsunanda @kpedro88 @malgeri
