### PR TITLE
Add missing initialization to some local array in PPS ProtonReconstructionAlgorithm

### DIFF
--- a/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
+++ b/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
@@ -190,11 +190,10 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
     th_x_init = 0.;
 
   // initial estimate of th_y and vtx_y
-  double y[2], v_y[2], L_y[2];
+  double y[2]={0}, v_y[2]={0}, L_y[2]={0};
   unsigned int y_idx = 0;
   for (const auto &track : tracks) {
-    if (y_idx >= 2)
-      continue;
+    if (y_idx >= 2) break;
 
     auto oit = m_rp_optics_.find(track->getRPId());
 


### PR DESCRIPTION

#### PR description:

Catched by the static analyzer.

The missing initialization was implicitly avoided because there are always at least two tracks, and therefore those arrays will always get filled. By explicitely initializing them one can silence the static analyzer, though, and make the code more robust in case of future different usages.

#### PR validation:

It builds.
No changes are expected


@fabferro @jan-kaspar @vavati