### PR TITLE
Era based effective area to be used in Muon selectors

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2016_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_cff.py
@@ -5,6 +5,9 @@ from Configuration.Eras.Modifier_run2_25ns_specific_cff import run2_25ns_specifi
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTconditions_2016
+from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
 
-Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific, stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016)
+
+
+Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific, stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_muon_2016)
 

--- a/Configuration/Eras/python/Era_Run2_2016_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_cff.py
@@ -7,7 +7,6 @@ from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTconditions_2016
 from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
 
-
-
-Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific, stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_muon_2016)
+Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific,
+ stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_muon_2016)
 

--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -14,6 +14,7 @@ from Configuration.Eras.Modifier_run2_HLTconditions_2017_cff import run2_HLTcond
 from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
 from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
 
-
-Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016]), phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, trackingPhase1, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017)
+Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016]), 
+phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, 
+trackingPhase1, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017)
 

--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -11,6 +11,9 @@ from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
 from Configuration.Eras.Modifier_run2_HLTconditions_2017_cff import run2_HLTconditions_2017
+from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
+from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
 
-Run2_2017 = cms.ModifierChain(Run2_2016, phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, trackingPhase1, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017)
+
+Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016]), phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, trackingPhase1, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017)
 

--- a/Configuration/Eras/python/Era_Run2_2018_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
-
 from Configuration.Eras.Modifier_run2_CSC_2018_cff import run2_CSC_2018
 from Configuration.Eras.Modifier_run2_HB_2018_cff import run2_HB_2018
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
@@ -13,5 +12,6 @@ from Configuration.Eras.Modifier_run2_HLTconditions_2018_cff import run2_HLTcond
 from Configuration.Eras.Modifier_run2_muon_2018_cff import run2_muon_2018
 from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
 
-
-Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017]), run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018, run2_HLTconditions_2018, run2_muon_2018)
+Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017]), 
+run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018, 
+run2_HLTconditions_2018, run2_muon_2018)

--- a/Configuration/Eras/python/Era_Run2_2018_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_cff.py
@@ -10,5 +10,8 @@ from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
 from Configuration.Eras.Modifier_run2_DT_2018_cff import run2_DT_2018
 from Configuration.Eras.Modifier_run2_SiPixel_2018_cff import run2_SiPixel_2018
 from Configuration.Eras.Modifier_run2_HLTconditions_2018_cff import run2_HLTconditions_2018
+from Configuration.Eras.Modifier_run2_muon_2018_cff import run2_muon_2018
+from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
 
-Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017]), run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018, run2_HLTconditions_2018)
+
+Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017]), run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018, run2_HLTconditions_2018, run2_muon_2018)

--- a/Configuration/Eras/python/Modifier_run2_muon_2016_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_muon_2016_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_muon_2016 =cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run2_muon_2017_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_muon_2017_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_muon_2017 =cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run2_muon_2018_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_muon_2018_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_muon_2018 =cms.Modifier()

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -821,13 +821,13 @@ void PATMuonProducer::setMuonMiniIso(Muon& aMuon, const PackedCandidateCollectio
   aMuon.setMiniPFIsolation(miniiso);
 }
 
-double PATMuonProducer::getRelMiniIsoPUCorrected(const pat::Muon& muon, double rho, std::vector<double> &EA)
+double PATMuonProducer::getRelMiniIsoPUCorrected(const pat::Muon& muon, double rho, const std::vector<double> &area)
 {
   double mindr(miniIsoParams_[0]);
   double maxdr(miniIsoParams_[1]);
   double kt_scale(miniIsoParams_[2]);
   double drcut = pat::miniIsoDr(muon.p4(),mindr,maxdr,kt_scale);
-  return pat::muonRelMiniIsoPUCorrected(muon.miniPFIsolation(), muon.p4(), drcut, rho, EA);
+  return pat::muonRelMiniIsoPUCorrected(muon.miniPFIsolation(), muon.p4(), drcut, rho, area);
 }
 
 

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -156,6 +156,8 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavy
 
   computePuppiCombinedIso_ = iConfig.getParameter<bool>("computePuppiCombinedIso");
 
+  effectiveAreaVec_ = iConfig.getParameter<std::vector<double> >("effectiveAreaVec");
+
   miniIsoParams_ = iConfig.getParameter<std::vector<double> >("miniIsoParams");
   if(computeMiniIso_ && miniIsoParams_.size() != 9){
       throw cms::Exception("ParameterError") << "miniIsoParams must have exactly 9 elements.\n";
@@ -653,7 +655,7 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
     if (computeMiniIso_){
       // MiniIsolation working points
 
-      miniIsoValue = getRelMiniIsoPUCorrected(muon,*rho);
+      miniIsoValue = getRelMiniIsoPUCorrected(muon,*rho, effectiveAreaVec_);
 
       muon.setSelector(reco::Muon::MiniIsoLoose,     miniIsoValue<0.40);
       muon.setSelector(reco::Muon::MiniIsoMedium,    miniIsoValue<0.20);
@@ -819,13 +821,13 @@ void PATMuonProducer::setMuonMiniIso(Muon& aMuon, const PackedCandidateCollectio
   aMuon.setMiniPFIsolation(miniiso);
 }
 
-double PATMuonProducer::getRelMiniIsoPUCorrected(const pat::Muon& muon, float rho)
+double PATMuonProducer::getRelMiniIsoPUCorrected(const pat::Muon& muon, double rho, std::vector<double> &EA)
 {
-  float mindr(miniIsoParams_[0]);
-  float maxdr(miniIsoParams_[1]);
-  float kt_scale(miniIsoParams_[2]);
-  float drcut = pat::miniIsoDr(muon.p4(),mindr,maxdr,kt_scale);
-  return pat::muonRelMiniIsoPUCorrected(muon.miniPFIsolation(), muon.p4(), drcut, rho);
+  double mindr(miniIsoParams_[0]);
+  double maxdr(miniIsoParams_[1]);
+  double kt_scale(miniIsoParams_[2]);
+  double drcut = pat::miniIsoDr(muon.p4(),mindr,maxdr,kt_scale);
+  return pat::muonRelMiniIsoPUCorrected(muon.miniPFIsolation(), muon.p4(), drcut, rho, EA);
 }
 
 

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -99,7 +99,7 @@ namespace pat {
     template<typename T> void readIsolationLabels( const edm::ParameterSet & iConfig, const char* psetName, IsolationLabels& labels, std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens);
 
     void setMuonMiniIso(pat::Muon& aMuon, const pat::PackedCandidateCollection *pc);
-    double getRelMiniIsoPUCorrected(const pat::Muon& muon,  double rho, std::vector<double> &EA);
+    double getRelMiniIsoPUCorrected(const pat::Muon& muon,  double rho, const std::vector<double> &area);
 
     double puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection *pc);
     bool isNeutralHadron( long pdgid );

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -99,7 +99,7 @@ namespace pat {
     template<typename T> void readIsolationLabels( const edm::ParameterSet & iConfig, const char* psetName, IsolationLabels& labels, std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens);
 
     void setMuonMiniIso(pat::Muon& aMuon, const pat::PackedCandidateCollection *pc);
-    double getRelMiniIsoPUCorrected(const pat::Muon& muon, float rho);
+    double getRelMiniIsoPUCorrected(const pat::Muon& muon,  double rho, std::vector<double> &EA);
 
     double puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection *pc);
     bool isNeutralHadron( long pdgid );
@@ -139,6 +139,7 @@ namespace pat {
     edm::EDGetTokenT<pat::PackedCandidateCollection > pcToken_;
     bool computeMiniIso_;
     bool computePuppiCombinedIso_;
+    std::vector<double> effectiveAreaVec_;
     std::vector<double> miniIsoParams_;
     double relMiniIsoPUCorrected_;
 

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -99,6 +99,7 @@ patMuons = cms.EDProducer("PATMuonProducer",
     # PhysicsTools/PatUtils/src/PFIsolation.cc
     # only works in miniaod, so set to True in miniAOD_tools.py
     computeMiniIso = cms.bool(False),
+    effectiveAreaVec = cms.vdouble(0.0566, 0.0562, 0.0363, 0.0119, 0.0064),
     pfCandsForMiniIso = cms.InputTag("packedPFCandidates"),
     miniIsoParams = cms.vdouble(0.05, 0.2, 10.0, 0.5, 0.0001, 0.01, 0.01, 0.01, 0.0),
 

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -33,9 +33,9 @@ def miniAOD_customizeCommon(process):
     from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
     from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
     from Configuration.Eras.Modifier_run2_muon_2018_cff import run2_muon_2018
-    run2_muon_2018.toModify( process.patMuons, effectiveAreaVec = cms.vdouble(0.0566, 0.0562, 0.0363, 0.0119, 0.0064))
-    run2_muon_2017.toModify( process.patMuons, effectiveAreaVec = cms.vdouble(0.0566, 0.0562, 0.0363, 0.0119, 0.0064))
-    run2_muon_2016.toModify( process.patMuons, effectiveAreaVec = cms.vdouble(0.0735,0.0619,0.0465,0.0433,0.0577))
+    run2_muon_2016.toModify( process.patMuons, effectiveAreaVec = [0.0735,0.0619,0.0465,0.0433,0.0577])
+    run2_muon_2017.toModify( process.patMuons, effectiveAreaVec = [0.0566, 0.0562, 0.0363, 0.0119, 0.0064])
+    run2_muon_2018.toModify( process.patMuons, effectiveAreaVec = [0.0566, 0.0562, 0.0363, 0.0119, 0.0064])
 
     process.patMuons.computePuppiCombinedIso = True
     #

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -30,6 +30,12 @@ def miniAOD_customizeCommon(process):
     process.patMuons.computeSoftMuonMVA = True
 
     process.patMuons.addTriggerMatching = True
+    from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
+    from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
+    from Configuration.Eras.Modifier_run2_muon_2018_cff import run2_muon_2018
+    run2_muon_2018.toModify( process.patMuons, effectiveAreaVec = cms.vdouble(0.0566, 0.0562, 0.0363, 0.0119, 0.0064))
+    run2_muon_2017.toModify( process.patMuons, effectiveAreaVec = cms.vdouble(0.0566, 0.0562, 0.0363, 0.0119, 0.0064))
+    run2_muon_2016.toModify( process.patMuons, effectiveAreaVec = cms.vdouble(0.0735,0.0619,0.0465,0.0433,0.0577))
 
     process.patMuons.computePuppiCombinedIso = True
     #

--- a/PhysicsTools/PatUtils/interface/MiniIsolation.h
+++ b/PhysicsTools/PatUtils/interface/MiniIsolation.h
@@ -29,7 +29,7 @@ namespace pat{
 				   const math::XYZTLorentzVector& p4,
 				   double dr,
 				   double rho,
-                                   std::vector<double> &EA);
+                                   const std::vector<double> &area);
 }
 
 #endif

--- a/PhysicsTools/PatUtils/interface/MiniIsolation.h
+++ b/PhysicsTools/PatUtils/interface/MiniIsolation.h
@@ -25,10 +25,11 @@ namespace pat{
                                    float deadcone_pu=0.01, float deadcone_ph=0.01, float deadcone_nh=0.01,
                                    float dZ_cut=0.0);
 
-  float muonRelMiniIsoPUCorrected(const PFIsolation& iso,
-				  const math::XYZTLorentzVector& p4,
-				  float dr,
-				  float rho);
+  double muonRelMiniIsoPUCorrected(const PFIsolation& iso,
+				   const math::XYZTLorentzVector& p4,
+				   double dr,
+				   double rho,
+                                   std::vector<double> &EA);
 }
 
 #endif

--- a/PhysicsTools/PatUtils/src/MiniIsolation.cc
+++ b/PhysicsTools/PatUtils/src/MiniIsolation.cc
@@ -59,16 +59,16 @@ PFIsolation getMiniPFIsolation(const pat::PackedCandidateCollection *pfcands,
 				   const math::XYZTLorentzVector& p4,
 				   double dr,
 				   double rho,
-                                   std::vector<double> &EA)
+                                   const std::vector<double> &area)
   {
-    double absEta = fabs(p4.eta());
+    double absEta = std::abs(p4.eta());
     double ea = 0;
     //Eta dependent effective area
-    if      (absEta<0.800) ea = EA.at(0);
-    else if (absEta<1.300) ea = EA.at(1);
-    else if (absEta<2.000) ea = EA.at(2);
-    else if (absEta<2.200) ea = EA.at(3);
-    else if (absEta<2.500) ea = EA.at(4);
+    if      (absEta<0.800) ea = area.at(0);
+    else if (absEta<1.300) ea = area.at(1);
+    else if (absEta<2.000) ea = area.at(2);
+    else if (absEta<2.200) ea = area.at(3);
+    else if (absEta<2.500) ea = area.at(4);
 
     double correction = rho * ea * (dr/0.3) * (dr/0.3);
     double correctedIso = iso.chargedHadronIso() + std::max(0.0, iso.neutralHadronIso()+iso.photonIso() - correction);

--- a/PhysicsTools/PatUtils/src/MiniIsolation.cc
+++ b/PhysicsTools/PatUtils/src/MiniIsolation.cc
@@ -55,19 +55,21 @@ PFIsolation getMiniPFIsolation(const pat::PackedCandidateCollection *pfcands,
 
 }
 
-  float muonRelMiniIsoPUCorrected(const PFIsolation& iso,
-				  const math::XYZTLorentzVector& p4,
-				  float dr,
-				  float rho)
+  double muonRelMiniIsoPUCorrected(const PFIsolation& iso,
+				   const math::XYZTLorentzVector& p4,
+				   double dr,
+				   double rho,
+                                   std::vector<double> &EA)
   {
     double absEta = fabs(p4.eta());
     double ea = 0;
-    //Spring15 version
-    if      (absEta<0.800) ea = 0.0735;
-    else if (absEta<1.300) ea = 0.0619;
-    else if (absEta<2.000) ea = 0.0465;
-    else if (absEta<2.200) ea = 0.0433;
-    else if (absEta<2.500) ea = 0.0577;
+    //Eta dependent effective area
+    if      (absEta<0.800) ea = EA.at(0);
+    else if (absEta<1.300) ea = EA.at(1);
+    else if (absEta<2.000) ea = EA.at(2);
+    else if (absEta<2.200) ea = EA.at(3);
+    else if (absEta<2.500) ea = EA.at(4);
+
     double correction = rho * ea * (dr/0.3) * (dr/0.3);
     double correctedIso = iso.chargedHadronIso() + std::max(0.0, iso.neutralHadronIso()+iso.photonIso() - correction);
     return correctedIso/p4.pt();


### PR DESCRIPTION
#### PR description:
- This PR is made after closing the PR #26292
- Adding Era dependent effective area for mini isolation calculation
- The ticket that concerns this is : https://its.cern.ch/jira/browse/CMSMUONS-206
- The effective areas that are used to calculate the mini Isolation changes with Era
- All comments from the previous PR are addressed here. 
- @perrotta @slava77 @folguera @drkovalskyi 
Please look at the Era implementation. This is important as newly created tags run2_muon_2016, run2_muon_2017 and run2_muon_2017 will be used in other future muon POG related PRs.
--

