### PR TITLE
atomize counters in BaseIsolator.h

### DIFF
--- a/PhysicsTools/PatAlgos/interface/BaseIsolator.h
+++ b/PhysicsTools/PatAlgos/interface/BaseIsolator.h
@@ -6,6 +6,8 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
+#include <atomic>
+
 namespace pat { namespace helper {
 class BaseIsolator {
     public:
@@ -34,7 +36,7 @@ class BaseIsolator {
         edm::InputTag input_;
         edm::EDGetTokenT<Isolation> inputToken_;
         float cut_;
-        mutable uint64_t try_, fail_;
+        mutable std::atomic<uint64_t> try_, fail_;
 }; // class BaseIsolator
 } } // namespaces
 


### PR DESCRIPTION
some mutables are used as counters and are showing up as static analyzer warnings. In the case of  BaseIsolator, the simplest is to atomize them, as done in this PR.

The counters here are used for printing of statistics of the ```test ``` method calls. I do not see a strong need for a correctness of this in a multithreaded environment.
The ```atomic``` is effectively to just silence the warning.