### PR TITLE
Cleanup ECAL topology construction

### DIFF
--- a/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
@@ -405,23 +405,22 @@ Pi0FixedMassWindowCalibration::duringLoop(const edm::Event& event,
   setup.get<CaloGeometryRecord>().get(geoHandle);
 
   const CaloSubdetectorGeometry *geometry_p;
-  CaloSubdetectorTopology *topology_p;
 
   std::string clustershapetag;
   geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-  topology_p = new EcalBarrelTopology(geoHandle);
+  EcalBarrelTopology topology{*geoHandle};
 
   const CaloSubdetectorGeometry *geometryES_p;
   geometryES_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
 
   /*
   reco::BasicClusterCollection clusters;
-  clusters = island_p->makeClusters(ecalRecHitBarrelCollection,geometry_p,topology_p,geometryES_p,IslandClusterAlgo::barrel);
+  clusters = island_p->makeClusters(ecalRecHitBarrelCollection,geometry_p,&topology,geometryES_p,IslandClusterAlgo::barrel);
   
   //Create associated ClusterShape objects.
   std::vector <reco::ClusterShape> ClusVec;
   for (int erg=0;erg<int(clusters.size());++erg){
-    reco::ClusterShape TestShape = shapeAlgo_.Calculate(clusters[erg],ecalRecHitBarrelCollection,geometry_p,topology_p);
+    reco::ClusterShape TestShape = shapeAlgo_.Calculate(clusters[erg],ecalRecHitBarrelCollection,geometry_p,&topology);
     ClusVec.push_back(TestShape);
   }
 
@@ -441,12 +440,12 @@ Pi0FixedMassWindowCalibration::duringLoop(const edm::Event& event,
 
   // recalibrated clusters
   reco::BasicClusterCollection clusters_recalib;
-  clusters_recalib = island_p->makeClusters(recalibEcalRecHitCollection,geometry_p,topology_p,geometryES_p,IslandClusterAlgo::barrel);
+  clusters_recalib = island_p->makeClusters(recalibEcalRecHitCollection,geometry_p,&topology,geometryES_p,IslandClusterAlgo::barrel);
   
   //Create associated ClusterShape objects.
   std::vector <reco::ClusterShape> ClusVec_recalib;
   for (int erg=0;erg<int(clusters_recalib.size());++erg){
-    reco::ClusterShape TestShape_recalib = shapeAlgo_.Calculate(clusters_recalib[erg],recalibEcalRecHitCollection,geometry_p,topology_p);
+    reco::ClusterShape TestShape_recalib = shapeAlgo_.Calculate(clusters_recalib[erg],recalibEcalRecHitCollection,geometry_p,&topology);
     ClusVec_recalib.push_back(TestShape_recalib);
   }
 

--- a/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.cc
@@ -38,12 +38,12 @@ CaloTopologyBuilder::produceCalo( const CaloTopologyRecord& iRecord )
    //ECAL parts      
    ct->setSubdetTopology( DetId::Ecal,
 			  EcalBarrel,
-			  new EcalBarrelTopology( *theGeometry ) ) ;
+			  std::make_unique<EcalBarrelTopology>( *theGeometry ) ) ;
    ct->setSubdetTopology( DetId::Ecal,
 			  EcalEndcap,
-			  new EcalEndcapTopology( *theGeometry ) ) ;
+			  std::make_unique<EcalEndcapTopology>( *theGeometry ) ) ;
    ct->setSubdetTopology( DetId::Ecal,
 			  EcalPreshower,
-			  new EcalPreshowerTopology());
+			  std::make_unique<EcalPreshowerTopology>());
    return ct ;
 }

--- a/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.cc
@@ -38,12 +38,12 @@ CaloTopologyBuilder::produceCalo( const CaloTopologyRecord& iRecord )
    //ECAL parts      
    ct->setSubdetTopology( DetId::Ecal,
 			  EcalBarrel,
-			  new EcalBarrelTopology( theGeometry ) ) ;
+			  new EcalBarrelTopology( *theGeometry ) ) ;
    ct->setSubdetTopology( DetId::Ecal,
 			  EcalEndcap,
-			  new EcalEndcapTopology( theGeometry ) ) ;
+			  new EcalEndcapTopology( *theGeometry ) ) ;
    ct->setSubdetTopology( DetId::Ecal,
 			  EcalPreshower,
-			  new EcalPreshowerTopology(theGeometry));
+			  new EcalPreshowerTopology());
    return ct ;
 }

--- a/Geometry/CaloTopology/interface/CaloTopology.h
+++ b/Geometry/CaloTopology/interface/CaloTopology.h
@@ -4,6 +4,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/CaloTopology/interface/CaloDirection.h"
 #include <map>
+#include <memory>
 #include <vector>
 
 class CaloSubdetectorTopology;
@@ -18,13 +19,13 @@ $Revision: 1.4 $
 class CaloTopology {
 public:
 
-      typedef std::map<int, const CaloSubdetectorTopology*> TopMap ;
+  typedef std::map<int, std::unique_ptr<const CaloSubdetectorTopology>> TopMap ;
 
   CaloTopology();
 
   ~CaloTopology();
   /// Register a subdetector Topology
-  void setSubdetTopology(DetId::Detector det, int subdet, const CaloSubdetectorTopology* geom);
+  void setSubdetTopology(DetId::Detector det, int subdet, std::unique_ptr<const CaloSubdetectorTopology> geom);
   /// access the subdetector Topology for the given subdetector directly
   const CaloSubdetectorTopology* getSubdetectorTopology(const DetId& id) const;
   /// access the subdetector Topology for the given subdetector directly

--- a/Geometry/CaloTopology/interface/EcalBarrelTopology.h
+++ b/Geometry/CaloTopology/interface/EcalBarrelTopology.h
@@ -8,7 +8,6 @@
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 class EcalBarrelTopology final : public CaloSubdetectorTopology
 {
@@ -21,8 +20,8 @@ public:
   ~EcalBarrelTopology() override { }  
 
   /// create a new Topology from geometry
-  EcalBarrelTopology(edm::ESHandle<CaloGeometry> theGeom) {
-    theGeom_ = theGeom->getSubdetectorGeometry(DetId::Ecal,EcalBarrel);
+  EcalBarrelTopology(CaloGeometry const& theGeom) {
+    theGeom_ = theGeom.getSubdetectorGeometry(DetId::Ecal,EcalBarrel);
   }
   
  /// move the Topology north (increment iphi)

--- a/Geometry/CaloTopology/interface/EcalEndcapTopology.h
+++ b/Geometry/CaloTopology/interface/EcalEndcapTopology.h
@@ -20,8 +20,8 @@ public:
   ~EcalEndcapTopology() override { }  
   
   /// create a new Topology from geometry
-  EcalEndcapTopology(edm::ESHandle<CaloGeometry> theGeom) {
-    theGeom_ = theGeom.product()->getSubdetectorGeometry(DetId::Ecal,EcalEndcap);
+  EcalEndcapTopology(CaloGeometry const& theGeom) {
+    theGeom_ = theGeom.getSubdetectorGeometry(DetId::Ecal,EcalEndcap);
   }
 
   /// move the Topology north (increment iy)  

--- a/Geometry/CaloTopology/interface/EcalPreshowerTopology.h
+++ b/Geometry/CaloTopology/interface/EcalPreshowerTopology.h
@@ -13,16 +13,11 @@ class EcalPreshowerTopology final : public CaloSubdetectorTopology {
 
  public:
   /// create a new Topology
-  EcalPreshowerTopology() : theGeom_(nullptr) {};
+  EcalPreshowerTopology() = default;
 
   /// virtual destructor
   ~EcalPreshowerTopology() override { }  
   
-  /// create a new Topology from geometry
-  EcalPreshowerTopology(edm::ESHandle<CaloGeometry> theGeom) : theGeom_(std::move(theGeom))
-    {
-    }
-
   
   /// move the Topology north (increment iy)  
   DetId  goNorth(const DetId& id) const override {
@@ -119,8 +114,6 @@ class EcalPreshowerTopology final : public CaloSubdetectorTopology {
 
   /// move the nagivator to smaller iz
   ESDetId decrementIz(const ESDetId& id) const;
-
-  edm::ESHandle<CaloGeometry> theGeom_;
 };
 
 #endif

--- a/Geometry/CaloTopology/src/CaloTopology.cc
+++ b/Geometry/CaloTopology/src/CaloTopology.cc
@@ -5,31 +5,26 @@
 CaloTopology::CaloTopology() {
 }
 
-CaloTopology::~CaloTopology() 
-{
-   for(auto & theTopologie : theTopologies_)
-   {
-      delete theTopologie.second ;
-   }
-}
+CaloTopology::~CaloTopology() = default;
+
 
 int CaloTopology::makeIndex(DetId::Detector det, int subdet) const {
   return (int(det)<<4) | (subdet&0xF);
 }
 
-void CaloTopology::setSubdetTopology(DetId::Detector det, int subdet, const CaloSubdetectorTopology* geom) {
+void CaloTopology::setSubdetTopology(DetId::Detector det, int subdet, std::unique_ptr<const CaloSubdetectorTopology> geom) {
   int index=makeIndex(det,subdet);
-  theTopologies_[index]=geom;
+  theTopologies_[index]=std::move(geom);
 }
 
 const CaloSubdetectorTopology* CaloTopology::getSubdetectorTopology(const DetId& id) const {
-  std::map<int, const CaloSubdetectorTopology*>::const_iterator i=theTopologies_.find(makeIndex(id.det(),id.subdetId()));
-  return (i==theTopologies_.end())?(nullptr):(i->second);
+  auto i=theTopologies_.find(makeIndex(id.det(),id.subdetId()));
+  return (i==theTopologies_.end())?(nullptr):(i->second.get());
 }
 
 const CaloSubdetectorTopology* CaloTopology::getSubdetectorTopology(DetId::Detector det, int subdet) const {
-    std::map<int, const CaloSubdetectorTopology*>::const_iterator i=theTopologies_.find(makeIndex(det,subdet));
-    return (i==theTopologies_.end())?(nullptr):(i->second);
+    auto i=theTopologies_.find(makeIndex(det,subdet));
+    return (i==theTopologies_.end())?(nullptr):(i->second.get());
 }
 
 static const std::vector<DetId> emptyDetIdVector;

--- a/HLTrigger/special/plugins/HLTEcalResonanceFilter.cc
+++ b/HLTrigger/special/plugins/HLTEcalResonanceFilter.cc
@@ -231,9 +231,9 @@ HLTEcalResonanceFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
   edm::ESHandle<CaloGeometry> geoHandle;
   iSetup.get<CaloGeometryRecord>().get(geoHandle); 
   const CaloSubdetectorGeometry *geometry_es = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-  CaloSubdetectorTopology *topology_es=nullptr;
+  std::unique_ptr<CaloSubdetectorTopology> topology_es;
   if (geometry_es) {
-    topology_es  = new EcalPreshowerTopology(geoHandle);
+    topology_es  = std::make_unique<EcalPreshowerTopology>();
   }else{
     storeRecHitES_ = false; ///if no preshower
   }
@@ -395,7 +395,7 @@ HLTEcalResonanceFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
       ///save preshower rechits 
       if(storeRecHitES_){
 	std::set<DetId> used_strips_before = m_used_strips;  
-	makeClusterES(it_bc3->x(),it_bc3->y(),it_bc3->z(),geometry_es,topology_es);
+	makeClusterES(it_bc3->x(),it_bc3->y(),it_bc3->z(),geometry_es,topology_es.get());
 	auto ites = m_used_strips.begin();
 	for(; ites != m_used_strips.end(); ++ ites ){
 	  ESDetId d1 = ESDetId(*ites);
@@ -449,8 +449,6 @@ HLTEcalResonanceFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
   }// end of selection for eta/pi0->gg in the endcap
     
  
-  
-  delete topology_es;
   
   ////==============End of endcap ===============///
   
@@ -917,8 +915,8 @@ float HLTEcalResonanceFilter::GetDeltaR(float eta1, float eta2, float phi1, floa
 }
 
 
-void HLTEcalResonanceFilter::makeClusterES(float x, float y, float z,const CaloSubdetectorGeometry*& geometry_es,
-					CaloSubdetectorTopology*& topology_es
+void HLTEcalResonanceFilter::makeClusterES(float x, float y, float z, const CaloSubdetectorGeometry* geometry_es,
+                                           const CaloSubdetectorTopology* topology_es
 					){
   
   

--- a/HLTrigger/special/plugins/HLTEcalResonanceFilter.h
+++ b/HLTrigger/special/plugins/HLTEcalResonanceFilter.h
@@ -91,7 +91,7 @@ class HLTEcalResonanceFilter : public edm::EDFilter {
 		       ); 
       
       
-      void makeClusterES(float x, float y, float z,const CaloSubdetectorGeometry*&iSubGeom,CaloSubdetectorTopology*& topology_p);
+      void makeClusterES(float x, float y, float z,const CaloSubdetectorGeometry* iSubGeom,const CaloSubdetectorTopology* topology_p);
       
       void calcPaircluster(const reco::BasicCluster &bc1, const reco::BasicCluster &bc2, float &mpair, float &ptpair,float &etapair,float &phipair); 
       

--- a/HLTrigger/special/plugins/HLTRegionalEcalResonanceFilter.cc
+++ b/HLTrigger/special/plugins/HLTRegionalEcalResonanceFilter.cc
@@ -318,9 +318,9 @@ bool HLTRegionalEcalResonanceFilter::filter(edm::Event& iEvent, const edm::Event
   edm::ESHandle<CaloGeometry> geoHandle;
   iSetup.get<CaloGeometryRecord>().get(geoHandle); 
   const CaloSubdetectorGeometry *geometry_es = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-  CaloSubdetectorTopology *topology_es=nullptr;
+  std::unique_ptr<CaloSubdetectorTopology> topology_es;
   if (geometry_es) {
-    topology_es  = new EcalPreshowerTopology(geoHandle);
+    topology_es  = std::make_unique<EcalPreshowerTopology>();
   }else{
     storeRecHitES_ = false; ///if no preshower
   }
@@ -485,7 +485,7 @@ bool HLTRegionalEcalResonanceFilter::filter(edm::Event& iEvent, const edm::Event
       ///save preshower rechits 
       if(storeRecHitES_){
 	std::set<DetId> used_strips_before = m_used_strips;  
-	makeClusterES(it_bc3->x(),it_bc3->y(),it_bc3->z(),geometry_es,topology_es);
+	makeClusterES(it_bc3->x(),it_bc3->y(),it_bc3->z(),geometry_es,topology_es.get());
 	auto ites = m_used_strips.begin();
 	for(; ites != m_used_strips.end(); ++ ites ){
 	  ESDetId d1 = ESDetId(*ites);
@@ -539,8 +539,6 @@ bool HLTRegionalEcalResonanceFilter::filter(edm::Event& iEvent, const edm::Event
   }// end of selection for eta/pi0->gg in the endcap
     
  
-  
-  delete topology_es;
   
   ////==============End of endcap ===============///
   
@@ -1120,8 +1118,8 @@ bool HLTRegionalEcalResonanceFilter::checkStatusOfEcalRecHit(const EcalChannelSt
 }
 
 
-void HLTRegionalEcalResonanceFilter::makeClusterES(float x, float y, float z,const CaloSubdetectorGeometry*& geometry_es,
-					CaloSubdetectorTopology*& topology_es
+void HLTRegionalEcalResonanceFilter::makeClusterES(float x, float y, float z,const CaloSubdetectorGeometry* geometry_es,
+                                                   const CaloSubdetectorTopology* topology_es
 					){
   
   

--- a/HLTrigger/special/plugins/HLTRegionalEcalResonanceFilter.h
+++ b/HLTrigger/special/plugins/HLTRegionalEcalResonanceFilter.h
@@ -92,7 +92,7 @@ class HLTRegionalEcalResonanceFilter : public edm::stream::EDFilter<>
 		       ); 
       
       
-      void makeClusterES(float x, float y, float z,const CaloSubdetectorGeometry*&iSubGeom,CaloSubdetectorTopology*& topology_p);
+      void makeClusterES(float x, float y, float z,const CaloSubdetectorGeometry* iSubGeom,const CaloSubdetectorTopology* topology_p);
       
       void calcPaircluster(const reco::BasicCluster &bc1, const reco::BasicCluster &bc2, float &mpair, float &ptpair,float &etapair,float &phipair); 
       

--- a/RecoEcal/EgammaClusterAlgos/interface/PreshowerClusterAlgo.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/PreshowerClusterAlgo.h
@@ -44,8 +44,8 @@ class PreshowerClusterAlgo {
    reco::PreshowerCluster makeOneCluster(ESDetId strip,
 					 HitsID *used_strips,
                                          RecHitsMap *rechits_map,
-                                         const CaloSubdetectorGeometry*& geometry_p,
-                                         CaloSubdetectorTopology*& topology_p);
+                                         const CaloSubdetectorGeometry* geometry_p,
+                                         const CaloSubdetectorTopology* topology_p);
 
    bool goodStrip(RecHitsMap::iterator candidate_it);
 

--- a/RecoEcal/EgammaClusterAlgos/interface/PreshowerPhiClusterAlgo.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/PreshowerPhiClusterAlgo.h
@@ -36,8 +36,7 @@ class PreshowerPhiClusterAlgo {
     reco::PreshowerCluster makeOneCluster(ESDetId strip,
 					  HitsID *used_strips,
 					  RecHitsMap *rechits_map,
-					  const CaloSubdetectorGeometry*& geometry_p,
-					  CaloSubdetectorTopology*& topology_p,
+					  const CaloSubdetectorGeometry* geometry_p,
 					  double deltaEta, double minDeltaPhi, double maxDeltaPhi);
     
     bool goodStrip(RecHitsMap::iterator candidate_it);

--- a/RecoEcal/EgammaClusterAlgos/src/PreshowerClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PreshowerClusterAlgo.cc
@@ -13,8 +13,8 @@
 reco::PreshowerCluster PreshowerClusterAlgo::makeOneCluster(ESDetId strip,
 							    HitsID *used_strips,
                                                             RecHitsMap *the_rechitsMap_p,
-                                                            const CaloSubdetectorGeometry*& geometry_p,
-                                                            CaloSubdetectorTopology*& topology_p)
+                                                            const CaloSubdetectorGeometry* geometry_p,
+                                                            const CaloSubdetectorTopology* topology_p)
 {
   road_2d.clear();
 

--- a/RecoEcal/EgammaClusterAlgos/src/PreshowerPhiClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PreshowerPhiClusterAlgo.cc
@@ -15,8 +15,7 @@
 reco::PreshowerCluster PreshowerPhiClusterAlgo::makeOneCluster(ESDetId strip,
 							       HitsID *used_strips,
 							       RecHitsMap *the_rechitsMap_p,
-							       const CaloSubdetectorGeometry*& geometry_p,
-							       CaloSubdetectorTopology*& topology_p,
+							       const CaloSubdetectorGeometry* geometry_p,
 							       double deltaEta, double minDeltaPhi, double maxDeltaPhi)
 {
 

--- a/RecoEcal/EgammaClusterProducers/interface/ReducedESRecHitCollectionProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/ReducedESRecHitCollectionProducer.h
@@ -34,7 +34,7 @@ class ReducedESRecHitCollectionProducer : public edm::stream::EDProducer<> {
  private :
 
   const EcalPreshowerGeometry *geometry_p;
-  CaloSubdetectorTopology *topology_p;
+  std::unique_ptr<CaloSubdetectorTopology> topology_p;
 
   double scEtThresh_;
 

--- a/RecoEcal/EgammaClusterProducers/src/HybridClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/HybridClusterProducer.cc
@@ -124,7 +124,7 @@ void HybridClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   es.get<EcalSeverityLevelAlgoRcd>().get(sevLv);
  
   geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-  topology = std::make_unique<EcalBarrelTopology>(geoHandle);
+  topology = std::make_unique<EcalBarrelTopology>(*geoHandle);
 
   // make the Basic clusters!
   reco::BasicClusterCollection basicClusters;

--- a/RecoEcal/EgammaClusterProducers/src/IslandClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/IslandClusterProducer.cc
@@ -165,18 +165,18 @@ void IslandClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::Event
   es.get<CaloGeometryRecord>().get(geoHandle);
 
   const CaloSubdetectorGeometry *geometry_p;
-  CaloSubdetectorTopology *topology_p;
+  std::unique_ptr<CaloSubdetectorTopology> topology_p;
 
   std::string clustershapetag;
   if (ecalPart == IslandClusterAlgo::barrel) 
     {
       geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-      topology_p = new EcalBarrelTopology(geoHandle);
+      topology_p = std::make_unique<EcalBarrelTopology>(*geoHandle);
     }
   else
     {
       geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-      topology_p = new EcalEndcapTopology(geoHandle); 
+      topology_p = std::make_unique<EcalEndcapTopology>(*geoHandle);
    }
 
   const CaloSubdetectorGeometry *geometryES_p;
@@ -184,12 +184,12 @@ void IslandClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::Event
 
   // Run the clusterization algorithm:
   reco::BasicClusterCollection clusters;
-  clusters = island_p->makeClusters(hitCollection_p, geometry_p, topology_p, geometryES_p, ecalPart);
+  clusters = island_p->makeClusters(hitCollection_p, geometry_p, topology_p.get(), geometryES_p, ecalPart);
 
   //Create associated ClusterShape objects.
   std::vector <reco::ClusterShape> ClusVec;
   for (int erg=0;erg<int(clusters.size());++erg){
-    reco::ClusterShape TestShape = shapeAlgo_.Calculate(clusters[erg],hitCollection_p,geometry_p,topology_p);
+    reco::ClusterShape TestShape = shapeAlgo_.Calculate(clusters[erg],hitCollection_p,geometry_p,topology_p.get());
     ClusVec.push_back(TestShape);
   }
 
@@ -218,6 +218,4 @@ void IslandClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::Event
     shapeAssocs_p->insert(edm::Ref<reco::BasicClusterCollection>(bccHandle,i),edm::Ref<reco::ClusterShapeCollection>(clusHandle,i));
   }  
   evt.put(std::move(shapeAssocs_p),clusterShapeAssociation);
-
-  delete topology_p;
 }

--- a/RecoEcal/EgammaClusterProducers/src/Multi5x5ClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/Multi5x5ClusterProducer.cc
@@ -125,17 +125,17 @@ void Multi5x5ClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::Eve
   es.get<CaloGeometryRecord>().get(geoHandle);
 
   const CaloSubdetectorGeometry *geometry_p;
-  CaloSubdetectorTopology *topology_p;
+  std::unique_ptr<CaloSubdetectorTopology> topology_p;
 
   if (detector == reco::CaloID::DET_ECAL_BARREL) 
     {
       geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-      topology_p = new EcalBarrelTopology(geoHandle);
+      topology_p = std::make_unique<EcalBarrelTopology>(*geoHandle);
     }
   else
     {
       geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-      topology_p = new EcalEndcapTopology(geoHandle); 
+      topology_p = std::make_unique<EcalEndcapTopology>(*geoHandle);
    }
 
   const CaloSubdetectorGeometry *geometryES_p;
@@ -143,7 +143,7 @@ void Multi5x5ClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::Eve
 
   // Run the clusterization algorithm:
   reco::BasicClusterCollection clusters;
-  clusters = island_p->makeClusters(hitCollection_p, geometry_p, topology_p, geometryES_p, detector);
+  clusters = island_p->makeClusters(hitCollection_p, geometry_p, topology_p.get(), geometryES_p, detector);
 
   // create a unique_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
   auto clusters_p = std::make_unique<reco::BasicClusterCollection>();
@@ -153,6 +153,4 @@ void Multi5x5ClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::Eve
     bccHandle = evt.put(std::move(clusters_p), barrelClusterCollection_);
   else
     bccHandle = evt.put(std::move(clusters_p), endcapClusterCollection_);
-
-  delete topology_p;
 }

--- a/RecoEcal/EgammaClusterProducers/src/PreshowerClusterShapeProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PreshowerClusterShapeProducer.cc
@@ -96,9 +96,9 @@ void PreshowerClusterShapeProducer::produce(Event& evt, const EventSetup& es) {
   auto ps_cl_for_pi0_disc_y = std::make_unique<reco::PreshowerClusterShapeCollection>();
 
 
-  CaloSubdetectorTopology* topology_p=nullptr;
+  std::unique_ptr<CaloSubdetectorTopology> topology_p;
   if (geometry)
-      topology_p = new EcalPreshowerTopology(geoHandle);
+    topology_p = std::make_unique<EcalPreshowerTopology>();
 
   
   // fetch the Preshower product (RecHits)
@@ -156,8 +156,8 @@ void PreshowerClusterShapeProducer::produce(Event& evt, const EventSetup& es) {
 	      ESDetId stripX = (tmp_stripX == DetId(0)) ? ESDetId(0) : ESDetId(tmp_stripX);
 	      ESDetId stripY = (tmp_stripY == DetId(0)) ? ESDetId(0) : ESDetId(tmp_stripY);
 	      
-	      vector<float> vout_stripE1 = presh_pi0_algo->findPreshVector(stripX, &rechits_map, topology_p);
-	      vector<float> vout_stripE2 = presh_pi0_algo->findPreshVector(stripY, &rechits_map, topology_p);
+	      vector<float> vout_stripE1 = presh_pi0_algo->findPreshVector(stripX, &rechits_map, topology_p.get());
+	      vector<float> vout_stripE2 = presh_pi0_algo->findPreshVector(stripY, &rechits_map, topology_p.get());
 	      
 	      LogTrace("EcalClusters") << "PreshowerClusterShapeProducer : ES Energy vector associated to the given SC = " ;
 	      for(int k1=0;k1<11;k1++) {
@@ -187,9 +187,6 @@ void PreshowerClusterShapeProducer::produce(Event& evt, const EventSetup& es) {
   evt.put(std::move(ps_cl_for_pi0_disc_x), PreshowerClusterShapeCollectionX_);
   evt.put(std::move(ps_cl_for_pi0_disc_y), PreshowerClusterShapeCollectionY_);  
   LogTrace("EcalClusters") << "PreshowerClusterShapeCollection added to the event" ;
-  
-  if (topology_p)
-    delete topology_p;
 
   nEvt_++;
 

--- a/RecoEcal/EgammaClusterProducers/src/PreshowerPhiClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PreshowerPhiClusterProducer.cc
@@ -95,10 +95,6 @@ void PreshowerPhiClusterProducer::produce(edm::Event& evt, const edm::EventSetup
   // create new collection of corrected super clusters
   auto superclusters_p = std::make_unique<reco::SuperClusterCollection>();
   
-  CaloSubdetectorTopology * topology_p=nullptr;
-  if (geometry_p)
-    topology_p  = new EcalPreshowerTopology(geoHandle);
-  
   // fetch the product (pSuperClusters)
   evt.getByToken(endcapSClusterToken_, pSuperClusters);   
   const reco::SuperClusterCollection* SClusts = pSuperClusters.product();
@@ -197,13 +193,13 @@ void PreshowerPhiClusterProducer::produce(edm::Event& evt, const edm::EventSetup
 	  //cout<<"starting cluster : "<<maxDeltaPhi<<" "<<minDeltaPhi<<" "<<esPhiClusterDeltaEta_<<endl;
 	  //cout<<"do plane 1 === "<<strip1.zside()<<" "<<strip1.plane()<<" "<<strip1.six()<<" "<<strip1.siy()<<" "<<strip1.strip()<<endl;
 	  // Get a vector of ES clusters (found by the PreshSeeded algorithm) associated with a given EE basic cluster.           
-	  reco::PreshowerCluster cl1 = presh_algo->makeOneCluster(strip1,&used_strips,&rechits_map,geometry_p,topology_p,esPhiClusterDeltaEta_,minDeltaPhi,maxDeltaPhi);   
+	  reco::PreshowerCluster cl1 = presh_algo->makeOneCluster(strip1,&used_strips,&rechits_map,geometry_p,esPhiClusterDeltaEta_,minDeltaPhi,maxDeltaPhi);
 	  cl1.setBCRef(*bc_iter);
 	  clusters1.push_back(cl1);
 	  e1 += cl1.energy();       
 	  
 	  //cout<<"do plane 2 === "<<strip2.zside()<<" "<<strip2.plane()<<" "<<strip2.six()<<" "<<strip2.siy()<<" "<<strip2.strip()<<endl;
-	  reco::PreshowerCluster cl2 = presh_algo->makeOneCluster(strip2,&used_strips,&rechits_map,geometry_p,topology_p,esPhiClusterDeltaEta_,minDeltaPhi,maxDeltaPhi); 
+	  reco::PreshowerCluster cl2 = presh_algo->makeOneCluster(strip2,&used_strips,&rechits_map,geometry_p,esPhiClusterDeltaEta_,minDeltaPhi,maxDeltaPhi);
 	  cl2.setBCRef(*bc_iter);
 	  clusters2.push_back(cl2);
 	  e2 += cl2.energy();
@@ -272,8 +268,6 @@ void PreshowerPhiClusterProducer::produce(edm::Event& evt, const edm::EventSetup
   superclusters_p->assign(new_SC.begin(), new_SC.end());
   evt.put(std::move(superclusters_p), assocSClusterCollection_);
   LogTrace("EcalClusters") << "Corrected SClusters added to the event" ;
-  
-  if (topology_p) delete topology_p;
 }
 
 void PreshowerPhiClusterProducer::set(const edm::EventSetup& es) {

--- a/RecoEcal/EgammaClusterProducers/src/ReducedESRecHitCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/ReducedESRecHitCollectionProducer.cc
@@ -18,8 +18,7 @@ using namespace std;
 using namespace reco;
 
 ReducedESRecHitCollectionProducer::ReducedESRecHitCollectionProducer(const edm::ParameterSet& ps):
-  geometry_p(nullptr),
-  topology_p(nullptr)
+  geometry_p(nullptr)
 {
 
  scEtThresh_          = ps.getParameter<double>("scEtThreshold");
@@ -48,9 +47,7 @@ ReducedESRecHitCollectionProducer::ReducedESRecHitCollectionProducer(const edm::
  
 }
 
-ReducedESRecHitCollectionProducer::~ReducedESRecHitCollectionProducer() {
-  if (topology_p) delete topology_p;
-}
+ReducedESRecHitCollectionProducer::~ReducedESRecHitCollectionProducer() = default;
 
 void ReducedESRecHitCollectionProducer::beginRun (edm::Run const&, const edm::EventSetup&iSetup){
   ESHandle<CaloGeometry> geoHandle;
@@ -61,7 +58,7 @@ void ReducedESRecHitCollectionProducer::beginRun (edm::Run const&, const edm::Ev
       "could not cast the subdet geometry to preshower geometry";
   }
   
-  if (geometry_p) topology_p = new EcalPreshowerTopology(geoHandle);
+  if (geometry_p) topology_p = std::make_unique<EcalPreshowerTopology>();
   
 }
 
@@ -178,10 +175,10 @@ void ReducedESRecHitCollectionProducer::collectIds(const ESDetId esDetId1, const
   strip1 = esDetId1;
   strip2 = esDetId2;
 
-  EcalPreshowerNavigator theESNav1(strip1, topology_p);
+  EcalPreshowerNavigator theESNav1(strip1, topology_p.get());
   theESNav1.setHome(strip1);
   
-  EcalPreshowerNavigator theESNav2(strip2, topology_p);
+  EcalPreshowerNavigator theESNav2(strip2, topology_p.get());
   theESNav2.setHome(strip2);
 
   if (row == 1) {

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -41,9 +41,8 @@ EcalClusterLazyToolsBase::EcalClusterLazyToolsBase( const edm::Event &ev, const 
 {
   const CaloSubdetectorGeometry *geometryES = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
   if (geometryES) {
-    ecalPS_topology_.reset(new EcalPreshowerTopology(geometry_));
+    ecalPS_topology_ = std::make_shared<EcalPreshowerTopology>();
   } else {
-    ecalPS_topology_.reset();
     edm::LogInfo("subdetector geometry not available") << "EcalPreshower geometry is missing" << std::endl;
   }
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHybridClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTHybridClusterProducer.cc
@@ -174,13 +174,13 @@ void EgammaHLTHybridClusterProducer::produce(edm::Event& evt, const edm::EventSe
  
   if(hitcollection_.instance() == "EcalRecHitsEB") {
     geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-    topology.reset(new EcalBarrelTopology(geoHandle));
+    topology = std::make_unique<EcalBarrelTopology>(*geoHandle);
   } else if(hitcollection_.instance() == "EcalRecHitsEE") {
     geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-    topology.reset(new EcalEndcapTopology(geoHandle));
+    topology = std::make_unique<EcalEndcapTopology>(*geoHandle);
   } else if(hitcollection_.instance() == "EcalRecHitsPS") {
     geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-    topology.reset(new EcalPreshowerTopology (geoHandle));
+    topology = std::make_unique<EcalPreshowerTopology>();
   } else throw(std::runtime_error("\n\nHybrid Cluster Producer encountered invalied ecalhitcollection type.\n\n"));
     
   //Get the L1 EM Particle Collection

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTIslandClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTIslandClusterProducer.cc
@@ -274,17 +274,17 @@ const {
   es.get<CaloGeometryRecord>().get(geoHandle);
 
   const CaloSubdetectorGeometry *geometry_p;
-  CaloSubdetectorTopology *topology_p;
+  std::unique_ptr<CaloSubdetectorTopology> topology_p;
 
   if (ecalPart == IslandClusterAlgo::barrel) 
     {
       geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-      topology_p = new EcalBarrelTopology(geoHandle);
+      topology_p = std::make_unique<EcalBarrelTopology>(*geoHandle);
     }
   else
     {
       geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-      topology_p = new EcalEndcapTopology(geoHandle); 
+      topology_p = std::make_unique<EcalEndcapTopology>(*geoHandle);
    }
 
   const CaloSubdetectorGeometry *geometryES_p;
@@ -292,7 +292,7 @@ const {
 
   // Run the clusterization algorithm:
   reco::BasicClusterCollection clusters;
-  clusters = island_p->makeClusters(hitCollection_p, geometry_p, topology_p, geometryES_p, ecalPart, true, regions);
+  clusters = island_p->makeClusters(hitCollection_p, geometry_p, topology_p.get(), geometryES_p, ecalPart, true, regions);
 
   // create an unique_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
   auto clusters_p = std::make_unique<reco::BasicClusterCollection>();
@@ -302,6 +302,4 @@ const {
     bccHandle = evt.put(std::move(clusters_p), barrelClusterCollection_);
   else
     bccHandle = evt.put(std::move(clusters_p), endcapClusterCollection_);
-
-  delete topology_p;
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTMulti5x5ClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTMulti5x5ClusterProducer.cc
@@ -277,17 +277,17 @@ void EgammaHLTMulti5x5ClusterProducer::clusterizeECALPart(edm::Event &evt, const
   es.get<CaloGeometryRecord>().get(geoHandle);
 
   const CaloSubdetectorGeometry *geometry_p;
-  CaloSubdetectorTopology *topology_p;
+  std::unique_ptr<CaloSubdetectorTopology>topology_p;
 
   if (detector == reco::CaloID::DET_ECAL_BARREL) 
     {
       geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-      topology_p = new EcalBarrelTopology(geoHandle);
+      topology_p = std::make_unique<EcalBarrelTopology>(*geoHandle);
     }
   else
     {
       geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-      topology_p = new EcalEndcapTopology(geoHandle); 
+      topology_p = std::make_unique<EcalEndcapTopology>(*geoHandle);
    }
 
 
@@ -296,7 +296,7 @@ void EgammaHLTMulti5x5ClusterProducer::clusterizeECALPart(edm::Event &evt, const
 
   // Run the clusterization algorithm:
   reco::BasicClusterCollection clusters;
-  clusters = Multi5x5_p->makeClusters(hitCollection_p, geometry_p, topology_p, geometryES_p, detector, true, regions);
+  clusters = Multi5x5_p->makeClusters(hitCollection_p, geometry_p, topology_p.get(), geometryES_p, detector, true, regions);
 
   // create an unique_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
   auto clusters_p = std::make_unique<reco::BasicClusterCollection>();
@@ -306,6 +306,4 @@ void EgammaHLTMulti5x5ClusterProducer::clusterizeECALPart(edm::Event &evt, const
     bccHandle = evt.put(std::move(clusters_p), barrelClusterCollection_);
   else
     bccHandle = evt.put(std::move(clusters_p), endcapClusterCollection_);
-
-  delete topology_p;
 }

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTNxNClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTNxNClusterProducer.cc
@@ -184,10 +184,10 @@ void EgammaHLTNxNClusterProducer::makeNxNClusters(edm::Event &evt, const edm::Ev
   std::unique_ptr<CaloSubdetectorTopology> topology_p;
   if (detector == reco::CaloID::DET_ECAL_BARREL) {
     geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-    topology_p.reset(new EcalBarrelTopology(geoHandle));
+    topology_p = std::make_unique<EcalBarrelTopology>(*geoHandle);
   }else {
     geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-    topology_p.reset(new EcalEndcapTopology(geoHandle)); 
+    topology_p = std::make_unique<EcalEndcapTopology>(*geoHandle);
   }
   
   const CaloSubdetectorGeometry *geometryES_p;

--- a/RecoEgamma/EgammaHLTProducers/src/HLTRechitInRegionsProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTRechitInRegionsProducer.cc
@@ -139,13 +139,13 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
       if (!uncalibRecHits->empty()) {
 	if ((*uncalibRecHits)[0].id().subdetId() == EcalBarrel) {
 	  geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-	  topology = std::make_unique<EcalBarrelTopology>(geoHandle);
+	  topology = std::make_unique<EcalBarrelTopology>(*geoHandle);
 	} else if ((*uncalibRecHits)[0].id().subdetId() == EcalEndcap) {
 	  geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-	  topology = std::make_unique<EcalEndcapTopology>(geoHandle);
+	  topology = std::make_unique<EcalEndcapTopology>(*geoHandle);
 	} else if ((*uncalibRecHits)[0].id().subdetId() == EcalPreshower) {
 	  geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-	  topology = std::make_unique<EcalPreshowerTopology>(geoHandle);
+	  topology = std::make_unique<EcalPreshowerTopology>();
 	} else throw(std::runtime_error("\n\nProducer encountered invalied ecalhitcollection type.\n\n"));
 	
 	if(!regions.empty()) {
@@ -184,13 +184,13 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
       if (!recHits->empty()) {
 	if ((*recHits)[0].id().subdetId() == EcalBarrel) {
 	  geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-	  topology = std::make_unique<EcalBarrelTopology>(geoHandle);
+	  topology = std::make_unique<EcalBarrelTopology>(*geoHandle);
 	} else if ((*recHits)[0].id().subdetId() == EcalEndcap) {
 	  geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-	  topology = std::make_unique<EcalEndcapTopology>(geoHandle);
+	  topology = std::make_unique<EcalEndcapTopology>(*geoHandle);
 	} else if ((*recHits)[0].id().subdetId() == EcalPreshower) {
 	  geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-	  topology = std::make_unique<EcalPreshowerTopology>(geoHandle);
+	  topology = std::make_unique<EcalPreshowerTopology>();
 	} else throw(std::runtime_error("\n\nProducer encountered invalied ecalhitcollection type.\n\n"));
 	
 	if(!regions.empty()) {

--- a/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
@@ -59,8 +59,8 @@ class PFECALHashNavigator : public PFRecHitNavigatorBase {
       endcapGeometry_  = dynamic_cast < const EcalEndcapGeometry* > (eeTmp);
 
       // get the ecalBarrel topology
-      barrelTopology_ = new  EcalBarrelTopology(geoHandle);
-      endcapTopology_ = new  EcalEndcapTopology(geoHandle);
+      barrelTopology_ = std::make_unique<EcalBarrelTopology>(*geoHandle);
+      endcapTopology_ = std::make_unique<EcalEndcapTopology>(*geoHandle);
 
       ecalNeighbArray(*barrelGeometry_,*barrelTopology_,*endcapGeometry_,*endcapTopology_);
 
@@ -418,8 +418,8 @@ DetId move(DetId cell,
 }
 
 
-  EcalEndcapTopology *endcapTopology_;
-  EcalBarrelTopology *barrelTopology_;
+  std::unique_ptr<EcalEndcapTopology> endcapTopology_;
+  std::unique_ptr<EcalBarrelTopology> barrelTopology_;
 
   const EcalEndcapGeometry *endcapGeometry_;
   const EcalBarrelGeometry *barrelGeometry_;

--- a/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
@@ -20,7 +20,7 @@ class PFRecHitEcalBarrelNavigatorWithTime : public PFRecHitCaloNavigatorWithTime
   void beginEvent(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle;
     iSetup.get<CaloGeometryRecord>().get(geoHandle);
-    topology_.reset( new EcalBarrelTopology(geoHandle) );
+    topology_ = std::make_unique<EcalBarrelTopology>(*geoHandle);
   }
 };
 
@@ -35,7 +35,7 @@ class PFRecHitEcalEndcapNavigatorWithTime : public PFRecHitCaloNavigatorWithTime
   void beginEvent(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle;
     iSetup.get<CaloGeometryRecord>().get(geoHandle);
-    topology_.reset( new EcalEndcapTopology(geoHandle) );
+    topology_ = std::make_unique<EcalEndcapTopology>(*geoHandle);
   }
 };
 
@@ -48,7 +48,7 @@ class PFRecHitEcalBarrelNavigator final : public PFRecHitCaloNavigator<EBDetId,E
   void beginEvent(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle;
     iSetup.get<CaloGeometryRecord>().get(geoHandle);
-    topology_.reset( new EcalBarrelTopology(geoHandle) );
+    topology_ = std::make_unique<EcalBarrelTopology>(*geoHandle);
   }
 };
 
@@ -61,7 +61,7 @@ class PFRecHitEcalEndcapNavigator final : public PFRecHitCaloNavigator<EEDetId,E
   void beginEvent(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle;
     iSetup.get<CaloGeometryRecord>().get(geoHandle);
-    topology_.reset( new EcalEndcapTopology(geoHandle) );
+    topology_ = std::make_unique<EcalEndcapTopology>(*geoHandle);
   }
 };
 
@@ -73,9 +73,7 @@ class PFRecHitPreshowerNavigator final : public PFRecHitCaloNavigator<ESDetId,Ec
 
 
   void beginEvent(const edm::EventSetup& iSetup) override {
-    edm::ESHandle<CaloGeometry> geoHandle;
-    iSetup.get<CaloGeometryRecord>().get(geoHandle);
-    topology_.reset( new EcalPreshowerTopology(geoHandle) );
+    topology_ = std::make_unique<EcalPreshowerTopology>();
   }
 };
 


### PR DESCRIPTION
#### PR description:

This PR came out as a preparatory cleanup for migrating `Geometry/CaloEventSetup/CaloTopologyBuilder` to EventSetup-consumes and `ESGetToken`:
- `RecoEcal/EgammaClusterAlgos/PreshowerPhiClusterAlgo` and `RecoEcal/EgammaClusterProducers/PreshowerPhiClusterProducer` do not use `CaloSubdetectorTopology` so its use is removed from those classes
- Construct `EcalBarrelTopology` and `EcalEndcapTopology` directly from `CaloGeometry` instead of `edm::ESHandle<CaloGeometry>`, and remove the `CaloGeometry` parameter from `EcalPreshowerTopology` constructor as it was not used
- `CaloTopology` takes and stores the subdetector topologies as `std::unique_ptr`s.

I was surprised how widely spread it is to create the ECAL topology objects on the fly (for each event) instead of asking them from EventSetup.

#### PR validation:

Tested in CMSSW_10_6_X_2019-04-15-1100 that the code compiles and limited matrix runs. No changes expected.