### PR TITLE
Remove FWCore/PythonParameterSet dependencies from unit tests in FWCore/Integration

### DIFF
--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -139,7 +139,7 @@
   <bin   file="SwitchProducer_t.cpp">
     <use   name="FWCore/Framework"/>
     <use   name="FWCore/ParameterSet"/>
-    <use   name="FWCore/PythonParameterSet"/>
+    <use   name="FWCore/PyDevParameterSet"/>
     <use   name="FWCore/TestProcessor"/>
     <use   name="DataFormats/Provenance"/>
     <use   name="catch2"/>

--- a/FWCore/Integration/test/EDAlias_t.cpp
+++ b/FWCore/Integration/test/EDAlias_t.cpp
@@ -3,7 +3,6 @@
 
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 
 #include <iostream>

--- a/FWCore/Integration/test/SwitchProducer_t.cpp
+++ b/FWCore/Integration/test/SwitchProducer_t.cpp
@@ -3,7 +3,7 @@
 
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
+#include "FWCore/PyDevParameterSet/interface/MakePyBind11ParameterSets.h"
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 
 #include <iostream>
@@ -49,8 +49,8 @@ TEST_CASE("Configuration", s_tag) {
   const std::string baseConfigTest2Disabled = makeConfig(false, test1, test2);
 
   SECTION("Configuration hash is not changed") {
-    auto pset = edm::boost_python::readConfig(baseConfig);
-    auto psetTest2Disabled = edm::boost_python::readConfig(baseConfigTest2Disabled);
+    auto pset = edm::cmspybind11::readConfig(baseConfig);
+    auto psetTest2Disabled = edm::cmspybind11::readConfig(baseConfigTest2Disabled);
     pset->registerIt();
     psetTest2Disabled->registerIt();
     REQUIRE(pset->id() == psetTest2Disabled->id());
@@ -107,8 +107,8 @@ TEST_CASE("Configuration with EDAlias", s_tag) {
   const std::string baseConfigTest2Disabled = makeConfig(false, test1, test2, otherprod, othername);
 
   SECTION("Configuration hash is not changed") {
-    auto pset = edm::boost_python::readConfig(baseConfig);
-    auto psetTest2Disabled = edm::boost_python::readConfig(baseConfigTest2Disabled);
+    auto pset = edm::cmspybind11::readConfig(baseConfig);
+    auto psetTest2Disabled = edm::cmspybind11::readConfig(baseConfigTest2Disabled);
     pset->registerIt();
     psetTest2Disabled->registerIt();
     REQUIRE(pset->id() == psetTest2Disabled->id());


### PR DESCRIPTION

Remove FWCore/PythonParameterSet dependencies from unit tests in FWCore/Integration

#### PR validation:

unit tests still run
