### PR TITLE
xrange migration for python3

### DIFF
--- a/Alignment/CommonAlignment/scripts/tkal_create_file_lists.py
+++ b/Alignment/CommonAlignment/scripts/tkal_create_file_lists.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+from builtins import range
 import os
 import re
 import sys
@@ -581,7 +582,7 @@ class FileListCreator(object):
         name += "_JSON.txt"
         print_msg("Creating JSON file: "+name)
 
-        json_file = LumiList.LumiList(runs = xrange(first, last+1))
+        json_file = LumiList.LumiList(runs = range(first, last+1))
         if self._args.json:
             global_json = LumiList.LumiList(filename = self._args.json)
             json_file = json_file & global_json
@@ -912,7 +913,7 @@ def das_client(query, check_key = None):
     """
 
     error = True
-    for i in xrange(5):         # maximum of 5 tries
+    for i in range(5):         # maximum of 5 tries
         try:
             das_data = cmssw_das_client.get_data(query, limit = 0)
         except IOError as e:
@@ -1127,7 +1128,7 @@ def get_chunks(long_list, chunk_size):
     - `chunk_size`: maximum size of created sub-lists
     """
 
-    for i in xrange(0, len(long_list), chunk_size):
+    for i in range(0, len(long_list), chunk_size):
         yield long_list[i:i+chunk_size]
 
 

--- a/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/helper.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/helper.py
@@ -1,3 +1,4 @@
+from builtins import range
 import os
 import FWCore.ParameterSet.Config as cms
 
@@ -34,7 +35,7 @@ def set_pede_option(process, option, drop = False):
     existing_options = process.AlignmentProducer.algoConfig.pedeSteerer.options
 
     exists = False
-    for i in xrange(len(existing_options)):
+    for i in range(len(existing_options)):
         if existing_options[i].split()[0] == option.split()[0]:
            existing_options[i] = option.strip()
            exists = True

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/Mpslibclass.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/Mpslibclass.py
@@ -38,6 +38,7 @@ from __future__ import print_function
 #       JOBSP3      - possible name as given to mps_setup.pl -N <name> ...
 #       JOBID       - ID of the LSF/HTCondor job
 
+from builtins import range
 import datetime
 import time
 import os
@@ -146,7 +147,7 @@ class jobdatabase:
         #print interesting Job-level lists ---- to add: t/evt, fix remarks
         print('###     dir      jobid    stat  try  rtime      nevt  remark   weight  name')
         print("------------------------------------------------------------------------------")
-        for i in xrange(self.nJobs):
+        for i in range(self.nJobs):
             print('%03d  %6s  %9s  %6s  %3d  %5d  %8d  %8s  %5s  %s' % (
                 self.JOBNUMBER[i],
                 self.JOBDIR[i],
@@ -161,7 +162,7 @@ class jobdatabase:
 
         #print merge Jobs if merge mode
         if self.driver == 'merge':
-            for i in xrange(self.nJobs,len(self.JOBDIR)):
+            for i in range(self.nJobs,len(self.JOBDIR)):
                 print('%s  %6s  %9s  %6s  %3d  %5d  %8d  %8s  %5s  %s' % (
                     'MMM',
                     self.JOBDIR[i],
@@ -217,7 +218,7 @@ class jobdatabase:
             DBFILE.write("%s\n" % item)
 
         #write mps.db jobinfo
-        for i in xrange(len(self.JOBID)):
+        for i in range(len(self.JOBID)):
             DBFILE.write('%03d:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s\n' %
                          (i+1,
                           self.JOBDIR[i],

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/tools.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/tools.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import os
 import re
 import sys
@@ -248,7 +249,7 @@ def remove_existing_object(path):
         except OSError as e:
             if e.args != (13, "Permission denied"): raise
             backup_path = path.rstrip("/")+"~"
-            for _ in xrange(5):
+            for _ in range(5):
                 try:
                     if os.path.exists(backup_path): remove_method(backup_path)
                     move_method(path, backup_path)

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/beamerCreator.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/beamerCreator.py
@@ -2,6 +2,7 @@
 # Creates beamer out of the histograms, parsed data and a given template.
 ##
 
+from builtins import range
 import logging
 import os
 import string

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/bigModule.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/bigModule.py
@@ -3,6 +3,7 @@
 # a list of PlotData objects.
 ##
 
+from builtins import range
 import logging
 
 import ROOT

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/bigStructure.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/bigStructure.py
@@ -3,6 +3,7 @@
 # as humanreadable text.
 ##
 
+from builtins import range
 import logging
 
 import ROOT

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/geometry.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/geometry.py
@@ -2,6 +2,7 @@
 # Classes which provide the geometry information.
 ##
 
+from builtins import range
 import itertools
 import os
 
@@ -71,7 +72,7 @@ class Alignables:
             # loop over discriminators -> create patterns
             # pattern {"half": 2, "side": 2, "layer": 6, ...}
             ranges = struct.ndiscriminator
-            pranges = [range(1, x+1) for x in ranges]
+            pranges = [list(range(1, x+1)) for x in ranges]
             # loop over all possible combinations of the values of the
             # discriminators
             for number in itertools.product(*pranges):

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/pdfCreator.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/pdfCreator.py
@@ -2,6 +2,7 @@
 # Creates pdf out of the histograms, parsed data and a given template.
 ##
 
+from builtins import range
 import logging
 import os
 import string

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/subModule.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/subModule.py
@@ -4,6 +4,7 @@
 # list with the PlotData of the histograms
 ##
 
+from builtins import range
 import logging
 
 import ROOT

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/timeStructure.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/timeStructure.py
@@ -4,6 +4,7 @@
 # get a time dependent plot.
 ##
 
+from builtins import range
 import logging
 
 import ROOT

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.py
@@ -12,6 +12,7 @@
 #  It also retirieves number of events from alignment.log and cputime from STDOUT
 
 from __future__ import print_function
+from builtins import range
 import Alignment.MillePedeAlignmentAlgorithm.mpslib.Mpslibclass as mpslib
 import subprocess
 import re
@@ -28,7 +29,7 @@ except subprocess.CalledProcessError:
     eoslsoutput = ""
 
 # loop over FETCH jobs
-for i in xrange(len(lib.JOBID)):
+for i in range(len(lib.JOBID)):
     # FIXME use bools?
     batchSuccess = 0
     batchExited = 0

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fetch.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fetch.py
@@ -8,6 +8,7 @@
 #  hence this function does hardly anything except for calling
 #  mps_check.py.
 
+from builtins import range
 import Alignment.MillePedeAlignmentAlgorithm.mpslib.Mpslibclass as mpslib
 import os
 
@@ -18,7 +19,7 @@ lib = mpslib.jobdatabase()
 lib.read_db()
 
 # loop over DONE jobs
-for i in xrange(len(lib.JOBID)):
+for i in range(len(lib.JOBID)):
     # check also "FETCH" to recover from possibly failed runs of 'mps_fetch.py'
     if lib.JOBSTATUS[i] in ("DONE", "EXIT", "FETCH", "DISABLEDFETCH"):
         # move the LSF output to /jobData/

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
@@ -13,6 +13,7 @@
 #  mps_fire.py -h
 
 from __future__ import print_function
+from builtins import range
 import Alignment.MillePedeAlignmentAlgorithm.mpslib.Mpslibclass as mpslib
 import Alignment.MillePedeAlignmentAlgorithm.mpslib.tools as mps_tools
 import os
@@ -256,7 +257,7 @@ if not args.fireMerge:
         resources = '-q '+resources
 
     nSub = 0 # number of submitted Jobs
-    for i in xrange(lib.nJobs):
+    for i in range(lib.nJobs):
         if lib.JOBDIR[i] not in job_mask: continue
         if lib.JOBSTATUS[i] == 'SETUP':
             if nSub < args.maxJobs:
@@ -319,7 +320,7 @@ else:
 
     # check whether all other jobs are OK
     mergeOK = True
-    for i in xrange(lib.nJobs):
+    for i in range(lib.nJobs):
         if lib.JOBSTATUS[i] != 'OK':
             if 'DISABLED' not in lib.JOBSTATUS[i]:
                 mergeOK = False
@@ -420,7 +421,7 @@ else:
                               job_submit_file]
             else:
                 submission = ["bsub", "-J", curJobName, resources, scriptPath]
-            for _ in xrange(5):
+            for _ in range(5):
                 try:
                     result = subprocess.check_output(submission, stderr=subprocess.STDOUT)
                     break

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_merge.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_merge.py
@@ -7,6 +7,7 @@
 #  mps_merge.pl [-c] inCfg mergeCfg mergeDir njobs
 
 from __future__ import print_function
+from builtins import range
 import Alignment.MillePedeAlignmentAlgorithm.mpslib.Mpslibclass as mpslib
 import re
 import os
@@ -74,7 +75,7 @@ else:
 # build list of binary files
 binaryList = ''
 firstentry = True
-for i in xrange(nJobs):
+for i in range(nJobs):
     separator = ',\n                '
     if firstentry:
         separator = '\n                '
@@ -105,7 +106,7 @@ else:
 # build list of tree files
 treeList =''
 firstentry = True
-for i in xrange(nJobs):
+for i in range(nJobs):
     separator = ',\n                '
     if firstentry:
         separator = '\n                '

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_monitormerge.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_monitormerge.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import os
 import subprocess
 import argparse
@@ -20,29 +21,29 @@ eosDir = args.eosDir
 # read mps.db
 lib = mpslib.jobdatabase()
 lib.read_db()
-for i in xrange(lib.nJobs):
+for i in range(lib.nJobs):
 	print(lib.JOBSP3[i])
 
 # count how much jobs there are of each dataset
 occurences = []
 items      = []
-for i in xrange(lib.nJobs):
+for i in range(lib.nJobs):
 	if lib.JOBSP3[i] not in items:
 		items.append(lib.JOBSP3[i])
 
-for i in xrange(len(items)):
+for i in range(len(items)):
 	occurences.append(lib.JOBSP3.count(items[i]))
 
 # copy files from eos and combine root-files of each dataset with "hadd"
 counter = 0
-for i in xrange(len(items)):
+for i in range(len(items)):
 	command  = 'hadd '
 	command += 'monitormerge_'+items[i]+'.root '	
-	for j in xrange(occurences[i]):
+	for j in range(occurences[i]):
 		os.system('cp '+eosDir+'/millePedeMonitor%03d.root .' % (counter+j+1))
 		command += 'millePedeMonitor%03d.root ' % (counter+j+1)	
 	os.system(command)
-	for j in xrange(occurences[i]):
+	for j in range(occurences[i]):
 		os.system('rm millePedeMonitor%03d.root' % (counter+j+1))
 	counter += occurences[i]
 

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import os
 import re
 import sys
@@ -166,7 +167,7 @@ if nJobExist == 0 or nJobExist <=0 or nJobExist > 999: # quite rude method... ->
     os.makedirs("jobData")
     nJobExist = 0;
 
-for j in xrange(1, args.n_jobs + 1):
+for j in range(1, args.n_jobs + 1):
     i = j+nJobExist
     jobdir = "job{0:03d}".format(i)
     print("jobdir", jobdir)
@@ -216,7 +217,7 @@ if args.append:
 
 
 # Create (update) the local database
-for j in xrange(1, args.n_jobs + 1):
+for j in range(1, args.n_jobs + 1):
     i = j+nJobExist
     jobdir = "job{0:03d}".format(i)
     lib.JOBDIR.append(jobdir)

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_splice.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_splice.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import re
 import argparse
 import math
@@ -59,7 +60,7 @@ numberOfFiles   = len(fileNames)
 numberOfExtends = int(math.ceil(numberOfFiles/255.))
 
 # Create and insert the readFile.extend lines
-for j in xrange(numberOfExtends):
+for j in range(numberOfExtends):
     insertBlock = "readFiles.extend([\n    "
     i=0
     currentStart = j*255

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_update.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_update.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from builtins import range
 import os
 import re
 import subprocess
@@ -46,7 +47,7 @@ lib = mpslib.jobdatabase()
 lib.read_db()
 
 submitted_jobs = {}
-for i in xrange(len(lib.JOBID)):
+for i in range(len(lib.JOBID)):
     submitted = True
     for status in ("SETUP", "OK", "DONE", "FETCH", "ABEND", "WARN", "FAIL"):
         if status in lib.JOBSTATUS[i]:

--- a/Alignment/MuonAlignment/python/MCScenario_CRAFT1_22X.py
+++ b/Alignment/MuonAlignment/python/MCScenario_CRAFT1_22X.py
@@ -23,6 +23,7 @@
 #         ./Alignment/MuonAlignment/python/geometryXMLtoCSV.py < MCScenario_CRAFT1_22X_CHECKME.xml > MCScenario_CRAFT1_22X_CHECKME.csv
 #         and then open MCScenario_CRAFT1_22X_CHECKME.csv in Excel
 
+from builtins import range
 import random, os
 from math import *
 

--- a/Alignment/MuonAlignment/python/MuonGeometrySanityCheck_cfi.py
+++ b/Alignment/MuonAlignment/python/MuonGeometrySanityCheck_cfi.py
@@ -1,3 +1,4 @@
+from builtins import range
 import FWCore.ParameterSet.Config as cms
 
 MuonGeometrySanityCheck = cms.EDAnalyzer(
@@ -16,7 +17,7 @@ def detectors(dt=True, csc=True, me42=False, chambers=True, superlayers=False, l
             for stationName in "1", "2", "3", "4":
                 numSectors = 12
                 if stationName == "4": numSectors = 14
-                for sectorName in map(str, range(1, numSectors+1)):
+                for sectorName in map(str, list(range(1, numSectors+1))):
                     name = "MB" + wheelName + "/" + stationName + "/" + sectorName
                     if chambers: output.append(name)
 
@@ -37,7 +38,7 @@ def detectors(dt=True, csc=True, me42=False, chambers=True, superlayers=False, l
             for ringName in ringNames:
                 numChambers = 36
                 if stationName + "/" + ringName in ("-4/1", "-3/1", "-2/1", "+2/1", "+3/1", "+4/1"): numChambers = 18
-                for chamberName in map(str, range(1, numChambers+1)):
+                for chamberName in map(str, list(range(1, numChambers+1))):
                     name = "ME" + stationName + "/" + ringName + "/" + chamberName
                     if chambers:
                         if me42 or stationName + "/" + ringName not in ("-4/2", "+4/2"):

--- a/Alignment/MuonAlignment/python/geometryDiff.py
+++ b/Alignment/MuonAlignment/python/geometryDiff.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 from Alignment.MuonAlignment.geometryXMLparser import MuonGeometry, dtorder, cscorder
 import sys, getopt
 

--- a/Alignment/MuonAlignment/python/makeMuonMisalignmentScenario.py
+++ b/Alignment/MuonAlignment/python/makeMuonMisalignmentScenario.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 from optparse import OptionParser
 from random import gauss
 from math import sqrt

--- a/Alignment/MuonAlignment/python/svgfig.py
+++ b/Alignment/MuonAlignment/python/svgfig.py
@@ -16,6 +16,7 @@
 # 
 # Full licence is in the file COPYING and at http://www.gnu.org/copyleft/gpl.html
 
+from builtins import range
 import re, codecs, os, platform, copy, itertools, math, cmath, random, sys, copy
 _epsilon = 1e-5
 
@@ -1744,7 +1745,7 @@ class Poly:
       mode = "S"
 
       vx, vy = [0.]*len(self.d), [0.]*len(self.d)
-      for i in xrange(len(self.d)):
+      for i in range(len(self.d)):
         inext = (i+1) % len(self.d)
         iprev = (i-1) % len(self.d)
 
@@ -1757,7 +1758,7 @@ class Poly:
       raise ValueError("mode must be \"lines\", \"bezier\", \"velocity\", \"foreback\", \"smooth\", or an abbreviation")
 
     d = []
-    indexes = range(len(self.d))
+    indexes = list(range(len(self.d)))
     if self.loop and len(self.d) > 0: indexes.append(0)
 
     for i in indexes:
@@ -2611,7 +2612,7 @@ class Ticks:
     if N >= 0:
       output = {}
       x = self.low
-      for i in xrange(N):
+      for i in range(N):
         if format == unumber and abs(x) < eps: label = u"0"
         else: label = format(x)
         output[x] = label
@@ -2681,7 +2682,7 @@ class Ticks:
     """
     output = []
     x = self.low
-    for i in xrange(N):
+    for i in range(N):
       output.append(x)
       x += (self.high - self.low)/(N-1.)
     return output
@@ -2727,7 +2728,7 @@ class Ticks:
     if N >= 0:
       output = {}
       x = self.low
-      for i in xrange(N):
+      for i in range(N):
         if format == unumber and abs(x) < eps: label = u"0"
         else: label = format(x)
         output[x] = label

--- a/Alignment/MuonAlignmentAlgorithms/scripts/alignmentValidation.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/alignmentValidation.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import re,os,sys,shutil
 import optparse
 

--- a/Alignment/MuonAlignmentAlgorithms/scripts/applyRadialCorrections.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/applyRadialCorrections.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 mep11angle = 0.002  # guess
 mep12angle = 0.002  # guess
 mep13angle = 0.002  # guess

--- a/Alignment/MuonAlignmentAlgorithms/scripts/corrVsCorr.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/corrVsCorr.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import sys, optparse
 
 copyargs = sys.argv[:]

--- a/Alignment/MuonAlignmentAlgorithms/scripts/createBeamHaloJobs.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/createBeamHaloJobs.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import os, sys, re, optparse, math
 
 copyargs = sys.argv[:]

--- a/Alignment/MuonAlignmentAlgorithms/scripts/createCSCRingsJobs.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/createCSCRingsJobs.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import os, sys, optparse, math
 
 copyargs = sys.argv[:]

--- a/Alignment/MuonAlignmentAlgorithms/scripts/createJobs.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/createJobs.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import os, sys, optparse, math
 
 copyargs = sys.argv[:]

--- a/Alignment/MuonAlignmentAlgorithms/scripts/createTree.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/createTree.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import re,os,sys
 import optparse
 

--- a/Alignment/MuonAlignmentAlgorithms/scripts/findQualityFiles.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/findQualityFiles.py
@@ -7,6 +7,7 @@
 ######################################################
 
 from __future__ import print_function
+from builtins import range
 import os,sys, DLFCN
 import optparse
 

--- a/Alignment/MuonAlignmentAlgorithms/scripts/groupFilesInBlocks.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/groupFilesInBlocks.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import re,os,sys,shutil,math
 import optparse
 

--- a/Alignment/MuonAlignmentAlgorithms/scripts/motionPolicyChamber.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/motionPolicyChamber.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import os, sys, optparse, math, copy
 from Alignment.MuonAlignment.geometryXMLparser import MuonGeometry, dtorder, cscorder
 

--- a/Alignment/MuonAlignmentAlgorithms/scripts/plotscripts.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/plotscripts.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT, array, os, re, random
 from math import *
 import time
@@ -1407,7 +1408,7 @@ def createPeaksProfile(the2d, rebin=1):
   hpeaks.Reset()
   hpeaks.Rebin(rebin)
   bad_fit_bins = []
-  for i in xrange(0, int(the2d.GetNbinsX()), rebin):
+  for i in range(0, int(the2d.GetNbinsX()), rebin):
     tmp = the2d.ProjectionY("tmp", i+1, i + rebin)
     nn = tmp.GetEntries()
 
@@ -1515,7 +1516,7 @@ def mapplot(tfiles, name, param, mode="from2d", window=10., abscissa=None, title
             skip = 10
 
         #f = ROOT.TF1("g", "gaus", -40., 40)
-        for i in xrange(0, int(the2d.GetNbinsX()), skip):
+        for i in range(0, int(the2d.GetNbinsX()), skip):
             tmp = the2d.ProjectionY("tmp", i+1, i + skip)
             if tmp.GetEntries() > 1:
                 #tmp.Fit("g","LNq")
@@ -1840,7 +1841,7 @@ def curvatureplot(tfiles, name, param, mode="from2d", window=15., widebins=False
                         hist2d.Add(tfile.Get(hdir+"th2f"+hsuffix))
 
     hist = ROOT.TH1F("hist", "", prof.GetNbinsX(), prof.GetBinLowEdge(1), -prof.GetBinLowEdge(1))
-    for i in xrange(1, prof.GetNbinsX()+1):
+    for i in range(1, prof.GetNbinsX()+1):
         hist.SetBinContent(i, prof.GetBinContent(i))
         hist.SetBinError(i, prof.GetBinError(i))
 
@@ -1854,7 +1855,7 @@ def curvatureplot(tfiles, name, param, mode="from2d", window=15., widebins=False
         htmp = ROOT.gROOT.FindObject("tmp")
         if htmp != None: htmp.Delete()
 
-        for i in xrange(0, int(prof.GetNbinsX()), skip):
+        for i in range(0, int(prof.GetNbinsX()), skip):
             tmp = hist2d.ProjectionY("tmp", i+1, i + skip)
             if tmp.GetEntries() > 1:
                 hist.SetBinContent(i/skip+1, tmp.GetMean())
@@ -2484,7 +2485,7 @@ def polynomials(tfile, reports, name, twobin=True, suppressblue=False):
     trackdxdz_minimum, trackdxdz_maximum = None, None
     for h in chamber_x_trackdxdz, chamber_y_trackdxdz, chamber_dxdz_trackdxdz, chamber_dydz_trackdxdz:
         if not not h:
-            for i in xrange(1, h.GetNbinsX()+1):
+            for i in range(1, h.GetNbinsX()+1):
                 if h.GetBinError(i) > 0.01 and h.GetBinContent(i) - h.GetBinError(i) < 10. and \
                    h.GetBinContent(i) + h.GetBinError(i) > -10.:
                     if not trackdxdz_minimum or trackdxdz_minimum > h.GetBinCenter(i): 
@@ -2499,7 +2500,7 @@ def polynomials(tfile, reports, name, twobin=True, suppressblue=False):
     trackdydz_minimum, trackdydz_maximum = None, None
     for h in chamber_x_trackdydz, chamber_y_trackdydz, chamber_dxdz_trackdydz, chamber_dydz_trackdydz:
         if not not h:
-            for i in xrange(1, h.GetNbinsX()+1):
+            for i in range(1, h.GetNbinsX()+1):
                 if h.GetBinError(i) > 0.01 and h.GetBinContent(i) - h.GetBinError(i) < 10. and \
                    h.GetBinContent(i) + h.GetBinError(i) > -10.:
                     if not trackdydz_minimum or trackdydz_minimum > h.GetBinCenter(i): 
@@ -2967,7 +2968,7 @@ def segdiff(tfiles, component, pair, **args):
         tmppos.Add(tfile.Get(pdir + posname))
         tmpneg.Add(tfile.Get(pdir + negname))
 
-    for i in xrange(1, tmpprof.GetNbinsX()+1):
+    for i in range(1, tmpprof.GetNbinsX()+1):
         if tmpprof.GetBinError(i) < 1e-5:
             tmpprof.SetBinError(i, 100.)
     tmpprof.SetAxisRange(-window, window, "Y")
@@ -3193,7 +3194,7 @@ def segdiffvsphi_xalign(tfiles, wheel, window=10.):
     gtemp_11_phi, gtemp_11_val, gtemp_11_err = [], [], []
     gtemp_12_phi, gtemp_12_val, gtemp_12_err = [], [], []
     gtemp_21_phi, gtemp_21_val, gtemp_21_err = [], [], []
-    for sector in xrange(1, 12+1):
+    for sector in range(1, 12+1):
       #print "sect", sector
       r1 = segdiff_xalign(tfiles, "x_dt1_csc", wheel=wheel, sector=sector, cscstations = "12")
       r2 = segdiff_xalign(tfiles, "x_dt2_csc", wheel=wheel, sector=sector, cscstations = "1")
@@ -3308,7 +3309,7 @@ def segdiffvsphi(tfiles, reports, component, wheel, window=5., excludesectors=()
     gtemp_12_phi, gtemp_12_val, gtemp_12_err, gtemp_12_val2, gtemp_12_err2 = [], [], [], [], []
     gtemp_23_phi, gtemp_23_val, gtemp_23_err, gtemp_23_val2, gtemp_23_err2 = [], [], [], [], []
     gtemp_34_phi, gtemp_34_val, gtemp_34_err, gtemp_34_val2, gtemp_34_err2 = [], [], [], [], []
-    for sector in xrange(1, 12+1):
+    for sector in range(1, 12+1):
         #print "sect", sector
         r1_found, r2_found, r3_found, r4_found = False, False, False, False
         for r1 in reports:
@@ -3466,8 +3467,8 @@ def segdiffvsphicsc(tfiles, component, pair, window=5., **args):
     gtemp_2_phi, gtemp_2_val, gtemp_2_err, gtemp_2_val2, gtemp_2_err2 = [], [], [], [], []
     
     for ring in rings:
-      chambers = xrange(1,37)
-      if ring == 1: chambers = xrange(1,19)
+      chambers = range(1,37)
+      if ring == 1: chambers = range(1,19)
       
       for chamber in chambers:
         phi, val, err, val2, err2, fit1, fit2, fit3 = segdiff(tfiles, component, pair, endcap=endcap, ring=ring, chamber=chamber)

--- a/Alignment/MuonAlignmentAlgorithms/scripts/reportVsReport.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/reportVsReport.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
+from builtins import range
 import sys, optparse
 
 copyargs = sys.argv[:]

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 # idea stolen from:
 # http://cmssw.cvs.cern.ch/cgi-bin/cmssw.cgi/CMSSW/
 #        PhysicsTools/PatAlgos/python/tools/cmsswVersionTools.py
+from builtins import range
 import bisect
 import datetime
 import json
@@ -88,7 +89,7 @@ class Dataset(object):
     def __chunks( self, theList, n ):
         """ Yield successive n-sized chunks from theList.
         """
-        for i in xrange( 0, len( theList ), n ):
+        for i in range( 0, len( theList ), n ):
             yield theList[i:i+n]
 
     __source_template= ("%(header)s"

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 from abc import ABCMeta, abstractmethod, abstractproperty
 import os
 import re

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/helperFunctions.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/helperFunctions.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 import os
 import re
 import ROOT

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/plottingOptions.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/plottingOptions.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from builtins import range
 import os
 import random
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/presentation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/presentation.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import range
 import abc
 import math
 import os
@@ -65,7 +66,7 @@ class PageLayout(object):
         if residual != 0:
             rowlengths.append(residual)
             nrows += 1
-        for _ in xrange(fullRows):
+        for _ in range(fullRows):
             rowlengths.append(length)
 
         # Now, fill the pattern.
@@ -73,12 +74,12 @@ class PageLayout(object):
         if residual == 0 and len(plots[0])%length != 0 and\
            len(plots[0])%nrows == 0:
             # It's better to arrange plots in columns, not rows.
-            self.pattern.extend(range(i, i+nrows*(length-1)+1, nrows)
+            self.pattern.extend(list(range(i, i+nrows*(length-1)+1, nrows))
                                 for i in range(1, nrows+1))
         else:
             if residual != 0:
-                self.pattern.append(range(1, 1+residual))
-            self.pattern.extend(range(i, i+length) for i in
+                self.pattern.append(list(range(1, 1+residual)))
+            self.pattern.extend(list(range(i, i+length)) for i in
                                 range(residual+1, nplots-length+2, length))
 
         self.width = 1.0/length
@@ -166,7 +167,7 @@ def writePage(plots, title, layout):
     plotrows = []
     for row in layout.pattern:
         plotrow = []
-        for i in xrange(len(row)):
+        for i in range(len(row)):
             plotrow.append(plotTemplate.replace('[width]', str(layout.width)).\
                            replace('[height]', str(layout.height)).\
                            replace('[path]', plots[row[i]-1]))

--- a/Alignment/OfflineValidation/test/submitAllJobs.py
+++ b/Alignment/OfflineValidation/test/submitAllJobs.py
@@ -4,6 +4,7 @@
 '''
 from __future__ import print_function
 
+from builtins import range
 __author__ = 'Marco Musich'
 __copyright__ = 'Copyright 2015, CERN CMS'
 __credits__ = ['Ernesto Migliore', 'Salvatore Di Guida', 'Javier Duarte']
@@ -167,7 +168,7 @@ def split(sequence, size):
 # based on http://sandrotosi.blogspot.com/2011/04/python-group-list-in-sub-lists-of-n.html
 # about generators see also http://stackoverflow.com/questions/231767/the-python-yield-keyword-explained
 ##########################
-    for i in xrange(0, len(sequence), size):
+    for i in range(0, len(sequence), size):
         yield sequence[i:i+size] 
 
 #############


### PR DESCRIPTION
at least one unit test in my python3 fwk test fails due to the use of xrange (now range in python3). Migrate using

futurize -f libfuturize.fixes.fix_xrange_with_import -w --no-diffs -n .

(the alignment packages)