### PR TITLE
Making filling conversion vtx fit prob optional

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -99,6 +99,9 @@ class GsfElectronAlgo {
       // GED-Regression (ECAL and combination)
       bool useEcalRegression;
       bool useCombinationRegression;  
+      //heavy ion in 2015 has no conversions and so cant fill conv vtx fit prob so this bool
+      //stops it from being filled
+      bool fillConvVtxFitProb;
      } ;
 
     struct CutsConfiguration

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -77,6 +77,7 @@ void GsfElectronBaseProducer::fillDescriptions( edm::ConfigurationDescriptions &
   desc.add<unsigned int>("ambSortingStrategy", 1);
   desc.add<unsigned int>("ambClustersOverlapStrategy", 1);
   desc.add<bool>("addPflowElectrons", true); // this one should be transfered to the "core" level
+  desc.add<bool>("fillConvVtxFitProb", true); 
 
   // Ecal rec hits configuration
   desc.add<std::vector<std::string>>("recHitFlagsToBeExcludedBarrel");
@@ -254,7 +255,7 @@ GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg, 
   inputCfg_.beamSpotTag = consumes<reco::BeamSpot>(cfg.getParameter<edm::InputTag>("beamSpotTag"));
   inputCfg_.gsfPfRecTracksTag = consumes<reco::GsfPFRecTrackCollection>(cfg.getParameter<edm::InputTag>("gsfPfRecTracksTag"));
   inputCfg_.vtxCollectionTag = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vtxTag"));
-  inputCfg_.conversions = consumes<reco::ConversionCollection>(cfg.getParameter<edm::InputTag>("conversionsTag"));
+  if(cfg.getParameter<bool>("fillConvVtxFitProb") ) inputCfg_.conversions = consumes<reco::ConversionCollection>(cfg.getParameter<edm::InputTag>("conversionsTag"));
 
   if ( cfg.getParameter<bool>("useIsolationValues") ) {
     inputCfg_.pfIsoVals = cfg.getParameter<edm::ParameterSet> ("pfIsolationValues");
@@ -285,6 +286,7 @@ GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg, 
   strategyCfg_.MaxElePtForOnlyMVA = cfg.getParameter<double>("MaxElePtForOnlyMVA");
   strategyCfg_.useEcalRegression = cfg.getParameter<bool>("useEcalRegression");
   strategyCfg_.useCombinationRegression = cfg.getParameter<bool>("useCombinationRegression");
+  strategyCfg_.fillConvVtxFitProb = cfg.getParameter<bool>("fillConvVtxFitProb");
 
   // hcal helpers
   auto const& psetPreselection = cfg.getParameter<edm::ParameterSet>("preselection");

--- a/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
@@ -12,6 +12,8 @@ gedGsfElectronsTmp.ctfTracksTag = cms.InputTag("hiGeneralTracks")
 gedGsfElectronsTmp.vtxTag = cms.InputTag("hiSelectedVertex")
 gedGsfElectronsTmp.preselection.minSCEtBarrel = cms.double(15.0)
 gedGsfElectronsTmp.preselection.minSCEtEndcaps = cms.double(15.0)
+gedGsfElectronsTmp.fillConvVtxFitProb = cms.bool(False)
+
 gedPhotonsTmp.primaryVertexProducer = cms.InputTag("hiSelectedVertex")
 gedPhotonsTmp.isolationSumsCalculatorSet.trackProducer = cms.InputTag("hiGeneralTracks")
 gedPhotons.primaryVertexProducer = cms.InputTag("hiSelectedVertex")

--- a/RecoHI/HiEgammaAlgos/python/HiElectronSequence_cff.py
+++ b/RecoHI/HiEgammaAlgos/python/HiElectronSequence_cff.py
@@ -20,6 +20,8 @@ gsfElectrons.ctfTracks     = cms.InputTag("hiGeneralTracks")
 gsfElectronCores.ctfTracks = cms.InputTag("hiGeneralTracks")
 pfElectronTranslator.emptyIsOk = cms.bool(True)
 
+gsfElectrons.fillConvVtxFitProb = cms.bool(False)
+
 ecalDrivenGsfElectrons.ctfTracksTag = cms.InputTag("hiGeneralTracks")
 ecalDrivenGsfElectronCores.ctfTracks = cms.InputTag("hiGeneralTracks")
 ecalDrivenGsfElectrons.vtxTag = cms.InputTag("hiSelectedVertex")
@@ -28,7 +30,7 @@ ecalDrivenGsfElectrons.preselection.maxHOverEBarrelCone = cms.double(0.25)
 ecalDrivenGsfElectrons.preselection.maxHOverEEndcapsCone = cms.double(0.25)
 ecalDrivenGsfElectrons.preselection.maxHOverEBarrelTower = cms.double(0.)
 ecalDrivenGsfElectrons.preselection.maxHOverEEndcapsTower = cms.double(0.)
-
+ecalDrivenGsfElectrons.fillConvVtxFitProb = cms.bool(False)
 
 
 from RecoParticleFlow.PFTracking.pfTrack_cfi import *


### PR DESCRIPTION
#### PR description:
Fixes issue raised here https://github.com/cms-sw/cmssw/issues/26562

This makes filling the conversion vertex fit probability optional for GsfElectrons. HION doesnt have conversions and thus has issues here. So added a simple flag to disable it for cases like this rather than having to run the conversion workflow in HION. 
