### PR TITLE
Removed unnecesary include from EcalLaserDbService

### DIFF
--- a/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h
+++ b/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 #include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_hash_map.h>
 
 
 #include "DataFormats/DetId/interface/DetId.h"


### PR DESCRIPTION
#### PR description:

The header file tbb/concurrent_hash_map.h was unnecessary for this class.
In addition, that header does not presently compile with gcc9.

#### PR validation:

After change the code compiles using CMSSW_10_6_DEVEL_X_2019-04-07-2300 with architecture slc7_amd64_gcc900.