### PR TITLE
Migrate Geometry/DTGeometryBuilder to EventSetup consumes

### DIFF
--- a/Geometry/DTGeometryBuilder/plugins/DTGeometryESModule.h
+++ b/Geometry/DTGeometryBuilder/plugins/DTGeometryESModule.h
@@ -12,9 +12,25 @@
 #include "FWCore/Framework/interface/ESProductHost.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 #include <Geometry/DTGeometry/interface/DTGeometry.h>
+
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
+#include "Geometry/Records/interface/MuonNumberingRecord.h"
+#include "CondFormats/GeometryObjects/interface/RecoIdealGeometry.h"
+#include "Geometry/Records/interface/DTRecoGeometryRcd.h"
+
+// Alignments
+#include "CondFormats/Alignment/interface/Alignments.h"
+#include "CondFormats/Alignment/interface/AlignmentErrors.h"
+#include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
+#include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
+#include "CondFormats/AlignmentRecord/interface/DTAlignmentRcd.h"
+#include "CondFormats/AlignmentRecord/interface/DTAlignmentErrorRcd.h"
+#include "CondFormats/AlignmentRecord/interface/DTAlignmentErrorExtendedRcd.h"
 
 #include <memory>
 #include <string>
@@ -40,6 +56,13 @@ private:
   void setupDBGeometry(DTRecoGeometryRcd const&, std::shared_ptr<HostType>&);
 
   edm::ReusableObjectHolder<HostType> holder_;
+
+  edm::ESGetToken<Alignments, GlobalPositionRcd> globalPositionToken_;
+  edm::ESGetToken<Alignments, DTAlignmentRcd> alignmentsToken_;
+  edm::ESGetToken<AlignmentErrorsExtended, DTAlignmentErrorExtendedRcd> alignmentErrorsToken_;
+  edm::ESGetToken<MuonDDDConstants, MuonNumberingRecord> mdcToken_;
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvToken_;
+  edm::ESGetToken<RecoIdealGeometry, DTRecoGeometryRcd> rigToken_;
 
   bool applyAlignment_; // Switch to apply alignment corrections
   const std::string alignmentsLabel_;

--- a/Geometry/DTGeometryBuilder/plugins/DTGeometryValidate.cc
+++ b/Geometry/DTGeometryBuilder/plugins/DTGeometryValidate.cc
@@ -69,6 +69,7 @@ private:
     thicknesses_.clear();
   }
   
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeometryToken_;
   edm::ESHandle<DTGeometry> dtGeometry_;
   FWGeometry                fwGeometry_;
   TFile*                    outFile_;
@@ -84,7 +85,8 @@ private:
 
 
 DTGeometryValidate::DTGeometryValidate(const edm::ParameterSet& iConfig)
-  : infileName_(iConfig.getUntrackedParameter<string>("infileName", "cmsGeom10.root")),
+  : dtGeometryToken_{esConsumes<DTGeometry, MuonGeometryRecord>(edm::ESInputTag{})},
+    infileName_(iConfig.getUntrackedParameter<string>("infileName", "cmsGeom10.root")),
     outfileName_(iConfig.getUntrackedParameter<string>("outfileName", "validateDTGeometry.root")),
     tolerance_(iConfig.getUntrackedParameter<int>("tolerance", 6))
 {
@@ -95,7 +97,7 @@ DTGeometryValidate::DTGeometryValidate(const edm::ParameterSet& iConfig)
 void 
 DTGeometryValidate::analyze(const edm::Event& event, const edm::EventSetup& eventSetup)
 {
-  eventSetup.get<MuonGeometryRecord>().get(dtGeometry_);
+  dtGeometry_ = eventSetup.getHandle(dtGeometryToken_);
 
   if(dtGeometry_.isValid()) {
     LogVerbatim("DTGeometry") << "Validating DT chamber geometry";

--- a/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryTest.cc
+++ b/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryTest.cc
@@ -23,18 +23,19 @@ public:
 
 private:  
   const string m_label;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> m_token;
 };
 
 DTGeometryTest::DTGeometryTest(const ParameterSet& iConfig)
-  : m_label(iConfig.getUntrackedParameter<string>("fromDataLabel", ""))
+  : m_label(iConfig.getUntrackedParameter<string>("fromDataLabel", "")),
+    m_token(esConsumes<DTGeometry, MuonGeometryRecord>(edm::ESInputTag{"", m_label}))
 {}
 
 void
 DTGeometryTest::analyze(const Event&, const EventSetup& iEventSetup)
 {
   LogVerbatim("Geometry") << "DTGeometryTest::analyze: " << m_label;
-  ESTransientHandle<DTGeometry> pDD;
-  iEventSetup.get<MuonGeometryRecord>().get(m_label, pDD);
+  ESTransientHandle<DTGeometry> pDD = iEventSetup.getTransientHandle(m_token);
   
   LogVerbatim("Geometry") << " Geometry node for DTGeom is  " << &(*pDD);   
   LogVerbatim("Geometry") << " I have " << pDD->detTypes().size()    << " detTypes";


### PR DESCRIPTION
#### PR description:

This PR migrates all ES and ED modules in Geometry/DTGeometryBuilder to EventSetup consumes (#26584).

#### PR validation:

Limited matrix runs.