### PR TITLE
PPS: fix in proton reconstruction

### DIFF
--- a/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
+++ b/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
@@ -290,18 +290,16 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
           }
         }
 
-        // do multi-RP reco if chosen
-        if (doMultiRPReconstruction_)
-        {
-          // check that exactly two tracking RPs are involved
-          //    - 1 is insufficient for multi-RP reconstruction
-          //    - PPS did not use more than 2 tracking RPs per arm -> algorithms are tuned to this
-          std::set<unsigned int> rpIds;
-          for (const auto &idx : indices)
-            rpIds.insert(hTracks->at(idx).getRPId());
-          if (rpIds.size() != 2)
-            continue;
+        // check that exactly two tracking RPs are involved
+        //    - 1 is insufficient for multi-RP reconstruction
+        //    - PPS did not use more than 2 tracking RPs per arm -> algorithms are tuned to this
+        std::set<unsigned int> rpIds;
+        for (const auto &idx : indices)
+          rpIds.insert(hTracks->at(idx).getRPId());
 
+        // do multi-RP reco if chosen
+        if (doMultiRPReconstruction_ && rpIds.size() == 2)
+        {
           // find matching track pairs from different tracking RPs
           std::vector<std::pair<unsigned int, unsigned int>> idx_pairs;
           std::map<unsigned int, unsigned int> idx_pair_multiplicity;


### PR DESCRIPTION
#### PR description:

This PR provides a fix to a bug which sometimes prevented saving single-RP results due to a misplaced "continue" statement in the multi-RP reconstruction block.

#### PR validation:

Below a comparison of several histograms of proton-reconstruction quantities, where
  * blue: with this PR
  * red dashed: before this PR

The only difference can be seen in the 1st and 5th column - showing single-RP results. As expected, the blue histograms are always larger than the red ones - additional evens are recuperated. All other columns are related to multi-RP reconstruction, not affected by the bug neither this fix.

![make_cmp](https://user-images.githubusercontent.com/17830858/56913664-86cfd080-6ab2-11e9-8574-40284695beed.png)

