### PR TITLE
Have checkImportPermission work properly under python3

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -40,7 +40,7 @@ def checkImportPermission(minLevel = 2, allowedPatterns = []):
     import inspect
     import os
 
-    ignorePatterns = ['FWCore/ParameterSet/Config.py','<string>']
+    ignorePatterns = ['FWCore/ParameterSet/Config.py','<string>','<frozen ']
     CMSSWPath = [os.environ['CMSSW_BASE'],os.environ['CMSSW_RELEASE_BASE']]
 
     # Filter the stack to things in CMSSWPath and not in ignorePatterns


### PR DESCRIPTION
#### PR description:

python3 added additional calls in the stack track which are internal details to python. checkImportPermission now ignores those internal details and can work like it does in python2.

#### PR validation:

Made sure the various `FWCore/Integration/test/importRestrictions*.py` configurations now work under python 3.