### PR TITLE
Add get() and getHandle() to dependent ES records, and getTransientHandle() to EventSetup

### DIFF
--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -76,6 +76,33 @@ class DependentRecordImplementation : public EventSetupRecordImplementation<Reco
         return eventSetupT.tryToGet<DepRecordT>();
       }
 
+      using EventSetupRecordImplementation<RecordT>::getHandle;
+
+      template<typename ProductT, typename DepRecordT>
+      ESHandle<ProductT> getHandle(ESGetToken<ProductT, DepRecordT> const& iToken) const {
+        //Make sure that DepRecordT is a type in ListT
+        using EndItrT = typename boost::mpl::end< ListT >::type;
+        using FoundItrT = typename boost::mpl::find< ListT, DepRecordT >::type;
+        static_assert(! std::is_same<FoundItrT, EndItrT>::value, "Trying to get a a product with an ESGetToken specifying a Record from another Record where the second Record is not dependent on the first Record.");
+        return getRecord<DepRecordT>().getHandle(iToken);
+      }
+
+      using EventSetupRecordImplementation<RecordT>::get;
+
+      template<typename ProductT, typename DepRecordT>
+      ProductT const& get(ESGetToken<ProductT, DepRecordT> const& iToken) const {
+        //Make sure that DepRecordT is a type in ListT
+        using EndItrT = typename boost::mpl::end< ListT >::type;
+        using FoundItrT = typename boost::mpl::find< ListT, DepRecordT >::type;
+        static_assert(! std::is_same<FoundItrT, EndItrT>::value, "Trying to get a a product with an ESGetToken specifying a Record from another Record where the second Record is not dependent on the first Record.");
+        return getRecord<DepRecordT>().get(iToken);
+      }
+
+      template<typename ProductT, typename DepRecordT>
+      ProductT const& get(ESGetToken<ProductT, DepRecordT>& iToken) const {
+        return get(const_cast<ESGetToken<ProductT, DepRecordT> const&>(iToken));
+      }
+
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -83,7 +83,7 @@ class DependentRecordImplementation : public EventSetupRecordImplementation<Reco
         //Make sure that DepRecordT is a type in ListT
         using EndItrT = typename boost::mpl::end< ListT >::type;
         using FoundItrT = typename boost::mpl::find< ListT, DepRecordT >::type;
-        static_assert(! std::is_same<FoundItrT, EndItrT>::value, "Trying to get a a product with an ESGetToken specifying a Record from another Record where the second Record is not dependent on the first Record.");
+        static_assert(! std::is_same<FoundItrT, EndItrT>::value, "Trying to get a product with an ESGetToken specifying a Record from another Record where the second Record is not dependent on the first Record.");
         return getRecord<DepRecordT>().getHandle(iToken);
       }
 
@@ -94,7 +94,7 @@ class DependentRecordImplementation : public EventSetupRecordImplementation<Reco
         //Make sure that DepRecordT is a type in ListT
         using EndItrT = typename boost::mpl::end< ListT >::type;
         using FoundItrT = typename boost::mpl::find< ListT, DepRecordT >::type;
-        static_assert(! std::is_same<FoundItrT, EndItrT>::value, "Trying to get a a product with an ESGetToken specifying a Record from another Record where the second Record is not dependent on the first Record.");
+        static_assert(! std::is_same<FoundItrT, EndItrT>::value, "Trying to get a product with an ESGetToken specifying a Record from another Record where the second Record is not dependent on the first Record.");
         return getRecord<DepRecordT>().getTransientHandle(iToken);
       }
 
@@ -105,7 +105,7 @@ class DependentRecordImplementation : public EventSetupRecordImplementation<Reco
         //Make sure that DepRecordT is a type in ListT
         using EndItrT = typename boost::mpl::end< ListT >::type;
         using FoundItrT = typename boost::mpl::find< ListT, DepRecordT >::type;
-        static_assert(! std::is_same<FoundItrT, EndItrT>::value, "Trying to get a a product with an ESGetToken specifying a Record from another Record where the second Record is not dependent on the first Record.");
+        static_assert(! std::is_same<FoundItrT, EndItrT>::value, "Trying to get a product with an ESGetToken specifying a Record from another Record where the second Record is not dependent on the first Record.");
         return getRecord<DepRecordT>().get(iToken);
       }
 

--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -87,6 +87,17 @@ class DependentRecordImplementation : public EventSetupRecordImplementation<Reco
         return getRecord<DepRecordT>().getHandle(iToken);
       }
 
+      using EventSetupRecordImplementation<RecordT>::getTransientHandle;
+
+      template<typename ProductT, typename DepRecordT>
+      ESTransientHandle<ProductT> getTransientHandle(ESGetToken<ProductT, DepRecordT> const& iToken) const {
+        //Make sure that DepRecordT is a type in ListT
+        using EndItrT = typename boost::mpl::end< ListT >::type;
+        using FoundItrT = typename boost::mpl::find< ListT, DepRecordT >::type;
+        static_assert(! std::is_same<FoundItrT, EndItrT>::value, "Trying to get a a product with an ESGetToken specifying a Record from another Record where the second Record is not dependent on the first Record.");
+        return getRecord<DepRecordT>().getTransientHandle(iToken);
+      }
+
       using EventSetupRecordImplementation<RecordT>::get;
 
       template<typename ProductT, typename DepRecordT>

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -28,6 +28,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/EventSetupRecord.h"
 #include "FWCore/Framework/interface/EventSetupImpl.h"
@@ -143,6 +144,17 @@ namespace edm {
           } else {
              auto const& rec = this->get<R>();
              return rec.getHandle(iToken);
+          }
+      }
+
+      template <typename T, typename R>
+       ESTransientHandle<T> getTransientHandle(const ESGetToken<T, R>& iToken) const {
+          if constexpr ( std::is_same_v<R, edm::DefaultRecord> ) {
+             auto const& rec = this->get<eventsetup::default_record_t<ESTransientHandle<T>>>();
+             return rec.getTransientHandle(iToken);
+          } else {
+             auto const& rec = this->get<R>();
+             return rec.getTransientHandle(iToken);
           }
       }
 

--- a/FWCore/Framework/interface/EventSetupRecordImplementation.h
+++ b/FWCore/Framework/interface/EventSetupRecordImplementation.h
@@ -25,6 +25,7 @@
 
 #include "FWCore/Framework/interface/EventSetupRecord.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/data_default_record_trait.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 
@@ -48,30 +49,41 @@ namespace edm {
 
          template<typename PRODUCT>
          ESHandle<PRODUCT> getHandle(ESGetToken<PRODUCT,T> const& iToken) const {
-           return getHandleImpl(iToken);
+           return getHandleImpl<ESHandle>(iToken);
          }
 
          template<typename PRODUCT>
          ESHandle<PRODUCT> getHandle(ESGetToken<PRODUCT,edm::DefaultRecord> const& iToken) const {
            static_assert(std::is_same_v<T, eventsetup::default_record_t<ESHandle<PRODUCT>>>, "The Record being used to retrieve the product is not the default record for the product type");
-           return getHandleImpl(iToken);
+           return getHandleImpl<ESHandle>(iToken);
          }
+
+        template<typename PRODUCT>
+        ESTransientHandle<PRODUCT> getTransientHandle(ESGetToken<PRODUCT,T> const& iToken) const {
+          return getHandleImpl<ESTransientHandle>(iToken);
+        }
+
+        template<typename PRODUCT>
+        ESTransientHandle<PRODUCT> getTransientHandle(ESGetToken<PRODUCT,edm::DefaultRecord> const& iToken) const {
+          static_assert(std::is_same_v<T, eventsetup::default_record_t<ESTransientHandle<PRODUCT>>>, "The Record being used to retrieve the product is not the default record for the product type");
+          return getHandleImpl<ESTransientHandle>(iToken);
+        }
 
          using EventSetupRecord::get;
         
          template<typename PRODUCT>
          PRODUCT const& get(ESGetToken<PRODUCT,T> const& iToken) const {
-           return *getHandleImpl(iToken);
+           return *getHandleImpl<ESHandle>(iToken);
          }
         template<typename PRODUCT>
         PRODUCT const& get(ESGetToken<PRODUCT,T>& iToken) const {
-          return *getHandleImpl(const_cast<const ESGetToken<PRODUCT,T>&>(iToken));
+          return *getHandleImpl<ESHandle>(const_cast<const ESGetToken<PRODUCT,T>&>(iToken));
         }
 
          template<typename PRODUCT>
          PRODUCT const& get(ESGetToken<PRODUCT,edm::DefaultRecord> const& iToken) const {
            static_assert(std::is_same_v<T, eventsetup::default_record_t<ESHandle<PRODUCT>>>, "The Record being used to retrieve the product is not the default record for the product type");
-           return *getHandleImpl(iToken);
+           return *getHandleImpl<ESHandle>(iToken);
          }
         template<typename PRODUCT>
         PRODUCT const& get(ESGetToken<PRODUCT,edm::DefaultRecord>& iToken) const {


### PR DESCRIPTION
#### PR description:

This PR adds `get()` and `getHandle`() to dependent record enabling the same ESProduct retrieval pattern as from the non-dependent records, i.e. instead of
```cpp
edm::ESGetToken<BarData, BarRecord> barToken_;
...
std::unique_ptr<Foo> FooESProducer::produce(const FooRecord& iRecord) {
  const auto& barData = iRecord.getGetRecord<BarRecord>().get(barToken_);
  // or
  edm::ESHandle<BarData> barHandle = iRecord.getRecord<BarRecord>().get(barToken_);
  ...
}
```
one can do
```cpp
edm::ESGetToken<BarData, BarRecord> barToken_;
...
std::unique_ptr<FooData> FooESProducer::produce(const FooRecord& iRecord) {
  const auto& barData = iRecord.get(barToken_)
  // or
  edm::ESHandle<BarData> barHandle = iRecord.getHandle(barToken_);
  ...
}
```

This PR also adds `getTransientHandle()` to `EventSetup`, `EventSetupRecordImplementation`, and `DependentRecordImplementation` along the `getHandle()`. These functions are needed to support `edm::ESTransientHandle<T>` with `edm::ESGetToken`.

#### PR validation:

Framework compiles and relevant unit tests run.
