### PR TITLE
[muon] a workaround for enum to int conversion problem in pyROOT

### DIFF
--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -281,8 +281,10 @@ namespace pat {
       void  setSoftMvaValue(float softmva){ softMvaValue_ = softmva; }
 
       /// MC matching information
-      reco::MuonSimType simType() const { return simType_; }
-      reco::ExtendedMuonSimType simExtType() const { return simExtType_; }
+      /// returns reco::MuonSimType - we cast it to int to avoid issues in pyROOT
+      int simType() const { return simType_; }
+      /// reco::ExtendedMuonSimType - we cast it to int to avoid issues in pyROOT
+      int simExtType() const { return simExtType_; }
       //  FLAVOUR:
       //  - for non-muons: 0
       //  - for primary muons: 13


### PR DESCRIPTION
There is a subtle problem with python type conversion from signed enums to basic types. In some cases it converts negative enums to an unsigned int. For example instead of -10 you get 4294967286. This problem was report to ROOT team, but it was never fixed. 
It's very easy to miss this problem and unfortunately one cannot rely on enum checks to avoid it, since for example ROOT.reco.GhostMuonFromGaugeOrHiggsBoson evaluates to -10 as it should, but simExtType() returns 4294967286.
The current workaround is documented on Muon POG twiki, but it's not a reliable solution. People (including me keep rediscovering this problem).
https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideMuonIdRun2#SimHit_Muon_matching_since_CMSSW

The pull request provides a trivial fix - return int instead of the enum. I know it's ugly, but getting wrong physics results is worse.
