### PR TITLE
Allow python 3 execution of test configs in FWCore/Framework

### DIFF
--- a/FWCore/Framework/test/test_global_modules_cfg.py
+++ b/FWCore/Framework/test/test_global_modules_cfg.py
@@ -28,110 +28,110 @@ process.source = cms.Source("EmptySource",
 )
 
 process.StreamIntProd = cms.EDProducer("edmtest::global::StreamIntProducer",
-    transitions = cms.int32(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2))
+    transitions = cms.int32(int(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2)))
     ,cachevalue = cms.int32(1)
 )
 
 process.RunIntProd = cms.EDProducer("edmtest::global::RunIntProducer",
-    transitions = cms.int32(2*(nEvt/nEvtRun))
+    transitions = cms.int32(int(2*(nEvt/nEvtRun)))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiIntProd = cms.EDProducer("edmtest::global::LumiIntProducer",
-    transitions = cms.int32(2*(nEvt/nEvtLumi))
+    transitions = cms.int32(int(2*(nEvt/nEvtLumi)))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.RunSumIntProd = cms.EDProducer("edmtest::global::RunSummaryIntProducer",
-    transitions = cms.int32(nStreams*(nEvt/nEvtRun)+2*(nEvt/nEvtRun))
+    transitions = cms.int32(int(nStreams*(nEvt/nEvtRun)+2*(nEvt/nEvtRun)))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiSumIntProd = cms.EDProducer("edmtest::global::LumiSummaryIntProducer",
-    transitions = cms.int32(nStreams*(nEvt/nEvtLumi)+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(int(nStreams*(nEvt/nEvtLumi)+2*(nEvt/nEvtLumi)))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.TestBeginRunProd = cms.EDProducer("edmtest::global::TestBeginRunProducer",
-    transitions = cms.int32((nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt/nEvtRun))
 )
 
 process.TestEndRunProd = cms.EDProducer("edmtest::global::TestEndRunProducer",
-    transitions = cms.int32((nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt/nEvtRun))
 )
 
 process.TestBeginLumiBlockProd = cms.EDProducer("edmtest::global::TestBeginLumiBlockProducer",
-    transitions = cms.int32((nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt/nEvtLumi))
 )
 
 process.TestEndLumiBlockProd = cms.EDProducer("edmtest::global::TestEndLumiBlockProducer",
-    transitions = cms.int32((nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt/nEvtLumi))
 )
 
 process.StreamIntAn = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer",
-    transitions = cms.int32(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2))
+    transitions = cms.int32(int(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2)))
     ,cachevalue = cms.int32(1)
 )
 
 process.RunIntAn= cms.EDAnalyzer("edmtest::global::RunIntAnalyzer",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt+2*(nEvt/nEvtRun)))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiIntAn = cms.EDAnalyzer("edmtest::global::LumiIntAnalyzer",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt+2*(nEvt/nEvtLumi)))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.RunSumIntAn = cms.EDAnalyzer("edmtest::global::RunSummaryIntAnalyzer",
-    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtRun)+1)+2*(nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt+nStreams*((nEvt/nEvtRun)+1)+2*(nEvt/nEvtRun)))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiSumIntAn = cms.EDAnalyzer("edmtest::global::LumiSummaryIntAnalyzer",
-    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtLumi)+1)+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt+nStreams*((nEvt/nEvtLumi)+1)+2*(nEvt/nEvtLumi)))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.StreamIntFil = cms.EDFilter("edmtest::global::StreamIntFilter",
-    transitions = cms.int32(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2))
+    transitions = cms.int32(int(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2)))
     ,cachevalue = cms.int32(1)
 )
 
 process.RunIntFil = cms.EDFilter("edmtest::global::RunIntFilter",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt+2*(nEvt/nEvtRun)))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiIntFil = cms.EDFilter("edmtest::global::LumiIntFilter",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt+2*(nEvt/nEvtLumi)))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.RunSumIntFil = cms.EDFilter("edmtest::global::RunSummaryIntFilter",
-    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtRun)+1)+2*(nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt+nStreams*((nEvt/nEvtRun)+1)+2*(nEvt/nEvtRun)))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiSumIntFil = cms.EDFilter("edmtest::global::LumiSummaryIntFilter",
-    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtLumi)+1)+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt+nStreams*((nEvt/nEvtLumi)+1)+2*(nEvt/nEvtLumi)))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.TestBeginRunFil = cms.EDFilter("edmtest::global::TestBeginRunFilter",
-    transitions = cms.int32((nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt/nEvtRun))
 )
 
 process.TestEndRunFil = cms.EDFilter("edmtest::global::TestEndRunFilter",
-    transitions = cms.int32((nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt/nEvtRun))
 )
 
 process.TestBeginLumiBlockFil = cms.EDFilter("edmtest::global::TestBeginLumiBlockFilter",
-    transitions = cms.int32((nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt/nEvtLumi))
 )
 
 process.TestEndLumiBlockFil = cms.EDFilter("edmtest::global::TestEndLumiBlockFilter",
-    transitions = cms.int32((nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt/nEvtLumi))
 )
 
 process.TestAccumulator1 = cms.EDProducer("edmtest::global::TestAccumulator",

--- a/FWCore/Framework/test/test_limited_modules_cfg.py
+++ b/FWCore/Framework/test/test_limited_modules_cfg.py
@@ -31,132 +31,132 @@ process.source = cms.Source("EmptySource",
 
 process.StreamIntProd = cms.EDProducer("edmtest::limited::StreamIntProducer",
     concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2))
+    transitions = cms.int32(nEvt+nStreams*(2*int(nEvt/nEvtRun)+2*int(nEvt/nEvtLumi)+2))
     ,cachevalue = cms.int32(1)
 )
 
 process.RunIntProd = cms.EDProducer("edmtest::limited::RunIntProducer",
                                     concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(2*(nEvt/nEvtRun))
+    transitions = cms.int32(2*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiIntProd = cms.EDProducer("edmtest::limited::LumiIntProducer",
                                      concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(2*(nEvt/nEvtLumi))
+    transitions = cms.int32(2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.RunSumIntProd = cms.EDProducer("edmtest::limited::RunSummaryIntProducer",
                                        concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nStreams*(nEvt/nEvtRun)+2*(nEvt/nEvtRun))
+    transitions = cms.int32(nStreams*int(nEvt/nEvtRun)+2*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiSumIntProd = cms.EDProducer("edmtest::limited::LumiSummaryIntProducer",
                                         concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nStreams*(nEvt/nEvtLumi)+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(nStreams*int(nEvt/nEvtLumi)+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.TestBeginRunProd = cms.EDProducer("edmtest::limited::TestBeginRunProducer",
                                           concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32((nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt/nEvtRun))
 )
 
 process.TestEndRunProd = cms.EDProducer("edmtest::limited::TestEndRunProducer",
                                         concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32((nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt/nEvtRun))
 )
 
 process.TestBeginLumiBlockProd = cms.EDProducer("edmtest::limited::TestBeginLumiBlockProducer",
                                                 concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32((nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt/nEvtLumi))
 )
 
 process.TestEndLumiBlockProd = cms.EDProducer("edmtest::limited::TestEndLumiBlockProducer",
                                               concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32((nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt/nEvtLumi))
 )
 
 process.StreamIntAn = cms.EDAnalyzer("edmtest::limited::StreamIntAnalyzer",
                                      concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2))
+    transitions = cms.int32(nEvt+nStreams*(2*int(nEvt/nEvtRun)+2*int(nEvt/nEvtLumi)+2))
     ,cachevalue = cms.int32(1)
 )
 
 process.RunIntAn= cms.EDAnalyzer("edmtest::limited::RunIntAnalyzer",
                                  concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiIntAn = cms.EDAnalyzer("edmtest::limited::LumiIntAnalyzer",
                                    concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.RunSumIntAn = cms.EDAnalyzer("edmtest::limited::RunSummaryIntAnalyzer",
                                      concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtRun)+1)+2*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+nStreams*(int(nEvt/nEvtRun)+1)+2*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiSumIntAn = cms.EDAnalyzer("edmtest::limited::LumiSummaryIntAnalyzer",
                                       concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtLumi)+1)+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+nStreams*(int(nEvt/nEvtLumi)+1)+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.StreamIntFil = cms.EDFilter("edmtest::limited::StreamIntFilter",
                                     concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2))
+    transitions = cms.int32(nEvt+nStreams*(2*int(nEvt/nEvtRun)+2*int(nEvt/nEvtLumi)+2))
     ,cachevalue = cms.int32(1)
 )
 
 process.RunIntFil = cms.EDFilter("edmtest::limited::RunIntFilter",
                                  concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiIntFil = cms.EDFilter("edmtest::limited::LumiIntFilter",
                                   concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.RunSumIntFil = cms.EDFilter("edmtest::limited::RunSummaryIntFilter",
                                     concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtRun)+1)+2*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+nStreams*(int(nEvt/nEvtRun)+1)+2*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiSumIntFil = cms.EDFilter("edmtest::limited::LumiSummaryIntFilter",
                                      concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtLumi)+1)+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+nStreams*(int(nEvt/nEvtLumi)+1)+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.TestBeginRunFil = cms.EDFilter("edmtest::limited::TestBeginRunFilter",
                                        concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32((nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt/nEvtRun))
 )
 
 process.TestEndRunFil = cms.EDFilter("edmtest::limited::TestEndRunFilter",
                                      concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32((nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt/nEvtRun))
 )
 
 process.TestBeginLumiBlockFil = cms.EDFilter("edmtest::limited::TestBeginLumiBlockFilter",
                                              concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32((nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt/nEvtLumi))
 )
 
 process.TestEndLumiBlockFil = cms.EDFilter("edmtest::limited::TestEndLumiBlockFilter",
                                            concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32((nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt/nEvtLumi))
 )
 
 process.TestAccumulator1 = cms.EDProducer("edmtest::limited::TestAccumulator",

--- a/FWCore/Framework/test/test_one_modules_cfg.py
+++ b/FWCore/Framework/test/test_one_modules_cfg.py
@@ -33,35 +33,35 @@ process.SharedResProd = cms.EDProducer("edmtest::one::SharedResourcesProducer",
 )
 
 process.WatchRunProd = cms.EDProducer("edmtest::one::WatchRunsProducer",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtRun))
 )
 
 process.WatchLumiBlockProd = cms.EDProducer("edmtest::one::WatchLumiBlocksProducer",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
 )
 
 process.RunCacheProd = cms.EDProducer("edmtest::one::RunCacheProducer",
-                                    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+                                    transitions = cms.int32(nEvt+2*int(nEvt/nEvtRun))
                                     )
 
 process.LumiBlockCacheProd = cms.EDProducer("edmtest::one::LumiBlockCacheProducer",
-                                          transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+                                          transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
                                           )
 
 process.BeginRunProd = cms.EDProducer("edmtest::one::TestBeginRunProducer",
-    transitions = cms.int32(nEvt+(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+int(nEvt/nEvtRun))
 )
 
 process.BeginLumiBlockProd = cms.EDProducer("edmtest::one::TestBeginLumiBlockProducer",
-    transitions = cms.int32(nEvt+(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+int(nEvt/nEvtLumi))
 )
 
 process.EndRunProd = cms.EDProducer("edmtest::one::TestEndRunProducer",
-    transitions = cms.int32(nEvt+(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+int(nEvt/nEvtRun))
 )
 
 process.EndLumiBlockProd = cms.EDProducer("edmtest::one::TestEndLumiBlockProducer",
-    transitions = cms.int32(nEvt+(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+int(nEvt/nEvtLumi))
 )
 
 
@@ -70,19 +70,19 @@ process.SharedResAn = cms.EDAnalyzer("edmtest::one::SharedResourcesAnalyzer",
 )
 
 process.WatchRunAn = cms.EDAnalyzer("edmtest::one::WatchRunsAnalyzer",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtRun))
 )
 
 process.WatchLumiBlockAn = cms.EDAnalyzer("edmtest::one::WatchLumiBlocksAnalyzer",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
 )
 
 process.RunCacheAn = cms.EDAnalyzer("edmtest::one::RunCacheAnalyzer",
-                                    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+                                    transitions = cms.int32(nEvt+2*int(nEvt/nEvtRun))
                                     )
 
 process.LumiBlockCacheAn = cms.EDAnalyzer("edmtest::one::LumiBlockCacheAnalyzer",
-                                          transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+                                          transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
                                           )
 
 process.SharedResFil = cms.EDFilter("edmtest::one::SharedResourcesFilter",
@@ -90,34 +90,34 @@ process.SharedResFil = cms.EDFilter("edmtest::one::SharedResourcesFilter",
 )
 
 process.WatchRunFil = cms.EDFilter("edmtest::one::WatchRunsFilter",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtRun))
 )
 
 process.WatchLumiBlockFil = cms.EDFilter("edmtest::one::WatchLumiBlocksFilter",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
 )
 process.RunCacheFil = cms.EDFilter("edmtest::one::RunCacheFilter",
-                                    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+                                    transitions = cms.int32(nEvt+2*int(nEvt/nEvtRun))
                                     )
 
 process.LumiBlockCacheFil = cms.EDFilter("edmtest::one::LumiBlockCacheFilter",
-                                          transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+                                          transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
                                           )
 
 process.BeginRunFil = cms.EDFilter("edmtest::one::BeginRunFilter",
-    transitions = cms.int32(nEvt+(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+int(nEvt/nEvtRun))
 )
 
 process.BeginLumiBlockFil = cms.EDFilter("edmtest::one::BeginLumiBlockFilter",
-    transitions = cms.int32(nEvt+(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+int(nEvt/nEvtLumi))
 )
 
 process.EndRunFil = cms.EDFilter("edmtest::one::EndRunFilter",
-    transitions = cms.int32(nEvt+(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+int(nEvt/nEvtRun))
 )
 
 process.EndLumiBlockFil = cms.EDFilter("edmtest::one::EndLumiBlockFilter",
-    transitions = cms.int32(nEvt+(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+int(nEvt/nEvtLumi))
 )
 
 process.TestAccumulator1 = cms.EDProducer("edmtest::one::TestAccumulator",

--- a/FWCore/Framework/test/test_stream_modules_cfg.py
+++ b/FWCore/Framework/test/test_stream_modules_cfg.py
@@ -34,42 +34,42 @@ process.GlobIntProd = cms.EDProducer("edmtest::stream::GlobalIntProducer",
 )
 
 process.RunIntProd = cms.EDProducer("edmtest::stream::RunIntProducer",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt+2*(nEvt/nEvtRun)))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiIntProd = cms.EDProducer("edmtest::stream::LumiIntProducer",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.RunSumIntProd = cms.EDProducer("edmtest::stream::RunSummaryIntProducer",
-    transitions = cms.int32(nEvt+4*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+4*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiSumIntProd = cms.EDProducer("edmtest::stream::LumiSummaryIntProducer",
-    transitions = cms.int32(nEvt+4*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+4*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.TestBeginRunProd = cms.EDProducer("edmtest::stream::TestBeginRunProducer",
-    transitions = cms.int32((nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvt)
 )
 
 process.TestEndRunProd = cms.EDProducer("edmtest::stream::TestEndRunProducer",
-    transitions = cms.int32((nEvt/nEvtRun))
+    transitions = cms.int32(int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvt)
 )
 
 process.TestBeginLumiBlockProd = cms.EDProducer("edmtest::stream::TestBeginLumiBlockProducer",
-    transitions = cms.int32((nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvt)
 )
 
 process.TestEndLumiBlockProd = cms.EDProducer("edmtest::stream::TestEndLumiBlockProducer",
-    transitions = cms.int32((nEvt/nEvtLumi))
+    transitions = cms.int32(int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvt)
 )
 
@@ -80,22 +80,22 @@ process.GlobIntAn = cms.EDAnalyzer("edmtest::stream::GlobalIntAnalyzer",
 )
 
 process.RunIntAn= cms.EDAnalyzer("edmtest::stream::RunIntAnalyzer",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiIntAn = cms.EDAnalyzer("edmtest::stream::LumiIntAnalyzer",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.RunSumIntAn = cms.EDAnalyzer("edmtest::stream::RunSummaryIntAnalyzer",
-    transitions = cms.int32(nEvt+4*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+4*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiSumIntAn = cms.EDAnalyzer("edmtest::stream::LumiSummaryIntAnalyzer",
-    transitions = cms.int32(nEvt+4*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+4*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
@@ -105,41 +105,41 @@ process.GlobIntFil = cms.EDFilter("edmtest::stream::GlobalIntFilter",
 )
 
 process.RunIntFil = cms.EDFilter("edmtest::stream::RunIntFilter",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiIntFil = cms.EDFilter("edmtest::stream::LumiIntFilter",
-    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
 process.RunSumIntFil = cms.EDFilter("edmtest::stream::RunSummaryIntFilter",
-    transitions = cms.int32(nEvt+4*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+4*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvtRun)
 )
 
 process.LumiSumIntFil = cms.EDFilter("edmtest::stream::LumiSummaryIntFilter",
-    transitions = cms.int32(nEvt+4*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+4*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 process.TestBeginRunFil = cms.EDFilter("edmtest::stream::TestBeginRunFilter",
-    transitions = cms.int32(nEvt+3*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+3*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvt)
 )
 
 process.TestEndRunFil = cms.EDFilter("edmtest::stream::TestEndRunFilter",
-    transitions = cms.int32(nEvt+3*(nEvt/nEvtRun))
+    transitions = cms.int32(nEvt+3*int(nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvt)
 )
 
 process.TestBeginLumiBlockFil = cms.EDFilter("edmtest::stream::TestBeginLumiBlockFilter",
-    transitions = cms.int32(nEvt+3*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+3*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvt)
 )
 
 process.TestEndLumiBlockFil = cms.EDFilter("edmtest::stream::TestEndLumiBlockFilter",
-    transitions = cms.int32(nEvt+3*(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+3*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvt)
 )
 


### PR DESCRIPTION
#### PR description:

The configurations were dividing two integers. In python 2 that returned another integer, in python 3 that returned a double. Using the value in a cms.(u)int32 type then failed conversion.
Now explicitly convert result to int.

#### PR validation:

All tests in FWCore/Framework now pass when using python3 via CMSSW_10_6_DEVEL_X.

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
