### PR TITLE
Add DT digis and CSC strip digis to RECO event content

### DIFF
--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
@@ -18,7 +18,9 @@ RecoLocalMuonRECO = cms.PSet(
         'keep *_dt4DCosmicSegments_*_*',
         'keep *_csc2DRecHits_*_*', 
         'keep *_cscSegments_*_*', 
-        'keep *_rpcRecHits_*_*')
+        'keep *_rpcRecHits_*_*',
+        'keep *_muonDTDigis_*_*',
+        'keep *_muonCSCDigis_MuonCSCStripDigi_*')
 )
 # AOD content
 RecoLocalMuonAOD = cms.PSet(


### PR DESCRIPTION
#### PR description:

This PR is intended as a temporary fix for the problem with RECOfromRECO workflow arose in [PR 26369](https://github.com/cms-sw/cmssw/pull/26369#discussion_r276960586). It was implemented as a follow-up action from today's RECO meeting.

#### PR validation:

The increase in event size was tested in the following workflows:

**136.879** (RunSingleMu2018C)
[...]
muonCSCDigis:MuonCSCStripDigi (CSCDetIdCSCStripDigiMuonDigiCollection) 183824 18999.5
muonDTDigis: (DTLayerIdDTDigiMuonDigiCollection) 14911.6 2932.03
[...]
for a total of ~ 2.8 M event for the RECO dataset from step3

**1102.0_RR** (TTbar 8 TeV simulation with RECOfromRECO step)
[...]
uonCSCDigis:MuonCSCStripDigi (CSCDetIdCSCStripDigiMuonDigiCollection) 22364.8 2211.07
muonDTDigis: (DTLayerIdDTDigiMuonDigiCollection) 639.1 131.29
[...]
for a total of ~ 0.64 M event for the RECO dataset from step3

@Fedespring @slava77 @fabiocos 