### PR TITLE
RelMon histogram comparison: adapt ranges in a compatible way with the definition of getNbins

### DIFF
--- a/Utilities/RelMon/python/utils.py
+++ b/Utilities/RelMon/python/utils.py
@@ -90,11 +90,20 @@ def literal2root (literal,rootType):
 #-------------------------------------------------------------------------------
 
 def getNbins(h):
+  """
+  To be used in loops on bin number with range()
+  In case of 1-d histograms the end-of-range value should be GetNbinsX()+2 
+  In case of 2-d or 3-d histograms the product of GetNbins.()+2 gives the total number of bins, and 1 needs to be added
+  Managed using an offset variable 
+  """
+  offset=0
   biny=h.GetNbinsY()
-  if biny>1:biny+=1
+  if biny>1:
+    offset=1
+    biny+=2
   binz=h.GetNbinsZ()
-  if binz>1:binz+=1
-  return (h.GetNbinsX()+1)*(biny)*(binz)
+  if binz>1:binz+=2
+  return (h.GetNbinsX()+2)*(biny)*(binz)+offset
 
 #-------------------------------------------------------------------------------
 
@@ -168,7 +177,7 @@ class StatisticalTest(object):
 #-------------------------------------------------------------------------------
 
 def is_empty(h):
-  for i in range(0,getNbins(h)+1):
+  for i in range(0,getNbins(h)):
     if h.GetBinContent(i)!=0: return False
   return True
   #return h.GetSumOfWeights()==0
@@ -253,7 +262,7 @@ class Chi2(StatisticalTest):
   def absval(self):
     nbins=getNbins(self.h1)
     binc=0
-    for i in range(0,nbins+1):
+    for i in range(0,nbins):
       for h in self.h1,self.h2:
         binc=h.GetBinContent(i)
         if binc<0:
@@ -329,7 +338,7 @@ class BinToBin(StatisticalTest):
     equal = 1
     nbins = getNbins(self.h1)
     n_ok_bins=0.0
-    for ibin in range(0, nbins+1):
+    for ibin in range(0, nbins):
       h1bin=self.h1.GetBinContent(ibin)
       h2bin=self.h2.GetBinContent(ibin)
       bindiff=h1bin-h2bin
@@ -345,7 +354,7 @@ class BinToBin(StatisticalTest):
       #if abs(bindiff)!=0 :
         #print "Bin %ibin: bindiff %s" %(ibin,bindiff)
     
-    rank=n_ok_bins/(nbins+1)
+    rank=n_ok_bins/nbins
     
     if rank!=1:
       print("Histogram %s differs: nok: %s ntot: %s" %(self.h1.GetName(),n_ok_bins,nbins))
@@ -387,7 +396,7 @@ class BinToBin1percent(StatisticalTest):
     equal = 1
     nbins = getNbins(self.h1)
     n_ok_bins=0.0
-    for ibin in range(0,nbins+1):
+    for ibin in range(0,nbins):
       ibin+=1
       h1bin=self.h1.GetBinContent(ibin)
       h2bin=self.h2.GetBinContent(ibin)
@@ -404,7 +413,7 @@ class BinToBin1percent(StatisticalTest):
       #if abs(bindiff)!=0 :
         #print "Bin %ibin: bindiff %s" %(ibin,bindiff)
     
-    rank=n_ok_bins/(nbins+1)
+    rank=n_ok_bins/nbins
     
     if rank!=1:
       print("%s nok: %s ntot: %s" %(self.h1.GetName(),n_ok_bins,nbins))

--- a/Utilities/RelMon/python/utils.py
+++ b/Utilities/RelMon/python/utils.py
@@ -92,18 +92,16 @@ def literal2root (literal,rootType):
 def getNbins(h):
   """
   To be used in loops on bin number with range()
-  In case of 1-d histograms the end-of-range value should be GetNbinsX()+2 
-  In case of 2-d or 3-d histograms the product of GetNbins.()+2 gives the total number of bins, and 1 needs to be added
-  Managed using an offset variable 
+  For each dimension there are GetNbinsX()+2 bins including underflow 
+  and overflow, and range() loops starts from 0. So the total number
+  of bins as upper limit of a range() loop already includes the next 
+  to last value needed.
   """
-  offset=0
   biny=h.GetNbinsY()
-  if biny>1:
-    offset=1
-    biny+=2
+  if biny>1: biny+=2
   binz=h.GetNbinsZ()
   if binz>1:binz+=2
-  return (h.GetNbinsX()+2)*(biny)*(binz)+offset
+  return (h.GetNbinsX()+2)*(biny)*(binz)
 
 #-------------------------------------------------------------------------------
 

--- a/Utilities/RelMon/python/utils.py
+++ b/Utilities/RelMon/python/utils.py
@@ -168,7 +168,7 @@ class StatisticalTest(object):
 #-------------------------------------------------------------------------------
 
 def is_empty(h):
-  for i in range(1,getNbins(h)):
+  for i in range(0,getNbins(h)+1):
     if h.GetBinContent(i)!=0: return False
   return True
   #return h.GetSumOfWeights()==0
@@ -178,7 +178,7 @@ def is_empty(h):
 def is_sparse(h):
   filled_bins=0.
   nbins=h.GetNbinsX()
-  for ibin in range(nbins):
+  for ibin in range(0,nbins+2):
     if h.GetBinContent(ibin)>0:
       filled_bins+=1
   #print "%s %s --> %s" %(filled_bins,nbins,filled_bins/nbins)
@@ -227,7 +227,7 @@ def profile2histo(profile):
     bin_low_edges.append(profile.GetBinLowEdge(ibin))
   bin_low_edges=array.array('f',bin_low_edges)
   histo=TH1F(profile.GetName(),profile.GetTitle(),n_bins,bin_low_edges)
-  for ibin in range(0,n_bins+1):
+  for ibin in range(0,n_bins+2):
     histo.SetBinContent(ibin,profile.GetBinContent(ibin))
     histo.SetBinError(ibin,profile.GetBinError(ibin))    
   
@@ -244,7 +244,7 @@ class Chi2(StatisticalTest):
     n_filled_l=[]
     for h in self.h1,self.h2:
       nfilled=0.
-      for ibin in range(1,nbins+1):
+      for ibin in range(0,nbins+2):
         if h.GetBinContent(ibin)>0:
           nfilled+=1
       n_filled_l.append(nfilled)
@@ -253,7 +253,7 @@ class Chi2(StatisticalTest):
   def absval(self):
     nbins=getNbins(self.h1)
     binc=0
-    for i in range(1,nbins):
+    for i in range(0,nbins+1):
       for h in self.h1,self.h2:
         binc=h.GetBinContent(i)
         if binc<0:
@@ -329,7 +329,7 @@ class BinToBin(StatisticalTest):
     equal = 1
     nbins = getNbins(self.h1)
     n_ok_bins=0.0
-    for ibin in range(0, nbins+2):
+    for ibin in range(0, nbins+1):
       h1bin=self.h1.GetBinContent(ibin)
       h2bin=self.h2.GetBinContent(ibin)
       bindiff=h1bin-h2bin
@@ -338,14 +338,14 @@ class BinToBin(StatisticalTest):
 
       if binavg==0 or abs(bindiff) < self.epsilon:
         n_ok_bins+=1
-        #print "Bin %ibin: bindiff %s" %(ibin,bindiff)
+        #print("Bin %ibin: bindiff %s" %(ibin,bindiff))
       else:
         print("Bin %ibin: bindiff %s" %(ibin,bindiff))
 
       #if abs(bindiff)!=0 :
         #print "Bin %ibin: bindiff %s" %(ibin,bindiff)
     
-    rank=n_ok_bins/nbins
+    rank=n_ok_bins/(nbins+1)
     
     if rank!=1:
       print("Histogram %s differs: nok: %s ntot: %s" %(self.h1.GetName(),n_ok_bins,nbins))
@@ -387,7 +387,7 @@ class BinToBin1percent(StatisticalTest):
     equal = 1
     nbins = getNbins(self.h1)
     n_ok_bins=0.0
-    for ibin in range(0,nbins):
+    for ibin in range(0,nbins+1):
       ibin+=1
       h1bin=self.h1.GetBinContent(ibin)
       h2bin=self.h2.GetBinContent(ibin)
@@ -404,7 +404,7 @@ class BinToBin1percent(StatisticalTest):
       #if abs(bindiff)!=0 :
         #print "Bin %ibin: bindiff %s" %(ibin,bindiff)
     
-    rank=n_ok_bins/nbins
+    rank=n_ok_bins/(nbins+1)
     
     if rank!=1:
       print("%s nok: %s ntot: %s" %(self.h1.GetName(),n_ok_bins,nbins))


### PR DESCRIPTION
#### PR description:

The RelMon DQM histogram comparison is complaining about differences between histograms when comparing a file with itself, which is clearly incorrect, see the discussion in https://github.com/cms-sw/cmssw/issues/26496 . This issue looks linked to the inconsistent use in the utility package https://cmssdt.cern.ch/lxr/source/Utilities/RelMon/python/utils.py of number of bins and ranges. In python the range function has as a second argument not the last value of the list but the next to last. This looks likely the motivation for the function getNbins adding 1 unit to the number of bins as returned by the ROOT function getNbinsX(). There seems to be also some inconsistency between the starting point of the different range loops, in several cases bin 0 is used (underflow), sometime bin 1 (the first histogram bin). 

This PR tries to solve the issue, having all the range based loops running from the underflow (bin=0) to the overflow (bin=GetNbinsX()+1), which means setting in the range loops as last item GetNbinsX()+2. 

#### PR validation:

Running the test BinToBin to compare a file with itself does not show any more the problem. Using the DQM output of the generator workflow 503 with a syntax similar to cms-bot:
```
13:51 cmsdev25 4149> compare_using_files.py -B DQM/TimerService@3 -o out -C -R -p --no_successes -s b2b 503.0_MinBias_13TeV_pythia8+MinBias_13TeV_pythia8+HARVESTGEN/DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root 503.0_MinBias_13TeV_pythia8+MinBias_13TeV_pythia8+HARVESTGEN/DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root
Analysing Histograms located in directory  at: 
 o 503.0_MinBias_13TeV_pythia8+MinBias_13TeV_pythia8+HARVESTGEN/DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root
 o 503.0_MinBias_13TeV_pythia8+MinBias_13TeV_pythia8+HARVESTGEN/DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root
We have a Blacklist:
 o Directory TimerService at level 3
++++++++++++++++++++++++++++++
Output Directory will be  out
Studying directory Info, 1/2
Studying directory Generator, 2/2
 ->Appending Generator... Appended.
Finished

 - summary of 840 tests:
 o Failiures: 0.00% (0/840)
 o Nulls: 0.00% (0/840) 
 o Successes: 100.00% (840/840) 
 o Skipped: 0.00% (0/840) 
 o Missing objects: 0
Pickleing the directory as out.pkl in dir /build/fabiocos/106X/relmon/CMSSW_10_6_X_2019-04-29-2300/work/out
Reading directory from out.pkl
Calculating stats for the directory...
Producing html...
```

