### PR TITLE
DMRs separated by charge - Tracker Alignment

### DIFF
--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -274,6 +274,8 @@ private:
   const bool useOverflowForRMS_;
   const bool dqmMode_;
   const std::string moduleDirectory_;
+
+  const int chargeCut_;
   
   // a vector to keep track which pointers should be deleted at the very end
   std::vector<TH1*> vDeleteObjects_;
@@ -389,6 +391,7 @@ TrackerOfflineValidation::TrackerOfflineValidation(const edm::ParameterSet& iCon
     useOverflowForRMS_(parSet_.getParameter<bool>("useOverflowForRMS")),
     dqmMode_(parSet_.getParameter<bool>("useInDqmMode")),
     moduleDirectory_(parSet_.getParameter<std::string>("moduleDirectoryInOutput")),
+    chargeCut_(parSet_.getParameter<int>("chargeCut")),
     nTracks_(0),
     maxTracks_(parSet_.getParameter<unsigned long long>("maxTracks")),
     avalidator_(iConfig, consumesCollector())
@@ -1022,6 +1025,8 @@ TrackerOfflineValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   for (std::vector<TrackerValidationVariables::AVTrackStruct>::const_iterator itT = vTrackstruct.begin();	 
        itT != vTrackstruct.end();
        ++itT) {
+
+    if (itT->charge * chargeCut_ < 0) continue;
     
     if (maxTracks_ > 0 && nTracks_++ >= maxTracks_) break; //exit the loop after hitting the max number of tracks
     // Fill 1D track histos

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidation.py
@@ -17,6 +17,7 @@ class OfflineValidation(GenericValidationData_CTSR, ParallelValidation, Validati
         "offlineModuleLevelProfiles": "True",
         "stripYResiduals": "False",
         "maxtracks": "0",
+        "chargeCut": "0",
         }
     deprecateddefaults = {
         "DMRMethod":"",

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
@@ -32,7 +32,7 @@ process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..moduleLevelHistsTr
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..moduleLevelProfiles = .oO[offlineModuleLevelProfiles]Oo.
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..stripYResiduals = .oO[stripYResiduals]Oo.
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..maxTracks = .oO[maxtracks]Oo./ .oO[parallelJobs]Oo.
-process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..chargeCut = .oO[chargecut]Oo.
+process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..chargeCut = .oO[chargeCut]Oo.
 """
 
 OfflineValidationSequence = "process.seqTrackerOfflineValidation.oO[offlineValidationMode]Oo."

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
@@ -32,6 +32,7 @@ process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..moduleLevelHistsTr
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..moduleLevelProfiles = .oO[offlineModuleLevelProfiles]Oo.
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..stripYResiduals = .oO[stripYResiduals]Oo.
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..maxTracks = .oO[maxtracks]Oo./ .oO[parallelJobs]Oo.
+process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..chargeCut = .oO[chargecut]Oo.
 """
 
 OfflineValidationSequence = "process.seqTrackerOfflineValidation.oO[offlineValidationMode]Oo."

--- a/Alignment/OfflineValidation/python/TrackerOfflineValidation_cfi.py
+++ b/Alignment/OfflineValidation/python/TrackerOfflineValidation_cfi.py
@@ -15,7 +15,7 @@ TrackerOfflineValidation = cms.EDAnalyzer("TrackerOfflineValidation",
     useCombinedTrajectory     = cms.bool(False),
     useOverflowForRMS         = cms.bool(False),
     maxTracks                 = cms.uint64(0),
-    chargeCut                 = cms.int(0),
+    chargeCut                 = cms.int32(0),
     # Normalized X Residuals, normal local coordinates (Strip)
     TH1NormXResStripModules = cms.PSet(
         Nbinx = cms.int32(100), xmin = cms.double(-5.0), xmax = cms.double(5.0)

--- a/Alignment/OfflineValidation/python/TrackerOfflineValidation_cfi.py
+++ b/Alignment/OfflineValidation/python/TrackerOfflineValidation_cfi.py
@@ -15,6 +15,7 @@ TrackerOfflineValidation = cms.EDAnalyzer("TrackerOfflineValidation",
     useCombinedTrajectory     = cms.bool(False),
     useOverflowForRMS         = cms.bool(False),
     maxTracks                 = cms.uint64(0),
+    chargeCut                 = cms.int(0),
     # Normalized X Residuals, normal local coordinates (Strip)
     TH1NormXResStripModules = cms.PSet(
         Nbinx = cms.int32(100), xmin = cms.double(-5.0), xmax = cms.double(5.0)


### PR DESCRIPTION
Option to make DMR using only positive or negative tracks.
Presentation on March 20 about z expansion in TEC, using discrepancies between positive and negative tracks:[https://indico.cern.ch/event/787662/contributions/3362985/attachments/1815177/2966437/z_expansion.pdf](url)
@hroskes @adewit @connorpa @mmusich