### PR TITLE
Only declare accept methods that are overridden in BPHMultiSelect

### DIFF
--- a/HeavyFlavorAnalysis/RecoDecay/interface/BPHFitSelect.h
+++ b/HeavyFlavorAnalysis/RecoDecay/interface/BPHFitSelect.h
@@ -40,6 +40,7 @@ class BPHFitSelect {
    */
   virtual ~BPHFitSelect();
 
+  using AcceptArg = BPHKinematicFit;
   /** Operations
    */
   /// accept function

--- a/HeavyFlavorAnalysis/RecoDecay/interface/BPHMomentumSelect.h
+++ b/HeavyFlavorAnalysis/RecoDecay/interface/BPHMomentumSelect.h
@@ -40,6 +40,7 @@ class BPHMomentumSelect {
    */
   virtual ~BPHMomentumSelect();
 
+  using AcceptArg = BPHDecayMomentum;
   /** Operations
    */
   /// accept function

--- a/HeavyFlavorAnalysis/RecoDecay/interface/BPHRecoSelect.h
+++ b/HeavyFlavorAnalysis/RecoDecay/interface/BPHRecoSelect.h
@@ -44,6 +44,7 @@ class BPHRecoSelect {
    */
   virtual ~BPHRecoSelect();
 
+  using AcceptArg = reco::Candidate;
   /** Operations
    */
   /// accept function

--- a/HeavyFlavorAnalysis/RecoDecay/interface/BPHVertexSelect.h
+++ b/HeavyFlavorAnalysis/RecoDecay/interface/BPHVertexSelect.h
@@ -40,6 +40,7 @@ class BPHVertexSelect {
    */
   virtual ~BPHVertexSelect();
 
+  using AcceptArg = BPHDecayVertex;
   /** Operations
    */
   /// accept function

--- a/HeavyFlavorAnalysis/RecoDecay/src/BPHMultiSelect.cc
+++ b/HeavyFlavorAnalysis/RecoDecay/src/BPHMultiSelect.cc
@@ -41,20 +41,16 @@
 //--------------
 // Operations --
 //--------------
-template<>
 bool BPHMultiSelect<BPHRecoSelect    >::accept(
                                         const reco::Candidate & cand,
                                         const BPHRecoBuilder* build ) const {
   return select( cand, build );
 }
 
-
-template<>
 bool BPHMultiSelect<BPHRecoSelect    >::accept(
                                         const reco::Candidate & cand ) const {
   return select( cand );
 }
-
 
 template<>
 bool BPHMultiSelect<BPHMomentumSelect>::accept(


### PR DESCRIPTION
#### PR description:

The template class BPHMultiSelect now only declares accept methods
which are to be overriden from the class from which it is inheriting.
This fixes a clang warning and avoids calling unnecessary methods.

#### PR validation:

The code compiles without warnings using clang.