### PR TITLE
[PPS] [UL rereco] Labels for PPS/TOTEM timing calibration

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,16 +24,16 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v9',
+    'run1_data'         :   '106X_dataRun2_v10',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v9',
+    'run2_data'         :   '106X_dataRun2_v10',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v7',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v9',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v4',
+    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v5',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v5',
-    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v5',
+    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v6',
+    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v6',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,16 +24,16 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v8',
+    'run1_data'         :   '106X_dataRun2_v9',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v8',
+    'run2_data'         :   '106X_dataRun2_v9',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v7',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v4',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v4',
-    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v4',
+    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v5',
+    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v5',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
@@ -92,12 +92,12 @@ CTPPSDiamondRecHitProducer::fillDescriptions( edm::ConfigurationDescriptions& de
 
   desc.add<edm::InputTag>( "digiTag", edm::InputTag( "ctppsDiamondRawToDigi", "TimingDiamond" ) )
     ->setComment( "input digis collection to retrieve" );
+  desc.add<std::string>( "timingCalibrationTag", "GlobalTag:PPSDiamondTimingCalibration" )
+    ->setComment( "input tag for timing calibrations retrieval" );
   desc.add<double>( "timeSliceNs", 25.0/1024.0 )
     ->setComment( "conversion constant between HPTDC timing bin size and nanoseconds" );
   desc.add<int>( "timeShift", 0 ) // to be determined at calibration level, will be replaced by a map channel id -> time shift
     ->setComment( "overall time offset to apply on all hits in all channels" );
-  desc.add<std::string>( "timingCalibrationTag", "GlobalTag:PPSDiamondTimingCalibration" )
-    ->setComment( "input tag for timing calibrations retrieval" );
 
   descr.add( "ctppsDiamondRecHits", desc );
 }

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
@@ -93,6 +93,8 @@ CTPPSDiamondRecHitProducer::fillDescriptions( edm::ConfigurationDescriptions& de
     ->setComment( "conversion constant between HPTDC timing bin size and nanoseconds" );
   desc.add<int>( "timeShift", 0 ) // to be determined at calibration level, will be replaced by a map channel id -> time shift
     ->setComment( "overall time offset to apply on all hits in all channels" );
+  desc.add<std::string>( "timingCalibrationTag", "GlobalTag:PPSDiamondTimingCalibration" )
+    ->setComment( "input tag for timing calibrations retrieval" );
 
   descr.add( "ctppsDiamondRecHits", desc );
 }

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
@@ -43,6 +43,8 @@ class CTPPSDiamondRecHitProducer : public edm::stream::EDProducer<>
 
     edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondDigi> > digiToken_;
 
+    /// Label to timing calibration tag
+    edm::ESInputTag timingCalibrationTag_;
     /// A watcher to detect timing calibration changes.
     edm::ESWatcher<PPSTimingCalibrationRcd> calibWatcher_;
 
@@ -51,6 +53,7 @@ class CTPPSDiamondRecHitProducer : public edm::stream::EDProducer<>
 
 CTPPSDiamondRecHitProducer::CTPPSDiamondRecHitProducer( const edm::ParameterSet& iConfig ) :
   digiToken_( consumes<edm::DetSetVector<CTPPSDiamondDigi> >( iConfig.getParameter<edm::InputTag>( "digiTag" ) ) ),
+  timingCalibrationTag_( iConfig.getParameter<std::string>( "timingCalibrationTag" ) ),
   algo_( iConfig )
 {
   produces<edm::DetSetVector<CTPPSDiamondRecHit> >();
@@ -68,7 +71,7 @@ CTPPSDiamondRecHitProducer::produce( edm::Event& iEvent, const edm::EventSetup& 
   if ( !digis->empty() ) {
     if ( calibWatcher_.check( iSetup ) ) {
       edm::ESHandle<PPSTimingCalibration> hTimingCalib;
-      iSetup.get<PPSTimingCalibrationRcd>().get( hTimingCalib );
+      iSetup.get<PPSTimingCalibrationRcd>().get( timingCalibrationTag_, hTimingCalib );
       algo_.setCalibration( *hTimingCalib );
     }
     // get the geometry

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemTimingRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemTimingRecHitProducer.cc
@@ -55,7 +55,7 @@ class TotemTimingRecHitProducer : public edm::stream::EDProducer<>
 
 TotemTimingRecHitProducer::TotemTimingRecHitProducer( const edm::ParameterSet& iConfig ) :
   digiToken_( consumes<edm::DetSetVector<TotemTimingDigi> >( iConfig.getParameter<edm::InputTag>( "digiTag" ) ) ),
-  timingCalibrationTag_( iConfig.getParameter<edm::ESInputTag>( "timingCalibrationTag" ) ),
+  timingCalibrationTag_( iConfig.getParameter<std::string>( "timingCalibrationTag" ) ),
   algo_( iConfig )
 {
   produces<edm::DetSetVector<TotemTimingRecHit> >();
@@ -97,7 +97,7 @@ TotemTimingRecHitProducer::fillDescriptions( edm::ConfigurationDescriptions& des
 
   desc.add<edm::InputTag>( "digiTag", edm::InputTag( "totemTimingRawToDigi", "TotemTiming" ) )
     ->setComment( "input digis collection to retrieve" );
-  desc.add<edm::InputTag>( "timingCalibrationTag", edm::InputTag( "TotemTimingCalibration" ) )
+  desc.add<std::string>( "timingCalibrationTag", "GlobalTag:TotemTimingCalibration" )
     ->setComment( "input tag for timing calibrations retrieval" );
   desc.add<int>( "baselinePoints", 8 )
     ->setComment( "number of points to be used for the baseline" );

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemTimingRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemTimingRecHitProducer.cc
@@ -45,6 +45,8 @@ class TotemTimingRecHitProducer : public edm::stream::EDProducer<>
 
     /// Input digi collection
     edm::EDGetTokenT<edm::DetSetVector<TotemTimingDigi> > digiToken_;
+    /// Label to timing calibration tag
+    edm::ESInputTag timingCalibrationTag_;
     /// Digi-to-rechits transformation algorithm
     TotemTimingRecHitProducerAlgorithm algo_;
     /// Timing calibration parameters watcher
@@ -53,6 +55,7 @@ class TotemTimingRecHitProducer : public edm::stream::EDProducer<>
 
 TotemTimingRecHitProducer::TotemTimingRecHitProducer( const edm::ParameterSet& iConfig ) :
   digiToken_( consumes<edm::DetSetVector<TotemTimingDigi> >( iConfig.getParameter<edm::InputTag>( "digiTag" ) ) ),
+  timingCalibrationTag_( iConfig.getParameter<edm::ESInputTag>( "timingCalibrationTag" ) ),
   algo_( iConfig )
 {
   produces<edm::DetSetVector<TotemTimingRecHit> >();
@@ -72,7 +75,7 @@ TotemTimingRecHitProducer::produce( edm::Event& iEvent, const edm::EventSetup& i
     // check for timing calibration parameters update
     if ( calibWatcher_.check( iSetup ) ) {
       edm::ESHandle<PPSTimingCalibration> hTimingCalib;
-      iSetup.get<PPSTimingCalibrationRcd>().get( hTimingCalib );
+      iSetup.get<PPSTimingCalibrationRcd>().get( timingCalibrationTag_, hTimingCalib );
       algo_.setCalibration( *hTimingCalib );
     }
 
@@ -94,6 +97,8 @@ TotemTimingRecHitProducer::fillDescriptions( edm::ConfigurationDescriptions& des
 
   desc.add<edm::InputTag>( "digiTag", edm::InputTag( "totemTimingRawToDigi", "TotemTiming" ) )
     ->setComment( "input digis collection to retrieve" );
+  desc.add<edm::InputTag>( "timingCalibrationTag", edm::InputTag( "TotemTimingCalibration" ) )
+    ->setComment( "input tag for timing calibrations retrieval" );
   desc.add<int>( "baselinePoints", 8 )
     ->setComment( "number of points to be used for the baseline" );
   desc.add<double>( "saturationLimit", 0.85 )


### PR DESCRIPTION
#### PR description:

***PR intended for UL re-reco, cannot be tested prior to GT update!***
Following discussion triggered in [last AlCaDB meeting](https://indico.cern.ch/event/814179/contributions/3396956/attachments/1829964/2996758/AlCaDB_15.04.2019.pdf), labels are now used to specify which calibrations payload is to be used for which subdetector's offline SW. Rechits producers are hence adapted and labels are parsed from an extra string in `ESProducer` configuration.
Autocond list is updated to include new GTs introducing this new and labelled timing calibrations collection.

#### PR validation:

Tested for randomised Run 1-2 physics runs with (IOV local) calibration JSON, SQLite file, and `106X_dataRun2_Candidate_2019_04_27_14_01_54` GT candidate. All results behave as expected.

Matrix tests yielded `32 30 26 20 11 2 1 1 1 tests passed, 1 1 3 0 0 0 0 0 0 failed` (DAS errors + segfault in step3 of 136.85, 25202.0, and 10224.0 workflows, do not look related to this PR)

#### if this PR is a backport please specify the original PR: N/A

Before submitting your pull requests, make sure you followed this checklist:
- [x] verify that the PR is really intended for the chosen branch
- [x] verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- [x] verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

cc: @fabferro @jan-kaspar @vavati