### PR TITLE
Remove infinite recursion in operator<< for FSimVertex

### DIFF
--- a/FastSimulation/Event/src/FSimVertex.cc
+++ b/FastSimulation/Event/src/FSimVertex.cc
@@ -10,5 +10,5 @@ FSimVertex::FSimVertex(const XYZTLorentzVector& v, int im, int id, FBaseSimEvent
   position_(v) {;}
 
 std::ostream& operator <<(std::ostream& o , const FSimVertex& t) {
-  return o << t;
+  return o << static_cast<SimVertex const&>(t);
 }


### PR DESCRIPTION
#### PR description:

This fixes a clang warning.

#### PR validation:

The code compiles using clang with no warnings.