### PR TITLE
xrange migration to L1 and egammaanalysis

### DIFF
--- a/EgammaAnalysis/ElectronTools/test/compareMass.py
+++ b/EgammaAnalysis/ElectronTools/test/compareMass.py
@@ -1,3 +1,4 @@
+from builtins import range
 import ROOT
 
 masseb = []
@@ -9,7 +10,7 @@ e = t1.GetEntries()
 
 masseb.append(ROOT.TH1F("masseb1", "", 80, 70, 110))
 massee.append(ROOT.TH1F("massee1", "", 80, 70, 110))
-for z in xrange(e):
+for z in range(e):
     t1.GetEntry(z)
     if(abs(t1.l1eta)<1.479  and abs(t1.l2eta)<1.479):
         masseb[-1].Fill(t1.mass)
@@ -23,7 +24,7 @@ e = t2.GetEntries()
 masseb.append(ROOT.TH1F("masseb2", "", 80, 70, 110))
 massee.append(ROOT.TH1F("massee2", "", 80, 70, 110))
 
-for z in xrange(e):
+for z in range(e):
     t2.GetEntry(z)
     if(abs(t2.l1eta)<1.479  and abs(t2.l2eta)<1.479):
         masseb[-1].Fill(t2.mass)
@@ -37,7 +38,7 @@ e = t3.GetEntries()
 masseb.append(ROOT.TH1F("masseb3", "", 80, 70, 110))
 massee.append(ROOT.TH1F("massee3", "", 80, 70, 110))
 
-for z in xrange(e):
+for z in range(e):
     t3.GetEntry(z)
     if(abs(t3.l1eta)<1.479  and abs(t3.l2eta)<1.479):
         masseb[-1].Fill(t3.mass)
@@ -51,7 +52,7 @@ e = t4.GetEntries()
 masseb.append(ROOT.TH1F("masseb4", "", 80, 70, 110))
 massee.append(ROOT.TH1F("massee4", "", 80, 70, 110))
 
-for z in xrange(e):
+for z in range(e):
     t4.GetEntry(z)
     if(abs(t4.l1eta)<1.479  and abs(t4.l2eta)<1.479):
         masseb[-1].Fill(t4.mass)
@@ -61,7 +62,7 @@ for z in xrange(e):
 
 c = []
 ratio = []
-for i in xrange(2):
+for i in range(2):
     c.append(ROOT.TCanvas("c"+str(i), "c"))
     c[-1].Divide(2,2)
     c[-1].cd(1)

--- a/L1Trigger/L1THGCal/test/macros/DrawingUtilities.py
+++ b/L1Trigger/L1THGCal/test/macros/DrawingUtilities.py
@@ -1,3 +1,4 @@
+from builtins import range
 import ROOT
 import waferGeometry
 import math
@@ -147,7 +148,7 @@ class Cell:
     def hexagon_lines(self):
         xs,ys = self.hexagon_points()
         lines = []
-        for i in xrange(len(xs)-1):
+        for i in range(len(xs)-1):
             lines.append(ROOT.TLine(xs[i], ys[i], xs[i+1], ys[i+1]))
         self.lines = lines
         return lines

--- a/L1Trigger/L1THGCal/test/macros/drawTriggerCells.py
+++ b/L1Trigger/L1THGCal/test/macros/drawTriggerCells.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT
 import random
 
@@ -94,7 +95,7 @@ entryList1 = ROOT.gDirectory.Get("elist1")
 entryList1.__class__ = ROOT.TEntryList
 nentry = entryList1.GetN()
 treeCells.SetEntryList(entryList1)
-for ie in xrange(nentry):
+for ie in range(nentry):
     if ie%10000==0: print("Entry {0}/{1}".format(ie, nentry))
     entry = entryList1.GetEntry(ie)
     treeCells.GetEntry(entry)
@@ -123,7 +124,7 @@ entryList2 = ROOT.gDirectory.Get("elist2")
 entryList2.__class__ = ROOT.TEntryList
 nentry = entryList2.GetN()
 treeTriggerCells.SetEntryList(entryList2)
-for ie in xrange(nentry):
+for ie in range(nentry):
     if ie%10000==0: print("Entry {0}/{1}".format(ie, nentry))
     entry = entryList2.GetEntry(ie)
     treeTriggerCells.GetEntry(entry)

--- a/L1Trigger/L1THGCal/test/macros/drawTriggerModules.py
+++ b/L1Trigger/L1THGCal/test/macros/drawTriggerModules.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT
 import random
 
@@ -108,7 +109,7 @@ entryList1 = ROOT.gDirectory.Get("elist1")
 entryList1.__class__ = ROOT.TEntryList
 nentry = entryList1.GetN()
 treeCells.SetEntryList(entryList1)
-for ie in xrange(nentry):
+for ie in range(nentry):
     if ie%10000==0: print("Entry {0}/{1}".format(ie, nentry))
     entry = entryList1.GetEntry(ie)
     treeCells.GetEntry(entry)
@@ -137,7 +138,7 @@ entryList2 = ROOT.gDirectory.Get("elist2")
 entryList2.__class__ = ROOT.TEntryList
 nentry = entryList2.GetN()
 treeTriggerCells.SetEntryList(entryList2)
-for ie in xrange(nentry):
+for ie in range(nentry):
     if ie%10000==0: print("Entry {0}/{1}".format(ie, nentry))
     entry = entryList2.GetEntry(ie)
     treeTriggerCells.GetEntry(entry)
@@ -164,7 +165,7 @@ entryList3 = ROOT.gDirectory.Get("elist3")
 entryList3.__class__ = ROOT.TEntryList
 nentry = entryList3.GetN()
 treeModules.SetEntryList(entryList3)
-for ie in xrange(nentry):
+for ie in range(nentry):
     if ie%10000==0: print("Entry {0}/{1}".format(ie, nentry))
     entry = entryList3.GetEntry(ie)
     treeModules.GetEntry(entry)

--- a/L1Trigger/L1THGCal/test/macros/drawTriggerModulesHex.py
+++ b/L1Trigger/L1THGCal/test/macros/drawTriggerModulesHex.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import ROOT
 from DrawingUtilities import Cell, TriggerCell, Module
 
@@ -27,7 +28,7 @@ entryList1.__class__ = ROOT.TEntryList
 nentry = entryList1.GetN()
 treeCells.SetEntryList(entryList1)
 print('>> Reading cell tree')
-for ie in xrange(nentry):
+for ie in range(nentry):
     if ie%10000==0: print(" Entry {0}/{1}".format(ie, nentry))
     entry = entryList1.GetEntry(ie)
     treeCells.GetEntry(entry)
@@ -59,7 +60,7 @@ entryList2.__class__ = ROOT.TEntryList
 nentry = entryList2.GetN()
 treeTriggerCells.SetEntryList(entryList2)
 print('>> Reading trigger cell tree')
-for ie in xrange(nentry):
+for ie in range(nentry):
     if ie%10000==0: print(" Entry {0}/{1}".format(ie, nentry))
     entry = entryList2.GetEntry(ie)
     treeTriggerCells.GetEntry(entry)
@@ -86,7 +87,7 @@ entryList3.__class__ = ROOT.TEntryList
 nentry = entryList3.GetN()
 treeModules.SetEntryList(entryList3)
 print('>> Reading module tree')
-for ie in xrange(nentry):
+for ie in range(nentry):
     if ie%10000==0: print(" Entry {0}/{1}".format(ie, nentry))
     entry = entryList3.GetEntry(ie)
     treeModules.GetEntry(entry)


### PR DESCRIPTION
at least one unit test in my python3 fwk test fails due to the use of xrange (now range in python3). Migrate using

futurize -f libfuturize.fixes.fix_xrange_with_import -w --no-diffs -n .

