### PR TITLE
Avoid importing Configuration.StandardSequences.Eras

### DIFF
--- a/CalibTracker/SiPixelQuality/test/step3_SiPixelStatusAlCaRecoProducer.py
+++ b/CalibTracker/SiPixelQuality/test/step3_SiPixelStatusAlCaRecoProducer.py
@@ -1,7 +1,7 @@
 import os
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('PCL',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('PCL',Run2_2017)
 
 # ----------------------------------------------------------------------
 process.load("FWCore.MessageLogger.MessageLogger_cfi")

--- a/CalibTracker/SiPixelQuality/test/step4_ALCAHARVEST.py
+++ b/CalibTracker/SiPixelQuality/test/step4_ALCAHARVEST.py
@@ -5,9 +5,9 @@
 # with command line options: step4 --conditions 100X_dataRun2_Express_v2 -s ALCAHARVEST:SiPixelQuality --data --era Run2_2017 --filein file:PromptCalibProdSiPixel.root --scenario pp -n 1 --fileout file:step4.root
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('ALCAHARVEST',eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process('ALCAHARVEST',Run2_2018)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_HARVEST_FromRECO.py
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_HARVEST_FromRECO.py
@@ -5,7 +5,6 @@
 # with command line options: stepHarvest --data --conditions auto:run2_data --scenario pp -s ALCAHARVEST:SiStripGains --filein file:PromptCalibProdSiStripGains.root -n -1 --fileout file:calib.root
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process('ALCAHARVEST')
 

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO_cfg.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import os
 
-from Configuration.StandardSequences.Eras import eras
 import Utilities.General.cmssw_das_client as das_client
 
 ###################################################################

--- a/Calibration/HcalAlCaRecoProducers/test/AlCaIsoTrackFilterProducer_cfg.py
+++ b/Calibration/HcalAlCaRecoProducers/test/AlCaIsoTrackFilterProducer_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("ALCAISOTRACK",eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process("ALCAISOTRACK",Run2_2017)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')

--- a/Calibration/HcalCalibAlgos/test/isoTrackAlCaRecoAnalysis_cfg.py
+++ b/Calibration/HcalCalibAlgos/test/isoTrackAlCaRecoAnalysis_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("ANALYSIS",eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process("ANALYSIS",Run2_2017)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Calibration/HcalCalibAlgos/test/isoTrackRecoAnalysis_cfg.py
+++ b/Calibration/HcalCalibAlgos/test/isoTrackRecoAnalysis_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("ANALYSIS",eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process("ANALYSIS",Run2_2017)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Calibration/HcalCalibAlgos/test/recAnalyzerHF_cfg.py
+++ b/Calibration/HcalCalibAlgos/test/recAnalyzerHF_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('recHitHF',eras.Run2_25ns)
+from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+process = cms.Process('recHitHF',Run2_25ns)
 process.load('Calibration.HcalCalibAlgos.recAnalyzerHF_cfi')
 process.load("FWCore.MessageService.MessageLogger_cfi")
 

--- a/CaloOnlineTools/HcalOnlineDb/test/template.py
+++ b/CaloOnlineTools/HcalOnlineDb/test/template.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process("TEST", eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("TEST", Run2_2018)
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.categories.append('LUT')

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2072,13 +2072,14 @@ class ConfigBuilder(object):
         # now set up the modifies
         modifiers=[]
         modifierStrings=[]
-        modifierImports=['from Configuration.StandardSequences.Eras import eras']
+        modifierImports=[]
 
         if hasattr(self._options,"era") and self._options.era :
         # Multiple eras can be specified in a comma seperated list
             from Configuration.StandardSequences.Eras import eras
             for requestedEra in self._options.era.split(",") :
-                modifierStrings.append("eras."+requestedEra)
+                modifierStrings.append(requestedEra)
+                modifierImports.append(eras.pythonCfgLines[requestedEra])
                 modifiers.append(getattr(eras,requestedEra))
 
 

--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -12,6 +12,9 @@ from Configuration.Applications.ConfigBuilder import ConfigBuilder, defaultOptio
 import traceback
 from functools import reduce
 
+def checkModifier(era):
+    from FWCore.ParameterSet.Config import Modifier, ModifierChain
+    return isinstance( era, Modifier ) or isinstance( era, ModifierChain )
 
 def checkOptions():
     return
@@ -242,15 +245,14 @@ def OptionsFromItems(items):
     # If an "era" argument was supplied make sure it is one of the valid possibilities
     if options.era :
         from Configuration.StandardSequences.Eras import eras
-        from FWCore.ParameterSet.Config import Modifier, ModifierChain
         # Split the string by commas to check individual eras
         requestedEras = options.era.split(",")
         # Check that the entry is a valid era
         for eraName in requestedEras :
-            if not hasattr( eras, eraName ) : # Not valid, so print a helpful message
+            if not hasattr( eras, eraName ) or not checkModifier(getattr(eras,eraName)): # Not valid, so print a helpful message
                 validOptions="" # Create a stringified list of valid options to print to the user
                 for key in eras.__dict__ :
-                    if isinstance( eras.__dict__[key], Modifier ) or isinstance( eras.__dict__[key], ModifierChain ) :
+                    if checkModifier(eras.__dict__[key]):
                         if validOptions!="" : validOptions+=", " 
                         validOptions+="'"+key+"'"
                 raise Exception( "'%s' is not a valid option for '--era'. Valid options are %s." % (eraName, validOptions) )

--- a/Configuration/Skimming/test/test_MONOPOLEskim.py
+++ b/Configuration/Skimming/test/test_MONOPOLEskim.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('RECO',eras.Run2_2016)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('RECO',Run2_2016)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -68,18 +68,22 @@ class Eras (object):
                            'bParking']
         internalUseModChains = ['run2_2017_noTrackingModifier']
 
+        self.pythonCfgLines = {}
 
         for e in allEras:
             eObj=getattr(__import__('Configuration.Eras.Era_'+e+'_cff',globals(),locals(),[e],0),e)
             self.addEra(e,eObj)
+            self.pythonCfgLines[e] = 'from Configuration.Eras.Era_'+e+'_cff import '+e
 
         for e in internalUseMods:
             eObj=getattr(__import__('Configuration.Eras.Modifier_'+e+'_cff',globals(),locals(),[e],0),e)
             self.addEra(e,eObj)
+            self.pythonCfgLines[e] = 'from Configuration.Eras.Modifier_'+e+'_cff import '+e
 
         for e in internalUseModChains:
             eObj=getattr(__import__('Configuration.Eras.ModifierChain_'+e+'_cff',globals(),locals(),[e],0),e)
             self.addEra(e,eObj)
+            self.pythonCfgLines[e] = 'from Configuration.Eras.ModifierChain_'+e+'_cff import '+e
 
 
     def addEra(self,name,obj):

--- a/DPGAnalysis/SiStripTools/test/APVShot_Selector_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/APVShot_Selector_cfg.py
@@ -5,9 +5,9 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 
 process = cms.Process("APVShotAnalyzer")
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('APVShotAnalyzer',eras.Run2_2016)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('APVShotAnalyzer',Run2_2016)
 
 #prepare options
 

--- a/DQM/CTPPS/test/all_ctpps_dqm_test_from_aod_cfg.py
+++ b/DQM/CTPPS/test/all_ctpps_dqm_test_from_aod_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('ctppsDQMfromAOD', eras.ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+process = cms.Process('ctppsDQMfromAOD', ctpps_2016)
 
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",

--- a/DQM/CTPPS/test/all_ctpps_dqm_test_from_dat_cfg.py
+++ b/DQM/CTPPS/test/all_ctpps_dqm_test_from_dat_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('ctppsDQMfromRAW', eras.ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+process = cms.Process('ctppsDQMfromRAW', ctpps_2016)
 
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",

--- a/DQM/CTPPS/test/all_ctpps_dqm_test_from_raw_cfg.py
+++ b/DQM/CTPPS/test/all_ctpps_dqm_test_from_raw_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('ctppsDQMfromRAW', eras.ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+process = cms.Process('ctppsDQMfromRAW', ctpps_2016)
 
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -1,9 +1,10 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-#process = cms.Process("BeamMonitor", eras.Run2_2018) FIXME
-process = cms.Process("BeamMonitor", eras.Run2_2018_pp_on_AA)
+#from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+#process = cms.Process("BeamMonitor", Run2_2018) FIXME
+from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
+process = cms.Process("BeamMonitor", Run2_2018_pp_on_AA)
 
 #
 process.MessageLogger = cms.Service("MessageLogger",

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -1,9 +1,10 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-#process = cms.Process("BeamMonitor", eras.Run2_2018) # FIMXE
-process = cms.Process("BeamMonitor", eras.Run2_2018_pp_on_AA)
+#from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+#process = cms.Process("BeamMonitor", Run2_2018) # FIMXE
+from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
+process = cms.Process("BeamMonitor", Run2_2018_pp_on_AA)
 
 # Message logger
 #process.load("FWCore.MessageLogger.MessageLogger_cfi")

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("BeamPixel", eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("BeamPixel", Run2_2018)
 
 
 #----------------------------

--- a/DQM/Integration/python/clients/ctpps_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ctpps_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('CTPPSDQM', eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process('CTPPSDQM', Run2_2018)
 
 test = False
 

--- a/DQM/Integration/python/clients/hcal2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal2_dqm_sourceclient-live_cfg.py
@@ -19,8 +19,8 @@ import FWCore.ParameterSet.Config as cms
 # Configuration/StandardSequences/python/Eras.py
 # PRocess accepts a (*list) of modifiers
 #
-from Configuration.StandardSequences.Eras import eras
-process      = cms.Process('HCALDQM', eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process      = cms.Process('HCALDQM', Run2_2018)
 subsystem    = 'Hcal2'
 cmssw        = os.getenv("CMSSW_VERSION").split("_")
 debugstr     = "### HcalDQM::cfg::DEBUG: "

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -11,8 +11,8 @@ import os, sys, socket, string
 #	Standard CMSSW Imports/Definitions
 #-------------------------------------
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
-process      = cms.Process('HCALDQM', eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process      = cms.Process('HCALDQM', Run2_2018)
 subsystem    = 'Hcal'
 cmssw        = os.getenv("CMSSW_VERSION").split("_")
 debugstr     = "### HcalDQM::cfg::DEBUG: "

--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -10,7 +10,6 @@ import os, sys, socket, string
 #-------------------------------------
 #	Standard CMSSW Imports/Definitions
 #-------------------------------------
-from Configuration.StandardSequences.Eras import eras
 import FWCore.ParameterSet.Config as cms
 process      = cms.Process('HCALDQM')
 subsystem    = 'HcalCalib'

--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process("L1TStage2DQM", eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("L1TStage2DQM", Run2_2018)
 
 #--------------------------------------------------
 # Event Source and Condition

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process("L1TStage2EmulatorDQM", eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("L1TStage2EmulatorDQM", Run2_2018)
 
 #--------------------------------------------------
 # Event Source and Condition

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -1,9 +1,9 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("PIXELDQMLIVE", eras.Run2_2018_pp_on_AA)
+from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
+process = cms.Process("PIXELDQMLIVE", Run2_2018_pp_on_AA)
 
 live=True
 #set to false for lxplus offline testing

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -1,9 +1,9 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("SiStrpDQMLive", eras.Run2_2018_pp_on_AA)
+from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
+process = cms.Process("SiStrpDQMLive", Run2_2018_pp_on_AA)
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('siStripDigis',

--- a/DQM/RPCMonitorDigi/test/rpcdqm_cfg.py
+++ b/DQM/RPCMonitorDigi/test/rpcdqm_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('DQM',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('DQM',Run2_2017)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')

--- a/DQM/SiPixelPhase1Config/test/pixelphase1_dqm_sourceclient-live_cfg.py
+++ b/DQM/SiPixelPhase1Config/test/pixelphase1_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('PIXELDQMDEV',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('PIXELDQMDEV',Run2_2017)
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring( 

--- a/DQM/SiPixelPhase1Config/test/pixelphase1_for_timing_scan_dqm_sourceclient-live_cfg.py
+++ b/DQM/SiPixelPhase1Config/test/pixelphase1_for_timing_scan_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('PIXELDQMDEV',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('PIXELDQMDEV',Run2_2017)
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring( 

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
@@ -1,7 +1,6 @@
 import os
 import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing
-from Configuration.StandardSequences.Eras import eras
 
 
 def get_root_files(path):
@@ -36,7 +35,8 @@ inputFilesRAW = {
 }
 
 
-process = cms.Process('L1TStage2EmulatorDQM', eras.Run2_2016)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('L1TStage2EmulatorDQM', Run2_2016)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/DQMOffline/Lumi/python/ZCounting_cff.py
+++ b/DQMOffline/Lumi/python/ZCounting_cff.py
@@ -57,7 +57,6 @@ zcounting = DQMEDAnalyzer('ZCounting',
                                  )
 
 
-from Configuration.StandardSequences.Eras import eras
 
 eras.run2_HLTconditions_2016.toModify( zcounting, MuonTriggerNames = cms.vstring("HLT_IsoMu24_v*","HLT_IsoTkMu24_v*"),
                                     MuonTriggerObjectNames = cms.vstring("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p07",

--- a/DQMOffline/Lumi/python/ZCounting_cff.py
+++ b/DQMOffline/Lumi/python/ZCounting_cff.py
@@ -57,21 +57,23 @@ zcounting = DQMEDAnalyzer('ZCounting',
                                  )
 
 
-
-eras.run2_HLTconditions_2016.toModify( zcounting, MuonTriggerNames = cms.vstring("HLT_IsoMu24_v*","HLT_IsoTkMu24_v*"),
+from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTconditions_2016
+run2_HLTconditions_2016.toModify( zcounting, MuonTriggerNames = cms.vstring("HLT_IsoMu24_v*","HLT_IsoTkMu24_v*"),
                                     MuonTriggerObjectNames = cms.vstring("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p07",
                                                                          "hltL3fL1sMu22L1f0Tkf24QL3trkIsoFiltered0p09"),
                                     PtCutL1  = cms.untracked.double(27.0),
                                     PtCutL2  = cms.untracked.double(27.0)
                        )
 
-eras.run2_HLTconditions_2017.toModify(zcounting, MuonTriggerNames = cms.vstring("HLT_IsoMu27_v*"),
+from Configuration.Eras.Modifier_run2_HLTconditions_2017_cff import run2_HLTconditions_2017
+run2_HLTconditions_2017.toModify(zcounting, MuonTriggerNames = cms.vstring("HLT_IsoMu27_v*"),
                                    MuonTriggerObjectNames = cms.vstring("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07"),
                                    PtCutL1  = cms.untracked.double(30.0),
                                    PtCutL2  = cms.untracked.double(30.0)
                        )
 
-eras.run2_HLTconditions_2018.toModify(zcounting, MuonTriggerNames = cms.vstring("HLT_IsoMu24_v*"),
+from Configuration.Eras.Modifier_run2_HLTconditions_2018_cff import run2_HLTconditions_2018
+run2_HLTconditions_2018.toModify(zcounting, MuonTriggerNames = cms.vstring("HLT_IsoMu24_v*"),
                                    MuonTriggerObjectNames = cms.vstring("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p07"),
                                    PtCutL1  = cms.untracked.double(27.0),
                                    PtCutL2  = cms.untracked.double(27.0)

--- a/DQMOffline/Lumi/test/ZCounting_cfg.py
+++ b/DQMOffline/Lumi/test/ZCounting_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('RECODQM', eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process('RECODQM', Run2_2018)
 
 # import of standard configurations
 process.load('Configuration/StandardSequences/Services_cff')

--- a/EventFilter/GEMRawToDigi/test/unpackData-GEM.py
+++ b/EventFilter/GEMRawToDigi/test/unpackData-GEM.py
@@ -68,9 +68,10 @@ options.register('evtDisp',
 options.parseArguments()
 
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('RECO',eras.Run2_2017,eras.run2_GEM_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
+process = cms.Process('RECO',Run2_2017,run2_GEM_2017)
 
 process.load('Configuration.StandardSequences.L1Reco_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')

--- a/EventFilter/GEMRawToDigi/test/unpackData-GEM.py
+++ b/EventFilter/GEMRawToDigi/test/unpackData-GEM.py
@@ -49,11 +49,6 @@ options.register('valEvents',
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.bool,
                  "Filter on validation events")
-options.register('process',
-                 '',
-                 VarParsing.VarParsing.multiplicity.singleton,
-                 VarParsing.VarParsing.varType.string,
-                 "Rename process if used")
 options.register('mps',
                  '',
                  VarParsing.VarParsing.multiplicity.list,
@@ -73,13 +68,6 @@ options.register('evtDisp',
 options.parseArguments()
 
 
-pname="Raw2Digi"
-if (options.process!=""):
-    pname=options.process
-#process = cms.Process(pname)
-
-#from Configuration.StandardSequences.Eras import eras
-#process = cms.Process(pname, eras.Run2_2017, eras.run2_GEM_2017)
 from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process('RECO',eras.Run2_2017,eras.run2_GEM_2017)

--- a/GeneratorInterface/GenFilters/test/test_doubleEMEnrichingHepMCfilter.py
+++ b/GeneratorInterface/GenFilters/test/test_doubleEMEnrichingHepMCfilter.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('GEN2',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('GEN2',Run2_2017)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/GeneratorInterface/Herwig7Interface/test/Herwig7Test_ConfigFile_GEN_SIM.py
+++ b/GeneratorInterface/Herwig7Interface/test/Herwig7Test_ConfigFile_GEN_SIM.py
@@ -5,9 +5,9 @@
 # with command line options: GeneratorInterface/Herwig7Interface/python/Herwig7_Dummy_ConfigFile_cff.py --fileout file:Herwigpp_ConfigFile_GEN_SIM.root --mc --eventcontent RAWSIM --datatier GEN-SIM --conditions auto:run2_mc --beamspot Realistic25ns13TeVEarly2017Collision --step GEN,SIM --nThreads 8 --geometry DB:Extended --era Run2_2017 --python_filename Herwig7Test_ConfigFile_GEN_SIM.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 100
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('SIM',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('SIM',Run2_2017)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/GeneratorInterface/Herwig7Interface/test/Herwig7_Matchbox_90X_ppToee_GEN_SIM.py
+++ b/GeneratorInterface/Herwig7Interface/test/Herwig7_Matchbox_90X_ppToee_GEN_SIM.py
@@ -5,9 +5,9 @@
 # with command line options: GeneratorInterface/Herwig7Interface/python/Herwig7_Dummy_Matchbox_90X_ppToee.py --fileout file:Matchbox_90X_ppToee.root --mc --eventcontent RAWSIM --datatier GEN-SIM --conditions auto:run2_mc --beamspot Realistic25ns13TeVEarly2017Collision --step GEN,SIM --nThreads 1 --geometry DB:Extended --era Run2_2017 --python_filename Herwig7_Matchbox_90X_ppToee_GEN_SIM.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('SIM',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('SIM',Run2_2017)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Geometry/HGCalGeometry/test/python/testHGCalGeometryCheck_cfg.py
+++ b/Geometry/HGCalGeometry/test/python/testHGCalGeometryCheck_cfg.py
@@ -1,11 +1,12 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-#process = cms.Process('PROD',eras.Phase2C4)
+#from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+#process = cms.Process('PROD',Phase2C4)
 #process.load('Configuration.Geometry.GeometryExtended2023D28_cff')
 #process.load('Configuration.Geometry.GeometryExtended2023D28Reco_cff')
 
-process = cms.Process('PROD',eras.Phase2C4_timing_layer_bar)
+from Configuration.Eras.Era_Phase2C4_timing_layer_bar_cff import Phase2C4_timing_layer_bar
+process = cms.Process('PROD',Phase2C4_timing_layer_bar)
 process.load('Configuration.Geometry.GeometryExtended2023D41_cff')
 process.load('Configuration.Geometry.GeometryExtended2023D41Reco_cff')
 

--- a/Geometry/HGCalGeometry/test/python/testHGCalNeighbor_cfg.py
+++ b/Geometry/HGCalGeometry/test/python/testHGCalNeighbor_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("PROD",eras.Phase2C4)
+from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+process = cms.Process("PROD",Phase2C4)
 
 process.load("SimGeneral.HepPDTESSource.pdt_cfi")
 process.load("Configuration.Geometry.GeometryExtended2023D28Reco_cff")

--- a/HLTrigger/Configuration/python/CustomConfigs.py
+++ b/HLTrigger/Configuration/python/CustomConfigs.py
@@ -122,9 +122,9 @@ def HLTDropPrevious(process):
 
 def L1REPACK(process,sequence="Full"):
 
-    from Configuration.StandardSequences.Eras import eras
 
-    l1repack = cms.Process('L1REPACK',eras.Run2_2018)
+    from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+    l1repack = cms.Process('L1REPACK',Run2_2018)
     l1repack.load('Configuration.StandardSequences.SimL1EmulatorRepack_'+sequence+'_cff')
 
     for module in l1repack.es_sources_():

--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -503,7 +503,9 @@ from HLTrigger.Configuration.CustomConfigs import L1REPACK
   def addEras(self):
     if self.config.eras is None:
       return
-    self.data = re.sub(r'process = cms.Process\( *"\w+"', 'from Configuration.StandardSequences.Eras import eras\n\g<0>, '+', '.join('eras.' + era for era in self.config.eras.split(',')), self.data)
+    from Configuration.StandardSequences.Eras import eras
+    erasSplit = self.config.eras.split(',')
+    self.data = re.sub(r'process = cms.Process\( *"\w+"', '\n'.join(eras.pythonCfgLines[era] for era in erasSplit)+'\n\g<0>, '+', '.join(era for era in erasSplit), self.data)
 
   # select specific Eras
   def loadSetupCff(self):

--- a/HLTrigger/HLTfilters/test/devHLT_Stage2.py
+++ b/HLTrigger/HLTfilters/test/devHLT_Stage2.py
@@ -5,10 +5,11 @@
 # with command line options: debug --no_exec --conditions auto:run2_mc_25ns14e33_v4 -s DIGI:pdigi_valid,L1,DIGI2RAW,RAW2DIGI --datatier GEN-SIM-DIGI-RAW-HLTDEBUG -n 10 --era Run2_25ns --eventcontent FEVTDEBUGHLT --filein filelist:step1_dasquery.log --fileout file:step2.root
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-#process = cms.Process('L1SEQS',eras.Run2_25ns)
-process = cms.Process('HLT',eras.Run2_2016)
+#from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+#process = cms.Process('L1SEQS',Run2_25ns)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('HLT',Run2_2016)
 
 
 # import of standard configurations

--- a/HLTrigger/HLTfilters/test/runHLTMuonL1TFilter_Stage2.py
+++ b/HLTrigger/HLTfilters/test/runHLTMuonL1TFilter_Stage2.py
@@ -5,10 +5,11 @@
 
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-#process = cms.Process('L1SEQS',eras.Run2_25ns)
-process = cms.Process('HLT',eras.Run2_2016)
+#from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+#process = cms.Process('L1SEQS',Run2_25ns)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('HLT',Run2_2016)
 
 
 # import of standard configurations

--- a/JetMETCorrections/Type1MET/python/pfMETmultShiftCorrections_cfi.py
+++ b/JetMETCorrections/Type1MET/python/pfMETmultShiftCorrections_cfi.py
@@ -35,9 +35,4 @@ pfMEtMultShiftCorr = cms.EDProducer("MultShiftMETcorrInputProducer",
 
 pfMEtSysShiftCorrSequence = cms.Sequence( pfMEtMultShiftCorr )
 
-#from Configuration.StandardSequences.Eras import eras
-#eras.run2_common.toModify(pfMEtMultShiftCorr, parameters=multPhiCorrParams_Txy_25ns )
-#eras.run2_50ns_specific.toModify(pfMEtMultShiftCorr, parameters=multPhiCorrParams_Txy_50ns )
-#eras.run2_25ns_specific.toModify(pfMEtMultShiftCorr, parameters=multPhiCorrParams_Txy_25ns )
-
 

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTPEmulator_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTPEmulator_cfg.py
@@ -3,9 +3,9 @@
 # Slava Valuev; October, 2006.
 
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("CSCTPEmulator", eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("CSCTPEmulator", Run2_2018)
 
 process.maxEvents = cms.untracked.PSet(
   input = cms.untracked.int32(10000)

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesProducerTest_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesProducerTest_cfg.py
@@ -2,9 +2,9 @@
 # Slava Valuev May-2006.
 
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("MuonCSCTriggerPrimitives", eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("MuonCSCTriggerPrimitives", Run2_2018)
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring("digis.root")

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader_cfg.py
@@ -1,12 +1,12 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
 # Hack to add "test" directory to the python path.
 import sys, os
 sys.path.insert(0, os.path.join(os.environ['CMSSW_BASE'],
                                 'src/L1Trigger/CSCTriggerPrimitives/test'))
 
-process = cms.Process("L1CSCTriggerPrimitivesReader", eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("L1CSCTriggerPrimitivesReader", Run2_2018)
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring("file:lcts.root")

--- a/L1Trigger/CSCTriggerPrimitives/test/runL1CSCTPEmulatorConfigAnalyzer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runL1CSCTPEmulatorConfigAnalyzer_cfg.py
@@ -18,9 +18,9 @@ else:
     sys.exit(1)
 
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("TEST",eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("TEST",Run2_2018)
 
 process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load('L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigis_cfi')

--- a/L1Trigger/L1TCaloLayer1/test/testL1TCaloLayer1EmulatorWithSpy.py
+++ b/L1Trigger/L1TCaloLayer1/test/testL1TCaloLayer1EmulatorWithSpy.py
@@ -7,8 +7,8 @@ options.register('setupString', "captures:/data/dasu/Layer1ZeroBiasCaptureData/r
 options.register('maxEvents', 162, VarParsing.multiplicity.singleton, VarParsing.varType.int, 'Maximum number of evnets')
 options.parseArguments()
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process("Layer1EmulatorWithSpy", eras.Run2_2016)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process("Layer1EmulatorWithSpy", Run2_2016)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1TCommon/test/devHLT.py
+++ b/L1Trigger/L1TCommon/test/devHLT.py
@@ -5,10 +5,11 @@
 # with command line options: step2 --conditions auto:run2_mc_25ns14e33_v4 -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval25ns --datatier GEN-SIM-DIGI-RAW-HLTDEBUG -n 10 --era Run2_25ns --eventcontent FEVTDEBUGHLT --filein filelist:step1_dasquery.log --fileout file:step2.root
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-#process = cms.Process('HLT',eras.Run2_25ns)
-process = cms.Process('HLT',eras.Run2_2016)
+#from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+#process = cms.Process('HLT',Run2_25ns)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('HLT',Run2_2016)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1TCommon/test/runHLT.py
+++ b/L1Trigger/L1TCommon/test/runHLT.py
@@ -5,10 +5,11 @@
 # with command line options: debug --no_exec --conditions auto:run2_mc_25ns14e33_v4 -s DIGI:pdigi_valid,L1,DIGI2RAW,RAW2DIGI --datatier GEN-SIM-DIGI-RAW-HLTDEBUG -n 10 --era Run2_25ns --eventcontent FEVTDEBUGHLT --filein filelist:step1_dasquery.log --fileout file:step2.root
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-#process = cms.Process('L1SEQS',eras.Run2_25ns)
-process = cms.Process('L1SEQS',eras.Run2_2016)
+#from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+#process = cms.Process('L1SEQS',Run2_25ns)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('L1SEQS',Run2_2016)
 
 
 # import of standard configurations

--- a/L1Trigger/L1TCommon/test/runL1T.py
+++ b/L1Trigger/L1TCommon/test/runL1T.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("L1TMuonEmulation", eras.Run2_2016)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process("L1TMuonEmulation", Run2_2016)
 import os
 import sys
 import commands

--- a/L1Trigger/L1TCommon/test/runStandardSequences.py
+++ b/L1Trigger/L1TCommon/test/runStandardSequences.py
@@ -6,10 +6,11 @@ from __future__ import print_function
 # with command line options: debug --no_exec --conditions auto:run2_mc_25ns14e33_v4 -s DIGI:pdigi_valid,L1,DIGI2RAW,RAW2DIGI --datatier GEN-SIM-DIGI-RAW-HLTDEBUG -n 10 --era Run2_25ns --eventcontent FEVTDEBUGHLT --filein filelist:step1_dasquery.log --fileout file:step2.root
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-#process = cms.Process('L1SEQS',eras.Run2_25ns)
-process = cms.Process('L1SEQS',eras.Run2_2016)
+#from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+#process = cms.Process('L1SEQS',Run2_25ns)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('L1SEQS',Run2_2016)
 
 process.MessageLogger = cms.Service(
     "MessageLogger",

--- a/L1Trigger/L1TGlobal/test/runGTSummary.py
+++ b/L1Trigger/L1TGlobal/test/runGTSummary.py
@@ -3,8 +3,8 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('L1GTSUMMARY',eras.Run2_2016)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('L1GTSUMMARY',Run2_2016)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')

--- a/L1Trigger/L1THGCal/test/L1Clustering_cfg.py
+++ b/L1Trigger/L1THGCal/test/L1Clustering_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('test',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('test',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1THGCal/test/L1TC_CalibWeightExt_cfg.py
+++ b/L1Trigger/L1THGCal/test/L1TC_CalibWeightExt_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('test',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('test',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV9Imp2_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV9Imp2_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('DIGI',eras.Phase2C4)
+from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+process = cms.Process('DIGI',Phase2C4)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV9_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV9_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('DIGI',eras.Phase2C4)
+from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+process = cms.Process('DIGI',Phase2C4)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1THGCal/test/testHGCalL1TGeometry_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TGeometry_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('DIGI',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('DIGI',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_RelValV9_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_RelValV9_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('DIGI',eras.Phase2C4)
+from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+process = cms.Process('DIGI',Phase2C4)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_RelVal_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_RelVal_cfg.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms 
-from Configuration.StandardSequences.Eras import eras
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 
 # For old samples use the digi converter
-#process = cms.Process('DIGI',eras.Phase2,convertHGCalDigisSim)
-process = cms.Process('DIGI',eras.Phase2)
+#from Configuration.Eras.Era_Phase2_cff import Phase2
+#process = cms.Process('DIGI',Phase2,convertHGCalDigisSim)
+process = cms.Process('DIGI',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1T_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('DIGI',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('DIGI',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelValV9_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelValV9_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('DIGI',eras.Phase2C4)
+from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+process = cms.Process('DIGI',Phase2C4)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelVal_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_RelVal_cfg.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms 
-from Configuration.StandardSequences.Eras import eras
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 
 # For old samples use the digi converter
-#process = cms.Process('DIGI',eras.Phase2,convertHGCalDigisSim)
-process = cms.Process('DIGI',eras.Phase2)
+#from Configuration.Eras.Era_Phase2_cff import Phase2
+#process = cms.Process('DIGI',Phase2,convertHGCalDigisSim)
+process = cms.Process('DIGI',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_cfg.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms 
-from Configuration.StandardSequences.Eras import eras
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 
 # For old samples use the digi converter
-#process = cms.Process('DIGI',eras.Phase2,convertHGCalDigisSim)
-process = cms.Process('DIGI',eras.Phase2)
+#from Configuration.Eras.Era_Phase2_cff import Phase2
+#process = cms.Process('DIGI',Phase2,convertHGCalDigisSim)
+process = cms.Process('DIGI',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1TMuon/test/runMuon.py
+++ b/L1Trigger/L1TMuon/test/runMuon.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process("L1TMuonEmulation", eras.Run2_2016)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process("L1TMuonEmulation", Run2_2016)
 import os
 import sys
 import commands

--- a/L1Trigger/L1TMuonEndCap/test/RunTrackFinder_MC.py
+++ b/L1Trigger/L1TMuonEndCap/test/RunTrackFinder_MC.py
@@ -8,9 +8,9 @@ import subprocess
 
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('reL1T', eras.Run2_2016)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('reL1T', Run2_2016)
 
 ## Import standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1Trigger/L1TMuonEndCap/test/RunTrackFinder_data.py
+++ b/L1Trigger/L1TMuonEndCap/test/RunTrackFinder_data.py
@@ -6,7 +6,6 @@ import os
 import sys
 import commands
 import subprocess
-from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process('L1TMuonEmulation')
 

--- a/L1Trigger/L1TMuonEndCap/test/UnpackTrackFinder_data_2016_10_04.py
+++ b/L1Trigger/L1TMuonEndCap/test/UnpackTrackFinder_data_2016_10_04.py
@@ -5,7 +5,6 @@ import os
 import sys
 import commands
 import subprocess
-from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process('L1TMuonEmulation')
 

--- a/L1Trigger/L1TMuonEndCap/test/tools/make_coordlut_data.py
+++ b/L1Trigger/L1TMuonEndCap/test/tools/make_coordlut_data.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Whatever",eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("Whatever",Run2_2018)
 
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')  # load from DB
 process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')

--- a/L1Trigger/L1TNtuples/python/L1NtupleEMUCalo_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleEMUCalo_cff.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
 from L1Trigger.L1TNtuples.l1CaloTowerTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTree_cfi import *

--- a/L1Trigger/ME0Trigger/test/ME0TPEmulator_cfg.py
+++ b/L1Trigger/ME0Trigger/test/ME0TPEmulator_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("ME0TPEmulator", eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process("ME0TPEmulator", Phase2)
 
 process.maxEvents = cms.untracked.PSet(
   input = cms.untracked.int32(10)

--- a/L1Trigger/ME0Trigger/test/runME0_Reco_L1.py
+++ b/L1Trigger/ME0Trigger/test/runME0_Reco_L1.py
@@ -5,9 +5,9 @@
 # with command line options: step2 --conditions auto:phase2_realistic -s DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 --datatier GEN-SIM-DIGI-RAW -n 10 --geometry Extended2023D22 --era Phase2 --eventcontent FEVTDEBUGHLT --filein file:step1.root --fileout file:step2.root
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('L1',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('L1',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/MuonAnalysis/MuonAssociators/test/MuonMCClassifier/testClassByHitsTP_cfg.py
+++ b/MuonAnalysis/MuonAssociators/test/MuonMCClassifier/testClassByHitsTP_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('MuonClassif',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('MuonClassif',Phase2)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -17,7 +17,8 @@ _tauPlots80X.append(Plot1D('idMVAoldDMdR03', 'idMVAoldDMdR03', 64, -0.5, 63.5, '
 _tauPlots80X.append(Plot1D('rawMVAnewDM', 'rawMVAnewDM', 20, -1, 1, 'byIsolationMVArun2v1DBnewDMwLT raw output discriminator'))
 _tauPlots80X.append(Plot1D('rawMVAoldDMdR03', 'rawMVAoldDMdR03', 20, -1, 1, 'byIsolationMVArun2v1DBdR03oldDMwLT raw output discriminator'))
 _vplots80X.Tau.plots = _tauPlots80X
-eras.run2_miniAOD_80XLegacy.toModify(nanoDQM,
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+run2_miniAOD_80XLegacy.toModify(nanoDQM,
                                      vplots = _vplots80X
 )
 
@@ -27,7 +28,9 @@ for plot in _METFixEE2017_DQMentry.plots:
     if plot.name.value().find("fiducial")>-1: continue
     _METFixEE2017_plots.append(plot)
 _METFixEE2017_DQMentry.plots = _METFixEE2017_plots
-for modifier in eras.run2_nanoAOD_94XMiniAODv1, eras.run2_nanoAOD_94XMiniAODv2:
+from Configuration.Eras.Modifier_run2_nanoAOD_94XMiniAODv1_cff import run2_nanoAOD_94XMiniAODv1
+from Configuration.Eras.Modifier_run2_nanoAOD_94XMiniAODv2_cff import run2_nanoAOD_94XMiniAODv2
+for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
     modifier.toModify(nanoDQM.vplots, METFixEE2017 = _METFixEE2017_DQMentry)
 
 _Electron_plots_with_eCorr = copy.deepcopy(nanoDQM.vplots.Electron.plots)
@@ -60,16 +63,17 @@ _Flag_plots_80x = copy.deepcopy(nanoDQM.vplots.Flag.plots)
 _Flag_plots_80x.append(Plot1D('BadGlobalMuon', 'BadGlobalMuon', 2, -0.5, 1.5, 'Bad muon flag'))
 _Flag_plots_80x.append(Plot1D('CloneGlobalMuon', 'CloneGlobalMuon', 2, -0.5, 1.5, 'Clone muon flag'))
 
-for modifier in eras.run2_nanoAOD_94XMiniAODv1, eras.run2_nanoAOD_94XMiniAODv2:
+for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
     modifier.toModify(nanoDQM.vplots.Electron, plots = _Electron_plots_with_eCorr)
     modifier.toModify(nanoDQM.vplots.Photon, plots = _Photon_plots_with_eCorr)
-for modifier in eras.run2_miniAOD_80XLegacy, eras.run2_nanoAOD_94X2016:
+from Configuration.Eras.Modifier_run2_nanoAOD_94X2016_cff import run2_nanoAOD_94X2016
+for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
     modifier.toModify(nanoDQM.vplots.Electron, plots = _Electron_plots_with_eCorr_2016)
     modifier.toModify(nanoDQM.vplots.Photon, plots = _Photon_plots_with_eCorr_2016)
-eras.run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots.FatJet, plots = _FatJet_plots_80x)
-eras.run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots.Flag, plots = _Flag_plots_80x)
+run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots.FatJet, plots = _FatJet_plots_80x)
+run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots.Flag, plots = _Flag_plots_80x)
 
-eras.run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots, IsoTrack = None)
+run2_miniAOD_80XLegacy.toModify(nanoDQM.vplots, IsoTrack = None)
 
 ## MC
 nanoDQMMC = nanoDQM.clone()

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -5,7 +5,6 @@ from PhysicsTools.NanoAOD.nanoDQM_cfi import nanoDQM
 from PhysicsTools.NanoAOD.nanoDQM_tools_cff import *
 
 ## Modify plots accordingly to era
-from Configuration.StandardSequences.Eras import eras
 _vplots80X = nanoDQM.vplots.clone()
 # Tau plots
 _tauPlots80X = cms.VPSet()

--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -15,11 +15,14 @@ finalTaus = cms.EDFilter("PATTauRefSelector",
     cut = cms.string("pt > 18 && tauID('decayModeFindingNewDMs') && (tauID('byLooseCombinedIsolationDeltaBetaCorr3Hits') || tauID('byVLooseIsolationMVArun2v1DBoldDMwLT2015') || tauID('byVLooseIsolationMVArun2v1DBnewDMwLT') || tauID('byVLooseIsolationMVArun2v1DBdR03oldDMwLT') || tauID('byVVLooseIsolationMVArun2v1DBoldDMwLT') || tauID('byVVLooseIsolationMVArun2v1DBoldDMwLT2017v2') || tauID('byVVLooseIsolationMVArun2v1DBnewDMwLT2017v2') || tauID('byVVLooseIsolationMVArun2v1DBdR03oldDMwLT2017v2'))")
 )
 
-for era in [eras.run2_nanoAOD_94XMiniAODv1,eras.run2_nanoAOD_92X]:
+from Configuration.Eras.Modifier_run2_nanoAOD_94XMiniAODv1_cff import run2_nanoAOD_94XMiniAODv1
+from Configuration.Eras.Modifier_run2_nanoAOD_92X_cff import run2_nanoAOD_92X
+for era in [run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_92X]:
     era.toModify(finalTaus,
                  cut = cms.string("pt > 18 && tauID('decayModeFindingNewDMs') && (tauID('byLooseCombinedIsolationDeltaBetaCorr3Hits') || tauID('byVLooseIsolationMVArun2v1DBoldDMwLT') || tauID('byVLooseIsolationMVArun2v1DBnewDMwLT') || tauID('byVLooseIsolationMVArun2v1DBdR03oldDMwLT') || tauID('byVVLooseIsolationMVArun2v1DBoldDMwLT2017v1') || tauID('byVVLooseIsolationMVArun2v1DBoldDMwLT2017v2') || tauID('byVVLooseIsolationMVArun2v1DBnewDMwLT2017v2') || tauID('byVVLooseIsolationMVArun2v1DBdR03oldDMwLT2017v2'))")
     )
-eras.run2_miniAOD_80XLegacy.toModify(finalTaus,
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+run2_miniAOD_80XLegacy.toModify(finalTaus,
                                      src = cms.InputTag("slimmedTaus"),
                                      cut =  cms.string("pt > 18 && tauID('decayModeFindingNewDMs') && (tauID('byLooseCombinedIsolationDeltaBetaCorr3Hits') || tauID('byVLooseIsolationMVArun2v1DBoldDMwLT') || tauID('byVLooseIsolationMVArun2v1DBnewDMwLT') || tauID('byVLooseIsolationMVArun2v1DBdR03oldDMwLT'))")
     )
@@ -124,11 +127,11 @@ _variables80X =  cms.PSet(
 
 tauTable.variables=_variablesMiniV2
 
-for era in [eras.run2_nanoAOD_94XMiniAODv1,eras.run2_nanoAOD_92X]:
+for era in [run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_92X]:
     era.toModify(tauTable,
                  variables = _variablesMiniV1
     )
-eras.run2_miniAOD_80XLegacy.toModify(tauTable,
+run2_miniAOD_80XLegacy.toModify(tauTable,
                                      variables = _variables80X
 )
 tauGenJets.GenParticles = cms.InputTag("prunedGenParticles")
@@ -194,7 +197,7 @@ tauMCTable = cms.EDProducer("CandMCMatchTableProducer",
 
 tauSequence = cms.Sequence(patTauMVAIDsSeq + finalTaus)
 _tauSequence80X =  cms.Sequence(finalTaus)
-eras.run2_miniAOD_80XLegacy.toReplaceWith(tauSequence,_tauSequence80X)
+run2_miniAOD_80XLegacy.toReplaceWith(tauSequence,_tauSequence80X)
 tauTables = cms.Sequence(tauTable)
 tauMC = cms.Sequence(tauGenJets + tauGenJetsSelectorAllHadrons + genVisTaus + genVisTauTable + tausMCMatchLepTauForTable + tausMCMatchHadTauForTable + tauMCTable)
 

--- a/PhysicsTools/NanoAOD/python/taus_updatedMVAIds_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_updatedMVAIds_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 ##################### Updated tau collection with MVA-based tau-Ids rerun #######
 # Used only in some eras
-from Configuration.StandardSequences.Eras import eras
 from RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi import *
 from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import *
 

--- a/PhysicsTools/NanoAOD/python/taus_updatedMVAIds_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_updatedMVAIds_cff.py
@@ -299,7 +299,9 @@ patTauMVAIDsSeq += patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2015Seq
 
 _patTauMVAIDsSeqWith2017v1 = _patTauMVAIDsSeq2017v2.copy()
 _patTauMVAIDsSeqWith2017v1 += patTauDiscriminationByIsolationMVArun2v1DBoldDMwLT2017v1Seq
-for era in [eras.run2_nanoAOD_94XMiniAODv1,eras.run2_nanoAOD_92X]:
+from Configuration.Eras.Modifier_run2_nanoAOD_94XMiniAODv1_cff import run2_nanoAOD_94XMiniAODv1
+from Configuration.Eras.Modifier_run2_nanoAOD_92X_cff import run2_nanoAOD_92X
+for era in [run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_92X]:
     era.toReplaceWith(patTauMVAIDsSeq,_patTauMVAIDsSeqWith2017v1)
 
 # embed new MVA tau-Ids into new tau collection
@@ -365,7 +367,7 @@ _tauIDSourcesWith2015 = cms.PSet(
 )
 slimmedTausUpdated.tauIDSources=_tauIDSourcesWith2015
 
-for era in [eras.run2_nanoAOD_94XMiniAODv1,eras.run2_nanoAOD_92X]:
+for era in [run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_92X]:
     era.toModify(slimmedTausUpdated,
                  tauIDSources = _tauIDSourcesWith2017v1
     )

--- a/PhysicsTools/NanoAOD/test/nano_cfg.py
+++ b/PhysicsTools/NanoAOD/test/nano_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('NANO',eras.Run2_2017,eras.run2_nanoAOD_92X)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+from Configuration.Eras.Modifier_run2_nanoAOD_92X_cff import run2_nanoAOD_92X
+process = cms.Process('NANO',Run2_2017,run2_nanoAOD_92X)
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 

--- a/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
+++ b/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
@@ -95,10 +95,6 @@ patMultPhiCorrParams_T1T2SmearTxy_25ns = cms.VPSet( [pset for pset in _shiftMod.
 patMultPhiCorrParams_T0pcT1SmearTxy_25ns = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T0pcT1Txy_25ns])
 patMultPhiCorrParams_T0pcT1T2SmearTxy_25ns = cms.VPSet( [pset for pset in _shiftMod.multPhiCorrParams_T0pcT1T2Txy_25ns])
 
-#from Configuration.StandardSequences.Eras import eras
-#eras.run2_50ns_specific.toModify(patPFMetTxyCorr, parameters=patMultPhiCorrParams_Txy_50ns )
-#eras.run2_25ns_specific.toModify(patPFMetTxyCorr, parameters=patMultPhiCorrParams_Txy_25ns )
-
 patPFMetTxyCorrTask = cms.Task(patPFMetTxyCorr)
 patPFMetTxyCorrSequence = cms.Sequence(patPFMetTxyCorrTask)
 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -993,10 +993,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             }
 
         getattr(process, "patPFMetTxyCorr"+postfix).parameters = xyTags[corScheme+"_25ns"] 
-        ##for automatic switch to 50ns / 25ns corrections ==> does not work...
-        #from Configuration.StandardSequences.Eras import eras
-        #eras.run2_50ns_specific.toModify( getattr(process, "patPFMetTxyCorr"+postfix) , parameters=xyTags[corScheme+"_50ns"] )
-        #eras.run2_25ns_specific.toModify( getattr(process, "patPFMetTxyCorr"+postfix) , parameters=xyTags[corScheme+"_25ns"] )
 
 
 #====================================================================================================

--- a/RecoCTPPS/Configuration/test/raw_data_test.py
+++ b/RecoCTPPS/Configuration/test/raw_data_test.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("CTPPSReconstructionChainTest", eras.ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+process = cms.Process("CTPPSReconstructionChainTest", ctpps_2016)
 
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",

--- a/RecoCTPPS/PixelLocal/test/_aa_real_ALL_GT_2.py
+++ b/RecoCTPPS/PixelLocal/test/_aa_real_ALL_GT_2.py
@@ -5,9 +5,9 @@
 # with command line options: step2 --filein=file:GluGluTo2Jets_M_300_2000_13TeV_exhume_cff_py_GEN_SIM_HECTOR_CTPPS.root --conditions auto:run2_mc -s DIGI:pdigi_valid,DIGI2RAW --datatier GEN-SIM-DIGI-RAW -n 10 --era Run2_2016 --eventcontent FEVTDEBUG --no_exec
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('CTPPS2',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('CTPPS2',Run2_2017)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/RecoCTPPS/PixelLocal/test/run_only_CTPPS_cfg_CLU_DB_real_mem.py
+++ b/RecoCTPPS/PixelLocal/test/run_only_CTPPS_cfg_CLU_DB_real_mem.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('CTPPS2',eras.Run2_25ns)
+from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+process = cms.Process('CTPPS2',Run2_25ns)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/RecoCTPPS/PixelLocal/test/run_only_CTPPS_cfg_CLU_REC_DAQ_TRK.py
+++ b/RecoCTPPS/PixelLocal/test/run_only_CTPPS_cfg_CLU_REC_DAQ_TRK.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 import FWCore.ParameterSet.VarParsing as VarParsing
 
-process = cms.Process('CTPPS2',eras.Run2_25ns)
+from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+process = cms.Process('CTPPS2',Run2_25ns)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/RecoCTPPS/PixelLocal/test/run_only_CTPPS_cfg_CLU_REC_DB_real_mem.py
+++ b/RecoCTPPS/PixelLocal/test/run_only_CTPPS_cfg_CLU_REC_DB_real_mem.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('CTPPS2',eras.Run2_25ns)
+from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+process = cms.Process('CTPPS2',Run2_25ns)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/RecoCTPPS/PixelLocal/test/run_only_CTPPS_cfg_CLU_REC_mem_testDB_300811.py
+++ b/RecoCTPPS/PixelLocal/test/run_only_CTPPS_cfg_CLU_REC_mem_testDB_300811.py
@@ -1,9 +1,9 @@
 
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('CTPPS2',eras.Run2_25ns)
+from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+process = cms.Process('CTPPS2',Run2_25ns)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/RecoEgamma/EgammaMCTools/test/pfClusterForCalibration.py
+++ b/RecoEgamma/EgammaMCTools/test/pfClusterForCalibration.py
@@ -4,8 +4,8 @@
 import FWCore.ParameterSet.Config as cms
 
 # Run with the 2017 detector
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('SKIM',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('SKIM',Run2_2017)
 
 # Import the standard packages for reconstruction and digitization
 process.load('Configuration.StandardSequences.Services_cff')

--- a/RecoLocalMuon/GEMRecHit/test/SingleMuPt100_cfi_DIGI_Extended2015MuonGEMDev_RPCGEMME0Customs_cfg.py
+++ b/RecoLocalMuon/GEMRecHit/test/SingleMuPt100_cfi_DIGI_Extended2015MuonGEMDev_RPCGEMME0Customs_cfg.py
@@ -5,9 +5,9 @@
 # with command line options: step2 -s DIGI --conditions auto:run2_mc --magField 38T_PostLS1 --datatier GEN-SIM-DIGI --geometry Extended2015MuonGEMDev,Extended2015MuonGEMDevReco --eventcontent FEVTDEBUGHLT --era Run2_25ns --customise=SimMuon/GEMDigitizer/customizeGEMDigi.customize_digi_addGEM_nocalo,SLHCUpgradeSimulations/Configuration/fixMissingUpgradeGTPayloads.fixRPCConditions,SLHCUpgradeSimulations/Configuration/me0Customs.customise -n 100 --no_exec --filein file:out_sim.root --fileout out_digi.root --python_filename SingleMuPt100_cfi_DIGI_Extended2015MuonGEMDev_RPCGEMME0Customs_cfg.py
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('DIGI',eras.Run2_25ns)
+from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+process = cms.Process('DIGI',Run2_25ns)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/RecoLocalMuon/GEMRecHit/test/SingleMuPt100_cfi_GEM-SIM-DIGI_Extended2015MuonGEMDev.py
+++ b/RecoLocalMuon/GEMRecHit/test/SingleMuPt100_cfi_GEM-SIM-DIGI_Extended2015MuonGEMDev.py
@@ -5,9 +5,9 @@
 # with command line options: SingleMuPt100_cfi -s GEN,SIM,DIGI --conditions auto:run2_mc --magField 38T_PostLS1 --datatier GEN-SIM-DIGI --geometry Extended2015MuonGEMDev,Extended2015MuonGEMDevReco --eventcontent FEVTDEBUGHLT --era Run2_25ns --customise=SimMuon/GEMDigitizer/customizeGEMDigi.customize_digi_addGEM_muon_only,SLHCUpgradeSimulations/Configuration/fixMissingUpgradeGTPayloads.fixRPCConditions,SLHCUpgradeSimulations/Configuration/me0Customs.customize_Digi -n 100 --no_exec --fileout out_digi.root --python_filename SingleMuPt100_cfi_GEM-SIM-DIGI_Extended2015MuonGEMDev_cfg.py
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('DIGI',eras.Run2_25ns)
+from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+process = cms.Process('DIGI',Run2_25ns)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/RecoLocalMuon/GEMRecHit/test/SingleMuPt100_cfi_GEM-SIM-DIGI_Extended2015MuonGEMDev_RPCGEMME0Customs_cfg.py
+++ b/RecoLocalMuon/GEMRecHit/test/SingleMuPt100_cfi_GEM-SIM-DIGI_Extended2015MuonGEMDev_RPCGEMME0Customs_cfg.py
@@ -5,9 +5,9 @@
 # with command line options: SingleMuPt100_cfi -s GEN,SIM,DIGI --conditions auto:run2_mc --magField 38T_PostLS1 --datatier GEN-SIM-DIGI --geometry Extended2015MuonGEMDev,Extended2015MuonGEMDevReco --eventcontent FEVTDEBUGHLT --era Run2_25ns --customise=SimMuon/GEMDigitizer/customizeGEMDigi.customize_digi_addGEM_nocalo,SLHCUpgradeSimulations/Configuration/fixMissingUpgradeGTPayloads.fixRPCConditions,SLHCUpgradeSimulations/Configuration/me0Customs.customise -n 100 --no_exec --fileout out_digi.root --python_filename SingleMuPt100_cfi_GEM-SIM-DIGI_Extended2015MuonGEMDev_RPCGEMME0Customs_cfg.py
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('DIGI',eras.Run2_25ns)
+from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+process = cms.Process('DIGI',Run2_25ns)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/RecoLocalMuon/GEMRecHit/test/SingleMuPt100_cfi_GEM-SIM_Extended2015MuonGEMDev_RPCGEMME0Customs_cfg.py
+++ b/RecoLocalMuon/GEMRecHit/test/SingleMuPt100_cfi_GEM-SIM_Extended2015MuonGEMDev_RPCGEMME0Customs_cfg.py
@@ -5,9 +5,9 @@
 # with command line options: SingleMuPt100_cfi -s GEN,SIM --conditions auto:run2_mc --magField 38T_PostLS1 --datatier GEN-SIM --geometry Extended2015MuonGEMDev,Extended2015MuonGEMDevReco --eventcontent FEVTDEBUGHLT --era Run2_25ns --customise=SLHCUpgradeSimulations/Configuration/me0Customs.customise -n 100 --no_exec --fileout out_sim.root --python_filename SingleMuPt100_cfi_GEM-SIM_Extended2015MuonGEMDev_RPCGEMME0Customs_cfg.py
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('SIM',eras.Run2_25ns)
+from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+process = cms.Process('SIM',Run2_25ns)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/RecoPixelVertexing/PixelLowPtUtilities/test/clusterShapeExtractor_phase1_cfg.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/test/clusterShapeExtractor_phase1_cfg.py
@@ -5,9 +5,9 @@
 # with command line options: step3 --conditions auto:phase1_2017_realistic -n 10 --era Run2_2017 --eventcontent RECOSIM,DQM --runUnscheduled -s RAW2DIGI,RECO:reconstruction_trackingOnly,VALIDATION:@trackingOnlyValidation,DQM:@trackingOnlyDQM --datatier GEN-SIM-RECO,DQMIO --geometry DB:Extended --filein file:step2.root --fileout file:step3.root
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('RECO',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('RECO',Run2_2017)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/RecoPixelVertexing/PixelLowPtUtilities/test/clusterShapeExtractor_phase2_cfg.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/test/clusterShapeExtractor_phase2_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('RECO',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('RECO',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/RecoTauTag/RecoTau/test/rerunTauRecoOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/rerunTauRecoOnMiniAOD.py
@@ -33,9 +33,11 @@ print('\t Use Phase2 settings:', phase2)
 print('\t Output mode:', outMode)
 
 #####
-era = eras.Run2_2018
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+era = Run2_2018
 if phase2:
-    era = eras.Phase2_timing
+    from Configuration.Eras.Era_Phase2_timing_cff import Phase2_timing
+    era = Phase2_timing
 process = cms.Process("TAURECO", era)
 # for CH reco
 process.load("Configuration.StandardSequences.MagneticField_cff")

--- a/RecoTauTag/RecoTau/test/rerunTauRecoOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/rerunTauRecoOnMiniAOD.py
@@ -33,7 +33,6 @@ print('\t Use Phase2 settings:', phase2)
 print('\t Output mode:', outMode)
 
 #####
-from Configuration.StandardSequences.Eras import eras
 era = eras.Run2_2018
 if phase2:
     era = eras.Phase2_timing

--- a/RecoTracker/MeasurementDet/test/measTkTest.py
+++ b/RecoTracker/MeasurementDet/test/measTkTest.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("TEST",eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process("TEST",Run2_2017)
 
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(

--- a/RecoTracker/TrackProducer/test/RefitWithSim.py
+++ b/RecoTracker/TrackProducer/test/RefitWithSim.py
@@ -5,9 +5,9 @@
 # with command line options: step3 --conditions auto:phase1_2018_realistic -n 10 --era Run2_2018 --eventcontent RECOSIM,DQM --runUnscheduled -s RAW2DIGI,RECO:reconstruction_trackingOnly,VALIDATION:@trackingOnlyValidation,DQM:@trackingOnlyDQM --datatier GEN-SIM-RECO,DQMIO --geometry DB:Extended -n 10 --filein file:step2.root --fileout file:step3.root --nThreads 8 --no_exec
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('RECO',eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process('RECO',Run2_2018)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -10,9 +10,9 @@ def customise(process):
 #   If using cmsDriver:
 #       1) add the option "--era Run2_2017" 
 #   If using a pre-made configuration file:
-#       1) add "from Configuration.StandardSequences.Eras import eras" to the TOP of the config file (above
+#       1) add "from Configuration.Eras.Era_Run2_2017_cff import Run2_2017" to the TOP of the config file (above
 #          the process declaration).
-#       2) add "eras.Run2_2017" as a parameter to the process object, e.g. "process = cms.Process('HLT',eras.Run2_2017)" 
+#       2) add "Run2_2017" as a parameter to the process object, e.g. "process = cms.Process('HLT',Run2_2017)" 
 #
 # If you are targeting something else than 2017 and have to use a
 # customize function from SLHC-times, you have to modify the customize

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -55,9 +55,9 @@ def customisePostLS1(process,displayDeprecationWarning=True):
         #       2) add the option "--era Run2_25ns" 
         #   If using a pre-made configuration file:
         #       1) remove or comment out the "process = customisePostLS1(process)" line.
-        #       2) add "from Configuration.StandardSequences.Eras import eras" to the TOP of the config file (above
+        #       2) add "from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns" to the TOP of the config file (above
         #          the process declaration).
-        #       3) add "eras.Run2_25ns" as a parameter to the process object, e.g. "process = cms.Process('HLT',eras.Run2_25ns)" 
+        #       3) add "Run2_25ns" as a parameter to the process object, e.g. "process = cms.Process('HLT',Run2_25ns)" 
         #
         # There is more information at https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCmsDriverEras
         #
@@ -99,9 +99,9 @@ def customisePostLS1_50ns(process,displayDeprecationWarning=True):
         #       2) add the option "--era Run2_50ns"
         #   If using a pre-made configuration file:
         #       1) remove or comment out the "process = customisePostLS1_50ns(process)" line.
-        #       2) add "from Configuration.StandardSequences.Eras import eras" to the TOP of the config file (above
+        #       2) add "from Configuration.Eras.Era_Run2_50ns_cff import Run2_50ns" to the TOP of the config file (above
         #          the process declaration).
-        #       3) add "eras.Run2_50ns" as a parameter to the process object, e.g. "process = cms.Process('HLT',eras.Run2_50ns)"
+        #       3) add "Run2_50ns" as a parameter to the process object, e.g. "process = cms.Process('HLT',Run2_50ns)"
         #
         # There is more information at https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCmsDriverEras
         #
@@ -130,9 +130,9 @@ def customisePostLS1_HI(process,displayDeprecationWarning=True):
         #       2) add the option "--era Run2_HI"
         #   If using a pre-made configuration file:
         #       1) remove or comment out the "process = customisePostLS1_HI(process)" line.
-        #       2) add "from Configuration.StandardSequences.Eras import eras" to the TOP of the config file (above
+        #       2) add "from Configuration.Eras.Era_Run2_HI_cff import Run2_HI" to the TOP of the config file (above
         #          the process declaration).
-        #       3) add "eras.Run2_HI" as a parameter to the process object, e.g. "process = cms.Process('HLT',eras.Run2_HI)"
+        #       3) add "Run2_HI" as a parameter to the process object, e.g. "process = cms.Process('HLT',Run2_HI)"
         #
         # There is more information at https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCmsDriverEras
         #

--- a/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
@@ -5,9 +5,9 @@
 # with command line options: step2 --conditions auto:phase2_realistic -s DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2,RAW2DIGI,L1Reco,RECO --datatier GEN-SIM-RECO -n 10 --geometry Extended2023D21 --era Phase2 --eventcontent FEVTDEBUGHLT --filein file:SingleMuPt1000_pythia8_cfi_GEN_SIM.root --runUnscheduled --no_exec
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('Phase2PixelNtuple',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('Phase2PixelNtuple',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/SLHCUpgradeSimulations/Geometry/test/phase2_reco_pixelntuple_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_reco_pixelntuple_cfg.py
@@ -5,9 +5,9 @@
 # with command line options: step2 --conditions auto:phase2_realistic -s DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2,RAW2DIGI,L1Reco,RECO --datatier GEN-SIM-RECO -n 10 --geometry Extended2023D21 --era Phase2 --eventcontent FEVTDEBUGHLT --filein file:SingleMuPt1000_pythia8_cfi_GEN_SIM.root --runUnscheduled --no_exec
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('Phase2PixelNtuple',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('Phase2PixelNtuple',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/SimG4CMS/Calo/test/python/calostep_cfg.py
+++ b/SimG4CMS/Calo/test/python/calostep_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Sim",eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("Sim",Run2_2018)
 
 process.load("SimG4CMS.Calo.PythiaMinBias_cfi")
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")

--- a/SimG4CMS/Calo/test/python/minbias_cfg.py
+++ b/SimG4CMS/Calo/test/python/minbias_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Sim",eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("Sim",Run2_2018)
 
 process.load("SimG4CMS.Calo.PythiaMinBias_cfi")
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBGenSimCERNMB_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBGenSimCERNMB_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('SIM',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('SIM',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/SimMuon/GEMDigitizer/test/runGEMDigiProducer_cfg.py
+++ b/SimMuon/GEMDigitizer/test/runGEMDigiProducer_cfg.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process("GEMDIGI", eras.Phase2C2)
 

--- a/SimMuon/GEMDigitizer/test/runGEMDigiProducer_cfg.py
+++ b/SimMuon/GEMDigitizer/test/runGEMDigiProducer_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-
-process = cms.Process("GEMDIGI", eras.Phase2C2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process("GEMDIGI", Phase2)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')

--- a/SimMuon/GEMDigitizer/test/runME0ReDigiProducer_cfg.py
+++ b/SimMuon/GEMDigitizer/test/runME0ReDigiProducer_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("GEMDIGI", eras.Phase2C2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process("GEMDIGI", Phase2)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')

--- a/SimMuon/GEMDigitizer/test/runME0ReDigiProducer_cfg.py
+++ b/SimMuon/GEMDigitizer/test/runME0ReDigiProducer_cfg.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process("GEMDIGI", eras.Phase2C2)
 

--- a/SimTracker/SiPhase2Digitizer/test/DigiTest_cfg.py
+++ b/SimTracker/SiPhase2Digitizer/test/DigiTest_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('digiTest',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('digiTest',Phase2)
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )

--- a/SimTracker/TrackerHitAssociation/test/TestAssoc_Phase0-1_cfg.py
+++ b/SimTracker/TrackerHitAssociation/test/TestAssoc_Phase0-1_cfg.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 import os 
 
 # Create a new CMS process
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('assocTest',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('assocTest',Run2_2017)
 
 # Import all the necessary files
 process.load('Configuration.StandardSequences.Services_cff')

--- a/SimTracker/TrackerHitAssociation/test/TestAssoc_Phase2_cfg.py
+++ b/SimTracker/TrackerHitAssociation/test/TestAssoc_Phase2_cfg.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 import os 
 
 # Create a new CMS process
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('assocTest',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('assocTest',Phase2)
 
 # Import all the necessary files
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/CTPPS/test/year_2016/beam_smearing_validation/test_beam_smearing_cfg.py
+++ b/Validation/CTPPS/test/year_2016/beam_smearing_validation/test_beam_smearing_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('CTPPSTestBeamSmearing', eras.ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+process = cms.Process('CTPPSTestBeamSmearing', ctpps_2016)
 
 # minimal logger settings
 process.MessageLogger = cms.Service("MessageLogger",

--- a/Validation/CTPPS/test/year_2016/direct_simulation_validation/test_acceptance_cfg.py
+++ b/Validation/CTPPS/test/year_2016/direct_simulation_validation/test_acceptance_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('CTPPSTestAcceptance', eras.ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+process = cms.Process('CTPPSTestAcceptance', ctpps_2016)
 
 # minimal logger settings
 process.MessageLogger = cms.Service("MessageLogger",

--- a/Validation/CTPPS/test/year_2016/direct_simulation_validation/test_smearing_effects_cfg.py
+++ b/Validation/CTPPS/test/year_2016/direct_simulation_validation/test_smearing_effects_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('CTPPSTestAcceptance', eras.ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+process = cms.Process('CTPPSTestAcceptance', ctpps_2016)
 
 # minimal logger settings
 process.MessageLogger = cms.Service("MessageLogger",

--- a/Validation/CTPPS/test/year_2016/direct_simulation_validation/test_xy_pattern_cfg.py
+++ b/Validation/CTPPS/test/year_2016/direct_simulation_validation/test_xy_pattern_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('CTPPSFastSimulation', eras.ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+process = cms.Process('CTPPSFastSimulation', ctpps_2016)
 
 # minimal logger settings
 process.MessageLogger = cms.Service("MessageLogger",

--- a/Validation/CTPPS/test/year_2016/proton_gun_validation/test_proton_gun_cfg.py
+++ b/Validation/CTPPS/test/year_2016/proton_gun_validation/test_proton_gun_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('CTPPSFastSimulation', eras.ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+process = cms.Process('CTPPSFastSimulation', ctpps_2016)
 
 # minimal logger settings
 process.MessageLogger = cms.Service("MessageLogger",

--- a/Validation/CTPPS/test/year_2016/proton_reconstruction_LHC_data/test_reconstruction_cfg.py
+++ b/Validation/CTPPS/test/year_2016/proton_reconstruction_LHC_data/test_reconstruction_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("CTPPSTestProtonReconstruction", eras.ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+process = cms.Process("CTPPSTestProtonReconstruction", ctpps_2016)
 
 # declare global tag
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')

--- a/Validation/CTPPS/test/year_2016/proton_reconstruction_MC/misalignment/template_cfg.py
+++ b/Validation/CTPPS/test/year_2016/proton_reconstruction_MC/misalignment/template_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('CTPPSProtonReconstructionTest', eras.ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+process = cms.Process('CTPPSProtonReconstructionTest', ctpps_2016)
 
 # minimal logger settings
 process.MessageLogger = cms.Service("MessageLogger",

--- a/Validation/CTPPS/test/year_2016/proton_reconstruction_MC/resolution/template_cfg.py
+++ b/Validation/CTPPS/test/year_2016/proton_reconstruction_MC/resolution/template_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('CTPPSProtonReconstructionTest', eras.ctpps_2016)
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+process = cms.Process('CTPPSProtonReconstructionTest', ctpps_2016)
 
 # minimal logger settings
 process.MessageLogger = cms.Service("MessageLogger",

--- a/Validation/CaloTowers/test/CaloScan/template_2017.py
+++ b/Validation/CaloTowers/test/CaloScan/template_2017.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('TEST',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('TEST',Run2_2017)
 
 ### RANDOM setting (change last digit(s) to make runs different !)
 process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")

--- a/Validation/CaloTowers/test/CaloScan/template_2018_since_1010pre2.py
+++ b/Validation/CaloTowers/test/CaloScan/template_2018_since_1010pre2.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('TEST',eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process('TEST',Run2_2018)
 
 ### RANDOM setting (change last digit(s) to make runs different !)
 process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")

--- a/Validation/Geometry/test/runMaterialMapForReco_fromReco.py
+++ b/Validation/Geometry/test/runMaterialMapForReco_fromReco.py
@@ -7,7 +7,6 @@ import FWCore.ParameterSet.Config as cms
 
 from FWCore.ParameterSet.VarParsing import VarParsing
 
-from Configuration.StandardSequences.Eras import eras
 
 options = VarParsing ('analysis')
 options.register('inputFile',
@@ -84,7 +83,8 @@ if options.sample == 'TTbar_PU25':
 if options.inputFile is not None:
   input_file = options.inputFile
 
-process = cms.Process('MATERIAL',eras.Run2_2016)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('MATERIAL',Run2_2016)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/Geometry/test/runMaterialMapForReco_fromReco_Harvesting.py
+++ b/Validation/Geometry/test/runMaterialMapForReco_fromReco_Harvesting.py
@@ -6,7 +6,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from FWCore.ParameterSet.VarParsing import VarParsing 
-from Configuration.StandardSequences.Eras import eras
 
 options = VarParsing ('analysis')
 options.register('inputFile',
@@ -21,7 +20,8 @@ options.register('label',
                 "Label to use in the final ROOT file.")
 options.parseArguments()
 
-process = cms.Process('HARVESTING',eras.Run2_2016)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('HARVESTING',Run2_2016)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/Geometry/test/step3_PhaseI_testing.py
+++ b/Validation/Geometry/test/step3_PhaseI_testing.py
@@ -5,9 +5,9 @@
 # with command line options: step3 --conditions auto:phase1_2017_realistic --pileup_input das:/RelValMinBias_13/CMSSW_8_1_0_pre7-81X_upgrade2017_realistic_v3_UPG17newGT-v1/GEN-SIM -n 10 --era Run2_2017 --eventcontent RECOSIM,DQM -s RAW2DIGI,L1Reco,RECO:reconstruction_trackingOnly,VALIDATION:@trackingOnlyValidation,DQM:@trackingOnlyDQM --datatier GEN-SIM-RECO,DQMIO --pileup AVE_35_BX_25ns --geometry DB:Extended --conditions 81X_upgrade2017_realistic_v3 --no_exec --filein file:step2.root --fileout file:step3.root --nThreads 4 --python_filename fuffa.py
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('RECO',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('RECO',Run2_2017)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/Geometry/test/step4_PhaseI_testing.py
+++ b/Validation/Geometry/test/step4_PhaseI_testing.py
@@ -5,9 +5,9 @@
 # with command line options: step4 --filetype DQM --mc --conditions auto:phase1_2017_realistic --era Run2_2017 -s HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM -n -1 --filein file:matbdgForReco_FromReco_TTbarPhaseI_inDQM.root --python_filename fuffa_harvesting.py --no_exec
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('HARVESTING',eras.Run2_2017)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process('HARVESTING',Run2_2017)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/HGCalValidation/test/digiValidation_cfg.py
+++ b/Validation/HGCalValidation/test/digiValidation_cfg.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 import six
 
-process = cms.Process('SIM',eras.Phase2C2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('SIM',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/HGCalValidation/test/digiValidation_cfg.py
+++ b/Validation/HGCalValidation/test/digiValidation_cfg.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 import six
 
 process = cms.Process('SIM',eras.Phase2C2)

--- a/Validation/HGCalValidation/test/rechitValidation_cfg.py
+++ b/Validation/HGCalValidation/test/rechitValidation_cfg.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 import six
 
 process = cms.Process('SIMDIGIRECO',eras.Phase2C2)

--- a/Validation/HGCalValidation/test/rechitValidation_cfg.py
+++ b/Validation/HGCalValidation/test/rechitValidation_cfg.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 import six
 
-process = cms.Process('SIMDIGIRECO',eras.Phase2C2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('SIMDIGIRECO',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/HGCalValidation/test/runHFNoseDigiStudy_cfg.py
+++ b/Validation/HGCalValidation/test/runHFNoseDigiStudy_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('PROD',eras.Phase2C6)
+from Configuration.Eras.Era_Phase2C6_cff import Phase2C6
+process = cms.Process('PROD',Phase2C6)
 
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load('Configuration.Geometry.GeometryExtended2023D31_cff')

--- a/Validation/HGCalValidation/test/runHFNoseSimHitStudy_cfg.py
+++ b/Validation/HGCalValidation/test/runHFNoseSimHitStudy_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('PROD',eras.Phase2C6)
+from Configuration.Eras.Era_Phase2C6_cff import Phase2C6
+process = cms.Process('PROD',Phase2C6)
 
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load("IOMC.EventVertexGenerators.VtxSmearedGauss_cfi")

--- a/Validation/HGCalValidation/test/runHGCGeomCheck_cfg.py
+++ b/Validation/HGCalValidation/test/runHGCGeomCheck_cfg.py
@@ -1,13 +1,15 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-#process = cms.Process("HGCGeomAnalysis",eras.Phase2)
+#from Configuration.Eras.Era_Phase2_cff import Phase2
+#process = cms.Process("HGCGeomAnalysis",Phase2)
 #process.load('Configuration.Geometry.GeometryExtended2023D21Reco_cff')
 #process.load('Configuration.Geometry.GeometryExtended2023D21_cff')
-#process = cms.Process("HGCGeomAnalysis",eras.Phase2C4)
+#from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+#process = cms.Process("HGCGeomAnalysis",Phase2C4)
 #process.load('Configuration.Geometry.GeometryExtended2023D28Reco_cff')
 #process.load('Configuration.Geometry.GeometryExtended2023D28_cff')
-process = cms.Process("HGCGeomAnalysis",eras.Phase2C4_timing_layer_bar)
+from Configuration.Eras.Era_Phase2C4_timing_layer_bar_cff import Phase2C4_timing_layer_bar
+process = cms.Process("HGCGeomAnalysis",Phase2C4_timing_layer_bar)
 process.load('Configuration.Geometry.GeometryExtended2023D41Reco_cff')
 process.load('Configuration.Geometry.GeometryExtended2023D41_cff')
 

--- a/Validation/HGCalValidation/test/runHGCHitAnalyzer_cfg.py
+++ b/Validation/HGCalValidation/test/runHGCHitAnalyzer_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('HGCGeomAnalysis',eras.Phase2C4)
+from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+process = cms.Process('HGCGeomAnalysis',Phase2C4)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')    

--- a/Validation/HGCalValidation/test/runHGCalDigiStudy_cfg.py
+++ b/Validation/HGCalValidation/test/runHGCalDigiStudy_cfg.py
@@ -1,11 +1,12 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-#process = cms.Process('PROD',eras.Phase2C4)
+#from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+#process = cms.Process('PROD',Phase2C4)
 #process.load('Configuration.Geometry.GeometryExtended2023D28_cff')
 #process.load('Configuration.Geometry.GeometryExtended2023D28Reco_cff')
 
-process = cms.Process('PROD',eras.Phase2C4_timing_layer_bar)
+from Configuration.Eras.Era_Phase2C4_timing_layer_bar_cff import Phase2C4_timing_layer_bar
+process = cms.Process('PROD',Phase2C4_timing_layer_bar)
 process.load('Configuration.Geometry.GeometryExtended2023D41_cff')
 process.load('Configuration.Geometry.GeometryExtended2023D41Reco_cff')
 

--- a/Validation/HGCalValidation/test/runHGCalRecHitStudy_cfg.py
+++ b/Validation/HGCalValidation/test/runHGCalRecHitStudy_cfg.py
@@ -1,12 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 import FWCore.Utilities.FileUtils as FileUtils
-from Configuration.StandardSequences.Eras import eras
 
-#process = cms.Process('PROD',eras.Phase2C4)
+#from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+#process = cms.Process('PROD',Phase2C4)
 #process.load('Configuration.Geometry.GeometryExtended2023D28_cff')
 #process.load('Configuration.Geometry.GeometryExtended2023D28Reco_cff')
 
-process = cms.Process('PROD',eras.Phase2C4_timing_layer_bar)
+from Configuration.Eras.Era_Phase2C4_timing_layer_bar_cff import Phase2C4_timing_layer_bar
+process = cms.Process('PROD',Phase2C4_timing_layer_bar)
 process.load('Configuration.Geometry.GeometryExtended2023D41_cff')
 process.load('Configuration.Geometry.GeometryExtended2023D41Reco_cff')
 

--- a/Validation/HGCalValidation/test/runHGCalSimHitStudy_cfg.py
+++ b/Validation/HGCalValidation/test/runHGCalSimHitStudy_cfg.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-#process = cms.Process('PROD',eras.Phase2C4)
+#from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+#process = cms.Process('PROD',Phase2C4)
 #process.load('Configuration.Geometry.GeometryExtended2023D28_cff')
 
-process = cms.Process('PROD',eras.Phase2C4_timing_layer_bar)
+from Configuration.Eras.Era_Phase2C4_timing_layer_bar_cff import Phase2C4_timing_layer_bar
+process = cms.Process('PROD',Phase2C4_timing_layer_bar)
 process.load('Configuration.Geometry.GeometryExtended2023D41_cff')
 
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")

--- a/Validation/HGCalValidation/test/runHGCalWaferStudy_cfg.py
+++ b/Validation/HGCalValidation/test/runHGCalWaferStudy_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('PROD',eras.Phase2C4)
+from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+process = cms.Process('PROD',Phase2C4)
 
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load('Configuration.Geometry.GeometryExtended2023D28_cff')

--- a/Validation/HGCalValidation/test/simHitValidation_cfg.py
+++ b/Validation/HGCalValidation/test/simHitValidation_cfg.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 import six
 
 process = cms.Process("SIM",eras.Phase2C2)

--- a/Validation/HGCalValidation/test/simHitValidation_cfg.py
+++ b/Validation/HGCalValidation/test/simHitValidation_cfg.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 import six
 
-process = cms.Process("SIM",eras.Phase2C2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process("SIM",Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/HGCalValidation/test/standalone_fromRECO.py
+++ b/Validation/HGCalValidation/test/standalone_fromRECO.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('HGCAL',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('HGCAL',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/HGCalValidation/test/standalone_fromRECO_HARVESTING.py
+++ b/Validation/HGCalValidation/test/standalone_fromRECO_HARVESTING.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('HARVESTING',eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('HARVESTING',Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/HGCalValidation/test/testHGCalBHValid_cfg.py
+++ b/Validation/HGCalValidation/test/testHGCalBHValid_cfg.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 import six
 
-process = cms.Process("testHGCalRecoLocal",eras.Phase2C2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process("testHGCalRecoLocal",Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/HGCalValidation/test/testHGCalBHValid_cfg.py
+++ b/Validation/HGCalValidation/test/testHGCalBHValid_cfg.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 import six
 
 process = cms.Process("testHGCalRecoLocal",eras.Phase2C2)

--- a/Validation/HGCalValidation/test/testHGCalSimHitStudy_cfg.py
+++ b/Validation/HGCalValidation/test/testHGCalSimHitStudy_cfg.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-#process = cms.Process('PROD',eras.Phase2C4)
+#from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+#process = cms.Process('PROD',Phase2C4)
 #process.load('Configuration.Geometry.GeometryExtended2023D28_cff')
 
-process = cms.Process('PROD',eras.Phase2C4_timing_layer_bar)
+from Configuration.Eras.Era_Phase2C4_timing_layer_bar_cff import Phase2C4_timing_layer_bar
+process = cms.Process('PROD',Phase2C4_timing_layer_bar)
 process.load('Configuration.Geometry.GeometryExtended2023D41_cff')
 
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")

--- a/Validation/HGCalValidation/test/testHGCalSimWatcherV10_cfg.py
+++ b/Validation/HGCalValidation/test/testHGCalSimWatcherV10_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('testHGCalRecoLocal',eras.Phase2C4_timing_layer_bar)
+from Configuration.Eras.Era_Phase2C4_timing_layer_bar_cff import Phase2C4_timing_layer_bar
+process = cms.Process('testHGCalRecoLocal',Phase2C4_timing_layer_bar)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/HGCalValidation/test/testHGCalSimWatcherV8_cfg.py
+++ b/Validation/HGCalValidation/test/testHGCalSimWatcherV8_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("testHGCalRecoLocal",eras.Phase2)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process("testHGCalRecoLocal",Phase2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/HGCalValidation/test/testHGCalSimWatcherV9_cfg.py
+++ b/Validation/HGCalValidation/test/testHGCalSimWatcherV9_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('testHGCalRecoLocal',eras.Phase2C4)
+from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+process = cms.Process('testHGCalRecoLocal',Phase2C4)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/HGCalValidation/test/testValidationHGCalTrigPrim_RelVal_cfg.py
+++ b/Validation/HGCalValidation/test/testValidationHGCalTrigPrim_RelVal_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms 
-from Configuration.StandardSequences.Eras import eras
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 
-process = cms.Process('DIGI',eras.Phase2,convertHGCalDigisSim)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('DIGI',Phase2,convertHGCalDigisSim)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/Validation/RecoEgamma/test/ElectronMcFakePostValidation_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcFakePostValidation_cfg.py
@@ -9,11 +9,12 @@ cmsEnv = env() # be careful, cmsEnv != cmsenv. cmsEnv is local
 cmsEnv.checkSample() # check the sample value
 cmsEnv.checkValues()
 
-from Configuration.StandardSequences.Eras import eras
 if cmsEnv.beginTag() == 'Run2_2017':
-    process = cms.Process("electronPostValidation",eras.Run2_2017)
+    from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+    process = cms.Process("electronPostValidation",Run2_2017)
 else:
-    process = cms.Process('electronPostValidation',eras.Phase2) 
+    from Configuration.Eras.Era_Phase2_cff import Phase2
+    process = cms.Process('electronPostValidation',Phase2) 
 
 process.DQMStore = cms.Service("DQMStore")
 process.load("Validation.RecoEgamma.ElectronMcFakePostValidator_cfi")

--- a/Validation/RecoEgamma/test/ElectronMcFakeValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcFakeValidation_gedGsfElectrons_cfg.py
@@ -10,11 +10,12 @@ cmsEnv = env() # be careful, cmsEnv != cmsenv. cmsEnv is local
 cmsEnv.checkSample() # check the sample value
 cmsEnv.checkValues()
 
-from Configuration.StandardSequences.Eras import eras
 if cmsEnv.beginTag() == 'Run2_2017':
-    process = cms.Process("electronValidation",eras.Run2_2017)
+    from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+    process = cms.Process("electronValidation",Run2_2017)
 else:
-    process = cms.Process('electronValidation',eras.Phase2) 
+    from Configuration.Eras.Era_Phase2_cff import Phase2
+    process = cms.Process('electronValidation',Phase2) 
 
 process.DQMStore = cms.Service("DQMStore")
 process.load("DQMServices.Components.DQMStoreStats_cfi")

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
@@ -3,11 +3,12 @@ import sys
 import os
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras 
 
 #process = cms.Process("electronValidation")
-#process = cms.Process("electronPostValidation",eras.Run2_2017)
-process = cms.Process('electronPostValidation',eras.Phase2) 
+#from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+#process = cms.Process("electronPostValidation",Run2_2017)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('electronPostValidation',Phase2) 
 
 process.options = cms.untracked.PSet( )
 

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidationPt1000_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidationPt1000_cfg.py
@@ -9,11 +9,12 @@ cmsEnv = env() # be careful, cmsEnv != cmsenv. cmsEnv is local
 cmsEnv.checkSample() # check the sample value
 cmsEnv.checkValues()
 
-from Configuration.StandardSequences.Eras import eras 
 if cmsEnv.beginTag() == 'Run2_2017':
-    process = cms.Process("electronPostValidation",eras.Run2_2017)
+    from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+    process = cms.Process("electronPostValidation",Run2_2017)
 else:
-    process = cms.Process('electronPostValidation',eras.Phase2) 
+    from Configuration.Eras.Era_Phase2_cff import Phase2
+    process = cms.Process('electronPostValidation',Phase2) 
 
 process.DQMStore = cms.Service("DQMStore")
 process.load("Validation.RecoEgamma.ElectronMcSignalPostValidatorPt1000_cfi")

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
@@ -9,11 +9,12 @@ cmsEnv = env() # be careful, cmsEnv != cmsenv. cmsEnv is local
 cmsEnv.checkSample() # check the sample value
 cmsEnv.checkValues()
 
-from Configuration.StandardSequences.Eras import eras 
 if cmsEnv.beginTag() == 'Run2_2017':
-    process = cms.Process("electronPostValidation",eras.Run2_2017)
+    from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+    process = cms.Process("electronPostValidation",Run2_2017)
 else:
-    process = cms.Process('electronPostValidation',eras.Phase2) 
+    from Configuration.Eras.Era_Phase2_cff import Phase2
+    process = cms.Process('electronPostValidation',Phase2) 
 
 process.DQMStore = cms.Service("DQMStore")
 process.load("Validation.RecoEgamma.ElectronMcSignalPostValidator_cfi")

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
@@ -5,11 +5,12 @@ import os
 import DQMOffline.EGamma.electronDataDiscovery as dd
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras 
 
 #process = cms.Process("electronValidation")
-#process = cms.Process("electronValidation",eras.Run2_2017)
-process = cms.Process('electronValidation',eras.Phase2) 
+#from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+#process = cms.Process("electronValidation",Run2_2017)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+process = cms.Process('electronValidation',Phase2) 
 
 process.options = cms.untracked.PSet( )
 

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py
@@ -10,11 +10,12 @@ cmsEnv = env() # be careful, cmsEnv != cmsenv. cmsEnv is local
 cmsEnv.checkSample() # check the sample value
 cmsEnv.checkValues()
 
-from Configuration.StandardSequences.Eras import eras
 if cmsEnv.beginTag() == 'Run2_2017':
-    process = cms.Process("electronValidation",eras.Run2_2017)
+    from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+    process = cms.Process("electronValidation",Run2_2017)
 else:
-    process = cms.Process('electronValidation',eras.Phase2) 
+    from Configuration.Eras.Era_Phase2_cff import Phase2
+    process = cms.Process('electronValidation',Phase2) 
 
 process.DQMStore = cms.Service("DQMStore")
 process.load("DQMServices.Components.DQMStoreStats_cfi")

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
@@ -17,11 +17,12 @@ cmsEnv = env() # be careful, cmsEnv != cmsenv. cmsEnv is local
 cmsEnv.checkSample() # check the sample value
 cmsEnv.checkValues()
 
-from Configuration.StandardSequences.Eras import eras 
 if cmsEnv.beginTag() == 'Run2_2017':
-    process = cms.Process("electronValidation",eras.Run2_2017)
+    from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+    process = cms.Process("electronValidation",Run2_2017)
 else:
-    process = cms.Process('electronValidation',eras.Phase2) 
+    from Configuration.Eras.Era_Phase2_cff import Phase2
+    process = cms.Process('electronValidation',Phase2) 
 
 process.DQMStore = cms.Service("DQMStore")
 process.load("DQMServices.Components.DQMStoreStats_cfi")

--- a/Validation/TrackerRecHits/test/RecHitsValid_cfg.py
+++ b/Validation/TrackerRecHits/test/RecHitsValid_cfg.py
@@ -8,9 +8,10 @@
 
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
-# process = cms.Process("RecHitsValid", eras.Run2_2016)
-process = cms.Process("RecHitsValid", eras.Run2_2017)
+# from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+# process = cms.Process("RecHitsValid", Run2_2016)
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+process = cms.Process("RecHitsValid", Run2_2017)
 
 process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag

--- a/Validation/TrackerRecHits/test/stripClusterMCanalysis_cfg.py
+++ b/Validation/TrackerRecHits/test/stripClusterMCanalysis_cfg.py
@@ -19,9 +19,9 @@ readFiles.extend( [
 '/store/relval/CMSSW_9_0_0_pre2/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW-HLTDEBUG/90X_mcRun2_asymptotic_v0-v1/10000/DC4B89FA-62C2-E611-BEA8-0025905A6060.root',
 '/store/relval/CMSSW_9_0_0_pre2/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW-HLTDEBUG/90X_mcRun2_asymptotic_v0-v1/10000/EEB73D90-3BC2-E611-B0A4-0025905A60FE.root' ] );
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('makeNtuples',eras.Run2_2016)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('makeNtuples',Run2_2016)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')


### PR DESCRIPTION
#### PR description:

Continues to address #14895:
* fixes all Era imports (mostly in test configs) to import the Era-specific python file instead of `Configuration.StandardSequences.Eras`
* fixes `cmsDriver.py` to import the Era-specific python file when making `cmsRun` configs

The goal of this PR is to reduce unnecessary dependencies. This is done in a backwards-compatible way, so importing `Configuration.StandardSequences.Eras` is not prevented, just reduced (and hopefully will stop occurring in the future). 

#### PR validation:

Checked WF 29034.0 to ensure `cmsDriver.py` still runs and generates usable configs with Eras.
