### PR TITLE
Migrate Simulation step to Tasks

### DIFF
--- a/Configuration/StandardSequences/python/SimExtended_cff.py
+++ b/Configuration/StandardSequences/python/SimExtended_cff.py
@@ -9,6 +9,7 @@ from SimG4Core.Configuration.SimG4Core_cff import *
 # use Hector output instead of the generator one
 g4SimHits.Generator.HepMCProductLabel = cms.string('LHCTransport')
 
-psim = cms.Sequence(cms.SequencePlaceholder("randomEngineStateProducer")*LHCTransport*g4SimHits)
+psimTask = cms.Task(cms.TaskPlaceholder("randomEngineStateProducer"), LHCTransport, g4SimHits)
+psim = cms.Sequence(psimTask)
 
 

--- a/Configuration/StandardSequences/python/SimIdeal_cff.py
+++ b/Configuration/StandardSequences/python/SimIdeal_cff.py
@@ -3,4 +3,5 @@ import FWCore.ParameterSet.Config as cms
 # CMSSW/Geant4 interface
 from SimG4Core.Configuration.SimG4Core_cff import *
 
-psim = cms.Sequence(cms.SequencePlaceholder("randomEngineStateProducer")*g4SimHits)
+psimTask = cms.Task(cms.TaskPlaceholder("randomEngineStateProducer"), g4SimHits)
+psim = cms.Sequence(psimTask)

--- a/Configuration/StandardSequences/python/SimNOBEAM_cff.py
+++ b/Configuration/StandardSequences/python/SimNOBEAM_cff.py
@@ -7,6 +7,7 @@ g4SimHits.NonBeamEvent = cms.bool(True)
 g4SimHits.Generator.HepMCProductLabel = cms.InputTag('generatorSmeared')
 g4SimHits.Generator.ApplyEtaCuts = cms.bool(False)
 
-psim = cms.Sequence(cms.SequencePlaceholder("randomEngineStateProducer")*g4SimHits)
+psimTask = cms.Task(cms.TaskPlaceholder("randomEngineStateProducer"), g4SimHits)
+psim = cms.Sequence(psimTask)
 
 

--- a/Configuration/StandardSequences/python/Simulation_cff.py
+++ b/Configuration/StandardSequences/python/Simulation_cff.py
@@ -35,6 +35,7 @@ from Configuration.StandardSequences.Sim_cff import *
 #
 from Configuration.StandardSequences.Digi_cff import *
 from SimGeneral.HepPDTESSource.pythiapdt_cfi import *
-simulation = cms.Sequence(psim*pdigi)
+simulationTask = cms.Task(psimTask)
+simulation = cms.Sequence(pdigi, simulationTask)
 
 


### PR DESCRIPTION
#### PR description:

This PR migrates the Simulation step to use Tasks in the configuration. This change should increase the available concurrency in the jobs running Simulation.

#### PR validation:

Limited matrix runs.