### PR TITLE
Use brace initialization in DQMFileSaverPB

### DIFF
--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -164,7 +164,7 @@ DQMFileSaverPB::fillJson(int run, int lumi, const std::string& dataFilePathName,
     pt.put("definition", "/fakeDefinition.jsn");
   } else {
     // The availability test of the EvFDaqDirector Service was done in the ctor.
-    bfs::path outJsonDefName(edm::Service<evf::EvFDaqDirector>()->baseRunDir()); //we assume this file is written bu the EvF Output module
+    bfs::path outJsonDefName{edm::Service<evf::EvFDaqDirector>()->baseRunDir()}; //we assume this file is written bu the EvF Output module
     outJsonDefName /= (std::string("output_") + oss_pid.str() + std::string(".jsd"));
     pt.put("definition", outJsonDefName.string());
   }


### PR DESCRIPTION
#### PR description:

gcc9 was trying to parse the line as a function declaration. Using brace initialization avoids the confusion.

#### PR validation:

The code compiles without errors using the gcc9 build.