### PR TITLE
Remove stray includes from PFBlockAlgo.h and minor cleanups

### DIFF
--- a/RecoParticleFlow/PFProducer/interface/PFBlockAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFBlockAlgo.h
@@ -38,13 +38,6 @@ class PFBlockAlgo {
  public:
   // the element list should **always** be a list of (smart) pointers
   typedef std::vector<std::unique_ptr<reco::PFBlockElement> > ElementList;
-  typedef std::unique_ptr<BlockElementImporterBase> ImporterPtr;
-  typedef std::unique_ptr<BlockElementLinkerBase> LinkTestPtr;  
-  typedef std::unique_ptr<KDTreeLinkerBase> KDTreePtr;
-  /// define these in *Fwd files in DataFormats/ParticleFlowReco?
-  typedef ElementList::iterator IE;
-  typedef ElementList::const_iterator IEC;  
-  typedef reco::PFBlockCollection::const_iterator IBC;
   //for skipping ranges
   typedef std::array<std::pair<unsigned int,unsigned int>,reco::PFBlockElement::kNBETypes> ElementRanges;
   
@@ -76,10 +69,6 @@ class PFBlockAlgo {
   void packLinks(reco::PFBlock& block, 
 		 const std::unordered_map<std::pair<unsigned int,unsigned int>,double>& links) const; 
   
-  /// Avoid to check links when not useful
-  inline bool linkPrefilter(const reco::PFBlockElement* last, 
-			    const reco::PFBlockElement* next) const;
-
   /// check whether 2 elements are linked. Returns distance
   inline void link( const reco::PFBlockElement* el1, 
 		    const reco::PFBlockElement* el2, 
@@ -95,22 +84,14 @@ class PFBlockAlgo {
   friend std::ostream& operator<<(std::ostream&, const PFBlockAlgo&);
   bool useHO_;
 
-  std::vector<ImporterPtr> importers_;
+  std::vector<std::unique_ptr<BlockElementImporterBase>> importers_;
 
   const std::unordered_map<std::string,reco::PFBlockElement::Type> 
     elementTypes_;
-  std::vector<LinkTestPtr> linkTests_;
+  std::vector<std::unique_ptr<BlockElementLinkerBase>> linkTests_;
   unsigned int linkTestSquare_[reco::PFBlockElement::kNBETypes][reco::PFBlockElement::kNBETypes];
   
-  std::vector<KDTreePtr> kdtrees_;
+  std::vector<std::unique_ptr<KDTreeLinkerBase>> kdtrees_;
 };
 
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h"
-#include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
-
 #endif
-
-

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
@@ -116,8 +116,6 @@ class PFEGammaAlgo {
 
   //constructor
   PFEGammaAlgo(const PFEGConfigInfo&);
-  //destructor
-  ~PFEGammaAlgo(){ };
 
   void setEEtoPSAssociation(EEtoPSAssociation const& eetops) { eetops_ = &eetops; }
 
@@ -133,9 +131,6 @@ class PFEGammaAlgo {
     cfg_.primaryVtx = & primary;
   }
 
-  void RunPFEG(const pfEGHelpers::HeavyObjectCache* hoc,
-               const reco::PFBlockRef&  blockRef);
-  
   //get PFCandidate collection
   reco::PFCandidateCollection& getCandidates() {return outcands_;}
 
@@ -144,6 +139,10 @@ class PFEGammaAlgo {
   
   //get refined SCs
   reco::SuperClusterCollection& getRefinedSCs() {return refinedscs_;}
+
+  // this runs the functions below
+  void buildAndRefineEGObjects(const pfEGHelpers::HeavyObjectCache* hoc,
+                               const reco::PFBlockRef& block);
   
 private: 
   
@@ -177,9 +176,6 @@ private:
   std::list<ProtoEGObject> _refinableObjects;
 
   // functions:
-  // this runs the functions below
-  void buildAndRefineEGObjects(const pfEGHelpers::HeavyObjectCache* hoc,
-                               const reco::PFBlockRef& block);
 
   // build proto eg object using all available unflagged resources in block.
   // this will be kind of like the old 'SetLinks' but with simplified and 
@@ -258,14 +254,6 @@ private:
 
   bool isPrimaryTrack(const reco::PFBlockElementTrack& KfEl,
 		      const reco::PFBlockElementGsfTrack& GsfEl);  
-  
- 
-  //std::vector<double> BDToutput_;
-  //std::vector<reco::PFCandidateElectronExtra > electronExtra_;
-  std::vector<bool> lockExtraKf_;
-  std::vector<bool> GsfTrackSingleEcal_;
-  std::vector< std::pair <unsigned int, unsigned int> > fifthStepKfTrack_;
-  std::vector< std::pair <unsigned int, unsigned int> > convGsfTrack_;
 
   PFEGConfigInfo cfg_;
 

--- a/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.cc
@@ -47,9 +47,8 @@ PFBlockProducer::produce(Event& iEvent,
     str<<"number of blocks : "<<blocks.size()<<endl;
     str<<endl;
     
-    for(PFBlockAlgo::IBC ib=blocks.begin(); 
-	ib != blocks.end(); ++ib) {
-      str<<(*ib)<<endl;
+    for(auto const& block : blocks) {
+      str<< block <<endl;
     }
 
     LogInfo("PFBlockProducer") << str.str()<<endl;

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
@@ -187,7 +187,7 @@ PFEGammaProducer::produce(edm::Event& iEvent,
     // make a copy of the link data, which will be edited.
     //PFBlock::LinkData linkData =  block.linkData();
     
-    pfeg_->RunPFEG(globalCache(),blockref);
+    pfeg_->buildAndRefineEGObjects(globalCache(),blockref);
 
     if( !pfeg_->getCandidates().empty() ) {
       LOGDRESSED("PFEGammaProducer")

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -582,16 +582,6 @@ PFEGammaAlgo::
 PFEGammaAlgo(const PFEGammaAlgo::PFEGConfigInfo& cfg) : cfg_(cfg)
 {}
 
-void PFEGammaAlgo::RunPFEG(const pfEGHelpers::HeavyObjectCache* hoc,
-                           const reco::PFBlockRef&  blockRef)
-{  
-
-  fifthStepKfTrack_.clear();
-  convGsfTrack_.clear();
-  
-  buildAndRefineEGObjects(hoc, blockRef);
-}
-
 float PFEGammaAlgo::evaluateSingleLegMVA(const pfEGHelpers::HeavyObjectCache* hoc,
                                          const reco::PFBlockRef& blockRef, 
                                          const reco::Vertex& primaryVtx, 
@@ -1758,8 +1748,8 @@ linkRefinableObjectSecondaryKFsToECAL(ProtoEGObject& RO) {
 	docast(const reco::PFBlockElementCluster*,ecal->first);      
       if( addPFClusterToROSafe(elemascluster,RO) ) {
 	attachPSClusters(elemascluster,RO.ecal2ps[elemascluster]);
-	RO.localMap.push_back(ElementMap::value_type(skf.first,elemascluster));
-	RO.localMap.push_back(ElementMap::value_type(elemascluster,skf.first));
+	RO.localMap.emplace_back(skf.first,elemascluster);
+	RO.localMap.emplace_back(elemascluster,skf.first);
 	ecal->second = false;      
       }
     }
@@ -1984,7 +1974,7 @@ float PFEGammaAlgo::calculateEleMVA(const pfEGHelpers::HeavyObjectCache* hoc,
     xtra.setGsfElectronClusterRef(_currentblock,*(ro.electronClusters[0]));
     firstEcalGsfEnergy = cref->correctedEnergy();    
     dEtGsfEcal = cref->positionREP().eta() - etaOutGsf;
-    gsfCluster.push_back(&*cref);
+    gsfCluster.push_back(cref.get());
     PFClusterWidthAlgo pfwidth(gsfCluster);
     sigmaEtaEta = pfwidth.pflowSigmaEtaEta();
   } 


### PR DESCRIPTION
#### PR description:

Sorry, quick follow up on https://github.com/cms-sw/cmssw/pull/26519: there were still include files hiding at the  bottom of `PFBlockAlgo.h` which I forgot to remove. Also some minor cleaning of PFBlockAlgo and PFEgammaAlgo.

#### PR validation:

CMSSW compiles and matrix tests pass.