### PR TITLE
Remove unused variable in Geometry/MTDNumberingBuilder 

### DIFF
--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDSubStrctBuilder.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDSubStrctBuilder.cc
@@ -9,10 +9,6 @@
 
 #include <bitset>
 
-namespace {
-  constexpr std::array<const char*,2> sides{ { "PositiveZ","NegativeZ" } };
-}
-
 CmsMTDSubStrctBuilder::CmsMTDSubStrctBuilder()
 {}
 


### PR DESCRIPTION

#### PR description:

Remove unused variable in Geometry/MTDNumberingBuilder class CmsMTDSubStrctBuilder, pointed by clang warning.

#### PR validation:

Code compiles.
