### PR TITLE
fixing getPayloadData.py script to be able to compile

### DIFF
--- a/CondCore/Utilities/scripts/getPayloadData.py
+++ b/CondCore/Utilities/scripts/getPayloadData.py
@@ -219,8 +219,8 @@ def discover():
 
 def output(description, param):
     if args.verbose:
-        print ''
-        print description, param
+        print('')
+        print(description, param)
 
 if __name__ == '__main__':
 
@@ -299,9 +299,9 @@ if __name__ == '__main__':
             try:
                 filename = json.loads( result )['file']
                 #print 'File name',filename
-            except ValueError, e:
+            except ValueError as e:
                 os.write( 2, 'Value error when getting image name: %s\n' % str( e ))
-            except KeyError, e:
+            except KeyError as e:
                 os.write( 2, 'Key error when getting image name: %s\n' % str( e ))
 
             if not filename or not os.path.isfile( filename ):
@@ -310,7 +310,7 @@ if __name__ == '__main__':
             try:
                 with open( filename, 'r' ) as f:
                     shutil.copyfileobj( f, sys.stdout )
-            except IOError, e:
+            except IOError as e:
                 os.write( 2, 'IO error when streaming image: %s' % str( e ))
             finally:
                 os.remove( filename )


### PR DESCRIPTION
#### PR description:
As I pointed out in https://github.com/cms-sw/cmssw/pull/26294#discussion_r273390845 the changes proposed in https://github.com/cms-sw/cmssw/pull/26294/commits/3923fdc6cffce8fe40edea4689a5acfe7c1668b6 are breaking the `getPayloadData.py` script, as it is rolling back the changes introduced in commits e303d9f2c3d4f25397db5feb7ad59d2f20c842f2 and a896189efb23151f73c193aa2b9a8c5facab06f7. 

#### PR validation:

This command:
```bash
getPayloadData.py --plugin pluginTrackerAlignment_PayloadInspector --plot plot_X_BPixBarycenterHistory --tag Alignments --time_type Run --iovs '{"start_iov": "297049", "end_iov": "307082"}' --db sqlite_file:/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/MP/MPproduction/um0001/jobData/jobm/um0001.db --test
```

executed in `CMSSW_10_6_X_2019-04-15-2300` results in:

```
  File "/cvmfs/cms-ib.cern.ch/nweek-02572/slc7_amd64_gcc700/cms/cmssw/CMSSW_10_6_X_2019-04-15-2300/bin/slc7_amd64_gcc700/getPayloadData.py", line 222
    print ''
           ^
SyntaxError: invalid syntax
```
while it works with this fix.





