### PR TITLE
BugFix for the reconstruction_fromReco sequences: https://github.com/cms-sw/cmssw/issues/26500

### DIFF
--- a/Configuration/ProcessModifiers/python/recoFromReco_cff.py
+++ b/Configuration/ProcessModifiers/python/recoFromReco_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier sets the flag used to run the showerDigiInfo off in the reco from reco step4
+recoFromReco = cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2742,6 +2742,7 @@ steps['RECOFROMRECO']=merge([{'-s':'RECO,EI',
                               '--process':'reRECO',
                               '--datatier':'AODSIM',
                               '--eventcontent':'AODSIM',
+                              '--procModifiers':'recoFromReco', 
                               },
                              stCond,step3Defaults])
 

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -100,3 +100,11 @@ muonEcalDetIds = cms.EDProducer("InterestingEcalDetIdProducer",
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toModify(muons1stStep, minPt = 0.8)
+
+from Configuration.ProcessModifiers.recoFromReco_cff import recoFromReco
+recoFromReco.toModify(muons1stStep,fillShowerDigis = cms.bool(False))
+
+
+
+
+   


### PR DESCRIPTION
#### PR description:
The PR fixes the reconstruction_fromReco sequences. The fix is needed in pre4, because the #26369 takes in input collections of digis which are missing running the reRECO process. The fix consists in switching off the process which uses the digi info. The temporary fix done in PR #26501 is not needed anymore. And the #26501 can be reverted.

#### PR validation:
Validation has been successfully done on the process  runTheMatrix.py -l 1102.0. 

