### PR TITLE
Adding digi-based shower tagging to reco::Muon

### DIFF
--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -186,9 +186,6 @@ namespace reco {
     enum ArbitrationType { NoArbitration, SegmentArbitration, SegmentAndTrackArbitration, SegmentAndTrackArbitrationCleaned,
 			   RPCHitAndTrackArbitration, GEMSegmentAndTrackArbitration, ME0SegmentAndTrackArbitration };
 
-    /// ranges to be used for digi-based shower counting
-    enum DigiRange { FullChamber, InRange };
-    
     ///
     /// ====================== STANDARD SELECTORS ===========================
     ///
@@ -264,11 +261,13 @@ namespace reco {
     /// same as above for given number of sigmas
     unsigned int stationGapMaskPull( float sigmaCut = 3. ) const;
     /// # of digis in a given station layer
-    /// index 0-1-2-3 = DT stations 1-2-3-4                                                             /// index 4-5-6-7 = CSC stations 1-2-3-4
-    int nDigisInStation( int index, DigiRange range = InRange ) const;
-    /// # of digis in a given station layer
-    /// index 0-1-2-3 = DT stations 1-2-3-4                                                             /// index 4-5-6-7 = CSC stations 1-2-3-4
-    bool hasShowerInStation( int index, DigiRange range = InRange, int nDtDigisCut = 20, int nCscDigisCut = 36 ) const;
+    /// index 0-1-2-3 = DT stations 1-2-3-4                                                             
+    /// index 4-5-6-7 = CSC stations 1-2-3-4
+    int nDigisInStation( int index) const;
+    /// tag a shower in a given station layer
+    /// index 0-1-2-3 = DT stations 1-2-3-4
+    /// index 4-5-6-7 = CSC stations 1-2-3-4
+    bool hasShowerInStation( int index, int nDtDigisCut = 20, int nCscDigisCut = 36 ) const;
 
     /// muon type - type of the algorithm that reconstructed this muon
     /// multiple algorithms can reconstruct the same muon

--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -268,6 +268,8 @@ namespace reco {
     /// index 0-1-2-3 = DT stations 1-2-3-4
     /// index 4-5-6-7 = CSC stations 1-2-3-4
     bool hasShowerInStation( int index, int nDtDigisCut = 20, int nCscDigisCut = 36 ) const;
+    /// count the number of showers along a muon track
+    int numberOfShowers( int nDtDigisCut = 20, int nCscDigisCut = 36 ) const;
 
     /// muon type - type of the algorithm that reconstructed this muon
     /// multiple algorithms can reconstruct the same muon

--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -185,6 +185,9 @@ namespace reco {
 
     enum ArbitrationType { NoArbitration, SegmentArbitration, SegmentAndTrackArbitration, SegmentAndTrackArbitrationCleaned,
 			   RPCHitAndTrackArbitration, GEMSegmentAndTrackArbitration, ME0SegmentAndTrackArbitration };
+
+    /// ranges to be used for digi-based shower counting
+    enum DigiRange { FullChamber, InRange };
     
     ///
     /// ====================== STANDARD SELECTORS ===========================
@@ -260,7 +263,13 @@ namespace reco {
     unsigned int stationGapMaskDistance( float distanceCut = 10. ) const;
     /// same as above for given number of sigmas
     unsigned int stationGapMaskPull( float sigmaCut = 3. ) const;
-     
+    /// # of digis in a given station layer
+    /// index 0-1-2-3 = DT stations 1-2-3-4                                                             /// index 4-5-6-7 = CSC stations 1-2-3-4
+    int nDigisInStation( int index, DigiRange range = InRange ) const;
+    /// # of digis in a given station layer
+    /// index 0-1-2-3 = DT stations 1-2-3-4                                                             /// index 4-5-6-7 = CSC stations 1-2-3-4
+    bool hasShowerInStation( int index, DigiRange range = InRange, int nDtDigisCut = 20, int nCscDigisCut = 36 ) const;
+
     /// muon type - type of the algorithm that reconstructed this muon
     /// multiple algorithms can reconstruct the same muon
     static const unsigned int GlobalMuon     =  1<<1;

--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -261,13 +261,9 @@ namespace reco {
     /// same as above for given number of sigmas
     unsigned int stationGapMaskPull( float sigmaCut = 3. ) const;
     /// # of digis in a given station layer
-    /// index 0-1-2-3 = DT stations 1-2-3-4                                                             
-    /// index 4-5-6-7 = CSC stations 1-2-3-4
-    int nDigisInStation( int index) const;
+    int nDigisInStation( int station, int muonSubdetId) const;
     /// tag a shower in a given station layer
-    /// index 0-1-2-3 = DT stations 1-2-3-4
-    /// index 4-5-6-7 = CSC stations 1-2-3-4
-    bool hasShowerInStation( int index, int nDtDigisCut = 20, int nCscDigisCut = 36 ) const;
+    bool hasShowerInStation( int station, int muonSubdetId, int nDtDigisCut = 20, int nCscDigisCut = 36 ) const;
     /// count the number of showers along a muon track
     int numberOfShowers( int nDtDigisCut = 20, int nCscDigisCut = 36 ) const;
 

--- a/DataFormats/MuonReco/interface/MuonChamberMatch.h
+++ b/DataFormats/MuonReco/interface/MuonChamberMatch.h
@@ -26,7 +26,6 @@ namespace reco {
          float dYdZErr;     // propagation uncertainty in dY/dZ
          DetId id;          // chamber ID
 
-	 int nDigisInChamb; // # of DT/CSC digis in the chamber
 	 int nDigisInRange; // # of DT/CSC digis in the chamber close-by to the propagated track
 
          int detector() const { return id.subdetId(); }

--- a/DataFormats/MuonReco/interface/MuonChamberMatch.h
+++ b/DataFormats/MuonReco/interface/MuonChamberMatch.h
@@ -14,17 +14,20 @@ namespace reco {
          std::vector<reco::MuonSegmentMatch> me0Matches;    // segments matching propagated track trajectory
          std::vector<reco::MuonSegmentMatch> truthMatches;      // SimHit projection matching propagated track trajectory
          std::vector<reco::MuonRPCHitMatch>  rpcMatches;        // rpc hits matching propagated track trajectory 
-         float edgeX;      // distance to closest edge in X (negative - inside, positive - outside)
-         float edgeY;      // distance to closest edge in Y (negative - inside, positive - outside)
-         float x;          // X position of the track
-         float y;          // Y position of the track
-         float xErr;       // propagation uncertainty in X
-         float yErr;       // propagation uncertainty in Y
-         float dXdZ;       // dX/dZ of the track
-         float dYdZ;       // dY/dZ of the track
-         float dXdZErr;    // propagation uncertainty in dX/dZ
-         float dYdZErr;    // propagation uncertainty in dY/dZ
-         DetId id;         // chamber ID
+         float edgeX;       // distance to closest edge in X (negative - inside, positive - outside)
+         float edgeY;       // distance to closest edge in Y (negative - inside, positive - outside)
+         float x;           // X position of the track
+         float y;           // Y position of the track
+         float xErr;        // propagation uncertainty in X
+         float yErr;        // propagation uncertainty in Y
+         float dXdZ;        // dX/dZ of the track
+         float dYdZ;        // dY/dZ of the track
+         float dXdZErr;     // propagation uncertainty in dX/dZ
+         float dYdZErr;     // propagation uncertainty in dY/dZ
+         DetId id;          // chamber ID
+
+	 int nDigisInChamb; // # of DT/CSC digis in the chamber
+	 int nDigisInRange; // # of DT/CSC digis in the chamber close-by to the propagated track
 
          int detector() const { return id.subdetId(); }
          int station()  const;

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -385,21 +385,20 @@ int Muon::nDigisInStation( int station, int muonSubdetId ) const
 
 bool Muon::hasShowerInStation( int station, int muonSubdetId, int nDtDigisCut, int nCscDigisCut ) const
 {
-  bool hasShower = muonSubdetId == MuonSubdetId::DT ? 
-    nDigisInStation(station,muonSubdetId) >= nDtDigisCut :
-    nDigisInStation(station,muonSubdetId) >= nCscDigisCut;
+  if (muonSubdetId != MuonSubdetId::DT || muonSubdetId != MuonSubdetId::CSC) return false;
+  auto nDigisCut = muonSubdetId == MuonSubdetId::DT ? nDtDigisCut : nCscDigisCut;
 
-  return hasShower;   
+  return nDigisInStation(station,muonSubdetId) >= nDigisCut ;   
 }
 
 int Muon::numberOfShowers( int nDtDigisCut, int nCscDigisCut ) const
 {
   int nShowers = 0;
-  for ( int iCh = 1; iCh < 5; ++iCh )
+  for ( int station = 1; station < 5; ++station )
     {
-      if ( hasShowerInStation(iCh,MuonSubdetId::DT,nDtDigisCut,nCscDigisCut) )
+      if ( hasShowerInStation(station,MuonSubdetId::DT,nDtDigisCut,nCscDigisCut) )
 	nShowers++;
-      if ( hasShowerInStation(iCh,MuonSubdetId::CSC,nDtDigisCut,nCscDigisCut) )
+      if ( hasShowerInStation(station,MuonSubdetId::CSC,nDtDigisCut,nCscDigisCut) )
 	nShowers++;
     }
 

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -334,7 +334,7 @@ unsigned int Muon::stationGapMaskPull( float sigmaCut ) const
    return totMask;
 }
 
-int Muon::nDigisInStation( int index, DigiRange range ) const
+int Muon::nDigisInStation( int index ) const
 {
   int nDigis(0);
   std::map<int, int> me11DigisPerCh;
@@ -345,7 +345,7 @@ int Muon::nDigisInStation( int index, DigiRange range ) const
 	   match.detector() != MuonSubdetId::DT  )
 	continue;
 	  
-      int nDigisInCh = range == InRange ? match.nDigisInRange : match.nDigisInChamb;
+      int nDigisInCh = match.nDigisInRange;
       int iStation = match.detector() == MuonSubdetId::CSC ? index - 3 : index + 1;
 
       if( match.detector() == MuonSubdetId::CSC && iStation == 1)
@@ -381,11 +381,11 @@ int Muon::nDigisInStation( int index, DigiRange range ) const
   return nDigis;
 }
 
-bool Muon::hasShowerInStation( int index, DigiRange range, int nDtDigisCut, int nCscDigisCut ) const
+bool Muon::hasShowerInStation( int index, int nDtDigisCut, int nCscDigisCut ) const
 {
   bool hasShower = index < 4 ? 
-			   nDigisInStation(index, range) >= nDtDigisCut :
-                           nDigisInStation(index, range) >= nCscDigisCut;
+			   nDigisInStation(index) >= nDtDigisCut :
+                           nDigisInStation(index) >= nCscDigisCut;
   return hasShower;   
 }
 

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -385,7 +385,7 @@ int Muon::nDigisInStation( int station, int muonSubdetId ) const
 
 bool Muon::hasShowerInStation( int station, int muonSubdetId, int nDtDigisCut, int nCscDigisCut ) const
 {
-  if (muonSubdetId != MuonSubdetId::DT || muonSubdetId != MuonSubdetId::CSC) return false;
+  if (muonSubdetId != MuonSubdetId::DT && muonSubdetId != MuonSubdetId::CSC) return false;
   auto nDigisCut = muonSubdetId == MuonSubdetId::DT ? nDtDigisCut : nCscDigisCut;
 
   return nDigisInStation(station,muonSubdetId) >= nDigisCut ;   

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -348,7 +348,7 @@ int Muon::nDigisInStation( int index ) const
       int nDigisInCh = match.nDigisInRange;
       int iStation = match.detector() == MuonSubdetId::CSC ? index - 3 : index + 1;
 
-      if( match.detector() == MuonSubdetId::CSC && iStation == 1)
+      if( match.detector() == MuonSubdetId::CSC && iStation == 1 )
 	{
 	  CSCDetId id(match.id.rawId());
 	  
@@ -358,7 +358,7 @@ int Muon::nDigisInStation( int index ) const
 	    
 	  if ( station == 1 && (ring == 1 || ring == 4) ) // merge ME1/1a and ME1/1b digis
 	    {
-	      if(me11DigisPerCh.find(chamber) == me11DigisPerCh.end())
+	      if( me11DigisPerCh.find(chamber) == me11DigisPerCh.end() )
 		me11DigisPerCh[chamber] = 0;
 	      
 	      me11DigisPerCh[chamber] += nDigisInCh;
@@ -367,11 +367,11 @@ int Muon::nDigisInStation( int index ) const
 	    }
 	}
 
-      if( iStation == match.station() && nDigisInCh > nDigis)
+      if( iStation == match.station() && nDigisInCh > nDigis )
 	nDigis = nDigisInCh;
     }
 
-  for (const auto & me11DigisInCh : me11DigisPerCh)
+  for ( const auto & me11DigisInCh : me11DigisPerCh )
     {  
       int nMe11DigisInCh = me11DigisInCh.second;
       if (nMe11DigisInCh > nDigis)
@@ -387,6 +387,18 @@ bool Muon::hasShowerInStation( int index, int nDtDigisCut, int nCscDigisCut ) co
 			   nDigisInStation(index) >= nDtDigisCut :
                            nDigisInStation(index) >= nCscDigisCut;
   return hasShower;   
+}
+
+int Muon::numberOfShowers( int nDtDigisCut, int nCscDigisCut ) const
+{
+  int nShowers = 0;
+  for ( int iCh = 0; iCh < 8; ++iCh )
+    {
+      if ( hasShowerInStation(iCh,nDtDigisCut,nCscDigisCut) )
+	nShowers++;
+    }
+
+  return nShowers;
 }
 
 int Muon::numberOfSegments( int station, int muonSubdetId, ArbitrationType type ) const

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -334,6 +334,35 @@ unsigned int Muon::stationGapMaskPull( float sigmaCut ) const
    return totMask;
 }
 
+int Muon::nDigisInStation( int index, DigiRange range ) const
+{
+
+  int nDigis(0);
+
+  for ( auto & match : muMatches_ )
+    {
+      if ( match.detector() != MuonSubdetId::CSC  &&
+	   match.detector() != MuonSubdetId::DT  )
+	continue;
+	  
+      int nDigisInCh = range == InRange ? match.nDigisInRange : match.nDigisInChamb;
+      int iStation = match.detector() == MuonSubdetId::CSC ? index - 3 : index + 1;
+
+      if( iStation == match.station() && nDigisInCh > nDigis)
+	nDigis = nDigisInCh;
+    }
+
+  return nDigis;
+}
+
+bool Muon::hasShowerInStation( int index, DigiRange range, int nDtDigisCut, int nCscDigisCut ) const
+{
+  bool hasShower = index < 4 ? 
+			   nDigisInStation(index, range) >= nDtDigisCut :
+                           nDigisInStation(index, range) >= nCscDigisCut;
+  return hasShower;   
+}
+
 int Muon::numberOfSegments( int station, int muonSubdetId, ArbitrationType type ) const
 {
    int segments(0);

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -57,7 +57,8 @@ initial version number of a class which has never been stored before.
   <class name="reco::HcalMuonRecHit" ClassVersion="3">
    <version ClassVersion="3" checksum="2031556424"/>
   </class>
-  <class name="reco::MuonChamberMatch" ClassVersion="12">
+  <class name="reco::MuonChamberMatch" ClassVersion="13">
+   <version ClassVersion="13" checksum="1228394"/>
    <version ClassVersion="12" checksum="2575855272"/>
    <version ClassVersion="11" checksum="541727491"/>
    <version ClassVersion="10" checksum="4050071853"/>

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -58,7 +58,7 @@ initial version number of a class which has never been stored before.
    <version ClassVersion="3" checksum="2031556424"/>
   </class>
   <class name="reco::MuonChamberMatch" ClassVersion="13">
-   <version ClassVersion="13" checksum="1228394"/>
+   <version ClassVersion="13" checksum="2674954213"/>
    <version ClassVersion="12" checksum="2575855272"/>
    <version ClassVersion="11" checksum="541727491"/>
    <version ClassVersion="10" checksum="4050071853"/>

--- a/RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h
@@ -1,0 +1,75 @@
+#ifndef MuonIdentification_MuonShowerDigiFiller_h
+#define MuonIdentification_MuonShowerDigiFiller_h
+
+// -*- C++ -*-
+//
+// Package:    MuonShowerDigiFiller
+// Class:      MuonShowerDigiFiller
+// 
+/**\class MuonShowerDigiFiller MuonShowerDigiFiller.h RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h
+
+ Description: Class filling shower information using DT and CSC digis
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Carlo Battilana, INFN BO
+//         Created:  Sat Mar 23 14:36:22 CET 2019
+//
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "DataFormats/DTDigi/interface/DTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCStripDigiCollection.h"
+
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+
+#include "DataFormats/MuonReco/interface/MuonChamberMatch.h"
+#include "TrackingTools/TrackAssociator/interface/TAMuonChamberMatch.h"
+
+//
+// class decleration
+//
+
+class MuonShowerDigiFiller 
+{
+
+ public:
+
+  MuonShowerDigiFiller(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
+  ~MuonShowerDigiFiller();
+
+  void getES( const edm::EventSetup& iSetup );
+  void getDigis( edm::Event& iEvent );   
+
+  void fill( reco::MuonChamberMatch & muChMatch ) const;
+
+ private:
+  
+  double m_digiMaxDistanceX;
+
+  edm::EDGetTokenT<DTDigiCollection> m_dtDigisToken;
+  edm::EDGetTokenT<CSCStripDigiCollection> m_cscDigisToken;
+
+  edm::ESHandle<DTGeometry>  m_dtGeometry;
+  edm::ESHandle<CSCGeometry> m_cscGeometry;
+
+  edm::Handle<DTDigiCollection> m_dtDigis;
+  edm::Handle<CSCStripDigiCollection> m_cscDigis;
+
+};
+
+#endif

--- a/RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h
@@ -50,12 +50,12 @@ class MuonShowerDigiFiller
  public:
 
   MuonShowerDigiFiller(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
-  ~MuonShowerDigiFiller();
 
   void getES( const edm::EventSetup& iSetup );
   void getDigis( edm::Event& iEvent );   
 
   void fill( reco::MuonChamberMatch & muChMatch ) const;
+  void fillDefault( reco::MuonChamberMatch & muChMatch ) const;
 
  private:
   

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -893,7 +893,6 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
        theShowerDigiFiller_->fill(matchedChamber);
      }
      else {
-       matchedChamber.nDigisInChamb = 0;
        matchedChamber.nDigisInRange = 0;
      }
 
@@ -979,7 +978,6 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
        matchedChamber.edgeX = chamber.localDistanceX;
        matchedChamber.edgeY = chamber.localDistanceY;
 
-       matchedChamber.nDigisInChamb = 0;
        matchedChamber.nDigisInRange = 0;
 
        matchedChamber.id = chamber.id;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -59,6 +59,7 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
    storeCrossedHcalRecHits_ = iConfig.getParameter<bool>("storeCrossedHcalRecHits");
    fillMatching_            = iConfig.getParameter<bool>("fillMatching");
    fillIsolation_           = iConfig.getParameter<bool>("fillIsolation");
+   fillShowerDigis_         = iConfig.getParameter<bool>("fillShowerDigis");
    writeIsoDeposits_        = iConfig.getParameter<bool>("writeIsoDeposits");
    fillGlobalTrackQuality_  = iConfig.getParameter<bool>("fillGlobalTrackQuality");
    fillGlobalTrackRefits_   = iConfig.getParameter<bool>("fillGlobalTrackRefits");
@@ -80,7 +81,13 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
    // Load parameters for the TimingFiller
    edm::ParameterSet timingParameters = iConfig.getParameter<edm::ParameterSet>("TimingFillerParameters");
    theTimingFiller_ = std::make_unique<MuonTimingFiller>(timingParameters,consumesCollector());
-   
+
+   // Load parameters for the ShowerDigiFiller
+   if (fillShowerDigis_ && fillMatching_)
+     {
+       edm::ParameterSet showerDigiParameters = iConfig.getParameter<edm::ParameterSet>("ShowerDigiFillerParameters");
+       theShowerDigiFiller_ = std::make_unique<MuonShowerDigiFiller>(showerDigiParameters,consumesCollector());
+     }
 
    if (fillCaloCompatibility_){
       // Load MuonCaloCompatibility parameters
@@ -426,6 +433,8 @@ void MuonIdProducer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
 
   meshAlgo_->setCSCGeometry(geomHandle.product());
 
+  if (fillShowerDigis_ && fillMatching_)
+    theShowerDigiFiller_->getES(iSetup);
 }
 
 bool validateGlobalMuonPair( const reco::MuonTrackLinks& goodMuon,
@@ -449,6 +458,9 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    auto caloMuons = std::make_unique<reco::CaloMuonCollection>();
 
    init(iEvent, iSetup);
+
+  if (fillShowerDigis_ && fillMatching_)
+      theShowerDigiFiller_->getDigis(iEvent);
 
    // loop over input collections
 
@@ -876,6 +888,15 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
      matchedChamber.edgeY = chamber.localDistanceY;
 
      matchedChamber.id = chamber.id;
+
+     if (fillShowerDigis_) {
+       theShowerDigiFiller_->fill(matchedChamber);
+     }
+     else {
+       matchedChamber.nDigisInChamb = 0;
+       matchedChamber.nDigisInRange = 0;
+     }
+
      if ( ! chamber.segments.empty() ) ++nubmerOfMatchesAccordingToTrackAssociator;
 
      // fill segments
@@ -957,6 +978,9 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
 
        matchedChamber.edgeX = chamber.localDistanceX;
        matchedChamber.edgeY = chamber.localDistanceY;
+
+       matchedChamber.nDigisInChamb = 0;
+       matchedChamber.nDigisInRange = 0;
 
        matchedChamber.id = chamber.id;
 
@@ -1324,6 +1348,7 @@ void MuonIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   
   desc.add<bool>("arbitrateTrackerMuons",false);
   desc.add<bool>("storeCrossedHcalRecHits",false);
+  desc.add<bool>("fillShowerDigis",false);
 
   edm::ParameterSetDescription descTrkAsoPar;
   descTrkAsoPar.add<edm::InputTag>("GEMSegmentCollectionLabel",edm::InputTag("gemSegments"));

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -893,7 +893,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
        theShowerDigiFiller_->fill(matchedChamber);
      }
      else {
-       matchedChamber.nDigisInRange = 0;
+       theShowerDigiFiller_->fillDefault(matchedChamber);
      }
 
      if ( ! chamber.segments.empty() ) ++nubmerOfMatchesAccordingToTrackAssociator;
@@ -978,7 +978,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
        matchedChamber.edgeX = chamber.localDistanceX;
        matchedChamber.edgeY = chamber.localDistanceY;
 
-       matchedChamber.nDigisInRange = 0;
+       theShowerDigiFiller_->fillDefault(matchedChamber);
 
        matchedChamber.id = chamber.id;
 

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -47,8 +47,9 @@
 #include "RecoMuon/MuonIdentification/interface/MuonTimingFiller.h"
 #include "RecoMuon/MuonIdentification/interface/MuonCaloCompatibility.h"
 #include "PhysicsTools/IsolationAlgos/interface/IsoDepositExtractor.h"
-// RPC-Muon stuffs
+#include "RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h"
 
+// RPC-Muon stuffs
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/MuonReco/interface/MuonRPCHitMatch.h"
@@ -177,6 +178,8 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
 
   std::unique_ptr<MuonTimingFiller> theTimingFiller_;
 
+  std::unique_ptr<MuonShowerDigiFiller> theShowerDigiFiller_;
+
    // selections
    double minPt_;
    double minP_;
@@ -196,6 +199,7 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    bool fillEnergy_;
    bool storeCrossedHcalRecHits_;
    bool fillMatching_;
+   bool fillShowerDigis_;
    bool fillIsolation_;
    bool writeIsoDeposits_;
    double ptThresholdToFillCandidateP4WithGlobalFit_;

--- a/RecoMuon/MuonIdentification/python/MuonShowerDigiFiller_cfi.py
+++ b/RecoMuon/MuonIdentification/python/MuonShowerDigiFiller_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+MuonShowerDigiFillerBlock = cms.PSet(
+  ShowerDigiFillerParameters = cms.PSet(
+      digiMaxDistanceX = cms.double(25.0),
+      dtDigiCollectionLabel  = cms.InputTag("muonDTDigis"),
+      cscDigiCollectionLabel = cms.InputTag("muonCSCDigis","MuonCSCStripDigi")
+  )
+)
+
+

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -4,6 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoMuon.MuonIdentification.isolation_cff import *
 from RecoMuon.MuonIdentification.caloCompatibility_cff import *
 from RecoMuon.MuonIdentification.MuonTimingFiller_cfi import *
+from RecoMuon.MuonIdentification.MuonShowerDigiFiller_cfi import *
 from RecoMuon.MuonIdentification.TrackerKinkFinder_cfi import *
 from TrackingTools.TrackAssociator.default_cfi import *
 muons1stStep = cms.EDProducer("MuonIdProducer",
@@ -15,6 +16,8 @@ muons1stStep = cms.EDProducer("MuonIdProducer",
     MIdIsoExtractorPSetBlock,
     # MuonTiming
     TimingFillerBlock,
+    # MuonShowerDigi
+    MuonShowerDigiFillerBlock,
     # Kink finder
     TrackerKinkFinderParametersBlock,
 
@@ -55,6 +58,7 @@ muons1stStep = cms.EDProducer("MuonIdProducer",
     writeIsoDeposits = cms.bool(True),
     minNumberOfMatches = cms.int32(1),
     fillMatching = cms.bool(True),
+    fillShowerDigis = cms.bool(True),
 
     # global fit for candidate p4 requirements
     ptThresholdToFillCandidateP4WithGlobalFit = cms.double(200.0),

--- a/RecoMuon/MuonIdentification/src/MuonShowerDigiFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonShowerDigiFiller.cc
@@ -1,0 +1,157 @@
+//
+// Package:    MuonShowerDigiFiller
+// Class:      MuonShowerDigiFiller
+// 
+/**\class MuonShowerDigiFiller MuonShowerDigiFiller.cc RecoMuon/MuonIdentification/src/MuonShowerDigiFiller.cc
+
+ Description: Class filling shower information using DT and CSC digis 
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Carlo Battilana, INFN BO 
+//         Created:  Sat Mar 23 14:36:22 CET 2019
+//
+//
+
+
+// system include files
+
+// user include files
+#include "RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h"
+
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+
+//
+// constructors and destructor
+//
+
+MuonShowerDigiFiller::MuonShowerDigiFiller(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) : 
+  m_digiMaxDistanceX(iConfig.getParameter<double>("digiMaxDistanceX"))
+
+{
+
+  edm::InputTag label = iConfig.getParameter<edm::InputTag>("dtDigiCollectionLabel");
+  m_dtDigisToken=iC.consumes<DTDigiCollection>(label);
+
+  label = iConfig.getParameter<edm::InputTag>("cscDigiCollectionLabel");
+  m_cscDigisToken=iC.consumes<CSCStripDigiCollection>(label);
+   
+}
+
+
+MuonShowerDigiFiller::~MuonShowerDigiFiller()
+{
+
+}
+
+
+//
+// member functions
+//
+
+void 
+MuonShowerDigiFiller::getES( const edm::EventSetup& iSetup )
+{
+
+  iSetup.get<MuonGeometryRecord>().get(m_dtGeometry);
+  iSetup.get<MuonGeometryRecord>().get(m_cscGeometry);
+
+}
+
+void 
+MuonShowerDigiFiller::getDigis( edm::Event& iEvent )
+{
+  
+  iEvent.getByToken(m_dtDigisToken,  m_dtDigis);
+  iEvent.getByToken(m_cscDigisToken, m_cscDigis);
+
+}
+
+void 
+MuonShowerDigiFiller::fill( reco::MuonChamberMatch & muChMatch ) const 
+{
+
+  int nDigisInChamb = 0;
+  int nDigisInRange = 0;
+
+  // DT chamber
+  if( muChMatch.detector() == MuonSubdetId::DT ) 
+    {
+      double xTrack = muChMatch.x;
+      
+      for (int sl = 1; sl < 4; sl += 2) 
+	{
+	  for (int layer = 1; layer < 5; ++layer) 
+	    {
+	      const DTLayerId layerId(DTChamberId(muChMatch.id.rawId()),sl,layer);
+	      
+	      auto range =  m_dtDigis->get(layerId);
+	      
+	      for (auto digiIt = range.first ;digiIt!=range.second; ++digiIt) 
+		{
+		  const auto topo = m_dtGeometry->layer(layerId)->specificTopology();
+		  
+		  double xWire = topo.wirePosition((*digiIt).wire());
+		  double dX = std::abs(xWire - xTrack);
+		  
+		  nDigisInChamb++;
+		  if (dX < m_digiMaxDistanceX)
+		    nDigisInRange++;
+		}
+	    }
+	}
+    }
+
+  else if(muChMatch.detector() == MuonSubdetId::CSC) 
+    {
+
+      double xTrack = muChMatch.x;
+      double yTrack = muChMatch.y;
+
+      for (int iLayer = 1; iLayer < 7; ++iLayer) 
+	{
+	  const CSCDetId chId(muChMatch.id.rawId());
+	  const CSCDetId layerId(chId.endcap(), chId.station(),
+				 chId.ring(),   chId.chamber(),
+				 iLayer);
+	  
+	  auto range =  m_cscDigis->get(layerId);
+	  
+	  for (auto digiIt = range.first ;digiIt!=range.second; ++digiIt) 
+	    {
+	    
+	      std::vector<int> adcVals = digiIt->getADCCounts();
+	      bool hasFired = false;
+	      float pedestal = 0.5*(float)(adcVals[0]+adcVals[1]);
+	      float threshold = 13.3 ;
+	      float diff = 0.;
+	      for (const auto & adcVal : adcVals) 
+		{
+		  diff = (float)adcVal - pedestal;
+		  if (diff > threshold) 
+		    { 
+		      hasFired = true; 
+		      break;
+		    }
+		} 
+
+	      if (!hasFired) continue;
+
+	      const CSCLayerGeometry* layerGeom = m_cscGeometry->layer(layerId)->geometry();      
+	      
+	      Float_t xStrip = layerGeom->xOfStrip(digiIt->getStrip(), yTrack);
+	      float dX = std::abs(xStrip - xTrack);
+	      
+	      nDigisInChamb++;
+	      if (dX < m_digiMaxDistanceX)
+		nDigisInRange++;
+	    }
+	}
+    }
+
+  muChMatch.nDigisInChamb = nDigisInChamb;
+  muChMatch.nDigisInRange = nDigisInRange;
+  
+}

--- a/RecoMuon/MuonIdentification/src/MuonShowerDigiFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonShowerDigiFiller.cc
@@ -73,7 +73,6 @@ void
 MuonShowerDigiFiller::fill( reco::MuonChamberMatch & muChMatch ) const 
 {
 
-  int nDigisInChamb = 0;
   int nDigisInRange = 0;
 
   // DT chamber
@@ -96,7 +95,6 @@ MuonShowerDigiFiller::fill( reco::MuonChamberMatch & muChMatch ) const
 		  double xWire = topo.wirePosition((*digiIt).wire());
 		  double dX = std::abs(xWire - xTrack);
 		  
-		  nDigisInChamb++;
 		  if (dX < m_digiMaxDistanceX)
 		    nDigisInRange++;
 		}
@@ -144,14 +142,12 @@ MuonShowerDigiFiller::fill( reco::MuonChamberMatch & muChMatch ) const
 	      Float_t xStrip = layerGeom->xOfStrip(digiIt->getStrip(), yTrack);
 	      float dX = std::abs(xStrip - xTrack);
 	      
-	      nDigisInChamb++;
 	      if (dX < m_digiMaxDistanceX)
 		nDigisInRange++;
 	    }
 	}
     }
 
-  muChMatch.nDigisInChamb = nDigisInChamb;
   muChMatch.nDigisInRange = nDigisInRange;
   
 }

--- a/RecoMuon/MuonIdentification/src/MuonShowerDigiFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonShowerDigiFiller.cc
@@ -28,22 +28,11 @@
 //
 
 MuonShowerDigiFiller::MuonShowerDigiFiller(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) : 
-  m_digiMaxDistanceX(iConfig.getParameter<double>("digiMaxDistanceX"))
-
+  m_digiMaxDistanceX(iConfig.getParameter<double>("digiMaxDistanceX")),
+  m_dtDigisToken(iC.consumes<DTDigiCollection>(iConfig.getParameter<edm::InputTag>("dtDigiCollectionLabel"))),
+  m_cscDigisToken(iC.consumes<CSCStripDigiCollection>(iConfig.getParameter<edm::InputTag>("cscDigiCollectionLabel")))
 {
-
-  edm::InputTag label = iConfig.getParameter<edm::InputTag>("dtDigiCollectionLabel");
-  m_dtDigisToken=iC.consumes<DTDigiCollection>(label);
-
-  label = iConfig.getParameter<edm::InputTag>("cscDigiCollectionLabel");
-  m_cscDigisToken=iC.consumes<CSCStripDigiCollection>(label);
    
-}
-
-
-MuonShowerDigiFiller::~MuonShowerDigiFiller()
-{
-
 }
 
 
@@ -80,9 +69,9 @@ MuonShowerDigiFiller::fill( reco::MuonChamberMatch & muChMatch ) const
     {
       double xTrack = muChMatch.x;
       
-      for (int sl = 1; sl < 4; sl += 2) 
+      for (int sl = 1; sl <= DTChamberId::maxSuperLayerId; sl += 2) 
 	{
-	  for (int layer = 1; layer < 5; ++layer) 
+	  for (int layer = 1; layer <= DTChamberId::maxLayerId; ++layer) 
 	    {
 	      const DTLayerId layerId(DTChamberId(muChMatch.id.rawId()),sl,layer);
 	      
@@ -108,7 +97,7 @@ MuonShowerDigiFiller::fill( reco::MuonChamberMatch & muChMatch ) const
       double xTrack = muChMatch.x;
       double yTrack = muChMatch.y;
 
-      for (int iLayer = 1; iLayer < 7; ++iLayer) 
+      for (int iLayer = 1; iLayer <= CSCDetId::maxLayerId(); ++iLayer) 
 	{
 	  const CSCDetId chId(muChMatch.id.rawId());
 	  const CSCDetId layerId(chId.endcap(), chId.station(),
@@ -150,4 +139,12 @@ MuonShowerDigiFiller::fill( reco::MuonChamberMatch & muChMatch ) const
 
   muChMatch.nDigisInRange = nDigisInRange;
   
+}
+
+void 
+MuonShowerDigiFiller::fillDefault( reco::MuonChamberMatch & muChMatch ) const 
+{
+
+  muChMatch.nDigisInRange = 0;
+
 }

--- a/TauAnalysis/MCEmbeddingTools/python/customisers.py
+++ b/TauAnalysis/MCEmbeddingTools/python/customisers.py
@@ -367,6 +367,8 @@ def customiseMerging(process, changeProcessname=True,reselect=False):
     process.muons.FillShoweringInfo = cms.bool(False)
     process.muons.FillCosmicsIdMap = cms.bool(False)
 
+    process.muonsFromCosmics.fillShowerDigis = cms.bool(False)
+    process.muonsFromCosmics1Leg.fillShowerDigis = cms.bool(False)
 
     process.merge_step += process.highlevelreco
 


### PR DESCRIPTION
#### PR description:

This PR adds to the muon object a variable that counts the number of digis per station that are collected in the vicinity of an extrapolated track. Based on this variable, member functions are added to `reco::Muon` to tag showers based on digi information similarly to what is done , for example, [in this study](https://indico.cern.ch/event/804955/#2-follow-up-shower-tagging-met). 

Besides the addition of one more variable to `MuonChamberMatch` (which propagates up to miniAOD), no change to `reco::Muon` objects expected.
 
#### PR validation:

The consistency of the `reco::Muon::nDigisInStation` method with the digi counting made a posteriori in ntuples (used for studies like the ones linked above) has been tested on 1K events of a flat pT muon gun and is available [here](https://battilan.web.cern.ch/battilan/HighPt/PullRequest/hit_count/), in such sample. No discrepancy between the two sources of information was found. 

Event dumps were used to test that `reco::Muon::hasShowerInStation` and `reco::Muon::numberOfShowers` behave as expected.

The increase in event size, for slimmedMuons in miniAOD and for the workflow 136.891, was checked to be less than 1%.
