### PR TITLE
xrange migration for python3

### DIFF
--- a/DQM/Integration/python/config/fileinputsource_cfi.py
+++ b/DQM/Integration/python/config/fileinputsource_cfi.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 # Parameters for runType

--- a/DQM/Integration/scripts/XMLcfgfiles/ExtractAppInfoFromXML.py
+++ b/DQM/Integration/scripts/XMLcfgfiles/ExtractAppInfoFromXML.py
@@ -21,6 +21,7 @@ Notes:
 """
 from __future__ import print_function
 ################################################################################
+from builtins import range
 import sys, os.path
 from xml.dom import minidom
 ################################################################################

--- a/DQM/Integration/scripts/XMLcfgfiles/psClasses.py
+++ b/DQM/Integration/scripts/XMLcfgfiles/psClasses.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import os,subprocess,sys,re,time,random
 from threading import *
 from subprocess import call
 #Some Constants
-STATE_CREATED,STATE_COMPLETED,STATE_ERROR=range(3) 
+STATE_CREATED,STATE_COMPLETED,STATE_ERROR=list(range(3)) 
 
 ### Classes
 class BuildThread(Thread):

--- a/DQM/Integration/scripts/filecollector/fileCollector.py
+++ b/DQM/Integration/scripts/filecollector/fileCollector.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import os, time, sys, glob, re, shutil, stat, smtplib, socket
 from email.MIMEText import MIMEText
 from fcntl import lockf, LOCK_EX, LOCK_UN

--- a/DQM/Integration/scripts/filecollector/fileCollector2.py
+++ b/DQM/Integration/scripts/filecollector/fileCollector2.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import os,time,sys,zipfile,re,shutil,stat
 from fcntl import lockf, LOCK_EX, LOCK_UN
 from hashlib import md5

--- a/DQM/Integration/scripts/harvesting_tools/cmsHarvester.py
+++ b/DQM/Integration/scripts/harvesting_tools/cmsHarvester.py
@@ -35,6 +35,7 @@ from __future__ import print_function
 
 ###########################################################################
 
+from builtins import range
 __version__ = "3.8.2p1" # (version jump to match release)
 __author__ = "Jeroen Hegeman (jeroen.hegeman@cern.ch)," \
              "Niklas Pietsch (niklas.pietsch@desy.de)"
@@ -1568,7 +1569,7 @@ class CMSHarvester(object):
         path = ""
         check_sizes = sorted(castor_paths_dont_touch.keys())
         len_castor_path_pieces = len(castor_path_pieces)
-        for piece_index in xrange (len_castor_path_pieces):
+        for piece_index in range (len_castor_path_pieces):
             skip_this_path_piece = False
             piece = castor_path_pieces[piece_index]
 ##            self.logger.debug("Checking CASTOR path piece `%s'" % \

--- a/DQMServices/Components/python/HTTP.py
+++ b/DQMServices/Components/python/HTTP.py
@@ -1,3 +1,4 @@
+from builtins import range
 from cStringIO import StringIO
 from pycurl import *
 
@@ -46,7 +47,7 @@ object as it's created and queued to the idle connection list."""
     self.request_error = request_error or self._request_error
     self.request_init = request_init or self._request_init
     self.cm = CurlMulti()
-    self.handles = [Curl() for i in xrange(0, num_connections)]
+    self.handles = [Curl() for i in range(0, num_connections)]
     self.free = [c for c in self.handles]
     self.queue = []
 

--- a/DQMServices/Components/python/test/check_file4.py
+++ b/DQMServices/Components/python/test/check_file4.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT as R
 import sys
 
@@ -56,22 +57,22 @@ nHistsBar = 2
 nLumiPerRun = 10
 startIndex = 0
 lastIndex =-1
-for i in xrange(0, nRuns):
+for i in range(0, nRuns):
     # LS-based histograms follow
-    for l in xrange(0, nLumiPerRun):
-        for j in xrange(0, nHistsBar):
+    for l in range(0, nLumiPerRun):
+        for j in range(0, nHistsBar):
             lastIndex += 1
             values.append((folder + "Bar" + str(j) + "_lumi", 0, 55.0))
-        for j in xrange(0, nHistsFoo):
+        for j in range(0, nHistsFoo):
             lastIndex += 1
             values.append((folder + "Foo" + str(j) + "_lumi", 0, 1.0))
         expectedIndices.append( (i + 1, l + 1, 3, startIndex, lastIndex) )
         startIndex = lastIndex + 1
     # Run-based histograms follow
-    for j in xrange(0, nHistsBar):
+    for j in range(0, nHistsBar):
         lastIndex += 1
         values.append((folder + "Bar" + str(j), 0, 55.0))
-    for j in xrange(0, nHistsFoo):
+    for j in range(0, nHistsFoo):
         lastIndex += 1
         values.append((folder + "Foo" + str(j), 0, 1.0))
     expectedIndices.append( (i + 1, 0, 3, startIndex, lastIndex) )
@@ -82,22 +83,22 @@ nRuns = 1
 nHistsFoo = 10
 nHistsBar = 2
 nLumiPerRun = 10
-for i in xrange(0, nRuns):
+for i in range(0, nRuns):
     # LS-based histograms follow
-    for l in xrange(0, nLumiPerRun):
-        for j in xrange(0, nHistsBar):
+    for l in range(0, nLumiPerRun):
+        for j in range(0, nHistsBar):
             lastIndex += 1
             values.append((folder + "Bar" + str(j) + "_lumi", 0, 55.0))
-        for j in xrange(0, nHistsFoo):
+        for j in range(0, nHistsFoo):
             lastIndex += 1
             values.append((folder + "Foo" + str(j) + "_lumi", 0, 1.0))
         expectedIndices.append( (i + 2, l + 1, 3, startIndex, lastIndex) )
         startIndex = lastIndex + 1
     # Run-based histograms follow
-    for j in xrange(0, nHistsBar):
+    for j in range(0, nHistsBar):
         lastIndex += 1
         values.append((folder + "Bar" + str(j), 0, 55.0))
-    for j in xrange(0, nHistsFoo):
+    for j in range(0, nHistsFoo):
         lastIndex += 1
         values.append((folder + "Foo" + str(j), 0, 1.0))
     expectedIndices.append( (i + 2, 0, 3, startIndex, lastIndex) )
@@ -115,8 +116,8 @@ if 2*(nRuns+nRuns*nLumiPerRun) != indices.GetEntries():
 
 indexTreeIndex = 0
 # First check on Run 1
-for run in xrange(0, nRuns):
-    for lumi in xrange(0, nLumiPerRun):
+for run in range(0, nRuns):
+    for lumi in range(0, nLumiPerRun):
         indices.GetEntry(indexTreeIndex)
         v = (indices.Run, indices.Lumi, indices.Type, indices.FirstIndex, indices.LastIndex)
         if v != expectedIndices[indexTreeIndex]:
@@ -124,7 +125,7 @@ for run in xrange(0, nRuns):
             print(' expected:', expectedIndices[indexTreeIndex])
             print(' found:', v)
             sys.exit(1)
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -135,7 +136,7 @@ for run in xrange(0, nRuns):
                 sys.exit(1)
         indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -147,8 +148,8 @@ for run in xrange(0, nRuns):
     indexTreeIndex +=1
 
 # Second check on Run 2
-for run in xrange(0, nRuns):
-    for lumi in xrange(0, nLumiPerRun):
+for run in range(0, nRuns):
+    for lumi in range(0, nLumiPerRun):
         indices.GetEntry(indexTreeIndex)
         v = (indices.Run, indices.Lumi, indices.Type, indices.FirstIndex, indices.LastIndex)
         if v != expectedIndices[indexTreeIndex]:
@@ -156,7 +157,7 @@ for run in xrange(0, nRuns):
             print(' expected:', expectedIndices[indexTreeIndex])
             print(' found:', v)
             sys.exit(1)
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -167,7 +168,7 @@ for run in xrange(0, nRuns):
                 sys.exit(1)
         indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())

--- a/DQMServices/Components/python/test/check_merged_file1_file2.py
+++ b/DQMServices/Components/python/test/check_merged_file1_file2.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT as R
 import sys
 
@@ -46,22 +47,22 @@ nHistsBar = 2
 nLumiPerRun = 20
 startIndex = 0
 lastIndex =-1
-for i in xrange(0, nRuns):
+for i in range(0, nRuns):
     # LS-based histograms follow
-    for l in xrange(0, nLumiPerRun):
-        for j in xrange(0, nHistsBar):
+    for l in range(0, nLumiPerRun):
+        for j in range(0, nHistsBar):
             lastIndex += 1
             values.append((folder + "Bar" + str(j) + "_lumi", 0, 55.0))
-        for j in xrange(0, nHistsFoo):
+        for j in range(0, nHistsFoo):
             lastIndex += 1
             values.append((folder + "Foo" + str(j) + "_lumi", 0, 1.0))
         expectedIndices.append( (i + 1, l + 1, 3, startIndex, lastIndex) )
         startIndex = lastIndex + 1
     # Run-based histograms follow
-    for j in xrange(0, nHistsBar):
+    for j in range(0, nHistsBar):
         lastIndex += 1
         values.append((folder + "Bar" + str(j), 0, 110.0))
-    for j in xrange(0, nHistsFoo):
+    for j in range(0, nHistsFoo):
         lastIndex += 1
         values.append((folder + "Foo" + str(j), 0, 2.0))
     expectedIndices.append( (i + 1, 0, 3, startIndex, lastIndex) )
@@ -78,8 +79,8 @@ if nRuns+nRuns*nLumiPerRun != indices.GetEntries():
     sys.exit(1)
 
 indexTreeIndex = 0
-for run in xrange(0, nRuns):
-    for lumi in xrange(0, nLumiPerRun):
+for run in range(0, nRuns):
+    for lumi in range(0, nLumiPerRun):
         indices.GetEntry(indexTreeIndex)
         v = (indices.Run, indices.Lumi, indices.Type, indices.FirstIndex, indices.LastIndex)
         if v != expectedIndices[indexTreeIndex]:
@@ -87,7 +88,7 @@ for run in xrange(0, nRuns):
             print(' expected:', expectedIndices[indexTreeIndex])
             print(' found:', v)
             sys.exit(1)
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -98,7 +99,7 @@ for run in xrange(0, nRuns):
                 sys.exit(1)
         indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())

--- a/DQMServices/Components/python/test/check_merged_file1_file2_cfg.py
+++ b/DQMServices/Components/python/test/check_merged_file1_file2_cfg.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT as R
 import sys
 
@@ -46,22 +47,22 @@ nHistsBar = 2
 nLumiPerRun = 20
 startIndex = 0
 lastIndex =-1
-for i in xrange(0, nRuns):
+for i in range(0, nRuns):
     # LS-based histograms follow
-    for l in xrange(0, nLumiPerRun):
-        for j in xrange(0, nHistsBar):
+    for l in range(0, nLumiPerRun):
+        for j in range(0, nHistsBar):
             lastIndex += 1
             values.append((folder + "Bar" + str(j) + "_lumi", 0, 55.0))
-        for j in xrange(0, nHistsFoo):
+        for j in range(0, nHistsFoo):
             lastIndex += 1
             values.append((folder + "Foo" + str(j) + "_lumi", 0, 1.0))
         expectedIndices.append( (i + 1, l + 1, 3, startIndex, lastIndex) )
         startIndex = lastIndex + 1
     # Run-based histograms follow
-    for j in xrange(0, nHistsBar):
+    for j in range(0, nHistsBar):
         lastIndex += 1
         values.append((folder + "Bar" + str(j), 0, 110.0))
-    for j in xrange(0, nHistsFoo):
+    for j in range(0, nHistsFoo):
         lastIndex += 1
         values.append((folder + "Foo" + str(j), 0, 2.0))
     expectedIndices.append( (i + 1, 0, 3, startIndex, lastIndex) )
@@ -78,8 +79,8 @@ if nRuns+nRuns*nLumiPerRun != indices.GetEntries():
     sys.exit(1)
 
 indexTreeIndex = 0
-for run in xrange(0, nRuns):
-    for lumi in xrange(0, nLumiPerRun):
+for run in range(0, nRuns):
+    for lumi in range(0, nLumiPerRun):
         indices.GetEntry(indexTreeIndex)
         v = (indices.Run, indices.Lumi, indices.Type, indices.FirstIndex, indices.LastIndex)
         if v != expectedIndices[indexTreeIndex]:
@@ -87,7 +88,7 @@ for run in xrange(0, nRuns):
             print(' expected:', expectedIndices[indexTreeIndex])
             print(' found:', v)
             sys.exit(1)
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -98,7 +99,7 @@ for run in xrange(0, nRuns):
                 sys.exit(1)
         indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())

--- a/DQMServices/Components/python/test/check_merged_file1_file2_file3_cfg.py
+++ b/DQMServices/Components/python/test/check_merged_file1_file2_file3_cfg.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT as R
 import sys
 
@@ -56,22 +57,22 @@ nHistsBar = 2
 nLumiPerRun1 = 20
 startIndex = 0
 lastIndex =-1
-for i in xrange(0, nRuns):
+for i in range(0, nRuns):
     # LS-based histograms follow
-    for l in xrange(0, nLumiPerRun1):
-        for j in xrange(0, nHistsBar):
+    for l in range(0, nLumiPerRun1):
+        for j in range(0, nHistsBar):
             lastIndex += 1
             values.append((folder + "Bar" + str(j) + "_lumi", 0, 55.0))
-        for j in xrange(0, nHistsFoo):
+        for j in range(0, nHistsFoo):
             lastIndex += 1
             values.append((folder + "Foo" + str(j) + "_lumi", 0, 1.0))
         expectedIndices.append( (i + 1, l + 1, 3, startIndex, lastIndex) )
         startIndex = lastIndex + 1
     # Run-based histograms follow
-    for j in xrange(0, nHistsBar):
+    for j in range(0, nHistsBar):
         lastIndex += 1
         values.append((folder + "Bar" + str(j), 0, 110.0))
-    for j in xrange(0, nHistsFoo):
+    for j in range(0, nHistsFoo):
         lastIndex += 1
         values.append((folder + "Foo" + str(j), 0, 2.0))
     expectedIndices.append( (i + 1, 0, 3, startIndex, lastIndex) )
@@ -82,22 +83,22 @@ nRuns = 1
 nHistsFoo = 10
 nHistsBar = 2
 nLumiPerRun2 = 10
-for i in xrange(0, nRuns):
+for i in range(0, nRuns):
     # LS-based histograms follow
-    for l in xrange(0, nLumiPerRun2):
-        for j in xrange(0, nHistsBar):
+    for l in range(0, nLumiPerRun2):
+        for j in range(0, nHistsBar):
             lastIndex += 1
             values.append((folder + "Bar" + str(j) + "_lumi", 0, 55.0))
-        for j in xrange(0, nHistsFoo):
+        for j in range(0, nHistsFoo):
             lastIndex += 1
             values.append((folder + "Foo" + str(j) + "_lumi", 0, 1.0))
         expectedIndices.append( (i + 2, l + 1, 3, startIndex, lastIndex) )
         startIndex = lastIndex + 1
     # Run-based histograms follow
-    for j in xrange(0, nHistsBar):
+    for j in range(0, nHistsBar):
         lastIndex += 1
         values.append((folder + "Bar" + str(j), 0, 55.0))
-    for j in xrange(0, nHistsFoo):
+    for j in range(0, nHistsFoo):
         lastIndex += 1
         values.append((folder + "Foo" + str(j), 0, 1.0))
     expectedIndices.append( (i + 2, 0, 3, startIndex, lastIndex) )
@@ -116,8 +117,8 @@ if (nRuns+nRuns*nLumiPerRun2)+(nRuns+nRuns*nLumiPerRun1) != indices.GetEntries()
 
 indexTreeIndex = 0
 # First check on Run 1
-for run in xrange(0, nRuns):
-    for lumi in xrange(0, nLumiPerRun1):
+for run in range(0, nRuns):
+    for lumi in range(0, nLumiPerRun1):
         indices.GetEntry(indexTreeIndex)
         v = (indices.Run, indices.Lumi, indices.Type, indices.FirstIndex, indices.LastIndex)
         if v != expectedIndices[indexTreeIndex]:
@@ -125,7 +126,7 @@ for run in xrange(0, nRuns):
             print(' expected:', expectedIndices[indexTreeIndex])
             print(' found:', v)
             sys.exit(1)
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -136,7 +137,7 @@ for run in xrange(0, nRuns):
                 sys.exit(1)
         indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -148,8 +149,8 @@ for run in xrange(0, nRuns):
     indexTreeIndex +=1
 
 # Second check on Run 2
-for run in xrange(0, nRuns):
-    for lumi in xrange(0, nLumiPerRun2):
+for run in range(0, nRuns):
+    for lumi in range(0, nLumiPerRun2):
         indices.GetEntry(indexTreeIndex)
         v = (indices.Run, indices.Lumi, indices.Type, indices.FirstIndex, indices.LastIndex)
         if v != expectedIndices[indexTreeIndex]:
@@ -157,7 +158,7 @@ for run in xrange(0, nRuns):
             print(' expected:', expectedIndices[indexTreeIndex])
             print(' found:', v)
             sys.exit(1)
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -168,7 +169,7 @@ for run in xrange(0, nRuns):
                 sys.exit(1)
         indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())

--- a/DQMServices/Components/python/test/check_merged_file1_file3.py
+++ b/DQMServices/Components/python/test/check_merged_file1_file3.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT as R
 import sys
 
@@ -56,22 +57,22 @@ nHistsBar = 2
 nLumiPerRun = 10
 startIndex = 0
 lastIndex =-1
-for i in xrange(0, nRuns):
+for i in range(0, nRuns):
     # LS-based histograms follow
-    for l in xrange(0, nLumiPerRun):
-        for j in xrange(0, nHistsBar):
+    for l in range(0, nLumiPerRun):
+        for j in range(0, nHistsBar):
             lastIndex += 1
             values.append((folder + "Bar" + str(j) + "_lumi", 0, 55.0))
-        for j in xrange(0, nHistsFoo):
+        for j in range(0, nHistsFoo):
             lastIndex += 1
             values.append((folder + "Foo" + str(j) + "_lumi", 0, 1.0))
         expectedIndices.append( (i + 1, l + 1, 3, startIndex, lastIndex) )
         startIndex = lastIndex + 1
     # Run-based histograms follow
-    for j in xrange(0, nHistsBar):
+    for j in range(0, nHistsBar):
         lastIndex += 1
         values.append((folder + "Bar" + str(j), 0, 55.0))
-    for j in xrange(0, nHistsFoo):
+    for j in range(0, nHistsFoo):
         lastIndex += 1
         values.append((folder + "Foo" + str(j), 0, 1.0))
     expectedIndices.append( (i + 1, 0, 3, startIndex, lastIndex) )
@@ -82,22 +83,22 @@ nRuns = 1
 nHistsFoo = 10
 nHistsBar = 2
 nLumiPerRun = 10
-for i in xrange(0, nRuns):
+for i in range(0, nRuns):
     # LS-based histograms follow
-    for l in xrange(0, nLumiPerRun):
-        for j in xrange(0, nHistsBar):
+    for l in range(0, nLumiPerRun):
+        for j in range(0, nHistsBar):
             lastIndex += 1
             values.append((folder + "Bar" + str(j) + "_lumi", 0, 55.0))
-        for j in xrange(0, nHistsFoo):
+        for j in range(0, nHistsFoo):
             lastIndex += 1
             values.append((folder + "Foo" + str(j) + "_lumi", 0, 1.0))
         expectedIndices.append( (i + 2, l + 1, 3, startIndex, lastIndex) )
         startIndex = lastIndex + 1
     # Run-based histograms follow
-    for j in xrange(0, nHistsBar):
+    for j in range(0, nHistsBar):
         lastIndex += 1
         values.append((folder + "Bar" + str(j), 0, 55.0))
-    for j in xrange(0, nHistsFoo):
+    for j in range(0, nHistsFoo):
         lastIndex += 1
         values.append((folder + "Foo" + str(j), 0, 1.0))
     expectedIndices.append( (i + 2, 0, 3, startIndex, lastIndex) )
@@ -115,8 +116,8 @@ if 2*(nRuns+nRuns*nLumiPerRun) != indices.GetEntries():
 
 indexTreeIndex = 0
 # First check on Run 1
-for run in xrange(0, nRuns):
-    for lumi in xrange(0, nLumiPerRun):
+for run in range(0, nRuns):
+    for lumi in range(0, nLumiPerRun):
         indices.GetEntry(indexTreeIndex)
         v = (indices.Run, indices.Lumi, indices.Type, indices.FirstIndex, indices.LastIndex)
         if v != expectedIndices[indexTreeIndex]:
@@ -124,7 +125,7 @@ for run in xrange(0, nRuns):
             print(' expected:', expectedIndices[indexTreeIndex])
             print(' found:', v)
             sys.exit(1)
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -135,7 +136,7 @@ for run in xrange(0, nRuns):
                 sys.exit(1)
         indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -147,8 +148,8 @@ for run in xrange(0, nRuns):
     indexTreeIndex +=1
 
 # Second check on Run 2
-for run in xrange(0, nRuns):
-    for lumi in xrange(0, nLumiPerRun):
+for run in range(0, nRuns):
+    for lumi in range(0, nLumiPerRun):
         indices.GetEntry(indexTreeIndex)
         v = (indices.Run, indices.Lumi, indices.Type, indices.FirstIndex, indices.LastIndex)
         if v != expectedIndices[indexTreeIndex]:
@@ -156,7 +157,7 @@ for run in xrange(0, nRuns):
             print(' expected:', expectedIndices[indexTreeIndex])
             print(' found:', v)
             sys.exit(1)
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -167,7 +168,7 @@ for run in xrange(0, nRuns):
                 sys.exit(1)
         indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())

--- a/DQMServices/Components/python/test/createElements.py
+++ b/DQMServices/Components/python/test/createElements.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 def createElements():
     elements = list()
-    for i in xrange(0,10):
+    for i in range(0,10):
         elements.append(cms.untracked.PSet(lowX   = cms.untracked.double(0),
                                            highX  = cms.untracked.double(11),
                                            nchX   = cms.untracked.int32(11),
@@ -30,7 +31,7 @@ def createElements():
 
 def createReadRunElements():
     readRunElements = list()
-    for i in xrange(0,10):
+    for i in range(0,10):
         readRunElements.append(cms.untracked.PSet(name    = cms.untracked.string("Foo"+str(i)),
                                                   means   = cms.untracked.vdouble(i),
                                                   entries = cms.untracked.vdouble(1)
@@ -45,18 +46,18 @@ def createReadRunElements():
 
 def createReadLumiElements():
     readLumiElements = list()
-    for i in xrange(0,10):
+    for i in range(0,10):
         readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
-                                                   means = cms.untracked.vdouble([i for x in xrange(0,10)]),
-                                                   entries=cms.untracked.vdouble([1 for x in xrange(0,10)])
+                                                   means = cms.untracked.vdouble([i for x in range(0,10)]),
+                                                   entries=cms.untracked.vdouble([1 for x in range(0,10)])
                                                    ))
     readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Bar0"),
-                                               means = cms.untracked.vdouble([7 for x in xrange(0,10)]),
-                                               entries=cms.untracked.vdouble([55 for x in xrange(0,10)])
+                                               means = cms.untracked.vdouble([7 for x in range(0,10)]),
+                                               entries=cms.untracked.vdouble([55 for x in range(0,10)])
                                                ))
     readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Bar1"),
-                                               means = cms.untracked.vdouble([3 for x in xrange(0,10)]),
-                                               entries=cms.untracked.vdouble([55 for x in xrange(0,10)])
+                                               means = cms.untracked.vdouble([3 for x in range(0,10)]),
+                                               entries=cms.untracked.vdouble([55 for x in range(0,10)])
                                                ))
     return readLumiElements
 
@@ -64,7 +65,7 @@ def createReadLumiElements():
 
 def createReadRunElements_merged_file1_file2():
     readRunElements = list()
-    for i in xrange(0,10):
+    for i in range(0,10):
         readRunElements.append(cms.untracked.PSet(name    = cms.untracked.string("Foo"+str(i)),
                                                   means   = cms.untracked.vdouble(i),
                                                   entries = cms.untracked.vdouble(2)
@@ -79,17 +80,17 @@ def createReadRunElements_merged_file1_file2():
 
 def createReadLumiElements_merged_file1_file2():
     readLumiElements = list()
-    for i in xrange(0,10):
+    for i in range(0,10):
         readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
-                                                   means = cms.untracked.vdouble([i for x in xrange(0,20)]),
-                                                   entries=cms.untracked.vdouble([1 for x in xrange(0,20)])
+                                                   means = cms.untracked.vdouble([i for x in range(0,20)]),
+                                                   entries=cms.untracked.vdouble([1 for x in range(0,20)])
                                                    ))
     readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Bar0"),
-                                               means = cms.untracked.vdouble([7 for x in xrange(0,20)]),
-                                               entries=cms.untracked.vdouble([55 for x in xrange(0,20)])
+                                               means = cms.untracked.vdouble([7 for x in range(0,20)]),
+                                               entries=cms.untracked.vdouble([55 for x in range(0,20)])
                                                ))
     readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Bar1"),
-                                               means = cms.untracked.vdouble([3 for x in xrange(0,20)]),
-                                               entries=cms.untracked.vdouble([55 for x in xrange(0,20)])
+                                               means = cms.untracked.vdouble([3 for x in range(0,20)]),
+                                               entries=cms.untracked.vdouble([55 for x in range(0,20)])
                                                ))
     return readLumiElements

--- a/DQMServices/Components/python/test/py2html_new.py
+++ b/DQMServices/Components/python/test/py2html_new.py
@@ -3,6 +3,7 @@
 #         Created:  Tue Feb 9 10:06:02 CEST 2010
 
 from __future__ import print_function
+from builtins import range
 import re
 import sys, os
 import sqlite3

--- a/DQMServices/Components/test/test_fastHaddMerge.py
+++ b/DQMServices/Components/test/test_fastHaddMerge.py
@@ -7,6 +7,7 @@ final merged output matches what is expected.
 """
 from __future__ import print_function
 
+from builtins import range
 from optparse import OptionParser
 import sys
 import commands

--- a/DQMServices/Components/test/whiteRabbit.py
+++ b/DQMServices/Components/test/whiteRabbit.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python -u
 
 from __future__ import print_function
+from builtins import range
 import os, sys, re, time, commands, glob
 from optparse import OptionParser, OptionGroup
 from threading import Thread

--- a/DQMServices/FileIO/python/DQM.py
+++ b/DQMServices/FileIO/python/DQM.py
@@ -1,6 +1,7 @@
 #!/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import ROOT as R
 import os, re
 
@@ -33,7 +34,7 @@ class DQMReader(object):
     def read_objects_dqmio(self):
         indices = self._root_file.Get("Indices")
 
-        for y in xrange(indices.GetEntries()):
+        for y in range(indices.GetEntries()):
             indices.GetEntry(y)
             # print indices.Run, indices.Lumi, indices.Type
 
@@ -45,7 +46,7 @@ class DQMReader(object):
             object_type = self.DQMIO_TYPES[indices.Type]
             t_tree = self._root_file.Get(object_type)
 
-            for i in xrange(indices.FirstIndex, indices.LastIndex + 1):
+            for i in range(indices.FirstIndex, indices.LastIndex + 1):
                 t_tree.GetEntry(i)
 
                 fullname = str(t_tree.FullName)

--- a/DQMServices/FwkIO/scripts/DQMIO2histo.py
+++ b/DQMServices/FwkIO/scripts/DQMIO2histo.py
@@ -9,6 +9,7 @@ formatted input.
 """
 from __future__ import print_function
 
+from builtins import range
 import ROOT as R
 import sys
 import re
@@ -51,13 +52,13 @@ class DQMIO:
         if args.debug:
             print("## DEBUG ##:")
             print("Run,\tLumi,\tType,\t\tFirstIndex,\tLastIndex")
-            for i in xrange(indices.GetEntries()):
+            for i in range(indices.GetEntries()):
                 indices.GetEntry(i)
                 print('{0:4d}\t{1:4d}\t{2:4d}({3:s})\t\t{4:4d}\t{5:4d}'.format(
                     indices.Run, indices.Lumi, indices.Type, 
                     DQMIO.types[indices.Type], indices.FirstIndex, indices.LastIndex))
 
-        for i in xrange(indices.GetEntries()):
+        for i in range(indices.GetEntries()):
             indices.GetEntry(i)
             if indices.Type < len(DQMIO.types):
                 self.write_to_file(self.types[indices.Type],

--- a/DQMServices/FwkIO/test/check_lumi_only_file.py
+++ b/DQMServices/FwkIO/test/check_lumi_only_file.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT as R
 import sys
 
@@ -14,8 +15,8 @@ nRuns = 10
 nHists = 10
 startIndex = 0
 lastIndex =-1
-for i in xrange(0,nRuns):
-    for j in xrange(0,nHists):
+for i in range(0,nRuns):
+    for j in range(0,nHists):
         lastIndex +=1
         values.append(("Foo"+str(j)+"_lumi", 0, 1.0))
     expectedIndices.append( (i+1,1,3,startIndex,lastIndex) )
@@ -30,7 +31,7 @@ if nRuns != indices.GetEntries():
     print("wrong number of entries in Indices", indices.GetEntries())
     sys.exit(1)
 
-for run in xrange(0,nRuns):
+for run in range(0,nRuns):
     indices.GetEntry(run)
     v = (indices.Run,indices.Lumi,indices.Type,indices.FirstIndex,indices.LastIndex)
     if v != expectedIndices[run]:
@@ -38,7 +39,7 @@ for run in xrange(0,nRuns):
         print(' expected:', expectedIndices[run])
         print(' found:',v)
         sys.exit(1)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())

--- a/DQMServices/FwkIO/test/check_merged_file1_file2.py
+++ b/DQMServices/FwkIO/test/check_merged_file1_file2.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT as R
 import sys
 
@@ -15,14 +16,14 @@ nHists = 10
 nLumiPerRun = 20
 startIndex = 0
 lastIndex =-1
-for i in xrange(0,nRuns):
-    for l in xrange(0,nLumiPerRun):
-        for j in xrange(0,nHists):
+for i in range(0,nRuns):
+    for l in range(0,nLumiPerRun):
+        for j in range(0,nHists):
             lastIndex +=1
             values.append(("Foo"+str(j)+"_lumi", 0, 1.0))
         expectedIndices.append( (i+1,l+1,3,startIndex,lastIndex) )
         startIndex = lastIndex+1
-    for j in xrange(0,nHists):
+    for j in range(0,nHists):
         lastIndex +=1
         values.append(("Foo"+str(j), 0, 2.0))
     expectedIndices.append( (i+1,0,3,startIndex,lastIndex) )
@@ -39,8 +40,8 @@ if nRuns+nRuns*nLumiPerRun != indices.GetEntries():
     sys.exit(1)
 
 indexTreeIndex = 0
-for run in xrange(0,nRuns):
-    for lumi in xrange(0,nLumiPerRun):
+for run in range(0,nRuns):
+    for lumi in range(0,nLumiPerRun):
         indices.GetEntry(indexTreeIndex)
         v = (indices.Run,indices.Lumi,indices.Type,indices.FirstIndex,indices.LastIndex)
         if v != expectedIndices[indexTreeIndex]:
@@ -48,7 +49,7 @@ for run in xrange(0,nRuns):
             print(' expected:', expectedIndices[indexTreeIndex])
             print(' found:',v)
             sys.exit(1)
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -59,7 +60,7 @@ for run in xrange(0,nRuns):
                 sys.exit(1)
         indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())

--- a/DQMServices/FwkIO/test/check_merged_file1_file3_file2_filterOnRun1_cfg.py
+++ b/DQMServices/FwkIO/test/check_merged_file1_file3_file2_filterOnRun1_cfg.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT as R
 import sys
 
@@ -15,20 +16,20 @@ nHists = 10
 nLumiPerRun = 20
 startIndex = 0
 lastIndex =-1
-for i in xrange(0,nRuns):
-    for l in xrange(0,nLumiPerRun):
+for i in range(0,nRuns):
+    for l in range(0,nLumiPerRun):
         if l == 10:
-            for j in xrange(0,nHists):
+            for j in range(0,nHists):
                 lastIndex +=1
                 values.append(("Foo"+str(j), 0, 1.0))
             expectedIndices.append( (i+1,0,3,startIndex,lastIndex) )
             startIndex = lastIndex+1
-        for j in xrange(0,nHists):
+        for j in range(0,nHists):
             lastIndex +=1
             values.append(("Foo"+str(j)+"_lumi", 0, 1.0))
         expectedIndices.append( (i+1,l+1,3,startIndex,lastIndex) )
         startIndex = lastIndex+1
-    for j in xrange(0,nHists):
+    for j in range(0,nHists):
         lastIndex +=1
         values.append(("Foo"+str(j), 0, 1.0))
     expectedIndices.append( (i+1,0,3,startIndex,lastIndex) )
@@ -45,8 +46,8 @@ if 2*nRuns+nRuns*nLumiPerRun != indices.GetEntries():
     sys.exit(1)
 
 indexTreeIndex = 0
-for run in xrange(0,nRuns):
-    for lumi in xrange(0,nLumiPerRun):
+for run in range(0,nRuns):
+    for lumi in range(0,nLumiPerRun):
         indices.GetEntry(indexTreeIndex)
         v = (indices.Run,indices.Lumi,indices.Type,indices.FirstIndex,indices.LastIndex)
         if v != expectedIndices[indexTreeIndex]:
@@ -54,7 +55,7 @@ for run in xrange(0,nRuns):
             print(' expected:', expectedIndices[indexTreeIndex])
             print(' found:',v)
             sys.exit(1)
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -65,7 +66,7 @@ for run in xrange(0,nRuns):
                 sys.exit(1)
         indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -76,7 +77,7 @@ for run in xrange(0,nRuns):
             sys.exit(1)
     indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())

--- a/DQMServices/FwkIO/test/check_merged_file1_file3_file2_filterOnRun1_copy_cfg.py
+++ b/DQMServices/FwkIO/test/check_merged_file1_file3_file2_filterOnRun1_copy_cfg.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT as R
 import sys
 
@@ -15,14 +16,14 @@ nHists = 10
 nLumiPerRun = 20
 startIndex = 0
 lastIndex =-1
-for i in xrange(0,nRuns):
-    for l in xrange(0,nLumiPerRun):
-        for j in xrange(0,nHists):
+for i in range(0,nRuns):
+    for l in range(0,nLumiPerRun):
+        for j in range(0,nHists):
             lastIndex +=1
             values.append(("Foo"+str(j)+"_lumi", 0, 1.0))
         expectedIndices.append( (i+1,l+1,3,startIndex,lastIndex) )
         startIndex = lastIndex+1
-    for j in xrange(0,nHists):
+    for j in range(0,nHists):
         lastIndex +=1
         values.append(("Foo"+str(j), 0, 2.0))
     expectedIndices.append( (i+1,0,3,startIndex,lastIndex) )
@@ -39,8 +40,8 @@ if nRuns+nRuns*nLumiPerRun != indices.GetEntries():
     sys.exit(1)
 
 indexTreeIndex = 0
-for run in xrange(0,nRuns):
-    for lumi in xrange(0,nLumiPerRun):
+for run in range(0,nRuns):
+    for lumi in range(0,nLumiPerRun):
         indices.GetEntry(indexTreeIndex)
         v = (indices.Run,indices.Lumi,indices.Type,indices.FirstIndex,indices.LastIndex)
         if v != expectedIndices[indexTreeIndex]:
@@ -48,7 +49,7 @@ for run in xrange(0,nRuns):
             print(' expected:', expectedIndices[indexTreeIndex])
             print(' found:',v)
             sys.exit(1)
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -59,7 +60,7 @@ for run in xrange(0,nRuns):
                 sys.exit(1)
         indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())

--- a/DQMServices/FwkIO/test/check_multi_types.py
+++ b/DQMServices/FwkIO/test/check_multi_types.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT as R
 import sys
 
@@ -18,17 +19,17 @@ nLumiPerRun = 10
 startIndex = 0
 lastIndex =-1
 typeValues =[3,6]
-for i in xrange(0,nRuns):
-    for l in xrange(0,nLumiPerRun):
-        for t in xrange(0,nTypes):
+for i in range(0,nRuns):
+    for l in range(0,nLumiPerRun):
+        for t in range(0,nTypes):
             lastIndex = startIndex-1
-            for j in xrange(0,nHists):
+            for j in range(0,nHists):
                 lastIndex +=1
                 values.append(("Foo"+str(j)+"_lumi", 0, 1.0))
             expectedIndices.append( (i+1,l+1,typeValues[t],startIndex,lastIndex) )
         startIndex = lastIndex+1
-    for t in xrange(0,nTypes):
-        for j in xrange(0,nHists):
+    for t in range(0,nTypes):
+        for j in range(0,nHists):
             lastIndex +=1
             values.append(("Foo"+str(j), 0, 2.0))
         expectedIndices.append( (i+1,0,typeValues[t],startIndex,lastIndex) )
@@ -49,8 +50,8 @@ if (nRuns+nRuns*nLumiPerRun)*nTypes != indices.GetEntries():
     sys.exit(1)
 
 indexTreeIndex = 0
-for run in xrange(0,nRuns):
-    for lumi in xrange(0,nLumiPerRun):
+for run in range(0,nRuns):
+    for lumi in range(0,nLumiPerRun):
         indices.GetEntry(indexTreeIndex)
         v = (indices.Run,indices.Lumi,indices.Type,indices.FirstIndex,indices.LastIndex)
         if v != expectedIndices[indexTreeIndex]:
@@ -58,7 +59,7 @@ for run in xrange(0,nRuns):
             print(' expected:', expectedIndices[indexTreeIndex])
             print(' found:',v)
             sys.exit(1)
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -69,7 +70,7 @@ for run in xrange(0,nRuns):
                 sys.exit(1)
         indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())

--- a/DQMServices/FwkIO/test/check_run_lumi_file.py
+++ b/DQMServices/FwkIO/test/check_run_lumi_file.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT as R
 import sys
 
@@ -15,14 +16,14 @@ nHists = 10
 nLumiPerRun = 1
 startIndex = 0
 lastIndex =-1
-for i in xrange(0,nRuns):
-    for l in xrange(0,1):
-        for j in xrange(0,nHists):
+for i in range(0,nRuns):
+    for l in range(0,1):
+        for j in range(0,nHists):
             lastIndex +=1
             values.append(("Foo"+str(j)+"_lumi", 0, 1.0))
         expectedIndices.append( (i+1,l+1,3,startIndex,lastIndex) )
         startIndex = lastIndex+1
-    for j in xrange(0,nHists):
+    for j in range(0,nHists):
         lastIndex +=1
         values.append(("Foo"+str(j), 0, 1.0))
     expectedIndices.append( (i+1,0,3,startIndex,lastIndex) )
@@ -38,8 +39,8 @@ if nRuns+nRuns*nLumiPerRun != indices.GetEntries():
     sys.exit(1)
 
 indexTreeIndex = 0
-for run in xrange(0,nRuns):
-    for lumi in xrange(0,1):
+for run in range(0,nRuns):
+    for lumi in range(0,1):
         indices.GetEntry(indexTreeIndex)
         v = (indices.Run,indices.Lumi,indices.Type,indices.FirstIndex,indices.LastIndex)
         if v != expectedIndices[indexTreeIndex]:
@@ -47,7 +48,7 @@ for run in xrange(0,nRuns):
             print(' expected:', expectedIndices[indexTreeIndex])
             print(' found:',v)
             sys.exit(1)
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())
@@ -58,7 +59,7 @@ for run in xrange(0,nRuns):
                 sys.exit(1)
         indexTreeIndex +=1
     indices.GetEntry(indexTreeIndex)
-    for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+    for ihist in range(indices.FirstIndex,indices.LastIndex+1):
         index = ihist
         th1fs.GetEntry(ihist)
         v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())

--- a/DQMServices/FwkIO/test/check_run_only_file.py
+++ b/DQMServices/FwkIO/test/check_run_only_file.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT as R
 import sys
 
@@ -15,11 +16,11 @@ nLumiPerRun = 1
 nHists = 10
 startIndex = 0
 lastIndex =-1
-for i in xrange(0,nRuns):
-    for l in xrange(0,nLumiPerRun):
+for i in range(0,nRuns):
+    for l in range(0,nLumiPerRun):
         #we put dummy lumi entries in for each lumi seen
         expectedIndices.append((i+1,l+1,1000,0,0))
-    for j in xrange(0,nHists):
+    for j in range(0,nHists):
         lastIndex +=1
         values.append(("Foo"+str(j), 0, 1.0))
     expectedIndices.append( (i+1,0,3,startIndex,lastIndex) )
@@ -34,7 +35,7 @@ if nRuns+nRuns*nLumiPerRun != indices.GetEntries():
     print("wrong number of entries in Indices", indices.GetEntries())
     sys.exit(1)
 
-for run in xrange(0,nRuns+nRuns*nLumiPerRun):
+for run in range(0,nRuns+nRuns*nLumiPerRun):
     indices.GetEntry(run)
     v = (indices.Run,indices.Lumi,indices.Type,indices.FirstIndex,indices.LastIndex)
     if v != expectedIndices[run]:
@@ -43,7 +44,7 @@ for run in xrange(0,nRuns+nRuns*nLumiPerRun):
         print(' found:',v)
         sys.exit(1)
     if indices.Type !=1000:
-        for ihist in xrange(indices.FirstIndex,indices.LastIndex+1):
+        for ihist in range(indices.FirstIndex,indices.LastIndex+1):
             index = ihist
             th1fs.GetEntry(ihist)
             v = (th1fs.FullName,th1fs.Flags,th1fs.Value.GetEntries())

--- a/DQMServices/FwkIO/test/create_empty_file_cfg.py
+++ b/DQMServices/FwkIO/test/create_empty_file_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 process =cms.Process("TEST")
 
@@ -7,7 +8,7 @@ process.source = cms.Source("EmptySource", numberEventsInRun = cms.untracked.uin
                             numberEventsInLuminosityBlock = cms.untracked.uint32(1))
 
 elements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     elements.append(cms.untracked.PSet(lowX=cms.untracked.double(0),
                                        highX=cms.untracked.double(11),
                                        nchX=cms.untracked.int32(11),
@@ -24,17 +25,17 @@ process.out = cms.OutputModule("DQMRootOutputModule",
                                fileName = cms.untracked.string("dqm_empty.root"))
 
 readRunElements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     readRunElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                               means = cms.untracked.vdouble(i),
                                               entries=cms.untracked.vdouble(1)
     ))
 
 readLumiElements=list()
-for i in xrange(0,10):
+for i in range(0,10):
     readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
-                                              means = cms.untracked.vdouble([i for x in xrange(0,10)]),
-                                              entries=cms.untracked.vdouble([1 for x in xrange(0,10)])
+                                              means = cms.untracked.vdouble([i for x in range(0,10)]),
+                                              entries=cms.untracked.vdouble([1 for x in range(0,10)])
     ))
 
 process.reader = cms.EDAnalyzer("DummyReadDQMStore",

--- a/DQMServices/FwkIO/test/create_file1_cfg.py
+++ b/DQMServices/FwkIO/test/create_file1_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 process =cms.Process("TEST")
 
@@ -7,7 +8,7 @@ process.source = cms.Source("EmptySource", numberEventsInRun = cms.untracked.uin
                             numberEventsInLuminosityBlock = cms.untracked.uint32(1))
 
 elements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     elements.append(cms.untracked.PSet(lowX=cms.untracked.double(0),
                                        highX=cms.untracked.double(11),
                                        nchX=cms.untracked.int32(11),
@@ -24,17 +25,17 @@ process.out = cms.OutputModule("DQMRootOutputModule",
                                fileName = cms.untracked.string("dqm_file1.root"))
 
 readRunElements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     readRunElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                               means = cms.untracked.vdouble(i),
                                               entries=cms.untracked.vdouble(1)
     ))
 
 readLumiElements=list()
-for i in xrange(0,10):
+for i in range(0,10):
     readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
-                                              means = cms.untracked.vdouble([i for x in xrange(0,10)]),
-                                              entries=cms.untracked.vdouble([1 for x in xrange(0,10)])
+                                              means = cms.untracked.vdouble([i for x in range(0,10)]),
+                                              entries=cms.untracked.vdouble([1 for x in range(0,10)])
     ))
 
 process.reader = cms.EDAnalyzer("DummyReadDQMStore",

--- a/DQMServices/FwkIO/test/create_file2_cfg.py
+++ b/DQMServices/FwkIO/test/create_file2_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 process =cms.Process("TEST")
 
@@ -7,7 +8,7 @@ process.source = cms.Source("EmptySource", numberEventsInRun = cms.untracked.uin
                             numberEventsInLuminosityBlock = cms.untracked.uint32(1))
 
 elements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     elements.append(cms.untracked.PSet(lowX=cms.untracked.double(0),
                                        highX=cms.untracked.double(11),
                                        nchX=cms.untracked.int32(11),
@@ -24,17 +25,17 @@ process.out = cms.OutputModule("DQMRootOutputModule",
                                fileName = cms.untracked.string("dqm_file2.root"))
 
 readRunElements = list()
-for i in xrange(0,10):
+for i in range(0,10):
    readRunElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                              means = cms.untracked.vdouble(i),
                                              entries=cms.untracked.vdouble(1)
    ))
 
 readLumiElements=list()
-for i in xrange(0,10):
+for i in range(0,10):
    readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
-                                             means = cms.untracked.vdouble([i for x in xrange(0,10)]),
-                                             entries=cms.untracked.vdouble([1 for x in xrange(0,10)])
+                                             means = cms.untracked.vdouble([i for x in range(0,10)]),
+                                             entries=cms.untracked.vdouble([1 for x in range(0,10)])
    ))
 
 process.reader = cms.EDAnalyzer("DummyReadDQMStore",

--- a/DQMServices/FwkIO/test/create_file3_cfg.py
+++ b/DQMServices/FwkIO/test/create_file3_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 process =cms.Process("TEST")
 
@@ -8,7 +9,7 @@ process.source = cms.Source("EmptySource", numberEventsInRun = cms.untracked.uin
                             numberEventsInLuminosityBlock = cms.untracked.uint32(1))
 
 elements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     elements.append(cms.untracked.PSet(lowX=cms.untracked.double(0),
                                        highX=cms.untracked.double(11),
                                        nchX=cms.untracked.int32(11),
@@ -25,17 +26,17 @@ process.out = cms.OutputModule("DQMRootOutputModule",
                                fileName = cms.untracked.string("dqm_file3.root"))
 
 readRunElements = list()
-for i in xrange(0,10):
+for i in range(0,10):
    readRunElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                              means = cms.untracked.vdouble(i+1),
                                              entries=cms.untracked.vdouble(1)
    ))
 
 readLumiElements=list()
-for i in xrange(0,10):
+for i in range(0,10):
    readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
-                                             means = cms.untracked.vdouble([i+1 for x in xrange(0,10)]),
-                                             entries=cms.untracked.vdouble([1 for x in xrange(0,10)])
+                                             means = cms.untracked.vdouble([i+1 for x in range(0,10)]),
+                                             entries=cms.untracked.vdouble([1 for x in range(0,10)])
    ))
 
 process.reader = cms.EDAnalyzer("DummyReadDQMStore",

--- a/DQMServices/FwkIO/test/create_file4_cfg.py
+++ b/DQMServices/FwkIO/test/create_file4_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 process =cms.Process("TEST")
 
@@ -7,7 +8,7 @@ process.source = cms.Source("EmptySource", numberEventsInRun = cms.untracked.uin
                             numberEventsInLuminosityBlock = cms.untracked.uint32(1))
 
 elements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     elements.append(cms.untracked.PSet(lowX=cms.untracked.double(0),
                                        highX=cms.untracked.double(11),
                                        nchX=cms.untracked.int32(11),
@@ -27,17 +28,17 @@ process.out = cms.OutputModule("DQMRootOutputModule",
                                fileName = cms.untracked.string("dqm_file4.root"))
 
 readRunElements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     readRunElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                               means = cms.untracked.vdouble(i),
                                               entries=cms.untracked.vdouble(1)
     ))
 
 readLumiElements=list()
-for i in xrange(0,10):
+for i in range(0,10):
     readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
-                                              means = cms.untracked.vdouble([i for x in xrange(0,10)]),
-                                              entries=cms.untracked.vdouble([1 for x in xrange(0,10)])
+                                              means = cms.untracked.vdouble([i for x in range(0,10)]),
+                                              entries=cms.untracked.vdouble([1 for x in range(0,10)])
     ))
 
 process.reader = cms.EDAnalyzer("DummyReadDQMStore",

--- a/DQMServices/FwkIO/test/create_file_multi_types_cfg.py
+++ b/DQMServices/FwkIO/test/create_file_multi_types_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 process =cms.Process("TEST")
 
@@ -9,7 +10,7 @@ process.source = cms.Source("EmptySource", numberEventsInRun = cms.untracked.uin
 elements = list()
 extensions = ["","2D"]
 for t in [0,1]:
-    for i in xrange(0,10):
+    for i in range(0,10):
         elements.append(cms.untracked.PSet(type = cms.untracked.uint32(t+1),
                                            lowX=cms.untracked.double(0),
                                            highX=cms.untracked.double(10),

--- a/DQMServices/FwkIO/test/create_lumi_only_file_cfg.py
+++ b/DQMServices/FwkIO/test/create_lumi_only_file_cfg.py
@@ -1,10 +1,11 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 process =cms.Process("TEST")
 
 process.source = cms.Source("EmptySource", numberEventsInRun = cms.untracked.uint32(1))
 
 elements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     elements.append(cms.untracked.PSet(lowX=cms.untracked.double(0),
                                        highX=cms.untracked.double(10),
                                        nchX=cms.untracked.int32(10),

--- a/DQMServices/FwkIO/test/create_one_run_one_lumi_run_only_file_cfg.py
+++ b/DQMServices/FwkIO/test/create_one_run_one_lumi_run_only_file_cfg.py
@@ -1,10 +1,11 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 process =cms.Process("TEST")
 
 process.source = cms.Source("EmptySource", numberEventsInRun = cms.untracked.uint32(1))
 
 elements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     elements.append(cms.untracked.PSet(lowX=cms.untracked.double(0),
                                        highX=cms.untracked.double(10),
                                        nchX=cms.untracked.int32(10),

--- a/DQMServices/FwkIO/test/create_run_lumi_file_cfg.py
+++ b/DQMServices/FwkIO/test/create_run_lumi_file_cfg.py
@@ -1,10 +1,11 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 process =cms.Process("TEST")
 
 process.source = cms.Source("EmptySource", numberEventsInRun = cms.untracked.uint32(1))
 
 elements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     elements.append(cms.untracked.PSet(lowX=cms.untracked.double(0),
                                        highX=cms.untracked.double(10),
                                        nchX=cms.untracked.int32(10),

--- a/DQMServices/FwkIO/test/create_run_only_file_cfg.py
+++ b/DQMServices/FwkIO/test/create_run_only_file_cfg.py
@@ -1,10 +1,11 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 process =cms.Process("TEST")
 
 process.source = cms.Source("EmptySource", numberEventsInRun = cms.untracked.uint32(1))
 
 elements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     elements.append(cms.untracked.PSet(lowX=cms.untracked.double(0),
                                        highX=cms.untracked.double(10),
                                        nchX=cms.untracked.int32(10),

--- a/DQMServices/FwkIO/test/read_file1_file2_cfg.py
+++ b/DQMServices/FwkIO/test/read_file1_file2_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("READ")
@@ -6,10 +7,10 @@ process.source = cms.Source("DQMRootSource",
                             fileNames = cms.untracked.vstring("file:dqm_file1.root","file:dqm_file2.root"))
 
 seq = cms.untracked.VEventID()
-for r in xrange(1,2):
+for r in range(1,2):
     #begin run
     seq.append(cms.EventID(r,0,0))
-    for l in xrange(1,21):
+    for l in range(1,21):
         #begin lumi
         seq.append(cms.EventID(r,l,0))
         #end lumi
@@ -21,17 +22,17 @@ process.check = cms.EDAnalyzer("RunLumiEventChecker",
                                eventSequence = seq)
 
 readRunElements = list()
-for i in xrange(0,10):
+for i in range(0,10):
   readRunElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                             means = cms.untracked.vdouble(i),
                                             entries=cms.untracked.vdouble(2)
   ))
 
 readLumiElements=list()
-for i in xrange(0,10):
+for i in range(0,10):
   readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
-                                            means = cms.untracked.vdouble([i for x in xrange(0,20)]),
-                                            entries=cms.untracked.vdouble([1 for x in xrange(0,20)])
+                                            means = cms.untracked.vdouble([i for x in range(0,20)]),
+                                            entries=cms.untracked.vdouble([1 for x in range(0,20)])
   ))
 
 process.reader = cms.EDAnalyzer("DummyReadDQMStore",

--- a/DQMServices/FwkIO/test/read_file1_file3_cfg.py
+++ b/DQMServices/FwkIO/test/read_file1_file3_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("READ")
@@ -9,7 +10,7 @@ seq = cms.untracked.VEventID()
 for r in [1,2]:
     #begin run
     seq.append(cms.EventID(r,0,0))
-    for l in xrange(1,11):
+    for l in range(1,11):
         #begin lumi
         seq.append(cms.EventID(r,l,0))
         #end lumi
@@ -21,18 +22,18 @@ process.check = cms.EDAnalyzer("RunLumiEventChecker",
                                eventSequence = seq)
 
 readRunElements = list()
-for i in xrange(0,10):
+for i in range(0,10):
  readRunElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                            means = cms.untracked.vdouble([i+x for x in (0,1)]),
                                            entries=cms.untracked.vdouble([1 for x in (0,1)])
  ))
 
 readLumiElements=list()
-for i in xrange(0,10):
+for i in range(0,10):
  readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                            #file3 has means shifted by 1
-                                           means = cms.untracked.vdouble([i+x/10 for x in xrange(0,20)]),
-                                           entries=cms.untracked.vdouble([1 for x in xrange(0,20)])
+                                           means = cms.untracked.vdouble([i+x/10 for x in range(0,20)]),
+                                           entries=cms.untracked.vdouble([1 for x in range(0,20)])
  ))
 
 process.reader = cms.EDAnalyzer("DummyReadDQMStore",

--- a/DQMServices/FwkIO/test/read_lumi_only_file_cfg.py
+++ b/DQMServices/FwkIO/test/read_lumi_only_file_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("READ")
@@ -6,10 +7,10 @@ process.source = cms.Source("DQMRootSource",
                             fileNames = cms.untracked.vstring("file:dqm_lumi_only.root"))
 
 seq = cms.untracked.VEventID()
-for r in xrange(1,11):
+for r in range(1,11):
     #begin run
     seq.append(cms.EventID(r,0,0))
-    for l in xrange(1,2):
+    for l in range(1,2):
         #begin lumi
         seq.append(cms.EventID(r,l,0))
         #end lumi

--- a/DQMServices/FwkIO/test/read_merged_file1_file2_cfg.py
+++ b/DQMServices/FwkIO/test/read_merged_file1_file2_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("READ")
@@ -10,7 +11,7 @@ lumisPerRun = [21,]
 for r in [1,]:
     #begin run
     seq.append(cms.EventID(r,0,0))
-    for l in xrange(1,lumisPerRun[r-1]):
+    for l in range(1,lumisPerRun[r-1]):
         #begin lumi
         seq.append(cms.EventID(r,l,0))
         #end lumi
@@ -22,17 +23,17 @@ process.check = cms.EDAnalyzer("RunLumiEventChecker",
                                eventSequence = seq)
 
 readRunElements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     readRunElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                           means = cms.untracked.vdouble(i),
                                           entries=cms.untracked.vdouble(2)
                                           ))
 
 readLumiElements=list()
-for i in xrange(0,10):
+for i in range(0,10):
     readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
-                                          means = cms.untracked.vdouble([i for x in xrange(0,20)]),
-                                          entries=cms.untracked.vdouble([1 for x in xrange(0,20)])
+                                          means = cms.untracked.vdouble([i for x in range(0,20)]),
+                                          entries=cms.untracked.vdouble([1 for x in range(0,20)])
                                           ))
 
 process.reader = cms.EDAnalyzer("DummyReadDQMStore",

--- a/DQMServices/FwkIO/test/read_merged_file1_file3_file2_cfg.py
+++ b/DQMServices/FwkIO/test/read_merged_file1_file3_file2_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("READ")
@@ -10,7 +11,7 @@ lumisPerRun = [21,11]
 for r in [1,2]:
     #begin run
     seq.append(cms.EventID(r,0,0))
-    for l in xrange(1,lumisPerRun[r-1]):
+    for l in range(1,lumisPerRun[r-1]):
         #begin lumi
         seq.append(cms.EventID(r,l,0))
         #end lumi
@@ -22,18 +23,18 @@ process.check = cms.EDAnalyzer("RunLumiEventChecker",
                                eventSequence = seq)
 
 readRunElements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     readRunElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                           means = cms.untracked.vdouble([i+x for x in (0,1)]),
                                           entries=cms.untracked.vdouble([x for x in (2,1)])
                                           ))
 
 readLumiElements=list()
-for i in xrange(0,10):
+for i in range(0,10):
     readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                           #file3, which is run 2 has means shifted by 1
-                                          means = cms.untracked.vdouble([i+x/20 for x in xrange(0,30)]),
-                                          entries=cms.untracked.vdouble([1 for x in xrange(0,30)])
+                                          means = cms.untracked.vdouble([i+x/20 for x in range(0,30)]),
+                                          entries=cms.untracked.vdouble([1 for x in range(0,30)])
                                           ))
 
 process.reader = cms.EDAnalyzer("DummyReadDQMStore",

--- a/DQMServices/FwkIO/test/read_merged_file1_file3_file4_cfg.py
+++ b/DQMServices/FwkIO/test/read_merged_file1_file3_file4_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("READ")
@@ -10,7 +11,7 @@ lumisPerRun = [21,11]
 r = 1
 #begin run
 seq.append(cms.EventID(r,0,0))
-for l in xrange(1,11):
+for l in range(1,11):
     #begin lumi
     seq.append(cms.EventID(r,l,0))
     #end lumi
@@ -20,7 +21,7 @@ seq.append(cms.EventID(r,0,0))
 r = 2
 #begin run
 seq.append(cms.EventID(r,0,0))
-for l in xrange(1,11):
+for l in range(1,11):
     #begin lumi
     seq.append(cms.EventID(r,l,0))
     #end lumi
@@ -30,7 +31,7 @@ seq.append(cms.EventID(r,0,0))
 r = 1
 #begin run
 seq.append(cms.EventID(r,0,0))
-for l in xrange(100,110):
+for l in range(100,110):
     #begin lumi
     seq.append(cms.EventID(r,l,0))
     #end lumi
@@ -42,18 +43,18 @@ process.check = cms.EDAnalyzer("RunLumiEventChecker",
                                eventSequence = seq)
 
 readRunElements = list()
-for i in xrange(0,10):
+for i in range(0,10):
     readRunElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                           means = cms.untracked.vdouble([i+x for x in (0,1,0)]),
                                           entries=cms.untracked.vdouble([x for x in (1,1,1)])
                                           ))
 
 readLumiElements=list()
-for i in xrange(0,10):
+for i in range(0,10):
     readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                           #file3, which is run 2 has means shifted by 1
-                                          means = cms.untracked.vdouble([(i+x/10-x/20-x/20) for x in xrange(0,30)]),
-                                          entries=cms.untracked.vdouble([1 for x in xrange(0,30)])
+                                          means = cms.untracked.vdouble([(i+x/10-x/20-x/20) for x in range(0,30)]),
+                                          entries=cms.untracked.vdouble([1 for x in range(0,30)])
                                           ))
 
 process.reader = cms.EDAnalyzer("DummyReadDQMStore",

--- a/DQMServices/FwkIO/test/read_run_lumi_file_cfg.py
+++ b/DQMServices/FwkIO/test/read_run_lumi_file_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("READ")
@@ -6,10 +7,10 @@ process.source = cms.Source("DQMRootSource",
                             fileNames = cms.untracked.vstring("file:dqm_run_lumi.root"))
 
 seq = cms.untracked.VEventID()
-for r in xrange(1,11):
+for r in range(1,11):
     #begin run
     seq.append(cms.EventID(r,0,0))
-    for l in xrange(1,2):
+    for l in range(1,2):
         #begin lumi
         seq.append(cms.EventID(r,l,0))
         #end lumi

--- a/DQMServices/FwkIO/test/read_run_only_file_cfg.py
+++ b/DQMServices/FwkIO/test/read_run_only_file_cfg.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("READ")
@@ -7,10 +8,10 @@ process.source = cms.Source("DQMRootSource",
 
 #NOTE: even though we only store histograms on runs, we still record the lumis that were seen
 seq = cms.untracked.VEventID()
-for r in xrange(1,11):
+for r in range(1,11):
     #begin run
     seq.append(cms.EventID(r,0,0))
-    for l in xrange(1,2):
+    for l in range(1,2):
         #begin lumi
         seq.append(cms.EventID(r,l,0))
         #end lumi

--- a/Validation/Performance/python/parserPerfsuiteMetadata.py
+++ b/Validation/Performance/python/parserPerfsuiteMetadata.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 import re
 import os, sys
 import time
@@ -120,7 +121,7 @@ class parserPerfsuiteMetadata:
     def findLineBefore(self, line_index, lines, test_condition):
         """ finds a line satisfying the `test_condition` comming before the `line_index` """
         # we're going backwards the lines list
-        for line_index in  xrange(line_index -1, -1, -1):
+        for line_index in  range(line_index -1, -1, -1):
             line = lines[line_index]
 
             if test_condition(line):
@@ -131,7 +132,7 @@ class parserPerfsuiteMetadata:
     def findLineAfter(self, line_index, lines, test_condition, return_index = False):
         """ finds a line satisfying the `test_condition` comming after the `line_index` """
         # we're going forward the lines list
-        for line_index in xrange(line_index + 1, len(lines)):
+        for line_index in range(line_index + 1, len(lines)):
             line = lines[line_index]
 
             if test_condition(line):	
@@ -322,11 +323,11 @@ class parserPerfsuiteMetadata:
 		"""
         tags_start_index = -1 # set some default
         try:
-            tags_start_index = [i for i in xrange(0, len(lines)) if lines[i].startswith("--- Tag ---")][0]
+            tags_start_index = [i for i in range(0, len(lines)) if lines[i].startswith("--- Tag ---")][0]
         except:
             pass
         if tags_start_index > -1:
-            tags_end_index = [i for i in xrange(tags_start_index + 1, len(lines)) if lines[i].startswith("---------------------------------------")][0]
+            tags_end_index = [i for i in range(tags_start_index + 1, len(lines)) if lines[i].startswith("---------------------------------------")][0]
             # print "tags start index: %s, end index: %s" % (tags_start_index, tags_end_index)
             tags = lines[tags_start_index:tags_end_index+2]
             # print [tag.split("  ") for tag in tags]
@@ -415,7 +416,7 @@ class parserPerfsuiteMetadata:
         jobs = []
 
         #can split it into jobs ! just have to reparse it for the exit codes later....
-        for line_index in xrange(0, len(lines)):
+        for line_index in range(0, len(lines)):
             line = lines[line_index]
             if reSubmit.match(line):
                 end_index = self.findLineAfter(line_index, lines, test_condition=lambda l: reWaiting.match(l), return_index = True)
@@ -469,7 +470,7 @@ class parserPerfsuiteMetadata:
                 test[testName] = []
             test[testName].append(info)
 
-        for line_index in xrange(0, len(lines)):
+        for line_index in range(0, len(lines)):
             line = lines[line_index]
 
             if reEnd.match(line):
@@ -523,7 +524,7 @@ class parserPerfsuiteMetadata:
         jobs = []
         start = False
         timesize_start_indicator = re.compile(r"""^taskset -c (\d+) cmsRelvalreportInput.py""")
-        for line_index in xrange(0, len(lines)):
+        for line_index in range(0, len(lines)):
             line = lines[line_index]
             # search for start of each TimeSize job (with a certain candle and step)
             if timesize_start_indicator.match(line):

--- a/Validation/Performance/scripts/cmsBenchmark.py
+++ b/Validation/Performance/scripts/cmsBenchmark.py
@@ -56,6 +56,7 @@ OR
 
 """
 from __future__ import print_function
+from builtins import range
 import os
 #Get some environment variables to use
 cmssw_base=os.environ["CMSSW_BASE"]

--- a/Validation/Performance/scripts/cmsPerfClient.py
+++ b/Validation/Performance/scripts/cmsPerfClient.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import socket, xml, xmlrpclib, os, sys, threading, Queue, time, random, pickle, exceptions
 import optparse as opt
 from functools import reduce

--- a/Validation/Performance/scripts/cmsPerfCommons.py
+++ b/Validation/Performance/scripts/cmsPerfCommons.py
@@ -1,3 +1,4 @@
+from builtins import range
 import os, re
 
 #Sort the candles to make sure MinBias is executed before QCD_80_120, otherwise DIGI PILEUP would not find its MinBias root files

--- a/Validation/Performance/scripts/cmsPerfPublish.py
+++ b/Validation/Performance/scripts/cmsPerfPublish.py
@@ -12,6 +12,7 @@
 #            before python v2.6, when we upgrade to python 2.6 we should use this
 #            functionality.
 from __future__ import print_function
+from builtins import range
 import tempfile as tmp
 import optparse as opt
 import cmsPerfRegress as cpr

--- a/Validation/Performance/scripts/cmsPerfRegress.py
+++ b/Validation/Performance/scripts/cmsPerfRegress.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import time, os, sys, math, re, gzip
 import tempfile as tmp
 import optparse as opt

--- a/Validation/Performance/scripts/cmsPerfServer.py
+++ b/Validation/Performance/scripts/cmsPerfServer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import cmsPerfPublish as cspp
 import cmsPerfSuite      as cps
 import cmsPerfHarvest    as cph

--- a/Validation/Performance/scripts/cmsPerfStripChart.py
+++ b/Validation/Performance/scripts/cmsPerfStripChart.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import os, sys
 try: import simplejson as json
 except ImportError: import json

--- a/Validation/Performance/scripts/cmsPerfSuite.py
+++ b/Validation/Performance/scripts/cmsPerfSuite.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from builtins import range
 import os, time, sys, re, glob, exceptions
 import optparse as opt
 import cmsRelRegress as crr
@@ -1180,7 +1181,7 @@ class PerfSuite:
                                          # specifying the same number of cores and cpus (like: --cores 3, --cpu 3,4,5)
                 AvailableCores=cpus
             else:
-                AvailableCores=range(cores)
+                AvailableCores=list(range(cores))
                 
             #Initialize a list that will contain all the simpleGenReport keyword arguments (1 dictionary per test):
             TestsToDo=[]

--- a/Validation/Performance/scripts/cmsRelvalreportInput.py
+++ b/Validation/Performance/scripts/cmsRelvalreportInput.py
@@ -22,6 +22,7 @@
 #
 
 from __future__ import print_function
+from builtins import range
 import sys, os, re, operator
 import optparse as opt
 from cmsPerfCommons import Candles, CandDesc, FileName, KeywordToCfi, CustomiseFragment, CandFname, EventContents

--- a/Validation/Performance/scripts/cmsTiming_parser.py
+++ b/Validation/Performance/scripts/cmsTiming_parser.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import sys, os
 import time
 import optparse

--- a/Validation/RecoTau/Tools/MultipleCompare.py
+++ b/Validation/RecoTau/Tools/MultipleCompare.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 import sys
 import os

--- a/Validation/RecoTau/Tools/web_templates.py
+++ b/Validation/RecoTau/Tools/web_templates.py
@@ -1,3 +1,4 @@
+from builtins import range
 main_page_template = '''<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 <head>

--- a/Validation/RecoTau/python/compare.py
+++ b/Validation/RecoTau/python/compare.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 from .officialStyle import officialStyle
 from array import array
 from ROOT import gROOT, gStyle, TH1F, TH1D, TF1, TFile, TCanvas, TH2F, TLegend, TGraphAsymmErrors, Double, TLatex

--- a/Validation/RecoTau/python/runTauDisplay.py
+++ b/Validation/RecoTau/python/runTauDisplay.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 import ROOT, os, math, sys
 import numpy as num
 from DataFormats.FWLite import Events, Handle

--- a/Validation/RecoTau/test/LXBatchValidation.py
+++ b/Validation/RecoTau/test/LXBatchValidation.py
@@ -3,6 +3,7 @@
 # Script to submit Tau Validation jobs to lxbatch
 #  Author: Evan Friis evan.klose.friis@cern.ch
 from __future__ import print_function
+from builtins import range
 import time
 import random
 from Validation.RecoTau.ValidationOptions_cff import *
@@ -73,7 +74,7 @@ cleanupCommands = ""
 if options.writeEDMFile != "":
    cleanupCommand += " rfcp *.root %s;" % options.copyToCastorDir
 
-for iJob in xrange(0, options.nJobs):
+for iJob in range(0, options.nJobs):
    options.batchNumber = iJob #increment batch number
    #setupCommands = "cd $PWD; scramv1 runtime -sh > tempEnvs_%s_%i; source tempEnvs_%s_%i; rm tempEnvs_%s_%i; export PYTHONPATH=$PWD:$PYTHONPATH; cd -;" % (options.eventType, iJob, options.eventType, iJob, options.eventType, iJob)
    #cmsRunCommand = "cmsRun $PWD/RunValidation_cfg.py %s;" % returnOptionsString()

--- a/Validation/RecoTrack/python/plotting/ntupleDataFormat.py
+++ b/Validation/RecoTrack/python/plotting/ntupleDataFormat.py
@@ -1,3 +1,4 @@
+from builtins import range
 import math
 import collections
 
@@ -40,7 +41,7 @@ class _Collection(object):
 
     def __iter__(self):
         """Returns generator for the objects."""
-        for index in xrange(self.size()):
+        for index in range(self.size()):
             yield self._objclass(self._tree, index)
 
 class _Object(object):
@@ -291,7 +292,7 @@ class _SimHitMatchAdaptor(object):
         The generator returns SimHitMatchInfo objects.
         """
         self._checkIsValid()
-        for imatch in xrange(self._nMatchedSimHits()):
+        for imatch in range(self._nMatchedSimHits()):
             yield SimHitMatchInfo(self._tree, self._index, imatch, self._prefix)
 
 class _TrackingParticleMatchAdaptor(object):
@@ -315,7 +316,7 @@ class _TrackingParticleMatchAdaptor(object):
 
         """
         self._checkIsValid()
-        for imatch in xrange(self._nMatchedTrackingParticles()):
+        for imatch in range(self._nMatchedTrackingParticles()):
             yield TrackingParticleMatchInfo(self._tree, self._index, imatch, self._prefix)
 
     def bestMatchingTrackingParticle(self):
@@ -423,7 +424,7 @@ class TrackingNtuple(object):
         Generator returns Event objects.
 
         """
-        for jentry in xrange(self._entries):
+        for jentry in range(self._entries):
             # get the next tree in the chain and verify
             ientry = self._tree.LoadTree( jentry )
             if ientry < 0: break
@@ -937,7 +938,7 @@ class Seeds(_Collection):
         Generator returns Seed object.
         """
         (offset, next_offset) = _seedOffsetForAlgo(self._tree, algo)
-        for isee in xrange(offset, next_offset):
+        for isee in range(offset, next_offset):
             yield Seed(self._tree, isee)
 
     def seedForAlgo(self, algo, iseed):
@@ -994,7 +995,7 @@ class TrackingParticle(_Object):
         The generator returns TrackMatchInfo objects.
         """
         self._checkIsValid()
-        for imatch in xrange(self._nMatchedTracks()):
+        for imatch in range(self._nMatchedTracks()):
             yield TrackMatchInfo(self._tree, self._index, imatch, self._prefix)
 
     def bestMatchingTrack(self):
@@ -1041,7 +1042,7 @@ class TrackingParticle(_Object):
         The generator returns SeedMatchInfo objects.
         """
         self._checkIsValid()
-        for imatch in xrange(self._nMatchedSeeds()):
+        for imatch in range(self._nMatchedSeeds()):
             yield SeedMatchInfo(self._tree, self._index, imatch, self._prefix)
 
     def nSimHits(self):

--- a/Validation/RecoTrack/python/plotting/ntuplePrintersDiff.py
+++ b/Validation/RecoTrack/python/plotting/ntuplePrintersDiff.py
@@ -1,3 +1,4 @@
+from builtins import range
 import re
 import sys
 import math
@@ -913,7 +914,7 @@ class TrackPrinter(_RecHitPrinter):
         oriAlgo = track.originalAlgo()
         algos = []
         algoMask = track.algoMask()
-        for i in xrange(Algo.algoSize):
+        for i in range(Algo.algoSize):
             if algoMask & 1:
                 algos.append(Algo.toString(i))
             algoMask = algoMask >> 1

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 import os
 import sys
 import math
@@ -99,7 +100,7 @@ def _getDirectory(*args, **kwargs):
 
 def _th1ToOrderedDict(th1, renameBin=None):
     values = collections.OrderedDict()
-    for i in xrange(1, th1.GetNbinsX()+1):
+    for i in range(1, th1.GetNbinsX()+1):
         binLabel = th1.GetXaxis().GetBinLabel(i)
         if renameBin is not None:
             binLabel = renameBin(binLabel)
@@ -198,7 +199,7 @@ def _calculateRatios(histos, ratioUncertainty=False):
             xaxis = th1.GetXaxis()
             xaxis_arr = xaxis.GetXbins()
             if xaxis_arr.GetSize() > 0: # unequal binning
-                lst = [xaxis_arr[i] for i in xrange(0, xaxis_arr.GetSize())]
+                lst = [xaxis_arr[i] for i in range(0, xaxis_arr.GetSize())]
                 arr = array.array("d", lst)
                 self._ratio = ROOT.TH1F("foo", "foo", xaxis.GetNbins(), arr)
             else:
@@ -320,11 +321,11 @@ def _calculateRatios(histos, ratioUncertainty=False):
     ref = wrappers[0]
 
     wrappers_bins = []
-    ref_bins = [ref.xvalues(b) for b in xrange(ref.begin(), ref.end())]
+    ref_bins = [ref.xvalues(b) for b in range(ref.begin(), ref.end())]
     for w in wrappers:
         wrappers_bins.append(findBins(w, ref_bins))
 
-    for i, bin in enumerate(xrange(ref.begin(), ref.end())):
+    for i, bin in enumerate(range(ref.begin(), ref.end())):
         (scale, ylow, yhigh) = ref.yvalues(bin)
         for w, bins in zip(wrappers, wrappers_bins):
             if bins[i] is None:
@@ -341,7 +342,7 @@ def _getXmin(obj, limitToNonZeroContent=False):
     if isinstance(obj, ROOT.TH1):
         xaxis = obj.GetXaxis()
         if limitToNonZeroContent:
-            for i in xrange(1, obj.GetNbinsX()+1):
+            for i in range(1, obj.GetNbinsX()+1):
                 if obj.GetBinContent(i) != 0:
                     return xaxis.GetBinLowEdge(i)
             # None for all bins being zero
@@ -349,7 +350,7 @@ def _getXmin(obj, limitToNonZeroContent=False):
         else:
             return xaxis.GetBinLowEdge(xaxis.GetFirst())
     elif isinstance(obj, ROOT.TGraph) or isinstance(obj, ROOT.TGraph2D):
-        m = min([obj.GetX()[i] for i in xrange(0, obj.GetN())])
+        m = min([obj.GetX()[i] for i in range(0, obj.GetN())])
         return m*0.9 if m > 0 else m*1.1
     raise Exception("Unsupported type %s" % str(obj))
 
@@ -357,7 +358,7 @@ def _getXmax(obj, limitToNonZeroContent=False):
     if isinstance(obj, ROOT.TH1):
         xaxis = obj.GetXaxis()
         if limitToNonZeroContent:
-            for i in xrange(obj.GetNbinsX(), 0, -1):
+            for i in range(obj.GetNbinsX(), 0, -1):
                 if obj.GetBinContent(i) != 0:
                     return xaxis.GetBinUpEdge(i)
             # None for all bins being zero
@@ -365,7 +366,7 @@ def _getXmax(obj, limitToNonZeroContent=False):
         else:
             return xaxis.GetBinUpEdge(xaxis.GetLast())
     elif isinstance(obj, ROOT.TGraph) or isinstance(obj, ROOT.TGraph2D):
-        m = max([obj.GetX()[i] for i in xrange(0, obj.GetN())])
+        m = max([obj.GetX()[i] for i in range(0, obj.GetN())])
         return m*1.1 if m > 0 else m*0.9
     raise Exception("Unsupported type %s" % str(obj))
 
@@ -375,12 +376,12 @@ def _getYmin(obj, limitToNonZeroContent=False):
         return yaxis.GetBinLowEdge(yaxis.GetFirst())
     elif isinstance(obj, ROOT.TH1):
         if limitToNonZeroContent:
-            lst = [obj.GetBinContent(i) for i in xrange(1, obj.GetNbinsX()+1) if obj.GetBinContent(i) != 0 ]
+            lst = [obj.GetBinContent(i) for i in range(1, obj.GetNbinsX()+1) if obj.GetBinContent(i) != 0 ]
             return min(lst) if len(lst) != 0 else 0
         else:
             return obj.GetMinimum()
     elif isinstance(obj, ROOT.TGraph) or isinstance(obj, ROOT.TGraph2D):
-        m = min([obj.GetY()[i] for i in xrange(0, obj.GetN())])
+        m = min([obj.GetY()[i] for i in range(0, obj.GetN())])
         return m*0.9 if m > 0 else m*1.1
     raise Exception("Unsupported type %s" % str(obj))
 
@@ -390,20 +391,20 @@ def _getYmax(obj, limitToNonZeroContent=False):
         return yaxis.GetBinUpEdge(yaxis.GetLast())
     elif isinstance(obj, ROOT.TH1):
         if limitToNonZeroContent:
-            lst = [obj.GetBinContent(i) for i in xrange(1, obj.GetNbinsX()+1) if obj.GetBinContent(i) != 0 ]
+            lst = [obj.GetBinContent(i) for i in range(1, obj.GetNbinsX()+1) if obj.GetBinContent(i) != 0 ]
             return max(lst) if len(lst) != 0 else 0
         else:
             return obj.GetMaximum()
     elif isinstance(obj, ROOT.TGraph) or isinstance(obj, ROOT.TGraph2D):
-        m = max([obj.GetY()[i] for i in xrange(0, obj.GetN())])
+        m = max([obj.GetY()[i] for i in range(0, obj.GetN())])
         return m*1.1 if m > 0 else m*0.9
     raise Exception("Unsupported type %s" % str(obj))
 
 def _getYmaxWithError(th1):
-    return max([th1.GetBinContent(i)+th1.GetBinError(i) for i in xrange(1, th1.GetNbinsX()+1)])
+    return max([th1.GetBinContent(i)+th1.GetBinError(i) for i in range(1, th1.GetNbinsX()+1)])
 
 def _getYminIgnoreOutlier(th1):
-    yvals = sorted([n for n in [th1.GetBinContent(i) for i in xrange(1, th1.GetNbinsX()+1)] if n>0])
+    yvals = sorted([n for n in [th1.GetBinContent(i) for i in range(1, th1.GetNbinsX()+1)] if n>0])
     if len(yvals) == 0:
         return th1.GetMinimum()
     if len(yvals) == 1:
@@ -412,7 +413,7 @@ def _getYminIgnoreOutlier(th1):
     # Define outlier as being x10 less than minimum of the 95 % of the non-zero largest values
     ind_min = len(yvals)-1 - int(len(yvals)*0.95)
     min_val = yvals[ind_min]
-    for i in xrange(0, ind_min):
+    for i in range(0, ind_min):
         if yvals[i] > 0.1*min_val:
             return yvals[i]
 
@@ -426,10 +427,10 @@ def _getYminMaxAroundMedian(obj, coverage, coverageRange=None):
         inRange2 = lambda xmin,xmax: coverageRange[0] <= xmin and xmax <= coverageRange[1]
 
     if isinstance(obj, ROOT.TH1):
-        yvals = [obj.GetBinContent(i) for i in xrange(1, obj.GetNbinsX()+1) if inRange2(obj.GetXaxis().GetBinLowEdge(i), obj.GetXaxis().GetBinUpEdge(i))]
+        yvals = [obj.GetBinContent(i) for i in range(1, obj.GetNbinsX()+1) if inRange2(obj.GetXaxis().GetBinLowEdge(i), obj.GetXaxis().GetBinUpEdge(i))]
         yvals = [x for x in yvals if x != 0]
     elif isinstance(obj, ROOT.TGraph) or isinstance(obj, ROOT.TGraph2D):
-        yvals = [obj.GetY()[i] for i in xrange(0, obj.GetN()) if inRange(obj.GetX()[i])]
+        yvals = [obj.GetY()[i] for i in range(0, obj.GetN()) if inRange(obj.GetX()[i])]
     else:
         raise Exception("Unsupported type %s" % str(obj))
     if len(yvals) == 0:
@@ -604,7 +605,7 @@ def _findBoundsY(th1s, ylog, ymin=None, ymax=None, coverage=None, coverageRange=
 
 def _th1RemoveEmptyBins(histos, xbinlabels):
     binsToRemove = set()
-    for b in xrange(1, histos[0].GetNbinsX()+1):
+    for b in range(1, histos[0].GetNbinsX()+1):
         binEmpty = True
         for h in histos:
             if h.GetBinContent(b) > 0:
@@ -616,7 +617,7 @@ def _th1RemoveEmptyBins(histos, xbinlabels):
     if len(binsToRemove) > 0:
         # filter xbinlabels
         xbinlab_new = []
-        for i in xrange(len(xbinlabels)):
+        for i in range(len(xbinlabels)):
             if (i+1) not in binsToRemove:
                 xbinlab_new.append(xbinlabels[i])
         xbinlabels = xbinlab_new
@@ -625,7 +626,7 @@ def _th1RemoveEmptyBins(histos, xbinlabels):
         histos_new = []
         for h in histos:
             values = []
-            for b in xrange(1, h.GetNbinsX()+1):
+            for b in range(1, h.GetNbinsX()+1):
                 if b not in binsToRemove:
                     values.append( (h.GetXaxis().GetBinLabel(b), h.GetBinContent(b), h.GetBinError(b)) )
 
@@ -646,9 +647,9 @@ def _th2RemoveEmptyBins(histos, xbinlabels, ybinlabels):
     xbinsToRemove = set()
     ybinsToRemove = set()
     for ih, h in enumerate(histos):
-        for bx in xrange(1, h.GetNbinsX()+1):
+        for bx in range(1, h.GetNbinsX()+1):
             binEmpty = True
-            for by in xrange(1, h.GetNbinsY()+1):
+            for by in range(1, h.GetNbinsY()+1):
                 if h.GetBinContent(bx, by) > 0:
                     binEmpty = False
                     break
@@ -657,9 +658,9 @@ def _th2RemoveEmptyBins(histos, xbinlabels, ybinlabels):
             elif ih > 0:
                 xbinsToRemove.discard(bx)
 
-        for by in xrange(1, h.GetNbinsY()+1):
+        for by in range(1, h.GetNbinsY()+1):
             binEmpty = True
-            for bx in xrange(1, h.GetNbinsX()+1):
+            for bx in range(1, h.GetNbinsX()+1):
                 if h.GetBinContent(bx, by) > 0:
                     binEmpty = False
                     break
@@ -671,14 +672,14 @@ def _th2RemoveEmptyBins(histos, xbinlabels, ybinlabels):
     if len(xbinsToRemove) > 0 or len(ybinsToRemove) > 0:
         xbinlabels_new = []
         xbins = []
-        for b in xrange(1, len(xbinlabels)+1):
+        for b in range(1, len(xbinlabels)+1):
             if b not in xbinsToRemove:
                 xbinlabels_new.append(histos[0].GetXaxis().GetBinLabel(b))
                 xbins.append(b)
         xbinlabels = xbinlabels_new
         ybinlabels_new = []
         ybins = []
-        for b in xrange(1, len(ybinlabels)+1):
+        for b in range(1, len(ybinlabels)+1):
             if b not in ybinsToRemove:
                 ybinlabels.append(histos[0].GetYaxis().GetBinLabel(b))
                 ybins.append(b)
@@ -703,10 +704,10 @@ def _th2RemoveEmptyBins(histos, xbinlabels, ybinlabels):
     return (histos, xbinlabels, ybinlabels)
 
 def _mergeBinLabelsX(histos):
-    return _mergeBinLabels([[h.GetXaxis().GetBinLabel(i) for i in xrange(1, h.GetNbinsX()+1)] for h in histos])
+    return _mergeBinLabels([[h.GetXaxis().GetBinLabel(i) for i in range(1, h.GetNbinsX()+1)] for h in histos])
 
 def _mergeBinLabelsY(histos):
-    return _mergeBinLabels([[h.GetYaxis().GetBinLabel(i) for i in xrange(1, h.GetNbinsY()+1)] for h in histos])
+    return _mergeBinLabels([[h.GetYaxis().GetBinLabel(i) for i in range(1, h.GetNbinsY()+1)] for h in histos])
 
 def _mergeBinLabels(labelsAll):
     labels_merged = labelsAll[0]
@@ -797,7 +798,7 @@ class Subtract:
         # effects downstream
         ret.SetCanExtend(False)
 
-        for i in xrange(0, histoA.GetNbinsX()+2): # include under- and overflow too
+        for i in range(0, histoA.GetNbinsX()+2): # include under- and overflow too
             val = histoA.GetBinContent(i)-histoB.GetBinContent(i)
             ret.SetBinContent(i, val)
             ret.SetBinError(i, math.sqrt(val))
@@ -837,7 +838,7 @@ class Transform:
         # effects downstream
         ret.SetCanExtend(False)
 
-        for i in xrange(0, histo.GetNbinsX()+2):
+        for i in range(0, histo.GetNbinsX()+2):
             ret.SetBinContent(i, self._func(histo.GetBinContent(i)))
         return ret
 
@@ -881,7 +882,7 @@ class FakeDuplicate:
         hfakedup = hreco.Clone(self._name)
         hfakedup.SetTitle(self._title)
 
-        for i in xrange(1, hassoc.GetNbinsX()+1):
+        for i in range(1, hassoc.GetNbinsX()+1):
             numerVal = hassoc.GetBinContent(i) - hdup.GetBinContent(i)
             denomVal = hreco.GetBinContent(i)
 
@@ -935,7 +936,7 @@ class CutEfficiency:
         ret.SetTitle(self._title)
 
         # calculate efficiency
-        for i in xrange(1, histo.GetNbinsX()+1):
+        for i in range(1, histo.GetNbinsX()+1):
             n = histo.GetBinContent(i)
             val = n/n_tot
             errVal = math.sqrt(val*(1-val)/n_tot)
@@ -1026,7 +1027,7 @@ class AggregateBins:
             binIndexOrder.sort(key=lambda t: t[0])
             tmpVal = []
             tmpLab = []
-            for i in xrange(0, len(binValues)):
+            for i in range(0, len(binValues)):
                 fromIndex = binIndexOrder[i][1]
                 tmpVal.append(binValues[fromIndex])
                 tmpLab.append(binLabels[fromIndex])
@@ -1153,7 +1154,7 @@ class ROC:
         yerrdown = []
         z = []
 
-        for i in xrange(1, xhisto.GetNbinsX()+1):
+        for i in range(1, xhisto.GetNbinsX()+1):
             x.append(xhisto.GetBinContent(i))
             xerrup.append(xhisto.GetBinError(i))
             xerrdown.append(xhisto.GetBinError(i))
@@ -1216,7 +1217,7 @@ def _drawFrame(pad, bounds, zmax=None, xbinlabels=None, xbinlabelsize=None, xbin
         frame.Draw("")
 
         xaxis = frame.GetXaxis()
-        for i in xrange(nbins):
+        for i in range(nbins):
             xaxis.SetBinLabel(i+1, xbinlabels[i])
         if xbinlabelsize is not None:
             xaxis.SetLabelSize(xbinlabelsize)
@@ -1890,7 +1891,7 @@ class Plot:
 
         if self._fallback is not None:
             profileX = [self._profileX]*len(self._histograms)
-            for i in xrange(0, len(self._histograms)):
+            for i in range(0, len(self._histograms)):
                 if self._histograms[i] is None:
                     self._histograms[i] = self._createOne(self._fallback["name"], i, tdirNEvents[i][0], tdirNEvents[i][1])
                     profileX[i] = self._fallback.get("profileX", self._profileX)
@@ -2074,7 +2075,7 @@ class Plot:
             print(self._name)
             width = max([len(l) for l in xbinlabels])
             tmp = "%%-%ds " % width
-            for b in xrange(1, histos[0].GetNbinsX()+1):
+            for b in range(1, histos[0].GetNbinsX()+1):
                 s = tmp % xbinlabels[b-1]
                 for h in histos:
                     s += "%.3f " % h.GetBinContent(b)
@@ -2947,7 +2948,7 @@ class PlotterTableItem:
             return None
 
         # Replace all None columns with lists of column length
-        for i in xrange(len(tbl)):
+        for i in range(len(tbl)):
             if tbl[i] is None:
                 tbl[i] = [None]*colLen
 

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from builtins import range
 import os
 import copy
 import collections
@@ -1076,7 +1077,7 @@ class TrackingSeedingLayerTable:
         legendLabels = legendLabels[:]
         if max(map(len, legendLabels)) > 20:
             haveShortLabels = True
-            labels_short = [str(chr(ord('A')+i)) for i in xrange(len(legendLabels))]
+            labels_short = [str(chr(ord('A')+i)) for i in range(len(legendLabels))]
             for i, ls in enumerate(labels_short):
                 legendLabels[i] = "%s: %s" % (ls, legendLabels[i])
         else:
@@ -1130,7 +1131,7 @@ class TrackingSeedingLayerTable:
         if len(histos_linear) == 0:
             return []
 
-        data = [ [h.GetBinContent(i) for i in xrange(1, h.GetNbinsX()+1)] for h in histos_linear]
+        data = [ [h.GetBinContent(i) for i in range(1, h.GetNbinsX()+1)] for h in histos_linear]
         table = html.Table(["dummy"]*len(histos_linear), xbinlabels, data, None, None, None)
         data = table.tableAsRowColumn()
 
@@ -1637,7 +1638,7 @@ class TimePerEventPlot:
 
         ret = timeTh1.Clone(self._name)
         xaxis = ret.GetXaxis()
-        for i in xrange(1, ret.GetNbinsX()+1):
+        for i in range(1, ret.GetNbinsX()+1):
             ret.SetBinContent(i, ret.GetBinContent(i)/nevents)
             ret.SetBinError(i, ret.GetBinError(i)/nevents)
             xaxis.SetBinLabel(i, xaxis.GetBinLabel(i).replace(" (unscheduled)", ""))
@@ -1689,12 +1690,12 @@ class TimePerTrackPlot:
         if h_reco_per_iter is None:
             return None
         values = {}
-        for i in xrange(1, h_reco_per_iter.GetNbinsX()+1):
+        for i in range(1, h_reco_per_iter.GetNbinsX()+1):
             values[h_reco_per_iter.GetXaxis().GetBinLabel(i)] = h_reco_per_iter.GetBinContent(i)
 
 
         result = []
-        for i in xrange(1, timeTh1.GetNbinsX()+1):
+        for i in range(1, timeTh1.GetNbinsX()+1):
             iterName = timeTh1.GetXaxis().GetBinLabel(i)
             if iterName in values:
                 ntrk = values[iterName]
@@ -1726,10 +1727,10 @@ class TrackingIterationOrder:
             # remove "Tracks" from the track producer name to get the iteration name
             # muonSeeded iterations do not have "Step" in the producer name, so add it here
             return s.replace("Tracks", "").replace("muonSeeded", "muonSeededStep")
-        return [_edit(xaxis.GetBinLabel(i)) for i in xrange(1, h.GetNbinsX()+1)]
+        return [_edit(xaxis.GetBinLabel(i)) for i in range(1, h.GetNbinsX()+1)]
 
     def __call__(self, tdirectory, labels):
-        ret = range(0, len(labels))
+        ret = list(range(0, len(labels)))
         f = tdirectory.GetFile()
         if not f:
             return ret

--- a/Validation/RecoTrack/test/analyseMVA.py
+++ b/Validation/RecoTrack/test/analyseMVA.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from builtins import range
 import array
 import collections
 import itertools
@@ -112,7 +113,7 @@ def makeHistos():
             new_bins = array.array("d", [0]*(bins+1))
             new_bins[0] = 10**minLog10
             mult = 10**width
-            for i in xrange(1, bins+1):
+            for i in range(1, bins+1):
                 new_bins[i] = new_bins[i-1]*mult
             axis.Set(bins, new_bins)
         h[name] = _h

--- a/Validation/RecoTrack/test/fakeAnalysis/analysis.py
+++ b/Validation/RecoTrack/test/fakeAnalysis/analysis.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import ROOT
 from array import array
 from collections import OrderedDict

--- a/Validation/RecoTrack/test/fakeAnalysis/graphics.py
+++ b/Validation/RecoTrack/test/fakeAnalysis/graphics.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import ROOT
 from array import array
 from copy import copy

--- a/Validation/RecoTrack/test/fakeAnalysis/graphics_vertical.py
+++ b/Validation/RecoTrack/test/fakeAnalysis/graphics_vertical.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import ROOT
 from array import array
 

--- a/Validation/RecoTrack/test/publicPlots/plot.py
+++ b/Validation/RecoTrack/test/publicPlots/plot.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import copy
 import math
 import array
@@ -978,7 +979,7 @@ def plotResol(files, prefix, pileup, hasPU70=False):
         x = []
         y = []
         axis = h.GetXaxis()
-        for i in xrange(1, h.GetNbinsX()+1):
+        for i in range(1, h.GetNbinsX()+1):
             x.append(axis.GetBinCenter(i)**2)
             y.append(h.GetBinContent(i))
 

--- a/Validation/RecoVertex/python/plotting/vertexPlots.py
+++ b/Validation/RecoVertex/python/plotting/vertexPlots.py
@@ -1,3 +1,4 @@
+from builtins import range
 import copy
 
 from Validation.RecoTrack.plotting.plotting import Plot, PlotGroup, PlotFolder, Plotter
@@ -16,8 +17,8 @@ _minMaxRes = [0.1, 0.5, 1, 5, 10, 50, 100, 200, 500, 1000, 2000, 5000]
 _minMaxPt = [5e-1, 1, 5, 1e1, 5e1, 1e2, 5e2, 1e3, 5e3, 1e4]
 _minPull = [0, 0.5, 0.8, 0.9]
 _maxPull = [1.1, 1.2, 1.5, 2]
-_minVertexZ = range(-60,-10,10)
-_maxVertexZ = range(20,70,10)
+_minVertexZ = list(range(-60,-10,10))
+_maxVertexZ = list(range(20,70,10))
 
 _vertexNumberOfEventsHistogram = "DQMData/Run 1/Vertexing/Run summary/PrimaryVertexV/GenPV_Z"
 
@@ -205,7 +206,7 @@ _lambda_mass = PlotGroup("mass", [
 
 ## Extended set of plots
 _common = dict(drawStyle = "HIST", stat=True)
-_commonXY = dict(xmin=[x*0.1 for x in xrange(-6, 6, 1)], xmax=[x*0.1 for x in xrange(-5, 7, 1)])
+_commonXY = dict(xmin=[x*0.1 for x in range(-6, 6, 1)], xmax=[x*0.1 for x in range(-5, 7, 1)])
 _commonZ = dict(xmin=[-60,-30], xmax=[30,60])
 _commonXY.update(_common)
 _commonZ.update(_common)
@@ -394,7 +395,7 @@ class VertexSummaryTable:
         h = tdirectory.Get("globalEfficiencies")
         if h:
             d = {}
-            for i in xrange(1, h.GetNbinsX()+1):
+            for i in range(1, h.GetNbinsX()+1):
                 d[h.GetXaxis().GetBinLabel(i)] = h.GetBinContent(i)
             ret.extend([
                 _formatOrNone(d.get("effic_vs_Z", None), lambda n: "%.4f"%n),

--- a/Validation/Tools/python/GenObject.py
+++ b/Validation/Tools/python/GenObject.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 ##  the classes may not function as intended.
 
 
+from builtins import range
 from FWCore.Utilities.Enumerate import Enumerate
 from DataFormats.FWLite import Events, Handle
 import re
@@ -1030,7 +1031,7 @@ class GenObject (object):
     def getRunEventEntryDict (chain, tupleName, numEntries):
         """Returns a dictionary of run, event tuples to entryIndicies"""
         reeDict = {}
-        for entryIndex in xrange (numEntries):
+        for entryIndex in range (numEntries):
             event = GenObject.loadEventFromTree (chain,
                                                  entryIndex,
                                                  onlyRunEvent = True)
@@ -1110,11 +1111,11 @@ class GenObject (object):
         if not len1 or not len2:
             # Nothing to see here folks.  Keep moving.
             if len1:
-                noMatch1Set = set( xrange(len1) )
+                noMatch1Set = set( range(len1) )
             else:
                 noMatch1Set = set ()
             if len2:
-                noMatch2Set = set( xrange(len2) )
+                noMatch2Set = set( range(len2) )
             else:
                 noMatch2Set = set ()
             if debug: warn ("Nothing found", sapces=6)
@@ -1127,8 +1128,8 @@ class GenObject (object):
         if GenObject._kitchenSinkDict.get ('strictPairing') or \
                equivList == [('index', 0)]:
             # we're only matching on index, nothing else matters
-            matchedSet = set (zip ( range( min (len1, len2) ),
-                                    range( min (len1, len2) ) ) )
+            matchedSet = set (zip ( list(range( min (len1, len2))),
+                                    list(range( min (len1, len2))) ) )
             if len1 > len2:
                 # since main pairing goes from 0..len2-1, we now want
                 # to go from len2..len1 inclusive
@@ -1155,10 +1156,10 @@ class GenObject (object):
         
         # First, look for vec2 objects that are equivalent to a
         # given vec1 object.
-        for index1 in xrange (len1):
+        for index1 in range (len1):
             objList = []
             obj1 = vec1[index1]
-            for index2 in xrange (len2):
+            for index2 in range (len2):
                 total = 0.
                 obj2 = vec2[index2]
                 ok = True
@@ -1182,10 +1183,10 @@ class GenObject (object):
             firstDict[index1] = objList
         # Now do the same thing, but this time look for vec1 objects
         # that are equivalent to a given vec2 object
-        for index2 in xrange (len2):
+        for index2 in range (len2):
             objList = []
             obj2 = vec2[index2]
-            for index1 in xrange (len1):
+            for index1 in range (len1):
                 total = 0.
                 obj1 = vec1[index1]
                 ok = True
@@ -1463,7 +1464,7 @@ class GenObject (object):
         print("saveTupleAs")
         rootfile, tree = GenObject.setupOutputTree (rootFile, "goTree")
         numEntries = GenObject._kitchenSinkDict[chain]['numEntries']        
-        for entryIndex in xrange (numEntries):
+        for entryIndex in range (numEntries):
             event = GenObject.loadEventFromTree (chain, entryIndex)            
             if GenObject._kitchenSinkDict.get('blur'):
                 where = "run %d event %d" % (event['runevent'].run,
@@ -1496,7 +1497,7 @@ class GenObject (object):
         numEntries = GenObject._kitchenSinkDict[chain]['numEntries']
         debug = GenObject._kitchenSinkDict.get ('debug', False)
         if debug: warn (numEntries)
-        for entryIndex in xrange (numEntries):
+        for entryIndex in range (numEntries):
             if debug: warn (entryIndex, spaces=3)
             event = GenObject.loadEventFromTree (chain, entryIndex)            
             GenObject.printEvent (event)

--- a/Validation/Tools/scripts/diffTreeTool.py
+++ b/Validation/Tools/scripts/diffTreeTool.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import optparse
 import os
 import re

--- a/Validation/Tools/scripts/simpleEdmComparison.py
+++ b/Validation/Tools/scripts/simpleEdmComparison.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import inspect
 import itertools
 import logging
@@ -148,7 +149,7 @@ if __name__ == "__main__":
             chain2.toBegin()
             logging.info("Testing identity for handle=%s, label=%s" % (handleName, label))
             # Use itertools to iterate over lists in ||
-            for ev1, ev2, count in itertools.izip(chain1, chain2, xrange(numEvents)):
+            for ev1, ev2, count in itertools.izip(chain1, chain2, range(numEvents)):
                 evCount, evMismatch = compareEvents(event1=ev1, event2=ev2, handleName=handleName, label=label, options=options)
                 totalCount += evCount
                 mismatches += evMismatch

--- a/Validation/Tools/scripts/useReflexToDescribeForGenObject.py
+++ b/Validation/Tools/scripts/useReflexToDescribeForGenObject.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import ROOT
 import re
 import pprint


### PR DESCRIPTION
at least one unit test in my python3 fwk test fails due to the use of xrange (now range in python3). Migrate using

futurize -f libfuturize.fixes.fix_xrange_with_import -w --no-diffs -n .

(the dqm packages)