### PR TITLE
Migrate EcalElectronicsMappingBuilder to EventSetup consumes

### DIFF
--- a/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.cc
+++ b/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.cc
@@ -4,15 +4,11 @@
 #include "DataFormats/EcalDetId/interface/EcalTriggerElectronicsId.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "CondFormats/DataRecord/interface/EcalMappingElectronicsRcd.h"
 
-EcalElectronicsMappingBuilder::EcalElectronicsMappingBuilder(const edm::ParameterSet&)
-{
-  //the following line is needed to tell the framework what
-  // data is being produced
-  setWhatProduced(this);
-}
+EcalElectronicsMappingBuilder::EcalElectronicsMappingBuilder(const edm::ParameterSet&):
+  eeToken_{setWhatProduced(this).consumesFrom<EcalMappingElectronics, EcalMappingElectronicsRcd>(edm::ESInputTag{})}
+{}
 
 // ------------ method called to produce the data  ------------
 EcalElectronicsMappingBuilder::ReturnType
@@ -20,11 +16,9 @@ EcalElectronicsMappingBuilder::produce(const EcalMappingRcd& iRecord)
 {
    auto prod = std::make_unique<EcalElectronicsMapping>();
 
-   const EcalMappingElectronicsRcd& fRecord = iRecord.getRecord<EcalMappingElectronicsRcd>();
-   edm::ESHandle <EcalMappingElectronics> item;
-   fRecord.get(item);
+   const auto& item = iRecord.get(eeToken_);
 
-   const std::vector<EcalMappingElement>& ee = item->endcapItems();
+   const std::vector<EcalMappingElement>& ee = item.endcapItems();
    FillFromDatabase(ee,*prod);
    return prod;
 }

--- a/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.h
+++ b/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.h
@@ -6,6 +6,7 @@
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
 #include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
@@ -27,5 +28,7 @@ class EcalElectronicsMappingBuilder : public edm::ESProducer
  private:
   void FillFromDatabase(const std::vector<EcalMappingElement>& ee,
                         EcalElectronicsMapping& theMap);
+
+  edm::ESGetToken<EcalMappingElectronics, EcalMappingElectronicsRcd> eeToken_;
 };
 #endif


### PR DESCRIPTION
#### PR description:

This PR migrates the `EcalElectronicsMappingBuilder` (the only ES/ED module in `Geometry/EcalMapping` package) to EventSetup consumes (#26584).

#### PR validation:

Limited matrix runs.