### PR TITLE
Migrate Geometry/GlobalTrackingGeometryBuilder to EventSetup consumes

### DIFF
--- a/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.cc
+++ b/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.cc
@@ -20,7 +20,14 @@
 using namespace edm;
 
 GlobalTrackingGeometryESProducer::GlobalTrackingGeometryESProducer(const edm::ParameterSet & p){
-  setWhatProduced(this);
+  auto cc = setWhatProduced(this);
+  trackerToken_ = cc.consumesFrom<TrackerGeometry, TrackerDigiGeometryRecord>(edm::ESInputTag{});
+  mtdToken_ = cc.consumesFrom<MTDGeometry, MTDDigiGeometryRecord>(edm::ESInputTag{});
+  dtToken_ = cc.consumesFrom<DTGeometry, MuonGeometryRecord>(edm::ESInputTag{});
+  cscToken_ = cc.consumesFrom<CSCGeometry, MuonGeometryRecord>(edm::ESInputTag{});
+  rpcToken_ = cc.consumesFrom<RPCGeometry, MuonGeometryRecord>(edm::ESInputTag{});
+  gemToken_ = cc.consumesFrom<GEMGeometry, MuonGeometryRecord>(edm::ESInputTag{});
+  me0Token_ = cc.consumesFrom<ME0Geometry, MuonGeometryRecord>(edm::ESInputTag{});
 }
 
 GlobalTrackingGeometryESProducer::~GlobalTrackingGeometryESProducer(){}
@@ -36,10 +43,8 @@ GlobalTrackingGeometryESProducer::produce(const GlobalTrackingGeometryRecord& re
   GEMGeometry const* gem = nullptr;
   ME0Geometry const* me0 = nullptr;
 
-  edm::ESHandle<TrackerGeometry> tkH;
   if( auto tkRecord = record.tryToGetRecord<TrackerDigiGeometryRecord>() ) {
-    tkRecord->get(tkH);
-    if(tkH.isValid()) {
+    if(auto tkH = tkRecord->getHandle(trackerToken_)) {
       tk = tkH.product();
     } else {
       LogWarning("GeometryGlobalTrackingGeometryBuilder") << "No Tracker geometry is available.";
@@ -48,10 +53,8 @@ GlobalTrackingGeometryESProducer::produce(const GlobalTrackingGeometryRecord& re
     LogWarning("GeometryGlobalTrackingGeometryBuilder") << "No TrackerDigiGeometryRecord is available.";    
   }
 
-  edm::ESHandle<MTDGeometry> mtdH;
   if( auto mtdRecord = record.tryToGetRecord<MTDDigiGeometryRecord>() ) {
-    mtdRecord->get(mtdH);
-    if( mtdH.isValid() ) {
+    if(auto mtdH = mtdRecord->getHandle(mtdToken_)) {
       mtd = mtdH.product();
     } else {
       LogInfo("GeometryGlobalTrackingGeometryBuilder") << "No MTD geometry is available.";
@@ -60,42 +63,32 @@ GlobalTrackingGeometryESProducer::produce(const GlobalTrackingGeometryRecord& re
      LogInfo("GeometryGlobalTrackingGeometryBuilder") << "No MTDDigiGeometryRecord is available.";
   }
   
-  edm::ESHandle<DTGeometry> dtH;
-  edm::ESHandle<CSCGeometry> cscH;
-  edm::ESHandle<RPCGeometry> rpcH;
-  edm::ESHandle<GEMGeometry> gemH;
-  edm::ESHandle<ME0Geometry> me0H;
   if( auto muonRecord = record.tryToGetRecord<MuonGeometryRecord>() ) {
-    muonRecord->get(dtH);
-    if(dtH.isValid()) {
+    if(auto dtH = muonRecord->getHandle(dtToken_)) {
       dt = dtH.product();
     } else {
       LogWarning("GeometryGlobalTrackingGeometryBuilder") << "No DT geometry is available.";
     }
     
-    muonRecord->get(cscH);
-    if(cscH.isValid()) {
+    if(auto cscH = muonRecord->getHandle(cscToken_)) {
       csc = cscH.product();
     } else {
       LogWarning("GeometryGlobalTrackingGeometryBuilder") << "No CSC geometry is available.";
     }    
     
-    muonRecord->get(rpcH);
-    if(rpcH.isValid()) {
+    if(auto rpcH = muonRecord->getHandle(rpcToken_)) {
       rpc = rpcH.product();
     } else {
       LogWarning("GeometryGlobalTrackingGeometryBuilder") << "No RPC geometry is available.";
     }
     
-    muonRecord->get(gemH);
-    if(gemH.isValid()) {
+    if(auto gemH = muonRecord->getHandle(gemToken_)) {
       gem = gemH.product();
     } else {
       LogInfo("GeometryGlobalTrackingGeometryBuilder") << "No GEM geometry is available.";
     }
     
-    muonRecord->get(me0H);
-    if(me0H.isValid()) {
+    if(auto me0H = muonRecord->getHandle(me0Token_)) {
       me0 = me0H.product();
     } else {
       LogInfo("GeometryGlobalTrackingGeometryBuilder") << "No ME0 geometry is available.";

--- a/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.h
+++ b/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.h
@@ -16,6 +16,16 @@
 #include <string>
 
 class GlobalTrackingGeometry;
+class TrackerGeometry;
+class MTDGeometry;
+class DTGeometry;
+class CSCGeometry;
+class RPCGeometry;
+class GEMGeometry;
+class ME0Geometry;
+class TrackerDigiGeometryRecord;
+class MTDDigiGeometryRecord;
+class MuonGeometryRecord;
 
 class GlobalTrackingGeometryESProducer : public edm::ESProducer {
 public:
@@ -31,6 +41,13 @@ public:
 
 private:  
 
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerToken_;
+  edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> mtdToken_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtToken_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscToken_;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcToken_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemToken_;
+  edm::ESGetToken<ME0Geometry, MuonGeometryRecord> me0Token_;
 };
 #endif
 

--- a/Geometry/GlobalTrackingGeometryBuilder/test/GlobalTrackingGeometryTest.cc
+++ b/Geometry/GlobalTrackingGeometryBuilder/test/GlobalTrackingGeometryTest.cc
@@ -47,10 +47,13 @@ private:
   void analyzeTracker(const GlobalTrackingGeometry* geo, const TrackerGeometry* tkGeometry);
   const std::string& myName() { return my_name; }
   std::string my_name;    
+  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> geometryToken_;
 };
 
 GlobalTrackingGeometryTest::GlobalTrackingGeometryTest( const edm::ParameterSet& /*iConfig*/)
- : my_name( "GlobalTrackingGeometryTest" ) {}
+  : my_name( "GlobalTrackingGeometryTest" ),
+    geometryToken_{esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>(edm::ESInputTag{})}
+ {}
 
 GlobalTrackingGeometryTest::~GlobalTrackingGeometryTest() {}
 
@@ -196,14 +199,13 @@ void GlobalTrackingGeometryTest::analyze( const edm::Event& /*iEvent*/, const ed
 {
   std::cout << myName() << ": Analyzer..." << std::endl;
 
-  edm::ESHandle<GlobalTrackingGeometry> geo;
-  iSetup.get<GlobalTrackingGeometryRecord>().get(geo);     
+  const auto& geo = iSetup.getData(geometryToken_);
     
   DetId detId1(DetId::Tracker, 0);
   const TrackerGeometry* trackerGeometry = nullptr;
   std::cout << "Pointer to Tracker Geometry: ";
   try {
-    trackerGeometry = (const TrackerGeometry*) geo->slaveGeometry(detId1);
+    trackerGeometry = (const TrackerGeometry*) geo.slaveGeometry(detId1);
     std::cout << trackerGeometry << std::endl;
   } catch (...) {
     std::cout << "N/A" << std::endl;
@@ -213,7 +215,7 @@ void GlobalTrackingGeometryTest::analyze( const edm::Event& /*iEvent*/, const ed
   const MTDGeometry* mtdGeometry = nullptr;
   std::cout << "Pointer to MTD Geometry: ";
   try {
-    mtdGeometry = (const MTDGeometry*) geo->slaveGeometry(detId6);
+    mtdGeometry = (const MTDGeometry*) geo.slaveGeometry(detId6);
     std::cout << mtdGeometry << std::endl;
   } catch (...) {
     std::cout << "N/A" << std::endl;
@@ -223,7 +225,7 @@ void GlobalTrackingGeometryTest::analyze( const edm::Event& /*iEvent*/, const ed
   const DTGeometry* dtGeometry = nullptr;
   std::cout << "Pointer to DT Geometry: ";
   try {
-    dtGeometry = (const DTGeometry*) geo->slaveGeometry(detId2);
+    dtGeometry = (const DTGeometry*) geo.slaveGeometry(detId2);
     std::cout << dtGeometry << std::endl;
   } catch (...) {
     std::cout << "N/A" << std::endl;
@@ -233,7 +235,7 @@ void GlobalTrackingGeometryTest::analyze( const edm::Event& /*iEvent*/, const ed
   const CSCGeometry* cscGeometry = nullptr;
   std::cout << "Pointer to CSC Geometry: "; 
   try {
-    cscGeometry = (const CSCGeometry*) geo->slaveGeometry(detId3);
+    cscGeometry = (const CSCGeometry*) geo.slaveGeometry(detId3);
     std::cout << cscGeometry << std::endl;
   } catch (...) {
     std::cout << "N/A" << std::endl;
@@ -243,7 +245,7 @@ void GlobalTrackingGeometryTest::analyze( const edm::Event& /*iEvent*/, const ed
   const RPCGeometry* rpcGeometry = nullptr;
   std::cout << "Pointer to RPC Geometry: ";
   try {
-    rpcGeometry = (const RPCGeometry*) geo->slaveGeometry(detId4);
+    rpcGeometry = (const RPCGeometry*) geo.slaveGeometry(detId4);
     std::cout <<  rpcGeometry << std::endl;
   } catch (...) {
     std::cout << "N/A" << std::endl;
@@ -253,18 +255,18 @@ void GlobalTrackingGeometryTest::analyze( const edm::Event& /*iEvent*/, const ed
   const GEMGeometry* gemGeometry = nullptr;
   std::cout << "Pointer to GEM Geometry: ";
   try {
-    gemGeometry = (const GEMGeometry*) geo->slaveGeometry(detId5);
+    gemGeometry = (const GEMGeometry*) geo.slaveGeometry(detId5);
     std::cout <<  gemGeometry << std::endl;
   } catch (...) {
     std::cout << "N/A" << std::endl;
   }
 
-  if (cscGeometry) analyzeCSC(geo.product(), cscGeometry);
-  if (dtGeometry) analyzeDT(geo.product(), dtGeometry);
-  if (rpcGeometry) analyzeRPC(geo.product(), rpcGeometry);
-  if (gemGeometry) analyzeGEM(geo.product(), gemGeometry);
-  if (mtdGeometry) analyzeMTD(geo.product(), mtdGeometry);
-  if (trackerGeometry) analyzeTracker(geo.product(), trackerGeometry);
+  if (cscGeometry) analyzeCSC(&geo, cscGeometry);
+  if (dtGeometry) analyzeDT(&geo, dtGeometry);
+  if (rpcGeometry) analyzeRPC(&geo, rpcGeometry);
+  if (gemGeometry) analyzeGEM(&geo, gemGeometry);
+  if (mtdGeometry) analyzeMTD(&geo, mtdGeometry);
+  if (trackerGeometry) analyzeTracker(&geo, trackerGeometry);
 }
 
 //define this as a plug-in


### PR DESCRIPTION
#### PR description:

This PR migrates all ES and ED modules in Geometry/GlobalTrackingGeometryBuilder to EventSetup consumes.

#### PR validation:

Limited matrix runs.