### PR TITLE
Remove unused DQMStore pointers

### DIFF
--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
@@ -92,7 +92,6 @@ class SiStripGainFromData : public ConditionDBWriter<SiStripApvGain> {
 
       std::unique_ptr<SiStripApvGain> getNewObject() override;
       DQMStore* dqmStore_;
-      DQMStore* dqmStore_infile;
 
       double              ComputeChargeOverPath(const SiStripCluster*   Cluster,TrajectoryStateOnSurface trajState, const edm::EventSetup* iSetup, const Track* track, double trajChi2OverN);
       bool                IsFarFromBorder(TrajectoryStateOnSurface trajState, const uint32_t detid, const edm::EventSetup* iSetup);
@@ -317,7 +316,6 @@ SiStripGainFromData::SiStripGainFromData(const edm::ParameterSet& iConfig) : Con
    VInputFiles         = iConfig.getParameter<vector<string> >("VInputFiles");
 
    dqmStore_       = edm::Service<DQMStore>().operator->();
-   dqmStore_infile = edm::Service<DQMStore>().operator->();
 
    //if( OutputHistos!="" )
    //  dqmStore_->open(OutputHistos.c_str(), true);

--- a/DQM/Physics/src/QcdLowPtDQM.h
+++ b/DQM/Physics/src/QcdLowPtDQM.h
@@ -240,7 +240,6 @@ class QcdLowPtDQM : public one::DQMEDAnalyzer<edm::LuminosityBlockCache<qlpd::Ca
   TH3F *AlphaTracklets23_;                  // alpha correction for tracklets 23
   HLTConfigProvider hltConfig_;
   const TrackerGeometry *tgeo_;                  // tracker geometry
-  DQMStore *theDbe_;                             // dqm store
   MonitorElement *repSumMap_;                    // report summary map
   MonitorElement *repSummary_;                   // report summary
   MonitorElement *h2TrigCorr_;                   // trigger correlation plot

--- a/DQM/SiStripCommissioningClients/interface/CommissioningHistograms.h
+++ b/DQM/SiStripCommissioningClients/interface/CommissioningHistograms.h
@@ -80,10 +80,6 @@ class CommissioningHistograms {
   static void copyCustomInformation( DQMStore* const,
 				     const std::vector<std::string>& );
   
-  /** Retrieves list of histograms in form of strings. */
-  static void getContents( DQMStore* const,
-			   std::vector<std::string>& );
-  
   void extractHistograms( const std::vector<std::string>& );
 
   // DEPRECATE

--- a/DQM/SiStripCommissioningClients/src/CommissioningHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/CommissioningHistograms.cc
@@ -249,12 +249,6 @@ sistrip::RunType CommissioningHistograms::runType( DQMStore* const bei,
 }
 
 // -----------------------------------------------------------------------------
-// Temporary fix: builds a list of histogram directories
-void CommissioningHistograms::getContents( DQMStore* const bei,
-					   std::vector<std::string>& contents ) {  
-}
-
-// -----------------------------------------------------------------------------
 //
 void CommissioningHistograms::copyCustomInformation( DQMStore* const bei,
 						     const std::vector<std::string>& contents ) {

--- a/DQM/SiStripMonitorCluster/interface/MonitorLTC.h
+++ b/DQM/SiStripMonitorCluster/interface/MonitorLTC.h
@@ -32,7 +32,6 @@ class MonitorLTC : public DQMEDAnalyzer {
                       edm::EventSetup const &) override;
 
  private:
-  DQMStore *dqmStore_;
   edm::ParameterSet conf_;
   // trigger decision from LTC digis
   MonitorElement *LTCTriggerDecision_all;

--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorFilter.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorFilter.h
@@ -32,7 +32,6 @@ class SiStripMonitorFilter : public DQMEDAnalyzer {
 
  private:
   edm::EDGetTokenT<int> filerDecisionToken_;
-  DQMStore *dqmStore_;
   edm::ParameterSet conf_;
   MonitorElement *FilterDecision;
   // all events

--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorHLT.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorHLT.h
@@ -36,7 +36,6 @@ class SiStripMonitorHLT : public DQMEDAnalyzer {
   edm::EDGetTokenT<std::map<uint, std::vector<SiStripCluster> > >
       clusterInSubComponentsToken_;
 
-  DQMStore *dqmStore_;
   edm::ParameterSet conf_;
   MonitorElement *HLTDecision;
   // all events

--- a/DQM/SiStripMonitorCluster/src/MonitorLTC.cc
+++ b/DQM/SiStripMonitorCluster/src/MonitorLTC.cc
@@ -20,7 +20,6 @@ MonitorLTC::MonitorLTC(
                   //  ltcDigiCollectionTag_(iConfig.getParameter<edm::InputTag>("ltcDigiCollectionTag"))
 {
   HLTDirectory = "HLTResults";
-  dqmStore_ = edm::Service<DQMStore>().operator->();
   conf_ = iConfig;
 
   ltcDigiCollectionTagToken_ = consumes<LTCDigiCollection>(

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorFilter.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorFilter.cc
@@ -18,7 +18,6 @@
 
 SiStripMonitorFilter::SiStripMonitorFilter(const edm::ParameterSet& iConfig) {
   FilterDirectory = "FilterResults";
-  dqmStore_ = edm::Service<DQMStore>().operator->();
   conf_ = iConfig;
 
   filerDecisionToken_ =

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorHLT.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorHLT.cc
@@ -20,7 +20,6 @@
 
 SiStripMonitorHLT::SiStripMonitorHLT(const edm::ParameterSet& iConfig) {
   HLTDirectory = "HLTResults";
-  dqmStore_ = edm::Service<DQMStore>().operator->();
   conf_ = iConfig;
 
   filerDecisionToken_ =

--- a/DQM/SiStripMonitorHardware/interface/HistogramBase.hh
+++ b/DQM/SiStripMonitorHardware/interface/HistogramBase.hh
@@ -184,7 +184,6 @@ public:
         );
 protected:
 
-  DQMStore* dqm_;
 
 private:
 

--- a/DQMOffline/EGamma/plugins/PhotonOfflineClient.h
+++ b/DQMOffline/EGamma/plugins/PhotonOfflineClient.h
@@ -125,7 +125,6 @@ class PhotonOfflineClient : public  DQMEDHarvester
   void dividePlots(MonitorElement* dividend, MonitorElement* numerator, MonitorElement* denominator);
   void dividePlots(MonitorElement* dividend, MonitorElement* numerator, double denominator); 
   
-  DQMStore *dbe_;
   int verbosity_;
 
   edm::ParameterSet parameters_;

--- a/DQMOffline/Muon/interface/EfficiencyPlotter.h
+++ b/DQMOffline/Muon/interface/EfficiencyPlotter.h
@@ -49,7 +49,6 @@ private:
   // Switch for verbosity
   std::string metname;
 
-  DQMStore* theDbe;
   edm::ParameterSet parameters;
 
    //histo binning parameters

--- a/DQMOffline/Muon/interface/MuonKinVsEtaAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonKinVsEtaAnalyzer.h
@@ -47,7 +47,6 @@ class MuonKinVsEtaAnalyzer : public DQMEDAnalyzer {
   
   // ----------member data ---------------------------
   MuonServiceProxy *theService;
-  DQMStore* theDbe;
   edm::ParameterSet parameters;
  
   // Switch for verbosity

--- a/DQMOffline/Muon/interface/MuonSeedsAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonSeedsAnalyzer.h
@@ -43,7 +43,6 @@ class MuonSeedsAnalyzer : public  DQMEDAnalyzer {
   
   private:
   // ----------member data ---------------------------
-  DQMStore *theDbe;
   MuonServiceProxy *theService;
   edm::ParameterSet parameters;
 

--- a/DQMOffline/Muon/interface/MuonTestSummary.h
+++ b/DQMOffline/Muon/interface/MuonTestSummary.h
@@ -58,7 +58,6 @@ protected:
 
 private:
 
-  DQMStore* dbe;
   // Switch for verbosity
   std::string metname;
 

--- a/DQMOffline/Muon/interface/TriggerMatchEfficiencyPlotter.h
+++ b/DQMOffline/Muon/interface/TriggerMatchEfficiencyPlotter.h
@@ -46,7 +46,6 @@ protected:
 
 private:
   
-  DQMStore* theDbe;
   edm::ParameterSet parameters;
 
   std::string triggerhistName1_;

--- a/DQMOffline/Muon/interface/TriggerMatchMonitor.h
+++ b/DQMOffline/Muon/interface/TriggerMatchMonitor.h
@@ -52,7 +52,6 @@ class TriggerMatchMonitor : public DQMEDAnalyzer {
   
   // ----------member data ---------------------------
   MuonServiceProxy *theService;
-  DQMStore* theDbe;
   edm::ParameterSet parameters;
  
   // triggerNames to be passed from config

--- a/DQMOffline/Muon/src/MuonKinVsEtaAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonKinVsEtaAnalyzer.cc
@@ -24,7 +24,6 @@ MuonKinVsEtaAnalyzer::MuonKinVsEtaAnalyzer(const edm::ParameterSet& pSet) {
 
   // the services
   theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
-  theDbe = edm::Service<DQMStore>().operator->();
 
   theMuonCollectionLabel_ = consumes<edm::View<reco::Muon> >  (parameters.getParameter<edm::InputTag>("MuonCollection"));
   theVertexLabel_          = consumes<reco::VertexCollection>(parameters.getParameter<edm::InputTag>("VertexLabel"));

--- a/DQMOffline/Muon/src/TriggerMatchMonitor.cc
+++ b/DQMOffline/Muon/src/TriggerMatchMonitor.cc
@@ -25,7 +25,6 @@ TriggerMatchMonitor::TriggerMatchMonitor(const edm::ParameterSet& pSet) {
 
   // the services
   theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
-  theDbe = edm::Service<DQMStore>().operator->();
   
   beamSpotToken_ = consumes<reco::BeamSpot >(parameters.getUntrackedParameter<edm::InputTag>("offlineBeamSpot")),
   primaryVerticesToken_ = consumes<std::vector<reco::Vertex> >(parameters.getUntrackedParameter<edm::InputTag>("offlinePrimaryVertices")),

--- a/DQMServices/Components/plugins/DQMEventInfo.h
+++ b/DQMServices/Components/plugins/DQMEventInfo.h
@@ -49,7 +49,6 @@ private:
 
 //  double getUTCtime(timeval* a, timeval* b = NULL);
 
-  DQMStore *dbe_;
 
   std::string eventInfoFolder_;
   std::string subsystemname_;

--- a/HLTriggerOffline/HeavyFlavor/src/HeavyFlavorValidation.cc
+++ b/HLTriggerOffline/HeavyFlavor/src/HeavyFlavorValidation.cc
@@ -112,7 +112,6 @@ class HeavyFlavorValidation : public DQMEDAnalyzer {
     vector<double> dimuonPtBins;
     vector<double> dimuonEtaBins;
     vector<double> dimuonDRBins;
-    DQMStore* dqmStore;
     map<TString, MonitorElement *> ME;
     vector<pair<string,int> > filterNamesLevels;
     const double muonMass;

--- a/Validation/EcalDigis/interface/EcalMixingModuleValidation.h
+++ b/Validation/EcalDigis/interface/EcalMixingModuleValidation.h
@@ -107,7 +107,6 @@ private:
  
  bool verbose_;
 
- DQMStore* dbe_;
  
  std::string outputFile_;
  

--- a/Validation/MuonIsolation/interface/MuIsoValidation.h
+++ b/Validation/MuonIsolation/interface/MuIsoValidation.h
@@ -125,7 +125,6 @@ private:
   //---------------Dynamic Variables---------------------
   
   //MonitorElement
-  DQMStore* dbe;
 
   edm::ParameterSet iConfig;  
   //The Data

--- a/Validation/MuonIsolation/src/MuIsoValidation.cc
+++ b/Validation/MuonIsolation/src/MuIsoValidation.cc
@@ -83,8 +83,6 @@ MuIsoValidation::MuIsoValidation(const edm::ParameterSet& ps)
   InitStatics();
   
   //Set up DAQ
-  dbe = nullptr;
-  dbe = edm::Service<DQMStore>().operator->();
   subsystemname_ = iConfig.getUntrackedParameter<std::string>("subSystemFolder", "YourSubsystem") ;
   
   //------"allocate" space for the data vectors-------


### PR DESCRIPTION
#### PR description:
This PR removes `DQMStore` member variables that are not used for anything.
These are likely residues from the "threaded migration" and where used in the past, but forgotten to remove once the last usages disappeared.

#### PR validation:
Manual review. The changes where machine-generated and manually adapted, behavior should not change.