### PR TITLE
Fix generation of DTuROSControlData in case of missing FEDs

### DIFF
--- a/DataFormats/DTDigi/interface/DTuROSControlData.h
+++ b/DataFormats/DTDigi/interface/DTuROSControlData.h
@@ -24,10 +24,9 @@ class DTuROSROSData {
 public:
 
   /// Constructor
-  DTuROSROSData() {
-    slot_ = -1;
-    for (int i=0; i<SEISXOK; i++) okxword_[i] = 0;
-  }
+  DTuROSROSData() : slot_(-1), header1_(0), header2_(0), 
+                    trailer_(0), okword1_(0), okword2_(0)
+    { for (int i=0; i<SEISXOK; i++) okxword_[i] = 0; }
 
   /// Destructor
   ~DTuROSROSData(){};
@@ -92,7 +91,7 @@ private:
 
   long header1_, header2_, trailer_;
 
-  long okword1_=0, okword2_=0, okxword_[SEISXOK];
+  long okword1_, okword2_, okxword_[SEISXOK];
 
   std::vector<long> exword_;
 
@@ -106,7 +105,9 @@ class DTuROSFEDData {
 public:
 
   /// Constructor
-  DTuROSFEDData() {for (int i=0; i<DOCESLOTS; i++) rsize_[i] = 0;} 
+  DTuROSFEDData() : header1_(0), header2_(0), trailer_(0),
+                    fed_(-1), nslots_(0), evtLgth_(0) 
+  { for (int i=0; i<DOCESLOTS; i++) rsize_[i] = 0; } 
 
   /// Destructor
   ~DTuROSFEDData(){};

--- a/EventFilter/DTRawToDigi/plugins/DTuROSRawToDigi.cc
+++ b/EventFilter/DTRawToDigi/plugins/DTuROSRawToDigi.cc
@@ -77,7 +77,7 @@ bool DTuROSRawToDigi::fillRawData(edm::Event& e, const edm::EventSetup& c,
   for (int w_i = 0; w_i < nfeds_; ++w_i) {
     DTuROSFEDData fwords;
     process(feds_[w_i], data, mapping, digis, fwords);
-    words.push_back(fwords);
+    if (fwords.getfed() >= 0) words.push_back(fwords);
   }
   
   return true;


### PR DESCRIPTION
#### PR description:

This PR adds the initialisation of the variables within the `DTuROSControlData` format and and provides a fix for the filling of `DTuROSControlData` monitoring data within `DTuROSRawToDigi.cc`.

It was noticed during the first MWGR of 2019 that, in case a FED is missing from the datataking, the `DTuROSControlData` payload contains twice the information from the FED "before" the missing one (see [DQM](https://cmsweb.cern.ch/dqm/online/start?runnr=328759;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=DT;size=M;root=DT/00-DataIntegrity;focus=DT/00-DataIntegrity/FEDEntries;zoom=yes;)). The PR addresses this problem.

#### PR validation:

The same cosmic run was processed with the DT prompt offline analysis programs twice [with](http://cmsdoc.cern.ch/cms/MUON/dt/sx5/Results/GlobalRuns/Commissioning2019/unpackerFix/Run328759/SummaryGifFiles/) and [without](http://cmsdoc.cern.ch/cms/MUON/dt/sx5/Results/GlobalRuns/Commissioning2019/Cosmics/Run328759/SummaryGifFiles/) this PR. It was tested that `DTuROSControlData` is filled properly after the fix and that the fillng of `DTDigi` information is unaffected by the change.
