### PR TITLE
Remove constructors taking CSCDMBStatusDigi from CSCDMBHeader and CSCDMBTrailer

### DIFF
--- a/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
@@ -4,10 +4,10 @@
 #include <cassert>
 #include <iosfwd>
 #include <cstring> // bzero
+#include <memory>
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/CSCDigi/interface/CSCDMBStatusDigi.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBHeaderFormat.h"
-#include <boost/shared_ptr.hpp>
 
 struct CSCDMBHeader2005;
 struct CSCDMBHeader2013;
@@ -68,7 +68,7 @@ public:
 
  private:
 
-  boost::shared_ptr<CSCVDMBHeaderFormat> theHeaderFormat;
+  std::shared_ptr<CSCVDMBHeaderFormat> theHeaderFormat;
   int theFirmwareVersion;
 
 

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
@@ -19,11 +19,6 @@ public:
   
   CSCDMBHeader(const uint16_t * buf, uint16_t firmware_version = 2005);
 
-  CSCDMBHeader(const CSCDMBStatusDigi & digi)
-    {
-      memcpy(this, digi.header(), sizeInWords()*2);
-    }
-
 
 
   bool cfebAvailable(unsigned icfeb) { 

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer.h
@@ -21,11 +21,6 @@ public:
   CSCDMBTrailer(uint16_t firmware_version = 2005);
 
   CSCDMBTrailer(const uint16_t * buf, uint16_t firmware_version = 2005);
-  
-  CSCDMBTrailer(const CSCDMBStatusDigi & digi) 
-    {
-      memcpy(this, digi.trailer(), sizeInWords()*2);
-    }
 
 
   ///@@ NEEDS TO BE DONE

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer.h
@@ -4,11 +4,11 @@
 #include <cassert>
 #include <iosfwd>
 #include <cstring> // bzero
+#include <memory>
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/CSCDigi/interface/CSCDMBStatusDigi.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBTrailerFormat.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
-#include <boost/shared_ptr.hpp>
 
 
 // class CSCDMBHeader;
@@ -73,7 +73,7 @@ public:
 
  private:
   
-  boost::shared_ptr<CSCVDMBTrailerFormat> theTrailerFormat;
+  std::shared_ptr<CSCVDMBTrailerFormat> theTrailerFormat;
   int theFirmwareVersion;
 
 };

--- a/EventFilter/CSCRawToDigi/src/CSCDMBHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDMBHeader.cc
@@ -10,9 +10,9 @@ CSCDMBHeader::CSCDMBHeader(uint16_t firmware_version)
 {
 
   if (theFirmwareVersion == 2013) {
-    theHeaderFormat = boost::shared_ptr<CSCVDMBHeaderFormat>(new CSCDMBHeader2013());
+    theHeaderFormat = std::make_shared<CSCDMBHeader2013>();
   } else {
-    theHeaderFormat = boost::shared_ptr<CSCVDMBHeaderFormat>(new CSCDMBHeader2005());
+    theHeaderFormat = std::make_shared<CSCDMBHeader2005>();
   }
 
 }
@@ -21,14 +21,14 @@ CSCDMBHeader::CSCDMBHeader(const uint16_t * buf, uint16_t firmware_version)
 : theHeaderFormat(), theFirmwareVersion(firmware_version) 
 {
   if (theFirmwareVersion == 2013) {
-    theHeaderFormat = boost::shared_ptr<CSCVDMBHeaderFormat>(new CSCDMBHeader2013(buf));
+    theHeaderFormat = std::make_shared<CSCDMBHeader2013>(buf);
   } else {
-    theHeaderFormat = boost::shared_ptr<CSCVDMBHeaderFormat>(new CSCDMBHeader2005(buf));
+    theHeaderFormat = std::make_shared<CSCDMBHeader2005>(buf);
   }
 }
 
 CSCDMBHeader2005 CSCDMBHeader::dmbHeader2005()   const {
-  CSCDMBHeader2005 * result = dynamic_cast<CSCDMBHeader2005 *>(theHeaderFormat.get());
+  const CSCDMBHeader2005 * result = dynamic_cast<const CSCDMBHeader2005 *>(theHeaderFormat.get());
   if(result == nullptr)
   {
     throw cms::Exception("Could not get 2005 DMB header format");
@@ -38,7 +38,7 @@ CSCDMBHeader2005 CSCDMBHeader::dmbHeader2005()   const {
 
 
 CSCDMBHeader2013 CSCDMBHeader::dmbHeader2013()   const {
-  CSCDMBHeader2013 * result = dynamic_cast<CSCDMBHeader2013 *>(theHeaderFormat.get());
+  const CSCDMBHeader2013 * result = dynamic_cast<const CSCDMBHeader2013 *>(theHeaderFormat.get());
   if(result == nullptr)
   {
     throw cms::Exception("Could not get 2013 DMB header format");

--- a/EventFilter/CSCRawToDigi/src/CSCDMBTrailer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDMBTrailer.cc
@@ -10,9 +10,9 @@ CSCDMBTrailer::CSCDMBTrailer(uint16_t firmware_version)
 {
 
   if (theFirmwareVersion == 2013) {
-    theTrailerFormat = boost::shared_ptr<CSCVDMBTrailerFormat>(new CSCDMBTrailer2013());
+    theTrailerFormat = std::make_shared<CSCDMBTrailer2013>();
   } else {
-    theTrailerFormat = boost::shared_ptr<CSCVDMBTrailerFormat>(new CSCDMBTrailer2005());
+    theTrailerFormat = std::make_shared<CSCDMBTrailer2005>();
   }
 
 }
@@ -21,14 +21,14 @@ CSCDMBTrailer::CSCDMBTrailer(const uint16_t * buf, uint16_t firmware_version)
 : theTrailerFormat(), theFirmwareVersion(firmware_version) 
 {
   if (theFirmwareVersion == 2013) {
-    theTrailerFormat = boost::shared_ptr<CSCVDMBTrailerFormat>(new CSCDMBTrailer2013(buf));
+    theTrailerFormat = std::make_shared<CSCDMBTrailer2013>(buf);
   } else {
-    theTrailerFormat = boost::shared_ptr<CSCVDMBTrailerFormat>(new CSCDMBTrailer2005(buf));
+    theTrailerFormat = std::make_shared<CSCDMBTrailer2005>(buf);
   }
 }
 
 CSCDMBTrailer2005 CSCDMBTrailer::dmbTrailer2005()   const {
-  CSCDMBTrailer2005 * result = dynamic_cast<CSCDMBTrailer2005 *>(theTrailerFormat.get());
+  const CSCDMBTrailer2005 * result = dynamic_cast<const CSCDMBTrailer2005 *>(theTrailerFormat.get());
   if(result == nullptr)
   {
     throw cms::Exception("Could not get 2005 DMB trailer format");
@@ -38,7 +38,7 @@ CSCDMBTrailer2005 CSCDMBTrailer::dmbTrailer2005()   const {
 
 
 CSCDMBTrailer2013 CSCDMBTrailer::dmbTrailer2013()   const {
-  CSCDMBTrailer2013 * result = dynamic_cast<CSCDMBTrailer2013 *>(theTrailerFormat.get());
+  const CSCDMBTrailer2013 * result = dynamic_cast<const CSCDMBTrailer2013 *>(theTrailerFormat.get());
   if(result == nullptr)
   {
     throw cms::Exception("Could not get 2013 DMB trailer format");


### PR DESCRIPTION
#### PR description:

`CSCDMBHeader` and `CSCDMBTrailer` both have a constructor taking `CSCDMBStatusDigi` and doing a `memcpy(this, ...)` from it. The problem is that both `CSCDMBHeader` and `CSCDMBTrailer` have a `boost::shared_ptr` as their first member, and it makes no sense to overwrite those via a `memcpy`. These constructors are not called (anymore?) in CMSSW, and judging from the git history it looks like they could be leftovers from #4034. This PR suggests to remove these constructors.

This issue was found by GCC 9.

In addition this PR replaces the `boost::shared_ptr`'s with `std::shared_ptr` in these two classes, and makes the `dynamic_cast`s const-correct.

#### PR validation:

The code compiles without warnings with GCC 9.