### PR TITLE
Fix clang warnings in FastSimulation/Muons

### DIFF
--- a/FastSimulation/Muons/plugins/FastTSGFromPropagation.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromPropagation.cc
@@ -371,7 +371,7 @@ void FastTSGFromPropagation::setEvent(const edm::Event& iEvent) {
     trackerGeomChanged = true;
   }
 
-  if ( trackerGeomChanged && (&*theTracker) ) {
+  if ( trackerGeomChanged && theTracker.product() ) {
     theNavigation.reset(new DirectTrackerNavigation(theTracker));
   }
 }

--- a/FastSimulation/Muons/plugins/FastTSGFromPropagation.h
+++ b/FastSimulation/Muons/plugins/FastTSGFromPropagation.h
@@ -41,7 +41,7 @@ class Propagator;
 class MeasurementTracker;
 class GeometricSearchTracker;
 class DirectTrackerNavigation;
-class TrajectoryStateTransform;
+struct TrajectoryStateTransform;
 class SimTrack;
 class TrackerGeometry;
 class TrackerTopology;


### PR DESCRIPTION
#### PR description:

- Avoid comparing reference to nullptr in FastTSGFromPropagation
- Declare TrajectoryStateTransform as struct in FastTSGFromPropagation
#### PR validation:

Compiles using clang with no warnings.