### PR TITLE
migrate away from commands in das utility

### DIFF
--- a/Utilities/General/python/cmssw_das_client.py
+++ b/Utilities/General/python/cmssw_das_client.py
@@ -1,4 +1,3 @@
-from commands import getstatusoutput
 import time
 import os
 from json import loads, dumps
@@ -79,6 +78,8 @@ def get_data(query, limit=None, threshold=None, idx=None, host=None, cmd=None):
       if  os.path.isfile(os.path.join(path, 'dasgoclient')):
         cmd = "dasgoclient"
         break
-  err, out = getstatusoutput("%s %s --query '%s'" % (cmd, cmd_opts, query))
-  if not err: return loads(out)
-  return {'status' : 'error', 'reason' : out}
+
+  p = subprocess.Popen("%s %s --query '%s'" % (cmd, cmd_opts, query),shell=True, stdout=PIPE, stderr=subprocess.STDOUT)
+  stdout, stderr = p.communicate()
+  if not p.returncode: return loads(out)
+  return {'status' : 'error', 'reason' : stdout}

--- a/Utilities/General/python/cmssw_das_client.py
+++ b/Utilities/General/python/cmssw_das_client.py
@@ -2,6 +2,7 @@ import time
 import os
 from json import loads, dumps
 from types import GeneratorType
+import subprocess
 
 #Copied from das_client.py
 
@@ -79,7 +80,7 @@ def get_data(query, limit=None, threshold=None, idx=None, host=None, cmd=None):
         cmd = "dasgoclient"
         break
 
-  p = subprocess.Popen("%s %s --query '%s'" % (cmd, cmd_opts, query),shell=True, stdout=PIPE, stderr=subprocess.STDOUT)
+  p = subprocess.Popen("%s %s --query '%s'" % (cmd, cmd_opts, query),shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
   stdout, stderr = p.communicate()
-  if not p.returncode: return loads(out)
+  if not p.returncode: return loads(stdout)
   return {'status' : 'error', 'reason' : stdout}


### PR DESCRIPTION
#### PR description:

The python module 'commands' is deprecated in python2.7 and removed from python3. Replace it

#### PR validation:

checked unit tests using das utility work ok

