### PR TITLE
xrange migration for python3

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
@@ -1,3 +1,4 @@
+from builtins import range
 from PhysicsTools.Heppy.analyzers.core.TreeAnalyzerNumpy import TreeAnalyzerNumpy
 from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
 #from ROOT import TriggerBitChecker
@@ -168,7 +169,7 @@ class AutoFillTreeProducer( TreeAnalyzerNumpy ):
             if isinstance(c, tuple) and isinstance(c[0], AutoHandle):
                 if not isMC and c[-1].mcOnly: continue
                 objects = self.handles[cn].product()
-                setattr(event, cn, [objects[i] for i in xrange(objects.size())])
+                setattr(event, cn, [objects[i] for i in range(objects.size())])
                 c = c[-1]
             if not isMC and c.mcOnly: continue
             if self.scalar:

--- a/PhysicsTools/Heppy/python/analyzers/core/ProvenanceAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/ProvenanceAnalyzer.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import itertools
 
 from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
@@ -52,7 +53,7 @@ class ProvenanceAnalyzer( Analyzer ):
         if eid != self.lastId:
             #import pdb; pdb.set_trace()
             history = event.input.object().processHistory()
-            for i in reversed(range(history.size())):
+            for i in reversed(list(range(history.size()))):
                 conf = history.at(i)
                 release = conf.releaseVersion().replace('"',"")
                 vnums = self.cmsswVNums(release)

--- a/PhysicsTools/Heppy/python/analyzers/core/autovars.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/autovars.py
@@ -6,6 +6,7 @@
 #
 # TODO: more documentation needed here!
 
+from builtins import range
 class NTupleVariable:
     """Branch containing an individual variable (either of the event or of an object), created with a name and a function to compute it
        - name, type, help, default: obvious 
@@ -174,7 +175,7 @@ class NTupleCollection:
         treeNumpy.var("n"+self.name, int)
         allvars = self.objectType.allVars(isMC)
         for v in allvars:
-            for i in xrange(1,self.maxlen+1):
+            for i in range(1,self.maxlen+1):
                 h = v.help
                 if self.help: h = "%s for %s [%d]" % ( h if h else v.name, self.help, i-1 )
                 treeNumpy.var("%s%d_%s" % (self.name, i, v.name), type=v.type, default=v.default, title=h, filler=v.filler)
@@ -195,7 +196,7 @@ class NTupleCollection:
         num = min(self.maxlen,len(collection))
         treeNumpy.fill("n"+self.name, num)
         allvars = self.objectType.allVars(isMC)
-        for i in xrange(num): 
+        for i in range(num): 
             o = collection[i]
             for v in allvars:
                 treeNumpy.fill("%s%d_%s" % (self.name, i+1, v.name), v(o))
@@ -209,7 +210,7 @@ class NTupleCollection:
         allvars = self.objectType.allVars(isMC)
         for v in allvars:
             name="%s_%s" % (self.name, v.name) if v.name != "" else self.name
-            treeNumpy.vfill(name, [ v(collection[i]) for i in xrange(num) ])
+            treeNumpy.vfill(name, [ v(collection[i]) for i in range(num) ])
     def __repr__(self):
         return "<NTupleCollection[%s]>" % self.name
 

--- a/PhysicsTools/Heppy/python/analyzers/eventtopology/MT2Analyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/eventtopology/MT2Analyzer.py
@@ -1,3 +1,4 @@
+from builtins import range
 import operator 
 import itertools
 import copy

--- a/PhysicsTools/Heppy/python/analyzers/gen/GeneratorAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/gen/GeneratorAnalyzer.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
 from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
 from PhysicsTools.Heppy.physicsutils.genutils import isNotFromHadronicShower, realGenMothers, realGenDaughters
@@ -84,12 +85,12 @@ class GeneratorAnalyzer( Analyzer ):
             #        "  ".join("%d[%d]" % (p.daughter(i).pdgId(), p.daughter(i).status()) for i in xrange(p.numberOfDaughters())))
             if id in self.savePreFSRParticleIds:
                 # for light objects, we want them pre-radiation
-                if any((p.mother(j).pdgId() == p.pdgId()) for j in xrange(p.numberOfMothers())):
+                if any((p.mother(j).pdgId() == p.pdgId()) for j in range(p.numberOfMothers())):
                     #print "    fail auto-decay"
                     continue
             else:
                 # everything else, we want it after radiation, i.e. just before decay
-                if any((p.daughter(j).pdgId() == p.pdgId() and p.daughter(j).status() > 2) for j in xrange(p.numberOfDaughters())):
+                if any((p.daughter(j).pdgId() == p.pdgId() and p.daughter(j).status() > 2) for j in range(p.numberOfDaughters())):
                     #print "    fail auto-decay"
                     continue
             # FIXME find a better criterion to discard there
@@ -110,7 +111,7 @@ class GeneratorAnalyzer( Analyzer ):
                 if interestingPdgId(mom.pdgId()) or (getattr(mom,'rawIndex',-1) in keymap):
                     #print "    interesting mom"
                     # exclude extra x from p -> p + x
-                    if not any(mom.daughter(j2).pdgId() == mom.pdgId() for j2 in xrange(mom.numberOfDaughters())):
+                    if not any(mom.daughter(j2).pdgId() == mom.pdgId() for j2 in range(mom.numberOfDaughters())):
                         #print "         pass no-self-decay"
                         ok = True
                     # Account for generator feature with Higgs decaying to itself with same four-vector but no daughters
@@ -170,7 +171,7 @@ class GeneratorAnalyzer( Analyzer ):
                 print("%3d  {%6d}: %+8d  %3d :  %8.2f   %+5.2f   %+5.2f : %d %2d : %+8d {%3d}: %s" % ( ip,p.rawIndex,
                         p.pdgId(), p.status(), p.pt(), p.eta(), p.phi(), len(moms), p.numberOfDaughters(), 
                         p.motherId, p.motherIndex,
-                        "  ".join("%d[%d]" % (p.daughter(i).pdgId(), p.daughter(i).status()) for i in xrange(p.numberOfDaughters()))))
+                        "  ".join("%d[%d]" % (p.daughter(i).pdgId(), p.daughter(i).status()) for i in range(p.numberOfDaughters()))))
         if verbose:
             print("\n\n")
 

--- a/PhysicsTools/Heppy/python/analyzers/gen/LHEAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/gen/LHEAnalyzer.py
@@ -1,3 +1,4 @@
+from builtins import range
 from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
 from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
 import PhysicsTools.HeppyCore.framework.config as cfg
@@ -43,7 +44,7 @@ class LHEAnalyzer( Analyzer ):
         lBar=None
         nu=None
         nuBar=None 
-        for i in xrange(0,len(pup)):
+        for i in range(0,len(pup)):
           id=hepeup.IDUP[i]
           status = hepeup.ISTUP[i]
           idabs=abs(id)

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import math, os
 from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
 from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle

--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
 from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
 from PhysicsTools.Heppy.physicsobjects.Electron import Electron
@@ -543,7 +544,7 @@ class LeptonAnalyzer( Analyzer ):
             lep.mcLep=gen
 
     def isFromB(self,particle,bid=5, done={}):
-        for i in xrange( particle.numberOfMothers() ): 
+        for i in range( particle.numberOfMothers() ): 
             mom  = particle.mother(i)
             momid = abs(mom.pdgId())
             if momid / 1000 == bid or momid / 100 == bid or momid == bid: 

--- a/PhysicsTools/Heppy/python/physicsobjects/Jet.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Jet.py
@@ -1,3 +1,4 @@
+from builtins import range
 from PhysicsTools.Heppy.physicsobjects.PhysicsObject import *
 from PhysicsTools.HeppyCore.utils.deltar import deltaPhi
 import math

--- a/PhysicsTools/Heppy/python/physicsutils/JetReCalibrator.py
+++ b/PhysicsTools/Heppy/python/physicsutils/JetReCalibrator.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT
 import os, types
 from math import *
@@ -88,7 +89,7 @@ class JetReCalibrator:
         if emf > self.type1METParams['skipEMfractionThreshold']:
             return None
         if self.type1METParams['skipMuons']:
-            for idau in xrange(jet.numberOfDaughters()):
+            for idau in range(jet.numberOfDaughters()):
                 pfcand = jet.daughter(idau)
                 if pfcand.isGlobalMuon() or pfcand.isStandAloneMuon(): 
                     p4 -= pfcand.p4()

--- a/PhysicsTools/Heppy/python/physicsutils/QGLikelihoodCalculator.py
+++ b/PhysicsTools/Heppy/python/physicsutils/QGLikelihoodCalculator.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT
 import math
 

--- a/PhysicsTools/Heppy/python/physicsutils/genutils.py
+++ b/PhysicsTools/Heppy/python/physicsutils/genutils.py
@@ -1,3 +1,4 @@
+from builtins import range
 from PhysicsTools.Heppy.physicsobjects.PhysicsObjects import printOut 
 from PhysicsTools.Heppy.physicsobjects.PhysicsObjects import GenParticle 
 
@@ -63,7 +64,7 @@ def isPromptLepton(lepton, beforeFSR, includeMotherless=True, includeTauDecays=F
 
 
 def isNotFromHadronicShower(l):
-    for x in xrange(l.numberOfMothers()):
+    for x in range(l.numberOfMothers()):
         mom = l.mother(x)
         if mom.status() > 2: return True
         id = abs(mom.pdgId())
@@ -85,7 +86,7 @@ def realGenDaughters(gp,excludeRadiation=True):
            realGenDaughters(X, excludeRadiation=True)  = { b, c }
            realGenDaughters(X, excludeRadiation=False) = { a, b, c }"""
     ret = []
-    for i in xrange(gp.numberOfDaughters()):
+    for i in range(gp.numberOfDaughters()):
         dau = gp.daughter(i)
         if dau.pdgId() == gp.pdgId():
             if excludeRadiation:
@@ -100,7 +101,7 @@ def realGenMothers(gp):
     """Get the mothers of a particle X going through intermediate X -> X' chains.
        e.g. if Y -> X, X -> X' realGenMothers(X') = Y"""
     ret = []
-    for i in xrange(gp.numberOfMothers()):
+    for i in range(gp.numberOfMothers()):
         mom = gp.mother(i)
         if mom.pdgId() == gp.pdgId():
             ret += realGenMothers(mom)
@@ -110,7 +111,7 @@ def realGenMothers(gp):
 
 def lastGenCopy(gp):
     me = gp.pdgId();
-    for i in xrange(gp.numberOfDaughters()):
+    for i in range(gp.numberOfDaughters()):
         if gp.daughter(i).pdgId() == me:
             return False
     return True

--- a/PhysicsTools/Heppy/scripts/cmsBatch.py
+++ b/PhysicsTools/Heppy/scripts/cmsBatch.py
@@ -3,6 +3,7 @@
 # batch mode for cmsRun, March 2009
 
 from __future__ import print_function
+from builtins import range
 import os, sys,  imp, re, pprint, string, time,shutil,copy,pickle,math
 from optparse import OptionParser
 

--- a/PhysicsTools/Heppy/scripts/cmsStageWithFailover.py
+++ b/PhysicsTools/Heppy/scripts/cmsStageWithFailover.py
@@ -3,6 +3,7 @@
 #this script runs cmsStage multiple times in the case where it failes for some reason
 
 from __future__ import print_function
+from builtins import range
 if __name__ == '__main__':
 
     import PhysicsTools.HeppyCore.utils.eostools as eostools
@@ -31,7 +32,7 @@ if __name__ == '__main__':
     
     sleep_lengths = [1,10,60,600,1800]
     return_code = 0
-    for i in xrange(5):
+    for i in range(5):
 
         #sleep for a while before running
         time.sleep(sleep_lengths[i])

--- a/PhysicsTools/Heppy/scripts/heppy_report.py
+++ b/PhysicsTools/Heppy/scripts/heppy_report.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 from optparse import OptionParser
 import json
 import six
@@ -15,7 +16,7 @@ def root2map(dir,ana,treename):
         print("Error: rootfile %s/%s/%s.root does not contain a TTree %s" % (dir,ana,treename,treename))
         return None
     jsonind = {}
-    for e in xrange(tree.GetEntries()):
+    for e in range(tree.GetEntries()):
         tree.GetEntry(e)
         run,lumi = tree.run, tree.lumi
         if run not in jsonind:

--- a/PhysicsTools/Heppy/test/crab/heppy_crab_script.py
+++ b/PhysicsTools/Heppy/test/crab/heppy_crab_script.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import os
 # probably easier to fetch everything without subdirs, but that's up to user preferences
 #import PhysicsTools.HeppyCore.framework.config as cfg
@@ -14,7 +15,7 @@ crabFiles=PSet.process.source.fileNames
 print(crabFiles)
 firstInput = crabFiles[0]
 print("--------------- using edmFileUtil to convert PFN to LFN -------------------------")
-for i in xrange(0,len(crabFiles)) :
+for i in range(0,len(crabFiles)) :
      pfn=os.popen("edmFileUtil -d %s"%(crabFiles[i])).read() 
      pfn=re.sub("\n","",pfn)
      print(crabFiles[i],"->",pfn)

--- a/PhysicsTools/HeppyCore/python/framework/heppy_loop.py
+++ b/PhysicsTools/HeppyCore/python/framework/heppy_loop.py
@@ -3,6 +3,7 @@
 # https://github.com/cbernet/heppy/blob/master/LICENSE
 
 from __future__ import print_function
+from builtins import range
 import os
 import shutil
 import glob
@@ -99,7 +100,7 @@ def split(comps):
     splitComps = []
     for comp in comps:
         if hasattr( comp, 'fineSplitFactor') and comp.fineSplitFactor>1:
-            subchunks = range(comp.fineSplitFactor)
+            subchunks = list(range(comp.fineSplitFactor))
             for ichunk, chunk in enumerate([(f,i) for f in comp.files for i in subchunks]):
                 newComp = copy.deepcopy(comp)
                 newComp.files = [chunk[0]]

--- a/PhysicsTools/HeppyCore/python/framework/looper.py
+++ b/PhysicsTools/HeppyCore/python/framework/looper.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 # Copyright (C) 2014 Colin Bernet
 # https://github.com/cbernet/heppy/blob/master/LICENSE
 
+from builtins import range
 import os
 import sys
 import imp

--- a/PhysicsTools/HeppyCore/python/statistics/counter.py
+++ b/PhysicsTools/HeppyCore/python/statistics/counter.py
@@ -1,6 +1,7 @@
  # Copyright (C) 2014 Colin Bernet
 # https://github.com/cbernet/heppy/blob/master/LICENSE
 
+from builtins import range
 import pickle
 from PhysicsTools.HeppyCore.utils.diclist import diclist
 

--- a/PhysicsTools/HeppyCore/python/utils/dataset.py
+++ b/PhysicsTools/HeppyCore/python/utils/dataset.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 import os
 import pprint
 import re
@@ -170,7 +171,7 @@ class CMSDataset( BaseDataset ):
         if num_files > limit:
             num_steps = int(num_files/limit)+1
             self.files = []
-            for i in xrange(num_steps):
+            for i in range(num_steps):
                 DBSFiles=self.buildListOfFilesDBS(pattern,
                                                   i*limit,
                                                   ((i+1)*limit)-1)

--- a/PhysicsTools/HeppyCore/python/utils/dataset_test.py
+++ b/PhysicsTools/HeppyCore/python/utils/dataset_test.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from builtins import range
 from .dataset import * 
 
 import unittest 

--- a/PhysicsTools/HeppyCore/python/utils/edmIntegrityCheck.py
+++ b/PhysicsTools/HeppyCore/python/utils/edmIntegrityCheck.py
@@ -5,6 +5,7 @@ Classes to check that a set of ROOT files are OK and publish a report
 from __future__ import print_function
 from __future__ import absolute_import
 
+from builtins import range
 import datetime, fnmatch, json, os, shutil, sys, tempfile, time
 import subprocess
 
@@ -145,7 +146,7 @@ class IntegrityCheck(object):
         good_duplicates = {}
         bad_jobs = set()
         sum_dup = 0
-        for i in xrange(mmin, mmax+1):
+        for i in range(mmin, mmax+1):
             if i in files:
                 duplicates = sorted(files[i])
 

--- a/PhysicsTools/HeppyCore/python/utils/production_tasks.py
+++ b/PhysicsTools/HeppyCore/python/utils/production_tasks.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+from builtins import range
 import copy, datetime, inspect, fnmatch, os, re, subprocess, sys, tempfile, time
 import glob
 import gzip
@@ -606,7 +607,7 @@ class MonitorJobs(Task):
             """Parse the header from bjobs"""
             tokens = [t for t in header.split(' ') if t]
             result = {}
-            for i in xrange(len(tokens)):
+            for i in range(len(tokens)):
                 result[tokens[i]] = i          
 
             return result

--- a/PhysicsTools/HeppyCore/python/utils/testtree.py
+++ b/PhysicsTools/HeppyCore/python/utils/testtree.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 from ROOT import TFile
 from PhysicsTools.HeppyCore.statistics.tree import Tree
 

--- a/PhysicsTools/HeppyCore/scripts/heppy_batch.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_batch.py
@@ -1,6 +1,7 @@
 #!/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import sys
 import imp
 import copy
@@ -362,7 +363,7 @@ if __name__ == '__main__':
     handle.close()
 
     components = split( [comp for comp in config.components if len(comp.files)>0] )
-    listOfValues = range(0, len(components))
+    listOfValues = list(range(0, len(components)))
     listOfNames = [comp.name for comp in components]
 
     batchManager.PrepareJobs( listOfValues, listOfNames )

--- a/PhysicsTools/NanoAOD/test/inspectNanoFile.py
+++ b/PhysicsTools/NanoAOD/test/inspectNanoFile.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from builtins import range
 import sys, os.path, json
 from collections import defaultdict
 import six
@@ -93,7 +94,7 @@ def inspectRootFile(infile):
         entries = tree.GetEntries()
         trees[treeName] = tree
         branchList = tree.GetListOfBranches()
-        allbranches = [ Branch(tree,branchList.At(i)) for i in xrange(branchList.GetSize()) ]
+        allbranches = [ Branch(tree,branchList.At(i)) for i in range(branchList.GetSize()) ]
         branchmap = dict((b.name,b) for b in allbranches)
         branchgroups = {}
         # make list of counters and countees

--- a/PhysicsTools/PatAlgos/python/tools/cmsswVersionTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/cmsswVersionTools.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 from FWCore.GuiBrowsers.ConfigToolBase import *

--- a/PhysicsTools/PatAlgos/python/tools/coreTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/coreTools.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 from FWCore.GuiBrowsers.ConfigToolBase import *
 
 from PhysicsTools.PatAlgos.tools.helpers import *

--- a/PhysicsTools/PatAlgos/python/tools/trigTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/trigTools.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 from FWCore.GuiBrowsers.ConfigToolBase import *
 
 from PhysicsTools.PatAlgos.tools.helpers import *

--- a/PhysicsTools/PatAlgos/test/miniAOD/example_packedCandidates.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/example_packedCandidates.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 # import ROOT in batch mode
+from builtins import range
 import sys
 oldargv = sys.argv[:]
 sys.argv = [ '-b-' ]
@@ -49,7 +50,7 @@ for iev,event in enumerate(events):
         pileup  = 0
         # now get a list of the PF candidates used to build this lepton, so to exclude them
         footprint = set()
-        for i in xrange(lep.numberOfSourceCandidatePtrs()):
+        for i in range(lep.numberOfSourceCandidatePtrs()):
             footprint.add(lep.sourceCandidatePtr(i).key()) # the key is the index in the pf collection
         # now loop on pf candidates
         for ipf,pf in enumerate(pfs.product()):
@@ -73,7 +74,7 @@ for iev,event in enumerate(events):
     for i,j in enumerate(jets.product()):
         if j.pt() < 40 or abs(j.eta()) > 2.4: continue
         sums = [0,0]
-        for id in xrange(j.numberOfDaughters()):
+        for id in range(j.numberOfDaughters()):
             dau = j.daughter(id)
             if (dau.charge() == 0): continue
             sums[ abs(dau.dz())<0.1 ] += dau.pt()

--- a/PhysicsTools/PythonAnalysis/python/ParticleDecayDrawer.py
+++ b/PhysicsTools/PythonAnalysis/python/ParticleDecayDrawer.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 # this tool is based on Luca Lista's tree drawer module
 
 
+from builtins import range
 class ParticleDecayDrawer(object):
     """Draws particle decay tree """
     
@@ -21,7 +22,7 @@ class ParticleDecayDrawer(object):
          
     def _hasValidDaughters(self, candidate):
         nDaughters = candidate.numChildren()
-        for i in xrange(nDaughters):
+        for i in range(nDaughters):
             if self._select(candidate.listChildren()[i]): return True
         return False        
 
@@ -41,13 +42,13 @@ class ParticleDecayDrawer(object):
     
           validDau = 0
           nOfDaughters = candidate.numChildren()
-          for i in xrange(nOfDaughters):
+          for i in range(nOfDaughters):
               if self._accept(candidate.listChildren()[i], skipList): validDau+=1
           if validDau == 0: return out
     
           out += " ->"
     
-          for i in xrange(nOfDaughters):
+          for i in range(nOfDaughters):
               d = candidate.listChildren()[i]
               if self._accept(d, skipList):
                   decString = self._decay(d, skipList)
@@ -65,7 +66,7 @@ class ParticleDecayDrawer(object):
                 if self._select(particle):
                     skipList.append(particle)
                     nodesList.append(particle)
-                    for j in xrange(particle.numParents()):
+                    for j in range(particle.numParents()):
                         mom = particle.listParents()[j]
                         while (mom.mother()):# != None ):
                             mom = mom.mother()
@@ -75,7 +76,7 @@ class ParticleDecayDrawer(object):
         print("-- decay --")  
         if len(momsList) > 0:
             if len(momsList) > 1:
-                for m in xrange(len(momsList)):
+                for m in range(len(momsList)):
                     decString = self._decay( momsList[m], skipList)
                     if len(decString) > 0:
                        print("{ %s } " %decString)

--- a/PhysicsTools/PythonAnalysis/python/cmstools.py
+++ b/PhysicsTools/PythonAnalysis/python/cmstools.py
@@ -5,6 +5,7 @@ benedikt.hegner@cern.ch
 """
 from __future__ import absolute_import
 from __future__ import print_function
+from builtins import range
 import re
 import ROOT
 import exceptions
@@ -29,7 +30,7 @@ def all(container):
   if hasattr(container,'GetEntries'):
     try:
       entries = container.GetEntries()
-      for entry in xrange(entries):
+      for entry in range(entries):
         yield entry
     except:
         raise cmserror("Looping of %s failed" %container) 
@@ -38,7 +39,7 @@ def all(container):
   elif hasattr(container, 'size'):
     try:
       entries = container.size()
-      for entry in xrange(entries):
+      for entry in range(entries):
         yield container[entry]
     except:
       pass
@@ -133,7 +134,7 @@ class EventTree(object):
           self.__setBranchIndicies()
           self._tree.GetEntry(self._index,0)
           # the real loop
-          for entry in xrange(self._tree.GetEntries()):
+          for entry in range(self._tree.GetEntries()):
               self._index = entry
               self.__setBranchIndicies()
               self._tree.GetEntry(self._index,0)

--- a/PhysicsTools/PythonAnalysis/python/diffProv.py
+++ b/PhysicsTools/PythonAnalysis/python/diffProv.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from builtins import range
 class difference :
     
     def __init__(self,v):

--- a/PhysicsTools/PythonAnalysis/python/diff_provenance.py
+++ b/PhysicsTools/PythonAnalysis/python/diff_provenance.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 class difference :
     
     def __init__(self,v):

--- a/PhysicsTools/PythonAnalysis/python/iterators.py
+++ b/PhysicsTools/PythonAnalysis/python/iterators.py
@@ -3,6 +3,7 @@
 
 #import cmserror
 
+from builtins import range
 def addIterator(obj):
     """function for adding iterators to objects""" 
     if not hasattr(obj, "__iter__"):
@@ -25,7 +26,7 @@ def addIterator(obj):
 def iteratorForSizedObjects(self):
     """dynamically added iterator"""
     entries = container.size()
-    for entry in xrange(entries):
+    for entry in range(entries):
         yield obj[entry]
   
         

--- a/PhysicsTools/PythonAnalysis/python/rootplot/core.py
+++ b/PhysicsTools/PythonAnalysis/python/rootplot/core.py
@@ -4,6 +4,7 @@ An API and a CLI for quickly building complex figures.
 from __future__ import absolute_import
 from __future__ import print_function
 
+from builtins import range
 __license__ = '''\
 Copyright (c) 2009-2010 Jeff Klukas <klukas@wisc.edu>
 
@@ -1723,7 +1724,7 @@ def process_options(options):
         elif options.histfill: plot_style = 'histfill'
         if options.stack: plot_style = 'stack'
     if not options.markers and use_mpl:
-        options.marker_styles = ['o' for i in xrange(nhists)]
+        options.marker_styles = ['o' for i in range(nhists)]
     if not options.line_colors:
         options.line_colors = options.colors
     if not options.fill_colors:
@@ -1732,38 +1733,38 @@ def process_options(options):
         options.marker_colors = options.colors
     if use_mpl:
         if not options.line_styles:
-            options.line_styles = ['solid' for i in xrange(nhists)]
+            options.line_styles = ['solid' for i in range(nhists)]
         if not options.plot_styles:
-            options.plot_styles = [plot_style for i in xrange(nhists)]
+            options.plot_styles = [plot_style for i in range(nhists)]
         if not options.errorbar_colors:
-            options.errorbar_colors = [None for i in xrange(nhists)]
+            options.errorbar_colors = [None for i in range(nhists)]
         if not options.alphas:
-            options.alphas = [options.alpha for i in xrange(nhists)]
+            options.alphas = [options.alpha for i in range(nhists)]
     else:
         if not options.line_styles:
-            options.line_styles = [1 for i in xrange(nhists)]
+            options.line_styles = [1 for i in range(nhists)]
         if not options.draw_commands:
             if options.stack:
                 options.draw_commands = ['stack ' + options.draw
-                                         for i in xrange(nhists)]
+                                         for i in range(nhists)]
             else:
                 options.draw_commands = [options.draw
-                                         for i in xrange(nhists)]
+                                         for i in range(nhists)]
     if not options.fill_styles:
         if use_mpl:
-            options.fill_styles = [None for i in xrange(nhists)]
+            options.fill_styles = [None for i in range(nhists)]
         else:
             if options.fill:
-                options.fill_styles = [1001 for i in xrange(nhists)]
+                options.fill_styles = [1001 for i in range(nhists)]
             else:
-                options.fill_styles = [0 for i in xrange(nhists)]
+                options.fill_styles = [0 for i in range(nhists)]
     if not options.marker_sizes:
         if options.markers:
             if use_mpl: size = mpl.rcParams['lines.markersize']
             else: size = ROOT.gStyle.GetMarkerSize()
         else:
             size = 0
-        options.marker_sizes = [size for i in xrange(nhists)]
+        options.marker_sizes = [size for i in range(nhists)]
     if options.data:
         i = options.data - 1
         options.line_styles[i] = options.data_linestyle

--- a/PhysicsTools/PythonAnalysis/python/rootplot/root2matplotlib.py
+++ b/PhysicsTools/PythonAnalysis/python/rootplot/root2matplotlib.py
@@ -2,6 +2,7 @@
 Utilities for plotting ROOT histograms in matplotlib.
 """
 
+from builtins import range
 __license__ = '''\
 Copyright (c) 2009-2010 Jeff Klukas <klukas@wisc.edu>
 
@@ -278,7 +279,7 @@ class HistStack(utilities.HistStack):
                          **all_kwargs)
             plots.append(bar)
         from matplotlib.ticker import FixedLocator
-        locator = FixedLocator(range(len(labels)))
+        locator = FixedLocator(list(range(len(labels))))
         ax.w_yaxis.set_major_locator(locator)
         ax.w_yaxis.set_ticklabels(labels)
         ax.set_ylim3d(-1, len(labels))

--- a/PhysicsTools/PythonAnalysis/python/rootplot/rootinfo.py
+++ b/PhysicsTools/PythonAnalysis/python/rootplot/rootinfo.py
@@ -4,6 +4,7 @@ Print information about objects in a ROOT file.
 from __future__ import absolute_import
 from __future__ import print_function
 
+from builtins import range
 from .version import __version__
 
 from ROOT import Double
@@ -46,7 +47,7 @@ def recurse_thru_file(in_tfile, options, full_path='/'):
                         if obj.InheritsFrom('TH2'):
                             # Print contents as they would look on the 2D graph
                             # Left to right, top to bottom.  Start in upper left corner.
-                            for j in reversed(range(obj.GetNbinsY())):
+                            for j in reversed(list(range(obj.GetNbinsY()))):
                                 print()
                                 print(" %s" % ' '.join(
                                     [str(obj.GetBinContent(i+1, j+1)) for i in range(obj.GetNbinsX())]), end=' ')
@@ -55,7 +56,7 @@ def recurse_thru_file(in_tfile, options, full_path='/'):
                                 [str(obj.GetBinContent(i+1)) for i in range(obj.GetNbinsX())]), end=' ')
                     if "errors" == arg:
                         if obj.InheritsFrom('TH2'):
-                            for j in reversed(range(obj.GetNbinsY())):
+                            for j in reversed(list(range(obj.GetNbinsY()))):
                                 print()
                                 print(" %s" % ' '.join(
                                     [str(obj.GetBinError(i+1, j+1)) for i in range(obj.GetNbinsX())]), end=' ')

--- a/PhysicsTools/PythonAnalysis/python/rootplot/rootmath.py
+++ b/PhysicsTools/PythonAnalysis/python/rootplot/rootmath.py
@@ -4,6 +4,7 @@ rootmath description
 from __future__ import absolute_import
 from __future__ import print_function
 
+from builtins import range
 __license__ = '''\
 Copyright (c) 2009-2010 Jeff Klukas <klukas@wisc.edu>
 

--- a/PhysicsTools/PythonAnalysis/python/rootplot/utilities.py
+++ b/PhysicsTools/PythonAnalysis/python/rootplot/utilities.py
@@ -3,6 +3,7 @@ Utilities for rootplot including histogram classes.
 """
 from __future__ import print_function
 
+from builtins import range
 __license__ = '''\
 Copyright (c) 2009-2010 Jeff Klukas <klukas@wisc.edu>
 
@@ -148,13 +149,13 @@ class Hist(object):
             hist.GetPoint(i, x, y)
             self.x.append(copy.copy(x))
             self.y.append(copy.copy(y))
-        lower = [max(0, hist.GetErrorXlow(i))  for i in xrange(n)]
-        upper = [max(0, hist.GetErrorXhigh(i)) for i in xrange(n)]
+        lower = [max(0, hist.GetErrorXlow(i))  for i in range(n)]
+        upper = [max(0, hist.GetErrorXhigh(i)) for i in range(n)]
         self.xerr = [lower[:], upper[:]]
-        lower = [max(0, hist.GetErrorYlow(i))  for i in xrange(n)]
-        upper = [max(0, hist.GetErrorYhigh(i)) for i in xrange(n)]
+        lower = [max(0, hist.GetErrorYlow(i))  for i in range(n)]
+        upper = [max(0, hist.GetErrorYhigh(i)) for i in range(n)]
         self.yerr = [lower[:], upper[:]]
-        self.xedges = [self.x[i] - self.xerr[0][i] for i in xrange(n)]
+        self.xedges = [self.x[i] - self.xerr[0][i] for i in range(n)]
         self.xedges.append(self.x[n - 1] + self.xerr[1][n - 1])
         self.width = [self.xedges[i + 1] - self.xedges[i] for i in range(n)]
         self.underflow, self.overflow = 0, 0

--- a/PhysicsTools/PythonAnalysis/test/testHistogrammar.py
+++ b/PhysicsTools/PythonAnalysis/test/testHistogrammar.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from builtins import range
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as pyplot
@@ -9,7 +10,7 @@ import histogrammar as hg
 
 # generate a stream of uniform random numbers
 import random
-data = [random.random() for i in xrange(2000)]
+data = [random.random() for i in range(2000)]
 
 # aggregation structure and fill rule
 histogram = hg.Bin(num=20, low=0, high=1, quantity=lambda x: x, value=hg.Count())

--- a/PhysicsTools/PythonAnalysis/test/testNumba.py
+++ b/PhysicsTools/PythonAnalysis/test/testNumba.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 # from examples in numba documentaiton
 # http://numba.pydata.org/numba-doc/dev/user/examples.html (0.33.0)
 
+from builtins import range
 import numpy as np
 
 from numba import guvectorize

--- a/PhysicsTools/PythonAnalysis/test/testRootpy.py
+++ b/PhysicsTools/PythonAnalysis/test/testRootpy.py
@@ -8,6 +8,7 @@ Working with ROOT histograms
 This example demonstrates how to create and work with ROOT histogram in rootpy.
 """
 from __future__ import print_function
+from builtins import range
 print(__doc__)
 from rootpy.extern.six.moves import range
 from rootpy.plotting import Hist, Hist2D, Hist3D, HistStack, Legend, Canvas

--- a/PhysicsTools/PythonAnalysis/test/testhep_ml.py
+++ b/PhysicsTools/PythonAnalysis/test/testhep_ml.py
@@ -6,6 +6,7 @@ Testing all the nnet library
 """
 from __future__ import division, print_function
 
+from builtins import range
 import numpy
 from sklearn.linear_model.logistic import LogisticRegression
 from sklearn.datasets import make_blobs

--- a/PhysicsTools/TagAndProbe/test/utilities/dumpPileup.py
+++ b/PhysicsTools/TagAndProbe/test/utilities/dumpPileup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import sys
 import ROOT
 fin=ROOT.TFile.Open(sys.argv[1])
 pu = fin.Get("pileup")
-pileup = map( pu.GetBinContent, xrange(1,pu.GetNbinsX()+1) )
+pileup = map( pu.GetBinContent, range(1,pu.GetNbinsX()+1) )
 print(",".join(map(lambda x: "%1.3g"%x, pileup)))

--- a/RecoBTag/PerformanceDB/test/plotPerformanceDB.py
+++ b/RecoBTag/PerformanceDB/test/plotPerformanceDB.py
@@ -9,6 +9,7 @@
 #____________________________________________________________
 
 from __future__ import print_function
+from builtins import range
 import sys
 import math
 import commands
@@ -56,7 +57,7 @@ def main():
     MCefferrarray_alleta = array('d')
         
 
-    for ipt in xrange(0,ptNbins):
+    for ipt in range(0,ptNbins):
         SF_alleta = 0.
         SFerr_alleta = 0.
         Eff_alleta = 0.
@@ -68,7 +69,7 @@ def main():
         ptarray.append( apt )
         pterrarray.append( ptbinwidth*0.5 )
                     
-        for ieta in xrange(0,etaNbins):
+        for ieta in range(0,etaNbins):
 
             aeta = etamin = ieta*etabinwidth
 

--- a/RecoLuminosity/LumiDB/plotdata/checklumidiff.py
+++ b/RecoLuminosity/LumiDB/plotdata/checklumidiff.py
@@ -1,3 +1,4 @@
+from builtins import range
 import sys,os,os.path,glob,csv,math,datetime
 def parseplotcache(filelist,fillmin,fillmax):
     result={}#{fill:{run:delivered}}
@@ -9,7 +10,7 @@ def parseplotcache(filelist,fillmin,fillmax):
             if idx!=0:
                 [run,fill]=row[0].split(':')
                 [lumils,cmsls]=row[1].split(':')
-                if int(fill) not in range(fillmin,fillmax+1):
+                if int(fill) not in list(range(fillmin,fillmax+1)):
                     continue
                 delivered=float(row[5])
                 if int(fill) not in result:

--- a/RecoLuminosity/LumiDB/plotdata/create_public_lumi_plots.py
+++ b/RecoLuminosity/LumiDB/plotdata/create_public_lumi_plots.py
@@ -5,6 +5,7 @@
 ######################################################################
 
 from __future__ import print_function
+from builtins import range
 import sys
 import os
 import commands
@@ -729,8 +730,8 @@ if __name__ == "__main__":
     print("  last day to consider:  %s (%d, week %d)" % \
           (date_end.isoformat(), year_end, week_end))
     num_days = (date_end - date_begin).days + 1
-    days = [date_begin + datetime.timedelta(days=i) for i in xrange(num_days)]
-    years = range(year_begin, year_end + 1)
+    days = [date_begin + datetime.timedelta(days=i) for i in range(num_days)]
+    years = list(range(year_begin, year_end + 1))
     weeks = []
     day_cur = date_begin
     while day_cur <= date_end:
@@ -1588,7 +1589,7 @@ if __name__ == "__main__":
                                                  for i in times_tmp]
                         times = [matplotlib.dates.date2num(i) for i in times_tmp]
                         # DEBUG DEBUG DEBUG
-                        for i in xrange(len(times) - 1):
+                        for i in range(len(times) - 1):
                             assert times[i] < times[i + 1]
                         # DEBUG DEBUG DEBUG end
                         weights_del = lumi_data.lum_del(units)
@@ -1748,7 +1749,7 @@ if __name__ == "__main__":
                     times_tmp = [AtMidnight(i) for i in lumi_data.times()]
                     times = [matplotlib.dates.date2num(i) for i in times_tmp]
                     # DEBUG DEBUG DEBUG
-                    for i in xrange(len(times) - 1):
+                    for i in range(len(times) - 1):
                         assert times[i] < times[i + 1]
                     # DEBUG DEBUG DEBUG end
                     weights_inst = lumi_data.lum_inst_max(units)

--- a/RecoLuminosity/LumiDB/plotdata/create_public_pileup_plots.py
+++ b/RecoLuminosity/LumiDB/plotdata/create_public_pileup_plots.py
@@ -11,6 +11,7 @@
 # --calcMode true --maxPileupBin=40 pu2012DCSONLY.root
 
 from __future__ import print_function
+from builtins import range
 import sys
 import os
 import commands
@@ -195,11 +196,11 @@ if __name__ == "__main__":
 
     # Turn the ROOT histogram into a Matplotlib one.
     bin_edges = [pileup_hist.GetBinLowEdge(i) \
-                 for i in xrange(1, pileup_hist.GetNbinsX() + 1)]
+                 for i in range(1, pileup_hist.GetNbinsX() + 1)]
     vals = [pileup_hist.GetBinCenter(i) \
-            for i in xrange(1, pileup_hist.GetNbinsX() + 1)]
+            for i in range(1, pileup_hist.GetNbinsX() + 1)]
     weights = [pileup_hist.GetBinContent(i) \
-               for i in xrange(1, pileup_hist.GetNbinsX() + 1)]
+               for i in range(1, pileup_hist.GetNbinsX() + 1)]
     # NOTE: Convert units to /pb!
     weights = [1.e-6 * i for i in weights]
 

--- a/RecoLuminosity/LumiDB/python/CommonUtil.py
+++ b/RecoLuminosity/LumiDB/python/CommonUtil.py
@@ -1,6 +1,7 @@
 '''This module collects some frequently used helper functions
 '''
 from __future__ import print_function
+from builtins import range
 import time,ast,re,json,coral,array
 def flatten(obj):
     '''Given nested lists or tuples, returns a single flattened list'''

--- a/RecoLuminosity/LumiDB/python/dataDML.py
+++ b/RecoLuminosity/LumiDB/python/dataDML.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 import os,coral,fnmatch,time
 from RecoLuminosity.LumiDB import nameDealer,dbUtil,revisionDML,lumiTime,CommonUtil,lumiCorrections
 from datetime import datetime

--- a/RecoLuminosity/LumiDB/python/dbUtil.py
+++ b/RecoLuminosity/LumiDB/python/dbUtil.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import coral
 from RecoLuminosity.LumiDB import nameDealer        
 class dbUtil(object):

--- a/RecoLuminosity/LumiDB/python/generateDummyData.py
+++ b/RecoLuminosity/LumiDB/python/generateDummyData.py
@@ -1,3 +1,4 @@
+from builtins import range
 import array,coral
 from RecoLuminosity.LumiDB import CommonUtil
 def lumiSummary(schema,nlumils):

--- a/RecoLuminosity/LumiDB/python/lumiCalcAPI.py
+++ b/RecoLuminosity/LumiDB/python/lumiCalcAPI.py
@@ -1,3 +1,4 @@
+from builtins import range
 import os,coral,datetime,fnmatch,time
 from RecoLuminosity.LumiDB import nameDealer,revisionDML,dataDML,lumiTime,CommonUtil,selectionParser,hltTrgSeedMapper,normFunctors,lumiParameters
 
@@ -339,7 +340,7 @@ def instLumiForIds(schema,irunlsdict,dataidmap,runsummaryMap,beamstatusfilter=No
                                 bxvaluelist.append(bxval)
                                 bxerrorlist.append(bxerrArray[idx])
                     else:
-                        bxidxlist=range(0,len(bxvalueArray))
+                        bxidxlist=list(range(0,len(bxvalueArray)))
                         bxvaluelist=bxvalueArray.tolist()
                         bxerrorlist=bxerrArray.tolist()
                     del bxvalueArray[:]

--- a/RecoLuminosity/LumiDB/python/lumiReport.py
+++ b/RecoLuminosity/LumiDB/python/lumiReport.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 # Author:      Zhen Xie                                   #
 ###########################################################
 
+from builtins import range
 import os,sys,time
 from RecoLuminosity.LumiDB import tablePrinter, csvReporter,CommonUtil
 from RecoLuminosity.LumiDB.wordWrappers import wrap_always, wrap_onspace, wrap_onspace_strict

--- a/RecoLuminosity/LumiDB/python/lumidbDDL.py
+++ b/RecoLuminosity/LumiDB/python/lumidbDDL.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 import coral
 from RecoLuminosity.LumiDB import nameDealer,dbUtil
 #=======================================================

--- a/RecoLuminosity/LumiDB/python/matplotRender.py
+++ b/RecoLuminosity/LumiDB/python/matplotRender.py
@@ -5,6 +5,7 @@ Specs:
 -- we support http mode by sending string buf via meme type image/png. Sending a premade static plot to webserver is considered a uploading process instead of http dynamic graphical mode. 
 '''
 from __future__ import print_function
+from builtins import range
 import sys,os
 import numpy,datetime
 import matplotlib
@@ -471,7 +472,7 @@ class matplotRender():
         flat=[]
         MinDay=minTime.date().toordinal()
         MaxDay=maxTime.date().toordinal()
-        fulldays=range(MinDay,MaxDay+1)
+        fulldays=list(range(MinDay,MaxDay+1))
         allstarts=[]
         allstops=[]
         for label,yvalues in rawdata.items():
@@ -617,7 +618,7 @@ class matplotRender():
         flat=[]
         MinDay=minTime.date().toordinal()
         MaxDay=maxTime.date().toordinal()
-        fulldays=range(MinDay,MaxDay+1)
+        fulldays=list(range(MinDay,MaxDay+1))
         for label in rawdata.keys():
             yvalues=sorted(rawdata[label])
             alldays=[t[0] for t in yvalues]
@@ -729,7 +730,7 @@ class matplotRender():
         peakinst=max(rawydata['Delivered'])/lslength
         totaldelivered=sum(rawydata['Delivered'])
         totalrecorded=sum(rawydata['Recorded'])
-        xpoints=range(1,totalls+1)        
+        xpoints=list(range(1,totalls+1))        
         #print len(xpoints)
         ypoints={}
         ymax={}

--- a/RecoLuminosity/LumiDB/python/mpl_axes_hist_fix.py
+++ b/RecoLuminosity/LumiDB/python/mpl_axes_hist_fix.py
@@ -4,6 +4,7 @@
 
 # This is used by the create_public_lumi_plots.py script.
 
+from builtins import range
 import numpy as np
 import itertools
 import matplotlib.cbook as cbook
@@ -196,7 +197,7 @@ def hist(self, x, bins=10, range=None, normed=False, weights=None,
 
     if color is None:
         color = [next(self._get_lines.color_cycle)
-                                        for i in xrange(nx)]
+                                        for i in range(nx)]
     else:
         color = mcolors.colorConverter.to_rgba_array(color)
         if len(color) != nx:
@@ -217,7 +218,7 @@ def hist(self, x, bins=10, range=None, normed=False, weights=None,
 
         if len(w) != nx:
             raise ValueError('weights should have the same shape as x')
-        for i in xrange(nx):
+        for i in range(nx):
             if len(w[i]) != len(x[i]):
                 raise ValueError(
                     'weights should have the same shape as x')
@@ -259,7 +260,7 @@ def hist(self, x, bins=10, range=None, normed=False, weights=None,
         hist_kwargs['new'] = True
 
     n = []
-    for i in xrange(nx):
+    for i in range(nx):
         # this will automatically overwrite bins,
         # so that each histogram uses the same bins
         m, bins = np.histogram(x[i], bins, weights=w[i], **hist_kwargs)

--- a/RecoLuminosity/LumiDB/python/pyrootRender.py
+++ b/RecoLuminosity/LumiDB/python/pyrootRender.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import sys
 import ROOT
 from ROOT import TCanvas,TH1F,gROOT,TFile,gStyle,gDirectory,TDatime,TLegend

--- a/RecoLuminosity/LumiDB/python/queryDataSource.py
+++ b/RecoLuminosity/LumiDB/python/queryDataSource.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import array,coral
 from RecoLuminosity.LumiDB import CommonUtil,nameDealer
 

--- a/RecoLuminosity/LumiDB/python/selectionParser.py
+++ b/RecoLuminosity/LumiDB/python/selectionParser.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import json
 class selectionParser(object):
     def __init__(self,selectStr):

--- a/RecoLuminosity/LumiDB/python/wordWrappers.py
+++ b/RecoLuminosity/LumiDB/python/wordWrappers.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 # word-wrap functions
 # written by Mike Brown
 # http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/148061
+from builtins import range
 import math,re
 from functools import reduce
 def wrap_always(text, width):
@@ -10,7 +11,7 @@ def wrap_always(text, width):
     It doesn't split the text in words.
     """
     return '\n'.join([ text[width*i:width*(i+1)] \
-                       for i in xrange(int(math.ceil(1.*len(text)/width))) ])
+                       for i in range(int(math.ceil(1.*len(text)/width))) ])
 
 def wrap_onspace(text,width):
     """

--- a/RecoLuminosity/LumiDB/scripts/estimatePileup.py
+++ b/RecoLuminosity/LumiDB/scripts/estimatePileup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import os, sys
 import coral
 import array
@@ -58,7 +59,7 @@ def fillPileupHistogram (deadTable, parameters,
             # here we only want the instantaneous luminosities and don't
             # care which crosings they fall in.  So we only want the odd 
             instLumiArray = [(xingInstLumiArray[index], xingInstLumiArray[index + 1]) \
-                             for index in xrange( 0, len (xingInstLumiArray), 2 ) ]
+                             for index in range( 0, len (xingInstLumiArray), 2 ) ]
             livetime = 1
             if numerator < 0:
                 numerator = 0

--- a/RecoLuminosity/LumiDB/scripts/estimatePileup2.py
+++ b/RecoLuminosity/LumiDB/scripts/estimatePileup2.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 VERSION='2.00'
 import os, sys
 import coral

--- a/RecoLuminosity/LumiDB/scripts/lumiPatch.py
+++ b/RecoLuminosity/LumiDB/scripts/lumiPatch.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 VERSION='1.00'
 import os,sys,datetime
 import coral

--- a/RecoLuminosity/LumiDB/scripts/pileupCalc.py
+++ b/RecoLuminosity/LumiDB/scripts/pileupCalc.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 VERSION='1.00'
 import os,sys,time
 import optparse

--- a/RecoLuminosity/LumiDB/test/bunchanalysis.py
+++ b/RecoLuminosity/LumiDB/test/bunchanalysis.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import sys,os,os.path,csv
 #analyse result from lumicalc2 cmmd to find perbunchlumi after subtracting noise
 #the following example analyses the output from:

--- a/RecoLuminosity/LumiDB/test/dumptrgmask.py
+++ b/RecoLuminosity/LumiDB/test/dumptrgmask.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import coral
 from RecoLuminosity.LumiDB import sessionManager,dbUtil,nameDealer,dataDML
 '''

--- a/RecoLuminosity/LumiDB/test/patchkit/analyze148829.py
+++ b/RecoLuminosity/LumiDB/test/patchkit/analyze148829.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import csv,os,sys,coral,array
 from RecoLuminosity.LumiDB import CommonUtil,idDealer,dbUtil,dataDML,revisionDML
 ilsfilename='/build/zx/patch/Run170899-ls.txt'
@@ -21,7 +22,7 @@ beam2intensity=8932813306.0
 def convertlist(l):
     '''yield successive pairs for l
     '''
-    for i in xrange(0,len(l),2):
+    for i in range(0,len(l),2):
         idx=int(l[i])
         val=float(l[i+1])
         yield (idx,val)

--- a/RecoLuminosity/LumiDB/test/patchkit/analyzelostruns.py
+++ b/RecoLuminosity/LumiDB/test/patchkit/analyzelostruns.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import csv,os,sys,coral,array
 from RecoLuminosity.LumiDB import argparse,sessionManager,CommonUtil,idDealer,dbUtil,dataDML,revisionDML
 beamenergy=4.0e03
@@ -12,7 +13,7 @@ beam2intensity=8932813306.0
 def convertlist(l):
     '''yield successive pairs for l
     '''
-    for i in xrange(0,len(l),2):
+    for i in range(0,len(l),2):
         idx=int(l[i])
         val=float(l[i+1])
         yield (idx,val)

--- a/RecoLuminosity/LumiDB/test/patchkit/csvLumiLoader.py
+++ b/RecoLuminosity/LumiDB/test/patchkit/csvLumiLoader.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import os,os.path,sys,time,csv,array,coral
 from RecoLuminosity.LumiDB import sessionManager,argparse,nameDealer,revisionDML,dataDML,lumiParameters,CommonUtil,lumiTime
 

--- a/RecoLuminosity/LumiDB/test/patchkit/generateFakeLumi.py
+++ b/RecoLuminosity/LumiDB/test/patchkit/generateFakeLumi.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import sys
 def main(*args):
     filename=args[1]

--- a/RecoLuminosity/LumiDB/test/patchkit/patchHLT.py
+++ b/RecoLuminosity/LumiDB/test/patchkit/patchHLT.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import sys,os,csv,re,coral,array
 from RecoLuminosity.LumiDB import argparse,sessionManager,CommonUtil,dataDML,revisionDML,nameDealer,dbUtil
 DATABRANCH_ID=3
@@ -144,7 +145,7 @@ def parsepresc(inputlistoflist,minlsnum,maxlsnum,lsboundaries):
         minlsnum=int(minlsnum)
     pathnames=[]
     dataresult={}#{cmslsnum:[presc...]}
-    alllsnum=range(minlsnum,maxlsnum+1)
+    alllsnum=list(range(minlsnum,maxlsnum+1))
     prescidxdict={}#{cmsls:prescidx}
     for cmsls in alllsnum:
         dataresult[cmsls]=[]

--- a/RecoLuminosity/LumiDB/test/patchkit/patchinstlumi.py
+++ b/RecoLuminosity/LumiDB/test/patchkit/patchinstlumi.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import csv,os,sys,coral,array
 from RecoLuminosity.LumiDB import CommonUtil,idDealer,dbUtil
 ilsfilename='Run152474-ls.txt'
@@ -21,7 +22,7 @@ beam2intensity=8932813306.0
 def convertlist(l):
     '''yield successive pairs for l
     '''
-    for i in xrange(0,len(l),2):
+    for i in range(0,len(l),2):
         idx=int(l[i])
         val=float(l[i+1])
         yield (idx,val)

--- a/RecoLuminosity/LumiDB/test/pixelLumiLoader.py
+++ b/RecoLuminosity/LumiDB/test/pixelLumiLoader.py
@@ -6,6 +6,7 @@
 ###################################################################
 
 from __future__ import print_function
+from builtins import range
 import os,sys,time,json,coral
 from datetime import datetime
 from RecoLuminosity.LumiDB import sessionManager,argparse,nameDealer,revisionDML,dataDML,lumiParameters,lumiTime

--- a/RecoLuminosity/LumiDB/test/pyrootLumi.py
+++ b/RecoLuminosity/LumiDB/test/pyrootLumi.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+from builtins import range
 import commands
 import sys, os, string, fileinput
 import Tkinter as tk

--- a/RecoMET/METFilters/python/GenerateHcalLaserBadRunList.py
+++ b/RecoMET/METFilters/python/GenerateHcalLaserBadRunList.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 import sys, os, string
 import time
 

--- a/RecoMET/METFilters/python/badGlobalMuonTaggerFWLite.py
+++ b/RecoMET/METFilters/python/badGlobalMuonTaggerFWLite.py
@@ -1,3 +1,4 @@
+from builtins import range
 import ROOT
 ROOT.gInterpreter.ProcessLine("#include <DataFormats/MuonReco/interface/MuonSelectors.h>")
 
@@ -53,13 +54,13 @@ class BadGlobalMuonTagger:
                 goodMuon.append(3); # maybe good, maybe bad, but we don't care
 
         n = len(muons)
-        for i in xrange(n):
+        for i in range(n):
             if (muons[i].pt() < self.ptCut_ or goodMuon[i] != 0): continue;
             bad = True;
             if (self.selectClones_):
                 bad = False; # unless proven otherwise
                 n1 = muons[i].numberOfMatches(ROOT.reco.Muon.SegmentArbitration);
-                for j in xrange(n):
+                for j in range(n):
                     if (j == i or goodMuon[j] <= 0 or not(self.partnerId(muons[j]))): continue
                     n2 = muons[j].numberOfMatches(ROOT.reco.Muon.SegmentArbitration);
                     if (deltaR(muons[i],muons[j]) < 0.4 or (n1 > 0 and n2 > 0 and ROOT.muon.sharedSegments(muons[i],muons[j]) >= 0.5*min(n1,n2))):

--- a/RecoTauTag/Configuration/python/tools/DisplayManager.py
+++ b/RecoTauTag/Configuration/python/tools/DisplayManager.py
@@ -1,3 +1,4 @@
+from builtins import range
 import ROOT
 import copy
 import math

--- a/RecoTauTag/Configuration/test/compareTauVariables.py
+++ b/RecoTauTag/Configuration/test/compareTauVariables.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import sys
 import numpy as np
 
@@ -60,15 +61,15 @@ def interSect(tree1, tree2, var='ull_dumpTauVariables_EventNumber_DUMP.obj', com
     tree1.Draw(var)
     r_evt1 = tree1.GetV1()
     if len(titles) > 0 and titles[0] == 'Reference':
-        evt1 = np.array([int(r_evt1[i]) & 0xffffffff for i in xrange(tree2.GetEntries())], dtype=int)
+        evt1 = np.array([int(r_evt1[i]) & 0xffffffff for i in range(tree2.GetEntries())], dtype=int)
     else:
-        evt1 = np.array([r_evt1[i] for i in xrange(tree1.GetEntries())], dtype=int)
+        evt1 = np.array([r_evt1[i] for i in range(tree1.GetEntries())], dtype=int)
     tree2.Draw(var)
     r_evt2 = tree2.GetV1()
     if len(titles) > 1 and titles[1] == 'Reference':
-        evt2 = np.array([int(r_evt2[i]) & 0xffffffff for i in xrange(tree2.GetEntries())], dtype=int)
+        evt2 = np.array([int(r_evt2[i]) & 0xffffffff for i in range(tree2.GetEntries())], dtype=int)
     else:
-        evt2 = np.array([int(r_evt2[i]) for i in xrange(tree2.GetEntries())], dtype=int)
+        evt2 = np.array([int(r_evt2[i]) for i in range(tree2.GetEntries())], dtype=int)
     if common:
         indices1 = np.nonzero(np.in1d(evt1, evt2))
         indices2 = np.nonzero(np.in1d(evt2, evt1))

--- a/RecoTauTag/TauTagTools/test/training/castor.py
+++ b/RecoTauTag/TauTagTools/test/training/castor.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 # date:   May 2006
 # @author: Sebastien Binet <binet@cern.ch>
 
+from builtins import range
 import datetime
 import commands
 import os
@@ -39,7 +40,7 @@ def group(iterator, count):
     """
     itr = iter(iterator)
     while True:
-        yield tuple([next(itr) for i in xrange(count)])
+        yield tuple([next(itr) for i in range(count)])
 
 __author__  = "Sebastien Binet <binet@cern.ch>"
 __doc__ = """A set of simple helper methods to handle simple tasks with CASTOR.
@@ -191,7 +192,7 @@ def pool_nsls( path ) :
     for an xmlfile_catalog file.
     """
     files = nsls(path)
-    for i in xrange(len(files)) :
+    for i in range(len(files)) :
         files[i] = "rfio:"+files[i]
         pass
 

--- a/RecoTauTag/TauTagTools/test/training/computeTransform.py
+++ b/RecoTauTag/TauTagTools/test/training/computeTransform.py
@@ -14,6 +14,7 @@ Authors: Evan K. Friis, Christian Veelken (UC Davis)
 '''
 from __future__ import print_function
 
+from builtins import range
 from RecoLuminosity.LumiDB import argparse
 
 parser = argparse.ArgumentParser(

--- a/RecoTauTag/TauTagTools/test/training/make_eval_plots.py
+++ b/RecoTauTag/TauTagTools/test/training/make_eval_plots.py
@@ -8,6 +8,7 @@ Author: Evan K. Friis
 
 '''
 from __future__ import print_function
+from builtins import range
 import math
 
 import sys

--- a/RecoTauTag/TauTagTools/test/training/skimming/buildBackgroundDataSet_cfg.py
+++ b/RecoTauTag/TauTagTools/test/training/skimming/buildBackgroundDataSet_cfg.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 import RecoTauTag.TauTagTools.RecoTauCommonJetSelections_cfi as common
 import sys

--- a/RecoTauTag/TauTagTools/test/training/skimming/buildSignalDataSet_cfg.py
+++ b/RecoTauTag/TauTagTools/test/training/skimming/buildSignalDataSet_cfg.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 import RecoTauTag.TauTagTools.RecoTauCommonJetSelections_cfi as common
 import sys

--- a/RecoTauTag/TauTagTools/test/training/training_control_plots.py
+++ b/RecoTauTag/TauTagTools/test/training/training_control_plots.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import sys
 import re
 import os

--- a/RecoVertex/BeamSpotProducer/scripts/BeamSpotWorkflow.py
+++ b/RecoVertex/BeamSpotProducer/scripts/BeamSpotWorkflow.py
@@ -33,6 +33,7 @@
 from __future__ import print_function
 
 
+from builtins import range
 import sys,os
 import commands, re, time
 import datetime

--- a/RecoVertex/BeamSpotProducer/scripts/CommonMethods.py
+++ b/RecoVertex/BeamSpotProducer/scripts/CommonMethods.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import math, re, optparse, commands, os, sys, time, datetime
 from BeamSpotObj import BeamSpot
 from IOVObj import IOV

--- a/RecoVertex/BeamSpotProducer/scripts/beamvalidation.py
+++ b/RecoVertex/BeamSpotProducer/scripts/beamvalidation.py
@@ -28,6 +28,7 @@
 from __future__ import print_function
 
 
+from builtins import range
 import os, string, re, sys, math
 import commands, time
 import six

--- a/RecoVertex/BeamSpotProducer/scripts/checkRuns.py
+++ b/RecoVertex/BeamSpotProducer/scripts/checkRuns.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import sys,os,commands,re
 import xmlrpclib
 from CommonMethods import *

--- a/RecoVertex/BeamSpotProducer/scripts/createPayload.py
+++ b/RecoVertex/BeamSpotProducer/scripts/createPayload.py
@@ -37,6 +37,7 @@
 from __future__ import print_function
 
 
+from builtins import range
 import sys,os
 import commands, re, time
 import datetime

--- a/RecoVertex/BeamSpotProducer/scripts/ntuplemaker.py
+++ b/RecoVertex/BeamSpotProducer/scripts/ntuplemaker.py
@@ -34,6 +34,7 @@
 from __future__ import print_function
 
 
+from builtins import range
 import os, string, re, sys, math
 import commands, time
 from BeamSpotObj import BeamSpot

--- a/RecoVertex/BeamSpotProducer/scripts/plotBeamSpotDB.py
+++ b/RecoVertex/BeamSpotProducer/scripts/plotBeamSpotDB.py
@@ -44,6 +44,7 @@
 from __future__ import print_function
 
 
+from builtins import range
 import os, string, re, sys, math
 import commands, time
 from BeamSpotObj import BeamSpot

--- a/RecoVertex/BeamSpotProducer/scripts/rename.py
+++ b/RecoVertex/BeamSpotProducer/scripts/rename.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import sys,os,commands,re
 from CommonMethods import *
 def main():

--- a/RecoVertex/BeamSpotProducer/scripts/root/BxAnalysis/lumiregperbunch.py
+++ b/RecoVertex/BeamSpotProducer/scripts/root/BxAnalysis/lumiregperbunch.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import sys,commands,os,calendar
 from ROOT import gDirectory,TFile
 

--- a/RecoVertex/BeamSpotProducer/test/scripts/AnalyzeLumiScan.py
+++ b/RecoVertex/BeamSpotProducer/test/scripts/AnalyzeLumiScan.py
@@ -15,6 +15,7 @@
 #____________________________________________________________
 
 from __future__ import print_function
+from builtins import range
 import sys,os,re,string
 import commands
 

--- a/RecoVertex/BeamSpotProducer/test/scripts/PlotLumiScan.py
+++ b/RecoVertex/BeamSpotProducer/test/scripts/PlotLumiScan.py
@@ -15,6 +15,7 @@
 #____________________________________________________________
 
 from __future__ import print_function
+from builtins import range
 import sys,os
 import string
 from array import array

--- a/RecoVertex/BeamSpotProducer/test/scripts/pv.py
+++ b/RecoVertex/BeamSpotProducer/test/scripts/pv.py
@@ -2,6 +2,7 @@
 
 #import ROOT
 from __future__ import print_function
+from builtins import range
 from ROOT import *
 #gROOT, TFile, TCanvas, TH1F, TH1I, TLegend, TH2F, gPad
 
@@ -176,7 +177,7 @@ def main():
 
     pvStore = ROOT.vector( BeamSpotFitPVData )(0)
 
-    for jentry in xrange( entries ):
+    for jentry in range( entries ):
 	# get the next tree in the chain
 	ientry = fchain.LoadTree(jentry)
 	if ientry < 0:


### PR DESCRIPTION
at least one unit test in my python3 fwk test fails due to the use of xrange (now range in python3). Migrate using

futurize -f libfuturize.fixes.fix_xrange_with_import -w --no-diffs -n .

(the physics/reco packages )