### PR TITLE
BTagCalibration: Added protection against -ve eta values for SFs calculated on abs(eta) [102X]

### DIFF
--- a/CondTools/BTau/src/BTagCalibrationReader.cc
+++ b/CondTools/BTau/src/BTagCalibrationReader.cc
@@ -163,6 +163,11 @@ double BTagCalibrationReader::BTagCalibrationReaderImpl::eval_auto_bounds(
   bool eta_is_out_of_bounds = false;
 
   if (sf_bounds_eta.first < 0) sf_bounds_eta.first = -sf_bounds_eta.second;   
+
+  if (useAbsEta_[jf] && eta < 0) {
+    eta = -eta;
+  }
+
   if (eta <= sf_bounds_eta.first || eta > sf_bounds_eta.second ) {
     eta_is_out_of_bounds = true;
   }

--- a/CondTools/BTau/test/BTagCalibrationStandalone.cpp
+++ b/CondTools/BTau/test/BTagCalibrationStandalone.cpp
@@ -528,7 +528,12 @@ double BTagCalibrationReader::BTagCalibrationReaderImpl::eval_auto_bounds(
   auto sf_bounds_eta = min_max_eta(jf, discr);
   bool eta_is_out_of_bounds = false;
 
-  if (sf_bounds_eta.first < 0) sf_bounds_eta.first = -sf_bounds_eta.second;   
+  if (sf_bounds_eta.first < 0) sf_bounds_eta.first = -sf_bounds_eta.second;  
+
+  if (useAbsEta_[jf] && eta < 0) {
+      eta = -eta;
+  } 
+
   if (eta <= sf_bounds_eta.first || eta > sf_bounds_eta.second ) {
     eta_is_out_of_bounds = true;
   }


### PR DESCRIPTION
Backport of #26248 
