### PR TITLE
Added Residuals plots and fix monitoring plots for Pixel ClusterRepairs (backport)

### DIFF
--- a/Alignment/OfflineValidation/interface/TrackerValidationVariables.h
+++ b/Alignment/OfflineValidation/interface/TrackerValidationVariables.h
@@ -26,7 +26,7 @@ class TrackerValidationVariables
   AVHitStruct() : resX(-999.), resY(-999.), resErrX(-999.), resErrY(-999.), resXprime(-999.), resXatTrkY(-999.), resXprimeErr(-999.),  
       resYprime(-999.), resYprimeErr(-999.), phi(-999.), eta(-999.),
      inside(false), localX(-999.), localY(-999.), localXnorm(-999.), localYnorm(-999.), localAlpha(-999.), localBeta(-999.),
-      rawDetId(0) {}
+      rawDetId(0), isOnEdgePixel(false), isOtherBadPixel(false) {}
     float resX;
     float resY;
     float resErrX;
@@ -46,6 +46,8 @@ class TrackerValidationVariables
     float localAlpha;    
     float localBeta;
     uint32_t rawDetId;
+    bool isOnEdgePixel;
+    bool isOtherBadPixel;
   };
   
   struct AVTrackStruct
@@ -68,7 +70,7 @@ class TrackerValidationVariables
     float dz;
     int charge;
     int numberOfValidHits;
-    int numberOfLostHits;
+    int numberOfLostHits;    
     std::vector<AVHitStruct> hits;
   };
 

--- a/Alignment/OfflineValidation/src/TrackerValidationVariables.cc
+++ b/Alignment/OfflineValidation/src/TrackerValidationVariables.cc
@@ -29,6 +29,7 @@
 
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
@@ -79,6 +80,12 @@ void TrackerValidationVariables::fillHitQuantities(reco::Track const & track, st
       auto IntSubDetID = hit_detId.subdetId();
 
       if(IntSubDetID == 0) continue;
+
+      if (IntSubDetID == PixelSubdetector::PixelBarrel || IntSubDetID == PixelSubdetector::PixelEndcap){
+	const SiPixelRecHit* prechit = dynamic_cast<const SiPixelRecHit*>(hit);//to be used to get the associated cluster and the cluster probability      
+	if(prechit->isOnEdge())      hitStruct.isOnEdgePixel=true;
+	if(prechit->hasBadPixels())  hitStruct.isOtherBadPixel=true;
+      }
 
       auto lPTrk = trajParams[h].position();   // update state
       auto lVTrk = trajParams[h].direction();
@@ -214,6 +221,12 @@ TrackerValidationVariables::fillHitQuantities(const Trajectory* trajectory, std:
     unsigned int IntSubDetID = (hit_detId.subdetId());
     
     if(IntSubDetID == 0) continue;
+
+    if (IntSubDetID == PixelSubdetector::PixelBarrel || IntSubDetID == PixelSubdetector::PixelEndcap){
+      const SiPixelRecHit* prechit = dynamic_cast<const SiPixelRecHit*>(hit.get());//to be used to get the associated cluster and the cluster probability            
+      if(prechit->isOnEdge())      hitStruct.isOnEdgePixel=true;
+      if(prechit->hasBadPixels())  hitStruct.isOtherBadPixel=true;
+    }
     
     //first calculate residuals in cartesian coordinates in the local module coordinate system
     

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1RecHits.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1RecHits.cc
@@ -32,7 +32,9 @@ class SiPixelPhase1RecHits final : public SiPixelPhase1Base {
     ERROR_X,
     ERROR_Y,
     POS,
-    CLUSTER_PROB
+    CLUSTER_PROB,
+    NONEDGE,
+    NOTHERBAD
   };
 
   public:
@@ -142,6 +144,8 @@ void SiPixelPhase1RecHits::analyze(const edm::Event& iEvent, const edm::EventSet
       float lerr_y = sqrt(lerr.yy());
 
       histo[NRECHITS].fill(id, &iEvent, col, row); //in general a inclusive counter of missing/valid/inactive hits
+      if(prechit->isOnEdge()) histo[NONEDGE].fill(id, &iEvent, col, row);
+      if(prechit->hasBadPixels()) histo[NOTHERBAD].fill(id, &iEvent, col, row);
 
       if (isHitValid){
 	histo[CLUST_X].fill(sizeX, id, &iEvent, col, row);
@@ -162,6 +166,8 @@ void SiPixelPhase1RecHits::analyze(const edm::Event& iEvent, const edm::EventSet
   }
 
   histo[NRECHITS].executePerEventHarvesting(&iEvent);
+  histo[NONEDGE].executePerEventHarvesting(&iEvent);
+  histo[NOTHERBAD].executePerEventHarvesting(&iEvent);
 }
 
 } //namespace

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackResiduals.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackResiduals.cc
@@ -25,7 +25,11 @@ namespace {
 class SiPixelPhase1TrackResiduals final : public SiPixelPhase1Base {
   enum {
     RESIDUAL_X,
-    RESIDUAL_Y
+    RESIDUAL_Y,
+    RESONEDGE_X,
+    RESONEDGE_Y,
+    RESOTHERBAD_X,
+    RESOTHERBAD_Y
   };
 
   public:
@@ -80,6 +84,17 @@ void SiPixelPhase1TrackResiduals::analyze(const edm::Event& iEvent, const edm::E
       
       histo[RESIDUAL_X].fill(it.resXprime, id, &iEvent);
       histo[RESIDUAL_Y].fill(it.resYprime, id, &iEvent);
+
+      if(it.isOnEdgePixel){
+	histo[RESONEDGE_X].fill(it.resXprime, id, &iEvent);
+	histo[RESONEDGE_Y].fill(it.resYprime, id, &iEvent);
+      }
+
+      if(it.isOtherBadPixel){      
+	histo[RESOTHERBAD_X].fill(it.resXprime, id, &iEvent);
+	histo[RESOTHERBAD_Y].fill(it.resYprime, id, &iEvent);
+      }
+
     }
   }
 

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1RecHits_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1RecHits_cfi.py
@@ -108,6 +108,100 @@ SiPixelPhase1RecHitsProb = DefaultHistoTrack.clone(
   )
 )
 
+SiPixelPhase1RecHitsOnEdge = DefaultHistoTrack.clone(
+  name = "onedge",
+  title = "OnEdge",
+  range_min = 0, range_max = 30, range_nbins = 30,
+  xlabel = "onedge",
+  dimensions = 0,
+  specs = VPSet(
+
+   StandardSpecificationTrend_Num,
+   StandardSpecificationOccupancy,
+   Specification().groupBy("PXBarrel/PXLayer/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/PXLayer/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer","EXTEND_X")
+                   .save(),
+   Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/PXDisk/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk","EXTEND_X")
+                   .save(),
+   Specification().groupBy("PXBarrel/PXLayer/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/PXLayer/")
+                   .save(nbins=100, xmin=0, xmax=500),
+   Specification().groupBy("PXBarrel/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel")
+                   .save(nbins=100, xmin=0, xmax=500),
+
+    Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/PXDisk/")
+                   .save(nbins=100, xmin=0, xmax=500),
+    Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward")
+                   .save(nbins=100, xmin=0, xmax=500),
+
+    Specification().groupBy("PXAll/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXAll")
+                   .save(nbins=100, xmin=0, xmax=500)
+
+  )
+)
+
+SiPixelPhase1RecHitsOtherBad = DefaultHistoTrack.clone(
+  name = "otherbad",
+  title = "OtherBad",
+  range_min = 0, range_max = 30, range_nbins = 30,
+  xlabel = "otherbad",
+  dimensions = 0,
+  specs = VPSet(
+
+   StandardSpecificationTrend_Num,
+   StandardSpecificationOccupancy,
+   Specification().groupBy("PXBarrel/PXLayer/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/PXLayer/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer","EXTEND_X")
+                   .save(),
+   Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/PXDisk/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk","EXTEND_X")
+                   .save(),
+   Specification().groupBy("PXBarrel/PXLayer/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/PXLayer/")
+                   .save(nbins=100, xmin=0, xmax=500),
+   Specification().groupBy("PXBarrel/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel")
+                   .save(nbins=100, xmin=0, xmax=500),
+
+    Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/PXDisk/")
+                   .save(nbins=100, xmin=0, xmax=500),
+    Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward")
+                   .save(nbins=100, xmin=0, xmax=500),
+
+    Specification().groupBy("PXAll/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXAll")
+                   .save(nbins=100, xmin=0, xmax=500)
+  )
+)
 
 SiPixelPhase1RecHitsConf = cms.VPSet(
   SiPixelPhase1RecHitsNRecHits,
@@ -117,6 +211,8 @@ SiPixelPhase1RecHitsConf = cms.VPSet(
   SiPixelPhase1RecHitsErrorY,
   SiPixelPhase1RecHitsPosition,
   SiPixelPhase1RecHitsProb,
+  SiPixelPhase1RecHitsOnEdge,
+  SiPixelPhase1RecHitsOtherBad,
 )
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackResiduals_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackResiduals_cfi.py
@@ -35,9 +35,55 @@ SiPixelPhase1TrackResidualsResidualsY = SiPixelPhase1TrackResidualsResidualsX.cl
   xlabel = "(y_rec - y_pred) [cm]",
 )
 
+SiPixelPhase1TrackResidualsResOnEdgeX = DefaultHistoTrack.clone(
+  name = "residual_OnEdge_x",
+  title = "Track Residuals X (OnEdge Clusters)",
+  range_min = -0.1, range_max = 0.1, range_nbins = 100,
+  xlabel = "(x_rec - x_pred) [cm]",
+  dimensions = 1,
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer").saveAll(),
+    Specification().groupBy("PXForward/PXDisk").saveAll(),
+    Specification(PerLayer1D).groupBy("PXBarrel/Shell/PXLayer").save(),
+    Specification(PerLayer1D).groupBy("PXForward/HalfCylinder/PXRing/PXDisk").save()
+  )
+)
+
+SiPixelPhase1TrackResidualsResOnEdgeY = SiPixelPhase1TrackResidualsResOnEdgeX.clone(
+  name = "residual_OnEdge_y",
+  title = "Track Residuals Y (OnEdge Clusters)",
+  xlabel = "(y_rec - y_pred) [cm]",
+)
+
+
+SiPixelPhase1TrackResidualsResOtherBadX = DefaultHistoTrack.clone(
+  name = "residual_OtherBad_x",
+  title = "Track Residuals X (OtherBad Clusters)",
+  range_min = -0.1, range_max = 0.1, range_nbins = 100,
+  xlabel = "(x_rec - x_pred) [cm]",
+  dimensions = 1,
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer").saveAll(),
+    Specification().groupBy("PXForward/PXDisk").saveAll(),
+    Specification(PerLayer1D).groupBy("PXBarrel/Shell/PXLayer").save(),
+    Specification(PerLayer1D).groupBy("PXForward/HalfCylinder/PXRing/PXDisk").save()
+  )
+)
+
+SiPixelPhase1TrackResidualsResOtherBadY = SiPixelPhase1TrackResidualsResOtherBadX.clone(
+  name = "residual_OtherBad_y",
+  title = "Track Residuals Y (OtherBad Clusters)",
+  xlabel = "(y_rec - y_pred) [cm]",
+)
+
+
 SiPixelPhase1TrackResidualsConf = cms.VPSet(
   SiPixelPhase1TrackResidualsResidualsX,
-  SiPixelPhase1TrackResidualsResidualsY
+  SiPixelPhase1TrackResidualsResidualsY,
+  SiPixelPhase1TrackResidualsResOnEdgeX,
+  SiPixelPhase1TrackResidualsResOnEdgeY,
+  SiPixelPhase1TrackResidualsResOtherBadX,
+  SiPixelPhase1TrackResidualsResOtherBadY
 )
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer


### PR DESCRIPTION
#### PR description:

Some additional DQM plots to monitor Pixel ClusterRepairs (introduced in #26263) and small fix to already present ones (introduced in #26326)

#### PR validation:

Standard runTheMatrix sequence

#### if this PR is a backport please specify the original PR:

Backport of #26430