### PR TITLE
Migrate Digi step to Tasks

### DIFF
--- a/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
@@ -34,11 +34,11 @@ DMEcalDigis.trigPrimProducer = cms.string('DMEcalTriggerPrimitiveDigis')
 DMEcalPreshowerDigis.digiProducer = cms.string('mixData')
 #DMEcalPreshowerDigis.ESdigiCollection = cms.string('ESDigiCollectionDM')
 
-ecalDigiSequenceDM = cms.Sequence(DMEcalTriggerPrimitiveDigis*DMEcalDigis*DMEcalPreshowerDigis)
+ecalDigiTaskDM = cms.Task(DMEcalTriggerPrimitiveDigis, DMEcalDigis, DMEcalPreshowerDigis)
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-_phase2_ecalDigiSequenceDM = ecalDigiSequenceDM.copy()
-_phase2_ecalDigiSequenceDM.insert(0,DMEcalEBTriggerPrimitiveDigis)
-phase2_common.toReplaceWith(ecalDigiSequenceDM, _phase2_ecalDigiSequenceDM)
+_phase2_ecalDigiTaskDM = ecalDigiTaskDM.copy()
+_phase2_ecalDigiTaskDM.add(DMEcalEBTriggerPrimitiveDigis)
+phase2_common.toReplaceWith(ecalDigiTaskDM, _phase2_ecalDigiTaskDM)
 
 # same for Hcal:
 
@@ -54,9 +54,9 @@ DMHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(cms.InputTag('mixD
 DMHcalDigis.digiLabel = cms.string('mixData')
 DMHcalTTPDigis.HFDigiCollection = cms.InputTag("mixData")
 
-hcalDigiSequenceDM = cms.Sequence(DMHcalTriggerPrimitiveDigis+DMHcalDigis*DMHcalTTPDigis)
+hcalDigiTaskDM = cms.Task(DMHcalTriggerPrimitiveDigis, DMHcalDigis, DMHcalTTPDigis)
 
-postDMDigi = cms.Sequence(ecalDigiSequenceDM+hcalDigiSequenceDM+muonDigi)
+postDMDigi = cms.Task(ecalDigiTaskDM, hcalDigiTaskDM, muonDigiTask)
 
 # disable adding noise to HCAL cells with no MC signal
 #mixData.doEmpty = False
@@ -68,8 +68,8 @@ postDMDigi = cms.Sequence(ecalDigiSequenceDM+hcalDigiSequenceDM+muonDigi)
 from SimGeneral.PileupInformation.AddPileupSummary_cfi import *
 
 
-
-pdatamix = cms.Sequence(mixData+postDMDigi+addPileupInfo)
+pdatamixTask = cms.Task(mixData, postDMDigi, addPileupInfo)
+pdatamix = cms.Sequence(pdatamixTask)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 def _fastSimDigis(process):

--- a/Configuration/StandardSequences/python/DigiCosmics_cff.py
+++ b/Configuration/StandardSequences/python/DigiCosmics_cff.py
@@ -51,7 +51,10 @@ simHcalDigis.HElevel = cms.int32(-10000)
 simHcalDigis.HOlevel   = cms.int32(-10000)
 simHcalDigis.HFlevel   = cms.int32(-10000)
 
-doAllDigi = cms.Sequence(calDigi+muonDigi)
-pdigi = cms.Sequence(cms.SequencePlaceholder("randomEngineStateProducer")*cms.SequencePlaceholder("mix")*doAllDigi)
-pdigi_valid = cms.Sequence(pdigi)
+doAllDigiTask = cms.Task(calDigiTask, muonDigiTask)
+pdigiTask = cms.Task(cms.TaskPlaceholder("randomEngineStateProducer"), cms.TaskPlaceholder("mix"), doAllDigiTask)
+
+doAllDigi = cms.Sequence(doAllDigiTask)
+pdigi = cms.Sequence(pdigiTask)
+pdigi_valid = cms.Sequence(pdigiTask)
 

--- a/Configuration/StandardSequences/python/DigiDM_cff.py
+++ b/Configuration/StandardSequences/python/DigiDM_cff.py
@@ -39,15 +39,15 @@ from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 
 # remove unnecessary modules from 'pdigi' sequence - run after DataMixing
 # standard mixing module now makes unsuppressed digis for calorimeter
-pdigi.remove(simEcalTriggerPrimitiveDigis)
-pdigi.remove(simEcalEBTriggerPrimitiveDigis) # phase2
-pdigi.remove(simEcalDigis)  # does zero suppression
-pdigi.remove(simEcalPreshowerDigis)  # does zero suppression
-pdigi.remove(simHcalDigis)
-pdigi.remove(simHcalTTPDigis)
+pdigiTask.remove(simEcalTriggerPrimitiveDigis)
+pdigiTask.remove(simEcalEBTriggerPrimitiveDigis) # phase2
+pdigiTask.remove(simEcalDigis)  # does zero suppression
+pdigiTask.remove(simEcalPreshowerDigis)  # does zero suppression
+pdigiTask.remove(simHcalDigis)
+pdigiTask.remove(simHcalTTPDigis)
 
 # premixing stage2 runs addPileupInfo, and muon digis after PreMixingModule (configured in DataMixerPreMix_cff)
-premix_stage2.toReplaceWith(pdigi, pdigi.copyAndExclude([addPileupInfo, genPUProtons, muonDigi]))
+premix_stage2.toReplaceWith(pdigiTask, pdigiTask.copyAndExclude([addPileupInfo, genPUProtons, muonDigiTask]))
 
 # genPUProtons, on the other hand, is an EDAlias. In principle it is
 # already loaded with digitizers_cfi, but in practice that gets

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -30,15 +30,21 @@ from Configuration.StandardSequences.Generator_cff import *
 from GeneratorInterface.Core.generatorSmeared_cfi import *
 from SimGeneral.PileupInformation.genPUProtons_cfi import *
 
-doAllDigi = cms.Sequence(generatorSmeared*calDigi+muonDigi)
-pdigi = cms.Sequence(generatorSmeared*fixGenInfo*cms.SequencePlaceholder("randomEngineStateProducer")*cms.SequencePlaceholder("mix")*doAllDigi*addPileupInfo*genPUProtons)
-pdigi_valid = cms.Sequence(pdigi)
-pdigi_nogen=cms.Sequence(generatorSmeared*cms.SequencePlaceholder("randomEngineStateProducer")*cms.SequencePlaceholder("mix")*doAllDigi*addPileupInfo*genPUProtons)
-pdigi_valid_nogen=cms.Sequence(pdigi_nogen)
+doAllDigiTask = cms.Task(generatorSmeared, calDigiTask, muonDigiTask)
+pdigiTask_nogen = cms.Task(generatorSmeared, cms.TaskPlaceholder("randomEngineStateProducer"), cms.TaskPlaceholder("mix"), doAllDigiTask, addPileupInfo, genPUProtons)
+pdigiTask = cms.Task(pdigiTask_nogen, fixGenInfoTask)
+
+doAllDigi = cms.Sequence(doAllDigiTask)
+pdigi = cms.Sequence(pdigiTask)
+pdigi_valid = cms.Sequence(pdigiTask)
+pdigi_nogen=cms.Sequence(pdigiTask_nogen)
+pdigi_valid_nogen=cms.Sequence(pdigiTask_nogen)
 
 from GeneratorInterface.HiGenCommon.HeavyIon_cff import *
-pdigi_hi=cms.Sequence(pdigi+heavyIon)
-pdigi_hi_nogen=cms.Sequence(pdigi_nogen+genJetMET+heavyIon)
+pdigiTask_hi = cms.Task(pdigiTask, heavyIon)
+pdigiTask_hi_nogen = cms.Task(pdigiTask_nogen, genJetMETTask, heavyIon)
+pdigi_hi=cms.Sequence(pdigiTask_hi)
+pdigi_hi_nogen=cms.Sequence(pdigiTask_hi_nogen)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 def _fastSimDigis(process):

--- a/Configuration/StandardSequences/python/Generator_cff.py
+++ b/Configuration/StandardSequences/python/Generator_cff.py
@@ -47,11 +47,13 @@ from RecoMET.Configuration.GenMETParticles_cff import *
 #   }
 # }
 
+GeneInfoTask = cms.Task(genParticles)
+genJetMETTask = cms.Task(genJetParticlesTask, recoGenJetsTask, genMETParticlesTask, recoGenMETTask)
 
 VertexSmearing = cms.Sequence(cms.SequencePlaceholder("VtxSmeared"))
 GenSmeared = cms.Sequence(generatorSmeared)
-GeneInfo = cms.Sequence(genParticles)
-genJetMET = cms.Sequence(genJetParticles*recoGenJets+genMETParticles*recoGenMET)
+GeneInfo = cms.Sequence(GeneInfoTask)
+genJetMET = cms.Sequence(genJetMETTask)
 
 pgen = cms.Sequence(cms.SequencePlaceholder("randomEngineStateProducer")+VertexSmearing+GenSmeared+GeneInfo+genJetMET)
 
@@ -59,7 +61,8 @@ pgen = cms.Sequence(cms.SequencePlaceholder("randomEngineStateProducer")+VertexS
 
 pgen_genonly = cms.Sequence(cms.SequencePlaceholder("randomEngineStateProducer"))
 
-fixGenInfo = cms.Sequence(GeneInfo * genJetMET)
+fixGenInfoTask = cms.Task(GeneInfoTask, genJetMETTask)
+fixGenInfo = cms.Sequence(fixGenInfoTask)
 
 
 import HLTrigger.HLTfilters.triggerResultsFilter_cfi

--- a/RecoJets/Configuration/python/GenJetParticles_cff.py
+++ b/RecoJets/Configuration/python/GenJetParticles_cff.py
@@ -27,4 +27,5 @@ genParticlesForJetsNoNu.ignoreParticleIDs += cms.vuint32( 12,14,16)
 genParticlesForJetsNoMuNoNu = genParticlesForJets.clone()
 genParticlesForJetsNoMuNoNu.ignoreParticleIDs += cms.vuint32( 12,13,14,16)
 
-genJetParticles = cms.Sequence(genParticlesForJets+genParticlesForJetsNoNu)
+genJetParticlesTask = cms.Task(genParticlesForJets, genParticlesForJetsNoNu)
+genJetParticles = cms.Sequence(genJetParticlesTask)

--- a/RecoJets/Configuration/python/RecoGenJets_cff.py
+++ b/RecoJets/Configuration/python/RecoGenJets_cff.py
@@ -12,11 +12,12 @@ ak8GenJetsNoNu = ak8GenJets.clone( src = cms.InputTag("genParticlesForJetsNoNu")
 ak4GenJetsNoMuNoNu = ak4GenJets.clone( src = cms.InputTag("genParticlesForJetsNoMuNoNu") )
 ak8GenJetsNoMuNoNu = ak8GenJets.clone( src = cms.InputTag("genParticlesForJetsNoMuNoNu") )
 
-recoGenJets  = cms.Sequence(ak4GenJets+
-                            ak8GenJets+
-                            ak4GenJetsNoNu+
-                            ak8GenJetsNoNu
-			    )
+recoGenJetsTask = cms.Task(ak4GenJets,
+                           ak8GenJets,
+                           ak4GenJetsNoNu,
+                           ak8GenJetsNoNu
+                           )
+recoGenJets  = cms.Sequence(recoGenJetsTask)
 
 recoAllGenJets=cms.Sequence(ak4GenJets+
                             ak8GenJets)

--- a/RecoMET/Configuration/python/GenMETParticles_cff.py
+++ b/RecoMET/Configuration/python/GenMETParticles_cff.py
@@ -53,4 +53,5 @@ genParticlesForMETAllVisible = cms.EDProducer(
     )
     )                                        
 
-genMETParticles = cms.Sequence(genCandidatesForMET+genParticlesForMETAllVisible)
+genMETParticlesTask = cms.Task(genCandidatesForMET, genParticlesForMETAllVisible)
+genMETParticles = cms.Sequence(genMETParticlesTask)

--- a/RecoMET/Configuration/python/RecoGenMET_cff.py
+++ b/RecoMET/Configuration/python/RecoGenMET_cff.py
@@ -11,5 +11,6 @@ from RecoMET.METProducers.genMetTrue_cfi import *
 from RecoMET.METProducers.genMetFromGenJets_cfi import *
 #
 
-recoGenMET = cms.Sequence(genMetCalo+genMetTrue)
+recoGenMETTask = cms.Task(genMetCalo, genMetTrue)
+recoGenMET = cms.Sequence(recoGenMETTask)
 

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_cff.py
@@ -3,8 +3,10 @@ import FWCore.ParameterSet.Config as cms
 from SimCalorimetry.Configuration.ecalDigiSequence_cff import *
 from SimCalorimetry.Configuration.hcalDigiSequence_cff import *
 from SimCalorimetry.Configuration.castorDigiSequence_cff import *
-calDigi = cms.Sequence(ecalDigiSequence+hcalDigiSequence+castorDigiSequence)
+
+calDigiTask = cms.Task(ecalDigiTask, hcalDigiTask, castorDigiTask)
+calDigi = cms.Sequence(calDigiTask)
 
 # fastsim has no castor model
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toReplaceWith(calDigi, calDigi.copyAndExclude([castorDigiSequence]))
+fastSim.toReplaceWith(calDigiTask, calDigiTask.copyAndExclude([castorDigiTask]))

--- a/SimCalorimetry/Configuration/python/castorDigiSequence_cff.py
+++ b/SimCalorimetry/Configuration/python/castorDigiSequence_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from SimCalorimetry.CastorSim.castordigi_cfi import *
+castorDigiTask = cms.Task()
 castorDigiSequence = cms.Sequence()
 

--- a/SimCalorimetry/Configuration/python/ecalDigiSequence_cff.py
+++ b/SimCalorimetry/Configuration/python/ecalDigiSequence_cff.py
@@ -9,18 +9,19 @@ from SimCalorimetry.EcalSelectiveReadoutProducers.ecalDigis_cfi import *
 # Preshower Zero suppression producer
 from SimCalorimetry.EcalZeroSuppressionProducers.ecalPreshowerDigis_cfi import *
 # simEcalUnsuppressedDigis is now done inside mixing module
-ecalDigiSequence = cms.Sequence(simEcalTriggerPrimitiveDigis*simEcalDigis*simEcalPreshowerDigis)
+ecalDigiTask = cms.Task(simEcalTriggerPrimitiveDigis, simEcalDigis, simEcalPreshowerDigis)
+ecalDigiSequence = cms.Sequence(ecalDigiTask)
 
 
 # This is extra, since the configuration skips it anyway.  Belts and suspenders.
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
-premix_stage1.toReplaceWith(ecalDigiSequence, ecalDigiSequence.copyAndExclude([simEcalPreshowerDigis]))
+premix_stage1.toReplaceWith(ecalDigiTask, ecalDigiTask.copyAndExclude([simEcalPreshowerDigis]))
 
 from SimCalorimetry.EcalEBTrigPrimProducers.ecalEBTriggerPrimitiveDigis_cff import *
-_phase2_ecalDigiSequence = ecalDigiSequence.copy()
-_phase2_ecalDigiSequence.insert(0,simEcalEBTriggerPrimitiveDigis)
+_phase2_ecalDigiTask = ecalDigiTask.copy()
+_phase2_ecalDigiTask.add(simEcalEBTriggerPrimitiveDigis)
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toReplaceWith(ecalDigiSequence,_phase2_ecalDigiSequence)
+phase2_common.toReplaceWith(ecalDigiTask,_phase2_ecalDigiTask)
 
 

--- a/SimCalorimetry/Configuration/python/hcalDigiSequence_cff.py
+++ b/SimCalorimetry/Configuration/python/hcalDigiSequence_cff.py
@@ -5,11 +5,10 @@ from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
 from SimCalorimetry.HcalTrigPrimProducers.hcalTTPDigis_cfi import *
 
 # simHcalUnsuppressedDigis is now done inside mixing module
-hcalDigiSequence = cms.Sequence(simHcalTriggerPrimitiveDigis
-                                +simHcalDigis
-                                *simHcalTTPDigis)
+hcalDigiTask = cms.Task(simHcalTriggerPrimitiveDigis, simHcalDigis, simHcalTTPDigis)
+hcalDigiSequence = cms.Sequence(hcalDigiTask)
 
 # remove HCAL TP sim for premixing stage1
 # not needed, sometimes breaks
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
-premix_stage1.toReplaceWith(hcalDigiSequence, cms.Sequence(simHcalDigis))
+premix_stage1.toReplaceWith(hcalDigiTask, cms.Task(simHcalDigis))

--- a/SimMuon/Configuration/python/SimMuon_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_cff.py
@@ -12,21 +12,22 @@ from SimMuon.DTDigitizer.muondtdigi_cfi import *
 # RPC digitizer
 # 
 from SimMuon.RPCDigitizer.muonrpcdigi_cfi import *
-muonDigi = cms.Sequence(simMuonCSCDigis+simMuonDTDigis+simMuonRPCDigis)
+muonDigiTask = cms.Task(simMuonCSCDigis, simMuonDTDigis, simMuonRPCDigis)
+muonDigi = cms.Sequence(muonDigiTask)
 
 from SimMuon.GEMDigitizer.muonGEMDigi_cff import *
 from SimMuon.GEMDigitizer.muonME0Digi_cff import *
 
-_run3_muonDigi = muonDigi.copy()
-_run3_muonDigi += muonGEMDigi
+_run3_muonDigiTask = muonDigiTask.copy()
+_run3_muonDigiTask.add(muonGEMDigiTask)
 
-_phase2_muonDigi = _run3_muonDigi.copy()
-_phase2_muonDigi += muonME0Digi
+_phase2_muonDigiTask = _run3_muonDigiTask.copy()
+_phase2_muonDigiTask.add(muonME0DigiTask)
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
-run2_GEM_2017.toReplaceWith( muonDigi, _run3_muonDigi )
+run2_GEM_2017.toReplaceWith( muonDigiTask, _run3_muonDigiTask )
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-run3_GEM.toReplaceWith( muonDigi, _run3_muonDigi )
+run3_GEM.toReplaceWith( muonDigiTask, _run3_muonDigiTask )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-phase2_muon.toReplaceWith( muonDigi, _phase2_muonDigi )
+phase2_muon.toReplaceWith( muonDigiTask, _phase2_muonDigiTask )
 

--- a/SimMuon/GEMDigitizer/python/muonGEMDigi_cff.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMDigi_cff.py
@@ -4,4 +4,5 @@ from SimMuon.GEMDigitizer.muonGEMDigis_cfi import *
 from SimMuon.GEMDigitizer.muonGEMPadDigis_cfi import *
 from SimMuon.GEMDigitizer.muonGEMPadDigiClusters_cfi import *
 
-muonGEMDigi = cms.Sequence(simMuonGEMDigis*simMuonGEMPadDigis*simMuonGEMPadDigiClusters)
+muonGEMDigiTask = cms.Task(simMuonGEMDigis, simMuonGEMPadDigis, simMuonGEMPadDigiClusters)
+muonGEMDigi = cms.Sequence(muonGEMDigiTask)

--- a/SimMuon/GEMDigitizer/python/muonME0Digi_cff.py
+++ b/SimMuon/GEMDigitizer/python/muonME0Digi_cff.py
@@ -6,8 +6,9 @@ from SimMuon.GEMDigitizer.muonME0PadDigiClusters_cfi import *
 from SimMuon.GEMDigitizer.muonME0PseudoDigis_cfi import *
 from SimMuon.GEMDigitizer.muonME0PseudoReDigis_cfi import *
 
-muonME0RealDigi = cms.Sequence(simMuonME0Digis * simMuonME0PadDigis + simMuonME0PadDigiClusters)
+muonME0RealDigi = cms.Task(simMuonME0Digis, simMuonME0PadDigis, simMuonME0PadDigiClusters)
 
-muonME0PseudoDigi = cms.Sequence(simMuonME0PseudoDigis * simMuonME0PseudoReDigis)
+muonME0PseudoDigi = cms.Task(simMuonME0PseudoDigis, simMuonME0PseudoReDigis)
 
-muonME0Digi = cms.Sequence(muonME0RealDigi * muonME0PseudoDigi)
+muonME0DigiTask = cms.Task(muonME0RealDigi, muonME0PseudoDigi)
+muonME0Digi = cms.Sequence(muonME0DigiTask)


### PR DESCRIPTION
#### PR description:

This PR migrates the Digi step and also the `DataMixerPreMix_cff` (as it is closely related to Digi step) to use Tasks in the configuration. This change should increase the available concurrency in the jobs running the Digi step.

#### PR validation:

Limited matrix runs.