### PR TITLE
Bug fixes for EventSetup consumes corner cases

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -241,7 +241,16 @@ namespace edm {
       eventsetup::DataKey m_key;
       unsigned int m_startOfComponentName;
     };
-    
+
+    // TODO We would like to be able to access m_esTokenInfo from the
+    // index in the token, but this is currently not possible. One idea
+    // for this is to order the entries in m_esToken so that all the ones
+    // for transition 0 come first, then the ones for for transition 1
+    // and so on for all the transitions. Within a transition, the
+    // entries would be in the same order in m_esTokenInfo and
+    // esItemsToGetFromTransition_. This is something for future
+    // development and might require a change to SoATuple to support
+    // inserts in the middle of the data structure.
     enum {kESLookupInfo, kESProxyIndex};
     edm::SoATuple<ESTokenLookupInfo, ESProxyIndex> m_esTokenInfo;
     std::array<std::vector<ESProxyIndex>, static_cast<unsigned int>(edm::Transition::NumberOfTransitions)> esItemsToGetFromTransition_;

--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -157,7 +157,8 @@ namespace edm {
                          TReturn (T ::* iMethod)(const TRecord&),
                          const TArg& iDec,
                          const es::Label& iLabel = {}) {
-      const auto id = static_cast<unsigned int>(numberOfFactories());
+
+      const auto id = consumesInfos_.size();
       auto callback = std::make_shared<eventsetup::Callback<T,
                                                             TReturn,
                                                             TRecord,
@@ -171,7 +172,6 @@ namespace edm {
                        static_cast<const typename eventsetup::produce::product_traits<TReturn>::type *>(nullptr),
                        static_cast<const TRecord*>(nullptr),
                        iLabel);
-      assert(id == consumesInfos_.size());
       consumesInfos_.push_back(std::make_unique<ESConsumesInfo>());
       return ESConsumesCollectorT<TRecord>(consumesInfos_.back().get(),id);
     }

--- a/FWCore/Framework/interface/ESProxyFactoryProducer.h
+++ b/FWCore/Framework/interface/ESProxyFactoryProducer.h
@@ -116,10 +116,6 @@ class ESProxyFactoryProducer : public eventsetup::DataProxyProvider
       virtual void registerFactoryWithKey(const eventsetup::EventSetupRecordKey& iRecord ,
                                           std::unique_ptr<eventsetup::ProxyFactoryBase> iFactory,
                                           const std::string& iLabel= std::string() );
-  
-      size_t numberOfFactories() const noexcept {
-         return record2Factories_.size();
-      }
 
    private:
       ESProxyFactoryProducer(const ESProxyFactoryProducer&) = delete; // stop default

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -259,8 +259,9 @@ EDConsumerBase::recordESConsumes(Transition iTrans,
 
   auto index = static_cast<ESProxyIndex::Value_t>(m_esTokenInfo.size());
   m_esTokenInfo.emplace_back(ESTokenLookupInfo{iRecord, eventsetup::DataKey{iDataType,iTag.data().c_str()},startOfComponentName}, ESProxyIndex{-1} );
+  auto indexForToken = esItemsToGetFromTransition_[static_cast<unsigned int>(iTrans)].size();
   esItemsToGetFromTransition_[static_cast<unsigned int>(iTrans)].push_back(ESProxyIndex{-1*(index+1)});
-  return ESTokenIndex{static_cast<ESTokenIndex::Value_t>(index)};
+  return ESTokenIndex{static_cast<ESTokenIndex::Value_t>(indexForToken)};
 }
 
 //

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -131,8 +131,8 @@ private:
     enum {kFi, kFum};
     typedef edm::ESProducts< edm::es::L<DummyData,kFi>, edm::es::L<DummyData,kFum> > ReturnProducts;
     LabelledProducer() {
-      setWhatProduced(this,"foo");
       setWhatProduced(this, &LabelledProducer::produceMore, edm::es::label("fi",kFi)("fum",kFum));
+      setWhatProduced(this,"foo");
     }
 
     std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {

--- a/FWCore/Framework/test/stubs/TestESDummyDataAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/TestESDummyDataAnalyzer.cc
@@ -45,6 +45,10 @@ private:
   int m_counter{};
   int m_totalCounter{};
   int const m_totalNEvents;
+  // At the moment the begin run token is not used to get anything,
+  // but just its existence tests the indexing used in the esConsumes
+  // function call
+  edm::ESGetToken<edm::eventsetup::test::DummyData, edm::DefaultRecord> const m_esTokenBeginRun;
   edm::ESGetToken<edm::eventsetup::test::DummyData, edm::DefaultRecord> const m_esToken;
 };
 
@@ -52,6 +56,8 @@ TestESDummyDataAnalyzer::TestESDummyDataAnalyzer(const edm::ParameterSet& iConfi
   m_expectedValue{iConfig.getParameter<int>("expected")},
   m_nEventsValue{iConfig.getUntrackedParameter<int>("nEvents",0)},
   m_totalNEvents{iConfig.getUntrackedParameter<int>("totalNEvents",-1)},
+  m_esTokenBeginRun{esConsumes<edm::eventsetup::test::DummyData, 
+                               edm::DefaultRecord, edm::Transition::BeginRun>()},
   m_esToken{esConsumes<edm::eventsetup::test::DummyData, edm::DefaultRecord>()}
 {}
 


### PR DESCRIPTION
#### PR description:

Fixes 2 bugs. One causes an assert failure and the other an out
of bounds read. These bugs were only introduced recently and
only in 10_6_X.  The assert occurs for ESProducers that after a
call to setWhatProduced for multiple products call setWhatProduced
another time. The out of bounds read failure occurs when
esConsumes is called for multiple types of transitions (event,
beginRun, ...) in the same producer, filter, or analyzer.

I am not aware of any existing code in CMSSW that actually
hits these corner cases. As far as I know this will not affect the output
of any existing tests.

#### PR validation:

Modifies existing unit tests so the assert bug would now fail
a unit test. Modified another test to hit the out of bounds read,
although you need valgrind to actually see it with this test, but
there is a new and more complex test coming soon in the PR
that implements concurrent IOVs that fails when the out of bounds
read bug is hit. These bugs were noticed while testing the concurrent
IOV PR.
