### PR TITLE
Avoid ambiguous statement in dqmfilesaver::fillJson

### DIFF
--- a/DQMServices/Components/src/fillJson.cc
+++ b/DQMServices/Components/src/fillJson.cc
@@ -94,7 +94,7 @@ dqmfilesaver::fillJson(int run, int lumi, const std::string& dataFilePathName, c
     pt.put("definition", "/fakeDefinition.jsn");
   } else {
     // The availability test of the EvFDaqDirector Service was done in the ctor.
-    bfs::path outJsonDefName(edm::Service<evf::EvFDaqDirector>()->baseRunDir()); //we assume this file is written bu the EvF Output module
+    bfs::path outJsonDefName{edm::Service<evf::EvFDaqDirector>()->baseRunDir()}; //we assume this file is written bu the EvF Output module
     outJsonDefName /= (std::string("output_") + oss_pid.str() + std::string(".jsd"));
     pt.put("definition", outJsonDefName.string());
   }


### PR DESCRIPTION
#### PR description:

gcc 9 was parsing the statement as a function declaration rather than a variable declaration. Using brace initialization resolved the ambiguity.

#### PR validation:

Compiles using gcc 9.