### PR TITLE
adding fixedGridRhoFastjetAllTmp to MiniAOD event content

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -47,6 +47,7 @@ MicroEventContent = cms.PSet(
 
         'keep double_fixedGridRhoAll__*',
         'keep double_fixedGridRhoFastjetAll__*',
+        'keep double_fixedGridRhoFastjetAllTmp__*',
         'keep double_fixedGridRhoFastjetAllCalo__*',
         'keep double_fixedGridRhoFastjetCentral_*_*',
         'keep double_fixedGridRhoFastjetCentralCalo__*',


### PR DESCRIPTION
#### PR description:
The E/gamma energy regressions use fixedGridRhoFastJetAllTmp as an input. While this is very similar to fixedGridRhoFastJetAll (its done on PF candidates before e/gamma feeds back its energy corrected electrons) it would be nice to have it in the miniAOD as we can use it to exactly reproduce the original application of the regression. Its already in AOD, this corrects the oversight that it is not in MINIAOD

Its a single double added to the event and there are already several fixedGridRhoFastjet flavours so it shouldnt have any impact,.
