### PR TITLE
add bool method to cms.Bool

### DIFF
--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -151,7 +151,8 @@ class bool(_SimpleParameterTypeBase):
         parameterSet.addBool(self.isTracked(), myname, self.value())
     def __nonzero__(self):
         return self.value()
-
+    def __bool__(self):
+        return self.__nonzero__()
 
 
 class string(_SimpleParameterTypeBase):


### PR DESCRIPTION
#### PR description:

needed by Python3 so that if cms.Bool(False): evaluates to False