### PR TITLE
Migrate Geometry/CaloEventSetup to EventSetup consumes

### DIFF
--- a/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
@@ -7,8 +7,7 @@
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
@@ -31,6 +30,56 @@
 // class declaration
 //
 
+namespace calogeometryDBEPimpl {
+  // For U::writeFlag() == true
+  template <typename T, bool>
+  struct GeometryTraits {
+    using TokenType = edm::ESGetToken<CaloSubdetectorGeometry, typename T::AlignedRecord>;
+
+    static TokenType makeToken(edm::ESConsumesCollectorT<typename T::AlignedRecord>& cc) {
+      return cc.template consumes<CaloSubdetectorGeometry>(edm::ESInputTag{"", T::producerTag() + std::string("_master")});
+    }
+  };
+
+  template <typename T>
+  struct GeometryTraits<T, false> {
+    using TokenType = edm::ESGetToken<PCaloGeometry, typename T::PGeometryRecord>;
+
+    static TokenType makeToken(edm::ESConsumesCollectorT<typename T::AlignedRecord>& cc) {
+      return cc.template consumesFrom<PCaloGeometry, typename T::PGeometryRecord>(edm::ESInputTag{});
+    }
+  };
+
+  // For the case of non-existent AlignmentRecord
+  //
+  // SFINAE tricks to detect if T::AlignmentRecord exists. Note that
+  // the declarations of the following are sufficient.
+  template <typename T> std::false_type has_AlignmentRecord(...);
+  template <typename T> std::true_type has_AlignmentRecord(typename T::AlignmentRecord *);
+
+  template <typename T>
+  struct HasAlignmentRecord {
+    static constexpr bool value = std::is_same<decltype(has_AlignmentRecord<T>(nullptr)), std::true_type>::value;
+  };
+
+
+  // Then define tokens from alignment record
+  template <typename T, bool = HasAlignmentRecord<T>::value>
+  struct AlignmentTokens {
+    edm::ESGetToken<Alignments, typename T::AlignmentRecord> alignments;
+    edm::ESGetToken<Alignments, GlobalPositionRcd> globals;
+  };
+  template <typename T>
+  struct AlignmentTokens<T, false> {};
+
+
+  // Some partial specializations need additional tokens...
+  template <typename T>
+  struct AdditionalTokens {
+    void makeTokens(edm::ESConsumesCollectorT<typename T::AlignedRecord>& cc) {}
+  };
+}
+
 template <class T, class U>
 class CaloGeometryDBEP : public edm::ESProducer 
 {
@@ -51,57 +100,47 @@ class CaloGeometryDBEP : public edm::ESProducer
 	  m_pSet( ps )
 
       {
-	 setWhatProduced( this,
-			  &CaloGeometryDBEP<T,U>::produceAligned,
-			  edm::es::Label( T::producerTag() ) ) ;//+std::string("TEST") ) ) ;
+         auto cc = setWhatProduced( this,
+                                    &CaloGeometryDBEP<T,U>::produceAligned,
+                                    edm::es::Label( T::producerTag() ) ) ;//+std::string("TEST") ) ) ;
+
+         if constexpr (calogeometryDBEPimpl::HasAlignmentRecord<T>::value) {
+           if( m_applyAlignment ) {
+             alignmentTokens_.alignments = cc.template consumesFrom<Alignments, typename T::AlignmentRecord>(edm::ESInputTag{});
+             alignmentTokens_.globals = cc.template consumesFrom<Alignments, GlobalPositionRcd>(edm::ESInputTag{});
+           }
+         }
+         geometryToken_ = calogeometryDBEPimpl::GeometryTraits<T, U::writeFlag()>::makeToken(cc);
+
+         additionalTokens_.makeTokens(cc);
       }
 
       ~CaloGeometryDBEP<T,U>() override {}
     
       PtrType produceAligned( const typename T::AlignedRecord& iRecord ) 
       {
-	 const Alignments* alignPtr  ( nullptr ) ;
-	 const Alignments* globalPtr ( nullptr ) ;
-	 if( m_applyAlignment ) // get ptr if necessary
-	 {
-	    edm::ESHandle< Alignments >                                      alignments ;
-	    iRecord.template getRecord< typename T::AlignmentRecord >().get( alignments ) ;
-
-	    assert( alignments.isValid() && // require valid alignments and expected size
-		    ( alignments->m_align.size() == T::numberOfAlignments() ) ) ;
-	    alignPtr = alignments.product() ;
-
-	    edm::ESHandle< Alignments >                          globals   ;
-	    iRecord.template getRecord<GlobalPositionRcd>().get( globals ) ;
-
-	    assert( globals.isValid() ) ;
-	    globalPtr = globals.product() ;
-	 }
+	 const auto [alignPtr, globalPtr] = getAlignGlobal(iRecord);
 
 	 TrVec  tvec ;
 	 DimVec dvec ;
 	 IVec   ivec ;
 	 std::vector<uint32_t> dins;
 
-	 if( U::writeFlag() )
+	 if constexpr ( U::writeFlag() )
 	 {
-	    edm::ESHandle<CaloSubdetectorGeometry> pG ;
-	    iRecord.get( T::producerTag() + std::string("_master"), pG ) ; 
+	    const auto& pG = iRecord.get( geometryToken_ ) ;
 
-	    const CaloSubdetectorGeometry* pGptr ( pG.product() ) ;
-
-	    pGptr->getSummary( tvec, ivec, dvec, dins ) ;
+	    pG.getSummary( tvec, ivec, dvec, dins ) ;
 
 	    U::write( tvec, dvec, ivec, T::dbString() ) ;
 	 }
 	 else
 	 {
-	    edm::ESHandle<PCaloGeometry> pG ;
-	    iRecord.template getRecord<typename T::PGeometryRecord >().get( pG ) ; 
+	    const auto& pG = iRecord.get( geometryToken_ ) ;
 
-	    tvec = pG->getTranslation() ;
-	    dvec = pG->getDimension() ;
-	    ivec = pG->getIndexes() ;
+	    tvec = pG.getTranslation() ;
+	    dvec = pG.getDimension() ;
+	    ivec = pG.getIndexes() ;
 	 }	 
 //*********************************************************************************************
 
@@ -207,7 +246,27 @@ class CaloGeometryDBEP : public edm::ESProducer
       }
     
 private:
+      std::tuple<const Alignments *, const Alignments *> getAlignGlobal(const typename T::AlignedRecord& iRecord) const {
+	 const Alignments* alignPtr  ( nullptr ) ;
+	 const Alignments* globalPtr ( nullptr ) ;
+         if constexpr (calogeometryDBEPimpl::HasAlignmentRecord<T>::value) {
+	    if( m_applyAlignment ) // get ptr if necessary
+	    {
+	       const auto& alignments = iRecord.get( alignmentTokens_.alignments ) ;
+	       // require expected size
+	       assert( alignments.m_align.size() == T::numberOfAlignments() ) ;
+	       alignPtr = &alignments ;
 
+	       const auto& globals = iRecord.get( alignmentTokens_.globals ) ;
+	       globalPtr = &globals ;
+	    }
+	 }
+         return std::make_tuple(alignPtr, globalPtr);
+      }
+
+    typename calogeometryDBEPimpl::AlignmentTokens<T> alignmentTokens_;
+    typename calogeometryDBEPimpl::GeometryTraits<T, U::writeFlag()>::TokenType geometryToken_;
+    typename calogeometryDBEPimpl::AdditionalTokens<T> additionalTokens_;
     bool        m_applyAlignment ;
     const edm::ParameterSet m_pSet;
 };

--- a/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
@@ -96,14 +96,14 @@ class CaloGeometryDBEP : public edm::ESProducer
       typedef CaloSubdetectorGeometry::IVec   IVec       ;
       
       CaloGeometryDBEP<T,U>( const edm::ParameterSet& ps ) :
-	  m_applyAlignment ( ps.getParameter<bool>("applyAlignment") )
+	  applyAlignment_ ( ps.getParameter<bool>("applyAlignment") )
       {
          auto cc = setWhatProduced( this,
                                     &CaloGeometryDBEP<T,U>::produceAligned,
                                     edm::es::Label( T::producerTag() ) ) ;//+std::string("TEST") ) ) ;
 
          if constexpr (calogeometryDBEPimpl::HasAlignmentRecord<T>::value) {
-           if( m_applyAlignment ) {
+           if( applyAlignment_ ) {
              alignmentTokens_.alignments = cc.template consumesFrom<Alignments, typename T::AlignmentRecord>(edm::ESInputTag{});
              alignmentTokens_.globals = cc.template consumesFrom<Alignments, GlobalPositionRcd>(edm::ESInputTag{});
            }
@@ -248,7 +248,7 @@ private:
 	 const Alignments* alignPtr  ( nullptr ) ;
 	 const Alignments* globalPtr ( nullptr ) ;
          if constexpr (calogeometryDBEPimpl::HasAlignmentRecord<T>::value) {
-	    if( m_applyAlignment ) // get ptr if necessary
+	    if( applyAlignment_ ) // get ptr if necessary
 	    {
 	       const auto& alignments = iRecord.get( alignmentTokens_.alignments ) ;
 	       // require expected size
@@ -265,7 +265,7 @@ private:
     typename calogeometryDBEPimpl::AlignmentTokens<T> alignmentTokens_;
     typename calogeometryDBEPimpl::GeometryTraits<T, U::writeFlag()>::TokenType geometryToken_;
     typename calogeometryDBEPimpl::AdditionalTokens<T> additionalTokens_;
-    bool        m_applyAlignment ;
+    bool        applyAlignment_ ;
 };
 
 #endif

--- a/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
@@ -96,9 +96,7 @@ class CaloGeometryDBEP : public edm::ESProducer
       typedef CaloSubdetectorGeometry::IVec   IVec       ;
       
       CaloGeometryDBEP<T,U>( const edm::ParameterSet& ps ) :
-	  m_applyAlignment ( ps.getParameter<bool>("applyAlignment") ),
-	  m_pSet( ps )
-
+	  m_applyAlignment ( ps.getParameter<bool>("applyAlignment") )
       {
          auto cc = setWhatProduced( this,
                                     &CaloGeometryDBEP<T,U>::produceAligned,
@@ -268,7 +266,6 @@ private:
     typename calogeometryDBEPimpl::GeometryTraits<T, U::writeFlag()>::TokenType geometryToken_;
     typename calogeometryDBEPimpl::AdditionalTokens<T> additionalTokens_;
     bool        m_applyAlignment ;
-    const edm::ParameterSet m_pSet;
 };
 
 #endif

--- a/Geometry/CaloEventSetup/interface/CaloGeometryDBReader.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryDBReader.h
@@ -22,7 +22,7 @@ public:
 			    const std::vector<uint32_t>& /*dins*/,
 			    const std::string&   /*tag*/   ) {}
 
-  static bool writeFlag() { return false ; }
+  static constexpr bool writeFlag() { return false ; }
 
   CaloGeometryDBReader() {}
   virtual ~CaloGeometryDBReader() {}

--- a/Geometry/CaloEventSetup/interface/CaloGeometryDBWriter.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryDBWriter.h
@@ -15,7 +15,7 @@ class CaloGeometryDBWriter
       typedef CaloSubdetectorGeometry::DimVec DimVec     ;
       typedef CaloSubdetectorGeometry::IVec   IVec       ;
 
-      static bool writeFlag() { return true ; }
+      static constexpr bool writeFlag() { return true ; }
 
       static void write( const TrVec&  tvec, 
 			 const DimVec& dvec, 

--- a/Geometry/CaloEventSetup/interface/CaloGeometryEP.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryEP.h
@@ -33,14 +33,14 @@ class CaloGeometryEP : public edm::ESProducer
       using PtrType = typename LoaderType::PtrType;
 
       CaloGeometryEP<T>( const edm::ParameterSet& ps ) :
-	 m_applyAlignment ( ps.getParameter<bool>("applyAlignment") )
+	 applyAlignment_ ( ps.getParameter<bool>("applyAlignment") )
       {
          auto cc = setWhatProduced( this,
                                     &CaloGeometryEP<T>::produceAligned,
 //                                  dependsOn( &CaloGeometryEP<T>::idealRecordCallBack ),
                                     edm::es::Label( T::producerTag() ) ) ;
 
-         if(m_applyAlignment) {
+         if(applyAlignment_) {
            alignmentsToken_ = cc.template consumesFrom<Alignments, typename T::AlignmentRecord>(edm::ESInputTag{});
            globalsToken_ = cc.template consumesFrom<Alignments, GlobalPositionRcd>(edm::ESInputTag{});
          }
@@ -52,7 +52,7 @@ class CaloGeometryEP : public edm::ESProducer
       {
 	 const Alignments* alignPtr  ( nullptr ) ;
 	 const Alignments* globalPtr ( nullptr ) ;
-	 if( m_applyAlignment ) // get ptr if necessary
+	 if( applyAlignment_ ) // get ptr if necessary
 	 {
 	    const auto& alignments = iRecord.get( alignmentsToken_ ) ;
 	    // require expected size
@@ -72,7 +72,7 @@ class CaloGeometryEP : public edm::ESProducer
       edm::ESGetToken<Alignments, typename T::AlignmentRecord> alignmentsToken_;
       edm::ESGetToken<Alignments, GlobalPositionRcd> globalsToken_;
       edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvToken_;
-      bool        m_applyAlignment ;
+      bool        applyAlignment_ ;
 };
 
 #endif

--- a/Geometry/CaloEventSetup/interface/CaloGeometryEP.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryEP.h
@@ -8,7 +8,7 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
@@ -35,10 +35,16 @@ class CaloGeometryEP : public edm::ESProducer
       CaloGeometryEP<T>( const edm::ParameterSet& ps ) :
 	 m_applyAlignment ( ps.getParameter<bool>("applyAlignment") )
       {
-	 setWhatProduced( this,
-			  &CaloGeometryEP<T>::produceAligned,
-//			  dependsOn( &CaloGeometryEP<T>::idealRecordCallBack ),
-			  edm::es::Label( T::producerTag() ) ) ;
+         auto cc = setWhatProduced( this,
+                                    &CaloGeometryEP<T>::produceAligned,
+//                                  dependsOn( &CaloGeometryEP<T>::idealRecordCallBack ),
+                                    edm::es::Label( T::producerTag() ) ) ;
+
+         if(m_applyAlignment) {
+           alignmentsToken_ = cc.template consumesFrom<Alignments, typename T::AlignmentRecord>(edm::ESInputTag{});
+           globalsToken_ = cc.template consumesFrom<Alignments, GlobalPositionRcd>(edm::ESInputTag{});
+         }
+         cpvToken_ = cc.template consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag{});
       }
 
       ~CaloGeometryEP<T>() override {}
@@ -48,29 +54,24 @@ class CaloGeometryEP : public edm::ESProducer
 	 const Alignments* globalPtr ( nullptr ) ;
 	 if( m_applyAlignment ) // get ptr if necessary
 	 {
-	    edm::ESHandle< Alignments >                                      alignments ;
-	    iRecord.template getRecord< typename T::AlignmentRecord >().get( alignments ) ;
+	    const auto& alignments = iRecord.get( alignmentsToken_ ) ;
+	    // require expected size
+	    assert( alignments.m_align.size() == T::numberOfAlignments() ) ;
+	    alignPtr = &alignments ;
 
-	    assert( alignments.isValid() && // require valid alignments and expected size
-		    ( alignments->m_align.size() == T::numberOfAlignments() ) ) ;
-	    alignPtr = alignments.product() ;
-
-	    edm::ESHandle< Alignments >                          globals   ;
-	    iRecord.template getRecord<GlobalPositionRcd>().get( globals ) ;
-
-	    assert( globals.isValid() ) ;
-	    globalPtr = globals.product() ;
+	    const auto& globals = iRecord.get( globalsToken_ ) ;
+	    globalPtr = &globals ;
 	 }
-	 edm::ESTransientHandle<DDCompactView> cpv ;
-	 iRecord.template getRecord<IdealGeometryRecord>().get( cpv ) ;
+	 edm::ESTransientHandle<DDCompactView> cpv = iRecord.getTransientHandle( cpvToken_ ) ;
 
 	 LoaderType loader ;
-	 return loader.load( &(*cpv), alignPtr, globalPtr );
+	 return loader.load( cpv.product(), alignPtr, globalPtr );
       }
 
    private:
-
-
+      edm::ESGetToken<Alignments, typename T::AlignmentRecord> alignmentsToken_;
+      edm::ESGetToken<Alignments, GlobalPositionRcd> globalsToken_;
+      edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvToken_;
       bool        m_applyAlignment ;
 };
 

--- a/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.cc
@@ -30,8 +30,19 @@
 #include "Geometry/HcalTowerAlgo/interface/CaloTowerGeometry.h"
 #include "Geometry/ForwardGeometry/interface/CastorGeometry.h"
 #include "Geometry/ForwardGeometry/interface/ZdcGeometry.h"
-#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+namespace {
+  template <typename Record>
+  void makeToken(edm::ESConsumesCollector& cc, std::vector<std::string>& list, std::string const& tag, edm::ESGetToken<CaloSubdetectorGeometry, Record>& token) {
+    auto found = std::find(list.begin(), list.end(), tag);
+    if(found != list.end()) {
+      token = cc.consumesFrom<CaloSubdetectorGeometry, Record>(edm::ESInputTag{"", *found});
+      list.erase(found);
+    }
+  }
+}
+
 //
 // member functions
 //
@@ -39,14 +50,43 @@ CaloGeometryBuilder::CaloGeometryBuilder( const edm::ParameterSet& iConfig )
 {
    //the following line is needed to tell the framework what
    // data is being produced
-   setWhatProduced( this, 
-		    &CaloGeometryBuilder::produceAligned );
+   auto cc = setWhatProduced( this,
+                              &CaloGeometryBuilder::produceAligned );
 
    //now do what ever other initialization is needed
-   
-   theCaloList = iConfig.getParameter< std::vector<std::string> >("SelectedCalos");
-   if ( theCaloList.empty() ) throw cms::Exception("Configuration") 
+   auto caloList = iConfig.getParameter< std::vector<std::string> >("SelectedCalos");
+   theCaloList = caloList;
+   if ( caloList.empty() ) throw cms::Exception("Configuration")
       << "No calorimeter specified for geometry, aborting";
+
+   makeToken(cc, caloList, HcalGeometry::producerTag(), hcalToken_);
+   makeToken(cc, caloList, ZdcGeometry::producerTag(), zdcToken_);
+   makeToken(cc, caloList, CastorGeometry::producerTag(), castorToken_);
+   makeToken(cc, caloList, EcalBarrelGeometry::producerTag(), ecalBarrelToken_);
+   makeToken(cc, caloList, EcalEndcapGeometry::producerTag(), ecalEndcapToken_);
+   makeToken(cc, caloList, EcalPreshowerGeometry::producerTag(), ecalPreshowerToken_);
+   makeToken(cc, caloList, CaloTowerGeometry::producerTag(), caloTowerToken_);
+
+   // Move HGC elements to the end
+   auto hgcBegin = std::partition(caloList.begin(), caloList.end(), [](std::string const& elem) {
+       return elem.find(HGCalGeometry::producerTag()) == std::string::npos;
+     });
+   // Process HGC elements
+   for(auto iter = hgcBegin; iter != caloList.end(); ++iter) {
+     hgcalTokens_.emplace_back(cc.consumesFrom<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", *iter}), *iter);
+   }
+   // Erase HGC elements
+   caloList.erase(hgcBegin, caloList.end());
+
+   // Throw if any elements are left
+   if(not caloList.empty()) {
+     cms::Exception ex{"Configuration"};
+     ex << "Reconstruction geometry requested for a not implemented sub-detectors:";
+     for(auto const& elem: caloList) {
+       ex << " " << elem;
+     }
+     throw ex;
+   }
 }
 
 // ------------ method called to produce the data  ------------
@@ -58,76 +98,60 @@ CaloGeometryBuilder::produceAligned( const CaloGeometryRecord& iRecord )
 
    ReturnType pCalo  = std::make_unique<CaloGeometry>();
 
-   // loop on selected calorimeters
+   // look for HCAL parts
+   // assume 'HCAL' for all of HCAL.
+   if(hcalToken_.isInitialized()) {
+     edm::LogInfo("CaloGeometryBuilder") << "Building HCAL reconstruction geometry";
 
-   for ( std::vector<std::string>::const_iterator ite ( theCaloList.begin() ) ;
-	 ite != theCaloList.end(); ++ite ) 
-   {
-      // look for HCAL parts
-      // assume 'HCAL' for all of HCAL.  
-      if ( (*ite) == HcalGeometry::producerTag() ) 
-      {
-	 edm::LogInfo("CaloGeometryBuilder") << "Building HCAL reconstruction geometry";
-
-	 iRecord.getRecord< HcalGeometryRecord >().get( HcalGeometry::producerTag(), pG );  
-	 pCalo->setSubdetGeometry( DetId::Hcal, HcalBarrel , pG.product() );
-	 pCalo->setSubdetGeometry( DetId::Hcal, HcalEndcap , pG.product() );
-	 pCalo->setSubdetGeometry( DetId::Hcal, HcalOuter  , pG.product() );
-	 pCalo->setSubdetGeometry( DetId::Hcal, HcalForward, pG.product() );
-      }
-      else if ( (*ite) == ZdcGeometry::producerTag() ) 
-      {
-	 edm::LogInfo("CaloGeometryBuilder") << "Building ZDC reconstruction geometry";
-	 iRecord.getRecord< ZDCGeometryRecord >().get( ZdcGeometry::producerTag(), pG ); 
-	 pCalo->setSubdetGeometry( DetId::Calo, HcalZDCDetId::SubdetectorId,pG.product());
-      }
-      else if ( (*ite) == CastorGeometry::producerTag() ) 
-      {
-	 edm::LogInfo("CaloGeometryBuilder") << "Building CASTOR reconstruction geometry";
-	 iRecord.getRecord< CastorGeometryRecord >().get( CastorGeometry::producerTag(), pG ); 
-	 pCalo->setSubdetGeometry( DetId::Calo, HcalCastorDetId::SubdetectorId,pG.product());
-      }
-      // look for Ecal Barrel
-      else if ( (*ite) == EcalBarrelGeometry::producerTag() ) 
-      {
-	 edm::LogInfo("CaloGeometryBuilder") << "Building EcalBarrel reconstruction geometry";
-	 iRecord.getRecord<EcalBarrelGeometryRecord>().get( EcalBarrelGeometry::producerTag(), pG ); 
-	 pCalo->setSubdetGeometry(DetId::Ecal,EcalBarrel,pG.product());
-      }
-      // look for Ecal Endcap
-      else if ( (*ite) == EcalEndcapGeometry::producerTag() ) 
-      {
-	 edm::LogInfo("CaloGeometryBuilder") << "Building EcalEndcap reconstruction geometry";
-	 iRecord.getRecord<EcalEndcapGeometryRecord>().get( EcalEndcapGeometry::producerTag(), pG ); 
-	 pCalo->setSubdetGeometry(DetId::Ecal,EcalEndcap,pG.product());
-      }
-      // look for Ecal Preshower
-      else if ( (*ite) == EcalPreshowerGeometry::producerTag() ) 
-      {
-	 edm::LogInfo("CaloGeometryBuilder") << "Building EcalPreshower reconstruction geometry";
- 	 iRecord.getRecord<EcalPreshowerGeometryRecord>().get(EcalPreshowerGeometry::producerTag(), pG); 
-	 pCalo->setSubdetGeometry(DetId::Ecal,EcalPreshower,pG.product());
-      }
-      // look for TOWER parts
-      else if ( (*ite) == CaloTowerGeometry::producerTag() ) 
-      {
-	 edm::LogInfo("CaloGeometryBuilder") << "Building TOWER reconstruction geometry";
-	 iRecord.getRecord<CaloTowerGeometryRecord>().get(CaloTowerGeometry::producerTag(),pG);
-	 pCalo->setSubdetGeometry(DetId::Calo,1,pG.product());
-      }
-      else if ( ite->find(HGCalGeometry::producerTag()) != std::string::npos ) {
-	edm::LogInfo("CaloGeometryBuilder") << "Building " << *ite << " reconstruction geometry";
-	edm::ESHandle<HGCalGeometry> pHG;
-	iRecord.getRecord<IdealGeometryRecord>().get(*ite,pHG);
-	const auto& topo = pHG->topology();
-	pCalo->setSubdetGeometry(topo.detector(),topo.subDetector(),pHG.product());
-      }
-      else 
-      {
-	 edm::LogWarning("CaloGeometryBuilder") 
-	    << "Reconstruction geometry requested for a not implemented sub-detector: " 
-	    << (*ite); 
-      }
+     auto const& pG = iRecord.get(hcalToken_);
+     pCalo->setSubdetGeometry( DetId::Hcal, HcalBarrel , &pG );
+     pCalo->setSubdetGeometry( DetId::Hcal, HcalEndcap , &pG );
+     pCalo->setSubdetGeometry( DetId::Hcal, HcalOuter  , &pG );
+     pCalo->setSubdetGeometry( DetId::Hcal, HcalForward, &pG );
    }
+   if(zdcToken_.isInitialized()) {
+     edm::LogInfo("CaloGeometryBuilder") << "Building ZDC reconstruction geometry";
+     auto const& pG = iRecord.get( zdcToken_ );
+     pCalo->setSubdetGeometry( DetId::Calo, HcalZDCDetId::SubdetectorId, &pG);
+   }
+   if(castorToken_.isInitialized()) {
+     edm::LogInfo("CaloGeometryBuilder") << "Building CASTOR reconstruction geometry";
+     auto const& pG = iRecord.get( castorToken_ );
+     pCalo->setSubdetGeometry( DetId::Calo, HcalCastorDetId::SubdetectorId, &pG);
+   }
+
+   // look for Ecal Barrel
+   if(ecalBarrelToken_.isInitialized()) {
+     edm::LogInfo("CaloGeometryBuilder") << "Building EcalBarrel reconstruction geometry";
+     auto const& pG = iRecord.get( ecalBarrelToken_ );
+     pCalo->setSubdetGeometry(DetId::Ecal, EcalBarrel, &pG);
+   }
+   // look for Ecal Endcap
+   if(ecalEndcapToken_.isInitialized()) {
+     edm::LogInfo("CaloGeometryBuilder") << "Building EcalEndcap reconstruction geometry";
+     auto const& pG = iRecord.get( ecalEndcapToken_ );
+     pCalo->setSubdetGeometry(DetId::Ecal, EcalEndcap, &pG);
+   }
+   // look for Ecal Preshower
+   if(ecalPreshowerToken_.isInitialized()) {
+     edm::LogInfo("CaloGeometryBuilder") << "Building EcalPreshower reconstruction geometry";
+     const auto& pG = iRecord.get(ecalPreshowerToken_);
+     pCalo->setSubdetGeometry(DetId::Ecal, EcalPreshower, &pG);
+   }
+
+   // look for TOWER parts
+   if(caloTowerToken_.isInitialized()) {
+     edm::LogInfo("CaloGeometryBuilder") << "Building TOWER reconstruction geometry";
+     const auto& pG = iRecord.get(caloTowerToken_);
+     pCalo->setSubdetGeometry(DetId::Calo, 1, &pG);
+   }
+
+   for(auto const& hgcTokenLabel: hgcalTokens_) {
+     edm::LogInfo("CaloGeometryBuilder") << "Building " << hgcTokenLabel.second << " reconstruction geometry";
+     auto const& pHG = iRecord.get(hgcTokenLabel.first);
+     const auto& topo = pHG.topology();
+     pCalo->setSubdetGeometry(topo.detector(), topo.subDetector(), &pHG);
+   }
+
    return pCalo ;
 }

--- a/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.cc
@@ -55,7 +55,6 @@ CaloGeometryBuilder::CaloGeometryBuilder( const edm::ParameterSet& iConfig )
 
    //now do what ever other initialization is needed
    auto caloList = iConfig.getParameter< std::vector<std::string> >("SelectedCalos");
-   theCaloList = caloList;
    if ( caloList.empty() ) throw cms::Exception("Configuration")
       << "No calorimeter specified for geometry, aborting";
 

--- a/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.h
@@ -51,7 +51,6 @@ class CaloGeometryBuilder : public edm::ESProducer
    private:
       // ----------member data ---------------------------
       
-      std::vector<std::string> theCaloList;
       edm::ESGetToken<CaloSubdetectorGeometry, HcalGeometryRecord> hcalToken_;
       edm::ESGetToken<CaloSubdetectorGeometry, ZDCGeometryRecord> zdcToken_;
       edm::ESGetToken<CaloSubdetectorGeometry, CastorGeometryRecord> castorToken_;

--- a/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.h
@@ -25,9 +25,12 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/HcalGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 
 //
 // class decleration
@@ -39,8 +42,6 @@ class CaloGeometryBuilder : public edm::ESProducer
 
       using ReturnType = std::unique_ptr<CaloGeometry>;
 
-      typedef edm::ESHandle<CaloSubdetectorGeometry> SubdType ;
-
       CaloGeometryBuilder( const edm::ParameterSet& iConfig ) ;
 
       ~CaloGeometryBuilder() override {} ;
@@ -51,5 +52,13 @@ class CaloGeometryBuilder : public edm::ESProducer
       // ----------member data ---------------------------
       
       std::vector<std::string> theCaloList;
+      edm::ESGetToken<CaloSubdetectorGeometry, HcalGeometryRecord> hcalToken_;
+      edm::ESGetToken<CaloSubdetectorGeometry, ZDCGeometryRecord> zdcToken_;
+      edm::ESGetToken<CaloSubdetectorGeometry, CastorGeometryRecord> castorToken_;
+      edm::ESGetToken<CaloSubdetectorGeometry, EcalBarrelGeometryRecord> ecalBarrelToken_;
+      edm::ESGetToken<CaloSubdetectorGeometry, EcalEndcapGeometryRecord> ecalEndcapToken_;
+      edm::ESGetToken<CaloSubdetectorGeometry, EcalPreshowerGeometryRecord> ecalPreshowerToken_;
+      edm::ESGetToken<CaloSubdetectorGeometry, CaloTowerGeometryRecord> caloTowerToken_;
+      std::vector<std::pair<edm::ESGetToken<HGCalGeometry, IdealGeometryRecord>, std::string>> hgcalTokens_;
 };
 

--- a/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.cc
@@ -3,20 +3,12 @@
 #include "Geometry/CaloTopology/interface/EcalBarrelTopology.h"
 #include "Geometry/CaloTopology/interface/EcalEndcapTopology.h"
 #include "Geometry/CaloTopology/interface/EcalPreshowerTopology.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 
 
-CaloTopologyBuilder::CaloTopologyBuilder( const edm::ParameterSet& /*iConfig*/ )
-{
-   //the following line is needed to tell the framework what
-   // data is being produced
-
-// disable
-//   setWhatProduced( this, &CaloTopologyBuilder::produceIdeal );
-   setWhatProduced( this, &CaloTopologyBuilder::produceCalo  );
-}
-
+CaloTopologyBuilder::CaloTopologyBuilder( const edm::ParameterSet& /*iConfig*/ ):
+  geometryToken_{setWhatProduced(this, &CaloTopologyBuilder::produceCalo).consumesFrom<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})}
+{}
 
 CaloTopologyBuilder::~CaloTopologyBuilder()
 { 
@@ -31,17 +23,16 @@ CaloTopologyBuilder::~CaloTopologyBuilder()
 CaloTopologyBuilder::ReturnType
 CaloTopologyBuilder::produceCalo( const CaloTopologyRecord& iRecord )
 {
-   edm::ESHandle<CaloGeometry>                  theGeometry   ;
-   iRecord.getRecord<CaloGeometryRecord>().get( theGeometry ) ;
+   const auto& geometry = iRecord.get(geometryToken_);
 
    ReturnType ct = std::make_unique<CaloTopology>();
    //ECAL parts      
    ct->setSubdetTopology( DetId::Ecal,
 			  EcalBarrel,
-			  std::make_unique<EcalBarrelTopology>( *theGeometry ) ) ;
+			  std::make_unique<EcalBarrelTopology>( geometry ) ) ;
    ct->setSubdetTopology( DetId::Ecal,
 			  EcalEndcap,
-			  std::make_unique<EcalEndcapTopology>( *theGeometry ) ) ;
+			  std::make_unique<EcalEndcapTopology>( geometry ) ) ;
    ct->setSubdetTopology( DetId::Ecal,
 			  EcalPreshower,
 			  std::make_unique<EcalPreshowerTopology>());

--- a/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.h
@@ -22,9 +22,10 @@
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "Geometry/Records/interface/CaloTopologyRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 
 //
@@ -43,5 +44,6 @@ class CaloTopologyBuilder : public edm::ESProducer
 
    private:
       // ----------member data ---------------------------
+      edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
 };
 

--- a/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
@@ -23,10 +23,13 @@
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "Geometry/CaloTopology/interface/CaloTowerConstituentsMap.h"
+#include "Geometry/CaloTopology/interface/CaloTowerTopology.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
 namespace edm {
@@ -50,6 +53,9 @@ public:
 private:
   void parseTextMap(const std::string& filename,CaloTowerConstituentsMap& theMap);
   void assignEEtoHE(const CaloGeometry* geometry, CaloTowerConstituentsMap& theMap, const CaloTowerTopology * cttopo);
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> hcaltopoToken_;
+  edm::ESGetToken<CaloTowerTopology, HcalRecNumberingRecord> cttopoToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
   std::string mapFile_;
   bool mapAuto_, skipHE_;
 };

--- a/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.h
@@ -24,7 +24,6 @@
 // user include files
 #include "FWCore/Framework/interface/ESProducer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"

--- a/Geometry/CaloEventSetup/plugins/FastTimeTopologyBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/FastTimeTopologyBuilder.cc
@@ -23,8 +23,8 @@
 #include <FWCore/Framework/interface/ModuleFactory.h>
 #include "FWCore/Framework/interface/ESProducer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "Geometry/CaloTopology/interface/FastTimeTopology.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 #include "Geometry/HGCalCommonData/interface/FastTimeDDDConstants.h"
@@ -50,7 +50,7 @@ public:
 
 private:
   // ----------member data ---------------------------
-  std::string        name_;
+  edm::ESGetToken<FastTimeDDDConstants, IdealGeometryRecord> ftlToken_;
   int                type_;
   ForwardSubdetector subdet_;
 };
@@ -58,14 +58,14 @@ private:
 
 FastTimeTopologyBuilder::FastTimeTopologyBuilder(const edm::ParameterSet& iConfig) {
 
-  name_     = iConfig.getUntrackedParameter<std::string>("Name");
+  auto name = iConfig.getUntrackedParameter<std::string>("Name");
   type_     = iConfig.getUntrackedParameter<int>("Type");
   subdet_   = FastTime;
 #ifdef EDM_ML_DEBUG
-  std::cout <<"constructing FastTimeTopology for " << name_ << " Type "
+  std::cout <<"constructing FastTimeTopology for " << name << " Type "
 	    << type_ << std::endl;
 #endif
-  setWhatProduced(this, name_);
+  ftlToken_ = setWhatProduced(this, name).consumes<FastTimeDDDConstants>(edm::ESInputTag{"", name});
 }
 
 
@@ -80,9 +80,7 @@ FastTimeTopologyBuilder::~FastTimeTopologyBuilder() { }
 FastTimeTopologyBuilder::ReturnType
 FastTimeTopologyBuilder::produce(const IdealGeometryRecord& iRecord ) {
 
-  edm::ESHandle<FastTimeDDDConstants>  pHGDC;
-  iRecord.get(pHGDC) ;
-  const FastTimeDDDConstants & hgdc = (*pHGDC);
+  const FastTimeDDDConstants & hgdc = iRecord.get(ftlToken_);
 
 #ifdef EDM_ML_DEBUG
   std::cout << "Create FastTimeTopology(hgdc,subdet,type)" << std::endl;

--- a/Geometry/CaloEventSetup/plugins/HGCalTopologyBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/HGCalTopologyBuilder.cc
@@ -23,9 +23,10 @@
 #include <FWCore/Framework/interface/ModuleFactory.h>
 #include "FWCore/Framework/interface/ESProducer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
 #include "Geometry/CaloTopology/interface/HGCalTopology.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 #include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
@@ -51,20 +52,20 @@ public:
 
 private:
   // ----------member data ---------------------------
-  std::string        name_;
+  edm::ESGetToken<HGCalDDDConstants, IdealGeometryRecord> hgcToken_;
   int                det_;
 };
 
 
 HGCalTopologyBuilder::HGCalTopologyBuilder(const edm::ParameterSet& iConfig) {
 
-  name_     = iConfig.getParameter<std::string>("Name");
+  auto name = iConfig.getParameter<std::string>("Name");
   det_      = iConfig.getParameter<int>("Type");
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "constructing HGCalTopology for " << name_
+  edm::LogVerbatim("HGCalGeom") << "constructing HGCalTopology for " << name
 				<< " and det " << det_;
 #endif
-  setWhatProduced(this, name_);
+  hgcToken_ = setWhatProduced(this, name).consumes<HGCalDDDConstants>(edm::ESInputTag{"", name});
 }
 
 
@@ -78,9 +79,7 @@ HGCalTopologyBuilder::~HGCalTopologyBuilder() { }
 HGCalTopologyBuilder::ReturnType
 HGCalTopologyBuilder::produce(const IdealGeometryRecord& iRecord ) {
 
-  edm::ESHandle<HGCalDDDConstants>  pHGDC;
-  iRecord.get(name_, pHGDC);
-  const HGCalDDDConstants & hgdc = (*pHGDC);
+  const HGCalDDDConstants & hgdc = iRecord.get(hgcToken_);
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "Create HGCalTopology(hgdc,det)";

--- a/Geometry/CaloEventSetup/test/TestEcalGetWindow.cc
+++ b/Geometry/CaloEventSetup/test/TestEcalGetWindow.cc
@@ -2,8 +2,8 @@
 
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
@@ -37,10 +37,16 @@ private:
 
   void build(const CaloGeometry& cg, const CaloTopology& etmap, DetId::Detector det, int subdetn, const char* name);
   int towerColor(const EcalTrigTowerDetId& theTower);
+
+  edm::ESGetToken<CaloTopology, CaloTopologyRecord> topologyToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
+
   int pass_;
 };
 
-TestEcalGetWindow::TestEcalGetWindow( const edm::ParameterSet& /*iConfig*/ )
+TestEcalGetWindow::TestEcalGetWindow( const edm::ParameterSet& /*iConfig*/ ):
+  topologyToken_{esConsumes<CaloTopology, CaloTopologyRecord>(edm::ESInputTag{})},
+  geometryToken_{esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})}
 {
    //now do what ever initialization is needed
   pass_=0;
@@ -187,17 +193,14 @@ TestEcalGetWindow::analyze( const edm::Event& /*iEvent*/, const edm::EventSetup&
    
    std::cout << "Here I am " << std::endl;
 
-   edm::ESHandle<CaloTopology> theCaloTopology;
-   iSetup.get<CaloTopologyRecord>().get(theCaloTopology);     
-
-   edm::ESHandle<CaloGeometry> pG;
-   iSetup.get<CaloGeometryRecord>().get(pG);     
+   const auto& theCaloTopology = iSetup.getData(topologyToken_);
+   const auto& pG = iSetup.getData(geometryToken_);
 
    if (pass_==1) {
-     build(*pG,*theCaloTopology,DetId::Ecal,EcalBarrel,"EBGetWindowTest.eps");
+     build(pG,theCaloTopology,DetId::Ecal,EcalBarrel,"EBGetWindowTest.eps");
    }
    if (pass_==2) {
-     build(*pG,*theCaloTopology,DetId::Ecal,EcalEndcap,"EEGetWindowTest.eps");
+     build(pG,theCaloTopology,DetId::Ecal,EcalEndcap,"EEGetWindowTest.eps");
    }
    
    pass_++;

--- a/Geometry/HGCalGeometry/interface/CaloGeometryDBHGCal.h
+++ b/Geometry/HGCalGeometry/interface/CaloGeometryDBHGCal.h
@@ -1,0 +1,26 @@
+#ifndef Geometry_HGCalGeometry_CaloGeometryDBHGCal_h
+#define Geometry_HGCalGeometry_CaloGeometryDBHGCal_h
+
+#include "Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h"
+
+// Specializations for HGCal
+namespace calogeometryDBEPimpl {
+  static constexpr auto nameHGCal = "HGCalEESensitive";
+  template <>
+  struct GeometryTraits<HGCalGeometry, true> {
+    using TokenType = edm::ESGetToken<HGCalGeometry, IdealGeometryRecord>;
+
+    static TokenType makeToken(edm::ESConsumesCollectorT<HGCalGeometry::AlignedRecord>& cc) {
+      return cc.template consumesFrom<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameHGCal});
+    }
+  };
+  template <>
+  struct AdditionalTokens<HGCalGeometry> {
+    void makeTokens(edm::ESConsumesCollectorT<HGCalGeometry::AlignedRecord>& cc) {
+      topology = cc.consumesFrom<HGCalTopology, IdealGeometryRecord>(edm::ESInputTag{"", nameHGCal});
+    }
+    edm::ESGetToken<HGCalTopology, IdealGeometryRecord> topology;
+  };
+}
+
+#endif

--- a/Geometry/HcalTowerAlgo/interface/CaloGeometryDBCaloTower.h
+++ b/Geometry/HcalTowerAlgo/interface/CaloGeometryDBCaloTower.h
@@ -1,0 +1,16 @@
+#ifndef Geometry_HcalTowerAlgo_CaloGeometryDBCaloTower_h
+#define Geometry_HcalTowerAlgo_CaloGeometryDBCaloTower_h
+
+#include "Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h"
+
+namespace calogeometryDBEPimpl {
+  template <>
+  struct AdditionalTokens<CaloTowerGeometry> {
+    void makeTokens(edm::ESConsumesCollectorT<CaloTowerGeometry::AlignedRecord>& cc) {
+      topology = cc.consumesFrom<CaloTowerTopology, HcalRecNumberingRecord>(edm::ESInputTag{});
+    }
+    edm::ESGetToken<CaloTowerTopology, HcalRecNumberingRecord> topology;
+  };
+}
+
+#endif

--- a/Geometry/HcalTowerAlgo/interface/CaloGeometryDBHcal.h
+++ b/Geometry/HcalTowerAlgo/interface/CaloGeometryDBHcal.h
@@ -1,0 +1,16 @@
+#ifndef Geometry_HcalTowerAlgo_CaloGeometryDBHcal_h
+#define Geometry_HcalTowerAlgo_CaloGeometryDBHcal_h
+
+#include "Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h"
+
+namespace calogeometryDBEPimpl {
+  template <>
+  struct AdditionalTokens<HcalGeometry> {
+    void makeTokens(edm::ESConsumesCollectorT<HcalGeometry::AlignedRecord>& cc) {
+      topology = cc.consumesFrom<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag{});
+    }
+    edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topology;
+  };
+}
+
+#endif


### PR DESCRIPTION
#### PR description:

This PR migrates all ES and ED modules in `Geometry/CaloEventSetup` to EventSetup consumes (#26584).

In `CaloGeometryBuilder` I replaced the "for-switch" structure in `produceAligned()` with searches done at the constructor. Also now in case of superfluous geometry components the constructor throws an exception instead of issuing LogWarnings.

The `CaloGeometryDBEP` required a bit more work because the `CaloGeometryDBEP::produceAligned()` is specialized for various geometry types, and those specializations used additional ESProducts. I added a mechanism (employing class templace specialization as well) to call consumes() to get ESGetTokens for such products.

#### PR validation:

Limited matrix runs.