### PR TITLE
Add trigger bit to emulated GlobalExtBlk to indicate event was not selected …

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
@@ -14,7 +14,11 @@ stage2L1Trigger.toModify(None, _print)
 (~stage2L1Trigger).toModify(None, lambda x: print("L1T INFO:  L1REPACK:Full (intended for 2016 & 2017 data) will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
 
 # First, Unpack all inputs to L1:
-    
+
+import EventFilter.Utilities.tcdsRawToDigi_cfi
+unpackTcds = EventFilter.Utilities.tcdsRawToDigi_cfi.tcdsRawToDigi.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
 import EventFilter.L1TRawToDigi.bmtfDigis_cfi
 unpackBmtf = EventFilter.L1TRawToDigi.bmtfDigis_cfi.bmtfDigis.clone(
     InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
@@ -119,6 +123,15 @@ simEmtfDigis.RPCInput            = 'unpackRPC'
 simCaloStage2Layer1Digis.ecalToken = 'unpackEcal:EcalTriggerPrimitives'
 simCaloStage2Layer1Digis.hcalToken = 'unpackLayer1'
 
+
+## GT
+stage2L1Trigger_2017.toModify(simGtExtFakeStage2Digis,
+    tcdsRecordLabel= cms.InputTag("unpackTcds","tcdsRecord")
+)
+stage2L1Trigger.toModify(simGtExtFakeStage2Digis,
+    tcdsRecordLabel= cms.InputTag("unpackTcds","tcdsRecord")
+)
+
 # Finally, pack the new L1T output back into RAW
     
 from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
@@ -141,6 +154,7 @@ rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawD
 SimL1Emulator = cms.Sequence()
 stage2L1Trigger.toReplaceWith(SimL1Emulator, cms.Sequence(unpackEcal+unpackHcal+unpackCSC+unpackDT+unpackRPC+unpackRPCTwinMux+unpackTwinMux+unpackOmtf+unpackEmtf+unpackCsctf+unpackBmtf
                                                           +unpackLayer1
+                                                          +unpackTcds
                                                           +SimL1EmulatorCore+packCaloStage2
                                                           +packGmtStage2+packGtStage2+rawDataCollector))
 

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
@@ -11,12 +11,20 @@ def _print(ignored):
 stage2L1Trigger.toModify(None, _print)
 (~stage2L1Trigger).toModify(None, lambda x: print("L1T INFO:  L1REPACK:uGT (intended for 2016 data) will unpack uGMT and CaloLaye2 outputs and re-emulate uGT"))
 
+
 # First, inputs to uGT:
 import EventFilter.L1TRawToDigi.gtStage2Digis_cfi
 unpackGtStage2 = EventFilter.L1TRawToDigi.gtStage2Digis_cfi.gtStage2Digis.clone(
     InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
+import EventFilter.Utilities.tcdsRawToDigi_cfi
+unpackTcds = EventFilter.Utilities.tcdsRawToDigi_cfi.tcdsRawToDigi.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+
 from L1Trigger.Configuration.SimL1Emulator_cff import *
+
+simGtExtFakeStage2Digis.tcdsRecordLabel= cms.InputTag("unpackTcds","tcdsRecord")
+
 simGtStage2Digis.MuonInputTag   = "unpackGtStage2:Muon"
 simGtStage2Digis.EGammaInputTag = "unpackGtStage2:EGamma"
 simGtStage2Digis.TauInputTag    = "unpackGtStage2:Tau"
@@ -51,6 +59,8 @@ rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawD
 
 SimL1Emulator = cms.Sequence()
 stage2L1Trigger.toReplaceWith(SimL1Emulator, cms.Sequence(unpackGtStage2
+                                                          +unpackTcds
+                                                          +SimL1TechnicalTriggers
                                                           +SimL1TGlobal
                                                           +packGtStage2
                                                           +rawDataCollector))

--- a/L1Trigger/L1TGlobal/plugins/BuildFile.xml
+++ b/L1Trigger/L1TGlobal/plugins/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
+<use name="DataFormats/TCDS"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="CondFormats/L1TObjects"/>
 <use name="CondFormats/DataRecord"/>

--- a/L1Trigger/L1TGlobal/python/simGtExtFakeProd_cfi.py
+++ b/L1Trigger/L1TGlobal/python/simGtExtFakeProd_cfi.py
@@ -8,5 +8,7 @@ simGtExtFakeProd = cms.EDProducer("L1TExtCondProducer",
                                   setBptxPlus = cms.bool(True),
                                   setBptxMinus = cms.bool(True),
                                   setBptxOR = cms.bool(True),
+                                  tcdsRecordLabel= cms.InputTag("")
+                                  ## tcdsRecordLabel= cms.InputTag("tcdsDigis","tcdsRecord") ## use this tag to trigger fetching the tcds record and set the Prefire veto bit
 )
 


### PR DESCRIPTION
…due to prefiring of the trigger

#### PR description:

<!-- This PR supersedes #26378 --  Add trigger bit to emulated GlobalExtBlk to indicate event could not have been caused by prefiring of the trigger. GlobalExtBlk contains the technical trigger bit information. Since these bits are not properly emulated anyway it is save to add the bit here. -->

#### PR validation:

<!-- Ran basic battery of tests, runTheMatrix.py -l limited -i all --ibeos, as well as "scram b runtests" with unit test in TauAnalysis/MCEmbeddingTools.  -->

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
