### PR TITLE
update tracker mis-alignment in 2018 simulation

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -54,15 +54,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '105X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v4',
+    'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '105X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v5',
+    'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v8',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v5',
+    'phase1_2018_cosmics'      :   '105X_upgrade2018cosmics_realistic_deco_v8',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v5',
+    'phase1_2018_cosmics_peak' :   '105X_upgrade2018cosmics_realistic_peak_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '105X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase1 2019


### PR DESCRIPTION
#### PR description:

Update tracker mis-alignment in 2018 simulation

#### **2018 MC**
Differences are due to **Tracker mis-alignment scenario**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018_realistic_v7/105X_upgrade2018_realistic_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018_realistic_HEfail_v8/105X_upgrade2018_realistic_HEfail_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018cosmics_realistic_deco_v8/105X_upgrade2018cosmics_realistic_deco_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/105X_upgrade2018cosmics_realistic_peak_v8/105X_upgrade2018cosmics_realistic_peak_v5

#### PR validation:

Tracker mis-alignment scenario for 2018 : see [hn announcement](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4112.html)

**The update of conditions in 105X is to be consistent with pixel local reco simulation conditions 
which have entered 10.5.X with this PR: https://github.com/cms-sw/cmssw/pull/25929**



