### PR TITLE
Fix TT6NTPedestalCalculator::resetPedestals() to actually clear the vector

### DIFF
--- a/CalibTracker/SiStripAPVAnalysis/interface/TT6NTPedestalCalculator.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/TT6NTPedestalCalculator.h
@@ -25,7 +25,7 @@ class TT6NTPedestalCalculator: public TkPedestalCalculator
      * @brief
      *   Celar all Pedestals
      */
-    inline void resetPedestals() override { pedestals_.empty(); }
+    inline void resetPedestals() override { pedestals_.clear(); }
 
     /*
      * @brief


### PR DESCRIPTION
#### PR description:

The `std::vector<T>::empty()` returns a boolean telling whether the vector is empty or not. Having a `void` function to call only it without checking the return value looks suspicious, especially the function has "reset" in its name. This PR assumes that the intention was to call `clear()` instead. According to DXR the `resetPedestals()` is not called from anywhere in CMSSW.

This issue was found by GCC 9.

#### PR validation:

The code compiles without warnings with GCC 9.