### PR TITLE
add missing includes for HcalDepthEnergyFractions.h

### DIFF
--- a/DataFormats/PatCandidates/interface/HcalDepthEnergyFractions.h
+++ b/DataFormats/PatCandidates/interface/HcalDepthEnergyFractions.h
@@ -1,6 +1,9 @@
 #ifndef DataFormats_PatCandidates_HcalDepthEnergyFractions_h
 #define DataFormats_PatCandidates_HcalDepthEnergyFractions_h
 
+#include <vector>
+#include <cstdint>
+
 namespace pat{
 
   //


### PR DESCRIPTION
Recent header consistency checks showed that there is a problem with the DataFormats/PatCandidates/interface/HcalDepthEnergyFractions.h file

This PR should fix that.


