### PR TITLE
Updating lepton mva and adding era modifiers

### DIFF
--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -219,7 +219,9 @@ namespace reco {
       MultiIsoMedium         = 1UL<<26,   // miniIso with ptRatio and ptRel 
       PuppiIsoLoose          = 1UL<<27,
       PuppiIsoMedium         = 1UL<<28,
-      PuppiIsoTight          = 1UL<<29
+      PuppiIsoTight          = 1UL<<29, 
+      MvaVTight              = 1UL<<30,   // > 0.45
+      MvaVVTight             = 1UL<<31,   // > 0.9
     };
     
     bool passed( unsigned int selection ) const { return (selectors_ & selection)==selection; }

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -716,6 +716,8 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 	muon.setSelector(reco::Muon::MvaLoose,  muon.mvaValue()>-0.60);
 	muon.setSelector(reco::Muon::MvaMedium, muon.mvaValue()>-0.20);
 	muon.setSelector(reco::Muon::MvaTight,  muon.mvaValue()> 0.15);
+	muon.setSelector(reco::Muon::MvaVTight,  muon.mvaValue()> 0.45);
+	muon.setSelector(reco::Muon::MvaVVTight,  muon.mvaValue()> 0.9);
       }
     }
 

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 patMuons = cms.EDProducer("PATMuonProducer",
     # input
@@ -107,7 +108,7 @@ patMuons = cms.EDProducer("PATMuonProducer",
     # Depends on MiniIsolation, so only works in miniaod
     # Don't forget to set flags properly in miniAOD_tools.py                      
     computeMuonMVA = cms.bool(False),
-    mvaTrainingFile = cms.FileInPath("RecoMuon/MuonIdentification/data/mu_BDTG_Run2017.weights.xml"),
+    mvaTrainingFile = cms.FileInPath("RecoMuon/MuonIdentification/data/MVA_Legacy_deepFlav_together_mu_2017_v17_BDTG.weights.xml"),
     recomputeBasicSelectors = cms.bool(True),
     mvaUseJec = cms.bool(True),
     mvaDrMax = cms.double(0.4),
@@ -132,7 +133,7 @@ patMuons = cms.EDProducer("PATMuonProducer",
 
 
 
-
+eras.run2_miniAOD_80XLegacy.toModify(patMuons, mvaTrainingFile=cms.FileInPath("RecoMuon/MuonIdentification/data/MVA_Legacy_deepFlav_together_mu_2016_BDTG.weights.xml"))
 
 
 

--- a/PhysicsTools/PatAlgos/src/MuonMvaEstimator.cc
+++ b/PhysicsTools/PatAlgos/src/MuonMvaEstimator.cc
@@ -30,10 +30,10 @@ namespace {
       kMiniRelIsoCharged,
       kMiniRelIsoNeutral,
       kJetPtRel,
-      kJetPtRatio,
       kJetBTagCSV,
-      kSip,
+      kJetPtRatio,
       kLog_abs_dxyBS,
+      kSip,
       kLog_abs_dzPV,
       kSegmentCompatibility,
       kLast


### PR DESCRIPTION
#### PR description:

Updating to the new training of the lepton MVA. Also adding era modifiers to take into account the different geometry between (2016) and (2017 and 2018). 
This updates have been discussed in this JIRA ticket: https://its.cern.ch/jira/browse/CMSMUONS-158

This PR depends on https://github.com/cms-data/RecoMuon-MuonIdentification/pull/4 

#### PR validation:
I have run "runTheMatrix.py -l 136.863 -t 4" to validate this PR

