### PR TITLE
Migrate Geometry/HGCalCommonData to EventSetup consumes

### DIFF
--- a/Geometry/HGCalCommonData/plugins/FastTimeNumberingInitialization.cc
+++ b/Geometry/HGCalCommonData/plugins/FastTimeNumberingInitialization.cc
@@ -21,7 +21,6 @@
 
 // user include files
 #include <FWCore/Framework/interface/ESProducer.h>
-#include <FWCore/Framework/interface/ESTransientHandle.h>
 #include <FWCore/Framework/interface/ModuleFactory.h>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -43,15 +42,18 @@ class FastTimeNumberingInitialization : public edm::ESProducer {
   using ReturnType = std::unique_ptr<FastTimeDDDConstants>;
 
   ReturnType produce(const IdealGeometryRecord&);
+
+private:
+  edm::ESGetToken<FastTimeParameters, IdealGeometryRecord> ftParToken_;
 };
 
-FastTimeNumberingInitialization::FastTimeNumberingInitialization(
-    const edm::ParameterSet&) {
+FastTimeNumberingInitialization::FastTimeNumberingInitialization(const edm::ParameterSet&):
+  ftParToken_{setWhatProduced(this).consumes<FastTimeParameters>(edm::ESInputTag{})}
+{
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") 
     << "constructing FastTimeNumberingInitialization";
 #endif
-  setWhatProduced(this);
 }
 
 FastTimeNumberingInitialization::~FastTimeNumberingInitialization() {}
@@ -63,9 +65,8 @@ FastTimeNumberingInitialization::produce(const IdealGeometryRecord& iRecord) {
   edm::LogVerbatim("HGCalGeom")
     << "in FastTimeNumberingInitialization::produce";
 #endif
-  edm::ESHandle<FastTimeParameters> pFTpar;
-  iRecord.get(pFTpar);
-  return std::make_unique<FastTimeDDDConstants>(&(*pFTpar));
+  const auto& pFTpar = iRecord.get(ftParToken_);
+  return std::make_unique<FastTimeDDDConstants>(&pFTpar);
 }
 
 // define this as a plug-in

--- a/Geometry/HGCalCommonData/plugins/HGCalParametersESModule.cc
+++ b/Geometry/HGCalCommonData/plugins/HGCalParametersESModule.cc
@@ -21,6 +21,7 @@ class HGCalParametersESModule : public edm::ESProducer {
 
  private:
   std::string name_, namew_, namec_, namet_;
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvToken_;
 };
 
 HGCalParametersESModule::HGCalParametersESModule(const edm::ParameterSet& iC) {
@@ -33,7 +34,8 @@ HGCalParametersESModule::HGCalParametersESModule(const edm::ParameterSet& iC) {
     << "HGCalParametersESModule for " << name_ << ":" << namew_ << ":"
     << namec_ << ":" << namet_;
 #endif
-  setWhatProduced(this, name_);
+  auto cc = setWhatProduced(this, name_);
+  cpvToken_ = cc.consumes<DDCompactView>(edm::ESInputTag{});
 }
 
 HGCalParametersESModule::~HGCalParametersESModule() {}
@@ -42,12 +44,11 @@ HGCalParametersESModule::ReturnType HGCalParametersESModule::produce(
     const IdealGeometryRecord& iRecord) {
   edm::LogVerbatim("HGCalGeom")
       << "HGCalParametersESModule::produce(const IdealGeometryRecord& iRecord)";
-  edm::ESTransientHandle<DDCompactView> cpv;
-  iRecord.get(cpv);
+  edm::ESTransientHandle<DDCompactView> cpv = iRecord.getTransientHandle(cpvToken_);
 
   auto ptp = std::make_unique<HGCalParameters>(name_);
   HGCalParametersFromDD builder;
-  builder.build(&(*cpv), *ptp, name_, namew_, namec_, namet_);
+  builder.build(cpv.product(), *ptp, name_, namew_, namec_, namet_);
 
   return ptp;
 }

--- a/Geometry/HGCalCommonData/test/FastTimeNumberingTester.cc
+++ b/Geometry/HGCalCommonData/test/FastTimeNumberingTester.cc
@@ -29,8 +29,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -51,19 +49,20 @@ class FastTimeNumberingTester : public edm::one::EDAnalyzer<> {
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
+private:
+  edm::ESGetToken<FastTimeDDDConstants, IdealGeometryRecord> token_;
 };
 
-FastTimeNumberingTester::FastTimeNumberingTester(const edm::ParameterSet&) {}
+FastTimeNumberingTester::FastTimeNumberingTester(const edm::ParameterSet&):
+  token_{esConsumes<FastTimeDDDConstants, IdealGeometryRecord>(edm::ESInputTag{})}
+ {}
 
 FastTimeNumberingTester::~FastTimeNumberingTester() {}
 
 // ------------ method called to produce the data  ------------
 void FastTimeNumberingTester::analyze(const edm::Event& iEvent,
                                       const edm::EventSetup& iSetup) {
-  edm::ESHandle<FastTimeDDDConstants> pFTNDC;
-
-  iSetup.get<IdealGeometryRecord>().get(pFTNDC);
-  const FastTimeDDDConstants fTnDC(*pFTNDC);
+  const FastTimeDDDConstants& fTnDC = iSetup.getData(token_);
   std::cout << "Fast timing device with " << fTnDC.getCells(1) << ":"
             << fTnDC.getCells(2) << " cells"
             << " for barrel and endcap\n";

--- a/Geometry/HGCalCommonData/test/HGCGeometryTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCGeometryTester.cc
@@ -26,8 +26,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -49,10 +47,13 @@ class HGCGeometryTester : public edm::one::EDAnalyzer<> {
   void endJob() override {}
 
  private:
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> ddToken_;
   bool square;
 };
 
-HGCGeometryTester::HGCGeometryTester(const edm::ParameterSet& iC) {
+HGCGeometryTester::HGCGeometryTester(const edm::ParameterSet& iC):
+  ddToken_{esConsumes<DDCompactView, IdealGeometryRecord>(edm::ESInputTag{})}
+{
   square = iC.getUntrackedParameter<bool>("SquareType", true);
 }
 
@@ -61,11 +62,10 @@ HGCGeometryTester::~HGCGeometryTester() {}
 // ------------ method called to produce the data  ------------
 void HGCGeometryTester::analyze(const edm::Event& iEvent,
                                 const edm::EventSetup& iSetup) {
-  edm::ESTransientHandle<DDCompactView> pDD;
-  iSetup.get<IdealGeometryRecord>().get(pDD);
+  const auto& pDD = iSetup.getData(ddToken_);
 
   // parse the DD for sensitive volumes
-  DDExpandedView eview(*pDD);
+  DDExpandedView eview(pDD);
   std::map<std::string, std::pair<double, double> > svPars;
   do {
     const DDLogicalPart& logPart = eview.logicalPart();

--- a/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
@@ -28,8 +28,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -51,6 +49,7 @@ class HGCalNumberingTester : public edm::one::EDAnalyzer<> {
   void endJob() override {}
 
  private:
+  edm::ESGetToken<HGCalDDDConstants, IdealGeometryRecord> dddToken_;
   std::string nameSense_, nameDetector_;
   std::vector<double> positionX_, positionY_;
   int increment_, detType_;
@@ -65,6 +64,9 @@ HGCalNumberingTester::HGCalNumberingTester(const edm::ParameterSet& iC) {
   increment_ = iC.getParameter<int>("Increment");
   detType_ = iC.getParameter<int>("DetType");
   reco_ = iC.getParameter<bool>("Reco");
+
+  dddToken_ = esConsumes<HGCalDDDConstants, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_});
+
   std::string unit("mm");
   if (reco_) {
     for (unsigned int k = 0; k < positionX_.size(); ++k) {
@@ -92,10 +94,7 @@ HGCalNumberingTester::~HGCalNumberingTester() {}
 // ------------ method called to produce the data  ------------
 void HGCalNumberingTester::analyze(const edm::Event& iEvent,
                                    const edm::EventSetup& iSetup) {
-  edm::ESHandle<HGCalDDDConstants> pHGNDC;
-
-  iSetup.get<IdealGeometryRecord>().get(nameSense_, pHGNDC);
-  const HGCalDDDConstants hgdc(*pHGNDC);
+  const HGCalDDDConstants& hgdc = iSetup.getData(dddToken_);
   std::cout << nameDetector_ << " Layers = " << hgdc.layers(reco_)
             << " Sectors = " << hgdc.sectors()
             << " Minimum Slope = " << hgdc.minSlope() << std::endl;

--- a/Geometry/HGCalCommonData/test/HGCalParametersAnalyzer.cc
+++ b/Geometry/HGCalCommonData/test/HGCalParametersAnalyzer.cc
@@ -1,6 +1,5 @@
 #include <iostream>
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -11,20 +10,22 @@
 
 class HGCalParametersAnalyzer : public edm::one::EDAnalyzer<> {
  public:
-  explicit HGCalParametersAnalyzer(const edm::ParameterSet&) {}
+  explicit HGCalParametersAnalyzer(const edm::ParameterSet&):
+    token_{esConsumes<PHGCalParameters, PHGCalParametersRcd>(edm::ESInputTag{})}
+  {}
   ~HGCalParametersAnalyzer() override {}
 
-  void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
-  void endJob() override {}
+ private:
+  edm::ESGetToken<PHGCalParameters, PHGCalParametersRcd> token_;
 };
 
 void HGCalParametersAnalyzer::analyze(const edm::Event& iEvent,
                                       const edm::EventSetup& iSetup) {
   edm::LogInfo("HGCalParametersAnalyzer") << "Here I am";
 
-  edm::ESHandle<PHGCalParameters> phgp;
-  iSetup.get<PHGCalParametersRcd>().get(phgp);
+  const auto& hgp = iSetup.getData(token_);
+  const auto* phgp = &hgp;
 
   std::cout << phgp->name_ << "\n";
   for (auto it : phgp->cellSize_) std::cout << it << ", ";


### PR DESCRIPTION
#### PR description:

This PR migrates all ES and ED modules in Geometry/HGCalCommonData to EventSetup consumes (#26584).

In addition
- Fix a use-after-delete in `HGCalNumberingInitialization` in case of an IOV change
- Move away from `edm::ESTransientHandle` in `HGCGeometryTester::analyze()`, because the transient handle should be used only after IOV changes, not for every event

#### PR validation:

Limited matrix runs