### PR TITLE
Removed self assignment in MTDModuleNumbering

### DIFF
--- a/Geometry/MTDNumberingBuilder/test/MTDModuleNumbering.cc
+++ b/Geometry/MTDNumberingBuilder/test/MTDModuleNumbering.cc
@@ -891,7 +891,7 @@ MTDModuleNumbering::analyze( const edm::Event& iEvent, const edm::EventSetup& iS
 			// TEC+
 		      case 2:
 			{
-			  phiRad = phiRad;
+			  //phiRad unchanged
 			  break;
 			}
 			// TEC-


### PR DESCRIPTION
#### PR description:

This fixes a clang warning.

#### PR validation:

Code compiles under clang with no warnings.