### PR TITLE
Migrate CSCGeometryESModule to EventSetup consumes

### DIFF
--- a/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
+++ b/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
@@ -4,24 +4,8 @@
 #include "Geometry/CSCGeometryBuilder/src/CSCGeometryBuilder.h"
 #include "Geometry/CSCGeometry/interface/CSCChamberSpecs.h"
 
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "Geometry/Records/interface/MuonNumberingRecord.h"
-
-#include "Geometry/Records/interface/CSCRecoGeometryRcd.h"
-#include "Geometry/Records/interface/CSCRecoDigiParametersRcd.h"
-#include "CondFormats/GeometryObjects/interface/RecoIdealGeometry.h"
-#include "CondFormats/GeometryObjects/interface/CSCRecoDigiParameters.h"
-#include "DetectorDescription/Core/interface/DDCompactView.h"
-
-// Alignments
-#include "CondFormats/Alignment/interface/DetectorGlobalPosition.h"
-#include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
-#include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
-#include "CondFormats/AlignmentRecord/interface/CSCAlignmentRcd.h"
-#include "CondFormats/AlignmentRecord/interface/CSCAlignmentErrorExtendedRcd.h"
 #include "Geometry/CommonTopologies/interface/GeometryAligner.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/ModuleFactory.h"
 
@@ -33,6 +17,7 @@ CSCGeometryESModule::CSCGeometryESModule(const edm::ParameterSet & p)
   : alignmentsLabel_(p.getParameter<std::string>("alignmentsLabel")),
     myLabel_(p.getParameter<std::string>("appendToDataLabel"))
 {
+  auto cc = setWhatProduced(this);
 
   // Choose wire geometry modelling
   // We now _require_ some wire geometry specification in the CSCOrcaSpec.xml file
@@ -64,16 +49,28 @@ CSCGeometryESModule::CSCGeometryESModule(const edm::ParameterSet & p)
 
   // Find out if using the DDD or CondDB Geometry source.
   useDDD_ = p.getParameter<bool>("useDDD");
+  if(useDDD_) {
+    cpvToken_ = cc.consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag{});
+    mdcToken_ = cc.consumesFrom<MuonDDDConstants, MuonNumberingRecord>(edm::ESInputTag{});
+  }
+  else {
+    rigToken_ = cc.consumesFrom<RecoIdealGeometry, CSCRecoGeometryRcd>(edm::ESInputTag{});
+    rdpToken_ = cc.consumesFrom<CSCRecoDigiParameters, CSCRecoDigiParametersRcd>(edm::ESInputTag{});
+  }
 
   // Feed these value to where I need them
   applyAlignment_ = p.getParameter<bool>("applyAlignment");
+  if(applyAlignment_) {
+    globalPositionToken_ = cc.consumesFrom<Alignments, GlobalPositionRcd>(edm::ESInputTag{"", alignmentsLabel_});
+    alignmentsToken_ = cc.consumesFrom<Alignments, CSCAlignmentRcd>(edm::ESInputTag{"", alignmentsLabel_});
+    alignmentErrorsToken_ = cc.consumesFrom<AlignmentErrorsExtended, CSCAlignmentErrorExtendedRcd>(edm::ESInputTag{"", alignmentsLabel_});
+  }
 
 
   edm::LogInfo("Geometry") << "@SUB=CSCGeometryESModule" 
 			   << "Label '" << myLabel_ << "' "
 			   << (applyAlignment_ ? "looking for" : "IGNORING")
 			   << " alignment labels '" << alignmentsLabel_ << "'.";
-  setWhatProduced(this);
 }
 
 
@@ -97,22 +94,19 @@ std::shared_ptr<CSCGeometry> CSCGeometryESModule::produce(const MuonGeometryReco
   if ( applyAlignment_ ) {
     // applyAlignment_ is scheduled for removal. 
     // Ideal geometry obtained by using 'fake alignment' (with applyAlignment_ = true)
-    edm::ESHandle<Alignments> globalPosition;
-    record.getRecord<GlobalPositionRcd>().get(alignmentsLabel_, globalPosition);
-    edm::ESHandle<Alignments> alignments;
-    record.getRecord<CSCAlignmentRcd>().get(alignmentsLabel_, alignments);
-    edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-    record.getRecord<CSCAlignmentErrorExtendedRcd>().get(alignmentsLabel_,  alignmentErrors);
+    const auto& globalPosition = record.get(globalPositionToken_);
+    const auto& alignments = record.get(alignmentsToken_);
+    const auto& alignmentErrors = record.get(alignmentErrorsToken_);
     // Only apply alignment if values exist
-    if (alignments->empty() && alignmentErrors->empty() && globalPosition->empty()) {
+    if (alignments.empty() && alignmentErrors.empty() && globalPosition.empty()) {
       edm::LogInfo("Config") << "@SUB=CSCGeometryRecord::produce"
 			     << "Alignment(Error)s and global position (label '"
 			     << alignmentsLabel_ << "') empty: Geometry producer (label "
 			     << "'" << myLabel_ << "') assumes fake and does not apply.";
     } else {
       GeometryAligner aligner;
-      aligner.applyAlignments<CSCGeometry>( &(*host), &(*alignments), &(*alignmentErrors),
-	                    align::DetectorGlobalPosition(*globalPosition, DetId(DetId::Muon)) );
+      aligner.applyAlignments<CSCGeometry>( &(*host), &alignments, &alignmentErrors,
+	                    align::DetectorGlobalPosition(globalPosition, DetId(DetId::Muon)) );
     }
   }
   return host; // automatically converts to std::shared_ptr<CSCGeometry>
@@ -124,14 +118,12 @@ void CSCGeometryESModule::initCSCGeometry_( const MuonGeometryRecord& record, st
   if ( useDDD_ ) {
 
     host->ifRecordChanges<MuonNumberingRecord>(record,
-                                               [&host, &record](auto const& rec) {
+                                               [&host, &record, this](auto const& rec) {
       host->clear();
-      edm::ESTransientHandle<DDCompactView> cpv;
-      edm::ESHandle<MuonDDDConstants> mdc;
-      record.getRecord<IdealGeometryRecord>().get(cpv);
-      rec.get(mdc);
+      edm::ESTransientHandle<DDCompactView> cpv = record.getTransientHandle(cpvToken_);
+      const auto& mdc = rec.get(mdcToken_);
       CSCGeometryBuilderFromDDD builder;
-      builder.build(*host, &(*cpv), *mdc);
+      builder.build(*host, cpv.product(), mdc);
     });
   } else {
     bool recreateGeometry = false;
@@ -148,12 +140,10 @@ void CSCGeometryESModule::initCSCGeometry_( const MuonGeometryRecord& record, st
 
     if (recreateGeometry) {
       host->clear();
-      edm::ESHandle<RecoIdealGeometry> rig;
-      edm::ESHandle<CSCRecoDigiParameters> rdp;
-      record.getRecord<CSCRecoGeometryRcd>().get(rig);
-      record.getRecord<CSCRecoDigiParametersRcd>().get(rdp);
+      const auto& rig = record.get(rigToken_);
+      const auto& rdp = record.get(rdpToken_);
       CSCGeometryBuilder cscgb;
-      cscgb.build(*host, *rig, *rdp);
+      cscgb.build(*host, rig, rdp);
     }
   }
 }

--- a/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.h
+++ b/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.h
@@ -11,9 +11,28 @@
 #include <FWCore/Framework/interface/ESProducer.h>
 #include "FWCore/Framework/interface/ESProductHost.h"
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 #include <Geometry/CSCGeometry/interface/CSCGeometry.h>
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/MuonNumberingRecord.h"
+
+#include "Geometry/Records/interface/CSCRecoGeometryRcd.h"
+#include "Geometry/Records/interface/CSCRecoDigiParametersRcd.h"
+#include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
+#include "CondFormats/GeometryObjects/interface/RecoIdealGeometry.h"
+#include "CondFormats/GeometryObjects/interface/CSCRecoDigiParameters.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+
+// Alignments
+#include "CondFormats/Alignment/interface/DetectorGlobalPosition.h"
+#include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
+#include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
+#include "CondFormats/AlignmentRecord/interface/CSCAlignmentRcd.h"
+#include "CondFormats/AlignmentRecord/interface/CSCAlignmentErrorExtendedRcd.h"
 
 #include <memory>
 #include <string>
@@ -40,6 +59,16 @@ private:
   void initCSCGeometry_(const MuonGeometryRecord&, std::shared_ptr<HostType>& host);
 
   edm::ReusableObjectHolder<HostType> holder_;
+
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvToken_;
+  edm::ESGetToken<MuonDDDConstants, MuonNumberingRecord> mdcToken_;
+
+  edm::ESGetToken<RecoIdealGeometry, CSCRecoGeometryRcd> rigToken_;
+  edm::ESGetToken<CSCRecoDigiParameters, CSCRecoDigiParametersRcd> rdpToken_;
+
+  edm::ESGetToken<Alignments, GlobalPositionRcd> globalPositionToken_;
+  edm::ESGetToken<Alignments, CSCAlignmentRcd> alignmentsToken_;
+  edm::ESGetToken<AlignmentErrorsExtended, CSCAlignmentErrorExtendedRcd> alignmentErrorsToken_;
 
   // Flags for controlling geometry modelling during build of CSCGeometry
   bool useRealWireGeometry;


### PR DESCRIPTION
#### PR description:

This PR migrates `CSCGeometryESModule` (which is the only ED/ES module in Geometry/CSCGeometryBuilder) to use EventSetup-consumes (#26584).

#### PR validation:

Limited matrix runs.