### PR TITLE
Add bx skim and corresponding RelVal

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -399,6 +399,10 @@ workflows[136.894] = ['',['RunNoBPTX2018D','HLTDR2_2018','RECODR2_2018reHLTAlCaT
 workflows[136.895] = ['',['RunDisplacedJet2018D','HLTDR2_2018','RECODR2_2018reHLT_skimDisplacedJet_Prompt','HARVEST2018_Prompt']]
 workflows[136.896] = ['',['RunCharmonium2018D','HLTDR2_2018','RECODR2_2018reHLT_skimCharmonium_Prompt','HARVEST2018_Prompt']]
 
+### run 2018E ###
+workflows[136.899] = ['',['RunHLTPhy2018E','HLTDR2_2018','RECODR2_2018reHLT_skimHLTPhy_Prompt','HARVEST2018_Prompt']]
+workflows[136.900] = ['',['RunZeroBias2018E','HLTDR2_2018','RECODR2_2018reHLT_skimZeroBias_Prompt','HARVEST2018_Prompt']]
+
 # multi-run harvesting
 workflows[137.8] = ['',['RunEGamma2018C','HLTDR2_2018','RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM',
                         'RunEGamma2018D','HLTDR2_2018','RECODR2_2018reHLT_skimEGamma_Prompt_L1TEgDQM','HARVEST2018_L1TEgDQM_MULTIRUN']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -457,6 +457,11 @@ steps['RunNoBPTX2018D']={'INPUT':InputInfo(dataSet='/NoBPTX/Run2018D-v1/RAW',lab
 steps['RunDisplacedJet2018D']={'INPUT':InputInfo(dataSet='/DisplacedJet/Run2018D-v1/RAW',label='displacedJet2018D',events=100000,location='STD', ls=Run2018D)}
 steps['RunCharmonium2018D']={'INPUT':InputInfo(dataSet='/Charmonium/Run2018D-v1/RAW',label='charm2018D',events=100000,location='STD', ls=Run2018D)}
 
+#### run2 2018E ####
+Run2018E={325594: [[1, 100]]}
+steps['RunHLTPhy2018E']={'INPUT':InputInfo(dataSet='/HLTPhysics/Run2018E-v1/RAW',label='hltPhy2018E',events=100000,location='STD', ls=Run2018E)}
+steps['RunZeroBias2018E']={'INPUT':InputInfo(dataSet='/ZeroBias/Run2018E-v1/RAW',label='zb2018E',events=100000,location='STD', ls=Run2018E)}
+
 # Highstat HLTPhysics
 Run2015DHS=selectedLS([258712,258713,258714,258741,258742,258745,258749,258750,259626,259637,259683,259685,259686,259721,259809,259810,259818,259820,259821,259822,259862,259890,259891])
 steps['RunHLTPhy2015DHS']={'INPUT':InputInfo(dataSet='/HLTPhysics/Run2015D-v1/RAW',label='hltPhy2015DHS',events=100000,location='STD', ls=Run2015DHS)}
@@ -2131,6 +2136,8 @@ steps['RECODR2_2018reHLT_skimMET']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:HighM
 steps['RECODR2_2018reHLT_skimMuOnia']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:BPHSkim,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@standardDQM+@ExtraHLT+@miniAODDQM'},steps['RECODR2_2018reHLT']])
 steps['RECODR2_2018reHLT_skimCharmonium']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:MuonPOGJPsiSkim+BPHSkim,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@standardDQM+@ExtraHLT+@miniAODDQM'},steps['RECODR2_2018reHLT']])
 steps['RECODR2_2018reHLT_skimParkingBPH']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:SkimBPark,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@standardDQM+@ExtraHLT+@miniAODDQM','--era':'Run2_2018,bParking'},steps['RECODR2_2018reHLT']])
+steps['RECODR2_2018reHLT_skimHLTPhy']=merge([{'-s':'SKIM:BunchCrossingSkim'},steps['RECODR2_2018reHLT']])
+steps['RECODR2_2018reHLT_skimZeroBias']=merge([{'-s':'SKIM:BunchCrossingSkim'},steps['RECODR2_2018reHLT']])
 
 
 
@@ -2199,6 +2206,11 @@ steps['RECODR2_2018reHLT_Prompt_hBStar']=merge([{'--era':'Run2_2018_highBetaStar
 steps['RECODR2_2018reHLT_Offline_hBStar']=merge([{'--era':'Run2_2018_highBetaStar'},steps['RECODR2_2018reHLT_Offline']])
 steps['RECODR2_2018reHLT_skimJetHT_Prompt_HEfail']=merge([{'--conditions':'auto:run2_data_promptlike_HEfail'},steps['RECODR2_2018reHLT_skimJetHT']])
 steps['RECODR2_2018reHLT_skimJetHT_Prompt_BadHcalMitig']=merge([{'--conditions':'auto:run2_data_promptlike_HEfail','--era':'Run2_2018,pf_badHcalMitigation'},steps['RECODR2_2018reHLT_skimJetHT']])
+steps['RECODR2_2018reHLT_skimHLTPhy_Prompt']=merge([{'--conditions':'auto:run2_data_promptlike'},steps['RECODR2_2018reHLT_skimHLTPhy']])
+steps['RECODR2_2018reHLT_skimHLTPhy_Offline']=merge([{'--conditions':'auto:run2_data'},steps['RECODR2_2018reHLT_skimHLTPhy']])
+steps['RECODR2_2018reHLT_skimZeroBias_Prompt']=merge([{'--conditions':'auto:run2_data_promptlike'},steps['RECODR2_2018reHLT_skimZeroBias']])
+steps['RECODR2_2018reHLT_skimZeroBias_Offline']=merge([{'--conditions':'auto:run2_data'},steps['RECODR2_2018reHLT_skimZeroBias']])
+
 
 steps['RECO']=merge([step3Defaults])
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2136,8 +2136,8 @@ steps['RECODR2_2018reHLT_skimMET']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:HighM
 steps['RECODR2_2018reHLT_skimMuOnia']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:BPHSkim,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@standardDQM+@ExtraHLT+@miniAODDQM'},steps['RECODR2_2018reHLT']])
 steps['RECODR2_2018reHLT_skimCharmonium']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:MuonPOGJPsiSkim+BPHSkim,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@standardDQM+@ExtraHLT+@miniAODDQM'},steps['RECODR2_2018reHLT']])
 steps['RECODR2_2018reHLT_skimParkingBPH']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:SkimBPark,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@standardDQM+@ExtraHLT+@miniAODDQM','--era':'Run2_2018,bParking'},steps['RECODR2_2018reHLT']])
-steps['RECODR2_2018reHLT_skimHLTPhy']=merge([{'-s':'SKIM:BunchCrossingSkim'},steps['RECODR2_2018reHLT']])
-steps['RECODR2_2018reHLT_skimZeroBias']=merge([{'-s':'SKIM:BunchCrossingSkim'},steps['RECODR2_2018reHLT']])
+steps['RECODR2_2018reHLT_skimHLTPhy']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:BunchCrossingSkim,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@standardDQM+@ExtraHLT+@miniAODDQM'},steps['RECODR2_2018reHLT']])
+steps['RECODR2_2018reHLT_skimZeroBias']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:BunchCrossingSkim,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@standardDQM+@ExtraHLT+@miniAODDQM'},steps['RECODR2_2018reHLT']])
 
 
 

--- a/DPGAnalysis/Skims/python/BunchCrossingSkim_cff.py
+++ b/DPGAnalysis/Skims/python/BunchCrossingSkim_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+from FWCore.Modules.bunchCrossingFilter_cfi import bunchCrossingFilter as _bunchCrossingFilter
+selectRange1 = _bunchCrossingFilter.clone(                                                                                                                                                           
+    bunches = cms.vuint32(range(757,759)) 
+)                                                                                                                                                                                                          
+
+selectSingle = _bunchCrossingFilter.clone(
+    bunches = cms.vuint32(755)
+)
+
+selectRange2 = _bunchCrossingFilter.clone(
+    bunches = cms.vuint32(range(1646,1651)) 
+)
+
+BXSeq1 = cms.Sequence( selectRange1 )
+BXSeq2 = cms.Sequence( selectSingle )
+BXSeq3 = cms.Sequence( selectRange2 )
+

--- a/DPGAnalysis/Skims/python/Skims_DPG_cff.py
+++ b/DPGAnalysis/Skims/python/Skims_DPG_cff.py
@@ -58,6 +58,20 @@ SKIMStreamLogErrorMonitor = cms.FilteredStream(
     dataTier = cms.untracked.string('USER')
     )
 
+#############
+from DPGAnalysis.Skims.BunchCrossingSkim_cff import *
+BXfilter1 = cms.Path(BXSeq1)
+BXfilter2 = cms.Path(BXSeq2)
+BXfilter3 = cms.Path(BXSeq3)
+SKIMStreamBunchCrossingSkim = cms.FilteredStream(
+    responsible = 'TSG',
+    name = 'BunchCrossingSkim',
+    paths = (BXfilter1,BXfilter2,BXfilter3),
+    content = cms.untracked.vstring( 'keep *' ),
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('RAW')
+)
+
 ##############
 #from  DPGAnalysis.Skims.BeamBkgSkim_cff import *
 #pathpfgskim3noncross = cms.Path(pfgskim3noncrossseq)


### PR DESCRIPTION
#### PR description:

This PR includes the proposal of BunchCrossingSkim PR #26419 and the corresponding updates for RelVal. This is for the master branch.

#### PR validation:

RelVal workflows are added to 2018E HLTPhy and ZeroBias. Given the special situation of the BunchCrossingSkim the RelVal has only SKIM part, without RECO and other steps. 
The corresponding workflows are
136.899
136.900
