### PR TITLE
New slopes for S9S1filter

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -1,5 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
+# Slopes for the S9S1 filter
+_slopes_S9S1_run1 = [-99999,0.0164905,0.0238698,0.0321383,
+                     0.041296,0.0513428,0.0622789,0.0741041,
+                     0.0868186,0.100422,0.135313,0.136289,0.0589927]
+
+_coeffs = [1.0, 2.5, 2.2, 2.0, 1.8, 1.6, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+
+_slopes_S9S1_run2 = [s*c for s, c in zip(_slopes_S9S1_run1, _coeffs)]
+
+
 hfreco = cms.EDProducer("HFPhase1Reconstructor",
     # Label for the input HFPreRecHitCollection
     inputLabel = cms.InputTag("hfprereco"),
@@ -88,10 +98,7 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
     #
     S9S1stat = cms.PSet(
         # WARNING!  ONLY LONG PARAMETERS ARE USED IN DEFAULT RECO; SHORT S9S1 IS NOT USED!
-        short_optimumSlope   = cms.vdouble([-99999,0.0164905,0.0238698,0.0321383,
-                                            0.041296,0.0513428,0.0622789,0.0741041,
-                                            0.0868186,0.100422,0.135313,0.136289,
-                                            0.0589927]),
+        short_optimumSlope   = cms.vdouble(_slopes_S9S1_run2),
 
         # Short energy cut is 129.9 - 6.61*|ieta|+0.1153*|ieta|^2
         shortEnergyParams    = cms.vdouble([35.1773, 35.37, 35.7933, 36.4472,
@@ -102,10 +109,7 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
                                             0,0,0,0,
                                             0,0,0,0,0]),
 
-        long_optimumSlope    = cms.vdouble([-99999,0.0164905,0.0238698,0.0321383,
-                                            0.041296,0.0513428,0.0622789,0.0741041,
-                                            0.0868186,0.100422,0.135313,0.136289,
-                                            0.0589927]),
+        long_optimumSlope    = cms.vdouble(_slopes_S9S1_run2),
 
         # Long energy cut is 162.4-10.9*abs(ieta)+0.21*ieta*ieta
         longEnergyParams     = cms.vdouble([43.5, 45.7, 48.32, 51.36,


### PR DESCRIPTION
#### PR description:
This PR is devoted to the definition of new slopes for the limit lines in the planes 'S9S1 vs log(ELong)' for HF S9S1 filter. The slopes are different for the different HF Ieta values.
All parameters of S9S1(S8S1) filter were defined in ~2010 with lower energy of colliding beams and lower luminosity. It is the isolation filter and with much higher luminosity we have now the isolation
parameters could be different. See report in ref. 1 from slide 29.
On slide 30 presented distributions S9S1 vs log(ELong) for different Ieta. There are 2 inclined lines in each plot for Ieta 30 - 34. The lower lines correspond to the current slope parameters, the upper
lines correspond to the proposed new parameters.
The goal of this work is to reduce populations of hits above the old slope lines. These hits could be responsible for fake jets originated in HF.
On slides 34 and 35 presented the examples of HF hits which could be marked by S9S1 filter if slopes would be increased. In the lower lines in the captions to the pictures you can see S9S1 as the value calculated by filter, S9S1cut is the limit defined with old slopes, S9S1max is the new limit defined with changed slopes.   

References:
1. https://indico.cern.ch/event/807827/contributions/3362430/attachments/1816769/2969579/HFStripFilter_22Mar2019.pdf

#### PR validation:
In this PR only python file HFPhase1Reconstructor_cfi.py was modified. S9S1 slopes were multiplied by vector of constants to increase their values. These modifications are for Run 2 data. This file is for Run 2 reconstruction and this PR cannot affect data of Run 1.

The performance of reconstruction with the new slopes was tested. On the Screenshot of EventDisplay (FireWorks) below presented HF hit (signal in Long fiber) which was not marked by S9S1 filter. For these pictures threshold = 40 GeV was applied.

<img width="1201" alt="image" src="https://user-images.githubusercontent.com/7665869/55708684-cd1b9d80-59e6-11e9-821f-992fa131fd4b.png">

On the picture below presented the same hit marked by S9S1 filter after slopes were increased. In the column 'flags' uppermost hit has flag value 1048577. It means it has bit0 = 1 which corresponds to the S9S1 filter decision. 

<img width="1199" alt="image" src="https://user-images.githubusercontent.com/7665869/55708847-3bf8f680-59e7-11e9-9f59-c4ba65ac6d44.png">
