### PR TITLE
HCAL updates for phase 1 HB digis

### DIFF
--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -628,7 +628,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 	    continue;
       }
       ///////////////////////////////////////////////HE UNPACKER//////////////////////////////////////////////////////////////////////////////////////
-      if (i.flavor() == 1 || i.flavor() == 0) {
+      if (i.flavor() == 1 || i.flavor() == 0 || i.flavor() == 3) {
           int ifiber=((i.channelid()>>3)&0x1F);
           int ichan=(i.channelid()&0x7);
           HcalElectronicsId eid(crate,slot,ifiber,ichan, false);


### PR DESCRIPTION
#### PR description:

This PR contains two changes needed to unpack and use digis from phase 1 HB:
- In HcalUnpacker, add `flavor==3` condition to unpack phase 1 HB digis along with existing phase 1 HE digis.
- In QIE11DataFrame, add bit logic for phase 1 HB digis, which is different from HE. 

#### PR validation:

- Successfully use phase 1 HB digis in online DQM for runs 328788 and 328903, with upgraded HBM10 and HBM11 included in run. 
   - ADC, TDC, SOI, and capID bits work as expected. 
   - Link error bits not checked. 
- `./runTheMatrix.py -l 11624.0 -j4` passes with no errors.

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

@jmmans @abdoulline @mariadalfonso @arapyan @kpedro88 