### PR TITLE
Run3-gem30 Use edm::Log in the code rather than cout in Geometry/MuonNumbering

### DIFF
--- a/Geometry/MuonNumbering/plugins/DDTestMuonNumbering.cc
+++ b/Geometry/MuonNumbering/plugins/DDTestMuonNumbering.cc
@@ -6,30 +6,24 @@
 #include "Geometry/Records/interface/MuonNumberingRecord.h"
 #include "Geometry/MuonNumbering/interface/DD4hep_MuonNumbering.h"
 
-#include <iostream>
-
-using namespace std;
-using namespace cms;
-using namespace edm;
-
-class DDTestMuonNumbering : public one::EDAnalyzer<> {
+class DDTestMuonNumbering : public edm::one::EDAnalyzer<> {
 public:
-  explicit DDTestMuonNumbering(const ParameterSet&){}
+  explicit DDTestMuonNumbering(const edm::ParameterSet&){}
 
   void beginJob() override {}
-  void analyze(Event const& iEvent, EventSetup const&) override;
+  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
 };
 
 void
-DDTestMuonNumbering::analyze(const Event&, const EventSetup& iEventSetup)
+DDTestMuonNumbering::analyze(const edm::Event&, const edm::EventSetup& iEventSetup)
 {
-  LogVerbatim("Geometry") << "DDTestMuonNumbering::analyze";
-  ESTransientHandle<MuonNumbering> numbering;
+  edm::LogVerbatim("Geometry") << "DDTestMuonNumbering::analyze";
+  edm::ESTransientHandle<cms::MuonNumbering> numbering;
   iEventSetup.get<MuonNumberingRecord>().get(numbering);
 
-  LogVerbatim("Geometry") << "MuonNumbering size: " << numbering->values().size();
-  LogVerbatim("Geometry").log([&numbering](auto& log) {
+  edm::LogVerbatim("Geometry") << "MuonNumbering size: " << numbering->values().size();
+  edm::LogVerbatim("Geometry").log([&numbering](auto& log) {
       for(const auto& i: numbering->values()) {
 	log << " " << i.first << " = " << i.second;
 	log << '\n';

--- a/Geometry/MuonNumbering/plugins/MuonNumberingESProducer.cc
+++ b/Geometry/MuonNumbering/plugins/MuonNumberingESProducer.cc
@@ -17,7 +17,6 @@
 //
 
 #include <memory>
-#include <iostream>
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
@@ -28,25 +27,21 @@
 #include "Geometry/Records/interface/DDSpecParRegistryRcd.h"
 #include "DetectorDescription/DDCMS/interface/DDSpecParRegistry.h"
 
-using namespace std;
-using namespace cms;
-using namespace edm;
-
-class MuonNumberingESProducer : public ESProducer {
+class MuonNumberingESProducer : public edm::ESProducer {
 public:
-  MuonNumberingESProducer(const ParameterSet&);
+  MuonNumberingESProducer(const edm::ParameterSet&);
   ~MuonNumberingESProducer() override;
   
-  using ReturnType = unique_ptr<MuonNumbering>;
+  using ReturnType = std::unique_ptr<cms::MuonNumbering>;
   
   ReturnType produce(const MuonNumberingRecord&);
 
 private:
-  const string m_label;
-  const string m_key;
+  const std::string m_label;
+  const std::string m_key;
 };
 
-MuonNumberingESProducer::MuonNumberingESProducer(const ParameterSet& iConfig)
+MuonNumberingESProducer::MuonNumberingESProducer(const edm::ParameterSet& iConfig)
   : m_label(iConfig.getParameter<std::string>("label")),
     m_key(iConfig.getParameter<std::string>("key"))
 
@@ -61,9 +56,9 @@ MuonNumberingESProducer::ReturnType
 MuonNumberingESProducer::produce(const MuonNumberingRecord& iRecord)
 {
   LogDebug("Geometry") << "MuonNumberingESProducer::produce from " << m_label << " with " << m_key;
-  auto product = make_unique<MuonNumbering>();
+  auto product = std::make_unique<cms::MuonNumbering>();
 
-  ESHandle<DDSpecParRegistry> registry;
+  edm::ESHandle<cms::DDSpecParRegistry> registry;
   iRecord.getRecord<DDSpecParRegistryRcd>().get(m_label, registry);
   auto it = registry->specpars.find(m_key);
   if(it != end(registry->specpars)) {

--- a/Geometry/MuonNumbering/src/CSCNumberingScheme.cc
+++ b/Geometry/MuonNumbering/src/CSCNumberingScheme.cc
@@ -4,8 +4,6 @@
 #include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include <iostream>
-
 //#define LOCAL_DEBUG
 
 CSCNumberingScheme::CSCNumberingScheme( const MuonDDDConstants& muonConstants ) {
@@ -27,23 +25,24 @@ void CSCNumberingScheme::initMe (  const MuonDDDConstants& muonConstants ) {
   theRingLevel=muonConstants.getValue("me_ring")/theLevelPart;
   theLayerLevel=muonConstants.getValue("me_layer")/theLevelPart;
 #ifdef LOCAL_DEBUG
-  std::cout << "Initialize CSCNumberingScheme" << std::endl;
-  std::cout << "theRegionLevel " << theRegionLevel <<std::endl;
-  std::cout << "theStationLevel " << theStationLevel <<std::endl;
-  std::cout << "theSubringLevel " << theSubringLevel <<std::endl;
-  std::cout << "theSectorLevel " << theSectorLevel <<std::endl;
-  std::cout << "theRingLevel " << theRingLevel <<std::endl;
-  std::cout << "theLayerLevel " << theLayerLevel <<std::endl;
+  edm::LogVerbatim("CSCNumbering") 
+    << "Initialize CSCNumberingScheme" 
+    << "\ntheRegionLevel " << theRegionLevel
+    << "\ntheStationLevel " << theStationLevel
+    << "\ntheSubringLevel " << theSubringLevel
+    << "\ntheSectorLevel " << theSectorLevel
+    << "\ntheRingLevel " << theRingLevel
+    << "\ntheLayerLevel " << theLayerLevel;
 #endif
 }
 
 int CSCNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num){
 
 #ifdef LOCAL_DEBUG
-  std::cout << "CSCNumbering "<<num.getLevels()<<std::endl;
+  edm::LogVerbatim("CSCNumbering") << "CSCNumbering " << num.getLevels();
   for (int level=1;level<=num.getLevels();level++) {
-    std::cout << level << " " << num.getSuperNo(level)
-	 << " " << num.getBaseNo(level) << std::endl;
+    edm::LogVerbatim("CSCNumbering") 
+      << level << " " << num.getSuperNo(level) << " " << num.getBaseNo(level);
   }
 #endif
 
@@ -121,30 +120,25 @@ int CSCNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num){
   // find appropriate chamber label
     
    int chamber_id=chamberIndex(station_id, ring_id,
-			      subring_id, sector_id);
+			       subring_id, sector_id);
     
   // convert into raw id of appropriate DetId
     
   int intIndex=CSCDetId::rawIdMaker(fwbw_id, station_id, ring_id,
-		     chamber_id, layer_id);
+				    chamber_id, layer_id);
 
 #ifdef LOCAL_DEBUG
-  std::cout << "CSCNumberingScheme : ";
-  std::cout << " fw/bw " <<  fwbw_id;
-  std::cout << " station " <<  station_id;
-  std::cout << " ring " <<  ring_id;
-  std::cout << " subring " <<  subring_id;
-  std::cout << " chamber " <<  chamber_id;
-  std::cout << " sector " <<  sector_id;
-  std::cout << " layer " <<  layer_id;
-  std::cout << std::endl;
+  edm::LogVerbatim("CSCNumbering") 
+    << "CSCNumberingScheme :  fw/bw " <<  fwbw_id << " station " <<  station_id
+    << " ring " <<  ring_id << " subring " <<  subring_id << " chamber " 
+    <<  chamber_id << " sector " <<  sector_id << " layer " <<  layer_id;
 #endif
 
   return intIndex;
 }
 
-int CSCNumberingScheme::chamberIndex(int station_id,  
-           int ring_id, int subring_id, int sector_id) const {
+int CSCNumberingScheme::chamberIndex(int station_id,  int ring_id, int subring_id,
+				     int sector_id) const {
 
   int chamber_id=0;
 

--- a/Geometry/MuonNumbering/src/DD4hep_MuonNumbering.cc
+++ b/Geometry/MuonNumbering/src/DD4hep_MuonNumbering.cc
@@ -2,10 +2,7 @@
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include <iostream>
-
 using namespace cms;
-using namespace std;
 using namespace edm;
 
 const MuonBaseNumber
@@ -19,20 +16,20 @@ MuonNumbering::geoHistoryToBaseNumber(const cms::ExpandedNodes &nodes) const {
 
   // some consistency checks
   if(basePart != 1) {
-    LogError("Geometry") << "MuonNumbering finds unusual base constant:"
-			 << basePart;
+    edm::LogError("Geometry") << "MuonNumbering finds unusual base constant:"
+			      << basePart;
   }
   if(superPart < 100) {
-    LogError("Geometry") << "MuonNumbering finds unusual super constant:"
-			 << superPart;
+    edm::LogError("Geometry") << "MuonNumbering finds unusual super constant:"
+			      << superPart;
   }
   if(levelPart < 10*superPart) {
-    LogError("Geometry") << "MuonNumbering finds unusual level constant:"
-			 << levelPart;
+    edm::LogError("Geometry") << "MuonNumbering finds unusual level constant:"
+			      << levelPart;
   }
   if((startCopyNo !=0 ) && (startCopyNo != 1)) {
-    LogError("Geometry") << "MuonNumbering finds unusual start value for copy numbers:"
-			 << startCopyNo;
+    edm::LogError("Geometry") << "MuonNumbering finds unusual start value for copy numbers:"
+			      << startCopyNo;
   }
   int ctr(0);
   for(auto const& it : nodes.tags) {
@@ -58,7 +55,7 @@ MuonNumbering::get(const char* key) const {
 }
 
 void
-MuonNumbering::put(string_view str, int num) {
+MuonNumbering::put(std::string_view str, int num) {
   values_.emplace(str, num);
 }
 

--- a/Geometry/MuonNumbering/src/DTNumberingScheme.cc
+++ b/Geometry/MuonNumbering/src/DTNumberingScheme.cc
@@ -2,7 +2,7 @@
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
-#include <iostream>
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //#define LOCAL_DEBUG
 
@@ -24,13 +24,14 @@ void DTNumberingScheme::initMe ( const MuonDDDConstants& muonConstants ) {
   theLayerLevel=muonConstants.getValue("mb_layer")/theLevelPart;
   theWireLevel=muonConstants.getValue("mb_wire")/theLevelPart;
 #ifdef LOCAL_DEBUG
-  std::cout << "Initialize DTNumberingScheme" << std::endl;
-  std::cout << "theRegionLevel " << theRegionLevel <<std::endl;
-  std::cout << "theWheelLevel " << theWheelLevel <<std::endl;
-  std::cout << "theStationLevel " << theStationLevel <<std::endl;
-  std::cout << "theSuperLayerLevel " << theSuperLayerLevel <<std::endl;
-  std::cout << "theLayerLevel " << theLayerLevel <<std::endl;
-  std::cout << "theWireLevel " << theWireLevel <<std::endl;
+  edm::LogVerbatim("DTNumberingScheme") 
+    << "Initialize DTNumberingScheme"
+    << "\ntheRegionLevel " << theRegionLevel
+    << "\ntheWheelLevel " << theWheelLevel
+    << "\ntheStationLevel " << theStationLevel
+    << "\ntheSuperLayerLevel " << theSuperLayerLevel
+    << "\ntheLayerLevel " << theLayerLevel
+    << "\ntheWireLevel " << theWireLevel;
 #endif
 
 }
@@ -38,16 +39,16 @@ void DTNumberingScheme::initMe ( const MuonDDDConstants& muonConstants ) {
 int DTNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num){
   
 #ifdef LOCAL_DEBUG
-  std::cout << "DTNumbering "<<num.getLevels()<<std::endl;
+  edm::LogVerbatim("DTNumberingScheme") << "DTNumbering " << num.getLevels();
   for (int level=1;level<=num.getLevels();level++) {
-    std::cout << level << " " << num.getSuperNo(level)
-	      << " " << num.getBaseNo(level) << std::endl;
+    edm::LogVerbatim("DTNumberingScheme") 
+      << level << " " << num.getSuperNo(level) << " " << num.getBaseNo(level);
   }
 #endif
   if (num.getLevels()!=theWireLevel) {
-    std::cout << "DTNS::BNToUN "
-	      << "BaseNumber has " << num.getLevels() << " levels,"
-	      << "need "<<theWireLevel<<std::endl;
+    edm::LogWarning("DTNumberingScheme") 
+      << "DTNumberingScheme::BNToUN: BaseNumber has " << num.getLevels() 
+      << " levels, need "<< theWireLevel;
     return 0;
   }
   
@@ -117,7 +118,7 @@ int DTNumberingScheme::getDetId(const MuonBaseNumber& num) const {
   DTWireId id(wheel_id,station_id,sector_id,superlayer_id,layer_id,wire_id);
   
 #ifdef LOCAL_DEBUG
-  std::cout << "DTNumberingScheme: " << id << std::endl;
+  edm::LogVerbatim("DTNumberingScheme") << "DTNumberingScheme: " << id;
 #endif
   
   return id.rawId();

--- a/Geometry/MuonNumbering/src/GEMNumberingScheme.cc
+++ b/Geometry/MuonNumbering/src/GEMNumberingScheme.cc
@@ -2,7 +2,7 @@
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
-#include <iostream>
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //#define LOCAL_DEBUG
 
@@ -23,30 +23,31 @@ void GEMNumberingScheme::initMe ( const MuonDDDConstants& muonConstants ) {
   theSectorLevel  = muonConstants.getValue("mg_sector")/theLevelPart;
   theRollLevel    = muonConstants.getValue("mg_roll")/theLevelPart;
 #ifdef LOCAL_DEBUG
-  std::cout << "Initialize GEMNumberingScheme" <<std::endl;
-  std::cout << "theRegionLevel " << theRegionLevel <<std::endl;
-  std::cout << "theStationLevel "<< theStationLevel<<std::endl;
-  std::cout << "theRingLevel "   << theRingLevel   <<std::endl;
-  std::cout << "theSectorLevel " << theSectorLevel <<std::endl;
-  std::cout << "theRollLevel "   << theRollLevel   <<std::endl;
+  edm::LogVerbatim("GEMNumberingScheme") 
+    << "Initialize GEMNumberingScheme" 
+    << "\ntheRegionLevel " << theRegionLevel 
+    << "\ntheStationLevel "<< theStationLevel
+    << "\ntheRingLevel "   << theRingLevel   
+    << "\ntheSectorLevel " << theSectorLevel 
+    << "\ntheRollLevel "   << theRollLevel;
 #endif
 }
 
 int GEMNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) {
 
 #ifdef LOCAL_DEBUG
-  std::cout << "GEMNumbering "<<num.getLevels()<<std::endl;
+  edm::LogVerbatim("GEMNumberingScheme") << "GEMNumbering " << num.getLevels();
   for (int level=1;level<=num.getLevels();level++) {
-    std::cout << level << " " << num.getSuperNo(level)
-	      << " " << num.getBaseNo(level) << std::endl;
+    edm::LogVerbatim("GEMNumberingScheme") 
+      << level << " " << num.getSuperNo(level) << " " << num.getBaseNo(level);
   }
 #endif
 
   int maxLevel = theRollLevel;
   if (num.getLevels()!=maxLevel) {
-    std::cout << "MuonGEMNS::BNToUN "
-	      << "BaseNumber has " << num.getLevels() << " levels,"
-	      << "need "<<maxLevel<<std::endl;
+    edm::LogWarning("GEMNumberingScheme") 
+      << "MuonGEMNumberingScheme::BNToUN: BaseNumber has " << num.getLevels() 
+      << " levels, need " << maxLevel;
     return 0;
   }
 
@@ -66,8 +67,9 @@ int GEMNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) {
   ring = 1;
   station = num.getSuperNo(theStationLevel);
 #ifdef LOCAL_DEBUG
-  std::cout << "GEMNumbering: Ring " << ring << " Station " 
-	    << num.getSuperNo(theStationLevel) << ":" << station << std::endl;
+  edm::LogVerbatim("GEMNumberingScheme") 
+    << "GEMNumbering: Ring " << ring << " Station "
+    << num.getSuperNo(theStationLevel) << ":" << station;
 #endif
   
   roll    = num.getBaseNo(theRollLevel)+1;
@@ -94,9 +96,10 @@ int GEMNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) {
   // collect all info
   
 #ifdef LOCAL_DEBUG
-  std::cout << "GEMNumberingScheme: Region " << region << " Ring "
-	    << ring << " Station " << station << " Layer " << layer
-	    << " Chamber " << chamber << " Roll " << roll << std::endl;
+  edm::LogVerbatim("GEMNumberingScheme") 
+    << "GEMNumberingScheme: Region " << region << " Ring "
+    << ring << " Station " << station << " Layer " << layer
+    << " Chamber " << chamber << " Roll " << roll;
 #endif
 
   // Build the actual numbering
@@ -104,7 +107,7 @@ int GEMNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) {
   
   
 #ifdef LOCAL_DEBUG
-  std::cout << id.rawId() << " DetId " << id << std::endl;
+  edm::LogVerbatim("GEMNumberingScheme") << id.rawId() << " DetId " << id;
 #endif
       
   return id.rawId();

--- a/Geometry/MuonNumbering/src/ME0NumberingScheme.cc
+++ b/Geometry/MuonNumbering/src/ME0NumberingScheme.cc
@@ -5,8 +5,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include <iostream>
-
 //#define LOCAL_DEBUG
 
 ME0NumberingScheme::ME0NumberingScheme( const MuonDDDConstants& muonConstants ) {
@@ -27,55 +25,32 @@ void ME0NumberingScheme::initMe ( const MuonDDDConstants& muonConstants ) {
   theNEtaPart     = muonConstants.getValue("m0_nroll");
 
   // Debug using LOCAL_DEBUG
-  #ifdef LOCAL_DEBUG
-    std::cout << "Initialize ME0NumberingScheme" <<std::endl;
-    std::cout << "theRegionLevel " << theRegionLevel <<std::endl;
-    std::cout << "theLayerLevel "  << theLayerLevel   <<std::endl;
-    std::cout << "theSectorLevel " << theSectorLevel <<std::endl;
-    std::cout << "theRollLevel "   << theRollLevel   <<std::endl;
-    std::cout << "theNEtaPart  "   << theNEtaPart    <<std::endl;
-  #endif
+#ifdef LOCAL_DEBUG
+  edm::LogVerbatim("ME0NumberingScheme") 
+    << "Initialize ME0NumberingScheme" 
+    << "\ntheRegionLevel " << theRegionLevel
+    << "\ntheLayerLevel "  << theLayerLevel 
+    << "\ntheSectorLevel " << theSectorLevel
+    << "\ntheRollLevel "   << theRollLevel
+    << "\ntheNEtaPart  "   << theNEtaPart;
+#endif
   // -----------------------
-
-  // Debug using LogDebug
-  std::stringstream DebugStringStream;
-  DebugStringStream << "Initialize ME0NumberingScheme" <<std::endl;
-  DebugStringStream << "theRegionLevel " << theRegionLevel <<std::endl;
-  DebugStringStream << "theLayerLevel "  << theLayerLevel   <<std::endl;
-  DebugStringStream << "theSectorLevel " << theSectorLevel <<std::endl;
-  DebugStringStream << "theRollLevel "   << theRollLevel   <<std::endl;
-  DebugStringStream << "theNEtaPart  "   << theNEtaPart    <<std::endl;
-  std::string DebugString = DebugStringStream.str();
-  edm::LogVerbatim("ME0NumberingScheme")<<DebugString;
-  // --------------------
 }
 
 int ME0NumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) {
 
-    edm::LogVerbatim("ME0NumberingScheme")<<"ME0NumberingScheme::baseNumberToUnitNumber BEGIN "<<std::endl;
+    edm::LogVerbatim("ME0NumberingScheme")
+      << "ME0NumberingScheme::baseNumberToUnitNumber BEGIN ";
   // Debug using LOCAL_DEBUG
-  #ifdef LOCAL_DEBUG
-    std::cout << "ME0Numbering "<<num.getLevels()<<std::endl;
+#ifdef LOCAL_DEBUG
+    edm::LogVerbatim("ME0NumberingScheme") << "ME0Numbering "<< num.getLevels();
     for (int level=1;level<=num.getLevels();level++) {
-      std::cout << "level "<<level << " " << num.getSuperNo(level)
-  	      << " " << num.getBaseNo(level) << std::endl;
+      edm::LogVerbatim("ME0NumberingScheme") 
+	<< "level "<<level << " " << num.getSuperNo(level)
+	<< " " << num.getBaseNo(level);
     }
-  #endif
+#endif
   // -----------------------
-
-  // Debug using LogDebug
-  std::stringstream DebugStringStream;
-  DebugStringStream << "ME0Numbering :: number of levels = "<<num.getLevels()<<std::endl;
-  DebugStringStream << "Level \t SuperNo \t BaseNo"<<std::endl;
-  for (int level=1;level<=num.getLevels();level++) {
-    DebugStringStream <<level << " \t " << num.getSuperNo(level)
-		      << " \t " << num.getBaseNo(level) << std::endl;
-  }
-  std::string DebugString = DebugStringStream.str();
-  edm::LogVerbatim("ME0NumberingScheme")<<DebugString;
-  // -----------------------
-
-
 
   int maxLevel = theRollLevel;
   if (num.getLevels()!=maxLevel) {
@@ -100,35 +75,21 @@ int ME0NumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) {
   // collect all info
   
   // Debug using LOCAL_DEBUG
-  #ifdef LOCAL_DEBUG
-    std::cout << "ME0NumberingScheme: Region " << region 
-	      << " Layer " << layer
-	      << " Chamber " << chamber << " Roll " << roll << std::endl;
-  #endif
+#ifdef LOCAL_DEBUG
+  edm::LogVerbatim("ME0NumberingScheme") 
+    << "ME0NumberingScheme: Region " << region << " Layer " << layer
+    << " Chamber " << chamber << " Roll " << roll;
+#endif
   // -----------------------
-
-  // Debug using LogDebug
-  edm::LogVerbatim("ME0NumberingScheme") << "ME0NumberingScheme: Region " << region 
-					 << " Layer " << layer
-					 << " Chamber " << chamber << " Roll " << roll << std::endl;
-  // -----------------------                                  
 
   // Build the actual numbering
   ME0DetId id(region,layer,chamber,roll);
   
   // Debug using LOCAL_DEBUG  
-  #ifdef LOCAL_DEBUG
-    std::cout << " DetId " << id << std::endl;
-  #endif
+#ifdef LOCAL_DEBUG
+  edm::LogVerbatim("ME0NumberingScheme") << " DetId " << id;
+#endif
   // ---------------------
-    
-  // Debug using LogDebug
-  edm::LogVerbatim("ME0NumberingScheme")<< " DetId " << id << std::endl;
-  // -----------------------                                    
     
   return id.rawId();
 }
-
-
-
-

--- a/Geometry/MuonNumbering/src/MuonBaseNumber.cc
+++ b/Geometry/MuonNumbering/src/MuonBaseNumber.cc
@@ -1,6 +1,5 @@
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <iostream>
 
 //#define LOCAL_DEBUG
 
@@ -13,14 +12,11 @@ void MuonBaseNumber::addBase(const LevelBaseNumber& num){
   while (cur!=end) {
     if (num.level()==(*cur).level()) {
 #ifdef LOCAL_DEBUG
-      std::cout << "MuonBaseNumber::addBase was asked to add "
-		<<num.level()<<" "
-		<<num.super()<<" "
-		<<num.base()
-		<<" to existing level "
-		<<(*cur).level()<<" "
-		<<(*cur).super()<<" "
-		<<(*cur).base() << " but refused.";
+      edm::LogVerbatim("Geometry") 
+	<< "MuonBaseNumber::addBase was asked to add " << num.level() << " "
+	<< num.super() << " " << num.base() << " to existing level "
+	<< (*cur).level() << " " << (*cur).super() << " " << (*cur).base() 
+	<< " but refused.";
 #endif
       return; // don't overwrite current volume stored
     }
@@ -37,15 +33,14 @@ void MuonBaseNumber::addBase(const LevelBaseNumber& num){
 #ifdef LOCAL_DEBUG
   cur=sortedBaseNumber.begin();
   end=sortedBaseNumber.end();
-  std::cout << "MuonBaseNumber::AddBase ";
+  edm::LogVerbatim("Geometry") << "MuonBaseNumber::AddBase ";
+  unsigned int k(0);
   while (cur!=end) {
-    std::cout<<(*cur).level()<<" ";
-    std::cout<<(*cur).super()<<" ";
-    std::cout<<(*cur).base();
-    std::cout<<",";
-    cur++;
+    edm::LogVerbatim("Geometry") 
+      << "[" << k << "] " << (*cur).level() << " "  << (*cur).super() << " "
+      << (*cur).base();
+    cur++; ++k;
   }
-  std::cout <<std::endl;
 #endif
 
 }

--- a/Geometry/MuonNumbering/src/MuonDDDConstants.cc
+++ b/Geometry/MuonNumbering/src/MuonDDDConstants.cc
@@ -6,12 +6,12 @@
 #include "DetectorDescription/Core/interface/DDValue.h"
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
 
-
 //#define LOCAL_DEBUG
 
 MuonDDDConstants::MuonDDDConstants( const DDCompactView& cpv ) {
 #ifdef LOCAL_DEBUG
-  std::cout << "MuonDDDConstants;:MuonDDDConstants ( const DDCompactView& cpv ) constructor " << std::endl;
+  edm::LogVerbatim("Geometry") 
+    << "MuonDDDConstants;:MuonDDDConstants ( const DDCompactView& cpv ) constructor ";
 #endif
   std::string attribute = "OnlyForMuonNumbering"; 
   
@@ -25,12 +25,13 @@ MuonDDDConstants::MuonDDDConstants( const DDCompactView& cpv ) {
   
   const DDsvalues_type mySpecs (fview.mergedSpecifics());
 #ifdef LOCAL_DEBUG
-  std::cout << "mySpecs.size() = " << mySpecs.size() << std::endl;
+  edm::LogVerbatim("Geometry") 
+    << "MuonDDDConstants::mySpecs.size() = " << mySpecs.size();
 #endif
   if ( mySpecs.size() < 25 ) {
-    edm::LogError("MuonDDDConstants") << " MuonDDDConstants: Missing SpecPars from DetectorDescription." << std::endl;
-    std::string msg = "MuonDDDConstants does not have the appropriate number of SpecPars associated";
-    msg+= " with the part //MUON.";
+    edm::LogError("MuonDDDConstants") 
+      << " MuonDDDConstants: Missing SpecPars from DetectorDescription.";
+    std::string msg = "MuonDDDConstants does not have the appropriate number of SpecPars associated with the part //MUON.";
     throw cms::Exception("GeometryBuildFailure", msg);
   }
 
@@ -40,7 +41,9 @@ MuonDDDConstants::MuonDDDConstants( const DDCompactView& cpv ) {
     if ( bit->second.isEvaluated() ) {
       this->addValue( bit->second.name(), int(bit->second.doubles()[0]) );
 #ifdef LOCAL_DEBUG
-      std::cout << "adding DDConstant of " << bit->second.name() << " = " << int(bit->second.doubles()[0]) << std::endl;
+      edm::LogVerbatim("Geometry") 
+	<< "MuonDDDConstants::adding DDConstant of " << bit->second.name() 
+	<< " = " << int(bit->second.doubles()[0]);
 #endif
     }
   }  
@@ -48,21 +51,22 @@ MuonDDDConstants::MuonDDDConstants( const DDCompactView& cpv ) {
 
 int MuonDDDConstants::getValue( const std::string& name ) const {
 #ifdef LOCAL_DEBUG
-  std::cout << "about to look for ... " << name << std::endl;
+  edm::LogVerbatim("Geometry") << "about to look for ... " << name << std::endl;
 #endif
   if ( namesAndValues_.empty() ) {
-    std::cout << "MuonDDDConstants::getValue HAS NO VALUES!" << std::endl;
+    edm::LogWarning("Geometry") << "MuonDDDConstants::getValue HAS NO VALUES!";
     throw cms::Exception("GeometryBuildFailure", "MuonDDDConstants does not have requested value for " + name);
   }
 
   std::map<std::string, int>::const_iterator findIt = namesAndValues_.find(name);
 
   if ( findIt == namesAndValues_.end() ) {
-    std::cout << "MuonDDDConstants::getValue was asked for " << name << " and had NO clue!" << std::endl;
+    edm::LogWarning("Geometry") << "MuonDDDConstants::getValue was asked for " << name << " and had NO clue!";
     throw cms::Exception("GeometryBuildFailure", "MuonDDDConstants does not have requested value for " + name);
   }
 #ifdef LOCAL_DEBUG
-  std::cout << "Value for " << name << " is " << findIt->second << std::endl;
+  edm::LogVerbatim("Geometry") 
+    << "MuonDDDConstants::Value for " << name << " is " << findIt->second;
 #endif
   return findIt->second;
 }

--- a/Geometry/MuonNumbering/src/MuonDDDNumbering.cc
+++ b/Geometry/MuonNumbering/src/MuonDDDNumbering.cc
@@ -1,8 +1,7 @@
 #include "Geometry/MuonNumbering/interface/MuonDDDNumbering.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
-
-#include <iostream>
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //#define LOCAL_DEBUG
 
@@ -16,28 +15,28 @@ MuonDDDNumbering::MuonDDDNumbering( const MuonDDDConstants& muonConstants ){
   // some consistency checks
 
   if (theBasePart!=1) {
-    std::cout << "MuonDDDNumbering finds unusual base constant:"
-	 <<theBasePart<<std::endl;
+    edm::LogWarning("Geometry") 
+      << "MuonDDDNumbering finds unusual base constant:" << theBasePart;
   }
   if (theSuperPart<100) {
-    std::cout << "MuonDDDNumbering finds unusual super constant:"
-	 <<theSuperPart<<std::endl;
+    edm::LogWarning("Geometry") 
+      << "MuonDDDNumbering finds unusual super constant:" << theSuperPart;
   }
   if (theLevelPart<10*theSuperPart) {
-    std::cout << "MuonDDDNumbering finds unusual level constant:"
-	 <<theLevelPart<<std::endl;
+    edm::LogWarning("Geometry") 
+      << "MuonDDDNumbering finds unusual level constant:" << theLevelPart;
   }
   if ((theStartCopyNo!=0)&&(theStartCopyNo!=1)) {
-    std::cout << "MuonDDDNumbering finds unusual start value for copy numbers:"
-	 <<theStartCopyNo<<std::endl;
+    edm::LogWarning("Geometry") 
+      << "MuonDDDNumbering finds unusual start value for copy numbers:"
+      << theStartCopyNo;
   }
 
 #ifdef LOCAL_DEBUG
-  std::cout << "MuonDDDNumbering configured with"<<std::endl;
-  std::cout << "Level = "<<theLevelPart<<" ";
-  std::cout << "Super = "<<theSuperPart<<" ";
-  std::cout << "Base = "<<theBasePart<<" ";
-  std::cout << "StartCopyNo = "<<theStartCopyNo<<std::endl;
+  edm::LogVerbatim("Geometry")
+    << "MuonDDDNumbering configured with"
+    << " Level = " << theLevelPart << " Super = " << theSuperPart
+    << " Base = " << theBasePart << " StartCopyNo = " << theStartCopyNo;
 #endif
 
 }
@@ -46,8 +45,8 @@ MuonBaseNumber MuonDDDNumbering::geoHistoryToBaseNumber(const DDGeoHistory & his
   MuonBaseNumber num;
 
 #ifdef LOCAL_DEBUG
-  std::cout << "MuonDDDNumbering create MuonBaseNumber for"<<std::endl;
-  std::cout << history <<std::endl;
+  edm::LogVerbatim("Geometry") 
+    << "MuonDDDNumbering create MuonBaseNumber for " << history;
 #endif
 
   //loop over all parents and check
@@ -66,9 +65,10 @@ MuonBaseNumber MuonDDDNumbering::geoHistoryToBaseNumber(const DDGeoHistory & his
   }
 
 #ifdef LOCAL_DEBUG
-  std::cout << num.getLevels() <<std::endl;
+  edm::LogVerbatim("Geometry") << "MuonDDDNumbering::" <<  num.getLevels();
   for (int i=1;i<=num.getLevels();i++) {
-    std::cout << num.getSuperNo(i)<<" "<<num.getBaseNo(i)<<std::endl;
+    edm::LogVerbatim("Geometry") 
+      << "[" << i << "] " << num.getSuperNo(i) << " " << num.getBaseNo(i);
   }
 #endif
  
@@ -91,7 +91,9 @@ int MuonDDDNumbering::getInt(const std::string & s, const DDLogicalPart & part)
       std::vector<double> temp = val.doubles();
       if (temp.size() != 1)
       {
-	std::cout << " ERROR: I need only 1 " << s << " in DDLogicalPart " << part.name() << std::endl;
+	edm::LogError("Geometry") 
+	  << "MuonDDDNumbering:: ERROR: I need only 1 " << s 
+	  << " in DDLogicalPart " << part.name();
 	 abort();
       }      
       return int(temp[0]);

--- a/Geometry/MuonNumbering/src/MuonNumberingScheme.cc
+++ b/Geometry/MuonNumbering/src/MuonNumberingScheme.cc
@@ -1,8 +1,6 @@
 #include "Geometry/MuonNumbering/interface/MuonNumberingScheme.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 
-//#define LOCAL_DEBUG
-
 int MuonNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber&) {
   return 0;  
 }

--- a/Geometry/MuonNumbering/src/MuonSimHitNumberingScheme.cc
+++ b/Geometry/MuonNumbering/src/MuonSimHitNumberingScheme.cc
@@ -8,8 +8,6 @@
 #include "Geometry/MuonNumbering/interface/MuonSubDetector.h"
 #include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
 
-//#define LOCAL_DEBUG
-
 MuonSimHitNumberingScheme::MuonSimHitNumberingScheme(MuonSubDetector* d, const DDCompactView& cpv) :
   MuonSimHitNumberingScheme(d,MuonDDDConstants(cpv)){ }
 

--- a/Geometry/MuonNumbering/src/MuonSubDetector.cc
+++ b/Geometry/MuonNumbering/src/MuonSubDetector.cc
@@ -1,5 +1,5 @@
 #include "Geometry/MuonNumbering/interface/MuonSubDetector.h"
-#include <iostream>
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 
 MuonSubDetector::MuonSubDetector(const std::string& name) 
@@ -15,8 +15,8 @@ MuonSubDetector::MuonSubDetector(const std::string& name)
   } else if (name=="MuonME0Hits") {
     detector=me0;
   } else {
-    std::cout << "MuonSubDetector::MuonSubDetector does not recognize ";
-    std::cout << name <<std::endl;
+    edm::LogWarning("Geometry") 
+      << "MuonSubDetector::MuonSubDetector does not recognize " << name;
     detector=nodef;
   } 
 }

--- a/Geometry/MuonNumbering/src/RPCNumberingScheme.cc
+++ b/Geometry/MuonNumbering/src/RPCNumberingScheme.cc
@@ -2,7 +2,7 @@
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
-#include <iostream>
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //#define LOCAL_DEBUG
 
@@ -26,24 +26,25 @@ void RPCNumberingScheme::initMe ( const MuonDDDConstants& muonConstants ) {
   theESectorLevel=muonConstants.getValue("mr_esector")/theLevelPart;
   theERollLevel=muonConstants.getValue("mr_eroll")/theLevelPart;
 #ifdef LOCAL_DEBUG
-  std::cout << "theRegionLevel " << theRegionLevel <<std::endl;
-  std::cout << "theBWheelLevel " << theBWheelLevel <<std::endl;
-  std::cout << "theBStationLevel " << theBStationLevel <<std::endl;
-  std::cout << "theBPlaneLevel " << theBPlaneLevel <<std::endl;
-  std::cout << "theBChamberLevel " << theBChamberLevel <<std::endl;
-  std::cout << "theEPlaneLevel " << theEPlaneLevel <<std::endl;
-  std::cout << "theESectorLevel " << theESectorLevel <<std::endl;
-  std::cout << "theERollLevel " << theERollLevel <<std::endl;
+  edm::LogVerbatim("RPCNumberingScheme") 
+    << "RPCNumberingScheme::theRegionLevel " << theRegionLevel
+    << "\ntheBWheelLevel " << theBWheelLevel
+    << "\ntheBStationLevel " << theBStationLevel
+    << "\ntheBPlaneLevel " << theBPlaneLevel
+    << "\ntheBChamberLevel " << theBChamberLevel
+    << "\ntheEPlaneLevel " << theEPlaneLevel
+    << "\ntheESectorLevel " << theESectorLevel
+    << "\ntheERollLevel " << theERollLevel;
 #endif
 }
 
 int RPCNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) {
 
 #ifdef LOCAL_DEBUG
-  std::cout << "RPCNumbering "<<num.getLevels()<<std::endl;
+  edm::LogVerbatim("RPCNumberingScheme") << "RPCNumbering " << num.getLevels();
   for (int level=1;level<=num.getLevels();level++) {
-    std::cout << level << " " << num.getSuperNo(level)
-	 << " " << num.getBaseNo(level) << std::endl;
+    edm::LogVerbatim("RPCNumberingScheme") 
+      << level << " " << num.getSuperNo(level) << " " << num.getBaseNo(level);
   }
 #endif
 
@@ -57,9 +58,9 @@ int RPCNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) {
   }
 
   if (num.getLevels()!=maxLevel) {
-    std::cout << "MuonRpcNS::BNToUN "
-	 << "BaseNumber has " << num.getLevels() << " levels,"
-	 << "need "<<maxLevel<<std::endl;
+    edm::LogWarning("RPCNumberingScheme")
+      << "RPCNumberingScheme::BNToUN: BaseNumber has " << num.getLevels() 
+      << " levels, need " << maxLevel;
     return 0;
   }
 
@@ -196,25 +197,21 @@ int RPCNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) {
 
   // collect all info
   
-  int trIndex=(eta_id*10000+plane_id*1000+sector_id*10+copy_id)*10+
-    roll_id;
+  int trIndex=(eta_id*10000+plane_id*1000+sector_id*10+copy_id)*10+roll_id;
   
 #ifdef LOCAL_DEBUG
   if (barrel_muon) {
-    std::cout << "RPCNumberingScheme (barrel): ";
+    edm::LogVerbatim("RPCNumberingScheme") << "RPCNumberingScheme (barrel): ";
   } else {
     if (forward) {
-      std::cout << "RPCNumberingScheme (forward): ";
+      edm::LogVerbatim("RPCNumberingScheme") << "RPCNumberingScheme (forward): ";
     } else {
-      std::cout << "RPCNumberingScheme (backward): ";
+      edm::LogVerbatim("RPCNumberingScheme") << "RPCNumberingScheme (backward): ";
     }
   }
-  std::cout << " roll " << roll_id;
-  std::cout << " copy " << copy_id;
-  std::cout << " sector " << sector_id;
-  std::cout << " plane " << plane_id;
-  std::cout << " eta " << eta_id;
-  std::cout << " rr12 " << rr12_id;
+  edm::LogVerbatim("RPCNumberingScheme") 
+    << " roll " << roll_id << " copy " << copy_id << " sector " << sector_id
+    << " plane " << plane_id << " eta " << eta_id << " rr12 " << rr12_id;
 #endif
 
   // Build the actual numbering
@@ -223,8 +220,7 @@ int RPCNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) {
   
   
 #ifdef LOCAL_DEBUG
-  std::cout << " DetId " << id;  
-  std::cout << std::endl;
+  edm::LogVerbatim("RPCNumberingScheme") << "RPCNumberingScheme:: DetId " << id;  
 #endif
       
   return id.rawId();


### PR DESCRIPTION
#### PR description:

Avoid using out in the debug codes of Geometry/MuonNumbering

#### PR validation:

Passes the standard matrix of tests

#### if this PR is a backport please specify the original PR:

Nothing special