### PR TITLE
(Backport) Provide forward compatibility to HepMC::GenEvent reading

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -72,6 +72,8 @@ namespace SimDataFormats_GeneratorProducts {
 
 //needed for backward compatibility between HepMC 2.06.xx and 2.05.yy
 namespace hepmc_rootio {
+  void add_to_particles_in(HepMC::GenVertex*, HepMC::GenParticle*);
+
   inline void weightcontainer_set_default_names(unsigned int n, std::map<std::string,HepMC::WeightContainer::size_type>& names) {
       std::ostringstream name;
       for ( HepMC::WeightContainer::size_type count = 0; count<n; ++count ) 

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -13,6 +13,11 @@
 		<!-- <field name="itsParticleData" transient="true"/> -->
 		<!-- <field name="itsDecayData" transient="true"/> -->
 	</class>
+	<ioread sourceClass = "HepMC::GenParticle" source="int m_barcode" version="[11]" targetClass="HepMC::GenParticle" target="m_barcode">
+          <![CDATA[m_barcode = onfile.m_barcode;
+                   if(newObj->end_vertex()) { hepmc_rootio::add_to_particles_in(newObj->end_vertex(), newObj); }
+	  ]]> 
+        </ioread>
     <class name="HepMC::GenCrossSection" ClassVersion="10">
      <version ClassVersion="10" checksum="920043842"/>
     </class>

--- a/SimDataFormats/GeneratorProducts/src/hepmc_rootio.cc
+++ b/SimDataFormats/GeneratorProducts/src/hepmc_rootio.cc
@@ -1,0 +1,25 @@
+#include <HepMC/GenParticle.h>
+#include <HepMC/GenVertex.h>
+#include <iostream>
+
+//HACK We need to change the internals of GenVertex when reading
+// back via ROOT. We use the private access of GenEvent to 
+// accomplish it.
+namespace HepMC {
+  class GenEvent {
+  public:
+    static void clear_particles_in(HepMC::GenVertex* iVertex) {
+      iVertex->m_particles_in.clear();
+    }
+    static void add_to_particles_in(HepMC::GenVertex* iVertex, HepMC::GenParticle* iPart) {
+      iVertex->m_particles_in.push_back(iPart);
+    }
+  };
+}
+
+
+namespace hepmc_rootio {                                                                                                                      
+  void add_to_particles_in(HepMC::GenVertex* iVertex, HepMC::GenParticle* iPart) {
+    HepMC::GenEvent::add_to_particles_in(iVertex, iPart);
+  }
+}


### PR DESCRIPTION
#### PR description:

To provide forward compatibility to HepMC::GenEvent reading. This is used for ultra-legacy processing with 2016 (CMSSW_8_0) HLT.

#### PR validation:

**CMSSW_8_0_X_2019-04-07-0000 with this PR on top**
`cmsDriver.py HLT --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 -s HLT:@frozen2016 --datatier GEN-SIM-DIGI-RAW-HLTDEBUG -n -1 --era Run2_2016 --eventcontent FEVTDEBUGHLT --filein file:step2.root --python step2a_HLT.py --fileout step2a.root --no_exec --customise_commands 'process.source.bypassVersionCheck = cms.untracked.bool(True)' --customise Configuration/DataProcessing/Utils.addMonitoring --outputCommand 'keep *_mix_*_*','keep *_genPUProtons_*_*' --inputCommand 'keep *','drop *_*_BMTF_*','drop *PixelFEDChannel*_*_*_*' --mc`

#### if this PR is a backport please specify the original PR:

backport of https://github.com/cms-sw/cmssw/pull/26211 
Thx @Dr15Jones

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
