### PR TITLE
Remove unnecessary calls to vector::empty() and vector::clear() from CmsTrackerPhase{1,2TP}DiskBuilder

### DIFF
--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase1DiskBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase1DiskBuilder.cc
@@ -26,8 +26,6 @@ CmsTrackerPhase1DiskBuilder::PhiPosNegSplit_innerOuter( std::vector< GeometricDe
 
   // now put positive phi (in order) ahead of negative phi as in std geometry
   std::vector<const GeometricDet*> theCompsPosNeg;
-  theCompsPosNeg.empty();
-  theCompsPosNeg.clear();
   // also find the average radius (used to split inner and outer disk panels)
   double theRmin = (**begin).rho();
   double theRmax = theRmin;
@@ -47,8 +45,6 @@ CmsTrackerPhase1DiskBuilder::PhiPosNegSplit_innerOuter( std::vector< GeometricDe
   // force the split radius to be 100 mm to be able to deal with disks with only outer ring
   double radius_split = 100.;
   std::vector<const GeometricDet*> theCompsInnerOuter;
-  theCompsInnerOuter.empty();
-  theCompsInnerOuter.clear();
   unsigned int num_inner = 0;
   for(vector<const GeometricDet*>::const_iterator it=theCompsPosNeg.begin();
       it!=theCompsPosNeg.end();it++){

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase2TPDiskBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase2TPDiskBuilder.cc
@@ -26,8 +26,6 @@ CmsTrackerPhase2TPDiskBuilder::PhiPosNegSplit_innerOuter( std::vector< Geometric
 
   // now put positive phi (in order) ahead of negative phi as in std geometry
   std::vector<const GeometricDet*> theCompsPosNeg;
-  theCompsPosNeg.empty();
-  theCompsPosNeg.clear();
   // also find the average radius (used to split inner and outer disk panels)
   double theRmin = (**begin).rho();
   double theRmax = theRmin;
@@ -47,8 +45,6 @@ CmsTrackerPhase2TPDiskBuilder::PhiPosNegSplit_innerOuter( std::vector< Geometric
   // force the split radius to be 100 mm to be able to deal with disks with only outer ring
   double radius_split = 100.;
   std::vector<const GeometricDet*> theCompsInnerOuter;
-  theCompsInnerOuter.empty();
-  theCompsInnerOuter.clear();
   unsigned int num_inner = 0;
   for(vector<const GeometricDet*>::const_iterator it=theCompsPosNeg.begin();
       it!=theCompsPosNeg.end();it++){


### PR DESCRIPTION
#### PR description:

There is no need to call `clear()` to an default-constructor `std::vector`, and calling `empty()` without checking the return value has no effect. This PR suggests to remove such unnecessary calls from `CmsTrackerPhase1DiskBuilder` and `CmsTrackerPhase2TPDiskBuilder`. These were found by GCC 9.

#### PR validation:

The code compiles without warnings with GCC 9.
