### PR TITLE
swapping order of cuts to avoid expensive dxy/dz calc

### DIFF
--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -397,11 +397,20 @@ float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photo
         math::XYZVector phoWrtVtx(photon.superCluster()->x() - vtx->x(),
             photon.superCluster()->y() - vtx->y(), photon.superCluster()->z() - vtx->z());
 
+	const float phoWrtVtxPhi = phoWrtVtx.phi();
+	const float phoWrtVtxEta = phoWrtVtx.eta();
+
         float sum = 0;
         // Loop over the PFCandidates
         for (auto const& aCCand : chargedCands) {
 
-            float dxy = -999;
+            auto iCand = aCCand.candidate;
+            float dR2 = deltaR2(phoWrtVtxEta, phoWrtVtxPhi, iCand->eta(), iCand->phi());
+            if (dR2 > coneSizeDR * coneSizeDR ||
+                    (options & DR_VETO && dR2 < dRveto * dRveto))
+                continue;
+
+	    float dxy = -999;
             float dz = -999;
             if (options & PV_CONSTRAINT)
                 getImpactParameters(aCCand, pv, dxy, dz);
@@ -411,11 +420,6 @@ float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photo
             if (fabs(dxy) > dxyMax || fabs(dz) > dzMax)
                 continue;
 
-            auto iCand = aCCand.candidate;
-            float dR2 = deltaR2(phoWrtVtx.Eta(), phoWrtVtx.Phi(), iCand->eta(), iCand->phi());
-            if (dR2 > coneSizeDR * coneSizeDR ||
-                    (options & DR_VETO && dR2 < dRveto * dRveto))
-                continue;
 
             sum += iCand->pt();
         }

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -145,11 +145,11 @@ const std::string names[nVars_] = {
 };
 
 // options and bitflags
-constexpr float coneSizeDR = 0.3;
+constexpr float coneSizeDR2 = 0.3*0.3;
 constexpr float dxyMax = 0.1;
 constexpr float dzMax = 0.2;
-constexpr float dRvetoBarrel = 0.02;
-constexpr float dRvetoEndcap = 0.02;
+constexpr float dRveto2Barrel = 0.02*0.02;
+constexpr float dRveto2Endcap = 0.02*0.02;
 constexpr float ptMin = 0.1;
 
 const unsigned char PV_CONSTRAINT  = 0x1;
@@ -272,7 +272,7 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
 
             // Check if this candidate is within the isolation cone
             float dR2 = deltaR2(phoWrtVtx.Eta(), phoWrtVtx.Phi(), iCand->eta(), iCand->phi());
-            if (dR2 > coneSizeDR * coneSizeDR)
+            if (dR2 > coneSizeDR2)
                 continue;
 
             // Check if this candidate is not in the footprint
@@ -372,7 +372,7 @@ float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photo
 {
     float worstIsolation = 0.0;
 
-    const float dRveto = photon.isEB() ? dRvetoBarrel : dRvetoEndcap;
+    const float dRveto2 = photon.isEB() ? dRveto2Barrel : dRveto2Endcap;
 
     std::vector<CachingPtrCandidate> chargedCands;
     chargedCands.reserve(pfCands.size());
@@ -406,8 +406,8 @@ float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photo
 
             auto iCand = aCCand.candidate;
             float dR2 = deltaR2(phoWrtVtxEta, phoWrtVtxPhi, iCand->eta(), iCand->phi());
-            if (dR2 > coneSizeDR * coneSizeDR ||
-                    (options & DR_VETO && dR2 < dRveto * dRveto))
+            if (dR2 > coneSizeDR2  ||
+                    (options & DR_VETO && dR2 < dRveto2))
                 continue;
 
 	    float dxy = -999;


### PR DESCRIPTION
#### PR description:

The PhotonIDValueMap producer is a known slow module. Part of this is that it does expensive dxy/dz corrections (calling the slow ones too in miniAOD but thats another story).

This is a simple fix which speeds it up by doing a dR match first rather than a slow dxy./dz cut. Further optimisations are more than possible, however this is already significant and is obvious that it is safe.

I'm going to request this back to 102X because it'll speed up analysis user jobs significantly

#### PR validation:

A simple test job on running on (I think) EGamma Run2018 AOD and MINIAOD. This just running VID & scale and smearing in a job and writing out the result. So a typical analysis job.
AOD:
http://sharper.web.cern.ch/sharper/cgi-bin/igprof-navigator/forPRs/aodVIDRef
http://sharper.web.cern.ch/sharper/cgi-bin/igprof-navigator/forPRs/aodVIDSpeedup
time counts PhotonIDValueMapProducer::produce 186.44 -> 81.66
MINIAOD:
http://sharper.web.cern.ch/sharper/cgi-bin/igprof-navigator/forPRs/worstIsolRef
http://sharper.web.cern.ch/sharper/cgi-bin/igprof-navigator/forPRs/worstIsolSpeedup
time counts of PhotonIDValueMapProducer::produce 3,379.67 -> 433.96

