### PR TITLE
Run3-gem31 Change GEMDetId in view of merging ME0 with GE1/2

### DIFF
--- a/DataFormats/MuonDetId/interface/GEMDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMDetId.h
@@ -8,147 +8,291 @@
  */
 
 #include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include <iosfwd>
 #include <iostream>
 
-class GEMDetId :public DetId {
+class GEMDetId : public DetId {
+
+public:
+  static constexpr int32_t minRegionId  =-1;
+  static constexpr int32_t maxRegionId  = 1;
+  static constexpr int32_t minRingId    = 1;
+  static constexpr int32_t maxRingId    = 3;
+  static constexpr int32_t minStationId = 0;
+  static constexpr int32_t maxStationId = 2;  // in the detId there is space to go up to 5 stations. Only 3 implemented now (0,1,2)
+  static constexpr int32_t minChamberId = 0;
+  static constexpr int32_t maxChamberId = 36;
+  static constexpr int32_t minLayerId   = 0;  // LayerId = 0 is superChamber
+  static constexpr int32_t maxLayerId   = 6;
+  static constexpr int32_t maxLayerId12 = 2;  // GE1/GE2 has 2 layers
+  static constexpr int32_t minRollId    = 0;
+  static constexpr int32_t maxRollId    = 15;
+
+private:
+  static constexpr uint32_t RegionNumBits      =  2;
+  static constexpr uint32_t RegionStartBit     =  0;  
+  static constexpr uint32_t RegionMask         =  0x3;
+  static constexpr uint32_t RingNumBits        =  3;
+  static constexpr uint32_t RingStartBit       =  RegionStartBit+RegionNumBits;
+  static constexpr uint32_t RingMask           =  0x7;
+  static constexpr uint32_t StationNumBits     =  3;
+  static constexpr uint32_t StationStartBit    =  RingStartBit+RingNumBits;  
+  static constexpr uint32_t StationMask        =  0x7;
+  static constexpr uint32_t ChamberNumBits     =  6;
+  static constexpr uint32_t ChamberStartBit    =  StationStartBit+StationNumBits;  
+  static constexpr uint32_t ChamberStartBitM   =  RegionStartBit+RegionNumBits;
+  static constexpr uint32_t ChamberMask        =  0x3F;
+  static constexpr uint32_t LayerNumBits       =  5;
+  static constexpr uint32_t LayerNumBitsP      =  2;
+  static constexpr uint32_t LayerStartBit      =  ChamberStartBit+ChamberNumBits;
+  static constexpr uint32_t LayerStartBitM     =  ChamberStartBitM+ChamberNumBits;  
+  static constexpr uint32_t LayerMask          =  0x1F;
+  static constexpr uint32_t LayerMaskP         =  0x3;
+  static constexpr uint32_t RollNumBits        =  5;
+  static constexpr uint32_t RollStartBit       =  LayerStartBit+LayerNumBits;
+  static constexpr uint32_t RollStartBitP      =  LayerStartBit+LayerNumBitsP;
+  static constexpr uint32_t RollStartBitM      =  LayerStartBitM+LayerNumBits;
+  static constexpr uint32_t RollMask           =  0x1F;
+  static constexpr uint32_t FormatNumBits      =  1;
+  static constexpr uint32_t FormatStartBit     =  RollStartBit+RollNumBits;
+  static constexpr uint32_t FormatMask         =  0x1;
+  static constexpr uint32_t kGEMIdFormat       =  0x1000000;
+  static constexpr uint32_t kMuonIdMask        =  0xF0000000;
+  static constexpr uint32_t chamberIdMask      = ~(RollMask<<RollStartBit);
+  static constexpr uint32_t superChamberIdMask = chamberIdMask + ~(LayerMask<<LayerStartBit);
   
- public:
-      
-  GEMDetId();
-
-  /// Construct from a packed id. It is required that the Detector part of
-  /// id is Muon and the SubDet part is GEM, otherwise an exception is thrown.
-  GEMDetId(uint32_t id);
-  GEMDetId(DetId id);
-
-
+public:
+  /** Create a null detId */
+  constexpr GEMDetId() : DetId(DetId::Muon, MuonSubdetId::GEM) { }
+  /** Construct from a packed id. It is required that the Detector part of
+      id is Muon and the SubDet part is GEM, otherwise an exception is thrown*/
+  constexpr GEMDetId(uint32_t id) : DetId(id) {
+    if (det() != DetId::Muon || (subdetId() != MuonSubdetId::GEM && 
+				 subdetId() != MuonSubdetId::ME0))
+      throw cms::Exception("InvalidDetId") 
+	<< "GEMDetId ctor: det: " << det() << " subdet: " << subdetId()
+	<< " is not a valid GEM id\n";  
+    
+    if (oldFormat()) id_ = newForm(id);
+  }
+  /** Construct from a generic cell ID */
+  constexpr GEMDetId(DetId id) : DetId(id) {
+    if (det() != DetId::Muon || (subdetId() != MuonSubdetId::GEM && 
+				 subdetId() != MuonSubdetId::ME0))
+      throw cms::Exception("InvalidDetId") 
+	<< "GEMDetId ctor: det: " << det() << " subdet: " << subdetId()
+	<< " is not a valid GEM id\n";  
+    if (oldFormat()) id_ = newForm(id.rawId());
+  }
   /// Construct from fully qualified identifier.
-  GEMDetId(int region, 
-	   int ring,
-	   int station, 
-	   int layer,
-	   int chamber,
-	   int roll);
+  constexpr GEMDetId(int region,int ring, int station, int layer,int chamber,
+		     int roll)  : DetId(DetId::Muon, MuonSubdetId::GEM) {
+    if ( region     < minRegionId    || region    > maxRegionId ||
+	 ring       < minRingId      || ring      > maxRingId ||
+	 station    < minStationId   || station   > maxStationId ||
+	 layer      < minLayerId     || layer     > maxLayerId ||
+	 chamber    < minChamberId   || chamber   > maxChamberId ||
+	 roll       < minRollId      || roll      > maxRollId)
+      throw cms::Exception("InvalidDetId") 
+	<< "GEMDetId ctor: Invalid parameters:  region " << region
+	<< " ring " << ring << " station " << station << " layer " << layer
+	<< " chamber " << chamber << " roll " << roll << std::endl;
+      
+    int regionInBits  = region-minRegionId;
+    int ringInBits    = ring-minRingId;
+    int stationInBits = station-minStationId;
+    int layerInBits   = layer-minLayerId;
+    int chamberInBits = chamber-(minChamberId+1);
+    int rollInBits    = roll;
+ 
+    id_ |= (( regionInBits    & RegionMask)    << RegionStartBit    | 
+	    ( ringInBits      & RingMask)      << RingStartBit      |
+	    ( stationInBits   & StationMask)   << StationStartBit   |
+	    ( layerInBits     & LayerMask)     << LayerStartBit     |
+	    ( chamberInBits   & ChamberMask)   << ChamberStartBit   |
+	    ( rollInBits      & RollMask)      << RollStartBit      |
+	    kGEMIdFormat);
+  }
 	   
+  /** Assignment from a generic cell id */
+  constexpr GEMDetId& operator=(const DetId& gen) {
+    if (!gen.null()) {
+      int subdet = gen.subdetId();
+      if (gen.det() != Muon || (subdet != MuonSubdetId::GEM && 
+				subdet != MuonSubdetId::ME0))
+	throw cms::Exception("InvalidDetId") 
+	  << "GEMDetId ctor: Cannot assign GEMDetID from  " << std::hex
+	  << gen.rawId() << std::dec;
+      if (oldFormat()) id_ = newForm(gen.rawId());
+      else             id_ = gen.rawId();
+    } else {
+      id_ = gen.rawId();
+    }
+    return (*this);
+  }
 
-  /// Sort Operator based on the raw detector id
-  bool operator < (const GEMDetId& r) const{
-    if (r.station() == this->station()  ){
-      if (this->layer() ==  r.layer()  ){
+  /** Comparison operator */
+  constexpr bool operator==(const GEMDetId& gen) const {
+    uint32_t rawid = gen.rawId();
+    if (rawid == id_) return true;
+    int reg(0), ri(0), stn(-1), lay(0), chamb(0), rol(0);
+    unpackId(rawid, reg, ri, stn, lay, chamb, rol);
+    return (((id_&kMuonIdMask) == (rawid&kMuonIdMask)) && 
+	    (reg == region()) && (ri == ring()) && 
+	    (stn == station()) && (lay == layer()) &&
+	    (chamb == chamber()) && (rol == roll()));
+  }
+  constexpr bool operator!=(const GEMDetId& gen) const {
+    uint32_t rawid = gen.rawId();
+    if (rawid == id_) return false;
+    int reg(0), ri(0), stn(-1), lay(0), chamb(0), rol(0);
+    unpackId(rawid, reg, ri, stn, lay, chamb, rol);
+    return (((id_&kMuonIdMask) != (rawid&kMuonIdMask)) ||
+	    (reg != region()) || (ri != ring()) ||
+	    (stn != station()) || (lay != layer()) ||
+	    (chamb != chamber()) || (rol != roll()));
+  }
+
+  /** Sort Operator based on the raw detector id */
+  constexpr bool operator < (const GEMDetId& r) const {
+    if (r.station() == this->station()  ) {
+      if (this->layer() ==  r.layer()  ) {
 	return this->rawId()<r.rawId();
-      }
-      else{
+      } else {
 	return (this->layer() < r.layer());
       }
-    }
-    else {
+    } else {
       return this->station() < r.station();
     }
   }
 
-  /// Region id: 0 for Barrel Not in use, +/-1 For +/- Endcap
-  int region() const{
-    return int((id_>>RegionStartBit_) & RegionMask_) + minRegionId;
+  /** Check the format */
+  constexpr bool oldFormat() const {
+    return (((id_&kGEMIdFormat) == 0) ? true : false);
   }
 
-  /// Ring id: GEM are installed only on ring 1
-  /// the ring is the group of chambers with same r (distance of beam axis) and increasing phi
-  int ring() const{
-      return int((id_>>RingStartBit_) & RingMask_) + minRingId;
+  /** Region id: 0 for Barrel Not in use, +/-1 For +/- Endcap */
+  constexpr int region() const {
+    return (static_cast<int>((id_>>RegionStartBit) & RegionMask)+minRegionId);
   }
 
-  /// Station id : the station is the pair of chambers at same disk
-  int station() const{
-    return int((id_>>StationStartBit_) & StationMask_) + minStationId;
+  /** Ring id: GEM are installed only on ring 1
+      the ring is the group of chambers with same r (distance of beam axis) 
+      and increasing phi */
+  constexpr int ring() const {
+    return (static_cast<int>((id_>>RingStartBit) & RingMask) + minRingId);
   }
 
-  /// Layer id: each station have two layers of chambers: layer 1 is the inner chamber and layer 2 is the outer chamber (when present)  
-  int layer() const{
-    return int((id_>>LayerStartBit_) & LayerMask_) + minLayerId;
+  /** Station id : the station is the set of chambers at same disk */
+  constexpr int station() const {
+    return (static_cast<int>((id_>>StationStartBit) & StationMask)+minStationId);
   }
 
-  /// Chamber id: it identifies a chamber in a ring it goes from 1 to 36 
-  int chamber() const{
-    return int((id_>>ChamberStartBit_) & ChamberMask_) + (minChamberId+1);
+  /** Chamber id: it identifies a chamber in a ring it goes from 1 to 36 
+      for GE1 and GE2 and 1 to 18 for ME0 */
+  constexpr int chamber() const {
+    return (static_cast<int>((id_>>ChamberStartBit) & ChamberMask) + (minChamberId+1));
   }
 
- /// Roll id  (also known as eta partition): each chamber is divided along the strip direction in  
- /// several parts  (rolls) GEM up to 10
-  int roll() const{
-    return int((id_>>RollStartBit_) & RollMask_); // value 0 is used as wild card
+  /** Layer id: each station have two layers of chambers for GE1 and GE2: 
+      layer 1 is the inner chamber and layer 2 is the outer chamber 
+      For ME0 there are 6 layers of chambers */
+  constexpr int layer() const {
+    return (static_cast<int>((id_>>LayerStartBit) & LayerMask) + minLayerId);
   }
 
-  /// Return the corresponding ChamberId
-  GEMDetId chamberId() const {
-    return GEMDetId(id_ & chamberIdMask_);
+  /** Roll id  (also known as eta partition): each chamber is divided along 
+      the strip direction in  several parts  (rolls) GEM up to 12 */
+  constexpr int roll() const {
+    return (static_cast<int>((id_>>RollStartBit) & RollMask)); // value 0 is used as wild card
   }
 
-  /// Return the corresponding superChamberId
-  GEMDetId superChamberId() const {
-    return GEMDetId(id_ & superChamberIdMask_);
+  /** Return the corresponding ChamberId */
+  constexpr GEMDetId chamberId() const {
+    return GEMDetId(id_ & chamberIdMask);
   }
 
-  static const int minRegionId=     -1;
-  static const int maxRegionId=      1;
- 
-  static const int minRingId=   1;
-  static const int maxRingId=   3;
+  /** Return the corresponding superChamberId */
+  constexpr GEMDetId superChamberId() const {
+    return GEMDetId(id_ & superChamberIdMask);
+  }
 
-  static const int minStationId=     1;
-  static const int maxStationId=     2;  // in the detId there is space to go up to 4 stations. Only 2 implemented now
+  /** Return the corresponding LayerId (mask eta partition) */
+  constexpr GEMDetId layerId() const {
+    return GEMDetId(id_ & chamberIdMask);
+  }
 
-  static const int minChamberId=     0;
-  static const int maxChamberId=     36;
+  /** Return total # of layers for this type of detector */
+  constexpr int nlayers() const {
+    return ((station() == 0) ? maxLayerId : ((station() > maxStationId) ?
+					     0 : maxLayerId12));
+  }
 
-  // LayerId = 0 is superChamber
-  static const int minLayerId=     0;
-  static const int maxLayerId=     2;
+  constexpr uint32_t newForm() const {
+    return newForm(id_);
+  }
 
-  static const int minRollId=	  0;
-  static const int maxRollId=	 15;
+  constexpr static uint32_t newForm(const uint32_t& inpid) {
+    uint32_t rawid(inpid);
+    if ((rawid&kGEMIdFormat) == 0) {
+      int region(0), ring(0), station(-1), layer(0), chamber(0), roll(0);
+      unpackId(rawid, region, ring, station, layer, chamber, roll);
+      int regionInBits  = region-minRegionId;
+      int ringInBits    = ring-minRingId;
+      int stationInBits = station-minStationId;
+      int layerInBits   = layer-minLayerId;
+      int chamberInBits = chamber-(minChamberId+1);
+      int rollInBits    = roll;
+      rawid = (((DetId::Muon & DetId::kDetMask) << DetId::kDetOffset) |
+	       ((MuonSubdetId::GEM & DetId::kSubdetMask) << DetId::kSubdetOffset) |
+	       ((regionInBits    & RegionMask)    << RegionStartBit)  | 
+	       ((ringInBits      & RingMask)      << RingStartBit)    |
+	       ((stationInBits   & StationMask)   << StationStartBit) |
+	       ((layerInBits     & LayerMask)     << LayerStartBit)   |
+	       ((chamberInBits   & ChamberMask)   << ChamberStartBit) |
+	       ((rollInBits      & RollMask)      << RollStartBit)    |
+	       kGEMIdFormat);
+    }
+    return rawid;
+  }
 
- private:
-  static const int RegionNumBits_  =  2;
-  static const int RegionStartBit_ =  0;  
-  static const int RegionMask_     =  0X3;
+private:
 
-  static const int RingNumBits_  =  3;
-  static const int RingStartBit_ =  RegionStartBit_+RegionNumBits_;  
-  static const unsigned int RingMask_     =  0X7;
+  constexpr void newFromOld(const uint32_t& rawid) {
+    id_ = newForm(rawid);
+  }
 
-  static const int StationNumBits_  =  3;
-  static const int StationStartBit_ =  RingStartBit_+RingNumBits_;  
-  static const unsigned int StationMask_     =  0X7;
-
-
-  static const int ChamberNumBits_  =  6;
-  static const int ChamberStartBit_ =  StationStartBit_+StationNumBits_;  
-  static const unsigned int ChamberMask_     =  0X3F;
-
-  static const int LayerNumBits_  =  2;
-  static const int LayerStartBit_ =  ChamberStartBit_+ChamberNumBits_;  
-  static const unsigned int LayerMask_     =  0X3;
-
-  static const int RollNumBits_  =  5;
-  static const int RollStartBit_ =  LayerStartBit_+LayerNumBits_;  
-  static const unsigned int RollMask_     =  0X1F;
- 
-  static const uint32_t chamberIdMask_ = ~(RollMask_<<RollStartBit_);
-
-  static const uint32_t superChamberIdMask_ = chamberIdMask_ + ~(LayerMask_<<LayerStartBit_);
+  constexpr static void unpackId(const uint32_t& rawid, int& region, int& ring,
+				 int& station, int& layer, int& chamber, 
+				 int& roll) {
+    if (((rawid>>DetId::kDetOffset) & DetId::kDetMask) == DetId::Muon) {
+      int subdet = ((rawid >> DetId::kSubdetOffset) & DetId::kSubdetMask);
+      if (subdet == MuonSubdetId::GEM) {
+	region = static_cast<int>(((rawid>>RegionStartBit) & RegionMask)+minRegionId);
+	ring   = (static_cast<int>((rawid>>RingStartBit) & RingMask) + minRingId);
+	station= (static_cast<int>((rawid>>StationStartBit) & StationMask)+minStationId);
+	chamber= (static_cast<int>((rawid>>ChamberStartBit) & ChamberMask) + (minChamberId+1));
+	if ((rawid&kGEMIdFormat) == 0) {
+	  layer = (static_cast<int>((rawid>>LayerStartBit) & LayerMaskP) + minLayerId);
+	  roll  = (static_cast<int>((rawid>>RollStartBitP) & RollMask));
+	} else {
+	  layer = (static_cast<int>((rawid>>LayerStartBit) & LayerMask) + minLayerId);
+	  roll  = (static_cast<int>((rawid>>RollStartBit) & RollMask));
+	}
+      } else if (subdet == MuonSubdetId::ME0) {
+	region = static_cast<int>(((rawid>>RegionStartBit) & RegionMask)+minRegionId);
+	ring   = 1;
+	station= 0;
+	chamber= (static_cast<int>((rawid>>ChamberStartBitM) & ChamberMask) + (minChamberId));
+	layer = (static_cast<int>((rawid>>LayerStartBitM) & LayerMask) + minLayerId);
+	roll  = (static_cast<int>((rawid>>RollStartBitM) & RollMask));
+      }
+    }
+  }
   
- private:
-  void init(int region, 
-	    int ring,
-	    int station, 
-	    int layer,
-	    int chamber,
-	    int roll);
-  
-  int trind;
 }; // GEMDetId
 
 std::ostream& operator<<( std::ostream& os, const GEMDetId& id );

--- a/DataFormats/MuonDetId/interface/GEMDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMDetId.h
@@ -172,7 +172,7 @@ public:
 
   /** Check the format */
   constexpr bool v11Format() const {
-    return (((id_&kGEMIdFormat) == 0) ? true : false);
+    return ((id_&kGEMIdFormat) == 0);
   }
 
   /** Region id: 0 for Barrel Not in use, +/-1 For +/- Endcap */

--- a/DataFormats/MuonDetId/interface/GEMDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMDetId.h
@@ -21,13 +21,14 @@ public:
   static constexpr int32_t maxRegionId  = 1;
   static constexpr int32_t minRingId    = 1;
   static constexpr int32_t maxRingId    = 3;
-  static constexpr int32_t minStationId = 0;
+  static constexpr int32_t minStationId0= 0;
+  static constexpr int32_t minStationId = 1;
   static constexpr int32_t maxStationId = 2;  // in the detId there is space to go up to 5 stations. Only 3 implemented now (0,1,2)
   static constexpr int32_t minChamberId = 0;
   static constexpr int32_t maxChamberId = 36;
   static constexpr int32_t minLayerId   = 0;  // LayerId = 0 is superChamber
-  static constexpr int32_t maxLayerId   = 6;
-  static constexpr int32_t maxLayerId12 = 2;  // GE1/GE2 has 2 layers
+  static constexpr int32_t maxLayerId0  = 6;
+  static constexpr int32_t maxLayerId   = 2;  // GE1/GE2 has 2 layers
   static constexpr int32_t minRollId    = 0;
   static constexpr int32_t maxRollId    = 15;
 
@@ -92,8 +93,8 @@ public:
 		     int roll)  : DetId(DetId::Muon, MuonSubdetId::GEM) {
     if ( region     < minRegionId    || region    > maxRegionId ||
 	 ring       < minRingId      || ring      > maxRingId ||
-	 station    < minStationId   || station   > maxStationId ||
-	 layer      < minLayerId     || layer     > maxLayerId ||
+	 station    < minStationId0  || station   > maxStationId ||
+	 layer      < minLayerId     || layer     > maxLayerId0 ||
 	 chamber    < minChamberId   || chamber   > maxChamberId ||
 	 roll       < minRollId      || roll      > maxRollId)
       throw cms::Exception("InvalidDetId") 
@@ -103,7 +104,7 @@ public:
       
     int regionInBits  = region-minRegionId;
     int ringInBits    = ring-minRingId;
-    int stationInBits = station-minStationId;
+    int stationInBits = station-minStationId0;
     int layerInBits   = layer-minLayerId;
     int chamberInBits = chamber-(minChamberId+1);
     int rollInBits    = roll;
@@ -188,7 +189,7 @@ public:
 
   /** Station id : the station is the set of chambers at same disk */
   constexpr int station() const {
-    return (static_cast<int>((id_>>StationStartBit) & StationMask)+minStationId);
+    return (static_cast<int>((id_>>StationStartBit) & StationMask)+minStationId0);
   }
 
   /** Chamber id: it identifies a chamber in a ring it goes from 1 to 36 
@@ -227,8 +228,8 @@ public:
 
   /** Return total # of layers for this type of detector */
   constexpr int nlayers() const {
-    return ((station() == 0) ? maxLayerId : ((station() > maxStationId) ?
-					     0 : maxLayerId12));
+    return ((station() == 0) ? maxLayerId0 : ((station() > maxStationId) ?
+					     0 : maxLayerId));
   }
 
   constexpr uint32_t newForm() const {
@@ -242,7 +243,7 @@ public:
       unpackId(rawid, region, ring, station, layer, chamber, roll);
       int regionInBits  = region-minRegionId;
       int ringInBits    = ring-minRingId;
-      int stationInBits = station-minStationId;
+      int stationInBits = station-minStationId0;
       int layerInBits   = layer-minLayerId;
       int chamberInBits = chamber-(minChamberId+1);
       int rollInBits    = roll;
@@ -273,7 +274,7 @@ private:
       if (subdet == MuonSubdetId::GEM) {
 	region = static_cast<int>(((rawid>>RegionStartBit) & RegionMask)+minRegionId);
 	ring   = (static_cast<int>((rawid>>RingStartBit) & RingMask) + minRingId);
-	station= (static_cast<int>((rawid>>StationStartBit) & StationMask)+minStationId);
+	station= (static_cast<int>((rawid>>StationStartBit) & StationMask)+minStationId0);
 	chamber= (static_cast<int>((rawid>>ChamberStartBit) & ChamberMask) + (minChamberId+1));
 	if ((rawid&kGEMIdFormat) == 0) {
 	  layer = (static_cast<int>((rawid>>LayerStartBit) & LayerMaskP) + minLayerId);

--- a/DataFormats/MuonDetId/interface/GEMDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMDetId.h
@@ -77,7 +77,7 @@ public:
 	<< "GEMDetId ctor: det: " << det() << " subdet: " << subdetId()
 	<< " is not a valid GEM id\n";  
     
-    if (oldFormat()) id_ = newForm(id);
+    if (v11Format()) id_ = v12Form(id);
   }
   /** Construct from a generic cell ID */
   constexpr GEMDetId(DetId id) : DetId(id) {
@@ -86,7 +86,7 @@ public:
       throw cms::Exception("InvalidDetId") 
 	<< "GEMDetId ctor: det: " << det() << " subdet: " << subdetId()
 	<< " is not a valid GEM id\n";  
-    if (oldFormat()) id_ = newForm(id.rawId());
+    if (v11Format()) id_ = v12Form(id.rawId());
   }
   /// Construct from fully qualified identifier.
   constexpr GEMDetId(int region,int ring, int station, int layer,int chamber,
@@ -127,7 +127,7 @@ public:
 	throw cms::Exception("InvalidDetId") 
 	  << "GEMDetId ctor: Cannot assign GEMDetID from  " << std::hex
 	  << gen.rawId() << std::dec;
-      if (oldFormat()) id_ = newForm(gen.rawId());
+      if (v11Format()) id_ = v12Form(gen.rawId());
       else             id_ = gen.rawId();
     } else {
       id_ = gen.rawId();
@@ -171,7 +171,7 @@ public:
   }
 
   /** Check the format */
-  constexpr bool oldFormat() const {
+  constexpr bool v11Format() const {
     return (((id_&kGEMIdFormat) == 0) ? true : false);
   }
 
@@ -232,11 +232,11 @@ public:
 					     0 : maxLayerId));
   }
 
-  constexpr uint32_t newForm() const {
-    return newForm(id_);
+  constexpr uint32_t v12Form() const {
+    return v12Form(id_);
   }
 
-  constexpr static uint32_t newForm(const uint32_t& inpid) {
+  constexpr static uint32_t v12Form(const uint32_t& inpid) {
     uint32_t rawid(inpid);
     if ((rawid&kGEMIdFormat) == 0) {
       int region(0), ring(0), station(-1), layer(0), chamber(0), roll(0);
@@ -262,8 +262,8 @@ public:
 
 private:
 
-  constexpr void newFromOld(const uint32_t& rawid) {
-    id_ = newForm(rawid);
+  constexpr void v12FromV11(const uint32_t& rawid) {
+    id_ = v12Form(rawid);
   }
 
   constexpr static void unpackId(const uint32_t& rawid, int& region, int& ring,

--- a/DataFormats/MuonDetId/interface/GEMDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMDetId.h
@@ -274,12 +274,13 @@ private:
       if (subdet == MuonSubdetId::GEM) {
 	region = static_cast<int>(((rawid>>RegionStartBit) & RegionMask)+minRegionId);
 	ring   = (static_cast<int>((rawid>>RingStartBit) & RingMask) + minRingId);
-	station= (static_cast<int>((rawid>>StationStartBit) & StationMask)+minStationId0);
 	chamber= (static_cast<int>((rawid>>ChamberStartBit) & ChamberMask) + (minChamberId+1));
 	if ((rawid&kGEMIdFormat) == 0) {
+	  station= (static_cast<int>((rawid>>StationStartBit) & StationMask)+minStationId);
 	  layer = (static_cast<int>((rawid>>LayerStartBit) & LayerMaskP) + minLayerId);
 	  roll  = (static_cast<int>((rawid>>RollStartBitP) & RollMask));
 	} else {
+	  station= (static_cast<int>((rawid>>StationStartBit) & StationMask)+minStationId0);
 	  layer = (static_cast<int>((rawid>>LayerStartBit) & LayerMask) + minLayerId);
 	  roll  = (static_cast<int>((rawid>>RollStartBit) & RollMask));
 	}

--- a/DataFormats/MuonDetId/src/GEMDetId.cc
+++ b/DataFormats/MuonDetId/src/GEMDetId.cc
@@ -6,12 +6,12 @@
 
 std::ostream& operator<<( std::ostream& os, const GEMDetId& id ){
 
-  os << " Region "  << id.region()
-     << " Ring "    << id.ring()
-     << " Station " << id.station()
-     << " Layer "   << id.layer()
-     << " Chamber " << id.chamber()
-     << " Roll "    << id.roll()
+  os << " Re " << id.region()
+     << " Ri " << id.ring()
+     << " St " << id.station()
+     << " La " << id.layer()
+     << " Ch " << id.chamber()
+     << " Ro " << id.roll()
      <<" ";
 
   return os;

--- a/DataFormats/MuonDetId/src/GEMDetId.cc
+++ b/DataFormats/MuonDetId/src/GEMDetId.cc
@@ -3,82 +3,15 @@
  */
 
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
-#include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
-
-GEMDetId::GEMDetId():DetId(DetId::Muon, MuonSubdetId::GEM){}
-
-
-GEMDetId::GEMDetId(uint32_t id):DetId(id){
-  if (det()!=DetId::Muon || subdetId()!=MuonSubdetId::GEM) {
-    throw cms::Exception("InvalidDetId") << "GEMDetId ctor:"
-					 << " det: " << det()
-					 << " subdet: " << subdetId()
-					 << " is not a valid GEM id";  
-  }
-}
-
-GEMDetId::GEMDetId(DetId id):DetId(id) {
-  if (det()!=DetId::Muon || subdetId()!=MuonSubdetId::GEM) {
-    throw cms::Exception("InvalidDetId") << "GEMDetId ctor:"
-					 << " det: " << det()
-					 << " subdet: " << subdetId()
-					 << " is not a valid GEM id";  
-  }
-}
-
-GEMDetId::GEMDetId(int region, int ring, int station, int layer,int chamber, int roll):	      
-  DetId(DetId::Muon, MuonSubdetId::GEM)
-{
-  this->init(region,ring,station,layer,chamber,roll);
-}
-
-void
-GEMDetId::init(int region,int ring,int station,
-	       int layer,int chamber,int roll)
-{
-  if ( region     < minRegionId    || region    > maxRegionId ||
-       ring       < minRingId      || ring      > maxRingId ||
-       station    < minStationId   || station   > maxStationId ||
-       layer      < minLayerId     || layer     > maxLayerId ||
-       chamber    < minChamberId   || chamber   > maxChamberId ||
-       roll       < minRollId      || roll      > maxRollId) {
-    throw cms::Exception("InvalidDetId") << "GEMDetId ctor:" 
-					 << " Invalid parameters: " 
-					 << " region "<<region
-					 << " ring "<<ring
-					 << " station "<<station
-					 << " layer "<<layer
-					 << " chamber "<<chamber
-					 << " roll "<<roll
-					 << std::endl;
-  }
-  int regionInBits=region-minRegionId;
-  int ringInBits = ring-minRingId;
-  int stationInBits=station-minStationId;
-  int layerInBits=layer-minLayerId;
-  int chamberInBits=chamber-(minChamberId+1);
-  int rollInBits=roll;
-  
-  id_ |= ( regionInBits    & RegionMask_)    << RegionStartBit_    | 
-         ( ringInBits      & RingMask_)      << RingStartBit_      |
-         ( stationInBits   & StationMask_)   << StationStartBit_   |
-         ( layerInBits     & LayerMask_)     << LayerStartBit_     |
-         ( chamberInBits   & ChamberMask_)    << ChamberStartBit_  |
-         ( rollInBits      & RollMask_)      << RollStartBit_        ;
-   
-}
-
-
 
 std::ostream& operator<<( std::ostream& os, const GEMDetId& id ){
 
-
-  os <<  " Re "<<id.region()
-     << " Ri "<<id.ring()
-     << " St "<<id.station()
-     << " La "<<id.layer()
-     << " Ch "<<id.chamber()
-     << " Ro "<<id.roll()
+  os << " Region "  << id.region()
+     << " Ring "    << id.ring()
+     << " Station " << id.station()
+     << " Layer "   << id.layer()
+     << " Chamber " << id.chamber()
+     << " Roll "    << id.roll()
      <<" ";
 
   return os;

--- a/DataFormats/MuonDetId/src/classes_def.xml
+++ b/DataFormats/MuonDetId/src/classes_def.xml
@@ -44,7 +44,7 @@
    <version ClassVersion="10" checksum="3587583837"/>
    <ioread sourceClass = "GEMDetId" version="[-11]" targetClass="GEMDetId" source="" target="">
     <![CDATA[
-      GEMDetId tmp(GEMDetId::newForm(newObj->rawId()));
+      GEMDetId tmp(GEMDetId::v12Form(newObj->rawId()));
       *newObj=tmp;
     ]]>
    </ioread>

--- a/DataFormats/MuonDetId/src/classes_def.xml
+++ b/DataFormats/MuonDetId/src/classes_def.xml
@@ -38,9 +38,16 @@
   <class name="DTSectCollId" ClassVersion="10">
    <version ClassVersion="10" checksum="1624682691"/>
   </class>
-  <class name="GEMDetId" ClassVersion="11">
+  <class name="GEMDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="1195033659"/>
    <version ClassVersion="11" checksum="2300896813"/>
    <version ClassVersion="10" checksum="3587583837"/>
+   <ioread sourceClass = "GEMDetId" version="[-11]" targetClass="GEMDetId" source="" target="">
+    <![CDATA[
+      GEMDetId tmp(GEMDetId::newForm(newObj->rawId()));
+      *newObj=tmp;
+    ]]>
+   </ioread>
   </class>
   <class name="ME0DetId" ClassVersion="11">
    <version ClassVersion="11" checksum="1292662416"/>

--- a/DataFormats/MuonDetId/test/BuildFile.xml
+++ b/DataFormats/MuonDetId/test/BuildFile.xml
@@ -18,3 +18,6 @@
 <library   file="RPCDetIdAnalyzer.cc" name="RPCDetIdAnalyzer">
   <flags   EDM_PLUGIN="1"/>
 </library>
+<library   file="GEMDetIdAnalyzer.cc" name="GEMDetIdAnalyzer">
+  <flags   EDM_PLUGIN="1"/>
+</library>

--- a/DataFormats/MuonDetId/test/GEMDetIdAnalyzer.cc
+++ b/DataFormats/MuonDetId/test/GEMDetIdAnalyzer.cc
@@ -1,0 +1,99 @@
+// system include files
+#include <iostream>
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
+#include "DataFormats/GEMRecHit/interface/ME0RecHitCollection.h"
+//
+// class declaration
+//
+
+class GEMDetIdAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+public:
+  explicit GEMDetIdAnalyzer(const edm::ParameterSet&);
+  ~GEMDetIdAnalyzer() override {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void beginJob() override {}
+  void beginRun(edm::Run const&, edm::EventSetup const&) override {}
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override {}
+
+private:
+  edm::EDGetToken gemRecHit_, me0RecHit_;
+  bool            newGEM_;
+};
+
+GEMDetIdAnalyzer::GEMDetIdAnalyzer(const edm::ParameterSet& iConfig) {
+  gemRecHit_ = consumes<GEMRecHitCollection>(iConfig.getParameter<edm::InputTag>("gemInputLabel"));
+  me0RecHit_ = consumes<ME0RecHitCollection>(iConfig.getParameter<edm::InputTag>("me0InputLabel"));
+  newGEM_    = iConfig.getParameter<bool>("newGEMDetID");
+}
+
+void GEMDetIdAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("gemInputLabel",edm::InputTag("gemRecHits"));
+  desc.add<edm::InputTag>("me0InputLabel",edm::InputTag("me0RecHits"));
+  desc.add<bool>("newGEMDetID",true);
+  descriptions.add("gemDetIdAnalyzer",desc);
+}
+
+void GEMDetIdAnalyzer::analyze(edm::Event const& iEvent, 
+			       edm::EventSetup const& iSetup) {
+
+
+  edm::Handle<GEMRecHitCollection> gemRecHits;
+  iEvent.getByToken(gemRecHit_, gemRecHits);
+  if (!gemRecHits.isValid()) {
+    edm::LogError("GEMAnalysis") << "GEM RecHit is not valid";
+  } else {
+    edm::LogVerbatim("GEMAnalysis") << "GEMRecHit collection with "
+				    << gemRecHits.product()->size() << " hits";
+    unsigned int k(0);
+    for (const auto& hit : *(gemRecHits.product())) {
+      GEMDetId id = hit.gemId();
+      edm::LogVerbatim("GEMAnalysis") << "Hit[" << k << "] " << std::hex 
+				      << id.rawId() << std::dec << " " << id;
+      ++k;
+    }
+  }
+
+  edm::Handle<ME0RecHitCollection> me0RecHits;
+  iEvent.getByToken(me0RecHit_, me0RecHits);
+  if (!me0RecHits.isValid()) {
+    edm::LogError("GEMAnalysis") << "ME0 RecHit is not valid";
+  } else {
+    edm::LogVerbatim("GEMAnalysis") << "ME0RecHit collection with "
+				    << me0RecHits.product()->size() << " hits";
+    unsigned int k(0);
+    for (const auto& hit : *(me0RecHits.product())) {
+      ME0DetId id = hit.me0Id();
+      edm::LogVerbatim("GEMAnalysis") << "Hit[" << k << "] " << std::hex 
+				      << id.rawId() << std::dec << " " << id;
+      if (newGEM_) {
+	GEMDetId idx(id.rawId());
+	edm::LogVerbatim("GEMAnalysis") << "for GEM " << std::hex 
+					<< idx.rawId() << std::dec << " "
+					<< idx;
+      }
+	
+      ++k;
+    }
+  }
+  
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(GEMDetIdAnalyzer);

--- a/DataFormats/MuonDetId/test/runGEMDetIdAnalysis_cfg.py
+++ b/DataFormats/MuonDetId/test/runGEMDetIdAnalysis_cfg.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process('PROD',eras.Phase2C4_timing_layer_bar)
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('DataFormats.MuonDetId.gemDetIdAnalyzer_cfi')
+
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.categories.append('GEMAnalysis')
+
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring(
+        'file:step3_29034.root',
+#       'root://cms-xrd-global.cern.ch//store/relval/CMSSW_9_1_1_patch1/RelValSingleElectronPt35Extended/GEN-SIM-RECO/91X_upgrade2023_realistic_v1_D17-v1/10000/10D95AC2-B14A-E711-BC4A-0CC47A7C3638.root',
+        )
+                            )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(20)
+)
+
+# Schedule definition
+process.p = cms.Path(process.gemDetIdAnalyzer)

--- a/Geometry/GEMGeometry/src/GEMGeometry.cc
+++ b/Geometry/GEMGeometry/src/GEMGeometry.cc
@@ -36,7 +36,7 @@ const GeomDet* GEMGeometry::idToDetUnit(DetId id) const{
 
 
 const GeomDet* GEMGeometry::idToDet(DetId id) const{
-  mapIdToDet::const_iterator i = theMap.find(id);
+  mapIdToDet::const_iterator i = theMap.find(DetId(GEMDetId(id)));
   return (i != theMap.end()) ? i->second : nullptr;
 }
 

--- a/Geometry/GEMGeometry/src/GEMGeometry.cc
+++ b/Geometry/GEMGeometry/src/GEMGeometry.cc
@@ -82,7 +82,7 @@ const GEMStation* GEMGeometry::station(int re, int st) const{
 
 const GEMRing* GEMGeometry::ring(int re, int st, int ri) const{
   for (auto ring : allRings) {
-    if (re != ring->region() || st != ring->station() || ri != ring->ring()) continue;	
+    if ((re != ring->region()) || (st != ring->station()) || (ri != ring->ring())) continue;	
     return ring;
   }
   return nullptr;

--- a/Geometry/GEMGeometry/src/GEMGeometry.cc
+++ b/Geometry/GEMGeometry/src/GEMGeometry.cc
@@ -36,7 +36,7 @@ const GeomDet* GEMGeometry::idToDetUnit(DetId id) const{
 
 
 const GeomDet* GEMGeometry::idToDet(DetId id) const{
-  mapIdToDet::const_iterator i = theMap.find(DetId(GEMDetId(id)));
+  mapIdToDet::const_iterator i = theMap.find(id);
   return (i != theMap.end()) ? i->second : nullptr;
 }
 
@@ -82,7 +82,7 @@ const GEMStation* GEMGeometry::station(int re, int st) const{
 
 const GEMRing* GEMGeometry::ring(int re, int st, int ri) const{
   for (auto ring : allRings) {
-    if ((re != ring->region()) || (st != ring->station()) || (ri != ring->ring())) continue;	
+    if (re != ring->region() || st != ring->station() || ri != ring->ring()) continue;	
     return ring;
   }
   return nullptr;

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilder.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilder.cc
@@ -201,7 +201,7 @@ void GEMCSCSegmentBuilder::build(const GEMRecHitCollection* recHits, const CSCSe
 		{
 		
 		  GEMDetId gemIdfromCSC(*gemRollIt);
-		  if(gemIdfromHit == gemIdfromCSC.rawId()) 
+		  if(gemIdfromHit == GEMDetId(gemIdfromCSC.rawId())) 
 		    {
 		      // get GEM RecHit vector associated to this CSC DetId
 		      // if no vector is associated yet to this CSC DetId, create empty vector

--- a/SimMuon/GEMDigitizer/src/GEMDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/GEMDigiProducer.cc
@@ -74,7 +74,7 @@ void GEMDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup) 
   // arrange the hits by eta partition
   std::map<uint32_t, edm::PSimHitContainer> hitMap;
   for (const auto& hit : hits) {
-    hitMap[hit.detUnitId()].emplace_back(hit);
+    hitMap[GEMDetId(hit.detUnitId()).rawId()].emplace_back(hit);
   }
 
   // simulate signal and noise for each eta partition

--- a/Validation/MuonGEMHits/src/GEMBaseValidation.cc
+++ b/Validation/MuonGEMHits/src/GEMBaseValidation.cc
@@ -78,8 +78,8 @@ string GEMBaseValidation::getSuffixTitle(int region){
 }
 
 string GEMBaseValidation::getStationLabel(int i) {
-  string stationLabel[] = {"1","2"};
-  return stationLabel[i-1];
+  string stationLabel[] = {"0","1","2"};
+  return stationLabel[i];
 }
 
 

--- a/Validation/MuonGEMHits/src/GEMHitsValidation.cc
+++ b/Validation/MuonGEMHits/src/GEMHitsValidation.cc
@@ -28,7 +28,7 @@ void GEMHitsValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Run con
   
   LogDebug("MuonGEMHitsValidation")<<"+++ Region independant part.\n";
   // Region independant.
-  for( auto const& station : GEMGeometry_->regions()[0]->stations() ){
+  for( auto& station : GEMGeometry_->regions()[0]->stations() ){
     int st = station->station();
     // TOF and Energy loss part are indepent from Region.
     // Labeling TOF and Energy loss

--- a/Validation/MuonGEMHits/src/GEMHitsValidation.cc
+++ b/Validation/MuonGEMHits/src/GEMHitsValidation.cc
@@ -79,7 +79,6 @@ void GEMHitsValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Run con
     for( auto& region : GEMGeometry_->regions() ){
       for( auto& station : region->stations() ){    
         for( auto& ring : station->rings()){
-          GEMDetId id;
           if ( ring->ring() != 1 ) break ; // Only Ring1 is interesting.
           string name_suffix = getSuffixName(region->region(), station->station());
           string title_suffix= getSuffixTitle(region->region(), station->station());

--- a/Validation/MuonGEMHits/src/GEMHitsValidation.cc
+++ b/Validation/MuonGEMHits/src/GEMHitsValidation.cc
@@ -167,7 +167,7 @@ void GEMHitsValidation::analyze(const edm::Event& e,
     Int_t nroll = (Int_t) id.roll();
 
     //Int_t even_odd = id.chamber()%2;
-    if ( GEMGeometry_->idToDet(hits->detUnitId()) == nullptr) {
+    if ( GEMGeometry_->idToDet(GEMDetId(hits->detUnitId())) == nullptr) {
       std::cout<<"simHit did not matched with GEMGeometry."<<std::endl;
       continue;
     }
@@ -175,7 +175,7 @@ void GEMHitsValidation::analyze(const edm::Event& e,
     //const GlobalPoint Gp0(GEMGeometry_->idToDet(hits->detUnitId())->surface().toGlobal(p0));
     const LocalPoint hitLP(hits->localPosition());
     
-    const GlobalPoint hitGP(GEMGeometry_->idToDet(hits->detUnitId())->surface().toGlobal(hitLP));
+    const GlobalPoint hitGP(GEMGeometry_->idToDet(GEMDetId(hits->detUnitId()))->surface().toGlobal(hitLP));
     Float_t g_r = hitGP.perp();
     Float_t g_x = hitGP.x();
     Float_t g_y = hitGP.y();

--- a/Validation/MuonGEMHits/src/GEMHitsValidation.cc
+++ b/Validation/MuonGEMHits/src/GEMHitsValidation.cc
@@ -28,7 +28,7 @@ void GEMHitsValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Run con
   
   LogDebug("MuonGEMHitsValidation")<<"+++ Region independant part.\n";
   // Region independant.
-  for( auto& station : GEMGeometry_->regions()[0]->stations() ){
+  for( auto const& station : GEMGeometry_->regions()[0]->stations() ){
     int st = station->station();
     // TOF and Energy loss part are indepent from Region.
     // Labeling TOF and Energy loss


### PR DESCRIPTION
#### PR description:

ME0 also contains GEM detectors like in GE11 and GE21. Attempt to merge the 2 DetID's ME0DetId and GEMDetId. GEMDetId will be used in all future applications

#### PR validation:

Standard runTheMatrix.py is run to test the changes. Also a file created in earlier production is read in with the changed GEMDetId class and tested to yield the same results

#### if this PR is a backport please specify the original PR:

No back porting is needed. However any change in DetId class needs recompilation a large part of the CMSSW code