### PR TITLE
Hcal depth energy fraction packed candidates 10 6

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -44,7 +44,7 @@ namespace pat {
       packedPuppiweightNoLepDiff_(0),
       rawCaloFraction_(0),
       hcalFraction_(0),
-      //hcalDepthEnergyFractions_({0,0,0,0,0,0,0}),
+      hcalDepthEnergyFractions_({{0,0,0,0,0,0,0}}),
       packedTime_(0),
       packedTimeError_(0),
       isIsolatedChargedHadron_(false),
@@ -57,7 +57,7 @@ namespace pat {
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
       packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), rawCaloFraction_(0), hcalFraction_(0),
-      //hcalDepthEnergyFractions_({0,0,0,0,0,0,0}),
+      hcalDepthEnergyFractions_({{0,0,0,0,0,0,0}}),
       packedTime_(0), packedTimeError_(0), isIsolatedChargedHadron_(false),
       p4_( new PolarLorentzVector(c.pt(), c.eta(), c.phi(), c.mass())), 
       p4c_( new LorentzVector(*p4_)), vertex_( new Point(c.vertex())), 
@@ -73,7 +73,7 @@ namespace pat {
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
       packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), rawCaloFraction_(0), hcalFraction_(0),
-      //hcalDepthEnergyFractions_({0,0,0,0,0,0,0}),
+      hcalDepthEnergyFractions_({{0,0,0,0,0,0,0}}),
       packedTime_(0), packedTimeError_(0), isIsolatedChargedHadron_(false),
       p4_( new PolarLorentzVector(p4) ), p4c_( new LorentzVector(*p4_)), 
       vertex_( new Point(vtx) ), 
@@ -91,7 +91,7 @@ namespace pat {
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
       packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), rawCaloFraction_(0), hcalFraction_(0),
-      //hcalDepthEnergyFractions_({0,0,0,0,0,0,0}),
+      hcalDepthEnergyFractions_({{0,0,0,0,0,0,0}}),
       packedTime_(0), packedTimeError_(0), isIsolatedChargedHadron_(false),
       p4_(new PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M())), 
       p4c_( new LorentzVector(p4)), vertex_( new Point(vtx) ) ,
@@ -652,8 +652,8 @@ namespace pat {
     float rawCaloFraction() const { return (rawCaloFraction_/100.); }    /// Raw ECAL+HCAL energy over candidate energy for isolated charged hadrons
     void setHcalFraction(float p);                      /// Set the fraction of Hcal needed for HF and neutral hadrons and isolated charged hadrons
     float hcalFraction() const { return (hcalFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
-    void setHcalDepthEnergyFractions(std::array<float,7> p);                      /// set fraction of Hcal energies in each depth
-    float hcalDepthEnergyFraction(int iDepth) const { return (hcalDepthEnergyFractions_[iDepth]/100.); }    /// Fraction of Hcal energies in each depth
+    void setHcalDepthEnergyFractions(const std::array<float,7> & fracs);                      /// set fraction of Hcal energies in each depth
+    float hcalDepthEnergyFraction(unsigned int depth) const { return (hcalDepthEnergyFractions_[depth-1]/100.); }    /// Fraction of Hcal energies in each depth
 
      // isolated charged hadrons
     void setIsIsolatedChargedHadron(bool p);                      /// Set isolation (as in particle flow, i.e. at calorimeter surface rather than at PV) flat for charged hadrons

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -653,7 +653,7 @@ namespace pat {
     void setHcalFraction(float p);                      /// Set the fraction of Hcal needed for HF and neutral hadrons and isolated charged hadrons
     float hcalFraction() const { return (hcalFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
     void setHcalDepthEnergyFractions(const std::array<float,7> & fracs);                      /// set fraction of Hcal energies in each depth
-    float hcalDepthEnergyFraction(unsigned int depth) const { return (hcalDepthEnergyFractions_[depth-1]/100.); }    /// Fraction of Hcal energies in each depth
+    float hcalDepthEnergyFraction(unsigned int depth) const { return (hcalDepthEnergyFractions_[depth-1]/200.); }    /// Fraction of Hcal energies in each depth
 
      // isolated charged hadrons
     void setIsIsolatedChargedHadron(bool p);                      /// Set isolation (as in particle flow, i.e. at calorimeter surface rather than at PV) flat for charged hadrons
@@ -725,7 +725,7 @@ namespace pat {
     int8_t packedPuppiweightNoLepDiff_; // storing the DIFFERENCE of (all - "no lep") for compression optimization
     uint8_t rawCaloFraction_;
     int8_t hcalFraction_;
-    std::array<int8_t,7> hcalDepthEnergyFractions_;
+    std::array<uint8_t,7> hcalDepthEnergyFractions_;
     int16_t packedTime_;
     uint8_t packedTimeError_;
 

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -3,6 +3,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <array>
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Common/interface/RefVector.h"
@@ -43,6 +44,7 @@ namespace pat {
       packedPuppiweightNoLepDiff_(0),
       rawCaloFraction_(0),
       hcalFraction_(0),
+      //hcalDepthEnergyFractions_({0,0,0,0,0,0,0}),
       packedTime_(0),
       packedTimeError_(0),
       isIsolatedChargedHadron_(false),
@@ -55,6 +57,7 @@ namespace pat {
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
       packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), rawCaloFraction_(0), hcalFraction_(0),
+      //hcalDepthEnergyFractions_({0,0,0,0,0,0,0}),
       packedTime_(0), packedTimeError_(0), isIsolatedChargedHadron_(false),
       p4_( new PolarLorentzVector(c.pt(), c.eta(), c.phi(), c.mass())), 
       p4c_( new LorentzVector(*p4_)), vertex_( new Point(c.vertex())), 
@@ -70,6 +73,7 @@ namespace pat {
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
       packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), rawCaloFraction_(0), hcalFraction_(0),
+      //hcalDepthEnergyFractions_({0,0,0,0,0,0,0}),
       packedTime_(0), packedTimeError_(0), isIsolatedChargedHadron_(false),
       p4_( new PolarLorentzVector(p4) ), p4c_( new LorentzVector(*p4_)), 
       vertex_( new Point(vtx) ), 
@@ -87,6 +91,7 @@ namespace pat {
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
       packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), rawCaloFraction_(0), hcalFraction_(0),
+      //hcalDepthEnergyFractions_({0,0,0,0,0,0,0}),
       packedTime_(0), packedTimeError_(0), isIsolatedChargedHadron_(false),
       p4_(new PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M())), 
       p4c_( new LorentzVector(p4)), vertex_( new Point(vtx) ) ,
@@ -109,6 +114,7 @@ namespace pat {
       packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
       rawCaloFraction_(iOther.rawCaloFraction_),
       hcalFraction_(iOther.hcalFraction_),
+      hcalDepthEnergyFractions_(iOther.hcalDepthEnergyFractions_),
       packedTime_(iOther.packedTime_),
       packedTimeError_(iOther.packedTimeError_),
       isIsolatedChargedHadron_(iOther.isIsolatedChargedHadron_),
@@ -135,6 +141,7 @@ namespace pat {
       packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
       rawCaloFraction_(iOther.rawCaloFraction_),
       hcalFraction_(iOther.hcalFraction_),
+      hcalDepthEnergyFractions_(iOther.hcalDepthEnergyFractions_),
       packedTime_(iOther.packedTime_),
       packedTimeError_(iOther.packedTimeError_),
       isIsolatedChargedHadron_(iOther.isIsolatedChargedHadron_),
@@ -169,6 +176,7 @@ namespace pat {
       packedPuppiweightNoLepDiff_=iOther.packedPuppiweightNoLepDiff_;
       rawCaloFraction_=iOther.rawCaloFraction_;
       hcalFraction_=iOther.hcalFraction_;
+      hcalDepthEnergyFractions_ = iOther.hcalDepthEnergyFractions_;
       packedTime_=iOther.packedTime_;
       packedTimeError_=iOther.packedTimeError_;
       isIsolatedChargedHadron_=iOther.isIsolatedChargedHadron_;
@@ -246,6 +254,7 @@ namespace pat {
       packedPuppiweightNoLepDiff_=iOther.packedPuppiweightNoLepDiff_;
       rawCaloFraction_=iOther.rawCaloFraction_;
       hcalFraction_=iOther.hcalFraction_;
+      hcalDepthEnergyFractions_ = iOther.hcalDepthEnergyFractions_;
       packedTime_=iOther.packedTime_;
       packedTimeError_=iOther.packedTimeError_;
       isIsolatedChargedHadron_=iOther.isIsolatedChargedHadron_;
@@ -643,6 +652,8 @@ namespace pat {
     float rawCaloFraction() const { return (rawCaloFraction_/100.); }    /// Raw ECAL+HCAL energy over candidate energy for isolated charged hadrons
     void setHcalFraction(float p);                      /// Set the fraction of Hcal needed for HF and neutral hadrons and isolated charged hadrons
     float hcalFraction() const { return (hcalFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
+    void setHcalDepthEnergyFractions(std::array<float,7> p);                      /// set fraction of Hcal energies in each depth
+    float hcalDepthEnergyFraction(int iDepth) const { return (hcalDepthEnergyFractions_[iDepth]/100.); }    /// Fraction of Hcal energies in each depth
 
      // isolated charged hadrons
     void setIsIsolatedChargedHadron(bool p);                      /// Set isolation (as in particle flow, i.e. at calorimeter surface rather than at PV) flat for charged hadrons
@@ -714,6 +725,7 @@ namespace pat {
     int8_t packedPuppiweightNoLepDiff_; // storing the DIFFERENCE of (all - "no lep") for compression optimization
     uint8_t rawCaloFraction_;
     int8_t hcalFraction_;
+    std::array<int8_t,7> hcalDepthEnergyFractions_;
     int16_t packedTime_;
     uint8_t packedTimeError_;
 

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -374,7 +374,7 @@ void pat::PackedCandidate::setHcalFraction(float p) {
 }
 
 void pat::PackedCandidate::setHcalDepthEnergyFractions(const std::array<float,7> & fracs) {
-  for (unsigned int i=0; i<hcalDepthEnergyFractions_.size(); i++) hcalDepthEnergyFractions_[i] = 100*fracs[i];
+  for (unsigned int i=0; i<hcalDepthEnergyFractions_.size(); i++) hcalDepthEnergyFractions_[i] = 200*fracs[i];
 }
 
 void pat::PackedCandidate::setIsIsolatedChargedHadron(bool p) {

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -373,6 +373,10 @@ void pat::PackedCandidate::setHcalFraction(float p) {
   hcalFraction_ = 100*p;
 }
 
+void pat::PackedCandidate::setHcalDepthEnergyFractions(std::array<float,7> p) {
+  for (unsigned int i=0; i<hcalDepthEnergyFractions_.size(); ++i) hcalDepthEnergyFractions_[i] = 100*p[i];
+}
+
 void pat::PackedCandidate::setIsIsolatedChargedHadron(bool p) {
   isIsolatedChargedHadron_ = p;
 }

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -373,8 +373,8 @@ void pat::PackedCandidate::setHcalFraction(float p) {
   hcalFraction_ = 100*p;
 }
 
-void pat::PackedCandidate::setHcalDepthEnergyFractions(std::array<float,7> p) {
-  for (unsigned int i=0; i<hcalDepthEnergyFractions_.size(); ++i) hcalDepthEnergyFractions_[i] = 100*p[i];
+void pat::PackedCandidate::setHcalDepthEnergyFractions(const std::array<float,7> & fracs) {
+  for (unsigned int i=0; i<hcalDepthEnergyFractions_.size(); i++) hcalDepthEnergyFractions_[i] = 100*fracs[i];
 }
 
 void pat::PackedCandidate::setIsIsolatedChargedHadron(bool p) {

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -334,7 +334,8 @@
   <class name="pat::PackedCandidate::PackedCovariance" ClassVersion="3">
    <version ClassVersion="3" checksum="3320406063"/>
   </class>
-  <class name="pat::PackedCandidate" ClassVersion="33">
+  <class name="pat::PackedCandidate" ClassVersion="34">
+   <version ClassVersion="34" checksum="2680106475"/>
    <version ClassVersion="33" checksum="1092680546"/>
    <version ClassVersion="32" checksum="926869123"/>
    <version ClassVersion="31" checksum="1248040002"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -335,7 +335,7 @@
    <version ClassVersion="3" checksum="3320406063"/>
   </class>
   <class name="pat::PackedCandidate" ClassVersion="34">
-   <version ClassVersion="34" checksum="2680106475"/>
+   <version ClassVersion="34" checksum="1041010130"/>
    <version ClassVersion="33" checksum="1092680546"/>
    <version ClassVersion="32" checksum="926869123"/>
    <version ClassVersion="31" checksum="1248040002"/>

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -126,8 +126,12 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::Parameter
   covarianceVersion_(iConfig.getParameter<int >("covarianceVersion")),
   covariancePackingSchemas_(iConfig.getParameter<std::vector<int> >("covariancePackingSchemas")),
   pfCandidateTypesForHcalDepth_(iConfig.getParameter<std::vector<int> >("pfCandidateTypesForHcalDepth")),
+<<<<<<< HEAD
   storeHcalDepthEndcapOnly_(iConfig.getParameter<bool>("storeHcalDepthEndcapOnly")),
   storeTiming_(iConfig.getParameter<bool>("storeTiming"))
+=======
+  storeTiming_(iConfig.getParameter<bool>("storeTiming"))  
+>>>>>>> fill hcalDepthEnergyFractions information - first attempt
 {
   std::vector<edm::InputTag> sv_tags = iConfig.getParameter<std::vector<edm::InputTag> >("secondaryVerticesForWhiteList");
   for(auto itag : sv_tags){
@@ -326,6 +330,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 	}
 
 	// storing HcalDepthEnergyFraction information
+<<<<<<< HEAD
 	if ( std::find(pfCandidateTypesForHcalDepth_.begin(), pfCandidateTypesForHcalDepth_.end(), abs(cand.pdgId())) != pfCandidateTypesForHcalDepth_.end() ){
 	  if (!storeHcalDepthEndcapOnly_ || fabs(outPtrP->back().eta())>1.3 ){  // storeHcalDepthEndcapOnly_==false -> store all eta of selected PF types, if true, only |eta|>1.3 of selected PF types will be stored  
 	    std::array<float,7> hcalDepthEnergyFractions {{
@@ -334,6 +339,15 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 		  }};
 	    outPtrP->back().setHcalDepthEnergyFractions(hcalDepthEnergyFractions);
 	  }
+=======
+	std::cout << cand.pdgId() << std::endl;
+	if ( std::find(pfCandidateTypesForHcalDepth_.begin(), pfCandidateTypesForHcalDepth_.end(), abs(cand.pdgId())) != pfCandidateTypesForHcalDepth_.end() ){
+	  std::array<float,7> hcalDepthEnergyFractions {{
+	      cand.hcalDepthEnergyFraction(1), cand.hcalDepthEnergyFraction(2), cand.hcalDepthEnergyFraction(3), cand.hcalDepthEnergyFraction(4),
+	      cand.hcalDepthEnergyFraction(5), cand.hcalDepthEnergyFraction(6), cand.hcalDepthEnergyFraction(7)
+	      }};
+	  outPtrP->back().setHcalDepthEnergyFractions(hcalDepthEnergyFractions);
+>>>>>>> fill hcalDepthEnergyFractions information - first attempt
 	}
 	
 	//specifically this is the PFLinker requirements to apply the e/gamma regression

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -91,6 +91,7 @@ namespace pat {
             const int covarianceVersion_;
             const std::vector<int> covariancePackingSchemas_;
             const std::vector<int> pfCandidateTypesForHcalDepth_;
+            const bool storeHcalDepthEndcapOnly_;
       
             const bool storeTiming_;
       
@@ -125,7 +126,8 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::Parameter
   covarianceVersion_(iConfig.getParameter<int >("covarianceVersion")),
   covariancePackingSchemas_(iConfig.getParameter<std::vector<int> >("covariancePackingSchemas")),
   pfCandidateTypesForHcalDepth_(iConfig.getParameter<std::vector<int> >("pfCandidateTypesForHcalDepth")),
-  storeTiming_(iConfig.getParameter<bool>("storeTiming"))  
+  storeHcalDepthEndcapOnly_(iConfig.getParameter<bool>("storeHcalDepthEndcapOnly")),
+  storeTiming_(iConfig.getParameter<bool>("storeTiming"))
 {
   std::vector<edm::InputTag> sv_tags = iConfig.getParameter<std::vector<edm::InputTag> >("secondaryVerticesForWhiteList");
   for(auto itag : sv_tags){
@@ -325,11 +327,13 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 
 	// storing HcalDepthEnergyFraction information
 	if ( std::find(pfCandidateTypesForHcalDepth_.begin(), pfCandidateTypesForHcalDepth_.end(), abs(cand.pdgId())) != pfCandidateTypesForHcalDepth_.end() ){
-	  std::array<float,7> hcalDepthEnergyFractions {{
-	      cand.hcalDepthEnergyFraction(1), cand.hcalDepthEnergyFraction(2), cand.hcalDepthEnergyFraction(3), cand.hcalDepthEnergyFraction(4),
-	      cand.hcalDepthEnergyFraction(5), cand.hcalDepthEnergyFraction(6), cand.hcalDepthEnergyFraction(7)
-	      }};
-	  outPtrP->back().setHcalDepthEnergyFractions(hcalDepthEnergyFractions);
+	  if (!storeHcalDepthEndcapOnly_ || fabs(outPtrP->back().eta())>1.3 ){  // storeHcalDepthEndcapOnly_==false -> store all eta of selected PF types, if true, only |eta|>1.3 of selected PF types will be stored  
+	    std::array<float,7> hcalDepthEnergyFractions {{
+		cand.hcalDepthEnergyFraction(1), cand.hcalDepthEnergyFraction(2), cand.hcalDepthEnergyFraction(3), cand.hcalDepthEnergyFraction(4),
+		  cand.hcalDepthEnergyFraction(5), cand.hcalDepthEnergyFraction(6), cand.hcalDepthEnergyFraction(7)
+		  }};
+	    outPtrP->back().setHcalDepthEnergyFractions(hcalDepthEnergyFractions);
+	  }
 	}
 	
 	//specifically this is the PFLinker requirements to apply the e/gamma regression

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -324,7 +324,6 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 	}
 
 	// storing HcalDepthEnergyFraction information
-	std::cout << cand.pdgId() << std::endl;
 	if ( std::find(pfCandidateTypesForHcalDepth_.begin(), pfCandidateTypesForHcalDepth_.end(), abs(cand.pdgId())) != pfCandidateTypesForHcalDepth_.end() ){
 	  std::array<float,7> hcalDepthEnergyFractions {{
 	      cand.hcalDepthEnergyFraction(1), cand.hcalDepthEnergyFraction(2), cand.hcalDepthEnergyFraction(3), cand.hcalDepthEnergyFraction(4),

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -126,12 +126,8 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::Parameter
   covarianceVersion_(iConfig.getParameter<int >("covarianceVersion")),
   covariancePackingSchemas_(iConfig.getParameter<std::vector<int> >("covariancePackingSchemas")),
   pfCandidateTypesForHcalDepth_(iConfig.getParameter<std::vector<int> >("pfCandidateTypesForHcalDepth")),
-<<<<<<< HEAD
   storeHcalDepthEndcapOnly_(iConfig.getParameter<bool>("storeHcalDepthEndcapOnly")),
   storeTiming_(iConfig.getParameter<bool>("storeTiming"))
-=======
-  storeTiming_(iConfig.getParameter<bool>("storeTiming"))  
->>>>>>> fill hcalDepthEnergyFractions information - first attempt
 {
   std::vector<edm::InputTag> sv_tags = iConfig.getParameter<std::vector<edm::InputTag> >("secondaryVerticesForWhiteList");
   for(auto itag : sv_tags){
@@ -331,6 +327,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 
 	// storing HcalDepthEnergyFraction information
 <<<<<<< HEAD
+<<<<<<< HEAD
 	if ( std::find(pfCandidateTypesForHcalDepth_.begin(), pfCandidateTypesForHcalDepth_.end(), abs(cand.pdgId())) != pfCandidateTypesForHcalDepth_.end() ){
 	  if (!storeHcalDepthEndcapOnly_ || fabs(outPtrP->back().eta())>1.3 ){  // storeHcalDepthEndcapOnly_==false -> store all eta of selected PF types, if true, only |eta|>1.3 of selected PF types will be stored  
 	    std::array<float,7> hcalDepthEnergyFractions {{
@@ -341,6 +338,8 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 	  }
 =======
 	std::cout << cand.pdgId() << std::endl;
+=======
+>>>>>>> Fill hcalDepthEnergyFractions. Clean up.
 	if ( std::find(pfCandidateTypesForHcalDepth_.begin(), pfCandidateTypesForHcalDepth_.end(), abs(cand.pdgId())) != pfCandidateTypesForHcalDepth_.end() ){
 	  std::array<float,7> hcalDepthEnergyFractions {{
 	      cand.hcalDepthEnergyFraction(1), cand.hcalDepthEnergyFraction(2), cand.hcalDepthEnergyFraction(3), cand.hcalDepthEnergyFraction(4),

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -90,6 +90,7 @@ namespace pat {
             const double minPtForTrackProperties_;
             const int covarianceVersion_;
             const std::vector<int> covariancePackingSchemas_;
+            const std::vector<int> pfCandidateTypesForHcalDepth_;
       
             const bool storeTiming_;
       
@@ -123,6 +124,7 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::Parameter
   minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties")),
   covarianceVersion_(iConfig.getParameter<int >("covarianceVersion")),
   covariancePackingSchemas_(iConfig.getParameter<std::vector<int> >("covariancePackingSchemas")),
+  pfCandidateTypesForHcalDepth_(iConfig.getParameter<std::vector<int> >("pfCandidateTypesForHcalDepth")),
   storeTiming_(iConfig.getParameter<bool>("storeTiming"))  
 {
   std::vector<edm::InputTag> sv_tags = iConfig.getParameter<std::vector<edm::InputTag> >("secondaryVerticesForWhiteList");
@@ -319,6 +321,16 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
           outPtrP->back().setHcalFraction(cand.rawHcalEnergy()/(cand.rawEcalEnergy()+cand.rawHcalEnergy()));
 	} else {
 	  outPtrP->back().setHcalFraction(0);
+	}
+
+	// storing HcalDepthEnergyFraction information
+	std::cout << cand.pdgId() << std::endl;
+	if ( std::find(pfCandidateTypesForHcalDepth_.begin(), pfCandidateTypesForHcalDepth_.end(), abs(cand.pdgId())) != pfCandidateTypesForHcalDepth_.end() ){
+	  std::array<float,7> hcalDepthEnergyFractions {{
+	      cand.hcalDepthEnergyFraction(1), cand.hcalDepthEnergyFraction(2), cand.hcalDepthEnergyFraction(3), cand.hcalDepthEnergyFraction(4),
+	      cand.hcalDepthEnergyFraction(5), cand.hcalDepthEnergyFraction(6), cand.hcalDepthEnergyFraction(7)
+	      }};
+	  outPtrP->back().setHcalDepthEnergyFractions(hcalDepthEnergyFractions);
 	}
 	
 	//specifically this is the PFLinker requirements to apply the e/gamma regression

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -326,8 +326,6 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 	}
 
 	// storing HcalDepthEnergyFraction information
-<<<<<<< HEAD
-<<<<<<< HEAD
 	if ( std::find(pfCandidateTypesForHcalDepth_.begin(), pfCandidateTypesForHcalDepth_.end(), abs(cand.pdgId())) != pfCandidateTypesForHcalDepth_.end() ){
 	  if (!storeHcalDepthEndcapOnly_ || fabs(outPtrP->back().eta())>1.3 ){  // storeHcalDepthEndcapOnly_==false -> store all eta of selected PF types, if true, only |eta|>1.3 of selected PF types will be stored  
 	    std::array<float,7> hcalDepthEnergyFractions {{
@@ -336,17 +334,6 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 		  }};
 	    outPtrP->back().setHcalDepthEnergyFractions(hcalDepthEnergyFractions);
 	  }
-=======
-	std::cout << cand.pdgId() << std::endl;
-=======
->>>>>>> Fill hcalDepthEnergyFractions. Clean up.
-	if ( std::find(pfCandidateTypesForHcalDepth_.begin(), pfCandidateTypesForHcalDepth_.end(), abs(cand.pdgId())) != pfCandidateTypesForHcalDepth_.end() ){
-	  std::array<float,7> hcalDepthEnergyFractions {{
-	      cand.hcalDepthEnergyFraction(1), cand.hcalDepthEnergyFraction(2), cand.hcalDepthEnergyFraction(3), cand.hcalDepthEnergyFraction(4),
-	      cand.hcalDepthEnergyFraction(5), cand.hcalDepthEnergyFraction(6), cand.hcalDepthEnergyFraction(7)
-	      }};
-	  outPtrP->back().setHcalDepthEnergyFractions(hcalDepthEnergyFractions);
->>>>>>> fill hcalDepthEnergyFractions information - first attempt
 	}
 	
 	//specifically this is the PFLinker requirements to apply the e/gamma regression

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -20,7 +20,7 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
     covarianceVersion = cms.int32(0), #so far: 0 is Phase0, 1 is Phase1   
 #    covariancePackingSchemas = cms.vint32(1,257,513,769,0),  # a cheaper schema in kb/ev 
     covariancePackingSchemas = cms.vint32(8,264,520,776,0),   # more accurate schema +0.6kb/ev   
-    pfCandidateTypesForHcalDepth = cms.vint32(5,2,4),  # PF candidate types for adding Hcal depth energy fraction information (5: neutral hadron, 2: PF electron, 4: PF photon)
+    pfCandidateTypesForHcalDepth = cms.vint32(130,11,22),  # PF candidate types for adding Hcal depth energy fraction information (130: neutral hadron, 11: PF electron, 22: PF photon)
     storeTiming = cms.bool(False)
 )
 

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -20,7 +20,8 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
     covarianceVersion = cms.int32(0), #so far: 0 is Phase0, 1 is Phase1   
 #    covariancePackingSchemas = cms.vint32(1,257,513,769,0),  # a cheaper schema in kb/ev 
     covariancePackingSchemas = cms.vint32(8,264,520,776,0),   # more accurate schema +0.6kb/ev   
-    pfCandidateTypesForHcalDepth = cms.vint32(130,11,22),  # PF candidate types for adding Hcal depth energy fraction information (130: neutral hadron, 11: PF electron, 22: PF photon)
+    pfCandidateTypesForHcalDepth = cms.vint32(),              # PF candidate types for adding Hcal depth energy fraction information, none by default
+    storeHcalDepthEndcapOnly = cms.bool(False),               # In case of 2018, need hcal depth info only for endcap. For run3 and beyond, we need information for barrel.
     storeTiming = cms.bool(False)
 )
 
@@ -33,3 +34,11 @@ run2_miniAOD_80XLegacy.toModify(packedPFCandidates, chargedHadronIsolation = "" 
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_timing.toModify(packedPFCandidates, storeTiming = cms.bool(True))
 
+from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+run2_HCAL_2018.toModify(packedPFCandidates,
+    pfCandidateTypesForHcalDepth = cms.vint32(130,11,22),  # PF candidate types for adding Hcal depth energy fraction information (130: neutral hadron, 11: PF electron, 22: PF photon)
+    storeHcalDepthEndcapOnly = cms.bool(True)
+)
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(packedPFCandidates, storeHcalDepthEndcapOnly = cms.bool(False))

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -20,6 +20,7 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
     covarianceVersion = cms.int32(0), #so far: 0 is Phase0, 1 is Phase1   
 #    covariancePackingSchemas = cms.vint32(1,257,513,769,0),  # a cheaper schema in kb/ev 
     covariancePackingSchemas = cms.vint32(8,264,520,776,0),   # more accurate schema +0.6kb/ev   
+    pfCandidateTypesForHcalDepth = cms.vint32(5,2,4),  # PF candidate types for adding Hcal depth energy fraction information (5: neutral hadron, 2: PF electron, 4: PF photon)
     storeTiming = cms.bool(False)
 )
 

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -21,7 +21,7 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
 #    covariancePackingSchemas = cms.vint32(1,257,513,769,0),  # a cheaper schema in kb/ev 
     covariancePackingSchemas = cms.vint32(8,264,520,776,0),   # more accurate schema +0.6kb/ev   
     pfCandidateTypesForHcalDepth = cms.vint32(),
-    storeHcalDepthEndcapOnly = cms.bool(False),               # In case of 2018, need hcal depth info only for endcap. For run3 and beyond, we need information for barrel.
+    storeHcalDepthEndcapOnly = cms.bool(False),               # In case of 2018, need hcal depth info only for endcap. For run3 and beyond, consider information also for barrel.
     storeTiming = cms.bool(False)
 )
 
@@ -41,4 +41,7 @@ run2_HCAL_2018.toModify(packedPFCandidates,
 )
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(packedPFCandidates, storeHcalDepthEndcapOnly = cms.bool(False))
+run3_common.toModify(packedPFCandidates,
+    pfCandidateTypesForHcalDepth = cms.vint32(), # For now, no PF cand type is considered for addition of Hcal depth energy frac 
+    storeHcalDepthEndcapOnly = cms.bool(False)
+)

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -20,7 +20,6 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
     covarianceVersion = cms.int32(0), #so far: 0 is Phase0, 1 is Phase1   
 #    covariancePackingSchemas = cms.vint32(1,257,513,769,0),  # a cheaper schema in kb/ev 
     covariancePackingSchemas = cms.vint32(8,264,520,776,0),   # more accurate schema +0.6kb/ev   
-    pfCandidateTypesForHcalDepth = cms.vint32(),              # PF candidate types for adding Hcal depth energy fraction information, none by default
     storeHcalDepthEndcapOnly = cms.bool(False),               # In case of 2018, need hcal depth info only for endcap. For run3 and beyond, we need information for barrel.
     storeTiming = cms.bool(False)
 )
@@ -36,7 +35,7 @@ phase2_timing.toModify(packedPFCandidates, storeTiming = cms.bool(True))
 
 from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
 run2_HCAL_2018.toModify(packedPFCandidates,
-    pfCandidateTypesForHcalDepth = cms.vint32(130,11,22),  # PF candidate types for adding Hcal depth energy fraction information (130: neutral hadron, 11: PF electron, 22: PF photon)
+                        pfCandidateTypesForHcalDepth = cms.vint32(130,11,22,211,13),  # PF candidate types for adding Hcal depth energy fraction information (130: neutral hadron, 11: PF electron, 22: PF photon, 211: charged hadron, 13: muon) # excluding still 0:X, 1:h_HF, 2:egamma_HF
     storeHcalDepthEndcapOnly = cms.bool(True)
 )
 

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -20,6 +20,7 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
     covarianceVersion = cms.int32(0), #so far: 0 is Phase0, 1 is Phase1   
 #    covariancePackingSchemas = cms.vint32(1,257,513,769,0),  # a cheaper schema in kb/ev 
     covariancePackingSchemas = cms.vint32(8,264,520,776,0),   # more accurate schema +0.6kb/ev   
+    pfCandidateTypesForHcalDepth = cms.vint32(),
     storeHcalDepthEndcapOnly = cms.bool(False),               # In case of 2018, need hcal depth info only for endcap. For run3 and beyond, we need information for barrel.
     storeTiming = cms.bool(False)
 )
@@ -35,7 +36,7 @@ phase2_timing.toModify(packedPFCandidates, storeTiming = cms.bool(True))
 
 from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
 run2_HCAL_2018.toModify(packedPFCandidates,
-                        pfCandidateTypesForHcalDepth = cms.vint32(130,11,22,211,13),  # PF candidate types for adding Hcal depth energy fraction information (130: neutral hadron, 11: PF electron, 22: PF photon, 211: charged hadron, 13: muon) # excluding still 0:X, 1:h_HF, 2:egamma_HF
+    pfCandidateTypesForHcalDepth = cms.vint32(130,11,22,211,13),  # PF cand types for adding Hcal depth energy frac information (130: neutral h, 11: ele, 22: photon, 211: charged h, 13: mu) # excluding e.g. 1:h_HF, 2:egamma_HF
     storeHcalDepthEndcapOnly = cms.bool(True)
 )
 


### PR DESCRIPTION
#### PR description:

Includes HCAL depth information for packed candidates in MINIAOD for high-level object use (e.g. PUPPI recomputation at the post ultra-legacy MINIAOD stage). The promising results are obtained [1,2], but needs more time to finalize it. It means it is important to have this information in packedCandidates, so that the PUPPI weights can be recomputed on-the-fly.

[1] https://indico.cern.ch/event/799365/contributions/3333038/attachments/1805670/2946660/pre.pdf
[2] https://indico.cern.ch/event/799365/contributions/3339621/attachments/1805694/2946705/JK_JetMET_03_19_2.pdf

JME leaders, please feel free to add more supporting items!

@peruzzim @fgolf  @zdemirag @ahinzmann @bendavid @mariadalfonso 

#### PR validation:

Made sure that the this information gets added to packedCandidates as intended. The size increase in TTbar sample with 2018 scenario is 0.7% with this PR.

#### if this PR is a backport please specify the original PR:

This is NOT a backport PR.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
