### PR TITLE
Make ESInputTag constructors explicit

### DIFF
--- a/FWCore/Utilities/interface/ESInputTag.h
+++ b/FWCore/Utilities/interface/ESInputTag.h
@@ -86,9 +86,9 @@
 namespace edm {
    class ESInputTag {
    public:
-      ESInputTag();
-      ESInputTag(const std::string& iModuleLabel, const std::string& iDataLabel);
-      ESInputTag(const std::string& iEncodedValue);
+      explicit ESInputTag();
+      explicit ESInputTag(const std::string& iModuleLabel, const std::string& iDataLabel);
+      explicit ESInputTag(const std::string& iEncodedValue);
 
       // ---------- const member functions ---------------------
 


### PR DESCRIPTION
#### PR description:

This PR makes the `ESInputTag` constructors `explicit`. The motivation comes from EventSetup-consumes. With implicit constructors it would be very easy to pass the old-style string for data label to ES-consumes() call leading to the string passed to the constructor taking the encoded value, and the string being interpreted as module label (with empty data label).

#### PR validation:

Framework code compiles and unit tests run successfully.
