### PR TITLE
Allow return value optimization in getAnyPtr

### DIFF
--- a/FWCore/Utilities/interface/getAnyPtr.h
+++ b/FWCore/Utilities/interface/getAnyPtr.h
@@ -18,8 +18,7 @@ namespace edm {
     assert(p != nullptr);
     pointerUnion.vp = p; 	 
     pointerUnion.ucp += offset; 	 
-    std::unique_ptr<T> tp(pointerUnion.tp);
-    return(std::move(tp));
+    return std::unique_ptr<T>(pointerUnion.tp);
   }
 }
 


### PR DESCRIPTION
#### PR description:

The gcc 9 compiler gave a warning stating the use of `std::move` was preventing return value optimization.

#### PR validation:

Compiles without any warnings under gcc 9.