### PR TITLE
[CXXMODULE] Enable building new Root modules for some base packages

### DIFF
--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/BuildFile.xml
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/BuildFile.xml
@@ -3,3 +3,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/CondFormats/DQMObjects/BuildFile.xml
+++ b/CondFormats/DQMObjects/BuildFile.xml
@@ -7,3 +7,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/CondFormats/Luminosity/BuildFile.xml
+++ b/CondFormats/Luminosity/BuildFile.xml
@@ -6,3 +6,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/Common/BuildFile.xml
+++ b/DataFormats/Common/BuildFile.xml
@@ -6,3 +6,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/DetId/BuildFile.xml
+++ b/DataFormats/DetId/BuildFile.xml
@@ -4,3 +4,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/EcalRawData/BuildFile.xml
+++ b/DataFormats/EcalRawData/BuildFile.xml
@@ -4,3 +4,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/FEDRawData/BuildFile.xml
+++ b/DataFormats/FEDRawData/BuildFile.xml
@@ -4,3 +4,4 @@
 <export>
   <lib   name="1"/>
 </export>
+#<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/FP420Cluster/BuildFile.xml
+++ b/DataFormats/FP420Cluster/BuildFile.xml
@@ -4,3 +4,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/FP420Digi/BuildFile.xml
+++ b/DataFormats/FP420Digi/BuildFile.xml
@@ -4,3 +4,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/HcalCalibObjects/BuildFile.xml
+++ b/DataFormats/HcalCalibObjects/BuildFile.xml
@@ -3,3 +3,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/Histograms/BuildFile.xml
+++ b/DataFormats/Histograms/BuildFile.xml
@@ -5,3 +5,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/L1GlobalMuonTrigger/BuildFile.xml
+++ b/DataFormats/L1GlobalMuonTrigger/BuildFile.xml
@@ -4,3 +4,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/LTCDigi/BuildFile.xml
+++ b/DataFormats/LTCDigi/BuildFile.xml
@@ -3,3 +3,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/OnlineMetaData/BuildFile.xml
+++ b/DataFormats/OnlineMetaData/BuildFile.xml
@@ -3,3 +3,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/Phase2ITPixelCluster/BuildFile.xml
+++ b/DataFormats/Phase2ITPixelCluster/BuildFile.xml
@@ -3,3 +3,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/Phase2TrackerDigi/BuildFile.xml
+++ b/DataFormats/Phase2TrackerDigi/BuildFile.xml
@@ -3,3 +3,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/Provenance/BuildFile.xml
+++ b/DataFormats/Provenance/BuildFile.xml
@@ -5,3 +5,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/Scalers/BuildFile.xml
+++ b/DataFormats/Scalers/BuildFile.xml
@@ -4,3 +4,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/Scouting/BuildFile.xml
+++ b/DataFormats/Scouting/BuildFile.xml
@@ -3,3 +3,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/SiPixelCluster/BuildFile.xml
+++ b/DataFormats/SiPixelCluster/BuildFile.xml
@@ -3,3 +3,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/SiPixelRawData/BuildFile.xml
+++ b/DataFormats/SiPixelRawData/BuildFile.xml
@@ -3,3 +3,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/SiStripCommon/BuildFile.xml
+++ b/DataFormats/SiStripCommon/BuildFile.xml
@@ -1,7 +1,9 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/FEDRawData" source_only="1"/>
 <use   name="boost"/>
 
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/SiStripDigi/BuildFile.xml
+++ b/DataFormats/SiStripDigi/BuildFile.xml
@@ -4,3 +4,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/StdDictionaries/BuildFile.xml
+++ b/DataFormats/StdDictionaries/BuildFile.xml
@@ -4,3 +4,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/Streamer/BuildFile.xml
+++ b/DataFormats/Streamer/BuildFile.xml
@@ -3,3 +3,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/TestObjects/BuildFile.xml
+++ b/DataFormats/TestObjects/BuildFile.xml
@@ -2,3 +2,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/DataFormats/TrajectoryState/BuildFile.xml
+++ b/DataFormats/TrajectoryState/BuildFile.xml
@@ -1,4 +1,4 @@
-
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>
 <use   name="boost_header"/>
 <use   name="rootcore"/>
 <export>

--- a/DataFormats/WrappedStdDictionaries/BuildFile.xml
+++ b/DataFormats/WrappedStdDictionaries/BuildFile.xml
@@ -2,3 +2,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/FWCore/Common/BuildFile.xml
+++ b/FWCore/Common/BuildFile.xml
@@ -1,6 +1,8 @@
 <use   name="DataFormats/Provenance"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>
+<use   name="DataFormats/Common" sourcE_only="1"/>
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/FWCore/FWLite/BuildFile.xml
+++ b/FWCore/FWLite/BuildFile.xml
@@ -6,3 +6,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/FWCore/MessageLogger/BuildFile.xml
+++ b/FWCore/MessageLogger/BuildFile.xml
@@ -1,3 +1,5 @@
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>
+<use   name="DataFormats/Provenance" source_only="1"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
 <use   name="tinyxml2"/>

--- a/FastSimDataFormats/PileUpEvents/BuildFile.xml
+++ b/FastSimDataFormats/PileUpEvents/BuildFile.xml
@@ -1,3 +1,4 @@
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>
 <use name="rootcore"/>
 <export>
   <lib   name="1"/>

--- a/Fireworks/TableWidget/BuildFile.xml
+++ b/Fireworks/TableWidget/BuildFile.xml
@@ -1,3 +1,4 @@
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>
 <use name="rootinteractive"/>
 <export>
   <lib name="1"/>

--- a/IOPool/TFileAdaptor/BuildFile.xml
+++ b/IOPool/TFileAdaptor/BuildFile.xml
@@ -7,3 +7,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/IORawData/HcalTBInputService/BuildFile.xml
+++ b/IORawData/HcalTBInputService/BuildFile.xml
@@ -1,3 +1,4 @@
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>
 <use   name="root"/>
 <export>
   <lib name="1"/>

--- a/PhysicsTools/KinFitter/BuildFile.xml
+++ b/PhysicsTools/KinFitter/BuildFile.xml
@@ -1,3 +1,4 @@
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>
 <use   name="root"/>
 <use   name="FWCore/MessageLogger"/>
 <export>

--- a/SimDataFormats/EncodedEventId/BuildFile.xml
+++ b/SimDataFormats/EncodedEventId/BuildFile.xml
@@ -1,3 +1,4 @@
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>
 <use   name="boost"/>
 <use   name="rootcore"/>
 

--- a/SimDataFormats/Forward/BuildFile.xml
+++ b/SimDataFormats/Forward/BuildFile.xml
@@ -4,3 +4,4 @@
 <use   name="DataFormats/Common"/>
 <use   name="FWCore/MessageLogger"/>
 
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/SimDataFormats/GeneratorProducts/BuildFile.xml
+++ b/SimDataFormats/GeneratorProducts/BuildFile.xml
@@ -7,3 +7,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/SimDataFormats/HcalTestBeam/BuildFile.xml
+++ b/SimDataFormats/HcalTestBeam/BuildFile.xml
@@ -4,3 +4,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/SimDataFormats/RandomEngine/BuildFile.xml
+++ b/SimDataFormats/RandomEngine/BuildFile.xml
@@ -5,3 +5,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/TBDataFormats/HcalTBObjects/BuildFile.xml
+++ b/TBDataFormats/HcalTBObjects/BuildFile.xml
@@ -4,3 +4,4 @@
 <export>
   <lib   name="1"/>
 </export>
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>

--- a/Validation/RecoParticleFlow/BuildFile.xml
+++ b/Validation/RecoParticleFlow/BuildFile.xml
@@ -1,3 +1,4 @@
+<release name="_CXXMODULE_"><flags   GENREFLEX_ARGS="--deep --cxxmodule"/></release>
 <use   name="root"/>
 <use   name="rootgpad"/>
 <use   name="rootcore"/>


### PR DESCRIPTION
#### PR description:

These changes are needed to test new ROOT modules in CXXMODULE IBs. This does not change any thing for non-CXXMODULE IBs.

#### PR validation:

Compiled locally for CXXMODULES and short runTheMatrix works
```
32 31 30 24 12 2 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed
```
for CXXMODULE Ibs it will now generate a new PCM  per dictionary library
```
DataFormatsProvenance_xr.pcm
DataFormatsProvenance_xr_rdict.pcm
```

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
