### PR TITLE
Avoid null reference in getTrackFromChargedHadron

### DIFF
--- a/RecoTauTag/RecoTau/src/pfRecoTauChargedHadronAuxFunctions.cc
+++ b/RecoTauTag/RecoTau/src/pfRecoTauChargedHadronAuxFunctions.cc
@@ -14,11 +14,11 @@ const reco::Track* getTrackFromChargedHadron(const reco::PFRecoTauChargedHadron&
     return chargedHadron.getTrack().get();
   }
   // In MiniAOD, even isolated tracks are saved as candidates, so the track Ptr doesn't exist
-  const pat::PackedCandidate* chargedPFPCand = dynamic_cast<const pat::PackedCandidate*> (&*chargedHadron.getChargedPFCandidate());
+  const pat::PackedCandidate* chargedPFPCand = dynamic_cast<const pat::PackedCandidate*> (chargedHadron.getChargedPFCandidate().get());
   if (chargedPFPCand != nullptr) {
     return chargedPFPCand->bestTrack();
   }
-  const pat::PackedCandidate* lostTrackCand = dynamic_cast<const pat::PackedCandidate*> (&*chargedHadron.getLostTrackCandidate());
+  const pat::PackedCandidate* lostTrackCand = dynamic_cast<const pat::PackedCandidate*> (chargedHadron.getLostTrackCandidate().get());
   if (lostTrackCand != nullptr) {
     return lostTrackCand->bestTrack();
   }


### PR DESCRIPTION

#### PR description:

Calling operator* on a edm:Ref can cause it to return a reference to a nullptr. This is not allowed in C++ which allows the compiler to remove checks. This lead to crashes when clang optimized the
code. Getting a pointer instead avoids the problem.

#### PR validation:

Ran workflow 4.23 which was crashing under CMSSW_10_6_CLANG_X_2019-04-07-0000 but now
runs fine with this change.