### PR TITLE
Remove std::move's preventing copy elision from return statements

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminantCutMultiplexer.cc
@@ -104,9 +104,7 @@ namespace
       throw cms::Exception("PATTauDiscriminantCutMultiplexer::loadObjectFromFile") 
 	<< " Failed to load Object = " << objectName.data() << " from file = " << inputFile.GetName() << " !!\n";
     //Need to use TObject::Clone since the type T might be a base class
-    std::unique_ptr<const T> copy{ static_cast<T*>(object->Clone()) };
-	
-    return std::move(copy);
+    return std::unique_ptr<const T>{ static_cast<T*>(object->Clone()) };
   }
 	
   std::unique_ptr<const TGraph> loadTGraphFromDB(const edm::EventSetup& es, const std::string& graphName, const int& verbosity_ = 0)

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
@@ -103,9 +103,7 @@ namespace
       throw cms::Exception("RecoTauDiscriminantCutMultiplexer::loadObjectFromFile") 
         << " Failed to load Object = " << objectName.data() << " from file = " << inputFile.GetName() << " !!\n";
     //Need to use TObject::Clone since the type T might be a base class
-    std::unique_ptr<const T> copy{ static_cast<T*>(object->Clone()) };
-
-    return std::move(copy);
+    return std::unique_ptr<const T>{ static_cast<T*>(object->Clone()) };
   }
 
   std::unique_ptr<const TGraph> loadTGraphFromDB(const edm::EventSetup& es, const std::string& graphName, const int& verbosity_ = 0)


### PR DESCRIPTION
#### PR description:

This PR suggests to remove `std::move`'s from return statements that currently prevent the compiler from eliding the copy/move altogether. These were found by GCC 9.

#### PR validation:

The code compiles without warnings with GCC 9.
