### PR TITLE
DD4hep: add an algorithm needed to build MTD geometry

### DIFF
--- a/DetectorDescription/DDCMS/data/cms-mf-geometry.xml
+++ b/DetectorDescription/DDCMS/data/cms-mf-geometry.xml
@@ -31,7 +31,7 @@
   
   <PosPartSection label="">
     <PosPart copyNumber="2">
-      <rParent name="world_volume"/>
+      <rParent name=":world_volume"/>
       <rChild name="cms:MCMS"/>
     </PosPart>
   </PosPartSection>

--- a/DetectorDescription/DDCMS/data/cms-test-shapes.xml
+++ b/DetectorDescription/DDCMS/data/cms-test-shapes.xml
@@ -44,7 +44,7 @@
   
   <PosPartSection label="">
     <PosPart copyNumber="2">
-      <rParent name="world_volume"/>
+      <rParent name=":world_volume"/>
       <rChild name="testLogicalParts:MotherOfAllBoxes"/>
     </PosPart>
   </PosPartSection>

--- a/DetectorDescription/DDCMS/data/cms-tracker.xml
+++ b/DetectorDescription/DDCMS/data/cms-tracker.xml
@@ -259,7 +259,7 @@
 
   <PosPartSection label="">
     <PosPart copyNumber="2">
-	<rParent name="world_volume"/>
+	<rParent name=":world_volume"/>
 	<rChild name="tracker:Tracker"/>
    </PosPart>
   </PosPartSection>

--- a/DetectorDescription/DDCMS/data/cms_tracker.xml
+++ b/DetectorDescription/DDCMS/data/cms_tracker.xml
@@ -267,7 +267,7 @@
 
   <PosPartSection label="">
     <PosPart copyNumber="2">
-	<rParent name="world_volume"/>
+	<rParent name=":world_volume"/>
 	<rChild name="tracker:Tracker"/>
    </PosPart>
   </PosPartSection>

--- a/DetectorDescription/DDCMS/data/testDDAngularAlgorithm.xml
+++ b/DetectorDescription/DDCMS/data/testDDAngularAlgorithm.xml
@@ -41,7 +41,7 @@
   </Algorithm>
   <PosPartSection label="">
     <PosPart copyNumber="2">
-      <rParent name="world_volume"/>
+      <rParent name=":world_volume"/>
       <rChild name="testDDAngularAlgorithm:MotherOfAllBoxes"/>
     </PosPart>
     <PosPart copyNumber="13">

--- a/DetectorDescription/DDCMS/data/testDDHGCalCellAlgorithm.xml
+++ b/DetectorDescription/DDCMS/data/testDDHGCalCellAlgorithm.xml
@@ -57,7 +57,7 @@
   </Algorithm>
   <PosPartSection label="">
     <PosPart copyNumber="2">
-      <rParent name="world_volume"/>
+      <rParent name=":world_volume"/>
       <rChild name="testDDHGCalCellAlgorithm:MotherOfAllBoxes"/>
     </PosPart>
     <PosPart copyNumber="1">

--- a/DetectorDescription/DDCMS/interface/DDAlgoArguments.h
+++ b/DetectorDescription/DDCMS/interface/DDAlgoArguments.h
@@ -14,6 +14,8 @@ namespace cms
 {
   using DD3Vector = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>>;
 
+  static constexpr long s_executed = 1l;
+  
   constexpr unsigned int hash( const char* str, int h = 0 )
   {
     return !str[h] ? 5381 : ( hash( str, h+1 )*33 ) ^ str[h];

--- a/DetectorDescription/DDCMS/plugins/DDCMSDetector.cc
+++ b/DetectorDescription/DDCMS/plugins/DDCMSDetector.cc
@@ -41,23 +41,27 @@ DDCMSDetector::analyze(const Event&, const EventSetup& iEventSetup)
   ESTransientHandle<DDDetector> det;
   iEventSetup.get<DetectorDescriptionRcd>().get(m_tag.module(), det);
 
-  LogInfo("DDCMS") << "Iterate over the detectors:\n";
-  for( auto const& it : det->description()->detectors()) {
-    dd4hep::DetElement det(it.second);
-    LogInfo("DDCMS") << it.first << ": " << det.path() << "\n";
-  }
-  LogInfo("DDCMS") << "..done!\n";
+  LogVerbatim("Geometry") << "Iterate over the detectors:\n";
+  LogVerbatim("Geometry").log([&](auto& log) {
+      for(auto const& it : det->description()->detectors()) {
+	dd4hep::DetElement det(it.second);
+	log << it.first << ": " << det.path();
+      }
+    });
+  LogVerbatim("Geometry") << "..done!";
   
   ESTransientHandle<DDVectorRegistry> registry;
   iEventSetup.get<DDVectorRegistryRcd>().get(m_tag.module(), registry);
 
-  LogInfo("DDCMS") << "DD Vector Registry size: " << registry->vectors.size() << "\n";
-  for( const auto& p: registry->vectors ) {
-    LogInfo("DDCMS") << " " << p.first << " => ";
-    for( const auto& i : p.second )
-      LogInfo("DDCMS") << i << ", ";
-    LogInfo("DDCMS") << '\n';
-  }
+  LogVerbatim("Geometry") << "DD Vector Registry size: " << registry->vectors.size();
+  LogVerbatim("Geometry").log([&](auto& log) {
+      for(const auto& p: registry->vectors) {
+	log << " " << p.first << " => ";
+	for(const auto& i : p.second)
+	  log << i << ", ";
+	log << '\n';
+      }
+    });
 }
 
 void

--- a/DetectorDescription/DDCMS/plugins/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDefinitions2Objects.cc
@@ -655,6 +655,9 @@ template <> void Converter<DDLPosPart>::operator()( xml_h element ) const {
   int         copy        = e.attr<int>( DD_CMU( copyNumber ));
   string      parentName  = ns.attr<string>( e.child( DD_CMU( rParent )), _U( name ));
   string      childName   = ns.attr<string>( e.child( DD_CMU( rChild )), _U( name ));
+
+  if( strchr( parentName.c_str(), NAMESPACE_SEP ) == nullptr )
+    parentName = ns.name() + parentName;
   Volume      parent      = ns.volume( parentName );
   
   if( strchr( childName.c_str(), NAMESPACE_SEP ) == nullptr )
@@ -1312,12 +1315,11 @@ template <> void Converter<DDRegistry>::operator()(xml_h /* element */) const {
   cms::DDParsingContext* context = _param<cms::DDParsingContext>();
   DDRegistry* res = _option<DDRegistry>();
   cms::DDNamespace ns( context );
-
+  int count = 0;
+  
   printout( context->debug_constants ? ALWAYS : DEBUG,
 	    "DD4CMS","+++ RESOLVING %ld unknown constants.....", res->unresolvedConst.size());
 
-  // FIXME: Avoid an infinite loop in a case
-  // when a referred constant is not defined
   while( !res->unresolvedConst.empty()) {
     for( auto i : res->unresolvedConst ) {
       const string& n = i.first;
@@ -1348,6 +1350,7 @@ template <> void Converter<DDRegistry>::operator()(xml_h /* element */) const {
         break;
       }
     }
+    if( ++count > 10000) break;
   }
   if( !res->unresolvedConst.empty()) {
     for(const auto& e : res->unresolvedConst)

--- a/DetectorDescription/DDCMS/plugins/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDefinitions2Objects.cc
@@ -1236,7 +1236,7 @@ template <> void Converter<DDLAlgorithm>::operator()(xml_h element) const {
 	   "DD4CMS","+++ Start executing algorithm %s....", type.c_str());
 
   long ret = PluginService::Create<long>(type, &description, ns.context(), &element, &sd);
-  if(ret == 1) {
+  if(ret == s_executed) {
     printout(ns.context()->debug_algorithms ? ALWAYS : DEBUG,
 	     "DD4CMS", "+++ Executed algorithm: %08lX = %s", ret, name.c_str());
     return;

--- a/DetectorDescription/DDCMS/plugins/DDPixBarLayerAlgo.cc
+++ b/DetectorDescription/DDCMS/plugins/DDPixBarLayerAlgo.cc
@@ -118,7 +118,7 @@ static long algorithm(Detector& description, cms::DDParsingContext& ctxt, xml_h 
 			    << "rotation: " << rots << "\t90., " 
 			    << convertRadToDeg( phix ) << ", 90.," << convertRadToDeg( phiy )
           << ", 0, 0";
-      rot = makeRotation3D(90_deg, phix, 90_deg, phiy, 0.,0.);
+      rot = makeRotation3D(90_deg, phix, 90_deg, phiy, 0., 0.);
 
       //cpv.position(ladderHalf, layer, copy, tran, rot);
       pv = layer.placeVolume(ladderHalfVol, copy, Transform3D(rot,tran));

--- a/DetectorDescription/DDCMS/src/DDNamespace.cc
+++ b/DetectorDescription/DDCMS/src/DDNamespace.cc
@@ -192,15 +192,12 @@ DDNamespace::addVolume( dd4hep::Volume vol ) const
 dd4hep::Volume
 DDNamespace::volume( const string& name, bool exc ) const
 {
-  size_t idx;
   auto i = m_context->volumes.find( name );
   if( i != m_context->volumes.end()) {
     return (*i).second;
   }
-  if(( idx = name.find( NAMESPACE_SEP )) != string::npos )  {
-    string n = name;
-    n[idx] = NAMESPACE_SEP;
-    i = m_context->volumes.find( n );
+  if(name.front() == NAMESPACE_SEP) {
+    i = m_context->volumes.find(name.substr(1,name.size()));
     if( i != m_context->volumes.end())
       return (*i).second;
   }

--- a/Geometry/EcalAlgo/test/python/testEcalGeometry.py
+++ b/Geometry/EcalAlgo/test/python/testEcalGeometry.py
@@ -1,0 +1,58 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("EcalGeometryTest")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.MessageLogger = cms.Service(
+    "MessageLogger",
+    statistics = cms.untracked.vstring('cout', 'ecalGeometry'),
+    categories = cms.untracked.vstring('Geometry'),
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING'),
+        noLineBreaks = cms.untracked.bool(True)
+        ),
+    ecalGeometry = cms.untracked.PSet(
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        noLineBreaks = cms.untracked.bool(True),
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        WARNING = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        ERROR = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        threshold = cms.untracked.string('INFO'),
+        Geometry = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            )
+        ),
+    destinations = cms.untracked.vstring('cout',
+                                         'ecalGeometry')
+    )
+
+process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('Geometry/EcalCommonData/data/dd4hep/cms-ecal-geometry.xml'),
+                                            appendToDataLabel = cms.string('Ecal')
+                                            )
+
+process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
+                                                     appendToDataLabel = cms.string('Ecal')
+                                                     )
+
+process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
+                                                    appendToDataLabel = cms.string('Ecal')
+                                                    )
+
+process.test = cms.EDAnalyzer("DDCMSDetector",
+                              DDDetector = cms.ESInputTag('Ecal')
+                              )
+
+process.p = cms.Path(process.test)

--- a/Geometry/EcalCommonData/data/dd4hep/cms-ecal-geometry.xml
+++ b/Geometry/EcalCommonData/data/dd4hep/cms-ecal-geometry.xml
@@ -36,7 +36,6 @@
     <Include ref='Geometry/CMSCommonData/data/cms/2023/v2/cms.xml'/>
     <Include ref='Geometry/CMSCommonData/data/eta3/etaMax.xml'/>
     <Include ref='Geometry/CMSCommonData/data/cmsMother.xml'/>
-    <Include ref='Geometry/CMSCommonData/data/cmsTracker.xml'/>
     <Include ref='Geometry/CMSCommonData/data/caloBase/2023/v1/caloBase.xml'/>
     <Include ref='Geometry/CMSCommonData/data/cmsCalo.xml'/>
     <Include ref='Geometry/CMSCommonData/data/muonBase/2023/v2/muonBase.xml'/>

--- a/Geometry/EcalCommonData/data/dd4hep/cms-ecal-geometry.xml
+++ b/Geometry/EcalCommonData/data/dd4hep/cms-ecal-geometry.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  <debug>
+    <debug_shapes/>
+    <debug_includes/>
+    <debug_rotations/>
+    <debug_includes/>
+    <debug_volumes/>
+    <debug_constants/>
+    <debug_materials/>
+    <debug_namespaces/>
+    <debug_placements/>
+    <debug_algorithms/>
+    <debug_materials/>
+    <debug_visattr/>
+    <debug_specpars/>
+  </debug>
+  
+  <open_geometry/>
+  <close_geometry/>
+
+  <ConstantsSection label="" eval="true">
+    <Constant name="world_x" value="100*m"/>
+    <Constant name="world_y" value="100*m"/>
+    <Constant name="world_z" value="100*m"/>
+    <Constant name="fm"      value="1e-12*m"/>
+    <Constant name="mum"     value="1.e-3*mm"/>
+    <Constant name="Air"     value="materials:Air"     type="string"/>
+    <Constant name="Vacuum"  value="materials:Vacuum"  type="string"/>
+  </ConstantsSection>
+
+  <IncludeSection>
+    <Include ref='Geometry/CMSCommonData/data/materials.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/rotations.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/extend/v2/cmsextent.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cms/2023/v2/cms.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/eta3/etaMax.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsMother.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsTracker.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/caloBase/2023/v1/caloBase.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsCalo.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/muonBase/2023/v2/muonBase.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsMuon.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/mgnt.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/beampipe/2023/v1/beampipe.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsBeam/2023/v1/cmsBeam.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/muonMB.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/muonMagnet.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cavern/2017/v2/cavern.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cavernData/2017/v1/cavernData.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cavernFloor/2017/v1/cavernFloor.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/caloBase/2023/v2/caloBase.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/ectkcable.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/PhaseII/eregalgo.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/ebalgo.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/ebcon.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/ebrot.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/eecon.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/PhaseII/escon.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/PhaseII/esalgo.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/trackermaterial.xml'/>
+  </IncludeSection>
+  
+  <PosPartSection label="">
+    <PosPart copyNumber="1">
+      <rParent name=":world_volume"/>
+      <rChild name="cms:OCMS"/>
+    </PosPart>
+  </PosPartSection>
+</DDDefinition>

--- a/Geometry/MTDCommonData/data/dd4hep/cms-mtd-geometry.xml
+++ b/Geometry/MTDCommonData/data/dd4hep/cms-mtd-geometry.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <DDDefinition>
   <debug>
-    <!--debug_shapes/>
+    <debug_shapes/>
     <debug_includes/>
     <debug_rotations/>
     <debug_includes/>
@@ -13,7 +13,7 @@
     <debug_algorithms/>
     <debug_materials/>
     <debug_visattr/>
-    <debug_specpars/-->
+    <debug_specpars/>
   </debug>
   
   <open_geometry/>
@@ -32,33 +32,32 @@
   <IncludeSection>
     <Include ref='Geometry/CMSCommonData/data/materials.xml'/>
     <Include ref='Geometry/CMSCommonData/data/rotations.xml'/>
-    <Include ref='Geometry/CMSCommonData/data/extend/cmsextent.xml'/>
-    <Include ref='Geometry/CMSCommonData/data/cms.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/extend/v2/cmsextent.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cms/2023/v2/cms.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/eta3/etaMax.xml'/>
     <Include ref='Geometry/CMSCommonData/data/cmsMother.xml'/>
     <Include ref='Geometry/CMSCommonData/data/cmsTracker.xml'/>
-    <Include ref='Geometry/CMSCommonData/data/caloBase.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/caloBase/2023/v1/caloBase.xml'/>
     <Include ref='Geometry/CMSCommonData/data/cmsCalo.xml'/>
-    <Include ref='Geometry/CMSCommonData/data/muonBase.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/muonBase/2023/v2/muonBase.xml'/>
     <Include ref='Geometry/CMSCommonData/data/cmsMuon.xml'/>
     <Include ref='Geometry/CMSCommonData/data/mgnt.xml'/>
-    <Include ref='Geometry/CMSCommonData/data/beampipe/2015/v1/beampipe.xml'/>
-    <Include ref='Geometry/CMSCommonData/data/cmsBeam.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/beampipe/2023/v1/beampipe.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsBeam/2023/v1/cmsBeam.xml'/>
     <Include ref='Geometry/CMSCommonData/data/muonMB.xml'/>
     <Include ref='Geometry/CMSCommonData/data/muonMagnet.xml'/>
-    <Include ref='Geometry/CMSCommonData/data/cavern.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/mbCommon/2015/v2/mbCommon.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/mb1/2015/v2/mb1.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/mb2/2015/v2/mb2.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/mb3/2015/v2/mb3.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/mb4/2015/v2/mb4.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/design/muonYoke.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/mf/2015/v1/mf.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/rpcf/2015/v1/rpcf.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/csc/2015/v2/csc.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/mfshield/2015/v1/mfshield.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/muonNumbering/2015/v2/muonNumbering.xml'/>
-    <Include ref='Geometry/DTGeometryBuilder/data/dtSpecsFilter/2019/v1/dtSpecsFilter.xml'/>
-    <Include ref='DetectorDescription/DDCMS/data/trackerParameters.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cavern/2017/v2/cavern.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cavernData/2017/v1/cavernData.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cavernFloor/2017/v1/cavernFloor.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/caloBase/2023/v2/caloBase.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseII/TiltedTracker613/pixfwd.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseII/TiltedTracker613/tracker.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseII/TiltedTracker404/pixbar.xml'/>
+    <Include ref='Geometry/MTDCommonData/data/btl.xml'/>
+    <Include ref='Geometry/MTDCommonData/data/etl/v2/etl.xml'/>
+    <Include ref='Geometry/MTDCommonData/data/CrystalBarPhiFlat/v2/mtd.xml'/>
+    <Include ref='Geometry/MTDCommonData/data/CrystalBarPhiFlat/mtdStructureTopology.xml'/>
+    <Include ref='Geometry/MTDCommonData/data/CrystalBarPhiFlat/mtdParameters.xml'/>
   </IncludeSection>
   
   <PosPartSection label="">

--- a/Geometry/MTDGeometryBuilder/test/python/testMTDGeometry.py
+++ b/Geometry/MTDGeometryBuilder/test/python/testMTDGeometry.py
@@ -1,0 +1,58 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MTDGeometryTest")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.MessageLogger = cms.Service(
+    "MessageLogger",
+    statistics = cms.untracked.vstring('cout', 'mtdGeometry'),
+    categories = cms.untracked.vstring('Geometry'),
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING'),
+        noLineBreaks = cms.untracked.bool(True)
+        ),
+    mtdGeometry = cms.untracked.PSet(
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        noLineBreaks = cms.untracked.bool(True),
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        WARNING = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        ERROR = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        threshold = cms.untracked.string('INFO'),
+        Geometry = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            )
+        ),
+    destinations = cms.untracked.vstring('cout',
+                                         'mtdGeometry')
+    )
+
+process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('Geometry/MTDCommonData/data/dd4hep/cms-mtd-geometry.xml'),
+                                            appendToDataLabel = cms.string('MTD')
+                                            )
+
+process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
+                                                     appendToDataLabel = cms.string('MTD')
+                                                     )
+
+process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
+                                                    appendToDataLabel = cms.string('MTD')
+                                                    )
+
+process.test = cms.EDAnalyzer("DDCMSDetector",
+                              DDDetector = cms.ESInputTag('MTD')
+                              )
+
+process.p = cms.Path(process.test)

--- a/Geometry/MTDGeometryBuilder/test/python/testMTDGeometry.py
+++ b/Geometry/MTDGeometryBuilder/test/python/testMTDGeometry.py
@@ -55,4 +55,8 @@ process.test = cms.EDAnalyzer("DDCMSDetector",
                               DDDetector = cms.ESInputTag('MTD')
                               )
 
-process.p = cms.Path(process.test)
+process.dump = cms.EDAnalyzer("DDTestDumpFile",
+                              DDDetector = cms.ESInputTag('MTD')
+)
+
+process.p = cms.Path(process.test+process.dump)

--- a/Geometry/TrackerCommonData/data/dd4hep/cms-tracker-geometry.xml
+++ b/Geometry/TrackerCommonData/data/dd4hep/cms-tracker-geometry.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  <debug>
+    <debug_shapes/>
+    <debug_includes/>
+    <debug_rotations/>
+    <debug_includes/>
+    <debug_volumes/>
+    <debug_constants/>
+    <debug_materials/>
+    <debug_namespaces/>
+    <debug_placements/>
+    <debug_algorithms/>
+    <debug_materials/>
+    <debug_visattr/>
+    <debug_specpars/>
+  </debug>
+  
+  <open_geometry/>
+  <close_geometry/>
+
+  <ConstantsSection label="" eval="true">
+    <Constant name="world_x" value="100*m"/>
+    <Constant name="world_y" value="100*m"/>
+    <Constant name="world_z" value="100*m"/>
+    <Constant name="fm"      value="1e-12*m"/>
+    <Constant name="mum"     value="1.e-3*mm"/>
+    <Constant name="Air"     value="materials:Air"     type="string"/>
+    <Constant name="Vacuum"  value="materials:Vacuum"  type="string"/>
+  </ConstantsSection>
+
+  <IncludeSection>
+    <Include ref='Geometry/CMSCommonData/data/materials.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/rotations.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/extend/v2/cmsextent.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cms/2023/v2/cms.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/eta3/etaMax.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsMother.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/caloBase/2023/v1/caloBase.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsCalo.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/muonBase/2023/v2/muonBase.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsMuon.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/mgnt.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/beampipe/2023/v1/beampipe.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsBeam/2023/v1/cmsBeam.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/muonMB.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/muonMagnet.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cavern/2017/v2/cavern.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cavernData/2017/v1/cavernData.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cavernFloor/2017/v1/cavernFloor.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/caloBase/2023/v2/caloBase.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseII/trackerParameters.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/pixfwdCommon.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseII/TiltedTracker613/pixfwd.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseII/TiltedTracker404/pixbar.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/trackermaterial.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseII/TiltedTracker404/otst.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseII/TiltedTracker613/tracker.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseII/TiltedTracker613/pixel.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseII/TiltedTracker404/trackerbar.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseII/TiltedTracker404/trackerfwd.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseII/TiltedTracker404/trackerStructureTopology.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseII/TiltedTracker613/pixelStructureTopology.xml'/>
+  </IncludeSection>
+  
+  <PosPartSection label="">
+    <PosPart copyNumber="1">
+      <rParent name=":world_volume"/>
+      <rChild name="cms:OCMS"/>
+    </PosPart>
+  </PosPartSection>
+</DDDefinition>

--- a/Geometry/TrackerCommonData/plugins/BuildFile.xml
+++ b/Geometry/TrackerCommonData/plugins/BuildFile.xml
@@ -3,3 +3,11 @@
  <use   name="FWCore/PluginManager"/>
  <flags   EDM_PLUGIN="1"/>
 </library>
+
+<library name="DD4hep_TrackerGeometryPlugins" file="dd4hep/*.cc">
+  <use name="DetectorDescription/DDCMS"/>
+  <use name="dd4hep"/>
+  <lib name="Geom"/>
+  <use name="rootgeom"/>
+  <flags DD4HEP_PLUGIN="1"/>
+</library>

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerRingAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerRingAlgo.cc
@@ -8,122 +8,124 @@ using namespace dd4hep;
 using namespace cms;
 using namespace geant_units::operators;
 
-static long algorithm(Detector& /* description */,
-		      cms::DDParsingContext& ctxt, xml_h e,
-		      SensitiveDetector& /* sens */)
-{
-  cms::DDNamespace ns(ctxt, e, true);
-  DDAlgoArguments args(ctxt, e);
-  Volume mother     = ns.volume(args.parentName());
-  string childName  = args.value<string>("ChildName");
-  Volume child      = ns.volume(childName); 
-  
-  string parentName = args.parentName();
-  int n             = args.value<int>("N");
-  int startCopyNo   = args.value<int>("StartCopyNo");
-  int incrCopyNo    = args.value<int>("IncrCopyNo");
-  double rangeAngle = args.value<double>("RangeAngle");
-  double startAngle = args.value<double>("StartAngle");
-  double radius     = args.value<double>("Radius");
-  vector<double> center = args.value<vector<double> >("Center");
-  bool isZPlus      = args.value<int>("IsZPlus") == 1;
-  double tiltAngle  = args.value<double>("TiltAngle");
-  bool isFlipped    = args.value<int>("IsFlipped") == 1;
-  double delta = 0.;
-  
-  if(fabs(rangeAngle - 360.0_deg) < 0.001_deg) {
-    delta = rangeAngle/double(n);
-  } else {
-    if(n > 1) {
-      delta = rangeAngle/double(n-1);
+namespace {
+  static long algorithm(Detector& /* description */,
+			cms::DDParsingContext& ctxt, xml_h e,
+			SensitiveDetector& /* sens */)
+  {
+    cms::DDNamespace ns(ctxt, e, true);
+    DDAlgoArguments args(ctxt, e);
+    Volume mother     = ns.volume(args.parentName());
+    string childName  = args.value<string>("ChildName");
+    Volume child      = ns.volume(childName); 
+    
+    string parentName = args.parentName();
+    int n             = args.value<int>("N");
+    int startCopyNo   = args.value<int>("StartCopyNo");
+    int incrCopyNo    = args.value<int>("IncrCopyNo");
+    double rangeAngle = args.value<double>("RangeAngle");
+    double startAngle = args.value<double>("StartAngle");
+    double radius     = args.value<double>("Radius");
+    vector<double> center = args.value<vector<double> >("Center");
+    bool isZPlus      = args.value<int>("IsZPlus") == 1;
+    double tiltAngle  = args.value<double>("TiltAngle");
+    bool isFlipped    = args.value<int>("IsFlipped") == 1;
+    double delta = 0.;
+    
+    if(abs(rangeAngle - 360.0_deg) < 0.001_deg) {
+      delta = rangeAngle/double(n);
     } else {
-      delta = 0.;
+      if(n > 1) {
+	delta = rangeAngle/double(n-1);
+      } else {
+	delta = 0.;
+      }
     }
-  }
-  
-  LogDebug("TrackerGeom") << "DDTrackerRingAlgo debug: Parameters for position"
-			  << "ing:: n " << n << " Start, Range, Delta "
-			  << convertRadToDeg(startAngle) << " "
-			  << convertRadToDeg(rangeAngle) << " " << convertRadToDeg(delta)
-			  << " Radius " << radius << " Centre " << center[0]
-			  << ", " << center[1] << ", "<< center[2];
-
-  LogDebug("TrackerGeom") << "DDTrackerRingAlgo debug: Parent " << parentName
-			  << "\tChild " << childName << " NameSpace "
-			  << ns.name();
-
-  Rotation3D flipRot, tiltRot, phiRot, globalRot; // Identity
-  Rotation3D flipMatrix, tiltMatrix, phiRotMatrix, globalRotMatrix; // Identity matrix
-  
-  // flipMatrix calculus
-  if(isFlipped) {
-    LogDebug("TrackerGeom") << "DDTrackerRingAlgo test: Creating a new rotation: "
-			    << "\t90., 180., "
-			    << "90., 90., "
-			    << "180., 0.";
-    flipRot = makeRotation3D(90._deg, 180._deg, 90._deg, 90._deg, 180._deg, 0._deg);
-    flipMatrix = flipRot;
-  }
-  // tiltMatrix calculus
-  if(isZPlus) {
-    LogDebug("TrackerGeom") << "DDTrackerRingAlgo test: Creating a new rotation: "
-			    << "\t90., 90., "
-			    << convertRadToDeg(tiltAngle) << ", 180., "
-			    << convertRadToDeg(90._deg - tiltAngle) << ", 0.";
-    tiltRot = makeRotation3D(90._deg, 90._deg, tiltAngle, 180._deg, 90._deg - tiltAngle, 0._deg);
-    tiltMatrix = tiltRot;
-    if(isFlipped) { tiltMatrix *= flipMatrix; }
-  }
-  else {
-    LogDebug("TrackerGeom") << "DDTrackerRingAlgo test: Creating a new rotation: "
-			    << "\t90., 90., "
-			    << convertRadToDeg(tiltAngle) << ", 0., "
-			    << convertRadToDeg(90._deg + tiltAngle) << ", 0.";
-    tiltRot = makeRotation3D(90._deg, 90._deg, tiltAngle, 0._deg, 90._deg + tiltAngle, 0._deg);
-    tiltMatrix = tiltRot;
-    if(isFlipped) { tiltMatrix *= flipMatrix; }
-  }
-  
-  // Loops for all phi values
-  double theta  = 90._deg;
-  int    copy   = startCopyNo;
-  double phi    = startAngle;
-  
-  for(int i = 0; i < n; ++i) {
-    // phiRotMatrix calculus
-    double phix = phi;
-    double phiy = phix + 90._deg;
-    double phideg = convertRadToDeg(phix);  
-    if(phideg != 0.) {
+    
+    LogDebug("TrackerGeom") << "DDTrackerRingAlgo debug: Parameters for position"
+			    << "ing:: n " << n << " Start, Range, Delta "
+			    << convertRadToDeg(startAngle) << " "
+			    << convertRadToDeg(rangeAngle) << " " << convertRadToDeg(delta)
+			    << " Radius " << radius << " Centre " << center[0]
+			    << ", " << center[1] << ", "<< center[2];
+    
+    LogDebug("TrackerGeom") << "DDTrackerRingAlgo debug: Parent " << parentName
+			    << "\tChild " << childName << " NameSpace "
+			    << ns.name();
+    
+    Rotation3D flipRot, tiltRot, phiRot, globalRot; // Identity
+    Rotation3D flipMatrix, tiltMatrix, phiRotMatrix, globalRotMatrix; // Identity matrix
+    
+    // flipMatrix calculus
+    if(isFlipped) {
       LogDebug("TrackerGeom") << "DDTrackerRingAlgo test: Creating a new rotation: "
-			      << "\t90., " << convertRadToDeg(phix)
-			      << ", 90.," << convertRadToDeg(phiy)
-			      <<", 0., 0.";
-      phiRot = makeRotation3D(theta, phix, theta, phiy, 0., 0.);
-      phiRotMatrix = phiRot;
+			      << "\t90., 180., "
+			      << "90., 90., "
+			      << "180., 0.";
+      flipRot = makeRotation3D(90._deg, 180._deg, 90._deg, 90._deg, 180._deg, 0._deg);
+      flipMatrix = flipRot;
     }
- 
-    // globalRot def
-    globalRotMatrix = phiRotMatrix * tiltMatrix;
-    globalRot = Rotation3D(globalRotMatrix);
+    // tiltMatrix calculus
+    if(isZPlus) {
+      LogDebug("TrackerGeom") << "DDTrackerRingAlgo test: Creating a new rotation: "
+			      << "\t90., 90., "
+			      << convertRadToDeg(tiltAngle) << ", 180., "
+			      << convertRadToDeg(90._deg - tiltAngle) << ", 0.";
+      tiltRot = makeRotation3D(90._deg, 90._deg, tiltAngle, 180._deg, 90._deg - tiltAngle, 0._deg);
+      tiltMatrix = tiltRot;
+      if(isFlipped) { tiltMatrix *= flipMatrix; }
+    }
+    else {
+      LogDebug("TrackerGeom") << "DDTrackerRingAlgo test: Creating a new rotation: "
+			      << "\t90., 90., "
+			      << convertRadToDeg(tiltAngle) << ", 0., "
+			      << convertRadToDeg(90._deg + tiltAngle) << ", 0.";
+      tiltRot = makeRotation3D(90._deg, 90._deg, tiltAngle, 0._deg, 90._deg + tiltAngle, 0._deg);
+      tiltMatrix = tiltRot;
+      if(isFlipped) { tiltMatrix *= flipMatrix; }
+    }
     
-    // translation def
-    double xpos = radius*cos(phi) + center[0];
-    double ypos = radius*sin(phi) + center[1];
-    double zpos = center[2];
-    Position tran(xpos, ypos, zpos);
-   
-    // Positions child with respect to parent
-    mother.placeVolume(child, copy, Transform3D(globalRot, tran));
-    LogDebug("TrackerGeom") << "DDTrackerRingAlgo test " << child << " number "
-			    << copy << " positioned in " << mother << " at "
-			    << tran  << " with " << globalRot;
+    // Loops for all phi values
+    double theta  = 90._deg;
+    int    copy   = startCopyNo;
+    double phi    = startAngle;
     
-    copy += incrCopyNo;
-    phi  += delta;
+    for(int i = 0; i < n; ++i) {
+      // phiRotMatrix calculus
+      double phix = phi;
+      double phiy = phix + 90._deg;
+      double phideg = convertRadToDeg(phix);  
+      if(phideg != 0.) {
+	LogDebug("TrackerGeom") << "DDTrackerRingAlgo test: Creating a new rotation: "
+				<< "\t90., " << convertRadToDeg(phix)
+				<< ", 90.," << convertRadToDeg(phiy)
+				<<", 0., 0.";
+	phiRot = makeRotation3D(theta, phix, theta, phiy, 0., 0.);
+	phiRotMatrix = phiRot;
+      }
+      
+      // globalRot def
+      globalRotMatrix = phiRotMatrix * tiltMatrix;
+      globalRot = Rotation3D(globalRotMatrix);
+      
+      // translation def
+      double xpos = radius*cos(phi) + center[0];
+      double ypos = radius*sin(phi) + center[1];
+      double zpos = center[2];
+      Position tran(xpos, ypos, zpos);
+      
+      // Positions child with respect to parent
+      mother.placeVolume(child, copy, Transform3D(globalRot, tran));
+      LogDebug("TrackerGeom") << "DDTrackerRingAlgo test " << child << " number "
+			      << copy << " positioned in " << mother << " at "
+			      << tran  << " with " << globalRot;
+      
+      copy += incrCopyNo;
+      phi  += delta;
+    }
+    return 1;
   }
-  return 1;
 }
-
 // first argument is the type from the xml file
-DECLARE_DDCMS_DETELEMENT(DDCMS_track_DDTrackerRingAlgo,algorithm)
+DECLARE_DDCMS_DETELEMENT(DDCMS_track_DDTrackerRingAlgo,::algorithm)
+  

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerRingAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerRingAlgo.cc
@@ -13,7 +13,7 @@ namespace {
 			cms::DDParsingContext& ctxt, xml_h e,
 			SensitiveDetector& /* sens */)
   {
-    cms::DDNamespace ns(ctxt, e, true);
+    DDNamespace ns(ctxt, e, true);
     DDAlgoArguments args(ctxt, e);
     Volume mother     = ns.volume(args.parentName());
     string childName  = args.value<string>("ChildName");
@@ -123,7 +123,7 @@ namespace {
       copy += incrCopyNo;
       phi  += delta;
     }
-    return 1;
+    return s_executed;
   }
 }
 // first argument is the type from the xml file

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerRingAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerRingAlgo.cc
@@ -1,0 +1,129 @@
+#include "DD4hep/DetFactoryHelper.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
+#include "DetectorDescription/DDCMS/interface/DDPlugins.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+using namespace std;
+using namespace dd4hep;
+using namespace cms;
+using namespace geant_units::operators;
+
+static long algorithm(Detector& /* description */,
+		      cms::DDParsingContext& ctxt, xml_h e,
+		      SensitiveDetector& /* sens */)
+{
+  cms::DDNamespace ns(ctxt, e, true);
+  DDAlgoArguments args(ctxt, e);
+  Volume mother     = ns.volume(args.parentName());
+  string childName  = args.value<string>("ChildName");
+  Volume child      = ns.volume(childName); 
+  
+  string parentName = args.parentName();
+  int n             = args.value<int>("N");
+  int startCopyNo   = args.value<int>("StartCopyNo");
+  int incrCopyNo    = args.value<int>("IncrCopyNo");
+  double rangeAngle = args.value<double>("RangeAngle");
+  double startAngle = args.value<double>("StartAngle");
+  double radius     = args.value<double>("Radius");
+  vector<double> center = args.value<vector<double> >("Center");
+  bool isZPlus      = args.value<int>("IsZPlus") == 1;
+  double tiltAngle  = args.value<double>("TiltAngle");
+  bool isFlipped    = args.value<int>("IsFlipped") == 1;
+  double delta = 0.;
+  
+  if(fabs(rangeAngle - 360.0_deg) < 0.001_deg) {
+    delta = rangeAngle/double(n);
+  } else {
+    if(n > 1) {
+      delta = rangeAngle/double(n-1);
+    } else {
+      delta = 0.;
+    }
+  }
+  
+  LogDebug("TrackerGeom") << "DDTrackerRingAlgo debug: Parameters for position"
+			  << "ing:: n " << n << " Start, Range, Delta "
+			  << convertRadToDeg(startAngle) << " "
+			  << convertRadToDeg(rangeAngle) << " " << convertRadToDeg(delta)
+			  << " Radius " << radius << " Centre " << center[0]
+			  << ", " << center[1] << ", "<< center[2];
+
+  LogDebug("TrackerGeom") << "DDTrackerRingAlgo debug: Parent " << parentName
+			  << "\tChild " << childName << " NameSpace "
+			  << ns.name();
+
+  Rotation3D flipRot, tiltRot, phiRot, globalRot; // Identity
+  Rotation3D flipMatrix, tiltMatrix, phiRotMatrix, globalRotMatrix; // Identity matrix
+  
+  // flipMatrix calculus
+  if(isFlipped) {
+    LogDebug("TrackerGeom") << "DDTrackerRingAlgo test: Creating a new rotation: "
+			    << "\t90., 180., "
+			    << "90., 90., "
+			    << "180., 0.";
+    flipRot = makeRotation3D(90._deg, 180._deg, 90._deg, 90._deg, 180._deg, 0._deg);
+    flipMatrix = flipRot;
+  }
+  // tiltMatrix calculus
+  if(isZPlus) {
+    LogDebug("TrackerGeom") << "DDTrackerRingAlgo test: Creating a new rotation: "
+			    << "\t90., 90., "
+			    << convertRadToDeg(tiltAngle) << ", 180., "
+			    << convertRadToDeg(90._deg - tiltAngle) << ", 0.";
+    tiltRot = makeRotation3D(90._deg, 90._deg, tiltAngle, 180._deg, 90._deg - tiltAngle, 0._deg);
+    tiltMatrix = tiltRot;
+    if(isFlipped) { tiltMatrix *= flipMatrix; }
+  }
+  else {
+    LogDebug("TrackerGeom") << "DDTrackerRingAlgo test: Creating a new rotation: "
+			    << "\t90., 90., "
+			    << convertRadToDeg(tiltAngle) << ", 0., "
+			    << convertRadToDeg(90._deg + tiltAngle) << ", 0.";
+    tiltRot = makeRotation3D(90._deg, 90._deg, tiltAngle, 0._deg, 90._deg + tiltAngle, 0._deg);
+    tiltMatrix = tiltRot;
+    if(isFlipped) { tiltMatrix *= flipMatrix; }
+  }
+  
+  // Loops for all phi values
+  double theta  = 90._deg;
+  int    copy   = startCopyNo;
+  double phi    = startAngle;
+  
+  for(int i = 0; i < n; ++i) {
+    // phiRotMatrix calculus
+    double phix = phi;
+    double phiy = phix + 90._deg;
+    double phideg = convertRadToDeg(phix);  
+    if(phideg != 0.) {
+      LogDebug("TrackerGeom") << "DDTrackerRingAlgo test: Creating a new rotation: "
+			      << "\t90., " << convertRadToDeg(phix)
+			      << ", 90.," << convertRadToDeg(phiy)
+			      <<", 0., 0.";
+      phiRot = makeRotation3D(theta, phix, theta, phiy, 0., 0.);
+      phiRotMatrix = phiRot;
+    }
+ 
+    // globalRot def
+    globalRotMatrix = phiRotMatrix * tiltMatrix;
+    globalRot = Rotation3D(globalRotMatrix);
+    
+    // translation def
+    double xpos = radius*cos(phi) + center[0];
+    double ypos = radius*sin(phi) + center[1];
+    double zpos = center[2];
+    Position tran(xpos, ypos, zpos);
+   
+    // Positions child with respect to parent
+    mother.placeVolume(child, copy, Transform3D(globalRot, tran));
+    LogDebug("TrackerGeom") << "DDTrackerRingAlgo test " << child << " number "
+			    << copy << " positioned in " << mother << " at "
+			    << tran  << " with " << globalRot;
+    
+    copy += incrCopyNo;
+    phi  += delta;
+  }
+  return 1;
+}
+
+// first argument is the type from the xml file
+DECLARE_DDCMS_DETELEMENT(DDCMS_track_DDTrackerRingAlgo,algorithm)

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerRingAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerRingAlgo.cc
@@ -9,9 +9,9 @@ using namespace cms;
 using namespace geant_units::operators;
 
 namespace {
-  static long algorithm(Detector& /* description */,
-			cms::DDParsingContext& ctxt, xml_h e,
-			SensitiveDetector& /* sens */)
+  long algorithm(Detector& /* description */,
+		 cms::DDParsingContext& ctxt, xml_h e,
+		 SensitiveDetector& /* sens */)
   {
     DDNamespace ns(ctxt, e, true);
     DDAlgoArguments args(ctxt, e);

--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerGeometry.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerGeometry.py
@@ -1,0 +1,58 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TrackerGeometryTest")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.MessageLogger = cms.Service(
+    "MessageLogger",
+    statistics = cms.untracked.vstring('cout', 'trackerGeometry'),
+    categories = cms.untracked.vstring('Geometry'),
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING'),
+        noLineBreaks = cms.untracked.bool(True)
+        ),
+    trackerGeometry = cms.untracked.PSet(
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        noLineBreaks = cms.untracked.bool(True),
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        WARNING = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        ERROR = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        threshold = cms.untracked.string('INFO'),
+        Geometry = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            )
+        ),
+    destinations = cms.untracked.vstring('cout',
+                                         'trackerGeometry')
+    )
+
+process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('Geometry/TrackerCommonData/data/dd4hep/cms-tracker-geometry.xml'),
+                                            appendToDataLabel = cms.string('Tracker')
+                                            )
+
+process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
+                                                     appendToDataLabel = cms.string('Tracker')
+                                                     )
+
+process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
+                                                    appendToDataLabel = cms.string('Tracker')
+                                                    )
+
+process.test = cms.EDAnalyzer("DDCMSDetector",
+                              DDDetector = cms.ESInputTag('Tracker')
+                              )
+
+process.p = cms.Path(process.test)


### PR DESCRIPTION
#### PR description:

* Add DDTrackerRingAlgo needed to build MTD geometry

@vargasa - please, check the algorithm implementation. 

#### PR validation:

```
cmsRun Geometry/MTDGeometryBuilder/test/python/testMTDGeometry.py
cmsShow -c geo.fwc --sim-geom-file cmsDD4HepGeom.root --tgeo-name=MTD
```

![Screenshot 2019-04-08 16 21 19](https://user-images.githubusercontent.com/1390682/55732254-fdc9fa00-5a1b-11e9-8fe3-4fbeb937915d.png)

Geometry description: left - DD CMS, right - DD4hep:
![Screenshot 2019-04-08 17 09 52](https://user-images.githubusercontent.com/1390682/55735339-6ff10d80-5a21-11e9-9524-d5db4c0e6bf6.png)

#### if this PR is a backport please specify the original PR:

no back port is needed
