### PR TITLE
Fix memory usage in PPSUtilities and PPSProtonTransport

### DIFF
--- a/FastSimulation/CTPPSFastTrackingProducer/plugins/CTPPSFastTrackingProducer.cc
+++ b/FastSimulation/CTPPSFastTrackingProducer/plugins/CTPPSFastTrackingProducer.cc
@@ -101,10 +101,6 @@ CTPPSFastTrackingProducer::CTPPSFastTrackingProducer(const edm::ParameterSet& iC
     detToF_F =std::unique_ptr<CTPPSToFDetector>(new CTPPSToFDetector(fToFNCellX,fToFNCellY,vToFCellWidth,fToFCellHeight,fToFPitchX,fToFPitchY,pos_tof,fTimeSigma)); 
     detToF_B =std::unique_ptr<CTPPSToFDetector>(new CTPPSToFDetector(fToFNCellX,fToFNCellY,vToFCellWidth,fToFCellHeight,fToFPitchX,fToFPitchY,pos_tof,fTimeSigma)); 
 //
-    PPSTools::fBeamMomentum=fBeamMomentum;
-    PPSTools::fBeamEnergy=fBeamEnergy;
-    PPSTools::fCrossingAngleBeam1=fCrossingAngleBeam1;
-    PPSTools::fCrossingAngleBeam2=fCrossingAngleBeam2;
 }
 CTPPSFastTrackingProducer::~CTPPSFastTrackingProducer()
 {
@@ -340,9 +336,12 @@ void CTPPSFastTrackingProducer::FastReco(int Direction,H_RecRPObject* station)
                 double  e = sqrt(partP*partP+PPSTools::ProtonMassSQ);
                 TLorentzVector p(px,py,pz,e);
                 // Invert the Lorentz boost made to take into account the crossing angle during simulation
-                if (fCrossAngleCorr) PPSTools::LorentzBoost(p,"MC");
+                if (fCrossAngleCorr) {
+                  PPSTools::LorentzBoost(p,"MC", {fCrossingAngleBeam1,
+                        fCrossingAngleBeam2,fBeamMomentum,fBeamEnergy});
+                }
                 //Getting the Xi and t (squared four momentum transferred) of the reconstructed track
-                PPSTools::Get_t_and_xi(const_cast<TLorentzVector*>(&p),t,xi);
+                PPSTools::Get_t_and_xi(const_cast<TLorentzVector*>(&p),t,xi, {fBeamMomentum,fBeamEnergy});
                 double pxx = p.Px(); double pyy = p.Py(); double pzz = p.Pz();
                 math::XYZVector momentum (pxx,pyy,pzz);
                 math::XYZPoint vertex (x0,y0,0);

--- a/SimTransport/PPSProtonTransport/interface/ProtonTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/ProtonTransport.h
@@ -38,7 +38,7 @@ class ProtonTransport {
             double fCrossingAngle_56;
 
             std::vector<LHCTransportLink> m_CorrespondenceMap;
-            std::map<unsigned int, TLorentzVector*> m_beamPart;
+            std::map<unsigned int, TLorentzVector> m_beamPart;
             std::map<unsigned int, double> m_xAtTrPoint;
             std::map<unsigned int, double> m_yAtTrPoint;
 

--- a/SimTransport/PPSProtonTransport/src/HectorTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/HectorTransport.cc
@@ -65,7 +65,6 @@ void HectorTransport::process( const HepMC::GenEvent * ev , const edm::EventSetu
 bool HectorTransport::transportProton(const HepMC::GenParticle* gpart)
 {
      edm::LogInfo("ProtonTransport")<<"Starting proton transport using HECTOR method\n";
-     H_BeamParticle* h_p  = nullptr;
 
      double px,py,pz,e;
      unsigned int line = (gpart)->barcode();
@@ -83,20 +82,20 @@ bool HectorTransport::transportProton(const HepMC::GenParticle* gpart)
      int direction = (pz>0)?1:-1;
 
      // Apply Beam and Crossing Angle Corrections
-     TLorentzVector* p_out = new TLorentzVector(px,py,pz,e);
-     PPSTools::LorentzBoost(*p_out,"LAB", {fCrossingAngle_56 ,//Beam1
+     TLorentzVector p_out(px,py,pz,e);
+     PPSTools::LorentzBoost(p_out,"LAB", {fCrossingAngle_56 ,//Beam1
            fCrossingAngle_45, //Beam2
            fBeamMomentum,fBeamEnergy});
 
-     ApplyBeamCorrection(*p_out);
+     ApplyBeamCorrection(p_out);
 
      // from mm to cm        
      double XforPosition = gpart->production_vertex()->position().x()/cm;//cm
      double YforPosition = gpart->production_vertex()->position().y()/cm;//cm
      double ZforPosition = gpart->production_vertex()->position().z()/cm;//cm
 
-     h_p = new H_BeamParticle(mass,charge);
-     h_p->set4Momentum(-direction*p_out->Px(), p_out->Py(), fabs(p_out->Pz()), p_out->E());
+     H_BeamParticle h_p(mass,charge);
+     h_p.set4Momentum(-direction*p_out.Px(), p_out.Py(), fabs(p_out.Pz()), p_out.E());
 // shift the beam position to the given beam position at IP (in cm)
      XforPosition=(XforPosition-fVtxMeanX)+fBeamXatIP*mm_to_cm;
      YforPosition=(YforPosition-fVtxMeanY)+fBeamYatIP*mm_to_cm;
@@ -104,15 +103,15 @@ bool HectorTransport::transportProton(const HepMC::GenParticle* gpart)
 //
 // shift the starting position of the track to Z=0 if configured so (all the variables below are still in cm)
      if (bApplyZShift) {
-        double fCrossingAngle = (p_out->Pz()>0)?fCrossingAngle_45:-fCrossingAngle_56;
-        XforPosition = XforPosition+(tan((long double)fCrossingAngle*urad)-((long double)p_out->Px())/((long double)p_out->Pz()))*ZforPosition;
-        YforPosition = YforPosition-((long double)p_out->Py())/((long double)p_out->Pz())*ZforPosition;
+        double fCrossingAngle = (p_out.Pz()>0)?fCrossingAngle_45:-fCrossingAngle_56;
+        XforPosition = XforPosition+(tan((long double)fCrossingAngle*urad)-((long double)p_out.Px())/((long double)p_out.Pz()))*ZforPosition;
+        YforPosition = YforPosition-((long double)p_out.Py())/((long double)p_out.Pz())*ZforPosition;
         ZforPosition = 0.;
      }
 
 //
 // set position, but do not invert the coordinate for the angles (TX,TY) because it is done by set4Momentum
-     h_p->setPosition(-direction*XforPosition*cm_to_um,YforPosition*cm_to_um,h_p->getTX(),h_p->getTY(),-direction*ZforPosition*cm_to_m);
+     h_p.setPosition(-direction*XforPosition*cm_to_um,YforPosition*cm_to_um,h_p.getTX(),h_p.getTY(),-direction*ZforPosition*cm_to_m);
      bool is_stop;
      float x1_ctpps;
      float y1_ctpps;
@@ -128,29 +127,23 @@ bool HectorTransport::transportProton(const HepMC::GenParticle* gpart)
                       break;
      }
      // insert protection for NULL beamlines here
-     h_p->computePath(&*_beamline);
-     is_stop = h_p->stopped(&*_beamline);
+     h_p.computePath(&*_beamline);
+     is_stop = h_p.stopped(&*_beamline);
      if(m_verbosity) LogDebug("HectorTransportEventProcessing") << "HectorTransport:filterPPS: barcode = "
              << line << " is_stop=  "<< is_stop;
-     if (p_out) {
-       delete p_out;
-       p_out = nullptr;
-     } 
      if (is_stop) {
-       delete h_p;
-       h_p=nullptr;
        return false;
      }
      //
      //propagating
      //
-     h_p->propagate( _targetZ );
+     h_p.propagate( _targetZ );
 
-     p_out = new TLorentzVector(PPSTools::HectorParticle2LorentzVector(*h_p,direction));
+     p_out = PPSTools::HectorParticle2LorentzVector(h_p,direction);
 
-     p_out->SetPx(direction*p_out->Px());
-     x1_ctpps = direction*h_p->getX()*um_to_mm; 
-     y1_ctpps = h_p->getY()*um_to_mm;
+     p_out.SetPx(direction*p_out.Px());
+     x1_ctpps = direction*h_p.getX()*um_to_mm; 
+     y1_ctpps = h_p.getY()*um_to_mm;
 
      if(m_verbosity) LogDebug("HectorTransportEventProcessing") <<
              "HectorTransport:filterPPS: barcode = " << line << " x=  "<< x1_ctpps <<" y= " << y1_ctpps;
@@ -158,8 +151,6 @@ bool HectorTransport::transportProton(const HepMC::GenParticle* gpart)
      m_beamPart[line]    = p_out;
      m_xAtTrPoint[line]  = x1_ctpps;
      m_yAtTrPoint[line]  = y1_ctpps;
-     delete p_out; p_out = nullptr;
-     delete h_p; h_p = nullptr;
      return true;
 }
 void HectorTransport::genProtonsLoop( const HepMC::GenEvent * evt ,const edm::EventSetup & iSetup)

--- a/SimTransport/PPSProtonTransport/src/HectorTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/HectorTransport.cc
@@ -47,10 +47,6 @@ HectorTransport::HectorTransport(const edm::ParameterSet & param, bool verbosity
          <<"             Bulding LHC Proton transporter based on HECTOR model\n"
          <<"=============================================================================\n";
     setBeamLine();
-    PPSTools::fBeamMomentum=fBeamMomentum;
-    PPSTools::fBeamEnergy=fBeamEnergy;
-    PPSTools::fCrossingAngleBeam1=fCrossingAngle_56;
-    PPSTools::fCrossingAngleBeam2=fCrossingAngle_45;
     fPPSRegionStart_56=m_b_ctpps_b;
     fPPSRegionStart_45=m_f_ctpps_f;
 }
@@ -88,7 +84,9 @@ bool HectorTransport::transportProton(const HepMC::GenParticle* gpart)
 
      // Apply Beam and Crossing Angle Corrections
      TLorentzVector* p_out = new TLorentzVector(px,py,pz,e);
-     PPSTools::LorentzBoost(*p_out,"LAB");
+     PPSTools::LorentzBoost(*p_out,"LAB", {fCrossingAngle_56 ,//Beam1
+           fCrossingAngle_45, //Beam2
+           fBeamMomentum,fBeamEnergy});
 
      ApplyBeamCorrection(*p_out);
 

--- a/SimTransport/PPSProtonTransport/src/ProtonTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/ProtonTransport.cc
@@ -8,7 +8,6 @@ ProtonTransport::ProtonTransport() {};
 ProtonTransport::~ProtonTransport() {};
 void ProtonTransport::clear()
 {
-     for (std::map<unsigned int,TLorentzVector* >::iterator it = m_beamPart.begin(); it != m_beamPart.end(); ++it ) delete (*it).second;
      m_beamPart.clear(); m_xAtTrPoint.clear(); m_yAtTrPoint.clear();
 };
 
@@ -16,14 +15,13 @@ void ProtonTransport::addPartToHepMC( HepMC::GenEvent * evt )
 {
     NEvent++;
     m_CorrespondenceMap.clear();
-    std::map< unsigned int, TLorentzVector* >::iterator it;
 
     int direction=0;
     HepMC::GenParticle * gpart;
 
     unsigned int line;
 
-    for( auto it : m_beamPart ) {
+    for( auto const& it : m_beamPart ) {
         line = (it ).first;
         gpart = evt->barcode_to_particle( line );
 
@@ -43,7 +41,7 @@ void ProtonTransport::addPartToHepMC( HepMC::GenEvent * evt )
                         <<"ProtonTransport:: z= "<< ddd * direction*m_to_mm << "\n"
                         <<"ProtonTransport:: t= "<< time;
         }
-        TLorentzVector* p_out = (it).second;
+        TLorentzVector const& p_out = (it).second;
 
         HepMC::GenVertex * vert = new HepMC::GenVertex(
                         HepMC::FourVector( (*(m_xAtTrPoint.find(line))).second,
@@ -52,7 +50,7 @@ void ProtonTransport::addPartToHepMC( HepMC::GenEvent * evt )
 
         gpart->set_status( 2 );
         vert->add_particle_in( gpart );
-        vert->add_particle_out( new HepMC::GenParticle( HepMC::FourVector(p_out->Px(),p_out->Py(),p_out->Pz(),p_out->E()), gpart->pdg_id(), 1, gpart->flow() )) ;
+        vert->add_particle_out( new HepMC::GenParticle( HepMC::FourVector(p_out.Px(),p_out.Py(),p_out.Pz(),p_out.E()), gpart->pdg_id(), 1, gpart->flow() )) ;
         evt->add_vertex( vert );
 
         int ingoing = (*vert->particles_in_const_begin())->barcode();

--- a/SimTransport/PPSProtonTransport/src/TotemTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/TotemTransport.cc
@@ -134,7 +134,7 @@ bool TotemTransport::transportProton( const HepMC::GenParticle* in_trk)
      double py = out_momentum[1];  // this need to be checked again, since it seems an invertion is occuring in  the prop.
      double pz = out_momentum[2];
      double e = sqrt(px*px+py*py+pz*pz+ProtonMassSQ);
-     TLorentzVector* p_out = new TLorentzVector(px,py,pz,e);
+     TLorentzVector p_out(px,py,pz,e);
      double x1_ctpps = -out_position[0]*meter; // Totem parameterization uses meter, one need it in millimeter
      double y1_ctpps = -out_position[1]*meter;
 

--- a/Utilities/PPS/interface/PPSUtilities.h
+++ b/Utilities/PPS/interface/PPSUtilities.h
@@ -16,10 +16,18 @@ namespace HepMC
 
 namespace PPSTools {
 
-double fCrossingAngleBeam1;
-double fCrossingAngleBeam2;
-double fBeamMomentum;
-double fBeamEnergy;
+  struct FullBeamInfo {
+    double fCrossingAngleBeam1;
+    double fCrossingAngleBeam2;
+    double fBeamMomentum;
+    double fBeamEnergy;
+  };
+
+  struct LimitedBeamInfo {
+    double fBeamMomentum;
+    double fBeamEnergy;
+  };
+
 const double   urad     = 1./1000000.; 
 const double ProtonMass=CLHEP::proton_mass_c2/GeV;
 const double ProtonMassSQ=pow(ProtonMass,2);
@@ -28,13 +36,13 @@ TLorentzVector HectorParticle2LorentzVector(H_BeamParticle hp,int );
 
 H_BeamParticle LorentzVector2HectorParticle(TLorentzVector p);
 
-void LorentzBoost(H_BeamParticle& h_p,int dir, const std::string& frame);
+void LorentzBoost(H_BeamParticle& h_p,int dir, const std::string& frame, FullBeamInfo const& bi);
 
-void LorentzBoost(TLorentzVector& p_out, const std::string& frame);
+void LorentzBoost(TLorentzVector& p_out, const std::string& frame, FullBeamInfo const& bi);
 
-void LorentzBoost(HepMC::GenParticle& p_out, const std::string& frame);
+void LorentzBoost(HepMC::GenParticle& p_out, const std::string& frame, FullBeamInfo const& bi);
 
-void Get_t_and_xi(const TLorentzVector* proton,double& t,double& xi) ;
+void Get_t_and_xi(const TLorentzVector* proton,double& t,double& xi, LimitedBeamInfo const& bi) ;
 
 };
 #endif

--- a/Utilities/PPS/src/PPSUtilities.cc
+++ b/Utilities/PPS/src/PPSUtilities.cc
@@ -20,22 +20,22 @@ H_BeamParticle PPSTools::LorentzVector2HectorParticle(TLorentzVector p)
      h_p.set4Momentum(p.Px(),p.Py(),abs(p.Pz()),p.E());
      return h_p;
 }
-void PPSTools::LorentzBoost(HepMC::GenParticle& p, const string& frame)
+void PPSTools::LorentzBoost(HepMC::GenParticle& p, const string& frame, FullBeamInfo const& bi)
 {
      TLorentzVector p_out;
      p_out.SetPx(p.momentum().px());
      p_out.SetPy(p.momentum().py());
      p_out.SetPz(p.momentum().pz());
-     LorentzBoost(p_out,frame);
+     LorentzBoost(p_out,frame, bi);
      p.set_momentum(HepMC::FourVector(p_out.Px(),p_out.Py(),p_out.Pz(),p_out.E()));
 }
-void PPSTools::LorentzBoost(H_BeamParticle& h_p, int dir , const string& frame)
+void PPSTools::LorentzBoost(H_BeamParticle& h_p, int dir , const string& frame, FullBeamInfo const& bi)
 {
      TLorentzVector p_out=HectorParticle2LorentzVector(h_p,dir);
-     LorentzBoost(p_out,frame);
+     LorentzBoost(p_out,frame, bi);
      h_p=LorentzVector2HectorParticle(p_out);
 }
-void PPSTools::LorentzBoost(TLorentzVector& p_out, const string& frame)
+void PPSTools::LorentzBoost(TLorentzVector& p_out, const string& frame, FullBeamInfo const& bi)
 {
     const long double microrad = 1.e-6;
     //
@@ -43,18 +43,18 @@ void PPSTools::LorentzBoost(TLorentzVector& p_out, const string& frame)
     double px_N, py_N,pz_N;
     double fBoostAngle1=0.;
     double fBoostAngle2=0.;
-    if (frame=="LAB") {fBoostAngle1=fCrossingAngleBeam1;fBoostAngle2=fCrossingAngleBeam2;}
-    if (frame=="MC")  {fBoostAngle1=-fCrossingAngleBeam1;fBoostAngle2=-fCrossingAngleBeam2;}
-    px_P = fBeamMomentum*sin(fBoostAngle2*microrad);
-    px_N = fBeamMomentum*sin(fBoostAngle1*microrad);
-    pz_P = fBeamMomentum*cos(fBoostAngle2*microrad);
-    pz_N = fBeamMomentum*cos(fBoostAngle1*microrad);
+    if (frame=="LAB") {fBoostAngle1=bi.fCrossingAngleBeam1;fBoostAngle2=bi.fCrossingAngleBeam2;}
+    if (frame=="MC")  {fBoostAngle1=-bi.fCrossingAngleBeam1;fBoostAngle2=-bi.fCrossingAngleBeam2;}
+    px_P = bi.fBeamMomentum*sin(fBoostAngle2*microrad);
+    px_N = bi.fBeamMomentum*sin(fBoostAngle1*microrad);
+    pz_P = bi.fBeamMomentum*cos(fBoostAngle2*microrad);
+    pz_N = bi.fBeamMomentum*cos(fBoostAngle1*microrad);
     py_P = 0.;
     py_N = 0.;
 
     TLorentzVector BeamP, BeamN, projVect;
-    BeamP.SetPx(px_P);BeamP.SetPy(py_P);BeamP.SetPz(pz_P);BeamP.SetE(fBeamEnergy);
-    BeamN.SetPx(px_N);BeamN.SetPy(py_N);BeamN.SetPz(-pz_N);BeamN.SetE(fBeamEnergy);
+    BeamP.SetPx(px_P);BeamP.SetPy(py_P);BeamP.SetPz(pz_P);BeamP.SetE(bi.fBeamEnergy);
+    BeamN.SetPx(px_N);BeamN.SetPy(py_N);BeamN.SetPz(-pz_N);BeamN.SetE(bi.fBeamEnergy);
     projVect = BeamP + BeamN;
     TVector3 beta;
     TLorentzVector boosted = p_out;
@@ -62,14 +62,14 @@ void PPSTools::LorentzBoost(TLorentzVector& p_out, const string& frame)
     boosted.Boost(beta);
     p_out=boosted;
 }
-void PPSTools::Get_t_and_xi(const TLorentzVector* proton,double& t,double& xi) {
+void PPSTools::Get_t_and_xi(const TLorentzVector* proton,double& t,double& xi, LimitedBeamInfo const& bi) {
     t = 0.;
     xi = -1.;
     if (!proton) return;
     double mom = sqrt((proton->Px())*(proton->Px())+(proton->Py())*(proton->Py())+(proton->Pz())*(proton->Pz()));
-    if (mom>fBeamMomentum) mom=fBeamMomentum;
+    if (mom>bi.fBeamMomentum) mom=bi.fBeamMomentum;
     double energy = proton->E();
     double theta  = (proton->Pz()>0)?proton->Theta():TMath::Pi()-proton->Theta();
-    t      = -2.*(ProtonMassSQ-fBeamEnergy*energy+fBeamMomentum*mom*cos(theta));
-    xi     = (1.0-energy/fBeamEnergy);
+    t      = -2.*(ProtonMassSQ-bi.fBeamEnergy*energy+bi.fBeamMomentum*mom*cos(theta));
+    xi     = (1.0-energy/bi.fBeamEnergy);
 }


### PR DESCRIPTION
#### PR description:

- Removed the use of non-const global variables in PPSUtilities. This was spotted by the static analyzer.
- Moved variables from pointers to just type in PPSProtonTransport. This also fixes a double delete in HectorTransport.
#### PR validation:

The code compiles.