### PR TITLE
Do not merge, Implement core support for concurrent IOVs

### DIFF
--- a/CondCore/ESSources/plugins/CondDBESSource.h
+++ b/CondCore/ESSources/plugins/CondDBESSource.h
@@ -47,9 +47,9 @@ class CondDBESSource : public edm::eventsetup::DataProxyProvider,
 			      const edm::IOVSyncValue& , 
 			      edm::ValidityInterval&) override ;
 
-  void registerProxies(const edm::eventsetup::EventSetupRecordKey& iRecordKey, KeyedProxies& aProxyList) override ;
-
-  void newInterval(const edm::eventsetup::EventSetupRecordKey& iRecordType, const edm::ValidityInterval& iInterval) override ;
+  void registerProxies(const edm::eventsetup::EventSetupRecordKey& iRecordKey,
+                       KeyedProxies& aProxyList,
+                       unsigned int /*iovIndex*/ ) override ;
 
  private:
 

--- a/FWCore/Framework/interface/Callback.h
+++ b/FWCore/Framework/interface/Callback.h
@@ -61,15 +61,10 @@ namespace edm {
             id_(iID),
             wasCalledForThisRecord_(false),
             decorator_(iDec) {}
-         
-         
-         // ---------- const member functions ---------------------
-         
-         // ---------- static member functions --------------------
-         
-         // ---------- member functions ---------------------------
-         
-         
+
+         Callback(const Callback&) = delete;
+         const Callback& operator=(const Callback&) = delete;
+
          void operator()(const TRecord& iRecord) { 
             if(!wasCalledForThisRecord_) {
                decorator_.pre(iRecord);
@@ -102,17 +97,20 @@ namespace edm {
          void newRecordComing() {
             wasCalledForThisRecord_ = false;
          }
-        
+
          unsigned int transitionID() const { return id_;}
          ESProxyIndex const* getTokenIndices() const { return producer_->getTokenIndices(id_);}
-     private:
-         Callback(const Callback&) = delete; // stop default
-         
-         const Callback& operator=(const Callback&) = delete; // stop default
+
+         T* get() { return producer_.get(); }
+         method_type method() const { return method_; }
+         TDecorator const& decorator() const { return decorator_; }
+
+      private:
 
          std::array<void*, produce::size< TReturn >::value> proxyData_;
          edm::propagate_const<T*> producer_;
          method_type method_;
+         // This transition id identifies which setWhatProduced call this Callback is associated with
          unsigned int id_;
          bool wasCalledForThisRecord_;
          TDecorator decorator_;

--- a/FWCore/Framework/interface/CallbackProxy.h
+++ b/FWCore/Framework/interface/CallbackProxy.h
@@ -37,8 +37,8 @@ namespace edm::eventsetup {
   class CallbackProxy : public DataProxy {
   public:
     using smart_pointer_traits = produce::smart_pointer_traits<DataT>;
-    using value_type = typename smart_pointer_traits::type;
-    using record_type = RecordT;
+    using ValueType = typename smart_pointer_traits::type;
+    using RecordType = RecordT;
 
     CallbackProxy(std::shared_ptr<CallbackT>& iCallback) :
       callback_{iCallback} {
@@ -53,10 +53,12 @@ namespace edm::eventsetup {
       callback_->holdOntoPointer(dummy);
     }
 
-    const void* getImpl(const EventSetupRecordImpl& iRecord, const DataKey&) override {
+    const void* getImpl(const EventSetupRecordImpl& iRecord, const DataKey&,
+                        EventSetupImpl const* iEventSetupImpl) override {
       assert(iRecord.key() == RecordT::keyForClass());
-      record_type rec;
+      RecordType rec;
       rec.setImpl(&iRecord, callback_->transitionID(), callback_->getTokenIndices());
+      rec.setEventSetupImpl(iEventSetupImpl);
       (*callback_)(rec);
       return smart_pointer_traits::getPointer(data_);
     }

--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -5,7 +5,7 @@
 // Package:     Framework
 // Class  :     DataProxy
 //
-/**\class DataProxy DataProxy.h FWCore/Framework/interface/DataProxy.h
+/**\class edm::eventsetup::DataProxy
 
  Description: Base class for data Proxies held by a EventSetupRecord
 
@@ -28,6 +28,7 @@
 // forward declarations
 namespace edm {
    class ActivityRegistry;
+   class EventSetupImpl;
 
    namespace eventsetup {
       struct ComponentDescription;
@@ -38,19 +39,22 @@ namespace edm {
 
       public:
          DataProxy();
+         DataProxy(DataProxy const&) = delete;
+         DataProxy const& operator=(DataProxy const&) = delete;
          virtual ~DataProxy();
 
          // ---------- const member functions ---------------------
          bool cacheIsValid() const { return cacheIsValid_.load(std::memory_order_acquire); }
 
-         void doGet(EventSetupRecordImpl const& iRecord, DataKey const& iKey, bool iTransiently, ActivityRegistry const*) const;
-         void const* get(EventSetupRecordImpl const&, DataKey const& iKey, bool iTransiently, ActivityRegistry const*) const;
+         void doGet(EventSetupRecordImpl const&, DataKey const&, bool iTransiently,
+                    ActivityRegistry const*, EventSetupImpl const*) const;
+         void const* get(EventSetupRecordImpl const&, DataKey const&, bool iTransiently,
+                         ActivityRegistry const*, EventSetupImpl const*) const;
 
          ///returns the description of the DataProxyProvider which owns this Proxy
          ComponentDescription const* providerDescription() const {
             return description_;
          }
-         // ---------- static member functions --------------------
 
          // ---------- member functions ---------------------------
          void invalidate() {
@@ -63,6 +67,7 @@ namespace edm {
          void setProviderDescription(ComponentDescription const* iDesc) {
             description_ = iDesc;
          }
+
       protected:
          /**This is the function which does the real work of getting the data if it is not
           already cached.  The returning 'void const*' must point to an instance of the class
@@ -70,7 +75,8 @@ namespace edm {
           the pointer must be a pointer to that base class interface and not a pointer to an inheriting class
           instance.
           */
-         virtual void const* getImpl(EventSetupRecordImpl const&, DataKey const& iKey) =0;
+         virtual void const* getImpl(EventSetupRecordImpl const&, DataKey const& iKey,
+                                     EventSetupImpl const*) = 0;
 
          /** indicates that the Proxy should invalidate any cached information
           as that information has 'expired' (i.e. we have moved to a new IOV)
@@ -85,16 +91,46 @@ namespace edm {
          virtual void invalidateTransientCache();
 
          void clearCacheIsValid();
-      private:
-         DataProxy(DataProxy const&) = delete; // stop default
 
-         DataProxy const& operator=(DataProxy const&) = delete; // stop default
+      private:
 
          // ---------- member data --------------------------------
          CMS_THREAD_SAFE mutable void const* cache_; //protected by a global mutex
          mutable std::atomic<bool> cacheIsValid_;
-         mutable std::atomic<bool> nonTransientAccessRequested_;
          ComponentDescription const* description_;
+
+         // While implementing the set of code changes that enabled support
+         // for concurrent IOVs, I have gone to some effort to maintain
+         // the same behavior for this variable and the things that depend on
+         // it. My thinking is that we are going to revisit this and make
+         // changes in the not so distant future so that the transient feature
+         // works again. Alternatively, we may go through and delete it and
+         // everything related to it.
+
+         // First comment is that there is only one context in which the value
+         // in nonTransientAccessRequested_ is used. This is in the resetIfTransient
+         // function. This function is only called immediately after invalidate
+         // was called. Therefore the value is always false and condition in
+         // resetIfTransient always evaluates true. So in the current code this
+         // data member does nothing and has absolutely no purpose. We should
+         // delete it and the associated code if we do not modify the code to
+         // actually make use of the value stored sometime soon.
+
+         // Currently, this usage occurs is when force cache clear
+         // is called from EventProcessor at beginRun (which only happens
+         // when a certain configuration parameter is set) and propagates down.
+         // It is also used when the looper is trying to start a new loop and
+         // calls resetRecordPlusDependentRecords. It is not currently used in
+         // any other context.
+         //
+         // One other thing to note is that the virtual invalidateTransientCache
+         // function is defined in this class to just call invalidateCache.
+         // Outside of unit tests, the only thing that overrides this definition
+         // is in CondCore/ESSources/interface/DataProxy.h. So in all other cases
+         // the behavior is that invalidateCache is called twice sometimes
+         // instead of just once. Possibly it is important that invalidateTransientCache
+         // is called in the CondCore code. I don't know.
+         mutable std::atomic<bool> nonTransientAccessRequested_;
       };
    }
 }

--- a/FWCore/Framework/interface/DataProxyTemplate.h
+++ b/FWCore/Framework/interface/DataProxyTemplate.h
@@ -9,9 +9,19 @@
 
  Description: A DataProxy base class which allows one to write type-safe proxies
 
+              Note that DataProxy types that inherit from this are not allowed
+              to get data from the EventSetup (they cannot consume anything).
+              This is intended mainly for use with ESSources that are also
+              not allowed to get data from the EventSetup. Currently (as of
+              April 2019), this class is used only in PoolDBESSource and
+              Framework unit tests.
+
+              This is also not used with ESProducers that inherit from
+              the ESProducer base class and use the setWhatProduced interface.
+              This class is used instead of CallProxy.
+
  Usage:
     <usage>
-
 */
 //
 // Author:      Chris Jones
@@ -29,7 +39,11 @@
 // forward declarations
 
 namespace edm {
+
+   class EventSetupImpl;
+
    namespace eventsetup {
+
 template<class RecordT, class DataT>
 class DataProxyTemplate : public DataProxy
 {
@@ -37,32 +51,21 @@ class DataProxyTemplate : public DataProxy
    public:
       typedef DataT value_type;
       typedef RecordT record_type;
-   
-      DataProxyTemplate(){}
-      //virtual ~DataProxyTemplate();
 
-      // ---------- const member functions ---------------------
+      DataProxyTemplate() {}
 
-      // ---------- static member functions --------------------
-
-      // ---------- member functions ---------------------------
       const void* getImpl(const EventSetupRecordImpl& iRecord,
-                                  const DataKey& iKey) override {
+                          const DataKey& iKey,
+                          EventSetupImpl const* iEventSetupImpl) override {
          assert(iRecord.key() == RecordT::keyForClass());
          RecordT rec;
          rec.setImpl(&iRecord, std::numeric_limits<unsigned int>::max(),nullptr);
+         rec.setEventSetupImpl(iEventSetupImpl);
          return this->make(rec, iKey);
       }
       
    protected:
       virtual const DataT* make(const RecordT&, const DataKey&) = 0;
-      
-   private:
-      DataProxyTemplate(const DataProxyTemplate&) = delete; // stop default
-
-      const DataProxyTemplate& operator=(const DataProxyTemplate&) = delete; // stop default
-
-      // ---------- member data --------------------------------
 };
 
    }

--- a/FWCore/Framework/interface/DependentRecordIntervalFinder.h
+++ b/FWCore/Framework/interface/DependentRecordIntervalFinder.h
@@ -1,11 +1,11 @@
-#ifndef Framework_DependentRecordIntervalFinder_h
-#define Framework_DependentRecordIntervalFinder_h
+#ifndef FWCore_Framework_DependentRecordIntervalFinder_h
+#define FWCore_Framework_DependentRecordIntervalFinder_h
 // -*- C++ -*-
 //
 // Package:     Framework
 // Class  :     DependentRecordIntervalFinder
 // 
-/**\class DependentRecordIntervalFinder DependentRecordIntervalFinder.h FWCore/Framework/interface/DependentRecordIntervalFinder.h
+/**\class edm::eventsetup::DependentRecordIntervalFinder
 
  Description: Finds the intersection of the ValidityInterval for several Providers
 
@@ -38,6 +38,8 @@ class DependentRecordIntervalFinder : public EventSetupRecordIntervalFinder
 
    public:
       DependentRecordIntervalFinder(const EventSetupRecordKey&);
+      DependentRecordIntervalFinder(const DependentRecordIntervalFinder&) = delete;
+      const DependentRecordIntervalFinder& operator=(const DependentRecordIntervalFinder&) = delete;
       ~DependentRecordIntervalFinder() override;
 
       // ---------- const member functions ---------------------
@@ -57,10 +59,13 @@ class DependentRecordIntervalFinder : public EventSetupRecordIntervalFinder
                                    ValidityInterval&) override;
       
    private:
-      DependentRecordIntervalFinder(const DependentRecordIntervalFinder&) = delete; // stop default
 
-      const DependentRecordIntervalFinder& operator=(const DependentRecordIntervalFinder&) = delete; // stop default
+      void doResetInterval(const eventsetup::EventSetupRecordKey&) override;
 
+      bool isLegacyESSource() const override;
+
+      bool isLegacyOutOfValidityInterval(const EventSetupRecordKey&,
+                                         const IOVSyncValue&) const override;
       // ---------- member data --------------------------------
       typedef std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordProvider>>> Providers;
       Providers providers_;

--- a/FWCore/Framework/interface/ESProxyFactoryProducer.h
+++ b/FWCore/Framework/interface/ESProxyFactoryProducer.h
@@ -81,21 +81,17 @@ class ESProxyFactoryProducer : public eventsetup::DataProxyProvider
 
    public:
       ESProxyFactoryProducer();
+
+      ESProxyFactoryProducer(const ESProxyFactoryProducer&) = delete;
+      const ESProxyFactoryProducer& operator=(const ESProxyFactoryProducer&) = delete;
+
       ~ESProxyFactoryProducer() noexcept(false) override;
 
-      // ---------- const member functions ---------------------
-
-      // ---------- static member functions --------------------
-
-      // ---------- member functions ---------------------------
-      ///overrides DataProxyProvider method
-      void newInterval(const eventsetup::EventSetupRecordKey& iRecordType,
-                                const ValidityInterval& iInterval) override ;
-
-   protected:
+  protected:
       ///override DataProxyProvider method
       void registerProxies(const eventsetup::EventSetupRecordKey& iRecord ,
-                                    KeyedProxies& aProxyList) override ;
+                           KeyedProxies& aProxyList,
+                           unsigned int iovIndex) override ;
 
       /** \param iFactory unique_ptr holding a new instance of a Factory
          \param iLabel extra string label used to get data (optional)
@@ -108,7 +104,7 @@ class ESProxyFactoryProducer : public eventsetup::DataProxyProvider
                               const std::string& iLabel = std::string()) {
             std::unique_ptr<eventsetup::ProxyFactoryBase> temp(iFactory.release());
             registerFactoryWithKey(
-                                   eventsetup::EventSetupRecordKey::makeKey<typename TFactory::record_type>(),
+                                   eventsetup::EventSetupRecordKey::makeKey<typename TFactory::RecordType>(),
                                    std::move(temp),
                                    iLabel);
          }
@@ -118,10 +114,6 @@ class ESProxyFactoryProducer : public eventsetup::DataProxyProvider
                                           const std::string& iLabel= std::string() );
 
    private:
-      ESProxyFactoryProducer(const ESProxyFactoryProducer&) = delete; // stop default
-
-      const ESProxyFactoryProducer& operator=(const ESProxyFactoryProducer&) = delete; // stop default
-
       
       // ---------- member data --------------------------------
       std::multimap< eventsetup::EventSetupRecordKey, eventsetup::FactoryInfo > record2Factories_;

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -273,7 +273,7 @@ namespace edm {
     //returns true if an asynchronous stop was requested
     bool checkForAsyncStopRequest(StatusCode&);
     
-    void processEventWithLooper(EventPrincipal&);
+    void processEventWithLooper(EventPrincipal&, unsigned int iStreamIndex);
 
     std::shared_ptr<ProductRegistry const> preg() const {return get_underlying_safe(preg_);}
     std::shared_ptr<ProductRegistry>& preg() {return get_underlying_safe(preg_);}
@@ -301,7 +301,7 @@ namespace edm {
     InputSource::ItemType lastSourceTransition_;
     edm::propagate_const<std::unique_ptr<eventsetup::EventSetupsController>> espController_;
     edm::propagate_const<std::shared_ptr<eventsetup::EventSetupProvider>> esp_;
-    edm::SerialTaskQueue iovQueue_;
+    edm::SerialTaskQueue legacyIOVQueue_;
     std::unique_ptr<ExceptionToActionTable const>          act_table_;
     std::shared_ptr<ProcessConfiguration const>       processConfiguration_;
     ProcessContext                                processContext_;

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -5,7 +5,7 @@
 // Package:     Framework
 // Class:      EventSetup
 //
-/**\class EventSetup EventSetup.h FWCore/Framework/interface/EventSetup.h
+/**\class edm::EventSetup
 
  Description: Container for all Records dealing with non-RunState info
 
@@ -42,7 +42,7 @@
 // forward declarations
 
 namespace edm {
-   class ActivityRegistry;
+
    class ESInputTag;
    template <class T, class R>
    class ESGetToken;
@@ -58,6 +58,7 @@ namespace edm {
   {
     ///Needed until a better solution can be found
     friend class edm::PileUp;
+
     public:
 
       explicit EventSetup(EventSetupImpl const& iSetup,
@@ -69,7 +70,6 @@ namespace edm {
       EventSetup(EventSetup const&) = delete;
       EventSetup& operator=(EventSetup const&) = delete;
 
-      // ---------- const member functions ---------------------
       /** returns the Record of type T.  If no such record available
           a eventsetup::NoRecordException<T> is thrown */
       template< typename T>
@@ -86,11 +86,12 @@ namespace edm {
             }
             T returnValue;
             returnValue.setImpl(temp,m_id,m_getTokenIndices);
+            returnValue.setEventSetupImpl(&m_setup);
             return returnValue;
          }
 
       /** returns the Record of type T.  If no such record available
-       a null pointer is returned */
+       a null optional is returned */
       template< typename T>
         std::optional<T> tryToGet() const {
            using namespace eventsetup;
@@ -102,6 +103,7 @@ namespace edm {
            if(temp != nullptr) {
               T rec;
               rec.setImpl(temp,m_id,m_getTokenIndices);
+              rec.setEventSetupImpl(&m_setup);
               return rec;
            }
            return std::nullopt;

--- a/FWCore/Framework/interface/EventSetupImpl.h
+++ b/FWCore/Framework/interface/EventSetupImpl.h
@@ -5,7 +5,7 @@
 // Package:     Framework
 // Class:      EventSetupImpl
 //
-/**\class EventSetupImpl EventSetupImpl.h FWCore/Framework/interface/EventSetupImpl.h
+/**\class edm::EventSetupImpl
 
  Description: Container for all Records dealing with non-RunState info
 
@@ -30,19 +30,19 @@
 
 // forward declarations
 
+class testEventsetup;
+
 namespace edm {
-   class ActivityRegistry;
    class ESInputTag;
 
    namespace eventsetup {
       class EventSetupProvider;
       class EventSetupRecordImpl;
+      class EventSetupRecordProvider;
    }
 
   class EventSetupImpl
   {
-    ///Only EventSetupProvider allowed to create a EventSetup
-    friend class eventsetup::EventSetupProvider;
     public:
       ~EventSetupImpl();
 
@@ -54,7 +54,7 @@ namespace edm {
 
       std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey&,
                                                               unsigned int iTransitionID,
-                                                               ESProxyIndex const* getTokenIndices) const;
+                                                              ESProxyIndex const* getTokenIndices) const;
 
       ///clears the oToFill vector and then fills it with the keys for all available records
       void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const;
@@ -62,23 +62,23 @@ namespace edm {
       ///returns true if the Record is provided by a Source or a Producer
       /// a value of true does not mean this EventSetup object holds such a record
       bool recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& ) const;
-      // ---------- static member functions --------------------
 
-      friend class eventsetup::EventSetupRecordImpl;
+      bool validRecord(eventsetup::EventSetupRecordKey const& iKey) const;
+
+      ///Only EventSetupProvider allowed to create a EventSetup
+      friend class eventsetup::EventSetupProvider;
+      friend class eventsetup::EventSetupRecordProvider;
+      friend class::testEventsetup;
 
     protected:
 
-      void add(const eventsetup::EventSetupRecordImpl& iRecord);
-
-      void clear();
+      void addRecordImpl(const eventsetup::EventSetupRecordImpl& iRecord);
 
     private:
-      EventSetupImpl(ActivityRegistry const*);
+      EventSetupImpl();
 
-      ActivityRegistry const* activityRegistry() const { return activityRegistry_; }
-
-      void insert(const eventsetup::EventSetupRecordKey&,
-                  const eventsetup::EventSetupRecordImpl*);
+      void insertRecordImpl(const eventsetup::EventSetupRecordKey&,
+                            const eventsetup::EventSetupRecordImpl*);
 
       void setKeyIters(std::vector<eventsetup::EventSetupRecordKey>::const_iterator const& keysBegin,
                        std::vector<eventsetup::EventSetupRecordKey>::const_iterator const& keysEnd);
@@ -88,9 +88,6 @@ namespace edm {
       std::vector<eventsetup::EventSetupRecordKey>::const_iterator keysBegin_;
       std::vector<eventsetup::EventSetupRecordKey>::const_iterator keysEnd_;
       std::vector<eventsetup::EventSetupRecordImpl const*> recordImpls_;
-      ActivityRegistry const* activityRegistry_;
   };
-
 }
-
-#endif // FWCore_Framework_EventSetup_h
+#endif

--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -5,7 +5,7 @@
 // Package:     Framework
 // Class  :     EventSetupRecordImpl
 //
-/**\class EventSetupRecordImpl EventSetupRecordImpl.h FWCore/Framework/interface/EventSetupRecordImpl.h
+/**\class edm::eventsetup::EventSetupRecordImpl
 
  Description: Base class for all Records in an EventSetup.  Holds data with the same lifetime.
 
@@ -14,32 +14,19 @@ This class contains the Proxies that make up a given Record.  It
 is designed to be reused time after time, rather than it being
 destroyed and a new one created every time a new Record is
 required.  Proxies can only be added by the EventSetupRecordProvider class which
-uses the 'add' function to do this.  The reason for this is
-that the EventSetupRecordProvider/DataProxyProvider pair are responsible for
-"invalidating" Proxies in a Record.  When a Record
-becomes "invalid" the EventSetupRecordProvider must invalidate
-all the  Proxies which it does using the DataProxyProvider.
+uses the 'add' function to do this.
 
 When the set of  Proxies for a Records changes, i.e. a
 DataProxyProvider is added of removed from the system, then the
-Proxies in a Record need to be changes as appropriate.
+Proxies in a Record need to be changed as appropriate.
 In this design it was decided the easiest way to achieve this was
-to erase all  Proxies in a Record.
+to erase all Proxies in a Record.
 
 It is important for the management of the Records that each Record
 know the ValidityInterval that represents the time over which its data is valid.
 The ValidityInterval is set by its EventSetupRecordProvider using the
 'set' function.  This quantity can be recovered
 through the 'validityInterval' method.
-
-For a Proxy to be able to derive its contents from the EventSetup, it
-must be able to access any Proxy (and thus any Record) in the
-EventSetup.  The 'make' function of a Proxy provides its
-containing Record as one of its arguments.  To be able to
-access the rest of the EventSetup, it is necessary for a Record to be
-able to access its containing EventSetup.  This task is handled by the
-'eventSetup' function.  The EventSetup is responsible for managing this
-using the 'setEventSetup' and 'clearEventSetup' functions.
 
 */
 //
@@ -54,6 +41,7 @@ using the 'setEventSetup' and 'clearEventSetup' functions.
 #include "FWCore/Framework/interface/NoProxyException.h"
 #include "FWCore/Framework/interface/ValidityInterval.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/ESInputTag.h"
 #include "FWCore/Utilities/interface/ESIndices.h"
@@ -73,6 +61,8 @@ namespace cms {
 }
 
 namespace edm {
+
+   class ActivityRegistry;
    class ESHandleExceptionFactory;
    class ESInputTag;
    class EventSetupImpl;
@@ -83,18 +73,18 @@ namespace edm {
 
       class EventSetupRecordImpl {
 
-        friend class EventSetupRecord;
+         friend class EventSetupRecord;
 
       public:
-         EventSetupRecordImpl(const EventSetupRecordKey& iKey);
+         EventSetupRecordImpl(const EventSetupRecordKey& iKey, ActivityRegistry const*, unsigned int iovIndex = 0);
+         EventSetupRecordImpl(EventSetupRecordImpl const&) = delete;
+         EventSetupRecordImpl const& operator=(EventSetupRecordImpl const&) = delete;
 
          // ---------- const member functions ---------------------
-         ValidityInterval const& validityInterval() const {
-            return validity_;
-         }
+         ValidityInterval validityInterval() const;
 
          ///returns false if no data available for key
-         bool doGet(DataKey const& aKey, bool aGetTransiently = false) const;
+         bool doGet(DataKey const& aKey, EventSetupImpl const*, bool aGetTransiently = false) const;
 
          /**returns true only if someone has already requested data for this key
           and the data was retrieved
@@ -123,6 +113,10 @@ namespace edm {
             return cacheIdentifier_;
          }
 
+         void setCacheIdentifier(unsigned long long value) { cacheIdentifier_ = value; }
+
+         unsigned int iovIndex() const { return iovIndex_; }
+
          ///clears the oToFill vector and then fills it with the keys for all registered data keys
          void fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const;
         ///there is a 1-to-1 correspondence between elements returned and the elements returned from fillRegisteredDataKey.
@@ -133,55 +127,51 @@ namespace edm {
 
          // The following member functions should only be used by EventSetupRecordProvider
          bool add(DataKey const& iKey ,
-                  DataProxy const* iProxy) ;
+                  DataProxy* iProxy) ;
          void clearProxies();
-         void cacheReset() ;
-         /// returns 'true' if a transient request has occurred since the last call to transientReset.
-         bool transientReset() ;
 
          void set(ValidityInterval const&);
-         void setEventSetup(EventSetupImpl const* iEventSetup) {eventSetup_ = iEventSetup; }
+         void setSafely(ValidityInterval const&) const;
 
-         void getESProducers(std::vector<ComponentDescription const*>& esproducers);
-      //protected:
+         void getESProducers(std::vector<ComponentDescription const*>& esproducers) const;
 
          DataProxy const* find(DataKey const& aKey) const ;
-
-        EventSetupImpl const& eventSetup() const {
-          return *eventSetup_;
-        }
 
          void validate(ComponentDescription const*, ESInputTag const&) const;
 
          void addTraceInfoToCmsException(cms::Exception& iException, char const* iName, ComponentDescription const*, DataKey const&) const;
-         void changeStdExceptionToCmsException(char const* iExceptionWhatMessage, char const* iName, ComponentDescription const*, DataKey const&) const;
 
-         void transientAccessRequested() const { transientAccessRequested_ = true;}
+         bool acquireResource() {
+           bool expected = true;
+           return isAvailable_.compare_exchange_strong(expected, false);
+         }
+         void invalidateProxies();
+         void resetIfTransientInProxies();
+
       private:
-         EventSetupRecordImpl(EventSetupRecordImpl const&) = delete;
-
-         EventSetupRecordImpl const& operator=(EventSetupRecordImpl const&) = delete;
-
          void const* getFromProxy(DataKey const& iKey ,
                                   ComponentDescription const*& iDesc,
-                                  bool iTransientAccessOnly) const;
+                                  bool iTransientAccessOnly,
+                                  EventSetupImpl const* = nullptr) const;
 
         void const* getFromProxy(ESProxyIndex iProxyIndex,
                                  bool iTransientAccessOnly,
                                  ComponentDescription const*& iDesc,
-                                 DataKey const*& oGottenKey) const;
+                                 DataKey const*& oGottenKey,
+                                 EventSetupImpl const* = nullptr) const;
 
          template <typename DataT>
          void getImplementation(DataT const*& iData ,
                                 char const* iName,
                                 ComponentDescription const*& iDesc,
                                 bool iTransientAccessOnly,
-                                std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory) const {
+                                std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory,
+                                EventSetupImpl const* iEventSetupImpl) const {
             DataKey dataKey(DataKey::makeTypeTag<DataT>(),
                             iName,
                             DataKey::kDoNotCopyMemory);
 
-            void const* pValue = this->getFromProxy(dataKey, iDesc, iTransientAccessOnly);
+            void const* pValue = this->getFromProxy(dataKey, iDesc, iTransientAccessOnly, iEventSetupImpl);
             if(nullptr == pValue) {
               whyFailedFactory =
                 makeESHandleExceptionFactory([=] {
@@ -197,8 +187,9 @@ namespace edm {
                                ESProxyIndex iProxyIndex,
                                bool iTransientAccessOnly,
                                ComponentDescription const*& oDesc,
-                               std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory) const {
-          
+                               std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory,
+                               EventSetupImpl const* iEventSetupImpl) const {
+
           DataKey const* dataKey=nullptr;
           if(iProxyIndex.value() == std::numeric_limits<int>::max()) {
             whyFailedFactory =
@@ -210,7 +201,7 @@ namespace edm {
             return;
           }
           assert( iProxyIndex.value() > -1 and iProxyIndex.value() <static_cast<ESProxyIndex::Value_t>(keysForProxies_.size()));
-          void const* pValue = this->getFromProxy(iProxyIndex, iTransientAccessOnly, oDesc, dataKey);
+          void const* pValue = this->getFromProxy(iProxyIndex, iTransientAccessOnly, oDesc, dataKey, iEventSetupImpl);
           if(nullptr == pValue) {
             whyFailedFactory =
             makeESHandleExceptionFactory([=] {
@@ -222,13 +213,24 @@ namespace edm {
         }
 
          // ---------- member data --------------------------------
-         ValidityInterval validity_;
+
+         // We allow the validity to be modified while it is being used in
+         // the case where a new sync value is being initialized and the
+         // first part of the new validity range is the same,
+         // but the last part of the validity range changes. In this case,
+         // we do not want to start a new IOV, all the cached data should
+         // remain valid. The following atomic bool protects access to validity_
+         // while this change is made.
+         mutable std::atomic<bool> validityModificationUnderway_;
+         CMS_THREAD_SAFE mutable ValidityInterval validity_;
+
          EventSetupRecordKey key_;
          std::vector<DataKey> keysForProxies_;
-         std::vector<DataProxy const*> proxies_;
-         EventSetupImpl const* eventSetup_;
+         std::vector<edm::propagate_const<DataProxy*>> proxies_;
+         ActivityRegistry const* activityRegistry_;
          unsigned long long cacheIdentifier_;
-         mutable std::atomic<bool> transientAccessRequested_;
+         unsigned int iovIndex_;
+         std::atomic<bool> isAvailable_;
       };
    }
 }

--- a/FWCore/Framework/interface/EventSetupRecordIntervalFinder.h
+++ b/FWCore/Framework/interface/EventSetupRecordIntervalFinder.h
@@ -35,6 +35,8 @@ class EventSetupRecordIntervalFinder
 
    public:
       EventSetupRecordIntervalFinder() : intervals_() {}
+      EventSetupRecordIntervalFinder(const EventSetupRecordIntervalFinder&) = delete;
+      const EventSetupRecordIntervalFinder& operator=(const EventSetupRecordIntervalFinder&) = delete;
       virtual ~EventSetupRecordIntervalFinder() noexcept(false);
 
       // ---------- const member functions ---------------------
@@ -49,7 +51,18 @@ class EventSetupRecordIntervalFinder
       */
       const ValidityInterval& findIntervalFor(const eventsetup::EventSetupRecordKey&,
                                             const IOVSyncValue&);
+
+      void resetInterval(const eventsetup::EventSetupRecordKey&);
    
+      bool legacyESSource() const {
+        return isLegacyESSource();
+      }
+
+      bool legacyOutOfValidityInterval(const eventsetup::EventSetupRecordKey& key,
+                                       const IOVSyncValue& syncValue) const {
+        return isLegacyOutOfValidityInterval(key, syncValue);
+      }
+
       void setDescriptionForFinder(const eventsetup::ComponentDescription& iDescription) {
         description_ = iDescription;
       }
@@ -66,14 +79,23 @@ class EventSetupRecordIntervalFinder
       void findingRecordWithKey(const eventsetup::EventSetupRecordKey&);
       
 private:
-      EventSetupRecordIntervalFinder(const EventSetupRecordIntervalFinder&) = delete; // stop default
 
-      const EventSetupRecordIntervalFinder& operator=(const EventSetupRecordIntervalFinder&) = delete; // stop default
+      virtual void doResetInterval(const eventsetup::EventSetupRecordKey&);
+
+      // Should be overridden in all ESSources at the time the ESSource is
+      // upgraded to support concurrent IOVs.
+      virtual bool isLegacyESSource() const;
+
+      // Should only be overridden by DependentRecordIntervalFinder and
+      // IntersectingIOVRecordIntervalFinder. Other ESSources should not
+      // need to override this.
+      virtual bool isLegacyOutOfValidityInterval(const eventsetup::EventSetupRecordKey&,
+                                                 const IOVSyncValue&) const;
 
       /** override this method if you need to delay setting what records you will be using until after all modules are loaded*/
       virtual void delaySettingRecords();
       // ---------- member data --------------------------------
-      typedef  std::map<eventsetup::EventSetupRecordKey,ValidityInterval> Intervals;
+      using Intervals = std::map<eventsetup::EventSetupRecordKey,ValidityInterval>;
       Intervals intervals_;
 
       eventsetup::ComponentDescription description_;

--- a/FWCore/Framework/interface/ProxyFactoryBase.h
+++ b/FWCore/Framework/interface/ProxyFactoryBase.h
@@ -1,11 +1,11 @@
-#ifndef Framework_ProxyFactoryBase_h
-#define Framework_ProxyFactoryBase_h
+#ifndef FWCore_Framework_ProxyFactoryBase_h
+#define FWCore_Framework_ProxyFactoryBase_h
 // -*- C++ -*-
 //
 // Package:     Framework
 // Class  :     ProxyFactoryBase
-// 
-/**\class ProxyFactoryBase ProxyFactoryBase.h FWCore/Framework/interface/ProxyFactoryBase.h
+//
+/**\class edm::eventsetup::ProxyFactoryBase
 
  Description: <one line class summary>
 
@@ -25,35 +25,24 @@
 // user include files
 #include "FWCore/Framework/interface/DataKey.h"
 
-// forward declarations
 namespace edm {
-   namespace eventsetup {
-      class DataProxy;
-class ProxyFactoryBase
-{
+  namespace eventsetup {
 
-   public:
-      ProxyFactoryBase() {}
-      virtual ~ProxyFactoryBase() {}
+    class DataProxy;
 
-      // ---------- const member functions ---------------------
-      virtual std::unique_ptr<DataProxy> makeProxy() const = 0;
-      
+    class ProxyFactoryBase {
+
+    public:
+
+      ProxyFactoryBase() = default;
+      ProxyFactoryBase(const ProxyFactoryBase&) = delete;
+      const ProxyFactoryBase& operator=(const ProxyFactoryBase&) = delete;
+      virtual ~ProxyFactoryBase() = default;
+
+      virtual std::unique_ptr<DataProxy> makeProxy(unsigned int iovIndex) = 0;
+
       virtual DataKey makeKey(const std::string& iName) const = 0;
-      // ---------- static member functions --------------------
-
-      // ---------- member functions ---------------------------
-
-   private:
-      ProxyFactoryBase(const ProxyFactoryBase&) = delete; // stop default
-
-      const ProxyFactoryBase& operator=(const ProxyFactoryBase&) = delete; // stop default
-
-      // ---------- member data --------------------------------
-
-};
-
-   }
+    };
+  }
 }
-
 #endif

--- a/FWCore/Framework/interface/ProxyFactoryTemplate.h
+++ b/FWCore/Framework/interface/ProxyFactoryTemplate.h
@@ -1,11 +1,11 @@
-#ifndef Framework_ProxyFactoryTemplate_h
-#define Framework_ProxyFactoryTemplate_h
+#ifndef FWCore_Framework_ProxyFactoryTemplate_h
+#define FWCore_Framework_ProxyFactoryTemplate_h
 // -*- C++ -*-
 //
 // Package:     Framework
 // Class  :     ProxyFactoryTemplate
 // 
-/**\class ProxyFactoryTemplate ProxyFactoryTemplate.h FWCore/Framework/interface/ProxyFactoryTemplate.h
+/**\class edm::eventsetup::ProxyFactoryTemplate
 
  Description: <one line class summary>
 
@@ -26,44 +26,31 @@
 #include "FWCore/Framework/interface/ProxyFactoryBase.h"
 #include "FWCore/Framework/interface/DataKey.h"
 
-// forward declarations
 namespace edm {
    namespace eventsetup {
 
-template <class T>
-class ProxyFactoryTemplate : public ProxyFactoryBase
-{
+     class DataProxy;
 
-   public:
-      typedef typename T::record_type record_type;
-   
-      ProxyFactoryTemplate() {}
-      //virtual ~ProxyFactoryTemplate();
+     template <class T>
+     class ProxyFactoryTemplate : public ProxyFactoryBase {
 
-      // ---------- const member functions ---------------------
-      virtual std::unique_ptr<DataProxy> makeProxy() const {
+     public:
+
+       using RecordType = typename T::record_type;
+
+       ProxyFactoryTemplate() = default;
+
+       ProxyFactoryTemplate(const ProxyFactoryTemplate&) = delete;
+       const ProxyFactoryTemplate& operator=(const ProxyFactoryTemplate&) = delete;
+
+       std::unique_ptr<DataProxy> makeProxy(unsigned int) override {
          return std::make_unique<T>();
-      }
-      
-      
-      virtual DataKey makeKey(const std::string& iName) const {
-         return DataKey(DataKey::makeTypeTag< typename T::value_type>(),iName.c_str());
-      }
-      
-      // ---------- static member functions --------------------
+       }
 
-      // ---------- member functions ---------------------------
-
-   private:
-      ProxyFactoryTemplate(const ProxyFactoryTemplate&); // stop default
-
-      const ProxyFactoryTemplate& operator=(const ProxyFactoryTemplate&); // stop default
-
-      // ---------- member data --------------------------------
-
-};
-
+       DataKey makeKey(const std::string& iName) const override {
+         return DataKey(DataKey::makeTypeTag<typename T::value_type>(), iName.c_str());
+       }
+     };
    }
 }
-
 #endif

--- a/FWCore/Framework/interface/RecordDependencyRegister.h
+++ b/FWCore/Framework/interface/RecordDependencyRegister.h
@@ -33,15 +33,18 @@ namespace edm {
       using DepFunction = std::set<EventSetupRecordKey> (*)();
       
       std::set<EventSetupRecordKey> dependencies(EventSetupRecordKey const&);
-      
-      void addDependencyFunction(EventSetupRecordKey iKey, DepFunction iFunction);
-      
-    
+      bool allowConcurrentIOVs(EventSetupRecordKey const&);
+
+      void addDependencyFunction(EventSetupRecordKey iKey,
+                                 DepFunction iFunction,
+                                 bool allowConcurrentIOVs);
+
     template<typename T>
     struct RecordDependencyRegister {
       RecordDependencyRegister() {
         addDependencyFunction(EventSetupRecordKey::makeKey<T>(),
-                              &findDependentRecordsFor<T>);
+                              &findDependentRecordsFor<T>,
+                              T::allowConcurrentIOVs_);
       }
     };
   }

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -23,11 +23,13 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <vector>
 
 namespace edm {
   class ActivityRegistry;
   class BranchDescription;
   class BranchIDListHelper;
+  class EventSetupImpl;
   class HistoryAppender;
   class IOVSyncValue;
   class MergeableRunProductMetadata;
@@ -74,15 +76,22 @@ namespace edm {
     void doEndJob();
 
     void doEventAsync(WaitingTaskHolder iHolder,
-                      EventPrincipal const& principal);
+                      EventPrincipal const& principal,
+                      std::vector<std::shared_ptr<const EventSetupImpl>> const*);
 
-    void doBeginRunAsync(WaitingTaskHolder iHolder, RunPrincipal const& principal, IOVSyncValue const& ts);
+    void doBeginRunAsync(WaitingTaskHolder iHolder, RunPrincipal const& principal, IOVSyncValue const& ts,
+                         std::vector<std::shared_ptr<const EventSetupImpl>> const*);
 
-    void doEndRunAsync(WaitingTaskHolder iHolder, RunPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
+    void doEndRunAsync(WaitingTaskHolder iHolder, RunPrincipal const& principal, IOVSyncValue const& ts,
+                       std::vector<std::shared_ptr<const EventSetupImpl>> const*,
+                       bool cleaningUpAfterException);
 
-    void doBeginLuminosityBlockAsync(WaitingTaskHolder iHolder, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts);
+    void doBeginLuminosityBlockAsync(WaitingTaskHolder iHolder, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts,
+                                     std::vector<std::shared_ptr<const EventSetupImpl>> const*);
 
-    void doEndLuminosityBlockAsync(WaitingTaskHolder iHolder, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
+    void doEndLuminosityBlockAsync(WaitingTaskHolder iHolder, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts,
+                                   std::vector<std::shared_ptr<const EventSetupImpl>> const*,
+                                   bool cleaningUpAfterException);
 
 
     void doBeginStream(unsigned int);
@@ -90,22 +99,26 @@ namespace edm {
     void doStreamBeginRunAsync(WaitingTaskHolder iHolder,
                                unsigned int iID,
                                RunPrincipal const& principal,
-                               IOVSyncValue const& ts);
+                               IOVSyncValue const& ts,
+                               std::vector<std::shared_ptr<const EventSetupImpl>> const*);
 
     void doStreamEndRunAsync(WaitingTaskHolder iHolder,
                              unsigned int iID, RunPrincipal const& principal,
                              IOVSyncValue const& ts,
+                             std::vector<std::shared_ptr<const EventSetupImpl>> const*,
                              bool cleaningUpAfterException);
 
     void doStreamBeginLuminosityBlockAsync(WaitingTaskHolder iHolder,
                                            unsigned int iID,
                                            LuminosityBlockPrincipal const& principal,
-                                           IOVSyncValue const& ts);
+                                           IOVSyncValue const& ts,
+                                           std::vector<std::shared_ptr<const EventSetupImpl>> const*);
 
     void doStreamEndLuminosityBlockAsync(WaitingTaskHolder iHolder,
                                          unsigned int iID,
                                          LuminosityBlockPrincipal const& principal,
                                          IOVSyncValue const& ts,
+                                         std::vector<std::shared_ptr<const EventSetupImpl>> const*,
                                          bool cleaningUpAfterException);
 
 
@@ -232,7 +245,7 @@ namespace edm {
   private:
     void beginJob();
     void endJob();
-    void processAsync(WaitingTaskHolder iHolder, EventPrincipal const& e);
+    void processAsync(WaitingTaskHolder iHolder, EventPrincipal const& e, std::vector<std::shared_ptr<const EventSetupImpl>> const*);
     void beginRun(RunPrincipal const& r, IOVSyncValue const& ts);
     void endRun(RunPrincipal const& r, IOVSyncValue const& ts, bool cleaningUpAfterException);
     void beginLuminosityBlock(LuminosityBlockPrincipal const& lb, IOVSyncValue const& ts);

--- a/FWCore/Framework/src/DataProxyProvider.cc
+++ b/FWCore/Framework/src/DataProxyProvider.cc
@@ -16,93 +16,45 @@
 // user include files
 #include "FWCore/Framework/interface/DataProxyProvider.h"
 #include "FWCore/Framework/interface/DataProxy.h"
+#include "FWCore/Framework/interface/RecordDependencyRegister.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include <cassert>
 
 namespace edm {
    namespace eventsetup {
-//
-// constants, enums and typedefs
-//
 
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
-DataProxyProvider::DataProxyProvider() : recordProxies_(), description_()
+DataProxyProvider::DataProxyProvider()
 {
 }
-
-// DataProxyProvider::DataProxyProvider(const DataProxyProvider& rhs)
-// {
-//    // do actual copying here;
-// }
 
 DataProxyProvider::~DataProxyProvider() noexcept(false)
 {
 }
 
-//
-// assignment operators
-//
-// const DataProxyProvider& DataProxyProvider::operator=(const DataProxyProvider& rhs)
-// {
-//   //An exception safe implementation is
-//   DataProxyProvider temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
-
-//
-// member functions
-//
-     
 void DataProxyProvider::updateLookup(eventsetup::ESRecordsToProxyIndices const&) {}
 
 void 
 DataProxyProvider::usingRecordWithKey(const EventSetupRecordKey& iKey)
 {
    recordProxies_[iKey];
-   //keys_.push_back(iKey);
 }
 
-void 
-DataProxyProvider::invalidateProxies(const EventSetupRecordKey& iRecordKey) 
-{
-   KeyedProxies& proxyList((*(recordProxies_.find(iRecordKey))).second) ;
-   KeyedProxies::iterator finished(proxyList.end()) ;
-   for (KeyedProxies::iterator keyedProxy(proxyList.begin()) ;
-         keyedProxy != finished ;
-         ++keyedProxy) {
-      (*((*keyedProxy).second)).invalidate() ;
-   }
-   
+void
+DataProxyProvider::fillRecordsNotAllowingConcurrentIOVs(std::set<EventSetupRecordKey>& recordsNotAllowingConcurrentIOVs) const {
+  for (auto const& it : recordProxies_) {
+    const EventSetupRecordKey& key = it.first;
+    if (!allowConcurrentIOVs(key)) {
+      recordsNotAllowingConcurrentIOVs.insert(recordsNotAllowingConcurrentIOVs.end(), key);
+    }
+  }
 }
 
-void 
-DataProxyProvider::resetProxies(const EventSetupRecordKey& iRecordKey)
-{
-  invalidateProxies(iRecordKey);
+void
+DataProxyProvider::resizeKeyedProxiesVector(EventSetupRecordKey const& key, unsigned int nConcurrentIOVs) {
+  recordProxies_[key].resize(nConcurrentIOVs);
 }
-      
-void 
-DataProxyProvider::resetProxiesIfTransient(const EventSetupRecordKey& iRecordKey) 
-{
-   KeyedProxies& proxyList((*(recordProxies_.find(iRecordKey))).second) ;
-   KeyedProxies::iterator finished(proxyList.end()) ;
-   for (KeyedProxies::iterator keyedProxy(proxyList.begin()) ;
-        keyedProxy != finished ;
-        ++keyedProxy) {
-      (*((*keyedProxy).second)).resetIfTransient() ;
-   }
-   
-}
-      
+
 void
 DataProxyProvider::setAppendToDataLabel(const edm::ParameterSet& iToAppend)
 {
@@ -115,64 +67,52 @@ DataProxyProvider::setAppendToDataLabel(const edm::ParameterSet& iToAppend)
     appendToDataLabel_ = iToAppend.getParameter<std::string>(kParamName);
   }
 }
-//
-// const member functions
-//
+
 bool 
 DataProxyProvider::isUsingRecord(const EventSetupRecordKey& iKey) const
 {
    return recordProxies_.end() != recordProxies_.find(iKey);
 }
 
-std::set<EventSetupRecordKey> 
+std::set<EventSetupRecordKey>
 DataProxyProvider::usingRecords() const
 {
    std::set<EventSetupRecordKey> returnValue;
-   for(RecordProxies::const_iterator itRecProxies = recordProxies_.begin(),
-        itRecProxiesEnd = recordProxies_.end();
-        itRecProxies != itRecProxiesEnd;
-        ++itRecProxies) {
-      returnValue.insert(returnValue.end(), itRecProxies->first);
+   for (auto const& it : recordProxies_) {
+      returnValue.insert(returnValue.end(), it.first);
    }
-   //copy_all(keys_, std::inserter(returnValue, returnValue.end()));
    return returnValue;
-}   
-
-const DataProxyProvider::KeyedProxies& 
-DataProxyProvider::keyedProxies(const EventSetupRecordKey& iRecordKey) const
-{
-   RecordProxies::const_iterator itFind = recordProxies_.find(iRecordKey);
-   assert(itFind != recordProxies_.end());
-   
-   if(itFind->second.empty()) {
-      //delayed registration
-      KeyedProxies& proxies = const_cast<KeyedProxies&>(itFind->second);
-      const_cast<DataProxyProvider*>(this)->registerProxies(iRecordKey,
-                                                            proxies);
-
-      bool mustChangeLabels = (!appendToDataLabel_.empty());
-      for(KeyedProxies::iterator itProxy = proxies.begin(), itProxyEnd = proxies.end();
-          itProxy != itProxyEnd;
-          ++itProxy) {
-        itProxy->second->setProviderDescription(&description());
-        if( mustChangeLabels ) {
-          //Using swap is fine since
-          // 1) the data structure is not a map and so we have not sorted on the keys
-          // 2) this is the first time filling this so no outside agency has yet seen
-          //   the label and therefore can not be dependent upon its value
-          std::string temp(std::string(itProxy->first.name().value())+appendToDataLabel_);
-          DataKey newKey(itProxy->first.type(),temp.c_str());
-          swap(itProxy->first,newKey);
-        }
-      }
-   }
-   
-   return itFind->second;
 }
 
-//
-// static member functions
-//
+DataProxyProvider::KeyedProxies&
+DataProxyProvider::keyedProxies(const EventSetupRecordKey& iRecordKey, unsigned int iovIndex)
+{
+   RecordProxies::iterator itFind = recordProxies_.find(iRecordKey);
+   assert(itFind != recordProxies_.end());
+   assert(iovIndex < itFind->second.size());
+   KeyedProxies& keyedProxies = itFind->second[iovIndex];
+
+   if (keyedProxies.empty()) {
+      //delayed registration
+      registerProxies(iRecordKey, keyedProxies, iovIndex);
+
+      bool mustChangeLabels = (!appendToDataLabel_.empty());
+      for (auto& itProxy : keyedProxies) {
+         itProxy.second->setProviderDescription(&description());
+         if (mustChangeLabels) {
+            //Using swap is fine since
+            // 1) the data structure is not a map and so we have not sorted on the keys
+            // 2) this is the first time filling this so no outside agency has yet seen
+            //   the label and therefore can not be dependent upon its value
+            std::string temp(std::string(itProxy.first.name().value()) + appendToDataLabel_);
+            DataKey newKey(itProxy.first.type(), temp.c_str());
+            swap(itProxy.first, newKey);
+         }
+      }
+   }
+   return keyedProxies;
+}
+
 static const std::string kAppendToDataLabel("appendToDataLabel");
 
 void
@@ -192,4 +132,3 @@ DataProxyProvider::prevalidate(ConfigurationDescriptions& iDesc)
 
    }
 }
-

--- a/FWCore/Framework/src/DependentRecordIntervalFinder.cc
+++ b/FWCore/Framework/src/DependentRecordIntervalFinder.cc
@@ -10,55 +10,23 @@
 // Created:     Sat Apr 30 19:37:22 EDT 2005
 //
 
-// system include files
-
-// user include files
 #include "FWCore/Framework/interface/DependentRecordIntervalFinder.h"
 #include "FWCore/Framework/interface/EventSetupRecordProvider.h"
 #include <cassert>
 
-//
-// constants, enums and typedefs
-//
 namespace edm {
    namespace eventsetup {
-//
-// static data member definitions
-//
 
-//
-// constructors and destructor
-//
 DependentRecordIntervalFinder::DependentRecordIntervalFinder(const EventSetupRecordKey& iKey) :
   providers_()
 {
    findingRecordWithKey(iKey);
 }
 
-// DependentRecordIntervalFinder::DependentRecordIntervalFinder(const DependentRecordIntervalFinder& rhs)
-// {
-//    // do actual copying here;
-// }
-
 DependentRecordIntervalFinder::~DependentRecordIntervalFinder()
 {
 }
 
-//
-// assignment operators
-//
-// const DependentRecordIntervalFinder& DependentRecordIntervalFinder::operator=(const DependentRecordIntervalFinder& rhs)
-// {
-//   //An exception safe implementation is
-//   DependentRecordIntervalFinder temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
-
-//
-// member functions
-//
 void 
 DependentRecordIntervalFinder::addProviderWeAreDependentOn(std::shared_ptr<EventSetupRecordProvider> iProvider)
 {
@@ -201,12 +169,27 @@ DependentRecordIntervalFinder::setIntervalFor(const EventSetupRecordKey& iKey,
    }
 }
 
-//
-// const member functions
-//
+void DependentRecordIntervalFinder::doResetInterval(const eventsetup::EventSetupRecordKey& key) {
+   if (alternate_.get()) {
+      alternate_->resetInterval(key);
+   }
+   previousIOVs_.clear();
+}
 
-//
-// static member functions
-//
+bool DependentRecordIntervalFinder::isLegacyESSource() const {
+   return false;
+}
+
+bool DependentRecordIntervalFinder::isLegacyOutOfValidityInterval(const EventSetupRecordKey& iKey,
+                                                                  const IOVSyncValue& iTime) const {
+   // Note that we do not worry about dependent records here because this function
+   // will get called once for every record and we would just be checking the
+   // dependent records multiple times if we checked them inside this function.
+   if (alternate_.get()) {
+      return alternate_->legacyOutOfValidityInterval(iKey, iTime);
+   }
+   return false;
+}
+
    }
 }

--- a/FWCore/Framework/src/ESProducer.cc
+++ b/FWCore/Framework/src/ESProducer.cc
@@ -61,7 +61,11 @@ ESProducer::~ESProducer() noexcept(false)
   ESProducer::updateLookup(eventsetup::ESRecordsToProxyIndices const& iProxyToIndices) {
     itemsToGetFromRecords_.reserve(consumesInfos_.size());
     recordsUsedDuringGet_.reserve(consumesInfos_.size());
-    
+
+    if (itemsToGetFromRecords_.size() == consumesInfos_.size()) {
+      return;
+    }
+
     for(auto& info: consumesInfos_) {
       auto & items = itemsToGetFromRecords_.emplace_back();
       items.reserve(info->size());

--- a/FWCore/Framework/src/ESProxyFactoryProducer.cc
+++ b/FWCore/Framework/src/ESProxyFactoryProducer.cc
@@ -66,13 +66,14 @@ ESProxyFactoryProducer::~ESProxyFactoryProducer() noexcept(false)
 //
 void
 ESProxyFactoryProducer::registerProxies(const EventSetupRecordKey& iRecord,
-                                       KeyedProxies& iProxies)
+                                       KeyedProxies& iProxies,
+                                       unsigned int iovIndex)
 {
    typedef Record2Factories::iterator Iterator;
    std::pair< Iterator, Iterator > range = record2Factories_.equal_range(iRecord);
    for(Iterator it = range.first; it != range.second; ++it) {
 
-      std::shared_ptr<DataProxy> proxy(it->second.factory_->makeProxy().release());
+      std::shared_ptr<DataProxy> proxy(it->second.factory_->makeProxy(iovIndex).release());
       if(nullptr != proxy.get()) {
          iProxies.push_back(KeyedProxies::value_type((*it).second.key_,
                                          proxy));
@@ -112,18 +113,4 @@ ESProxyFactoryProducer::registerFactoryWithKey(const EventSetupRecordKey& iRecor
                                                          std::move(info)));
 }
 
-void
-ESProxyFactoryProducer::newInterval(const EventSetupRecordKey& iRecordType,
-                                   const ValidityInterval& /*iInterval*/)
-{
-   invalidateProxies(iRecordType);
-}
-
-//
-// const member functions
-//
-
-//
-// static member functions
-//
 }

--- a/FWCore/Framework/src/EventSetup.cc
+++ b/FWCore/Framework/src/EventSetup.cc
@@ -12,50 +12,7 @@
 // Created:     Thu Mar 24 16:27:10 EST 2005
 //
 
-// system include files
-
-// user include files
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/EventSetupRecord.h"
 
 namespace edm {
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
-
-// EventSetup::EventSetup(EventSetup const& rhs)
-// {
-//    // do actual copying here;
-// }
-
-//
-// assignment operators
-//
-// EventSetup const& EventSetup::operator=(EventSetup const& rhs)
-// {
-//   //An exception safe implementation is
-//   EventSetup temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
-
-//
-// member functions
-//
-//
-// const member functions
-//
-
-//
-// static member functions
-//
 }

--- a/FWCore/Framework/src/EventSetupRecord.cc
+++ b/FWCore/Framework/src/EventSetupRecord.cc
@@ -11,68 +11,32 @@
 //
 
 // system include files
-#include <cassert>
-#include <string>
-#include <exception>
+#include <sstream>
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecord.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
-#include "FWCore/Framework/interface/DataProxy.h"
 #include "FWCore/Framework/interface/ComponentDescription.h"
 
-#include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 namespace edm {
    namespace eventsetup {
-//
-// constants, enums and typedefs
-//
-      typedef std::map< DataKey , const DataProxy* > Proxies;
-//
-// static data member definitions
-//
 
-//
-// constructors and destructor
-//
+      typedef std::map< DataKey , const DataProxy* > Proxies;
+
 EventSetupRecord::EventSetupRecord()
 {
 }
-
-// EventSetupRecord::EventSetupRecord(const EventSetupRecord& rhs)
-// {
-//    // do actual copying here;
-// }
 
 EventSetupRecord::~EventSetupRecord()
 {
 }
 
-//
-// assignment operators
-//
-// const EventSetupRecord& EventSetupRecord::operator=(const EventSetupRecord& rhs)
-// {
-//   //An exception safe implementation is
-//   EventSetupRecord temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
-
-//
-// member functions
-//
-//
-// const member functions
-//
-      
 bool
-EventSetupRecord::doGet(const DataKey& aKey, bool aGetTransiently) const {
-  return impl_->doGet(aKey,aGetTransiently);
+EventSetupRecord::doGet(const DataKey& aKey,
+                        bool aGetTransiently) const {
+  return impl_->doGet(aKey, eventSetupImpl_, aGetTransiently);
 }
 
 bool 
@@ -131,8 +95,25 @@ EventSetupRecord::makeInvalidTokenException(EventSetupRecordKey const& iRecordKe
   return std::make_exception_ptr(ex);
 }
 
-//
-// static member functions
-//
-   }
+    void
+    EventSetupRecord::throwWrongTransitionID() const {
+      cms::Exception ex("ESGetTokenWrongTransition");
+      ex << "The transition ID stored in the ESGetToken does not match the\n"
+         << "transition where the token is being used. The associated record\n"
+         << "type is: " << key().type().name() << "\n"
+         << "For producers, filters and analyzers this transition ID is\n"
+         << "set as a template parameter to the call to the esConsumes\n"
+         << "function that creates the token. Event is the default transition.\n"
+         << "Other possibilities are BeginRun, EndRun, BeginLuminosityBlock,\n"
+         << "or EndLuminosityBlock. You may need multiple tokens if you want to\n"
+         << "get the same data in multiple transitions. The transition ID has a\n"
+         << "different meaning in ESProducers. For ESProducers, the transition\n"
+         << "ID identifies the function that produces the EventSetup data (often\n"
+         << "there is one function named produce but there can be multiple\n"
+         << "functions with different names). For ESProducers, the ESGetToken\n"
+         << "must be used in the function associated with the ESConsumesCollector\n"
+         << "returned by the setWhatProduced function.";
+      throw ex;
+    }
+  }
 }

--- a/FWCore/Framework/src/EventSetupRecordIOVQueue.cc
+++ b/FWCore/Framework/src/EventSetupRecordIOVQueue.cc
@@ -1,0 +1,132 @@
+// -*- C++ -*-
+//
+// Package:     Framework
+// Class  :     EventSetupRecordIOVQueue
+//
+//
+// Author:      W. David Dagenhart
+// Created:     22 Feb 2019
+
+#include "FWCore/Framework/src/EventSetupRecordIOVQueue.h"
+#include "FWCore/Framework/interface/EventSetupRecordProvider.h"
+#include "FWCore/Concurrency/interface/WaitingTask.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include <exception>
+
+namespace edm {
+  namespace eventsetup {
+
+    EventSetupRecordIOVQueue::EventSetupRecordIOVQueue(unsigned int nConcurrentIOVs)
+        : nConcurrentIOVs_(nConcurrentIOVs), iovQueue_(nConcurrentIOVs), cacheIdentifier_(1) {
+      for (unsigned int i = 0; i < nConcurrentIOVs; ++i) {
+        isAvailable_.push_back(std::make_unique<std::atomic<bool>>(true));
+      }
+      waitForIOVsInFlight_ = edm::make_empty_waiting_task();
+      waitForIOVsInFlight_->increment_ref_count();
+      waitForIOVsInFlight_->increment_ref_count();
+    }
+
+    EventSetupRecordIOVQueue::~EventSetupRecordIOVQueue() {
+      { WaitingTaskHolder tmp{std::move(endIOVTaskHolder_)}; }
+      waitForIOVsInFlight_->decrement_ref_count();
+      waitForIOVsInFlight_->wait_for_all();
+    }
+
+    void EventSetupRecordIOVQueue::setNewIntervalForAnySubProcess() {
+      bool newIntervalForAnySubProcess = false;
+      for (auto const& recordProvider : recordProviders_) {
+        if (recordProvider->intervalStatus() == EventSetupRecordProvider::IntervalStatus::NewInterval) {
+          newIntervalForAnySubProcess = true;
+          break;
+        }
+      }
+      for (auto& recordProvider : recordProviders_) {
+        recordProvider->setNewIntervalForAnySubProcess(newIntervalForAnySubProcess);
+      }
+    }
+
+    void EventSetupRecordIOVQueue::checkForNewIOVs(WaitingTaskHolder const& taskToStartAfterIOVInit,
+                                                   WaitingTaskList& endIOVWaitingTasks,
+                                                   bool newEventSetupImpl) {
+      for (auto& recordProvider : recordProviders_) {
+        if (recordProvider->newIntervalForAnySubProcess()) {
+          startNewIOVAsync(taskToStartAfterIOVInit, endIOVWaitingTasks);
+          return;
+        }
+      }
+
+      for (auto& recordProvider : recordProviders_) {
+        if (recordProvider->intervalStatus() != EventSetupRecordProvider::IntervalStatus::Invalid) {
+          endIOVWaitingTasks.add(endIOVWaitingTask_);
+          break;
+        }
+      }
+
+      for (auto& recordProvider : recordProviders_) {
+        recordProvider->continueIOV(newEventSetupImpl);
+      }
+    }
+
+    void EventSetupRecordIOVQueue::startNewIOVAsync(WaitingTaskHolder const& taskToStartAfterIOVInit,
+                                                    WaitingTaskList& endIOVWaitingTasks) {
+      ++cacheIdentifier_;
+      {
+        // Let the old IOV end when all the lumis using it are done.
+        // otherwise we'll deadlock when there is only one thread.
+        WaitingTaskHolder tmp{std::move(endIOVTaskHolder_)};
+      }
+      auto taskHolder = std::make_shared<WaitingTaskHolder>(taskToStartAfterIOVInit);
+      auto startIOVForRecord =
+          [this, taskHolder, &endIOVWaitingTasks](edm::LimitedTaskQueue::Resumer iResumer) mutable {
+            try {
+              unsigned int iovIndex = 0;
+              for (; iovIndex < nConcurrentIOVs_; ++iovIndex) {
+                bool expected = true;
+                if (isAvailable_[iovIndex]->compare_exchange_strong(expected, false)) {
+                  break;
+                }
+              }
+              // Should never fail, just a sanity check
+              if (iovIndex == nConcurrentIOVs_) {
+                throw edm::Exception(edm::errors::LogicError)
+                    << "EventSetupRecordIOVQueue::startNewIOVAsync\n"
+                    << "Couldn't find available IOV slot. This should never happen.\n"
+                    << "Contact a Framework Developer\n";
+              }
+              for (auto recordProvider : recordProviders_) {
+                recordProvider->initializeForNewIOV(iovIndex, cacheIdentifier_);
+              }
+
+              // Needed so the EventSetupRecordIOVQueue destructor knows when
+              // it can run.
+              waitForIOVsInFlight_->increment_ref_count();
+
+              endIOVWaitingTask_ = make_waiting_task(tbb::task::allocate_root(),
+                                                     [this, iResumer, iovIndex](std::exception_ptr const*) mutable {
+                                                       for (auto recordProvider : recordProviders_) {
+                                                         recordProvider->endIOV(iovIndex);
+                                                       }
+                                                       isAvailable_[iovIndex]->store(true);
+                                                       iResumer.resume();
+                                                       waitForIOVsInFlight_->decrement_ref_count();
+                                                       // There is nothing in this task to catch an exception
+                                                       // because it is extremely unlikely to throw.
+                                                     });
+              endIOVTaskHolder_ = WaitingTaskHolder{endIOVWaitingTask_};
+              endIOVWaitingTasks.add(endIOVWaitingTask_);
+            } catch (...) {
+              taskHolder->doneWaiting(std::current_exception());
+              return;
+            }
+            taskHolder->doneWaiting(std::exception_ptr{});
+          };
+      iovQueue_.pushAndPause(std::move(startIOVForRecord));
+    }
+
+    void EventSetupRecordIOVQueue::addRecProvider(EventSetupRecordProvider* recProvider) {
+      recordProviders_.push_back(recProvider);
+    }
+
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/EventSetupRecordIOVQueue.h
+++ b/FWCore/Framework/src/EventSetupRecordIOVQueue.h
@@ -1,0 +1,82 @@
+#ifndef FWCore_Framework_EventSetupRecordIOVQueue_h
+#define FWCore_Framework_EventSetupRecordIOVQueue_h
+
+// -*- C++ -*-
+//
+// Package:     Framework
+// Class  :     EventSetupRecordIOVQueue
+//
+/** \class edm::eventsetup::EventSetupRecordIOVQueue
+
+ Description: Contains a LimitedQueue for each Record that
+ limits the number of IOVs that can be processed concurrently.
+ Also contains data closely related to starting and
+ stopping those IOVs.
+
+ This manages creating the TBB tasks that start and end IOVs.
+ It creates those tasks. It ensures those tasks wait until
+ the proper time to start and notify the proper other tasks
+ when done.
+
+ It protects the many EventSetupRecordImpl's from data races
+ by ensuring that while multiple threads are using them
+ concurrently only thread safe functions are being called.
+
+*/
+//
+// Original Author: W. David Dagenhart
+//          Created: 22 Feb 2019
+//
+
+#include "FWCore/Concurrency/interface/LimitedTaskQueue.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Concurrency/interface/WaitingTaskList.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+namespace edm {
+  namespace eventsetup {
+
+    class EventSetupRecordProvider;
+
+    class EventSetupRecordIOVQueue {
+    public:
+      EventSetupRecordIOVQueue(unsigned int nConcurrentIOVs);
+      ~EventSetupRecordIOVQueue();
+
+      void setNewIntervalForAnySubProcess();
+
+      void checkForNewIOVs(WaitingTaskHolder const& taskToStartAfterIOVInit,
+                           WaitingTaskList& endIOVWaitingTasks,
+                           bool newEventSetupImpl);
+
+      void startNewIOVAsync(WaitingTaskHolder const& taskToStartAfterIOVInit, WaitingTaskList& endIOVWaitingTasks);
+
+      void addRecProvider(EventSetupRecordProvider* recProvider);
+
+    private:
+      unsigned int nConcurrentIOVs_;
+
+      // Used to limit the number of concurrent IOVs
+      edm::LimitedTaskQueue iovQueue_;
+      std::unique_ptr<edm::EmptyWaitingTask, waitingtask::TaskDestroyer> waitForIOVsInFlight_;
+
+      // Each element of this vector corresponds to one IOV
+      // out the set of possible concurrent IOVs.
+      std::vector<edm::propagate_const<std::unique_ptr<std::atomic<bool>>>> isAvailable_;
+
+      // Unless there are SubProcesses this vector will have only 1 element
+      std::vector<edm::propagate_const<EventSetupRecordProvider*>> recordProviders_;
+
+      // These are associated with the most recent iov.
+      unsigned long long cacheIdentifier_;
+      WaitingTaskHolder endIOVTaskHolder_;
+      WaitingTask* endIOVWaitingTask_ = nullptr;
+    };
+
+  }  // namespace eventsetup
+}  // namespace edm
+#endif

--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -16,7 +16,9 @@
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordProvider.h"
+
 #include "FWCore/Framework/interface/ParameterSetIDHolder.h"
+#include "FWCore/Framework/interface/EventSetupImpl.h"
 #include "FWCore/Framework/interface/EventSetupProvider.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 #include "FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h"
@@ -29,52 +31,29 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "make_shared_noexcept_false.h"
 
-
-
-
-//
-// constants, enums and typedefs
-//
-
 namespace edm {
    namespace eventsetup {
-//
-// static data member definitions
-//
 
-//
-// constructors and destructor
-//
-EventSetupRecordProvider::EventSetupRecordProvider(const EventSetupRecordKey& iKey) :
-    record_(iKey),
+EventSetupRecordProvider::EventSetupRecordProvider(const EventSetupRecordKey& iKey,
+                                                   ActivityRegistry const* activityRegistry,
+                                                   unsigned int nConcurrentIOVs) :
     key_(iKey),
-    validityInterval_(), finder_(), providers_(),
-    multipleFinders_(new std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>()),
-    lastSyncWasBeginOfRun_(true)
+    nConcurrentIOVs_(nConcurrentIOVs),
+    validityInterval_(),
+    finder_(),
+    providers_(),
+    multipleFinders_(new std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>())
 {
+  for (unsigned int i = 0; i < nConcurrentIOVs_; ++i) {
+    recordImpls_.push_back(std::make_unique<EventSetupRecordImpl>(iKey, activityRegistry, i));
+  }
 }
 
-// EventSetupRecordProvider::EventSetupRecordProvider(const EventSetupRecordProvider& rhs)
-// {
-//    // do actual copying here;
-// }
+EventSetupRecordImpl const& EventSetupRecordProvider::firstRecordImpl() const {
+  return *recordImpls_[0];
+}
 
-//
-// assignment operators
-//
-// const EventSetupRecordProvider& EventSetupRecordProvider::operator=(const EventSetupRecordProvider& rhs)
-// {
-//   //An exception safe implementation is
-//   EventSetupRecordProvider temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
-
-//
-// member functions
-//
-void 
+void
 EventSetupRecordProvider::add(std::shared_ptr<DataProxyProvider> iProvider)
 {
    assert(iProvider->isUsingRecord(key_));
@@ -104,6 +83,7 @@ void
 EventSetupRecordProvider::setValidityInterval(const ValidityInterval& iInterval)
 {
    validityInterval_ = iInterval;
+   initializeForNewSyncValue();
 }
 
 void 
@@ -130,7 +110,13 @@ EventSetupRecordProvider::usePreferred(const DataToPreferredProviderMap& iMap)
      std::shared_ptr<IntersectingIOVRecordIntervalFinder> intFinder = make_shared_noexcept_false<IntersectingIOVRecordIntervalFinder>(key_);
      intFinder->swapFinders(*multipleFinders_);
      finder_ = intFinder;
+     hasLegacyESSource_ = intFinder->hasLegacyESSource();
+  } else {
+     if (finder_.get() != nullptr) {
+        hasLegacyESSource_ = finder_->legacyESSource();
+     }
   }
+
   //now we get rid of the temporary
   multipleFinders_.reset(nullptr);
 }
@@ -141,111 +127,137 @@ EventSetupRecordProvider::addProxiesToRecord(std::shared_ptr<DataProxyProvider> 
    typedef DataProxyProvider::KeyedProxies ProxyList ;
    typedef EventSetupRecordProvider::DataToPreferredProviderMap PreferredMap;
    
-   const ProxyList& keyedProxies(iProvider->keyedProxies(this->key())) ;
-   ProxyList::const_iterator finishedProxyList(keyedProxies.end()) ;
-   for (ProxyList::const_iterator keyedProxy(keyedProxies.begin()) ;
-        keyedProxy != finishedProxyList ;
-        ++keyedProxy) {
-      PreferredMap::const_iterator itFound = iMap.find(keyedProxy->first);
-      if(iMap.end() != itFound) {
-         if( itFound->second.type_ != keyedProxy->second->providerDescription()->type_ ||
-            itFound->second.label_ != keyedProxy->second->providerDescription()->label_ ) {
-            //this is not the preferred provider
-            continue;
-         }
-      }
-      record_.add((*keyedProxy).first , (*keyedProxy).second.get()) ;
-   }
-}
-      
-void 
-EventSetupRecordProvider::addRecordTo(EventSetupProvider& iEventSetupProvider) {
-   record_.set(this->validityInterval());
-   iEventSetupProvider.addRecordToEventSetup(record_);
-}
-      
-//
-// const member functions
-//
-void 
-EventSetupRecordProvider::resetTransients()
-{
+   for (unsigned int iovIndex = 0; iovIndex < nConcurrentIOVs_; ++iovIndex) {
 
-   using std::placeholders::_1;
-   if(checkResetTransients())  {
-      for_all(providers_, std::bind(&DataProxyProvider::resetProxiesIfTransient,_1,key_)); 
-   }
-}
+      ProxyList& keyedProxies(iProvider->keyedProxies(this->key(), iovIndex));
 
-      
-void 
-EventSetupRecordProvider::addRecordToIfValid(EventSetupProvider& iEventSetupProvider,
-                                          const IOVSyncValue& iTime)
-{
-   if(setValidityIntervalFor(iTime)) {
-      addRecordTo(iEventSetupProvider);
-   } 
-}
+      for (auto& keyedProxy : keyedProxies) {
 
-bool 
-EventSetupRecordProvider::setValidityIntervalFor(const IOVSyncValue& iTime)
-{
-   //we want to wait until after the first event of a new run before
-   // we reset any transients just in case some modules get their data at beginRun or beginLumi
-   // and others wait till the first event
-   if(!lastSyncWasBeginOfRun_) {
-      resetTransients();
-   }
-   lastSyncWasBeginOfRun_=iTime.eventID().event() == 0;
-   
-   if(validityInterval_.validFor(iTime)) {
-      return true;
-   }
-   bool returnValue = false;
-   //need to see if we get a new interval
-   if(nullptr != finder_.get()) {
-      IOVSyncValue oldFirst(validityInterval_.first());
-      
-      validityInterval_ = finder_->findIntervalFor(key_, iTime);
-      //are we in a valid range?
-      if(validityInterval_.first() != IOVSyncValue::invalidIOVSyncValue()) {
-         returnValue = true;
-         //did we actually change?
-         if(oldFirst != validityInterval_.first()) {
-            //tell all Providers to update
-            for(auto& provider : providers_) {
-               provider->newInterval(key_, validityInterval_);
+         PreferredMap::const_iterator itFound = iMap.find(keyedProxy.first);
+         if(iMap.end() != itFound) {
+            if ( itFound->second.type_ != keyedProxy.second->providerDescription()->type_ ||
+                 itFound->second.label_ != keyedProxy.second->providerDescription()->label_ ) {
+               //this is not the preferred provider
+               continue;
             }
-            cacheReset();
          }
+         recordImpls_.at(iovIndex)->add(keyedProxy.first, keyedProxy.second.get()) ;
       }
    }
-   return returnValue;
-}
-
-void 
-EventSetupRecordProvider::resetProxies()
-{
-   using std::placeholders::_1;
-   cacheReset();
-   for_all(providers_, std::bind(&DataProxyProvider::resetProxies,_1,key_));
-   //some proxies only clear if they were accessed transiently,
-   // since resetProxies resets that flag, calling resetTransients
-   // will force a clear
-   for_all(providers_, std::bind(&DataProxyProvider::resetProxiesIfTransient,_1,key_)); 
-
 }
 
 void
-EventSetupRecordProvider::getReferencedESProducers(std::map<EventSetupRecordKey, std::vector<ComponentDescription const*> >& referencedESProducers) {
-   record().getESProducers(referencedESProducers[key_]);
+EventSetupRecordProvider::initializeForNewIOV(unsigned int iovIndex,
+                                              unsigned long long cacheIdentifier) {
+  EventSetupRecordImpl* impl = recordImpls_[iovIndex].get();
+  recordImpl_ = impl;
+  impl->set(validityInterval_);
+  impl->setCacheIdentifier(cacheIdentifier);
+  eventSetupImpl_->addRecordImpl(*recordImpl_);
+}
+
+void
+EventSetupRecordProvider::continueIOV(bool newEventSetupImpl) {
+  if (intervalStatus_ == IntervalStatus::UpdateIntervalEnd) {
+    recordImpl_->setSafely(validityInterval_);
+  }
+  if (newEventSetupImpl && intervalStatus_ != IntervalStatus::Invalid) {
+    eventSetupImpl_->addRecordImpl(*recordImpl_);
+  }
+}
+
+void
+EventSetupRecordProvider::endIOV(unsigned int iovIndex) {
+  recordImpls_[iovIndex]->invalidateProxies();
+}
+
+void
+EventSetupRecordProvider::initializeForNewSyncValue() {
+  intervalStatus_ = IntervalStatus::NotInitializedForSyncValue;
+}
+
+bool EventSetupRecordProvider::legacyESSourceOutOfValidityInterval(IOVSyncValue const& iTime) const {
+   if (!hasLegacyESSource_) {
+      return false;
+   }
+   if (intervalStatus_ == IntervalStatus::Invalid ||
+       !validityInterval_.validFor(iTime)) {
+      return finder_->legacyOutOfValidityInterval(key_, iTime);
+   }
+   return false;
+}
+
+bool
+EventSetupRecordProvider::setValidityIntervalFor(const IOVSyncValue& iTime)
+{
+   // This function can be called multiple times for the same
+   // IOVSyncValue because DependentRecordIntervalFinder::setIntervalFor
+   // can call it in addition to it being called directly. Don't
+   // need to do the work multiple times for the same call to
+   // eventSetupForInstance.
+   if (intervalStatus_ == IntervalStatus::NotInitializedForSyncValue) {
+
+      intervalStatus_ = IntervalStatus::Invalid;
+
+      if (validityInterval_.first() != IOVSyncValue::invalidIOVSyncValue() &&
+          validityInterval_.validFor(iTime)) {
+         intervalStatus_ = IntervalStatus::SameInterval;
+
+      } else if (finder_.get() != nullptr) {
+         IOVSyncValue oldFirst(validityInterval_.first());
+         IOVSyncValue oldLast(validityInterval_.last());
+         validityInterval_ = finder_->findIntervalFor(key_, iTime);
+
+         // An interval is valid if and only if the start of the interval is
+         // valid. If the start is valid and the end is invalid, it means we
+         // do not know when the interval ends, but the interval is valid and
+         // iTime is within the interval.
+         if (validityInterval_.first() != IOVSyncValue::invalidIOVSyncValue()) {
+
+            // An interval is new if the start of the interval changes
+            if (validityInterval_.first() != oldFirst) {
+               intervalStatus_ = IntervalStatus::NewInterval;
+
+            // If the start is the same but the end changes, we consider
+            // this the same interval because we do not want to do the
+            // work to update the caches of data in this case.
+            } else if (validityInterval_.last() != oldLast) {
+               intervalStatus_ = IntervalStatus::UpdateIntervalEnd;
+            } else {
+               intervalStatus_ = IntervalStatus::SameInterval;
+            }
+         }
+      }
+   }
+   return intervalStatus_ != IntervalStatus::Invalid;
+}
+
+void
+EventSetupRecordProvider::resetProxies()
+{
+   // Clear out all the DataProxy's
+   for (auto& recordImplIter : recordImpls_) {
+      recordImplIter->invalidateProxies();
+      recordImplIter->resetIfTransientInProxies();
+   }
+   // Force a new IOV to start with a new cacheIdentifier
+   // on the next eventSetupForInstance call.
+   validityInterval_ = ValidityInterval{};
+   if (finder_.get() != nullptr) {
+      finder_->resetInterval(key_);
+   }
+}
+
+void
+EventSetupRecordProvider::getReferencedESProducers(std::map<EventSetupRecordKey, std::vector<ComponentDescription const*> >& referencedESProducers) const {
+   firstRecordImpl().getESProducers(referencedESProducers[key_]);
 }
 
 void
 EventSetupRecordProvider::fillReferencedDataKeys(std::map<DataKey, ComponentDescription const*>& referencedDataKeys) const {
    std::vector<DataKey> keys;
-   record().fillRegisteredDataKeys(keys);
-  std::vector<ComponentDescription const*> components = record().componentsForRegisteredDataKeys();
+   firstRecordImpl().fillRegisteredDataKeys(keys);
+   std::vector<ComponentDescription const*> components = firstRecordImpl().componentsForRegisteredDataKeys();
    auto itComponents = components.begin();
    for(auto const& k: keys) {
      referencedDataKeys.emplace(k, *itComponents);
@@ -255,23 +267,12 @@ EventSetupRecordProvider::fillReferencedDataKeys(std::map<DataKey, ComponentDesc
 
 void
 EventSetupRecordProvider::resetRecordToProxyPointers(DataToPreferredProviderMap const& iMap) {
+   for (auto& recordImplIter : recordImpls_) {
+      recordImplIter->clearProxies();
+   }
    using std::placeholders::_1;
-   record().clearProxies();
    for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecordHelper, this, _1, iMap));
 }
-
-void 
-EventSetupRecordProvider::cacheReset()
-{
-   record().cacheReset();
-}
-
-bool 
-EventSetupRecordProvider::checkResetTransients() 
-{
-   return record().transientReset();
-}
-      
 
 std::set<EventSetupRecordKey> 
 EventSetupRecordProvider::dependentRecords() const
@@ -318,6 +319,7 @@ EventSetupRecordProvider::resetProxyProvider(ParameterSetIDHolder const& psetID,
    for (auto& dataProxyProvider : providers_) {
       if (dataProxyProvider->description().pid_ == psetID.psetID()) {
          dataProxyProvider = sharedDataProxyProvider;
+         dataProxyProvider->resizeKeyedProxiesVector(key_, nConcurrentIOVs_);
       }
    }
 }
@@ -325,17 +327,14 @@ EventSetupRecordProvider::resetProxyProvider(ParameterSetIDHolder const& psetID,
 std::vector<DataKey>
 EventSetupRecordProvider::registeredDataKeys() const {
   std::vector<DataKey> ret;
-  record_.fillRegisteredDataKeys(ret);
+  firstRecordImpl().fillRegisteredDataKeys(ret);
   return ret;
 }
 
 std::vector<ComponentDescription const*>
 EventSetupRecordProvider::componentsForRegisteredDataKeys() const {
-  return record_.componentsForRegisteredDataKeys();
+  return firstRecordImpl().componentsForRegisteredDataKeys();
 }
 
-//
-// static member functions
-//
    }
 }

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -11,25 +11,30 @@
 //
 
 #include "FWCore/Framework/src/EventSetupsController.h"
+
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Concurrency/interface/WaitingTaskList.h"
 #include "FWCore/Framework/interface/DataKey.h"
 #include "FWCore/Framework/interface/DataProxy.h"
 #include "FWCore/Framework/interface/EventSetupProviderMaker.h"
 #include "FWCore/Framework/interface/EventSetupProvider.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/ParameterSetIDHolder.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
 #include <algorithm>
 #include <iostream>
+#include <set>
 
 namespace edm {
   namespace eventsetup {
 
-    EventSetupsController::EventSetupsController() : mustFinishConfiguration_(true) {
+    EventSetupsController::EventSetupsController() {
     }
 
     std::shared_ptr<EventSetupProvider>
-    EventSetupsController::makeProvider(ParameterSet& iPSet, ActivityRegistry* activityRegistry) {
+    EventSetupsController::makeProvider(ParameterSet& iPSet, ActivityRegistry* activityRegistry, ParameterSet const* optionsPset) {
 
       // Makes an EventSetupProvider
       // Also parses the prefer information from ParameterSets and puts
@@ -40,17 +45,26 @@ namespace edm {
       // shared_ptrs to them are temporarily stored in this
       // EventSetupsController and in the EventSetupProvider
       fillEventSetupProvider(*this, *returnValue, iPSet);
-   
+
+      numberOfConcurrentIOVs_.initialize(optionsPset);
+
       providers_.push_back(returnValue);
       return returnValue;
     }
 
     void
     EventSetupsController::finishConfiguration() {
+
       if (mustFinishConfiguration_) {
-        std::for_each(providers_.begin(), providers_.end(), [](std::shared_ptr<EventSetupProvider> const& esp) {
-          esp->finishConfiguration();
-        });
+
+        for (auto& eventSetupProvider : providers_) {
+          numberOfConcurrentIOVs_.initialize(*eventSetupProvider);
+        }
+
+        for (auto& eventSetupProvider : providers_) {
+          eventSetupProvider->finishConfiguration(numberOfConcurrentIOVs_, hasLegacyESSource_);
+        }
+
         // When the ESSources and ESProducers were constructed a first pass was
         // done which attempts to get component sharing between SubProcesses
         // correct, but in this pass only the configuration of the components
@@ -60,34 +74,109 @@ namespace edm {
         // also checked. The component sharing is appropriately fixed as necessary.
         checkESProducerSharing();
         clearComponents();
+
+        initializeEventSetupRecordIOVQueues();
         mustFinishConfiguration_ = false;
       }
     }
+
+    void
+    EventSetupsController::eventSetupForInstance(IOVSyncValue const& syncValue,
+                                                 WaitingTaskHolder const& taskToStartAfterIOVInit,
+                                                 WaitingTaskList& endIOVWaitingTasks,
+                                                 std::vector<std::shared_ptr<const EventSetupImpl>>& eventSetupImpls) {
+      finishConfiguration();
+
+      bool newEventSetupImpl = false;
+      eventSetupImpls.clear();
+      eventSetupImpls.reserve(providers_.size());
+
+      // Note that unless there are one or more SubProcesses providers_ will only
+      // contain one element.
+
+      for (auto & eventSetupProvider : providers_) {
+        eventSetupProvider->setAllValidityIntervals(syncValue);
+      }
+
+      for (auto & eventSetupRecordIOVQueue : eventSetupRecordIOVQueues_) {
+        eventSetupRecordIOVQueue->setNewIntervalForAnySubProcess();
+      }
+
+      for (auto & eventSetupProvider : providers_) {
+        eventSetupImpls.push_back(
+          eventSetupProvider->eventSetupForInstance(syncValue, newEventSetupImpl)
+        );
+      }
+
+      for (auto & eventSetupRecordIOVQueue : eventSetupRecordIOVQueues_) {
+        eventSetupRecordIOVQueue->checkForNewIOVs(taskToStartAfterIOVInit,
+                                                  endIOVWaitingTasks,
+                                                  newEventSetupImpl);
+      }
+    }
+
     void
     EventSetupsController::eventSetupForInstance(IOVSyncValue const& syncValue) {
-      finishConfiguration();
-      std::for_each(providers_.begin(), providers_.end(), [&syncValue](std::shared_ptr<EventSetupProvider> const& esp) {
-        esp->eventSetupForInstance(syncValue);
-      });
+
+      // This function only supports use cases where the event setup
+      // system is used without multiple concurrent IOVs.
+      // At the time this comment is being written, this is used for
+      // run transitions and in unit test code. In the future,
+      // it may only be needed for unit tests. This function uses
+      // the other version of eventSetupForInstance that
+      // supports concurrent IOVs. To get this to work, a couple
+      // arguments to that function need dummy objects that do
+      // not serve any purpose in this context. We also need to
+      // add in a task to wait for the asynchronous initialization
+      // of IOVs to complete.
+
+      auto waitUntilIOVInitializationCompletes = make_empty_waiting_task();
+      waitUntilIOVInitializationCompletes->increment_ref_count();
+
+      // These do nothing ...
+      WaitingTaskList dummyWaitingTaskList;
+      std::vector<WaitingTaskHolder> dummyVector;
+      std::vector<std::shared_ptr<const EventSetupImpl>> dummyEventSetupImpls;
+
+      {
+        WaitingTaskHolder waitingTaskHolder(waitUntilIOVInitializationCompletes.get());
+
+        try {
+          eventSetupForInstance(syncValue,
+                                waitingTaskHolder,
+                                dummyWaitingTaskList,
+                                dummyEventSetupImpls);
+          dummyWaitingTaskList.doneWaiting(std::exception_ptr{});
+        } catch(...) {
+          dummyWaitingTaskList.doneWaiting(std::exception_ptr{});
+          waitingTaskHolder.doneWaiting(std::current_exception());
+        }
+      }
+      waitUntilIOVInitializationCompletes->wait_for_all();
+
+      if (waitUntilIOVInitializationCompletes->exceptionPtr() != nullptr) {
+        std::rethrow_exception(* (waitUntilIOVInitializationCompletes->exceptionPtr()) );
+      }
+    }
+
+    bool EventSetupsController::legacyESSourceOutOfValidityInterval(IOVSyncValue const& syncValue) const {
+      if (hasLegacyESSource()) {
+        for (auto& eventSetupProvider : providers_) {
+          if (eventSetupProvider->legacyESSourceOutOfValidityInterval(syncValue)) {
+            return true;
+          }
+        }
+      }
+      return false;
     }
 
     void
-    EventSetupsController::forceCacheClear() const {
-      std::for_each(providers_.begin(), providers_.end(), [](std::shared_ptr<EventSetupProvider> const& esp) {
-        esp->forceCacheClear();
-      });
+    EventSetupsController::forceCacheClear() {
+      for (auto& eventSetupProvider : providers_) {
+        eventSetupProvider->forceCacheClear();
+      }
     }
 
-    bool
-    EventSetupsController::isWithinValidityInterval(IOVSyncValue const& syncValue) const {
-      for(auto const& provider: providers_) {
-        if( not provider->isWithinValidityInterval(syncValue)) {
-          return false;
-        }
-      }
-      return true;
-    }
-    
     std::shared_ptr<DataProxyProvider>
     EventSetupsController::getESProducerAndRegisterProcess(ParameterSet const& pset, unsigned subProcessIndex) {
       // Try to find a DataProxyProvider with a matching ParameterSet
@@ -356,10 +445,31 @@ namespace edm {
 
         (*esProvider)->resetRecordToProxyPointers();
       }
-      esProvider = providers_.begin();
-      for ( ; esProvider != esProviderEnd; ++esProvider) {
-        (*esProvider)->clearInitializationData();
+      for (auto& eventSetupProvider : providers_) {
+        eventSetupProvider->clearInitializationData();
       }
     }
+
+    void EventSetupsController::initializeEventSetupRecordIOVQueues() {
+
+      std::set<EventSetupRecordKey> keys;
+      for (auto const& provider : providers_) {
+        provider->fillKeys(keys);
+      }
+
+      for (auto const& key : keys) {
+        eventSetupRecordIOVQueues_.push_back(
+          std::make_unique<EventSetupRecordIOVQueue>(numberOfConcurrentIOVs_.numberOfConcurrentIOVs(key))
+        );
+        EventSetupRecordIOVQueue& iovQueue = *eventSetupRecordIOVQueues_.back();
+        for (auto& provider : providers_) {
+          EventSetupRecordProvider* recProvider = provider->tryToGetRecordProvider(key);
+          if (recProvider) {
+            iovQueue.addRecProvider(recProvider);
+          }
+        }
+      }
+    }
+
   }
 }

--- a/FWCore/Framework/src/EventSetupsController.h
+++ b/FWCore/Framework/src/EventSetupsController.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     EventSetupsController
-// 
+//
 /** \class edm::eventsetup::EventSetupsController
 
  Description: Manages a group of EventSetups which can share components
@@ -19,6 +19,9 @@
 //
 
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
+#include "FWCore/Framework/src/EventSetupRecordIOVQueue.h"
+#include "FWCore/Framework/src/NumberOfConcurrentIOVs.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <map>
 #include <memory>
@@ -27,10 +30,13 @@
 namespace edm {
 
    class ActivityRegistry;
+   class EventSetupImpl;
    class EventSetupRecordIntervalFinder;
    class ParameterSet;
    class IOVSyncValue;
-   
+   class WaitingTaskHolder;
+   class WaitingTaskList;
+
    namespace eventsetup {
 
       class DataProxyProvider;
@@ -39,17 +45,18 @@ namespace edm {
       class ESProducerInfo {
       public:
          ESProducerInfo(ParameterSet const* ps,
-                        std::shared_ptr<DataProxyProvider> const& pr) : 
+                        std::shared_ptr<DataProxyProvider> const& pr) :
             pset_(ps), provider_(pr), subProcessIndexes_() { }
 
          ParameterSet const* pset() const { return pset_; }
-         std::shared_ptr<DataProxyProvider> const& provider() const { return provider_; }
+         std::shared_ptr<DataProxyProvider> const& provider() { return get_underlying(provider_); }
+         DataProxyProvider const* providerGet() const { return provider_.get(); }
          std::vector<unsigned>& subProcessIndexes() { return subProcessIndexes_; }
          std::vector<unsigned> const& subProcessIndexes() const { return subProcessIndexes_; }
 
       private:
          ParameterSet const* pset_;
-         std::shared_ptr<DataProxyProvider> provider_;
+         propagate_const<std::shared_ptr<DataProxyProvider>> provider_;
          std::vector<unsigned> subProcessIndexes_;
       };
 
@@ -60,28 +67,38 @@ namespace edm {
             pset_(ps), finder_(fi), subProcessIndexes_() { }
 
          ParameterSet const* pset() const { return pset_; }
-         std::shared_ptr<EventSetupRecordIntervalFinder> const& finder() const { return finder_; }
+         std::shared_ptr<EventSetupRecordIntervalFinder> const& finder() { return get_underlying(finder_); }
+         EventSetupRecordIntervalFinder const* finderGet() const { return finder_.get(); }
          std::vector<unsigned>& subProcessIndexes() { return subProcessIndexes_; }
          std::vector<unsigned> const& subProcessIndexes() const { return subProcessIndexes_; }
 
       private:
          ParameterSet const* pset_;
-         std::shared_ptr<EventSetupRecordIntervalFinder> finder_;
+         propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>> finder_;
          std::vector<unsigned> subProcessIndexes_;
       };
 
       class EventSetupsController {
-         
+
       public:
          EventSetupsController();
 
-         std::shared_ptr<EventSetupProvider> makeProvider(ParameterSet&, ActivityRegistry*);
+         EventSetupsController(EventSetupsController const&) = delete;
+         EventSetupsController const& operator=(EventSetupsController const&) = delete;
 
-         void eventSetupForInstance(IOVSyncValue const& syncValue);
+         std::shared_ptr<EventSetupProvider> makeProvider(ParameterSet&, ActivityRegistry*, ParameterSet const* optionsPset = nullptr);
 
-         bool isWithinValidityInterval(IOVSyncValue const& syncValue) const;
-        
-         void forceCacheClear() const;
+         void eventSetupForInstance(IOVSyncValue const&,
+                                    WaitingTaskHolder const& taskToStartAfterIOVInit,
+                                    WaitingTaskList& endIOVWaitingTasks,
+                                    std::vector<std::shared_ptr<const EventSetupImpl>>&);
+
+         // Version to use when IOVs are not allowed to run concurrently
+         void eventSetupForInstance(IOVSyncValue const&);
+
+         bool legacyESSourceOutOfValidityInterval(IOVSyncValue const&) const;
+
+         void forceCacheClear();
 
          std::shared_ptr<DataProxyProvider> getESProducerAndRegisterProcess(ParameterSet const& pset, unsigned subProcessIndex);
          void putESProducer(ParameterSet const& pset, std::shared_ptr<DataProxyProvider> const& component, unsigned subProcessIndex);
@@ -119,23 +136,27 @@ namespace edm {
          ParameterSet const* getESProducerPSet(ParameterSetID const& psetID,
                                                unsigned subProcessIndex) const;
 
-         std::vector<std::shared_ptr<EventSetupProvider> > const& providers() const { return providers_; }
+         std::vector<propagate_const<std::shared_ptr<EventSetupProvider>>> const& providers() const { return providers_; }
 
          std::multimap<ParameterSetID, ESProducerInfo> const& esproducers() const { return esproducers_; }
 
          std::multimap<ParameterSetID, ESSourceInfo> const& essources() const { return essources_; }
 
+         bool hasLegacyESSource() const { return hasLegacyESSource_; }
          bool mustFinishConfiguration() const { return mustFinishConfiguration_; }
 
       private:
-         EventSetupsController(EventSetupsController const&) = delete; // stop default
-         
-         EventSetupsController const& operator=(EventSetupsController const&) = delete; // stop default
 
          void checkESProducerSharing();
-         
+         void initializeEventSetupRecordIOVQueues();
+
          // ---------- member data --------------------------------
-         std::vector<std::shared_ptr<EventSetupProvider> > providers_;
+         std::vector<propagate_const<std::shared_ptr<EventSetupProvider>>> providers_;
+         NumberOfConcurrentIOVs numberOfConcurrentIOVs_;
+
+         // This data member is intentionally declared after providers_
+         // It is important that this is destroyed first.
+         std::vector<propagate_const<std::unique_ptr<EventSetupRecordIOVQueue>>> eventSetupRecordIOVQueues_;
 
          // The following two multimaps have one entry for each unique
          // ParameterSet. The ESProducerInfo or ESSourceInfo object
@@ -150,7 +171,8 @@ namespace edm {
          std::multimap<ParameterSetID, ESProducerInfo> esproducers_;
          std::multimap<ParameterSetID, ESSourceInfo> essources_;
 
-         bool mustFinishConfiguration_;
+         bool hasLegacyESSource_ = false;
+         bool mustFinishConfiguration_ = true;
       };
    }
 }

--- a/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.cc
+++ b/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.cc
@@ -10,57 +10,33 @@
 //         Created:  Tue Aug 19 13:20:41 EDT 2008
 //
 
-// system include files
-
-// user include files
 #include "FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h"
+
 namespace edm {
    namespace eventsetup {
 
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
 IntersectingIOVRecordIntervalFinder::IntersectingIOVRecordIntervalFinder(const EventSetupRecordKey& iKey)
 {
    findingRecordWithKey(iKey);
 }
 
-// IntersectingIOVRecordIntervalFinder::IntersectingIOVRecordIntervalFinder(const IntersectingIOVRecordIntervalFinder& rhs)
-// {
-//    // do actual copying here;
-// }
-
 IntersectingIOVRecordIntervalFinder::~IntersectingIOVRecordIntervalFinder()
 {
 }
 
-//
-// assignment operators
-//
-// const IntersectingIOVRecordIntervalFinder& IntersectingIOVRecordIntervalFinder::operator=(const IntersectingIOVRecordIntervalFinder& rhs)
-// {
-//   //An exception safe implementation is
-//   IntersectingIOVRecordIntervalFinder temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
-
-//
-// member functions
-//
 void 
 IntersectingIOVRecordIntervalFinder::swapFinders(std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>& iFinders)
 {
    finders_.swap(iFinders);
+}
+
+bool IntersectingIOVRecordIntervalFinder::hasLegacyESSource() const {
+   for (auto const& finder : finders_) {
+      if (finder->legacyESSource()) {
+         return true;
+      }
+   }
+   return false;
 }
 
 void 
@@ -106,12 +82,25 @@ IntersectingIOVRecordIntervalFinder::setIntervalFor(const EventSetupRecordKey& i
    oInterval = newInterval;
 }
 
-//
-// const member functions
-//
+void IntersectingIOVRecordIntervalFinder::doResetInterval(const eventsetup::EventSetupRecordKey& key) {
+   for (auto& finder : finders_) {
+      finder->resetInterval(key);
+   }
+}
 
-//
-// static member functions
-//
+bool IntersectingIOVRecordIntervalFinder::isLegacyESSource() const {
+   return false;
+}
+
+bool IntersectingIOVRecordIntervalFinder::isLegacyOutOfValidityInterval(const EventSetupRecordKey& iKey,
+                                                                        const IOVSyncValue& iTime) const {
+   for (auto const& finder : finders_) {
+      if (finder->legacyOutOfValidityInterval(iKey, iTime)) {
+         return true;
+      }
+   }
+   return false;
+}
+
    }
 }

--- a/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h
+++ b/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h
@@ -34,6 +34,8 @@ namespace edm {
          
       public:
          explicit IntersectingIOVRecordIntervalFinder(const EventSetupRecordKey&);
+         IntersectingIOVRecordIntervalFinder(const IntersectingIOVRecordIntervalFinder&) = delete;
+         const IntersectingIOVRecordIntervalFinder& operator=(const IntersectingIOVRecordIntervalFinder&) = delete;
          ~IntersectingIOVRecordIntervalFinder() override;
          
          // ---------- const member functions ---------------------
@@ -42,16 +44,23 @@ namespace edm {
          
          // ---------- member functions ---------------------------
          void swapFinders(std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>&);
+
+         bool hasLegacyESSource() const;
+
       protected:
          void setIntervalFor(const EventSetupRecordKey&,
                                      const IOVSyncValue& , 
                                      ValidityInterval&) override;
          
       private:
-         IntersectingIOVRecordIntervalFinder(const IntersectingIOVRecordIntervalFinder&) = delete; // stop default
-         
-         const IntersectingIOVRecordIntervalFinder& operator=(const IntersectingIOVRecordIntervalFinder&) = delete; // stop default
-         
+
+         void doResetInterval(const eventsetup::EventSetupRecordKey&) override;
+
+         bool isLegacyESSource() const override;
+
+         bool isLegacyOutOfValidityInterval(const EventSetupRecordKey&,
+                                            const IOVSyncValue&) const override;
+
          // ---------- member data --------------------------------
          std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>> finders_;
       };

--- a/FWCore/Framework/src/NumberOfConcurrentIOVs.cc
+++ b/FWCore/Framework/src/NumberOfConcurrentIOVs.cc
@@ -1,0 +1,45 @@
+
+#include "FWCore/Framework/src/NumberOfConcurrentIOVs.h"
+
+#include "FWCore/Framework/interface/EventSetupProvider.h"
+#include "FWCore/Framework/interface/HCTypeTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <string>
+#include <vector>
+
+namespace edm {
+  namespace eventsetup {
+
+    NumberOfConcurrentIOVs::NumberOfConcurrentIOVs() : numberConcurrentIOVs_(1) {}
+
+    void NumberOfConcurrentIOVs::initialize(ParameterSet const* optionsPset) {
+      if (optionsPset) {  // this condition is false for SubProcesses
+        numberConcurrentIOVs_ = optionsPset->getUntrackedParameter<unsigned int>("numberOfConcurrentIOVs");
+
+        ParameterSet const& pset(optionsPset->getUntrackedParameterSet("forceNumberOfConcurrentIOVs"));
+        std::vector<std::string> recordNames = pset.getParameterNames();
+        for (auto const& recordName : recordNames) {
+          EventSetupRecordKey recordKey(eventsetup::EventSetupRecordKey::TypeTag::findType(recordName));
+          forceNumberOfConcurrentIOVs_[recordKey] = pset.getUntrackedParameter<unsigned int>(recordName);
+        }
+      }
+    }
+
+    void NumberOfConcurrentIOVs::initialize(EventSetupProvider const& eventSetupProvider) {
+      eventSetupProvider.fillRecordsNotAllowingConcurrentIOVs(recordsNotAllowingConcurrentIOVs_);
+    }
+
+    unsigned int NumberOfConcurrentIOVs::numberOfConcurrentIOVs(EventSetupRecordKey const& eventSetupKey) const {
+      auto iForce = forceNumberOfConcurrentIOVs_.find(eventSetupKey);
+      if (iForce != forceNumberOfConcurrentIOVs_.end()) {
+        return iForce->second;
+      }
+      if (recordsNotAllowingConcurrentIOVs_.find(eventSetupKey) != recordsNotAllowingConcurrentIOVs_.end()) {
+        return 1;
+      }
+      return numberConcurrentIOVs_;
+    }
+  }  // namespace eventsetup
+}  // namespace edm

--- a/FWCore/Framework/src/NumberOfConcurrentIOVs.h
+++ b/FWCore/Framework/src/NumberOfConcurrentIOVs.h
@@ -1,0 +1,75 @@
+#ifndef FWCore_Framework_NumberOfConcurrentIOVs_h
+#define FWCore_Framework_NumberOfConcurrentIOVs_h
+// -*- C++ -*-
+//
+// Package:     Framework
+// Class  :     NumberOfConcurrentIOVs
+//
+/** \class edm::eventsetup::NumberOfConcurrentIOVs
+
+ Description: Calculates and holds the number of concurrent
+              intervals of validity allowed for each record
+              in the EventSetup.
+
+ Usage: Used internally by the Framework
+
+*/
+//
+// Original Authors:  W. David Dagenhart
+//          Created:  1 February 2019
+
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
+
+#include <map>
+#include <set>
+
+namespace edm {
+
+  class ParameterSet;
+
+  namespace eventsetup {
+
+    class EventSetupProvider;
+
+    class NumberOfConcurrentIOVs {
+    public:
+      NumberOfConcurrentIOVs();
+
+      void initialize(ParameterSet const* optionsPset);
+
+      void initialize(EventSetupProvider const&);
+
+      unsigned int numberOfConcurrentIOVs(EventSetupRecordKey const&) const;
+
+    private:
+      // This is the single value configured in the top level options
+      // parameter set that determines the number of concurrent IOVs
+      // allowed for each record. This value can be overridden by
+      // either of the values of the next two data members. The default
+      // for this is one.
+      unsigned int numberConcurrentIOVs_;
+
+      // This is derived from a boolean value that can be hard coded
+      // into the C++ definition of a class deriving from EventSetupRecord.
+      // The data member is a static constexpr member of the class and
+      // this data member is named allowConcurrentIOVs_.
+      // If the value is defined as false, then the key to the record
+      // will get stored in the set defined below. This will be used to
+      // to limit the number of concurrent IOVs for a particular record
+      // to be one even if the overall "numberOfConcurrentIOVs" parameter
+      // is configured to be greater than one.
+      std::set<EventSetupRecordKey> recordsNotAllowingConcurrentIOVs_;
+
+      // It is possible to individually configure the number of concurrent
+      // IOVs allowed for each record. This is done by adding parameters
+      // to a nested parameter set in the top level options parameter set.
+      // Setting these parameters is optional. This map can contain an
+      // entry for all records, it can be empty, or contain an entry for
+      // any subset of records. Values in this map override both of the
+      // above data members.
+      std::map<EventSetupRecordKey, unsigned int> forceNumberOfConcurrentIOVs_;
+    };
+
+  }  // namespace eventsetup
+}  // namespace edm
+#endif

--- a/FWCore/Framework/src/RecordDependencyRegister.cc
+++ b/FWCore/Framework/src/RecordDependencyRegister.cc
@@ -29,8 +29,12 @@ namespace {
     static tbb::concurrent_unordered_map<EventSetupRecordKey, DepFunction, KeyHash> s_map;
     return s_map;
   }
-}
 
+  tbb::concurrent_unordered_map<EventSetupRecordKey, bool, KeyHash>& getAllowMap() {
+    static tbb::concurrent_unordered_map<EventSetupRecordKey, bool, KeyHash> s_allow_map;
+    return s_allow_map;
+  }
+}
 
 std::set<EventSetupRecordKey> dependencies(EventSetupRecordKey const& iKey) {
   auto& map = getMap();
@@ -41,11 +45,19 @@ std::set<EventSetupRecordKey> dependencies(EventSetupRecordKey const& iKey) {
   return std::set<EventSetupRecordKey>();
 }
 
-void addDependencyFunction(EventSetupRecordKey iKey, DepFunction iFunction) {
-  getMap().emplace(iKey,iFunction);
+bool allowConcurrentIOVs(EventSetupRecordKey const& iKey) {
+  auto& map = getAllowMap();
+  auto itFind = map.find(iKey);
+  if(itFind != map.end()) {
+    return itFind->second;
+  }
+  return false;
 }
 
-    
+void addDependencyFunction(EventSetupRecordKey iKey, DepFunction iFunction, bool allowConcurrentIOVs) {
+  getMap().emplace(iKey,iFunction);
+  getAllowMap().emplace(iKey, allowConcurrentIOVs);
+}
+
   }
 }
-

--- a/FWCore/Framework/test/DummyProxyProvider.h
+++ b/FWCore/Framework/test/DummyProxyProvider.h
@@ -51,12 +51,15 @@ namespace edm::eventsetup::test {
     DummyProxyProvider(const DummyData& iData=DummyData()): dummy_(iData) {
       usingRecord<DummyRecord>();
     }
-    void newInterval(const eventsetup::EventSetupRecordKey& /*iRecordType*/,
-                     const ValidityInterval& /*iInterval*/) {
-      //do nothing
+
+    void incrementData() {
+      ++dummy_.value_;
     }
+
   protected:
-    void registerProxies(const eventsetup::EventSetupRecordKey&, KeyedProxies& iProxies) {
+    void registerProxies(const eventsetup::EventSetupRecordKey&,
+                         KeyedProxies& iProxies,
+                         unsigned int) {
       std::shared_ptr<WorkingDummyProxy> pProxy = std::make_shared<WorkingDummyProxy>(&dummy_);
       insertProxy(iProxies, pProxy);
     }

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -7,38 +7,66 @@
  *
  */
 
-#include <iostream>
+// Note that repeatedly in this test we add the modules directly to
+// the EventSetupProvider instead of having the controller use the
+// plugin system and ModuleFactory to add the modules. This works OK
+// in tests as long as there are no SubProcesses, otherwise this needs
+// to be done as in a real job where the modules are added as plugins
+// through the parameter set passed to the controller.
 
-#include "cppunit/extensions/HelperMacros.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
+#include "FWCore/Framework/interface/ComponentDescription.h"
+#include "FWCore/Framework/interface/DataProxyProvider.h"
+#include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
-#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
-#include "FWCore/Framework/interface/EventSetupProvider.h"
-#include "FWCore/Framework/interface/EventSetupRecordProvider.h"
-#include "FWCore/Framework/interface/IOVSyncValue.h"
-#include "FWCore/Framework/interface/EDConsumerBase.h"
-#include "FWCore/Framework/interface/IOVSyncValue.h"
 #include "FWCore/Framework/interface/ESRecordsToProxyIndices.h"
-
-#include "FWCore/Framework/test/DummyRecord.h"
-#include "FWCore/Framework/test/DummyProxyProvider.h"
-
-#include "FWCore/Framework/interface/HCMethods.h"
-
+#include "FWCore/Framework/interface/EventSetupImpl.h"
+#include "FWCore/Framework/interface/EventSetupProvider.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
-#include "FWCore/Framework/interface/DataProxyProvider.h"
+#include "FWCore/Framework/interface/IOVSyncValue.h"
 #include "FWCore/Framework/interface/RecordDependencyRegister.h"
+#include "FWCore/Framework/interface/NoRecordException.h"
+#include "FWCore/Framework/interface/ValidityInterval.h"
+
+#include "FWCore/Framework/src/EventSetupsController.h"
+
+#include "FWCore/Framework/test/DummyData.h"
 #include "FWCore/Framework/test/DummyEventSetupRecordRetriever.h"
+#include "FWCore/Framework/test/DummyProxyProvider.h"
+#include "FWCore/Framework/test/DummyRecord.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "cppunit/extensions/HelperMacros.h"
+#include "tbb/task_scheduler_init.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
 using namespace edm;
+using namespace edm::eventsetup;
+using edm::eventsetup::test::DummyProxyProvider;
+using edm::eventsetup::test::DummyData;
+
 namespace {
+
   bool non_null(const void* iPtr) {
     return iPtr != nullptr;
+  }
+
+  edm::ParameterSet createDummyPset() {
+    edm::ParameterSet pset;
+    std::vector<std::string> emptyVStrings;
+    pset.addParameter<std::vector<std::string> >("@all_esprefers", emptyVStrings);
+    pset.addParameter<std::vector<std::string> >("@all_essources", emptyVStrings);
+    pset.addParameter<std::vector<std::string> >("@all_esmodules", emptyVStrings);
+    return pset;
   }
 }
 
@@ -50,16 +78,18 @@ class testEventsetup: public CppUnit::TestFixture
   CPPUNIT_TEST(getTest);
   CPPUNIT_TEST(tryToGetTest);
   CPPUNIT_TEST_EXCEPTION(getExcTest,edm::eventsetup::NoRecordException<DummyRecord>);
-  CPPUNIT_TEST(recordProviderTest);
   CPPUNIT_TEST(provenanceTest);
   CPPUNIT_TEST(getDataWithLabelTest);
   CPPUNIT_TEST(getDataWithESInputTagTest);
   CPPUNIT_TEST(getDataWithESGetTokenTest);
   CPPUNIT_TEST(getHandleWithESGetTokenTest);
   CPPUNIT_TEST(getTransientHandleWithESGetTokenTest);
-  CPPUNIT_TEST_EXCEPTION(recordValidityTest,edm::eventsetup::NoRecordException<DummyRecord>);
+  CPPUNIT_TEST(recordValidityTest);
   CPPUNIT_TEST_EXCEPTION(recordValidityExcTest,edm::eventsetup::NoRecordException<DummyRecord>);
-  CPPUNIT_TEST(proxyProviderTest);
+  CPPUNIT_TEST(recordValidityNoFinderTest);
+  CPPUNIT_TEST_EXCEPTION(recordValidityNoFinderExcTest,edm::eventsetup::NoRecordException<DummyRecord>);
+  CPPUNIT_TEST(recordValidityProxyNoFinderTest);
+  CPPUNIT_TEST_EXCEPTION(recordValidityProxyNoFinderExcTest,edm::eventsetup::NoRecordException<DummyRecord>);
 
   CPPUNIT_TEST_EXCEPTION(producerConflictTest,cms::Exception);
   CPPUNIT_TEST_EXCEPTION(sourceConflictTest,cms::Exception);
@@ -69,21 +99,28 @@ class testEventsetup: public CppUnit::TestFixture
 
   CPPUNIT_TEST(introspectionTest);
 
-  CPPUNIT_TEST(iovExtentionTest);
+  CPPUNIT_TEST(iovExtensionTest);
+  CPPUNIT_TEST(resetProxiesTest);
 
   CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp(){}
-  void tearDown(){}
+
+  void setUp() {
+    m_scheduler = std::make_unique<tbb::task_scheduler_init>(1);
+  }
+  void tearDown() {}
 
   void constructTest();
   void getTest();
   void tryToGetTest();
   void getExcTest();
-  void recordProviderTest();
   void recordValidityTest();
   void recordValidityExcTest();
-  void proxyProviderTest();
+  void recordValidityNoFinderTest();
+  void recordValidityNoFinderExcTest();
+  void recordValidityProxyNoFinderTest();
+  void recordValidityProxyNoFinderExcTest();
   void provenanceTest();
   void getDataWithLabelTest();
   void getDataWithESInputTagTest();
@@ -99,8 +136,15 @@ public:
 
   void introspectionTest();
 
-  void iovExtentionTest();
+  void iovExtensionTest();
+  void resetProxiesTest();
 
+private:
+
+  edm::propagate_const<std::unique_ptr<tbb::task_scheduler_init>> m_scheduler;
+
+  DummyData kGood{1};
+  DummyData kBad{0};
 };
 
 ///registration of the test so that the runner can find it
@@ -115,43 +159,53 @@ void testEventsetup::constructTest()
   eventsetup::EventSetupProvider provider(&activityRegistry);
   const Timestamp time(1);
   const IOVSyncValue timestamp(time);
-  EventSetup const eventSetup{  provider.eventSetupForInstance(timestamp), 0, nullptr};
-  CPPUNIT_ASSERT(non_null(&eventSetup));
+  bool newEventSetupImpl = false;
+  auto eventSetupImpl = provider.eventSetupForInstance(timestamp,
+                                                       newEventSetupImpl);
+  CPPUNIT_ASSERT(non_null(eventSetupImpl.get()));
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
 }
+
+// Note there is a similar test in dependentrecord_t.cppunit.cc
+// named getTest() that tests get and tryToGet using an EventSetupProvider.
+// No need to repeat that test here. The next two just test EventSetupImpl
+// at the lowest level.
 
 void testEventsetup::getTest()
 {
-  eventsetup::EventSetupProvider provider(&activityRegistry);
-  EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
-  CPPUNIT_ASSERT(non_null(&eventSetup));
-
-  eventsetup::EventSetupRecordImpl dummyRecord{ eventsetup::EventSetupRecordKey::makeKey<DummyRecord>() };
-  provider.addRecord(eventsetup::EventSetupRecordKey::makeKey<DummyRecord>());
-  provider.addRecordToEventSetup(dummyRecord);
+  EventSetupImpl eventSetupImpl;
+  std::vector<eventsetup::EventSetupRecordKey> keys;
+  EventSetupRecordKey key = EventSetupRecordKey::makeKey<DummyRecord>();
+  keys.push_back(key);
+  eventSetupImpl.setKeyIters(keys.begin(), keys.end());
+  EventSetupRecordImpl dummyRecordImpl{key, &activityRegistry};
+  eventSetupImpl.addRecordImpl(dummyRecordImpl);
+  const edm::EventSetup eventSetup(eventSetupImpl, 0, nullptr);
   const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
-  CPPUNIT_ASSERT(non_null(&gottenRecord));
-  CPPUNIT_ASSERT(&dummyRecord == gottenRecord.impl_);
+  CPPUNIT_ASSERT(&dummyRecordImpl == gottenRecord.impl_);
 }
 
 void testEventsetup::tryToGetTest()
 {
-  eventsetup::EventSetupProvider provider(&activityRegistry);
-  EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
-  CPPUNIT_ASSERT(non_null(&eventSetup));
-
-  eventsetup::EventSetupRecordImpl dummyRecord{ eventsetup::EventSetupRecordKey::makeKey<DummyRecord>() };
-  provider.addRecord(eventsetup::EventSetupRecordKey::makeKey<DummyRecord>());
-  provider.addRecordToEventSetup(dummyRecord);
-  auto gottenRecord = eventSetup.tryToGet<DummyRecord>();
-  CPPUNIT_ASSERT(gottenRecord);
-  CPPUNIT_ASSERT(&dummyRecord == gottenRecord->impl_);
+  EventSetupImpl eventSetupImpl;
+  std::vector<eventsetup::EventSetupRecordKey> keys;
+  EventSetupRecordKey key = EventSetupRecordKey::makeKey<DummyRecord>();
+  keys.push_back(key);
+  eventSetupImpl.setKeyIters(keys.begin(), keys.end());
+  EventSetupRecordImpl dummyRecordImpl{key, &activityRegistry};
+  eventSetupImpl.addRecordImpl(dummyRecordImpl);
+  const edm::EventSetup eventSetup(eventSetupImpl, 0, nullptr);
+  std::optional<DummyRecord> gottenRecord = eventSetup.tryToGet<DummyRecord>();
+  CPPUNIT_ASSERT(&dummyRecordImpl == gottenRecord.value().impl_);
 }
 
 void testEventsetup::getExcTest()
 {
-  eventsetup::EventSetupProvider provider(&activityRegistry);
-  EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
-  CPPUNIT_ASSERT(non_null(&eventSetup));
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+  controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
   eventSetup.get<DummyRecord>();
 }
 
@@ -166,23 +220,6 @@ public:
     edm::eventsetup::EventSetupProvider::insert(std::move(iRecord));
   }
 };
-
-void testEventsetup::recordProviderTest()
-{
-  DummyEventSetupProvider provider(&activityRegistry);
-  typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
-  provider.insert(std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass()));
-
-  //NOTE: use 'invalid' timestamp since the default 'interval of validity'
-  //       for a Record is presently an 'invalid' timestamp on both ends.
-  //       Since the EventSetup::get<> will only retrieve a Record if its
-  //       interval of validity is 'valid' for the present 'instance'
-  //       this is a 'hack' to have the 'get' succeed
-  EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
-  const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
-  CPPUNIT_ASSERT(non_null(&gottenRecord));
-}
-
 
 class DummyFinder : public EventSetupRecordIntervalFinder {
 public:
@@ -210,126 +247,164 @@ private:
 
 void testEventsetup::recordValidityTest()
 {
-  DummyEventSetupProvider provider(&activityRegistry);
-  typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
-  auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
-  auto finder = std::make_shared<DummyFinder>();
-  dummyRecordProvider->addFinder(finder);
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
-  provider.insert(std::move(dummyRecordProvider));
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
 
-  {
-    Timestamp time_1(1);
-    provider.eventSetupForInstance(IOVSyncValue(time_1));
-  }
+  // Note this manner of adding finders works OK in tests as long as there
+  // are no SubProcesses, otherwise this needs to be done as in a real
+  // job where they are added as plugins through the pset passed to the controller.
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
+  Timestamp time_1(1);
+  controller.eventSetupForInstance(IOVSyncValue(time_1));
+  const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr);
+  CPPUNIT_ASSERT(!eventSetup1.tryToGet<DummyRecord>().has_value());
 
   const Timestamp time_2(2);
-  finder->setInterval(ValidityInterval(IOVSyncValue(time_2), IOVSyncValue(Timestamp(3))));
-  {
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue(time_2)),0, nullptr};
-    eventSetup.get<DummyRecord>();
-  }
-  {
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue(Timestamp(3))),0, nullptr};
-    eventSetup.get<DummyRecord>();
-  }
-  {
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue(Timestamp(4))),0, nullptr};
-    eventSetup.get<DummyRecord>();
-  }
+  dummyFinder->setInterval(ValidityInterval(IOVSyncValue(time_2), IOVSyncValue(Timestamp(3))));
+  controller.eventSetupForInstance(IOVSyncValue(time_2));
+  const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr);
+  eventSetup2.get<DummyRecord>();
+  CPPUNIT_ASSERT(eventSetup2.tryToGet<DummyRecord>().has_value());
 
+  controller.eventSetupForInstance(IOVSyncValue(Timestamp(3)));
+  const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr);
+  eventSetup3.get<DummyRecord>();
+  CPPUNIT_ASSERT(eventSetup3.tryToGet<DummyRecord>().has_value());
 
+  controller.eventSetupForInstance(IOVSyncValue(Timestamp(4)));
+  const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr);
+  CPPUNIT_ASSERT(!eventSetup4.tryToGet<DummyRecord>().has_value());
 }
 
 void testEventsetup::recordValidityExcTest()
 {
-  DummyEventSetupProvider provider(&activityRegistry);
-  typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
-  auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
-  dummyRecordProvider->addFinder(std::make_shared<DummyFinder>());
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
-  provider.insert(std::move(dummyRecordProvider));
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
 
-  {
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue(Timestamp(1))),0, nullptr};
-    eventSetup.get<DummyRecord>();
-  }
+  // Note this manner of adding finders works OK in tests as long as there
+  // are no SubProcesses, otherwise this needs to be done as in a real
+  // job where they are added as plugins through the pset passed to the controller.
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
 
+  Timestamp time_1(1);
+  controller.eventSetupForInstance(IOVSyncValue(time_1));
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+  eventSetup.get<DummyRecord>();
 }
 
-class DummyProxyProvider : public eventsetup::DataProxyProvider {
-public:
-  DummyProxyProvider() {
-    usingRecord<DummyRecord>();
-  }
-  void newInterval(const eventsetup::EventSetupRecordKey& /*iRecordType*/,
-                   const ValidityInterval& /*iInterval*/) {
-    //do nothing
-  }
-protected:
-  void registerProxies(const eventsetup::EventSetupRecordKey&, KeyedProxies& /*iHolder*/) {
-  }
+void testEventsetup::recordValidityNoFinderTest()
+{
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
-};
+  Timestamp time_1(1);
+  controller.eventSetupForInstance(IOVSyncValue(time_1));
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+  CPPUNIT_ASSERT(!eventSetup.tryToGet<DummyRecord>().has_value());
+}
+
+void testEventsetup::recordValidityNoFinderExcTest()
+{
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+
+  Timestamp time_1(1);
+  controller.eventSetupForInstance(IOVSyncValue(time_1));
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+  eventSetup.get<DummyRecord>();
+}
 
 //create an instance of the register
 static eventsetup::RecordDependencyRegister<DummyRecord> s_factory;
 
-void testEventsetup::proxyProviderTest()
+void testEventsetup::recordValidityProxyNoFinderTest()
 {
-  eventsetup::EventSetupProvider provider(&activityRegistry);
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+
   provider.add(std::make_shared<DummyProxyProvider>());
 
-  EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
-  const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
-  CPPUNIT_ASSERT(non_null(&gottenRecord));
+  Timestamp time_1(1);
+  controller.eventSetupForInstance(IOVSyncValue(time_1));
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+  CPPUNIT_ASSERT(!eventSetup.tryToGet<DummyRecord>().has_value());
+}
+
+void testEventsetup::recordValidityProxyNoFinderExcTest()
+{
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+
+  provider.add(std::make_shared<DummyProxyProvider>());
+
+  Timestamp time_1(1);
+  controller.eventSetupForInstance(IOVSyncValue(time_1));
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+  eventSetup.get<DummyRecord>();
 }
 
 void testEventsetup::producerConflictTest()
 {
-  edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-  using edm::eventsetup::test::DummyProxyProvider;
-  eventsetup::EventSetupProvider provider(&activityRegistry);
-  {
-    auto dummyProv = std::make_shared<DummyProxyProvider>();
-    dummyProv->setDescription(description);
-    provider.add(dummyProv);
-  }
-  {
-    auto dummyProv = std::make_shared<DummyProxyProvider>();
-    dummyProv->setDescription(description);
-    provider.add(dummyProv);
-  }
-  //checking for conflicts is now delayed until first time EventSetup is requested
-  /*EventSetup const eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
+  edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
+
+  {
+    auto dummyProv = std::make_shared<DummyProxyProvider>();
+    dummyProv->setDescription(description);
+    provider.add(dummyProv);
+  }
+  {
+    auto dummyProv = std::make_shared<DummyProxyProvider>();
+    dummyProv->setDescription(description);
+    provider.add(dummyProv);
+  }
+  //checking for conflicts is delayed until first eventSetupForInstance
+  controller.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
 }
+
 void testEventsetup::sourceConflictTest()
 {
-  edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-  using edm::eventsetup::test::DummyProxyProvider;
-  eventsetup::EventSetupProvider provider(&activityRegistry);
-  {
-    auto dummyProv = std::make_shared<DummyProxyProvider>();
-    dummyProv->setDescription(description);
-    provider.add(dummyProv);
-  }
-  {
-    auto dummyProv = std::make_shared<DummyProxyProvider>();
-    dummyProv->setDescription(description);
-    provider.add(dummyProv);
-  }
-  //checking for conflicts is now delayed until first time EventSetup is requested
-  /*EventSetup const eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
+  edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+
+  {
+    auto dummyProv = std::make_shared<DummyProxyProvider>();
+    dummyProv->setDescription(description);
+    provider.add(dummyProv);
+  }
+  {
+    auto dummyProv = std::make_shared<DummyProxyProvider>();
+    dummyProv->setDescription(description);
+    provider.add(dummyProv);
+  }
+  //checking for conflicts is delayed until first eventSetupForInstance
+  controller.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
 }
-//#define TEST_EXCLUDE_DEF
 
 void testEventsetup::twoSourceTest()
 {
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+
   edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-  using edm::eventsetup::test::DummyProxyProvider;
-  eventsetup::EventSetupProvider provider(&activityRegistry);
   {
     auto dummyProv = std::make_shared<DummyProxyProvider>();
     dummyProv->setDescription(description);
@@ -344,18 +419,28 @@ void testEventsetup::twoSourceTest()
     provider.add(providerPtr);
     provider.add(finderPtr);
   }
-  //checking for conflicts is now delayed until first time EventSetup is requested
-  /*EventSetup const eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-
+  //checking for conflicts is delayed until first eventSetupForInstance
+  controller.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr);
+  CPPUNIT_ASSERT(!eventSetup3.tryToGet<DummyRecord>().has_value());
+  CPPUNIT_ASSERT(!eventSetup3.tryToGet<DummyEventSetupRecord>().has_value());
+  controller.eventSetupForInstance(IOVSyncValue(Timestamp(3)));
+  const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr);
+  CPPUNIT_ASSERT(!eventSetup4.tryToGet<DummyRecord>().has_value());
+  CPPUNIT_ASSERT(eventSetup4.tryToGet<DummyEventSetupRecord>().has_value());
+  eventSetup4.get<DummyEventSetupRecord>();
 }
+
 void testEventsetup::provenanceTest()
 {
-  using edm::eventsetup::test::DummyProxyProvider;
-  using edm::eventsetup::test::DummyData;
-  DummyData kGood{1};
-  DummyData kBad{0};
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
-  eventsetup::EventSetupProvider provider(&activityRegistry);
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+  dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
   try {
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
@@ -377,7 +462,8 @@ void testEventsetup::provenanceTest()
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
+    controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
     CPPUNIT_ASSERT(kGood.value_==data->value_);
@@ -391,12 +477,14 @@ void testEventsetup::provenanceTest()
 
 void testEventsetup::getDataWithLabelTest()
 {
-  using edm::eventsetup::test::DummyProxyProvider;
-  using edm::eventsetup::test::DummyData;
-  DummyData kGood{1};
-  DummyData kBad{0};
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
-  eventsetup::EventSetupProvider provider(&activityRegistry);
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+  dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
   try {
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
@@ -420,7 +508,8 @@ void testEventsetup::getDataWithLabelTest()
       dummyProv->setAppendToDataLabel(ps);
       provider.add(dummyProv);
     }
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
+    controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
     edm::ESHandle<DummyData> data;
     eventSetup.getData("blah",data);
     CPPUNIT_ASSERT(kGood.value_==data->value_);
@@ -434,12 +523,14 @@ void testEventsetup::getDataWithLabelTest()
 
 void testEventsetup::getDataWithESInputTagTest()
 {
-  using edm::eventsetup::test::DummyProxyProvider;
-  using edm::eventsetup::test::DummyData;
-  DummyData kGood{1};
-  DummyData kBad{0};
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
-  eventsetup::EventSetupProvider provider(&activityRegistry);
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+  dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
   try {
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","testOne",true);
@@ -463,7 +554,8 @@ void testEventsetup::getDataWithESInputTagTest()
       dummyProv->setAppendToDataLabel(ps);
       provider.add(dummyProv);
     }
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
+    controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
     {
       edm::ESHandle<DummyData> data;
       edm::ESInputTag blahTag("","blah");
@@ -509,19 +601,21 @@ namespace {
     explicit DummyDataConsumer( ESInputTag const& iTag):
     m_token{esConsumes<edm::eventsetup::test::DummyData, edm::DefaultRecord>(iTag)}
     {}
-    
+
     ESGetToken<edm::eventsetup::test::DummyData, edm::DefaultRecord> m_token;
   };
 }
 
 void testEventsetup::getDataWithESGetTokenTest()
 {
-  using edm::eventsetup::test::DummyProxyProvider;
-  using edm::eventsetup::test::DummyData;
-  DummyData kGood{1};
-  DummyData kBad{0};
-  
-  eventsetup::EventSetupProvider provider(&activityRegistry);
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+  dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
   try {
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","testOne",true);
@@ -545,41 +639,39 @@ void testEventsetup::getDataWithESGetTokenTest()
       dummyProv->setAppendToDataLabel(ps);
       provider.add(dummyProv);
     }
-    provider.finishConfiguration();
-    
-    auto const& eventSetupImpl = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
     {
       DummyDataConsumer consumer{edm::ESInputTag("","blah")};
       consumer.updateLookup(provider.recordsToProxyIndices());
-      EventSetup eventSetup{eventSetupImpl,static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
+      EventSetup eventSetup{provider.eventSetupImpl(),static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
       auto const& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_==data.value_);
     }
-    
+
     {
       DummyDataConsumer consumer{edm::ESInputTag("","")};
       consumer.updateLookup(provider.recordsToProxyIndices());
-      EventSetup eventSetup{eventSetupImpl,static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
+      EventSetup eventSetup{provider.eventSetupImpl(),static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
       const DummyData& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_==data.value_);
     }
-    
+
     {
       DummyDataConsumer consumer{edm::ESInputTag("testTwo","blah")};
       consumer.updateLookup(provider.recordsToProxyIndices());
-      EventSetup eventSetup{eventSetupImpl,static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
+      EventSetup eventSetup{provider.eventSetupImpl(),static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
       auto const& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_==data.value_);
     }
-    
+
     {
       DummyDataConsumer consumer{edm::ESInputTag("DoesNotExist","blah")};
       consumer.updateLookup(provider.recordsToProxyIndices());
-      EventSetup eventSetup{eventSetupImpl,static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
+      EventSetup eventSetup{provider.eventSetupImpl(),static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
       CPPUNIT_ASSERT_THROW(eventSetup.getData(consumer.m_token), cms::Exception);
     }
-    
-    
+
+
   } catch (const cms::Exception& iException) {
     std::cout <<"caught "<<iException.explainSelf()<<std::endl;
     throw;
@@ -588,12 +680,14 @@ void testEventsetup::getDataWithESGetTokenTest()
 
 void testEventsetup::getHandleWithESGetTokenTest()
 {
-  using edm::eventsetup::test::DummyProxyProvider;
-  using edm::eventsetup::test::DummyData;
-  DummyData kGood{1};
-  DummyData kBad{0};
-  
-  eventsetup::EventSetupProvider provider(&activityRegistry);
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+  dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
   try {
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","testOne",true);
@@ -617,49 +711,47 @@ void testEventsetup::getHandleWithESGetTokenTest()
       dummyProv->setAppendToDataLabel(ps);
       provider.add(dummyProv);
     }
-    provider.finishConfiguration();
-    
-    auto const& eventSetupImpl = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
     {
       DummyDataConsumer consumer{edm::ESInputTag("","blah")};
       consumer.updateLookup(provider.recordsToProxyIndices());
 
-      EventSetup eventSetup{eventSetupImpl,static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
+      EventSetup eventSetup{provider.eventSetupImpl(),static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_==data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
       CPPUNIT_ASSERT( desc->label_ == "testTwo");
     }
-    
+
     {
       DummyDataConsumer consumer{edm::ESInputTag("","")};
       consumer.updateLookup(provider.recordsToProxyIndices());
-      EventSetup eventSetup{eventSetupImpl,static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
+      EventSetup eventSetup{provider.eventSetupImpl(),static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_==data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
       CPPUNIT_ASSERT( desc->label_ == "testOne");
     }
-    
+
     {
       DummyDataConsumer consumer{edm::ESInputTag("testTwo","blah")};
       consumer.updateLookup(provider.recordsToProxyIndices());
-      EventSetup eventSetup{eventSetupImpl,static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
+      EventSetup eventSetup{provider.eventSetupImpl(),static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_==data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
       CPPUNIT_ASSERT( desc->label_ == "testTwo");
     }
-    
+
     {
       DummyDataConsumer consumer{edm::ESInputTag("DoesNotExist","blah")};
       consumer.updateLookup(provider.recordsToProxyIndices());
-      EventSetup eventSetup{eventSetupImpl,static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
+      EventSetup eventSetup{provider.eventSetupImpl(),static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
       CPPUNIT_ASSERT(not eventSetup.getHandle(consumer.m_token));
       CPPUNIT_ASSERT_THROW(*eventSetup.getHandle(consumer.m_token), cms::Exception);
     }
-    
-    
+
+
   } catch (const cms::Exception& iException) {
     std::cout <<"caught "<<iException.explainSelf()<<std::endl;
     throw;
@@ -673,7 +765,10 @@ void testEventsetup::getTransientHandleWithESGetTokenTest()
   DummyData kGood{1};
   DummyData kBad{0};
 
-  eventsetup::EventSetupProvider provider(&activityRegistry);
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+
   try {
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","testOne",true);
@@ -697,14 +792,16 @@ void testEventsetup::getTransientHandleWithESGetTokenTest()
       dummyProv->setAppendToDataLabel(ps);
       provider.add(dummyProv);
     }
-    provider.finishConfiguration();
+    std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+    dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 1)),
+                                                   edm::IOVSyncValue(edm::EventID(1, 1, 3))));
+    provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
 
-    auto const& eventSetupImpl = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
     {
       DummyDataConsumer consumer{edm::ESInputTag("","blah")};
       consumer.updateLookup(provider.recordsToProxyIndices());
-
-      EventSetup eventSetup{eventSetupImpl,static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
+      const edm::EventSetup eventSetup{provider.eventSetupImpl(), static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_==data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
@@ -714,7 +811,7 @@ void testEventsetup::getTransientHandleWithESGetTokenTest()
     {
       DummyDataConsumer consumer{edm::ESInputTag("","")};
       consumer.updateLookup(provider.recordsToProxyIndices());
-      EventSetup eventSetup{eventSetupImpl,static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
+      const edm::EventSetup eventSetup{provider.eventSetupImpl(), static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_==data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
@@ -724,7 +821,7 @@ void testEventsetup::getTransientHandleWithESGetTokenTest()
     {
       DummyDataConsumer consumer{edm::ESInputTag("testTwo","blah")};
       consumer.updateLookup(provider.recordsToProxyIndices());
-      EventSetup eventSetup{eventSetupImpl,static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
+      const edm::EventSetup eventSetup{provider.eventSetupImpl(), static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_==data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
@@ -734,12 +831,11 @@ void testEventsetup::getTransientHandleWithESGetTokenTest()
     {
       DummyDataConsumer consumer{edm::ESInputTag("DoesNotExist","blah")};
       consumer.updateLookup(provider.recordsToProxyIndices());
-      EventSetup eventSetup{eventSetupImpl,static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
+      const edm::EventSetup eventSetup{provider.eventSetupImpl(), static_cast<unsigned int>(edm::Transition::Event), consumer.esGetTokenIndices(edm::Transition::Event)};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(not data);
       CPPUNIT_ASSERT_THROW(*data, cms::Exception);
     }
-
 
   } catch (const cms::Exception& iException) {
     std::cout <<"caught "<<iException.explainSelf()<<std::endl;
@@ -749,13 +845,15 @@ void testEventsetup::getTransientHandleWithESGetTokenTest()
 
 void testEventsetup::sourceProducerResolutionTest()
 {
-  using edm::eventsetup::test::DummyProxyProvider;
-  using edm::eventsetup::test::DummyData;
-  DummyData kGood{1};
-  DummyData kBad{0};
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+  dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
 
   {
-    eventsetup::EventSetupProvider provider(&activityRegistry);
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
       auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
@@ -768,12 +866,8 @@ void testEventsetup::sourceProducerResolutionTest()
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
-    //NOTE: use 'invalid' timestamp since the default 'interval of validity'
-    //       for a Record is presently an 'invalid' timestamp on both ends.
-    //       Since the EventSetup::get<> will only retrieve a Record if its
-    //       interval of validity is 'valid' for the present 'instance'
-    //       this is a 'hack' to have the 'get' succeed
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
+    controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
+    const EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
     CPPUNIT_ASSERT(kGood.value_==data->value_);
@@ -781,7 +875,13 @@ void testEventsetup::sourceProducerResolutionTest()
 
   //reverse order
   {
-    eventsetup::EventSetupProvider provider(&activityRegistry);
+    EventSetupsController controller;
+    edm::ParameterSet pset = createDummyPset();
+    EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+
+    std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+    dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
+    provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
       auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
@@ -794,36 +894,34 @@ void testEventsetup::sourceProducerResolutionTest()
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
-    //NOTE: use 'invalid' timestamp since the default 'interval of validity'
-    //       for a Record is presently an 'invalid' timestamp on both ends.
-    //       Since the EventSetup::get<> will only retrieve a Record if its
-    //       interval of validity is 'valid' for the present 'instance'
-    //       this is a 'hack' to have the 'get' succeed
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
+    controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
     CPPUNIT_ASSERT(kGood.value_==data->value_);
   }
-
 }
 
 
 void testEventsetup::preferTest()
 {
+  edm::ParameterSet pset = createDummyPset();
+
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+  dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
+
   try {
-    using edm::eventsetup::test::DummyProxyProvider;
-    using edm::eventsetup::test::DummyData;
-    DummyData kGood{1};
-    DummyData kBad{0};
 
     {
-      using namespace edm::eventsetup;
+      EventSetupsController controller;
+      EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+      provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
       EventSetupProvider::PreferredProviderInfo preferInfo;
       EventSetupProvider::RecordToDataMap recordToData;
       //default means use all proxies
       preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
-
-      eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
+      provider.setPreferredProviderInfo(preferInfo);
       {
         edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",false);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
@@ -836,12 +934,8 @@ void testEventsetup::preferTest()
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
-      //NOTE: use 'invalid' timestamp since the default 'interval of validity'
-      //       for a Record is presently an 'invalid' timestamp on both ends.
-      //       Since the EventSetup::get<> will only retrieve a Record if its
-      //       interval of validity is 'valid' for the present 'instance'
-      //       this is a 'hack' to have the 'get' succeed
-      EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
+      controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
       CPPUNIT_ASSERT(kGood.value_==data->value_);
@@ -849,12 +943,15 @@ void testEventsetup::preferTest()
 
     //sources
     {
-      using namespace edm::eventsetup;
+      EventSetupsController controller;
+      EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+      provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
       EventSetupProvider::PreferredProviderInfo preferInfo;
       EventSetupProvider::RecordToDataMap recordToData;
       //default means use all proxies
       preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
-      eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
+      provider.setPreferredProviderInfo(preferInfo);
       {
         edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
@@ -867,12 +964,8 @@ void testEventsetup::preferTest()
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
-      //NOTE: use 'invalid' timestamp since the default 'interval of validity'
-      //       for a Record is presently an 'invalid' timestamp on both ends.
-      //       Since the EventSetup::get<> will only retrieve a Record if its
-      //       interval of validity is 'valid' for the present 'instance'
-      //       this is a 'hack' to have the 'get' succeed
-      EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
+      controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
       CPPUNIT_ASSERT(kGood.value_==data->value_);
@@ -880,13 +973,16 @@ void testEventsetup::preferTest()
 
     //specific name
     {
-      using namespace edm::eventsetup;
+      EventSetupsController controller;
+      EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+      provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
       EventSetupProvider::PreferredProviderInfo preferInfo;
       EventSetupProvider::RecordToDataMap recordToData;
       recordToData.insert(std::make_pair(std::string("DummyRecord"),
                                          std::make_pair(std::string("DummyData"),std::string())));
       preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
-      eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
+      provider.setPreferredProviderInfo(preferInfo);
       {
         edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
@@ -899,12 +995,8 @@ void testEventsetup::preferTest()
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
-      //NOTE: use 'invalid' timestamp since the default 'interval of validity'
-      //       for a Record is presently an 'invalid' timestamp on both ends.
-      //       Since the EventSetup::get<> will only retrieve a Record if its
-      //       interval of validity is 'valid' for the present 'instance'
-      //       this is a 'hack' to have the 'get' succeed
-      EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
+      controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
       CPPUNIT_ASSERT(kGood.value_==data->value_);
@@ -918,12 +1010,14 @@ void testEventsetup::preferTest()
 
 void testEventsetup::introspectionTest()
 {
-  using edm::eventsetup::test::DummyProxyProvider;
-  using edm::eventsetup::test::DummyData;
-  DummyData kGood{1};
-  DummyData kBad{0};
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
-  eventsetup::EventSetupProvider provider(&activityRegistry);
+  std::shared_ptr<DummyFinder> dummyFinder = std::make_shared<DummyFinder>();
+  dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
+
   try {
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
@@ -945,53 +1039,120 @@ void testEventsetup::introspectionTest()
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue()),0, nullptr};
+    EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
+    controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
+    {
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
 
-    std::vector<edm::eventsetup::EventSetupRecordKey> recordKeys;
-    eventSetup.fillAvailableRecordKeys(recordKeys);
-    CPPUNIT_ASSERT(1==recordKeys.size());
-    auto record = eventSetup.find(recordKeys[0]);
-    CPPUNIT_ASSERT(record.has_value());
+      CPPUNIT_ASSERT(eventSetup.recordIsProvidedByAModule(dummyRecordKey));
+      std::vector<edm::eventsetup::EventSetupRecordKey> recordKeys;
+      eventSetup.fillAvailableRecordKeys(recordKeys);
+      CPPUNIT_ASSERT(1 == recordKeys.size());
+      CPPUNIT_ASSERT(dummyRecordKey == recordKeys[0]);
+      auto record = eventSetup.find(recordKeys[0]);
+      CPPUNIT_ASSERT(record.has_value());
+    }
+    // Intentionally an out of range sync value so the IOV is invalid
+    // to test the find function with a record that exists in the
+    // EventSetupImpl but has a null pointer.
+    controller.eventSetupForInstance(IOVSyncValue(Timestamp(4)));
+    {
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+
+      CPPUNIT_ASSERT(eventSetup.recordIsProvidedByAModule(dummyRecordKey));
+      std::vector<edm::eventsetup::EventSetupRecordKey> recordKeys;
+      eventSetup.fillAvailableRecordKeys(recordKeys);
+      CPPUNIT_ASSERT(0 == recordKeys.size());
+      auto record = eventSetup.find(dummyRecordKey);
+      CPPUNIT_ASSERT(!record.has_value());
+
+      // Just to try all cases test find with a record type not in the EventSetupImpl
+      // at all.
+      EventSetupRecordKey dummyRecordKey1 = EventSetupRecordKey::makeKey<DummyEventSetupRecord>();
+      auto record1 = eventSetup.find(dummyRecordKey1);
+      CPPUNIT_ASSERT(!record1.has_value());
+    }
   } catch (const cms::Exception& iException) {
     std::cout <<"caught "<<iException.explainSelf()<<std::endl;
     throw;
   }
 }
 
-void testEventsetup::iovExtentionTest()
+void testEventsetup::iovExtensionTest()
 {
-  DummyEventSetupProvider provider(&activityRegistry);
-  typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
-  auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
-  auto finder = std::make_shared<DummyFinder>();
-  dummyRecordProvider->addFinder(finder);
+  std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
+  finder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(finder));
 
-  provider.insert(std::move(dummyRecordProvider));
-
-  const Timestamp time_2(2);
-  finder->setInterval(ValidityInterval(IOVSyncValue{time_2}, IOVSyncValue{Timestamp{3}}));
   {
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue{time_2}),0, nullptr};
-    CPPUNIT_ASSERT(2==eventSetup.get<DummyRecord>().cacheIdentifier());
+    controller.eventSetupForInstance(IOVSyncValue{Timestamp(2)});
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+    CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
   {
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue{Timestamp{3}}),0, nullptr};
+    controller.eventSetupForInstance(IOVSyncValue{Timestamp(3)});
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
     eventSetup.get<DummyRecord>();
-    CPPUNIT_ASSERT(2==eventSetup.get<DummyRecord>().cacheIdentifier());
+    CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
   //extending the IOV should not cause the cache to be reset
-  finder->setInterval(ValidityInterval(IOVSyncValue{time_2}, IOVSyncValue{Timestamp{4}}));
+  finder->setInterval(ValidityInterval(IOVSyncValue{Timestamp{2}}, IOVSyncValue{Timestamp{4}}));
   {
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue{Timestamp{4}}),0, nullptr};
-    CPPUNIT_ASSERT(2==eventSetup.get<DummyRecord>().cacheIdentifier());
+    controller.eventSetupForInstance(IOVSyncValue{Timestamp(4)});
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+    CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
 
   //this is a new IOV so should get cache reset
   finder->setInterval(ValidityInterval(IOVSyncValue{Timestamp{5}}, IOVSyncValue{Timestamp{6}}));
   {
-    EventSetup const eventSetup{  provider.eventSetupForInstance(IOVSyncValue{Timestamp{5}}),0, nullptr};
-    CPPUNIT_ASSERT(3==eventSetup.get<DummyRecord>().cacheIdentifier());
+    controller.eventSetupForInstance(IOVSyncValue{Timestamp(5)});
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+    CPPUNIT_ASSERT(3 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
+}
 
+void testEventsetup::resetProxiesTest()
+{
+  EventSetupsController controller;
+  edm::ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
+
+  std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
+  finder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
+  provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(finder));
+
+  ComponentDescription description("DummyProxyProvider","",true);
+  ParameterSet ps;
+  ps.addParameter<std::string>("name", "test11");
+  ps.registerIt();
+  description.pid_ = ps.id();
+  DummyData kOne{1};
+  auto dummyProv = std::make_shared<DummyProxyProvider>(kOne);
+  dummyProv->setDescription(description);
+  provider.add(dummyProv);
+
+  {
+    controller.eventSetupForInstance(IOVSyncValue{Timestamp(2)});
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+    CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
+    edm::ESHandle<DummyData> data;
+    eventSetup.getData(data);
+    CPPUNIT_ASSERT(data->value_ == 1);
+  }
+  provider.forceCacheClear();
+  {
+    controller.eventSetupForInstance(IOVSyncValue{Timestamp(2)});
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+    eventSetup.get<DummyRecord>();
+    CPPUNIT_ASSERT(3 == eventSetup.get<DummyRecord>().cacheIdentifier());
+    dummyProv->incrementData();
+    edm::ESHandle<DummyData> data;
+    eventSetup.getData(data);
+    CPPUNIT_ASSERT(data->value_ == 2);
+  }
 }

--- a/FWCore/Framework/test/eventsetupscontroller_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetupscontroller_t.cppunit.cc
@@ -18,7 +18,7 @@
 #include <vector>
 
 namespace {
-edm::ActivityRegistry activityRegistry;
+  edm::ActivityRegistry activityRegistry;
 }
 
 class TestEventSetupsController: public CppUnit::TestFixture
@@ -68,6 +68,7 @@ void TestEventSetupsController::constructorTest() {
 }
 
 void TestEventSetupsController::esProducerGetAndPutTest() {
+
   edm::eventsetup::EventSetupsController esController;
 
   edm::ParameterSet pset1;
@@ -143,15 +144,12 @@ void TestEventSetupsController::esProducerGetAndPutTest() {
   bool isPresent4 = false;
   
   CPPUNIT_ASSERT(esproducers.size() == 4);
-  for (auto esproducer : esproducers) {
-    auto const& esproducer1 = esproducer;
+  for (auto const& esproducer : esproducers) {
     if (esproducer.second.pset() == &pset1) {
       isPresent1 = true;
       CPPUNIT_ASSERT(esproducer.first == pset1.id());
-      CPPUNIT_ASSERT(esproducer.second.provider() == proxyProvider1);
-      edm::eventsetup::ESProducerInfo& info = esproducer.second;
-      edm::eventsetup::ESProducerInfo const& constInfo = esproducer1.second;
-      CPPUNIT_ASSERT(info.subProcessIndexes() == constInfo.subProcessIndexes());
+      CPPUNIT_ASSERT(esproducer.second.providerGet() == static_cast<edm::eventsetup::DataProxyProvider*>(proxyProvider1.get()));
+      edm::eventsetup::ESProducerInfo const& info = esproducer.second;
       CPPUNIT_ASSERT(info.subProcessIndexes().size() == 2);
       CPPUNIT_ASSERT(info.subProcessIndexes()[0] == 0);
       CPPUNIT_ASSERT(info.subProcessIndexes()[1] == 1);
@@ -159,10 +157,8 @@ void TestEventSetupsController::esProducerGetAndPutTest() {
     if (esproducer.second.pset() == &pset2) {
       isPresent2 = true;
       CPPUNIT_ASSERT(esproducer.first == pset1.id());
-      CPPUNIT_ASSERT(esproducer.second.provider() == proxyProvider2);
-      edm::eventsetup::ESProducerInfo& info = esproducer.second;
-      edm::eventsetup::ESProducerInfo const& constInfo = esproducer1.second;
-      CPPUNIT_ASSERT(info.subProcessIndexes() == constInfo.subProcessIndexes());
+      CPPUNIT_ASSERT(esproducer.second.providerGet() == static_cast<edm::eventsetup::DataProxyProvider*>(proxyProvider2.get()));
+      edm::eventsetup::ESProducerInfo const& info = esproducer.second;
       CPPUNIT_ASSERT(info.subProcessIndexes().size() == 2);
       CPPUNIT_ASSERT(info.subProcessIndexes()[0] == 0);
       CPPUNIT_ASSERT(info.subProcessIndexes()[1] == 2);
@@ -170,10 +166,8 @@ void TestEventSetupsController::esProducerGetAndPutTest() {
     if (esproducer.second.pset() == &pset3) {
       isPresent3 = true;
       CPPUNIT_ASSERT(esproducer.first == pset3.id());
-      CPPUNIT_ASSERT(esproducer.second.provider() == proxyProvider3);
-      edm::eventsetup::ESProducerInfo& info = esproducer.second;
-      edm::eventsetup::ESProducerInfo const& constInfo = esproducer1.second;
-      CPPUNIT_ASSERT(info.subProcessIndexes() == constInfo.subProcessIndexes());
+      CPPUNIT_ASSERT(esproducer.second.providerGet() == static_cast<edm::eventsetup::DataProxyProvider*>(proxyProvider3.get()));
+      edm::eventsetup::ESProducerInfo const& info = esproducer.second;
       CPPUNIT_ASSERT(info.subProcessIndexes().size() == 2);
       CPPUNIT_ASSERT(info.subProcessIndexes()[0] == 0);
       CPPUNIT_ASSERT(info.subProcessIndexes()[1] == 3);
@@ -181,10 +175,8 @@ void TestEventSetupsController::esProducerGetAndPutTest() {
     if (esproducer.second.pset() == &pset4) {
       isPresent4 = true;
       CPPUNIT_ASSERT(esproducer.first == pset4.id());
-      CPPUNIT_ASSERT(esproducer.second.provider() == proxyProvider4);
-      edm::eventsetup::ESProducerInfo& info = esproducer.second;
-      edm::eventsetup::ESProducerInfo const& constInfo = esproducer1.second;
-      CPPUNIT_ASSERT(info.subProcessIndexes() == constInfo.subProcessIndexes());
+      CPPUNIT_ASSERT(esproducer.second.providerGet() == static_cast<edm::eventsetup::DataProxyProvider*>(proxyProvider4.get()));
+      edm::eventsetup::ESProducerInfo const& info = esproducer.second;
       CPPUNIT_ASSERT(info.subProcessIndexes().size() == 3);
       CPPUNIT_ASSERT(info.subProcessIndexes()[0] == 0);
       CPPUNIT_ASSERT(info.subProcessIndexes()[1] == 4);
@@ -324,15 +316,12 @@ void TestEventSetupsController::esSourceGetAndPutTest() {
   bool isPresent4 = false;
   
   CPPUNIT_ASSERT(essources.size() == 4);
-  for (auto essource : essources) {
-    auto const& essource1 = essource;
+  for (auto const& essource : essources) {
     if (essource.second.pset() == &pset1) {
       isPresent1 = true;
       CPPUNIT_ASSERT(essource.first == pset1.id());
-      CPPUNIT_ASSERT(essource.second.finder() == finder1);
-      edm::eventsetup::ESSourceInfo& info = essource.second;
-      edm::eventsetup::ESSourceInfo const& constInfo = essource1.second;
-      CPPUNIT_ASSERT(info.subProcessIndexes() == constInfo.subProcessIndexes());
+      CPPUNIT_ASSERT(essource.second.finderGet() == static_cast<edm::EventSetupRecordIntervalFinder const*>(finder1.get()));
+      edm::eventsetup::ESSourceInfo const& info = essource.second;
       CPPUNIT_ASSERT(info.subProcessIndexes().size() == 2);
       CPPUNIT_ASSERT(info.subProcessIndexes()[0] == 0);
       CPPUNIT_ASSERT(info.subProcessIndexes()[1] == 1);
@@ -340,10 +329,8 @@ void TestEventSetupsController::esSourceGetAndPutTest() {
     if (essource.second.pset() == &pset2) {
       isPresent2 = true;
       CPPUNIT_ASSERT(essource.first == pset1.id());
-      CPPUNIT_ASSERT(essource.second.finder() == finder2);
-      edm::eventsetup::ESSourceInfo& info = essource.second;
-      edm::eventsetup::ESSourceInfo const& constInfo = essource1.second;
-      CPPUNIT_ASSERT(info.subProcessIndexes() == constInfo.subProcessIndexes());
+      CPPUNIT_ASSERT(essource.second.finderGet() == static_cast<edm::EventSetupRecordIntervalFinder const*>(finder2.get()));
+      edm::eventsetup::ESSourceInfo const& info = essource.second;
       CPPUNIT_ASSERT(info.subProcessIndexes().size() == 2);
       CPPUNIT_ASSERT(info.subProcessIndexes()[0] == 0);
       CPPUNIT_ASSERT(info.subProcessIndexes()[1] == 2);
@@ -351,10 +338,8 @@ void TestEventSetupsController::esSourceGetAndPutTest() {
     if (essource.second.pset() == &pset3) {
       isPresent3 = true;
       CPPUNIT_ASSERT(essource.first == pset3.id());
-      CPPUNIT_ASSERT(essource.second.finder() == finder3);
-      edm::eventsetup::ESSourceInfo& info = essource.second;
-      edm::eventsetup::ESSourceInfo const& constInfo = essource1.second;
-      CPPUNIT_ASSERT(info.subProcessIndexes() == constInfo.subProcessIndexes());
+      CPPUNIT_ASSERT(essource.second.finderGet() == static_cast<edm::EventSetupRecordIntervalFinder const*>(finder3.get()));
+      edm::eventsetup::ESSourceInfo const& info = essource.second;
       CPPUNIT_ASSERT(info.subProcessIndexes().size() == 2);
       CPPUNIT_ASSERT(info.subProcessIndexes()[0] == 0);
       CPPUNIT_ASSERT(info.subProcessIndexes()[1] == 3);
@@ -362,11 +347,9 @@ void TestEventSetupsController::esSourceGetAndPutTest() {
     if (essource.second.pset() == &pset4) {
       isPresent4 = true;
       CPPUNIT_ASSERT(essource.first == pset4.id());
-      CPPUNIT_ASSERT(essource.second.finder() == finder4);
-      edm::eventsetup::ESSourceInfo& info = essource.second;
-      edm::eventsetup::ESSourceInfo const& constInfo = essource1.second;
-      CPPUNIT_ASSERT(info.subProcessIndexes() == constInfo.subProcessIndexes());
-      CPPUNIT_ASSERT(info.subProcessIndexes().size() == 3);
+      CPPUNIT_ASSERT(essource.second.finderGet() == static_cast<edm::EventSetupRecordIntervalFinder const*>(finder4.get()));
+      edm::eventsetup::ESSourceInfo const& info = essource.second;
+     CPPUNIT_ASSERT(info.subProcessIndexes().size() == 3);
       CPPUNIT_ASSERT(info.subProcessIndexes()[0] == 0);
       CPPUNIT_ASSERT(info.subProcessIndexes()[1] == 4);
       CPPUNIT_ASSERT(info.subProcessIndexes()[2] == 5);

--- a/FWCore/Framework/test/fullchain_t.cppunit.cc
+++ b/FWCore/Framework/test/fullchain_t.cppunit.cc
@@ -6,39 +6,63 @@
  *  Changed by Viji Sundararajan on 29-Jun-05.
  *
  */
-#include <iostream>
+
+#include "DataFormats/Provenance/interface/Timestamp.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/EventSetupProvider.h"
 #include "FWCore/Framework/interface/IOVSyncValue.h"
-#include "FWCore/Framework/interface/HCMethods.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/test/DummyRecord.h"
+#include "FWCore/Framework/interface/ValidityInterval.h"
+
 #include "FWCore/Framework/test/DummyData.h"
 #include "FWCore/Framework/test/DummyFinder.h"
 #include "FWCore/Framework/test/DummyProxyProvider.h"
+#include "FWCore/Framework/test/DummyRecord.h"
+#include "FWCore/Framework/src/EventSetupsController.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+
 #include "cppunit/extensions/HelperMacros.h"
+#include "tbb/task_scheduler_init.h"
+
+#include <memory>
+#include <string>
+#include <vector>
 
 using namespace edm;
 using namespace edm::eventsetup;
 using namespace edm::eventsetup::test;
 
 namespace {
-edm::ActivityRegistry activityRegistry;
+  ActivityRegistry activityRegistry;
+
+  ParameterSet createDummyPset() {
+    ParameterSet pset;
+    std::vector<std::string> emptyVStrings;
+    pset.addParameter<std::vector<std::string> >("@all_esprefers", emptyVStrings);
+    pset.addParameter<std::vector<std::string> >("@all_essources", emptyVStrings);
+    pset.addParameter<std::vector<std::string> >("@all_esmodules", emptyVStrings);
+    return pset;
+  }
 }
 
 class testfullChain: public CppUnit::TestFixture
 {
-CPPUNIT_TEST_SUITE(testfullChain);
+  CPPUNIT_TEST_SUITE(testfullChain);
 
-CPPUNIT_TEST(getfromDataproxyproviderTest);
+  CPPUNIT_TEST(getfromDataproxyproviderTest);
 
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE_END();
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {
+    m_scheduler = std::make_unique<tbb::task_scheduler_init>(1);
+  }
+  void tearDown() {}
 
   void getfromDataproxyproviderTest();
+
+private:
+  edm::propagate_const<std::unique_ptr<tbb::task_scheduler_init>> m_scheduler;
 };
 
 ///registration of the test so that the runner can find it
@@ -46,26 +70,26 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testfullChain);
 
 void testfullChain::getfromDataproxyproviderTest()
 {
-   eventsetup::EventSetupProvider provider(&activityRegistry);
+  EventSetupsController controller;
+  ParameterSet pset = createDummyPset();
+  EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
-   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<DummyProxyProvider>();
-   provider.add(pProxyProv);
-   
-   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
-   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+  auto dummyFinder = std::make_shared<DummyFinder>();
+  dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(1)), IOVSyncValue(Timestamp(5))));
+  provider.add(dummyFinder);
 
-   const Timestamp time_1(1);
-   const IOVSyncValue sync_1(time_1);
-   pFinder->setInterval(ValidityInterval(sync_1, IOVSyncValue(Timestamp(5))));
-   for(unsigned int iTime=1; iTime != 6; ++iTime) {
-      const Timestamp time(iTime);
-     EventSetup const eventSetup{provider.eventSetupForInstance(IOVSyncValue(time)),0, nullptr};
-      ESHandle<DummyData> pDummy;
-      eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != pDummy.product());
-      
-      eventSetup.getData(pDummy);
-   
-      CPPUNIT_ASSERT(0 != pDummy.product());
-   }
+  auto proxyProvider = std::make_shared<DummyProxyProvider>();
+  provider.add(proxyProvider);
+
+  for (unsigned int iTime=1; iTime != 6; ++iTime) {
+    const Timestamp time(iTime);
+    controller.eventSetupForInstance(IOVSyncValue(time));
+    EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+    ESHandle<DummyData> pDummy;
+    eventSetup.get<DummyRecord>().get(pDummy);
+    CPPUNIT_ASSERT(0 != pDummy.product());
+
+    eventSetup.getData(pDummy);
+    CPPUNIT_ASSERT(0 != pDummy.product());
+  }
 }

--- a/FWCore/Framework/test/proxyfactoryproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/proxyfactoryproducer_t.cppunit.cc
@@ -7,56 +7,59 @@
 
 */
 
-#include "cppunit/extensions/HelperMacros.h"
+#include "FWCore/Framework/interface/DataProxyTemplate.h"
 #include "FWCore/Framework/interface/ESProxyFactoryProducer.h"
 #include "FWCore/Framework/interface/ProxyFactoryTemplate.h"
-#include "FWCore/Framework/interface/DataProxyTemplate.h"
 #include "FWCore/Framework/test/DummyData.h"
 #include "FWCore/Framework/test/DummyRecord.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-using edm::eventsetup::test::DummyData;
+#include "cppunit/extensions/HelperMacros.h"
+
+#include <memory>
+#include <string>
+
 using namespace edm::eventsetup;
+using edm::eventsetup::test::DummyData;
 using edm::ESProxyFactoryProducer;
 
 class DummyProxy : public DataProxyTemplate<DummyRecord, DummyData> {
 public:
-   DummyProxy() {}
+  DummyProxy() {}
 protected:
-   const value_type* make(const record_type&, const DataKey&) {
-      return static_cast<const value_type*>(nullptr) ;
-   }
-   void invalidateCache() {
-   }   
-private:
+  const value_type* make(const record_type&, const DataKey&) {
+    return static_cast<const value_type*>(nullptr) ;
+  }
+  void invalidateCache() {
+  }
 };
 
 class Test1Producer : public ESProxyFactoryProducer {
 public:
-   Test1Producer() {
-      registerFactory(std::make_unique<ProxyFactoryTemplate<DummyProxy>>());
-   }
+  Test1Producer() {
+    registerFactory(std::make_unique<ProxyFactoryTemplate<DummyProxy>>());
+  }
 };
 
 class TestLabelProducer : public ESProxyFactoryProducer {
 public:
-   TestLabelProducer() {
-      registerFactory(std::make_unique<ProxyFactoryTemplate<DummyProxy>>(), "fred");
-   }
+  TestLabelProducer() {
+    registerFactory(std::make_unique<ProxyFactoryTemplate<DummyProxy>>(), "fred");
+  }
 };
 
 class testProxyfactor: public CppUnit::TestFixture
 {
-CPPUNIT_TEST_SUITE(testProxyfactor);
+  CPPUNIT_TEST_SUITE(testProxyfactor);
 
-CPPUNIT_TEST(registerProxyfactorytemplateTest);
-CPPUNIT_TEST(labelTest);
-CPPUNIT_TEST(appendLabelTest);
+  CPPUNIT_TEST(registerProxyfactorytemplateTest);
+  CPPUNIT_TEST(labelTest);
+  CPPUNIT_TEST(appendLabelTest);
 
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE_END();
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void registerProxyfactorytemplateTest();
   void appendLabelTest();
@@ -68,30 +71,34 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testProxyfactor);
 
 void testProxyfactor::registerProxyfactorytemplateTest()
 {
-   Test1Producer testProd;
-   EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
-   CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
+  Test1Producer testProd;
+  EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
+  CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
 
-   const DataProxyProvider::KeyedProxies& keyedProxies =
-      testProd.keyedProxies(dummyRecordKey);
+  testProd.resizeKeyedProxiesVector(dummyRecordKey, 1);
 
-   CPPUNIT_ASSERT(keyedProxies.size() == 1);
-   CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
+  const DataProxyProvider::KeyedProxies& keyedProxies =
+    testProd.keyedProxies(dummyRecordKey);
+
+  CPPUNIT_ASSERT(keyedProxies.size() == 1);
+  CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
 }
 
 void testProxyfactor::labelTest()
 {
-   TestLabelProducer testProd;
-   EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
-   CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
-   
-   const DataProxyProvider::KeyedProxies& keyedProxies =
-      testProd.keyedProxies(dummyRecordKey);
-   
-   CPPUNIT_ASSERT(keyedProxies.size() == 1);
-   CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
-   const std::string kFred("fred");
-   CPPUNIT_ASSERT(kFred == keyedProxies.front().first.name().value());
+  TestLabelProducer testProd;
+  EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
+  CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
+
+  testProd.resizeKeyedProxiesVector(dummyRecordKey, 1);
+
+  const DataProxyProvider::KeyedProxies& keyedProxies =
+    testProd.keyedProxies(dummyRecordKey);
+
+  CPPUNIT_ASSERT(keyedProxies.size() == 1);
+  CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
+  const std::string kFred("fred");
+  CPPUNIT_ASSERT(kFred == keyedProxies.front().first.name().value());
 }
 
 void testProxyfactor::appendLabelTest()
@@ -106,10 +113,12 @@ void testProxyfactor::appendLabelTest()
     testProd.setAppendToDataLabel(pset);
     EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
     CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
-  
+
+    testProd.resizeKeyedProxiesVector(dummyRecordKey, 1);
+
     const DataProxyProvider::KeyedProxies& keyedProxies =
       testProd.keyedProxies(dummyRecordKey);
-    
+
     CPPUNIT_ASSERT(keyedProxies.size() == 1);
     CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
     const std::string kFredBarney("fredBarney");
@@ -120,13 +129,13 @@ void testProxyfactor::appendLabelTest()
   testProd.setAppendToDataLabel(pset);
   EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
   CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
-  
+
+  testProd.resizeKeyedProxiesVector(dummyRecordKey, 1);
   const DataProxyProvider::KeyedProxies& keyedProxies =
     testProd.keyedProxies(dummyRecordKey);
-  
+
   CPPUNIT_ASSERT(keyedProxies.size() == 1);
   CPPUNIT_ASSERT(nullptr != dynamic_cast<DummyProxy const*>(&(*(keyedProxies.front().second))));
   const std::string kBarney("Barney");
   CPPUNIT_ASSERT(kBarney == keyedProxies.front().first.name().value());
-  
 }

--- a/FWCore/Integration/interface/ESTestRecords.h
+++ b/FWCore/Integration/interface/ESTestRecords.h
@@ -6,7 +6,10 @@
 
 #include "boost/mpl/vector.hpp"
 
-class ESTestRecordA : public edm::eventsetup::EventSetupRecordImplementation<ESTestRecordA> {};
+class ESTestRecordA : public edm::eventsetup::EventSetupRecordImplementation<ESTestRecordA> {
+public:
+  static constexpr bool allowConcurrentIOVs_ = false;
+};
 
 class ESTestRecordC : public edm::eventsetup::EventSetupRecordImplementation<ESTestRecordC> {};
 

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -264,6 +264,11 @@
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/Framework"/>
   </library>
+  <library   file="ConcurrentIOVESSource.cc,ConcurrentIOVESProducer.cc,ConcurrentIOVAnalyzer.cc,GadgetRcd.cc,IOVTestInfo.cc,RunLumiESAnalyzer.cc,RunLumiESSource.cc" name="ConcurrentIOVESSource">
+    <flags   EDM_PLUGIN="1"/>
+    <use   name="FWCore/Integration"/>
+    <use   name="FWCore/Framework"/>
+  </library>
   <library   file="WhatsItESProducer.cc,WhatsIt.cc,Doodad.cc,GadgetRcd.cc" name="WhatsItESProducer">
     <flags   EDM_PLUGIN="1"/>
     <use   name="FWCore/Framework"/>

--- a/FWCore/Integration/test/ConcurrentIOVAnalyzer.cc
+++ b/FWCore/Integration/test/ConcurrentIOVAnalyzer.cc
@@ -1,0 +1,145 @@
+// -*- C++ -*-
+//
+// Package:    FWCore/Integration
+// Class:      ConcurrentIOVAnalyzer
+//
+/**\class edmtest::ConcurrentIOVAnalyzer
+
+ Description: Used in tests of the concurrent IOV features of the
+ EventSetup system
+*/
+// Original Author:  Chris Jones
+//         Created:  Fri Jun 24 19:13:25 EDT 2005
+
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Integration/interface/ESTestRecords.h"
+#include "FWCore/Integration/test/IOVTestInfo.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace edmtest {
+
+  class ConcurrentIOVAnalyzer : public edm::global::EDAnalyzer<> {
+  public:
+    explicit ConcurrentIOVAnalyzer(edm::ParameterSet const&);
+
+    void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    bool checkExpectedValues_;
+    edm::ESGetToken<IOVTestInfo, ESTestRecordI> const esTokenFromESSource_;
+    edm::ESGetToken<IOVTestInfo, ESTestRecordI> const esTokenFromESProducer_;
+  };
+
+  ConcurrentIOVAnalyzer::ConcurrentIOVAnalyzer(edm::ParameterSet const& pset)
+      : checkExpectedValues_{pset.getUntrackedParameter<bool>("checkExpectedValues")},
+        esTokenFromESSource_{esConsumes<IOVTestInfo, ESTestRecordI>(edm::ESInputTag("", ""))},
+        esTokenFromESProducer_{esConsumes<IOVTestInfo, ESTestRecordI>(edm::ESInputTag("", "fromESProducer"))} {}
+
+  void ConcurrentIOVAnalyzer::analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& eventSetup) const {
+    auto lumiNumber = event.eventAuxiliary().luminosityBlock();
+
+    edm::ESHandle<IOVTestInfo> iovTestInfoFromESSource = eventSetup.getHandle(esTokenFromESSource_);
+    edm::ESHandle<IOVTestInfo> iovTestInfoFromESProducer = eventSetup.getHandle(esTokenFromESProducer_);
+
+    ESTestRecordI esTestRecordI = eventSetup.get<ESTestRecordI>();
+    edm::ValidityInterval iov = esTestRecordI.validityInterval();
+
+    if (iovTestInfoFromESSource->iovStartLumi_ != iov.first().luminosityBlockNumber() ||
+        iovTestInfoFromESSource->iovEndLumi_ != iov.last().luminosityBlockNumber() ||
+        iovTestInfoFromESSource->iovIndex_ != esTestRecordI.iovIndex() ||
+        iovTestInfoFromESSource->cacheIdentifier_ != esTestRecordI.cacheIdentifier()) {
+      throw cms::Exception("TestFailure") << "ConcurrentIOVAnalyzer::analyze,"
+                                          << " values read from ESSource do not agree with record";
+    }
+
+    if (iovTestInfoFromESProducer->iovStartLumi_ != iov.first().luminosityBlockNumber() ||
+        iovTestInfoFromESProducer->iovEndLumi_ != iov.last().luminosityBlockNumber() ||
+        iovTestInfoFromESProducer->iovIndex_ != esTestRecordI.iovIndex() ||
+        iovTestInfoFromESProducer->cacheIdentifier_ != esTestRecordI.cacheIdentifier()) {
+      throw cms::Exception("TestFailure") << "ConcurrentIOVAnalyzer::analyze,"
+                                          << " values read from ESProducer do not agree with record";
+    }
+
+    if (!checkExpectedValues_) {
+      return;
+    }
+
+    // cacheIdentifier starts at 2 for beginRun and 3 is next here for the first lumi
+    if (lumiNumber == 1) {
+      if (iovTestInfoFromESProducer->iovStartLumi_ != 1 || iovTestInfoFromESProducer->iovEndLumi_ != 3 ||
+          iovTestInfoFromESProducer->cacheIdentifier_ != 3) {
+        throw cms::Exception("TestFailure") << "ConcurrentIOVAnalyzer::analyze,"
+                                            << " values read from ESProducer do not agree with expected values";
+      }
+    }
+    if (lumiNumber == 2) {
+      if (iovTestInfoFromESProducer->iovStartLumi_ != 1 || iovTestInfoFromESProducer->iovEndLumi_ != 3 ||
+          iovTestInfoFromESProducer->cacheIdentifier_ != 3) {
+        throw cms::Exception("TestFailure") << "ConcurrentIOVAnalyzer::analyze,"
+                                            << " values read from ESProducer do not agree with expected values";
+      }
+    }
+    if (lumiNumber == 3) {
+      if (iovTestInfoFromESProducer->iovStartLumi_ != 1 || iovTestInfoFromESProducer->iovEndLumi_ != 3 ||
+          iovTestInfoFromESProducer->cacheIdentifier_ != 3) {
+        throw cms::Exception("TestFailure") << "ConcurrentIOVAnalyzer::analyze,"
+                                            << " values read from ESProducer do not agree with expected values";
+      }
+    }
+    if (lumiNumber == 4) {
+      if (iovTestInfoFromESProducer->iovStartLumi_ != 4 || iovTestInfoFromESProducer->iovEndLumi_ != 5 ||
+          iovTestInfoFromESProducer->cacheIdentifier_ != 4) {
+        throw cms::Exception("TestFailure") << "ConcurrentIOVAnalyzer::analyze,"
+                                            << " values read from ESProducer do not agree with expected values";
+      }
+    }
+    if (lumiNumber == 5) {
+      if (iovTestInfoFromESProducer->iovStartLumi_ != 4 || iovTestInfoFromESProducer->iovEndLumi_ != 5 ||
+          iovTestInfoFromESProducer->cacheIdentifier_ != 4) {
+        throw cms::Exception("TestFailure") << "ConcurrentIOVAnalyzer::analyze,"
+                                            << " values read from ESProducer do not agree with expected values";
+      }
+    }
+    if (lumiNumber == 6) {
+      if (iovTestInfoFromESProducer->iovStartLumi_ != 6 || iovTestInfoFromESProducer->iovEndLumi_ != 6 ||
+          iovTestInfoFromESProducer->cacheIdentifier_ != 5) {
+        throw cms::Exception("TestFailure") << "ConcurrentIOVAnalyzer::analyze,"
+                                            << " values read from ESProducer do not agree with expected values";
+      }
+    }
+    if (lumiNumber == 7) {
+      if (iovTestInfoFromESProducer->iovStartLumi_ != 7 || iovTestInfoFromESProducer->iovEndLumi_ != 7 ||
+          iovTestInfoFromESProducer->cacheIdentifier_ != 6) {
+        throw cms::Exception("TestFailure") << "ConcurrentIOVAnalyzer::analyze,"
+                                            << " values read from ESProducer do not agree with expected values";
+      }
+    }
+    if (lumiNumber == 8) {
+      if (iovTestInfoFromESProducer->iovStartLumi_ != 8 || iovTestInfoFromESProducer->iovEndLumi_ != 8 ||
+          iovTestInfoFromESProducer->cacheIdentifier_ != 7) {
+        throw cms::Exception("TestFailure") << "ConcurrentIOVAnalyzer::analyze,"
+                                            << " values read from ESProducer do not agree with expected values";
+      }
+    }
+  }
+
+  void ConcurrentIOVAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.addUntracked<bool>("checkExpectedValues", true);
+    descriptions.addDefault(desc);
+  }
+}  // namespace edmtest
+using namespace edmtest;
+DEFINE_FWK_MODULE(ConcurrentIOVAnalyzer);

--- a/FWCore/Integration/test/ConcurrentIOVESProducer.cc
+++ b/FWCore/Integration/test/ConcurrentIOVESProducer.cc
@@ -1,0 +1,70 @@
+// -*- C++ -*-
+//
+// Package:    FWCore/Integration
+// Class:      ConcurrentIOVESProducer
+//
+/**\class edmtest::ConcurrentIOVESProducer
+
+  Description: Used in tests of the concurrent IOV feature of the
+  EventSetup system.
+*/
+// Original Author:  W. David Dagenhart
+//         Created:  22 March 2019
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Integration/interface/ESTestRecords.h"
+#include "FWCore/Integration/test/IOVTestInfo.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <memory>
+
+namespace edmtest {
+
+  class ConcurrentIOVESProducer : public edm::ESProducer {
+  public:
+    ConcurrentIOVESProducer(edm::ParameterSet const&);
+
+    std::unique_ptr<IOVTestInfo> produce(ESTestRecordI const&);
+
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    edm::ESGetToken<IOVTestInfo, ESTestRecordI> token_;
+  };
+
+  ConcurrentIOVESProducer::ConcurrentIOVESProducer(edm::ParameterSet const&) {
+    //auto collector = setWhatProduced(this);
+    auto collector = setWhatProduced(this, "fromESProducer");
+    token_ = collector.consumes<IOVTestInfo>(edm::ESInputTag{"", ""});
+  }
+
+  std::unique_ptr<IOVTestInfo> ConcurrentIOVESProducer::produce(ESTestRecordI const& record) {
+    edm::ESHandle<IOVTestInfo> iovTestInfo = record.getHandle(token_);
+
+    edm::ValidityInterval iov = record.validityInterval();
+    if (iovTestInfo->iovStartLumi_ != iov.first().luminosityBlockNumber() ||
+        iovTestInfo->iovEndLumi_ != iov.last().luminosityBlockNumber() || iovTestInfo->iovIndex_ != record.iovIndex() ||
+        iovTestInfo->cacheIdentifier_ != record.cacheIdentifier()) {
+      throw cms::Exception("TestFailure") << "ConcurrentIOVESProducer::ConcurrentIOVESProducer"
+                                          << "read values do not agree with record";
+    }
+
+    auto data = std::make_unique<IOVTestInfo>();
+    *data = *iovTestInfo;
+    return data;
+  }
+
+  void ConcurrentIOVESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    descriptions.add("concurrentIOVESProducer", desc);
+  }
+}  // namespace edmtest
+using namespace edmtest;
+DEFINE_FWK_EVENTSETUP_MODULE(ConcurrentIOVESProducer);

--- a/FWCore/Integration/test/ConcurrentIOVESSource.cc
+++ b/FWCore/Integration/test/ConcurrentIOVESSource.cc
@@ -1,0 +1,193 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Integration
+// Class  :     ConcurrentIOVESSource
+//
+// Implementation:
+//     ESSource used for tests of Framework support for
+//     concurrent IOVs in the EventSetup system
+//
+// Original Author:  W. David Dagenhart
+//         Created:  21 March 2019
+
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
+#include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/IOVSyncValue.h"
+#include "FWCore/Framework/interface/SourceFactory.h"
+#include "FWCore/Framework/interface/ValidityInterval.h"
+#include "FWCore/Integration/interface/ESTestData.h"
+#include "FWCore/Integration/interface/ESTestRecords.h"
+#include "FWCore/Integration/test/IOVTestInfo.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/WallclockTimer.h"
+
+#include <memory>
+#include <vector>
+
+namespace edmtest {
+
+  class ConcurrentIOVESSource : public edm::EventSetupRecordIntervalFinder, public edm::ESProducer {
+  public:
+    ConcurrentIOVESSource(edm::ParameterSet const&);
+
+    std::unique_ptr<IOVTestInfo> produce(ESTestRecordI const&);
+    std::unique_ptr<ESTestDataA> produceA(ESTestRecordA const&);
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    void setIntervalFor(edm::eventsetup::EventSetupRecordKey const&,
+                        edm::IOVSyncValue const&,
+                        edm::ValidityInterval&) override;
+
+    bool isLegacyESSource() const override { return testLegacyESSourceMode_; }
+
+    // These are thread safe because after the constructor we do not
+    // modify their state.
+    bool iovIsTime_;
+    std::set<edm::IOVSyncValue> setOfIOV_;
+    std::set<edm::IOVSyncValue> setOfInvalidIOV_;
+    bool testLegacyESSourceMode_;
+    bool testForceESSourceMode_;
+    bool findForRecordA_;
+    edm::WallclockTimer wallclockTimer_;
+
+    // Be careful with this. It is modified in setIntervalFor
+    // and the setIntervalFor function is called serially (nonconcurrent
+    // with itself). But it is not thread safe to use this data member
+    // in the produce methods unless testLegacyESSourceMode_ is true.
+    edm::ValidityInterval validityInterval_;
+  };
+
+  ConcurrentIOVESSource::ConcurrentIOVESSource(edm::ParameterSet const& pset)
+      : iovIsTime_(!pset.getParameter<bool>("iovIsRunNotTime")),
+        testLegacyESSourceMode_(pset.getParameter<bool>("testLegacyESSourceMode")),
+        testForceESSourceMode_(pset.getParameter<bool>("testForceESSourceMode")),
+        findForRecordA_(pset.getParameter<bool>("findForRecordA")) {
+    wallclockTimer_.start();
+
+    std::vector<unsigned int> temp(pset.getParameter<std::vector<unsigned int>>("firstValidLumis"));
+    for (auto val : temp) {
+      if (iovIsTime_) {
+        setOfIOV_.insert(edm::IOVSyncValue(edm::Timestamp(val)));
+      } else {
+        setOfIOV_.insert(edm::IOVSyncValue(edm::EventID(1, val, 0)));
+      }
+    }
+
+    std::vector<unsigned int> tempInvalid(pset.getParameter<std::vector<unsigned int>>("invalidLumis"));
+    for (auto val : tempInvalid) {
+      if (iovIsTime_) {
+        setOfInvalidIOV_.insert(edm::IOVSyncValue(edm::Timestamp(val)));
+      } else {
+        setOfInvalidIOV_.insert(edm::IOVSyncValue(edm::EventID(1, val, 0)));
+      }
+    }
+
+    this->findingRecord<ESTestRecordI>();
+    setWhatProduced(this);
+    if (findForRecordA_) {
+      this->findingRecord<ESTestRecordA>();
+      setWhatProduced(this, &ConcurrentIOVESSource::produceA);
+    }
+  }
+
+  std::unique_ptr<IOVTestInfo> ConcurrentIOVESSource::produce(ESTestRecordI const& record) {
+    auto data = std::make_unique<IOVTestInfo>();
+
+    edm::ValidityInterval iov = record.validityInterval();
+    edm::LogAbsolute("ConcurrentIOVESSource")
+        << "ConcurrentIOVESSource::produce startIOV = " << iov.first().luminosityBlockNumber()
+        << " endIOV = " << iov.last().luminosityBlockNumber() << " IOV index = " << record.iovIndex()
+        << " cache identifier = " << record.cacheIdentifier() << " time = " << wallclockTimer_.realTime();
+
+    if (testLegacyESSourceMode_) {
+      if (validityInterval_ != iov) {
+        throw cms::Exception("TestError") << "ConcurrentIOVESSource::produce, testing legacy mode and IOV changed!";
+      }
+    }
+
+    data->iovStartLumi_ = iov.first().luminosityBlockNumber();
+    data->iovEndLumi_ = iov.last().luminosityBlockNumber();
+    data->iovIndex_ = record.iovIndex();
+    data->cacheIdentifier_ = record.cacheIdentifier();
+    return data;
+  }
+
+  std::unique_ptr<ESTestDataA> ConcurrentIOVESSource::produceA(ESTestRecordA const& record) {
+    edm::ValidityInterval iov = record.validityInterval();
+    if (!testForceESSourceMode_ && record.iovIndex() != 0) {
+      // This criteria should never fail because the EventSetupRecord class
+      // is hard coded to allow only one IOV at a time.
+      throw cms::Exception("TestError")
+          << "ConcurrentIOVESSource::produce, more than one concurrent IOV for type ESTestRecordA!";
+    }
+    edm::LogAbsolute("ConcurrentIOVESSource")
+        << "ConcurrentIOVESSource::produceA startIOV = " << iov.first().luminosityBlockNumber()
+        << " endIOV = " << iov.last().luminosityBlockNumber() << " IOV index = " << record.iovIndex()
+        << " cache identifier = " << record.cacheIdentifier() << " time = " << wallclockTimer_.realTime();
+    return std::make_unique<ESTestDataA>(0);
+  }
+
+  void ConcurrentIOVESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    std::vector<unsigned int> emptyVector;
+    desc.add<bool>("iovIsRunNotTime", true);
+    desc.add<bool>("testLegacyESSourceMode", false);
+    desc.add<bool>("testForceESSourceMode", false);
+    desc.add<bool>("findForRecordA", false);
+    desc.add<std::vector<unsigned int>>("firstValidLumis", emptyVector);
+    desc.add<std::vector<unsigned int>>("invalidLumis", emptyVector);
+    descriptions.addDefault(desc);
+  }
+
+  void ConcurrentIOVESSource::setIntervalFor(edm::eventsetup::EventSetupRecordKey const& key,
+                                             edm::IOVSyncValue const& syncValue,
+                                             edm::ValidityInterval& interval) {
+    interval = edm::ValidityInterval::invalidInterval();
+    validityInterval_ = interval;
+
+    for (auto const& invalidSyncValue : setOfInvalidIOV_) {
+      if (syncValue == invalidSyncValue) {
+        return;
+      }
+    }
+
+    //if no intervals given, fail immediately
+    if (setOfIOV_.empty()) {
+      return;
+    }
+
+    std::pair<std::set<edm::IOVSyncValue>::iterator, std::set<edm::IOVSyncValue>::iterator> itFound =
+        setOfIOV_.equal_range(syncValue);
+
+    if (itFound.first == itFound.second) {
+      if (itFound.first == setOfIOV_.begin()) {
+        //request is before first valid interval, so fail
+        return;
+      }
+      //go back one step
+      --itFound.first;
+    }
+    edm::IOVSyncValue endOfInterval = edm::IOVSyncValue::endOfTime();
+
+    if (itFound.second != setOfIOV_.end()) {
+      if (iovIsTime_) {
+        endOfInterval = edm::IOVSyncValue(edm::Timestamp(itFound.second->time().value() - 1));
+      } else {
+        endOfInterval = edm::IOVSyncValue(
+            edm::EventID(1, itFound.second->eventID().luminosityBlock() - 1, edm::EventID::maxEventNumber()));
+      }
+    }
+    interval = edm::ValidityInterval(*(itFound.first), endOfInterval);
+    validityInterval_ = interval;
+  }
+}  // namespace edmtest
+using namespace edmtest;
+DEFINE_FWK_EVENTSETUP_SOURCE(ConcurrentIOVESSource);

--- a/FWCore/Integration/test/ESTestAnalyzers.cc
+++ b/FWCore/Integration/test/ESTestAnalyzers.cc
@@ -1,4 +1,5 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -16,7 +17,7 @@
 
 namespace edmtest {
 
-  class ESTestAnalyzerA : public edm::EDAnalyzer {
+  class ESTestAnalyzerA : public edm::stream::EDAnalyzer<> {
   public:
     explicit ESTestAnalyzerA(edm::ParameterSet const&);
     virtual void analyze(const edm::Event&, const edm::EventSetup&);
@@ -157,9 +158,24 @@ namespace edmtest {
       edm::LogAbsolute("ESTestAnalyzerAZ") << "ESTestAnalyzerAZ: process = " << moduleDescription().processName() << ": Data values = " << dataA->value() << "  " << dataZ->value();
     }
   }
+
+  class ESTestAnalyzerJ : public edm::EDAnalyzer {
+  public:
+    explicit ESTestAnalyzerJ(edm::ParameterSet const&) { }
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
+  };
+
+  void ESTestAnalyzerJ::analyze(edm::Event const& ev, edm::EventSetup const& es) {
+    ESTestRecordJ const& recJ = es.get<ESTestRecordJ>();
+    edm::ESHandle<ESTestDataJ> dataJ;
+    recJ.get(dataJ);
+    edm::LogAbsolute("ESTestAnalyzerJ") << "ESTestAnalyzerJ: process = " << moduleDescription().processName() << ": Data values = " << dataJ->value();
+  }
+
 }
 using namespace edmtest;
 DEFINE_FWK_MODULE(ESTestAnalyzerA);
 DEFINE_FWK_MODULE(ESTestAnalyzerB);
 DEFINE_FWK_MODULE(ESTestAnalyzerK);
 DEFINE_FWK_MODULE(ESTestAnalyzerAZ);
+DEFINE_FWK_MODULE(ESTestAnalyzerJ);

--- a/FWCore/Integration/test/ESTestProducers.cc
+++ b/FWCore/Integration/test/ESTestProducers.cc
@@ -1,13 +1,20 @@
+#include "FWCore/Framework/interface/DataKey.h"
+#include "FWCore/Framework/interface/DataProxyProvider.h"
+#include "FWCore/Framework/interface/DataProxyTemplate.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Integration/interface/ESTestData.h"
 #include "FWCore/Integration/interface/ESTestRecords.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 
 #include <memory>
+#include <vector>
 
 namespace edmtest {
 
@@ -299,6 +306,70 @@ namespace edmtest {
     return std::make_unique<ESTestDataZ>(valueZ_);
   }
 
+  class TestDataProxyTemplateJ : public edm::eventsetup::DataProxyTemplate<ESTestRecordJ, ESTestDataJ> {
+  public:
+    TestDataProxyTemplateJ(std::vector<unsigned int> const* expectedCacheIds) :
+      testDataJ_(1),
+      expectedCacheIds_(expectedCacheIds) { }
+
+  private:
+    const ESTestDataJ* make(const ESTestRecordJ& record, const edm::eventsetup::DataKey& key) override {
+      ESTestRecordK recordK = record.getRecord<ESTestRecordK>();
+      // Note that this test only reliably works when running with a
+      // single IOV at a time and a single stream. This test module
+      // should not be configured with expected values in other cases.
+      if (index_ < expectedCacheIds_->size() &&
+          recordK.cacheIdentifier() != expectedCacheIds_->at(index_)) {
+        throw cms::Exception("TestError") << "TestDataProxyTemplateJ::make, unexpected cacheIdentifier";
+      }
+      ++index_;
+      return &testDataJ_;
+    }
+
+    void invalidateCache() override { }
+
+    ESTestDataJ testDataJ_;
+    std::vector<unsigned> const* expectedCacheIds_;
+    unsigned int index_ = 0;
+  };
+
+  class ESTestDataProxyProviderJ : public edm::eventsetup::DataProxyProvider {
+  public:
+    ESTestDataProxyProviderJ(edm::ParameterSet const&);
+
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    void registerProxies(const edm::eventsetup::EventSetupRecordKey& iRecordKey,
+                         KeyedProxies& aProxyList,
+                         unsigned int iovIndex) override;
+
+    std::vector<std::shared_ptr<TestDataProxyTemplateJ>> proxies_;
+    std::vector<unsigned> expectedCacheIds_;
+  };
+
+  ESTestDataProxyProviderJ::ESTestDataProxyProviderJ(edm::ParameterSet const& pset) :
+    expectedCacheIds_(pset.getUntrackedParameter<std::vector<unsigned int>>("expectedCacheIds")) {
+
+    usingRecord<ESTestRecordJ>();
+  }
+
+  void
+  ESTestDataProxyProviderJ::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    std::vector<unsigned int> emptyDefaultVector;
+    desc.addUntracked<std::vector<unsigned int>>("expectedCacheIds", emptyDefaultVector);
+    descriptions.addDefault(desc);
+  }
+
+  void ESTestDataProxyProviderJ::registerProxies(const edm::eventsetup::EventSetupRecordKey&,
+                                                KeyedProxies& aProxyList,
+                                                unsigned int iovIndex) {
+    while (iovIndex >= proxies_.size()) {
+      proxies_.push_back(std::make_shared<TestDataProxyTemplateJ>(&expectedCacheIds_));
+    }
+    insertProxy(aProxyList, proxies_[iovIndex]);
+  }
 }
 
 using namespace edmtest;
@@ -315,3 +386,4 @@ DEFINE_FWK_EVENTSETUP_MODULE(ESTestProducerI);
 DEFINE_FWK_EVENTSETUP_MODULE(ESTestProducerJ);
 DEFINE_FWK_EVENTSETUP_MODULE(ESTestProducerK);
 DEFINE_FWK_EVENTSETUP_MODULE(ESTestProducerAZ);
+DEFINE_FWK_EVENTSETUP_MODULE(ESTestDataProxyProviderJ);

--- a/FWCore/Integration/test/EventSetupTest2_cfg.py
+++ b/FWCore/Integration/test/EventSetupTest2_cfg.py
@@ -16,16 +16,30 @@ process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
 
 process.DoodadESSource = cms.ESSource("DoodadESSource")
 
+process.emptyESSourceK = cms.ESSource("EmptyESSource",
+    recordName = cms.string("ESTestRecordK"),
+    firstValid = cms.vuint32(1,2,3,4,5,6,7,8),
+    iovIsRunNotTime = cms.bool(True)
+)
+
+process.testDataProxyProviderJ = cms.ESProducer("ESTestDataProxyProviderJ",
+    expectedCacheIds = cms.untracked.vuint32(2, 3, 4, 5, 6, 7, 8)
+)
+
 process.get = cms.EDAnalyzer("EventSetupRecordDataGetter",
-    toGet = cms.VPSet(cms.PSet(
-        record = cms.string('GadgetRcd'),
-        data = cms.vstring('edmtest::WhatsIt', 
-                           'edmtest::Doodad')
-    )),
+    toGet = cms.VPSet(
+        cms.PSet(
+            record = cms.string('GadgetRcd'),
+            data = cms.vstring('edmtest::WhatsIt',
+                               'edmtest::Doodad')
+        )
+    ),
     verbose = cms.untracked.bool(True)
 )
 
+process.esAnalyzerJ = cms.EDAnalyzer("ESTestAnalyzerJ")
+
 process.printIt = cms.OutputModule("AsciiOutputModule")
 
-process.p = cms.Path(process.get)
+process.p = cms.Path(process.get * process.esAnalyzerJ)
 process.ep = cms.EndPath(process.printIt)

--- a/FWCore/Integration/test/IOVTestInfo.cc
+++ b/FWCore/Integration/test/IOVTestInfo.cc
@@ -1,0 +1,14 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Integration
+// Class  :     IOVTestInfo
+//
+// Original Author:  W. David Dagenhart
+//         Created:  21 March 2019
+//
+
+#include "FWCore/Integration/test/IOVTestInfo.h"
+
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(edmtest::IOVTestInfo);

--- a/FWCore/Integration/test/IOVTestInfo.h
+++ b/FWCore/Integration/test/IOVTestInfo.h
@@ -1,0 +1,29 @@
+#ifndef FWCore_Integration_IOVTestInfo_h
+#define FWCore_Integration_IOVTestInfo_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Integration
+// Class  :     IOVTestInfo
+//
+/**\class edmtest::IOVTestInfo
+
+ Description: Class used to test the EventSetup in the integration test
+
+*/
+//
+// Original Author:  W. David Dagenhart
+//         Created:  21 March 2019
+//
+
+namespace edmtest {
+  struct IOVTestInfo {
+    IOVTestInfo() {}
+    unsigned int iovStartRun_ = 0;
+    unsigned int iovStartLumi_ = 0;
+    unsigned int iovEndRun_ = 0;
+    unsigned int iovEndLumi_ = 0;
+    unsigned int iovIndex_ = 0;
+    unsigned long long cacheIdentifier_ = 0;
+  };
+}  // namespace edmtest
+#endif

--- a/FWCore/Integration/test/RunLumiESAnalyzer.cc
+++ b/FWCore/Integration/test/RunLumiESAnalyzer.cc
@@ -1,0 +1,194 @@
+// -*- C++ -*-
+//
+// Package:    FWCore/Integration
+// Class:      RunLumiESAnalyzer
+//
+/**\class edmtest::RunLumiESAnalyzer
+
+ Description: Used in tests of the EventSetup system,
+ particularly testing its support of Run and Lumi
+ transitions.
+*/
+// Original Author:  W. David Dagenhart
+//         Created:  18 April 2019
+
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Integration/interface/ESTestRecords.h"
+#include "FWCore/Integration/test/IOVTestInfo.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <memory>
+
+namespace {
+  struct Cache {
+    Cache() : value(0) {}
+    //Using mutable since we want to update the value.
+    mutable std::atomic<unsigned int> value;
+  };
+
+  struct UnsafeCache {
+    UnsafeCache() : value(0) {}
+    unsigned int value;
+  };
+}  //end anonymous namespace
+
+namespace edmtest {
+
+  class RunLumiESAnalyzer : public edm::global::EDAnalyzer<edm::StreamCache<UnsafeCache>,
+                                                           edm::RunCache<Cache>,
+                                                           edm::LuminosityBlockCache<Cache>> {
+  public:
+    explicit RunLumiESAnalyzer(edm::ParameterSet const&);
+
+    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override;
+    void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override;
+    void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override;
+    void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override;
+    void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override;
+
+    std::shared_ptr<Cache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override;
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override;
+    std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                      edm::EventSetup const&) const override;
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override;
+
+    void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    void checkIOVInfo(edm::EventSetup const& eventSetup,
+                      unsigned int run,
+                      unsigned int lumiNumber,
+                      edm::ESHandle<IOVTestInfo> const& iovTestInfo,
+                      const char* functionName) const;
+
+    edm::ESGetToken<IOVTestInfo, ESTestRecordC> const esToken_;
+    edm::ESGetToken<IOVTestInfo, ESTestRecordC> const tokenBeginRun_;
+    edm::ESGetToken<IOVTestInfo, ESTestRecordC> const tokenBeginLumi_;
+    edm::ESGetToken<IOVTestInfo, ESTestRecordC> const tokenEndLumi_;
+    edm::ESGetToken<IOVTestInfo, ESTestRecordC> const tokenEndRun_;
+  };
+
+  RunLumiESAnalyzer::RunLumiESAnalyzer(edm::ParameterSet const&)
+      : esToken_{esConsumes<IOVTestInfo, ESTestRecordC>(edm::ESInputTag("", ""))},
+        tokenBeginRun_{esConsumes<IOVTestInfo, ESTestRecordC, edm::Transition::BeginRun>(edm::ESInputTag("", ""))},
+        tokenBeginLumi_{
+            esConsumes<IOVTestInfo, ESTestRecordC, edm::Transition::BeginLuminosityBlock>(edm::ESInputTag("", ""))},
+        tokenEndLumi_{
+            esConsumes<IOVTestInfo, ESTestRecordC, edm::Transition::EndLuminosityBlock>(edm::ESInputTag("", ""))},
+        tokenEndRun_{esConsumes<IOVTestInfo, ESTestRecordC, edm::Transition::EndRun>(edm::ESInputTag("", ""))} {}
+
+  std::unique_ptr<UnsafeCache> RunLumiESAnalyzer::beginStream(edm::StreamID iID) const {
+    return std::make_unique<UnsafeCache>();
+  }
+
+  void RunLumiESAnalyzer::checkIOVInfo(edm::EventSetup const& eventSetup,
+                                       unsigned int run,
+                                       unsigned int lumiNumber,
+                                       edm::ESHandle<IOVTestInfo> const& iovTestInfo,
+                                       const char* functionName) const {
+    ESTestRecordC recordC = eventSetup.get<ESTestRecordC>();
+    edm::ValidityInterval iov = recordC.validityInterval();
+
+    if (iovTestInfo->iovStartRun_ != run || iovTestInfo->iovEndRun_ != run ||
+        iovTestInfo->iovStartLumi_ != lumiNumber || iovTestInfo->iovEndLumi_ != lumiNumber) {
+      throw cms::Exception("TestFailure")
+          << functionName << ": values read from EventSetup do not agree with auxiliary";
+    }
+
+    if (iov.first().eventID().run() != run || iov.last().eventID().run() != run ||
+        iov.first().luminosityBlockNumber() != lumiNumber || iov.last().luminosityBlockNumber() != lumiNumber) {
+      throw cms::Exception("TestFailure") << functionName << ": values from EventSetup IOV do not agree with auxiliary";
+    }
+  }
+
+  void RunLumiESAnalyzer::streamBeginRun(edm::StreamID, edm::Run const& iRun, edm::EventSetup const& eventSetup) const {
+    auto run = iRun.runAuxiliary().run();
+    unsigned int lumiNumber = 0;
+    edm::ESHandle<IOVTestInfo> iovTestInfo = eventSetup.getHandle(tokenBeginRun_);
+    checkIOVInfo(eventSetup, run, lumiNumber, iovTestInfo, "RunLumiESAnalyzer::streamBeginRun");
+  }
+
+  void RunLumiESAnalyzer::streamBeginLuminosityBlock(edm::StreamID,
+                                                     edm::LuminosityBlock const& iLumi,
+                                                     edm::EventSetup const& eventSetup) const {
+    auto run = iLumi.luminosityBlockAuxiliary().run();
+    unsigned int lumiNumber = iLumi.luminosityBlockAuxiliary().luminosityBlock();
+    edm::ESHandle<IOVTestInfo> iovTestInfo = eventSetup.getHandle(tokenBeginLumi_);
+    checkIOVInfo(eventSetup, run, lumiNumber, iovTestInfo, "RunLumiESAnalyzer::streamBeginLuminosityBlock");
+  }
+
+  void RunLumiESAnalyzer::streamEndLuminosityBlock(edm::StreamID,
+                                                   edm::LuminosityBlock const& iLumi,
+                                                   edm::EventSetup const& eventSetup) const {
+    auto run = iLumi.luminosityBlockAuxiliary().run();
+    unsigned int lumiNumber = iLumi.luminosityBlockAuxiliary().luminosityBlock();
+    edm::ESHandle<IOVTestInfo> iovTestInfo = eventSetup.getHandle(tokenEndLumi_);
+    checkIOVInfo(eventSetup, run, lumiNumber, iovTestInfo, "RunLumiESAnalyzer::streamEndLuminosityBlock");
+  }
+
+  void RunLumiESAnalyzer::streamEndRun(edm::StreamID, edm::Run const& iRun, edm::EventSetup const& eventSetup) const {
+    auto run = iRun.runAuxiliary().run();
+    unsigned int lumiNumber = 4294967295;
+    edm::ESHandle<IOVTestInfo> iovTestInfo = eventSetup.getHandle(tokenEndRun_);
+    checkIOVInfo(eventSetup, run, lumiNumber, iovTestInfo, "RunLumiESAnalyzer::streamEndRun");
+  }
+
+  std::shared_ptr<Cache> RunLumiESAnalyzer::globalBeginRun(edm::Run const& iRun,
+                                                           edm::EventSetup const& eventSetup) const {
+    auto run = iRun.runAuxiliary().run();
+    unsigned int lumiNumber = 0;
+    edm::ESHandle<IOVTestInfo> iovTestInfo = eventSetup.getHandle(tokenBeginRun_);
+    checkIOVInfo(eventSetup, run, lumiNumber, iovTestInfo, "RunLumiESAnalyzer::globalBeginRun");
+    return std::make_shared<Cache>();
+  }
+
+  void RunLumiESAnalyzer::globalEndRun(edm::Run const& iRun, edm::EventSetup const& eventSetup) const {
+    auto run = iRun.runAuxiliary().run();
+    unsigned int lumiNumber = 4294967295;
+    edm::ESHandle<IOVTestInfo> iovTestInfo = eventSetup.getHandle(tokenEndRun_);
+    checkIOVInfo(eventSetup, run, lumiNumber, iovTestInfo, "RunLumiESAnalyzer::globalEndRun");
+  }
+
+  std::shared_ptr<Cache> RunLumiESAnalyzer::globalBeginLuminosityBlock(edm::LuminosityBlock const& iLumi,
+                                                                       edm::EventSetup const& eventSetup) const {
+    auto run = iLumi.luminosityBlockAuxiliary().run();
+    unsigned int lumiNumber = iLumi.luminosityBlockAuxiliary().luminosityBlock();
+    edm::ESHandle<IOVTestInfo> iovTestInfo = eventSetup.getHandle(tokenBeginLumi_);
+    checkIOVInfo(eventSetup, run, lumiNumber, iovTestInfo, "RunLumiESAnalyzer::globalBeginLuminosityBlock");
+    return std::make_shared<Cache>();
+  }
+
+  void RunLumiESAnalyzer::globalEndLuminosityBlock(edm::LuminosityBlock const& iLumi,
+                                                   edm::EventSetup const& eventSetup) const {
+    auto run = iLumi.luminosityBlockAuxiliary().run();
+    unsigned int lumiNumber = iLumi.luminosityBlockAuxiliary().luminosityBlock();
+    edm::ESHandle<IOVTestInfo> iovTestInfo = eventSetup.getHandle(tokenEndLumi_);
+    checkIOVInfo(eventSetup, run, lumiNumber, iovTestInfo, "RunLumiESAnalyzer::globalEndLuminosityBlock");
+  }
+
+  void RunLumiESAnalyzer::analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& eventSetup) const {
+    auto run = event.eventAuxiliary().run();
+    auto lumiNumber = event.eventAuxiliary().luminosityBlock();
+    edm::ESHandle<IOVTestInfo> iovTestInfo = eventSetup.getHandle(esToken_);
+    checkIOVInfo(eventSetup, run, lumiNumber, iovTestInfo, "RunLumiESAnalyzer::analyzer");
+  }
+
+  void RunLumiESAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    descriptions.addDefault(desc);
+  }
+}  // namespace edmtest
+using namespace edmtest;
+DEFINE_FWK_MODULE(RunLumiESAnalyzer);

--- a/FWCore/Integration/test/RunLumiESSource.cc
+++ b/FWCore/Integration/test/RunLumiESSource.cc
@@ -1,0 +1,81 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Integration
+// Class  :     RunLumiESSource
+//
+// Implementation:
+//     ESSource used for tests of Framework support for
+//     the EventSetup system in run and lumi transitions
+//
+// Original Author:  W. David Dagenhart
+//         Created:  18 April 2019
+
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/IOVSyncValue.h"
+#include "FWCore/Framework/interface/SourceFactory.h"
+#include "FWCore/Framework/interface/ValidityInterval.h"
+#include "FWCore/Integration/interface/ESTestRecords.h"
+#include "FWCore/Integration/test/IOVTestInfo.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include <memory>
+
+namespace edmtest {
+
+  class RunLumiESSource : public edm::EventSetupRecordIntervalFinder, public edm::ESProducer {
+  public:
+    RunLumiESSource(edm::ParameterSet const&);
+
+    std::unique_ptr<IOVTestInfo> produce(ESTestRecordC const&);
+
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    void setIntervalFor(edm::eventsetup::EventSetupRecordKey const&,
+                        edm::IOVSyncValue const&,
+                        edm::ValidityInterval&) override;
+
+    bool isLegacyESSource() const override { return false; }
+  };
+
+  RunLumiESSource::RunLumiESSource(edm::ParameterSet const&) {
+    findingRecord<ESTestRecordC>();
+    setWhatProduced(this);
+  }
+
+  std::unique_ptr<IOVTestInfo> RunLumiESSource::produce(ESTestRecordC const& record) {
+    auto data = std::make_unique<IOVTestInfo>();
+
+    edm::ValidityInterval iov = record.validityInterval();
+    edm::LogAbsolute("RunLumiESSource") << "RunLumiESSource::produce startIOV = " << iov.first().eventID().run() << ":"
+                                        << iov.first().luminosityBlockNumber()
+                                        << " endIOV = " << iov.last().eventID().run() << ":"
+                                        << iov.last().luminosityBlockNumber() << " IOV index = " << record.iovIndex()
+                                        << " cache identifier = " << record.cacheIdentifier();
+    data->iovStartRun_ = iov.first().eventID().run();
+    data->iovStartLumi_ = iov.first().luminosityBlockNumber();
+    data->iovEndRun_ = iov.last().eventID().run();
+    data->iovEndLumi_ = iov.last().luminosityBlockNumber();
+    data->iovIndex_ = record.iovIndex();
+    data->cacheIdentifier_ = record.cacheIdentifier();
+    return data;
+  }
+
+  void RunLumiESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    descriptions.addDefault(desc);
+  }
+
+  void RunLumiESSource::setIntervalFor(edm::eventsetup::EventSetupRecordKey const&,
+                                       edm::IOVSyncValue const& syncValue,
+                                       edm::ValidityInterval& interval) {
+    interval = edm::ValidityInterval(syncValue, syncValue);
+  }
+}  // namespace edmtest
+using namespace edmtest;
+DEFINE_FWK_EVENTSETUP_SOURCE(RunLumiESSource);

--- a/FWCore/Integration/test/eventSetupTest.sh
+++ b/FWCore/Integration/test/eventSetupTest.sh
@@ -7,10 +7,24 @@ pushd ${LOCAL_TMP_DIR}
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/EventSetupTest_cfg.py || die 'Failed in EventSetupTest_cfg.py' $?
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/EventSetupAppendLabelTest_cfg.py || die 'Failed in EventSetupAppendLabelTest_cfg.py' $?
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/EventSetupTest2_cfg.py || die 'Failed in EventSetupTest2_cfg.py' $?
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/EventSetupTest2_cfg.py || die 'Failed in EventSetupAppendLabelTest2_cfg.py' $?
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/EventSetupForceCacheClearTest_cfg.py || die 'Failed in EventSetupForceCacheClearTest_cfg.py' $?
 
 echo testESProductHost
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/ESProductHostTest_cfg.py || die 'Failed in ESProductHostTest_cfg.py' $?
+
+echo testConcurrentIOVs
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/testConcurrentIOVs_cfg.py || die 'Failed in testConcurrentIOVs_cfg.py' $?
+
+echo testConcurrentIOVsLegacy
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/testConcurrentIOVsLegacy_cfg.py || die 'Failed in testConcurrentIOVsLegacy_cfg.py' $?
+
+echo testAllowConcurrentIOVs_cfg
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/testAllowConcurrentIOVs_cfg.py || die 'Failed in testAllowConcurrentIOVs_cfg.py' $?
+
+echo testConcurrentIOVsForce_cfg
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/testConcurrentIOVsForce_cfg.py || die 'Failed in testConcurrentIOVsForce_cfg.py' $?
+
+echo testEventSetupRunLumi_cfg
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/testEventSetupRunLumi_cfg.py || die 'Failed in testEventSetupRunLumi_cfg.py' $?
 
 popd

--- a/FWCore/Integration/test/testAllowConcurrentIOVs_cfg.py
+++ b/FWCore/Integration/test/testAllowConcurrentIOVs_cfg.py
@@ -1,0 +1,61 @@
+# Similar to testConcurrentIOVsForce
+# Should only run 1 IOV at time for ESTestRecordA
+# because that limit is hard coded in the record's class definition.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(1),
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(1),
+    numberEventsInRun = cms.untracked.uint32(100)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(8)
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(4),
+    numberOfStreams = cms.untracked.uint32(4),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(4),
+    numberOfConcurrentIOVs = cms.untracked.uint32(4)
+)
+
+process.emptyESSourceI = cms.ESSource("EmptyESSource",
+    recordName = cms.string("ESTestRecordI"),
+    firstValid = cms.vuint32(1,100),
+    iovIsRunNotTime = cms.bool(True)
+)
+
+process.emptyESSourceK = cms.ESSource("EmptyESSource",
+    recordName = cms.string("ESTestRecordK"),
+    firstValid = cms.vuint32(1,100),
+    iovIsRunNotTime = cms.bool(True)
+)
+
+process.concurrentIOVESSource = cms.ESSource("ConcurrentIOVESSource",
+    iovIsRunNotTime = cms.bool(True),
+    firstValidLumis = cms.vuint32(1, 4, 6, 7, 8, 9),
+    invalidLumis = cms.vuint32(),
+    testLegacyESSourceMode = cms.bool(False),
+    findForRecordA = cms.bool(True)
+)
+
+process.esTestAnalyzerA = cms.EDAnalyzer("ESTestAnalyzerA",
+    runsToGetDataFor = cms.vint32(1)
+)
+
+process.concurrentIOVESProducer = cms.ESProducer("ConcurrentIOVESProducer")
+
+process.test = cms.EDAnalyzer("ConcurrentIOVAnalyzer",
+                              checkExpectedValues = cms.untracked.bool(True)
+)
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(10*1000*1000))
+
+process.p1 = cms.Path(process.busy1 * process.test * process.esTestAnalyzerA)

--- a/FWCore/Integration/test/testConcurrentIOVsForce_cfg.py
+++ b/FWCore/Integration/test/testConcurrentIOVsForce_cfg.py
@@ -1,0 +1,66 @@
+# Similar to testConcurrentIOVsForce
+# Uses the forceNumberOfConcurrentIOVs to for
+# 4 concurrent IOVs to be used for ESTestRecordA
+# Should see 4 lumis and 4 IOVs running concurrently
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(1),
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(1),
+    numberEventsInRun = cms.untracked.uint32(100)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(8)
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(4),
+    numberOfStreams = cms.untracked.uint32(4),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(4),
+    numberOfConcurrentIOVs = cms.untracked.uint32(4),
+    forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+        ESTestRecordA = cms.untracked.uint32(4)
+    )
+)
+
+process.emptyESSourceI = cms.ESSource("EmptyESSource",
+    recordName = cms.string("ESTestRecordI"),
+    firstValid = cms.vuint32(1,100),
+    iovIsRunNotTime = cms.bool(True)
+)
+
+process.emptyESSourceK = cms.ESSource("EmptyESSource",
+    recordName = cms.string("ESTestRecordK"),
+    firstValid = cms.vuint32(1,100),
+    iovIsRunNotTime = cms.bool(True)
+)
+
+process.concurrentIOVESSource = cms.ESSource("ConcurrentIOVESSource",
+    iovIsRunNotTime = cms.bool(True),
+    firstValidLumis = cms.vuint32(1, 4, 6, 7, 8, 9),
+    invalidLumis = cms.vuint32(),
+    testLegacyESSourceMode = cms.bool(False),
+    testForceESSourceMode = cms.bool(True),
+    findForRecordA = cms.bool(True)
+)
+
+process.esTestAnalyzerA = cms.EDAnalyzer("ESTestAnalyzerA",
+    runsToGetDataFor = cms.vint32(1)
+)
+
+process.concurrentIOVESProducer = cms.ESProducer("ConcurrentIOVESProducer")
+
+process.test = cms.EDAnalyzer("ConcurrentIOVAnalyzer",
+                              checkExpectedValues = cms.untracked.bool(True)
+)
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(10*1000*1000))
+
+process.p1 = cms.Path(process.busy1 * process.test * process.esTestAnalyzerA)

--- a/FWCore/Integration/test/testConcurrentIOVsLegacy_cfg.py
+++ b/FWCore/Integration/test/testConcurrentIOVsLegacy_cfg.py
@@ -1,0 +1,61 @@
+# Similar to testConcurrentIOVsForce
+# The difference is the ConcurrentIOVESSource
+# has been configured to run in legacy mode.
+# in all cases the produce method will refer
+# to the IOV from the immediately preceding
+# setIntervalFor function call. This effectively
+# forces one IOV at a time for IOVs related to
+# records found by that ESSource.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(1),
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(1),
+    numberEventsInRun = cms.untracked.uint32(100)
+)
+
+process.maxEvents = cms.untracked.PSet(
+  input = cms.untracked.int32(8)
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(4),
+    numberOfStreams = cms.untracked.uint32(4),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(4),
+    numberOfConcurrentIOVs = cms.untracked.uint32(2)
+)
+
+process.emptyESSourceI = cms.ESSource("EmptyESSource",
+    recordName = cms.string("ESTestRecordI"),
+    firstValid = cms.vuint32(1,100),
+    iovIsRunNotTime = cms.bool(True)
+)
+
+process.emptyESSourceK = cms.ESSource("EmptyESSource",
+    recordName = cms.string("ESTestRecordK"),
+    firstValid = cms.vuint32(1,100),
+    iovIsRunNotTime = cms.bool(True)
+)
+
+process.concurrentIOVESSource = cms.ESSource("ConcurrentIOVESSource",
+    iovIsRunNotTime = cms.bool(True),
+    firstValidLumis = cms.vuint32(1, 4, 6, 7, 8, 9),
+    invalidLumis = cms.vuint32(),
+    testLegacyESSourceMode = cms.bool(True)
+)
+
+process.concurrentIOVESProducer = cms.ESProducer("ConcurrentIOVESProducer")
+
+process.test = cms.EDAnalyzer("ConcurrentIOVAnalyzer",
+                              checkExpectedValues = cms.untracked.bool(False)
+)
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(10*1000*1000))
+
+process.p1 = cms.Path(process.busy1 * process.test)

--- a/FWCore/Integration/test/testConcurrentIOVs_cfg.py
+++ b/FWCore/Integration/test/testConcurrentIOVs_cfg.py
@@ -1,0 +1,61 @@
+# This test should almost always be running 4 lumis concurrently
+# and 2 IOVs concurrently. It prints out times that allow one
+# to verify this by manually looking at the log file. We did
+# not make the relationship between these times into a unit test
+# pass/fail criteria because in unusual cases the relationship
+# between times could vary. For example, if a thread got stuck on
+# a very busy machine the times could be very different. We do not
+# want unit tests that sometimes fail.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(1),
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(1),
+    numberEventsInRun = cms.untracked.uint32(100)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(8)
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(4),
+    numberOfStreams = cms.untracked.uint32(4),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(4),
+    numberOfConcurrentIOVs = cms.untracked.uint32(2)
+)
+
+process.emptyESSourceI = cms.ESSource("EmptyESSource",
+    recordName = cms.string("ESTestRecordI"),
+    firstValid = cms.vuint32(1,100),
+    iovIsRunNotTime = cms.bool(True)
+)
+
+process.emptyESSourceK = cms.ESSource("EmptyESSource",
+    recordName = cms.string("ESTestRecordK"),
+    firstValid = cms.vuint32(1,100),
+    iovIsRunNotTime = cms.bool(True)
+)
+
+process.concurrentIOVESSource = cms.ESSource("ConcurrentIOVESSource",
+    iovIsRunNotTime = cms.bool(True),
+    firstValidLumis = cms.vuint32(1, 4, 6, 7, 8, 9),
+    invalidLumis = cms.vuint32(),
+    testLegacyESSourceMode = cms.bool(False)
+)
+
+process.concurrentIOVESProducer = cms.ESProducer("ConcurrentIOVESProducer")
+
+process.test = cms.EDAnalyzer("ConcurrentIOVAnalyzer",
+                              checkExpectedValues = cms.untracked.bool(True)
+)
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(10*1000*1000))
+
+process.p1 = cms.Path(process.busy1 * process.test)

--- a/FWCore/Integration/test/testEventSetupRunLumi_cfg.py
+++ b/FWCore/Integration/test/testEventSetupRunLumi_cfg.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(1),
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(1),
+    numberEventsInRun = cms.untracked.uint32(10)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(30)
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(6),
+    numberOfStreams = cms.untracked.uint32(6),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(6),
+    numberOfConcurrentIOVs = cms.untracked.uint32(5)
+)
+
+process.runLumiESSource = cms.ESSource("RunLumiESSource")
+
+process.test = cms.EDAnalyzer("RunLumiESAnalyzer")
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(10*1000*1000))
+
+process.p1 = cms.Path(process.busy1 * process.test)
+
+# ---------------------------------------------------------------
+
+aSubProcess = cms.Process("TESTSUBPROCESS")
+process.addSubProcess(cms.SubProcess(aSubProcess))
+
+aSubProcess.runLumiESSource = cms.ESSource("RunLumiESSource")
+
+aSubProcess.test = cms.EDAnalyzer("RunLumiESAnalyzer")
+
+aSubProcess.p1 = cms.Path(aSubProcess.test)

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcessEventSetup.grep.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcessEventSetup.grep.txt
@@ -89,27 +89,27 @@ ESTestAnalyzerA: process = TEST10: Data value = 3
 ESTestAnalyzerA: process = TEST11: Data value = 2
 ESTestAnalyzerA: process = TEST12: Data value = 8
 ESTestAnalyzerAZ: process = TEST: Data values = 1  1
-ESTestAnalyzerAZ: process = TEST: Data values = 2  1
-ESTestAnalyzerAZ: process = TEST: Data values = 3  2
+ESTestAnalyzerAZ: process = TEST: Data values = 2  2
+ESTestAnalyzerAZ: process = TEST: Data values = 3  3
 ESTestAnalyzerAZ: process = TEST4: Data values = 1  1
-ESTestAnalyzerAZ: process = TEST: Data values = 4  2
+ESTestAnalyzerAZ: process = TEST: Data values = 4  3
 ESTestAnalyzerAZ: process = TEST4: Data values = 2  1
-ESTestAnalyzerAZ: process = TEST: Data values = 5  3
+ESTestAnalyzerAZ: process = TEST: Data values = 5  4
 ESTestAnalyzerAZ: process = TEST4: Data values = 3  2
 ESTestAnalyzerAZ: process = TEST5: Data values = 3  2
-ESTestAnalyzerAZ: process = TEST: Data values = 6  3
+ESTestAnalyzerAZ: process = TEST: Data values = 6  4
 ESTestAnalyzerAZ: process = TEST4: Data values = 4  2
 ESTestAnalyzerAZ: process = TEST5: Data values = 4  2
-ESTestAnalyzerAZ: process = TEST: Data values = 7  4
+ESTestAnalyzerAZ: process = TEST: Data values = 7  5
 ESTestAnalyzerAZ: process = TEST4: Data values = 5  3
 ESTestAnalyzerAZ: process = TEST5: Data values = 5  3
-ESTestAnalyzerAZ: process = TEST: Data values = 8  4
+ESTestAnalyzerAZ: process = TEST: Data values = 8  5
 ESTestAnalyzerAZ: process = TEST4: Data values = 6  3
 ESTestAnalyzerAZ: process = TEST5: Data values = 6  3
-ESTestAnalyzerAZ: process = TEST: Data values = 9  5
+ESTestAnalyzerAZ: process = TEST: Data values = 9  6
 ESTestAnalyzerAZ: process = TEST4: Data values = 7  4
 ESTestAnalyzerAZ: process = TEST5: Data values = 7  4
-ESTestAnalyzerAZ: process = TEST: Data values = 9  5
+ESTestAnalyzerAZ: process = TEST: Data values = 9  6
 ESTestAnalyzerAZ: process = TEST4: Data values = 7  4
 ESTestAnalyzerAZ: process = TEST5: Data values = 7  4
 Sharing ESSource: class=EmptyESSource label='emptyESSourceA'

--- a/FWCore/Modules/src/EventSetupRecordDataGetter.cc
+++ b/FWCore/Modules/src/EventSetupRecordDataGetter.cc
@@ -204,7 +204,7 @@ private:
             for(Keys::const_iterator itKey = keys.begin(), itKeyEnd = keys.end();
                  itKey != itKeyEnd;
                  ++itKey) {
-               if(! pRecord->doGet(*itKey)) {
+              if(! pRecord->doGet(*itKey)) {
                  edm::LogWarning("DataGetter") << "No data of type \""<<itKey->type().name() <<"\" with name \""<< itKey->name().value()<<"\" in record "<<itRecord->first.type().name() <<" found "<< std::endl;
                } else {
                   if(verbose_) {

--- a/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
+++ b/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
@@ -20,6 +20,15 @@ void fillOptionsDescription(ParameterSetDescription& description) {
   description.addUntracked<unsigned int>("numberOfConcurrentRuns", 1);
   description.addUntracked<unsigned int>("numberOfConcurrentLuminosityBlocks", 1)->
     setComment("If zero, then set the same as the number of runs");
+  description.addUntracked<unsigned int>("numberOfConcurrentIOVs", 1) ->
+    setComment("If zero, set to 1. Can be overridden by hard coded static in record C++ definition or by forceNumberOfConcurrentIOVs");
+
+  edm::ParameterSetDescription nestedDescription;
+  nestedDescription.addWildcardUntracked<unsigned int>("*")->
+    setComment("Parameter names should be record names and the values are the number of concurrent IOVS for each record."
+               " Overrides all other methods of setting number of concurrent IOVs.");
+  description.addUntracked<edm::ParameterSetDescription>("forceNumberOfConcurrentIOVs", nestedDescription);
+
   description.addUntracked<bool>("wantSummary", false)->
     setComment("Set true to print a report on the trigger decisions and timing of modules");
   description.addUntracked<std::string>("fileMode", "FULLMERGE")->
@@ -29,7 +38,6 @@ void fillOptionsDescription(ParameterSetDescription& description) {
     setComment("Set false to disable exception throws when configuration validation detects illegal parameters");
   description.addUntracked<bool>("printDependencies", false)->
     setComment("Print data dependencies between modules");
-
 
   // No default for this one because the parameter value is
   // actually used in the main function in cmsRun.cpp before

--- a/FWCore/TestProcessor/interface/EventSetupTestHelper.h
+++ b/FWCore/TestProcessor/interface/EventSetupTestHelper.h
@@ -33,40 +33,31 @@ namespace test {
   
   class EventSetupTestHelper : public eventsetup::DataProxyProvider, public EventSetupRecordIntervalFinder
 {
+public:
 
-   public:
   EventSetupTestHelper(std::vector<ESProduceEntry>);
-
-      // ---------- const member functions ---------------------
-
-      // ---------- static member functions --------------------
-
-      // ---------- member functions ---------------------------
-  void newInterval(const eventsetup::EventSetupRecordKey& iRecordType,
-                   const ValidityInterval& iInterval) final;
+  EventSetupTestHelper(const EventSetupTestHelper&) = delete;
+  const EventSetupTestHelper& operator=(const EventSetupTestHelper&) = delete;
 
   std::shared_ptr<eventsetup::DataProxy> getProxy(unsigned int index );
   
   void resetAllProxies();
+
 protected:
+
   void setIntervalFor(const eventsetup::EventSetupRecordKey&,
                       const IOVSyncValue& ,
                       ValidityInterval&) final;
 
   void registerProxies(const eventsetup::EventSetupRecordKey& iRecordKey ,
-                       KeyedProxies& aProxyList) final ;
+                       KeyedProxies& aProxyList,
+                       unsigned int) final ;
 
+private:
 
-   private:
-      EventSetupTestHelper(const EventSetupTestHelper&) = delete; // stop default
-
-      const EventSetupTestHelper& operator=(const EventSetupTestHelper&) = delete; // stop default
-
-      // ---------- member data --------------------------------
+  // ---------- member data --------------------------------
   std::vector<ESProduceEntry> proxies_;
 };
 }
 }
-
-
 #endif

--- a/FWCore/TestProcessor/interface/TestDataProxy.h
+++ b/FWCore/TestProcessor/interface/TestDataProxy.h
@@ -40,7 +40,7 @@ template< typename T>
     data_ = std::move(iData);
   }
   
-  void const* getImpl(eventsetup::EventSetupRecordImpl const&, eventsetup::DataKey const& iKey) final {
+  void const* getImpl(eventsetup::EventSetupRecordImpl const&, eventsetup::DataKey const&, EventSetupImpl const*) final {
     return data_.get();
   }
   

--- a/FWCore/TestProcessor/src/EventSetupTestHelper.cc
+++ b/FWCore/TestProcessor/src/EventSetupTestHelper.cc
@@ -45,30 +45,36 @@ EventSetupTestHelper::EventSetupTestHelper(std::vector<ESProduceEntry> iProxies)
 }
     
 void
-EventSetupTestHelper::newInterval(const eventsetup::EventSetupRecordKey& iRecordType,
-                                  const ValidityInterval& )  {
-}
-
-void
 EventSetupTestHelper::setIntervalFor(const eventsetup::EventSetupRecordKey&,
                                      const IOVSyncValue& iSync,
                                      ValidityInterval& oIOV) {
-  if(iSync.luminosityBlockNumber()==0) {
-    //make valid through first run
-    oIOV = ValidityInterval(iSync,
-                            IOVSyncValue(EventID(iSync.eventID().run(),1,1)));
-  } else if(iSync.eventID().event() == 0) {
-    oIOV = ValidityInterval(iSync,
-                            IOVSyncValue(EventID(iSync.eventID().run(),iSync.eventID().luminosityBlock(),1)));
-  } else {
-    //Make valid for only this point
-    oIOV = ValidityInterval(iSync,iSync);
-  }
+
+  // Note that we manually invalidate the proxies at the end of every call
+  // to test. And the beginning of the call to test is the only opportunity
+  // to reset this data, so we are not relying on the EventSetup system
+  // to manage invalidating the proxies in EventSetupTestHelper. The only
+  // reasonable thing to do is return an interval for all time so the EventSetup
+  // system does not invalidate these proxies when it shouldn't. There are two
+  // weaknesses to this:
+  //
+  //     1. If for the same record type there are DataProxies both managed
+  //     by this class and also others managed by the EventSetup, then
+  //     at IOV boundaries for this record this will fail. The EventSetup
+  //     will invalidate all the proxies for the record after this class
+  //     has set the ones it manages and they will stay invalid when they
+  //     are needed.
+  //
+  //     2. TestProcessor does not support the special case where the different
+  //     transitions executed in one call to test have different IOVs and different
+  //     EventSetup data. That would be a pretty strange case, especially for a test.
+
+  oIOV = edm::ValidityInterval( edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime() );
 }
-    
+
 void
 EventSetupTestHelper::registerProxies(const eventsetup::EventSetupRecordKey& iRecordKey ,
-                                      KeyedProxies& aProxyList) {
+                                      KeyedProxies& aProxyList,
+                                      unsigned int) {
   for(auto const& p: proxies_) {
     if(p.recordKey_ == iRecordKey) {
       aProxyList.emplace_back(p.dataKey_,p.proxy_);
@@ -87,7 +93,6 @@ EventSetupTestHelper::resetAllProxies() {
     p.proxy_->invalidate();
   }
 }
-
 
   }
 }

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -299,7 +299,7 @@ TestProcessor::beginRun() {
                   runPrincipal.beginTime());
   espController_->eventSetupForInstance(ts);
   
-  auto const& es = esp_->eventSetup();
+  auto const& es = esp_->eventSetupImpl();
 
   std::vector<edm::SubProcess> emptyList;
   {
@@ -311,6 +311,7 @@ TestProcessor::beginRun() {
                                        runPrincipal,
                                        ts,
                                        es,
+                                       nullptr,
                                        serviceToken_,
                                        emptyList);
     globalWaitTask->wait_for_all();
@@ -331,6 +332,7 @@ TestProcessor::beginRun() {
                                         runPrincipal,
                                         ts,
                                         es,
+                                        nullptr,
                                         serviceToken_,
                                         emptyList);
     
@@ -355,7 +357,7 @@ TestProcessor::beginLuminosityBlock() {
                   lumiPrincipal_->beginTime());
   espController_->eventSetupForInstance(ts);
   
-  auto const& es = esp_->eventSetup();
+  auto const& es = esp_->eventSetupImpl();
   
   std::vector<edm::SubProcess> emptyList;
   {
@@ -367,6 +369,7 @@ TestProcessor::beginLuminosityBlock() {
                                        *lumiPrincipal_,
                                        ts,
                                        es,
+                                       nullptr,
                                        serviceToken_,
                                        emptyList);
     globalWaitTask->wait_for_all();
@@ -387,6 +390,7 @@ TestProcessor::beginLuminosityBlock() {
                                         *lumiPrincipal_,
                                         ts,
                                         es,
+                                        nullptr,
                                         serviceToken_,
                                         emptyList);
     
@@ -429,7 +433,7 @@ TestProcessor::event() {
   waitTask->increment_ref_count();
 
   schedule_->processOneEventAsync(edm::WaitingTaskHolder(waitTask.get()),
-                                  0,*pep, esp_->eventSetup(), serviceToken_);
+                                  0,*pep, esp_->eventSetupImpl(), serviceToken_);
 
   waitTask->wait_for_all();
   if(waitTask->exceptionPtr() != nullptr) {
@@ -449,7 +453,7 @@ TestProcessor::endLuminosityBlock() {
                     lumiPrincipal->endTime());
     espController_->eventSetupForInstance(ts);
     
-    auto const& es = esp_->eventSetup();
+    auto const& es = esp_->eventSetupImpl();
 
     std::vector<edm::SubProcess> emptyList;
 
@@ -466,6 +470,7 @@ TestProcessor::endLuminosityBlock() {
                                         *lumiPrincipal,
                                         ts,
                                         es,
+                                        nullptr,
                                         serviceToken_,
                                         emptyList,
                                         false);
@@ -485,6 +490,7 @@ TestProcessor::endLuminosityBlock() {
                                        *lumiPrincipal,
                                        ts,
                                        es,
+                                       nullptr,
                                        serviceToken_,
                                        emptyList,
                                        false);
@@ -508,7 +514,7 @@ TestProcessor::endRun() {
                     runPrincipal.endTime());
     espController_->eventSetupForInstance(ts);
     
-    auto const& es = esp_->eventSetup();
+    auto const& es = esp_->eventSetupImpl();
     
     std::vector<edm::SubProcess> emptyList;
     
@@ -525,6 +531,7 @@ TestProcessor::endRun() {
                                         runPrincipal,
                                         ts,
                                         es,
+                                        nullptr,
                                         serviceToken_,
                                         emptyList,
                                         false);
@@ -544,6 +551,7 @@ TestProcessor::endRun() {
                                        runPrincipal,
                                        ts,
                                        es,
+                                       nullptr,
                                        serviceToken_,
                                        emptyList,
                                        false);

--- a/FWCore/TestProcessor/test/testprocessor_t.cppunit.cc
+++ b/FWCore/TestProcessor/test/testprocessor_t.cppunit.cc
@@ -101,7 +101,6 @@ void testTestProcessor::addProductTest() {
 
   //Check that event gets reset so the data product is not available
   CPPUNIT_ASSERT_THROW( tester.test(), cms::Exception);
-  
 }
 
 void testTestProcessor::missingProductTest() {
@@ -114,7 +113,6 @@ void testTestProcessor::missingProductTest() {
   edm::test::TestProcessor tester(config);
   
   CPPUNIT_ASSERT_THROW(tester.test(), cms::Exception);
-  
 }
 
 void testTestProcessor::filterTest() {
@@ -131,7 +129,6 @@ void testTestProcessor::filterTest() {
   CPPUNIT_ASSERT(tester.test().modulePassed());
   CPPUNIT_ASSERT(not tester.test().modulePassed());
   CPPUNIT_ASSERT(tester.test().modulePassed());
-
 }
 
 void testTestProcessor::extraProcessTest() {
@@ -150,7 +147,6 @@ void testTestProcessor::extraProcessTest() {
     
     CPPUNIT_ASSERT(event.get<edmtest::IntProduct>()->value == 1);
   }
-  
 }
 
 void testTestProcessor::eventSetupTest() {
@@ -210,7 +206,6 @@ void testTestProcessor::taskTest() {
     
     CPPUNIT_ASSERT(event.get<edmtest::IntProduct>()->value == 2);
   }
-
 }
 
 void testTestProcessor::emptyRunTest() {
@@ -226,7 +221,6 @@ process.moduleToTest(process.toTest)
   edm::test::TestProcessor tester(config);
   
   tester.testRunWithNoLuminosityBlocks();
-  
 }
 void testTestProcessor::emptyLumiTest() {
   auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
@@ -242,7 +236,6 @@ process.moduleToTest(process.toTest)
   edm::test::TestProcessor tester(config);
   
   tester.testLuminosityBlockWithNoEvents();
-  
 }
 
 #include <Utilities/Testing/interface/CppUnit_testdriver.icpp>

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
@@ -66,6 +66,9 @@ namespace fwliteeswriter {
 
 
 namespace edm {
+
+   class EventSetupImpl;
+
    namespace eventsetup {
       
       template <> 
@@ -73,7 +76,8 @@ namespace edm {
                                                                               const char* iName,
                                                                               const ComponentDescription*& iDesc,
                                                                               bool iTransientAccessOnly,
-                                                                              std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory) const {
+                                                                              std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory,
+                                                                              edm::EventSetupImpl const*) const {
          DataKey dataKey(*(iData->m_tag),
                          iName,
                          DataKey::kDoNotCopyMemory);
@@ -93,7 +97,7 @@ namespace edm {
          const fwliteeswriter::DummyType* value = &t;
          const ComponentDescription* desc = nullptr;
          std::shared_ptr<ESHandleExceptionFactory> dummy;
-         impl_->getImplementation(value, iName.c_str(),desc,true, dummy);
+         impl_->getImplementation(value, iName.c_str(),desc,true, dummy, nullptr);
          iHolder.m_data = t.m_data;
          iHolder.m_desc = desc;
          return true;

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESSource.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESSource.cc
@@ -38,6 +38,10 @@
 
 
 // forward declarations
+namespace edm {
+   class EventSetupImpl;
+}
+
 namespace  {
    struct TypeID : public edm::TypeIDBase {
       explicit TypeID(const std::type_info& iInfo): edm::TypeIDBase(iInfo) {}
@@ -75,7 +79,7 @@ namespace  {
       m_type(iTypeID),
       m_record(iRecord){}
       
-      const void* getImpl(const edm::eventsetup::EventSetupRecordImpl&, const edm::eventsetup::DataKey& iKey) override {
+      const void* getImpl(const edm::eventsetup::EventSetupRecordImpl&, const edm::eventsetup::DataKey& iKey, edm::EventSetupImpl const*) override {
          assert(iKey.type() == m_type);
          
          FWLiteESGenericHandle h(m_type);
@@ -102,22 +106,14 @@ public:
    FWLiteESSource(edm::ParameterSet const& iPS);
    ~FWLiteESSource() override;
    
-   // ---------- const member functions ---------------------
-   
-   // ---------- static member functions --------------------
-   
-   // ---------- member functions ---------------------------
-   void newInterval(const edm::eventsetup::EventSetupRecordKey& iRecordType,
-                            const edm::ValidityInterval& iInterval) override;
-   
-   
 private:
    FWLiteESSource(const FWLiteESSource&) = delete; // stop default
    
    const FWLiteESSource& operator=(const FWLiteESSource&) = delete; // stop default
    
    void registerProxies(const edm::eventsetup::EventSetupRecordKey& iRecordKey ,
-                                KeyedProxies& aProxyList) override;
+                        KeyedProxies& aProxyList,
+                        unsigned int) override;
    
    
    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
@@ -133,61 +129,20 @@ private:
    
 };
 
-
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
 FWLiteESSource::FWLiteESSource(edm::ParameterSet const& iPS):
 m_file( TFile::Open(iPS.getParameter<std::string>("fileName").c_str())),
 m_es( m_file.get())
 {
 }
 
-// FWLiteESSource::FWLiteESSource(const FWLiteESSource& rhs)
-// {
-//    // do actual copying here;
-// }
-
 FWLiteESSource::~FWLiteESSource()
 {
 }
 
-//
-// assignment operators
-//
-// const FWLiteESSource& FWLiteESSource::operator=(const FWLiteESSource& rhs)
-// {
-//   //An exception safe implementation is
-//   FWLiteESSource temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
-
-//
-// member functions
-//
-void 
-FWLiteESSource::newInterval(const edm::eventsetup::EventSetupRecordKey& iRecordType,
-                            const edm::ValidityInterval& /*iInterval*/)
-{
-   invalidateProxies(iRecordType);
-}
-
-//
-// const member functions
-//
 void 
 FWLiteESSource::registerProxies(const edm::eventsetup::EventSetupRecordKey& iRecordKey ,
-                                KeyedProxies& aProxyList)
+                                KeyedProxies& aProxyList,
+                                unsigned int)
 {
    using edm::eventsetup::heterocontainer::HCTypeTag;
 
@@ -253,11 +208,5 @@ FWLiteESSource::delaySettingRecords()
       }
    }
 }
-
-
-
-//
-// static member functions
-//
 
 DEFINE_FWK_EVENTSETUP_SOURCE(FWLiteESSource);


### PR DESCRIPTION
#### PR description:

Please do not merge this PR. This is not intended for 10_6_X. It is intended for 11_0_X. In addition, I intend to rebase this on top of the PR adds the scram code-format changes to the Framework before it gets merged into the master branch.

I am submitting this PR now to allow for review and comments so I can start work on any requested changes or questions. I'm hoping to get this merged as soon as possible after 11_0_X is open.

This implements core support for concurrent IOVs. More work needs to be done before CMSSW is actually running concurrent IOVs. Outside of core tests, there are not any ESSources or ESProducers that have been modified to actually support this kind of concurrency. Further work will be needed to convert ESSources and ESProducers outside the core. The core will continue to support and properly run existing ESSources and ESProducers, but the IOVs will not be processed concurrently.

The only changes outside the core are to CondDBESSource, FWLiteESSource, and FWLiteESRecordWriterAnalyzer. These changes are the minimal changes necessary to work with the revised core code. They do not migrate these modules to support concurrent IOVs.

There are two independent ways to control the number of concurrent IOVs:

First one can set the number of IOVs allowed to be processed at the same time for each EventSetupRecord as follows. In the configuration:

```
process.options = cms.untracked.PSet(
    numberOfConcurrentIOVs = cms.untracked.uint32(4),
    forceNumberOfConcurrentIOVs = cms.untracked.PSet(
        ESTestRecordA = cms.untracked.uint32(4)
    )
)
```

In the C++ definition of an EventSetupRecord type:

```
  static constexpr bool allowConcurrentIOVs_ = false;
```

numberOfConcurrentIOVs sets the number of IOVs for all types of EventSetupRecord (defaults to 1). The boolean defined in the C++ class overrides this for a specific EventSetupRecord type (by default this is defined true in the base class). The value in forceNumberOfConcurrentIOVs overrides both numberOfConcurrentIOVs and the value in the C++ class for specified EventSetupRecord types (by default this parameter set is empty).

The second way of controlling this relates to ESSources. Existing ESSources often rely on the time ordering of calls to setIntervalFor and the associated functions that produce data for that interval. In the past the produce function always referred to the immediately preceding setIntervalFor function call. But with concurrent IOVs, this can no longer be true. Existing ESSources will be treated as legacy ESSources. As ESSources are modified to support concurrent IOVs, the following function should be added to ESSource C++ class definition:

```
    bool isLegacyESSource() const override { return false; }
```

For legacy ESSources and when an IOV for that ESSource changes, then the Framework will wait until that IOV completes before moving forward to the next one. It would be nice someday to convert all ESSources and remove this function and this synchronization point entirely someday.

In many but not all cases, existing ESProducers will work in concurrent IOV mode without modification. Most ESSources are going to require work to migrate.

Note that the two mechanisms described above are independent of each other.

If numberOfConcurrentIOVs is set to greater than one and nothing else is done, things might fail horribly.  It will take a record by record review of the associated/dependent ESSource and ESProducer code to determine what will and will not function properly with more than one concurrent IOV.

The new EventSetupRecordIOVQueue class is at the heart of all this. It is probably the most important part of the new code in this PR.

#### PR validation:

This should not effect the results of existing tests. Without modifying things as described above, IOVs will not be running concurrently and everything should be the same. Even when IOVs are running concurrently, this should not modify behavior or results other than performance improvements caused by increasing concurrency at IOV boundaries.
