### PR TITLE
HCAL: adding Phase 1 HBX/HEX channels to CalibDetId and ASCII conditions processing 

### DIFF
--- a/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
+++ b/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
@@ -158,7 +158,17 @@ bool HcalText2DetIdConverter::init (DetId fId) {
       setField (1, calibId.rm());
       setField (2, calibId.fiber());
       setField (3, calibId.channel());
-    }
+    } else if ( calibId.calibFlavor()==HcalCalibDetId::HBX) {      
+      flavorName="HBX";
+      setField (1, calibId.ieta());
+      setField (2, calibId.iphi());
+      setField (3, calibId.depth());    
+    } else if ( calibId.calibFlavor()==HcalCalibDetId::HEX) {      
+      flavorName="HEX";
+      setField (1, calibId.ieta());
+      setField (2, calibId.iphi());
+      setField (3, calibId.depth());
+    }    
   }
   else {
     flavorName = "UNKNOWN_FLAVOR";
@@ -233,6 +243,19 @@ bool HcalText2DetIdConverter::init (const std::string& fFlavor, const std::strin
     int ieta=getField(1);
     int iphi=getField(2);
     mId = HcalCalibDetId (ieta,iphi);
+  }
+  else if (flavorName=="HBX") {
+    int ieta=getField(1);
+    int iphi=getField(2);
+    int depth=getField(3);  
+    mId = HcalCalibDetId (HcalCalibDetId::HBX, ieta, iphi, depth); 
+  }
+  else if (flavorName=="HEX") {
+    int ieta=getField(1);
+    int iphi=getField(2);
+    int depth=getField(3);  
+    mId = HcalCalibDetId (HcalCalibDetId::HEX, ieta, iphi, depth); 
+
   }
   else if (flavorName=="UMNQIE") {
     int channel=getField(1);

--- a/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
+++ b/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
@@ -162,12 +162,12 @@ bool HcalText2DetIdConverter::init (DetId fId) {
       flavorName="HBX";
       setField (1, calibId.ieta());
       setField (2, calibId.iphi());
-      setField (3, calibId.depth());    
+      setField (3, -999);
     } else if ( calibId.calibFlavor()==HcalCalibDetId::HEX) {      
       flavorName="HEX";
       setField (1, calibId.ieta());
       setField (2, calibId.iphi());
-      setField (3, calibId.depth());
+      setField (3, -999);
     }    
   }
   else {
@@ -239,23 +239,14 @@ bool HcalText2DetIdConverter::init (const std::string& fFlavor, const std::strin
     int channel = calibChannel (field3);
     mId = HcalCalibDetId (sd, ieta,iphi,channel);
   }
-  else if (flavorName=="HOX") {
+  else if (flavorName=="HOX" || flavorName=="HBX" || flavorName=="HEX") {
     int ieta=getField(1);
     int iphi=getField(2);
-    mId = HcalCalibDetId (ieta,iphi);
-  }
-  else if (flavorName=="HBX") {
-    int ieta=getField(1);
-    int iphi=getField(2);
-    int depth=getField(3);  
-    mId = HcalCalibDetId (HcalCalibDetId::HBX, ieta, iphi, depth); 
-  }
-  else if (flavorName=="HEX") {
-    int ieta=getField(1);
-    int iphi=getField(2);
-    int depth=getField(3);  
-    mId = HcalCalibDetId (HcalCalibDetId::HEX, ieta, iphi, depth); 
-
+    mId = (flavorName=="HOX")?
+      (HcalCalibDetId(HcalCalibDetId::HOCrosstalk,ieta,iphi)):
+      ((flavorName=="HBX")?(HcalCalibDetId(HcalCalibDetId::HBX,ieta,iphi)):
+                           (HcalCalibDetId(HcalCalibDetId::HEX,ieta,iphi))
+      );
   }
   else if (flavorName=="UMNQIE") {
     int channel=getField(1);

--- a/DataFormats/HcalDetId/interface/HcalCalibDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalCalibDetId.h
@@ -36,10 +36,9 @@
   *
   *  For HBX/HEX:
   *     [19:17]  6 or 7 (CalibType) 
-  *     [15:15]  0/1 (Side) 
-  *     [14:10]  ieta  (1-29)
-  *     [9:3]    iphi  (1-72)
-  *     [2:0]    depth (1-7)  
+  *     [12:12]  side (true = positive)
+  *     [11:7]   ieta (1-29)
+  *     [6:0]    iphi (1-72)
   *    
   * \author J. Mans - Minnesota
   */
@@ -57,7 +56,9 @@ public:
   HcalCalibDetId& operator=(const DetId& id);
   /** Construct a calibration box - channel detid */
   HcalCalibDetId(HcalSubdetector subdet, int ieta, int iphi, int ctype);
-  /** Construct an HO Crosstalk id  */
+  /** Construct an HOX/HBX/HEX Crosstalk id  */
+  HcalCalibDetId(CalibDetType dt, int ieta, int iphi);
+  /** Keep old HOX constructor for back-compatibility */
   HcalCalibDetId(int ieta, int iphi);
   /** Construct a uMNqie id or other id which uses a single value plus a DetType */
   HcalCalibDetId(CalibDetType dt, int value);
@@ -66,12 +67,10 @@ public:
 
   /// get the flavor of this calibration detid
   CalibDetType calibFlavor() const { return (CalibDetType)((id_>>17)&0x7); }
-
-
   /// get the HcalSubdetector (if relevant)
   HcalSubdetector hcalSubdet() const;
   /// get the rbx name (if relevant)
-//  std::string rbx() const;
+  /// std::string rbx() const;
   /// get the "ieta" identifier (if relevant)
   int ieta() const;
   /// get the low-edge iphi (if relevant)
@@ -90,8 +89,6 @@ public:
 
   /// get the sign of ieta (+/-1)
   int zside() const;
-  /// get the depth (where relevant)
-  int depth() const;
 
   /// constants
   static const int cbox_MixerHigh     = 0; // HB/HE/HO/HF

--- a/DataFormats/HcalDetId/interface/HcalCalibDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalCalibDetId.h
@@ -8,7 +8,7 @@
 /** \class HcalCalibDetId
   *  
   *  Contents of the HcalCalibDetId :
-  *     [19:17] Calibration Category (1 = CalibUnit, 2 = HX, 3=uMNio/qie, 4=CastorRad)
+  *     [19:17] Calibration Category (1 = CalibUnit, 2 = HOX, 3=uMNio/qie, 4=CastorRad, 5=LASMON, 6=HBX, 7=HEX)
   *
   *  For CalibUnit:
   *     [16:14] Subdetector
@@ -29,13 +29,24 @@
   *     [9:5] fiber-in-rm
   *     [4:0] channel-on-fiber
   *     
+  *  For Laser Monitoring channels: 
+  *     [16:10] ieta
+  *     [9:5]   iphi 
+  *     [3:0]   cbox  
   *
+  *  For HBX/HEX:
+  *     [19:17]  6 or 7 (CalibType) 
+  *     [15:15]  0/1 (Side) 
+  *     [14:10]  ieta  (1-29)
+  *     [9:3]    iphi  (1-72)
+  *     [2:0]    depth (1-7)  
+  *    
   * \author J. Mans - Minnesota
   */
 class HcalCalibDetId : public HcalOtherDetId {
 public:
   /** Type identifier within calibration det ids */
-  enum CalibDetType { CalibrationBox = 1, HOCrosstalk = 2, uMNqie = 3, CastorRadFacility = 4, LASERMON = 5 };
+  enum CalibDetType { CalibrationBox = 1, HOCrosstalk = 2, uMNqie = 3, CastorRadFacility = 4, LASERMON = 5, HBX = 6, HEX = 7 };
 
   /** Create a null det id */
   HcalCalibDetId();
@@ -50,7 +61,7 @@ public:
   HcalCalibDetId(int ieta, int iphi);
   /** Construct a uMNqie id or other id which uses a single value plus a DetType */
   HcalCalibDetId(CalibDetType dt, int value);
-    /** Construct a Castor radiation test facility id or other id which uses three values plus a DetType */
+  /** Construct a Castor radiation test facility id or other id which uses three values plus a DetType */
   HcalCalibDetId(CalibDetType dt, int value1, int value2, int value3);
 
   /// get the flavor of this calibration detid
@@ -79,6 +90,8 @@ public:
 
   /// get the sign of ieta (+/-1)
   int zside() const;
+  /// get the depth (where relevant)
+  int depth() const;
 
   /// constants
   static const int cbox_MixerHigh     = 0; // HB/HE/HO/HF

--- a/DataFormats/HcalDetId/src/HcalCalibDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalCalibDetId.cc
@@ -26,11 +26,21 @@ HcalCalibDetId::HcalCalibDetId(HcalSubdetector subdet, int ieta, int iphi, int c
   else id_|=((iphi&0x7F)<<4);      // phi index, bits [4:10], simply allow all values from 0-127, shouldn't be any
 }
 
+// keep old HOX constructor for back-compatibility 
 HcalCalibDetId::HcalCalibDetId(int ieta, int iphi) : HcalOtherDetId(HcalCalibration) {
-  id_|=(HOCrosstalk<<17);         // Calibration Category, bits [17:19] (= "2" for HOX)
-  id_|=(iphi&0x7F)                // phi index, bits [0:6]
-     |((abs(ieta)&0xF)<<7)        // eta index, bits [7:10]
-     |(((ieta > 0)?(1):(0))<<11); // z side, bit [11]
+  id_|=(HOCrosstalk<<17); // Calibration Category, bits [17:19] (= "2" for HOX)
+  id_|=(iphi&0x7F)               // phi index, bits [0:6]
+      |((abs(ieta)&0xF)<<7)     // eta index, bits [7:10]
+      |(((ieta > 0)?(1):(0))<<11); // z side, bit [11]
+}
+
+HcalCalibDetId::HcalCalibDetId(CalibDetType dt, int ieta, int iphi) : HcalOtherDetId(HcalCalibration) {
+  id_|=(dt<<17);         // Calibration Category, bits [17:19] (= "2" for HOX, "6" for HBX, "7" for HEX)
+  id_|=(iphi&0x7F);      // phi index, bits [0:6];
+
+  (dt==HOCrosstalk)?
+    (id_|=((abs(ieta)&0xF) <<7)|(((ieta > 0)?(1):(0))<<11)):
+    (id_|=((abs(ieta)&0x1F)<<7)|(((ieta > 0)?(1):(0))<<12)); 
 }
 
 HcalCalibDetId::HcalCalibDetId(CalibDetType dt, int value) : HcalOtherDetId(HcalCalibration) {
@@ -40,18 +50,9 @@ HcalCalibDetId::HcalCalibDetId(CalibDetType dt, int value) : HcalOtherDetId(Hcal
 
 HcalCalibDetId::HcalCalibDetId(CalibDetType dt, int value1, int value2, int value3)  : HcalOtherDetId(HcalCalibration) {
   id_|=(dt<<17);             // Calibration Category, bits [17:19]
-
-  if(dt == HBX || dt == HEX) {
-    id_|=(value3&0x7)                 // depth index, bits [0:2]
-       |((value2&0x7F)<<3)            // phi index,   bits [3:9]
-       |((value1&0x1F)<<10)           // eta index,   bits [10:14] 
-       |(((value1 > 0)?(1):(0))<<15); // z side,      bit  [15]
-  }
-  else {
-    id_|=(value1&0x3F)<<10;
-    id_|=(value2&0x1F)<<5;
-    id_|=(value3&0x1F);
-  }
+  id_|=(value1&0x3F)<<10;
+  id_|=(value2&0x1F)<<5;
+  id_|=(value3&0x1F);
 }
 
 HcalCalibDetId::HcalCalibDetId(const DetId& gen) {
@@ -84,21 +85,19 @@ HcalSubdetector HcalCalibDetId::hcalSubdet() const {
 }
     
 int HcalCalibDetId::ieta() const {
-  return (calibFlavor()==CalibrationBox)?(((id_>>11)&0x7)-2):((calibFlavor()==HOCrosstalk)?(((id_>>7)&0xF)*zside()):(calibFlavor()==LASERMON?((id_>>10)&0x3F):(((calibFlavor()==HBX || calibFlavor()==HEX)?((id_>>10)&0x1F)*zside():(0)))));
+  CalibDetType cf = calibFlavor();
+  return (cf==CalibrationBox)?(((id_>>11)&0x7)-2):((cf==HOCrosstalk)?(((id_>>7)&0xF)*zside()):(cf==LASERMON?((id_>>10)&0x3F):(((cf==HBX || cf==HEX)?((id_>>10)&0x1F)*zside():(0)))));
 }
 
 int HcalCalibDetId::iphi() const {
-  return (calibFlavor()==CalibrationBox)?((id_>>4)&0x7F):((calibFlavor()==HOCrosstalk)?(id_&0x7F):(calibFlavor()==LASERMON?((id_>>5)&0x1F):(((calibFlavor()==HBX || calibFlavor()==HEX)?((id_>>3)&0x7F):(0)))));
+  CalibDetType cf = calibFlavor();
+  return (cf==CalibrationBox)?((id_>>4)&0x7F):((cf==HOCrosstalk || cf==HBX || cf==HEX)?(id_&0x7F):(cf==LASERMON?((id_>>5)&0x1F):(0)));
 }
 
 int HcalCalibDetId::zside() const {
-  return (calibFlavor()==HOCrosstalk)?(((id_>>11)&0x1)?(1):(-1)):((calibFlavor()==HBX || calibFlavor()==HEX)?((id_>>15)&0x1)?(1):(-1):(0));
+  CalibDetType cf = calibFlavor(); 
+  return (cf==HOCrosstalk)?(((id_>>11)&0x1)?(1):(-1)):((cf==HBX || cf==HEX)?((id_>>12)&0x1)?(1):(-1):(0));
 }
-
-int HcalCalibDetId::depth() const { 
-  return (calibFlavor()==HBX || calibFlavor()==HEX)?(id_&0x7):(0);
-}
-
 
 std::string HcalCalibDetId::cboxChannelString() const {
   switch (cboxChannel()) {
@@ -145,9 +144,9 @@ std::ostream& operator<<(std::ostream& s,const HcalCalibDetId& id) {
   case (HcalCalibDetId::CastorRadFacility):
     return s << "(CastorRadFacility " << id.rm() << " / " << id.fiber() << " / " << id.channel() << ')';
   case (HcalCalibDetId::HBX):
-    return s << "(HBX "  << id.ieta() << "," << id.iphi() << "," << id.depth() << ")"; 
+    return s << "(HBX "  << id.ieta() << "," << id.iphi() << ")"; 
   case (HcalCalibDetId::HEX):
-    return s << "(HEX "  << id.ieta() << "," << id.iphi() << "," << id.depth() << ")"; 
+    return s << "(HEX "  << id.ieta() << "," << id.iphi() << ")"; 
   default: return s;
   };
 }


### PR DESCRIPTION
#### PR description:

Preparatory modifications/extensions of HcalCalibDetId and ASCII conditions interpreter (reading/dumping) for handling Phase 1  HB and HE monitoring channels.  

#### PR validation:

- runTheMatrix is OK. 

- simple sanity check: reading existing emap (from txt) with 2 newly added HBX and HEX channels shows expected behavior, with properly interpreted (packed/unpacked=set/got) attributes/fields.
Here is a diff of the dumped  emap wrt the input one (via CMSSW HCAL DB functionality, means txt input is read and parsed, a transient emap object is created and then dumped ): 

64c64

  4E2CC01C   3   3   t   24       2          5              2     HBX    16     3     -999
->
  4E240A03    3   3   t   24       2          5              2     HBX    16     3      -999

73c73

  4E2EC01C   3   3   t   24       2          8              2     HEX    16     3     -999
->
  4E240A01    3   3   t   24       2          8              2     HEX    16     3     -999

All other ~27k HCAL channels of various types (phys.channels, trig.primitives, several sorts of calib. channels) stays unchanged in this test. 
NB: no any changes expected  in any workflow at the moment.
When emap will be modified in GT _and_ HCAL DQM (to cope with new channels) will be updated, then some new DQM histos will show these channels in data.     
