### PR TITLE
Use brace initialization in FastMonitoringService

### DIFF
--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -192,7 +192,7 @@ namespace evf{
       throw cms::Exception("FastMonitoringService") << "EvFDaqDirector is not present";
     
     }
-    boost::filesystem::path runDirectory(edm::Service<evf::EvFDaqDirector>()->baseRunDir());
+    boost::filesystem::path runDirectory{edm::Service<evf::EvFDaqDirector>()->baseRunDir()};
     workingDirectory_ = runDirectory_ = runDirectory;
     workingDirectory_ /= "mon";
 


### PR DESCRIPTION
#### PR description:

gcc9 was trying to parse the line as a function declaration. Using brace initialization avoids the confusion.

#### PR validation:

The code compiles without error using gcc9 build.