### PR TITLE
PPS: proton reco finalisation before UL re-reco

### DIFF
--- a/CalibPPS/ESProducers/plugins/CTPPSLHCInfoESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSLHCInfoESSource.cc
@@ -53,14 +53,6 @@ CTPPSLHCInfoESSource::CTPPSLHCInfoESSource(const edm::ParameterSet& conf) :
 void CTPPSLHCInfoESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &key,
   const edm::IOVSyncValue& iosv, edm::ValidityInterval& oValidity)
 {
-  // TODO: the IOV specified in config is temporarily replaced with a hardcoded one
-  edm::IOVSyncValue beg(edm::EventID(270293, 0, 0), edm::Timestamp(1461016800ULL << 32));
-  edm::IOVSyncValue end(edm::EventID(290872, 0, 0), edm::Timestamp(1483138800ULL << 32));
-  oValidity = edm::ValidityInterval(beg, end);
-
-  m_insideValidityRange = (beg < iosv && iosv < end);
-
-  /*
   if (edm::contains(m_validityRange, iosv.eventID()))
   {
     m_insideValidityRange = true;
@@ -83,7 +75,6 @@ void CTPPSLHCInfoESSource::setIntervalFor(const edm::eventsetup::EventSetupRecor
       oValidity = edm::ValidityInterval(edm::IOVSyncValue(beginEvent), edm::IOVSyncValue::endOfTime());
     }
   }
-  */
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/CalibPPS/ESProducers/python/ctppsLHCInfo_cff.py
+++ b/CalibPPS/ESProducers/python/ctppsLHCInfo_cff.py
@@ -1,11 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
-ctppsLHCInfoLabel = cms.string("ctpps_minimal")
+# by default, LHCInfo is now loaded from CondDB using a GT
+ctppsLHCInfoLabel = cms.string("")
 
-# minimal LHCInfo for 2016 data
-ctppsLHCInfoESSource_2016 = cms.ESSource("CTPPSLHCInfoESSource",
-  label = ctppsLHCInfoLabel,
-  validityRange = cms.EventRange("270293:min - 290872:max"),
-  beamEnergy = cms.double(6500),  # GeV
-  xangle = cms.double(185)  # murad
-)
+## minimal LHCInfo for 2016 data
+#ctppsLHCInfoLabel = cms.string("ctpps_minimal")
+#ctppsLHCInfoESSource_2016 = cms.ESSource("CTPPSLHCInfoESSource",
+#  label = ctppsLHCInfoLabel,
+#  validityRange = cms.EventRange("270293:min - 290872:max"),
+#  beamEnergy = cms.double(6500),  # GeV
+#  xangle = cms.double(185)  # murad
+#)

--- a/CalibPPS/ESProducers/python/ctppsOpticalFunctions_cff.py
+++ b/CalibPPS/ESProducers/python/ctppsOpticalFunctions_cff.py
@@ -2,26 +2,28 @@ import FWCore.ParameterSet.Config as cms
 
 from CalibPPS.ESProducers.ctppsLHCInfo_cff import *
 
-from CalibPPS.ESProducers.ctppsOpticalFunctionsESSource_cfi import *
+# by default, (raw) optical functions are now loaded from CondDB using a GT
 
-# add 2016 pre-TS2 configuration
-config_2016_preTS2 = cms.PSet(
-  validityRange = cms.EventRange("273725:min - 280385:max"),
-
-  opticalFunctions = cms.VPSet(
-      cms.PSet( xangle = cms.double(185), fileName = cms.FileInPath("CalibPPS/ESProducers/data/optical_functions_2016.root") )
-  ),
-
-  scoringPlanes = cms.VPSet(
-      # z in cm
-      cms.PSet( rpId = cms.uint32(0x76100000), dirName = cms.string("XRPH_C6L5_B2"), z = cms.double(-20382.6) ),  # RP 002, strip
-      cms.PSet( rpId = cms.uint32(0x76180000), dirName = cms.string("XRPH_D6L5_B2"), z = cms.double(-21255.1) ),  # RP 003, strip
-      cms.PSet( rpId = cms.uint32(0x77100000), dirName = cms.string("XRPH_C6R5_B1"), z = cms.double(+20382.6) ),  # RP 102, strip
-      cms.PSet( rpId = cms.uint32(0x77180000), dirName = cms.string("XRPH_D6R5_B1"), z = cms.double(+21255.1) ),  # RP 103, strip
-  )
-)
-
-ctppsOpticalFunctionsESSource.configuration.append(config_2016_preTS2)
+#from CalibPPS.ESProducers.ctppsOpticalFunctionsESSource_cfi import *
+#
+## add 2016 pre-TS2 configuration
+#config_2016_preTS2 = cms.PSet(
+#  validityRange = cms.EventRange("273725:min - 280385:max"),
+#
+#  opticalFunctions = cms.VPSet(
+#      cms.PSet( xangle = cms.double(185), fileName = cms.FileInPath("CalibPPS/ESProducers/data/optical_functions_2016.root") )
+#  ),
+#
+#  scoringPlanes = cms.VPSet(
+#      # z in cm
+#      cms.PSet( rpId = cms.uint32(0x76100000), dirName = cms.string("XRPH_C6L5_B2"), z = cms.double(-20382.6) ),  # RP 002, strip
+#      cms.PSet( rpId = cms.uint32(0x76180000), dirName = cms.string("XRPH_D6L5_B2"), z = cms.double(-21255.1) ),  # RP 003, strip
+#      cms.PSet( rpId = cms.uint32(0x77100000), dirName = cms.string("XRPH_C6R5_B1"), z = cms.double(+20382.6) ),  # RP 102, strip
+#      cms.PSet( rpId = cms.uint32(0x77180000), dirName = cms.string("XRPH_D6R5_B1"), z = cms.double(+21255.1) ),  # RP 103, strip
+#  )
+#)
+#
+#ctppsOpticalFunctionsESSource.configuration.append(config_2016_preTS2)
 
 # optics interpolation between crossing angles
 from CalibPPS.ESProducers.ctppsInterpolatedOpticalFunctionsESSource_cfi import *

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,16 +24,16 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '105X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v4',
+    'run1_data'         :   '106X_dataRun2_v8',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v4',
+    'run2_data'         :   '106X_dataRun2_v8',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v2',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v6',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v1',
+    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v4',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v1',
-    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v1',
+    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v4',
+    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v4',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v8',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
+++ b/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
@@ -196,271 +196,277 @@ void CTPPSProtonProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
 
 void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  // get conditions
-  edm::ESHandle<LHCInfo> hLHCInfo;
-  iSetup.get<LHCInfoRcd>().get(lhcInfoLabel_, hLHCInfo);
-
-  edm::ESHandle<LHCInterpolatedOpticalFunctionsSetCollection> hOpticalFunctions;
-  iSetup.get<CTPPSInterpolatedOpticsRcd>().get(hOpticalFunctions);
-
-  edm::ESHandle<CTPPSGeometry> hGeometry;
-  iSetup.get<VeryForwardRealGeometryRecord>().get(hGeometry);
-
-  // re-initialise algorithm upon crossing-angle change
-  if (hLHCInfo->crossingAngle() != currentCrossingAngle_) {
-    currentCrossingAngle_ = hLHCInfo->crossingAngle();
-
-    if (hOpticalFunctions->empty()) {
-      edm::LogInfo("CTPPSProtonProducer") << "No optical functions available, reconstruction disabled.";
-      algorithm_.release();
-      opticsValid_ = false;
-    }
-    else {
-      algorithm_.init(*hOpticalFunctions);
-      opticsValid_ = true;
-    }
-  }
+  // get input
+  edm::Handle<CTPPSLocalTrackLiteCollection> hTracks;
+  iEvent.getByToken(tracksToken_, hTracks);
 
   // book output
   std::unique_ptr<reco::ForwardProtonCollection> pOutSingleRP(new reco::ForwardProtonCollection);
   std::unique_ptr<reco::ForwardProtonCollection> pOutMultiRP(new reco::ForwardProtonCollection);
 
-  // do reconstruction only if optics is valid
-  if (opticsValid_)
+  // continue only if there is something to process
+  // NB: this avoids loading (possibly non-existing) conditions in workflows without proton data
+  if (!hTracks->empty())
   {
-    // prepare log
-    std::ostringstream ssLog;
-    if (verbosity_)
-      ssLog << "* input tracks:" << std::endl;
+    // get conditions
+    edm::ESHandle<LHCInfo> hLHCInfo;
+    iSetup.get<LHCInfoRcd>().get(lhcInfoLabel_, hLHCInfo);
 
-    // get input
-    edm::Handle<CTPPSLocalTrackLiteCollection> hTracks;
-    iEvent.getByToken(tracksToken_, hTracks);
+    edm::ESHandle<LHCInterpolatedOpticalFunctionsSetCollection> hOpticalFunctions;
+    iSetup.get<CTPPSInterpolatedOpticsRcd>().get(hOpticalFunctions);
 
-    // select tracks with small local angles, split them by LHC sector and tracker/timing RPs
-    std::map<unsigned int, std::vector<unsigned int>> trackingSelection, timingSelection;
+    edm::ESHandle<CTPPSGeometry> hGeometry;
+    iSetup.get<VeryForwardRealGeometryRecord>().get(hGeometry);
 
-    for (unsigned int idx = 0; idx < hTracks->size(); ++idx)
+    // re-initialise algorithm upon crossing-angle change
+    if (hLHCInfo->crossingAngle() != currentCrossingAngle_)
     {
-      const auto& tr = hTracks->at(idx);
+      currentCrossingAngle_ = hLHCInfo->crossingAngle();
 
-      if (tr.getTx() < localAngleXMin_ || tr.getTx() > localAngleXMax_
-          || tr.getTy() < localAngleYMin_ || tr.getTy() > localAngleYMax_)
-        continue;
-
-      const CTPPSDetId rpId(tr.getRPId());
-
-      if (verbosity_)
-        ssLog << "\t"
-          << "[" << idx << "] "
-          << tr.getRPId() << " (" << (rpId.arm()*100 + rpId.station()*10 + rpId.rp()) << "): "
-          << "x=" << tr.getX() << " +- " << tr.getXUnc() << " mm, "
-          << "y=" << tr.getY() << " +- " << tr.getYUnc() << " mm" << std::endl;
-
-      const bool trackerRP = (rpId.subdetId() == CTPPSDetId::sdTrackingStrip || rpId.subdetId() == CTPPSDetId::sdTrackingPixel);
-
-      if (trackerRP)
-        trackingSelection[rpId.arm()].push_back(idx);
-      else
-        timingSelection[rpId.arm()].push_back(idx);
+      if (hOpticalFunctions->empty()) {
+        edm::LogInfo("CTPPSProtonProducer") << "No optical functions available, reconstruction disabled.";
+        algorithm_.release();
+        opticsValid_ = false;
+      }
+      else {
+        algorithm_.init(*hOpticalFunctions);
+        opticsValid_ = true;
+      }
     }
 
-    // process each arm
-    for (const auto &arm_it : trackingSelection)
+    // do reconstruction only if optics is valid
+    if (opticsValid_)
     {
-      const auto &indices = arm_it.second;
+      // prepare log
+      std::ostringstream ssLog;
+      if (verbosity_)
+        ssLog << "* input tracks:" << std::endl;
 
-      const auto &ac = association_cuts_[arm_it.first];
+      // select tracks with small local angles, split them by LHC sector and tracker/timing RPs
+      std::map<unsigned int, std::vector<unsigned int>> trackingSelection, timingSelection;
 
-      // do single-RP reco if needed
-      std::map<unsigned int, reco::ForwardProton> singleRPResultsIndexed;
-      if (doSingleRPReconstruction_ || ac.xi_cut_apply || ac.th_y_cut_apply)
+      for (unsigned int idx = 0; idx < hTracks->size(); ++idx)
       {
-        for (const auto &idx : indices)
-        {
-          if (verbosity_)
-            ssLog << std::endl << "* reconstruction from track " << idx << std::endl;
+        const auto& tr = hTracks->at(idx);
 
-          singleRPResultsIndexed[idx] = algorithm_.reconstructFromSingleRP(CTPPSLocalTrackLiteRef(hTracks, idx), *hLHCInfo, ssLog);
-        }
-      }
-
-      // do multi-RP reco if chosen
-      if (doMultiRPReconstruction_)
-      {
-        // check that exactly two tracking RPs are involved
-        //    - 1 is insufficient for multi-RP reconstruction
-        //    - PPS did not use more than 2 tracking RPs per arm -> algorithms are tuned to this
-        std::set<unsigned int> rpIds;
-        for (const auto &idx : indices)
-          rpIds.insert(hTracks->at(idx).getRPId());
-        if (rpIds.size() != 2)
+        if (tr.getTx() < localAngleXMin_ || tr.getTx() > localAngleXMax_
+            || tr.getTy() < localAngleYMin_ || tr.getTy() > localAngleYMax_)
           continue;
 
-        // find matching track pairs from different tracking RPs
-        std::vector<std::pair<unsigned int, unsigned int>> idx_pairs;
-        std::map<unsigned int, unsigned int> idx_pair_multiplicity;
-        for (const auto &i : indices)
+        const CTPPSDetId rpId(tr.getRPId());
+
+        if (verbosity_)
+          ssLog << "\t"
+            << "[" << idx << "] "
+            << tr.getRPId() << " (" << (rpId.arm()*100 + rpId.station()*10 + rpId.rp()) << "): "
+            << "x=" << tr.getX() << " +- " << tr.getXUnc() << " mm, "
+            << "y=" << tr.getY() << " +- " << tr.getYUnc() << " mm" << std::endl;
+
+        const bool trackerRP = (rpId.subdetId() == CTPPSDetId::sdTrackingStrip || rpId.subdetId() == CTPPSDetId::sdTrackingPixel);
+
+        if (trackerRP)
+          trackingSelection[rpId.arm()].push_back(idx);
+        else
+          timingSelection[rpId.arm()].push_back(idx);
+      }
+
+      // process each arm
+      for (const auto &arm_it : trackingSelection)
+      {
+        const auto &indices = arm_it.second;
+
+        const auto &ac = association_cuts_[arm_it.first];
+
+        // do single-RP reco if needed
+        std::map<unsigned int, reco::ForwardProton> singleRPResultsIndexed;
+        if (doSingleRPReconstruction_ || ac.xi_cut_apply || ac.th_y_cut_apply)
         {
-          for (const auto &j : indices)
+          for (const auto &idx : indices)
           {
-            if (j <= i)
+            if (verbosity_)
+              ssLog << std::endl << "* reconstruction from track " << idx << std::endl;
+
+            singleRPResultsIndexed[idx] = algorithm_.reconstructFromSingleRP(CTPPSLocalTrackLiteRef(hTracks, idx), *hLHCInfo, ssLog);
+          }
+        }
+
+        // do multi-RP reco if chosen
+        if (doMultiRPReconstruction_)
+        {
+          // check that exactly two tracking RPs are involved
+          //    - 1 is insufficient for multi-RP reconstruction
+          //    - PPS did not use more than 2 tracking RPs per arm -> algorithms are tuned to this
+          std::set<unsigned int> rpIds;
+          for (const auto &idx : indices)
+            rpIds.insert(hTracks->at(idx).getRPId());
+          if (rpIds.size() != 2)
+            continue;
+
+          // find matching track pairs from different tracking RPs
+          std::vector<std::pair<unsigned int, unsigned int>> idx_pairs;
+          std::map<unsigned int, unsigned int> idx_pair_multiplicity;
+          for (const auto &i : indices)
+          {
+            for (const auto &j : indices)
+            {
+              if (j <= i)
+                continue;
+
+              const auto &tr_i = hTracks->at(i);
+              const auto &tr_j = hTracks->at(j);
+
+              const auto &pr_i = singleRPResultsIndexed[i];
+              const auto &pr_j = singleRPResultsIndexed[j];
+
+              if (tr_i.getRPId() == tr_j.getRPId())
+                continue;
+
+              bool matching = true;
+
+              if (ac.x_cut_apply && std::abs(tr_i.getX() - tr_j.getX()) > ac.x_cut_value)
+                matching = false;
+              if (ac.y_cut_apply && std::abs(tr_i.getY() - tr_j.getY()) > ac.y_cut_value)
+                matching = false;
+              if (ac.xi_cut_apply && std::abs(pr_i.xi() - pr_j.xi()) > ac.xi_cut_value)
+                matching = false;
+              if (ac.th_y_cut_apply && std::abs(pr_i.thetaY() - pr_j.thetaY()) > ac.th_y_cut_value)
+                matching = false;
+
+              if (!matching)
+                continue;
+
+              idx_pairs.emplace_back(i, j);
+              idx_pair_multiplicity[i]++;
+              idx_pair_multiplicity[j]++;
+            }
+          }
+
+          // evaluate track multiplicity in each timing RP
+          std::map<unsigned int, unsigned int> timing_RP_track_multiplicity;
+          for (const auto &ti : timingSelection[arm_it.first])
+          {
+            const auto &tr = hTracks->at(ti);
+            timing_RP_track_multiplicity[tr.getRPId()]++;
+          }
+
+          // associate tracking-RP pairs with timing-RP tracks
+          std::map<unsigned int, std::vector<unsigned int>> matched_timing_track_indices;
+          std::map<unsigned int, unsigned int> matched_timing_track_multiplicity;
+          for (unsigned int pr_idx = 0; pr_idx < idx_pairs.size(); ++pr_idx)
+          {
+            const auto &i = idx_pairs[pr_idx].first;
+            const auto &j = idx_pairs[pr_idx].second;
+
+            // skip non-unique associations
+            if (idx_pair_multiplicity[i] > 1 || idx_pair_multiplicity[j] > 1)
               continue;
 
             const auto &tr_i = hTracks->at(i);
             const auto &tr_j = hTracks->at(j);
 
-            const auto &pr_i = singleRPResultsIndexed[i];
-            const auto &pr_j = singleRPResultsIndexed[j];
+            const double z_i = hGeometry->getRPTranslation(tr_i.getRPId()).z();
+            const double z_j = hGeometry->getRPTranslation(tr_j.getRPId()).z();
 
-            if (tr_i.getRPId() == tr_j.getRPId())
-              continue;
+            for (const auto &ti : timingSelection[arm_it.first])
+            {
+              const auto &tr_ti = hTracks->at(ti);
 
-            bool matching = true;
+              // skip if timing RP saturated (high track multiplicity)
+              if (timing_RP_track_multiplicity[tr_ti.getRPId()] > max_n_timing_tracks_)
+                continue;
 
-            if (ac.x_cut_apply && std::abs(tr_i.getX() - tr_j.getX()) > ac.x_cut_value)
-              matching = false;
-            if (ac.y_cut_apply && std::abs(tr_i.getY() - tr_j.getY()) > ac.y_cut_value)
-              matching = false;
-            if (ac.xi_cut_apply && std::abs(pr_i.xi() - pr_j.xi()) > ac.xi_cut_value)
-              matching = false;
-            if (ac.th_y_cut_apply && std::abs(pr_i.thetaY() - pr_j.thetaY()) > ac.th_y_cut_value)
-              matching = false;
+              // interpolation from tracking RPs
+              const double z_ti = - hGeometry->getRPTranslation(tr_ti.getRPId()).z(); // the minus sign fixes a bug in the diamond geometry
+              const double f_i = (z_ti - z_j) / (z_i - z_j), f_j = (z_i - z_ti) / (z_i - z_j);
+              const double x_inter = f_i * tr_i.getX() + f_j * tr_j.getX();
+              const double x_inter_unc_sq = f_i*f_i * tr_i.getXUnc()*tr_i.getXUnc() + f_j*f_j * tr_j.getXUnc()*tr_j.getXUnc();
 
-            if (!matching)
-              continue;
+              const double de_x = tr_ti.getX() - x_inter;
+              const double de_x_unc = sqrt(tr_ti.getXUnc()*tr_ti.getXUnc() + x_inter_unc_sq);
 
-            idx_pairs.emplace_back(i, j);
-            idx_pair_multiplicity[i]++;
-            idx_pair_multiplicity[j]++;
+              const bool matching = (std::abs(de_x) <= de_x_unc);
+
+              if (verbosity_)
+                ssLog << "ti=" << ti << ", i=" << i << ", j=" << j
+                  << " | z_ti=" << z_ti << ", z_i=" << z_i << ", z_j=" << z_j
+                  << " | x_ti=" << tr_ti.getX() << ", x_inter=" << x_inter << ", de_x=" << de_x << ", de_x_unc=" << de_x_unc
+                  << ", matching=" << matching << std::endl;
+
+              if (!matching)
+                continue;
+
+              matched_timing_track_indices[pr_idx].push_back(ti);
+              matched_timing_track_multiplicity[ti]++;
+            }
           }
-        }
 
-        // evaluate track multiplicity in each timing RP
-        std::map<unsigned int, unsigned int> timing_RP_track_multiplicity;
-        for (const auto &ti : timingSelection[arm_it.first])
-        {
-          const auto &tr = hTracks->at(ti);
-          timing_RP_track_multiplicity[tr.getRPId()]++;
-        }
-
-        // associate tracking-RP pairs with timing-RP tracks
-        std::map<unsigned int, std::vector<unsigned int>> matched_timing_track_indices;
-        std::map<unsigned int, unsigned int> matched_timing_track_multiplicity;
-        for (unsigned int pr_idx = 0; pr_idx < idx_pairs.size(); ++pr_idx)
-        {
-          const auto &i = idx_pairs[pr_idx].first;
-          const auto &j = idx_pairs[pr_idx].second;
-
-          // skip non-unique associations
-          if (idx_pair_multiplicity[i] > 1 || idx_pair_multiplicity[j] > 1)
-            continue;
-
-          const auto &tr_i = hTracks->at(i);
-          const auto &tr_j = hTracks->at(j);
-
-          const double z_i = hGeometry->getRPTranslation(tr_i.getRPId()).z();
-          const double z_j = hGeometry->getRPTranslation(tr_j.getRPId()).z();
-
-          for (const auto &ti : timingSelection[arm_it.first])
+          // process associated tracks
+          for (unsigned int pr_idx = 0; pr_idx < idx_pairs.size(); ++pr_idx)
           {
-            const auto &tr_ti = hTracks->at(ti);
+            const auto &i = idx_pairs[pr_idx].first;
+            const auto &j = idx_pairs[pr_idx].second;
 
-            // skip if timing RP saturated (high track multiplicity)
-            if (timing_RP_track_multiplicity[tr_ti.getRPId()] > max_n_timing_tracks_)
+            // skip non-unique associations of tracking-RP tracks
+            if (idx_pair_multiplicity[i] > 1 || idx_pair_multiplicity[j] > 1)
               continue;
-
-            // interpolation from tracking RPs
-            const double z_ti = - hGeometry->getRPTranslation(tr_ti.getRPId()).z(); // the minus sign fixes a bug in the diamond geometry
-            const double f_i = (z_ti - z_j) / (z_i - z_j), f_j = (z_i - z_ti) / (z_i - z_j);
-            const double x_inter = f_i * tr_i.getX() + f_j * tr_j.getX();
-            const double x_inter_unc_sq = f_i*f_i * tr_i.getXUnc()*tr_i.getXUnc() + f_j*f_j * tr_j.getXUnc()*tr_j.getXUnc();
-
-            const double de_x = tr_ti.getX() - x_inter;
-            const double de_x_unc = sqrt(tr_ti.getXUnc()*tr_ti.getXUnc() + x_inter_unc_sq);
-
-            const bool matching = (std::abs(de_x) <= de_x_unc);
 
             if (verbosity_)
-              ssLog << "ti=" << ti << ", i=" << i << ", j=" << j
-                << " | z_ti=" << z_ti << ", z_i=" << z_i << ", z_j=" << z_j
-                << " | x_ti=" << tr_ti.getX() << ", x_inter=" << x_inter << ", de_x=" << de_x << ", de_x_unc=" << de_x_unc
-                << ", matching=" << matching << std::endl;
+              ssLog << std::endl << "* reconstruction from tracking-RP tracks: " << i << ", " << j << " and timing-RP tracks: ";
 
-            if (!matching)
-              continue;
+            // process tracking-RP data
+            CTPPSLocalTrackLiteRefVector sel_tracks;
+            sel_tracks.push_back(CTPPSLocalTrackLiteRef(hTracks, i));
+            sel_tracks.push_back(CTPPSLocalTrackLiteRef(hTracks, j));
+            reco::ForwardProton proton = algorithm_.reconstructFromMultiRP(sel_tracks, *hLHCInfo, ssLog);
 
-            matched_timing_track_indices[pr_idx].push_back(ti);
-            matched_timing_track_multiplicity[ti]++;
-          }
-        }
+            // process timing-RP data
+            double sw=0., swt=0.;
+            for (const auto &ti : matched_timing_track_indices[pr_idx])
+            {
+              // skip non-unique associations of timing-RP tracks
+              if (matched_timing_track_multiplicity[ti] > 1)
+                continue;
 
-        // process associated tracks
-        for (unsigned int pr_idx = 0; pr_idx < idx_pairs.size(); ++pr_idx)
-        {
-          const auto &i = idx_pairs[pr_idx].first;
-          const auto &j = idx_pairs[pr_idx].second;
+              sel_tracks.push_back(CTPPSLocalTrackLiteRef(hTracks, ti));
 
-          // skip non-unique associations of tracking-RP tracks
-          if (idx_pair_multiplicity[i] > 1 || idx_pair_multiplicity[j] > 1)
-            continue;
+              if (verbosity_)
+                ssLog << ti << ", ";
 
-          if (verbosity_)
-            ssLog << std::endl << "* reconstruction from tracking-RP tracks: " << i << ", " << j << " and timing-RP tracks: ";
+              const auto &tr = hTracks->at(ti);
+              const double t_unc = tr.getTimeUnc();
+              const double w = (t_unc > 0.) ? 1./t_unc/t_unc : 1.;
+              sw += w;
+              swt += w * tr.getTime();
+            }
 
-          // process tracking-RP data
-          CTPPSLocalTrackLiteRefVector sel_tracks;
-          sel_tracks.push_back(CTPPSLocalTrackLiteRef(hTracks, i));
-          sel_tracks.push_back(CTPPSLocalTrackLiteRef(hTracks, j));
-          reco::ForwardProton proton = algorithm_.reconstructFromMultiRP(sel_tracks, *hLHCInfo, ssLog);
-
-          // process timing-RP data
-          double sw=0., swt=0.;
-          for (const auto &ti : matched_timing_track_indices[pr_idx])
-          {
-            // skip non-unique associations of timing-RP tracks
-            if (matched_timing_track_multiplicity[ti] > 1)
-              continue;
-
-            sel_tracks.push_back(CTPPSLocalTrackLiteRef(hTracks, ti));
+            float time = 0., time_unc = 0.;
+            if (sw > 0.)
+            {
+              time = swt / sw;
+              time_unc = 1. / sqrt(sw);
+            }
 
             if (verbosity_)
-              ssLog << ti << ", ";
+              ssLog << std::endl << "    time = " << time << " +- " << time_unc << std::endl;
 
-            const auto &tr = hTracks->at(ti);
-            const double t_unc = tr.getTimeUnc();
-            const double w = (t_unc > 0.) ? 1./t_unc/t_unc : 1.;
-            sw += w;
-            swt += w * tr.getTime();
+            // save combined output
+            proton.setContributingLocalTracks(sel_tracks);
+            proton.setTime(time);
+            proton.setTimeError(time_unc);
+
+            pOutMultiRP->emplace_back(proton);
           }
-
-          float time = 0., time_unc = 0.;
-          if (sw > 0.)
-          {
-            time = swt / sw;
-            time_unc = 1. / sqrt(sw);
-          }
-
-          if (verbosity_)
-            ssLog << std::endl << "    time = " << time << " +- " << time_unc << std::endl;
-
-          // save combined output
-          proton.setContributingLocalTracks(sel_tracks);
-          proton.setTime(time);
-          proton.setTimeError(time_unc);
-
-          pOutMultiRP->emplace_back(proton);
         }
+
+        // save single-RP results (un-indexed)
+        for (const auto &p : singleRPResultsIndexed)
+          pOutSingleRP->emplace_back(std::move(p.second));
       }
 
-      // save single-RP results (un-indexed)
-      for (const auto &p : singleRPResultsIndexed)
-        pOutSingleRP->emplace_back(std::move(p.second));
+      // dump log
+      if (verbosity_)
+        edm::LogInfo("CTPPSProtonProducer") << ssLog.str();
     }
-
-    // dump log
-    if (verbosity_)
-      edm::LogInfo("CTPPSProtonProducer") << ssLog.str();
   }
 
   // save output


### PR DESCRIPTION
#### PR description:

This PR contains several finalisation changes for PPS proton reconstruction before the UL re-reco:
  * c5c4e47: removes the hardcoded IOV as promised in #25495
  * ff4097a: switches to CondDB as the default source of LHCInfo and optical functions.
  * 9d56bb7: cherry-pick of @tocheng 's commit 3aececc to include optical functions in auto GT.
  * bfe7a0a: PPS proton-reconstruction module does nothing if input empty. This prevents loading non-existing conditions in workflows without PPS proton data.

