### PR TITLE
Avoid side-effects in typeid call within rz_harm_poly in MagneticField

### DIFF
--- a/MagneticField/ParametrizedEngine/src/rz_harm_poly.cc
+++ b/MagneticField/ParametrizedEngine/src/rz_harm_poly.cc
@@ -74,10 +74,9 @@ int rz_harm_poly::GetMaxM()
 //Return max abs(M) for all rz_harm_poly objects created
 //
    int M_cur, M_max = 0;
-   std::set<poly2d_base*>::iterator it;
-   for (it = poly2d_base_set.begin(); it != poly2d_base_set.end(); ++it) {
-      if (typeid(**it) == typeid(rz_harm_poly)) {
-         M_cur = std::abs(((rz_harm_poly*)(*it))->M);
+   for (auto const& poly:  poly2d_base_set) {
+      if (typeid(*poly) == typeid(rz_harm_poly)) {
+         M_cur = std::abs(static_cast<rz_harm_poly const*>(poly)->M);
          if (M_cur > M_max) M_max = M_cur;
       }
    }


### PR DESCRIPTION
#### PR description:

This fixes a clang warning.

#### PR validation:

The code compiles without warning using clang.