### PR TITLE
Advance the loop counter only in one place in SiStripPopConHandlerUnitTestGain

### DIFF
--- a/OnlineDB/SiStripO2O/plugins/SiStripPopConHandlerUnitTestGain.h
+++ b/OnlineDB/SiStripO2O/plugins/SiStripPopConHandlerUnitTestGain.h
@@ -193,7 +193,7 @@ namespace popcon{
 	  count++;
 	  //Generate Gains for det detid
 	  SiStripApvGain::InputVector inputApvGain;
-	  for(int apv=0; apv<it->second.nApvs; ++apv){
+	  for(int apv=0; apv<it->second.nApvs; ++(++apv)){
 	    
 	    float MeanTick = 555.;
 	    float RmsTick  = 55.;
@@ -210,7 +210,6 @@ namespace popcon{
 						   << std::endl; 	    
 	    inputApvGain.push_back(tick); //APV0
 	    inputApvGain.push_back(tick); //APV1
-	    apv++;
 	  }    
 	  
 	  


### PR DESCRIPTION
#### PR description:

This fixes a clang warning.

#### PR validation:

This compiles without warnings using clang.