### PR TITLE
Removed unused variable from SiPixelFedFillerWordEventNumber

### DIFF
--- a/CalibTracker/SiPixelTools/plugins/SiPixelFedFillerWordEventNumber.cc
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelFedFillerWordEventNumber.cc
@@ -365,7 +365,6 @@ SiPixelFedFillerWordEventNumber ::produce(edm::Event& iEvent, const edm::EventSe
   auto FillerWordEventNumbers2 = std::make_unique<std::vector<uint32_t>>();
   auto SaveFillerWords = std::make_unique<std::vector<uint32_t>>();
   //===== Loop over all the FEDs ========================================================
-  FEDNumbering fednum;
   std::pair<int,int> fedIds;
   fedIds.first  = 0;
   fedIds.second = 39; 


### PR DESCRIPTION
#### PR description:

This was causing a compiler warning.

#### PR validation:

The code compiles.