### PR TITLE
Add new TimeMemory configuration for minimal report in JobReport

### DIFF
--- a/Validation/Performance/bin/FFT.c
+++ b/Validation/Performance/bin/FFT.c
@@ -4,162 +4,148 @@
 
 #include "FFT.h"
 
-#define PI  3.1415926535897932
+#define PI 3.1415926535897932
 
 /*-----------------------------------------------------------------------*/
 
 static int int_log2(int n);
 
-double FFT_num_flops(int N)
-{
+double FFT_num_flops(int N) {
+  double Nd = (double)N;
+  double logN = (double)int_log2(N);
 
-     double Nd = (double) N;
-     double logN = (double) int_log2(N);
-
-     return (5.0*Nd-2)*logN + 2*(Nd+1);
+  return (5.0 * Nd - 2) * logN + 2 * (Nd + 1);
 }
 
-static int int_log2 (int n)
-{
-    int k = 1;
-    int log = 0;
-    for(/*k=1*/; k < n; k *= 2, log++);
-    if (n != (1 << log))
-    {
-      printf("FFT: Data length is not a power of 2!: %d ",n);
-      exit(1);
+static int int_log2(int n) {
+  int k = 1;
+  int log = 0;
+  for (/*k=1*/; k < n; k *= 2, log++)
+    ;
+  if (n != (1 << log)) {
+    printf("FFT: Data length is not a power of 2!: %d ", n);
+    exit(1);
+  }
+  return log;
+}
+
+static void FFT_transform_internal(int N, double *data, int direction) {
+  int n = N / 2;
+  int bit = 0;
+  int logn;
+  int dual = 1;
+
+  if (n == 1)
+    return; /* Identity operation! */
+  logn = int_log2(n);
+
+  if (N == 0)
+    return;
+
+  /* bit reverse the input data for decimation in time algorithm */
+  FFT_bitreverse(N, data);
+
+  /* apply fft recursion */
+  /* this loop executed int_log2(N) times */
+  for (bit = 0; bit < logn; bit++, dual *= 2) {
+    double w_real = 1.0;
+    double w_imag = 0.0;
+    int a;
+    int b;
+
+    double theta = 2.0 * direction * PI / (2.0 * (double)dual);
+    double s = sin(theta);
+    double t = sin(theta / 2.0);
+    double s2 = 2.0 * t * t;
+
+    for (a = 0, b = 0; b < n; b += 2 * dual) {
+      int i = 2 * b;
+      int j = 2 * (b + dual);
+
+      double wd_real = data[j];
+      double wd_imag = data[j + 1];
+
+      data[j] = data[i] - wd_real;
+      data[j + 1] = data[i + 1] - wd_imag;
+      data[i] += wd_real;
+      data[i + 1] += wd_imag;
     }
-    return log; 
-}
 
-static void FFT_transform_internal (int N, double *data, int direction) {
-    int n = N/2;
-    int bit = 0;
-    int logn;
-    int dual = 1;
-
-    if (n == 1) return;         /* Identity operation! */
-    logn = int_log2(n);
-
-
-    if (N == 0) return;    
-
-    /* bit reverse the input data for decimation in time algorithm */
-    FFT_bitreverse(N, data) ;
-
-    /* apply fft recursion */
-    /* this loop executed int_log2(N) times */
-    for (bit = 0; bit < logn; bit++, dual *= 2) {
-      double w_real = 1.0;
-      double w_imag = 0.0;
-      int a;
-      int b;
-
-      double theta = 2.0 * direction * PI / (2.0 * (double) dual);
-      double s = sin(theta);
-      double t = sin(theta / 2.0);
-      double s2 = 2.0 * t * t;
-
-      for (a=0, b = 0; b < n; b += 2 * dual) {
-        int i = 2*b ;
-        int j = 2*(b + dual);
-
-        double wd_real = data[j] ;
-        double wd_imag = data[j+1] ;
-          
-        data[j]   = data[i]   - wd_real;
-        data[j+1] = data[i+1] - wd_imag;
-        data[i]  += wd_real;
-        data[i+1]+= wd_imag;
+    /* a = 1 .. (dual-1) */
+    for (a = 1; a < dual; a++) {
+      /* trignometric recurrence for w-> exp(i theta) w */
+      {
+        double tmp_real = w_real - s * w_imag - s2 * w_real;
+        double tmp_imag = w_imag + s * w_real - s2 * w_imag;
+        w_real = tmp_real;
+        w_imag = tmp_imag;
       }
-      
-      /* a = 1 .. (dual-1) */
-      for (a = 1; a < dual; a++) {
-        /* trignometric recurrence for w-> exp(i theta) w */
-        {
-          double tmp_real = w_real - s * w_imag - s2 * w_real;
-          double tmp_imag = w_imag + s * w_real - s2 * w_imag;
-          w_real = tmp_real;
-          w_imag = tmp_imag;
-        }
-        for (b = 0; b < n; b += 2 * dual) {
-          int i = 2*(b + a);
-          int j = 2*(b + a + dual);
+      for (b = 0; b < n; b += 2 * dual) {
+        int i = 2 * (b + a);
+        int j = 2 * (b + a + dual);
 
-          double z1_real = data[j];
-          double z1_imag = data[j+1];
-              
-          double wd_real = w_real * z1_real - w_imag * z1_imag;
-          double wd_imag = w_real * z1_imag + w_imag * z1_real;
+        double z1_real = data[j];
+        double z1_imag = data[j + 1];
 
-          data[j]   = data[i]   - wd_real;
-          data[j+1] = data[i+1] - wd_imag;
-          data[i]  += wd_real;
-          data[i+1]+= wd_imag;
-        }
+        double wd_real = w_real * z1_real - w_imag * z1_imag;
+        double wd_imag = w_real * z1_imag + w_imag * z1_real;
+
+        data[j] = data[i] - wd_real;
+        data[j + 1] = data[i + 1] - wd_imag;
+        data[i] += wd_real;
+        data[i + 1] += wd_imag;
       }
     }
   }
-
+}
 
 void FFT_bitreverse(int N, double *data) {
-    /* This is the Goldrader bit-reversal algorithm */
-    int n=N/2;
-    int nm1 = n-1;
-    int i=0; 
-    int j=0;
-    for (; i < nm1; i++) {
+  /* This is the Goldrader bit-reversal algorithm */
+  int n = N / 2;
+  int nm1 = n - 1;
+  int i = 0;
+  int j = 0;
+  for (; i < nm1; i++) {
+    /*int ii = 2*i; */
+    int ii = i << 1;
 
-      /*int ii = 2*i; */
-      int ii = i << 1;
+    /*int jj = 2*j; */
+    int jj = j << 1;
 
-      /*int jj = 2*j; */
-      int jj = j << 1;
+    /* int k = n / 2 ; */
+    int k = n >> 1;
 
-      /* int k = n / 2 ; */
-      int k = n >> 1;
-
-      if (i < j) {
-        double tmp_real    = data[ii];
-        double tmp_imag    = data[ii+1];
-        data[ii]   = data[jj];
-        data[ii+1] = data[jj+1];
-        data[jj]   = tmp_real;
-        data[jj+1] = tmp_imag; }
-
-      while (k <= j) 
-      {
-        /*j = j - k ; */
-        j -= k;
-
-        /*k = k / 2 ;  */
-        k >>= 1 ; 
-      }
-      j += k ;
+    if (i < j) {
+      double tmp_real = data[ii];
+      double tmp_imag = data[ii + 1];
+      data[ii] = data[jj];
+      data[ii + 1] = data[jj + 1];
+      data[jj] = tmp_real;
+      data[jj + 1] = tmp_imag;
     }
+
+    while (k <= j) {
+      /*j = j - k ; */
+      j -= k;
+
+      /*k = k / 2 ;  */
+      k >>= 1;
+    }
+    j += k;
   }
-
-
-void FFT_transform(int N, double *data)
-{
-    FFT_transform_internal(N, data, -1);
 }
 
+void FFT_transform(int N, double *data) { FFT_transform_internal(N, data, -1); }
 
-void FFT_inverse(int N, double *data)
-{
-    int n = N/2;
-    double norm = 0.0;
-    int i=0;
-    FFT_transform_internal(N, data, +1);
+void FFT_inverse(int N, double *data) {
+  int n = N / 2;
+  double norm = 0.0;
+  int i = 0;
+  FFT_transform_internal(N, data, +1);
 
-    /* Normalize */
+  /* Normalize */
 
-
-    norm=1/((double) n);
-    for(i=0; i<N; i++)
-      data[i] *= norm;
-  
+  norm = 1 / ((double)n);
+  for (i = 0; i < N; i++)
+    data[i] *= norm;
 }
-
-

--- a/Validation/Performance/bin/LU.c
+++ b/Validation/Performance/bin/LU.c
@@ -1,102 +1,85 @@
 #include <math.h>
 #include "LU.h"
 
-double LU_num_flops(int N)
-{
-        /* rougly 2/3*N^3 */
+double LU_num_flops(int N) {
+  /* rougly 2/3*N^3 */
 
-    double Nd = (double) N;
+  double Nd = (double)N;
 
-    return (2.0 * Nd *Nd *Nd/ 3.0);
+  return (2.0 * Nd * Nd * Nd / 3.0);
 }
 
+void LU_copy_matrix(int M, int N, double **lu, double **A) {
+  int i;
+  int j;
 
-void LU_copy_matrix(int M, int N, double **lu, double **A)
-{
+  for (i = 0; i < M; i++)
+    for (j = 0; j < N; j++)
+      lu[i][j] = A[i][j];
+}
+
+int LU_factor(int M, int N, double **A, int *pivot) {
+  int minMN = M < N ? M : N;
+  int j = 0;
+
+  for (j = 0; j < minMN; j++) {
+    /* find pivot in column j and  test for singularity. */
+
+    int jp = j;
     int i;
-    int j;
 
-    for (i=0; i<M; i++)
-        for (j=0; j<N; j++)
-            lu[i][j] = A[i][j];
-}
-
-
-int LU_factor(int M, int N, double **A,  int *pivot)
-{
- 
-
-    int minMN =  M < N ? M : N;
-    int j=0;
-
-    for (j=0; j<minMN; j++)
-    {
-        /* find pivot in column j and  test for singularity. */
-
-        int jp=j;
-        int i;
-        
-        double t = fabs(A[j][j]);
-        for (i=j+1; i<M; i++)
-        {
-            double ab = fabs(A[i][j]);
-            if ( ab > t)
-            {
-                jp = i;
-                t = ab;
-            }
-        }
-        
-        pivot[j] = jp;
-
-        /* jp now has the index of maximum element  */
-        /* of column j, below the diagonal          */
-
-        if ( A[jp][j] == 0 )                 
-            return 1;       /* factorization failed because of zero pivot */
-
-
-        if (jp != j)
-        {
-            /* swap rows j and jp */
-            double *tA = A[j];
-            A[j] = A[jp];
-            A[jp] = tA;
-        }
-
-        if (j<M-1)                /* compute elements j+1:M of jth column  */
-        {
-            /* note A(j,j), was A(jp,p) previously which was */
-            /* guarranteed not to be zero (Label #1)         */
-
-            double recp =  1.0 / A[j][j];
-            int k;
-            for (k=j+1; k<M; k++)
-                A[k][j] *= recp;
-        }
-
-
-        if (j < minMN-1)
-        {
-            /* rank-1 update to trailing submatrix:   E = E - x*y; */
-            /* E is the region A(j+1:M, j+1:N) */
-            /* x is the column vector A(j+1:M,j) */
-            /* y is row vector A(j,j+1:N)        */
-
-            int ii;
-            for (ii=j+1; ii<M; ii++)
-            {
-                double *Aii = A[ii];
-                double *Aj = A[j];
-                double AiiJ = Aii[j];
-                int jj;
-                for (jj=j+1; jj<N; jj++)
-                  Aii[jj] -= AiiJ * Aj[jj];
-
-            }
-        }
+    double t = fabs(A[j][j]);
+    for (i = j + 1; i < M; i++) {
+      double ab = fabs(A[i][j]);
+      if (ab > t) {
+        jp = i;
+        t = ab;
+      }
     }
 
-    return 0;
-}
+    pivot[j] = jp;
 
+    /* jp now has the index of maximum element  */
+    /* of column j, below the diagonal          */
+
+    if (A[jp][j] == 0)
+      return 1; /* factorization failed because of zero pivot */
+
+    if (jp != j) {
+      /* swap rows j and jp */
+      double *tA = A[j];
+      A[j] = A[jp];
+      A[jp] = tA;
+    }
+
+    if (j < M - 1) /* compute elements j+1:M of jth column  */
+    {
+      /* note A(j,j), was A(jp,p) previously which was */
+      /* guarranteed not to be zero (Label #1)         */
+
+      double recp = 1.0 / A[j][j];
+      int k;
+      for (k = j + 1; k < M; k++)
+        A[k][j] *= recp;
+    }
+
+    if (j < minMN - 1) {
+      /* rank-1 update to trailing submatrix:   E = E - x*y; */
+      /* E is the region A(j+1:M, j+1:N) */
+      /* x is the column vector A(j+1:M,j) */
+      /* y is row vector A(j,j+1:N)        */
+
+      int ii;
+      for (ii = j + 1; ii < M; ii++) {
+        double *Aii = A[ii];
+        double *Aj = A[j];
+        double AiiJ = Aii[j];
+        int jj;
+        for (jj = j + 1; jj < N; jj++)
+          Aii[jj] -= AiiJ * Aj[jj];
+      }
+    }
+  }
+
+  return 0;
+}

--- a/Validation/Performance/bin/LU.h
+++ b/Validation/Performance/bin/LU.h
@@ -5,5 +5,4 @@ double LU_num_flops(int N);
 void LU_copy_matrix(int M, int N, double **lu, double **A);
 int LU_factor(int M, int N, double **A, int *pivot);
 
-
 #endif

--- a/Validation/Performance/bin/MonteCarlo.c
+++ b/Validation/Performance/bin/MonteCarlo.c
@@ -31,40 +31,27 @@
 
 static const int SEED = 113;
 
+double MonteCarlo_num_flops(int Num_samples) {
+  /* 3 flops in x^2+y^2 and 1 flop in random routine */
 
-    double MonteCarlo_num_flops(int Num_samples)
-    {
-        /* 3 flops in x^2+y^2 and 1 flop in random routine */
+  return ((double)Num_samples) * 4.0;
+}
 
-        return ((double) Num_samples)* 4.0;
+double MonteCarlo_integrate(int Num_samples) {
+  Random R = new_Random_seed(SEED);
 
-    }
+  int under_curve = 0;
+  int count;
 
-    
+  for (count = 0; count < Num_samples; count++) {
+    double x = Random_nextDouble(R);
+    double y = Random_nextDouble(R);
 
-    double MonteCarlo_integrate(int Num_samples)
-    {
+    if (x * x + y * y <= 1.0)
+      under_curve++;
+  }
 
+  Random_delete(R);
 
-        Random R = new_Random_seed(SEED);
-
-
-        int under_curve = 0;
-        int count;
-
-        for (count=0; count<Num_samples; count++)
-        {
-            double x= Random_nextDouble(R);
-            double y= Random_nextDouble(R);
-
-            if ( x*x + y*y <= 1.0)
-                 under_curve ++;
-            
-        }
-
-        Random_delete(R);
-
-        return ((double) under_curve / Num_samples) * 4.0;
-    }
-
-
+  return ((double)under_curve / Num_samples) * 4.0;
+}

--- a/Validation/Performance/bin/Random.c
+++ b/Validation/Performance/bin/Random.c
@@ -8,166 +8,146 @@
 #define NULL 0
 #endif
 
-
-  /* static const int mdig = 32; */
+/* static const int mdig = 32; */
 #define MDIG 32
 
-  /* static const int one = 1; */
+/* static const int one = 1; */
 #define ONE 1
 
-  static const int m1 = (ONE << (MDIG-2)) + ((ONE << (MDIG-2) )-ONE);
-  static const int m2 = ONE << MDIG/2;
+static const int m1 = (ONE << (MDIG - 2)) + ((ONE << (MDIG - 2)) - ONE);
+static const int m2 = ONE << MDIG / 2;
 
-  /* For mdig = 32 : m1 =          2147483647, m2 =      65536
+/* For mdig = 32 : m1 =          2147483647, m2 =      65536
      For mdig = 64 : m1 = 9223372036854775807, m2 = 4294967296 
   */
 
-                                /* move to initialize() because  */
-                                /* compiler could not resolve as */
-                                /*   a constant.                 */
+/* move to initialize() because  */
+/* compiler could not resolve as */
+/*   a constant.                 */
 
-  static /*const*/ double dm1;  /*  = 1.0 / (double) m1; */
-
+static /*const*/ double dm1; /*  = 1.0 / (double) m1; */
 
 /* private methods (defined below, but not in Random.h */
 
 static void initialize(Random R, int seed);
 
-Random new_Random_seed(int seed)
-{
-    Random R = (Random) malloc(sizeof(Random_struct));
+Random new_Random_seed(int seed) {
+  Random R = (Random)malloc(sizeof(Random_struct));
 
-    initialize(R, seed);
-    R->left = 0.0;
-    R->right = 1.0;
-    R->width = 1.0;
-    R->haveRange = 0 /*false*/;
+  initialize(R, seed);
+  R->left = 0.0;
+  R->right = 1.0;
+  R->width = 1.0;
+  R->haveRange = 0 /*false*/;
 
-    return R;
+  return R;
 }
 
-Random new_Random(int seed, double left, double right) 
-{
-    Random R = (Random) malloc(sizeof(Random_struct));
+Random new_Random(int seed, double left, double right) {
+  Random R = (Random)malloc(sizeof(Random_struct));
 
-    initialize(R, seed);
-    R->left = left;
-    R->right = right;
-    R->width = right - left;
-    R->haveRange = 1;          /* true */
+  initialize(R, seed);
+  R->left = left;
+  R->right = right;
+  R->width = right - left;
+  R->haveRange = 1; /* true */
 
-    return R;
+  return R;
 }
 
-void Random_delete(Random R)
-{
-    free(R);
-}
-
-
+void Random_delete(Random R) { free(R); }
 
 /* Returns the next random number in the sequence.  */
 
-double Random_nextDouble(Random R) 
-{
-    int k;
+double Random_nextDouble(Random R) {
+  int k;
 
-    int I = R->i;
-    int J = R->j;
-    int *m = R->m;
+  int I = R->i;
+  int J = R->j;
+  int *m = R->m;
 
-    k = m[I] - m[J];
-    if (k < 0) k += m1;
-    R->m[J] = k;
+  k = m[I] - m[J];
+  if (k < 0)
+    k += m1;
+  R->m[J] = k;
 
-    if (I == 0) 
-        I = 16;
-    else I--;
-    R->i = I;
+  if (I == 0)
+    I = 16;
+  else
+    I--;
+  R->i = I;
 
-    if (J == 0) 
-        J = 16 ;
-    else J--;
-    R->j = J;
+  if (J == 0)
+    J = 16;
+  else
+    J--;
+  R->j = J;
 
-    if (R->haveRange) 
-        return  R->left +  dm1 * (double) k * R->width;
-    else
-        return dm1 * (double) k;
-
-} 
-
-
-
+  if (R->haveRange)
+    return R->left + dm1 * (double)k * R->width;
+  else
+    return dm1 * (double)k;
+}
 
 /*--------------------------------------------------------------------
                            PRIVATE METHODS
   ----------------------------------------------------------------- */
 
-static void initialize(Random R, int seed) 
-{
+static void initialize(Random R, int seed) {
+  int jseed, k0, k1, j0, j1, iloop;
 
-    int jseed, k0, k1, j0, j1, iloop;
+  dm1 = 1.0 / (double)m1;
 
-    dm1  = 1.0 / (double) m1; 
+  R->seed = seed;
 
-    R->seed = seed;
-
-    if (seed < 0 ) seed = -seed;            /* seed = abs(seed) */  
-    jseed = (seed < m1 ? seed : m1);        /* jseed = min(seed, m1) */
-    if (jseed % 2 == 0) --jseed;
-    k0 = 9069 % m2;
-    k1 = 9069 / m2;
+  if (seed < 0)
+    seed = -seed;                  /* seed = abs(seed) */
+  jseed = (seed < m1 ? seed : m1); /* jseed = min(seed, m1) */
+  if (jseed % 2 == 0)
+    --jseed;
+  k0 = 9069 % m2;
+  k1 = 9069 / m2;
+  j0 = jseed % m2;
+  j1 = jseed / m2;
+  for (iloop = 0; iloop < 17; ++iloop) {
+    jseed = j0 * k0;
+    j1 = (jseed / m2 + j0 * k1 + j1 * k0) % (m2 / 2);
     j0 = jseed % m2;
-    j1 = jseed / m2;
-    for (iloop = 0; iloop < 17; ++iloop) 
-    {
-        jseed = j0 * k0;
-        j1 = (jseed / m2 + j0 * k1 + j1 * k0) % (m2 / 2);
-        j0 = jseed % m2;
-        R->m[iloop] = j0 + m2 * j1;
+    R->m[iloop] = j0 + m2 * j1;
+  }
+  R->i = 4;
+  R->j = 16;
+}
+
+double *RandomVector(int N, Random R) {
+  int i;
+  double *x = (double *)malloc(sizeof(double) * N);
+
+  for (i = 0; i < N; i++)
+    x[i] = Random_nextDouble(R);
+
+  return x;
+}
+
+double **RandomMatrix(int M, int N, Random R) {
+  int i;
+  int j;
+
+  /* allocate matrix */
+
+  double **A = (double **)malloc(sizeof(double *) * M);
+
+  if (A == NULL)
+    return NULL;
+
+  for (i = 0; i < M; i++) {
+    A[i] = (double *)malloc(sizeof(double) * N);
+    if (A[i] == NULL) {
+      free(A);
+      return NULL;
     }
-    R->i = 4;
-    R->j = 16;
-
+    for (j = 0; j < N; j++)
+      A[i][j] = Random_nextDouble(R);
+  }
+  return A;
 }
-
-double *RandomVector(int N, Random R)
-{
-    int i;
-    double *x = (double *) malloc(sizeof(double)*N);
-
-    for (i=0; i<N; i++)
-        x[i] = Random_nextDouble(R);
-
-    return x;
-}
-
-
-double **RandomMatrix(int M, int N, Random R)
-{
-    int i;
-    int j;
-
-    /* allocate matrix */
-
-    double **A = (double **) malloc(sizeof(double*)*M);
-
-    if (A == NULL) return NULL;
-
-    for (i=0; i<M; i++)
-    {
-        A[i] = (double *) malloc(sizeof(double)*N);
-        if (A[i] == NULL) 
-        {
-            free(A);
-            return NULL;
-        }
-        for (j=0; j<N; j++)
-            A[i][j] = Random_nextDouble(R);
-    }
-    return A;
-}
-
-
-

--- a/Validation/Performance/bin/Random.h
+++ b/Validation/Performance/bin/Random.h
@@ -1,18 +1,16 @@
 #ifndef RANDOM_H
 #define RANDOM_H
 
-typedef struct
-{
-  int m[17];                        
-  int seed;                             
-  int i;                                /* originally = 4 */
-  int j;                                /* originally =  16 */
-  int /*boolean*/ haveRange;            /* = false; */
-  double left;                          /*= 0.0; */
-  double right;                         /* = 1.0; */
-  double width;                         /* = 1.0; */
-}
-Random_struct, *Random;
+typedef struct {
+  int m[17];
+  int seed;
+  int i;                     /* originally = 4 */
+  int j;                     /* originally =  16 */
+  int /*boolean*/ haveRange; /* = false; */
+  double left;               /*= 0.0; */
+  double right;              /* = 1.0; */
+  double width;              /* = 1.0; */
+} Random_struct, *Random;
 
 Random new_Random_seed(int seed);
 double Random_nextDouble(Random R);

--- a/Validation/Performance/bin/SOR.c
+++ b/Validation/Performance/bin/SOR.c
@@ -1,43 +1,35 @@
 #include "SOR.h"
 
-    double SOR_num_flops(int M, int N, int num_iterations)
-    {
-        double Md = (double) M;
-        double Nd = (double) N;
-        double num_iterD = (double) num_iterations;
+double SOR_num_flops(int M, int N, int num_iterations) {
+  double Md = (double)M;
+  double Nd = (double)N;
+  double num_iterD = (double)num_iterations;
 
-        return (Md-1)*(Nd-1)*num_iterD*6.0;
+  return (Md - 1) * (Nd - 1) * num_iterD * 6.0;
+}
+
+void SOR_execute(int M, int N, double omega, double **G, int num_iterations) {
+  double omega_over_four = omega * 0.25;
+  double one_minus_omega = 1.0 - omega;
+
+  /* update interior points */
+
+  int Mm1 = M - 1;
+  int Nm1 = N - 1;
+  int p;
+  int i;
+  int j;
+  double *Gi;
+  double *Gim1;
+  double *Gip1;
+
+  for (p = 0; p < num_iterations; p++) {
+    for (i = 1; i < Mm1; i++) {
+      Gi = G[i];
+      Gim1 = G[i - 1];
+      Gip1 = G[i + 1];
+      for (j = 1; j < Nm1; j++)
+        Gi[j] = omega_over_four * (Gim1[j] + Gip1[j] + Gi[j - 1] + Gi[j + 1]) + one_minus_omega * Gi[j];
     }
-
-    void SOR_execute(int M, int N, double omega, double **G, int 
-            num_iterations)
-    {
-
-        double omega_over_four = omega * 0.25;
-        double one_minus_omega = 1.0 - omega;
-
-        /* update interior points */
-
-        int Mm1 = M-1;
-        int Nm1 = N-1; 
-        int p;
-        int i;
-        int j;
-        double *Gi;
-        double *Gim1;
-        double *Gip1;
-
-        for (p=0; p<num_iterations; p++)
-        {
-            for (i=1; i<Mm1; i++)
-            {
-                Gi = G[i];
-                Gim1 = G[i-1];
-                Gip1 = G[i+1];
-                for (j=1; j<Nm1; j++)
-                    Gi[j] = omega_over_four * (Gim1[j] + Gip1[j] + Gi[j-1] 
-                                + Gi[j+1]) + one_minus_omega * Gi[j];
-            }
-        }
-    }
-            
+  }
+}

--- a/Validation/Performance/bin/SOR.h
+++ b/Validation/Performance/bin/SOR.h
@@ -1,4 +1,3 @@
 
 double SOR_num_flops(int M, int N, int num_iterations);
-void SOR_execute(int M, int N,double omega, double **G, int num_iterations);
-
+void SOR_execute(int M, int N, double omega, double **G, int num_iterations);

--- a/Validation/Performance/bin/SparseCompRow.h
+++ b/Validation/Performance/bin/SparseCompRow.h
@@ -4,7 +4,6 @@
 
 double SparseCompRow_num_flops(int N, int nz, int num_iterations);
 
-void SparseCompRow_matmult( int M, double *y, double *val, int *row,
-        int *col, double *x, int NUM_ITERATIONS);
+void SparseCompRow_matmult(int M, double *y, double *val, int *row, int *col, double *x, int NUM_ITERATIONS);
 
 #endif

--- a/Validation/Performance/bin/Stopwatch.c
+++ b/Validation/Performance/bin/Stopwatch.c
@@ -1,82 +1,63 @@
 #include <stdlib.h>
 #include "Stopwatch.h"
 
-double seconds()
-{
-        return ((double) clock()) / (double) CLOCKS_PER_SEC; 
+double seconds() { return ((double)clock()) / (double)CLOCKS_PER_SEC; }
+
+void Stopwtach_reset(Stopwatch Q) {
+  Q->running = 0; /* false */
+  Q->last_time = 0.0;
+  Q->total = 0.0;
 }
 
-void Stopwtach_reset(Stopwatch Q)
-{
-    Q->running = 0;         /* false */
-    Q->last_time = 0.0;
-    Q->total= 0.0;
+Stopwatch new_Stopwatch(void) {
+  Stopwatch S = (Stopwatch)malloc(sizeof(Stopwatch_struct));
+  if (S == NULL)
+    return NULL;
+
+  Stopwtach_reset(S);
+  return S;
 }
 
-
-Stopwatch new_Stopwatch(void)
-{
-    Stopwatch S = (Stopwatch) malloc(sizeof(Stopwatch_struct));
-    if (S == NULL)
-        return NULL;
-
-    Stopwtach_reset(S);
-    return S;
+void Stopwatch_delete(Stopwatch S) {
+  if (S != NULL)
+    free(S);
 }
-
-void Stopwatch_delete(Stopwatch S)
-{
-    if (S != NULL)
-        free(S);
-}
-
 
 /* Start resets the timer to 0.0; use resume for continued total */
 
-void Stopwatch_start(Stopwatch Q)
-{
-    if (! (Q->running)  )
-    {
-        Q->running = 1;  /* true */
-        Q->total = 0.0;
-        Q->last_time = seconds();
-    }
+void Stopwatch_start(Stopwatch Q) {
+  if (!(Q->running)) {
+    Q->running = 1; /* true */
+    Q->total = 0.0;
+    Q->last_time = seconds();
+  }
 }
-   
+
 /** 
     Resume timing, after stopping.  (Does not wipe out
         accumulated times.)
 
 */
 
-void Stopwatch_resume(Stopwatch Q)
-{
-    if (!(Q->running))
-    {
-        Q-> last_time = seconds(); 
-        Q->running = 1;  /*true*/
-    }
+void Stopwatch_resume(Stopwatch Q) {
+  if (!(Q->running)) {
+    Q->last_time = seconds();
+    Q->running = 1; /*true*/
+  }
 }
-   
-void Stopwatch_stop(Stopwatch Q)  
-{ 
-    if (Q->running) 
-    { 
-        Q->total += seconds() - Q->last_time; 
-        Q->running = 0;  /* false */
-    }
+
+void Stopwatch_stop(Stopwatch Q) {
+  if (Q->running) {
+    Q->total += seconds() - Q->last_time;
+    Q->running = 0; /* false */
+  }
 }
-  
- 
-double Stopwatch_read(Stopwatch Q)
-{  
-    
-    if (Q->running) 
-    {
-        double t = seconds();
-        Q->total += t - Q->last_time;
-        Q->last_time = t;
-    }
-    return Q->total;
+
+double Stopwatch_read(Stopwatch Q) {
+  if (Q->running) {
+    double t = seconds();
+    Q->total += t - Q->last_time;
+    Q->last_time = t;
+  }
+  return Q->total;
 }
-        

--- a/Validation/Performance/bin/Stopwatch.h
+++ b/Validation/Performance/bin/Stopwatch.h
@@ -1,14 +1,12 @@
 
 #include <time.h>
 
-typedef struct{
-    int running;        /* boolean */
-    double last_time;
-    double total;
+typedef struct {
+  int running; /* boolean */
+  double last_time;
+  double total;
 
-} *Stopwatch, Stopwatch_struct;
-
-
+} * Stopwatch, Stopwatch_struct;
 
 double seconds();
 
@@ -20,4 +18,3 @@ void Stopwatch_start(Stopwatch Q);
 void Stopwatch_resume(Stopwatch Q);
 void Stopwatch_stop(Stopwatch Q);
 double Stopwatch_read(Stopwatch Q);
-        

--- a/Validation/Performance/bin/array.c
+++ b/Validation/Performance/bin/array.c
@@ -6,72 +6,61 @@
 #define NULL 0
 #endif
 
+double **new_Array2D_double(int M, int N) {
+  int i = 0;
+  int failed = 0;
 
-double** new_Array2D_double(int M, int N)
-{
-    int i=0;
-    int failed = 0;
+  double **A = (double **)malloc(sizeof(double *) * M);
+  if (A == NULL)
+    return NULL;
 
-    double **A = (double**) malloc(sizeof(double*)*M);
-    if (A == NULL)
-        return NULL;
-
-    for (i=0; i<M; i++)
-    {
-        A[i] = (double*) malloc(N * sizeof(double));
-        if (A[i] == NULL)
-        {
-            failed = 1;
-            break;
-        }
+  for (i = 0; i < M; i++) {
+    A[i] = (double *)malloc(N * sizeof(double));
+    if (A[i] == NULL) {
+      failed = 1;
+      break;
     }
-
-    /* if we didn't successfully allocate all rows of A      */
-    /* clean up any allocated memory (i.e. go back and free  */
-    /* previous rows) and return NULL                        */
-
-    if (failed)
-    {
-        i--;
-        for (; i<=0; i--)
-            free(A[i]);
-        free(A);
-        return NULL;
-    }
-    else
-        return A;
-}
-void Array2D_double_delete(int M, int N, double **A)
-{
-    int i;
-    if (A == NULL) return;
-
-    for (i=0; i<M; i++)
-        free(A[i]);
-
-    free(A);
-}
-
-
-  void Array2D_double_copy(int M, int N, double **B, double **A)
-  {
-
-        int remainder = N & 3;       /* N mod 4; */
-        int i=0;
-        int j=0;
-
-        for (i=0; i<M; i++)
-        {
-            double *Bi = B[i];
-            double *Ai = A[i];
-            for (j=0; j<remainder; j++)
-                Bi[j] = Ai[j];
-            for (j=remainder; j<N; j+=4)
-            {
-                Bi[j] = Ai[j];
-                Bi[j+1] = Ai[j+1];
-                Bi[j+2] = Ai[j+2];
-                Bi[j+3] = Ai[j+3];
-            }
-        }
   }
+
+  /* if we didn't successfully allocate all rows of A      */
+  /* clean up any allocated memory (i.e. go back and free  */
+  /* previous rows) and return NULL                        */
+
+  if (failed) {
+    i--;
+    for (; i <= 0; i--)
+      free(A[i]);
+    free(A);
+    return NULL;
+  } else
+    return A;
+}
+void Array2D_double_delete(int M, int N, double **A) {
+  int i;
+  if (A == NULL)
+    return;
+
+  for (i = 0; i < M; i++)
+    free(A[i]);
+
+  free(A);
+}
+
+void Array2D_double_copy(int M, int N, double **B, double **A) {
+  int remainder = N & 3; /* N mod 4; */
+  int i = 0;
+  int j = 0;
+
+  for (i = 0; i < M; i++) {
+    double *Bi = B[i];
+    double *Ai = A[i];
+    for (j = 0; j < remainder; j++)
+      Bi[j] = Ai[j];
+    for (j = remainder; j < N; j += 4) {
+      Bi[j] = Ai[j];
+      Bi[j + 1] = Ai[j + 1];
+      Bi[j + 2] = Ai[j + 2];
+      Bi[j + 3] = Ai[j + 3];
+    }
+  }
+}

--- a/Validation/Performance/bin/constants.h
+++ b/Validation/Performance/bin/constants.h
@@ -1,35 +1,34 @@
 #ifndef CONSTANTS_H_
 #define CONSTANTS_H_
 
-     const  double RESOLUTION_DEFAULT = 2.0;  /* secs (normally 2.0) */
-     const  int RANDOM_SEED = 101010;
+const double RESOLUTION_DEFAULT = 2.0; /* secs (normally 2.0) */
+const int RANDOM_SEED = 101010;
 
-    /* default: small (cache-contained) problem sizes */
+/* default: small (cache-contained) problem sizes */
 
-     const  int FFT_SIZE = 1024;  /* must be a power of two */
-     const  int SOR_SIZE =100; /* NxN grid */
-     const  int SPARSE_SIZE_M = 1000;
-     const  int SPARSE_SIZE_nz = 5000;
-     const  int LU_SIZE = 100;
+const int FFT_SIZE = 1024; /* must be a power of two */
+const int SOR_SIZE = 100;  /* NxN grid */
+const int SPARSE_SIZE_M = 1000;
+const int SPARSE_SIZE_nz = 5000;
+const int LU_SIZE = 100;
 
-    /* large (out-of-cache) problem sizes */
+/* large (out-of-cache) problem sizes */
 
-     const  int LG_FFT_SIZE = 1048576;  /* must be a power of two */
-     const  int LG_SOR_SIZE =1000;  /*  NxN grid  */
-     const  int LG_SPARSE_SIZE_M = 100000;
-     const  int LG_SPARSE_SIZE_nz =1000000;
-     const  int LG_LU_SIZE = 1000;
+const int LG_FFT_SIZE = 1048576; /* must be a power of two */
+const int LG_SOR_SIZE = 1000;    /*  NxN grid  */
+const int LG_SPARSE_SIZE_M = 100000;
+const int LG_SPARSE_SIZE_nz = 1000000;
+const int LG_LU_SIZE = 1000;
 
-    /* tiny problem sizes (used to mainly to preload network classes     */
-    /*                     for applet, so that network download times    */
-    /*                     are factored out of benchmark.)               */
-    /*                                                                   */
-     const  int TINY_FFT_SIZE = 16;  /* must be a power of two */
-     const  int TINY_SOR_SIZE =10; /* NxN grid */
-     const  int TINY_SPARSE_SIZE_M = 10;
-     const  int TINY_SPARSE_SIZE_N = 10;
-     const  int TINY_SPARSE_SIZE_nz = 50;
-     const  int TINY_LU_SIZE = 10;
+/* tiny problem sizes (used to mainly to preload network classes     */
+/*                     for applet, so that network download times    */
+/*                     are factored out of benchmark.)               */
+/*                                                                   */
+const int TINY_FFT_SIZE = 16; /* must be a power of two */
+const int TINY_SOR_SIZE = 10; /* NxN grid */
+const int TINY_SPARSE_SIZE_M = 10;
+const int TINY_SPARSE_SIZE_N = 10;
+const int TINY_SPARSE_SIZE_nz = 50;
+const int TINY_LU_SIZE = 10;
 
 #endif
-

--- a/Validation/Performance/bin/kernel.c
+++ b/Validation/Performance/bin/kernel.c
@@ -5,106 +5,93 @@
 #include "SOR.h"
 #include "MonteCarlo.h"
 #include "LU.h"
-#include "Random.h" 
-#include "Stopwatch.h"  
+#include "Random.h"
+#include "Stopwatch.h"
 #include "SparseCompRow.h"
 #include "array.h"
 
+double kernel_measureFFT(int N, double mintime, Random R) {
+  /* initialize FFT data as complex (N real/img pairs) */
 
-    double kernel_measureFFT(int N, double mintime, Random R)
-    {
-        /* initialize FFT data as complex (N real/img pairs) */
+  int twoN = 2 * N;
+  double *x = RandomVector(twoN, R);
+  long cycles = 1;
+  Stopwatch Q = new_Stopwatch();
+  int i = 0;
+  double result = 0.0;
 
-        int twoN = 2*N;
-        double *x = RandomVector(twoN, R);
-        long cycles = 1;
-        Stopwatch Q = new_Stopwatch();
-        int i=0;
-        double result = 0.0;
-
-        while(1)
-        {
-            Stopwatch_start(Q);
-            for (i=0; i<cycles; i++)
-            {
-                FFT_transform(twoN, x);     /* forward transform */
-                FFT_inverse(twoN, x);       /* backward transform */
-            }
-            Stopwatch_stop(Q);
-            if (Stopwatch_read(Q) >= mintime)
-                break;
-
-            cycles *= 2;
-
-        }
-        /* approx Mflops */
-
-        result = FFT_num_flops(N)*cycles/ Stopwatch_read(Q) * 1.0e-6;
-        Stopwatch_delete(Q);
-        free(x);
-        return result;
+  while (1) {
+    Stopwatch_start(Q);
+    for (i = 0; i < cycles; i++) {
+      FFT_transform(twoN, x); /* forward transform */
+      FFT_inverse(twoN, x);   /* backward transform */
     }
+    Stopwatch_stop(Q);
+    if (Stopwatch_read(Q) >= mintime)
+      break;
 
-    double kernel_measureSOR(int N, double min_time, Random R)
-    {
-        double **G = RandomMatrix(N, N, R);
-        double result = 0.0;
+    cycles *= 2;
+  }
+  /* approx Mflops */
 
-        Stopwatch Q = new_Stopwatch();
-        int cycles=1;
-        while(1)
-        {
-            Stopwatch_start(Q);
-            SOR_execute(N, N, 1.25, G, cycles);
-            Stopwatch_stop(Q);
+  result = FFT_num_flops(N) * cycles / Stopwatch_read(Q) * 1.0e-6;
+  Stopwatch_delete(Q);
+  free(x);
+  return result;
+}
 
-            if (Stopwatch_read(Q) >= min_time) break;
+double kernel_measureSOR(int N, double min_time, Random R) {
+  double **G = RandomMatrix(N, N, R);
+  double result = 0.0;
 
-            cycles *= 2;
-        }
-        /* approx Mflops */
+  Stopwatch Q = new_Stopwatch();
+  int cycles = 1;
+  while (1) {
+    Stopwatch_start(Q);
+    SOR_execute(N, N, 1.25, G, cycles);
+    Stopwatch_stop(Q);
 
-        result = SOR_num_flops(N, N, cycles) / Stopwatch_read(Q) * 1.0e-6;
-        Stopwatch_delete(Q);
-        Array2D_double_delete(N, N, G);
-        return result;
+    if (Stopwatch_read(Q) >= min_time)
+      break;
 
-    }
+    cycles *= 2;
+  }
+  /* approx Mflops */
 
+  result = SOR_num_flops(N, N, cycles) / Stopwatch_read(Q) * 1.0e-6;
+  Stopwatch_delete(Q);
+  Array2D_double_delete(N, N, G);
+  return result;
+}
 
+double kernel_measureMonteCarlo(double min_time, Random R) {
+  double result = 0.0;
+  Stopwatch Q = new_Stopwatch();
 
-    double kernel_measureMonteCarlo(double min_time, Random R)
-    {
-        double result = 0.0;
-        Stopwatch Q = new_Stopwatch();
+  int cycles = 1;
+  while (1) {
+    Stopwatch_start(Q);
+    MonteCarlo_integrate(cycles);
+    Stopwatch_stop(Q);
+    if (Stopwatch_read(Q) >= min_time)
+      break;
 
-        int cycles=1;
-        while(1)
-        {
-            Stopwatch_start(Q);
-            MonteCarlo_integrate(cycles);
-            Stopwatch_stop(Q);
-            if (Stopwatch_read(Q) >= min_time) break;
+    cycles *= 2;
+  }
+  /* approx Mflops */
+  result = MonteCarlo_num_flops(cycles) / Stopwatch_read(Q) * 1.0e-6;
+  Stopwatch_delete(Q);
+  return result;
+}
 
-            cycles *= 2;
-        }
-        /* approx Mflops */
-        result = MonteCarlo_num_flops(cycles) / Stopwatch_read(Q) * 1.0e-6;
-        Stopwatch_delete(Q);
-        return result;
-    }
+double kernel_measureSparseMatMult(int N, int nz, double min_time, Random R) {
+  /* initialize vector multipliers and storage for result */
+  /* y = A*y;  */
 
+  double *x = RandomVector(N, R);
+  double *y = (double *)malloc(sizeof(double) * N);
 
-    double kernel_measureSparseMatMult(int N, int nz, 
-            double min_time, Random R)
-    {
-        /* initialize vector multipliers and storage for result */
-        /* y = A*y;  */
-
-        double *x = RandomVector(N, R);
-        double *y = (double*) malloc(sizeof(double)*N);
-
-        double result = 0.0;
+  double result = 0.0;
 
 #if 0
         // initialize square sparse matrix
@@ -129,102 +116,91 @@
         // the diagonal.
 #endif
 
-        int nr = nz/N;      /* average number of nonzeros per row  */
-        int anz = nr *N;    /* _actual_ number of nonzeros         */
+  int nr = nz / N;  /* average number of nonzeros per row  */
+  int anz = nr * N; /* _actual_ number of nonzeros         */
 
-            
-        double *val = RandomVector(anz, R);
-        int *col = (int*) malloc(sizeof(int)*nz);
-        int *row = (int*) malloc(sizeof(int)*(N+1));
-        int r=0;
-        int cycles=1;
+  double *val = RandomVector(anz, R);
+  int *col = (int *)malloc(sizeof(int) * nz);
+  int *row = (int *)malloc(sizeof(int) * (N + 1));
+  int r = 0;
+  int cycles = 1;
 
-        Stopwatch Q = new_Stopwatch();
+  Stopwatch Q = new_Stopwatch();
 
-        row[0] = 0; 
-        for (r=0; r<N; r++)
-        {
-            /* initialize elements for row r */
+  row[0] = 0;
+  for (r = 0; r < N; r++) {
+    /* initialize elements for row r */
 
-            int rowr = row[r];
-            int step = r/ nr;
-            int i=0;
+    int rowr = row[r];
+    int step = r / nr;
+    int i = 0;
 
-            row[r+1] = rowr + nr;
-            if (step < 1) step = 1;   /* take at least unit steps */
+    row[r + 1] = rowr + nr;
+    if (step < 1)
+      step = 1; /* take at least unit steps */
 
+    for (i = 0; i < nr; i++)
+      col[rowr + i] = i * step;
+  }
 
-            for (i=0; i<nr; i++)
-                col[rowr+i] = i*step;
-                
-        }
+  while (1) {
+    Stopwatch_start(Q);
+    SparseCompRow_matmult(N, y, val, row, col, x, cycles);
+    Stopwatch_stop(Q);
+    if (Stopwatch_read(Q) >= min_time)
+      break;
 
+    cycles *= 2;
+  }
+  /* approx Mflops */
+  result = SparseCompRow_num_flops(N, nz, cycles) / Stopwatch_read(Q) * 1.0e-6;
 
-        while(1)
-        {
-            Stopwatch_start(Q);
-            SparseCompRow_matmult(N, y, val, row, col, x, cycles);
-            Stopwatch_stop(Q);
-            if (Stopwatch_read(Q) >= min_time) break;
+  Stopwatch_delete(Q);
+  free(row);
+  free(col);
+  free(val);
+  free(y);
+  free(x);
 
-            cycles *= 2;
-        }
-        /* approx Mflops */
-        result = SparseCompRow_num_flops(N, nz, cycles) / 
-                        Stopwatch_read(Q) * 1.0e-6;
+  return result;
+}
 
-        Stopwatch_delete(Q);
-        free(row);
-        free(col);
-        free(val);
-        free(y);
-        free(x);
+double kernel_measureLU(int N, double min_time, Random R) {
+  double **A = NULL;
+  double **lu = NULL;
+  int *pivot = NULL;
 
-        return result;
+  Stopwatch Q = new_Stopwatch();
+  double result = 0.0;
+  int i = 0;
+  int cycles = 1;
+
+  if ((A = RandomMatrix(N, N, R)) == NULL)
+    exit(1);
+  if ((lu = new_Array2D_double(N, N)) == NULL)
+    exit(1);
+  if ((pivot = (int *)malloc(N * sizeof(int))) == NULL)
+    exit(1);
+
+  while (1) {
+    Stopwatch_start(Q);
+    for (i = 0; i < cycles; i++) {
+      Array2D_double_copy(N, N, lu, A);
+      LU_factor(N, N, lu, pivot);
     }
+    Stopwatch_stop(Q);
+    if (Stopwatch_read(Q) >= min_time)
+      break;
 
+    cycles *= 2;
+  }
+  /* approx Mflops */
+  result = LU_num_flops(N) * cycles / Stopwatch_read(Q) * 1.0e-6;
 
-    double kernel_measureLU(int N, double min_time, Random R)
-    {
+  Stopwatch_delete(Q);
+  free(pivot);
+  Array2D_double_delete(N, N, lu);
+  Array2D_double_delete(N, N, A);
 
-        double **A = NULL;
-        double **lu = NULL; 
-        int *pivot = NULL;
-
-    
-
-        Stopwatch Q = new_Stopwatch();
-        double result = 0.0;
-        int i=0;
-        int cycles=1;
-
-        if ((A = RandomMatrix(N, N,  R)) == NULL) exit(1);
-        if ((lu = new_Array2D_double(N, N)) == NULL) exit(1);
-        if ((pivot = (int *) malloc(N * sizeof(int))) == NULL) exit(1);
-
-
-        while(1)
-        {
-            Stopwatch_start(Q);
-            for (i=0; i<cycles; i++)
-            {
-                Array2D_double_copy(N, N, lu, A);
-                LU_factor(N, N, lu, pivot);
-            }
-            Stopwatch_stop(Q);
-            if (Stopwatch_read(Q) >= min_time) break;
-
-            cycles *= 2;
-        }
-        /* approx Mflops */
-        result = LU_num_flops(N) * cycles / Stopwatch_read(Q) * 1.0e-6;
-
-        Stopwatch_delete(Q);
-        free(pivot); 
-        Array2D_double_delete(N, N, lu); 
-        Array2D_double_delete(N, N, A);
-
-        return result;
-
-    }
-
+  return result;
+}

--- a/Validation/Performance/bin/kernel.h
+++ b/Validation/Performance/bin/kernel.h
@@ -2,11 +2,10 @@
 #define KERNEL_H
 
 #include "Random.h"
-double kernel_measureFFT( int FFT_size, double min_time, Random R);
-double kernel_measureSOR( int SOR_size, double min_time, Random R);
-double kernel_measureMonteCarlo( double min_time, Random R);
-double kernel_measureSparseMatMult(int Sparse_size_N,
-    int Sparse_size_nz, double min_time, Random R);
-double kernel_measureLU( int LU_size, double min_time, Random R);
+double kernel_measureFFT(int FFT_size, double min_time, Random R);
+double kernel_measureSOR(int SOR_size, double min_time, Random R);
+double kernel_measureMonteCarlo(double min_time, Random R);
+double kernel_measureSparseMatMult(int Sparse_size_N, int Sparse_size_nz, double min_time, Random R);
+double kernel_measureLU(int LU_size, double min_time, Random R);
 
 #endif

--- a/Validation/Performance/bin/scimark2.c
+++ b/Validation/Performance/bin/scimark2.c
@@ -8,91 +8,72 @@
 
 void print_banner(void);
 
-int main(int argc, char *argv[])
-{
-        /* default to the (small) cache-contained version */
+int main(int argc, char *argv[]) {
+  /* default to the (small) cache-contained version */
 
-        double min_time = RESOLUTION_DEFAULT;
+  double min_time = RESOLUTION_DEFAULT;
 
-        int FFT_size = FFT_SIZE;
-        int SOR_size =  SOR_SIZE;
-        int Sparse_size_M = SPARSE_SIZE_M;
-        int Sparse_size_nz = SPARSE_SIZE_nz;
-        int LU_size = LU_SIZE;
+  int FFT_size = FFT_SIZE;
+  int SOR_size = SOR_SIZE;
+  int Sparse_size_M = SPARSE_SIZE_M;
+  int Sparse_size_nz = SPARSE_SIZE_nz;
+  int LU_size = LU_SIZE;
 
+  /* run the benchmark */
 
-        /* run the benchmark */
+  double res[6] = {0.0};
+  Random R = new_Random_seed(RANDOM_SEED);
 
-        double res[6] = {0.0};
-        Random R = new_Random_seed(RANDOM_SEED);
+  if (argc > 1) {
+    int current_arg = 1;
 
+    if (strcmp(argv[1], "-help") == 0 || strcmp(argv[1], "-h") == 0) {
+      fprintf(stderr, "Usage: [-large] [minimum_time]\n");
+      exit(0);
+    }
 
-        if (argc > 1)
-        {
-			int current_arg = 1;
+    if (strcmp(argv[1], "-large") == 0) {
+      FFT_size = LG_FFT_SIZE;
+      SOR_size = LG_SOR_SIZE;
+      Sparse_size_M = LG_SPARSE_SIZE_M;
+      Sparse_size_nz = LG_SPARSE_SIZE_nz;
+      LU_size = LG_LU_SIZE;
 
-			if (strcmp(argv[1], "-help")==0  ||
-					strcmp(argv[1], "-h") == 0)
-			{
-				fprintf(stderr, "Usage: [-large] [minimum_time]\n");
-				exit(0);
-			}
+      current_arg++;
+    }
 
-			if (strcmp(argv[1], "-large")==0)
-			{
-				FFT_size = LG_FFT_SIZE;
-				SOR_size = LG_SOR_SIZE;
-				Sparse_size_M = LG_SPARSE_SIZE_M;
-				Sparse_size_nz = LG_SPARSE_SIZE_nz;
-				LU_size = LG_LU_SIZE;
+    if (current_arg < argc) {
+      min_time = atof(argv[current_arg]);
+    }
+  }
 
-				current_arg++;
-			}
+  print_banner();
+  printf("Using %10.2f seconds min time per kenel.\n", min_time);
 
-			if (current_arg < argc)
-			{
-				min_time = atof(argv[current_arg]);
-			}
-			
-        }
+  res[1] = kernel_measureFFT(FFT_size, min_time, R);
+  res[2] = kernel_measureSOR(SOR_size, min_time, R);
+  res[3] = kernel_measureMonteCarlo(min_time, R);
+  res[4] = kernel_measureSparseMatMult(Sparse_size_M, Sparse_size_nz, min_time, R);
+  res[5] = kernel_measureLU(LU_size, min_time, R);
 
-	
-		print_banner();
-		printf("Using %10.2f seconds min time per kenel.\n", min_time);
+  res[0] = (res[1] + res[2] + res[3] + res[4] + res[5]) / 5;
 
-        res[1] = kernel_measureFFT( FFT_size, min_time, R);   
-        res[2] = kernel_measureSOR( SOR_size, min_time, R);   
-        res[3] = kernel_measureMonteCarlo(min_time, R); 
-        res[4] = kernel_measureSparseMatMult( Sparse_size_M, 
-                Sparse_size_nz, min_time, R);           
-        res[5] = kernel_measureLU( LU_size, min_time, R);  
+  /* print out results  */
+  printf("Composite Score:        %8.2f\n", res[0]);
+  printf("FFT             Mflops: %8.2f    (N=%d)\n", res[1], FFT_size);
+  printf("SOR             Mflops: %8.2f    (%d x %d)\n", res[2], SOR_size, SOR_size);
+  printf("MonteCarlo:     Mflops: %8.2f\n", res[3]);
+  printf("Sparse matmult  Mflops: %8.2f    (N=%d, nz=%d)\n", res[4], Sparse_size_M, Sparse_size_nz);
+  printf("LU              Mflops: %8.2f    (M=%d, N=%d)\n", res[5], LU_size, LU_size);
 
+  Random_delete(R);
 
-
-        res[0] = (res[1] + res[2] + res[3] + res[4] + res[5]) / 5;
-
-        /* print out results  */
-        printf("Composite Score:        %8.2f\n" ,res[0]);
-        printf("FFT             Mflops: %8.2f    (N=%d)\n", res[1], FFT_size);
-        printf("SOR             Mflops: %8.2f    (%d x %d)\n", 		
-				res[2], SOR_size, SOR_size);
-        printf("MonteCarlo:     Mflops: %8.2f\n", res[3]);
-        printf("Sparse matmult  Mflops: %8.2f    (N=%d, nz=%d)\n", res[4], 
-					Sparse_size_M, Sparse_size_nz);
-        printf("LU              Mflops: %8.2f    (M=%d, N=%d)\n", res[5],
-				LU_size, LU_size);
-
-
-        Random_delete(R);
-
-        return 0;
-  
+  return 0;
 }
 
-void print_banner()
-{
- printf("**                                                              **\n");
- printf("** SciMark2 Numeric Benchmark, see http://math.nist.gov/scimark **\n");
- printf("** for details. (Results can be submitted to pozo@nist.gov)     **\n");
- printf("**                                                              **\n");
+void print_banner() {
+  printf("**                                                              **\n");
+  printf("** SciMark2 Numeric Benchmark, see http://math.nist.gov/scimark **\n");
+  printf("** for details. (Results can be submitted to pozo@nist.gov)     **\n");
+  printf("**                                                              **\n");
 }

--- a/Validation/Performance/bin/scimark2.h
+++ b/Validation/Performance/bin/scimark2.h
@@ -4,7 +4,7 @@
 
 #define VERSION 2.0
 
-#ifndef NULL 
+#ifndef NULL
 #define NULL 0
 #endif
 
@@ -16,7 +16,4 @@
 #define FALSE 0
 #endif
 
-
-
 #endif
-

--- a/Validation/Performance/interface/PerformanceAnalyzer.h
+++ b/Validation/Performance/interface/PerformanceAnalyzer.h
@@ -7,34 +7,32 @@
 #include <DQMServices/Core/interface/MonitorElement.h>
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
-namespace edm {class EventTime;}
+namespace edm {
+  class EventTime;
+}
 
-class PerformanceAnalyzer : public DQMEDAnalyzer
-{
-
+class PerformanceAnalyzer : public DQMEDAnalyzer {
 public:
   explicit PerformanceAnalyzer(const edm::ParameterSet&);
   ~PerformanceAnalyzer() override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
   edm::EDGetTokenT<edm::EventTime> eventTime_Token_;
-  std::string              fOutputFile ;
-  MonitorElement*          fVtxSmeared ;
-  MonitorElement*          fg4SimHits ;
-  MonitorElement*          fMixing ;
-  MonitorElement*          fSiPixelDigis ;
-  MonitorElement*          fSiStripDigis ;
-  MonitorElement*          fEcalUnsuppDigis ;
-  MonitorElement*          fEcalZeroSuppDigis ;
-  MonitorElement*          fPreShwZeroSuppDigis ;
-  MonitorElement*          fHcalUnsuppDigis ;
-  MonitorElement*          fMuonCSCDigis ;
-  MonitorElement*          fMuonDTDigis ;
-  MonitorElement*          fMuonRPCDigis ;
-
+  std::string fOutputFile;
+  MonitorElement* fVtxSmeared;
+  MonitorElement* fg4SimHits;
+  MonitorElement* fMixing;
+  MonitorElement* fSiPixelDigis;
+  MonitorElement* fSiStripDigis;
+  MonitorElement* fEcalUnsuppDigis;
+  MonitorElement* fEcalZeroSuppDigis;
+  MonitorElement* fPreShwZeroSuppDigis;
+  MonitorElement* fHcalUnsuppDigis;
+  MonitorElement* fMuonCSCDigis;
+  MonitorElement* fMuonDTDigis;
+  MonitorElement* fMuonRPCDigis;
 };
 
 #endif
-

--- a/Validation/Performance/python/TimeMemoryJobReport.py
+++ b/Validation/Performance/python/TimeMemoryJobReport.py
@@ -20,5 +20,9 @@ def customiseWithTimeMemoryJobReport(process):
             wantSummary = cms.untracked.bool(False)
             )
 
+    #Silence the final Timing service report
+    process.MessageLogger.categories.append("TimeReport")
+    process.MessageLogger.cerr.TimeReport = cms.untracked.PSet(limit = cms.untracked.int32(0))
+
     return(process)
 

--- a/Validation/Performance/python/TimeMemoryJobReport.py
+++ b/Validation/Performance/python/TimeMemoryJobReport.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+def customiseWithTimeMemoryJobReport(process):
+
+    #Adding SimpleMemoryCheck service:
+    process.SimpleMemoryCheck=cms.Service("SimpleMemoryCheck",
+                                          ignoreTotal=cms.untracked.int32(1),
+                                          oncePerEventMode=cms.untracked.bool(False),
+                                          jobReportOutputOnly = cms.untracked.bool(True))
+    #Adding Timing service:
+    process.Timing=cms.Service("Timing",
+                               summaryOnly=cms.untracked.bool(True),
+                               excessiveTimeThreshold=cms.untracked.double(600))
+    
+    #Add these 3 lines to put back the summary for timing information at the end of the logfile
+    #(needed for TimeReport report)
+    if hasattr(process,"options"):
+        process.options.wantSummary = cms.untracked.bool(False)
+    else:
+        process.options = cms.untracked.PSet(
+            wantSummary = cms.untracked.bool(False)
+            )
+
+    return(process)
+

--- a/Validation/Performance/src/PerfomanceAnalyzer.cc
+++ b/Validation/Performance/src/PerfomanceAnalyzer.cc
@@ -14,57 +14,67 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 
 PerformanceAnalyzer::PerformanceAnalyzer(const edm::ParameterSet& ps)
-    : fOutputFile( ps.getUntrackedParameter<std::string>("outputFile", "") )
-{
-  eventTime_Token_ = consumes<edm::EventTime> (edm::InputTag("cputest"));
+    : fOutputFile(ps.getUntrackedParameter<std::string>("outputFile", "")) {
+  eventTime_Token_ = consumes<edm::EventTime>(edm::InputTag("cputest"));
 }
 
-PerformanceAnalyzer::~PerformanceAnalyzer()
-{
+PerformanceAnalyzer::~PerformanceAnalyzer() {
   // don't try to delete any pointers - they're handled by DQM machinery
 }
 
-void PerformanceAnalyzer::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const & iRun, edm::EventSetup const & /* iSetup */)
-{
+void PerformanceAnalyzer::bookHistograms(DQMStore::IBooker& iBooker,
+                                         edm::Run const& iRun,
+                                         edm::EventSetup const& /* iSetup */) {
   iBooker.setCurrentFolder("PerformanceV/CPUPerformanceTask");
 
-  fVtxSmeared          = iBooker.book1D("VtxSmeared",          "VtxSmeared",          100, 0., 0.1 );
-  fg4SimHits           = iBooker.book1D("g4SimHits",           "g4SimHits",           100, 0., 500.);
-  fMixing              = iBooker.book1D("Mixing",              "Mixing",              100, 0., 0.5 );
-  fSiPixelDigis        = iBooker.book1D("SiPixelDigis",        "SiPixelDigis",        100, 0., 0.5 );
-  fSiStripDigis        = iBooker.book1D("SiStripDigis",        "SiStripDigis",        100, 0., 2.  );
-  fEcalUnsuppDigis     = iBooker.book1D("EcalUnsuppDigis",     "EcalUnsuppDigis",     100, 0., 2.  );
-  fEcalZeroSuppDigis   = iBooker.book1D("EcalZeroSuppDigis",   "EcalZeroSuppDigis",   100, 0., 2.  );
-  fPreShwZeroSuppDigis = iBooker.book1D("PreShwZeroSuppDigis", "PreShwZeroSuppDigis", 100, 0., 0.1 );
-  fHcalUnsuppDigis     = iBooker.book1D("HcalUnsuppDigis",     "HcalUnsuppDigis",     100, 0., 0.5 );
-  fMuonCSCDigis        = iBooker.book1D("MuonCSCDigis",        "MuonCSCDigis",        100, 0., 0.1 );
-  fMuonDTDigis         = iBooker.book1D("MuonDTDigis",         "MuonDTDigis",         100, 0., 0.1 );
-  fMuonRPCDigis        = iBooker.book1D("MuonRPCDigis",        "MuonRPCDigis",        100, 0., 0.1 );
+  fVtxSmeared = iBooker.book1D("VtxSmeared", "VtxSmeared", 100, 0., 0.1);
+  fg4SimHits = iBooker.book1D("g4SimHits", "g4SimHits", 100, 0., 500.);
+  fMixing = iBooker.book1D("Mixing", "Mixing", 100, 0., 0.5);
+  fSiPixelDigis = iBooker.book1D("SiPixelDigis", "SiPixelDigis", 100, 0., 0.5);
+  fSiStripDigis = iBooker.book1D("SiStripDigis", "SiStripDigis", 100, 0., 2.);
+  fEcalUnsuppDigis = iBooker.book1D("EcalUnsuppDigis", "EcalUnsuppDigis", 100, 0., 2.);
+  fEcalZeroSuppDigis = iBooker.book1D("EcalZeroSuppDigis", "EcalZeroSuppDigis", 100, 0., 2.);
+  fPreShwZeroSuppDigis = iBooker.book1D("PreShwZeroSuppDigis", "PreShwZeroSuppDigis", 100, 0., 0.1);
+  fHcalUnsuppDigis = iBooker.book1D("HcalUnsuppDigis", "HcalUnsuppDigis", 100, 0., 0.5);
+  fMuonCSCDigis = iBooker.book1D("MuonCSCDigis", "MuonCSCDigis", 100, 0., 0.1);
+  fMuonDTDigis = iBooker.book1D("MuonDTDigis", "MuonDTDigis", 100, 0., 0.1);
+  fMuonRPCDigis = iBooker.book1D("MuonRPCDigis", "MuonRPCDigis", 100, 0., 0.1);
 }
 
-void PerformanceAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& eventSetup)
-{
-  if ( e.id().event() == 1) return ; // skip 1st event
+void PerformanceAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& eventSetup) {
+  if (e.id().event() == 1)
+    return;  // skip 1st event
 
   edm::Handle<edm::EventTime> EvtTime;
-  e.getByToken(eventTime_Token_, EvtTime ) ;
+  e.getByToken(eventTime_Token_, EvtTime);
 
-  for ( unsigned int i=0; i<EvtTime->size(); ++i )
-  {
-    if ( EvtTime->name(i) == "VtxSmeared" )   fVtxSmeared->Fill( EvtTime->time(i) ) ;
-    if ( EvtTime->name(i) == "g4SimHits"  )   fg4SimHits->Fill( EvtTime->time(i) ) ;
-    if ( EvtTime->name(i) == "mix" )          fMixing->Fill( EvtTime->time(i) ) ;
-    if ( EvtTime->name(i) == "siPixelDigis" ) fSiPixelDigis->Fill( EvtTime->time(i) ) ;
-    if ( EvtTime->name(i) == "siStripDigis" ) fSiStripDigis->Fill( EvtTime->time(i) ) ;
-    if ( EvtTime->name(i) == "ecalUnsuppressedDigis" ) fEcalUnsuppDigis->Fill( EvtTime->time(i) ) ;
-    if ( EvtTime->name(i) == "ecalDigis")     fEcalZeroSuppDigis->Fill( EvtTime->time(i) ) ;
-    if ( EvtTime->name(i) == "ecalPreshowerDigis") fPreShwZeroSuppDigis->Fill( EvtTime->time(i) ) ;
-    if ( EvtTime->name(i) == "hcalDigis" )    fHcalUnsuppDigis->Fill( EvtTime->time(i) ) ;
-    if ( EvtTime->name(i) == "muonCSCDigis" ) fMuonCSCDigis->Fill( EvtTime->time(i) ) ;
-    if ( EvtTime->name(i) == "muonDTDigis" )  fMuonDTDigis->Fill( EvtTime->time(i) ) ;
-    if ( EvtTime->name(i) == "muonRPCDigis" ) fMuonRPCDigis->Fill( EvtTime->time(i) ) ;
+  for (unsigned int i = 0; i < EvtTime->size(); ++i) {
+    if (EvtTime->name(i) == "VtxSmeared")
+      fVtxSmeared->Fill(EvtTime->time(i));
+    if (EvtTime->name(i) == "g4SimHits")
+      fg4SimHits->Fill(EvtTime->time(i));
+    if (EvtTime->name(i) == "mix")
+      fMixing->Fill(EvtTime->time(i));
+    if (EvtTime->name(i) == "siPixelDigis")
+      fSiPixelDigis->Fill(EvtTime->time(i));
+    if (EvtTime->name(i) == "siStripDigis")
+      fSiStripDigis->Fill(EvtTime->time(i));
+    if (EvtTime->name(i) == "ecalUnsuppressedDigis")
+      fEcalUnsuppDigis->Fill(EvtTime->time(i));
+    if (EvtTime->name(i) == "ecalDigis")
+      fEcalZeroSuppDigis->Fill(EvtTime->time(i));
+    if (EvtTime->name(i) == "ecalPreshowerDigis")
+      fPreShwZeroSuppDigis->Fill(EvtTime->time(i));
+    if (EvtTime->name(i) == "hcalDigis")
+      fHcalUnsuppDigis->Fill(EvtTime->time(i));
+    if (EvtTime->name(i) == "muonCSCDigis")
+      fMuonCSCDigis->Fill(EvtTime->time(i));
+    if (EvtTime->name(i) == "muonDTDigis")
+      fMuonDTDigis->Fill(EvtTime->time(i));
+    if (EvtTime->name(i) == "muonRPCDigis")
+      fMuonRPCDigis->Fill(EvtTime->time(i));
   }
-  return ;
+  return;
 }
 
 DEFINE_FWK_MODULE(PerformanceAnalyzer);

--- a/Validation/Performance/test/SimDigiDumper.cc
+++ b/Validation/Performance/test/SimDigiDumper.cc
@@ -24,100 +24,80 @@
 // muon DT info
 #include "CondFormats/DTObjects/interface/DTT0.h"
 
-
-SimDigiDumper::SimDigiDumper( const edm::ParameterSet& iPSet )
-{
+SimDigiDumper::SimDigiDumper(const edm::ParameterSet& iPSet) {
   //get Labels to use to extract information
-  ECalEBSrc_ = consumes<EBDigiCollection> (
-      iPSet.getParameter<edm::InputTag>("ECalEBSrc"));
-  ECalEESrc_ = consumes<EEDigiCollection> (
-      iPSet.getParameter<edm::InputTag>("ECalEESrc"));
-  ECalESSrc_ = consumes<ESDigiCollection> (
-      iPSet.getParameter<edm::InputTag>("ECalESSrc"));
-  HCalDigi_ = consumes<HBHEDigiCollection> (
-      iPSet.getParameter<edm::InputTag>("HCalDigi"));
-  HCalHODigi_ = consumes<HODigiCollection> (
-      iPSet.getParameter<edm::InputTag>("HCalDigi"));
-  HCalHFDigi_ = consumes<HFDigiCollection> (
-      iPSet.getParameter<edm::InputTag>("HCalDigi"));
-  ZdcDigi_ = consumes<ZDCDigiCollection> (
-      iPSet.getParameter<edm::InputTag>("ZdcDigi"));
-  SiStripSrc_ = consumes<edm::DetSetVector<SiStripDigi> > (
-      iPSet.getParameter<edm::InputTag>("SiStripSrc"));
-  SiPxlSrc_ = consumes<edm::DetSetVector<PixelDigi> > (
-      iPSet.getParameter<edm::InputTag>("SiPxlSrc"));
-  MuDTSrc_ = consumes<DTDigiCollection> (
-      iPSet.getParameter<edm::InputTag>("MuDTSrc"));
-  MuCSCStripSrc_ = consumes<CSCStripDigiCollection> (
-      iPSet.getParameter<edm::InputTag>("MuCSCStripSrc"));
-  MuCSCWireSrc_ = consumes<CSCWireDigiCollection> (
-      iPSet.getParameter<edm::InputTag>("MuCSCWireSrc"));
-  MuRPCSrc_ = consumes<RPCDigiCollection> (
-      iPSet.getParameter<edm::InputTag>("MuRPCSrc"));
+  ECalEBSrc_ = consumes<EBDigiCollection>(iPSet.getParameter<edm::InputTag>("ECalEBSrc"));
+  ECalEESrc_ = consumes<EEDigiCollection>(iPSet.getParameter<edm::InputTag>("ECalEESrc"));
+  ECalESSrc_ = consumes<ESDigiCollection>(iPSet.getParameter<edm::InputTag>("ECalESSrc"));
+  HCalDigi_ = consumes<HBHEDigiCollection>(iPSet.getParameter<edm::InputTag>("HCalDigi"));
+  HCalHODigi_ = consumes<HODigiCollection>(iPSet.getParameter<edm::InputTag>("HCalDigi"));
+  HCalHFDigi_ = consumes<HFDigiCollection>(iPSet.getParameter<edm::InputTag>("HCalDigi"));
+  ZdcDigi_ = consumes<ZDCDigiCollection>(iPSet.getParameter<edm::InputTag>("ZdcDigi"));
+  SiStripSrc_ = consumes<edm::DetSetVector<SiStripDigi> >(iPSet.getParameter<edm::InputTag>("SiStripSrc"));
+  SiPxlSrc_ = consumes<edm::DetSetVector<PixelDigi> >(iPSet.getParameter<edm::InputTag>("SiPxlSrc"));
+  MuDTSrc_ = consumes<DTDigiCollection>(iPSet.getParameter<edm::InputTag>("MuDTSrc"));
+  MuCSCStripSrc_ = consumes<CSCStripDigiCollection>(iPSet.getParameter<edm::InputTag>("MuCSCStripSrc"));
+  MuCSCWireSrc_ = consumes<CSCWireDigiCollection>(iPSet.getParameter<edm::InputTag>("MuCSCWireSrc"));
+  MuRPCSrc_ = consumes<RPCDigiCollection>(iPSet.getParameter<edm::InputTag>("MuRPCSrc"));
 
   // TODO(proper responsible): update the cout, for sure not my
   // business.
 
-//   // print out Parameter Set information being used
-//   std::cout
-//       << "\n===============================\n"
-//       << "Dumping event digis for the collections:\n"
-//       << "    ECalEBSrc     = " << ECalEBSrc_.label()
-//       << ":" << ECalEBSrc_.instance() << "\n"
-//       << "    ECalEESrc     = " << ECalEESrc_.label()
-//       << ":" << ECalEESrc_.instance() << "\n"
-//       << "    ECalESSrc     = " << ECalESSrc_.label()
-//       << ":" << ECalESSrc_.instance() << "\n"
-//       << "    HCalDigi       = " << HCalDigi_.label()
-//       << ":" << HCalDigi_.instance() << "\n"
-//       << "    ZdcDigi       = " << ZdcDigi_.label()
-//       << ":" << ZdcDigi_.instance() << "\n"
-//       << "    SiStripSrc    = " << SiStripSrc_.label()
-//       << ":" << SiStripSrc_.instance() << "\n"
-//       << "    SiPixelSrc    = " << SiPxlSrc_.label()
-//       << ":" << SiPxlSrc_.instance() << "\n"
-//       << "    MuDTSrc       = " << MuDTSrc_.label()
-//       << ":" << MuDTSrc_.instance() << "\n"
-//       << "    MuCSCStripSrc = " << MuCSCStripSrc_.label()
-//       << ":" << MuCSCStripSrc_.instance() << "\n"
-//       << "    MuCSCWireSrc  = " << MuCSCWireSrc_.label()
-//       << ":" << MuCSCWireSrc_.instance() << "\n"
-//       << "    MuRPCSrc      = " << MuRPCSrc_.label()
-//       << ":" << MuRPCSrc_.instance() << "\n"
-//       << "===============================\n"
-//       << std::endl;
-
+  //   // print out Parameter Set information being used
+  //   std::cout
+  //       << "\n===============================\n"
+  //       << "Dumping event digis for the collections:\n"
+  //       << "    ECalEBSrc     = " << ECalEBSrc_.label()
+  //       << ":" << ECalEBSrc_.instance() << "\n"
+  //       << "    ECalEESrc     = " << ECalEESrc_.label()
+  //       << ":" << ECalEESrc_.instance() << "\n"
+  //       << "    ECalESSrc     = " << ECalESSrc_.label()
+  //       << ":" << ECalESSrc_.instance() << "\n"
+  //       << "    HCalDigi       = " << HCalDigi_.label()
+  //       << ":" << HCalDigi_.instance() << "\n"
+  //       << "    ZdcDigi       = " << ZdcDigi_.label()
+  //       << ":" << ZdcDigi_.instance() << "\n"
+  //       << "    SiStripSrc    = " << SiStripSrc_.label()
+  //       << ":" << SiStripSrc_.instance() << "\n"
+  //       << "    SiPixelSrc    = " << SiPxlSrc_.label()
+  //       << ":" << SiPxlSrc_.instance() << "\n"
+  //       << "    MuDTSrc       = " << MuDTSrc_.label()
+  //       << ":" << MuDTSrc_.instance() << "\n"
+  //       << "    MuCSCStripSrc = " << MuCSCStripSrc_.label()
+  //       << ":" << MuCSCStripSrc_.instance() << "\n"
+  //       << "    MuCSCWireSrc  = " << MuCSCWireSrc_.label()
+  //       << ":" << MuCSCWireSrc_.instance() << "\n"
+  //       << "    MuRPCSrc      = " << MuRPCSrc_.label()
+  //       << ":" << MuRPCSrc_.instance() << "\n"
+  //       << "===============================\n"
+  //       << std::endl;
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+void SimDigiDumper::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
   // ECAL Barrel
 
   bool isBarrel = true;
   edm::Handle<EBDigiCollection> EcalDigiEB;
-  const EBDigiCollection *EBdigis = 0;
+  const EBDigiCollection* EBdigis = 0;
   iEvent.getByToken(ECalEBSrc_, EcalDigiEB);
   if (!EcalDigiEB.isValid()) {
     std::cout << "Unable to find EcalDigiEB in event!" << std::endl;
-  }
-  else {
+  } else {
     EBdigis = EcalDigiEB.product();
-    if ( EcalDigiEB->size() == 0) isBarrel = false;
+    if (EcalDigiEB->size() == 0)
+      isBarrel = false;
     std::cout << "Ecal Barrel, digi multiplicity = " << EcalDigiEB->size() << std::endl;
 
     if (isBarrel) {
       // loop over digis
-      for (unsigned int digis=0; digis<EcalDigiEB->size(); ++digis) {
-
+      for (unsigned int digis = 0; digis < EcalDigiEB->size(); ++digis) {
         EBDataFrame ebdf = (*EBdigis)[digis];
         std::cout << ebdf << std::endl;
       }
@@ -127,20 +107,19 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
   // ECAL Endcap
   bool isEndcap = true;
   edm::Handle<EEDigiCollection> EcalDigiEE;
-  const EEDigiCollection *EEdigis = 0;
+  const EEDigiCollection* EEdigis = 0;
   iEvent.getByToken(ECalEESrc_, EcalDigiEE);
   if (!EcalDigiEE.isValid()) {
     std::cout << "Unable to find EcalDigiEE in event!" << std::endl;
-  }
-  else {
+  } else {
     EEdigis = EcalDigiEE.product();
-    if ( EcalDigiEE->size() == 0) isEndcap = false;
+    if (EcalDigiEE->size() == 0)
+      isEndcap = false;
     std::cout << "Ecal Endcap, digi multiplicity = " << EcalDigiEE->size() << std::endl;
 
     if (isEndcap) {
       // loop over digis
-      for (unsigned int digis=0; digis<EcalDigiEE->size(); ++digis) {
-
+      for (unsigned int digis = 0; digis < EcalDigiEE->size(); ++digis) {
         EEDataFrame eedf = (*EEdigis)[digis];
         std::cout << eedf << std::endl;
       }
@@ -150,20 +129,19 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
   // ECAL Preshower
   bool isPreshower = true;
   edm::Handle<ESDigiCollection> EcalDigiES;
-  const ESDigiCollection *ESdigis = 0;
+  const ESDigiCollection* ESdigis = 0;
   iEvent.getByToken(ECalESSrc_, EcalDigiES);
   if (!EcalDigiES.isValid()) {
     std::cout << "Unable to find EcalDigiES in event!" << std::endl;
-  }
-  else {
+  } else {
     ESdigis = EcalDigiES.product();
-    if ( EcalDigiES->size() == 0) isPreshower = false;
+    if (EcalDigiES->size() == 0)
+      isPreshower = false;
     std::cout << "Ecal Preshower, digi multiplicity = " << EcalDigiES->size() << std::endl;
 
     if (isPreshower) {
       // loop over digis
-      for (unsigned int digis=0; digis<EcalDigiES->size(); ++digis) {
-
+      for (unsigned int digis = 0; digis < EcalDigiES->size(); ++digis) {
         ESDataFrame esdf = (*ESdigis)[digis];
         std::cout << esdf << std::endl;
       }
@@ -173,25 +151,25 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
   // HBHE
   bool isHBHE = true;
   edm::Handle<HBHEDigiCollection> hbhe;
-  const HBHEDigiCollection *HBHEdigis = 0;
+  const HBHEDigiCollection* HBHEdigis = 0;
   iEvent.getByToken(HCalDigi_, hbhe);
   if (!hbhe.isValid()) {
     std::cout << "Unable to find HBHEDataFrame in event!" << std::endl;
-  }
-  else {
+  } else {
     HBHEdigis = hbhe.product();
-    if ( hbhe->size() == 0 ) isHBHE = false;
+    if (hbhe->size() == 0)
+      isHBHE = false;
     std::cout << "HBHE, digi multiplicity = " << hbhe->size() << std::endl;
 
     if (isHBHE) {
       //loop over digis
-      for (unsigned int digis=0; digis<hbhe->size(); ++digis) {
+      for (unsigned int digis = 0; digis < hbhe->size(); ++digis) {
         HBHEDataFrame hehbdf = (*HBHEdigis)[digis];
         std::cout << hehbdf << std::endl;
-	//edm::SortedCollection<HBHEDataFrame>::const_iterator ihbhe;
-	//for  (ihbhe == hbhe->begin(); ihbhe != hbhe->end(); ihbhe++) {
-	//std::cout << "Nothing" << std::endl;
-	//std::cout << (*ihbhe) << std::endl;
+        //edm::SortedCollection<HBHEDataFrame>::const_iterator ihbhe;
+        //for  (ihbhe == hbhe->begin(); ihbhe != hbhe->end(); ihbhe++) {
+        //std::cout << "Nothing" << std::endl;
+        //std::cout << (*ihbhe) << std::endl;
       }
     }
   }
@@ -199,19 +177,19 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
   // HO
   bool isHO = true;
   edm::Handle<HODigiCollection> ho;
-  const HODigiCollection *HOdigis = 0;
+  const HODigiCollection* HOdigis = 0;
   iEvent.getByToken(HCalHODigi_, ho);
   if (!ho.isValid()) {
     std::cout << "Unable to find HODataFrame in event!" << std::endl;
-  }
-  else {
+  } else {
     HOdigis = ho.product();
-    if ( ho->size() == 0 ) isHO = false;
+    if (ho->size() == 0)
+      isHO = false;
     std::cout << "HO, digi multiplicity = " << ho->size() << std::endl;
 
     if (isHO) {
       //loop over digis
-      for (unsigned int digis=0; digis<ho->size(); ++digis) {
+      for (unsigned int digis = 0; digis < ho->size(); ++digis) {
         HODataFrame hodf = (*HOdigis)[digis];
         std::cout << hodf << std::endl;
       }
@@ -221,19 +199,19 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
   // HF
   bool isHF = true;
   edm::Handle<HFDigiCollection> hf;
-  const HFDigiCollection *HFdigis = 0;
-  iEvent.getByToken(HCalHFDigi_,hf);
+  const HFDigiCollection* HFdigis = 0;
+  iEvent.getByToken(HCalHFDigi_, hf);
   if (!hf.isValid()) {
     std::cout << "Unable to find HFDataFrame in event!" << std::endl;
-  }
-  else {
+  } else {
     HFdigis = hf.product();
-    if ( hf->size() == 0 ) isHF = false;
+    if (hf->size() == 0)
+      isHF = false;
     std::cout << "HF, digi multiplicity = " << hf->size() << std::endl;
 
     if (isHF) {
       //loop over digis
-      for (unsigned int digis=0; digis<hf->size(); ++digis) {
+      for (unsigned int digis = 0; digis < hf->size(); ++digis) {
         HFDataFrame hodf = (*HFdigis)[digis];
         std::cout << hodf << std::endl;
       }
@@ -243,19 +221,19 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
   // ZDC
   bool isZDC = true;
   edm::Handle<ZDCDigiCollection> zdc;
-  const ZDCDigiCollection *ZDCdigis = 0;
+  const ZDCDigiCollection* ZDCdigis = 0;
   iEvent.getByToken(ZdcDigi_, zdc);
   if (!zdc.isValid()) {
     std::cout << "Unable to find ZDCDataFrame in event!" << std::endl;
-  }
-  else {
+  } else {
     ZDCdigis = zdc.product();
-    if ( zdc->size() == 0 ) isZDC = false;
+    if (zdc->size() == 0)
+      isZDC = false;
     std::cout << "ZDC, digi multiplicity = " << zdc->size() << std::endl;
 
     if (isZDC) {
       //loop over digis
-      for (unsigned int digis=0; digis<zdc->size(); ++digis) {
+      for (unsigned int digis = 0; digis < zdc->size(); ++digis) {
         ZDCDataFrame hodf = (*ZDCdigis)[digis];
         std::cout << hodf << std::endl;
       }
@@ -268,14 +246,13 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
   iEvent.getByToken(SiStripSrc_, stripDigis);
   if (!stripDigis.isValid()) {
     std::cout << "Unable to find stripDigis in event!" << std::endl;
-  }
-  else {
-    if ( stripDigis->size() == 0 ) isStrip = false;
-    std::cout << "Strip Tracker, digi multiplicity = " <<  stripDigis->size() << std::endl;
+  } else {
+    if (stripDigis->size() == 0)
+      isStrip = false;
+    std::cout << "Strip Tracker, digi multiplicity = " << stripDigis->size() << std::endl;
     if (isStrip) {
       edm::DetSetVector<SiStripDigi>::const_iterator DSViter;
-      for (DSViter = stripDigis->begin(); DSViter != stripDigis->end();
-           ++DSViter) {
+      for (DSViter = stripDigis->begin(); DSViter != stripDigis->end(); ++DSViter) {
         edm::DetSet<SiStripDigi>::const_iterator begin = DSViter->data.begin();
         edm::DetSet<SiStripDigi>::const_iterator end = DSViter->data.end();
         edm::DetSet<SiStripDigi>::const_iterator iter;
@@ -284,11 +261,9 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
 
         if (detId.subdetId() == sdSiTIB) {
           std::cout << "TIB " << DSViter->data.size() << std::endl;
-        }
-        else if (detId.subdetId() == sdSiTOB) {
+        } else if (detId.subdetId() == sdSiTOB) {
           std::cout << "TOB " << DSViter->data.size() << std::endl;
-        }
-        else if (detId.subdetId() == sdSiTID) {
+        } else if (detId.subdetId() == sdSiTID) {
           std::cout << "TID " << DSViter->data.size() << std::endl;
         }
         if (detId.subdetId() == sdSiTEC) {
@@ -307,15 +282,14 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
   iEvent.getByToken(SiPxlSrc_, pixelDigis);
   if (!pixelDigis.isValid()) {
     std::cout << "Unable to find pixelDigis in event!" << std::endl;
-  }
-  else {
-    if ( pixelDigis->size() == 0 ) isPixel = false;
-    std::cout << "Pixel Tracker, digi multiplicity = " <<  pixelDigis->size() << std::endl;
+  } else {
+    if (pixelDigis->size() == 0)
+      isPixel = false;
+    std::cout << "Pixel Tracker, digi multiplicity = " << pixelDigis->size() << std::endl;
 
     if (isPixel) {
       edm::DetSetVector<PixelDigi>::const_iterator DSViter;
-      for (DSViter = pixelDigis->begin(); DSViter != pixelDigis->end();
-           ++DSViter) {
+      for (DSViter = pixelDigis->begin(); DSViter != pixelDigis->end(); ++DSViter) {
         edm::DetSet<PixelDigi>::const_iterator begin = DSViter->data.begin();
         edm::DetSet<PixelDigi>::const_iterator end = DSViter->data.end();
         edm::DetSet<PixelDigi>::const_iterator iter;
@@ -324,14 +298,12 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
 
         if (detId.subdetId() == sdPxlBrl) {
           std::cout << "Pixel barrel " << DSViter->data.size() << std::endl;
-        }
-        else if (detId.subdetId() == sdPxlFwd) {
+        } else if (detId.subdetId() == sdPxlFwd) {
           std::cout << "Pixel forward " << DSViter->data.size() << std::endl;
         }
         for (iter = begin; iter != end; ++iter) {
           std::cout << (*iter) << std::endl;
         }
-
       }
     }
   }
@@ -345,26 +317,22 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
     std::cout << "Unable to find dtDigis in event!" << std::endl;
   }
   unsigned int nDT = 0;
-  if ( dtDigis->begin() == dtDigis->end() ) {
+  if (dtDigis->begin() == dtDigis->end()) {
     isDT = false;
     std::cout << "dtDigis seem empty!" << std::endl;
   }
   if (isDT) {
     DTDigiCollection::DigiRangeIterator dtLayerIt;
-    for (dtLayerIt = dtDigis->begin();
-	 dtLayerIt != dtDigis->end();
-         ++dtLayerIt) {
+    for (dtLayerIt = dtDigis->begin(); dtLayerIt != dtDigis->end(); ++dtLayerIt) {
       const DTDigiCollection::Range& range = (*dtLayerIt).second;
       std::cout << "DT layer = " << (*dtLayerIt).first << " digi " << std::endl;
-      for (DTDigiCollection::const_iterator digiIt = range.first;
-           digiIt != range.second; ++digiIt) {
+      for (DTDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
         std::cout << (*digiIt) << std::endl;
         nDT++;
       }
     }
   }
   std::cout << "DT, digi multiplicity = " << nDT << std::endl;
-
 
   // CSC strip
   bool isCSCStrip = true;
@@ -373,17 +341,16 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
   if (!cscStripDigis.isValid()) {
     std::cout << "Unable to find cscStripDigis in event!" << std::endl;
   }
-  if ( cscStripDigis->begin() == cscStripDigis->end() ) isCSCStrip = false;
+  if (cscStripDigis->begin() == cscStripDigis->end())
+    isCSCStrip = false;
   unsigned int nCSCStrip = 0;
 
   if (isCSCStrip) {
     CSCStripDigiCollection::DigiRangeIterator detUnitIt;
-    for (detUnitIt = cscStripDigis->begin(); detUnitIt != cscStripDigis->end();
-         ++detUnitIt) {
+    for (detUnitIt = cscStripDigis->begin(); detUnitIt != cscStripDigis->end(); ++detUnitIt) {
       const CSCStripDigiCollection::Range& range = (*detUnitIt).second;
       std::cout << "CSC detid = " << (*detUnitIt).first << " digi " << std::endl;
-      for (CSCStripDigiCollection::const_iterator digiIt = range.first;
-           digiIt != range.second; ++digiIt) {
+      for (CSCStripDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
         std::cout << (*digiIt) << std::endl;
         nCSCStrip++;
       }
@@ -398,17 +365,16 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
   if (!cscWireDigis.isValid()) {
     std::cout << "Unable to find cscWireDigis in event!" << std::endl;
   }
-  if ( cscWireDigis->begin() == cscWireDigis->end() ) isCSCWire = false;
+  if (cscWireDigis->begin() == cscWireDigis->end())
+    isCSCWire = false;
   unsigned int nCSCWire = 0;
 
   if (isCSCWire) {
     CSCWireDigiCollection::DigiRangeIterator detUnitIt;
-    for (detUnitIt = cscWireDigis->begin(); detUnitIt != cscWireDigis->end();
-         ++detUnitIt) {
+    for (detUnitIt = cscWireDigis->begin(); detUnitIt != cscWireDigis->end(); ++detUnitIt) {
       const CSCWireDigiCollection::Range& range = (*detUnitIt).second;
       std::cout << "CSC detid = " << (*detUnitIt).first << " digi " << std::endl;
-      for (CSCWireDigiCollection::const_iterator digiIt = range.first;
-           digiIt != range.second; ++digiIt) {
+      for (CSCWireDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
         std::cout << (*digiIt) << std::endl;
         nCSCWire++;
       }
@@ -423,17 +389,16 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
   if (!rpcDigis.isValid()) {
     std::cout << "Unable to find rpcDigis in event!" << std::endl;
   }
-  if ( rpcDigis->begin() == rpcDigis->end() ) isRPC = false;
+  if (rpcDigis->begin() == rpcDigis->end())
+    isRPC = false;
   unsigned int nRPC = 0;
 
   if (isRPC) {
     RPCDigiCollection::DigiRangeIterator detUnitIt;
-    for (detUnitIt = rpcDigis->begin(); detUnitIt != rpcDigis->end();
-         ++detUnitIt) {
+    for (detUnitIt = rpcDigis->begin(); detUnitIt != rpcDigis->end(); ++detUnitIt) {
       const RPCDigiCollection::Range& range = (*detUnitIt).second;
       std::cout << "RPC detid = " << (*detUnitIt).first << " digi " << std::endl;
-      for (RPCDigiCollection::const_iterator digiIt = range.first;
-           digiIt != range.second; ++digiIt) {
+      for (RPCDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
         std::cout << (*digiIt) << std::endl;
         nRPC++;
       }
@@ -446,4 +411,3 @@ SimDigiDumper::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(SimDigiDumper);
-

--- a/Validation/Performance/test/SimDigiDumper.h
+++ b/Validation/Performance/test/SimDigiDumper.h
@@ -29,16 +29,16 @@
 
 #include <vector>
 
-class SimDigiDumper : public edm::EDAnalyzer{
+class SimDigiDumper : public edm::EDAnalyzer {
 public:
-  explicit SimDigiDumper( const edm::ParameterSet& );
-  virtual ~SimDigiDumper() {};
+  explicit SimDigiDumper(const edm::ParameterSet&);
+  virtual ~SimDigiDumper(){};
 
-  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void beginJob(){};
   virtual void endJob(){};
-private:
 
+private:
   edm::EDGetTokenT<EBDigiCollection> ECalEBSrc_;
   edm::EDGetTokenT<EEDigiCollection> ECalEESrc_;
   edm::EDGetTokenT<ESDigiCollection> ECalESSrc_;
@@ -61,14 +61,12 @@ private:
 
   edm::EDGetTokenT<RPCDigiCollection> MuRPCSrc_;
 
-  static const int sdSiTIB          = 3;
-  static const int sdSiTID          = 4;
-  static const int sdSiTOB          = 5;
-  static const int sdSiTEC          = 6;
-  static const int sdPxlBrl         = 1;
-  static const int sdPxlFwd         = 2;
-
-
+  static const int sdSiTIB = 3;
+  static const int sdSiTID = 4;
+  static const int sdSiTOB = 5;
+  static const int sdSiTEC = 6;
+  static const int sdPxlBrl = 1;
+  static const int sdPxlFwd = 2;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

A variant of the TimeMemorySummary customisation is provided, to avoid Memory report in the stdout and prevent the long Trigger and Time summary to be reported. Meant to solve the issue with tests within cms-bot, see https://github.com/cms-sw/cms-bot/pull/1122 

The code cleaning by ```scram b code-format-all``` is also provided.

#### PR validation:

Test wf 503 has been run with this customisation, providing the desired result:
```
runTheMatrix.py -l 503.0 --command "--customise Validation/Performance/TimeMemoryJobReport.customiseWithTimeMemoryJobReport -n 100"
```

cmsScimark2 (affected by the code cleaning) also runs and provide output.