### PR TITLE
Migrate WriteESAlignments to EventSetup consumes

### DIFF
--- a/Geometry/CaloEventSetup/test/TestWriteESAlignments.cc
+++ b/Geometry/CaloEventSetup/test/TestWriteESAlignments.cc
@@ -1,5 +1,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -15,7 +16,7 @@ class TestWriteESAlignments : public edm::one::EDAnalyzer<>
 public:
 
   explicit TestWriteESAlignments(const edm::ParameterSet& /*iConfig*/)
-    : nEventCalls_(0) {}
+    : writer_{consumesCollector()}, nEventCalls_{0} {}
   ~TestWriteESAlignments() override {}
   
   void beginJob() override {}
@@ -23,7 +24,7 @@ public:
   void endJob() override {}
 
 private:
-  
+  WriteESAlignments writer_;
   unsigned int nEventCalls_;
 };
   
@@ -48,14 +49,14 @@ void TestWriteESAlignments::analyze(const edm::Event& /*evt*/, const edm::EventS
    DVec ytranslVec ( nA, 0 ) ;
    DVec ztranslVec ( nA, 0 ) ;
 
-   const WriteESAlignments wea( evtSetup   ,
-				alphaVec   ,
-				betaVec    ,
-				gammaVec   ,
-				xtranslVec ,
-				ytranslVec ,
-				ztranslVec  ) ;
-   
+   writer_.writeAlignments( evtSetup   ,
+                            alphaVec   ,
+                            betaVec    ,
+                            gammaVec   ,
+                            xtranslVec ,
+                            ytranslVec ,
+                            ztranslVec  ) ;
+
    edm::LogInfo("TestWriteESAlignments") << "Done!";
    nEventCalls_++;
 }

--- a/Geometry/EcalAlgo/interface/WriteESAlignments.h
+++ b/Geometry/EcalAlgo/interface/WriteESAlignments.h
@@ -3,10 +3,14 @@
 
 namespace edm
 {
+   class ConsumesCollector;
    class EventSetup ;
 }
 
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "CondFormats/Alignment/interface/Alignments.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 
 class WriteESAlignments
@@ -23,15 +27,15 @@ class WriteESAlignments
 
       static const unsigned int k_nA ;
 
-      WriteESAlignments( const edm::EventSetup& eventSetup ,
-			 const DVec&            alphaVec   ,
-			 const DVec&            betaVec    ,
-			 const DVec&            gammaVec   ,
-			 const DVec&            xtranslVec ,
-			 const DVec&            ytranslVec ,
-			 const DVec&            ztranslVec  ) ;
+      WriteESAlignments(edm::ConsumesCollector&& cc);
 
-      ~WriteESAlignments() ;
+      void writeAlignments( const edm::EventSetup& eventSetup ,
+                            const DVec&            alphaVec   ,
+                            const DVec&            betaVec    ,
+                            const DVec&            gammaVec   ,
+                            const DVec&            xtranslVec ,
+                            const DVec&            ytranslVec ,
+                            const DVec&            ztranslVec  ) ;
 
    private:
 
@@ -45,6 +49,9 @@ class WriteESAlignments
 		    AliVec&                va  ) ;
 
       void write( AliPtr aliPtr ) ;
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
+  edm::ESGetToken<Alignments, ESAlignmentRcd> alignmentToken_;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

This PR migrates `WriteESAlignments` helper class (and thus the package Geometry/EcalAlgo) to EventSetup consumes (#26584).

#### PR validation:

Limited matrix runs.