### PR TITLE
Avoid conflict between HE and HGC in phase2 geometry when running an aged scenario

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -232,23 +232,27 @@ def customise_aging_300(process):
 
 def customise_aging_1000(process):
     process=ageHcal(process,1000,5.0e34,"nominal")
+    process=turn_off_HE_aging(process) #avoid conflict between HGCal and Hcal in phase2 geom configuration
     process=ageEcal(process,1000,5.0e34)
     return process
 
 def customise_aging_3000(process):
     process=ageHcal(process,3000,5.0e34,"nominal")
+    process=turn_off_HE_aging(process) #avoid conflict between HGCal and Hcal in phase2 geom configuration
     process=ageEcal(process,3000,5.0e34)
     process=agedHGCal(process)
     return process
 
 def customise_aging_3000_ultimate(process):
     process=ageHcal(process,3000,7.5e34,"ultimate")
+    process=turn_off_HE_aging(process) #avoid conflict between HGCal and Hcal in phase2 geom configuration
     process=ageEcal(process,3000,7.5e34)
     process=agedHGCal(process)
     return process
 
 def customise_aging_4500_ultimate(process):
     process=ageHcal(process,4500,7.5e34,"ultimate")
+    process=turn_off_HE_aging(process) #avoid conflict between HGCal and Hcal in phase2 geom configuration
     process=ageEcal(process,4500,7.5e34)
     process=agedHGCal(process)
     return process


### PR DESCRIPTION
this change cures a memory issue occurring when running a custom aging scenario. the issue arises at
`https://github.com/cms-sw/cmssw/blob/master/CalibCalorimetry/HcalAlgos/src/HBHERecalibration.cc#L53` where the HGC geometry interferes with the HE one.
the solution is to disable the aging for HE for the phase2 scenarios.

once integrated, the aging customizations run properly.
this PR isn't supposed to affect any prod workflow.

