### PR TITLE
Fix include for HFStripFilter

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h
@@ -5,6 +5,7 @@
 
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
 
 class HFStripFilter
 {

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -1,7 +1,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/METReco/interface/HcalPhase1FlagLabels.h"
-#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
 
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFStripFilter.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"


### PR DESCRIPTION
#### PR description:

Catched by header checker 
Moved one include from the implementation into the class header file


#### PR validation:

It compiles