### PR TITLE
Changed DQMStreamerReader method name to not clash with base class name

### DIFF
--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.h
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.h
@@ -41,10 +41,10 @@ class DQMStreamerReader : public edm::StreamerInputSource {
   // which will break things if called
   void reset_() override;
 
-  void openFile_(const DQMFileIterator::LumiEntry& entry);
-  void closeFile_(const std::string& reason);
+  void openFileImp_(const DQMFileIterator::LumiEntry& entry);
+  void closeFileImp_(const std::string& reason);
 
-  bool openNextFile_();
+  bool openNextFileImp_();
 
   InitMsgView const* getHeaderMsg();
   EventMsgView const* getEventMsg();


### PR DESCRIPTION

#### PR description:

closeFile_ was causing a clang warning since it was hiding a base class member function. Fixing the problem with 'using' did not work as the base class method was declared private. Therefore changing the function name avoids the warning.
Other *File_ names were changed as well to keep all the naming consistent.

#### PR validation:

The code compiles without warning using clang.