### PR TITLE
Migrate Geometry/EcalTestBeam to EventSetup consumes

### DIFF
--- a/Geometry/EcalTestBeam/plugins/EcalTBGeometryBuilder.cc
+++ b/Geometry/EcalTestBeam/plugins/EcalTBGeometryBuilder.cc
@@ -30,7 +30,10 @@ EcalTBGeometryBuilder::EcalTBGeometryBuilder(const edm::ParameterSet& iConfig)
 {
    //the following line is needed to tell the framework what
    // data is being produced
-   setWhatProduced(this);
+   auto cc = setWhatProduced(this);
+
+   barrelToken_ = cc.consumes<CaloSubdetectorGeometry>(edm::ESInputTag{"", "EcalBarrel"});
+   hodoscopeToken_ = cc.consumes<CaloSubdetectorGeometry>(edm::ESInputTag{"", "EcalLaserPnDiode"});
 
    //now do what ever other initialization is needed
 }
@@ -54,16 +57,16 @@ EcalTBGeometryBuilder::produce(const IdealGeometryRecord& iRecord)
    auto pCaloGeom = std::make_unique<CaloGeometry>();
 
    // TODO: Look for ECAL parts
-   try {
-     iRecord.get("EcalBarrel", pG); 
+   if(auto pG = iRecord.getHandle(barrelToken_)) {
      pCaloGeom->setSubdetGeometry(DetId::Ecal,EcalBarrel,pG.product());
-   } catch (...) {
+   }
+   else {
      edm::LogWarning("MissingInput") << "No Ecal Barrel Geometry found";     
    }
-   try {
-     iRecord.get("EcalLaserPnDiode", pG); 
+   if(auto pG = iRecord.getHandle(hodoscopeToken_)) {
      pCaloGeom->setSubdetGeometry(DetId::Ecal,EcalLaserPnDiode,pG.product());
-   } catch (...) {
+   }
+   else {
      edm::LogWarning("MissingInput") << "No Ecal TB Hodoscope Geometry found";     
    }
 

--- a/Geometry/EcalTestBeam/plugins/EcalTBGeometryBuilder.h
+++ b/Geometry/EcalTestBeam/plugins/EcalTBGeometryBuilder.h
@@ -25,8 +25,10 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 
 //
 // class decleration
@@ -42,5 +44,7 @@ class EcalTBGeometryBuilder : public edm::ESProducer {
   ReturnType produce(const IdealGeometryRecord&);
 private:
       // ----------member data ---------------------------
+  edm::ESGetToken<CaloSubdetectorGeometry, IdealGeometryRecord> barrelToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, IdealGeometryRecord> hodoscopeToken_;
 };
 

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.cc
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.cc
@@ -16,9 +16,7 @@
 //
 
 #include "Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.h"
-#include "Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.h"
 
-#include <iostream>
 //
 // constants, enums and typedefs
 //
@@ -32,15 +30,7 @@
 //
 EcalTBHodoscopeGeometryEP::EcalTBHodoscopeGeometryEP(const edm::ParameterSet& iConfig):
   cpvToken_{setWhatProduced(this,"EcalLaserPnDiode").consumes<DDCompactView>(edm::ESInputTag{})}
-{
-  loader_=new EcalTBHodoscopeGeometryLoaderFromDDD(); 
-}
-
-
-EcalTBHodoscopeGeometryEP::~EcalTBHodoscopeGeometryEP()
-{ 
-  delete loader_;
-}
+{}
 
 
 //
@@ -54,8 +44,8 @@ EcalTBHodoscopeGeometryEP::produce(const IdealGeometryRecord& iRecord)
 
    edm::ESTransientHandle<DDCompactView> cpv = iRecord.getTransientHandle(cpvToken_);
    
-   std::cout << "[EcalTBHodoscopeGeometryEP]::Constructing EcalTBHodoscopeGeometry" <<  std::endl;
-   return std::unique_ptr<CaloSubdetectorGeometry>(loader_->load(&(*cpv)));
+   LogDebug("EcalTBHodoscopeGeometryEP") << "[EcalTBHodoscopeGeometryEP]::Constructing EcalTBHodoscopeGeometry";
+   return std::unique_ptr<CaloSubdetectorGeometry>(loader_.load(&(*cpv)));
 }
 
 

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.cc
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.cc
@@ -30,12 +30,9 @@
 //
 // constructors and destructor
 //
-EcalTBHodoscopeGeometryEP::EcalTBHodoscopeGeometryEP(const edm::ParameterSet& iConfig)
+EcalTBHodoscopeGeometryEP::EcalTBHodoscopeGeometryEP(const edm::ParameterSet& iConfig):
+  cpvToken_{setWhatProduced(this,"EcalLaserPnDiode").consumes<DDCompactView>(edm::ESInputTag{})}
 {
-   //the following line is needed to tell the framework what
-   // data is being produced
-  setWhatProduced(this,"EcalLaserPnDiode");
-  //now do what ever other initialization is needed
   loader_=new EcalTBHodoscopeGeometryLoaderFromDDD(); 
 }
 
@@ -55,8 +52,7 @@ EcalTBHodoscopeGeometryEP::ReturnType
 EcalTBHodoscopeGeometryEP::produce(const IdealGeometryRecord& iRecord)
 {
 
-   edm::ESTransientHandle<DDCompactView> cpv;
-   iRecord.get( cpv );
+   edm::ESTransientHandle<DDCompactView> cpv = iRecord.getTransientHandle(cpvToken_);
    
    std::cout << "[EcalTBHodoscopeGeometryEP]::Constructing EcalTBHodoscopeGeometry" <<  std::endl;
    return std::unique_ptr<CaloSubdetectorGeometry>(loader_->load(&(*cpv)));

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.h
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.h
@@ -10,10 +10,11 @@
 #include "FWCore/Framework/interface/ESProducer.h"
 
 #include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
-
+#include "DetectorDescription/Core/interface/DDCompactView.h"
 
 //Forward declaration
 class EcalTBHodoscopeGeometryLoaderFromDDD;
@@ -35,6 +36,7 @@ class EcalTBHodoscopeGeometryEP : public edm::ESProducer {
 
   // ----------member data ---------------------------
   EcalTBHodoscopeGeometryLoaderFromDDD* loader_;
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvToken_;
 };
 
 

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.h
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.h
@@ -15,9 +15,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "DetectorDescription/Core/interface/DDCompactView.h"
-
-//Forward declaration
-class EcalTBHodoscopeGeometryLoaderFromDDD;
+#include "Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.h"
 
 //
 // class declaration
@@ -26,7 +24,7 @@ class EcalTBHodoscopeGeometryLoaderFromDDD;
 class EcalTBHodoscopeGeometryEP : public edm::ESProducer {
  public:
   EcalTBHodoscopeGeometryEP(const edm::ParameterSet&);
-  ~EcalTBHodoscopeGeometryEP() override;
+  ~EcalTBHodoscopeGeometryEP() override = default;
   
   typedef std::unique_ptr<CaloSubdetectorGeometry> ReturnType;
   
@@ -35,7 +33,7 @@ class EcalTBHodoscopeGeometryEP : public edm::ESProducer {
  private:
 
   // ----------member data ---------------------------
-  EcalTBHodoscopeGeometryLoaderFromDDD* loader_;
+  EcalTBHodoscopeGeometryLoaderFromDDD loader_;
   edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvToken_;
 };
 

--- a/Geometry/EcalTestBeam/test/CrystalCenterDump.cc
+++ b/Geometry/EcalTestBeam/test/CrystalCenterDump.cc
@@ -23,9 +23,9 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
@@ -60,6 +60,8 @@ private:
   double beamEnergy_;
 
   double crystalDepth(){ return A_*(B_+log(beamEnergy_)); }
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
 };
 
 CrystalCenterDump::CrystalCenterDump( const edm::ParameterSet& iConfig )
@@ -74,6 +76,7 @@ CrystalCenterDump::CrystalCenterDump( const edm::ParameterSet& iConfig )
   edm::LogInfo("CrysInfo") << "Position computed according to the depth " << crystalDepth() << 
     " based on:" << "\n A = " << A_ << " cm " << "\n B = " << B_ << "\n BeamEnergy = " << beamEnergy_ << " GeV";
 
+  geometryToken_ = esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{});
 }
 
 
@@ -135,13 +138,12 @@ CrystalCenterDump::analyze( const edm::Event& iEvent, const edm::EventSetup& iSe
    
    std::cout << "Writing the center (eta,phi) for crystals in barrel SM 1 " << std::endl;
 
-   edm::ESHandle<CaloGeometry> pG;
-   iSetup.get<CaloGeometryRecord>().get(pG);     
+   const auto& pG = iSetup.getData(geometryToken_);
    //
    // get the ecal & hcal geometry
    //
    if (pass_==0) {
-     build(*pG,DetId::Ecal,EcalBarrel,"BarrelSM1CrystalCenter.dat");
+     build(pG,DetId::Ecal,EcalBarrel,"BarrelSM1CrystalCenter.dat");
    }
 
    pass_++;

--- a/Geometry/EcalTestBeam/test/EcalTBHodoscopeGeometryAnalyzer.cc
+++ b/Geometry/EcalTestBeam/test/EcalTBHodoscopeGeometryAnalyzer.cc
@@ -22,9 +22,9 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
@@ -63,6 +63,7 @@ private:
   double phi_;
   CLHEP::HepRotation * fromCMStoTB_;
 
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
 };
 
 //
@@ -85,6 +86,8 @@ EcalTBHodoscopeGeometryAnalyzer::EcalTBHodoscopeGeometryAnalyzer( const edm::Par
   phi_ = iConfig.getUntrackedParameter<double>("phi",0.115052);
 
   fromCMStoTB_ = fromCMStoTB( eta_ , phi_ );
+
+  geometryToken_ = esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{});
 }
 
 
@@ -127,14 +130,13 @@ EcalTBHodoscopeGeometryAnalyzer::analyze( const edm::Event& iEvent, const edm::E
 {
    std::cout << "Here I am " << std::endl;
 
-   edm::ESHandle<CaloGeometry> pG;
-   iSetup.get<CaloGeometryRecord>().get(pG);     
+   auto const pG = iSetup.getData(geometryToken_);
    //
    // get the ecal & hcal geometry
    //
 
    if (pass_==0) {
-     build(*pG,DetId::Ecal,EcalLaserPnDiode);
+     build(pG,DetId::Ecal,EcalLaserPnDiode);
    }
 
    pass_++;

--- a/Geometry/EcalTestBeam/test/ee/SurveyToTransforms.cc
+++ b/Geometry/EcalTestBeam/test/ee/SurveyToTransforms.cc
@@ -1,7 +1,7 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "Geometry/EcalAlgo/interface/EcalBarrelGeometry.h"
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
@@ -40,6 +40,8 @@ private:
   TProfile* h_phi;
 
   TH1D* h_diffs[10][12];
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
 };
 
 SurveyToTransforms::SurveyToTransforms( const edm::ParameterSet& iConfig )
@@ -67,15 +69,16 @@ SurveyToTransforms::SurveyToTransforms( const edm::ParameterSet& iConfig )
 					  200, -200., 200. ) ;
      }
   }
+
+  geometryToken_ = esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{});
 }
 
 void
 SurveyToTransforms::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
-   edm::ESHandle<CaloGeometry> pG;
-   iSetup.get<CaloGeometryRecord>().get(pG);     
+  const auto& pG = iSetup.getData(geometryToken_);
 
-   pG->getSubdetectorGeometry( DetId::Ecal, EcalEndcap ) ;
+  pG.getSubdetectorGeometry( DetId::Ecal, EcalEndcap ) ;
 }
 
 DEFINE_FWK_MODULE(SurveyToTransforms);


### PR DESCRIPTION
#### PR description:

This PR migrates all ES and ED modules in Geometry/EcalTestBeam package to EventSetup consumes (#26584). It also removes unnecessary heap memory allocation from `EcalTBHodoscopeGeometryEP` and changes one `std::cout` to `LogDebug` there.

#### PR validation:

Limited matrix runs