### PR TITLE
xrange migration in fwk packages for python3

### DIFF
--- a/DataFormats/FWLite/examples/patZpeak.py
+++ b/DataFormats/FWLite/examples/patZpeak.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+from builtins import range
 import ROOT
 import sys
 from DataFormats.FWLite import Events, Handle
@@ -39,9 +40,9 @@ for event in events:
     # use muons to make Z peak
     numMuons = len (muons)
     if muons < 2: continue
-    for outer in xrange (numMuons - 1):
+    for outer in range (numMuons - 1):
         outerMuon = muons[outer]
-        for inner in xrange (outer + 1, numMuons):
+        for inner in range (outer + 1, numMuons):
             innerMuon = muons[inner]
             if outerMuon.charge() * innerMuon.charge() >= 0:
                 continue

--- a/DataFormats/FWLite/test/chainEvent_python.py
+++ b/DataFormats/FWLite/test/chainEvent_python.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 from DataFormats.FWLite import Events, Handle
 import optparse
 
@@ -34,7 +35,7 @@ for event in events:
     for loop in range (thing.size()):
         print(thing.at (loop).a)
 
-for i in xrange(events.size()):
+for i in range(events.size()):
     if not events.to(i):
         print("failed to go to index ",i)
         exit(1)

--- a/DataFormats/FWLite/test/pyroot_read_associationvector.py
+++ b/DataFormats/FWLite/test/pyroot_read_associationvector.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+from builtins import range
 import ROOT
 import sys
 from DataFormats.FWLite import Events, Handle
@@ -16,7 +17,7 @@ for event in events:
     #print "###################### ", count
     event.getByLabel (label, handle)
     cont = handle.product()
-    values = [ cont.value(i).value for i in xrange(len(cont))]
+    values = [ cont.value(i).value for i in range(len(cont))]
     for i,v in enumerate(handle.product()):
       #print v.second.value, values[i]
       if v.second.value != values[i]:

--- a/DataFormats/PatCandidates/test/dump_parameterization.py
+++ b/DataFormats/PatCandidates/test/dump_parameterization.py
@@ -1,5 +1,6 @@
 #!/bin/env python
 from __future__ import print_function
+from builtins import range
 import ROOT
 from ROOT import *
 import sys

--- a/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
+++ b/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 from itertools import groupby
 from operator import attrgetter,itemgetter
 import sys
@@ -317,7 +318,7 @@ def findStalledModules(processingSteps, numStreams):
     streamTime = [0]*numStreams
     streamState = [0]*numStreams
     stalledModules = {}
-    modulesActiveOnStream = [{} for x in xrange(numStreams)]
+    modulesActiveOnStream = [{} for x in range(numStreams)]
     for n,trans,s,time,isEvent in processingSteps:
 
         waitTime = None
@@ -351,7 +352,7 @@ def createModuleTiming(processingSteps, numStreams):
     streamTime = [0]*numStreams
     streamState = [0]*numStreams
     moduleTimings = defaultdict(list)
-    modulesActiveOnStream = [defaultdict(int) for x in xrange(numStreams)]
+    modulesActiveOnStream = [defaultdict(int) for x in range(numStreams)]
     for n,trans,s,time,isEvent in processingSteps:
         waitTime = None
         modulesOnStream = modulesActiveOnStream[s]
@@ -372,7 +373,7 @@ def createModuleTiming(processingSteps, numStreams):
 def createAsciiImage(processingSteps, numStreams, maxNameSize):
     streamTime = [0]*numStreams
     streamState = [0]*numStreams
-    modulesActiveOnStreams = [{} for x in xrange(numStreams)]
+    modulesActiveOnStreams = [{} for x in range(numStreams)]
     for n,trans,s,time,isEvent in processingSteps:
         waitTime = None
         modulesActiveOnStream = modulesActiveOnStreams[s]
@@ -505,9 +506,9 @@ class StreamInfoElement:
 # drastically reduces the size of the pdf file.
 def consolidateContiguousBlocks(numStreams, streamInfo):
     oldStreamInfo = streamInfo
-    streamInfo = [[] for x in xrange(numStreams)]
+    streamInfo = [[] for x in range(numStreams)]
 
-    for s in xrange(numStreams):
+    for s in range(numStreams):
         if oldStreamInfo[s]:
             lastStartTime,lastTimeLength,lastColor = oldStreamInfo[s][0].unpack()
             for info in oldStreamInfo[s][1:]:
@@ -580,23 +581,23 @@ def plotPerStreamAboveFirstAndPrepareStack(points, allStackTimes, ax, stream, he
 def createPDFImage(pdfFile, shownStacks, processingSteps, numStreams, stalledModuleInfo, displayExternalWork, checkOrder):
 
     stalledModuleNames = set([x for x in stalledModuleInfo.iterkeys()])
-    streamLowestRow = [[] for x in xrange(numStreams)]
-    modulesActiveOnStreams = [set() for x in xrange(numStreams)]
-    acquireActiveOnStreams = [set() for x in xrange(numStreams)]
-    externalWorkOnStreams  = [set() for x in xrange(numStreams)]
-    previousFinishTime = [None for x in xrange(numStreams)]
-    streamRunningTimes = [[] for x in xrange(numStreams)]
-    streamExternalWorkRunningTimes = [[] for x in xrange(numStreams)]
+    streamLowestRow = [[] for x in range(numStreams)]
+    modulesActiveOnStreams = [set() for x in range(numStreams)]
+    acquireActiveOnStreams = [set() for x in range(numStreams)]
+    externalWorkOnStreams  = [set() for x in range(numStreams)]
+    previousFinishTime = [None for x in range(numStreams)]
+    streamRunningTimes = [[] for x in range(numStreams)]
+    streamExternalWorkRunningTimes = [[] for x in range(numStreams)]
     maxNumberOfConcurrentModulesOnAStream = 1
     externalWorkModulesInJob = False
-    previousTime = [0 for x in xrange(numStreams)]
+    previousTime = [0 for x in range(numStreams)]
 
     # The next five variables are only used to check for out of order transitions
-    finishBeforeStart = [set() for x in xrange(numStreams)]
-    finishAcquireBeforeStart = [set() for x in xrange(numStreams)]
-    countSource = [0 for x in xrange(numStreams)]
-    countDelayedSource = [0 for x in xrange(numStreams)]
-    countExternalWork = [defaultdict(int) for x in xrange(numStreams)]
+    finishBeforeStart = [set() for x in range(numStreams)]
+    finishAcquireBeforeStart = [set() for x in range(numStreams)]
+    countSource = [0 for x in range(numStreams)]
+    countDelayedSource = [0 for x in range(numStreams)]
+    countExternalWork = [defaultdict(int) for x in range(numStreams)]
 
     timeOffset = None
     for n,trans,s,time,isEvent in processingSteps:
@@ -730,7 +731,7 @@ def createPDFImage(pdfFile, shownStacks, processingSteps, numStreams, stalledMod
     ax.set_xlabel("Time (sec)")
     ax.set_ylabel("Stream ID")
     ax.set_ylim(-0.5,numStreams-0.5)
-    ax.yaxis.set_ticks(xrange(numStreams))
+    ax.yaxis.set_ticks(range(numStreams))
 
     height = 0.8/maxNumberOfConcurrentModulesOnAStream
     allStackTimes={'green': [],'limegreen':[], 'red': [], 'blue': [], 'orange': [], 'darkviolet': []}

--- a/FWCore/GuiBrowsers/python/EnablePSetHistory.py
+++ b/FWCore/GuiBrowsers/python/EnablePSetHistory.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 from copy import deepcopy
 import inspect
 import six
@@ -575,7 +576,7 @@ if __name__=='__main__':
                     )
                 ),
                 seven = cms.vstring('alpha','bravo','charlie'),
-                eight = cms.vuint32(range(10)),
+                eight = cms.vuint32(list(range(10))),
                 nine = cms.int32(0)
             )
             ex.zero = cms.string('hello')

--- a/FWCore/GuiBrowsers/python/Vispa/Gui/PortConnection.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Gui/PortConnection.py
@@ -1,3 +1,4 @@
+from builtins import range
 import logging
 
 from PyQt4.QtCore import Qt, QPoint, QPointF, QRectF, QSizeF, SIGNAL

--- a/FWCore/GuiBrowsers/python/Vispa/Gui/ToolBoxContainer.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Gui/ToolBoxContainer.py
@@ -1,3 +1,4 @@
+from builtins import range
 from PyQt4.QtCore import *
 from PyQt4.QtGui import *
 

--- a/FWCore/GuiBrowsers/python/Vispa/Gui/VispaWidget.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Gui/VispaWidget.py
@@ -1,3 +1,4 @@
+from builtins import range
 import math
     
 from PyQt4.QtCore import *

--- a/FWCore/GuiBrowsers/python/Vispa/Main/Application.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Main/Application.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from builtins import range
 import os
 import sys
 import string

--- a/FWCore/GuiBrowsers/python/Vispa/Main/MainWindow.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Main/MainWindow.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from builtins import range
 import logging
 import os
 import math

--- a/FWCore/GuiBrowsers/python/Vispa/Main/RotatingIcon.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Main/RotatingIcon.py
@@ -1,3 +1,4 @@
+from builtins import range
 from PyQt4.QtCore import QTimeLine,SIGNAL,Qt
 from PyQt4.QtGui import QLabel,QPixmap,QMatrix,QPainter
 

--- a/FWCore/GuiBrowsers/python/Vispa/Main/SplitterTab.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Main/SplitterTab.py
@@ -1,3 +1,4 @@
+from builtins import range
 import logging
 
 from PyQt4.QtCore import Qt, SIGNAL, QCoreApplication, QEvent, QSize

--- a/FWCore/GuiBrowsers/python/Vispa/Main/StartupScreen.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Main/StartupScreen.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from builtins import range
 import logging
 
 from PyQt4.QtCore import SIGNAL,QRect,QSize,QPoint

--- a/FWCore/GuiBrowsers/python/Vispa/Main/TabController.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Main/TabController.py
@@ -1,3 +1,4 @@
+from builtins import range
 import os.path
 import logging
 import math

--- a/FWCore/GuiBrowsers/python/Vispa/Plugins/ConfigEditor/ConfigDataAccessor.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Plugins/ConfigEditor/ConfigDataAccessor.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import sys
 import os.path
 import logging

--- a/FWCore/GuiBrowsers/python/Vispa/Plugins/EdmBrowser/EdmDataAccessor.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Plugins/EdmBrowser/EdmDataAccessor.py
@@ -1,3 +1,4 @@
+from builtins import range
 import logging
 import os.path
 
@@ -20,7 +21,7 @@ def all(container):
   if hasattr(container,'GetEntries'):
     try:
       entries = container.GetEntries()
-      for entry in xrange(entries):
+      for entry in range(entries):
         yield entry
     except:
         raise cmserror("Looping of %s failed" %container) 
@@ -31,7 +32,7 @@ def all(container):
       container = container.ids()
     try:
       entries = container.size()
-      for entry in xrange(entries):
+      for entry in range(entries):
         yield container[entry]
     except:
       pass
@@ -204,7 +205,7 @@ class EdmDataAccessor(BasicDataAccessor, RelativeDataAccessor, ParticleDataAcces
                 split_typestring=typestring.split(" ")
                 templates=0
                 end_typestring=0
-                for i in reversed(range(len(split_typestring))):
+                for i in reversed(list(range(len(split_typestring)))):
                     templates+=split_typestring[i].count("<")
                     templates-=split_typestring[i].count(">")
                     if templates==0:

--- a/FWCore/GuiBrowsers/python/Vispa/Plugins/EdmBrowser/EventContentDataAccessor.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Plugins/EdmBrowser/EventContentDataAccessor.py
@@ -1,3 +1,4 @@
+from builtins import range
 import sys
 import logging
 import os.path

--- a/FWCore/GuiBrowsers/python/Vispa/Plugins/EdmBrowser/EventContentView.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Plugins/EdmBrowser/EventContentView.py
@@ -1,3 +1,4 @@
+from builtins import range
 import logging
 
 from PyQt4.QtGui import *

--- a/FWCore/GuiBrowsers/python/Vispa/Views/LineDecayView.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Views/LineDecayView.py
@@ -1,3 +1,4 @@
+from builtins import range
 import sys
 import math
 

--- a/FWCore/GuiBrowsers/python/Vispa/Views/PropertyView.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Views/PropertyView.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import logging
 import sys
 import os.path

--- a/FWCore/GuiBrowsers/python/Vispa/Views/TableView.py
+++ b/FWCore/GuiBrowsers/python/Vispa/Views/TableView.py
@@ -1,3 +1,4 @@
+from builtins import range
 import logging
 
 from PyQt4.QtGui import *

--- a/FWCore/Modules/test/emptysource_cfg.py
+++ b/FWCore/Modules/test/emptysource_cfg.py
@@ -1,5 +1,6 @@
 # Configuration file for EmptySource
 
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
@@ -22,7 +23,7 @@ numberOfEventsInRun = 0
 numberOfEventsPerRun = process.source.numberEventsInRun.value()
 run = process.source.firstRun.value()
 event=0
-for i in xrange(process.maxEvents.input.value()):
+for i in range(process.maxEvents.input.value()):
    numberOfEventsInRun +=1
    event += 1
    if numberOfEventsInRun > numberOfEventsPerRun:

--- a/FWCore/Modules/test/emptysource_firstLuminosityBlockForEachRun_cfg.py
+++ b/FWCore/Modules/test/emptysource_firstLuminosityBlockForEachRun_cfg.py
@@ -1,5 +1,6 @@
 # Configuration file for EmptySource
 
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
@@ -34,7 +35,7 @@ numberOfEventsPerLumi = process.source.numberEventsInLuminosityBlock.value()
 lumi = process.source.firstLuminosityBlock.value()
 event=0
 oldRun = 2
-for i in xrange(process.maxEvents.input.value()):
+for i in range(process.maxEvents.input.value()):
    numberOfEventsInLumi +=1
    event += 1
    run = findRunForLumi(lumi)

--- a/FWCore/Modules/test/testBunchCrossingFilter.py
+++ b/FWCore/Modules/test/testBunchCrossingFilter.py
@@ -22,6 +22,7 @@
 #   3275-3322, 3330-3377, 3385-3432
 # (see https://lpc.web.cern.ch/fillingSchemes/2018/25ns_2556b_2544_2215_2332_144bpi_20injV2.csv)
 
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.pfnInPath import *
 
@@ -51,7 +52,7 @@ process.selectNone = _bunchCrossingFilter.clone(
 
 # full range of possible bunch crossings [1,3564]
 process.selectAll = _bunchCrossingFilter.clone(
-   bunches = cms.vuint32(range(1,3565))
+   bunches = cms.vuint32(list(range(1,3565)))
 )
 
 # select bx 536
@@ -61,7 +62,7 @@ process.selectSingle = _bunchCrossingFilter.clone(
 
 # select the whole train 514-561
 process.selectTrain = _bunchCrossingFilter.clone(
-   bunches = cms.vuint32(range(514,562))
+   bunches = cms.vuint32(list(range(514,562)))
 )
 
 # inverted to veto (non-colliding) bx 1

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import inspect
 import six
 
@@ -744,7 +745,7 @@ if __name__ == "__main__":
         def testLargeList(self):
             #lists larger than 255 entries can not be initialized
             #using the constructor
-            args = [i for i in xrange(0,300)]
+            args = [i for i in range(0,300)]
             
             t = TestList(*args)
             pdump= t.dumpPython()
@@ -826,7 +827,7 @@ if __name__ == "__main__":
                 def __init__(self):
                     self.tLPTest = tLPTest
                     self.tLPTestType = tLPTestType
-            p = tLPTest("MyType",** dict( [ ("a"+str(x), tLPTestType(x)) for x in xrange(0,300) ] ) )
+            p = tLPTest("MyType",** dict( [ ("a"+str(x), tLPTestType(x)) for x in range(0,300) ] ) )
             #check they are the same
             self.assertEqual(p.dumpPython(), eval(p.dumpPython(),{"cms": __DummyModule()}).dumpPython())
         def testSpecialImportRegistry(self):

--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from builtins import range
 from .Mixins import _ConfigureComponent, PrintOptions
 from .Mixins import _Labelable, _Unlabelable
 from .Mixins import _ValidatingParameterListBase
@@ -195,7 +196,7 @@ class _ModuleSequenceType(_ConfigureComponent, _Labelable):
             typename = format_typename(self)
             msg = format_outerframe(2) 
             msg += "The %s constructor takes zero or one sequenceable argument followed by zero or more arguments of type Task. But the following types are given:\n" %typename
-            for item,i in zip(arg, xrange(1,20)):
+            for item,i in zip(arg, range(1,20)):
                 try:
                     msg += "    %i) %s \n"  %(i, item._errorstr())
                 except:

--- a/FWCore/ParameterSet/python/TreeCrawler.py
+++ b/FWCore/ParameterSet/python/TreeCrawler.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from builtins import range
 import sys, os, inspect, copy, struct, dis, imp
 import modulefinder
 import six
@@ -252,7 +253,7 @@ def removeRecursiveLoops( node, verbose=False, currentStack=None ) :
         duplicateIndex=currentStack.index( node ) # If there isn't a recursive loop this will raise a ValueError
         if verbose :
             print("Removing recursive loop in:")
-            for index in xrange(duplicateIndex,len(currentStack)) :
+            for index in range(duplicateIndex,len(currentStack)) :
                 print("   ",currentStack[index].name,"-->")
             print("   ",node.name)
         currentStack[-1].dependencies.remove(node)

--- a/FWCore/PythonUtilities/python/LumiList.py
+++ b/FWCore/PythonUtilities/python/LumiList.py
@@ -10,6 +10,7 @@ This code began life in COMP/CRAB/python/LumiList.py
 """
 
 
+from builtins import range
 import copy
 import json
 import re

--- a/FWCore/PythonUtilities/scripts/generateEDF.py
+++ b/FWCore/PythonUtilities/scripts/generateEDF.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import sys
 import re
 import optparse

--- a/FWCore/Skeletons/python/cms.py
+++ b/FWCore/Skeletons/python/cms.py
@@ -9,6 +9,7 @@ Description: CMS-related utils
 from __future__ import print_function
 
 # system modules
+from builtins import range
 import os
 import sys
 
@@ -26,7 +27,7 @@ def config(tmpl, pkg_help, tmpl_dir):
             print(pkg_help)
             sys.exit(0)
         kwds['pname'] = sys.argv[1]
-        for idx in xrange(2, len(sys.argv)):
+        for idx in range(2, len(sys.argv)):
             opt = sys.argv[idx]
             if  opt == '-author':
                 kwds['author'] = sys.argv[idx+1]

--- a/FWCore/Skeletons/python/utils.py
+++ b/FWCore/Skeletons/python/utils.py
@@ -9,6 +9,7 @@ Description: Utilities module
 from __future__ import print_function
 
 # system modules
+from builtins import range
 import os
 import re
 import sys
@@ -23,7 +24,7 @@ def parse_word(word):
     "Parse word which contas double underscore tag"
     output = set()
     words  = word.split()
-    for idx in xrange(0, len(words)):
+    for idx in range(0, len(words)):
         pat = words[idx]
         if  pat and len(pat) > 4 and pat[:2] == '__': # we found enclosure
             tag = pat[2:pat.rfind('__')]

--- a/Utilities/RelMon/python/directories2html.py
+++ b/Utilities/RelMon/python/directories2html.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 #                                                                              
 ################################################################################
 
+from builtins import range
 from os import chdir,getcwd,listdir,makedirs
 from os.path import basename,join,exists
 import cgi
@@ -379,7 +380,7 @@ def get_rank_section(directory):
     h=directory.rank_histo
     rank_histof=TH1F(h.GetName(),"",h.GetNbinsX(),h.GetXaxis().GetXmin(),h.GetXaxis().GetXmax())
     rank_histof.SetLineWidth(2)
-    for i in xrange(0,h.GetNbinsX()+1):
+    for i in range(0,h.GetNbinsX()+1):
       rank_histof.SetBinContent(i,h.GetBinContent(i))
     h.SetTitle("Ranks Summary;Rank;Frequency")
     h.Draw("Hist")
@@ -804,14 +805,14 @@ def make_summary_table(indir,aggregation_rules,aggregation_rules_twiki, hashing_
   page_html+='<div id="dir_chart"></div> <a href="#top">Top...</a><hr>'
   
   # Barbarian vertical space. Suggestions are welcome
-  for i in xrange(2):
+  for i in range(2):
     page_html+='<div class="span-24"><p></p></div>\n'
 
  
   # Prepare the table
   page_html+='<div class="span-24"><h2 class="alt"><a name="summary_table">Summary Table</a></h2></div>'
 
-  for i in xrange(5):
+  for i in range(5):
     page_html+='<div class="span-24"><p></p></div>\n'
     
   page_html+="""

--- a/Utilities/RelMon/python/dirstructure.py
+++ b/Utilities/RelMon/python/dirstructure.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 #                                                                              
 ################################################################################
 
+from builtins import range
 from array import array
 from copy import deepcopy
 from os import chdir,getcwd,listdir,makedirs,rmdir
@@ -384,7 +385,7 @@ class Comparison(Weighted):
     n_proc=len(tcanvas_print_processes)
     if n_proc>3:
       p_to_remove=[]
-      for iprocess in xrange(0,n_proc):
+      for iprocess in range(0,n_proc):
         p=tcanvas_print_processes[iprocess]
         p.join()
         p_to_remove.append(iprocess)

--- a/Utilities/RelMon/python/dqm_interfaces.py
+++ b/Utilities/RelMon/python/dqm_interfaces.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 #                                                                              
 ################################################################################
 
+from builtins import range
 from copy import deepcopy
 from os import chdir,getcwd,makedirs
 from os.path import abspath,exists,join, basename
@@ -111,7 +112,7 @@ class DQMcommunicator(object):
             raw_folder=eval(self.get_data(url))
         except:
             print("Retrying..")
-            for ntrials in xrange(5):
+            for ntrials in range(5):
                 try:
                     if ntrials!=0:
                         sleep(2)

--- a/Utilities/RelMon/python/utils.py
+++ b/Utilities/RelMon/python/utils.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 ################################################################################
 
 
+from builtins import range
 import array
 import os
 import re
@@ -167,7 +168,7 @@ class StatisticalTest(object):
 #-------------------------------------------------------------------------------
 
 def is_empty(h):
-  for i in xrange(1,getNbins(h)):
+  for i in range(1,getNbins(h)):
     if h.GetBinContent(i)!=0: return False
   return True
   #return h.GetSumOfWeights()==0
@@ -177,7 +178,7 @@ def is_empty(h):
 def is_sparse(h):
   filled_bins=0.
   nbins=h.GetNbinsX()
-  for ibin in xrange(nbins):
+  for ibin in range(nbins):
     if h.GetBinContent(ibin)>0:
       filled_bins+=1
   #print "%s %s --> %s" %(filled_bins,nbins,filled_bins/nbins)
@@ -222,11 +223,11 @@ def profile2histo(profile):
   bin_low_edges=[]
   n_bins=profile.GetNbinsX()
   
-  for ibin in xrange(1,n_bins+2):
+  for ibin in range(1,n_bins+2):
     bin_low_edges.append(profile.GetBinLowEdge(ibin))
   bin_low_edges=array.array('f',bin_low_edges)
   histo=TH1F(profile.GetName(),profile.GetTitle(),n_bins,bin_low_edges)
-  for ibin in xrange(0,n_bins+1):
+  for ibin in range(0,n_bins+1):
     histo.SetBinContent(ibin,profile.GetBinContent(ibin))
     histo.SetBinError(ibin,profile.GetBinError(ibin))    
   
@@ -243,7 +244,7 @@ class Chi2(StatisticalTest):
     n_filled_l=[]
     for h in self.h1,self.h2:
       nfilled=0.
-      for ibin in xrange(1,nbins+1):
+      for ibin in range(1,nbins+1):
         if h.GetBinContent(ibin)>0:
           nfilled+=1
       n_filled_l.append(nfilled)
@@ -252,7 +253,7 @@ class Chi2(StatisticalTest):
   def absval(self):
     nbins=getNbins(self.h1)
     binc=0
-    for i in xrange(1,nbins):
+    for i in range(1,nbins):
       for h in self.h1,self.h2:
         binc=h.GetBinContent(i)
         if binc<0:
@@ -328,7 +329,7 @@ class BinToBin(StatisticalTest):
     equal = 1
     nbins = getNbins(self.h1)
     n_ok_bins=0.0
-    for ibin in xrange(0, nbins+2):
+    for ibin in range(0, nbins+2):
       h1bin=self.h1.GetBinContent(ibin)
       h2bin=self.h2.GetBinContent(ibin)
       bindiff=h1bin-h2bin
@@ -386,7 +387,7 @@ class BinToBin1percent(StatisticalTest):
     equal = 1
     nbins = getNbins(self.h1)
     n_ok_bins=0.0
-    for ibin in xrange(0,nbins):
+    for ibin in range(0,nbins):
       ibin+=1
       h1bin=self.h1.GetBinContent(ibin)
       h2bin=self.h2.GetBinContent(ibin)

--- a/Utilities/RelMon/python/utils_v2.py
+++ b/Utilities/RelMon/python/utils_v2.py
@@ -7,6 +7,7 @@ e-mail:  albertasgim@gmail.com
 '''
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 import sys
 import re
 import time
@@ -310,7 +311,7 @@ class StatisticalTest(object):
         return (x + 1) * (y + 1) * (z + 1)
 
     def is_empty(self, h):
-        for i in xrange(1, self.get_N_bins(h)):
+        for i in range(1, self.get_N_bins(h)):
             if h.GetBinContent(i) != 0:
                 return False
             return True
@@ -347,7 +348,7 @@ class Chi2Test(StatisticalTest):
     name = 'Chi2'
 
     def make_absolute(self, h, bin_count):
-        for i in xrange(1, bin_count): # Why here is no +1?
+        for i in range(1, bin_count): # Why here is no +1?
             content = h.GetBinContent(i)
             if content < 0:
                 h.SetBinContent(i, -1 * content)
@@ -356,7 +357,7 @@ class Chi2Test(StatisticalTest):
 
     def enough_filled_bins(self, h, bin_count, more_than=3):
         filled_bins = 0
-        for i in xrange(1, bin_count):
+        for i in range(1, bin_count):
             if h.GetBinContent(i) > 0:
                 filled_bins += 1
             if filled_bins > more_than:

--- a/Utilities/RelMon/scripts/ValidationMatrix.py
+++ b/Utilities/RelMon/scripts/ValidationMatrix.py
@@ -10,6 +10,7 @@
 ################################################################################
 
 from __future__ import print_function
+from builtins import range
 from optparse import OptionParser
 
 import os
@@ -219,7 +220,7 @@ def get_filenames_from_pool(all_samples):
   #files_list.sort(key=name2version)
   #files_list.sort(key=name2sample) 
   #files_list.sort(key=name2run)
-  for iname in xrange(len(files_list)):
+  for iname in range(len(files_list)):
     filename=files_list[iname]
     if iname%2==0:
       ref_filenames.append(filename)

--- a/Utilities/ReleaseScripts/python/cmsCodeRules/cppFunctionSkipper.py
+++ b/Utilities/ReleaseScripts/python/cmsCodeRules/cppFunctionSkipper.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 __author__="Aurelija"
 __date__ ="$2010-09-23 15.00.20$"
 

--- a/Utilities/ReleaseScripts/python/cmsCodeRules/keyFinder.py
+++ b/Utilities/ReleaseScripts/python/cmsCodeRules/keyFinder.py
@@ -1,3 +1,4 @@
+from builtins import range
 __author__="Aurelija"
 __date__ ="$Jul 12, 2010 10:08:20 AM$"
 

--- a/Utilities/ReleaseScripts/python/cmsCodeRules/showPage.py
+++ b/Utilities/ReleaseScripts/python/cmsCodeRules/showPage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 __author__="Aurelija"
 __date__ ="$2010-08-12 10.50.40$"
 

--- a/Utilities/ReleaseScripts/python/commentSkipper/buildFileCommentSkipper.py
+++ b/Utilities/ReleaseScripts/python/commentSkipper/buildFileCommentSkipper.py
@@ -1,3 +1,4 @@
+from builtins import range
 __author__="Aurelija"
 __date__ ="$2010-07-20 11.52.22$"
 

--- a/Utilities/ReleaseScripts/python/commentSkipper/cppCommentSkipper.py
+++ b/Utilities/ReleaseScripts/python/commentSkipper/cppCommentSkipper.py
@@ -1,3 +1,4 @@
+from builtins import range
 __author__="Aurelija"
 __date__ ="$2010-07-13 12.17.20$"
 

--- a/Utilities/ReleaseScripts/scripts/addOnTests.py
+++ b/Utilities/ReleaseScripts/scripts/addOnTests.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import os
 import time
 import sys

--- a/Utilities/ReleaseScripts/scripts/cmsCodeRulesChecker.py
+++ b/Utilities/ReleaseScripts/scripts/cmsCodeRulesChecker.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 __author__="Aurelija"
 __date__ ="$2010-07-14 16.48.55$"
 

--- a/Utilities/ReleaseScripts/scripts/storeTreeInfo.py
+++ b/Utilities/ReleaseScripts/scripts/storeTreeInfo.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import os, sys, stat
 from operator import itemgetter
 

--- a/Utilities/StaticAnalyzers/scripts/statics.py
+++ b/Utilities/StaticAnalyzers/scripts/statics.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import re
 topfunc = re.compile("::(produce|analyze|filter|beginLuminosityBlock|beginRun|beginStream|streamBeginRun|streamBeginLuminosityBlock|streamEndRun|streamEndLuminosityBlock|globalBeginRun|globalEndRun|globalBeginLuminosityBlock|globalEndLuminosityBlock|endRun|endLuminosityBlock)\(")
 baseclass = re.compile("edm::(one::|stream::|global::)?ED(Producer|Filter|Analyzer)(Base)?")


### PR DESCRIPTION
#### PR description:

at least one unit test in my python3 fwk test fails due to the use of xrange (now range in python3). Migrate using

futurize -f libfuturize.fixes.fix_xrange_with_import -w --no-diffs -n .

(the fwk packages so far)