### PR TITLE
Restore FED error treatment for phase0 (required for UL Rereco of 2016)

### DIFF
--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -22,29 +22,29 @@ public:
 
   ErrorChecker();
 
-  void setErrorStatus(bool ErrorStatus);
+  void setErrorStatus(bool ErrorStatus) override;
 
-  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors);
+  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) override;
 
-  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors);
+  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) override;
 
-  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors);
+  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) override;
 
   bool checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
 		const SiPixelFedCabling* theCablingTree,
-		Word32& errorWord, Errors& errors);
+		Word32& errorWord, Errors& errors) override;
 
 
 
   void conversionError(int fedId, const SiPixelFrameConverter* converter, 
-		       int status, Word32& errorWord, Errors& errors);
+		       int status, Word32& errorWord, Errors& errors) override;
 
 private:
 
   bool includeErrors;
 
   cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, 
-	 	          int errorType, const Word32 & word) const;
+	 	          int errorType, const Word32 & word) const override;
 
 };
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -2,7 +2,7 @@
 #define ErrorChecker_H
 /** \class ErrorChecker
  *
- *  
+ *
  */
 
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h"
@@ -22,26 +22,28 @@ public:
 
   void setErrorStatus(bool ErrorStatus) override;
 
-  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) override;
+  bool checkCRC(bool &errorsInEvent, int fedId, const Word64 *trailer,
+                Errors &errors) override;
 
-  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) override;
+  bool checkHeader(bool &errorsInEvent, int fedId, const Word64 *header,
+                   Errors &errors) override;
 
-  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) override;
+  bool checkTrailer(bool &errorsInEvent, int fedId, unsigned int nWords,
+                    const Word64 *trailer, Errors &errors) override;
 
-  bool checkROC(bool& errorsInEvent,
-                int fedId,
-                const SiPixelFrameConverter* converter,
-                const SiPixelFedCabling* theCablingTree,
-                Word32& errorWord,
-                Errors& errors) override;
+  bool checkROC(bool &errorsInEvent, int fedId,
+                const SiPixelFrameConverter *converter,
+                const SiPixelFedCabling *theCablingTree, Word32 &errorWord,
+                Errors &errors) override;
 
-  void conversionError(
-      int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) override;
+  void conversionError(int fedId, const SiPixelFrameConverter *converter,
+                       int status, Word32 &errorWord, Errors &errors) override;
 
 private:
   bool includeErrors;
 
-  cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const override;
+  cms_uint32_t errorDetId(const SiPixelFrameConverter *converter, int errorType,
+                          const Word32 &word) const override;
 };
 
 #endif

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -8,12 +8,10 @@
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h"
 #include "FWCore/Utilities/interface/typedefs.h"
 
-
 class ErrorChecker : public ErrorCheckerBase {
-
 public:
-//  typedef unsigned int Word32;
-//  typedef long long Word64;
+  //  typedef unsigned int Word32;
+  //  typedef long long Word64;
   typedef cms_uint32_t Word32;
   typedef cms_uint64_t Word64;
 
@@ -30,22 +28,20 @@ public:
 
   bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) override;
 
-  bool checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
-		const SiPixelFedCabling* theCablingTree,
-		Word32& errorWord, Errors& errors) override;
+  bool checkROC(bool& errorsInEvent,
+                int fedId,
+                const SiPixelFrameConverter* converter,
+                const SiPixelFedCabling* theCablingTree,
+                Word32& errorWord,
+                Errors& errors) override;
 
-
-
-  void conversionError(int fedId, const SiPixelFrameConverter* converter, 
-		       int status, Word32& errorWord, Errors& errors) override;
+  void conversionError(
+      int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) override;
 
 private:
-
   bool includeErrors;
 
-  cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, 
-	 	          int errorType, const Word32 & word) const override;
-
+  cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const override;
 };
 
 #endif

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -2,13 +2,13 @@
 #define ErrorCheckerBase_H
 /** \class ErrorCheckerBase
  *
- *  
+ *
  */
 
 #include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
 
-#include <vector>
 #include <map>
+#include <vector>
 
 class SiPixelFrameConverter;
 class SiPixelFedCabling;
@@ -27,25 +27,28 @@ public:
 
   virtual void setErrorStatus(bool ErrorStatus) = 0;
 
-  virtual bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) = 0;
+  virtual bool checkCRC(bool &errorsInEvent, int fedId, const Word64 *trailer,
+                        Errors &errors) = 0;
 
-  virtual bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) = 0;
+  virtual bool checkHeader(bool &errorsInEvent, int fedId, const Word64 *header,
+                           Errors &errors) = 0;
 
-  virtual bool checkTrailer(
-      bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) = 0;
+  virtual bool checkTrailer(bool &errorsInEvent, int fedId, unsigned int nWords,
+                            const Word64 *trailer, Errors &errors) = 0;
 
-  virtual bool checkROC(bool& errorsInEvent,
-                        int fedId,
-                        const SiPixelFrameConverter* converter,
-                        const SiPixelFedCabling* theCablingTree,
-                        Word32& errorWord,
-                        Errors& errors) = 0;
+  virtual bool checkROC(bool &errorsInEvent, int fedId,
+                        const SiPixelFrameConverter *converter,
+                        const SiPixelFedCabling *theCablingTree,
+                        Word32 &errorWord, Errors &errors) = 0;
 
-  virtual void conversionError(
-      int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) = 0;
+  virtual void conversionError(int fedId,
+                               const SiPixelFrameConverter *converter,
+                               int status, Word32 &errorWord,
+                               Errors &errors) = 0;
 
 private:
-  virtual cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const = 0;
+  virtual cms_uint32_t errorDetId(const SiPixelFrameConverter *converter,
+                                  int errorType, const Word32 &word) const = 0;
 };
 
 #endif

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -10,45 +10,42 @@
 #include <vector>
 #include <map>
 
-
 class SiPixelFrameConverter;
 class SiPixelFedCabling;
 
 class ErrorCheckerBase {
-
 public:
-//  typedef unsigned int Word32;
-//  typedef long long Word64;
+  //  typedef unsigned int Word32;
+  //  typedef long long Word64;
   typedef cms_uint32_t Word32;
   typedef cms_uint64_t Word64;
 
   typedef std::vector<SiPixelRawDataError> DetErrors;
   typedef std::map<cms_uint32_t, DetErrors> Errors;
 
-  virtual ~ErrorCheckerBase() {};
+  virtual ~ErrorCheckerBase(){};
 
-  virtual void setErrorStatus(bool ErrorStatus)=0;
+  virtual void setErrorStatus(bool ErrorStatus) = 0;
 
-  virtual bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors)=0;
+  virtual bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) = 0;
 
-  virtual bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors)=0;
+  virtual bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) = 0;
 
-  virtual bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors)=0;
+  virtual bool checkTrailer(
+      bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) = 0;
 
-  virtual bool checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
-		const SiPixelFedCabling* theCablingTree,
-		Word32& errorWord, Errors& errors)=0;
+  virtual bool checkROC(bool& errorsInEvent,
+                        int fedId,
+                        const SiPixelFrameConverter* converter,
+                        const SiPixelFedCabling* theCablingTree,
+                        Word32& errorWord,
+                        Errors& errors) = 0;
 
-
-
-  virtual void conversionError(int fedId, const SiPixelFrameConverter* converter, 
-		       int status, Word32& errorWord, Errors& errors)=0;
+  virtual void conversionError(
+      int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) = 0;
 
 private:
-
-  virtual  cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, 
-	 	          int errorType, const Word32 & word) const =0;
-
+  virtual cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const = 0;
 };
 
 #endif

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -1,0 +1,54 @@
+#ifndef ErrorCheckerBase_H
+#define ErrorCheckerBase_H
+/** \class ErrorCheckerBase
+ *
+ *  
+ */
+
+#include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
+
+#include <vector>
+#include <map>
+
+
+class SiPixelFrameConverter;
+class SiPixelFedCabling;
+
+class ErrorCheckerBase {
+
+public:
+//  typedef unsigned int Word32;
+//  typedef long long Word64;
+  typedef cms_uint32_t Word32;
+  typedef cms_uint64_t Word64;
+
+  typedef std::vector<SiPixelRawDataError> DetErrors;
+  typedef std::map<cms_uint32_t, DetErrors> Errors;
+
+  virtual ~ErrorCheckerBase() {};
+
+  virtual void setErrorStatus(bool ErrorStatus)=0;
+
+  virtual bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors)=0;
+
+  virtual bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors)=0;
+
+  virtual bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors)=0;
+
+  virtual bool checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
+		const SiPixelFedCabling* theCablingTree,
+		Word32& errorWord, Errors& errors)=0;
+
+
+
+  virtual void conversionError(int fedId, const SiPixelFrameConverter* converter, 
+		       int status, Word32& errorWord, Errors& errors)=0;
+
+private:
+
+  virtual  cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, 
+	 	          int errorType, const Word32 & word) const =0;
+
+};
+
+#endif

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -2,7 +2,7 @@
 #define ErrorCheckerPhase0_H
 /** \class ErrorCheckerPhase0
  *
- *  
+ *
  */
 
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h"
@@ -22,26 +22,28 @@ public:
 
   void setErrorStatus(bool ErrorStatus) override;
 
-  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) override;
+  bool checkCRC(bool &errorsInEvent, int fedId, const Word64 *trailer,
+                Errors &errors) override;
 
-  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) override;
+  bool checkHeader(bool &errorsInEvent, int fedId, const Word64 *header,
+                   Errors &errors) override;
 
-  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) override;
+  bool checkTrailer(bool &errorsInEvent, int fedId, unsigned int nWords,
+                    const Word64 *trailer, Errors &errors) override;
 
-  bool checkROC(bool& errorsInEvent,
-                int fedId,
-                const SiPixelFrameConverter* converter,
-                const SiPixelFedCabling* theCablingTree,
-                Word32& errorWord,
-                Errors& errors) override;
+  bool checkROC(bool &errorsInEvent, int fedId,
+                const SiPixelFrameConverter *converter,
+                const SiPixelFedCabling *theCablingTree, Word32 &errorWord,
+                Errors &errors) override;
 
-  void conversionError(
-      int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) override;
+  void conversionError(int fedId, const SiPixelFrameConverter *converter,
+                       int status, Word32 &errorWord, Errors &errors) override;
 
 private:
   bool includeErrors;
 
-  cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const override;
+  cms_uint32_t errorDetId(const SiPixelFrameConverter *converter, int errorType,
+                          const Word32 &word) const override;
 };
 
 #endif

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -8,12 +8,10 @@
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h"
 #include "FWCore/Utilities/interface/typedefs.h"
 
-
 class ErrorCheckerPhase0 : public ErrorCheckerBase {
-
 public:
-//  typedef unsigned int Word32;
-//  typedef long long Word64;
+  //  typedef unsigned int Word32;
+  //  typedef long long Word64;
   typedef cms_uint32_t Word32;
   typedef cms_uint64_t Word64;
 
@@ -30,22 +28,20 @@ public:
 
   bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) override;
 
-  bool checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
-		const SiPixelFedCabling* theCablingTree,
-		Word32& errorWord, Errors& errors) override;
+  bool checkROC(bool& errorsInEvent,
+                int fedId,
+                const SiPixelFrameConverter* converter,
+                const SiPixelFedCabling* theCablingTree,
+                Word32& errorWord,
+                Errors& errors) override;
 
-
-
-  void conversionError(int fedId, const SiPixelFrameConverter* converter, 
-		       int status, Word32& errorWord, Errors& errors) override;
+  void conversionError(
+      int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) override;
 
 private:
-
   bool includeErrors;
 
-  cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, 
-	 	          int errorType, const Word32 & word) const override;
-
+  cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const override;
 };
 
 #endif

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -1,6 +1,6 @@
-#ifndef ErrorChecker_H
-#define ErrorChecker_H
-/** \class ErrorChecker
+#ifndef ErrorCheckerPhase0_H
+#define ErrorCheckerPhase0_H
+/** \class ErrorCheckerPhase0
  *
  *  
  */
@@ -9,7 +9,7 @@
 #include "FWCore/Utilities/interface/typedefs.h"
 
 
-class ErrorChecker : public ErrorCheckerBase {
+class ErrorCheckerPhase0 : public ErrorCheckerBase {
 
 public:
 //  typedef unsigned int Word32;
@@ -20,7 +20,7 @@ public:
   typedef std::vector<SiPixelRawDataError> DetErrors;
   typedef std::map<cms_uint32_t, DetErrors> Errors;
 
-  ErrorChecker();
+  ErrorCheckerPhase0();
 
   void setErrorStatus(bool ErrorStatus);
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -22,29 +22,29 @@ public:
 
   ErrorCheckerPhase0();
 
-  void setErrorStatus(bool ErrorStatus);
+  void setErrorStatus(bool ErrorStatus) override;
 
-  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors);
+  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) override;
 
-  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors);
+  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) override;
 
-  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors);
+  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) override;
 
   bool checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
 		const SiPixelFedCabling* theCablingTree,
-		Word32& errorWord, Errors& errors);
+		Word32& errorWord, Errors& errors) override;
 
 
 
   void conversionError(int fedId, const SiPixelFrameConverter* converter, 
-		       int status, Word32& errorWord, Errors& errors);
+		       int status, Word32& errorWord, Errors& errors) override;
 
 private:
 
   bool includeErrors;
 
   cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, 
-	 	          int errorType, const Word32 & word) const;
+	 	          int errorType, const Word32 & word) const override;
 
 };
 

--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -39,6 +39,7 @@
 #include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h"
+#include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h"
 #include "FWCore/Utilities/interface/typedefs.h"
 #include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 
@@ -101,7 +102,7 @@ private:
   bool debug;
   int allDetDigis;
   int hasDetDigis;
-  ErrorChecker errorcheck;
+  std::unique_ptr<ErrorCheckerBase> errorcheck;
 
   // For the 32bit data format (moved from *.cc namespace, keep uppercase for compatibility)
   // Add special layer 1 roc for phase1

--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -55,15 +55,13 @@ class SiPixelFrameReverter;
 class SiPixelFedCablingTree;
 
 class PixelDataFormatter {
-
 public:
-
   typedef edm::DetSetVector<PixelDigi> Collection;
 
   typedef std::map<int, FEDRawData> RawData;
   typedef std::vector<PixelDigi> DetDigis;
   typedef std::map<cms_uint32_t, DetDigis> Digis;
-  typedef std::pair<DetDigis::const_iterator, DetDigis::const_iterator> Range; 
+  typedef std::pair<DetDigis::const_iterator, DetDigis::const_iterator> Range;
   typedef std::vector<SiPixelRawDataError> DetErrors;
   typedef std::map<cms_uint32_t, DetErrors> Errors;
   typedef std::vector<PixelFEDChannel> DetBadChannels;
@@ -72,19 +70,19 @@ public:
   typedef cms_uint32_t Word32;
   typedef cms_uint64_t Word64;
 
-  PixelDataFormatter(const SiPixelFedCabling* map, bool phase1=false);
+  PixelDataFormatter(const SiPixelFedCabling* map, bool phase1 = false);
 
   void setErrorStatus(bool ErrorStatus);
   void setQualityStatus(bool QualityStatus, const SiPixelQuality* QualityInfo);
-  void setModulesToUnpack(const std::set<unsigned int> * moduleIds);
+  void setModulesToUnpack(const std::set<unsigned int>* moduleIds);
   void passFrameReverter(const SiPixelFrameReverter* reverter);
 
   int nDigis() const { return theDigiCounter; }
   int nWords() const { return theWordCounter; }
 
-  void interpretRawData(bool& errorsInEvent, int fedId,  const FEDRawData & data, Collection & digis, Errors & errors);
+  void interpretRawData(bool& errorsInEvent, int fedId, const FEDRawData& data, Collection& digis, Errors& errors);
 
-  void formatRawData( unsigned int lvl1_ID, RawData & fedRawData, const Digis & digis, const BadChannels & badChannels);
+  void formatRawData(unsigned int lvl1_ID, RawData& fedRawData, const Digis& digis, const BadChannels& badChannels);
 
   cms_uint32_t linkId(cms_uint32_t word32) { return (word32 >> LINK_shift) & LINK_mask; }
 
@@ -92,10 +90,10 @@ private:
   mutable int theDigiCounter;
   mutable int theWordCounter;
 
-  SiPixelFedCabling const * theCablingTree;
+  SiPixelFedCabling const* theCablingTree;
   const SiPixelFrameReverter* theFrameReverter;
   const SiPixelQuality* badPixelInfo;
-  const std::set<unsigned int> * modulesToUnpack;
+  const std::set<unsigned int>* modulesToUnpack;
 
   bool includeErrors;
   bool useQualityInfo;
@@ -106,34 +104,29 @@ private:
 
   // For the 32bit data format (moved from *.cc namespace, keep uppercase for compatibility)
   // Add special layer 1 roc for phase1
-  int ADC_shift, PXID_shift, DCOL_shift, ROC_shift, LINK_shift, 
-    ROW_shift, COL_shift;
-  Word32 LINK_mask, ROC_mask, DCOL_mask, PXID_mask, ADC_mask,
-    ROW_mask, COL_mask;
+  int ADC_shift, PXID_shift, DCOL_shift, ROC_shift, LINK_shift, ROW_shift, COL_shift;
+  Word32 LINK_mask, ROC_mask, DCOL_mask, PXID_mask, ADC_mask, ROW_mask, COL_mask;
   int maxROCIndex;
   bool phase1;
 
-
   int checkError(const Word32& data) const;
 
-  int digi2word(  cms_uint32_t detId, const PixelDigi& digi,
-                  std::map<int, std::vector<Word32> > & words) const;
-  int digi2wordPhase1Layer1(  cms_uint32_t detId, const PixelDigi& digi,
-                  std::map<int, std::vector<Word32> > & words) const;
+  int digi2word(cms_uint32_t detId, const PixelDigi& digi, std::map<int, std::vector<Word32> >& words) const;
+  int digi2wordPhase1Layer1(cms_uint32_t detId,
+                            const PixelDigi& digi,
+                            std::map<int, std::vector<Word32> >& words) const;
 
-  int word2digi(  const int fedId,
-                  const SiPixelFrameConverter* converter,
-		  const bool includeError,
-		  const bool useQuality,
-		  const Word32& word, 
-                  Digis & digis) const;
+  int word2digi(const int fedId,
+                const SiPixelFrameConverter* converter,
+                const bool includeError,
+                const bool useQuality,
+                const Word32& word,
+                Digis& digis) const;
 
-  std::string print(const PixelDigi & digi) const;
-  std::string print(const Word64    & word) const;
+  std::string print(const PixelDigi& digi) const;
+  std::string print(const Word64& word) const;
 
-  cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, 
-		      int fedId, int errorType, const Word32 & word) const;
-
+  cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int fedId, int errorType, const Word32& word) const;
 };
 
 #endif

--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -34,18 +34,17 @@
 // Add the phase1 format
 //
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h"
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h"
 #include "FWCore/Utilities/interface/typedefs.h"
-#include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 
-#include <vector>
 #include <map>
 #include <set>
+#include <vector>
 
 class FEDRawData;
 class SiPixelFedCabling;
@@ -70,30 +69,34 @@ public:
   typedef cms_uint32_t Word32;
   typedef cms_uint64_t Word64;
 
-  PixelDataFormatter(const SiPixelFedCabling* map, bool phase1 = false);
+  PixelDataFormatter(const SiPixelFedCabling *map, bool phase1 = false);
 
   void setErrorStatus(bool ErrorStatus);
-  void setQualityStatus(bool QualityStatus, const SiPixelQuality* QualityInfo);
-  void setModulesToUnpack(const std::set<unsigned int>* moduleIds);
-  void passFrameReverter(const SiPixelFrameReverter* reverter);
+  void setQualityStatus(bool QualityStatus, const SiPixelQuality *QualityInfo);
+  void setModulesToUnpack(const std::set<unsigned int> *moduleIds);
+  void passFrameReverter(const SiPixelFrameReverter *reverter);
 
   int nDigis() const { return theDigiCounter; }
   int nWords() const { return theWordCounter; }
 
-  void interpretRawData(bool& errorsInEvent, int fedId, const FEDRawData& data, Collection& digis, Errors& errors);
+  void interpretRawData(bool &errorsInEvent, int fedId, const FEDRawData &data,
+                        Collection &digis, Errors &errors);
 
-  void formatRawData(unsigned int lvl1_ID, RawData& fedRawData, const Digis& digis, const BadChannels& badChannels);
+  void formatRawData(unsigned int lvl1_ID, RawData &fedRawData,
+                     const Digis &digis, const BadChannels &badChannels);
 
-  cms_uint32_t linkId(cms_uint32_t word32) { return (word32 >> LINK_shift) & LINK_mask; }
+  cms_uint32_t linkId(cms_uint32_t word32) {
+    return (word32 >> LINK_shift) & LINK_mask;
+  }
 
 private:
   mutable int theDigiCounter;
   mutable int theWordCounter;
 
-  SiPixelFedCabling const* theCablingTree;
-  const SiPixelFrameReverter* theFrameReverter;
-  const SiPixelQuality* badPixelInfo;
-  const std::set<unsigned int>* modulesToUnpack;
+  SiPixelFedCabling const *theCablingTree;
+  const SiPixelFrameReverter *theFrameReverter;
+  const SiPixelQuality *badPixelInfo;
+  const std::set<unsigned int> *modulesToUnpack;
 
   bool includeErrors;
   bool useQualityInfo;
@@ -102,31 +105,31 @@ private:
   int hasDetDigis;
   std::unique_ptr<ErrorCheckerBase> errorcheck;
 
-  // For the 32bit data format (moved from *.cc namespace, keep uppercase for compatibility)
-  // Add special layer 1 roc for phase1
-  int ADC_shift, PXID_shift, DCOL_shift, ROC_shift, LINK_shift, ROW_shift, COL_shift;
-  Word32 LINK_mask, ROC_mask, DCOL_mask, PXID_mask, ADC_mask, ROW_mask, COL_mask;
+  // For the 32bit data format (moved from *.cc namespace, keep uppercase for
+  // compatibility) Add special layer 1 roc for phase1
+  int ADC_shift, PXID_shift, DCOL_shift, ROC_shift, LINK_shift, ROW_shift,
+      COL_shift;
+  Word32 LINK_mask, ROC_mask, DCOL_mask, PXID_mask, ADC_mask, ROW_mask,
+      COL_mask;
   int maxROCIndex;
   bool phase1;
 
-  int checkError(const Word32& data) const;
+  int checkError(const Word32 &data) const;
 
-  int digi2word(cms_uint32_t detId, const PixelDigi& digi, std::map<int, std::vector<Word32> >& words) const;
-  int digi2wordPhase1Layer1(cms_uint32_t detId,
-                            const PixelDigi& digi,
-                            std::map<int, std::vector<Word32> >& words) const;
+  int digi2word(cms_uint32_t detId, const PixelDigi &digi,
+                std::map<int, std::vector<Word32>> &words) const;
+  int digi2wordPhase1Layer1(cms_uint32_t detId, const PixelDigi &digi,
+                            std::map<int, std::vector<Word32>> &words) const;
 
-  int word2digi(const int fedId,
-                const SiPixelFrameConverter* converter,
-                const bool includeError,
-                const bool useQuality,
-                const Word32& word,
-                Digis& digis) const;
+  int word2digi(const int fedId, const SiPixelFrameConverter *converter,
+                const bool includeError, const bool useQuality,
+                const Word32 &word, Digis &digis) const;
 
-  std::string print(const PixelDigi& digi) const;
-  std::string print(const Word64& word) const;
+  std::string print(const PixelDigi &digi) const;
+  std::string print(const Word64 &word) const;
 
-  cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int fedId, int errorType, const Word32& word) const;
+  cms_uint32_t errorDetId(const SiPixelFrameConverter *converter, int fedId,
+                          int errorType, const Word32 &word) const;
 };
 
 #endif

--- a/EventFilter/SiPixelRawToDigi/interface/PixelUnpackingRegions.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelUnpackingRegions.h
@@ -18,7 +18,6 @@
 #include <vector>
 #include <set>
 
-
 /** \class PixelUnpackingRegions
  *
  * Input: One or several collections of Candidate-based seeds with their objects
@@ -27,30 +26,24 @@
  * Output: FED ids and module detIds that need to be unpacked
  *
  */
-class PixelUnpackingRegions
-{
+class PixelUnpackingRegions {
 public:
-
   /// container to define regions for objects of interest in each event by:
   ///   object direction
   ///   dphi max distance from region direction to center of a pixel module
   ///   maxZ max projected z of a pixel module (when projecting along region direction onto beamline)
-  struct Region
-  {
-    Region(const math::XYZVector &dir, float dphi = 0.5f, float maxz = 24.f):
-      v(dir), dPhi(dphi), maxZ(maxz)
-    {
-      cosphi = v.x()/v.rho();
-      sinphi = v.y()/v.rho();
-      atantheta = v.z()/v.rho();
+  struct Region {
+    Region(const math::XYZVector& dir, float dphi = 0.5f, float maxz = 24.f) : v(dir), dPhi(dphi), maxZ(maxz) {
+      cosphi = v.x() / v.rho();
+      sinphi = v.y() / v.rho();
+      atantheta = v.z() / v.rho();
     }
     math::XYZVector v;
     float dPhi, maxZ;
     float cosphi, sinphi, atantheta;
   };
 
-
-  PixelUnpackingRegions(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
+  PixelUnpackingRegions(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
 
   ~PixelUnpackingRegions() {}
 
@@ -62,9 +55,9 @@ public:
 
   /// check whether a module has to be unpacked
   bool mayUnpackModule(unsigned int id) const;
-  
+
   /// full set of module ids to unpack
-  const std::set<unsigned int> * modulesToUnpack() const {return &modules_;}
+  const std::set<unsigned int>* modulesToUnpack() const { return &modules_; }
 
   /// various informational accessors:
   unsigned int nFEDs() const { return feds_.size(); }
@@ -73,8 +66,7 @@ public:
   unsigned int nForwardModules() const;
   unsigned int nRegions() const { return nreg_; }
 
-  struct Module
-  {
+  struct Module {
     float phi;
     float x, y, z;
     unsigned int id;
@@ -83,16 +75,16 @@ public:
     Module() {}
     Module(float ph) : phi(ph), x(0.f), y(0.f), z(0.f), id(0), fed(0) {}
 
-    bool operator < (const Module& m) const
-    {
-      if(phi < m.phi) return true;
-      if(phi == m.phi && id < m.id) return true;
+    bool operator<(const Module& m) const {
+      if (phi < m.phi)
+        return true;
+      if (phi == m.phi && id < m.id)
+        return true;
       return false;
     }
   };
 
 private:
-
   // input parameters
   std::vector<edm::InputTag> inputs_;
   std::vector<double> dPhi_;
@@ -110,13 +102,13 @@ private:
   void initialize(const edm::EventSetup& es);
 
   // add a new direction of a region of interest
-  void addRegion(Region &r);
+  void addRegion(Region& r);
 
   // gather info into feds_ and modules_ from a range of a Module vector
-  void gatherFromRange(Region &r, std::vector<Module>::const_iterator, std::vector<Module>::const_iterator);
+  void gatherFromRange(Region& r, std::vector<Module>::const_iterator, std::vector<Module>::const_iterator);
 
   // addRegion for a local (BPIX or +-FPIX) container
-  void addRegionLocal(Region &r, std::vector<Module> &container, const Module& lo,const Module& hi);
+  void addRegionLocal(Region& r, std::vector<Module>& container, const Module& lo, const Module& hi);
 
   // local containers of barrel and endcaps Modules sorted by phi
   std::vector<Module> phiBPIX_;

--- a/EventFilter/SiPixelRawToDigi/interface/PixelUnpackingRegions.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelUnpackingRegions.h
@@ -1,13 +1,13 @@
 #ifndef PixelUnpackingRegions_H
 #define PixelUnpackingRegions_H
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESWatcher.h"
-#include "DataFormats/Math/interface/Point3D.h"
-#include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
+#include "DataFormats/Math/interface/Point3D.h"
+#include "DataFormats/Math/interface/Vector3D.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
@@ -15,15 +15,15 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <cmath>
-#include <vector>
 #include <set>
+#include <vector>
 
 /** \class PixelUnpackingRegions
  *
  * Input: One or several collections of Candidate-based seeds with their objects
- *        defining the directions of unpacking regions; separate deltaPhi and maxZ 
- *        tolerances could be given to each input collection.
- * Output: FED ids and module detIds that need to be unpacked
+ *        defining the directions of unpacking regions; separate deltaPhi and
+ * maxZ tolerances could be given to each input collection. Output: FED ids and
+ * module detIds that need to be unpacked
  *
  */
 class PixelUnpackingRegions {
@@ -31,9 +31,11 @@ public:
   /// container to define regions for objects of interest in each event by:
   ///   object direction
   ///   dphi max distance from region direction to center of a pixel module
-  ///   maxZ max projected z of a pixel module (when projecting along region direction onto beamline)
+  ///   maxZ max projected z of a pixel module (when projecting along region
+  ///   direction onto beamline)
   struct Region {
-    Region(const math::XYZVector& dir, float dphi = 0.5f, float maxz = 24.f) : v(dir), dPhi(dphi), maxZ(maxz) {
+    Region(const math::XYZVector &dir, float dphi = 0.5f, float maxz = 24.f)
+        : v(dir), dPhi(dphi), maxZ(maxz) {
       cosphi = v.x() / v.rho();
       sinphi = v.y() / v.rho();
       atantheta = v.z() / v.rho();
@@ -43,12 +45,12 @@ public:
     float cosphi, sinphi, atantheta;
   };
 
-  PixelUnpackingRegions(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
+  PixelUnpackingRegions(const edm::ParameterSet &, edm::ConsumesCollector &&iC);
 
   ~PixelUnpackingRegions() {}
 
   /// has to be run during each event
-  void run(const edm::Event& e, const edm::EventSetup& es);
+  void run(const edm::Event &e, const edm::EventSetup &es);
 
   /// check whether a FED has to be unpacked
   bool mayUnpackFED(unsigned int fed_n) const;
@@ -57,7 +59,7 @@ public:
   bool mayUnpackModule(unsigned int id) const;
 
   /// full set of module ids to unpack
-  const std::set<unsigned int>* modulesToUnpack() const { return &modules_; }
+  const std::set<unsigned int> *modulesToUnpack() const { return &modules_; }
 
   /// various informational accessors:
   unsigned int nFEDs() const { return feds_.size(); }
@@ -75,7 +77,7 @@ public:
     Module() {}
     Module(float ph) : phi(ph), x(0.f), y(0.f), z(0.f), id(0), fed(0) {}
 
-    bool operator<(const Module& m) const {
+    bool operator<(const Module &m) const {
       if (phi < m.phi)
         return true;
       if (phi == m.phi && id < m.id)
@@ -99,16 +101,18 @@ private:
   unsigned int nreg_;
 
   /// run by the run method: (re)initialize the cabling data when it's necessary
-  void initialize(const edm::EventSetup& es);
+  void initialize(const edm::EventSetup &es);
 
   // add a new direction of a region of interest
-  void addRegion(Region& r);
+  void addRegion(Region &r);
 
   // gather info into feds_ and modules_ from a range of a Module vector
-  void gatherFromRange(Region& r, std::vector<Module>::const_iterator, std::vector<Module>::const_iterator);
+  void gatherFromRange(Region &r, std::vector<Module>::const_iterator,
+                       std::vector<Module>::const_iterator);
 
   // addRegion for a local (BPIX or +-FPIX) container
-  void addRegionLocal(Region& r, std::vector<Module>& container, const Module& lo, const Module& hi);
+  void addRegionLocal(Region &r, std::vector<Module> &container,
+                      const Module &lo, const Module &hi);
 
   // local containers of barrel and endcaps Modules sorted by phi
   std::vector<Module> phiBPIX_;

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
@@ -1,14 +1,14 @@
-#include "FWCore/Framework/interface/ESWatcher.h"
-#include "FWCore/Framework/interface/global/EDProducer.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Utilities/interface/CPUTimer.h"
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/CPUTimer.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -20,15 +20,15 @@
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
-#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
 
-#include "EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h"
 #include "CondFormats/SiPixelObjects/interface/PixelFEDCabling.h"
+#include "EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h"
 
 #include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 
@@ -36,48 +36,56 @@
 #include <memory>
 
 namespace sipixeldigitoraw {
-  struct Cache {
-    std::unique_ptr<SiPixelFedCablingTree> cablingTree_;
-    std::unique_ptr<SiPixelFrameReverter> frameReverter_;
-  };
-}  // namespace sipixeldigitoraw
+struct Cache {
+  std::unique_ptr<SiPixelFedCablingTree> cablingTree_;
+  std::unique_ptr<SiPixelFrameReverter> frameReverter_;
+};
+} // namespace sipixeldigitoraw
 
 namespace pr = sipixeldigitoraw;
 
-class SiPixelDigiToRaw final : public edm::global::EDProducer<edm::LuminosityBlockCache<pr::Cache>> {
+class SiPixelDigiToRaw final
+    : public edm::global::EDProducer<edm::LuminosityBlockCache<pr::Cache>> {
 public:
   /// ctor
-  explicit SiPixelDigiToRaw(const edm::ParameterSet&);
+  explicit SiPixelDigiToRaw(const edm::ParameterSet &);
 
   /// get data, convert to raw event, attach again to Event
-  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const final;
+  void produce(edm::StreamID, edm::Event &,
+               const edm::EventSetup &) const final;
 
-  std::shared_ptr<pr::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
-                                                        edm::EventSetup const& iES) const final;
+  std::shared_ptr<pr::Cache>
+  globalBeginLuminosityBlock(edm::LuminosityBlock const &,
+                             edm::EventSetup const &iES) const final;
 
-  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const& iES) const final {}
+  void globalEndLuminosityBlock(edm::LuminosityBlock const &,
+                                edm::EventSetup const &iES) const final {}
 
   // Fill parameters descriptions
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
   mutable std::atomic_flag lock_ = ATOMIC_FLAG_INIT;
-  CMS_THREAD_GUARD(lock_) mutable edm::ESWatcher<SiPixelFedCablingMapRcd> recordWatcher;
+  CMS_THREAD_GUARD(lock_)
+  mutable edm::ESWatcher<SiPixelFedCablingMapRcd> recordWatcher;
   CMS_THREAD_GUARD(lock_) mutable std::shared_ptr<pr::Cache> previousCache_;
   const edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> tPixelDigi;
   const edm::EDGetTokenT<PixelFEDChannelCollection> theBadPixelFEDChannelsToken;
   const edm::EDPutTokenT<FEDRawDataCollection> putToken_;
-  const bool usePilotBlade = false;  // I am not yet sure we need it here?
+  const bool usePilotBlade = false; // I am not yet sure we need it here?
   const bool usePhase1;
 };
 
 using namespace std;
 
-SiPixelDigiToRaw::SiPixelDigiToRaw(const edm::ParameterSet& pset)
-    : tPixelDigi{consumes<edm::DetSetVector<PixelDigi>>(pset.getParameter<edm::InputTag>("InputLabel"))},
-      theBadPixelFEDChannelsToken{consumes<PixelFEDChannelCollection>(pset.getParameter<edm::InputTag>("InputLabel"))},
-      putToken_{produces<FEDRawDataCollection>()},
-      usePhase1{pset.getParameter<bool>("UsePhase1")} {
+SiPixelDigiToRaw::SiPixelDigiToRaw(const edm::ParameterSet &pset)
+    : tPixelDigi{consumes<edm::DetSetVector<PixelDigi>>(
+          pset.getParameter<edm::InputTag>("InputLabel"))},
+      theBadPixelFEDChannelsToken{consumes<PixelFEDChannelCollection>(
+          pset.getParameter<edm::InputTag>("InputLabel"))},
+      putToken_{produces<FEDRawDataCollection>()}, usePhase1{
+                                                       pset.getParameter<bool>(
+                                                           "UsePhase1")} {
   // Define EDProduct type
 
   if (usePhase1)
@@ -85,11 +93,12 @@ SiPixelDigiToRaw::SiPixelDigiToRaw(const edm::ParameterSet& pset)
 }
 
 // -----------------------------------------------------------------------------
-std::shared_ptr<pr::Cache> SiPixelDigiToRaw::globalBeginLuminosityBlock(edm::LuminosityBlock const&,
-                                                                        edm::EventSetup const& es) const {
+std::shared_ptr<pr::Cache>
+SiPixelDigiToRaw::globalBeginLuminosityBlock(edm::LuminosityBlock const &,
+                                             edm::EventSetup const &es) const {
   while (lock_.test_and_set(std::memory_order_acquire))
-    ;  //spin
-  auto rel = [](std::atomic_flag* f) { f->clear(std::memory_order_release); };
+    ; // spin
+  auto rel = [](std::atomic_flag *f) { f->clear(std::memory_order_release); };
   std::unique_ptr<std::atomic_flag, decltype(rel)> guard(&lock_, rel);
 
   if (recordWatcher.check(es)) {
@@ -97,13 +106,15 @@ std::shared_ptr<pr::Cache> SiPixelDigiToRaw::globalBeginLuminosityBlock(edm::Lum
     es.get<SiPixelFedCablingMapRcd>().get(cablingMap);
     previousCache_ = std::make_shared<pr::Cache>();
     previousCache_->cablingTree_ = cablingMap->cablingTree();
-    previousCache_->frameReverter_ = std::make_unique<SiPixelFrameReverter>(es, cablingMap.product());
+    previousCache_->frameReverter_ =
+        std::make_unique<SiPixelFrameReverter>(es, cablingMap.product());
   }
   return previousCache_;
 }
 
 // -----------------------------------------------------------------------------
-void SiPixelDigiToRaw::produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& es) const {
+void SiPixelDigiToRaw::produce(edm::StreamID, edm::Event &ev,
+                               const edm::EventSetup &es) const {
   using namespace sipixelobjects;
 
   edm::Handle<edm::DetSetVector<PixelDigi>> digiCollection;
@@ -113,7 +124,7 @@ void SiPixelDigiToRaw::produce(edm::StreamID, edm::Event& ev, const edm::EventSe
   PixelDataFormatter::Digis digis;
 
   int digiCounter = 0;
-  for (auto const& di : *digiCollection) {
+  for (auto const &di : *digiCollection) {
     digiCounter += (di.data).size();
     digis[di.id] = di.data;
   }
@@ -124,25 +135,30 @@ void SiPixelDigiToRaw::produce(edm::StreamID, edm::Event& ev, const edm::EventSe
 
   PixelDataFormatter::BadChannels badChannels;
   edm::Handle<PixelFEDChannelCollection> pixelFEDChannelCollectionHandle;
-  if (usePhase1 == true && ev.getByToken(theBadPixelFEDChannelsToken, pixelFEDChannelCollectionHandle)) {
-    for (auto const& fedChannels : *pixelFEDChannelCollectionHandle) {
+  if (usePhase1 == true && ev.getByToken(theBadPixelFEDChannelsToken,
+                                         pixelFEDChannelCollectionHandle)) {
+    for (auto const &fedChannels : *pixelFEDChannelCollectionHandle) {
       PixelDataFormatter::DetBadChannels detBadChannels;
-      for (const auto& fedChannel : fedChannels) {
-        sipixelobjects::CablingPathToDetUnit path = {fedChannel.fed, fedChannel.link, 1};
+      for (const auto &fedChannel : fedChannels) {
+        sipixelobjects::CablingPathToDetUnit path = {fedChannel.fed,
+                                                     fedChannel.link, 1};
         if (cache->cablingTree_->findItem(path) != nullptr) {
           detBadChannels.push_back(fedChannel);
         } else {
           edm::LogError("SiPixelDigiToRaw")
-              << " FED " << fedChannel.fed << " Link " << fedChannel.link << " for module " << fedChannels.detId()
-              << " marked bad, but this channel does not exist in the cabling map" << endl;
+              << " FED " << fedChannel.fed << " Link " << fedChannel.link
+              << " for module " << fedChannels.detId()
+              << " marked bad, but this channel does not exist in the cabling "
+                 "map"
+              << endl;
         }
-      }  // channels reading a module
+      } // channels reading a module
       if (!detBadChannels.empty())
         badChannels.insert({fedChannels.detId(), std::move(detBadChannels)});
-    }  // loop on detId-s
+    } // loop on detId-s
   }
 
-  //PixelDataFormatter formatter(cablingTree_.get());
+  // PixelDataFormatter formatter(cablingTree_.get());
   PixelDataFormatter formatter(cache->cablingTree_.get(), usePhase1);
 
   formatter.passFrameReverter(cache->frameReverter_.get());
@@ -154,23 +170,26 @@ void SiPixelDigiToRaw::produce(edm::StreamID, edm::Event& ev, const edm::EventSe
   formatter.formatRawData(ev.id().event(), rawdata, digis, badChannels);
 
   // pack raw data into collection
-  for (auto const* fed : cache->cablingTree_->fedList()) {
+  for (auto const *fed : cache->cablingTree_->fedList()) {
     LogDebug("SiPixelDigiToRaw") << " PRODUCE DATA FOR FED_id: " << fed->id();
-    FEDRawData& fedRawData = buffers.FEDData(fed->id());
+    FEDRawData &fedRawData = buffers.FEDData(fed->id());
     PixelDataFormatter::RawData::iterator fedbuffer = rawdata.find(fed->id());
     if (fedbuffer != rawdata.end())
       fedRawData = fedbuffer->second;
-    LogDebug("SiPixelDigiToRaw") << "size of data in fedRawData: " << fedRawData.size();
+    LogDebug("SiPixelDigiToRaw")
+        << "size of data in fedRawData: " << fedRawData.size();
   }
 
-  LogDebug("SiPixelDigiToRaw").log([&](auto& l) {
-    l << "Words/Digis this ev: " << digiCounter << "(fm:" << formatter.nDigis() << ")/" << formatter.nWords();
+  LogDebug("SiPixelDigiToRaw").log([&](auto &l) {
+    l << "Words/Digis this ev: " << digiCounter << "(fm:" << formatter.nDigis()
+      << ")/" << formatter.nWords();
   });
   ev.emplace(putToken_, std::move(buffers));
 }
 
 // -----------------------------------------------------------------------------
-void SiPixelDigiToRaw::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelDigiToRaw::fillDescriptions(
+    edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("InputLabel");
   desc.add<bool>("UsePhase1", false);

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
@@ -136,7 +136,7 @@ void SiPixelDigiToRaw::produce( edm::StreamID, edm::Event& ev,
 
   PixelDataFormatter::BadChannels badChannels;
   edm::Handle<PixelFEDChannelCollection> pixelFEDChannelCollectionHandle;
-  if (ev.getByToken(theBadPixelFEDChannelsToken, pixelFEDChannelCollectionHandle)){
+  if (usePhase1==true && ev.getByToken(theBadPixelFEDChannelsToken, pixelFEDChannelCollectionHandle)){
     for (auto const& fedChannels: *pixelFEDChannelCollectionHandle) {
       PixelDataFormatter::DetBadChannels detBadChannels;
       for(const auto& fedChannel: fedChannels) {

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
@@ -40,35 +40,31 @@ namespace sipixeldigitoraw {
     std::unique_ptr<SiPixelFedCablingTree> cablingTree_;
     std::unique_ptr<SiPixelFrameReverter> frameReverter_;
   };
-}
+}  // namespace sipixeldigitoraw
 
 namespace pr = sipixeldigitoraw;
 
 class SiPixelDigiToRaw final : public edm::global::EDProducer<edm::LuminosityBlockCache<pr::Cache>> {
 public:
-
   /// ctor
-  explicit SiPixelDigiToRaw( const edm::ParameterSet& );
-
+  explicit SiPixelDigiToRaw(const edm::ParameterSet&);
 
   /// get data, convert to raw event, attach again to Event
-  void produce( edm::StreamID, edm::Event&, const edm::EventSetup& ) const final;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const final;
 
-  std::shared_ptr<pr::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const&, 
+  std::shared_ptr<pr::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
                                                         edm::EventSetup const& iES) const final;
 
-  void globalEndLuminosityBlock(edm::LuminosityBlock const&,
-                                edm::EventSetup const& iES) const final {}
-  
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const& iES) const final {}
+
   // Fill parameters descriptions
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-
   mutable std::atomic_flag lock_ = ATOMIC_FLAG_INIT;
   CMS_THREAD_GUARD(lock_) mutable edm::ESWatcher<SiPixelFedCablingMapRcd> recordWatcher;
   CMS_THREAD_GUARD(lock_) mutable std::shared_ptr<pr::Cache> previousCache_;
-  const edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> tPixelDigi; 
+  const edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> tPixelDigi;
   const edm::EDGetTokenT<PixelFEDChannelCollection> theBadPixelFEDChannelsToken;
   const edm::EDPutTokenT<FEDRawDataCollection> putToken_;
   const bool usePilotBlade = false;  // I am not yet sure we need it here?
@@ -77,80 +73,73 @@ private:
 
 using namespace std;
 
-SiPixelDigiToRaw::SiPixelDigiToRaw( const edm::ParameterSet& pset ) :
-  tPixelDigi{ consumes<edm::DetSetVector<PixelDigi> >(pset.getParameter<edm::InputTag>("InputLabel")) },
-  theBadPixelFEDChannelsToken{ consumes<PixelFEDChannelCollection>(pset.getParameter<edm::InputTag>("InputLabel")) },
-  putToken_{produces<FEDRawDataCollection>()},
-  usePhase1{ pset.getParameter<bool> ("UsePhase1") }
-{
-
-
+SiPixelDigiToRaw::SiPixelDigiToRaw(const edm::ParameterSet& pset)
+    : tPixelDigi{consumes<edm::DetSetVector<PixelDigi>>(pset.getParameter<edm::InputTag>("InputLabel"))},
+      theBadPixelFEDChannelsToken{consumes<PixelFEDChannelCollection>(pset.getParameter<edm::InputTag>("InputLabel"))},
+      putToken_{produces<FEDRawDataCollection>()},
+      usePhase1{pset.getParameter<bool>("UsePhase1")} {
   // Define EDProduct type
 
-  if(usePhase1) edm::LogInfo("SiPixelRawToDigi")  << " Use pilot blade data (FED 40)";
-
+  if (usePhase1)
+    edm::LogInfo("SiPixelRawToDigi") << " Use pilot blade data (FED 40)";
 }
 
 // -----------------------------------------------------------------------------
-std::shared_ptr<pr::Cache> 
-SiPixelDigiToRaw::globalBeginLuminosityBlock(edm::LuminosityBlock const&, 
-                                             edm::EventSetup const& es) const {
-  while(lock_.test_and_set(std::memory_order_acquire)); //spin
+std::shared_ptr<pr::Cache> SiPixelDigiToRaw::globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                                        edm::EventSetup const& es) const {
+  while (lock_.test_and_set(std::memory_order_acquire))
+    ;  //spin
   auto rel = [](std::atomic_flag* f) { f->clear(std::memory_order_release); };
   std::unique_ptr<std::atomic_flag, decltype(rel)> guard(&lock_, rel);
 
-  if (recordWatcher.check( es )) {
+  if (recordWatcher.check(es)) {
     edm::ESHandle<SiPixelFedCablingMap> cablingMap;
-    es.get<SiPixelFedCablingMapRcd>().get( cablingMap );
+    es.get<SiPixelFedCablingMapRcd>().get(cablingMap);
     previousCache_ = std::make_shared<pr::Cache>();
-    previousCache_->cablingTree_= cablingMap->cablingTree();
-    previousCache_->frameReverter_ = std::make_unique<SiPixelFrameReverter>( es, cablingMap.product() );
+    previousCache_->cablingTree_ = cablingMap->cablingTree();
+    previousCache_->frameReverter_ = std::make_unique<SiPixelFrameReverter>(es, cablingMap.product());
   }
   return previousCache_;
 }
 
-
-
 // -----------------------------------------------------------------------------
-void SiPixelDigiToRaw::produce( edm::StreamID, edm::Event& ev,
-                                const edm::EventSetup& es) const
-{
+void SiPixelDigiToRaw::produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& es) const {
   using namespace sipixelobjects;
 
-  edm::Handle< edm::DetSetVector<PixelDigi> > digiCollection;
-  ev.getByToken( tPixelDigi, digiCollection);
+  edm::Handle<edm::DetSetVector<PixelDigi>> digiCollection;
+  ev.getByToken(tPixelDigi, digiCollection);
 
   PixelDataFormatter::RawData rawdata;
   PixelDataFormatter::Digis digis;
 
-  int digiCounter = 0; 
+  int digiCounter = 0;
   for (auto const& di : *digiCollection) {
-    digiCounter += (di.data).size(); 
-    digis[ di.id] = di.data;
+    digiCounter += (di.data).size();
+    digis[di.id] = di.data;
   }
 
-  auto cache =  luminosityBlockCache(ev.getLuminosityBlock().index());
-
+  auto cache = luminosityBlockCache(ev.getLuminosityBlock().index());
 
   LogDebug("SiPixelDigiToRaw") << cache->cablingTree_->version();
 
   PixelDataFormatter::BadChannels badChannels;
   edm::Handle<PixelFEDChannelCollection> pixelFEDChannelCollectionHandle;
-  if (usePhase1==true && ev.getByToken(theBadPixelFEDChannelsToken, pixelFEDChannelCollectionHandle)){
-    for (auto const& fedChannels: *pixelFEDChannelCollectionHandle) {
+  if (usePhase1 == true && ev.getByToken(theBadPixelFEDChannelsToken, pixelFEDChannelCollectionHandle)) {
+    for (auto const& fedChannels : *pixelFEDChannelCollectionHandle) {
       PixelDataFormatter::DetBadChannels detBadChannels;
-      for(const auto& fedChannel: fedChannels) {
-	sipixelobjects::CablingPathToDetUnit path={fedChannel.fed, fedChannel.link, 1};
-	if (cache->cablingTree_->findItem(path)!=nullptr) {
-	  detBadChannels.push_back(fedChannel);
-	} else {
-	  edm::LogError("SiPixelDigiToRaw")
-            <<" FED "<<fedChannel.fed<<" Link "<<fedChannel.link<<" for module "<<fedChannels.detId()
-            <<" marked bad, but this channel does not exist in the cabling map" <<endl;
-	}
-      } // channels reading a module
-      if (!detBadChannels.empty()) badChannels.insert({fedChannels.detId(), std::move(detBadChannels)});
-    } // loop on detId-s
+      for (const auto& fedChannel : fedChannels) {
+        sipixelobjects::CablingPathToDetUnit path = {fedChannel.fed, fedChannel.link, 1};
+        if (cache->cablingTree_->findItem(path) != nullptr) {
+          detBadChannels.push_back(fedChannel);
+        } else {
+          edm::LogError("SiPixelDigiToRaw")
+              << " FED " << fedChannel.fed << " Link " << fedChannel.link << " for module " << fedChannels.detId()
+              << " marked bad, but this channel does not exist in the cabling map" << endl;
+        }
+      }  // channels reading a module
+      if (!detBadChannels.empty())
+        badChannels.insert({fedChannels.detId(), std::move(detBadChannels)});
+    }  // loop on detId-s
   }
 
   //PixelDataFormatter formatter(cablingTree_.get());
@@ -162,33 +151,31 @@ void SiPixelDigiToRaw::produce( edm::StreamID, edm::Event& ev,
   FEDRawDataCollection buffers;
 
   // convert data to raw
-  formatter.formatRawData( ev.id().event(), rawdata, digis, badChannels);
+  formatter.formatRawData(ev.id().event(), rawdata, digis, badChannels);
 
   // pack raw data into collection
-  for (auto const* fed: cache->cablingTree_->fedList()) {
-    LogDebug("SiPixelDigiToRaw")<<" PRODUCE DATA FOR FED_id: " << fed->id();
-    FEDRawData& fedRawData = buffers.FEDData( fed->id() );
-    PixelDataFormatter::RawData::iterator fedbuffer = rawdata.find( fed->id() );
-    if( fedbuffer != rawdata.end() ) fedRawData = fedbuffer->second;
-    LogDebug("SiPixelDigiToRaw")<<"size of data in fedRawData: "<<fedRawData.size();
+  for (auto const* fed : cache->cablingTree_->fedList()) {
+    LogDebug("SiPixelDigiToRaw") << " PRODUCE DATA FOR FED_id: " << fed->id();
+    FEDRawData& fedRawData = buffers.FEDData(fed->id());
+    PixelDataFormatter::RawData::iterator fedbuffer = rawdata.find(fed->id());
+    if (fedbuffer != rawdata.end())
+      fedRawData = fedbuffer->second;
+    LogDebug("SiPixelDigiToRaw") << "size of data in fedRawData: " << fedRawData.size();
   }
 
-  LogDebug("SiPixelDigiToRaw").log([&](auto &l) {
-
-      l << "Words/Digis this ev: "<<digiCounter<<"(fm:"<<formatter.nDigis()<<")/"
-        <<formatter.nWords();
-    });
+  LogDebug("SiPixelDigiToRaw").log([&](auto& l) {
+    l << "Words/Digis this ev: " << digiCounter << "(fm:" << formatter.nDigis() << ")/" << formatter.nWords();
+  });
   ev.emplace(putToken_, std::move(buffers));
-  
 }
 
 // -----------------------------------------------------------------------------
-void SiPixelDigiToRaw::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+void SiPixelDigiToRaw::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("InputLabel");
   desc.add<bool>("UsePhase1", false);
   desc.addUntracked<bool>("Timing", false)->setComment("deprecated");
-  descriptions.add("siPixelRawData",  desc);
+  descriptions.add("siPixelRawData", desc);
 }
 
 // declare this as a framework plugin

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -42,284 +42,289 @@
 using namespace std;
 
 // -----------------------------------------------------------------------------
-SiPixelRawToDigi::SiPixelRawToDigi( const edm::ParameterSet& conf ) 
-  : config_(conf), 
-    badPixelInfo_(nullptr),
-    regions_(nullptr),
-    hCPU(nullptr), hDigi(nullptr)
-{
-  
+SiPixelRawToDigi::SiPixelRawToDigi(const edm::ParameterSet& conf)
+    : config_(conf), badPixelInfo_(nullptr), regions_(nullptr), hCPU(nullptr), hDigi(nullptr) {
   includeErrors = config_.getParameter<bool>("IncludeErrors");
   useQuality = config_.getParameter<bool>("UseQualityInfo");
   if (config_.exists("ErrorList")) {
-    tkerrorlist = config_.getParameter<std::vector<int> > ("ErrorList");
+    tkerrorlist = config_.getParameter<std::vector<int>>("ErrorList");
   }
   if (config_.exists("UserErrorList")) {
-    usererrorlist = config_.getParameter<std::vector<int> > ("UserErrorList");
+    usererrorlist = config_.getParameter<std::vector<int>>("UserErrorList");
   }
-  tFEDRawDataCollection = consumes <FEDRawDataCollection> (config_.getParameter<edm::InputTag>("InputLabel"));
-  
+  tFEDRawDataCollection = consumes<FEDRawDataCollection>(config_.getParameter<edm::InputTag>("InputLabel"));
+
   //start counters
   ndigis = 0;
   nwords = 0;
 
   // Products
-  produces< edm::DetSetVector<PixelDigi> >();
-  if(includeErrors){
-    produces< edm::DetSetVector<SiPixelRawDataError> >();
+  produces<edm::DetSetVector<PixelDigi>>();
+  if (includeErrors) {
+    produces<edm::DetSetVector<SiPixelRawDataError>>();
     produces<DetIdCollection>();
     produces<DetIdCollection>("UserErrorModules");
-    produces<edmNew::DetSetVector<PixelFEDChannel> >();
+    produces<edmNew::DetSetVector<PixelFEDChannel>>();
   }
-  
+
   // regions
   if (config_.exists("Regions")) {
-    if(!config_.getParameter<edm::ParameterSet>("Regions").getParameterNames().empty())
-    {
+    if (!config_.getParameter<edm::ParameterSet>("Regions").getParameterNames().empty()) {
       regions_ = new PixelUnpackingRegions(config_, consumesCollector());
     }
   }
 
   // Timing
-  bool timing = config_.getUntrackedParameter<bool>("Timing",false);
+  bool timing = config_.getUntrackedParameter<bool>("Timing", false);
   if (timing) {
-    theTimer.reset( new edm::CPUTimer );
-    hCPU = new TH1D ("hCPU","hCPU",100,0.,0.050);
-    hDigi = new TH1D("hDigi","hDigi",50,0.,15000.);
+    theTimer.reset(new edm::CPUTimer);
+    hCPU = new TH1D("hCPU", "hCPU", 100, 0., 0.050);
+    hDigi = new TH1D("hDigi", "hDigi", 50, 0., 15000.);
   }
 
   // Control the usage of pilot-blade data, FED=40
-  usePilotBlade = false; 
+  usePilotBlade = false;
   if (config_.exists("UsePilotBlade")) {
-    usePilotBlade = config_.getParameter<bool> ("UsePilotBlade");
-    if(usePilotBlade) edm::LogInfo("SiPixelRawToDigi")  << " Use pilot blade data (FED 40)";
+    usePilotBlade = config_.getParameter<bool>("UsePilotBlade");
+    if (usePilotBlade)
+      edm::LogInfo("SiPixelRawToDigi") << " Use pilot blade data (FED 40)";
   }
 
   // Control the usage of phase1
   usePhase1 = false;
   if (config_.exists("UsePhase1")) {
-    usePhase1 = config_.getParameter<bool> ("UsePhase1");
-    if(usePhase1) edm::LogInfo("SiPixelRawToDigi")  << " Using phase1";
+    usePhase1 = config_.getParameter<bool>("UsePhase1");
+    if (usePhase1)
+      edm::LogInfo("SiPixelRawToDigi") << " Using phase1";
   }
   //CablingMap could have a label //Tav
-  cablingMapLabel = config_.getParameter<std::string> ("CablingMapLabel");
-
+  cablingMapLabel = config_.getParameter<std::string>("CablingMapLabel");
 }
-
 
 // -----------------------------------------------------------------------------
 SiPixelRawToDigi::~SiPixelRawToDigi() {
-  edm::LogInfo("SiPixelRawToDigi")  << " HERE ** SiPixelRawToDigi destructor!";
+  edm::LogInfo("SiPixelRawToDigi") << " HERE ** SiPixelRawToDigi destructor!";
 
-  if (regions_) delete regions_;
+  if (regions_)
+    delete regions_;
 
   if (theTimer) {
     TFile rootFile("analysis.root", "RECREATE", "my histograms");
     hCPU->Write();
     hDigi->Write();
   }
-
 }
 
-void
-SiPixelRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<bool>("IncludeErrors",true);
-  desc.add<bool>("UseQualityInfo",false);
+  desc.add<bool>("IncludeErrors", true);
+  desc.add<bool>("UseQualityInfo", false);
   {
     std::vector<int> temp1;
     temp1.reserve(1);
     temp1.push_back(29);
-    desc.add<std::vector<int> >("ErrorList",temp1)->setComment("## ErrorList: list of error codes used by tracking to invalidate modules");
+    desc.add<std::vector<int>>("ErrorList", temp1)
+        ->setComment("## ErrorList: list of error codes used by tracking to invalidate modules");
   }
   {
     std::vector<int> temp1;
     temp1.reserve(1);
     temp1.push_back(40);
-    desc.add<std::vector<int> >("UserErrorList",temp1)->setComment("## UserErrorList: list of error codes used by Pixel experts for investigation");
+    desc.add<std::vector<int>>("UserErrorList", temp1)
+        ->setComment("## UserErrorList: list of error codes used by Pixel experts for investigation");
   }
-  desc.add<edm::InputTag>("InputLabel",edm::InputTag("siPixelRawData"));
+  desc.add<edm::InputTag>("InputLabel", edm::InputTag("siPixelRawData"));
   {
     edm::ParameterSetDescription psd0;
     psd0.addOptional<std::vector<edm::InputTag>>("inputs");
     psd0.addOptional<std::vector<double>>("deltaPhi");
     psd0.addOptional<std::vector<double>>("maxZ");
     psd0.addOptional<edm::InputTag>("beamSpot");
-    desc.add<edm::ParameterSetDescription>("Regions",psd0)->setComment("## Empty Regions PSet means complete unpacking");
+    desc.add<edm::ParameterSetDescription>("Regions", psd0)
+        ->setComment("## Empty Regions PSet means complete unpacking");
   }
-  desc.addUntracked<bool>("Timing",false);
-  desc.add<bool>("UsePilotBlade",false)->setComment("##  Use pilot blades");
-  desc.add<bool>("UsePhase1",false)->setComment("##  Use phase1");
-  desc.add<std::string>("CablingMapLabel","")->setComment("CablingMap label"); //Tav
+  desc.addUntracked<bool>("Timing", false);
+  desc.add<bool>("UsePilotBlade", false)->setComment("##  Use pilot blades");
+  desc.add<bool>("UsePhase1", false)->setComment("##  Use phase1");
+  desc.add<std::string>("CablingMapLabel", "")->setComment("CablingMap label");  //Tav
   desc.addOptional<bool>("CheckPixelOrder");  // never used, kept for back-compatibility
-  descriptions.add("siPixelRawToDigi",desc);
-  
+  descriptions.add("siPixelRawToDigi", desc);
 }
 
 // -----------------------------------------------------------------------------
 
-
 // -----------------------------------------------------------------------------
-void SiPixelRawToDigi::produce( edm::Event& ev,
-                              const edm::EventSetup& es) 
-{
+void SiPixelRawToDigi::produce(edm::Event& ev, const edm::EventSetup& es) {
   const uint32_t dummydetid = 0xffffffff;
   debug = edm::MessageDrop::instance()->debugEnabled;
 
-// initialize cabling map or update if necessary
-  if (recordWatcher.check( es )) {
+  // initialize cabling map or update if necessary
+  if (recordWatcher.check(es)) {
     // cabling map, which maps online address (fed->link->ROC->local pixel) to offline (DetId->global pixel)
     edm::ESTransientHandle<SiPixelFedCablingMap> cablingMap;
-    es.get<SiPixelFedCablingMapRcd>().get( cablingMapLabel, cablingMap ); //Tav
-    fedIds   = cablingMap->fedIds();
+    es.get<SiPixelFedCablingMapRcd>().get(cablingMapLabel, cablingMap);  //Tav
+    fedIds = cablingMap->fedIds();
     cabling_ = cablingMap->cablingTree();
-    LogDebug("map version:")<< cabling_->version();
+    LogDebug("map version:") << cabling_->version();
   }
-// initialize quality record or update if necessary
-  if (qualityWatcher.check( es )&&useQuality) {
+  // initialize quality record or update if necessary
+  if (qualityWatcher.check(es) && useQuality) {
     // quality info for dead pixel modules or ROCs
     edm::ESHandle<SiPixelQuality> qualityInfo;
-    es.get<SiPixelQualityRcd>().get( qualityInfo );
+    es.get<SiPixelQualityRcd>().get(qualityInfo);
     badPixelInfo_ = qualityInfo.product();
     if (!badPixelInfo_) {
-      edm::LogError("SiPixelQualityNotPresent")<<" Configured to use SiPixelQuality, but SiPixelQuality not present"<<endl;
+      edm::LogError("SiPixelQualityNotPresent")
+          << " Configured to use SiPixelQuality, but SiPixelQuality not present" << endl;
     }
   }
-  
+
   edm::Handle<FEDRawDataCollection> buffers;
   ev.getByToken(tFEDRawDataCollection, buffers);
 
-// create product (digis & errors)
+  // create product (digis & errors)
   auto collection = std::make_unique<edm::DetSetVector<PixelDigi>>();
   // collection->reserve(8*1024);
   auto errorcollection = std::make_unique<edm::DetSetVector<SiPixelRawDataError>>();
   auto tkerror_detidcollection = std::make_unique<DetIdCollection>();
   auto usererror_detidcollection = std::make_unique<DetIdCollection>();
-  auto disabled_channelcollection = std::make_unique<edmNew::DetSetVector<PixelFEDChannel> >();
+  auto disabled_channelcollection = std::make_unique<edmNew::DetSetVector<PixelFEDChannel>>();
 
   //PixelDataFormatter formatter(cabling_.get()); // phase 0 only
-  PixelDataFormatter formatter(cabling_.get(), usePhase1); // for phase 1 & 0
+  PixelDataFormatter formatter(cabling_.get(), usePhase1);  // for phase 1 & 0
 
   formatter.setErrorStatus(includeErrors);
 
-  if (useQuality) formatter.setQualityStatus(useQuality, badPixelInfo_);
+  if (useQuality)
+    formatter.setQualityStatus(useQuality, badPixelInfo_);
 
-  if (theTimer) theTimer->start();
+  if (theTimer)
+    theTimer->start();
   bool errorsInEvent = false;
   PixelDataFormatter::DetErrors nodeterrors;
 
   if (regions_) {
     regions_->run(ev, es);
     formatter.setModulesToUnpack(regions_->modulesToUnpack());
-    LogDebug("SiPixelRawToDigi") << "region2unpack #feds: "<<regions_->nFEDs();
-    LogDebug("SiPixelRawToDigi") << "region2unpack #modules (BPIX,EPIX,total): "<<regions_->nBarrelModules()<<" "<<regions_->nForwardModules()<<" "<<regions_->nModules();
+    LogDebug("SiPixelRawToDigi") << "region2unpack #feds: " << regions_->nFEDs();
+    LogDebug("SiPixelRawToDigi") << "region2unpack #modules (BPIX,EPIX,total): " << regions_->nBarrelModules() << " "
+                                 << regions_->nForwardModules() << " " << regions_->nModules();
   }
 
   for (auto aFed = fedIds.begin(); aFed != fedIds.end(); ++aFed) {
     int fedId = *aFed;
 
-    if(!usePilotBlade && (fedId==40) ) continue; // skip pilot blade data
+    if (!usePilotBlade && (fedId == 40))
+      continue;  // skip pilot blade data
 
-    if (regions_ && !regions_->mayUnpackFED(fedId)) continue;
+    if (regions_ && !regions_->mayUnpackFED(fedId))
+      continue;
 
-    if(debug) LogDebug("SiPixelRawToDigi")<< " PRODUCE DIGI FOR FED: " <<  fedId << endl;
+    if (debug)
+      LogDebug("SiPixelRawToDigi") << " PRODUCE DIGI FOR FED: " << fedId << endl;
 
     PixelDataFormatter::Errors errors;
 
     //get event data for this fed
-    const FEDRawData& fedRawData = buffers->FEDData( fedId );
+    const FEDRawData& fedRawData = buffers->FEDData(fedId);
 
     //convert data to digi and strip off errors
-    formatter.interpretRawData( errorsInEvent, fedId, fedRawData, *collection, errors);
+    formatter.interpretRawData(errorsInEvent, fedId, fedRawData, *collection, errors);
 
     //pack errors into collection
-    if(includeErrors) {
+    if (includeErrors) {
       typedef PixelDataFormatter::Errors::iterator IE;
       for (IE is = errors.begin(); is != errors.end(); is++) {
-	uint32_t errordetid = is->first;
-	if (errordetid==dummydetid) {           // errors given dummy detId must be sorted by Fed
-	  nodeterrors.insert( nodeterrors.end(), errors[errordetid].begin(), errors[errordetid].end() );
-	} else {
-	  edm::DetSet<SiPixelRawDataError>& errorDetSet = errorcollection->find_or_insert(errordetid);
-	  errorDetSet.data.insert(errorDetSet.data.end(), is->second.begin(), is->second.end());
-	  // Fill detid of the detectors where there is error AND the error number is listed
-	  // in the configurable error list in the job option cfi.
-	  // Code needs to be here, because there can be a set of errors for each 
-	  // entry in the for loop over PixelDataFormatter::Errors
+        uint32_t errordetid = is->first;
+        if (errordetid == dummydetid) {  // errors given dummy detId must be sorted by Fed
+          nodeterrors.insert(nodeterrors.end(), errors[errordetid].begin(), errors[errordetid].end());
+        } else {
+          edm::DetSet<SiPixelRawDataError>& errorDetSet = errorcollection->find_or_insert(errordetid);
+          errorDetSet.data.insert(errorDetSet.data.end(), is->second.begin(), is->second.end());
+          // Fill detid of the detectors where there is error AND the error number is listed
+          // in the configurable error list in the job option cfi.
+          // Code needs to be here, because there can be a set of errors for each
+          // entry in the for loop over PixelDataFormatter::Errors
 
-	  std::vector<PixelFEDChannel> disabledChannelsDetSet;
+          std::vector<PixelFEDChannel> disabledChannelsDetSet;
 
-	  for (auto const& aPixelError : errorDetSet) {
-	    // For the time being, we extend the error handling functionality with ErrorType 25
-	    // In the future, we should sort out how the usage of tkerrorlist can be generalized
-	    if (usePhase1==true && aPixelError.getType()==25) {
-	      assert(aPixelError.getFedId()==fedId);
-	      const sipixelobjects::PixelFEDCabling* fed = cabling_->fed(fedId);
-	      if (fed) {
-		cms_uint32_t linkId = formatter.linkId(aPixelError.getWord32());
-		const sipixelobjects::PixelFEDLink* link = fed->link(linkId);
-		if (link) {
-		  // The "offline" 0..15 numbering is fixed by definition, also, the FrameConversion depends on it
-		  // in contrast, the ROC-in-channel numbering is determined by hardware --> better to use the "offline" scheme
-		  PixelFEDChannel ch = {fed->id(), linkId, 25, 0};
-		  for (unsigned int iRoc=1; iRoc<=link->numberOfROCs(); iRoc++) {
-		    const sipixelobjects::PixelROC * roc = link->roc(iRoc);
-		    if (roc->idInDetUnit()<ch.roc_first) ch.roc_first=roc->idInDetUnit();
-		    if (roc->idInDetUnit()>ch.roc_last) ch.roc_last=roc->idInDetUnit();
-		  }
-		  disabledChannelsDetSet.push_back(ch);
-		}
-	      }
-	    } else {
-	      // fill list of detIds to be turned off by tracking
-	      if(!tkerrorlist.empty()) {
-		std::vector<int>::iterator it_find = find(tkerrorlist.begin(), tkerrorlist.end(), aPixelError.getType());
-		if(it_find != tkerrorlist.end()){
-		  tkerror_detidcollection->push_back(errordetid);
-		}
-	      }
-	    }
+          for (auto const& aPixelError : errorDetSet) {
+            // For the time being, we extend the error handling functionality with ErrorType 25
+            // In the future, we should sort out how the usage of tkerrorlist can be generalized
+            if (usePhase1 == true && aPixelError.getType() == 25) {
+              assert(aPixelError.getFedId() == fedId);
+              const sipixelobjects::PixelFEDCabling* fed = cabling_->fed(fedId);
+              if (fed) {
+                cms_uint32_t linkId = formatter.linkId(aPixelError.getWord32());
+                const sipixelobjects::PixelFEDLink* link = fed->link(linkId);
+                if (link) {
+                  // The "offline" 0..15 numbering is fixed by definition, also, the FrameConversion depends on it
+                  // in contrast, the ROC-in-channel numbering is determined by hardware --> better to use the "offline" scheme
+                  PixelFEDChannel ch = {fed->id(), linkId, 25, 0};
+                  for (unsigned int iRoc = 1; iRoc <= link->numberOfROCs(); iRoc++) {
+                    const sipixelobjects::PixelROC* roc = link->roc(iRoc);
+                    if (roc->idInDetUnit() < ch.roc_first)
+                      ch.roc_first = roc->idInDetUnit();
+                    if (roc->idInDetUnit() > ch.roc_last)
+                      ch.roc_last = roc->idInDetUnit();
+                  }
+                  disabledChannelsDetSet.push_back(ch);
+                }
+              }
+            } else {
+              // fill list of detIds to be turned off by tracking
+              if (!tkerrorlist.empty()) {
+                std::vector<int>::iterator it_find =
+                    find(tkerrorlist.begin(), tkerrorlist.end(), aPixelError.getType());
+                if (it_find != tkerrorlist.end()) {
+                  tkerror_detidcollection->push_back(errordetid);
+                }
+              }
+            }
 
-	    // fill list of detIds with errors to be studied
-	    if(!usererrorlist.empty()) {
-	      std::vector<int>::iterator it_find = find(usererrorlist.begin(), usererrorlist.end(), aPixelError.getType());
-	      if(it_find != usererrorlist.end()){
-		usererror_detidcollection->push_back(errordetid);
-	      }
-	    }
+            // fill list of detIds with errors to be studied
+            if (!usererrorlist.empty()) {
+              std::vector<int>::iterator it_find =
+                  find(usererrorlist.begin(), usererrorlist.end(), aPixelError.getType());
+              if (it_find != usererrorlist.end()) {
+                usererror_detidcollection->push_back(errordetid);
+              }
+            }
 
-	  } // loop on DetSet of errors
-	  
-	  if (!disabledChannelsDetSet.empty()) {
-	    disabled_channelcollection->insert(errordetid, disabledChannelsDetSet.data(), disabledChannelsDetSet.size());
-	  }	  
-	} // if error assigned to a real DetId
-      } // loop on errors in event for this FED
-    } // if errors to be included in the event
-  } // loop on FED data to be unpacked
+          }  // loop on DetSet of errors
 
-  if(includeErrors) {
+          if (!disabledChannelsDetSet.empty()) {
+            disabled_channelcollection->insert(
+                errordetid, disabledChannelsDetSet.data(), disabledChannelsDetSet.size());
+          }
+        }  // if error assigned to a real DetId
+      }    // loop on errors in event for this FED
+    }      // if errors to be included in the event
+  }        // loop on FED data to be unpacked
+
+  if (includeErrors) {
     edm::DetSet<SiPixelRawDataError>& errorDetSet = errorcollection->find_or_insert(dummydetid);
     errorDetSet.data = nodeterrors;
   }
-  if (errorsInEvent) LogDebug("SiPixelRawToDigi") << "Error words were stored in this event";
+  if (errorsInEvent)
+    LogDebug("SiPixelRawToDigi") << "Error words were stored in this event";
 
   if (theTimer) {
     theTimer->stop();
-    LogDebug("SiPixelRawToDigi") << "TIMING IS: (real)" << theTimer->realTime() ;
+    LogDebug("SiPixelRawToDigi") << "TIMING IS: (real)" << theTimer->realTime();
     ndigis += formatter.nDigis();
     nwords += formatter.nWords();
-    LogDebug("SiPixelRawToDigi") << " (Words/Digis) this ev: "
-         <<formatter.nWords()<<"/"<<formatter.nDigis() << "--- all :"<<nwords<<"/"<<ndigis;
-    hCPU->Fill( theTimer->realTime() ); 
+    LogDebug("SiPixelRawToDigi") << " (Words/Digis) this ev: " << formatter.nWords() << "/" << formatter.nDigis()
+                                 << "--- all :" << nwords << "/" << ndigis;
+    hCPU->Fill(theTimer->realTime());
     hDigi->Fill(formatter.nDigis());
   }
-  
+
   ev.put(std::move(collection));
-  if(includeErrors){
+  if (includeErrors) {
     ev.put(std::move(errorcollection));
     ev.put(std::move(tkerror_detidcollection));
-    ev.put(std::move(usererror_detidcollection), "UserErrorModules");      
+    ev.put(std::move(usererror_detidcollection), "UserErrorModules");
     ev.put(std::move(disabled_channelcollection));
   }
 }

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -252,7 +252,7 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
 	  for (auto const& aPixelError : errorDetSet) {
 	    // For the time being, we extend the error handling functionality with ErrorType 25
 	    // In the future, we should sort out how the usage of tkerrorlist can be generalized
-	    if (aPixelError.getType()==25) {
+	    if (usePhase1==true && aPixelError.getType()==25) {
 	      assert(aPixelError.getFedId()==fedId);
 	      const sipixelobjects::PixelFEDCabling* fed = cabling_->fed(fedId);
 	      if (fed) {

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -21,13 +21,13 @@
 #include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
 
 #include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
-#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
-#include "DataFormats/DetId/interface/DetIdCollection.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
+#include "DataFormats/DetId/interface/DetIdCollection.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h"
 
 #include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
@@ -36,14 +36,15 @@
 #include "EventFilter/SiPixelRawToDigi/interface/PixelUnpackingRegions.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-#include "TH1D.h"
 #include "TFile.h"
+#include "TH1D.h"
 
 using namespace std;
 
 // -----------------------------------------------------------------------------
-SiPixelRawToDigi::SiPixelRawToDigi(const edm::ParameterSet& conf)
-    : config_(conf), badPixelInfo_(nullptr), regions_(nullptr), hCPU(nullptr), hDigi(nullptr) {
+SiPixelRawToDigi::SiPixelRawToDigi(const edm::ParameterSet &conf)
+    : config_(conf), badPixelInfo_(nullptr), regions_(nullptr), hCPU(nullptr),
+      hDigi(nullptr) {
   includeErrors = config_.getParameter<bool>("IncludeErrors");
   useQuality = config_.getParameter<bool>("UseQualityInfo");
   if (config_.exists("ErrorList")) {
@@ -52,9 +53,10 @@ SiPixelRawToDigi::SiPixelRawToDigi(const edm::ParameterSet& conf)
   if (config_.exists("UserErrorList")) {
     usererrorlist = config_.getParameter<std::vector<int>>("UserErrorList");
   }
-  tFEDRawDataCollection = consumes<FEDRawDataCollection>(config_.getParameter<edm::InputTag>("InputLabel"));
+  tFEDRawDataCollection = consumes<FEDRawDataCollection>(
+      config_.getParameter<edm::InputTag>("InputLabel"));
 
-  //start counters
+  // start counters
   ndigis = 0;
   nwords = 0;
 
@@ -69,7 +71,9 @@ SiPixelRawToDigi::SiPixelRawToDigi(const edm::ParameterSet& conf)
 
   // regions
   if (config_.exists("Regions")) {
-    if (!config_.getParameter<edm::ParameterSet>("Regions").getParameterNames().empty()) {
+    if (!config_.getParameter<edm::ParameterSet>("Regions")
+             .getParameterNames()
+             .empty()) {
       regions_ = new PixelUnpackingRegions(config_, consumesCollector());
     }
   }
@@ -97,7 +101,7 @@ SiPixelRawToDigi::SiPixelRawToDigi(const edm::ParameterSet& conf)
     if (usePhase1)
       edm::LogInfo("SiPixelRawToDigi") << " Using phase1";
   }
-  //CablingMap could have a label //Tav
+  // CablingMap could have a label //Tav
   cablingMapLabel = config_.getParameter<std::string>("CablingMapLabel");
 }
 
@@ -115,7 +119,8 @@ SiPixelRawToDigi::~SiPixelRawToDigi() {
   }
 }
 
-void SiPixelRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelRawToDigi::fillDescriptions(
+    edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<bool>("IncludeErrors", true);
   desc.add<bool>("UseQualityInfo", false);
@@ -124,14 +129,16 @@ void SiPixelRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descript
     temp1.reserve(1);
     temp1.push_back(29);
     desc.add<std::vector<int>>("ErrorList", temp1)
-        ->setComment("## ErrorList: list of error codes used by tracking to invalidate modules");
+        ->setComment("## ErrorList: list of error codes used by tracking to "
+                     "invalidate modules");
   }
   {
     std::vector<int> temp1;
     temp1.reserve(1);
     temp1.push_back(40);
     desc.add<std::vector<int>>("UserErrorList", temp1)
-        ->setComment("## UserErrorList: list of error codes used by Pixel experts for investigation");
+        ->setComment("## UserErrorList: list of error codes used by Pixel "
+                     "experts for investigation");
   }
   desc.add<edm::InputTag>("InputLabel", edm::InputTag("siPixelRawData"));
   {
@@ -146,23 +153,26 @@ void SiPixelRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.addUntracked<bool>("Timing", false);
   desc.add<bool>("UsePilotBlade", false)->setComment("##  Use pilot blades");
   desc.add<bool>("UsePhase1", false)->setComment("##  Use phase1");
-  desc.add<std::string>("CablingMapLabel", "")->setComment("CablingMap label");  //Tav
-  desc.addOptional<bool>("CheckPixelOrder");  // never used, kept for back-compatibility
+  desc.add<std::string>("CablingMapLabel", "")
+      ->setComment("CablingMap label"); // Tav
+  desc.addOptional<bool>(
+      "CheckPixelOrder"); // never used, kept for back-compatibility
   descriptions.add("siPixelRawToDigi", desc);
 }
 
 // -----------------------------------------------------------------------------
 
 // -----------------------------------------------------------------------------
-void SiPixelRawToDigi::produce(edm::Event& ev, const edm::EventSetup& es) {
+void SiPixelRawToDigi::produce(edm::Event &ev, const edm::EventSetup &es) {
   const uint32_t dummydetid = 0xffffffff;
   debug = edm::MessageDrop::instance()->debugEnabled;
 
   // initialize cabling map or update if necessary
   if (recordWatcher.check(es)) {
-    // cabling map, which maps online address (fed->link->ROC->local pixel) to offline (DetId->global pixel)
+    // cabling map, which maps online address (fed->link->ROC->local pixel) to
+    // offline (DetId->global pixel)
     edm::ESTransientHandle<SiPixelFedCablingMap> cablingMap;
-    es.get<SiPixelFedCablingMapRcd>().get(cablingMapLabel, cablingMap);  //Tav
+    es.get<SiPixelFedCablingMapRcd>().get(cablingMapLabel, cablingMap); // Tav
     fedIds = cablingMap->fedIds();
     cabling_ = cablingMap->cablingTree();
     LogDebug("map version:") << cabling_->version();
@@ -175,7 +185,8 @@ void SiPixelRawToDigi::produce(edm::Event& ev, const edm::EventSetup& es) {
     badPixelInfo_ = qualityInfo.product();
     if (!badPixelInfo_) {
       edm::LogError("SiPixelQualityNotPresent")
-          << " Configured to use SiPixelQuality, but SiPixelQuality not present" << endl;
+          << " Configured to use SiPixelQuality, but SiPixelQuality not present"
+          << endl;
     }
   }
 
@@ -185,13 +196,15 @@ void SiPixelRawToDigi::produce(edm::Event& ev, const edm::EventSetup& es) {
   // create product (digis & errors)
   auto collection = std::make_unique<edm::DetSetVector<PixelDigi>>();
   // collection->reserve(8*1024);
-  auto errorcollection = std::make_unique<edm::DetSetVector<SiPixelRawDataError>>();
+  auto errorcollection =
+      std::make_unique<edm::DetSetVector<SiPixelRawDataError>>();
   auto tkerror_detidcollection = std::make_unique<DetIdCollection>();
   auto usererror_detidcollection = std::make_unique<DetIdCollection>();
-  auto disabled_channelcollection = std::make_unique<edmNew::DetSetVector<PixelFEDChannel>>();
+  auto disabled_channelcollection =
+      std::make_unique<edmNew::DetSetVector<PixelFEDChannel>>();
 
-  //PixelDataFormatter formatter(cabling_.get()); // phase 0 only
-  PixelDataFormatter formatter(cabling_.get(), usePhase1);  // for phase 1 & 0
+  // PixelDataFormatter formatter(cabling_.get()); // phase 0 only
+  PixelDataFormatter formatter(cabling_.get(), usePhase1); // for phase 1 & 0
 
   formatter.setErrorStatus(includeErrors);
 
@@ -206,63 +219,76 @@ void SiPixelRawToDigi::produce(edm::Event& ev, const edm::EventSetup& es) {
   if (regions_) {
     regions_->run(ev, es);
     formatter.setModulesToUnpack(regions_->modulesToUnpack());
-    LogDebug("SiPixelRawToDigi") << "region2unpack #feds: " << regions_->nFEDs();
-    LogDebug("SiPixelRawToDigi") << "region2unpack #modules (BPIX,EPIX,total): " << regions_->nBarrelModules() << " "
-                                 << regions_->nForwardModules() << " " << regions_->nModules();
+    LogDebug("SiPixelRawToDigi")
+        << "region2unpack #feds: " << regions_->nFEDs();
+    LogDebug("SiPixelRawToDigi")
+        << "region2unpack #modules (BPIX,EPIX,total): "
+        << regions_->nBarrelModules() << " " << regions_->nForwardModules()
+        << " " << regions_->nModules();
   }
 
   for (auto aFed = fedIds.begin(); aFed != fedIds.end(); ++aFed) {
     int fedId = *aFed;
 
     if (!usePilotBlade && (fedId == 40))
-      continue;  // skip pilot blade data
+      continue; // skip pilot blade data
 
     if (regions_ && !regions_->mayUnpackFED(fedId))
       continue;
 
     if (debug)
-      LogDebug("SiPixelRawToDigi") << " PRODUCE DIGI FOR FED: " << fedId << endl;
+      LogDebug("SiPixelRawToDigi")
+          << " PRODUCE DIGI FOR FED: " << fedId << endl;
 
     PixelDataFormatter::Errors errors;
 
-    //get event data for this fed
-    const FEDRawData& fedRawData = buffers->FEDData(fedId);
+    // get event data for this fed
+    const FEDRawData &fedRawData = buffers->FEDData(fedId);
 
-    //convert data to digi and strip off errors
-    formatter.interpretRawData(errorsInEvent, fedId, fedRawData, *collection, errors);
+    // convert data to digi and strip off errors
+    formatter.interpretRawData(errorsInEvent, fedId, fedRawData, *collection,
+                               errors);
 
-    //pack errors into collection
+    // pack errors into collection
     if (includeErrors) {
       typedef PixelDataFormatter::Errors::iterator IE;
       for (IE is = errors.begin(); is != errors.end(); is++) {
         uint32_t errordetid = is->first;
-        if (errordetid == dummydetid) {  // errors given dummy detId must be sorted by Fed
-          nodeterrors.insert(nodeterrors.end(), errors[errordetid].begin(), errors[errordetid].end());
+        if (errordetid ==
+            dummydetid) { // errors given dummy detId must be sorted by Fed
+          nodeterrors.insert(nodeterrors.end(), errors[errordetid].begin(),
+                             errors[errordetid].end());
         } else {
-          edm::DetSet<SiPixelRawDataError>& errorDetSet = errorcollection->find_or_insert(errordetid);
-          errorDetSet.data.insert(errorDetSet.data.end(), is->second.begin(), is->second.end());
-          // Fill detid of the detectors where there is error AND the error number is listed
-          // in the configurable error list in the job option cfi.
-          // Code needs to be here, because there can be a set of errors for each
-          // entry in the for loop over PixelDataFormatter::Errors
+          edm::DetSet<SiPixelRawDataError> &errorDetSet =
+              errorcollection->find_or_insert(errordetid);
+          errorDetSet.data.insert(errorDetSet.data.end(), is->second.begin(),
+                                  is->second.end());
+          // Fill detid of the detectors where there is error AND the error
+          // number is listed in the configurable error list in the job option
+          // cfi. Code needs to be here, because there can be a set of errors
+          // for each entry in the for loop over PixelDataFormatter::Errors
 
           std::vector<PixelFEDChannel> disabledChannelsDetSet;
 
-          for (auto const& aPixelError : errorDetSet) {
-            // For the time being, we extend the error handling functionality with ErrorType 25
-            // In the future, we should sort out how the usage of tkerrorlist can be generalized
+          for (auto const &aPixelError : errorDetSet) {
+            // For the time being, we extend the error handling functionality
+            // with ErrorType 25 In the future, we should sort out how the usage
+            // of tkerrorlist can be generalized
             if (usePhase1 == true && aPixelError.getType() == 25) {
               assert(aPixelError.getFedId() == fedId);
-              const sipixelobjects::PixelFEDCabling* fed = cabling_->fed(fedId);
+              const sipixelobjects::PixelFEDCabling *fed = cabling_->fed(fedId);
               if (fed) {
                 cms_uint32_t linkId = formatter.linkId(aPixelError.getWord32());
-                const sipixelobjects::PixelFEDLink* link = fed->link(linkId);
+                const sipixelobjects::PixelFEDLink *link = fed->link(linkId);
                 if (link) {
-                  // The "offline" 0..15 numbering is fixed by definition, also, the FrameConversion depends on it
-                  // in contrast, the ROC-in-channel numbering is determined by hardware --> better to use the "offline" scheme
+                  // The "offline" 0..15 numbering is fixed by definition, also,
+                  // the FrameConversion depends on it in contrast, the
+                  // ROC-in-channel numbering is determined by hardware -->
+                  // better to use the "offline" scheme
                   PixelFEDChannel ch = {fed->id(), linkId, 25, 0};
-                  for (unsigned int iRoc = 1; iRoc <= link->numberOfROCs(); iRoc++) {
-                    const sipixelobjects::PixelROC* roc = link->roc(iRoc);
+                  for (unsigned int iRoc = 1; iRoc <= link->numberOfROCs();
+                       iRoc++) {
+                    const sipixelobjects::PixelROC *roc = link->roc(iRoc);
                     if (roc->idInDetUnit() < ch.roc_first)
                       ch.roc_first = roc->idInDetUnit();
                     if (roc->idInDetUnit() > ch.roc_last)
@@ -275,7 +301,8 @@ void SiPixelRawToDigi::produce(edm::Event& ev, const edm::EventSetup& es) {
               // fill list of detIds to be turned off by tracking
               if (!tkerrorlist.empty()) {
                 std::vector<int>::iterator it_find =
-                    find(tkerrorlist.begin(), tkerrorlist.end(), aPixelError.getType());
+                    find(tkerrorlist.begin(), tkerrorlist.end(),
+                         aPixelError.getType());
                 if (it_find != tkerrorlist.end()) {
                   tkerror_detidcollection->push_back(errordetid);
                 }
@@ -285,25 +312,28 @@ void SiPixelRawToDigi::produce(edm::Event& ev, const edm::EventSetup& es) {
             // fill list of detIds with errors to be studied
             if (!usererrorlist.empty()) {
               std::vector<int>::iterator it_find =
-                  find(usererrorlist.begin(), usererrorlist.end(), aPixelError.getType());
+                  find(usererrorlist.begin(), usererrorlist.end(),
+                       aPixelError.getType());
               if (it_find != usererrorlist.end()) {
                 usererror_detidcollection->push_back(errordetid);
               }
             }
 
-          }  // loop on DetSet of errors
+          } // loop on DetSet of errors
 
           if (!disabledChannelsDetSet.empty()) {
-            disabled_channelcollection->insert(
-                errordetid, disabledChannelsDetSet.data(), disabledChannelsDetSet.size());
+            disabled_channelcollection->insert(errordetid,
+                                               disabledChannelsDetSet.data(),
+                                               disabledChannelsDetSet.size());
           }
-        }  // if error assigned to a real DetId
-      }    // loop on errors in event for this FED
-    }      // if errors to be included in the event
-  }        // loop on FED data to be unpacked
+        } // if error assigned to a real DetId
+      }   // loop on errors in event for this FED
+    }     // if errors to be included in the event
+  }       // loop on FED data to be unpacked
 
   if (includeErrors) {
-    edm::DetSet<SiPixelRawDataError>& errorDetSet = errorcollection->find_or_insert(dummydetid);
+    edm::DetSet<SiPixelRawDataError> &errorDetSet =
+        errorcollection->find_or_insert(dummydetid);
     errorDetSet.data = nodeterrors;
   }
   if (errorsInEvent)
@@ -314,8 +344,9 @@ void SiPixelRawToDigi::produce(edm::Event& ev, const edm::EventSetup& es) {
     LogDebug("SiPixelRawToDigi") << "TIMING IS: (real)" << theTimer->realTime();
     ndigis += formatter.nDigis();
     nwords += formatter.nWords();
-    LogDebug("SiPixelRawToDigi") << " (Words/Digis) this ev: " << formatter.nWords() << "/" << formatter.nDigis()
-                                 << "--- all :" << nwords << "/" << ndigis;
+    LogDebug("SiPixelRawToDigi")
+        << " (Words/Digis) this ev: " << formatter.nWords() << "/"
+        << formatter.nDigis() << "--- all :" << nwords << "/" << ndigis;
     hCPU->Fill(theTimer->realTime());
     hDigi->Fill(formatter.nDigis());
   }

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
@@ -25,9 +25,8 @@ class PixelUnpackingRegions;
 
 class SiPixelRawToDigi : public edm::stream::EDProducer<> {
 public:
-
   /// ctor
-  explicit SiPixelRawToDigi( const edm::ParameterSet& );
+  explicit SiPixelRawToDigi(const edm::ParameterSet&);
 
   /// dtor
   ~SiPixelRawToDigi() override;
@@ -35,15 +34,14 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   /// get data, convert to digis attach againe to Event
-  void produce( edm::Event&, const edm::EventSetup& ) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-  
   edm::ParameterSet config_;
   std::unique_ptr<SiPixelFedCablingTree> cabling_;
   const SiPixelQuality* badPixelInfo_;
   PixelUnpackingRegions* regions_;
-  edm::EDGetTokenT<FEDRawDataCollection> tFEDRawDataCollection; 
+  edm::EDGetTokenT<FEDRawDataCollection> tFEDRawDataCollection;
   TH1D *hCPU, *hDigi;
   std::unique_ptr<edm::CPUTimer> theTimer;
   bool includeErrors;
@@ -55,7 +53,7 @@ private:
   edm::ESWatcher<SiPixelFedCablingMapRcd> recordWatcher;
   edm::ESWatcher<SiPixelQualityRcd> qualityWatcher;
   edm::InputTag label;
-  
+
   int ndigis;
   int nwords;
   bool usePilotBlade;

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
@@ -2,19 +2,19 @@
 #define SiPixelRawToDigi_H
 
 /** \class SiPixelRawToDigi_H
- *  Plug-in module that performs Raw data to digi conversion 
+ *  Plug-in module that performs Raw data to digi conversion
  *  for pixel subdetector
  */
 
-#include "FWCore/Framework/interface/ESWatcher.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/CPUTimer.h"
 
 class SiPixelFedCablingTree;
@@ -26,21 +26,21 @@ class PixelUnpackingRegions;
 class SiPixelRawToDigi : public edm::stream::EDProducer<> {
 public:
   /// ctor
-  explicit SiPixelRawToDigi(const edm::ParameterSet&);
+  explicit SiPixelRawToDigi(const edm::ParameterSet &);
 
   /// dtor
   ~SiPixelRawToDigi() override;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
   /// get data, convert to digis attach againe to Event
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
 private:
   edm::ParameterSet config_;
   std::unique_ptr<SiPixelFedCablingTree> cabling_;
-  const SiPixelQuality* badPixelInfo_;
-  PixelUnpackingRegions* regions_;
+  const SiPixelQuality *badPixelInfo_;
+  PixelUnpackingRegions *regions_;
   edm::EDGetTokenT<FEDRawDataCollection> tFEDRawDataCollection;
   TH1D *hCPU, *hDigi;
   std::unique_ptr<edm::CPUTimer> theTimer;

--- a/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
@@ -20,43 +20,37 @@ using namespace sipixelobjects;
 namespace {
   constexpr int CRC_bits = 1;
   constexpr int LINK_bits = 6;
-  constexpr int ROC_bits  = 5;
+  constexpr int ROC_bits = 5;
   constexpr int DCOL_bits = 5;
   constexpr int PXID_bits = 8;
-  constexpr int ADC_bits  = 8;
+  constexpr int ADC_bits = 8;
   constexpr int OMIT_ERR_bits = 1;
-  
+
   constexpr int CRC_shift = 2;
-  constexpr int ADC_shift  = 0;
+  constexpr int ADC_shift = 0;
   constexpr int PXID_shift = ADC_shift + ADC_bits;
   constexpr int DCOL_shift = PXID_shift + PXID_bits;
-  constexpr int ROC_shift  = DCOL_shift + DCOL_bits;
+  constexpr int ROC_shift = DCOL_shift + DCOL_bits;
   constexpr int LINK_shift = ROC_shift + ROC_bits;
   constexpr int OMIT_ERR_shift = 20;
-  
+
   constexpr cms_uint32_t dummyDetId = 0xffffffff;
-  
+
   constexpr ErrorChecker::Word64 CRC_mask = ~(~ErrorChecker::Word64(0) << CRC_bits);
   constexpr ErrorChecker::Word32 ERROR_mask = ~(~ErrorChecker::Word32(0) << ROC_bits);
   constexpr ErrorChecker::Word32 LINK_mask = ~(~ErrorChecker::Word32(0) << LINK_bits);
-  constexpr ErrorChecker::Word32 ROC_mask  = ~(~ErrorChecker::Word32(0) << ROC_bits);
+  constexpr ErrorChecker::Word32 ROC_mask = ~(~ErrorChecker::Word32(0) << ROC_bits);
   constexpr ErrorChecker::Word32 OMIT_ERR_mask = ~(~ErrorChecker::Word32(0) << OMIT_ERR_bits);
-}  
+}  // namespace
 
-ErrorChecker::ErrorChecker() {
+ErrorChecker::ErrorChecker() { includeErrors = false; }
 
-  includeErrors = false;
-}
+void ErrorChecker::setErrorStatus(bool ErrorStatus) { includeErrors = ErrorStatus; }
 
-void ErrorChecker::setErrorStatus(bool ErrorStatus)
-{
-  includeErrors = ErrorStatus;
-}
-
-bool ErrorChecker::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors)
-{
+bool ErrorChecker::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) {
   int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
-  if (CRC_BIT == 0) return true;
+  if (CRC_BIT == 0)
+    return true;
   errorsInEvent = true;
   if (includeErrors) {
     int errorType = 39;
@@ -66,14 +60,13 @@ bool ErrorChecker::checkCRC(bool& errorsInEvent, int fedId, const Word64* traile
   return false;
 }
 
-bool ErrorChecker::checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors)
-{
-  FEDHeader fedHeader( reinterpret_cast<const unsigned char*>(header));
-  if ( !fedHeader.check() ) return false; // throw exception?
-  if ( fedHeader.sourceID() != fedId) { 
+bool ErrorChecker::checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) {
+  FEDHeader fedHeader(reinterpret_cast<const unsigned char*>(header));
+  if (!fedHeader.check())
+    return false;  // throw exception?
+  if (fedHeader.sourceID() != fedId) {
     LogDebug("PixelDataFormatter::interpretRawData, fedHeader.sourceID() != fedId")
-      <<", sourceID = " <<fedHeader.sourceID()
-      <<", fedId = "<<fedId<<", errorType = 32"; 
+        << ", sourceID = " << fedHeader.sourceID() << ", fedId = " << fedId << ", errorType = 32";
     errorsInEvent = true;
     if (includeErrors) {
       int errorType = 32;
@@ -84,24 +77,23 @@ bool ErrorChecker::checkHeader(bool& errorsInEvent, int fedId, const Word64* hea
   return fedHeader.moreHeaders();
 }
 
-bool ErrorChecker::checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors)
-{
+bool ErrorChecker::checkTrailer(
+    bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) {
   FEDTrailer fedTrailer(reinterpret_cast<const unsigned char*>(trailer));
-  if ( !fedTrailer.check()) { 
-    if(includeErrors) {
+  if (!fedTrailer.check()) {
+    if (includeErrors) {
       int errorType = 33;
       SiPixelRawDataError error(*trailer, errorType, fedId);
       errors[dummyDetId].push_back(error);
     }
     errorsInEvent = true;
-    LogError("FedTrailerCheck")
-      <<"fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
-    return false; 
-  } 
-  if ( fedTrailer.fragmentLength()!= nWords) {
-    LogError("FedTrailerLenght")<< "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId << ", errorType = 34";
+    LogError("FedTrailerCheck") << "fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
+    return false;
+  }
+  if (fedTrailer.fragmentLength() != nWords) {
+    LogError("FedTrailerLenght") << "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId << ", errorType = 34";
     errorsInEvent = true;
-    if(includeErrors) {
+    if (includeErrors) {
       int errorType = 34;
       SiPixelRawDataError error(*trailer, errorType, fedId);
       errors[dummyDetId].push_back(error);
@@ -110,143 +102,155 @@ bool ErrorChecker::checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWo
   return fedTrailer.moreTrailers();
 }
 
-bool ErrorChecker::checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
-			    const SiPixelFedCabling* theCablingTree, Word32& errorWord, Errors& errors)
-{
+bool ErrorChecker::checkROC(bool& errorsInEvent,
+                            int fedId,
+                            const SiPixelFrameConverter* converter,
+                            const SiPixelFedCabling* theCablingTree,
+                            Word32& errorWord,
+                            Errors& errors) {
   int errorType = (errorWord >> ROC_shift) & ERROR_mask;
-  if LIKELY(errorType<25) return true;
+  if
+    LIKELY(errorType < 25) return true;
 
- switch (errorType) {
-    case(25) : {
-     CablingPathToDetUnit cablingPath = { unsigned(fedId), (errorWord >> LINK_shift) & LINK_mask, 1 };
-     if (!theCablingTree->findItem(cablingPath)) return false;
-     LogDebug("")<<"  invalid ROC=25 found (errorType=25)";
-     errorsInEvent = true;
-     break;
-   }
-   case(26) : {
-     //LogDebug("")<<"  gap word found (errorType=26)";
-     return false;
-   }
-   case(27) : {
-     //LogDebug("")<<"  dummy word found (errorType=27)";
-     return false;
-   }
-   case(28) : {
-     LogDebug("")<<"  error fifo nearly full (errorType=28)";
-     errorsInEvent = true;
-     break;
-   }
-   case(29) : {
-     LogDebug("")<<"  timeout on a channel (errorType=29)";
-     errorsInEvent = true;
-     if ((errorWord >> OMIT_ERR_shift) & OMIT_ERR_mask) {
-       LogDebug("")<<"  ...first errorType=29 error, this gets masked out";
-       return false;
-     }
-     break;
-   }
-   case(30) : {
-     LogDebug("")<<"  TBM error trailer (errorType=30)";
-     int StateMatch_bits      = 4;
-     int StateMatch_shift     = 8;
-     uint32_t StateMatch_mask = ~(~uint32_t(0) << StateMatch_bits);
-     int StateMatch = (errorWord >> StateMatch_shift) & StateMatch_mask;
-     if( StateMatch!=1 && StateMatch!=8 ) {
-       LogDebug("")<<" FED error 30 with unexpected State Bits (errorType=30)";
-       return false;
-     }
-     if( StateMatch==1 ) errorType = 40; // 1=Overflow -> 40, 8=number of ROCs -> 30 
-     errorsInEvent = true;
-     break;
-   }
-   case(31) : {
-     LogDebug("")<<"  event number error (errorType=31)";
-     errorsInEvent = true;
-     break;
-   }
-   default: return true;
- };
+  switch (errorType) {
+    case (25): {
+      CablingPathToDetUnit cablingPath = {unsigned(fedId), (errorWord >> LINK_shift) & LINK_mask, 1};
+      if (!theCablingTree->findItem(cablingPath))
+        return false;
+      LogDebug("") << "  invalid ROC=25 found (errorType=25)";
+      errorsInEvent = true;
+      break;
+    }
+    case (26): {
+      //LogDebug("")<<"  gap word found (errorType=26)";
+      return false;
+    }
+    case (27): {
+      //LogDebug("")<<"  dummy word found (errorType=27)";
+      return false;
+    }
+    case (28): {
+      LogDebug("") << "  error fifo nearly full (errorType=28)";
+      errorsInEvent = true;
+      break;
+    }
+    case (29): {
+      LogDebug("") << "  timeout on a channel (errorType=29)";
+      errorsInEvent = true;
+      if ((errorWord >> OMIT_ERR_shift) & OMIT_ERR_mask) {
+        LogDebug("") << "  ...first errorType=29 error, this gets masked out";
+        return false;
+      }
+      break;
+    }
+    case (30): {
+      LogDebug("") << "  TBM error trailer (errorType=30)";
+      int StateMatch_bits = 4;
+      int StateMatch_shift = 8;
+      uint32_t StateMatch_mask = ~(~uint32_t(0) << StateMatch_bits);
+      int StateMatch = (errorWord >> StateMatch_shift) & StateMatch_mask;
+      if (StateMatch != 1 && StateMatch != 8) {
+        LogDebug("") << " FED error 30 with unexpected State Bits (errorType=30)";
+        return false;
+      }
+      if (StateMatch == 1)
+        errorType = 40;  // 1=Overflow -> 40, 8=number of ROCs -> 30
+      errorsInEvent = true;
+      break;
+    }
+    case (31): {
+      LogDebug("") << "  event number error (errorType=31)";
+      errorsInEvent = true;
+      break;
+    }
+    default:
+      return true;
+  };
 
- if(includeErrors) {
-   // store error
-   SiPixelRawDataError error(errorWord, errorType, fedId);
-   cms_uint32_t detId;
-   detId = errorDetId(converter, errorType, errorWord);
-   errors[detId].push_back(error);
- }
- return false;
+  if (includeErrors) {
+    // store error
+    SiPixelRawDataError error(errorWord, errorType, fedId);
+    cms_uint32_t detId;
+    detId = errorDetId(converter, errorType, errorWord);
+    errors[detId].push_back(error);
+  }
+  return false;
 }
 
-void ErrorChecker::conversionError(int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors)
-{
+void ErrorChecker::conversionError(
+    int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) {
   switch (status) {
-  case(1) : {
-    LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
-    if(includeErrors) {
-      int errorType = 35;
-      SiPixelRawDataError error(errorWord, errorType, fedId);
-      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-      errors[detId].push_back(error);
+    case (1): {
+      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
+      if (includeErrors) {
+        int errorType = 35;
+        SiPixelRawDataError error(errorWord, errorType, fedId);
+        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+        errors[detId].push_back(error);
+      }
+      break;
     }
-    break;
-  }
-  case(2) : {
-    LogDebug("ErrorChecker::conversionError")<< " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
-    if(includeErrors) {
-      int errorType = 36;
-      SiPixelRawDataError error(errorWord, errorType, fedId);
-      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-      errors[detId].push_back(error);
+    case (2): {
+      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
+      if (includeErrors) {
+        int errorType = 36;
+        SiPixelRawDataError error(errorWord, errorType, fedId);
+        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+        errors[detId].push_back(error);
+      }
+      break;
     }
-    break;
-  }
-  case(3) : {
-    LogDebug("ErrorChecker::conversionError")<< " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
-    if(includeErrors) {
-      int errorType = 37;
-      SiPixelRawDataError error(errorWord, errorType, fedId);
-      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-      errors[detId].push_back(error);
+    case (3): {
+      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
+      if (includeErrors) {
+        int errorType = 37;
+        SiPixelRawDataError error(errorWord, errorType, fedId);
+        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+        errors[detId].push_back(error);
+      }
+      break;
     }
-    break;
-  }
-  case(4) : {
-    LogDebug("ErrorChecker::conversionError")<< " Fed: " << fedId << "  dcol/pixel read out of order (errorType=38)";
-    if(includeErrors) {
-      int errorType = 38;
-      SiPixelRawDataError error(errorWord, errorType, fedId);
-      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-      errors[detId].push_back(error);
+    case (4): {
+      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  dcol/pixel read out of order (errorType=38)";
+      if (includeErrors) {
+        int errorType = 38;
+        SiPixelRawDataError error(errorWord, errorType, fedId);
+        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+        errors[detId].push_back(error);
+      }
+      break;
     }
-    break;
-  }
-  default: LogDebug("ErrorChecker::conversionError")<<"  cabling check returned unexpected result, status = "<< status;
+    default:
+      LogDebug("ErrorChecker::conversionError") << "  cabling check returned unexpected result, status = " << status;
   };
 }
 
 // this function finds the detId for an error word that cannot be processed in word2digi
-cms_uint32_t ErrorChecker::errorDetId(const SiPixelFrameConverter* converter, 
-    int errorType, const Word32 & word) const
-{
-  if (!converter) return dummyDetId;
+cms_uint32_t ErrorChecker::errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const {
+  if (!converter)
+    return dummyDetId;
 
   ElectronicIndex cabling;
 
   switch (errorType) {
-    case  25 : case  30 : case  31 : case  36 : case 40 : {
+    case 25:
+    case 30:
+    case 31:
+    case 36:
+    case 40: {
       // set dummy values for cabling just to get detId from link
       cabling.dcol = 0;
       cabling.pxid = 2;
-      cabling.roc  = 1;
-      cabling.link = (word >> LINK_shift) & LINK_mask;  
+      cabling.roc = 1;
+      cabling.link = (word >> LINK_shift) & LINK_mask;
 
       DetectorIndex detIdx;
       int status = converter->toDetector(cabling, detIdx);
-      if (!status) return detIdx.rawId;
+      if (!status)
+        return detIdx.rawId;
       break;
     }
-    case  29 : {
+    case 29: {
       int chanNmbr = 0;
       const int DB0_shift = 0;
       const int DB1_shift = DB0_shift + 1;
@@ -260,39 +264,46 @@ cms_uint32_t ErrorChecker::errorDetId(const SiPixelFrameConverter* converter,
       int CH3 = (word >> DB2_shift) & DataBit_mask;
       int CH4 = (word >> DB3_shift) & DataBit_mask;
       int CH5 = (word >> DB4_shift) & DataBit_mask;
-      int BLOCK_bits      = 3;
-      int BLOCK_shift     = 8;
+      int BLOCK_bits = 3;
+      int BLOCK_shift = 8;
       cms_uint32_t BLOCK_mask = ~(~cms_uint32_t(0) << BLOCK_bits);
       int BLOCK = (word >> BLOCK_shift) & BLOCK_mask;
-      int localCH = 1*CH1+2*CH2+3*CH3+4*CH4+5*CH5;
-      if (BLOCK%2==0) chanNmbr=(BLOCK/2)*9+localCH;
-      else chanNmbr = ((BLOCK-1)/2)*9+4+localCH;
-      if ((chanNmbr<1)||(chanNmbr>36)) break;  // signifies unexpected result
-      
+      int localCH = 1 * CH1 + 2 * CH2 + 3 * CH3 + 4 * CH4 + 5 * CH5;
+      if (BLOCK % 2 == 0)
+        chanNmbr = (BLOCK / 2) * 9 + localCH;
+      else
+        chanNmbr = ((BLOCK - 1) / 2) * 9 + 4 + localCH;
+      if ((chanNmbr < 1) || (chanNmbr > 36))
+        break;  // signifies unexpected result
+
       // set dummy values for cabling just to get detId from link if in Barrel
       cabling.dcol = 0;
       cabling.pxid = 2;
-      cabling.roc  = 1;
-      cabling.link = chanNmbr;  
+      cabling.roc = 1;
+      cabling.link = chanNmbr;
       DetectorIndex detIdx;
       int status = converter->toDetector(cabling, detIdx);
-      if (!status) return detIdx.rawId;
+      if (!status)
+        return detIdx.rawId;
       break;
     }
-    case  37 : case  38: {
+    case 37:
+    case 38: {
       cabling.dcol = 0;
       cabling.pxid = 2;
-      cabling.roc  = (word >> ROC_shift) & ROC_mask;
+      cabling.roc = (word >> ROC_shift) & ROC_mask;
       cabling.link = (word >> LINK_shift) & LINK_mask;
 
       DetectorIndex detIdx;
       int status = converter->toDetector(cabling, detIdx);
-      if (status) break;
+      if (status)
+        break;
 
       return detIdx.rawId;
       break;
     }
-  default : break;
+    default:
+      break;
   };
   return dummyDetId;
 }

--- a/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
@@ -3,51 +3,59 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/FEDRawData/interface/FEDHeader.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <bitset>
-#include <sstream>
 #include <iostream>
+#include <sstream>
 
 using namespace std;
 using namespace edm;
 using namespace sipixelobjects;
 
 namespace {
-  constexpr int CRC_bits = 1;
-  constexpr int LINK_bits = 6;
-  constexpr int ROC_bits = 5;
-  constexpr int DCOL_bits = 5;
-  constexpr int PXID_bits = 8;
-  constexpr int ADC_bits = 8;
-  constexpr int OMIT_ERR_bits = 1;
+constexpr int CRC_bits = 1;
+constexpr int LINK_bits = 6;
+constexpr int ROC_bits = 5;
+constexpr int DCOL_bits = 5;
+constexpr int PXID_bits = 8;
+constexpr int ADC_bits = 8;
+constexpr int OMIT_ERR_bits = 1;
 
-  constexpr int CRC_shift = 2;
-  constexpr int ADC_shift = 0;
-  constexpr int PXID_shift = ADC_shift + ADC_bits;
-  constexpr int DCOL_shift = PXID_shift + PXID_bits;
-  constexpr int ROC_shift = DCOL_shift + DCOL_bits;
-  constexpr int LINK_shift = ROC_shift + ROC_bits;
-  constexpr int OMIT_ERR_shift = 20;
+constexpr int CRC_shift = 2;
+constexpr int ADC_shift = 0;
+constexpr int PXID_shift = ADC_shift + ADC_bits;
+constexpr int DCOL_shift = PXID_shift + PXID_bits;
+constexpr int ROC_shift = DCOL_shift + DCOL_bits;
+constexpr int LINK_shift = ROC_shift + ROC_bits;
+constexpr int OMIT_ERR_shift = 20;
 
-  constexpr cms_uint32_t dummyDetId = 0xffffffff;
+constexpr cms_uint32_t dummyDetId = 0xffffffff;
 
-  constexpr ErrorChecker::Word64 CRC_mask = ~(~ErrorChecker::Word64(0) << CRC_bits);
-  constexpr ErrorChecker::Word32 ERROR_mask = ~(~ErrorChecker::Word32(0) << ROC_bits);
-  constexpr ErrorChecker::Word32 LINK_mask = ~(~ErrorChecker::Word32(0) << LINK_bits);
-  constexpr ErrorChecker::Word32 ROC_mask = ~(~ErrorChecker::Word32(0) << ROC_bits);
-  constexpr ErrorChecker::Word32 OMIT_ERR_mask = ~(~ErrorChecker::Word32(0) << OMIT_ERR_bits);
-}  // namespace
+constexpr ErrorChecker::Word64 CRC_mask =
+    ~(~ErrorChecker::Word64(0) << CRC_bits);
+constexpr ErrorChecker::Word32 ERROR_mask =
+    ~(~ErrorChecker::Word32(0) << ROC_bits);
+constexpr ErrorChecker::Word32 LINK_mask =
+    ~(~ErrorChecker::Word32(0) << LINK_bits);
+constexpr ErrorChecker::Word32 ROC_mask =
+    ~(~ErrorChecker::Word32(0) << ROC_bits);
+constexpr ErrorChecker::Word32 OMIT_ERR_mask =
+    ~(~ErrorChecker::Word32(0) << OMIT_ERR_bits);
+} // namespace
 
 ErrorChecker::ErrorChecker() { includeErrors = false; }
 
-void ErrorChecker::setErrorStatus(bool ErrorStatus) { includeErrors = ErrorStatus; }
+void ErrorChecker::setErrorStatus(bool ErrorStatus) {
+  includeErrors = ErrorStatus;
+}
 
-bool ErrorChecker::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) {
+bool ErrorChecker::checkCRC(bool &errorsInEvent, int fedId,
+                            const Word64 *trailer, Errors &errors) {
   int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
   if (CRC_BIT == 0)
     return true;
@@ -60,13 +68,16 @@ bool ErrorChecker::checkCRC(bool& errorsInEvent, int fedId, const Word64* traile
   return false;
 }
 
-bool ErrorChecker::checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) {
-  FEDHeader fedHeader(reinterpret_cast<const unsigned char*>(header));
+bool ErrorChecker::checkHeader(bool &errorsInEvent, int fedId,
+                               const Word64 *header, Errors &errors) {
+  FEDHeader fedHeader(reinterpret_cast<const unsigned char *>(header));
   if (!fedHeader.check())
-    return false;  // throw exception?
+    return false; // throw exception?
   if (fedHeader.sourceID() != fedId) {
-    LogDebug("PixelDataFormatter::interpretRawData, fedHeader.sourceID() != fedId")
-        << ", sourceID = " << fedHeader.sourceID() << ", fedId = " << fedId << ", errorType = 32";
+    LogDebug(
+        "PixelDataFormatter::interpretRawData, fedHeader.sourceID() != fedId")
+        << ", sourceID = " << fedHeader.sourceID() << ", fedId = " << fedId
+        << ", errorType = 32";
     errorsInEvent = true;
     if (includeErrors) {
       int errorType = 32;
@@ -77,9 +88,10 @@ bool ErrorChecker::checkHeader(bool& errorsInEvent, int fedId, const Word64* hea
   return fedHeader.moreHeaders();
 }
 
-bool ErrorChecker::checkTrailer(
-    bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) {
-  FEDTrailer fedTrailer(reinterpret_cast<const unsigned char*>(trailer));
+bool ErrorChecker::checkTrailer(bool &errorsInEvent, int fedId,
+                                unsigned int nWords, const Word64 *trailer,
+                                Errors &errors) {
+  FEDTrailer fedTrailer(reinterpret_cast<const unsigned char *>(trailer));
   if (!fedTrailer.check()) {
     if (includeErrors) {
       int errorType = 33;
@@ -87,11 +99,14 @@ bool ErrorChecker::checkTrailer(
       errors[dummyDetId].push_back(error);
     }
     errorsInEvent = true;
-    LogError("FedTrailerCheck") << "fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
+    LogError("FedTrailerCheck")
+        << "fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
     return false;
   }
   if (fedTrailer.fragmentLength() != nWords) {
-    LogError("FedTrailerLenght") << "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId << ", errorType = 34";
+    LogError("FedTrailerLenght")
+        << "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId
+        << ", errorType = 34";
     errorsInEvent = true;
     if (includeErrors) {
       int errorType = 34;
@@ -102,69 +117,68 @@ bool ErrorChecker::checkTrailer(
   return fedTrailer.moreTrailers();
 }
 
-bool ErrorChecker::checkROC(bool& errorsInEvent,
-                            int fedId,
-                            const SiPixelFrameConverter* converter,
-                            const SiPixelFedCabling* theCablingTree,
-                            Word32& errorWord,
-                            Errors& errors) {
+bool ErrorChecker::checkROC(bool &errorsInEvent, int fedId,
+                            const SiPixelFrameConverter *converter,
+                            const SiPixelFedCabling *theCablingTree,
+                            Word32 &errorWord, Errors &errors) {
   int errorType = (errorWord >> ROC_shift) & ERROR_mask;
   if
     LIKELY(errorType < 25) return true;
 
   switch (errorType) {
-    case (25): {
-      CablingPathToDetUnit cablingPath = {unsigned(fedId), (errorWord >> LINK_shift) & LINK_mask, 1};
-      if (!theCablingTree->findItem(cablingPath))
-        return false;
-      LogDebug("") << "  invalid ROC=25 found (errorType=25)";
-      errorsInEvent = true;
-      break;
-    }
-    case (26): {
-      //LogDebug("")<<"  gap word found (errorType=26)";
+  case (25): {
+    CablingPathToDetUnit cablingPath = {
+        unsigned(fedId), (errorWord >> LINK_shift) & LINK_mask, 1};
+    if (!theCablingTree->findItem(cablingPath))
+      return false;
+    LogDebug("") << "  invalid ROC=25 found (errorType=25)";
+    errorsInEvent = true;
+    break;
+  }
+  case (26): {
+    // LogDebug("")<<"  gap word found (errorType=26)";
+    return false;
+  }
+  case (27): {
+    // LogDebug("")<<"  dummy word found (errorType=27)";
+    return false;
+  }
+  case (28): {
+    LogDebug("") << "  error fifo nearly full (errorType=28)";
+    errorsInEvent = true;
+    break;
+  }
+  case (29): {
+    LogDebug("") << "  timeout on a channel (errorType=29)";
+    errorsInEvent = true;
+    if ((errorWord >> OMIT_ERR_shift) & OMIT_ERR_mask) {
+      LogDebug("") << "  ...first errorType=29 error, this gets masked out";
       return false;
     }
-    case (27): {
-      //LogDebug("")<<"  dummy word found (errorType=27)";
+    break;
+  }
+  case (30): {
+    LogDebug("") << "  TBM error trailer (errorType=30)";
+    int StateMatch_bits = 4;
+    int StateMatch_shift = 8;
+    uint32_t StateMatch_mask = ~(~uint32_t(0) << StateMatch_bits);
+    int StateMatch = (errorWord >> StateMatch_shift) & StateMatch_mask;
+    if (StateMatch != 1 && StateMatch != 8) {
+      LogDebug("") << " FED error 30 with unexpected State Bits (errorType=30)";
       return false;
     }
-    case (28): {
-      LogDebug("") << "  error fifo nearly full (errorType=28)";
-      errorsInEvent = true;
-      break;
-    }
-    case (29): {
-      LogDebug("") << "  timeout on a channel (errorType=29)";
-      errorsInEvent = true;
-      if ((errorWord >> OMIT_ERR_shift) & OMIT_ERR_mask) {
-        LogDebug("") << "  ...first errorType=29 error, this gets masked out";
-        return false;
-      }
-      break;
-    }
-    case (30): {
-      LogDebug("") << "  TBM error trailer (errorType=30)";
-      int StateMatch_bits = 4;
-      int StateMatch_shift = 8;
-      uint32_t StateMatch_mask = ~(~uint32_t(0) << StateMatch_bits);
-      int StateMatch = (errorWord >> StateMatch_shift) & StateMatch_mask;
-      if (StateMatch != 1 && StateMatch != 8) {
-        LogDebug("") << " FED error 30 with unexpected State Bits (errorType=30)";
-        return false;
-      }
-      if (StateMatch == 1)
-        errorType = 40;  // 1=Overflow -> 40, 8=number of ROCs -> 30
-      errorsInEvent = true;
-      break;
-    }
-    case (31): {
-      LogDebug("") << "  event number error (errorType=31)";
-      errorsInEvent = true;
-      break;
-    }
-    default:
-      return true;
+    if (StateMatch == 1)
+      errorType = 40; // 1=Overflow -> 40, 8=number of ROCs -> 30
+    errorsInEvent = true;
+    break;
+  }
+  case (31): {
+    LogDebug("") << "  event number error (errorType=31)";
+    errorsInEvent = true;
+    break;
+  }
+  default:
+    return true;
   };
 
   if (includeErrors) {
@@ -177,133 +191,142 @@ bool ErrorChecker::checkROC(bool& errorsInEvent,
   return false;
 }
 
-void ErrorChecker::conversionError(
-    int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) {
+void ErrorChecker::conversionError(int fedId,
+                                   const SiPixelFrameConverter *converter,
+                                   int status, Word32 &errorWord,
+                                   Errors &errors) {
   switch (status) {
-    case (1): {
-      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
-      if (includeErrors) {
-        int errorType = 35;
-        SiPixelRawDataError error(errorWord, errorType, fedId);
-        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-        errors[detId].push_back(error);
-      }
-      break;
+  case (1): {
+    LogDebug("ErrorChecker::conversionError")
+        << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
+    if (includeErrors) {
+      int errorType = 35;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
     }
-    case (2): {
-      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
-      if (includeErrors) {
-        int errorType = 36;
-        SiPixelRawDataError error(errorWord, errorType, fedId);
-        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-        errors[detId].push_back(error);
-      }
-      break;
+    break;
+  }
+  case (2): {
+    LogDebug("ErrorChecker::conversionError")
+        << " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
+    if (includeErrors) {
+      int errorType = 36;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
     }
-    case (3): {
-      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
-      if (includeErrors) {
-        int errorType = 37;
-        SiPixelRawDataError error(errorWord, errorType, fedId);
-        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-        errors[detId].push_back(error);
-      }
-      break;
+    break;
+  }
+  case (3): {
+    LogDebug("ErrorChecker::conversionError")
+        << " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
+    if (includeErrors) {
+      int errorType = 37;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
     }
-    case (4): {
-      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  dcol/pixel read out of order (errorType=38)";
-      if (includeErrors) {
-        int errorType = 38;
-        SiPixelRawDataError error(errorWord, errorType, fedId);
-        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-        errors[detId].push_back(error);
-      }
-      break;
+    break;
+  }
+  case (4): {
+    LogDebug("ErrorChecker::conversionError")
+        << " Fed: " << fedId << "  dcol/pixel read out of order (errorType=38)";
+    if (includeErrors) {
+      int errorType = 38;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
     }
-    default:
-      LogDebug("ErrorChecker::conversionError") << "  cabling check returned unexpected result, status = " << status;
+    break;
+  }
+  default:
+    LogDebug("ErrorChecker::conversionError")
+        << "  cabling check returned unexpected result, status = " << status;
   };
 }
 
-// this function finds the detId for an error word that cannot be processed in word2digi
-cms_uint32_t ErrorChecker::errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const {
+// this function finds the detId for an error word that cannot be processed in
+// word2digi
+cms_uint32_t ErrorChecker::errorDetId(const SiPixelFrameConverter *converter,
+                                      int errorType, const Word32 &word) const {
   if (!converter)
     return dummyDetId;
 
   ElectronicIndex cabling;
 
   switch (errorType) {
-    case 25:
-    case 30:
-    case 31:
-    case 36:
-    case 40: {
-      // set dummy values for cabling just to get detId from link
-      cabling.dcol = 0;
-      cabling.pxid = 2;
-      cabling.roc = 1;
-      cabling.link = (word >> LINK_shift) & LINK_mask;
+  case 25:
+  case 30:
+  case 31:
+  case 36:
+  case 40: {
+    // set dummy values for cabling just to get detId from link
+    cabling.dcol = 0;
+    cabling.pxid = 2;
+    cabling.roc = 1;
+    cabling.link = (word >> LINK_shift) & LINK_mask;
 
-      DetectorIndex detIdx;
-      int status = converter->toDetector(cabling, detIdx);
-      if (!status)
-        return detIdx.rawId;
-      break;
-    }
-    case 29: {
-      int chanNmbr = 0;
-      const int DB0_shift = 0;
-      const int DB1_shift = DB0_shift + 1;
-      const int DB2_shift = DB1_shift + 1;
-      const int DB3_shift = DB2_shift + 1;
-      const int DB4_shift = DB3_shift + 1;
-      const cms_uint32_t DataBit_mask = ~(~cms_uint32_t(0) << 1);
-
-      int CH1 = (word >> DB0_shift) & DataBit_mask;
-      int CH2 = (word >> DB1_shift) & DataBit_mask;
-      int CH3 = (word >> DB2_shift) & DataBit_mask;
-      int CH4 = (word >> DB3_shift) & DataBit_mask;
-      int CH5 = (word >> DB4_shift) & DataBit_mask;
-      int BLOCK_bits = 3;
-      int BLOCK_shift = 8;
-      cms_uint32_t BLOCK_mask = ~(~cms_uint32_t(0) << BLOCK_bits);
-      int BLOCK = (word >> BLOCK_shift) & BLOCK_mask;
-      int localCH = 1 * CH1 + 2 * CH2 + 3 * CH3 + 4 * CH4 + 5 * CH5;
-      if (BLOCK % 2 == 0)
-        chanNmbr = (BLOCK / 2) * 9 + localCH;
-      else
-        chanNmbr = ((BLOCK - 1) / 2) * 9 + 4 + localCH;
-      if ((chanNmbr < 1) || (chanNmbr > 36))
-        break;  // signifies unexpected result
-
-      // set dummy values for cabling just to get detId from link if in Barrel
-      cabling.dcol = 0;
-      cabling.pxid = 2;
-      cabling.roc = 1;
-      cabling.link = chanNmbr;
-      DetectorIndex detIdx;
-      int status = converter->toDetector(cabling, detIdx);
-      if (!status)
-        return detIdx.rawId;
-      break;
-    }
-    case 37:
-    case 38: {
-      cabling.dcol = 0;
-      cabling.pxid = 2;
-      cabling.roc = (word >> ROC_shift) & ROC_mask;
-      cabling.link = (word >> LINK_shift) & LINK_mask;
-
-      DetectorIndex detIdx;
-      int status = converter->toDetector(cabling, detIdx);
-      if (status)
-        break;
-
+    DetectorIndex detIdx;
+    int status = converter->toDetector(cabling, detIdx);
+    if (!status)
       return detIdx.rawId;
+    break;
+  }
+  case 29: {
+    int chanNmbr = 0;
+    const int DB0_shift = 0;
+    const int DB1_shift = DB0_shift + 1;
+    const int DB2_shift = DB1_shift + 1;
+    const int DB3_shift = DB2_shift + 1;
+    const int DB4_shift = DB3_shift + 1;
+    const cms_uint32_t DataBit_mask = ~(~cms_uint32_t(0) << 1);
+
+    int CH1 = (word >> DB0_shift) & DataBit_mask;
+    int CH2 = (word >> DB1_shift) & DataBit_mask;
+    int CH3 = (word >> DB2_shift) & DataBit_mask;
+    int CH4 = (word >> DB3_shift) & DataBit_mask;
+    int CH5 = (word >> DB4_shift) & DataBit_mask;
+    int BLOCK_bits = 3;
+    int BLOCK_shift = 8;
+    cms_uint32_t BLOCK_mask = ~(~cms_uint32_t(0) << BLOCK_bits);
+    int BLOCK = (word >> BLOCK_shift) & BLOCK_mask;
+    int localCH = 1 * CH1 + 2 * CH2 + 3 * CH3 + 4 * CH4 + 5 * CH5;
+    if (BLOCK % 2 == 0)
+      chanNmbr = (BLOCK / 2) * 9 + localCH;
+    else
+      chanNmbr = ((BLOCK - 1) / 2) * 9 + 4 + localCH;
+    if ((chanNmbr < 1) || (chanNmbr > 36))
+      break; // signifies unexpected result
+
+    // set dummy values for cabling just to get detId from link if in Barrel
+    cabling.dcol = 0;
+    cabling.pxid = 2;
+    cabling.roc = 1;
+    cabling.link = chanNmbr;
+    DetectorIndex detIdx;
+    int status = converter->toDetector(cabling, detIdx);
+    if (!status)
+      return detIdx.rawId;
+    break;
+  }
+  case 37:
+  case 38: {
+    cabling.dcol = 0;
+    cabling.pxid = 2;
+    cabling.roc = (word >> ROC_shift) & ROC_mask;
+    cabling.link = (word >> LINK_shift) & LINK_mask;
+
+    DetectorIndex detIdx;
+    int status = converter->toDetector(cabling, detIdx);
+    if (status)
       break;
-    }
-    default:
-      break;
+
+    return detIdx.rawId;
+    break;
+  }
+  default:
+    break;
   };
   return dummyDetId;
 }

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
@@ -1,0 +1,298 @@
+#include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h"
+
+#include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/FEDRawData/interface/FEDHeader.h"
+#include "DataFormats/FEDRawData/interface/FEDTrailer.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <bitset>
+#include <sstream>
+#include <iostream>
+
+using namespace std;
+using namespace edm;
+using namespace sipixelobjects;
+
+namespace {
+  constexpr int CRC_bits = 1;
+  constexpr int LINK_bits = 6;
+  constexpr int ROC_bits  = 5;
+  constexpr int DCOL_bits = 5;
+  constexpr int PXID_bits = 8;
+  constexpr int ADC_bits  = 8;
+  constexpr int OMIT_ERR_bits = 1;
+  
+  constexpr int CRC_shift = 2;
+  constexpr int ADC_shift  = 0;
+  constexpr int PXID_shift = ADC_shift + ADC_bits;
+  constexpr int DCOL_shift = PXID_shift + PXID_bits;
+  constexpr int ROC_shift  = DCOL_shift + DCOL_bits;
+  constexpr int LINK_shift = ROC_shift + ROC_bits;
+  constexpr int OMIT_ERR_shift = 20;
+  
+  constexpr cms_uint32_t dummyDetId = 0xffffffff;
+  
+  constexpr ErrorCheckerPhase0::Word64 CRC_mask = ~(~ErrorCheckerPhase0::Word64(0) << CRC_bits);
+  constexpr ErrorCheckerPhase0::Word32 ERROR_mask = ~(~ErrorCheckerPhase0::Word32(0) << ROC_bits);
+  constexpr ErrorCheckerPhase0::Word32 LINK_mask = ~(~ErrorCheckerPhase0::Word32(0) << LINK_bits);
+  constexpr ErrorCheckerPhase0::Word32 ROC_mask  = ~(~ErrorCheckerPhase0::Word32(0) << ROC_bits);
+  constexpr ErrorCheckerPhase0::Word32 OMIT_ERR_mask = ~(~ErrorCheckerPhase0::Word32(0) << OMIT_ERR_bits);
+}  
+
+ErrorCheckerPhase0::ErrorCheckerPhase0() {
+
+  includeErrors = false;
+}
+
+void ErrorCheckerPhase0::setErrorStatus(bool ErrorStatus)
+{
+  includeErrors = ErrorStatus;
+}
+
+bool ErrorCheckerPhase0::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors)
+{
+  int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
+  if (CRC_BIT == 0) return true;
+  errorsInEvent = true;
+  if (includeErrors) {
+    int errorType = 39;
+    SiPixelRawDataError error(*trailer, errorType, fedId);
+    errors[dummyDetId].push_back(error);
+  }
+  return false;
+}
+
+bool ErrorCheckerPhase0::checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors)
+{
+  FEDHeader fedHeader( reinterpret_cast<const unsigned char*>(header));
+  if ( !fedHeader.check() ) return false; // throw exception?
+  if ( fedHeader.sourceID() != fedId) { 
+    LogDebug("PixelDataFormatter::interpretRawData, fedHeader.sourceID() != fedId")
+      <<", sourceID = " <<fedHeader.sourceID()
+      <<", fedId = "<<fedId<<", errorType = 32"; 
+    errorsInEvent = true;
+    if (includeErrors) {
+      int errorType = 32;
+      SiPixelRawDataError error(*header, errorType, fedId);
+      errors[dummyDetId].push_back(error);
+    }
+  }
+  return fedHeader.moreHeaders();
+}
+
+bool ErrorCheckerPhase0::checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors)
+{
+  FEDTrailer fedTrailer(reinterpret_cast<const unsigned char*>(trailer));
+  if ( !fedTrailer.check()) { 
+    if(includeErrors) {
+      int errorType = 33;
+      SiPixelRawDataError error(*trailer, errorType, fedId);
+      errors[dummyDetId].push_back(error);
+    }
+    errorsInEvent = true;
+    LogError("FedTrailerCheck")
+      <<"fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
+    return false; 
+  } 
+  if ( fedTrailer.fragmentLength()!= nWords) {
+    LogError("FedTrailerLenght")<< "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId << ", errorType = 34";
+    errorsInEvent = true;
+    if(includeErrors) {
+      int errorType = 34;
+      SiPixelRawDataError error(*trailer, errorType, fedId);
+      errors[dummyDetId].push_back(error);
+    }
+  }
+  return fedTrailer.moreTrailers();
+}
+
+bool ErrorCheckerPhase0::checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
+			    const SiPixelFedCabling* theCablingTree, Word32& errorWord, Errors& errors)
+{
+  int errorType = (errorWord >> ROC_shift) & ERROR_mask;
+  if LIKELY(errorType<25) return true;
+
+ switch (errorType) {
+    case(25) : {
+     LogDebug("")<<"  invalid ROC=25 found (errorType=25)";
+     errorsInEvent = true;
+     break;
+   }
+   case(26) : {
+     //LogDebug("")<<"  gap word found (errorType=26)";
+     return false;
+   }
+   case(27) : {
+     //LogDebug("")<<"  dummy word found (errorType=27)";
+     return false;
+   }
+   case(28) : {
+     LogDebug("")<<"  error fifo nearly full (errorType=28)";
+     errorsInEvent = true;
+     break;
+   }
+   case(29) : {
+     LogDebug("")<<"  timeout on a channel (errorType=29)";
+     errorsInEvent = true;
+     if ((errorWord >> OMIT_ERR_shift) & OMIT_ERR_mask) {
+       LogDebug("")<<"  ...first errorType=29 error, this gets masked out";
+       return false;
+     }
+     break;
+   }
+   case(30) : {
+     LogDebug("")<<"  TBM error trailer (errorType=30)";
+     errorsInEvent = true;
+     break;
+   }
+   case(31) : {
+     LogDebug("")<<"  event number error (errorType=31)";
+     errorsInEvent = true;
+     break;
+   }
+   default: return true;
+ };
+
+ if(includeErrors) {
+   // check to see if overflow error for type 30, change type to 40 if so
+   if(errorType==30) {
+     int StateMach_bits      = 4;
+     int StateMach_shift     = 8;
+     uint32_t StateMach_mask = ~(~uint32_t(0) << StateMach_bits);
+     int StateMach = (errorWord >> StateMach_shift) & StateMach_mask;
+     if( StateMach==4 || StateMach==9 ) errorType = 40;
+   }
+
+   // store error
+   SiPixelRawDataError error(errorWord, errorType, fedId);
+   cms_uint32_t detId;
+   detId = errorDetId(converter, errorType, errorWord);
+   errors[detId].push_back(error);
+ }
+ return false;
+}
+
+void ErrorCheckerPhase0::conversionError(int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors)
+{
+  switch (status) {
+  case(1) : {
+    LogDebug("ErrorCheckerPhase0::conversionError") << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
+    if(includeErrors) {
+      int errorType = 35;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
+    }
+    break;
+  }
+  case(2) : {
+    LogDebug("ErrorCheckerPhase0::conversionError")<< " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
+    if(includeErrors) {
+      int errorType = 36;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
+    }
+    break;
+  }
+  case(3) : {
+    LogDebug("ErrorCheckerPhase0::conversionError")<< " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
+    if(includeErrors) {
+      int errorType = 37;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
+    }
+    break;
+  }
+  case(4) : {
+    LogDebug("ErrorCheckerPhase0::conversionError")<< " Fed: " << fedId << "  dcol/pixel read out of order (errorType=38)";
+    if(includeErrors) {
+      int errorType = 38;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
+    }
+    break;
+  }
+  default: LogDebug("ErrorCheckerPhase0::conversionError")<<"  cabling check returned unexpected result, status = "<< status;
+  };
+}
+
+// this function finds the detId for an error word that cannot be processed in word2digi
+cms_uint32_t ErrorCheckerPhase0::errorDetId(const SiPixelFrameConverter* converter, 
+    int errorType, const Word32 & word) const
+{
+  if (!converter) return dummyDetId;
+
+  ElectronicIndex cabling;
+
+  switch (errorType) {
+    case  25 : case  30 : case  31 : case  36 : case 40 : {
+      // set dummy values for cabling just to get detId from link if in Barrel
+      cabling.dcol = 0;
+      cabling.pxid = 2;
+      cabling.roc  = 1;
+      cabling.link = (word >> LINK_shift) & LINK_mask;  
+
+      DetectorIndex detIdx;
+      int status = converter->toDetector(cabling, detIdx);
+      if (status) break;
+      if(DetId(detIdx.rawId).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) return detIdx.rawId;
+      break;
+    }
+    case  29 : {
+      int chanNmbr = 0;
+      const int DB0_shift = 0;
+      const int DB1_shift = DB0_shift + 1;
+      const int DB2_shift = DB1_shift + 1;
+      const int DB3_shift = DB2_shift + 1;
+      const int DB4_shift = DB3_shift + 1;
+      const cms_uint32_t DataBit_mask = ~(~cms_uint32_t(0) << 1);
+
+      int CH1 = (word >> DB0_shift) & DataBit_mask;
+      int CH2 = (word >> DB1_shift) & DataBit_mask;
+      int CH3 = (word >> DB2_shift) & DataBit_mask;
+      int CH4 = (word >> DB3_shift) & DataBit_mask;
+      int CH5 = (word >> DB4_shift) & DataBit_mask;
+      int BLOCK_bits      = 3;
+      int BLOCK_shift     = 8;
+      cms_uint32_t BLOCK_mask = ~(~cms_uint32_t(0) << BLOCK_bits);
+      int BLOCK = (word >> BLOCK_shift) & BLOCK_mask;
+      int localCH = 1*CH1+2*CH2+3*CH3+4*CH4+5*CH5;
+      if (BLOCK%2==0) chanNmbr=(BLOCK/2)*9+localCH;
+      else chanNmbr = ((BLOCK-1)/2)*9+4+localCH;
+      if ((chanNmbr<1)||(chanNmbr>36)) break;  // signifies unexpected result
+      
+      // set dummy values for cabling just to get detId from link if in Barrel
+      cabling.dcol = 0;
+      cabling.pxid = 2;
+      cabling.roc  = 1;
+      cabling.link = chanNmbr;  
+      DetectorIndex detIdx;
+      int status = converter->toDetector(cabling, detIdx);
+      if (status) break;
+      if(DetId(detIdx.rawId).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) return detIdx.rawId;
+      break;
+    }
+    case  37 : case  38: {
+      cabling.dcol = 0;
+      cabling.pxid = 2;
+      cabling.roc  = (word >> ROC_shift) & ROC_mask;
+      cabling.link = (word >> LINK_shift) & LINK_mask;
+
+      DetectorIndex detIdx;
+      int status = converter->toDetector(cabling, detIdx);
+      if (status) break;
+
+      return detIdx.rawId;
+      break;
+    }
+  default : break;
+  };
+  return dummyDetId;
+}

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
@@ -20,43 +20,37 @@ using namespace sipixelobjects;
 namespace {
   constexpr int CRC_bits = 1;
   constexpr int LINK_bits = 6;
-  constexpr int ROC_bits  = 5;
+  constexpr int ROC_bits = 5;
   constexpr int DCOL_bits = 5;
   constexpr int PXID_bits = 8;
-  constexpr int ADC_bits  = 8;
+  constexpr int ADC_bits = 8;
   constexpr int OMIT_ERR_bits = 1;
-  
+
   constexpr int CRC_shift = 2;
-  constexpr int ADC_shift  = 0;
+  constexpr int ADC_shift = 0;
   constexpr int PXID_shift = ADC_shift + ADC_bits;
   constexpr int DCOL_shift = PXID_shift + PXID_bits;
-  constexpr int ROC_shift  = DCOL_shift + DCOL_bits;
+  constexpr int ROC_shift = DCOL_shift + DCOL_bits;
   constexpr int LINK_shift = ROC_shift + ROC_bits;
   constexpr int OMIT_ERR_shift = 20;
-  
+
   constexpr cms_uint32_t dummyDetId = 0xffffffff;
-  
+
   constexpr ErrorCheckerPhase0::Word64 CRC_mask = ~(~ErrorCheckerPhase0::Word64(0) << CRC_bits);
   constexpr ErrorCheckerPhase0::Word32 ERROR_mask = ~(~ErrorCheckerPhase0::Word32(0) << ROC_bits);
   constexpr ErrorCheckerPhase0::Word32 LINK_mask = ~(~ErrorCheckerPhase0::Word32(0) << LINK_bits);
-  constexpr ErrorCheckerPhase0::Word32 ROC_mask  = ~(~ErrorCheckerPhase0::Word32(0) << ROC_bits);
+  constexpr ErrorCheckerPhase0::Word32 ROC_mask = ~(~ErrorCheckerPhase0::Word32(0) << ROC_bits);
   constexpr ErrorCheckerPhase0::Word32 OMIT_ERR_mask = ~(~ErrorCheckerPhase0::Word32(0) << OMIT_ERR_bits);
-}  
+}  // namespace
 
-ErrorCheckerPhase0::ErrorCheckerPhase0() {
+ErrorCheckerPhase0::ErrorCheckerPhase0() { includeErrors = false; }
 
-  includeErrors = false;
-}
+void ErrorCheckerPhase0::setErrorStatus(bool ErrorStatus) { includeErrors = ErrorStatus; }
 
-void ErrorCheckerPhase0::setErrorStatus(bool ErrorStatus)
-{
-  includeErrors = ErrorStatus;
-}
-
-bool ErrorCheckerPhase0::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors)
-{
+bool ErrorCheckerPhase0::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) {
   int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
-  if (CRC_BIT == 0) return true;
+  if (CRC_BIT == 0)
+    return true;
   errorsInEvent = true;
   if (includeErrors) {
     int errorType = 39;
@@ -66,14 +60,13 @@ bool ErrorCheckerPhase0::checkCRC(bool& errorsInEvent, int fedId, const Word64* 
   return false;
 }
 
-bool ErrorCheckerPhase0::checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors)
-{
-  FEDHeader fedHeader( reinterpret_cast<const unsigned char*>(header));
-  if ( !fedHeader.check() ) return false; // throw exception?
-  if ( fedHeader.sourceID() != fedId) { 
+bool ErrorCheckerPhase0::checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) {
+  FEDHeader fedHeader(reinterpret_cast<const unsigned char*>(header));
+  if (!fedHeader.check())
+    return false;  // throw exception?
+  if (fedHeader.sourceID() != fedId) {
     LogDebug("PixelDataFormatter::interpretRawData, fedHeader.sourceID() != fedId")
-      <<", sourceID = " <<fedHeader.sourceID()
-      <<", fedId = "<<fedId<<", errorType = 32"; 
+        << ", sourceID = " << fedHeader.sourceID() << ", fedId = " << fedId << ", errorType = 32";
     errorsInEvent = true;
     if (includeErrors) {
       int errorType = 32;
@@ -84,24 +77,23 @@ bool ErrorCheckerPhase0::checkHeader(bool& errorsInEvent, int fedId, const Word6
   return fedHeader.moreHeaders();
 }
 
-bool ErrorCheckerPhase0::checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors)
-{
+bool ErrorCheckerPhase0::checkTrailer(
+    bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) {
   FEDTrailer fedTrailer(reinterpret_cast<const unsigned char*>(trailer));
-  if ( !fedTrailer.check()) { 
-    if(includeErrors) {
+  if (!fedTrailer.check()) {
+    if (includeErrors) {
       int errorType = 33;
       SiPixelRawDataError error(*trailer, errorType, fedId);
       errors[dummyDetId].push_back(error);
     }
     errorsInEvent = true;
-    LogError("FedTrailerCheck")
-      <<"fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
-    return false; 
-  } 
-  if ( fedTrailer.fragmentLength()!= nWords) {
-    LogError("FedTrailerLenght")<< "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId << ", errorType = 34";
+    LogError("FedTrailerCheck") << "fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
+    return false;
+  }
+  if (fedTrailer.fragmentLength() != nWords) {
+    LogError("FedTrailerLenght") << "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId << ", errorType = 34";
     errorsInEvent = true;
-    if(includeErrors) {
+    if (includeErrors) {
       int errorType = 34;
       SiPixelRawDataError error(*trailer, errorType, fedId);
       errors[dummyDetId].push_back(error);
@@ -110,142 +102,159 @@ bool ErrorCheckerPhase0::checkTrailer(bool& errorsInEvent, int fedId, unsigned i
   return fedTrailer.moreTrailers();
 }
 
-bool ErrorCheckerPhase0::checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
-			    const SiPixelFedCabling* theCablingTree, Word32& errorWord, Errors& errors)
-{
+bool ErrorCheckerPhase0::checkROC(bool& errorsInEvent,
+                                  int fedId,
+                                  const SiPixelFrameConverter* converter,
+                                  const SiPixelFedCabling* theCablingTree,
+                                  Word32& errorWord,
+                                  Errors& errors) {
   int errorType = (errorWord >> ROC_shift) & ERROR_mask;
-  if LIKELY(errorType<25) return true;
+  if
+    LIKELY(errorType < 25) return true;
 
- switch (errorType) {
-    case(25) : {
-     LogDebug("")<<"  invalid ROC=25 found (errorType=25)";
-     errorsInEvent = true;
-     break;
-   }
-   case(26) : {
-     //LogDebug("")<<"  gap word found (errorType=26)";
-     return false;
-   }
-   case(27) : {
-     //LogDebug("")<<"  dummy word found (errorType=27)";
-     return false;
-   }
-   case(28) : {
-     LogDebug("")<<"  error fifo nearly full (errorType=28)";
-     errorsInEvent = true;
-     break;
-   }
-   case(29) : {
-     LogDebug("")<<"  timeout on a channel (errorType=29)";
-     errorsInEvent = true;
-     if ((errorWord >> OMIT_ERR_shift) & OMIT_ERR_mask) {
-       LogDebug("")<<"  ...first errorType=29 error, this gets masked out";
-       return false;
-     }
-     break;
-   }
-   case(30) : {
-     LogDebug("")<<"  TBM error trailer (errorType=30)";
-     errorsInEvent = true;
-     break;
-   }
-   case(31) : {
-     LogDebug("")<<"  event number error (errorType=31)";
-     errorsInEvent = true;
-     break;
-   }
-   default: return true;
- };
+  switch (errorType) {
+    case (25): {
+      LogDebug("") << "  invalid ROC=25 found (errorType=25)";
+      errorsInEvent = true;
+      break;
+    }
+    case (26): {
+      //LogDebug("")<<"  gap word found (errorType=26)";
+      return false;
+    }
+    case (27): {
+      //LogDebug("")<<"  dummy word found (errorType=27)";
+      return false;
+    }
+    case (28): {
+      LogDebug("") << "  error fifo nearly full (errorType=28)";
+      errorsInEvent = true;
+      break;
+    }
+    case (29): {
+      LogDebug("") << "  timeout on a channel (errorType=29)";
+      errorsInEvent = true;
+      if ((errorWord >> OMIT_ERR_shift) & OMIT_ERR_mask) {
+        LogDebug("") << "  ...first errorType=29 error, this gets masked out";
+        return false;
+      }
+      break;
+    }
+    case (30): {
+      LogDebug("") << "  TBM error trailer (errorType=30)";
+      errorsInEvent = true;
+      break;
+    }
+    case (31): {
+      LogDebug("") << "  event number error (errorType=31)";
+      errorsInEvent = true;
+      break;
+    }
+    default:
+      return true;
+  };
 
- if(includeErrors) {
-   // check to see if overflow error for type 30, change type to 40 if so
-   if(errorType==30) {
-     int StateMach_bits      = 4;
-     int StateMach_shift     = 8;
-     uint32_t StateMach_mask = ~(~uint32_t(0) << StateMach_bits);
-     int StateMach = (errorWord >> StateMach_shift) & StateMach_mask;
-     if( StateMach==4 || StateMach==9 ) errorType = 40;
-   }
+  if (includeErrors) {
+    // check to see if overflow error for type 30, change type to 40 if so
+    if (errorType == 30) {
+      int StateMach_bits = 4;
+      int StateMach_shift = 8;
+      uint32_t StateMach_mask = ~(~uint32_t(0) << StateMach_bits);
+      int StateMach = (errorWord >> StateMach_shift) & StateMach_mask;
+      if (StateMach == 4 || StateMach == 9)
+        errorType = 40;
+    }
 
-   // store error
-   SiPixelRawDataError error(errorWord, errorType, fedId);
-   cms_uint32_t detId;
-   detId = errorDetId(converter, errorType, errorWord);
-   errors[detId].push_back(error);
- }
- return false;
+    // store error
+    SiPixelRawDataError error(errorWord, errorType, fedId);
+    cms_uint32_t detId;
+    detId = errorDetId(converter, errorType, errorWord);
+    errors[detId].push_back(error);
+  }
+  return false;
 }
 
-void ErrorCheckerPhase0::conversionError(int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors)
-{
+void ErrorCheckerPhase0::conversionError(
+    int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) {
   switch (status) {
-  case(1) : {
-    LogDebug("ErrorCheckerPhase0::conversionError") << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
-    if(includeErrors) {
-      int errorType = 35;
-      SiPixelRawDataError error(errorWord, errorType, fedId);
-      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-      errors[detId].push_back(error);
+    case (1): {
+      LogDebug("ErrorCheckerPhase0::conversionError") << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
+      if (includeErrors) {
+        int errorType = 35;
+        SiPixelRawDataError error(errorWord, errorType, fedId);
+        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+        errors[detId].push_back(error);
+      }
+      break;
     }
-    break;
-  }
-  case(2) : {
-    LogDebug("ErrorCheckerPhase0::conversionError")<< " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
-    if(includeErrors) {
-      int errorType = 36;
-      SiPixelRawDataError error(errorWord, errorType, fedId);
-      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-      errors[detId].push_back(error);
+    case (2): {
+      LogDebug("ErrorCheckerPhase0::conversionError") << " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
+      if (includeErrors) {
+        int errorType = 36;
+        SiPixelRawDataError error(errorWord, errorType, fedId);
+        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+        errors[detId].push_back(error);
+      }
+      break;
     }
-    break;
-  }
-  case(3) : {
-    LogDebug("ErrorCheckerPhase0::conversionError")<< " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
-    if(includeErrors) {
-      int errorType = 37;
-      SiPixelRawDataError error(errorWord, errorType, fedId);
-      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-      errors[detId].push_back(error);
+    case (3): {
+      LogDebug("ErrorCheckerPhase0::conversionError")
+          << " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
+      if (includeErrors) {
+        int errorType = 37;
+        SiPixelRawDataError error(errorWord, errorType, fedId);
+        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+        errors[detId].push_back(error);
+      }
+      break;
     }
-    break;
-  }
-  case(4) : {
-    LogDebug("ErrorCheckerPhase0::conversionError")<< " Fed: " << fedId << "  dcol/pixel read out of order (errorType=38)";
-    if(includeErrors) {
-      int errorType = 38;
-      SiPixelRawDataError error(errorWord, errorType, fedId);
-      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-      errors[detId].push_back(error);
+    case (4): {
+      LogDebug("ErrorCheckerPhase0::conversionError")
+          << " Fed: " << fedId << "  dcol/pixel read out of order (errorType=38)";
+      if (includeErrors) {
+        int errorType = 38;
+        SiPixelRawDataError error(errorWord, errorType, fedId);
+        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+        errors[detId].push_back(error);
+      }
+      break;
     }
-    break;
-  }
-  default: LogDebug("ErrorCheckerPhase0::conversionError")<<"  cabling check returned unexpected result, status = "<< status;
+    default:
+      LogDebug("ErrorCheckerPhase0::conversionError")
+          << "  cabling check returned unexpected result, status = " << status;
   };
 }
 
 // this function finds the detId for an error word that cannot be processed in word2digi
-cms_uint32_t ErrorCheckerPhase0::errorDetId(const SiPixelFrameConverter* converter, 
-    int errorType, const Word32 & word) const
-{
-  if (!converter) return dummyDetId;
+cms_uint32_t ErrorCheckerPhase0::errorDetId(const SiPixelFrameConverter* converter,
+                                            int errorType,
+                                            const Word32& word) const {
+  if (!converter)
+    return dummyDetId;
 
   ElectronicIndex cabling;
 
   switch (errorType) {
-    case  25 : case  30 : case  31 : case  36 : case 40 : {
+    case 25:
+    case 30:
+    case 31:
+    case 36:
+    case 40: {
       // set dummy values for cabling just to get detId from link if in Barrel
       cabling.dcol = 0;
       cabling.pxid = 2;
-      cabling.roc  = 1;
-      cabling.link = (word >> LINK_shift) & LINK_mask;  
+      cabling.roc = 1;
+      cabling.link = (word >> LINK_shift) & LINK_mask;
 
       DetectorIndex detIdx;
       int status = converter->toDetector(cabling, detIdx);
-      if (status) break;
-      if(DetId(detIdx.rawId).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) return detIdx.rawId;
+      if (status)
+        break;
+      if (DetId(detIdx.rawId).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel))
+        return detIdx.rawId;
       break;
     }
-    case  29 : {
+    case 29: {
       int chanNmbr = 0;
       const int DB0_shift = 0;
       const int DB1_shift = DB0_shift + 1;
@@ -259,40 +268,48 @@ cms_uint32_t ErrorCheckerPhase0::errorDetId(const SiPixelFrameConverter* convert
       int CH3 = (word >> DB2_shift) & DataBit_mask;
       int CH4 = (word >> DB3_shift) & DataBit_mask;
       int CH5 = (word >> DB4_shift) & DataBit_mask;
-      int BLOCK_bits      = 3;
-      int BLOCK_shift     = 8;
+      int BLOCK_bits = 3;
+      int BLOCK_shift = 8;
       cms_uint32_t BLOCK_mask = ~(~cms_uint32_t(0) << BLOCK_bits);
       int BLOCK = (word >> BLOCK_shift) & BLOCK_mask;
-      int localCH = 1*CH1+2*CH2+3*CH3+4*CH4+5*CH5;
-      if (BLOCK%2==0) chanNmbr=(BLOCK/2)*9+localCH;
-      else chanNmbr = ((BLOCK-1)/2)*9+4+localCH;
-      if ((chanNmbr<1)||(chanNmbr>36)) break;  // signifies unexpected result
-      
+      int localCH = 1 * CH1 + 2 * CH2 + 3 * CH3 + 4 * CH4 + 5 * CH5;
+      if (BLOCK % 2 == 0)
+        chanNmbr = (BLOCK / 2) * 9 + localCH;
+      else
+        chanNmbr = ((BLOCK - 1) / 2) * 9 + 4 + localCH;
+      if ((chanNmbr < 1) || (chanNmbr > 36))
+        break;  // signifies unexpected result
+
       // set dummy values for cabling just to get detId from link if in Barrel
       cabling.dcol = 0;
       cabling.pxid = 2;
-      cabling.roc  = 1;
-      cabling.link = chanNmbr;  
+      cabling.roc = 1;
+      cabling.link = chanNmbr;
       DetectorIndex detIdx;
       int status = converter->toDetector(cabling, detIdx);
-      if (status) break;
-      if(DetId(detIdx.rawId).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) return detIdx.rawId;
+      if (status)
+        break;
+      if (DetId(detIdx.rawId).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel))
+        return detIdx.rawId;
       break;
     }
-    case  37 : case  38: {
+    case 37:
+    case 38: {
       cabling.dcol = 0;
       cabling.pxid = 2;
-      cabling.roc  = (word >> ROC_shift) & ROC_mask;
+      cabling.roc = (word >> ROC_shift) & ROC_mask;
       cabling.link = (word >> LINK_shift) & LINK_mask;
 
       DetectorIndex detIdx;
       int status = converter->toDetector(cabling, detIdx);
-      if (status) break;
+      if (status)
+        break;
 
       return detIdx.rawId;
       break;
     }
-  default : break;
+    default:
+      break;
   };
   return dummyDetId;
 }

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
@@ -3,51 +3,59 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/FEDRawData/interface/FEDHeader.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <bitset>
-#include <sstream>
 #include <iostream>
+#include <sstream>
 
 using namespace std;
 using namespace edm;
 using namespace sipixelobjects;
 
 namespace {
-  constexpr int CRC_bits = 1;
-  constexpr int LINK_bits = 6;
-  constexpr int ROC_bits = 5;
-  constexpr int DCOL_bits = 5;
-  constexpr int PXID_bits = 8;
-  constexpr int ADC_bits = 8;
-  constexpr int OMIT_ERR_bits = 1;
+constexpr int CRC_bits = 1;
+constexpr int LINK_bits = 6;
+constexpr int ROC_bits = 5;
+constexpr int DCOL_bits = 5;
+constexpr int PXID_bits = 8;
+constexpr int ADC_bits = 8;
+constexpr int OMIT_ERR_bits = 1;
 
-  constexpr int CRC_shift = 2;
-  constexpr int ADC_shift = 0;
-  constexpr int PXID_shift = ADC_shift + ADC_bits;
-  constexpr int DCOL_shift = PXID_shift + PXID_bits;
-  constexpr int ROC_shift = DCOL_shift + DCOL_bits;
-  constexpr int LINK_shift = ROC_shift + ROC_bits;
-  constexpr int OMIT_ERR_shift = 20;
+constexpr int CRC_shift = 2;
+constexpr int ADC_shift = 0;
+constexpr int PXID_shift = ADC_shift + ADC_bits;
+constexpr int DCOL_shift = PXID_shift + PXID_bits;
+constexpr int ROC_shift = DCOL_shift + DCOL_bits;
+constexpr int LINK_shift = ROC_shift + ROC_bits;
+constexpr int OMIT_ERR_shift = 20;
 
-  constexpr cms_uint32_t dummyDetId = 0xffffffff;
+constexpr cms_uint32_t dummyDetId = 0xffffffff;
 
-  constexpr ErrorCheckerPhase0::Word64 CRC_mask = ~(~ErrorCheckerPhase0::Word64(0) << CRC_bits);
-  constexpr ErrorCheckerPhase0::Word32 ERROR_mask = ~(~ErrorCheckerPhase0::Word32(0) << ROC_bits);
-  constexpr ErrorCheckerPhase0::Word32 LINK_mask = ~(~ErrorCheckerPhase0::Word32(0) << LINK_bits);
-  constexpr ErrorCheckerPhase0::Word32 ROC_mask = ~(~ErrorCheckerPhase0::Word32(0) << ROC_bits);
-  constexpr ErrorCheckerPhase0::Word32 OMIT_ERR_mask = ~(~ErrorCheckerPhase0::Word32(0) << OMIT_ERR_bits);
-}  // namespace
+constexpr ErrorCheckerPhase0::Word64 CRC_mask =
+    ~(~ErrorCheckerPhase0::Word64(0) << CRC_bits);
+constexpr ErrorCheckerPhase0::Word32 ERROR_mask =
+    ~(~ErrorCheckerPhase0::Word32(0) << ROC_bits);
+constexpr ErrorCheckerPhase0::Word32 LINK_mask =
+    ~(~ErrorCheckerPhase0::Word32(0) << LINK_bits);
+constexpr ErrorCheckerPhase0::Word32 ROC_mask =
+    ~(~ErrorCheckerPhase0::Word32(0) << ROC_bits);
+constexpr ErrorCheckerPhase0::Word32 OMIT_ERR_mask =
+    ~(~ErrorCheckerPhase0::Word32(0) << OMIT_ERR_bits);
+} // namespace
 
 ErrorCheckerPhase0::ErrorCheckerPhase0() { includeErrors = false; }
 
-void ErrorCheckerPhase0::setErrorStatus(bool ErrorStatus) { includeErrors = ErrorStatus; }
+void ErrorCheckerPhase0::setErrorStatus(bool ErrorStatus) {
+  includeErrors = ErrorStatus;
+}
 
-bool ErrorCheckerPhase0::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) {
+bool ErrorCheckerPhase0::checkCRC(bool &errorsInEvent, int fedId,
+                                  const Word64 *trailer, Errors &errors) {
   int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
   if (CRC_BIT == 0)
     return true;
@@ -60,13 +68,16 @@ bool ErrorCheckerPhase0::checkCRC(bool& errorsInEvent, int fedId, const Word64* 
   return false;
 }
 
-bool ErrorCheckerPhase0::checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) {
-  FEDHeader fedHeader(reinterpret_cast<const unsigned char*>(header));
+bool ErrorCheckerPhase0::checkHeader(bool &errorsInEvent, int fedId,
+                                     const Word64 *header, Errors &errors) {
+  FEDHeader fedHeader(reinterpret_cast<const unsigned char *>(header));
   if (!fedHeader.check())
-    return false;  // throw exception?
+    return false; // throw exception?
   if (fedHeader.sourceID() != fedId) {
-    LogDebug("PixelDataFormatter::interpretRawData, fedHeader.sourceID() != fedId")
-        << ", sourceID = " << fedHeader.sourceID() << ", fedId = " << fedId << ", errorType = 32";
+    LogDebug(
+        "PixelDataFormatter::interpretRawData, fedHeader.sourceID() != fedId")
+        << ", sourceID = " << fedHeader.sourceID() << ", fedId = " << fedId
+        << ", errorType = 32";
     errorsInEvent = true;
     if (includeErrors) {
       int errorType = 32;
@@ -77,9 +88,10 @@ bool ErrorCheckerPhase0::checkHeader(bool& errorsInEvent, int fedId, const Word6
   return fedHeader.moreHeaders();
 }
 
-bool ErrorCheckerPhase0::checkTrailer(
-    bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) {
-  FEDTrailer fedTrailer(reinterpret_cast<const unsigned char*>(trailer));
+bool ErrorCheckerPhase0::checkTrailer(bool &errorsInEvent, int fedId,
+                                      unsigned int nWords,
+                                      const Word64 *trailer, Errors &errors) {
+  FEDTrailer fedTrailer(reinterpret_cast<const unsigned char *>(trailer));
   if (!fedTrailer.check()) {
     if (includeErrors) {
       int errorType = 33;
@@ -87,11 +99,14 @@ bool ErrorCheckerPhase0::checkTrailer(
       errors[dummyDetId].push_back(error);
     }
     errorsInEvent = true;
-    LogError("FedTrailerCheck") << "fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
+    LogError("FedTrailerCheck")
+        << "fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
     return false;
   }
   if (fedTrailer.fragmentLength() != nWords) {
-    LogError("FedTrailerLenght") << "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId << ", errorType = 34";
+    LogError("FedTrailerLenght")
+        << "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId
+        << ", errorType = 34";
     errorsInEvent = true;
     if (includeErrors) {
       int errorType = 34;
@@ -102,56 +117,54 @@ bool ErrorCheckerPhase0::checkTrailer(
   return fedTrailer.moreTrailers();
 }
 
-bool ErrorCheckerPhase0::checkROC(bool& errorsInEvent,
-                                  int fedId,
-                                  const SiPixelFrameConverter* converter,
-                                  const SiPixelFedCabling* theCablingTree,
-                                  Word32& errorWord,
-                                  Errors& errors) {
+bool ErrorCheckerPhase0::checkROC(bool &errorsInEvent, int fedId,
+                                  const SiPixelFrameConverter *converter,
+                                  const SiPixelFedCabling *theCablingTree,
+                                  Word32 &errorWord, Errors &errors) {
   int errorType = (errorWord >> ROC_shift) & ERROR_mask;
   if
     LIKELY(errorType < 25) return true;
 
   switch (errorType) {
-    case (25): {
-      LogDebug("") << "  invalid ROC=25 found (errorType=25)";
-      errorsInEvent = true;
-      break;
-    }
-    case (26): {
-      //LogDebug("")<<"  gap word found (errorType=26)";
+  case (25): {
+    LogDebug("") << "  invalid ROC=25 found (errorType=25)";
+    errorsInEvent = true;
+    break;
+  }
+  case (26): {
+    // LogDebug("")<<"  gap word found (errorType=26)";
+    return false;
+  }
+  case (27): {
+    // LogDebug("")<<"  dummy word found (errorType=27)";
+    return false;
+  }
+  case (28): {
+    LogDebug("") << "  error fifo nearly full (errorType=28)";
+    errorsInEvent = true;
+    break;
+  }
+  case (29): {
+    LogDebug("") << "  timeout on a channel (errorType=29)";
+    errorsInEvent = true;
+    if ((errorWord >> OMIT_ERR_shift) & OMIT_ERR_mask) {
+      LogDebug("") << "  ...first errorType=29 error, this gets masked out";
       return false;
     }
-    case (27): {
-      //LogDebug("")<<"  dummy word found (errorType=27)";
-      return false;
-    }
-    case (28): {
-      LogDebug("") << "  error fifo nearly full (errorType=28)";
-      errorsInEvent = true;
-      break;
-    }
-    case (29): {
-      LogDebug("") << "  timeout on a channel (errorType=29)";
-      errorsInEvent = true;
-      if ((errorWord >> OMIT_ERR_shift) & OMIT_ERR_mask) {
-        LogDebug("") << "  ...first errorType=29 error, this gets masked out";
-        return false;
-      }
-      break;
-    }
-    case (30): {
-      LogDebug("") << "  TBM error trailer (errorType=30)";
-      errorsInEvent = true;
-      break;
-    }
-    case (31): {
-      LogDebug("") << "  event number error (errorType=31)";
-      errorsInEvent = true;
-      break;
-    }
-    default:
-      return true;
+    break;
+  }
+  case (30): {
+    LogDebug("") << "  TBM error trailer (errorType=30)";
+    errorsInEvent = true;
+    break;
+  }
+  case (31): {
+    LogDebug("") << "  event number error (errorType=31)";
+    errorsInEvent = true;
+    break;
+  }
+  default:
+    return true;
   };
 
   if (includeErrors) {
@@ -174,142 +187,149 @@ bool ErrorCheckerPhase0::checkROC(bool& errorsInEvent,
   return false;
 }
 
-void ErrorCheckerPhase0::conversionError(
-    int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors) {
+void ErrorCheckerPhase0::conversionError(int fedId,
+                                         const SiPixelFrameConverter *converter,
+                                         int status, Word32 &errorWord,
+                                         Errors &errors) {
   switch (status) {
-    case (1): {
-      LogDebug("ErrorCheckerPhase0::conversionError") << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
-      if (includeErrors) {
-        int errorType = 35;
-        SiPixelRawDataError error(errorWord, errorType, fedId);
-        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-        errors[detId].push_back(error);
-      }
-      break;
+  case (1): {
+    LogDebug("ErrorCheckerPhase0::conversionError")
+        << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
+    if (includeErrors) {
+      int errorType = 35;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
     }
-    case (2): {
-      LogDebug("ErrorCheckerPhase0::conversionError") << " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
-      if (includeErrors) {
-        int errorType = 36;
-        SiPixelRawDataError error(errorWord, errorType, fedId);
-        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-        errors[detId].push_back(error);
-      }
-      break;
+    break;
+  }
+  case (2): {
+    LogDebug("ErrorCheckerPhase0::conversionError")
+        << " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
+    if (includeErrors) {
+      int errorType = 36;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
     }
-    case (3): {
-      LogDebug("ErrorCheckerPhase0::conversionError")
-          << " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
-      if (includeErrors) {
-        int errorType = 37;
-        SiPixelRawDataError error(errorWord, errorType, fedId);
-        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-        errors[detId].push_back(error);
-      }
-      break;
+    break;
+  }
+  case (3): {
+    LogDebug("ErrorCheckerPhase0::conversionError")
+        << " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
+    if (includeErrors) {
+      int errorType = 37;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
     }
-    case (4): {
-      LogDebug("ErrorCheckerPhase0::conversionError")
-          << " Fed: " << fedId << "  dcol/pixel read out of order (errorType=38)";
-      if (includeErrors) {
-        int errorType = 38;
-        SiPixelRawDataError error(errorWord, errorType, fedId);
-        cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
-        errors[detId].push_back(error);
-      }
-      break;
+    break;
+  }
+  case (4): {
+    LogDebug("ErrorCheckerPhase0::conversionError")
+        << " Fed: " << fedId << "  dcol/pixel read out of order (errorType=38)";
+    if (includeErrors) {
+      int errorType = 38;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
     }
-    default:
-      LogDebug("ErrorCheckerPhase0::conversionError")
-          << "  cabling check returned unexpected result, status = " << status;
+    break;
+  }
+  default:
+    LogDebug("ErrorCheckerPhase0::conversionError")
+        << "  cabling check returned unexpected result, status = " << status;
   };
 }
 
-// this function finds the detId for an error word that cannot be processed in word2digi
-cms_uint32_t ErrorCheckerPhase0::errorDetId(const SiPixelFrameConverter* converter,
-                                            int errorType,
-                                            const Word32& word) const {
+// this function finds the detId for an error word that cannot be processed in
+// word2digi
+cms_uint32_t
+ErrorCheckerPhase0::errorDetId(const SiPixelFrameConverter *converter,
+                               int errorType, const Word32 &word) const {
   if (!converter)
     return dummyDetId;
 
   ElectronicIndex cabling;
 
   switch (errorType) {
-    case 25:
-    case 30:
-    case 31:
-    case 36:
-    case 40: {
-      // set dummy values for cabling just to get detId from link if in Barrel
-      cabling.dcol = 0;
-      cabling.pxid = 2;
-      cabling.roc = 1;
-      cabling.link = (word >> LINK_shift) & LINK_mask;
+  case 25:
+  case 30:
+  case 31:
+  case 36:
+  case 40: {
+    // set dummy values for cabling just to get detId from link if in Barrel
+    cabling.dcol = 0;
+    cabling.pxid = 2;
+    cabling.roc = 1;
+    cabling.link = (word >> LINK_shift) & LINK_mask;
 
-      DetectorIndex detIdx;
-      int status = converter->toDetector(cabling, detIdx);
-      if (status)
-        break;
-      if (DetId(detIdx.rawId).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel))
-        return detIdx.rawId;
+    DetectorIndex detIdx;
+    int status = converter->toDetector(cabling, detIdx);
+    if (status)
       break;
-    }
-    case 29: {
-      int chanNmbr = 0;
-      const int DB0_shift = 0;
-      const int DB1_shift = DB0_shift + 1;
-      const int DB2_shift = DB1_shift + 1;
-      const int DB3_shift = DB2_shift + 1;
-      const int DB4_shift = DB3_shift + 1;
-      const cms_uint32_t DataBit_mask = ~(~cms_uint32_t(0) << 1);
-
-      int CH1 = (word >> DB0_shift) & DataBit_mask;
-      int CH2 = (word >> DB1_shift) & DataBit_mask;
-      int CH3 = (word >> DB2_shift) & DataBit_mask;
-      int CH4 = (word >> DB3_shift) & DataBit_mask;
-      int CH5 = (word >> DB4_shift) & DataBit_mask;
-      int BLOCK_bits = 3;
-      int BLOCK_shift = 8;
-      cms_uint32_t BLOCK_mask = ~(~cms_uint32_t(0) << BLOCK_bits);
-      int BLOCK = (word >> BLOCK_shift) & BLOCK_mask;
-      int localCH = 1 * CH1 + 2 * CH2 + 3 * CH3 + 4 * CH4 + 5 * CH5;
-      if (BLOCK % 2 == 0)
-        chanNmbr = (BLOCK / 2) * 9 + localCH;
-      else
-        chanNmbr = ((BLOCK - 1) / 2) * 9 + 4 + localCH;
-      if ((chanNmbr < 1) || (chanNmbr > 36))
-        break;  // signifies unexpected result
-
-      // set dummy values for cabling just to get detId from link if in Barrel
-      cabling.dcol = 0;
-      cabling.pxid = 2;
-      cabling.roc = 1;
-      cabling.link = chanNmbr;
-      DetectorIndex detIdx;
-      int status = converter->toDetector(cabling, detIdx);
-      if (status)
-        break;
-      if (DetId(detIdx.rawId).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel))
-        return detIdx.rawId;
-      break;
-    }
-    case 37:
-    case 38: {
-      cabling.dcol = 0;
-      cabling.pxid = 2;
-      cabling.roc = (word >> ROC_shift) & ROC_mask;
-      cabling.link = (word >> LINK_shift) & LINK_mask;
-
-      DetectorIndex detIdx;
-      int status = converter->toDetector(cabling, detIdx);
-      if (status)
-        break;
-
+    if (DetId(detIdx.rawId).subdetId() ==
+        static_cast<int>(PixelSubdetector::PixelBarrel))
       return detIdx.rawId;
+    break;
+  }
+  case 29: {
+    int chanNmbr = 0;
+    const int DB0_shift = 0;
+    const int DB1_shift = DB0_shift + 1;
+    const int DB2_shift = DB1_shift + 1;
+    const int DB3_shift = DB2_shift + 1;
+    const int DB4_shift = DB3_shift + 1;
+    const cms_uint32_t DataBit_mask = ~(~cms_uint32_t(0) << 1);
+
+    int CH1 = (word >> DB0_shift) & DataBit_mask;
+    int CH2 = (word >> DB1_shift) & DataBit_mask;
+    int CH3 = (word >> DB2_shift) & DataBit_mask;
+    int CH4 = (word >> DB3_shift) & DataBit_mask;
+    int CH5 = (word >> DB4_shift) & DataBit_mask;
+    int BLOCK_bits = 3;
+    int BLOCK_shift = 8;
+    cms_uint32_t BLOCK_mask = ~(~cms_uint32_t(0) << BLOCK_bits);
+    int BLOCK = (word >> BLOCK_shift) & BLOCK_mask;
+    int localCH = 1 * CH1 + 2 * CH2 + 3 * CH3 + 4 * CH4 + 5 * CH5;
+    if (BLOCK % 2 == 0)
+      chanNmbr = (BLOCK / 2) * 9 + localCH;
+    else
+      chanNmbr = ((BLOCK - 1) / 2) * 9 + 4 + localCH;
+    if ((chanNmbr < 1) || (chanNmbr > 36))
+      break; // signifies unexpected result
+
+    // set dummy values for cabling just to get detId from link if in Barrel
+    cabling.dcol = 0;
+    cabling.pxid = 2;
+    cabling.roc = 1;
+    cabling.link = chanNmbr;
+    DetectorIndex detIdx;
+    int status = converter->toDetector(cabling, detIdx);
+    if (status)
       break;
-    }
-    default:
+    if (DetId(detIdx.rawId).subdetId() ==
+        static_cast<int>(PixelSubdetector::PixelBarrel))
+      return detIdx.rawId;
+    break;
+  }
+  case 37:
+  case 38: {
+    cabling.dcol = 0;
+    cabling.pxid = 2;
+    cabling.roc = (word >> ROC_shift) & ROC_mask;
+    cabling.link = (word >> LINK_shift) & LINK_mask;
+
+    DetectorIndex detIdx;
+    int status = converter->toDetector(cabling, detIdx);
+    if (status)
       break;
+
+    return detIdx.rawId;
+    break;
+  }
+  default:
+    break;
   };
   return dummyDetId;
 }

--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -25,22 +25,22 @@ using namespace edm;
 using namespace sipixelobjects;
 namespace {
   constexpr int LINK_bits = 6;
-  constexpr int ROC_bits  = 5;
+  constexpr int ROC_bits = 5;
   constexpr int DCOL_bits = 5;
   constexpr int PXID_bits = 8;
-  constexpr int ADC_bits  = 8;
+  constexpr int ADC_bits = 8;
 
-  // Add phase1 constants 
-  // For phase1  
-  //GO BACK TO OLD VALUES. THE 48-CHAN FED DOES NOT NEED A NEW FORMAT 
+  // Add phase1 constants
+  // For phase1
+  //GO BACK TO OLD VALUES. THE 48-CHAN FED DOES NOT NEED A NEW FORMAT
   // 28/9/16 d.k.
-  constexpr int LINK_bits1 = 6; // 7;
-  constexpr int ROC_bits1  = 5; // 4;
+  constexpr int LINK_bits1 = 6;  // 7;
+  constexpr int ROC_bits1 = 5;   // 4;
   // Special for layer 1 bpix rocs 6/9/16 d.k. THIS STAYS.
   constexpr int COL_bits1_l1 = 6;
   constexpr int ROW_bits1_l1 = 7;
 
-  // Moved to the header file, keep commented out unti the final version is done/ 
+  // Moved to the header file, keep commented out unti the final version is done/
   // constexpr int ADC_shift  = 0;
   // constexpr int PXID_shift = ADC_shift + ADC_bits;
   // constexpr int DCOL_shift = PXID_shift + PXID_bits;
@@ -52,102 +52,98 @@ namespace {
   // constexpr PixelDataFormatter::Word32 PXID_mask = ~(~PixelDataFormatter::Word32(0) << PXID_bits);
   // constexpr PixelDataFormatter::Word32 ADC_mask  = ~(~PixelDataFormatter::Word32(0) << ADC_bits);
   //const bool DANEK = false;
-}
+}  // namespace
 
-PixelDataFormatter::PixelDataFormatter( const SiPixelFedCabling* map, bool phase)
-  : theDigiCounter(0), theWordCounter(0), theCablingTree(map), badPixelInfo(nullptr), modulesToUnpack(nullptr), phase1(phase)
-{
+PixelDataFormatter::PixelDataFormatter(const SiPixelFedCabling* map, bool phase)
+    : theDigiCounter(0),
+      theWordCounter(0),
+      theCablingTree(map),
+      badPixelInfo(nullptr),
+      modulesToUnpack(nullptr),
+      phase1(phase) {
   int s32 = sizeof(Word32);
   int s64 = sizeof(Word64);
-  int s8  = sizeof(char);
-  if ( s8 != 1 || s32 != 4*s8 || s64 != 2*s32) {
-     LogError("UnexpectedSizes")
-          <<" unexpected sizes: "
-          <<"  size of char is: " << s8
-          <<", size of Word32 is: " << s32
-          <<", size of Word64 is: " << s64
-          <<", send exception" ;
+  int s8 = sizeof(char);
+  if (s8 != 1 || s32 != 4 * s8 || s64 != 2 * s32) {
+    LogError("UnexpectedSizes") << " unexpected sizes: "
+                                << "  size of char is: " << s8 << ", size of Word32 is: " << s32
+                                << ", size of Word64 is: " << s64 << ", send exception";
   }
   includeErrors = false;
   useQualityInfo = false;
   allDetDigis = 0;
   hasDetDigis = 0;
 
-  ADC_shift  = 0;
+  ADC_shift = 0;
   PXID_shift = ADC_shift + ADC_bits;
   DCOL_shift = PXID_shift + PXID_bits;
-  ROC_shift  = DCOL_shift + DCOL_bits;
+  ROC_shift = DCOL_shift + DCOL_bits;
 
-  if(phase1) {  // for phase 1
+  if (phase1) {  // for phase 1
     LINK_shift = ROC_shift + ROC_bits1;
     LINK_mask = ~(~PixelDataFormatter::Word32(0) << LINK_bits1);
-    ROC_mask  = ~(~PixelDataFormatter::Word32(0) << ROC_bits1);
+    ROC_mask = ~(~PixelDataFormatter::Word32(0) << ROC_bits1);
     // special for layer 1 ROC
     ROW_shift = ADC_shift + ADC_bits;
     COL_shift = ROW_shift + ROW_bits1_l1;
     COL_mask = ~(~PixelDataFormatter::Word32(0) << COL_bits1_l1);
     ROW_mask = ~(~PixelDataFormatter::Word32(0) << ROW_bits1_l1);
-    maxROCIndex=8;
+    maxROCIndex = 8;
 
   } else {  // for phase 0
     LINK_shift = ROC_shift + ROC_bits;
     LINK_mask = ~(~PixelDataFormatter::Word32(0) << LINK_bits);
-    ROC_mask  = ~(~PixelDataFormatter::Word32(0) << ROC_bits);
-    maxROCIndex=25;
+    ROC_mask = ~(~PixelDataFormatter::Word32(0) << ROC_bits);
+    maxROCIndex = 25;
   }
 
   DCOL_mask = ~(~PixelDataFormatter::Word32(0) << DCOL_bits);
   PXID_mask = ~(~PixelDataFormatter::Word32(0) << PXID_bits);
-  ADC_mask  = ~(~PixelDataFormatter::Word32(0) << ADC_bits);
+  ADC_mask = ~(~PixelDataFormatter::Word32(0) << ADC_bits);
 
-  if (phase1==true) {
-    errorcheck=std::unique_ptr<ErrorCheckerBase>(new ErrorChecker());
+  if (phase1 == true) {
+    errorcheck = std::unique_ptr<ErrorCheckerBase>(new ErrorChecker());
   } else {
-    errorcheck=std::unique_ptr<ErrorCheckerBase>(new ErrorCheckerPhase0());
+    errorcheck = std::unique_ptr<ErrorCheckerBase>(new ErrorCheckerPhase0());
   }
 }
 
-void PixelDataFormatter::setErrorStatus(bool ErrorStatus)
-{
+void PixelDataFormatter::setErrorStatus(bool ErrorStatus) {
   includeErrors = ErrorStatus;
   errorcheck->setErrorStatus(includeErrors);
 }
 
-void PixelDataFormatter::setQualityStatus(bool QualityStatus, const SiPixelQuality* QualityInfo)
-{
+void PixelDataFormatter::setQualityStatus(bool QualityStatus, const SiPixelQuality* QualityInfo) {
   useQualityInfo = QualityStatus;
   badPixelInfo = QualityInfo;
 }
 
-void PixelDataFormatter::setModulesToUnpack(const std::set<unsigned int> * moduleIds)
-{
-  modulesToUnpack = moduleIds;
-}
+void PixelDataFormatter::setModulesToUnpack(const std::set<unsigned int>* moduleIds) { modulesToUnpack = moduleIds; }
 
-void PixelDataFormatter::passFrameReverter(const SiPixelFrameReverter* reverter)
-{
-  theFrameReverter = reverter;
-}
+void PixelDataFormatter::passFrameReverter(const SiPixelFrameReverter* reverter) { theFrameReverter = reverter; }
 
-void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const FEDRawData& rawData, Collection & digis, Errors& errors)
-{
+void PixelDataFormatter::interpretRawData(
+    bool& errorsInEvent, int fedId, const FEDRawData& rawData, Collection& digis, Errors& errors) {
   using namespace sipixelobjects;
 
-  int nWords = rawData.size()/sizeof(Word64);
-  if (nWords==0) return;
+  int nWords = rawData.size() / sizeof(Word64);
+  if (nWords == 0)
+    return;
 
   SiPixelFrameConverter converter(theCablingTree, fedId);
 
   // check CRC bit
-  const Word64* trailer = reinterpret_cast<const Word64* >(rawData.data())+(nWords-1);  
-  if(!errorcheck->checkCRC(errorsInEvent, fedId, trailer, errors)) return;
+  const Word64* trailer = reinterpret_cast<const Word64*>(rawData.data()) + (nWords - 1);
+  if (!errorcheck->checkCRC(errorsInEvent, fedId, trailer, errors))
+    return;
 
   // check headers
-  const Word64* header = reinterpret_cast<const Word64* >(rawData.data()); header--;
+  const Word64* header = reinterpret_cast<const Word64*>(rawData.data());
+  header--;
   bool moreHeaders = true;
   while (moreHeaders) {
     header++;
-    LogTrace("")<<"HEADER:  " <<  print(*header);
+    LogTrace("") << "HEADER:  " << print(*header);
     bool headerStatus = errorcheck->checkHeader(errorsInEvent, fedId, header, errors);
     moreHeaders = headerStatus;
   }
@@ -157,117 +153,134 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
   trailer++;
   while (moreTrailers) {
     trailer--;
-    LogTrace("")<<"TRAILER: " <<  print(*trailer);
+    LogTrace("") << "TRAILER: " << print(*trailer);
     bool trailerStatus = errorcheck->checkTrailer(errorsInEvent, fedId, nWords, trailer, errors);
     moreTrailers = trailerStatus;
   }
 
   // data words
-  theWordCounter += 2*(nWords-2);
-  LogTrace("")<<"data words: "<< (trailer-header-1);
+  theWordCounter += 2 * (nWords - 2);
+  LogTrace("") << "data words: " << (trailer - header - 1);
 
   int link = -1;
-  int roc  = -1;
+  int roc = -1;
   int layer = 0;
-  PixelROC const * rocp=nullptr;
-  bool skipROC=false;
-  edm::DetSet<PixelDigi> * detDigis=nullptr;
+  PixelROC const* rocp = nullptr;
+  bool skipROC = false;
+  edm::DetSet<PixelDigi>* detDigis = nullptr;
 
-  const  Word32 * bw =(const  Word32 *)(header+1);
-  const  Word32 * ew =(const  Word32 *)(trailer);
-  if ( *(ew-1) == 0 ) { ew--;  theWordCounter--;}
+  const Word32* bw = (const Word32*)(header + 1);
+  const Word32* ew = (const Word32*)(trailer);
+  if (*(ew - 1) == 0) {
+    ew--;
+    theWordCounter--;
+  }
   for (auto word = bw; word < ew; ++word) {
-    LogTrace("")<<"DATA: " <<  print(*word);
+    LogTrace("") << "DATA: " << print(*word);
 
     auto ww = *word;
-    if UNLIKELY(ww==0) { theWordCounter--; continue;}
-    int nlink = (ww >> LINK_shift) & LINK_mask; 
-    int nroc  = (ww >> ROC_shift) & ROC_mask;
+    if
+      UNLIKELY(ww == 0) {
+        theWordCounter--;
+        continue;
+      }
+    int nlink = (ww >> LINK_shift) & LINK_mask;
+    int nroc = (ww >> ROC_shift) & ROC_mask;
 
     //if(DANEK) cout<<" fed, link, roc "<<fedId<<" "<<nlink<<" "<<nroc<<endl;
 
-    if ( (nlink!=link) | (nroc!=roc) ) {  // new roc
-      link = nlink; roc=nroc;
-      skipROC = LIKELY(roc<maxROCIndex) ? false : !errorcheck->checkROC(errorsInEvent, fedId, &converter, theCablingTree, ww, errors);
-      if (skipROC) continue;
-      rocp = converter.toRoc(link,roc);
-      if UNLIKELY(!rocp) {
-	errorsInEvent = true;
-	errorcheck->conversionError(fedId, &converter, 2, ww, errors);
-	skipROC=true;
-	continue;
-      }
+    if ((nlink != link) | (nroc != roc)) {  // new roc
+      link = nlink;
+      roc = nroc;
+      skipROC = LIKELY(roc < maxROCIndex)
+                    ? false
+                    : !errorcheck->checkROC(errorsInEvent, fedId, &converter, theCablingTree, ww, errors);
+      if (skipROC)
+        continue;
+      rocp = converter.toRoc(link, roc);
+      if
+        UNLIKELY(!rocp) {
+          errorsInEvent = true;
+          errorcheck->conversionError(fedId, &converter, 2, ww, errors);
+          skipROC = true;
+          continue;
+        }
       auto rawId = rocp->rawId();
       bool barrel = PixelModuleName::isBarrel(rawId);
-      if(barrel) layer = PixelROC::bpixLayerPhase1(rawId);
-      else layer=0;
+      if (barrel)
+        layer = PixelROC::bpixLayerPhase1(rawId);
+      else
+        layer = 0;
 
       //if(DANEK) cout<<" rocp "<<rocp->print()<<" layer "<<rocp->bpixLayerPhase1(rawId)<<" "
       //  <<layer<<" phase1 "<<phase1<<" rawid "<<rawId<<endl;
 
-      if (useQualityInfo&(nullptr!=badPixelInfo)) {
-	short rocInDet = (short) rocp->idInDetUnit();
-	skipROC = badPixelInfo->IsRocBad(rawId, rocInDet);
-	if (skipROC) continue;
+      if (useQualityInfo & (nullptr != badPixelInfo)) {
+        short rocInDet = (short)rocp->idInDetUnit();
+        skipROC = badPixelInfo->IsRocBad(rawId, rocInDet);
+        if (skipROC)
+          continue;
       }
-      skipROC= modulesToUnpack && ( modulesToUnpack->find(rawId) == modulesToUnpack->end());
-      if (skipROC) continue;
-      
+      skipROC = modulesToUnpack && (modulesToUnpack->find(rawId) == modulesToUnpack->end());
+      if (skipROC)
+        continue;
+
       detDigis = &digis.find_or_insert(rawId);
-      if ( (*detDigis).empty() ) (*detDigis).data.reserve(32); // avoid the first relocations
+      if ((*detDigis).empty())
+        (*detDigis).data.reserve(32);  // avoid the first relocations
     }
 
     // skip is roc to be skipped ot invalid
-    if UNLIKELY(skipROC || !rocp) continue;
-    
-    int adc  = (ww >> ADC_shift) & ADC_mask;
+    if
+      UNLIKELY(skipROC || !rocp) continue;
+
+    int adc = (ww >> ADC_shift) & ADC_mask;
     std::unique_ptr<LocalPixel> local;
 
-    if(phase1 && layer==1) { // special case for layer 1ROC
+    if (phase1 && layer == 1) {  // special case for layer 1ROC
       // for l1 roc use the roc column and row index instead of dcol and pixel index.
       int col = (ww >> COL_shift) & COL_mask;
       int row = (ww >> ROW_shift) & ROW_mask;
       //if(DANEK) cout<<" layer 1: raw2digi "<<link<<" "<<roc<<" "
-      //  <<col<<" "<<row<<" "<<adc<<endl;      
+      //  <<col<<" "<<row<<" "<<adc<<endl;
 
-      LocalPixel::RocRowCol localCR = { row, col }; // build pixel
+      LocalPixel::RocRowCol localCR = {row, col};  // build pixel
       //if(DANEK)cout<<localCR.rocCol<<" "<<localCR.rocRow<<endl;
-      if UNLIKELY(!localCR.valid()) {
-	  LogDebug("PixelDataFormatter::interpretRawData") 
-	    << "status #3";
-	  errorsInEvent = true;
-	  errorcheck->conversionError(fedId, &converter, 3, ww, errors);
-	  continue;
-	}
-      local = std::make_unique<LocalPixel>(localCR); // local pixel coordinate 
+      if
+        UNLIKELY(!localCR.valid()) {
+          LogDebug("PixelDataFormatter::interpretRawData") << "status #3";
+          errorsInEvent = true;
+          errorcheck->conversionError(fedId, &converter, 3, ww, errors);
+          continue;
+        }
+      local = std::make_unique<LocalPixel>(localCR);  // local pixel coordinate
       //if(DANEK) cout<<local->dcol()<<" "<<local->pxid()<<" "<<local->rocCol()<<" "<<local->rocRow()<<endl;
 
-    } else { // phase0 and phase1 except bpix layer 1
+    } else {  // phase0 and phase1 except bpix layer 1
       int dcol = (ww >> DCOL_shift) & DCOL_mask;
       int pxid = (ww >> PXID_shift) & PXID_mask;
       //if(DANEK) cout<<" raw2digi "<<link<<" "<<roc<<" "
       //<<dcol<<" "<<pxid<<" "<<adc<<" "<<layer<<endl;
-      
-      LocalPixel::DcolPxid localDP = { dcol, pxid };
+
+      LocalPixel::DcolPxid localDP = {dcol, pxid};
       //if(DANEK) cout<<localDP.dcol<<" "<<localDP.pxid<<endl;
 
-      if UNLIKELY(!localDP.valid()) {
-	  LogDebug("PixelDataFormatter::interpretRawData") 
-	    << "status #3";
-	  errorsInEvent = true;
-	  errorcheck->conversionError(fedId, &converter, 3, ww, errors);
-	  continue;
-	}
-      local = std::make_unique<LocalPixel>(localDP); // local pixel coordinate 
+      if
+        UNLIKELY(!localDP.valid()) {
+          LogDebug("PixelDataFormatter::interpretRawData") << "status #3";
+          errorsInEvent = true;
+          errorcheck->conversionError(fedId, &converter, 3, ww, errors);
+          continue;
+        }
+      local = std::make_unique<LocalPixel>(localDP);  // local pixel coordinate
       //if(DANEK) cout<<local->dcol()<<" "<<local->pxid()<<" "<<local->rocCol()<<" "<<local->rocRow()<<endl;
-    }    
+    }
 
-    GlobalPixel global = rocp->toGlobal( *local ); // global pixel coordinate (in module)
+    GlobalPixel global = rocp->toGlobal(*local);  // global pixel coordinate (in module)
     (*detDigis).data.emplace_back(global.row, global.col, adc);
-    //if(DANEK) cout<<global.row<<" "<<global.col<<" "<<adc<<endl;    
+    //if(DANEK) cout<<global.row<<" "<<global.col<<" "<<adc<<endl;
     LogTrace("") << (*detDigis).data.back();
   }
-
 }
 
 // I do not know what this was for or if it is needed? d.k. 10.14
@@ -285,59 +298,60 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 //   }
 // }
 
-
-void PixelDataFormatter::formatRawData(unsigned int lvl1_ID, RawData & fedRawData, const Digis & digis, const BadChannels & badChannels) 
-{
+void PixelDataFormatter::formatRawData(unsigned int lvl1_ID,
+                                       RawData& fedRawData,
+                                       const Digis& digis,
+                                       const BadChannels& badChannels) {
   std::map<int, vector<Word32> > words;
 
   // translate digis into 32-bit raw words and store in map indexed by Fed
   for (Digis::const_iterator im = digis.begin(); im != digis.end(); im++) {
     allDetDigis++;
     cms_uint32_t rawId = im->first;
-    int layer=0;
+    int layer = 0;
     bool barrel = PixelModuleName::isBarrel(rawId);
-    if(barrel) layer = PixelROC::bpixLayerPhase1(rawId);
+    if (barrel)
+      layer = PixelROC::bpixLayerPhase1(rawId);
     //if(DANEK) cout<<" layer "<<layer<<" "<<phase1<<endl;
 
-    BadChannels::const_iterator detBadChannels=badChannels.find(rawId);
+    BadChannels::const_iterator detBadChannels = badChannels.find(rawId);
 
     hasDetDigis++;
-    const DetDigis & detDigis = im->second;
+    const DetDigis& detDigis = im->second;
     for (DetDigis::const_iterator it = detDigis.begin(); it != detDigis.end(); it++) {
       theDigiCounter++;
-      const PixelDigi & digi = (*it);
-      int fedId=0;
+      const PixelDigi& digi = (*it);
+      int fedId = 0;
 
-      if(layer==1 && phase1) fedId = digi2wordPhase1Layer1( rawId, digi, words);
-      else                   fedId = digi2word( rawId, digi, words);
+      if (layer == 1 && phase1)
+        fedId = digi2wordPhase1Layer1(rawId, digi, words);
+      else
+        fedId = digi2word(rawId, digi, words);
 
-      if (fedId<0) {
-         LogError("FormatDataException")
-            <<" digi2word returns error #"<<fedId
-            <<" Ndigis: "<<theDigiCounter << endl
-            <<" detector: "<<rawId<< endl
-            << print(digi) <<endl;
-      } else if (detBadChannels!=badChannels.end()) {
-	auto badChannel=std::find_if(detBadChannels->second.begin(), 
-				     detBadChannels->second.end(), 
-				     [&] (const PixelFEDChannel& ch) {
-				       return (int(ch.fed)==fedId && ch.link==linkId(words[fedId].back()));
-				     });
-	if (badChannel!=detBadChannels->second.end()) {
-	  LogError("FormatDataException")
-            <<" while marked bad, found digi for FED "<<fedId<<" Link "<<linkId(words[fedId].back())
-            <<" on module "<<rawId<< endl
-            << print(digi) <<endl;
-	}
-      } // if (fedId)
-    } // for (DetDigis
-  } // for (Digis
-  LogTrace(" allDetDigis/hasDetDigis : ") << allDetDigis<<"/"<<hasDetDigis;
+      if (fedId < 0) {
+        LogError("FormatDataException") << " digi2word returns error #" << fedId << " Ndigis: " << theDigiCounter
+                                        << endl
+                                        << " detector: " << rawId << endl
+                                        << print(digi) << endl;
+      } else if (detBadChannels != badChannels.end()) {
+        auto badChannel =
+            std::find_if(detBadChannels->second.begin(), detBadChannels->second.end(), [&](const PixelFEDChannel& ch) {
+              return (int(ch.fed) == fedId && ch.link == linkId(words[fedId].back()));
+            });
+        if (badChannel != detBadChannels->second.end()) {
+          LogError("FormatDataException") << " while marked bad, found digi for FED " << fedId << " Link "
+                                          << linkId(words[fedId].back()) << " on module " << rawId << endl
+                                          << print(digi) << endl;
+        }
+      }  // if (fedId)
+    }    // for (DetDigis
+  }      // for (Digis
+  LogTrace(" allDetDigis/hasDetDigis : ") << allDetDigis << "/" << hasDetDigis;
 
   // fill FED error 25 words
-  for(const auto& detBadChannels: badChannels) {
-    for(const auto& badChannel: detBadChannels.second) {
-      unsigned int FEDError25=25;
+  for (const auto& detBadChannels : badChannels) {
+    for (const auto& badChannel : detBadChannels.second) {
+      unsigned int FEDError25 = 25;
       Word32 word = (badChannel.link << LINK_shift) | (FEDError25 << ROC_shift);
       words[badChannel.fed].push_back(word);
       theWordCounter++;
@@ -349,164 +363,164 @@ void PixelDataFormatter::formatRawData(unsigned int lvl1_ID, RawData & fedRawDat
     int fedId = feddata->first;
     // since raw words are written in the form of 64-bit packets
     // add extra 32-bit word to make number of words even if necessary
-    if (words.find(fedId)->second.size() %2 != 0) words[fedId].push_back( Word32(0) );
+    if (words.find(fedId)->second.size() % 2 != 0)
+      words[fedId].push_back(Word32(0));
 
     // size in Bytes; create output structure
     int dataSize = words.find(fedId)->second.size() * sizeof(Word32);
     int nHeaders = 1;
     int nTrailers = 1;
-    dataSize += (nHeaders+nTrailers)*sizeof(Word64); 
-    FEDRawData * rawData = new FEDRawData(dataSize);
+    dataSize += (nHeaders + nTrailers) * sizeof(Word64);
+    FEDRawData* rawData = new FEDRawData(dataSize);
 
     // get begining of data;
-    Word64 * word = reinterpret_cast<Word64* >(rawData->data());
+    Word64* word = reinterpret_cast<Word64*>(rawData->data());
 
     // write one header
-    FEDHeader::set(  reinterpret_cast<unsigned char*>(word), 0, lvl1_ID, 0, fedId); 
+    FEDHeader::set(reinterpret_cast<unsigned char*>(word), 0, lvl1_ID, 0, fedId);
     word++;
 
     // write data
     unsigned int nWord32InFed = words.find(fedId)->second.size();
-    for (unsigned int i=0; i < nWord32InFed; i+=2) {
-      *word = (Word64(words.find(fedId)->second[i+1]) << 32 ) | words.find(fedId)->second[i];
-      LogDebug("PixelDataFormatter")  << print(*word);
+    for (unsigned int i = 0; i < nWord32InFed; i += 2) {
+      *word = (Word64(words.find(fedId)->second[i + 1]) << 32) | words.find(fedId)->second[i];
+      LogDebug("PixelDataFormatter") << print(*word);
       word++;
     }
 
     // write one trailer
-    FEDTrailer::set(  reinterpret_cast<unsigned char*>(word), dataSize/sizeof(Word64), 0,0,0);
+    FEDTrailer::set(reinterpret_cast<unsigned char*>(word), dataSize / sizeof(Word64), 0, 0, 0);
     word++;
 
     // check memory
-    if (word != reinterpret_cast<Word64* >(rawData->data()+dataSize)) {
+    if (word != reinterpret_cast<Word64*>(rawData->data() + dataSize)) {
       string s = "** PROBLEM in PixelDataFormatter !!!";
       throw cms::Exception(s);
-    } // if (word !=
+    }  // if (word !=
     fedRawData[fedId] = *rawData;
     delete rawData;
-  } // for (RI feddata 
+  }  // for (RI feddata
 }
 
-int PixelDataFormatter::digi2word( cms_uint32_t detId, const PixelDigi& digi, 
-    std::map<int, vector<Word32> > & words) const
-{
+int PixelDataFormatter::digi2word(cms_uint32_t detId,
+                                  const PixelDigi& digi,
+                                  std::map<int, vector<Word32> >& words) const {
   LogDebug("PixelDataFormatter")
-// <<" detId: " << detId 
-  <<print(digi);
+      // <<" detId: " << detId
+      << print(digi);
 
   DetectorIndex detector = {detId, digi.row(), digi.column()};
   ElectronicIndex cabling;
-  int fedId  = theFrameReverter->toCabling(cabling, detector);
-  if (fedId<0) return fedId;
+  int fedId = theFrameReverter->toCabling(cabling, detector);
+  if (fedId < 0)
+    return fedId;
 
   //if(DANEK) cout<<" digi2raw "<<detId<<" "<<digi.column()<<" "<<digi.row()<<" "<<digi.adc()<<" "
   //  <<cabling.link<<" "<<cabling.roc<<" "<<cabling.dcol<<" "<<cabling.pxid<<endl;
 
-  Word32 word =
-             (cabling.link << LINK_shift)
-           | (cabling.roc << ROC_shift)
-           | (cabling.dcol << DCOL_shift)
-           | (cabling.pxid << PXID_shift)
-           | (digi.adc() << ADC_shift);
+  Word32 word = (cabling.link << LINK_shift) | (cabling.roc << ROC_shift) | (cabling.dcol << DCOL_shift) |
+                (cabling.pxid << PXID_shift) | (digi.adc() << ADC_shift);
   words[fedId].push_back(word);
   theWordCounter++;
 
   return fedId;
 }
-int PixelDataFormatter::digi2wordPhase1Layer1( cms_uint32_t detId, const PixelDigi& digi, 
-    std::map<int, vector<Word32> > & words) const
-{
+int PixelDataFormatter::digi2wordPhase1Layer1(cms_uint32_t detId,
+                                              const PixelDigi& digi,
+                                              std::map<int, vector<Word32> >& words) const {
   LogDebug("PixelDataFormatter")
-// <<" detId: " << detId 
-  <<print(digi);
+      // <<" detId: " << detId
+      << print(digi);
 
   DetectorIndex detector = {detId, digi.row(), digi.column()};
   ElectronicIndex cabling;
-  int fedId  = theFrameReverter->toCabling(cabling, detector);
-  if (fedId<0) return fedId;
+  int fedId = theFrameReverter->toCabling(cabling, detector);
+  if (fedId < 0)
+    return fedId;
 
-  int col = ((cabling.dcol)*2)  + ((cabling.pxid)%2);
-  int row = LocalPixel::numRowsInRoc - ((cabling.pxid)/2);
+  int col = ((cabling.dcol) * 2) + ((cabling.pxid) % 2);
+  int row = LocalPixel::numRowsInRoc - ((cabling.pxid) / 2);
 
   //if(DANEK) cout<<" layer 1: digi2raw "<<detId<<" "<<digi.column()<<" "<<digi.row()<<" "<<digi.adc()<<" "
   //  <<cabling.link<<" "<<cabling.roc<<" "<<cabling.dcol<<" "<<cabling.pxid<<" "
   //  <<col<<" "<<row<<endl;
-  
-  Word32 word =
-             (cabling.link << LINK_shift)
-           | (cabling.roc << ROC_shift)
-           | (col << COL_shift)
-           | (row << ROW_shift)
-           | (digi.adc() << ADC_shift);
+
+  Word32 word = (cabling.link << LINK_shift) | (cabling.roc << ROC_shift) | (col << COL_shift) | (row << ROW_shift) |
+                (digi.adc() << ADC_shift);
   words[fedId].push_back(word);
   theWordCounter++;
 
   return fedId;
 }
 
-
 // obsolete...
-int PixelDataFormatter::word2digi(const int fedId, const SiPixelFrameConverter* converter, 
-    const bool includeErrors, const bool useQuality, const Word32 & word, Digis & digis) const
-{
+int PixelDataFormatter::word2digi(const int fedId,
+                                  const SiPixelFrameConverter* converter,
+                                  const bool includeErrors,
+                                  const bool useQuality,
+                                  const Word32& word,
+                                  Digis& digis) const {
   // do not interpret false digis
-  if (word == 0 ) return 0;
+  if (word == 0)
+    return 0;
 
   ElectronicIndex cabling;
   cabling.dcol = (word >> DCOL_shift) & DCOL_mask;
   cabling.pxid = (word >> PXID_shift) & PXID_mask;
   cabling.link = (word >> LINK_shift) & LINK_mask;
-  cabling.roc  = (word >> ROC_shift) & ROC_mask;
-  int adc      = (word >> ADC_shift) & ADC_mask;
+  cabling.roc = (word >> ROC_shift) & ROC_mask;
+  int adc = (word >> ADC_shift) & ADC_mask;
 
   if (debug) {
-    LocalPixel::DcolPxid pixel = {cabling.dcol,cabling.pxid};
+    LocalPixel::DcolPxid pixel = {cabling.dcol, cabling.pxid};
     LocalPixel local(pixel);
-    LogTrace("")<<" link: "<<cabling.link<<", roc: "<<cabling.roc
-                <<" rocRow: "<<local.rocRow()<<", rocCol:"<<local.rocCol()
-                <<" (dcol: "<<cabling.dcol<<", pxid:"<<cabling.pxid<<"), adc:"<<adc;
+    LogTrace("") << " link: " << cabling.link << ", roc: " << cabling.roc << " rocRow: " << local.rocRow()
+                 << ", rocCol:" << local.rocCol() << " (dcol: " << cabling.dcol << ", pxid:" << cabling.pxid
+                 << "), adc:" << adc;
   }
 
-  if (!converter) return 0;
+  if (!converter)
+    return 0;
 
   DetectorIndex detIdx;
   int status = converter->toDetector(cabling, detIdx);
-  if (status) return status;
+  if (status)
+    return status;
 
   // exclude ROC(raw) based on bad ROC list bad in SiPixelQuality
   // enable: process.siPixelDigis.UseQualityInfo = True
   // 20-10-2010 A.Y.
-  if (useQuality&&badPixelInfo) {
+  if (useQuality && badPixelInfo) {
     CablingPathToDetUnit path = {static_cast<unsigned int>(fedId),
                                  static_cast<unsigned int>(cabling.link),
                                  static_cast<unsigned int>(cabling.roc)};
-    const PixelROC * roc = theCablingTree->findItem(path);
-    short rocInDet = (short) roc->idInDetUnit();
+    const PixelROC* roc = theCablingTree->findItem(path);
+    short rocInDet = (short)roc->idInDetUnit();
     bool badROC = badPixelInfo->IsRocBad(detIdx.rawId, rocInDet);
-    if (badROC) return 0;
+    if (badROC)
+      return 0;
   }
 
-  if (modulesToUnpack && modulesToUnpack->find(detIdx.rawId) == modulesToUnpack->end()) return 0;
+  if (modulesToUnpack && modulesToUnpack->find(detIdx.rawId) == modulesToUnpack->end())
+    return 0;
 
   digis[detIdx.rawId].emplace_back(detIdx.row, detIdx.col, adc);
 
   theDigiCounter++;
 
-  if (debug)  LogTrace("") << digis[detIdx.rawId].back();
+  if (debug)
+    LogTrace("") << digis[detIdx.rawId].back();
   return 0;
 }
 
-std::string PixelDataFormatter::print(const PixelDigi & digi) const
-{
+std::string PixelDataFormatter::print(const PixelDigi& digi) const {
   ostringstream str;
-  str << " DIGI: row: " << digi.row() <<", col: " << digi.column() <<", adc: " << digi.adc();
+  str << " DIGI: row: " << digi.row() << ", col: " << digi.column() << ", adc: " << digi.adc();
   return str.str();
 }
 
-std::string PixelDataFormatter::print(const  Word64 & word) const
-{
+std::string PixelDataFormatter::print(const Word64& word) const {
   ostringstream str;
-  str  <<"word64:  " << reinterpret_cast<const bitset<64>&> (word);
+  str << "word64:  " << reinterpret_cast<const bitset<64>&>(word);
   return str.str();
 }
-

--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -100,12 +100,17 @@ PixelDataFormatter::PixelDataFormatter( const SiPixelFedCabling* map, bool phase
   PXID_mask = ~(~PixelDataFormatter::Word32(0) << PXID_bits);
   ADC_mask  = ~(~PixelDataFormatter::Word32(0) << ADC_bits);
 
+  if (phase1==true) {
+    errorcheck=std::unique_ptr<ErrorCheckerBase>(new ErrorChecker());
+  } else {
+    errorcheck=std::unique_ptr<ErrorCheckerBase>(new ErrorCheckerPhase0());
+  }
 }
 
 void PixelDataFormatter::setErrorStatus(bool ErrorStatus)
 {
   includeErrors = ErrorStatus;
-  errorcheck.setErrorStatus(includeErrors);
+  errorcheck->setErrorStatus(includeErrors);
 }
 
 void PixelDataFormatter::setQualityStatus(bool QualityStatus, const SiPixelQuality* QualityInfo)
@@ -135,7 +140,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 
   // check CRC bit
   const Word64* trailer = reinterpret_cast<const Word64* >(rawData.data())+(nWords-1);  
-  if(!errorcheck.checkCRC(errorsInEvent, fedId, trailer, errors)) return;
+  if(!errorcheck->checkCRC(errorsInEvent, fedId, trailer, errors)) return;
 
   // check headers
   const Word64* header = reinterpret_cast<const Word64* >(rawData.data()); header--;
@@ -143,7 +148,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
   while (moreHeaders) {
     header++;
     LogTrace("")<<"HEADER:  " <<  print(*header);
-    bool headerStatus = errorcheck.checkHeader(errorsInEvent, fedId, header, errors);
+    bool headerStatus = errorcheck->checkHeader(errorsInEvent, fedId, header, errors);
     moreHeaders = headerStatus;
   }
 
@@ -153,7 +158,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
   while (moreTrailers) {
     trailer--;
     LogTrace("")<<"TRAILER: " <<  print(*trailer);
-    bool trailerStatus = errorcheck.checkTrailer(errorsInEvent, fedId, nWords, trailer, errors);
+    bool trailerStatus = errorcheck->checkTrailer(errorsInEvent, fedId, nWords, trailer, errors);
     moreTrailers = trailerStatus;
   }
 
@@ -183,12 +188,12 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 
     if ( (nlink!=link) | (nroc!=roc) ) {  // new roc
       link = nlink; roc=nroc;
-      skipROC = LIKELY(roc<maxROCIndex) ? false : !errorcheck.checkROC(errorsInEvent, fedId, &converter, theCablingTree, ww, errors);
+      skipROC = LIKELY(roc<maxROCIndex) ? false : !errorcheck->checkROC(errorsInEvent, fedId, &converter, theCablingTree, ww, errors);
       if (skipROC) continue;
       rocp = converter.toRoc(link,roc);
       if UNLIKELY(!rocp) {
 	errorsInEvent = true;
-	errorcheck.conversionError(fedId, &converter, 2, ww, errors);
+	errorcheck->conversionError(fedId, &converter, 2, ww, errors);
 	skipROC=true;
 	continue;
       }
@@ -231,7 +236,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 	  LogDebug("PixelDataFormatter::interpretRawData") 
 	    << "status #3";
 	  errorsInEvent = true;
-	  errorcheck.conversionError(fedId, &converter, 3, ww, errors);
+	  errorcheck->conversionError(fedId, &converter, 3, ww, errors);
 	  continue;
 	}
       local = std::make_unique<LocalPixel>(localCR); // local pixel coordinate 
@@ -250,7 +255,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 	  LogDebug("PixelDataFormatter::interpretRawData") 
 	    << "status #3";
 	  errorsInEvent = true;
-	  errorcheck.conversionError(fedId, &converter, 3, ww, errors);
+	  errorcheck->conversionError(fedId, &converter, 3, ww, errors);
 	  continue;
 	}
       local = std::make_unique<LocalPixel>(localDP); // local pixel coordinate 

--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -1,73 +1,73 @@
 #include "EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h"
 
-#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
 
 #include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
 
-#include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "DataFormats/FEDRawData/interface/FEDHeader.h"
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
 
 #include "CondFormats/SiPixelObjects/interface/PixelROC.h"
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 
-#include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #include <bitset>
-#include <sstream>
 #include <iostream>
+#include <sstream>
 
 using namespace std;
 using namespace edm;
 using namespace sipixelobjects;
 namespace {
-  constexpr int LINK_bits = 6;
-  constexpr int ROC_bits = 5;
-  constexpr int DCOL_bits = 5;
-  constexpr int PXID_bits = 8;
-  constexpr int ADC_bits = 8;
+constexpr int LINK_bits = 6;
+constexpr int ROC_bits = 5;
+constexpr int DCOL_bits = 5;
+constexpr int PXID_bits = 8;
+constexpr int ADC_bits = 8;
 
-  // Add phase1 constants
-  // For phase1
-  //GO BACK TO OLD VALUES. THE 48-CHAN FED DOES NOT NEED A NEW FORMAT
-  // 28/9/16 d.k.
-  constexpr int LINK_bits1 = 6;  // 7;
-  constexpr int ROC_bits1 = 5;   // 4;
-  // Special for layer 1 bpix rocs 6/9/16 d.k. THIS STAYS.
-  constexpr int COL_bits1_l1 = 6;
-  constexpr int ROW_bits1_l1 = 7;
+// Add phase1 constants
+// For phase1
+// GO BACK TO OLD VALUES. THE 48-CHAN FED DOES NOT NEED A NEW FORMAT
+// 28/9/16 d.k.
+constexpr int LINK_bits1 = 6; // 7;
+constexpr int ROC_bits1 = 5;  // 4;
+// Special for layer 1 bpix rocs 6/9/16 d.k. THIS STAYS.
+constexpr int COL_bits1_l1 = 6;
+constexpr int ROW_bits1_l1 = 7;
 
-  // Moved to the header file, keep commented out unti the final version is done/
-  // constexpr int ADC_shift  = 0;
-  // constexpr int PXID_shift = ADC_shift + ADC_bits;
-  // constexpr int DCOL_shift = PXID_shift + PXID_bits;
-  // constexpr int ROC_shift  = DCOL_shift + DCOL_bits;
-  // constexpr int LINK_shift = ROC_shift + ROC_bits;
-  // constexpr PixelDataFormatter::Word32 LINK_mask = ~(~PixelDataFormatter::Word32(0) << LINK_bits);
-  // constexpr PixelDataFormatter::Word32 ROC_mask  = ~(~PixelDataFormatter::Word32(0) << ROC_bits);
-  // constexpr PixelDataFormatter::Word32 DCOL_mask = ~(~PixelDataFormatter::Word32(0) << DCOL_bits);
-  // constexpr PixelDataFormatter::Word32 PXID_mask = ~(~PixelDataFormatter::Word32(0) << PXID_bits);
-  // constexpr PixelDataFormatter::Word32 ADC_mask  = ~(~PixelDataFormatter::Word32(0) << ADC_bits);
-  //const bool DANEK = false;
-}  // namespace
+// Moved to the header file, keep commented out unti the final version is done/
+// constexpr int ADC_shift  = 0;
+// constexpr int PXID_shift = ADC_shift + ADC_bits;
+// constexpr int DCOL_shift = PXID_shift + PXID_bits;
+// constexpr int ROC_shift  = DCOL_shift + DCOL_bits;
+// constexpr int LINK_shift = ROC_shift + ROC_bits;
+// constexpr PixelDataFormatter::Word32 LINK_mask =
+// ~(~PixelDataFormatter::Word32(0) << LINK_bits); constexpr
+// PixelDataFormatter::Word32 ROC_mask  = ~(~PixelDataFormatter::Word32(0) <<
+// ROC_bits); constexpr PixelDataFormatter::Word32 DCOL_mask =
+// ~(~PixelDataFormatter::Word32(0) << DCOL_bits); constexpr
+// PixelDataFormatter::Word32 PXID_mask = ~(~PixelDataFormatter::Word32(0) <<
+// PXID_bits); constexpr PixelDataFormatter::Word32 ADC_mask  =
+// ~(~PixelDataFormatter::Word32(0) << ADC_bits);
+// const bool DANEK = false;
+} // namespace
 
-PixelDataFormatter::PixelDataFormatter(const SiPixelFedCabling* map, bool phase)
-    : theDigiCounter(0),
-      theWordCounter(0),
-      theCablingTree(map),
-      badPixelInfo(nullptr),
-      modulesToUnpack(nullptr),
-      phase1(phase) {
+PixelDataFormatter::PixelDataFormatter(const SiPixelFedCabling *map, bool phase)
+    : theDigiCounter(0), theWordCounter(0), theCablingTree(map),
+      badPixelInfo(nullptr), modulesToUnpack(nullptr), phase1(phase) {
   int s32 = sizeof(Word32);
   int s64 = sizeof(Word64);
   int s8 = sizeof(char);
   if (s8 != 1 || s32 != 4 * s8 || s64 != 2 * s32) {
-    LogError("UnexpectedSizes") << " unexpected sizes: "
-                                << "  size of char is: " << s8 << ", size of Word32 is: " << s32
-                                << ", size of Word64 is: " << s64 << ", send exception";
+    LogError("UnexpectedSizes")
+        << " unexpected sizes: "
+        << "  size of char is: " << s8 << ", size of Word32 is: " << s32
+        << ", size of Word64 is: " << s64 << ", send exception";
   }
   includeErrors = false;
   useQualityInfo = false;
@@ -79,7 +79,7 @@ PixelDataFormatter::PixelDataFormatter(const SiPixelFedCabling* map, bool phase)
   DCOL_shift = PXID_shift + PXID_bits;
   ROC_shift = DCOL_shift + DCOL_bits;
 
-  if (phase1) {  // for phase 1
+  if (phase1) { // for phase 1
     LINK_shift = ROC_shift + ROC_bits1;
     LINK_mask = ~(~PixelDataFormatter::Word32(0) << LINK_bits1);
     ROC_mask = ~(~PixelDataFormatter::Word32(0) << ROC_bits1);
@@ -90,7 +90,7 @@ PixelDataFormatter::PixelDataFormatter(const SiPixelFedCabling* map, bool phase)
     ROW_mask = ~(~PixelDataFormatter::Word32(0) << ROW_bits1_l1);
     maxROCIndex = 8;
 
-  } else {  // for phase 0
+  } else { // for phase 0
     LINK_shift = ROC_shift + ROC_bits;
     LINK_mask = ~(~PixelDataFormatter::Word32(0) << LINK_bits);
     ROC_mask = ~(~PixelDataFormatter::Word32(0) << ROC_bits);
@@ -113,17 +113,25 @@ void PixelDataFormatter::setErrorStatus(bool ErrorStatus) {
   errorcheck->setErrorStatus(includeErrors);
 }
 
-void PixelDataFormatter::setQualityStatus(bool QualityStatus, const SiPixelQuality* QualityInfo) {
+void PixelDataFormatter::setQualityStatus(bool QualityStatus,
+                                          const SiPixelQuality *QualityInfo) {
   useQualityInfo = QualityStatus;
   badPixelInfo = QualityInfo;
 }
 
-void PixelDataFormatter::setModulesToUnpack(const std::set<unsigned int>* moduleIds) { modulesToUnpack = moduleIds; }
+void PixelDataFormatter::setModulesToUnpack(
+    const std::set<unsigned int> *moduleIds) {
+  modulesToUnpack = moduleIds;
+}
 
-void PixelDataFormatter::passFrameReverter(const SiPixelFrameReverter* reverter) { theFrameReverter = reverter; }
+void PixelDataFormatter::passFrameReverter(
+    const SiPixelFrameReverter *reverter) {
+  theFrameReverter = reverter;
+}
 
-void PixelDataFormatter::interpretRawData(
-    bool& errorsInEvent, int fedId, const FEDRawData& rawData, Collection& digis, Errors& errors) {
+void PixelDataFormatter::interpretRawData(bool &errorsInEvent, int fedId,
+                                          const FEDRawData &rawData,
+                                          Collection &digis, Errors &errors) {
   using namespace sipixelobjects;
 
   int nWords = rawData.size() / sizeof(Word64);
@@ -133,18 +141,20 @@ void PixelDataFormatter::interpretRawData(
   SiPixelFrameConverter converter(theCablingTree, fedId);
 
   // check CRC bit
-  const Word64* trailer = reinterpret_cast<const Word64*>(rawData.data()) + (nWords - 1);
+  const Word64 *trailer =
+      reinterpret_cast<const Word64 *>(rawData.data()) + (nWords - 1);
   if (!errorcheck->checkCRC(errorsInEvent, fedId, trailer, errors))
     return;
 
   // check headers
-  const Word64* header = reinterpret_cast<const Word64*>(rawData.data());
+  const Word64 *header = reinterpret_cast<const Word64 *>(rawData.data());
   header--;
   bool moreHeaders = true;
   while (moreHeaders) {
     header++;
     LogTrace("") << "HEADER:  " << print(*header);
-    bool headerStatus = errorcheck->checkHeader(errorsInEvent, fedId, header, errors);
+    bool headerStatus =
+        errorcheck->checkHeader(errorsInEvent, fedId, header, errors);
     moreHeaders = headerStatus;
   }
 
@@ -154,7 +164,8 @@ void PixelDataFormatter::interpretRawData(
   while (moreTrailers) {
     trailer--;
     LogTrace("") << "TRAILER: " << print(*trailer);
-    bool trailerStatus = errorcheck->checkTrailer(errorsInEvent, fedId, nWords, trailer, errors);
+    bool trailerStatus =
+        errorcheck->checkTrailer(errorsInEvent, fedId, nWords, trailer, errors);
     moreTrailers = trailerStatus;
   }
 
@@ -165,12 +176,12 @@ void PixelDataFormatter::interpretRawData(
   int link = -1;
   int roc = -1;
   int layer = 0;
-  PixelROC const* rocp = nullptr;
+  PixelROC const *rocp = nullptr;
   bool skipROC = false;
-  edm::DetSet<PixelDigi>* detDigis = nullptr;
+  edm::DetSet<PixelDigi> *detDigis = nullptr;
 
-  const Word32* bw = (const Word32*)(header + 1);
-  const Word32* ew = (const Word32*)(trailer);
+  const Word32 *bw = (const Word32 *)(header + 1);
+  const Word32 *ew = (const Word32 *)(trailer);
   if (*(ew - 1) == 0) {
     ew--;
     theWordCounter--;
@@ -187,14 +198,15 @@ void PixelDataFormatter::interpretRawData(
     int nlink = (ww >> LINK_shift) & LINK_mask;
     int nroc = (ww >> ROC_shift) & ROC_mask;
 
-    //if(DANEK) cout<<" fed, link, roc "<<fedId<<" "<<nlink<<" "<<nroc<<endl;
+    // if(DANEK) cout<<" fed, link, roc "<<fedId<<" "<<nlink<<" "<<nroc<<endl;
 
-    if ((nlink != link) | (nroc != roc)) {  // new roc
+    if ((nlink != link) | (nroc != roc)) { // new roc
       link = nlink;
       roc = nroc;
       skipROC = LIKELY(roc < maxROCIndex)
                     ? false
-                    : !errorcheck->checkROC(errorsInEvent, fedId, &converter, theCablingTree, ww, errors);
+                    : !errorcheck->checkROC(errorsInEvent, fedId, &converter,
+                                            theCablingTree, ww, errors);
       if (skipROC)
         continue;
       rocp = converter.toRoc(link, roc);
@@ -212,7 +224,8 @@ void PixelDataFormatter::interpretRawData(
       else
         layer = 0;
 
-      //if(DANEK) cout<<" rocp "<<rocp->print()<<" layer "<<rocp->bpixLayerPhase1(rawId)<<" "
+      // if(DANEK) cout<<" rocp "<<rocp->print()<<" layer
+      // "<<rocp->bpixLayerPhase1(rawId)<<" "
       //  <<layer<<" phase1 "<<phase1<<" rawid "<<rawId<<endl;
 
       if (useQualityInfo & (nullptr != badPixelInfo)) {
@@ -221,13 +234,14 @@ void PixelDataFormatter::interpretRawData(
         if (skipROC)
           continue;
       }
-      skipROC = modulesToUnpack && (modulesToUnpack->find(rawId) == modulesToUnpack->end());
+      skipROC = modulesToUnpack &&
+                (modulesToUnpack->find(rawId) == modulesToUnpack->end());
       if (skipROC)
         continue;
 
       detDigis = &digis.find_or_insert(rawId);
       if ((*detDigis).empty())
-        (*detDigis).data.reserve(32);  // avoid the first relocations
+        (*detDigis).data.reserve(32); // avoid the first relocations
     }
 
     // skip is roc to be skipped ot invalid
@@ -237,15 +251,16 @@ void PixelDataFormatter::interpretRawData(
     int adc = (ww >> ADC_shift) & ADC_mask;
     std::unique_ptr<LocalPixel> local;
 
-    if (phase1 && layer == 1) {  // special case for layer 1ROC
-      // for l1 roc use the roc column and row index instead of dcol and pixel index.
+    if (phase1 && layer == 1) { // special case for layer 1ROC
+      // for l1 roc use the roc column and row index instead of dcol and pixel
+      // index.
       int col = (ww >> COL_shift) & COL_mask;
       int row = (ww >> ROW_shift) & ROW_mask;
-      //if(DANEK) cout<<" layer 1: raw2digi "<<link<<" "<<roc<<" "
+      // if(DANEK) cout<<" layer 1: raw2digi "<<link<<" "<<roc<<" "
       //  <<col<<" "<<row<<" "<<adc<<endl;
 
-      LocalPixel::RocRowCol localCR = {row, col};  // build pixel
-      //if(DANEK)cout<<localCR.rocCol<<" "<<localCR.rocRow<<endl;
+      LocalPixel::RocRowCol localCR = {row, col}; // build pixel
+      // if(DANEK)cout<<localCR.rocCol<<" "<<localCR.rocRow<<endl;
       if
         UNLIKELY(!localCR.valid()) {
           LogDebug("PixelDataFormatter::interpretRawData") << "status #3";
@@ -253,17 +268,18 @@ void PixelDataFormatter::interpretRawData(
           errorcheck->conversionError(fedId, &converter, 3, ww, errors);
           continue;
         }
-      local = std::make_unique<LocalPixel>(localCR);  // local pixel coordinate
-      //if(DANEK) cout<<local->dcol()<<" "<<local->pxid()<<" "<<local->rocCol()<<" "<<local->rocRow()<<endl;
+      local = std::make_unique<LocalPixel>(localCR); // local pixel coordinate
+      // if(DANEK) cout<<local->dcol()<<" "<<local->pxid()<<"
+      // "<<local->rocCol()<<" "<<local->rocRow()<<endl;
 
-    } else {  // phase0 and phase1 except bpix layer 1
+    } else { // phase0 and phase1 except bpix layer 1
       int dcol = (ww >> DCOL_shift) & DCOL_mask;
       int pxid = (ww >> PXID_shift) & PXID_mask;
-      //if(DANEK) cout<<" raw2digi "<<link<<" "<<roc<<" "
+      // if(DANEK) cout<<" raw2digi "<<link<<" "<<roc<<" "
       //<<dcol<<" "<<pxid<<" "<<adc<<" "<<layer<<endl;
 
       LocalPixel::DcolPxid localDP = {dcol, pxid};
-      //if(DANEK) cout<<localDP.dcol<<" "<<localDP.pxid<<endl;
+      // if(DANEK) cout<<localDP.dcol<<" "<<localDP.pxid<<endl;
 
       if
         UNLIKELY(!localDP.valid()) {
@@ -272,20 +288,23 @@ void PixelDataFormatter::interpretRawData(
           errorcheck->conversionError(fedId, &converter, 3, ww, errors);
           continue;
         }
-      local = std::make_unique<LocalPixel>(localDP);  // local pixel coordinate
-      //if(DANEK) cout<<local->dcol()<<" "<<local->pxid()<<" "<<local->rocCol()<<" "<<local->rocRow()<<endl;
+      local = std::make_unique<LocalPixel>(localDP); // local pixel coordinate
+      // if(DANEK) cout<<local->dcol()<<" "<<local->pxid()<<"
+      // "<<local->rocCol()<<" "<<local->rocRow()<<endl;
     }
 
-    GlobalPixel global = rocp->toGlobal(*local);  // global pixel coordinate (in module)
+    GlobalPixel global =
+        rocp->toGlobal(*local); // global pixel coordinate (in module)
     (*detDigis).data.emplace_back(global.row, global.col, adc);
-    //if(DANEK) cout<<global.row<<" "<<global.col<<" "<<adc<<endl;
+    // if(DANEK) cout<<global.row<<" "<<global.col<<" "<<adc<<endl;
     LogTrace("") << (*detDigis).data.back();
   }
 }
 
 // I do not know what this was for or if it is needed? d.k. 10.14
 // Keep it commented out until we are sure that it is not needed.
-// void doVectorize(int const * __restrict__ w, int * __restrict__ row, int * __restrict__ col, int * __restrict__ valid, int N, PixelROC const * rocp) {
+// void doVectorize(int const * __restrict__ w, int * __restrict__ row, int *
+// __restrict__ col, int * __restrict__ valid, int N, PixelROC const * rocp) {
 //   for (int i=0; i<N; ++i) {
 //     auto ww = w[i];
 //     int dcol = (ww >> DCOL_shift) & DCOL_mask;
@@ -299,10 +318,9 @@ void PixelDataFormatter::interpretRawData(
 // }
 
 void PixelDataFormatter::formatRawData(unsigned int lvl1_ID,
-                                       RawData& fedRawData,
-                                       const Digis& digis,
-                                       const BadChannels& badChannels) {
-  std::map<int, vector<Word32> > words;
+                                       RawData &fedRawData, const Digis &digis,
+                                       const BadChannels &badChannels) {
+  std::map<int, vector<Word32>> words;
 
   // translate digis into 32-bit raw words and store in map indexed by Fed
   for (Digis::const_iterator im = digis.begin(); im != digis.end(); im++) {
@@ -312,15 +330,16 @@ void PixelDataFormatter::formatRawData(unsigned int lvl1_ID,
     bool barrel = PixelModuleName::isBarrel(rawId);
     if (barrel)
       layer = PixelROC::bpixLayerPhase1(rawId);
-    //if(DANEK) cout<<" layer "<<layer<<" "<<phase1<<endl;
+    // if(DANEK) cout<<" layer "<<layer<<" "<<phase1<<endl;
 
     BadChannels::const_iterator detBadChannels = badChannels.find(rawId);
 
     hasDetDigis++;
-    const DetDigis& detDigis = im->second;
-    for (DetDigis::const_iterator it = detDigis.begin(); it != detDigis.end(); it++) {
+    const DetDigis &detDigis = im->second;
+    for (DetDigis::const_iterator it = detDigis.begin(); it != detDigis.end();
+         it++) {
       theDigiCounter++;
-      const PixelDigi& digi = (*it);
+      const PixelDigi &digi = (*it);
       int fedId = 0;
 
       if (layer == 1 && phase1)
@@ -329,28 +348,31 @@ void PixelDataFormatter::formatRawData(unsigned int lvl1_ID,
         fedId = digi2word(rawId, digi, words);
 
       if (fedId < 0) {
-        LogError("FormatDataException") << " digi2word returns error #" << fedId << " Ndigis: " << theDigiCounter
-                                        << endl
+        LogError("FormatDataException") << " digi2word returns error #" << fedId
+                                        << " Ndigis: " << theDigiCounter << endl
                                         << " detector: " << rawId << endl
                                         << print(digi) << endl;
       } else if (detBadChannels != badChannels.end()) {
-        auto badChannel =
-            std::find_if(detBadChannels->second.begin(), detBadChannels->second.end(), [&](const PixelFEDChannel& ch) {
-              return (int(ch.fed) == fedId && ch.link == linkId(words[fedId].back()));
+        auto badChannel = std::find_if(
+            detBadChannels->second.begin(), detBadChannels->second.end(),
+            [&](const PixelFEDChannel &ch) {
+              return (int(ch.fed) == fedId &&
+                      ch.link == linkId(words[fedId].back()));
             });
         if (badChannel != detBadChannels->second.end()) {
-          LogError("FormatDataException") << " while marked bad, found digi for FED " << fedId << " Link "
-                                          << linkId(words[fedId].back()) << " on module " << rawId << endl
-                                          << print(digi) << endl;
+          LogError("FormatDataException")
+              << " while marked bad, found digi for FED " << fedId << " Link "
+              << linkId(words[fedId].back()) << " on module " << rawId << endl
+              << print(digi) << endl;
         }
-      }  // if (fedId)
-    }    // for (DetDigis
-  }      // for (Digis
+      } // if (fedId)
+    }   // for (DetDigis
+  }     // for (Digis
   LogTrace(" allDetDigis/hasDetDigis : ") << allDetDigis << "/" << hasDetDigis;
 
   // fill FED error 25 words
-  for (const auto& detBadChannels : badChannels) {
-    for (const auto& badChannel : detBadChannels.second) {
+  for (const auto &detBadChannels : badChannels) {
+    for (const auto &badChannel : detBadChannels.second) {
       unsigned int FEDError25 = 25;
       Word32 word = (badChannel.link << LINK_shift) | (FEDError25 << ROC_shift);
       words[badChannel.fed].push_back(word);
@@ -358,7 +380,7 @@ void PixelDataFormatter::formatRawData(unsigned int lvl1_ID,
     }
   }
 
-  typedef std::map<int, vector<Word32> >::const_iterator RI;
+  typedef std::map<int, vector<Word32>>::const_iterator RI;
   for (RI feddata = words.begin(); feddata != words.end(); feddata++) {
     int fedId = feddata->first;
     // since raw words are written in the form of 64-bit packets
@@ -371,40 +393,42 @@ void PixelDataFormatter::formatRawData(unsigned int lvl1_ID,
     int nHeaders = 1;
     int nTrailers = 1;
     dataSize += (nHeaders + nTrailers) * sizeof(Word64);
-    FEDRawData* rawData = new FEDRawData(dataSize);
+    FEDRawData *rawData = new FEDRawData(dataSize);
 
     // get begining of data;
-    Word64* word = reinterpret_cast<Word64*>(rawData->data());
+    Word64 *word = reinterpret_cast<Word64 *>(rawData->data());
 
     // write one header
-    FEDHeader::set(reinterpret_cast<unsigned char*>(word), 0, lvl1_ID, 0, fedId);
+    FEDHeader::set(reinterpret_cast<unsigned char *>(word), 0, lvl1_ID, 0,
+                   fedId);
     word++;
 
     // write data
     unsigned int nWord32InFed = words.find(fedId)->second.size();
     for (unsigned int i = 0; i < nWord32InFed; i += 2) {
-      *word = (Word64(words.find(fedId)->second[i + 1]) << 32) | words.find(fedId)->second[i];
+      *word = (Word64(words.find(fedId)->second[i + 1]) << 32) |
+              words.find(fedId)->second[i];
       LogDebug("PixelDataFormatter") << print(*word);
       word++;
     }
 
     // write one trailer
-    FEDTrailer::set(reinterpret_cast<unsigned char*>(word), dataSize / sizeof(Word64), 0, 0, 0);
+    FEDTrailer::set(reinterpret_cast<unsigned char *>(word),
+                    dataSize / sizeof(Word64), 0, 0, 0);
     word++;
 
     // check memory
-    if (word != reinterpret_cast<Word64*>(rawData->data() + dataSize)) {
+    if (word != reinterpret_cast<Word64 *>(rawData->data() + dataSize)) {
       string s = "** PROBLEM in PixelDataFormatter !!!";
       throw cms::Exception(s);
-    }  // if (word !=
+    } // if (word !=
     fedRawData[fedId] = *rawData;
     delete rawData;
-  }  // for (RI feddata
+  } // for (RI feddata
 }
 
-int PixelDataFormatter::digi2word(cms_uint32_t detId,
-                                  const PixelDigi& digi,
-                                  std::map<int, vector<Word32> >& words) const {
+int PixelDataFormatter::digi2word(cms_uint32_t detId, const PixelDigi &digi,
+                                  std::map<int, vector<Word32>> &words) const {
   LogDebug("PixelDataFormatter")
       // <<" detId: " << detId
       << print(digi);
@@ -415,19 +439,22 @@ int PixelDataFormatter::digi2word(cms_uint32_t detId,
   if (fedId < 0)
     return fedId;
 
-  //if(DANEK) cout<<" digi2raw "<<detId<<" "<<digi.column()<<" "<<digi.row()<<" "<<digi.adc()<<" "
-  //  <<cabling.link<<" "<<cabling.roc<<" "<<cabling.dcol<<" "<<cabling.pxid<<endl;
+  // if(DANEK) cout<<" digi2raw "<<detId<<" "<<digi.column()<<" "<<digi.row()<<"
+  // "<<digi.adc()<<" "
+  //  <<cabling.link<<" "<<cabling.roc<<" "<<cabling.dcol<<"
+  //  "<<cabling.pxid<<endl;
 
-  Word32 word = (cabling.link << LINK_shift) | (cabling.roc << ROC_shift) | (cabling.dcol << DCOL_shift) |
-                (cabling.pxid << PXID_shift) | (digi.adc() << ADC_shift);
+  Word32 word = (cabling.link << LINK_shift) | (cabling.roc << ROC_shift) |
+                (cabling.dcol << DCOL_shift) | (cabling.pxid << PXID_shift) |
+                (digi.adc() << ADC_shift);
   words[fedId].push_back(word);
   theWordCounter++;
 
   return fedId;
 }
-int PixelDataFormatter::digi2wordPhase1Layer1(cms_uint32_t detId,
-                                              const PixelDigi& digi,
-                                              std::map<int, vector<Word32> >& words) const {
+int PixelDataFormatter::digi2wordPhase1Layer1(
+    cms_uint32_t detId, const PixelDigi &digi,
+    std::map<int, vector<Word32>> &words) const {
   LogDebug("PixelDataFormatter")
       // <<" detId: " << detId
       << print(digi);
@@ -441,11 +468,14 @@ int PixelDataFormatter::digi2wordPhase1Layer1(cms_uint32_t detId,
   int col = ((cabling.dcol) * 2) + ((cabling.pxid) % 2);
   int row = LocalPixel::numRowsInRoc - ((cabling.pxid) / 2);
 
-  //if(DANEK) cout<<" layer 1: digi2raw "<<detId<<" "<<digi.column()<<" "<<digi.row()<<" "<<digi.adc()<<" "
-  //  <<cabling.link<<" "<<cabling.roc<<" "<<cabling.dcol<<" "<<cabling.pxid<<" "
+  // if(DANEK) cout<<" layer 1: digi2raw "<<detId<<" "<<digi.column()<<"
+  // "<<digi.row()<<" "<<digi.adc()<<" "
+  //  <<cabling.link<<" "<<cabling.roc<<" "<<cabling.dcol<<" "<<cabling.pxid<<"
+  //  "
   //  <<col<<" "<<row<<endl;
 
-  Word32 word = (cabling.link << LINK_shift) | (cabling.roc << ROC_shift) | (col << COL_shift) | (row << ROW_shift) |
+  Word32 word = (cabling.link << LINK_shift) | (cabling.roc << ROC_shift) |
+                (col << COL_shift) | (row << ROW_shift) |
                 (digi.adc() << ADC_shift);
   words[fedId].push_back(word);
   theWordCounter++;
@@ -455,11 +485,10 @@ int PixelDataFormatter::digi2wordPhase1Layer1(cms_uint32_t detId,
 
 // obsolete...
 int PixelDataFormatter::word2digi(const int fedId,
-                                  const SiPixelFrameConverter* converter,
+                                  const SiPixelFrameConverter *converter,
                                   const bool includeErrors,
-                                  const bool useQuality,
-                                  const Word32& word,
-                                  Digis& digis) const {
+                                  const bool useQuality, const Word32 &word,
+                                  Digis &digis) const {
   // do not interpret false digis
   if (word == 0)
     return 0;
@@ -474,9 +503,10 @@ int PixelDataFormatter::word2digi(const int fedId,
   if (debug) {
     LocalPixel::DcolPxid pixel = {cabling.dcol, cabling.pxid};
     LocalPixel local(pixel);
-    LogTrace("") << " link: " << cabling.link << ", roc: " << cabling.roc << " rocRow: " << local.rocRow()
-                 << ", rocCol:" << local.rocCol() << " (dcol: " << cabling.dcol << ", pxid:" << cabling.pxid
-                 << "), adc:" << adc;
+    LogTrace("") << " link: " << cabling.link << ", roc: " << cabling.roc
+                 << " rocRow: " << local.rocRow()
+                 << ", rocCol:" << local.rocCol() << " (dcol: " << cabling.dcol
+                 << ", pxid:" << cabling.pxid << "), adc:" << adc;
   }
 
   if (!converter)
@@ -494,14 +524,15 @@ int PixelDataFormatter::word2digi(const int fedId,
     CablingPathToDetUnit path = {static_cast<unsigned int>(fedId),
                                  static_cast<unsigned int>(cabling.link),
                                  static_cast<unsigned int>(cabling.roc)};
-    const PixelROC* roc = theCablingTree->findItem(path);
+    const PixelROC *roc = theCablingTree->findItem(path);
     short rocInDet = (short)roc->idInDetUnit();
     bool badROC = badPixelInfo->IsRocBad(detIdx.rawId, rocInDet);
     if (badROC)
       return 0;
   }
 
-  if (modulesToUnpack && modulesToUnpack->find(detIdx.rawId) == modulesToUnpack->end())
+  if (modulesToUnpack &&
+      modulesToUnpack->find(detIdx.rawId) == modulesToUnpack->end())
     return 0;
 
   digis[detIdx.rawId].emplace_back(detIdx.row, detIdx.col, adc);
@@ -513,14 +544,15 @@ int PixelDataFormatter::word2digi(const int fedId,
   return 0;
 }
 
-std::string PixelDataFormatter::print(const PixelDigi& digi) const {
+std::string PixelDataFormatter::print(const PixelDigi &digi) const {
   ostringstream str;
-  str << " DIGI: row: " << digi.row() << ", col: " << digi.column() << ", adc: " << digi.adc();
+  str << " DIGI: row: " << digi.row() << ", col: " << digi.column()
+      << ", adc: " << digi.adc();
   return str.str();
 }
 
-std::string PixelDataFormatter::print(const Word64& word) const {
+std::string PixelDataFormatter::print(const Word64 &word) const {
   ostringstream str;
-  str << "word64:  " << reinterpret_cast<const bitset<64>&>(word);
+  str << "word64:  " << reinterpret_cast<const bitset<64> &>(word);
   return str.str();
 }

--- a/EventFilter/SiPixelRawToDigi/test/FedErrorDumper.cc
+++ b/EventFilter/SiPixelRawToDigi/test/FedErrorDumper.cc
@@ -11,7 +11,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 #include "DataFormats/Common/interface/Handle.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -22,13 +21,12 @@
 
 #include "EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h"
 
-// for detids 
+// for detids
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 #include "DataFormats/DetId/interface/DetId.h"
-
 
 // For L1  NOT IN RAW
 //#include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
@@ -36,7 +34,6 @@
 //#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
 //#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 //#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapRecord.h"
-
 
 // To use root histos
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -50,10 +47,8 @@
 #include <TH2F.h>
 #include <TH1F.h>
 
-
 #include <iostream>
 using namespace std;
-
 
 // Include the helper decoding class
 /////////////////////////////////////////////////////////////////////////////
@@ -61,249 +56,266 @@ class MyDecode {
 public:
   MyDecode() {}
   ~MyDecode() {}
-  static int error(int error, int & fedChannel, int fed, bool print=false);
-  static int data(int error, int & fedChannel, int fed, bool print=false);
+  static int error(int error, int &fedChannel, int fed, bool print = false);
+  static int data(int error, int &fedChannel, int fed, bool print = false);
   static int header(unsigned long long word64, int fed, bool print);
   static int trailer(unsigned long long word64, int fed, bool print);
+
 private:
 };
 /////////////////////////////////////////////////////////////////////////////
 int MyDecode::header(unsigned long long word64, int fed, bool print) {
-  int fed_id=(word64>>8)&0xfff;
-  int event_id=(word64>>32)&0xffffff;
-  unsigned int bx_id=(word64>>20)&0xfff;
-//   if(bx_id!=101) {
-//     cout<<" Header "<<" for FED "
-// 	<<fed_id<<" event "<<event_id<<" bx "<<bx_id<<endl;
-//     int dummy=0;
-//     cout<<" : ";
-//     cin>>dummy;
-//   }
-  if(print) cout<<" Header "<<" for FED "
-		<<fed_id<<" event "<<event_id<<" bx "<<bx_id<<endl;
+  int fed_id = (word64 >> 8) & 0xfff;
+  int event_id = (word64 >> 32) & 0xffffff;
+  unsigned int bx_id = (word64 >> 20) & 0xfff;
+  //   if(bx_id!=101) {
+  //     cout<<" Header "<<" for FED "
+  // 	<<fed_id<<" event "<<event_id<<" bx "<<bx_id<<endl;
+  //     int dummy=0;
+  //     cout<<" : ";
+  //     cin>>dummy;
+  //   }
+  if (print)
+    cout << " Header "
+         << " for FED " << fed_id << " event " << event_id << " bx " << bx_id << endl;
 
   return event_id;
 }
 //
 int MyDecode::trailer(unsigned long long word64, int fed, bool print) {
-  int slinkLength = int( (word64>>32) & 0xffffff );
-  int crc         = int( (word64&0xffff0000)>>16 );
-  int tts         = int( (word64&0xf0)>>4);
-  int slinkError  = int( (word64&0xf00)>>8);
-  if(print) cout<<" Trailer "<<" len "<<slinkLength
-		<<" tts "<<tts<<" error "<<slinkError<<" crc "<<hex<<crc<<dec<<endl;
+  int slinkLength = int((word64 >> 32) & 0xffffff);
+  int crc = int((word64 & 0xffff0000) >> 16);
+  int tts = int((word64 & 0xf0) >> 4);
+  int slinkError = int((word64 & 0xf00) >> 8);
+  if (print)
+    cout << " Trailer "
+         << " len " << slinkLength << " tts " << tts << " error " << slinkError << " crc " << hex << crc << dec << endl;
   return slinkLength;
 }
 //
 // Decode error FIFO
 // Works for both, the error FIFO and the SLink error words. d.k. 25/04/07
-int MyDecode::error(int word, int & fedChannel, int fed, bool print) {
+int MyDecode::error(int word, int &fedChannel, int fed, bool print) {
   int status = -1;
 
-  const unsigned int  errorMask      = 0x3e00000;
-  const unsigned int  dummyMask      = 0x03600000;
-  const unsigned int  gapMask        = 0x03400000;
-  const unsigned int  timeOut        = 0x3a00000;
-  const unsigned int  eventNumError  = 0x3e00000;
-  const unsigned int  trailError     = 0x3c00000;
-  const unsigned int  fifoError      = 0x3800000;
+  const unsigned int errorMask = 0x3e00000;
+  const unsigned int dummyMask = 0x03600000;
+  const unsigned int gapMask = 0x03400000;
+  const unsigned int timeOut = 0x3a00000;
+  const unsigned int eventNumError = 0x3e00000;
+  const unsigned int trailError = 0x3c00000;
+  const unsigned int fifoError = 0x3800000;
 
-//  const unsigned int  timeOutChannelMask = 0x1f;  // channel mask for timeouts
+  //  const unsigned int  timeOutChannelMask = 0x1f;  // channel mask for timeouts
   //const unsigned int  eventNumMask = 0x1fe000; // event number mask
-  const unsigned int  channelMask = 0xfc000000; // channel num mask
-  const unsigned int  tbmEventMask = 0xff;    // tbm event num mask
-  const unsigned int  overflowMask = 0x100;   // data overflow
-  const unsigned int  tbmStatusMask = 0xff;   //TBM trailer info
-  const unsigned int  BlkNumMask = 0x700;   //pointer to error fifo #
-  const unsigned int  FsmErrMask = 0x600;   //pointer to FSM errors
-  const unsigned int  RocErrMask = 0x800;   //pointer to #Roc errors
-  const unsigned int  ChnFifMask = 0x1f;   //channel mask for fifo error
-  const unsigned int  Fif2NFMask = 0x40;   //mask for fifo2 NF
-  const unsigned int  TrigNFMask = 0x80;   //mask for trigger fifo NF
-  
-  const int offsets[8] = {0,4,9,13,18,22,27,31};
+  const unsigned int channelMask = 0xfc000000;  // channel num mask
+  const unsigned int tbmEventMask = 0xff;       // tbm event num mask
+  const unsigned int overflowMask = 0x100;      // data overflow
+  const unsigned int tbmStatusMask = 0xff;      //TBM trailer info
+  const unsigned int BlkNumMask = 0x700;        //pointer to error fifo #
+  const unsigned int FsmErrMask = 0x600;        //pointer to FSM errors
+  const unsigned int RocErrMask = 0x800;        //pointer to #Roc errors
+  const unsigned int ChnFifMask = 0x1f;         //channel mask for fifo error
+  const unsigned int Fif2NFMask = 0x40;         //mask for fifo2 NF
+  const unsigned int TrigNFMask = 0x80;         //mask for trigger fifo NF
+
+  const int offsets[8] = {0, 4, 9, 13, 18, 22, 27, 31};
   unsigned int channel = 0;
 
   //cout<<"error word "<<hex<<word<<dec<<endl;
-  
-  if( (word&errorMask) == dummyMask ) { // DUMMY WORD
+
+  if ((word & errorMask) == dummyMask) {  // DUMMY WORD
     //cout<<" Dummy word";
     return 0;
-  } else if( (word&errorMask) == gapMask ) { // GAP WORD
+  } else if ((word & errorMask) == gapMask) {  // GAP WORD
     //cout<<" Gap word";
     return 0;
-    
-  } else if( (word&errorMask)==timeOut ) { // TIMEOUT
-    // More than 1 channel within a group can have a timeout error
-     unsigned int index = (word & 0x1F);  // index within a group of 4/5
-     unsigned int chip = (word& BlkNumMask)>>8;
-     int offset = offsets[chip];
-     if(print) cout<<"Timeout Error- channel: ";
-     for(int i=0;i<5;i++) {
-       if( (index & 0x1) != 0) {
-	 channel = offset + i + 1;
-	 if(print) cout<<channel<<" ";
-       }
-       index = index >> 1;
-     }
-     //if(print) cout<<" for Fed "<<fed<<endl;
-     status = -10;
-     fedChannel = channel;
-     //end of timeout  chip and channel decoding
 
-  } else if( (word&errorMask) == eventNumError ) { // EVENT NUMBER ERROR
-    channel =  (word & channelMask) >>26;
-    unsigned int tbm_event   =  (word & tbmEventMask);
-    
-    if(print) cout<<"Event Number Error- channel: "<<channel<<" tbm event nr. "
-		  <<tbm_event<<" ";
-     status = -11;
-     fedChannel = channel;
-    
-  } else if( ((word&errorMask) == trailError)) {  // TRAILER 
-    channel =  (word & channelMask) >>26;
-    unsigned int tbm_status   =  (word & tbmStatusMask);
-    
+  } else if ((word & errorMask) == timeOut) {  // TIMEOUT
+                                               // More than 1 channel within a group can have a timeout error
+    unsigned int index = (word & 0x1F);        // index within a group of 4/5
+    unsigned int chip = (word & BlkNumMask) >> 8;
+    int offset = offsets[chip];
+    if (print)
+      cout << "Timeout Error- channel: ";
+    for (int i = 0; i < 5; i++) {
+      if ((index & 0x1) != 0) {
+        channel = offset + i + 1;
+        if (print)
+          cout << channel << " ";
+      }
+      index = index >> 1;
+    }
+    //if(print) cout<<" for Fed "<<fed<<endl;
+    status = -10;
+    fedChannel = channel;
+    //end of timeout  chip and channel decoding
 
-    if(tbm_status!=0) {
-      if(print) cout<<"Trailer Error- "<<"channel: "<<channel<<" TBM status:0x"
-			  <<hex<<tbm_status<<dec<<" "; // <<endl;
-     status = -15;
-     // implement the resync/reset 17
+  } else if ((word & errorMask) == eventNumError) {  // EVENT NUMBER ERROR
+    channel = (word & channelMask) >> 26;
+    unsigned int tbm_event = (word & tbmEventMask);
+
+    if (print)
+      cout << "Event Number Error- channel: " << channel << " tbm event nr. " << tbm_event << " ";
+    status = -11;
+    fedChannel = channel;
+
+  } else if (((word & errorMask) == trailError)) {  // TRAILER
+    channel = (word & channelMask) >> 26;
+    unsigned int tbm_status = (word & tbmStatusMask);
+
+    if (tbm_status != 0) {
+      if (print)
+        cout << "Trailer Error- "
+             << "channel: " << channel << " TBM status:0x" << hex << tbm_status << dec << " ";  // <<endl;
+      status = -15;
+      // implement the resync/reset 17
     }
 
-    if(word & RocErrMask) {
-      if(print) cout<<"Number of Rocs Error- "<<"channel: "<<channel<<" "; // <<endl;
-     status = -12;
+    if (word & RocErrMask) {
+      if (print)
+        cout << "Number of Rocs Error- "
+             << "channel: " << channel << " ";  // <<endl;
+      status = -12;
     }
 
-    if(word & overflowMask) {
-      if(print) cout<<"Overflow Error- "<<"channel: "<<channel<<" "; // <<endl;
-     status = -14;
+    if (word & overflowMask) {
+      if (print)
+        cout << "Overflow Error- "
+             << "channel: " << channel << " ";  // <<endl;
+      status = -14;
     }
 
-    if(word & FsmErrMask) {
-      if(print) cout<<"Finite State Machine Error- "<<"channel: "<<channel
-			  <<" Error status:0x"<<hex<< ((word & FsmErrMask)>>9)<<dec<<" "; // <<endl;
-     status = -13;
+    if (word & FsmErrMask) {
+      if (print)
+        cout << "Finite State Machine Error- "
+             << "channel: " << channel << " Error status:0x" << hex << ((word & FsmErrMask) >> 9) << dec
+             << " ";  // <<endl;
+      status = -13;
     }
-
 
     fedChannel = channel;
 
-  } else if((word&errorMask)==fifoError) {  // FIFO
-    if(print) { 
-      if(word & Fif2NFMask) cout<<"A fifo 2 is Nearly full- ";
-      if(word & TrigNFMask) cout<<"The trigger fifo is nearly Full - ";
-      if(word & ChnFifMask) cout<<"fifo-1 is nearly full for channel"<<(word & ChnFifMask);
+  } else if ((word & errorMask) == fifoError) {  // FIFO
+    if (print) {
+      if (word & Fif2NFMask)
+        cout << "A fifo 2 is Nearly full- ";
+      if (word & TrigNFMask)
+        cout << "The trigger fifo is nearly Full - ";
+      if (word & ChnFifMask)
+        cout << "fifo-1 is nearly full for channel" << (word & ChnFifMask);
       //cout<<endl;
       status = -16;
     }
 
   } else {
-    cout<<" Unknown error?, error word "<<hex<<word<<dec<<endl;
+    cout << " Unknown error?, error word " << hex << word << dec << endl;
     status = -19;
   }
 
-  if(print && status <-1) cout<<" For FED "<<fed<<endl;
+  if (print && status < -1)
+    cout << " For FED " << fed << endl;
   return status;
 }
 ///////////////////////////////////////////////////////////////////////////
-int MyDecode::data(int word, int & fedChannel, int fed, bool print) {
+int MyDecode::data(int word, int &fedChannel, int fed, bool print) {
   const bool CHECK_PIXELS = true;
   //const int ROCMAX = 24;
-  const unsigned int plsmsk = 0xff;   // pulse height
-  const unsigned int pxlmsk = 0xff00; // pixel index
+  const unsigned int plsmsk = 0xff;    // pulse height
+  const unsigned int pxlmsk = 0xff00;  // pixel index
   const unsigned int dclmsk = 0x1f0000;
   const unsigned int rocmsk = 0x3e00000;
   const unsigned int chnlmsk = 0xfc000000;
   int status = 0;
 
-  int roc = ((word&rocmsk)>>21);
+  int roc = ((word & rocmsk) >> 21);
   // Check for embeded special words
-  if(roc>0 && roc<25) {  // valid ROCs go from 1-24
+  if (roc > 0 && roc < 25) {  // valid ROCs go from 1-24
     //if(print) cout<<"data "<<hex<<word<<dec;
-    unsigned int channel = ((word&chnlmsk)>>26);
-    if(channel>0 && channel<37) {  // valid channels 1-36
+    unsigned int channel = ((word & chnlmsk) >> 26);
+    if (channel > 0 && channel < 37) {  // valid channels 1-36
       //cout<<hex<<word<<dec;
-      int dcol=(word&dclmsk)>>16;
-      int pix=(word&pxlmsk)>>8;
-      int adc=(word&plsmsk);
+      int dcol = (word & dclmsk) >> 16;
+      int pix = (word & pxlmsk) >> 8;
+      int adc = (word & plsmsk);
       fedChannel = channel;
       // print the roc number according to the online 0-15 scheme
-      if(print) {
-	int dcol1 = dcol/6;
-	int dcol2 = dcol%6;
-	int pix1  = pix/36;
-	int pix2  = (pix%36)/6;
-	int pix3  = pix%6;
-	cout<<" Fed "<<fed<<" Channel- "<<channel<<" ROC- "<<(roc-1)<<" DCOL- "<<dcol<<" Pixel- "
-	    <<pix<<" ADC- "<<adc<<" : "<<dcol1<<dcol2<<"-"<<pix1<<pix2<<pix3<<endl;
+      if (print) {
+        int dcol1 = dcol / 6;
+        int dcol2 = dcol % 6;
+        int pix1 = pix / 36;
+        int pix2 = (pix % 36) / 6;
+        int pix3 = pix % 6;
+        cout << " Fed " << fed << " Channel- " << channel << " ROC- " << (roc - 1) << " DCOL- " << dcol << " Pixel- "
+             << pix << " ADC- " << adc << " : " << dcol1 << dcol2 << "-" << pix1 << pix2 << pix3 << endl;
       }
       status++;
-      if(CHECK_PIXELS) {
+      if (CHECK_PIXELS) {
+        if (dcol < 0 || dcol > 25) {
+          if (print)
+            cout << " Fed " << fed << " wrong dcol number chan/roc/dcol/pix/adc = " << channel << "/" << roc << "/"
+                 << dcol << "/" << pix << "/" << adc << endl;
+          status = -3;
+        }
 
-        if(dcol<0 || dcol>25) {
-          if(print) cout<<" Fed "<<fed<<" wrong dcol number chan/roc/dcol/pix/adc = "<<channel<<"/"<<roc<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<endl;
-	  status = -3;
-	}
+        if (pix < 2 || pix > 181) {
+          if (print)
+            cout << " Fed " << fed << " wrong pix number chan/roc/dcol/pix/adc = " << channel << "/" << roc << "/"
+                 << dcol << "/" << pix << "/" << adc << endl;
+          status = -3;
+        }
 
-        if(pix<2 || pix>181) {
-          if(print) cout<<" Fed "<<fed<<" wrong pix number chan/roc/dcol/pix/adc = "<<channel<<"/"<<roc<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<endl;
-	  status = -3;
-	}
+        if ((fed > 31 && roc > 24) || (fed <= 31 && roc > 16)) {
+          if (print)
+            cout << " Fed " << fed << " wrong roc number chan/roc/dcol/pix/adc = " << channel << "/" << roc << "/"
+                 << dcol << "/" << pix << "/" << adc << endl;
+          status = -4;
+        } else if (fed <= 31 && channel <= 24 && roc > 8) {
+          // ptorotect for rerouted signals
+          if (!((fed == 13 && channel == 17) || (fed == 15 && channel == 5) || (fed == 31 && channel == 10) ||
+                (fed == 27 && channel == 15))) {
+            if (print)
+              cout << " Fed " << fed << " wrong roc number, chan/roc/dcol/pix/adc = " << channel << "/" << roc << "/"
+                   << dcol << "/" << pix << "/" << adc << endl;
+            status = -4;
+          }
+        }
 
-	if( (fed>31 && roc>24) || (fed<=31 && roc>16)  ) {	  
-          if(print) cout<<" Fed "<<fed<<" wrong roc number chan/roc/dcol/pix/adc = "<<channel<<"/"<<roc<<"/"
-			<<dcol<<"/"<<pix<<"/"<<adc<<endl;
-	  status = -4;
-	} else if( fed<=31 && channel<=24 && roc>8 ) {
-	  // ptorotect for rerouted signals
-	  if( !( (fed==13 && channel==17) ||(fed==15 && channel==5) ||(fed==31 && channel==10) 
-		                          ||(fed==27 && channel==15) )  ) {
-	    if(print) cout<<" Fed "<<fed<<" wrong roc number, chan/roc/dcol/pix/adc = "<<channel<<"/"<<roc<<"/"
-			  <<dcol<<"/"<<pix<<"/"<<adc<<endl;
-	    status = -4;
-	  }
-	}
-
-        if(pix==0) {
-          if(print) cout<<" Fed "<<fed<<" pix=0 chan/roc/dcol/pix/adc = "<<channel<<"/"
-                        <<roc<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<endl;
-	  status = -5;
-	}
+        if (pix == 0) {
+          if (print)
+            cout << " Fed " << fed << " pix=0 chan/roc/dcol/pix/adc = " << channel << "/" << roc << "/" << dcol << "/"
+                 << pix << "/" << adc << endl;
+          status = -5;
+        }
       }
 
     } else {
-      cout<<"Wrong channel "<<channel<<endl;
+      cout << "Wrong channel " << channel << endl;
       return -2;
     }
 
-  } else if(roc==25) {  // 
+  } else if (roc == 25) {  //
 
-    unsigned int channel = ((word&chnlmsk)>>26);
-    cout<<"Wrong roc 25-"<<roc<<" in fed/chan "<<fed<<"/"<<channel<<endl;
-    status=-4;
+    unsigned int channel = ((word & chnlmsk) >> 26);
+    cout << "Wrong roc 25-" << roc << " in fed/chan " << fed << "/" << channel << endl;
+    status = -4;
 
   } else {  // error word
 
     //cout<<"error word "<<hex<<word<<dec;
-    status=error(word, fedChannel, fed, print);
+    status = error(word, fedChannel, fed, print);
 
-  } // end if
+  }  // end if
 
   return status;
 }
-
-
 
 ////////////////////////////////////////////////////////////////////////////
 
 class FedErrorDumper : public edm::EDAnalyzer {
 public:
-
   /// ctor
-  explicit FedErrorDumper( const edm::ParameterSet& cfg); 
+  explicit FedErrorDumper(const edm::ParameterSet &cfg);
 
   /// dtor
   virtual ~FedErrorDumper() {}
@@ -312,11 +324,11 @@ public:
 
   //void beginRun( const edm::EventSetup& ) {}
 
-  // end of job 
+  // end of job
   void endJob();
 
   /// get data, convert to digis attach againe to Event
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event &, const edm::EventSetup &);
 
 private:
   edm::ParameterSet theConfig;
@@ -334,505 +346,530 @@ private:
   TH1F *herrors, *herrorsF, *htype;
   TH1F *hmode, *hmodeF;
   TH1F *htbm, *htbmF;
-  TH2F *hfedErrors0,*hfedErrors1,*hfedErrors2,*hfedErrors3,*hfedErrors4,*hfedErrors5,
-    *hfedErrors6,*hfedErrors7,*hfedErrors8,*hfedErrors9;
-  TH2F *hfedErrors0F, *hfed2d,*hfed2d0;
+  TH2F *hfedErrors0, *hfedErrors1, *hfedErrors2, *hfedErrors3, *hfedErrors4, *hfedErrors5, *hfedErrors6, *hfedErrors7,
+      *hfedErrors8, *hfedErrors9;
+  TH2F *hfedErrors0F, *hfed2d, *hfed2d0;
 
   TH1F *hlumi, *hbx;
-
 };
 //----------------------------------
-FedErrorDumper::FedErrorDumper( const edm::ParameterSet& cfg) : theConfig(cfg) {
-
+FedErrorDumper::FedErrorDumper(const edm::ParameterSet &cfg) : theConfig(cfg) {
   //std::string src_ = theConfig.getUntrackedParameter<std::string>("InputLabel","source");
-  std::string src = theConfig.getUntrackedParameter<std::string>("InputLabel","siPixelDigis");
+  std::string src = theConfig.getUntrackedParameter<std::string>("InputLabel", "siPixelDigis");
 
   // For the ByToken method
   fedErrorContainer = consumes<edm::DetSetVector<SiPixelRawDataError> >(src);
-} 
+}
 
 //---------------------------------
 void FedErrorDumper::endJob() {
-  cout<<" fed-errors "<<fedErrors<<" module-Errors "<<moduleErrors<<" "<<spareCounts<<endl;
-  for(int i=0;i<40;++i) {
-    if(countErrors[i]>0 || countErrors2[i]>0 ) cout<<i<<" "<<countErrors[i]<<" "<<countErrors2[i]<<endl;
+  cout << " fed-errors " << fedErrors << " module-Errors " << moduleErrors << " " << spareCounts << endl;
+  for (int i = 0; i < 40; ++i) {
+    if (countErrors[i] > 0 || countErrors2[i] > 0)
+      cout << i << " " << countErrors[i] << " " << countErrors2[i] << endl;
   }
 
   //sumFedPixels[i] /= float(countEvents);
-//       hpixels4->Fill(float(i),sumFedPixels[i]); //pixels only 
-//     }
-//   }
+  //       hpixels4->Fill(float(i),sumFedPixels[i]); //pixels only
+  //     }
+  //   }
 
-//   if(countEvents>0) {
-//     sumPixels /= float(countEvents);
-//     sumFedSize /= float(countAllEvents);
-    
-//   cout<<" Total/non-empty events " <<countAllEvents<<" / "<<countEvents<<" average number of pixels "<<sumPixels<<endl;
+  //   if(countEvents>0) {
+  //     sumPixels /= float(countEvents);
+  //     sumFedSize /= float(countAllEvents);
 
-//   cout<<" Average Fed size for all events "<<sumFedSize<<endl;
-//   for(int i=0;i<40;++i) cout<<sumFedPixels[i]<<" ";
-//   cout<<endl;
+  //   cout<<" Total/non-empty events " <<countAllEvents<<" / "<<countEvents<<" average number of pixels "<<sumPixels<<endl;
 
-//   cout<<" Total number of errors "<<countErrors<<endl;
-//   cout<<" FED erros "<<endl<<"  Fed Channel Errors"<<endl;
-//   for(int i=0;i<40;++i) {
-//     for(int j=0;j<36;++j) if(fedErrors[i][j]>0) {
-//       cout<<i<<" "<<j<<" "<<fedErrors[i][j]<<endl;
-//     }
-//   }
-//   cout<<" Decode errors "<<endl<<"  Fed Channel Errors Pix_000"<<endl;
-//   for(int i=0;i<40;++i) {
-//     for(int j=0;j<36;++j) if(decodeErrors[i][j]>0) {
-//       cout<<i<<" "<<j<<" "<<decodeErrors[i][j]<<" "<<decodeErrors000[i][j]<<endl;
-//     }
-//   }
+  //   cout<<" Average Fed size for all events "<<sumFedSize<<endl;
+  //   for(int i=0;i<40;++i) cout<<sumFedPixels[i]<<" ";
+  //   cout<<endl;
 
-//   cout<<" Total errors for all feds "<<endl<<" Type Errors"<<endl;
-//   for(int i=0;i<20;++i) {
-//     if( errorType[i]>0 ) cout<<"   "<<i<<" "<<errorType[i]<<endl;
-//   }
+  //   cout<<" Total number of errors "<<countErrors<<endl;
+  //   cout<<" FED erros "<<endl<<"  Fed Channel Errors"<<endl;
+  //   for(int i=0;i<40;++i) {
+  //     for(int j=0;j<36;++j) if(fedErrors[i][j]>0) {
+  //       cout<<i<<" "<<j<<" "<<fedErrors[i][j]<<endl;
+  //     }
+  //   }
+  //   cout<<" Decode errors "<<endl<<"  Fed Channel Errors Pix_000"<<endl;
+  //   for(int i=0;i<40;++i) {
+  //     for(int j=0;j<36;++j) if(decodeErrors[i][j]>0) {
+  //       cout<<i<<" "<<j<<" "<<decodeErrors[i][j]<<" "<<decodeErrors000[i][j]<<endl;
+  //     }
+  //   }
 
+  //   cout<<" Total errors for all feds "<<endl<<" Type Errors"<<endl;
+  //   for(int i=0;i<20;++i) {
+  //     if( errorType[i]>0 ) cout<<"   "<<i<<" "<<errorType[i]<<endl;
+  //   }
 }
 
 void FedErrorDumper::beginJob() {
   //countEvents=0;
   //countAllEvents=0;
   //countErrors=0;
-  fedErrors=0;
-  moduleErrors=0;
-  spareCounts=0.;
-  //sumFedSize=0;  
+  fedErrors = 0;
+  moduleErrors = 0;
+  spareCounts = 0.;
+  //sumFedSize=0;
 
-  PRINT = theConfig.getUntrackedParameter<bool>("Verbosity",false);
-  for(int i=0;i<40;++i) {
-    countErrors[i]=0;
-    countErrors2[i]=0;
+  PRINT = theConfig.getUntrackedParameter<bool>("Verbosity", false);
+  for (int i = 0; i < 40; ++i) {
+    countErrors[i] = 0;
+    countErrors2[i] = 0;
   }
 
-//   for(int i=0;i<40;++i) {
-//     sumFedPixels[i]=0;
-//     for(int j=0;j<36;++j) fedErrors[i][j]=0;
-//     for(int j=0;j<36;++j) decodeErrors[i][j]=0;
-//     for(int j=0;j<36;++j) decodeErrors000[i][j]=0;
-//   }
-//   for(int i=0;i<20;++i) errorType[i]=0;
+  //   for(int i=0;i<40;++i) {
+  //     sumFedPixels[i]=0;
+  //     for(int j=0;j<36;++j) fedErrors[i][j]=0;
+  //     for(int j=0;j<36;++j) decodeErrors[i][j]=0;
+  //     for(int j=0;j<36;++j) decodeErrors000[i][j]=0;
+  //   }
+  //   for(int i=0;i<20;++i) errorType[i]=0;
 
   edm::Service<TFileService> fs;
 
-  htbm  = fs->make<TH1F>("htbm", "tbm errors ",256, -0.5, 255.5);
-  htbmF = fs->make<TH1F>("htbmF","tbm errors ",256, -0.5, 255.5);
+  htbm = fs->make<TH1F>("htbm", "tbm errors ", 256, -0.5, 255.5);
+  htbmF = fs->make<TH1F>("htbmF", "tbm errors ", 256, -0.5, 255.5);
 
-  hmode  = fs->make<TH1F>( "hmode", "mode",16, -0.5, 15.5);
-  hmodeF  = fs->make<TH1F>("hmodeF","mode",16, -0.5, 15.5);
+  hmode = fs->make<TH1F>("hmode", "mode", 16, -0.5, 15.5);
+  hmodeF = fs->make<TH1F>("hmodeF", "mode", 16, -0.5, 15.5);
 
-  hfeds  = fs->make<TH1F>( "hfeds", "errors per FED",40, -0.5, 39.5);
-  hfedsF = fs->make<TH1F>( "hfedsF", "errors per FED",40, -0.5, 39.5);
-  hfedsSlink = fs->make<TH1F>( "hfedsSlink", "errors per FED",40, -0.5, 39.5);
-  hfedsCRC = fs->make<TH1F>( "hfedsCRC", "errors per FED",40, -0.5, 39.5);
-  hfedsUnknown = fs->make<TH1F>( "hfedsUnknown", "errors per FED",40, -0.5, 39.5);
+  hfeds = fs->make<TH1F>("hfeds", "errors per FED", 40, -0.5, 39.5);
+  hfedsF = fs->make<TH1F>("hfedsF", "errors per FED", 40, -0.5, 39.5);
+  hfedsSlink = fs->make<TH1F>("hfedsSlink", "errors per FED", 40, -0.5, 39.5);
+  hfedsCRC = fs->make<TH1F>("hfedsCRC", "errors per FED", 40, -0.5, 39.5);
+  hfedsUnknown = fs->make<TH1F>("hfedsUnknown", "errors per FED", 40, -0.5, 39.5);
 
-  htype   = fs->make<TH1F>( "htype", "error type ",50, -0.5, 49.5);
-  herrors = fs->make<TH1F>( "herrors", "error type ",50, -0.5, 49.5);
-  herrorsF = fs->make<TH1F>( "herrorsF", "error type",50, -0.5, 49.5);
+  htype = fs->make<TH1F>("htype", "error type ", 50, -0.5, 49.5);
+  herrors = fs->make<TH1F>("herrors", "error type ", 50, -0.5, 49.5);
+  herrorsF = fs->make<TH1F>("herrorsF", "error type", 50, -0.5, 49.5);
 
-  hfedErrors0 = fs->make<TH2F>( "hfedErrors0", "errors", 40,-0.5,39.5,37, -0.5, 36.5); // ALL
-  hfedErrors0F = fs->make<TH2F>( "hfedErrors0F","errors",40,-0.5,39.5,37, -0.5, 36.5); // ALL
-  hfedErrors1 = fs->make<TH2F>( "hfedErrors1", "errors", 40,-0.5,39.5,37, -0.5, 36.5); // Timeout
-  hfedErrors2 = fs->make<TH2F>( "hfedErrors2", "errors", 40,-0.5,39.5,37, -0.5, 36.5); // Overflow
-  hfedErrors3 = fs->make<TH2F>( "hfedErrors3", "errors", 40,-0.5,39.5,37, -0.5, 36.5); // ENE
-  hfedErrors4 = fs->make<TH2F>( "hfedErrors4", "errors", 40,-0.5,39.5,37, -0.5, 36.5); // FIFO
-  hfedErrors5 = fs->make<TH2F>( "hfedErrors5", "errors", 40,-0.5,39.5,37, -0.5, 36.5); // NOR
-  hfedErrors6 = fs->make<TH2F>( "hfedErrors6", "errors", 40,-0.5,39.5,37, -0.5, 36.5); // TRAILER
-  hfedErrors7 = fs->make<TH2F>( "hfedErrors7", "errors", 40,-0.5,39.5,37, -0.5, 36.5); // FSM 
-  hfedErrors8 = fs->make<TH2F>( "hfedErrors8", "errors", 40,-0.5,39.5,37, -0.5, 36.5); // Invalid ROC
-  hfedErrors9 = fs->make<TH2F>( "hfedErrors9", "errors", 40,-0.5,39.5,37, -0.5, 36.5); // Invalid DCOL-PIX
+  hfedErrors0 = fs->make<TH2F>("hfedErrors0", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // ALL
+  hfedErrors0F = fs->make<TH2F>("hfedErrors0F", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);  // ALL
+  hfedErrors1 = fs->make<TH2F>("hfedErrors1", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // Timeout
+  hfedErrors2 = fs->make<TH2F>("hfedErrors2", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // Overflow
+  hfedErrors3 = fs->make<TH2F>("hfedErrors3", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // ENE
+  hfedErrors4 = fs->make<TH2F>("hfedErrors4", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // FIFO
+  hfedErrors5 = fs->make<TH2F>("hfedErrors5", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // NOR
+  hfedErrors6 = fs->make<TH2F>("hfedErrors6", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // TRAILER
+  hfedErrors7 = fs->make<TH2F>("hfedErrors7", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // FSM
+  hfedErrors8 = fs->make<TH2F>("hfedErrors8", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // Invalid ROC
+  hfedErrors9 = fs->make<TH2F>("hfedErrors9", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // Invalid DCOL-PIX
 
-  hfed2d = fs->make<TH2F>( "hfed2d", "errors", 40,-0.5,39.5,20, 19.5, 39.5); // ALL
-  hfed2d0 = fs->make<TH2F>("hfed2d0","errors", 40,-0.5,39.5,20, 19.5, 39.5); // ALL
+  hfed2d = fs->make<TH2F>("hfed2d", "errors", 40, -0.5, 39.5, 20, 19.5, 39.5);    // ALL
+  hfed2d0 = fs->make<TH2F>("hfed2d0", "errors", 40, -0.5, 39.5, 20, 19.5, 39.5);  // ALL
 
-  hlumi  = fs->make<TH1F>("hlumi", "lumi", 4000,0,4000.);
-  hbx    = fs->make<TH1F>("hbx",   "bx",   4000,0,4000.);  
-  
+  hlumi = fs->make<TH1F>("hlumi", "lumi", 4000, 0, 4000.);
+  hbx = fs->make<TH1F>("hbx", "bx", 4000, 0, 4000.);
 }
 //--------------------------------------------------------------------------------
-void FedErrorDumper::analyze(const  edm::Event& ev, const edm::EventSetup& es) {
+void FedErrorDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
   //const bool PRINT = false;
 
   // Access event information
-  int run       = ev.id().run();
-  int event     = ev.id().event();
+  int run = ev.id().run();
+  int event = ev.id().event();
   int lumiBlock = ev.luminosityBlock();
-  int bx        = ev.bunchCrossing();
-  //int orbit     = ev.orbitNumber(); // unused 
+  int bx = ev.bunchCrossing();
+  //int orbit     = ev.orbitNumber(); // unused
 
   hlumi->Fill(float(lumiBlock));
   hbx->Fill(float(bx));
 
-//   edm::Handle<FEDRawDataCollection> buffers;
-//   static std::string label = theConfig.getUntrackedParameter<std::string>("InputLabel","source");
-//   static std::string instance = theConfig.getUntrackedParameter<std::string>("InputInstance","");  
-//   ev.getByLabel( label, instance, buffers);
+  //   edm::Handle<FEDRawDataCollection> buffers;
+  //   static std::string label = theConfig.getUntrackedParameter<std::string>("InputLabel","source");
+  //   static std::string instance = theConfig.getUntrackedParameter<std::string>("InputInstance","");
+  //   ev.getByLabel( label, instance, buffers);
 
-  edm::Handle< edm::DetSetVector<SiPixelRawDataError> >  input;
+  edm::Handle<edm::DetSetVector<SiPixelRawDataError> > input;
   //static std::string src_ = theConfig.getUntrackedParameter<std::string>("InputLabel","source");
   //static std::string src_ = theConfig.getUntrackedParameter<std::string>("InputLabel","siPixelDigis");
-  //static std::string instance = theConfig.getUntrackedParameter<std::string>("InputInstance","");  
+  //static std::string instance = theConfig.getUntrackedParameter<std::string>("InputInstance","");
   //ev.getByLabel( src_, instance, input );
-  ev.getByToken(fedErrorContainer , input);  // the new bytoken
+  ev.getByToken(fedErrorContainer, input);  // the new bytoken
 
-  if (!input.isValid()) {cout<<" Container not found "<<endl; return;}
+  if (!input.isValid()) {
+    cout << " Container not found " << endl;
+    return;
+  }
 
-  if(PRINT) cout<<" Container found "<<run<<" "<<event<<" "<<lumiBlock<<" "<<bx<<endl;
+  if (PRINT)
+    cout << " Container found " << run << " " << event << " " << lumiBlock << " " << bx << endl;
 
   // Iterate on detector units
   edm::DetSetVector<SiPixelRawDataError>::const_iterator DSViter;
-  for(DSViter = input->begin(); DSViter != input->end(); DSViter++) {
+  for (DSViter = input->begin(); DSViter != input->end(); DSViter++) {
     //bool valid = false;
-    unsigned int detid = DSViter->id; // = rawid
+    unsigned int detid = DSViter->id;  // = rawid
     //cout<<hex<<detid<<dec<<endl;
 
-    if(detid==0xffffffff) { // whole fed
+    if (detid == 0xffffffff) {  // whole fed
 
-      if(PRINT) cout<<" FED errors "<<DSViter->data.size()<<endl;
-      // Look at FED errors now	
-      edm::DetSet<SiPixelRawDataError>::const_iterator  di;
+      if (PRINT)
+        cout << " FED errors " << DSViter->data.size() << endl;
+      // Look at FED errors now
+      edm::DetSet<SiPixelRawDataError>::const_iterator di;
 
-      for(di = DSViter->data.begin(); di != DSViter->data.end(); di++) {
-	int FedId = di->getFedId();                  // FED the error came from
-	int errorType = di->getType();               // type of error
-	uint32_t word32 = di->getWord32();
-	uint64_t word64 = di->getWord64();
+      for (di = DSViter->data.begin(); di != DSViter->data.end(); di++) {
+        int FedId = di->getFedId();     // FED the error came from
+        int errorType = di->getType();  // type of error
+        uint32_t word32 = di->getWord32();
+        uint64_t word64 = di->getWord64();
 
-	fedErrors++;
+        fedErrors++;
 
- 	herrors->Fill(float(errorType));
-	herrorsF->Fill(float(errorType));
-	hfedsF->Fill(float(FedId));
-	hfeds->Fill(float(FedId));
-	int errorTypeMod = errorType;
+        herrors->Fill(float(errorType));
+        herrorsF->Fill(float(errorType));
+        hfedsF->Fill(float(FedId));
+        hfeds->Fill(float(FedId));
+        int errorTypeMod = errorType;
 
-	if(PRINT) cout<<" fed " <<FedId<<" type "<<errorType<<" "<<hex<<word32<<" "<<word64<<dec<<" "<<di->getMessage()<<endl;
+        if (PRINT)
+          cout << " fed " << FedId << " type " << errorType << " " << hex << word32 << " " << word64 << dec << " "
+               << di->getMessage() << endl;
 
-	int status=0;
-	int fedChannel = -1;
-	//const bool printData    = true;
-	if(errorType>=26 && errorType<=31) {  // fed error	
-	  status = MyDecode::error(word32, fedChannel, FedId, PRINT);
-	  if(PRINT) cout<<" status "<<status<<endl;
+        int status = 0;
+        int fedChannel = -1;
+        //const bool printData    = true;
+        if (errorType >= 26 && errorType <= 31) {  // fed error
+          status = MyDecode::error(word32, fedChannel, FedId, PRINT);
+          if (PRINT)
+            cout << " status " << status << endl;
 
-	  if(fedChannel<1||fedChannel>36) {
-	    cout<<" Cannot get a valid  fed channel number of a -fed- error "<<fedChannel<<endl;
-	    continue; // skip this error
-	  }
-	    
-	  hfedErrors0->Fill(float(FedId),float(fedChannel));
-	  hfedErrors0F->Fill(float(FedId),float(fedChannel));
+          if (fedChannel < 1 || fedChannel > 36) {
+            cout << " Cannot get a valid  fed channel number of a -fed- error " << fedChannel << endl;
+            continue;  // skip this error
+          }
 
-	  switch(errorType) {
+          hfedErrors0->Fill(float(FedId), float(fedChannel));
+          hfedErrors0F->Fill(float(FedId), float(fedChannel));
 
-	  case(28) : { // FIFO
-	    hfedErrors4->Fill(float(FedId),float(fedChannel));
-	    hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	    htype->Fill(float(errorTypeMod));
-	    break;}
+          switch (errorType) {
+            case (28): {  // FIFO
+              hfedErrors4->Fill(float(FedId), float(fedChannel));
+              hfed2d0->Fill(float(FedId), float(errorTypeMod));
+              htype->Fill(float(errorTypeMod));
+              break;
+            }
 
-	  case(29) : {  // TIMEOUT 
-	    hfedErrors1->Fill(float(FedId),float(fedChannel));
-	    hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	    htype->Fill(float(errorTypeMod));
-	    break;}
+            case (29): {  // TIMEOUT
+              hfedErrors1->Fill(float(FedId), float(fedChannel));
+              hfed2d0->Fill(float(FedId), float(errorTypeMod));
+              htype->Fill(float(errorTypeMod));
+              break;
+            }
 
-	  case(30) : {  // TRAILER
+            case (30): {  // TRAILER
 
-	    int tbm = (word32& 0xff);
-	    int mode = (word32>>8) & 0xf;
-	    hmodeF->Fill(float(mode));
-	    hmode->Fill(float(mode));
-	    //cout<<" error 30 "<<hex<<mode<<dec<<endl;
-	    countErrors[30]++;
+              int tbm = (word32 & 0xff);
+              int mode = (word32 >> 8) & 0xf;
+              hmodeF->Fill(float(mode));
+              hmode->Fill(float(mode));
+              //cout<<" error 30 "<<hex<<mode<<dec<<endl;
+              countErrors[30]++;
 
-	    if( tbm != 0) { // trailer
-	      hfedErrors6->Fill(float(FedId),float(fedChannel));
-	      htbmF->Fill(float(tbm));
-	      errorTypeMod=20;
-	      hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	      htype->Fill(float(errorTypeMod));
-	    }
+              if (tbm != 0) {  // trailer
+                hfedErrors6->Fill(float(FedId), float(fedChannel));
+                htbmF->Fill(float(tbm));
+                errorTypeMod = 20;
+                hfed2d0->Fill(float(FedId), float(errorTypeMod));
+                htype->Fill(float(errorTypeMod));
+              }
 
-	    if( (mode&0x8) != 0) { // nor
-	      //cout<<" NOR "<<endl;
-	      hfedErrors5->Fill(float(FedId),float(fedChannel));
-	      errorTypeMod=21;
-	      hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	      htype->Fill(float(errorTypeMod));
-	    }
+              if ((mode & 0x8) != 0) {  // nor
+                //cout<<" NOR "<<endl;
+                hfedErrors5->Fill(float(FedId), float(fedChannel));
+                errorTypeMod = 21;
+                hfed2d0->Fill(float(FedId), float(errorTypeMod));
+                htype->Fill(float(errorTypeMod));
+              }
 
+              if ((mode & 0x1) != 0) {  // overflow
+                hfedErrors2->Fill(float(FedId), float(fedChannel));
+                errorTypeMod = 22;
+                hfed2d0->Fill(float(FedId), float(errorTypeMod));
+                htype->Fill(float(errorTypeMod));
+              }
 
-	    if( (mode&0x1) != 0) { // overflow
-	      hfedErrors2->Fill(float(FedId),float(fedChannel));
-	      errorTypeMod=22;
-	      hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	      htype->Fill(float(errorTypeMod));
-	    } 
+              if ((mode & 0x6) != 0) {  // fsm
+                hfedErrors7->Fill(float(FedId), float(fedChannel));
+                errorTypeMod = 23;
+                hfed2d0->Fill(float(FedId), float(errorTypeMod));
+                htype->Fill(float(errorTypeMod));
+              }
 
-	    if( (mode&0x6) != 0) { // fsm
-	      hfedErrors7->Fill(float(FedId),float(fedChannel));
-	      errorTypeMod=23;
-	      hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	      htype->Fill(float(errorTypeMod));
-	    } 
+              break;
+            }
 
-	    break;}
+            case (31): {  // EVE
+              hfedErrors3->Fill(float(FedId), float(fedChannel));
+              hfed2d0->Fill(float(FedId), float(errorTypeMod));
+              htype->Fill(float(errorTypeMod));
+              break;
+            }
+          }  // end switch
 
-	  case(31) : {  // EVE
-	    hfedErrors3->Fill(float(FedId),float(fedChannel));
-	    hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	    htype->Fill(float(errorTypeMod));
-	    break;}
-	  } // end switch
+        } else if (errorType >= 32 && errorType <= 34) {
+          cout << " Slink error " << endl;
 
-	} else if (errorType>=32 &&errorType<=34) {
-	  cout<<" Slink error "<<endl;
+          hfedsSlink->Fill(float(FedId));
+          hfed2d0->Fill(float(FedId), float(errorTypeMod));
+          htype->Fill(float(errorTypeMod));
 
-	  hfedsSlink->Fill(float(FedId));
-	  hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	  htype->Fill(float(errorTypeMod));
-	    
-	} else if (errorType==25 || (errorType>=35 && errorType<=38) ) { // conversion error
-	  cout<<" Should never happen, a -fed- conversion error?  "<<endl;
-	  status = MyDecode::data(word32, fedChannel, FedId, PRINT);
-	  if(PRINT) cout<<" status "<<status<<endl;
+        } else if (errorType == 25 || (errorType >= 35 && errorType <= 38)) {  // conversion error
+          cout << " Should never happen, a -fed- conversion error?  " << endl;
+          status = MyDecode::data(word32, fedChannel, FedId, PRINT);
+          if (PRINT)
+            cout << " status " << status << endl;
 
-	  hfedErrors0->Fill(float(FedId),float(fedChannel));
-	  hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	  htype->Fill(float(errorTypeMod));
+          hfedErrors0->Fill(float(FedId), float(fedChannel));
+          hfed2d0->Fill(float(FedId), float(errorTypeMod));
+          htype->Fill(float(errorTypeMod));
 
-	  switch(errorType) {
-	  case(25) : { // inv ROC
-	    hfedErrors8->Fill(float(FedId),float(fedChannel));
-	    break;}
-	  case(36) : { // inv ROC
-	    hfedErrors8->Fill(float(FedId),float(fedChannel));
-	    break;}
-	  case(37) : { // inv DCOL&PIX
-	    hfedErrors9->Fill(float(FedId),float(fedChannel));
-	    //spareCounts++;
-	    cout<<" does it ever happen "<<endl;
-	    break;}
-	  }
+          switch (errorType) {
+            case (25): {  // inv ROC
+              hfedErrors8->Fill(float(FedId), float(fedChannel));
+              break;
+            }
+            case (36): {  // inv ROC
+              hfedErrors8->Fill(float(FedId), float(fedChannel));
+              break;
+            }
+            case (37): {  // inv DCOL&PIX
+              hfedErrors9->Fill(float(FedId), float(fedChannel));
+              //spareCounts++;
+              cout << " does it ever happen " << endl;
+              break;
+            }
+          }
 
-	} else if ( errorType==39) { // CRC 
-	  cout<<" CRC error "<<endl;
-	  hfedsCRC->Fill(float(FedId));
-	  hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	  htype->Fill(float(errorTypeMod));
+        } else if (errorType == 39) {  // CRC
+          cout << " CRC error " << endl;
+          hfedsCRC->Fill(float(FedId));
+          hfed2d0->Fill(float(FedId), float(errorTypeMod));
+          htype->Fill(float(errorTypeMod));
 
-	} else {
-	  cout<<" unknown error "<<errorType<<endl;
-	  hfedsUnknown->Fill(float(FedId));
-	  errorTypeMod=24;	  
-	  hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	  htype->Fill(float(errorTypeMod));
-	}
+        } else {
+          cout << " unknown error " << errorType << endl;
+          hfedsUnknown->Fill(float(FedId));
+          errorTypeMod = 24;
+          hfed2d0->Fill(float(FedId), float(errorTypeMod));
+          htype->Fill(float(errorTypeMod));
+        }
 
-	hfed2d->Fill(float(FedId),float(errorTypeMod));
+        hfed2d->Fill(float(FedId), float(errorTypeMod));
 
-	if(errorTypeMod>=0 && errorTypeMod<40) countErrors[errorTypeMod]++;
+        if (errorTypeMod >= 0 && errorTypeMod < 40)
+          countErrors[errorTypeMod]++;
 
-      } // for errors
+      }  // for errors
 
-    } else { // module errors 
+    } else {  // module errors
 
       DetId detId(detid);
       //const GeomDetUnit      * geoUnit = geom->idToDetUnit( detId );
       //const PixelGeomDetUnit * pixDet  = dynamic_cast<const PixelGeomDetUnit*>(geoUnit);
-      unsigned int detType=detId.det(); // det type, tracker=1
-      unsigned int subid=detId.subdetId(); //subdetector type, barrel=1
-      
+      unsigned int detType = detId.det();     // det type, tracker=1
+      unsigned int subid = detId.subdetId();  //subdetector type, barrel=1
 
-      if(PRINT) {
-	cout<<" Module errors "<<DSViter->data.size()<<endl;
-	cout<<"Det: "<<detId.rawId()<<":";
+      if (PRINT) {
+        cout << " Module errors " << DSViter->data.size() << endl;
+        cout << "Det: " << detId.rawId() << ":";
         //cout<<"Det: "<<detId.rawId()<<" "<<detId.null()<<" "<<detType<<" "<<subid<<endl;
       }
 
-      int layer=0, ladder=0, module=0, disk=0, blade=0, zindex=0;
-      if(subid==1) { // bpix
-	PXBDetId pdetId = PXBDetId(detid);
-	// Barell layer = 1,2,3
-	int layerC=pdetId.layer(); // unused 
-	// Barrel ladder id 1-20,32,44.
-	int ladderC=pdetId.ladder(); // unused 
-	// Barrel Z-index=1,8
-	int zindex=pdetId.module();
-	// Convert to online 
-	PixelBarrelName pbn(pdetId);
-	int sector = pbn.sectorName();
-	ladder = pbn.ladderName();
-	layer  = pbn.layerName();
-	module = pbn.moduleName();
-	int half  = pbn.isHalfModule();
-	PixelBarrelName::Shell shell = pbn.shell();
+      int layer = 0, ladder = 0, module = 0, disk = 0, blade = 0, zindex = 0;
+      if (subid == 1) {  // bpix
+        PXBDetId pdetId = PXBDetId(detid);
+        // Barell layer = 1,2,3
+        int layerC = pdetId.layer();  // unused
+        // Barrel ladder id 1-20,32,44.
+        int ladderC = pdetId.ladder();  // unused
+        // Barrel Z-index=1,8
+        int zindex = pdetId.module();
+        // Convert to online
+        PixelBarrelName pbn(pdetId);
+        int sector = pbn.sectorName();
+        ladder = pbn.ladderName();
+        layer = pbn.layerName();
+        module = pbn.moduleName();
+        int half = pbn.isHalfModule();
+        PixelBarrelName::Shell shell = pbn.shell();
 
-	if(PRINT) 
-	  cout<<" BPix: layer "<<layer<<" ladder "<<ladder<<" module "<<module<<" shell "<<shell<<" sector "<<sector<<" "
-	      <<layerC<<" "<<ladderC<<" "<<zindex<<" "<<half<<" "<<detType<<endl;
+        if (PRINT)
+          cout << " BPix: layer " << layer << " ladder " << ladder << " module " << module << " shell " << shell
+               << " sector " << sector << " " << layerC << " " << ladderC << " " << zindex << " " << half << " "
+               << detType << endl;
 
-      } else if(subid==2) {  // fpix
+      } else if (subid == 2) {  // fpix
 
-	PXFDetId pdetId = PXFDetId(detid);
-	disk=pdetId.disk(); //1,2,3
-	blade=pdetId.blade(); //1-24
-	zindex=pdetId.module(); //
-	int side=pdetId.side(); //size=1 for -z, 2 for +z
-	int panel=pdetId.panel(); //panel=1
-	
-	if(PRINT) cout<<" FPix: disk "<<disk<<" "<<blade<<" "<<side<<" "<<panel<<endl; 
+        PXFDetId pdetId = PXFDetId(detid);
+        disk = pdetId.disk();        //1,2,3
+        blade = pdetId.blade();      //1-24
+        zindex = pdetId.module();    //
+        int side = pdetId.side();    //size=1 for -z, 2 for +z
+        int panel = pdetId.panel();  //panel=1
 
+        if (PRINT)
+          cout << " FPix: disk " << disk << " " << blade << " " << side << " " << panel << endl;
       }
 
-      // Look at FED errors now	
-      edm::DetSet<SiPixelRawDataError>::const_iterator  di;
-      for(di = DSViter->data.begin(); di != DSViter->data.end(); di++) {
-	int FedId = di->getFedId();                  // FED the error came from
-	int errorType = di->getType();               // type of error
-	uint32_t word32 = di->getWord32();
-	//uint64_t word64 = di->getWord64();  // unused 
-	
-	herrors->Fill(float(errorType));
-	moduleErrors++;
-	int errorTypeMod = errorType;
+      // Look at FED errors now
+      edm::DetSet<SiPixelRawDataError>::const_iterator di;
+      for (di = DSViter->data.begin(); di != DSViter->data.end(); di++) {
+        int FedId = di->getFedId();     // FED the error came from
+        int errorType = di->getType();  // type of error
+        uint32_t word32 = di->getWord32();
+        //uint64_t word64 = di->getWord64();  // unused
 
-	//cout<<" fed " <<FedId<<" type "<<errorType<<" "<<hex<<word32<<" "<<word64<<dec<<" "<<di->getMessage()<<endl;
-	if(PRINT) cout<<" fed " <<FedId<<" type "<<errorType<<endl;
+        herrors->Fill(float(errorType));
+        moduleErrors++;
+        int errorTypeMod = errorType;
 
-	int status=0;
-	int fedChannel = 0;
-	//const bool printData    = true;
+        //cout<<" fed " <<FedId<<" type "<<errorType<<" "<<hex<<word32<<" "<<word64<<dec<<" "<<di->getMessage()<<endl;
+        if (PRINT)
+          cout << " fed " << FedId << " type " << errorType << endl;
 
-	if(errorType>=26 && errorType<=31) {  // fed error	
-	  status = MyDecode::error(word32, fedChannel, FedId, PRINT);
-	  if(PRINT) cout<<" fed "<<FedId<<" "<<"Channel "<<fedChannel<<" "<<status<<endl;
+        int status = 0;
+        int fedChannel = 0;
+        //const bool printData    = true;
 
-	  hfedErrors0->Fill(float(FedId),float(fedChannel));
+        if (errorType >= 26 && errorType <= 31) {  // fed error
+          status = MyDecode::error(word32, fedChannel, FedId, PRINT);
+          if (PRINT)
+            cout << " fed " << FedId << " "
+                 << "Channel " << fedChannel << " " << status << endl;
 
-	  switch(errorType) {
+          hfedErrors0->Fill(float(FedId), float(fedChannel));
 
-	  case(28) : { // FIFO
-	    hfedErrors4->Fill(float(FedId),float(fedChannel));
-	    hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	    htype->Fill(float(errorTypeMod));
-	    break;}
+          switch (errorType) {
+            case (28): {  // FIFO
+              hfedErrors4->Fill(float(FedId), float(fedChannel));
+              hfed2d0->Fill(float(FedId), float(errorTypeMod));
+              htype->Fill(float(errorTypeMod));
+              break;
+            }
 
-	  case(29) : {  // TIMEOUT 
-	    hfedErrors1->Fill(float(FedId),float(fedChannel));
-	    hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	    htype->Fill(float(errorTypeMod));
-	    break;}
+            case (29): {  // TIMEOUT
+              hfedErrors1->Fill(float(FedId), float(fedChannel));
+              hfed2d0->Fill(float(FedId), float(errorTypeMod));
+              htype->Fill(float(errorTypeMod));
+              break;
+            }
 
-	  case(30) : {  // TRAILER
+            case (30): {  // TRAILER
 
-	    int tbm = (word32& 0xff);
-	    int mode = (word32>>8) & 0xf;
-	    hmode->Fill(float(mode));
-	    //cout<<" error 30 "<<hex<<mode<<dec<<endl;
+              int tbm = (word32 & 0xff);
+              int mode = (word32 >> 8) & 0xf;
+              hmode->Fill(float(mode));
+              //cout<<" error 30 "<<hex<<mode<<dec<<endl;
 
-	    if( tbm!=0 ) { // trailer
-	      htbm->Fill(float(tbm));
-	      hfedErrors6->Fill(float(FedId),float(fedChannel));
-	      errorTypeMod=20;
-	      hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	      htype->Fill(float(errorTypeMod));
-	    }
+              if (tbm != 0) {  // trailer
+                htbm->Fill(float(tbm));
+                hfedErrors6->Fill(float(FedId), float(fedChannel));
+                errorTypeMod = 20;
+                hfed2d0->Fill(float(FedId), float(errorTypeMod));
+                htype->Fill(float(errorTypeMod));
+              }
 
-	    if( (mode&0x8) != 0) { // nor
-	      //cout<<" NOR "<<endl;
-	      hfedErrors5->Fill(float(FedId),float(fedChannel));
-	      errorTypeMod=21;
-	      hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	      htype->Fill(float(errorTypeMod));
-	    }
+              if ((mode & 0x8) != 0) {  // nor
+                //cout<<" NOR "<<endl;
+                hfedErrors5->Fill(float(FedId), float(fedChannel));
+                errorTypeMod = 21;
+                hfed2d0->Fill(float(FedId), float(errorTypeMod));
+                htype->Fill(float(errorTypeMod));
+              }
 
-	    if( (mode&0x1) != 0) { // overflow
-	      hfedErrors2->Fill(float(FedId),float(fedChannel));
-	      errorTypeMod=22;
-	      hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	      htype->Fill(float(errorTypeMod));
-	    } 
+              if ((mode & 0x1) != 0) {  // overflow
+                hfedErrors2->Fill(float(FedId), float(fedChannel));
+                errorTypeMod = 22;
+                hfed2d0->Fill(float(FedId), float(errorTypeMod));
+                htype->Fill(float(errorTypeMod));
+              }
 
-	    if( (mode&0x6) != 0) { // fsm
-	      hfedErrors7->Fill(float(FedId),float(fedChannel));
-	      errorTypeMod=23;
-	      hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	      htype->Fill(float(errorTypeMod));
-	    } 
+              if ((mode & 0x6) != 0) {  // fsm
+                hfedErrors7->Fill(float(FedId), float(fedChannel));
+                errorTypeMod = 23;
+                hfed2d0->Fill(float(FedId), float(errorTypeMod));
+                htype->Fill(float(errorTypeMod));
+              }
 
-	    break;}
+              break;
+            }
 
-	  case(31) : {  // EVE
-	    hfedErrors3->Fill(float(FedId),float(fedChannel));
-	    hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	    htype->Fill(float(errorTypeMod));
-	    break;}
-	  } // end switch
+            case (31): {  // EVE
+              hfedErrors3->Fill(float(FedId), float(fedChannel));
+              hfed2d0->Fill(float(FedId), float(errorTypeMod));
+              htype->Fill(float(errorTypeMod));
+              break;
+            }
+          }  // end switch
 
-	} else if (errorType>=32 && errorType<=34) {
-	  cout<<" Slink error "<<endl;
-	  hfedsSlink->Fill(float(FedId));
-	  hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	  htype->Fill(float(errorTypeMod));
+        } else if (errorType >= 32 && errorType <= 34) {
+          cout << " Slink error " << endl;
+          hfedsSlink->Fill(float(FedId));
+          hfed2d0->Fill(float(FedId), float(errorTypeMod));
+          htype->Fill(float(errorTypeMod));
 
-	} else if (errorType==25 || (errorType>=35 &&errorType<=38) ) { // conversion error
+        } else if (errorType == 25 || (errorType >= 35 && errorType <= 38)) {  // conversion error
 
-	  status = MyDecode::data(word32, fedChannel, FedId, PRINT);
-	  if(PRINT) cout<<" fed "<<FedId<<" "<<"Channel "<<fedChannel<<" "<<status<<endl;
+          status = MyDecode::data(word32, fedChannel, FedId, PRINT);
+          if (PRINT)
+            cout << " fed " << FedId << " "
+                 << "Channel " << fedChannel << " " << status << endl;
 
-	  hfedErrors0->Fill(float(FedId),float(fedChannel));
-	  hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	  htype->Fill(float(errorTypeMod));
+          hfedErrors0->Fill(float(FedId), float(fedChannel));
+          hfed2d0->Fill(float(FedId), float(errorTypeMod));
+          htype->Fill(float(errorTypeMod));
 
-	  switch(errorType) {
-	  case(25) : { // inv ROC
-	    hfedErrors8->Fill(float(FedId),float(fedChannel));
-	    break;}
-	  case(36) : { // inv ROC
-	    hfedErrors8->Fill(float(FedId),float(fedChannel));
-	    break;}
-	  case(37) : { // inv DCOL&PIX
-	    hfedErrors9->Fill(float(FedId),float(fedChannel));
-	    if(FedId==6 && fedChannel==35) {
-	      spareCounts++;
-	      cout<<errorType <<" "<<FedId<<" "<<fedChannel;
-	      if(subid==1) cout<<" BPix: layer "<<layer<<" ladder "<<ladder<<" module "<<module<<endl;
-	      else         cout<<" FPix: disk "<<disk<<" "<<blade<<" "<<zindex<<endl; 
-	    }
-	    break;}
-	  }
+          switch (errorType) {
+            case (25): {  // inv ROC
+              hfedErrors8->Fill(float(FedId), float(fedChannel));
+              break;
+            }
+            case (36): {  // inv ROC
+              hfedErrors8->Fill(float(FedId), float(fedChannel));
+              break;
+            }
+            case (37): {  // inv DCOL&PIX
+              hfedErrors9->Fill(float(FedId), float(fedChannel));
+              if (FedId == 6 && fedChannel == 35) {
+                spareCounts++;
+                cout << errorType << " " << FedId << " " << fedChannel;
+                if (subid == 1)
+                  cout << " BPix: layer " << layer << " ladder " << ladder << " module " << module << endl;
+                else
+                  cout << " FPix: disk " << disk << " " << blade << " " << zindex << endl;
+              }
+              break;
+            }
+          }
 
-	} else if ( errorType==39) { // CRC 
-	  cout<<" CRC error "<<endl;
-	  hfedsCRC->Fill(float(FedId));
-	  hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	  htype->Fill(float(errorTypeMod));
+        } else if (errorType == 39) {  // CRC
+          cout << " CRC error " << endl;
+          hfedsCRC->Fill(float(FedId));
+          hfed2d0->Fill(float(FedId), float(errorTypeMod));
+          htype->Fill(float(errorTypeMod));
 
-	} else {
-	  cout<<" unknown error "<<errorType<<endl;
-	  hfedsUnknown->Fill(float(FedId));
-	  errorTypeMod=24;
-	  hfed2d0->Fill(float(FedId),float(errorTypeMod));
-	  htype->Fill(float(errorTypeMod));
-	}
+        } else {
+          cout << " unknown error " << errorType << endl;
+          hfedsUnknown->Fill(float(FedId));
+          errorTypeMod = 24;
+          hfed2d0->Fill(float(FedId), float(errorTypeMod));
+          htype->Fill(float(errorTypeMod));
+        }
 
-	hfed2d->Fill(float(FedId),float(errorTypeMod));
+        hfed2d->Fill(float(FedId), float(errorTypeMod));
 
-	if(errorTypeMod>=0 && errorTypeMod<40) countErrors2[errorTypeMod]++;
+        if (errorTypeMod >= 0 && errorTypeMod < 40)
+          countErrors2[errorTypeMod]++;
 
-      } // for
+      }  // for
 
-    } // if fed/module 
+    }  // if fed/module
 
-  } // end det loop 
-
+  }  // end det loop
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/EventFilter/SiPixelRawToDigi/test/FedErrorDumper.cc
+++ b/EventFilter/SiPixelRawToDigi/test/FedErrorDumper.cc
@@ -1,5 +1,5 @@
 /** \class SiPixelRawDumper_H
- *  Plug-in module that dump raw data file 
+ *  Plug-in module that dump raw data file
  *  for pixel subdetector
  *  Added class to interpret the data d.k. 30/10/08
  *  Add histograms. Add pix 0 detection.
@@ -13,39 +13,42 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
 #include "EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h"
 
 // for detids
-#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
-#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
 // For L1  NOT IN RAW
 //#include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
-//#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
+//#include
+//"DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
 //#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
-//#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
-//#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapRecord.h"
+//#include
+//"DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
+//#include
+//"DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapRecord.h"
 
 // To use root histos
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 
 // For ROOT
 #include <TROOT.h>
 //#include <TChain.h>
-#include <TFile.h>
 #include <TF1.h>
-#include <TH2F.h>
+#include <TFile.h>
 #include <TH1F.h>
+#include <TH2F.h>
 
 #include <iostream>
 using namespace std;
@@ -77,7 +80,8 @@ int MyDecode::header(unsigned long long word64, int fed, bool print) {
   //   }
   if (print)
     cout << " Header "
-         << " for FED " << fed_id << " event " << event_id << " bx " << bx_id << endl;
+         << " for FED " << fed_id << " event " << event_id << " bx " << bx_id
+         << endl;
 
   return event_id;
 }
@@ -89,7 +93,8 @@ int MyDecode::trailer(unsigned long long word64, int fed, bool print) {
   int slinkError = int((word64 & 0xf00) >> 8);
   if (print)
     cout << " Trailer "
-         << " len " << slinkLength << " tts " << tts << " error " << slinkError << " crc " << hex << crc << dec << endl;
+         << " len " << slinkLength << " tts " << tts << " error " << slinkError
+         << " crc " << hex << crc << dec << endl;
   return slinkLength;
 }
 //
@@ -106,34 +111,36 @@ int MyDecode::error(int word, int &fedChannel, int fed, bool print) {
   const unsigned int trailError = 0x3c00000;
   const unsigned int fifoError = 0x3800000;
 
-  //  const unsigned int  timeOutChannelMask = 0x1f;  // channel mask for timeouts
-  //const unsigned int  eventNumMask = 0x1fe000; // event number mask
-  const unsigned int channelMask = 0xfc000000;  // channel num mask
-  const unsigned int tbmEventMask = 0xff;       // tbm event num mask
-  const unsigned int overflowMask = 0x100;      // data overflow
-  const unsigned int tbmStatusMask = 0xff;      //TBM trailer info
-  const unsigned int BlkNumMask = 0x700;        //pointer to error fifo #
-  const unsigned int FsmErrMask = 0x600;        //pointer to FSM errors
-  const unsigned int RocErrMask = 0x800;        //pointer to #Roc errors
-  const unsigned int ChnFifMask = 0x1f;         //channel mask for fifo error
-  const unsigned int Fif2NFMask = 0x40;         //mask for fifo2 NF
-  const unsigned int TrigNFMask = 0x80;         //mask for trigger fifo NF
+  //  const unsigned int  timeOutChannelMask = 0x1f;  // channel mask for
+  //  timeouts
+  // const unsigned int  eventNumMask = 0x1fe000; // event number mask
+  const unsigned int channelMask = 0xfc000000; // channel num mask
+  const unsigned int tbmEventMask = 0xff;      // tbm event num mask
+  const unsigned int overflowMask = 0x100;     // data overflow
+  const unsigned int tbmStatusMask = 0xff;     // TBM trailer info
+  const unsigned int BlkNumMask = 0x700;       // pointer to error fifo #
+  const unsigned int FsmErrMask = 0x600;       // pointer to FSM errors
+  const unsigned int RocErrMask = 0x800;       // pointer to #Roc errors
+  const unsigned int ChnFifMask = 0x1f;        // channel mask for fifo error
+  const unsigned int Fif2NFMask = 0x40;        // mask for fifo2 NF
+  const unsigned int TrigNFMask = 0x80;        // mask for trigger fifo NF
 
   const int offsets[8] = {0, 4, 9, 13, 18, 22, 27, 31};
   unsigned int channel = 0;
 
-  //cout<<"error word "<<hex<<word<<dec<<endl;
+  // cout<<"error word "<<hex<<word<<dec<<endl;
 
-  if ((word & errorMask) == dummyMask) {  // DUMMY WORD
-    //cout<<" Dummy word";
+  if ((word & errorMask) == dummyMask) { // DUMMY WORD
+    // cout<<" Dummy word";
     return 0;
-  } else if ((word & errorMask) == gapMask) {  // GAP WORD
-    //cout<<" Gap word";
+  } else if ((word & errorMask) == gapMask) { // GAP WORD
+    // cout<<" Gap word";
     return 0;
 
-  } else if ((word & errorMask) == timeOut) {  // TIMEOUT
-                                               // More than 1 channel within a group can have a timeout error
-    unsigned int index = (word & 0x1F);        // index within a group of 4/5
+  } else if ((word & errorMask) == timeOut) { // TIMEOUT
+                                              // More than 1 channel within a
+                                              // group can have a timeout error
+    unsigned int index = (word & 0x1F);       // index within a group of 4/5
     unsigned int chip = (word & BlkNumMask) >> 8;
     int offset = offsets[chip];
     if (print)
@@ -146,28 +153,30 @@ int MyDecode::error(int word, int &fedChannel, int fed, bool print) {
       }
       index = index >> 1;
     }
-    //if(print) cout<<" for Fed "<<fed<<endl;
+    // if(print) cout<<" for Fed "<<fed<<endl;
     status = -10;
     fedChannel = channel;
-    //end of timeout  chip and channel decoding
+    // end of timeout  chip and channel decoding
 
-  } else if ((word & errorMask) == eventNumError) {  // EVENT NUMBER ERROR
+  } else if ((word & errorMask) == eventNumError) { // EVENT NUMBER ERROR
     channel = (word & channelMask) >> 26;
     unsigned int tbm_event = (word & tbmEventMask);
 
     if (print)
-      cout << "Event Number Error- channel: " << channel << " tbm event nr. " << tbm_event << " ";
+      cout << "Event Number Error- channel: " << channel << " tbm event nr. "
+           << tbm_event << " ";
     status = -11;
     fedChannel = channel;
 
-  } else if (((word & errorMask) == trailError)) {  // TRAILER
+  } else if (((word & errorMask) == trailError)) { // TRAILER
     channel = (word & channelMask) >> 26;
     unsigned int tbm_status = (word & tbmStatusMask);
 
     if (tbm_status != 0) {
       if (print)
         cout << "Trailer Error- "
-             << "channel: " << channel << " TBM status:0x" << hex << tbm_status << dec << " ";  // <<endl;
+             << "channel: " << channel << " TBM status:0x" << hex << tbm_status
+             << dec << " "; // <<endl;
       status = -15;
       // implement the resync/reset 17
     }
@@ -175,28 +184,28 @@ int MyDecode::error(int word, int &fedChannel, int fed, bool print) {
     if (word & RocErrMask) {
       if (print)
         cout << "Number of Rocs Error- "
-             << "channel: " << channel << " ";  // <<endl;
+             << "channel: " << channel << " "; // <<endl;
       status = -12;
     }
 
     if (word & overflowMask) {
       if (print)
         cout << "Overflow Error- "
-             << "channel: " << channel << " ";  // <<endl;
+             << "channel: " << channel << " "; // <<endl;
       status = -14;
     }
 
     if (word & FsmErrMask) {
       if (print)
         cout << "Finite State Machine Error- "
-             << "channel: " << channel << " Error status:0x" << hex << ((word & FsmErrMask) >> 9) << dec
-             << " ";  // <<endl;
+             << "channel: " << channel << " Error status:0x" << hex
+             << ((word & FsmErrMask) >> 9) << dec << " "; // <<endl;
       status = -13;
     }
 
     fedChannel = channel;
 
-  } else if ((word & errorMask) == fifoError) {  // FIFO
+  } else if ((word & errorMask) == fifoError) { // FIFO
     if (print) {
       if (word & Fif2NFMask)
         cout << "A fifo 2 is Nearly full- ";
@@ -204,7 +213,7 @@ int MyDecode::error(int word, int &fedChannel, int fed, bool print) {
         cout << "The trigger fifo is nearly Full - ";
       if (word & ChnFifMask)
         cout << "fifo-1 is nearly full for channel" << (word & ChnFifMask);
-      //cout<<endl;
+      // cout<<endl;
       status = -16;
     }
 
@@ -220,9 +229,9 @@ int MyDecode::error(int word, int &fedChannel, int fed, bool print) {
 ///////////////////////////////////////////////////////////////////////////
 int MyDecode::data(int word, int &fedChannel, int fed, bool print) {
   const bool CHECK_PIXELS = true;
-  //const int ROCMAX = 24;
-  const unsigned int plsmsk = 0xff;    // pulse height
-  const unsigned int pxlmsk = 0xff00;  // pixel index
+  // const int ROCMAX = 24;
+  const unsigned int plsmsk = 0xff;   // pulse height
+  const unsigned int pxlmsk = 0xff00; // pixel index
   const unsigned int dclmsk = 0x1f0000;
   const unsigned int rocmsk = 0x3e00000;
   const unsigned int chnlmsk = 0xfc000000;
@@ -230,11 +239,11 @@ int MyDecode::data(int word, int &fedChannel, int fed, bool print) {
 
   int roc = ((word & rocmsk) >> 21);
   // Check for embeded special words
-  if (roc > 0 && roc < 25) {  // valid ROCs go from 1-24
-    //if(print) cout<<"data "<<hex<<word<<dec;
+  if (roc > 0 && roc < 25) { // valid ROCs go from 1-24
+    // if(print) cout<<"data "<<hex<<word<<dec;
     unsigned int channel = ((word & chnlmsk) >> 26);
-    if (channel > 0 && channel < 37) {  // valid channels 1-36
-      //cout<<hex<<word<<dec;
+    if (channel > 0 && channel < 37) { // valid channels 1-36
+      // cout<<hex<<word<<dec;
       int dcol = (word & dclmsk) >> 16;
       int pix = (word & pxlmsk) >> 8;
       int adc = (word & plsmsk);
@@ -246,45 +255,56 @@ int MyDecode::data(int word, int &fedChannel, int fed, bool print) {
         int pix1 = pix / 36;
         int pix2 = (pix % 36) / 6;
         int pix3 = pix % 6;
-        cout << " Fed " << fed << " Channel- " << channel << " ROC- " << (roc - 1) << " DCOL- " << dcol << " Pixel- "
-             << pix << " ADC- " << adc << " : " << dcol1 << dcol2 << "-" << pix1 << pix2 << pix3 << endl;
+        cout << " Fed " << fed << " Channel- " << channel << " ROC- "
+             << (roc - 1) << " DCOL- " << dcol << " Pixel- " << pix << " ADC- "
+             << adc << " : " << dcol1 << dcol2 << "-" << pix1 << pix2 << pix3
+             << endl;
       }
       status++;
       if (CHECK_PIXELS) {
         if (dcol < 0 || dcol > 25) {
           if (print)
-            cout << " Fed " << fed << " wrong dcol number chan/roc/dcol/pix/adc = " << channel << "/" << roc << "/"
-                 << dcol << "/" << pix << "/" << adc << endl;
+            cout << " Fed " << fed
+                 << " wrong dcol number chan/roc/dcol/pix/adc = " << channel
+                 << "/" << roc << "/" << dcol << "/" << pix << "/" << adc
+                 << endl;
           status = -3;
         }
 
         if (pix < 2 || pix > 181) {
           if (print)
-            cout << " Fed " << fed << " wrong pix number chan/roc/dcol/pix/adc = " << channel << "/" << roc << "/"
-                 << dcol << "/" << pix << "/" << adc << endl;
+            cout << " Fed " << fed
+                 << " wrong pix number chan/roc/dcol/pix/adc = " << channel
+                 << "/" << roc << "/" << dcol << "/" << pix << "/" << adc
+                 << endl;
           status = -3;
         }
 
         if ((fed > 31 && roc > 24) || (fed <= 31 && roc > 16)) {
           if (print)
-            cout << " Fed " << fed << " wrong roc number chan/roc/dcol/pix/adc = " << channel << "/" << roc << "/"
-                 << dcol << "/" << pix << "/" << adc << endl;
+            cout << " Fed " << fed
+                 << " wrong roc number chan/roc/dcol/pix/adc = " << channel
+                 << "/" << roc << "/" << dcol << "/" << pix << "/" << adc
+                 << endl;
           status = -4;
         } else if (fed <= 31 && channel <= 24 && roc > 8) {
           // ptorotect for rerouted signals
-          if (!((fed == 13 && channel == 17) || (fed == 15 && channel == 5) || (fed == 31 && channel == 10) ||
-                (fed == 27 && channel == 15))) {
+          if (!((fed == 13 && channel == 17) || (fed == 15 && channel == 5) ||
+                (fed == 31 && channel == 10) || (fed == 27 && channel == 15))) {
             if (print)
-              cout << " Fed " << fed << " wrong roc number, chan/roc/dcol/pix/adc = " << channel << "/" << roc << "/"
-                   << dcol << "/" << pix << "/" << adc << endl;
+              cout << " Fed " << fed
+                   << " wrong roc number, chan/roc/dcol/pix/adc = " << channel
+                   << "/" << roc << "/" << dcol << "/" << pix << "/" << adc
+                   << endl;
             status = -4;
           }
         }
 
         if (pix == 0) {
           if (print)
-            cout << " Fed " << fed << " pix=0 chan/roc/dcol/pix/adc = " << channel << "/" << roc << "/" << dcol << "/"
-                 << pix << "/" << adc << endl;
+            cout << " Fed " << fed
+                 << " pix=0 chan/roc/dcol/pix/adc = " << channel << "/" << roc
+                 << "/" << dcol << "/" << pix << "/" << adc << endl;
           status = -5;
         }
       }
@@ -294,18 +314,19 @@ int MyDecode::data(int word, int &fedChannel, int fed, bool print) {
       return -2;
     }
 
-  } else if (roc == 25) {  //
+  } else if (roc == 25) { //
 
     unsigned int channel = ((word & chnlmsk) >> 26);
-    cout << "Wrong roc 25-" << roc << " in fed/chan " << fed << "/" << channel << endl;
+    cout << "Wrong roc 25-" << roc << " in fed/chan " << fed << "/" << channel
+         << endl;
     status = -4;
 
-  } else {  // error word
+  } else { // error word
 
-    //cout<<"error word "<<hex<<word<<dec;
+    // cout<<"error word "<<hex<<word<<dec;
     status = error(word, fedChannel, fed, print);
 
-  }  // end if
+  } // end if
 
   return status;
 }
@@ -322,7 +343,7 @@ public:
 
   void beginJob();
 
-  //void beginRun( const edm::EventSetup& ) {}
+  // void beginRun( const edm::EventSetup& ) {}
 
   // end of job
   void endJob();
@@ -332,44 +353,47 @@ public:
 
 private:
   edm::ParameterSet theConfig;
-  edm::EDGetTokenT<edm::DetSetVector<SiPixelRawDataError> > fedErrorContainer;
+  edm::EDGetTokenT<edm::DetSetVector<SiPixelRawDataError>> fedErrorContainer;
   bool PRINT;
-  //int countEvents, countAllEvents;
+  // int countEvents, countAllEvents;
   int fedErrors, moduleErrors, spareCounts;
-  //float sumPixels, sumFedSize, sumFedPixels[40];
-  //int fedErrors[40][36];
-  //int decodeErrors[40][36];
-  //int decodeErrors000[40][36];  // pix 0 problem
+  // float sumPixels, sumFedSize, sumFedPixels[40];
+  // int fedErrors[40][36];
+  // int decodeErrors[40][36];
+  // int decodeErrors000[40][36];  // pix 0 problem
   int countErrors[40], countErrors2[40];
 
   TH1F *hfeds, *hfedsF, *hfedsSlink, *hfedsCRC, *hfedsUnknown;
   TH1F *herrors, *herrorsF, *htype;
   TH1F *hmode, *hmodeF;
   TH1F *htbm, *htbmF;
-  TH2F *hfedErrors0, *hfedErrors1, *hfedErrors2, *hfedErrors3, *hfedErrors4, *hfedErrors5, *hfedErrors6, *hfedErrors7,
-      *hfedErrors8, *hfedErrors9;
+  TH2F *hfedErrors0, *hfedErrors1, *hfedErrors2, *hfedErrors3, *hfedErrors4,
+      *hfedErrors5, *hfedErrors6, *hfedErrors7, *hfedErrors8, *hfedErrors9;
   TH2F *hfedErrors0F, *hfed2d, *hfed2d0;
 
   TH1F *hlumi, *hbx;
 };
 //----------------------------------
 FedErrorDumper::FedErrorDumper(const edm::ParameterSet &cfg) : theConfig(cfg) {
-  //std::string src_ = theConfig.getUntrackedParameter<std::string>("InputLabel","source");
-  std::string src = theConfig.getUntrackedParameter<std::string>("InputLabel", "siPixelDigis");
+  // std::string src_ =
+  // theConfig.getUntrackedParameter<std::string>("InputLabel","source");
+  std::string src = theConfig.getUntrackedParameter<std::string>(
+      "InputLabel", "siPixelDigis");
 
   // For the ByToken method
-  fedErrorContainer = consumes<edm::DetSetVector<SiPixelRawDataError> >(src);
+  fedErrorContainer = consumes<edm::DetSetVector<SiPixelRawDataError>>(src);
 }
 
 //---------------------------------
 void FedErrorDumper::endJob() {
-  cout << " fed-errors " << fedErrors << " module-Errors " << moduleErrors << " " << spareCounts << endl;
+  cout << " fed-errors " << fedErrors << " module-Errors " << moduleErrors
+       << " " << spareCounts << endl;
   for (int i = 0; i < 40; ++i) {
     if (countErrors[i] > 0 || countErrors2[i] > 0)
       cout << i << " " << countErrors[i] << " " << countErrors2[i] << endl;
   }
 
-  //sumFedPixels[i] /= float(countEvents);
+  // sumFedPixels[i] /= float(countEvents);
   //       hpixels4->Fill(float(i),sumFedPixels[i]); //pixels only
   //     }
   //   }
@@ -378,7 +402,8 @@ void FedErrorDumper::endJob() {
   //     sumPixels /= float(countEvents);
   //     sumFedSize /= float(countAllEvents);
 
-  //   cout<<" Total/non-empty events " <<countAllEvents<<" / "<<countEvents<<" average number of pixels "<<sumPixels<<endl;
+  //   cout<<" Total/non-empty events " <<countAllEvents<<" / "<<countEvents<<"
+  //   average number of pixels "<<sumPixels<<endl;
 
   //   cout<<" Average Fed size for all events "<<sumFedSize<<endl;
   //   for(int i=0;i<40;++i) cout<<sumFedPixels[i]<<" ";
@@ -394,7 +419,8 @@ void FedErrorDumper::endJob() {
   //   cout<<" Decode errors "<<endl<<"  Fed Channel Errors Pix_000"<<endl;
   //   for(int i=0;i<40;++i) {
   //     for(int j=0;j<36;++j) if(decodeErrors[i][j]>0) {
-  //       cout<<i<<" "<<j<<" "<<decodeErrors[i][j]<<" "<<decodeErrors000[i][j]<<endl;
+  //       cout<<i<<" "<<j<<" "<<decodeErrors[i][j]<<"
+  //       "<<decodeErrors000[i][j]<<endl;
   //     }
   //   }
 
@@ -405,13 +431,13 @@ void FedErrorDumper::endJob() {
 }
 
 void FedErrorDumper::beginJob() {
-  //countEvents=0;
-  //countAllEvents=0;
-  //countErrors=0;
+  // countEvents=0;
+  // countAllEvents=0;
+  // countErrors=0;
   fedErrors = 0;
   moduleErrors = 0;
   spareCounts = 0.;
-  //sumFedSize=0;
+  // sumFedSize=0;
 
   PRINT = theConfig.getUntrackedParameter<bool>("Verbosity", false);
   for (int i = 0; i < 40; ++i) {
@@ -439,55 +465,74 @@ void FedErrorDumper::beginJob() {
   hfedsF = fs->make<TH1F>("hfedsF", "errors per FED", 40, -0.5, 39.5);
   hfedsSlink = fs->make<TH1F>("hfedsSlink", "errors per FED", 40, -0.5, 39.5);
   hfedsCRC = fs->make<TH1F>("hfedsCRC", "errors per FED", 40, -0.5, 39.5);
-  hfedsUnknown = fs->make<TH1F>("hfedsUnknown", "errors per FED", 40, -0.5, 39.5);
+  hfedsUnknown =
+      fs->make<TH1F>("hfedsUnknown", "errors per FED", 40, -0.5, 39.5);
 
   htype = fs->make<TH1F>("htype", "error type ", 50, -0.5, 49.5);
   herrors = fs->make<TH1F>("herrors", "error type ", 50, -0.5, 49.5);
   herrorsF = fs->make<TH1F>("herrorsF", "error type", 50, -0.5, 49.5);
 
-  hfedErrors0 = fs->make<TH2F>("hfedErrors0", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // ALL
-  hfedErrors0F = fs->make<TH2F>("hfedErrors0F", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);  // ALL
-  hfedErrors1 = fs->make<TH2F>("hfedErrors1", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // Timeout
-  hfedErrors2 = fs->make<TH2F>("hfedErrors2", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // Overflow
-  hfedErrors3 = fs->make<TH2F>("hfedErrors3", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // ENE
-  hfedErrors4 = fs->make<TH2F>("hfedErrors4", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // FIFO
-  hfedErrors5 = fs->make<TH2F>("hfedErrors5", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // NOR
-  hfedErrors6 = fs->make<TH2F>("hfedErrors6", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // TRAILER
-  hfedErrors7 = fs->make<TH2F>("hfedErrors7", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // FSM
-  hfedErrors8 = fs->make<TH2F>("hfedErrors8", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // Invalid ROC
-  hfedErrors9 = fs->make<TH2F>("hfedErrors9", "errors", 40, -0.5, 39.5, 37, -0.5, 36.5);    // Invalid DCOL-PIX
+  hfedErrors0 = fs->make<TH2F>("hfedErrors0", "errors", 40, -0.5, 39.5, 37,
+                               -0.5, 36.5); // ALL
+  hfedErrors0F = fs->make<TH2F>("hfedErrors0F", "errors", 40, -0.5, 39.5, 37,
+                                -0.5, 36.5); // ALL
+  hfedErrors1 = fs->make<TH2F>("hfedErrors1", "errors", 40, -0.5, 39.5, 37,
+                               -0.5, 36.5); // Timeout
+  hfedErrors2 = fs->make<TH2F>("hfedErrors2", "errors", 40, -0.5, 39.5, 37,
+                               -0.5, 36.5); // Overflow
+  hfedErrors3 = fs->make<TH2F>("hfedErrors3", "errors", 40, -0.5, 39.5, 37,
+                               -0.5, 36.5); // ENE
+  hfedErrors4 = fs->make<TH2F>("hfedErrors4", "errors", 40, -0.5, 39.5, 37,
+                               -0.5, 36.5); // FIFO
+  hfedErrors5 = fs->make<TH2F>("hfedErrors5", "errors", 40, -0.5, 39.5, 37,
+                               -0.5, 36.5); // NOR
+  hfedErrors6 = fs->make<TH2F>("hfedErrors6", "errors", 40, -0.5, 39.5, 37,
+                               -0.5, 36.5); // TRAILER
+  hfedErrors7 = fs->make<TH2F>("hfedErrors7", "errors", 40, -0.5, 39.5, 37,
+                               -0.5, 36.5); // FSM
+  hfedErrors8 = fs->make<TH2F>("hfedErrors8", "errors", 40, -0.5, 39.5, 37,
+                               -0.5, 36.5); // Invalid ROC
+  hfedErrors9 = fs->make<TH2F>("hfedErrors9", "errors", 40, -0.5, 39.5, 37,
+                               -0.5, 36.5); // Invalid DCOL-PIX
 
-  hfed2d = fs->make<TH2F>("hfed2d", "errors", 40, -0.5, 39.5, 20, 19.5, 39.5);    // ALL
-  hfed2d0 = fs->make<TH2F>("hfed2d0", "errors", 40, -0.5, 39.5, 20, 19.5, 39.5);  // ALL
+  hfed2d =
+      fs->make<TH2F>("hfed2d", "errors", 40, -0.5, 39.5, 20, 19.5, 39.5); // ALL
+  hfed2d0 = fs->make<TH2F>("hfed2d0", "errors", 40, -0.5, 39.5, 20, 19.5,
+                           39.5); // ALL
 
   hlumi = fs->make<TH1F>("hlumi", "lumi", 4000, 0, 4000.);
   hbx = fs->make<TH1F>("hbx", "bx", 4000, 0, 4000.);
 }
 //--------------------------------------------------------------------------------
 void FedErrorDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
-  //const bool PRINT = false;
+  // const bool PRINT = false;
 
   // Access event information
   int run = ev.id().run();
   int event = ev.id().event();
   int lumiBlock = ev.luminosityBlock();
   int bx = ev.bunchCrossing();
-  //int orbit     = ev.orbitNumber(); // unused
+  // int orbit     = ev.orbitNumber(); // unused
 
   hlumi->Fill(float(lumiBlock));
   hbx->Fill(float(bx));
 
   //   edm::Handle<FEDRawDataCollection> buffers;
-  //   static std::string label = theConfig.getUntrackedParameter<std::string>("InputLabel","source");
-  //   static std::string instance = theConfig.getUntrackedParameter<std::string>("InputInstance","");
+  //   static std::string label =
+  //   theConfig.getUntrackedParameter<std::string>("InputLabel","source");
+  //   static std::string instance =
+  //   theConfig.getUntrackedParameter<std::string>("InputInstance","");
   //   ev.getByLabel( label, instance, buffers);
 
-  edm::Handle<edm::DetSetVector<SiPixelRawDataError> > input;
-  //static std::string src_ = theConfig.getUntrackedParameter<std::string>("InputLabel","source");
-  //static std::string src_ = theConfig.getUntrackedParameter<std::string>("InputLabel","siPixelDigis");
-  //static std::string instance = theConfig.getUntrackedParameter<std::string>("InputInstance","");
-  //ev.getByLabel( src_, instance, input );
-  ev.getByToken(fedErrorContainer, input);  // the new bytoken
+  edm::Handle<edm::DetSetVector<SiPixelRawDataError>> input;
+  // static std::string src_ =
+  // theConfig.getUntrackedParameter<std::string>("InputLabel","source"); static
+  // std::string src_ =
+  // theConfig.getUntrackedParameter<std::string>("InputLabel","siPixelDigis");
+  // static std::string instance =
+  // theConfig.getUntrackedParameter<std::string>("InputInstance","");
+  // ev.getByLabel( src_, instance, input );
+  ev.getByToken(fedErrorContainer, input); // the new bytoken
 
   if (!input.isValid()) {
     cout << " Container not found " << endl;
@@ -495,16 +540,17 @@ void FedErrorDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
   }
 
   if (PRINT)
-    cout << " Container found " << run << " " << event << " " << lumiBlock << " " << bx << endl;
+    cout << " Container found " << run << " " << event << " " << lumiBlock
+         << " " << bx << endl;
 
   // Iterate on detector units
   edm::DetSetVector<SiPixelRawDataError>::const_iterator DSViter;
   for (DSViter = input->begin(); DSViter != input->end(); DSViter++) {
-    //bool valid = false;
-    unsigned int detid = DSViter->id;  // = rawid
-    //cout<<hex<<detid<<dec<<endl;
+    // bool valid = false;
+    unsigned int detid = DSViter->id; // = rawid
+    // cout<<hex<<detid<<dec<<endl;
 
-    if (detid == 0xffffffff) {  // whole fed
+    if (detid == 0xffffffff) { // whole fed
 
       if (PRINT)
         cout << " FED errors " << DSViter->data.size() << endl;
@@ -512,8 +558,8 @@ void FedErrorDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
       edm::DetSet<SiPixelRawDataError>::const_iterator di;
 
       for (di = DSViter->data.begin(); di != DSViter->data.end(); di++) {
-        int FedId = di->getFedId();     // FED the error came from
-        int errorType = di->getType();  // type of error
+        int FedId = di->getFedId();    // FED the error came from
+        int errorType = di->getType(); // type of error
         uint32_t word32 = di->getWord32();
         uint64_t word64 = di->getWord64();
 
@@ -526,89 +572,91 @@ void FedErrorDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
         int errorTypeMod = errorType;
 
         if (PRINT)
-          cout << " fed " << FedId << " type " << errorType << " " << hex << word32 << " " << word64 << dec << " "
-               << di->getMessage() << endl;
+          cout << " fed " << FedId << " type " << errorType << " " << hex
+               << word32 << " " << word64 << dec << " " << di->getMessage()
+               << endl;
 
         int status = 0;
         int fedChannel = -1;
-        //const bool printData    = true;
-        if (errorType >= 26 && errorType <= 31) {  // fed error
+        // const bool printData    = true;
+        if (errorType >= 26 && errorType <= 31) { // fed error
           status = MyDecode::error(word32, fedChannel, FedId, PRINT);
           if (PRINT)
             cout << " status " << status << endl;
 
           if (fedChannel < 1 || fedChannel > 36) {
-            cout << " Cannot get a valid  fed channel number of a -fed- error " << fedChannel << endl;
-            continue;  // skip this error
+            cout << " Cannot get a valid  fed channel number of a -fed- error "
+                 << fedChannel << endl;
+            continue; // skip this error
           }
 
           hfedErrors0->Fill(float(FedId), float(fedChannel));
           hfedErrors0F->Fill(float(FedId), float(fedChannel));
 
           switch (errorType) {
-            case (28): {  // FIFO
-              hfedErrors4->Fill(float(FedId), float(fedChannel));
+          case (28): { // FIFO
+            hfedErrors4->Fill(float(FedId), float(fedChannel));
+            hfed2d0->Fill(float(FedId), float(errorTypeMod));
+            htype->Fill(float(errorTypeMod));
+            break;
+          }
+
+          case (29): { // TIMEOUT
+            hfedErrors1->Fill(float(FedId), float(fedChannel));
+            hfed2d0->Fill(float(FedId), float(errorTypeMod));
+            htype->Fill(float(errorTypeMod));
+            break;
+          }
+
+          case (30): { // TRAILER
+
+            int tbm = (word32 & 0xff);
+            int mode = (word32 >> 8) & 0xf;
+            hmodeF->Fill(float(mode));
+            hmode->Fill(float(mode));
+            // cout<<" error 30 "<<hex<<mode<<dec<<endl;
+            countErrors[30]++;
+
+            if (tbm != 0) { // trailer
+              hfedErrors6->Fill(float(FedId), float(fedChannel));
+              htbmF->Fill(float(tbm));
+              errorTypeMod = 20;
               hfed2d0->Fill(float(FedId), float(errorTypeMod));
               htype->Fill(float(errorTypeMod));
-              break;
             }
 
-            case (29): {  // TIMEOUT
-              hfedErrors1->Fill(float(FedId), float(fedChannel));
+            if ((mode & 0x8) != 0) { // nor
+              // cout<<" NOR "<<endl;
+              hfedErrors5->Fill(float(FedId), float(fedChannel));
+              errorTypeMod = 21;
               hfed2d0->Fill(float(FedId), float(errorTypeMod));
               htype->Fill(float(errorTypeMod));
-              break;
             }
 
-            case (30): {  // TRAILER
-
-              int tbm = (word32 & 0xff);
-              int mode = (word32 >> 8) & 0xf;
-              hmodeF->Fill(float(mode));
-              hmode->Fill(float(mode));
-              //cout<<" error 30 "<<hex<<mode<<dec<<endl;
-              countErrors[30]++;
-
-              if (tbm != 0) {  // trailer
-                hfedErrors6->Fill(float(FedId), float(fedChannel));
-                htbmF->Fill(float(tbm));
-                errorTypeMod = 20;
-                hfed2d0->Fill(float(FedId), float(errorTypeMod));
-                htype->Fill(float(errorTypeMod));
-              }
-
-              if ((mode & 0x8) != 0) {  // nor
-                //cout<<" NOR "<<endl;
-                hfedErrors5->Fill(float(FedId), float(fedChannel));
-                errorTypeMod = 21;
-                hfed2d0->Fill(float(FedId), float(errorTypeMod));
-                htype->Fill(float(errorTypeMod));
-              }
-
-              if ((mode & 0x1) != 0) {  // overflow
-                hfedErrors2->Fill(float(FedId), float(fedChannel));
-                errorTypeMod = 22;
-                hfed2d0->Fill(float(FedId), float(errorTypeMod));
-                htype->Fill(float(errorTypeMod));
-              }
-
-              if ((mode & 0x6) != 0) {  // fsm
-                hfedErrors7->Fill(float(FedId), float(fedChannel));
-                errorTypeMod = 23;
-                hfed2d0->Fill(float(FedId), float(errorTypeMod));
-                htype->Fill(float(errorTypeMod));
-              }
-
-              break;
-            }
-
-            case (31): {  // EVE
-              hfedErrors3->Fill(float(FedId), float(fedChannel));
+            if ((mode & 0x1) != 0) { // overflow
+              hfedErrors2->Fill(float(FedId), float(fedChannel));
+              errorTypeMod = 22;
               hfed2d0->Fill(float(FedId), float(errorTypeMod));
               htype->Fill(float(errorTypeMod));
-              break;
             }
-          }  // end switch
+
+            if ((mode & 0x6) != 0) { // fsm
+              hfedErrors7->Fill(float(FedId), float(fedChannel));
+              errorTypeMod = 23;
+              hfed2d0->Fill(float(FedId), float(errorTypeMod));
+              htype->Fill(float(errorTypeMod));
+            }
+
+            break;
+          }
+
+          case (31): { // EVE
+            hfedErrors3->Fill(float(FedId), float(fedChannel));
+            hfed2d0->Fill(float(FedId), float(errorTypeMod));
+            htype->Fill(float(errorTypeMod));
+            break;
+          }
+          } // end switch
 
         } else if (errorType >= 32 && errorType <= 34) {
           cout << " Slink error " << endl;
@@ -617,7 +665,8 @@ void FedErrorDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
           hfed2d0->Fill(float(FedId), float(errorTypeMod));
           htype->Fill(float(errorTypeMod));
 
-        } else if (errorType == 25 || (errorType >= 35 && errorType <= 38)) {  // conversion error
+        } else if (errorType == 25 ||
+                   (errorType >= 35 && errorType <= 38)) { // conversion error
           cout << " Should never happen, a -fed- conversion error?  " << endl;
           status = MyDecode::data(word32, fedChannel, FedId, PRINT);
           if (PRINT)
@@ -628,23 +677,23 @@ void FedErrorDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
           htype->Fill(float(errorTypeMod));
 
           switch (errorType) {
-            case (25): {  // inv ROC
-              hfedErrors8->Fill(float(FedId), float(fedChannel));
-              break;
-            }
-            case (36): {  // inv ROC
-              hfedErrors8->Fill(float(FedId), float(fedChannel));
-              break;
-            }
-            case (37): {  // inv DCOL&PIX
-              hfedErrors9->Fill(float(FedId), float(fedChannel));
-              //spareCounts++;
-              cout << " does it ever happen " << endl;
-              break;
-            }
+          case (25): { // inv ROC
+            hfedErrors8->Fill(float(FedId), float(fedChannel));
+            break;
+          }
+          case (36): { // inv ROC
+            hfedErrors8->Fill(float(FedId), float(fedChannel));
+            break;
+          }
+          case (37): { // inv DCOL&PIX
+            hfedErrors9->Fill(float(FedId), float(fedChannel));
+            // spareCounts++;
+            cout << " does it ever happen " << endl;
+            break;
+          }
           }
 
-        } else if (errorType == 39) {  // CRC
+        } else if (errorType == 39) { // CRC
           cout << " CRC error " << endl;
           hfedsCRC->Fill(float(FedId));
           hfed2d0->Fill(float(FedId), float(errorTypeMod));
@@ -663,29 +712,31 @@ void FedErrorDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
         if (errorTypeMod >= 0 && errorTypeMod < 40)
           countErrors[errorTypeMod]++;
 
-      }  // for errors
+      } // for errors
 
-    } else {  // module errors
+    } else { // module errors
 
       DetId detId(detid);
-      //const GeomDetUnit      * geoUnit = geom->idToDetUnit( detId );
-      //const PixelGeomDetUnit * pixDet  = dynamic_cast<const PixelGeomDetUnit*>(geoUnit);
-      unsigned int detType = detId.det();     // det type, tracker=1
-      unsigned int subid = detId.subdetId();  //subdetector type, barrel=1
+      // const GeomDetUnit      * geoUnit = geom->idToDetUnit( detId );
+      // const PixelGeomDetUnit * pixDet  = dynamic_cast<const
+      // PixelGeomDetUnit*>(geoUnit);
+      unsigned int detType = detId.det();    // det type, tracker=1
+      unsigned int subid = detId.subdetId(); // subdetector type, barrel=1
 
       if (PRINT) {
         cout << " Module errors " << DSViter->data.size() << endl;
         cout << "Det: " << detId.rawId() << ":";
-        //cout<<"Det: "<<detId.rawId()<<" "<<detId.null()<<" "<<detType<<" "<<subid<<endl;
+        // cout<<"Det: "<<detId.rawId()<<" "<<detId.null()<<" "<<detType<<"
+        // "<<subid<<endl;
       }
 
       int layer = 0, ladder = 0, module = 0, disk = 0, blade = 0, zindex = 0;
-      if (subid == 1) {  // bpix
+      if (subid == 1) { // bpix
         PXBDetId pdetId = PXBDetId(detid);
         // Barell layer = 1,2,3
-        int layerC = pdetId.layer();  // unused
+        int layerC = pdetId.layer(); // unused
         // Barrel ladder id 1-20,32,44.
-        int ladderC = pdetId.ladder();  // unused
+        int ladderC = pdetId.ladder(); // unused
         // Barrel Z-index=1,8
         int zindex = pdetId.module();
         // Convert to online
@@ -698,44 +749,47 @@ void FedErrorDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
         PixelBarrelName::Shell shell = pbn.shell();
 
         if (PRINT)
-          cout << " BPix: layer " << layer << " ladder " << ladder << " module " << module << " shell " << shell
-               << " sector " << sector << " " << layerC << " " << ladderC << " " << zindex << " " << half << " "
-               << detType << endl;
+          cout << " BPix: layer " << layer << " ladder " << ladder << " module "
+               << module << " shell " << shell << " sector " << sector << " "
+               << layerC << " " << ladderC << " " << zindex << " " << half
+               << " " << detType << endl;
 
-      } else if (subid == 2) {  // fpix
+      } else if (subid == 2) { // fpix
 
         PXFDetId pdetId = PXFDetId(detid);
-        disk = pdetId.disk();        //1,2,3
-        blade = pdetId.blade();      //1-24
-        zindex = pdetId.module();    //
-        int side = pdetId.side();    //size=1 for -z, 2 for +z
-        int panel = pdetId.panel();  //panel=1
+        disk = pdetId.disk();       // 1,2,3
+        blade = pdetId.blade();     // 1-24
+        zindex = pdetId.module();   //
+        int side = pdetId.side();   // size=1 for -z, 2 for +z
+        int panel = pdetId.panel(); // panel=1
 
         if (PRINT)
-          cout << " FPix: disk " << disk << " " << blade << " " << side << " " << panel << endl;
+          cout << " FPix: disk " << disk << " " << blade << " " << side << " "
+               << panel << endl;
       }
 
       // Look at FED errors now
       edm::DetSet<SiPixelRawDataError>::const_iterator di;
       for (di = DSViter->data.begin(); di != DSViter->data.end(); di++) {
-        int FedId = di->getFedId();     // FED the error came from
-        int errorType = di->getType();  // type of error
+        int FedId = di->getFedId();    // FED the error came from
+        int errorType = di->getType(); // type of error
         uint32_t word32 = di->getWord32();
-        //uint64_t word64 = di->getWord64();  // unused
+        // uint64_t word64 = di->getWord64();  // unused
 
         herrors->Fill(float(errorType));
         moduleErrors++;
         int errorTypeMod = errorType;
 
-        //cout<<" fed " <<FedId<<" type "<<errorType<<" "<<hex<<word32<<" "<<word64<<dec<<" "<<di->getMessage()<<endl;
+        // cout<<" fed " <<FedId<<" type "<<errorType<<" "<<hex<<word32<<"
+        // "<<word64<<dec<<" "<<di->getMessage()<<endl;
         if (PRINT)
           cout << " fed " << FedId << " type " << errorType << endl;
 
         int status = 0;
         int fedChannel = 0;
-        //const bool printData    = true;
+        // const bool printData    = true;
 
-        if (errorType >= 26 && errorType <= 31) {  // fed error
+        if (errorType >= 26 && errorType <= 31) { // fed error
           status = MyDecode::error(word32, fedChannel, FedId, PRINT);
           if (PRINT)
             cout << " fed " << FedId << " "
@@ -744,67 +798,67 @@ void FedErrorDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
           hfedErrors0->Fill(float(FedId), float(fedChannel));
 
           switch (errorType) {
-            case (28): {  // FIFO
-              hfedErrors4->Fill(float(FedId), float(fedChannel));
+          case (28): { // FIFO
+            hfedErrors4->Fill(float(FedId), float(fedChannel));
+            hfed2d0->Fill(float(FedId), float(errorTypeMod));
+            htype->Fill(float(errorTypeMod));
+            break;
+          }
+
+          case (29): { // TIMEOUT
+            hfedErrors1->Fill(float(FedId), float(fedChannel));
+            hfed2d0->Fill(float(FedId), float(errorTypeMod));
+            htype->Fill(float(errorTypeMod));
+            break;
+          }
+
+          case (30): { // TRAILER
+
+            int tbm = (word32 & 0xff);
+            int mode = (word32 >> 8) & 0xf;
+            hmode->Fill(float(mode));
+            // cout<<" error 30 "<<hex<<mode<<dec<<endl;
+
+            if (tbm != 0) { // trailer
+              htbm->Fill(float(tbm));
+              hfedErrors6->Fill(float(FedId), float(fedChannel));
+              errorTypeMod = 20;
               hfed2d0->Fill(float(FedId), float(errorTypeMod));
               htype->Fill(float(errorTypeMod));
-              break;
             }
 
-            case (29): {  // TIMEOUT
-              hfedErrors1->Fill(float(FedId), float(fedChannel));
+            if ((mode & 0x8) != 0) { // nor
+              // cout<<" NOR "<<endl;
+              hfedErrors5->Fill(float(FedId), float(fedChannel));
+              errorTypeMod = 21;
               hfed2d0->Fill(float(FedId), float(errorTypeMod));
               htype->Fill(float(errorTypeMod));
-              break;
             }
 
-            case (30): {  // TRAILER
-
-              int tbm = (word32 & 0xff);
-              int mode = (word32 >> 8) & 0xf;
-              hmode->Fill(float(mode));
-              //cout<<" error 30 "<<hex<<mode<<dec<<endl;
-
-              if (tbm != 0) {  // trailer
-                htbm->Fill(float(tbm));
-                hfedErrors6->Fill(float(FedId), float(fedChannel));
-                errorTypeMod = 20;
-                hfed2d0->Fill(float(FedId), float(errorTypeMod));
-                htype->Fill(float(errorTypeMod));
-              }
-
-              if ((mode & 0x8) != 0) {  // nor
-                //cout<<" NOR "<<endl;
-                hfedErrors5->Fill(float(FedId), float(fedChannel));
-                errorTypeMod = 21;
-                hfed2d0->Fill(float(FedId), float(errorTypeMod));
-                htype->Fill(float(errorTypeMod));
-              }
-
-              if ((mode & 0x1) != 0) {  // overflow
-                hfedErrors2->Fill(float(FedId), float(fedChannel));
-                errorTypeMod = 22;
-                hfed2d0->Fill(float(FedId), float(errorTypeMod));
-                htype->Fill(float(errorTypeMod));
-              }
-
-              if ((mode & 0x6) != 0) {  // fsm
-                hfedErrors7->Fill(float(FedId), float(fedChannel));
-                errorTypeMod = 23;
-                hfed2d0->Fill(float(FedId), float(errorTypeMod));
-                htype->Fill(float(errorTypeMod));
-              }
-
-              break;
-            }
-
-            case (31): {  // EVE
-              hfedErrors3->Fill(float(FedId), float(fedChannel));
+            if ((mode & 0x1) != 0) { // overflow
+              hfedErrors2->Fill(float(FedId), float(fedChannel));
+              errorTypeMod = 22;
               hfed2d0->Fill(float(FedId), float(errorTypeMod));
               htype->Fill(float(errorTypeMod));
-              break;
             }
-          }  // end switch
+
+            if ((mode & 0x6) != 0) { // fsm
+              hfedErrors7->Fill(float(FedId), float(fedChannel));
+              errorTypeMod = 23;
+              hfed2d0->Fill(float(FedId), float(errorTypeMod));
+              htype->Fill(float(errorTypeMod));
+            }
+
+            break;
+          }
+
+          case (31): { // EVE
+            hfedErrors3->Fill(float(FedId), float(fedChannel));
+            hfed2d0->Fill(float(FedId), float(errorTypeMod));
+            htype->Fill(float(errorTypeMod));
+            break;
+          }
+          } // end switch
 
         } else if (errorType >= 32 && errorType <= 34) {
           cout << " Slink error " << endl;
@@ -812,7 +866,8 @@ void FedErrorDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
           hfed2d0->Fill(float(FedId), float(errorTypeMod));
           htype->Fill(float(errorTypeMod));
 
-        } else if (errorType == 25 || (errorType >= 35 && errorType <= 38)) {  // conversion error
+        } else if (errorType == 25 ||
+                   (errorType >= 35 && errorType <= 38)) { // conversion error
 
           status = MyDecode::data(word32, fedChannel, FedId, PRINT);
           if (PRINT)
@@ -824,29 +879,31 @@ void FedErrorDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
           htype->Fill(float(errorTypeMod));
 
           switch (errorType) {
-            case (25): {  // inv ROC
-              hfedErrors8->Fill(float(FedId), float(fedChannel));
-              break;
+          case (25): { // inv ROC
+            hfedErrors8->Fill(float(FedId), float(fedChannel));
+            break;
+          }
+          case (36): { // inv ROC
+            hfedErrors8->Fill(float(FedId), float(fedChannel));
+            break;
+          }
+          case (37): { // inv DCOL&PIX
+            hfedErrors9->Fill(float(FedId), float(fedChannel));
+            if (FedId == 6 && fedChannel == 35) {
+              spareCounts++;
+              cout << errorType << " " << FedId << " " << fedChannel;
+              if (subid == 1)
+                cout << " BPix: layer " << layer << " ladder " << ladder
+                     << " module " << module << endl;
+              else
+                cout << " FPix: disk " << disk << " " << blade << " " << zindex
+                     << endl;
             }
-            case (36): {  // inv ROC
-              hfedErrors8->Fill(float(FedId), float(fedChannel));
-              break;
-            }
-            case (37): {  // inv DCOL&PIX
-              hfedErrors9->Fill(float(FedId), float(fedChannel));
-              if (FedId == 6 && fedChannel == 35) {
-                spareCounts++;
-                cout << errorType << " " << FedId << " " << fedChannel;
-                if (subid == 1)
-                  cout << " BPix: layer " << layer << " ladder " << ladder << " module " << module << endl;
-                else
-                  cout << " FPix: disk " << disk << " " << blade << " " << zindex << endl;
-              }
-              break;
-            }
+            break;
+          }
           }
 
-        } else if (errorType == 39) {  // CRC
+        } else if (errorType == 39) { // CRC
           cout << " CRC error " << endl;
           hfedsCRC->Fill(float(FedId));
           hfed2d0->Fill(float(FedId), float(errorTypeMod));
@@ -865,11 +922,11 @@ void FedErrorDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
         if (errorTypeMod >= 0 && errorTypeMod < 40)
           countErrors2[errorTypeMod]++;
 
-      }  // for
+      } // for
 
-    }  // if fed/module
+    } // if fed/module
 
-  }  // end det loop
+  } // end det loop
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/EventFilter/SiPixelRawToDigi/test/SiPixelRawDumper.cc
+++ b/EventFilter/SiPixelRawToDigi/test/SiPixelRawDumper.cc
@@ -10,7 +10,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 #include "DataFormats/Common/interface/Handle.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -20,7 +19,6 @@
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
 #include "EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h"
-
 
 // For L1  NOT IN RAW
 //#include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
@@ -48,25 +46,24 @@
 #include <TProfile.h>
 #include <TProfile2D.h>
 
-
 #include <iostream>
 #include <fstream>
 
 using namespace std;
 
 // #define L1  // L1 information not in RAW
-//#define OUTFILE 
+//#define OUTFILE
 
 namespace {
-  bool printErrors  = true;
-  bool printData    = false;
+  bool printErrors = true;
+  bool printData = false;
   bool printHeaders = false;
   const bool CHECK_PIXELS = true;
   const bool PRINT_BASELINE = false;
-  // to store the previous pixel 
-  int fed0 = -1, chan0 = -1, roc0 = -1, dcol0 = -1, pix0 =-1, count0=-1;
-  int countDecodeErrors1=0, countDecodeErrors2=0;
-}
+  // to store the previous pixel
+  int fed0 = -1, chan0 = -1, roc0 = -1, dcol0 = -1, pix0 = -1, count0 = -1;
+  int countDecodeErrors1 = 0, countDecodeErrors2 = 0;
+}  // namespace
 
 // Include the helper decoding class
 /////////////////////////////////////////////////////////////////////////////
@@ -74,13 +71,14 @@ class MyDecode {
 public:
   MyDecode() {}
   ~MyDecode() {}
-  static int error(int error,int & fedChannel, int fed, int & stat1, int & stat2, bool print=false);
-  static int data(int error, int & fedChannel, int fed, int & stat1, int & stat2, bool print=false);
-  static int header(unsigned long long word64, int fed, bool print, unsigned int & bx);
+  static int error(int error, int &fedChannel, int fed, int &stat1, int &stat2, bool print = false);
+  static int data(int error, int &fedChannel, int fed, int &stat1, int &stat2, bool print = false);
+  static int header(unsigned long long word64, int fed, bool print, unsigned int &bx);
   static int trailer(unsigned long long word64, int fed, bool print);
-  static int convertToCol(int dcol,int pix);
+  static int convertToCol(int dcol, int pix);
   static int convertToRow(int pix);
   static int checkLayerLink(int fed, int chan);
+
 private:
 };
 /////////////////////////////////////////////////////////////////////////////
@@ -89,68 +87,79 @@ private:
 // needs fedid 0-31, and channel 1-36.
 int MyDecode::checkLayerLink(int fed, int chan) {
   int layer = 0;
-  if(fed<0 || fed>31) return layer;  // return 0 for invalid of fpix
+  if (fed < 0 || fed > 31)
+    return layer;  // return 0 for invalid of fpix
 
-  if( chan>24) {   // layer 3
+  if (chan > 24) {  // layer 3
 
-    if(fed==0 || fed==8 )  {  // Type A
+    if (fed == 0 || fed == 8) {  // Type A
 
-      if(chan==28 ||chan==34 ||chan==35 ||chan==36 ) layer=13;  // 1/2 module
-      else layer = 3;
+      if (chan == 28 || chan == 34 || chan == 35 || chan == 36)
+        layer = 13;  // 1/2 module
+      else
+        layer = 3;
 
-    } else if(fed==23 || fed==31 )  {  // Type A
+    } else if (fed == 23 || fed == 31) {  // Type A
 
-      if(chan==27 ||chan==31 ||chan==32 ||chan==33 ) layer=13;  // 1/2 module
-      else layer = 3;
-  
-    } else if(fed==7 || fed==15 || fed==16 || fed==24 )  { // Type D
+      if (chan == 27 || chan == 31 || chan == 32 || chan == 33)
+        layer = 13;  // 1/2 module
+      else
+        layer = 3;
 
-      if(chan==25 ||chan==26 ||chan==29 ||chan==30 ) layer=13;
-      else layer = 3;
+    } else if (fed == 7 || fed == 15 || fed == 16 || fed == 24) {  // Type D
 
-    }  else { layer = 3;}
-
-    return layer; // layer 3
-
-  } else if( (chan>=13 && chan<=19) || chan==24 ) {
-
-    return 2; //layer 2
-
-  } else {
-
-    if(fed==0 || fed==8 || fed==16 || fed==24 )  {  // Type A   WRONG AFTER FIBER SWAP
-
-      if(chan==5 ||chan==6 ||chan==22 ||chan==23 ) layer=12; // 1/2 module 
-      else if(chan==4 ||chan==10 ||chan==11 ||chan==12 ) layer=11; // 1/2 module 
-      else layer = 1;
-  
-    } else if(fed==7 || fed==15 || fed==23 || fed==31 )  { // Type D
-
-      if(chan==1 ||chan==2 ||chan==20 ||chan==21 ) layer=12; // 1/2
-      else if(chan==3 ||chan==7 ||chan==8 ||chan==9 ) layer=11; // 1/2 
-      else layer = 1;
-
-    } else if(
-              fed==1  || fed==2  || fed==3  ||   
-              fed==9  || fed==10 || fed==11 ||   
-              fed==17 || fed==18 || fed==19 ||   
-              fed==25 || fed==26 || fed==27  )  { // Type B
-
-      if( (chan>=4 && chan<=6) || (chan>=10 && chan<=12) || (chan>=22 && chan<=23) ) layer=2;
-      else layer = 1;
-
-    } else if(
-              fed==4  || fed==5  || fed==6  ||   
-              fed==12 || fed==13 || fed==14 ||   
-              fed==20 || fed==21 || fed==22 ||   
-              fed==28 || fed==29 || fed==30  )  { // Type C
-
-      if( (chan>=1 && chan<=3) || (chan>=7 && chan<=9) || (chan>=20 && chan<=21) ) layer=2;
-      else layer = 1;
+      if (chan == 25 || chan == 26 || chan == 29 || chan == 30)
+        layer = 13;
+      else
+        layer = 3;
 
     } else {
-      cout<<"unknown fed "<<fed<<endl;
-    } // if fed 
+      layer = 3;
+    }
+
+    return layer;  // layer 3
+
+  } else if ((chan >= 13 && chan <= 19) || chan == 24) {
+    return 2;  //layer 2
+
+  } else {
+    if (fed == 0 || fed == 8 || fed == 16 || fed == 24) {  // Type A   WRONG AFTER FIBER SWAP
+
+      if (chan == 5 || chan == 6 || chan == 22 || chan == 23)
+        layer = 12;  // 1/2 module
+      else if (chan == 4 || chan == 10 || chan == 11 || chan == 12)
+        layer = 11;  // 1/2 module
+      else
+        layer = 1;
+
+    } else if (fed == 7 || fed == 15 || fed == 23 || fed == 31) {  // Type D
+
+      if (chan == 1 || chan == 2 || chan == 20 || chan == 21)
+        layer = 12;  // 1/2
+      else if (chan == 3 || chan == 7 || chan == 8 || chan == 9)
+        layer = 11;  // 1/2
+      else
+        layer = 1;
+
+    } else if (fed == 1 || fed == 2 || fed == 3 || fed == 9 || fed == 10 || fed == 11 || fed == 17 || fed == 18 ||
+               fed == 19 || fed == 25 || fed == 26 || fed == 27) {  // Type B
+
+      if ((chan >= 4 && chan <= 6) || (chan >= 10 && chan <= 12) || (chan >= 22 && chan <= 23))
+        layer = 2;
+      else
+        layer = 1;
+
+    } else if (fed == 4 || fed == 5 || fed == 6 || fed == 12 || fed == 13 || fed == 14 || fed == 20 || fed == 21 ||
+               fed == 22 || fed == 28 || fed == 29 || fed == 30) {  // Type C
+
+      if ((chan >= 1 && chan <= 3) || (chan >= 7 && chan <= 9) || (chan >= 20 && chan <= 21))
+        layer = 2;
+      else
+        layer = 1;
+
+    } else {
+      cout << "unknown fed " << fed << endl;
+    }  // if fed
 
     return layer;
 
@@ -159,319 +168,336 @@ int MyDecode::checkLayerLink(int fed, int chan) {
 
 int MyDecode::convertToCol(int dcol, int pix) {
   // First find if we are in the first or 2nd col of a dcol.
-  int colEvenOdd = pix%2;  // module(2), 0-1st sol, 1-2nd col.
+  int colEvenOdd = pix % 2;  // module(2), 0-1st sol, 1-2nd col.
   // Transform
-  return (dcol * 2 + colEvenOdd); // col address, starts from 0
-
+  return (dcol * 2 + colEvenOdd);  // col address, starts from 0
 }
 int MyDecode::convertToRow(int pix) {
-  return abs( int(pix/2) - 80); // row addres, starts from 0
+  return abs(int(pix / 2) - 80);  // row addres, starts from 0
 }
 
-int MyDecode::header(unsigned long long word64, int fed, bool print, unsigned int & bx) {
-  int fed_id=(word64>>8)&0xfff;
-  int event_id=(word64>>32)&0xffffff;
-  bx =(word64>>20)&0xfff;
-//   if(bx!=101) {
-//     cout<<" Header "<<" for FED "
-// 	<<fed_id<<" event "<<event_id<<" bx "<<bx<<endl;
-//     int dummy=0;
-//     cout<<" : ";
-//     cin>>dummy;
-//   }
-  if(print) cout<<"Header "<<" for FED "
-		<<fed_id<<" event "<<event_id<<" bx "<<bx<<endl;
-  fed0=-1; // reset the previous hit fed id
+int MyDecode::header(unsigned long long word64, int fed, bool print, unsigned int &bx) {
+  int fed_id = (word64 >> 8) & 0xfff;
+  int event_id = (word64 >> 32) & 0xffffff;
+  bx = (word64 >> 20) & 0xfff;
+  //   if(bx!=101) {
+  //     cout<<" Header "<<" for FED "
+  // 	<<fed_id<<" event "<<event_id<<" bx "<<bx<<endl;
+  //     int dummy=0;
+  //     cout<<" : ";
+  //     cin>>dummy;
+  //   }
+  if (print)
+    cout << "Header "
+         << " for FED " << fed_id << " event " << event_id << " bx " << bx << endl;
+  fed0 = -1;  // reset the previous hit fed id
   return event_id;
 }
 //
 int MyDecode::trailer(unsigned long long word64, int fed, bool print) {
-  int slinkLength = int( (word64>>32) & 0xffffff );
-  int crc         = int( (word64&0xffff0000)>>16 );
-  int tts         = int( (word64&0xf0)>>4);
-  int slinkError  = int( (word64&0xf00)>>8);
-  if(print) cout<<"Trailer "<<" len "<<slinkLength
-		<<" tts "<<tts<<" error "<<slinkError<<" crc "<<hex<<crc<<dec<<endl;
+  int slinkLength = int((word64 >> 32) & 0xffffff);
+  int crc = int((word64 & 0xffff0000) >> 16);
+  int tts = int((word64 & 0xf0) >> 4);
+  int slinkError = int((word64 & 0xf00) >> 8);
+  if (print)
+    cout << "Trailer "
+         << " len " << slinkLength << " tts " << tts << " error " << slinkError << " crc " << hex << crc << dec << endl;
   return slinkLength;
 }
 //
 // Decode error FIFO
 // Works for both, the error FIFO and the SLink error words. d.k. 25/04/07
-int MyDecode::error(int word, int & fedChannel, int fed, int & stat1, int & stat2, bool print) {
+int MyDecode::error(int word, int &fedChannel, int fed, int &stat1, int &stat2, bool print) {
   int status = -1;
   print = print || printErrors;
 
-  const unsigned int  errorMask      = 0x3e00000;
-  const unsigned int  dummyMask      = 0x03600000;
-  const unsigned int  gapMask        = 0x03400000;
-  const unsigned int  timeOut        = 0x3a00000;
-  const unsigned int  eventNumError  = 0x3e00000;
-  const unsigned int  trailError     = 0x3c00000;
-  const unsigned int  fifoError      = 0x3800000;
+  const unsigned int errorMask = 0x3e00000;
+  const unsigned int dummyMask = 0x03600000;
+  const unsigned int gapMask = 0x03400000;
+  const unsigned int timeOut = 0x3a00000;
+  const unsigned int eventNumError = 0x3e00000;
+  const unsigned int trailError = 0x3c00000;
+  const unsigned int fifoError = 0x3800000;
 
-//  const unsigned int  timeOutChannelMask = 0x1f;  // channel mask for timeouts
+  //  const unsigned int  timeOutChannelMask = 0x1f;  // channel mask for timeouts
   //const unsigned int  eventNumMask = 0x1fe000; // event number mask
-  const unsigned int  channelMask = 0xfc000000; // channel num mask
-  const unsigned int  tbmEventMask = 0xff;    // tbm event num mask
-  const unsigned int  overflowMask = 0x100;   // data overflow
-  const unsigned int  tbmStatusMask = 0xff;   //TBM trailer info
-  const unsigned int  BlkNumMask = 0x700;   //pointer to error fifo #
-  const unsigned int  FsmErrMask = 0x600;   //pointer to FSM errors
-  const unsigned int  RocErrMask = 0x800;   //pointer to #Roc errors
-  const unsigned int  ChnFifMask = 0x1f;   //channel mask for fifo error
-  const unsigned int  Fif2NFMask = 0x40;   //mask for fifo2 NF
-  const unsigned int  TrigNFMask = 0x80;   //mask for trigger fifo NF
-  
-  const int offsets[8] = {0,4,9,13,18,22,27,31};
+  const unsigned int channelMask = 0xfc000000;  // channel num mask
+  const unsigned int tbmEventMask = 0xff;       // tbm event num mask
+  const unsigned int overflowMask = 0x100;      // data overflow
+  const unsigned int tbmStatusMask = 0xff;      //TBM trailer info
+  const unsigned int BlkNumMask = 0x700;        //pointer to error fifo #
+  const unsigned int FsmErrMask = 0x600;        //pointer to FSM errors
+  const unsigned int RocErrMask = 0x800;        //pointer to #Roc errors
+  const unsigned int ChnFifMask = 0x1f;         //channel mask for fifo error
+  const unsigned int Fif2NFMask = 0x40;         //mask for fifo2 NF
+  const unsigned int TrigNFMask = 0x80;         //mask for trigger fifo NF
+
+  const int offsets[8] = {0, 4, 9, 13, 18, 22, 27, 31};
   unsigned int channel = 0;
 
   //cout<<"error word "<<hex<<word<<dec<<endl;
-  
-  if( (word&errorMask) == dummyMask ) { // DUMMY WORD
+
+  if ((word & errorMask) == dummyMask) {  // DUMMY WORD
     //cout<<" Dummy word";
     return 0;
 
-  } else if( (word&errorMask) == gapMask ) { // GAP WORD
+  } else if ((word & errorMask) == gapMask) {  // GAP WORD
     //cout<<" Gap word";
     return 0;
-    
-  } else if( (word&errorMask)==timeOut ) { // TIMEOUT
 
-    unsigned int bit20 =      (word & 0x100000)>>20; // works only for slink format
+  } else if ((word & errorMask) == timeOut) {  // TIMEOUT
 
-    if(bit20 == 0) { // 2nd word 
+    unsigned int bit20 = (word & 0x100000) >> 20;  // works only for slink format
 
-      unsigned int timeoutCnt = (word &  0x7f800)>>11; // only for slink
+    if (bit20 == 0) {  // 2nd word
+
+      unsigned int timeoutCnt = (word & 0x7f800) >> 11;  // only for slink
       // unsigned int timeoutCnt = ((word&0xfc000000)>>24) + ((word&0x1800)>>11); // only for fifo
       // More than 1 channel within a group can have a timeout error
       // More than 1 channel within a group can have a timeout error
 
       unsigned int index = (word & 0x1F);  // index within a group of 4/5
-      unsigned int chip = (word& BlkNumMask)>>8;
+      unsigned int chip = (word & BlkNumMask) >> 8;
       int offset = offsets[chip];
-      if(print) cout<<"Timeout Error- channel: ";
+      if (print)
+        cout << "Timeout Error- channel: ";
       //cout<<"Timeout Error- channel: ";
-      for(int i=0;i<5;i++) {
-	if( (index & 0x1) != 0) {
-	  channel = offset + i + 1;
-	  if(print) cout<<channel<<" ";
-	  //cout<<channel<<" ";
-	}
-	index = index >> 1;
+      for (int i = 0; i < 5; i++) {
+        if ((index & 0x1) != 0) {
+          channel = offset + i + 1;
+          if (print)
+            cout << channel << " ";
+          //cout<<channel<<" ";
+        }
+        index = index >> 1;
       }
 
-      if(print) cout << " TimeoutCount: " << timeoutCnt;
+      if (print)
+        cout << " TimeoutCount: " << timeoutCnt;
       //cout << " TimeoutCount: " << timeoutCnt<<endl;;
-     
-     //if(print) cout<<" for Fed "<<fed<<endl;
-     status = -10;
-     fedChannel = channel;
-     //end of timeout  chip and channel decoding
 
-    } else {  // this is the 1st timout word with the baseline correction 
-   
+      //if(print) cout<<" for Fed "<<fed<<endl;
+      status = -10;
+      fedChannel = channel;
+      //end of timeout  chip and channel decoding
+
+    } else {  // this is the 1st timout word with the baseline correction
+
       int baselineCorr = 0;
-      if(word&0x200){
-	baselineCorr = -(((~word)&0x1ff) + 1);
+      if (word & 0x200) {
+        baselineCorr = -(((~word) & 0x1ff) + 1);
       } else {
-	baselineCorr = (word&0x1ff);
+        baselineCorr = (word & 0x1ff);
       }
 
-      if(PRINT_BASELINE && print) cout<<"Timeout BaselineCorr: "<<baselineCorr<<endl;
+      if (PRINT_BASELINE && print)
+        cout << "Timeout BaselineCorr: " << baselineCorr << endl;
       //cout<<"Timeout BaselineCorr: "<<baselineCorr<<endl;
       status = 0;
     }
 
+  } else if ((word & errorMask) == eventNumError) {  // EVENT NUMBER ERROR
+    channel = (word & channelMask) >> 26;
+    unsigned int tbm_event = (word & tbmEventMask);
 
-  } else if( (word&errorMask) == eventNumError ) { // EVENT NUMBER ERROR
-    channel =  (word & channelMask) >>26;
-    unsigned int tbm_event   =  (word & tbmEventMask);
-    
-    if(print) cout<<" Event Number Error- channel: "<<channel<<" tbm event nr. "
-		  <<tbm_event<<" ";
-     status = -11;
-     fedChannel = channel;
-    
-  } else if( ((word&errorMask) == trailError)) {  // TRAILER 
-    channel =  (word & channelMask) >>26;
-    unsigned int tbm_status   =  (word & tbmStatusMask);
-    
+    if (print)
+      cout << " Event Number Error- channel: " << channel << " tbm event nr. " << tbm_event << " ";
+    status = -11;
+    fedChannel = channel;
 
-    if(tbm_status!=0) {
-      if(print) cout<<" Trailer Error- "<<"channel: "<<channel<<" TBM status:0x"
-			  <<hex<<tbm_status<<dec<<" "; // <<endl;
-     status = -15;
-     // implement the resync/reset 17
+  } else if (((word & errorMask) == trailError)) {  // TRAILER
+    channel = (word & channelMask) >> 26;
+    unsigned int tbm_status = (word & tbmStatusMask);
+
+    if (tbm_status != 0) {
+      if (print)
+        cout << " Trailer Error- "
+             << "channel: " << channel << " TBM status:0x" << hex << tbm_status << dec << " ";  // <<endl;
+      status = -15;
+      // implement the resync/reset 17
     }
 
-    if(word & RocErrMask) {
-      if(print) cout<<"Number of Rocs Error- "<<"channel: "<<channel<<" "; // <<endl;
-     status = -12;
+    if (word & RocErrMask) {
+      if (print)
+        cout << "Number of Rocs Error- "
+             << "channel: " << channel << " ";  // <<endl;
+      status = -12;
     }
 
-    if(word & overflowMask) {
-      if(print) cout<<"Overflow Error- "<<"channel: "<<channel<<" "; // <<endl;
-     status = -14;
+    if (word & overflowMask) {
+      if (print)
+        cout << "Overflow Error- "
+             << "channel: " << channel << " ";  // <<endl;
+      status = -14;
     }
 
-    if(word & FsmErrMask) {
-      if(print) cout<<"Finite State Machine Error- "<<"channel: "<<channel
-			  <<" Error status:0x"<<hex<< ((word & FsmErrMask)>>9)<<dec<<" "; // <<endl;
-     status = -13;
+    if (word & FsmErrMask) {
+      if (print)
+        cout << "Finite State Machine Error- "
+             << "channel: " << channel << " Error status:0x" << hex << ((word & FsmErrMask) >> 9) << dec
+             << " ";  // <<endl;
+      status = -13;
     }
-
 
     fedChannel = channel;
 
-  } else if((word&errorMask)==fifoError) {  // FIFO
-    if(print) { 
-      if(word & Fif2NFMask) cout<<"A fifo 2 is Nearly full- ";
-      if(word & TrigNFMask) cout<<"The trigger fifo is nearly Full - ";
-      if(word & ChnFifMask) cout<<"fifo-1 is nearly full for channel"<<(word & ChnFifMask);
+  } else if ((word & errorMask) == fifoError) {  // FIFO
+    if (print) {
+      if (word & Fif2NFMask)
+        cout << "A fifo 2 is Nearly full- ";
+      if (word & TrigNFMask)
+        cout << "The trigger fifo is nearly Full - ";
+      if (word & ChnFifMask)
+        cout << "fifo-1 is nearly full for channel" << (word & ChnFifMask);
       //cout<<endl;
       status = -16;
     }
 
   } else {
-    cout<<" Unknown error?"<<" : ";
-    cout<<" for FED "<<fed<<" Word "<<hex<<word<<dec<<endl;
+    cout << " Unknown error?"
+         << " : ";
+    cout << " for FED " << fed << " Word " << hex << word << dec << endl;
   }
 
-  if(print && status <0) cout<<" FED "<<fed<<" status "<<status<<endl;
+  if (print && status < 0)
+    cout << " FED " << fed << " status " << status << endl;
   return status;
 }
 ///////////////////////////////////////////////////////////////////////////
-int MyDecode::data(int word, int & fedChannel, int fed, int & stat1, int & stat2, bool print) {
-
+int MyDecode::data(int word, int &fedChannel, int fed, int &stat1, int &stat2, bool print) {
   //const int ROCMAX = 24;
-  const unsigned int plsmsk = 0xff;   // pulse height
-  const unsigned int pxlmsk = 0xff00; // pixel index
+  const unsigned int plsmsk = 0xff;    // pulse height
+  const unsigned int pxlmsk = 0xff00;  // pixel index
   const unsigned int dclmsk = 0x1f0000;
   const unsigned int rocmsk = 0x3e00000;
   const unsigned int chnlmsk = 0xfc000000;
   int status = 0;
 
-  int roc = ((word&rocmsk)>>21); // rocs start from 1
+  int roc = ((word & rocmsk) >> 21);  // rocs start from 1
   // Check for embeded special words
-  if(roc>0 && roc<25) {  // valid ROCs go from 1-24
+  if (roc > 0 && roc < 25) {  // valid ROCs go from 1-24
     //if(print) cout<<"data "<<hex<<word<<dec;
-    int channel = ((word&chnlmsk)>>26);
+    int channel = ((word & chnlmsk) >> 26);
 
-    if(channel>0 && channel<37) {  // valid channels 1-36
+    if (channel > 0 && channel < 37) {  // valid channels 1-36
       //cout<<hex<<word<<dec;
-      int dcol=(word&dclmsk)>>16;
-      int pix=(word&pxlmsk)>>8;
-      int adc=(word&plsmsk);
+      int dcol = (word & dclmsk) >> 16;
+      int pix = (word & pxlmsk) >> 8;
+      int adc = (word & plsmsk);
       fedChannel = channel;
 
-      int col = convertToCol(dcol,pix);
+      int col = convertToCol(dcol, pix);
       int row = convertToRow(pix);
 
       // print the roc number according to the online 0-15 scheme
-      if(print) cout<<" Fed "<<fed<<" Channel- "<<channel<<" ROC- "<<(roc-1)<<" DCOL- "<<dcol<<" Pixel- "
-		    <<pix<<" ("<<col<<","<<row<<") ADC- "<<adc<<endl;
+      if (print)
+        cout << " Fed " << fed << " Channel- " << channel << " ROC- " << (roc - 1) << " DCOL- " << dcol << " Pixel- "
+             << pix << " (" << col << "," << row << ") ADC- " << adc << endl;
       status++;
 
-      if(CHECK_PIXELS) {
+      if (CHECK_PIXELS) {
+        // invalid roc number
+        if ((fed > 31 && roc > 24) || (fed <= 31 && roc > 16)) {  //inv ROC
+                                                                  //if(printErrors)
+          cout << " Fed " << fed << " wrong roc number chan/roc/dcol/pix/adc = " << channel << "/" << roc - 1 << "/"
+               << dcol << "/" << pix << "/" << adc << endl;
+          status = -4;
 
-	// invalid roc number
-	if( (fed>31 && roc>24) || (fed<=31 && roc>16)  ) {  //inv ROC
-          //if(printErrors) 
-	  cout<<" Fed "<<fed<<" wrong roc number chan/roc/dcol/pix/adc = "<<channel<<"/"
-			      <<roc-1<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<endl;
-	  status = -4;
+        } else if (fed <= 31 && channel <= 24 && roc > 8) {
+          // Check invalid ROC numbers
 
-	 
-	} else if( fed<=31 && channel<=24 && roc>8 ) {
-	  // Check invalid ROC numbers
+          // protect for rerouted signals
+          if (!((fed == 13 && channel == 17) || (fed == 15 && channel == 5) || (fed == 31 && channel == 10) ||
+                (fed == 27 && channel == 15))) {
+            //if(printErrors)
+            cout << " Fed " << fed << " wrong roc number, chan/roc/dcol/pix/adc = " << channel << "/" << roc - 1 << "/"
+                 << dcol << "/" << pix << "/" << adc << endl;
+            status = -4;
+          }
+        }
 
-	  // protect for rerouted signals
-	  if( !( (fed==13 && channel==17) ||(fed==15 && channel==5) ||(fed==31 && channel==10) 
-		                          ||(fed==27 && channel==15) )  ) {
-	    //if(printErrors) 
-	    cout<<" Fed "<<fed<<" wrong roc number, chan/roc/dcol/pix/adc = "<<channel<<"/"
-				<<roc-1<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<endl;
-	    status = -4;
-	  }
-	}
+        // Check pixels
+        if (pix == 0) {  // PIX=0
+                         // Detect pixel 0 events
+          if (printErrors)
+            cout << " Fed " << fed << " pix=0 chan/roc/dcol/pix/adc = " << channel << "/" << roc - 1 << "/" << dcol
+                 << "/" << pix << "/" << adc << " (" << col << "," << row << ")" << endl;
+          count0++;
+          stat1 = roc - 1;
+          stat2 = count0;
+          status = -5;
 
+        } else if (fed == fed0 && channel == chan0 && roc == roc0 && dcol == dcol0 && pix == pix0) {
+          // detect multiple pixels
 
-	// Check pixels
-        if(pix==0) {  // PIX=0
-	  // Detect pixel 0 events
-          if(printErrors) 
-	    cout<<" Fed "<<fed
-		<<" pix=0 chan/roc/dcol/pix/adc = "<<channel<<"/"<<roc-1<<"/"<<dcol<<"/"
-		<<pix<<"/"<<adc<<" ("<<col<<","<<row<<")"<<endl;
-	  count0++;
-	  stat1 = roc-1;
-	  stat2 = count0;
-	  status = -5;
+          count0++;
+          if (printErrors)
+            cout << " Fed "
+                 << fed
+                 //cout<<" Fed "<<fed
+                 << " double pixel  chan/roc/dcol/pix/adc = " << channel << "/" << roc - 1 << "/" << dcol << "/" << pix
+                 << "/" << adc << " (" << col << "," << row << ") " << count0 << endl;
+          stat1 = roc - 1;
+          stat2 = count0;
+          status = -6;
 
-	} else if( fed==fed0 && channel==chan0 && roc==roc0 && dcol==dcol0 && pix==pix0 ) {
-	  // detect multiple pixels 
+        } else {  // normal
 
-	  count0++;
-          if(printErrors) cout<<" Fed "<<fed
-	    //cout<<" Fed "<<fed
-	      <<" double pixel  chan/roc/dcol/pix/adc = "<<channel<<"/"<<roc-1<<"/"<<dcol<<"/"
-	      <<pix<<"/"<<adc<<" ("<<col<<","<<row<<") "<<count0<<endl;
-	  stat1 = roc-1;
-	  stat2 = count0;
-	  status = -6;
+          count0 = 0;
 
-	} else {  // normal
+          fed0 = fed;
+          chan0 = channel;
+          roc0 = roc;
+          dcol0 = dcol;
+          pix0 = pix;
 
-	  count0=0;
+          // Decode errors
+          if (pix < 2 || pix > 161) {  // inv PIX
+            if (printErrors)
+              cout << " Fed " << fed << " wrong pix number chan/roc/dcol/pix/adc = " << channel << "/" << roc - 1 << "/"
+                   << dcol << "/" << pix << "/" << adc << " (" << col << "," << row << ")" << endl;
+            status = -3;
+          }
 
-	  fed0 = fed; chan0 =channel; roc0 =roc; dcol0 =dcol; pix0=pix;
+          if (dcol < 0 || dcol > 25) {  // inv DCOL
+            if (printErrors)
+              cout << " Fed " << fed << " wrong dcol number chan/roc/dcol/pix/adc = " << channel << "/" << roc - 1
+                   << "/" << dcol << "/" << pix << "/" << adc << " (" << col << "," << row << ")" << endl;
+            status = -3;
+          }
 
-	  // Decode errors
-	  if(pix<2 || pix>161) {  // inv PIX
-	    if(printErrors)cout<<" Fed "<<fed<<" wrong pix number chan/roc/dcol/pix/adc = "<<channel<<"/"
-			       <<roc-1<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<" ("<<col<<","<<row<<")"<<endl;
-	    status = -3;
-	  }
-	  
-	  if(dcol<0 || dcol>25) {  // inv DCOL
-	    if(printErrors) cout<<" Fed "<<fed<<" wrong dcol number chan/roc/dcol/pix/adc = "<<channel<<"/"
-				<<roc-1<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<" ("<<col<<","<<row<<")"<<endl;
-	    status = -3;
-	  }
+        }  // check pixels
 
-	} // check pixels
-
-	  // Summary error count (for testing only)
-	if(pix<2 || pix>161 || dcol<0 || dcol>25) {
-	  countDecodeErrors2++;  // count pixels with errors 
-	  if(pix<2 || pix>161)  countDecodeErrors1++; // count errors
-	  if(dcol<0 || dcol>25) countDecodeErrors1++; // count errors
-	  //if(fed==6 && channel==35 ) cout<<" Fed "<<fed<<" wrong dcol number chan/roc/dcol/pix/adc = "<<channel<<"/"
-	  //			 <<roc-1<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<" ("<<col<<","<<row<<")"<<endl;
-	}
-	
-	
+        // Summary error count (for testing only)
+        if (pix < 2 || pix > 161 || dcol < 0 || dcol > 25) {
+          countDecodeErrors2++;  // count pixels with errors
+          if (pix < 2 || pix > 161)
+            countDecodeErrors1++;  // count errors
+          if (dcol < 0 || dcol > 25)
+            countDecodeErrors1++;  // count errors
+          //if(fed==6 && channel==35 ) cout<<" Fed "<<fed<<" wrong dcol number chan/roc/dcol/pix/adc = "<<channel<<"/"
+          //			 <<roc-1<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<" ("<<col<<","<<row<<")"<<endl;
+        }
 
       }  // if CHECK_PIXELS
 
-    } else { // channel
+    } else {  // channel
 
-      cout<<" Wrong channel "<<channel<<" : ";
-      cout<<" for FED "<<fed<<" Word "<<hex<<word<<dec<<endl;
+      cout << " Wrong channel " << channel << " : ";
+      cout << " for FED " << fed << " Word " << hex << word << dec << endl;
       return -2;
-
     }
 
-  } else if(roc==25) {  // ROC? 
-    unsigned int channel = ((word&chnlmsk)>>26);
-    cout<<"Wrong roc 25 "<<" in fed/chan "<<fed<<"/"<<channel<<endl;
-    status=-4;
+  } else if (roc == 25) {  // ROC?
+    unsigned int channel = ((word & chnlmsk) >> 26);
+    cout << "Wrong roc 25 "
+         << " in fed/chan " << fed << "/" << channel << endl;
+    status = -4;
 
   } else {  // error word
 
     //cout<<"error word "<<hex<<word<<dec;
-    status=error(word, fedChannel, fed, stat1, stat2, print);
-
+    status = error(word, fedChannel, fed, stat1, stat2, print);
   }
 
   return status;
@@ -480,12 +506,11 @@ int MyDecode::data(int word, int & fedChannel, int fed, int & stat1, int & stat2
 
 class SiPixelRawDumper : public edm::EDAnalyzer {
 public:
-
   /// ctor
-  explicit SiPixelRawDumper( const edm::ParameterSet& cfg);
+  explicit SiPixelRawDumper(const edm::ParameterSet &cfg);
 
   //explicit SiPixelRawDumper( const edm::ParameterSet& cfg) : theConfig(cfg) {
-  //consumes<FEDRawDataCollection>(theConfig.getUntrackedParameter<std::string>("InputLabel","source"));} 
+  //consumes<FEDRawDataCollection>(theConfig.getUntrackedParameter<std::string>("InputLabel","source"));}
 
   /// dtor
   virtual ~SiPixelRawDumper() {}
@@ -494,11 +519,11 @@ public:
 
   //void beginRun( const edm::EventSetup& ) {}
 
-  // end of job 
+  // end of job
   void endJob();
 
   /// get data, convert to digis attach againe to Event
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event &, const edm::EventSetup &);
 
 private:
   edm::ParameterSet theConfig;
@@ -514,7 +539,7 @@ private:
   int fedErrorsTime[40][36];
   int fedErrorsOver[40][36];
   int decodeErrors[40][36];
-  int decodeErrors000[40][36];  // pix 0 problem
+  int decodeErrors000[40][36];     // pix 0 problem
   int decodeErrorsDouble[40][36];  // double pix  problem
   int errorType[20];
 
@@ -522,55 +547,68 @@ private:
   ofstream outfile;
 #endif
 
-  TH1D *hsize,*hsize0, *hsize1, *hsize2, *hsize3;
+  TH1D *hsize, *hsize0, *hsize1, *hsize2, *hsize3;
 #ifdef IND_FEDS
   TH1D *hsizeFeds[40];
 #endif
   TH1D *hpixels, *hpixels0, *hpixels1, *hpixels2, *hpixels3, *hpixels4;
-  TH1D *htotPixels,*htotPixels0, *htotPixels1;
+  TH1D *htotPixels, *htotPixels0, *htotPixels1;
   TH1D *herrors, *htotErrors;
-  TH1D *herrorType1, *herrorType1Fed, *herrorType1Chan,*herrorType2, *herrorType2Fed, *herrorType2Chan;
+  TH1D *herrorType1, *herrorType1Fed, *herrorType1Chan, *herrorType2, *herrorType2Fed, *herrorType2Chan;
   TH1D *hcountDouble, *hcount000, *hrocDouble, *hroc000;
 
-  TH2F *hfed2DErrorsType1,*hfed2DErrorsType2;
-  TH2F *hfed2DErrors1,*hfed2DErrors2,*hfed2DErrors3,*hfed2DErrors4,*hfed2DErrors5,
-    *hfed2DErrors6,*hfed2DErrors7,*hfed2DErrors8,*hfed2DErrors9,*hfed2DErrors10,*hfed2DErrors11,*hfed2DErrors12,
-    *hfed2DErrors13,*hfed2DErrors14,*hfed2DErrors15,*hfed2DErrors16;
-  TH2F *hfed2d, *hsize2d,*hfedErrorType1ls,*hfedErrorType2ls, *hcountDouble2, *hcount0002;
-  TH2F *hfed2DErrors1ls,*hfed2DErrors2ls,*hfed2DErrors3ls,*hfed2DErrors4ls,*hfed2DErrors5ls,
-    *hfed2DErrors6ls,*hfed2DErrors7ls,*hfed2DErrors8ls,*hfed2DErrors9ls,*hfed2DErrors10ls,*hfed2DErrors11ls,*hfed2DErrors12ls,
-    *hfed2DErrors13ls,*hfed2DErrors14ls,*hfed2DErrors15ls,*hfed2DErrors16ls;
+  TH2F *hfed2DErrorsType1, *hfed2DErrorsType2;
+  TH2F *hfed2DErrors1, *hfed2DErrors2, *hfed2DErrors3, *hfed2DErrors4, *hfed2DErrors5, *hfed2DErrors6, *hfed2DErrors7,
+      *hfed2DErrors8, *hfed2DErrors9, *hfed2DErrors10, *hfed2DErrors11, *hfed2DErrors12, *hfed2DErrors13,
+      *hfed2DErrors14, *hfed2DErrors15, *hfed2DErrors16;
+  TH2F *hfed2d, *hsize2d, *hfedErrorType1ls, *hfedErrorType2ls, *hcountDouble2, *hcount0002;
+  TH2F *hfed2DErrors1ls, *hfed2DErrors2ls, *hfed2DErrors3ls, *hfed2DErrors4ls, *hfed2DErrors5ls, *hfed2DErrors6ls,
+      *hfed2DErrors7ls, *hfed2DErrors8ls, *hfed2DErrors9ls, *hfed2DErrors10ls, *hfed2DErrors11ls, *hfed2DErrors12ls,
+      *hfed2DErrors13ls, *hfed2DErrors14ls, *hfed2DErrors15ls, *hfed2DErrors16ls;
 
   TH1D *hevent, *hlumi, *horbit, *hbx, *hlumi0, *hbx0;
-  //TH1D *hbx1,*hbx2,*hbx3,*hbx4,*hbx5,*hbx6,*hbx7,*hbx8,*hbx9,*hbx10,*hbx11,*hbx12; 
-  TProfile *htotPixelsls, *hsizels, *herrorType1ls, *herrorType2ls, *havsizels, *htotPixelsbx, 
-    *herrorType1bx,*herrorType2bx,*havsizebx,*hsizep;
-  TProfile *herror1ls,*herror2ls,*herror3ls,*herror4ls,*herror5ls,*herror6ls,*herror7ls,*herror8ls,
-    *herror9ls,*herror10ls,*herror11ls,*herror12ls,*herror13ls,*herror14ls,*herror15ls,*herror16ls; 
+  //TH1D *hbx1,*hbx2,*hbx3,*hbx4,*hbx5,*hbx6,*hbx7,*hbx8,*hbx9,*hbx10,*hbx11,*hbx12;
+  TProfile *htotPixelsls, *hsizels, *herrorType1ls, *herrorType2ls, *havsizels, *htotPixelsbx, *herrorType1bx,
+      *herrorType2bx, *havsizebx, *hsizep;
+  TProfile *herror1ls, *herror2ls, *herror3ls, *herror4ls, *herror5ls, *herror6ls, *herror7ls, *herror8ls, *herror9ls,
+      *herror10ls, *herror11ls, *herror12ls, *herror13ls, *herror14ls, *herror15ls, *herror16ls;
   TProfile2D *hfedchannelsize;
-  TH1D *herrorTimels, *herrorOverls, *herrorTimels1, *herrorOverls1, *herrorTimels2, *herrorOverls2, 
-       *herrorTimels3, *herrorOverls3, *herrorTimels0, *herrorOverls0;
-  TH1D *hfedchannelsizeb,*hfedchannelsizeb1,*hfedchannelsizeb2,*hfedchannelsizeb3,
-    *hfedchannelsizef;
-
+  TH1D *herrorTimels, *herrorOverls, *herrorTimels1, *herrorOverls1, *herrorTimels2, *herrorOverls2, *herrorTimels3,
+      *herrorOverls3, *herrorTimels0, *herrorOverls0;
+  TH1D *hfedchannelsizeb, *hfedchannelsizeb1, *hfedchannelsizeb2, *hfedchannelsizeb3, *hfedchannelsizef;
 };
 //----------------------------------------------------------------------------------
-SiPixelRawDumper::SiPixelRawDumper( const edm::ParameterSet& cfg) : theConfig(cfg) {
-  string label = theConfig.getUntrackedParameter<std::string>("InputLabel","source");
+SiPixelRawDumper::SiPixelRawDumper(const edm::ParameterSet &cfg) : theConfig(cfg) {
+  string label = theConfig.getUntrackedParameter<std::string>("InputLabel", "source");
   // For the ByToken method
   rawData = consumes<FEDRawDataCollection>(label);
-} 
+}
 //----------------------------------------------------------------------------------------
 void SiPixelRawDumper::endJob() {
-  string errorName[18] = {" "," ","wrong channel","wrong pix or dcol","wrong roc","pix=0",
-			  " double-pix"," "," "," ","timeout","ENE","NOR","FSM","overflow",
-			  "trailer","fifo","reset/resync"};
+  string errorName[18] = {" ",
+                          " ",
+                          "wrong channel",
+                          "wrong pix or dcol",
+                          "wrong roc",
+                          "pix=0",
+                          " double-pix",
+                          " ",
+                          " ",
+                          " ",
+                          "timeout",
+                          "ENE",
+                          "NOR",
+                          "FSM",
+                          "overflow",
+                          "trailer",
+                          "fifo",
+                          "reset/resync"};
 
-// 2 - wrong channel
-// 3 - wrong pix or dcol 
-// 4 - wrong roc
-// 5 - pix=0
-// 6 - double pixel 
+  // 2 - wrong channel
+  // 3 - wrong pix or dcol
+  // 4 - wrong roc
+  // 5 - pix=0
+  // 6 - double pixel
   // 10 - timeout ()
   // 11 - ene ()
   // 12 - mum pf rocs error ()
@@ -580,360 +618,376 @@ void SiPixelRawDumper::endJob() {
   // 16 - fifo  (30)
   // 17 - reset/resync NOT INCLUDED YET
 
-  if(countEvents>0) {
+  if (countEvents > 0) {
     sumPixels /= float(countEvents);
     sumFedSize /= float(countAllEvents);
-    for(int i=0;i<40;++i) {
+    for (int i = 0; i < 40; ++i) {
       sumFedPixels[i] /= float(countEvents);
-      hpixels4->Fill(float(i),sumFedPixels[i]); //pixels only 
+      hpixels4->Fill(float(i), sumFedPixels[i]);  //pixels only
     }
   }
-    
-  cout<<" Total/non-empty events " <<countAllEvents<<" / "<<countEvents<<" average number of pixels "<<sumPixels<<endl;
 
-  cout<<" Average Fed size per event for all events (in 4-words) "<< (sumFedSize*2./40.) 
-      <<" total for all feds "<<(sumFedSize*2.) <<endl;
+  cout << " Total/non-empty events " << countAllEvents << " / " << countEvents << " average number of pixels "
+       << sumPixels << endl;
 
-  cout<<" Size for ech FED per event in units of hit pixels:" <<endl;
+  cout << " Average Fed size per event for all events (in 4-words) " << (sumFedSize * 2. / 40.)
+       << " total for all feds " << (sumFedSize * 2.) << endl;
 
-  for(int i=0;i<40;++i) cout<< sumFedPixels[i]<<" ";
-  cout<<endl;
+  cout << " Size for ech FED per event in units of hit pixels:" << endl;
 
-  cout<<" Total number of errors "<<countTotErrors<<" print threshold "<< int(countEvents*printThreshold) << " total errors per fed channel"<<endl;
-  cout<<" FED errors "<<endl<<"Fed Channel Tot-Errors ENE-Errors Time-Errors Over-Errors"<<endl;
+  for (int i = 0; i < 40; ++i)
+    cout << sumFedPixels[i] << " ";
+  cout << endl;
 
-  for(int i=0;i<40;++i) {
-    for(int j=0;j<36;++j) if( (fedErrors[i][j]) > int(countEvents*printThreshold) || (fedErrorsENE[i][j] > 0) ) {
-      cout<<" "<<i<<"  -  "<<(j+1)<<" -  "<<fedErrors[i][j]<<" - "<<fedErrorsENE[i][j]<<" -  "<<fedErrorsTime[i][j]<<" - "<<fedErrorsOver[i][j]<<endl;
-    }
+  cout << " Total number of errors " << countTotErrors << " print threshold " << int(countEvents * printThreshold)
+       << " total errors per fed channel" << endl;
+  cout << " FED errors " << endl << "Fed Channel Tot-Errors ENE-Errors Time-Errors Over-Errors" << endl;
+
+  for (int i = 0; i < 40; ++i) {
+    for (int j = 0; j < 36; ++j)
+      if ((fedErrors[i][j]) > int(countEvents * printThreshold) || (fedErrorsENE[i][j] > 0)) {
+        cout << " " << i << "  -  " << (j + 1) << " -  " << fedErrors[i][j] << " - " << fedErrorsENE[i][j] << " -  "
+             << fedErrorsTime[i][j] << " - " << fedErrorsOver[i][j] << endl;
+      }
   }
-  cout<<" Decode errors "<<endl<<"Fed Channel Errors Pix_000 Double_Pix"<<endl;
-  for(int i=0;i<40;++i) {
-    for(int j=0;j<36;++j) {
+  cout << " Decode errors " << endl << "Fed Channel Errors Pix_000 Double_Pix" << endl;
+  for (int i = 0; i < 40; ++i) {
+    for (int j = 0; j < 36; ++j) {
       int tmp = decodeErrors[i][j] + decodeErrors000[i][j] + decodeErrorsDouble[i][j];
-      if(tmp>10) 
-	cout<<" "<<i<<" -  "<<(j+1)<<"   -  "
-	    <<decodeErrors[i][j]<<"  -    "
-	    <<decodeErrors000[i][j]<<"  -   "
-	    <<decodeErrorsDouble[i][j]<<endl;
+      if (tmp > 10)
+        cout << " " << i << " -  " << (j + 1) << "   -  " << decodeErrors[i][j] << "  -    " << decodeErrors000[i][j]
+             << "  -   " << decodeErrorsDouble[i][j] << endl;
     }
   }
 
-  cout<<" Total errors for all feds "<<endl<<" Type Name Num-Of-Errors"<<endl;
-  for(int i=0;i<20;++i) {
-    if( errorType[i]>0 ) cout<<"   "<<i<<" - "<<errorName[i]<<" - "<<errorType[i]<<endl;
+  cout << " Total errors for all feds " << endl << " Type Name Num-Of-Errors" << endl;
+  for (int i = 0; i < 20; ++i) {
+    if (errorType[i] > 0)
+      cout << "   " << i << " - " << errorName[i] << " - " << errorType[i] << endl;
   }
 
-  cout<<" Test decode errors "<<countDecodeErrors1<<" "<<countDecodeErrors2<<endl;
+  cout << " Test decode errors " << countDecodeErrors1 << " " << countDecodeErrors2 << endl;
 
 #ifdef OUTFILE
   outfile.close();
 #endif
-
-
-
 }
 //----------------------------------------------------------------------
 void SiPixelRawDumper::beginJob() {
+  printLocal = theConfig.getUntrackedParameter<int>("Verbosity", 1);
+  printThreshold =
+      theConfig.getUntrackedParameter<double>("PrintThreshold", 0.001);  // threshold per event for printing errors
+  cout << " beginjob " << printLocal << " " << printThreshold << endl;
 
-  printLocal = theConfig.getUntrackedParameter<int>("Verbosity",1);
-  printThreshold = theConfig.getUntrackedParameter<double>("PrintThreshold",0.001); // threshold per event for printing errors
-  cout<<" beginjob "<<printLocal<<" "<<printThreshold<<endl;  
+  if (printLocal > 0)
+    printErrors = true;
+  else
+    printErrors = false;
+  if (printLocal > 1)
+    printData = true;
+  else
+    printData = false;
+  if (printLocal > 2)
+    printHeaders = true;
+  else
+    printHeaders = false;
 
-  if(printLocal>0) printErrors  = true;
-  else printErrors = false;
-  if(printLocal>1) printData  = true;
-  else printData = false;
-  if(printLocal>2) printHeaders  = true;
-  else printHeaders = false;
-
-  countEvents=0;
-  countAllEvents=0;
-  countTotErrors=0;
-  sumPixels=0.;
-  sumFedSize=0;
-  for(int i=0;i<40;++i) {
-    sumFedPixels[i]=0;
-    for(int j=0;j<36;++j) {fedErrors[i][j]=0; fedErrorsENE[i][j]=0; fedErrorsTime[i][j]=0; fedErrorsOver[i][j]=0;}
-    for(int j=0;j<36;++j) {decodeErrors[i][j]=0; decodeErrors000[i][j]=0; decodeErrorsDouble[i][j]=0;}
+  countEvents = 0;
+  countAllEvents = 0;
+  countTotErrors = 0;
+  sumPixels = 0.;
+  sumFedSize = 0;
+  for (int i = 0; i < 40; ++i) {
+    sumFedPixels[i] = 0;
+    for (int j = 0; j < 36; ++j) {
+      fedErrors[i][j] = 0;
+      fedErrorsENE[i][j] = 0;
+      fedErrorsTime[i][j] = 0;
+      fedErrorsOver[i][j] = 0;
+    }
+    for (int j = 0; j < 36; ++j) {
+      decodeErrors[i][j] = 0;
+      decodeErrors000[i][j] = 0;
+      decodeErrorsDouble[i][j] = 0;
+    }
   }
-  for(int i=0;i<20;++i) errorType[i]=0;
+  for (int i = 0; i < 20; ++i)
+    errorType[i] = 0;
 
   edm::Service<TFileService> fs;
 
-  //const float pixMax = 5999.5;   // pp value 
-  //const float totMax = 99999.5;  // pp value 
+  //const float pixMax = 5999.5;   // pp value
+  //const float totMax = 99999.5;  // pp value
   //const float maxLink = 200.;    // pp value
 
-  const float pixMax = 19999.5;  // hi value 
-  const float totMax = 399999.5; // hi value 
-  const float maxLink = 1000.;   // hi value
+  const float pixMax = 19999.5;   // hi value
+  const float totMax = 399999.5;  // hi value
+  const float maxLink = 1000.;    // hi value
 
+  hsize = fs->make<TH1D>("hsize", "FED event size in words-4", 6000, -0.5, pixMax);
+  hsize0 = fs->make<TH1D>("hsize0", "FED event size in words-4", 2000, -0.5, 19999.5);
+  hsize1 = fs->make<TH1D>("hsize1", "bpix FED event size in words-4", 6000, -0.5, pixMax);
+  hsize2 = fs->make<TH1D>("hsize2", "fpix FED event size in words-4", 6000, -0.5, pixMax);
+  hsize3 = fs->make<TH1D>("hsize3", "ave bpix FED event size in words-4", 6000, -0.5, pixMax);
 
-  hsize = fs->make<TH1D>( "hsize", "FED event size in words-4", 6000, -0.5, pixMax);
-  hsize0 = fs->make<TH1D>( "hsize0", "FED event size in words-4", 2000, -0.5, 19999.5);
-  hsize1 = fs->make<TH1D>( "hsize1", "bpix FED event size in words-4", 6000, -0.5, pixMax);
-  hsize2 = fs->make<TH1D>( "hsize2", "fpix FED event size in words-4", 6000, -0.5, pixMax);
-  hsize3 = fs->make<TH1D>( "hsize3", "ave bpix FED event size in words-4", 6000, -0.5, pixMax);
+  hpixels = fs->make<TH1D>("hpixels", "pixels per FED", 2000, -0.5, 19999.5);
+  hpixels0 = fs->make<TH1D>("hpixels0", "pixels per FED", 6000, -0.5, pixMax);
+  hpixels1 = fs->make<TH1D>("hpixels1", "pixels >0 per FED", 6000, -0.5, pixMax);
+  hpixels2 = fs->make<TH1D>("hpixels2", "pixels >0 per BPix FED", 6000, -0.5, pixMax);
+  hpixels3 = fs->make<TH1D>("hpixels3", "pixels >0 per Fpix FED", 6000, -0.5, pixMax);
+  hpixels4 = fs->make<TH1D>("hpixels4", "pixels per each FED", 40, -0.5, 39.5);
 
-  hpixels = fs->make<TH1D>( "hpixels", "pixels per FED", 2000, -0.5, 19999.5);
-  hpixels0 = fs->make<TH1D>( "hpixels0", "pixels per FED", 6000, -0.5, pixMax);
-  hpixels1 = fs->make<TH1D>( "hpixels1", "pixels >0 per FED", 6000, -0.5, pixMax);
-  hpixels2 = fs->make<TH1D>( "hpixels2", "pixels >0 per BPix FED", 6000, -0.5, pixMax);
-  hpixels3 = fs->make<TH1D>( "hpixels3", "pixels >0 per Fpix FED", 6000, -0.5, pixMax);
-  hpixels4 = fs->make<TH1D>( "hpixels4", "pixels per each FED", 40, -0.5, 39.5);
+  htotPixels = fs->make<TH1D>("htotPixels", "pixels per event", 10000, -0.5, totMax);
+  htotPixels0 = fs->make<TH1D>("htotPixels0", "pixels per event, zoom low region", 20000, -0.5, 19999.5);
+  htotPixels1 = fs->make<TH1D>("htotPixels1", "pixels >0 per event", 10000, -0.5, totMax);
 
-  htotPixels = fs->make<TH1D>( "htotPixels", "pixels per event", 10000, -0.5, totMax);
-  htotPixels0 = fs->make<TH1D>( "htotPixels0", "pixels per event, zoom low region", 20000, -0.5, 19999.5);
-  htotPixels1 = fs->make<TH1D>( "htotPixels1", "pixels >0 per event", 10000, -0.5, totMax);
+  herrors = fs->make<TH1D>("herrors", "errors per FED", 100, -0.5, 99.5);
+  htotErrors = fs->make<TH1D>("htotErrors", "errors per event", 1000, -0.5, 999.5);
 
-  herrors = fs->make<TH1D>( "herrors", "errors per FED", 100, -0.5, 99.5);
-  htotErrors = fs->make<TH1D>( "htotErrors", "errors per event", 1000, -0.5, 999.5);
+  herrorType1 = fs->make<TH1D>("herrorType1", "errors 1 per type", 20, -0.5, 19.5);
+  herrorType1Fed = fs->make<TH1D>("herrorType1Fed", "errors 1 per FED", 40, -0.5, 39.5);
+  herrorType1Chan = fs->make<TH1D>("herrorType1Chan", "errors 1 per chan", 37, -0.5, 36.5);
+  herrorType2 = fs->make<TH1D>("herrorType2", "readout errors 2 per type", 20, -0.5, 19.5);
+  herrorType2Fed = fs->make<TH1D>("herrorType2Fed", "readout errors 2 per FED", 40, -0.5, 39.5);
+  herrorType2Chan = fs->make<TH1D>("herrorType2Chan", "readout errors 2 per chan", 37, -0.5, 36.5);
 
-  herrorType1     = fs->make<TH1D>( "herrorType1", "errors 1 per type", 20, -0.5, 19.5);
-  herrorType1Fed  = fs->make<TH1D>( "herrorType1Fed", "errors 1 per FED", 40, -0.5, 39.5);
-  herrorType1Chan = fs->make<TH1D>( "herrorType1Chan", "errors 1 per chan", 37, -0.5, 36.5);
-  herrorType2     = fs->make<TH1D>( "herrorType2", "readout errors 2 per type", 20, -0.5, 19.5);
-  herrorType2Fed  = fs->make<TH1D>( "herrorType2Fed", "readout errors 2 per FED", 40, -0.5, 39.5);
-  herrorType2Chan = fs->make<TH1D>( "herrorType2Chan", "readout errors 2 per chan", 37, -0.5, 36.5);
+  hcountDouble = fs->make<TH1D>("hcountDouble", "count double pixels", 100, -0.5, 99.5);
+  hcountDouble2 = fs->make<TH2F>("hcountDouble2", "count double pixels", 40, -0.5, 39.5, 10, 0., 10.);
+  hcount000 = fs->make<TH1D>("hcount000", "count 000 pixels", 100, -0.5, 99.5);
+  hcount0002 = fs->make<TH2F>("hcount0002", "count 000 pixels", 40, -0.5, 39.5, 10, 0., 10.);
+  hrocDouble = fs->make<TH1D>("hrocDouble", "double pixels rocs", 25, -0.5, 24.5);
+  hroc000 = fs->make<TH1D>("hroc000", "000 pixels rocs", 25, -0.5, 24.5);
 
-  hcountDouble = fs->make<TH1D>( "hcountDouble", "count double pixels", 100, -0.5, 99.5);
-  hcountDouble2 = fs->make<TH2F>("hcountDouble2","count double pixels",40,-0.5,39.5, 10,0.,10.); 
-  hcount000 = fs->make<TH1D>( "hcount000", "count 000 pixels", 100, -0.5, 99.5);
-  hcount0002 = fs->make<TH2F>("hcount0002","count 000 pixels",40,-0.5,39.5, 10,0.,10.); 
-  hrocDouble = fs->make<TH1D>( "hrocDouble", "double pixels rocs", 25,-0.5, 24.5);
-  hroc000    = fs->make<TH1D>( "hroc000", "000 pixels rocs", 25,-0.5, 24.5);
+  hfed2d = fs->make<TH2F>("hfed2d", "errors", 40, -0.5, 39.5, 21, -0.5, 20.5);  // ALL
 
-  hfed2d = fs->make<TH2F>( "hfed2d", "errors", 40,-0.5,39.5,21, -0.5, 20.5); // ALL
-
-  hsize2d = fs->make<TH2F>( "hsize2d", "size vs fed",40,-0.5,39.5, 50,0,500); // ALL
-  hsizep  = fs->make<TProfile>( "hsizep", "size vs fed",40,-0.5,39.5,0,100000); // ALL
+  hsize2d = fs->make<TH2F>("hsize2d", "size vs fed", 40, -0.5, 39.5, 50, 0, 500);   // ALL
+  hsizep = fs->make<TProfile>("hsizep", "size vs fed", 40, -0.5, 39.5, 0, 100000);  // ALL
   //hsize2dls = fs->make<TH2F>( "hsize2dls", "size vs lumi",100,0,1000, 50,0.,500.); // ALL
 
 #ifdef IND_FEDS
-  hsizeFeds[0] = fs->make<TH1D>( "hsizeFed0", "FED 0 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[1] = fs->make<TH1D>( "hsizeFed1", "FED 1 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[2] = fs->make<TH1D>( "hsizeFed2", "FED 2 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[3] = fs->make<TH1D>( "hsizeFed3", "FED 3 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[4] = fs->make<TH1D>( "hsizeFed4", "FED 4 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[5] = fs->make<TH1D>( "hsizeFed5", "FED 5 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[6] = fs->make<TH1D>( "hsizeFed6", "FED 6 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[7] = fs->make<TH1D>( "hsizeFed7", "FED 7 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[8] = fs->make<TH1D>( "hsizeFed8", "FED 8 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[9] = fs->make<TH1D>( "hsizeFed9", "FED 9 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[10] = fs->make<TH1D>( "hsizeFed10", "FED 10 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[11] = fs->make<TH1D>( "hsizeFed11", "FED 11 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[12] = fs->make<TH1D>( "hsizeFed12", "FED 12 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[13] = fs->make<TH1D>( "hsizeFed13", "FED 13 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[14] = fs->make<TH1D>( "hsizeFed14", "FED 14 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[15] = fs->make<TH1D>( "hsizeFed15", "FED 15 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[16] = fs->make<TH1D>( "hsizeFed16", "FED 16 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[17] = fs->make<TH1D>( "hsizeFed17", "FED 17 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[18] = fs->make<TH1D>( "hsizeFed18", "FED 18 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[19] = fs->make<TH1D>( "hsizeFed19", "FED 19 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[20] = fs->make<TH1D>( "hsizeFed20", "FED 20 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[21] = fs->make<TH1D>( "hsizeFed21", "FED 21 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[22] = fs->make<TH1D>( "hsizeFed22", "FED 22 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[23] = fs->make<TH1D>( "hsizeFed23", "FED 23 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[24] = fs->make<TH1D>( "hsizeFed24", "FED 24 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[25] = fs->make<TH1D>( "hsizeFed25", "FED 25 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[26] = fs->make<TH1D>( "hsizeFed26", "FED 26 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[27] = fs->make<TH1D>( "hsizeFed27", "FED 27 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[28] = fs->make<TH1D>( "hsizeFed28", "FED 28 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[29] = fs->make<TH1D>( "hsizeFed29", "FED 29 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[30] = fs->make<TH1D>( "hsizeFed30", "FED 30 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[31] = fs->make<TH1D>( "hsizeFed31", "FED 31 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[32] = fs->make<TH1D>( "hsizeFed32", "FED 32 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[33] = fs->make<TH1D>( "hsizeFed33", "FED 33 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[34] = fs->make<TH1D>( "hsizeFed34", "FED 34 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[35] = fs->make<TH1D>( "hsizeFed35", "FED 35 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[36] = fs->make<TH1D>( "hsizeFed36", "FED 36 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[37] = fs->make<TH1D>( "hsizeFed37", "FED 37 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[38] = fs->make<TH1D>( "hsizeFed38", "FED 38 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[39] = fs->make<TH1D>( "hsizeFed39", "FED 39 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[0] = fs->make<TH1D>("hsizeFed0", "FED 0 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[1] = fs->make<TH1D>("hsizeFed1", "FED 1 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[2] = fs->make<TH1D>("hsizeFed2", "FED 2 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[3] = fs->make<TH1D>("hsizeFed3", "FED 3 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[4] = fs->make<TH1D>("hsizeFed4", "FED 4 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[5] = fs->make<TH1D>("hsizeFed5", "FED 5 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[6] = fs->make<TH1D>("hsizeFed6", "FED 6 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[7] = fs->make<TH1D>("hsizeFed7", "FED 7 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[8] = fs->make<TH1D>("hsizeFed8", "FED 8 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[9] = fs->make<TH1D>("hsizeFed9", "FED 9 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[10] = fs->make<TH1D>("hsizeFed10", "FED 10 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[11] = fs->make<TH1D>("hsizeFed11", "FED 11 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[12] = fs->make<TH1D>("hsizeFed12", "FED 12 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[13] = fs->make<TH1D>("hsizeFed13", "FED 13 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[14] = fs->make<TH1D>("hsizeFed14", "FED 14 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[15] = fs->make<TH1D>("hsizeFed15", "FED 15 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[16] = fs->make<TH1D>("hsizeFed16", "FED 16 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[17] = fs->make<TH1D>("hsizeFed17", "FED 17 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[18] = fs->make<TH1D>("hsizeFed18", "FED 18 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[19] = fs->make<TH1D>("hsizeFed19", "FED 19 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[20] = fs->make<TH1D>("hsizeFed20", "FED 20 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[21] = fs->make<TH1D>("hsizeFed21", "FED 21 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[22] = fs->make<TH1D>("hsizeFed22", "FED 22 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[23] = fs->make<TH1D>("hsizeFed23", "FED 23 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[24] = fs->make<TH1D>("hsizeFed24", "FED 24 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[25] = fs->make<TH1D>("hsizeFed25", "FED 25 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[26] = fs->make<TH1D>("hsizeFed26", "FED 26 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[27] = fs->make<TH1D>("hsizeFed27", "FED 27 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[28] = fs->make<TH1D>("hsizeFed28", "FED 28 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[29] = fs->make<TH1D>("hsizeFed29", "FED 29 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[30] = fs->make<TH1D>("hsizeFed30", "FED 30 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[31] = fs->make<TH1D>("hsizeFed31", "FED 31 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[32] = fs->make<TH1D>("hsizeFed32", "FED 32 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[33] = fs->make<TH1D>("hsizeFed33", "FED 33 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[34] = fs->make<TH1D>("hsizeFed34", "FED 34 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[35] = fs->make<TH1D>("hsizeFed35", "FED 35 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[36] = fs->make<TH1D>("hsizeFed36", "FED 36 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[37] = fs->make<TH1D>("hsizeFed37", "FED 37 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[38] = fs->make<TH1D>("hsizeFed38", "FED 38 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[39] = fs->make<TH1D>("hsizeFed39", "FED 39 event size ", 1000, -0.5, pixMax);
 #endif
 
-  hevent = fs->make<TH1D>("hevent","event",1000,0,10000000.);
+  hevent = fs->make<TH1D>("hevent", "event", 1000, 0, 10000000.);
   //horbit = fs->make<TH1D>("horbit","orbit",100, 0,100000000.);
-  hlumi  = fs->make<TH1D>("hlumi", "lumi", 3000,0,3000.);
-  hlumi0  = fs->make<TH1D>("hlumi0", "lumi", 3000,0,3000.);
- 
-  hbx    = fs->make<TH1D>("hbx",   "bx",   4000,0,4000.);  
-  hbx0    = fs->make<TH1D>("hbx0",   "bx",   4000,0,4000.);  
+  hlumi = fs->make<TH1D>("hlumi", "lumi", 3000, 0, 3000.);
+  hlumi0 = fs->make<TH1D>("hlumi0", "lumi", 3000, 0, 3000.);
 
-//   hbx1    = fs->make<TH1D>("hbx1",   "bx",   4000,0,4000.);  
-//   hbx2    = fs->make<TH1D>("hbx2",   "bx",   4000,0,4000.);  
-//   hbx3    = fs->make<TH1D>("hbx3",   "bx",   4000,0,4000.);  
-//   hbx4    = fs->make<TH1D>("hbx4",   "bx",   4000,0,4000.);  
-//   hbx5    = fs->make<TH1D>("hbx5",   "bx",   4000,0,4000.);  
-//   hbx6    = fs->make<TH1D>("hbx6",   "bx",   4000,0,4000.);  
-//   hbx7    = fs->make<TH1D>("hbx7",   "bx",   4000,0,4000.);  
-//   hbx8    = fs->make<TH1D>("hbx8",   "bx",   4000,0,4000.);  
-//   hbx9    = fs->make<TH1D>("hbx9",   "bx",   4000,0,4000.);  
-//   hbx10    = fs->make<TH1D>("hbx10",   "bx",   4000,0,4000.);  
-//   hbx11    = fs->make<TH1D>("hbx11",   "bx",   4000,0,4000.);  
-//   hbx12    = fs->make<TH1D>("hbx12",   "bx",   4000,0,4000.);  
+  hbx = fs->make<TH1D>("hbx", "bx", 4000, 0, 4000.);
+  hbx0 = fs->make<TH1D>("hbx0", "bx", 4000, 0, 4000.);
 
-  herrorTimels = fs->make<TH1D>( "herrorTimels", "timeouts vs ls", 1000,0,3000);
-  herrorOverls = fs->make<TH1D>( "herrorOverls", "overflows vs ls",1000,0,3000);
-  herrorTimels1 = fs->make<TH1D>("herrorTimels1","timeouts vs ls", 1000,0,3000);
-  herrorOverls1 = fs->make<TH1D>("herrorOverls1","overflows vs ls",1000,0,3000);
-  herrorTimels2 = fs->make<TH1D>("herrorTimels2","timeouts vs ls", 1000,0,3000);
-  herrorOverls2 = fs->make<TH1D>("herrorOverls2","overflows vs ls",1000,0,3000);
-  herrorTimels3 = fs->make<TH1D>("herrorTimels3","timeouts vs ls", 1000,0,3000);
-  herrorOverls3 = fs->make<TH1D>("herrorOverls3","overflows vs ls",1000,0,3000);
-  herrorTimels0 = fs->make<TH1D>("herrorTimels0","timeouts vs ls", 1000,0,3000);
-  herrorOverls0 = fs->make<TH1D>("herrorOverls0","overflows vs ls",1000,0,3000);
+  //   hbx1    = fs->make<TH1D>("hbx1",   "bx",   4000,0,4000.);
+  //   hbx2    = fs->make<TH1D>("hbx2",   "bx",   4000,0,4000.);
+  //   hbx3    = fs->make<TH1D>("hbx3",   "bx",   4000,0,4000.);
+  //   hbx4    = fs->make<TH1D>("hbx4",   "bx",   4000,0,4000.);
+  //   hbx5    = fs->make<TH1D>("hbx5",   "bx",   4000,0,4000.);
+  //   hbx6    = fs->make<TH1D>("hbx6",   "bx",   4000,0,4000.);
+  //   hbx7    = fs->make<TH1D>("hbx7",   "bx",   4000,0,4000.);
+  //   hbx8    = fs->make<TH1D>("hbx8",   "bx",   4000,0,4000.);
+  //   hbx9    = fs->make<TH1D>("hbx9",   "bx",   4000,0,4000.);
+  //   hbx10    = fs->make<TH1D>("hbx10",   "bx",   4000,0,4000.);
+  //   hbx11    = fs->make<TH1D>("hbx11",   "bx",   4000,0,4000.);
+  //   hbx12    = fs->make<TH1D>("hbx12",   "bx",   4000,0,4000.);
 
-  hfed2DErrorsType1 = fs->make<TH2F>("hfed2DErrorsType1", "errors type 1 per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrorsType2 = fs->make<TH2F>("hfed2DErrorsType2", "errors type 2 per FED", 40,-0.5,39.5,37, -0.5, 36.5);
+  herrorTimels = fs->make<TH1D>("herrorTimels", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls = fs->make<TH1D>("herrorOverls", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels1 = fs->make<TH1D>("herrorTimels1", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls1 = fs->make<TH1D>("herrorOverls1", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels2 = fs->make<TH1D>("herrorTimels2", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls2 = fs->make<TH1D>("herrorOverls2", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels3 = fs->make<TH1D>("herrorTimels3", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls3 = fs->make<TH1D>("herrorOverls3", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels0 = fs->make<TH1D>("herrorTimels0", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls0 = fs->make<TH1D>("herrorOverls0", "overflows vs ls", 1000, 0, 3000);
 
-  hfed2DErrors1 = fs->make<TH2F>("hfed2DErrors1", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
+  hfed2DErrorsType1 = fs->make<TH2F>("hfed2DErrorsType1", "errors type 1 per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrorsType2 = fs->make<TH2F>("hfed2DErrorsType2", "errors type 2 per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+
+  hfed2DErrors1 = fs->make<TH2F>("hfed2DErrors1", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
   //hfed2DErrors2 = fs->make<TH2F>("hfed2DErrors2", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors3 = fs->make<TH2F>("hfed2DErrors3", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors4 = fs->make<TH2F>("hfed2DErrors4", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors5 = fs->make<TH2F>("hfed2DErrors5", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors6 = fs->make<TH2F>("hfed2DErrors6", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
+  hfed2DErrors3 = fs->make<TH2F>("hfed2DErrors3", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors4 = fs->make<TH2F>("hfed2DErrors4", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors5 = fs->make<TH2F>("hfed2DErrors5", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors6 = fs->make<TH2F>("hfed2DErrors6", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
   //hfed2DErrors7 = fs->make<TH2F>("hfed2DErrors7", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
   //hfed2DErrors8 = fs->make<TH2F>("hfed2DErrors8", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
   //hfed2DErrors9 = fs->make<TH2F>("hfed2DErrors9", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors10 = fs->make<TH2F>("hfed2DErrors10", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors11 = fs->make<TH2F>("hfed2DErrors11", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors12 = fs->make<TH2F>("hfed2DErrors12", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors13 = fs->make<TH2F>("hfed2DErrors13", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors14 = fs->make<TH2F>("hfed2DErrors14", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors15 = fs->make<TH2F>("hfed2DErrors15", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors16 = fs->make<TH2F>("hfed2DErrors16", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
+  hfed2DErrors10 = fs->make<TH2F>("hfed2DErrors10", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors11 = fs->make<TH2F>("hfed2DErrors11", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors12 = fs->make<TH2F>("hfed2DErrors12", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors13 = fs->make<TH2F>("hfed2DErrors13", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors14 = fs->make<TH2F>("hfed2DErrors14", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors15 = fs->make<TH2F>("hfed2DErrors15", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors16 = fs->make<TH2F>("hfed2DErrors16", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
 
+  hfedErrorType1ls = fs->make<TH2F>("hfedErrorType1ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfedErrorType2ls = fs->make<TH2F>("hfedErrorType2ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
 
-  hfedErrorType1ls = fs->make<TH2F>( "hfedErrorType1ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); // 
-  hfedErrorType2ls = fs->make<TH2F>( "hfedErrorType2ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-
-  hfed2DErrors1ls  = fs->make<TH2F>("hfed2DErrors1ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
+  hfed2DErrors1ls = fs->make<TH2F>("hfed2DErrors1ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
   //hfed2DErrors2ls  = fs->make<TH2F>("hfed2DErrors2ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors3ls  = fs->make<TH2F>("hfed2DErrors3ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors4ls  = fs->make<TH2F>("hfed2DErrors4ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors5ls  = fs->make<TH2F>("hfed2DErrors5ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors6ls  = fs->make<TH2F>("hfed2DErrors6ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
+  hfed2DErrors3ls = fs->make<TH2F>("hfed2DErrors3ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors4ls = fs->make<TH2F>("hfed2DErrors4ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors5ls = fs->make<TH2F>("hfed2DErrors5ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors6ls = fs->make<TH2F>("hfed2DErrors6ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
   //hfed2DErrors7ls  = fs->make<TH2F>("hfed2DErrors7ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
   //hfed2DErrors8ls  = fs->make<TH2F>("hfed2DErrors8ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
   //hfed2DErrors9ls  = fs->make<TH2F>("hfed2DErrors9ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors10ls = fs->make<TH2F>("hfed2DErrors10ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors11ls = fs->make<TH2F>("hfed2DErrors11ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors12ls = fs->make<TH2F>("hfed2DErrors12ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors13ls = fs->make<TH2F>("hfed2DErrors13ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors14ls = fs->make<TH2F>("hfed2DErrors14ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors15ls = fs->make<TH2F>("hfed2DErrors15ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors16ls = fs->make<TH2F>("hfed2DErrors16ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
+  hfed2DErrors10ls = fs->make<TH2F>("hfed2DErrors10ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors11ls = fs->make<TH2F>("hfed2DErrors11ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors12ls = fs->make<TH2F>("hfed2DErrors12ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors13ls = fs->make<TH2F>("hfed2DErrors13ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors14ls = fs->make<TH2F>("hfed2DErrors14ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors15ls = fs->make<TH2F>("hfed2DErrors15ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors16ls = fs->make<TH2F>("hfed2DErrors16ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
 
-  herrorTimels = fs->make<TH1D>( "herrorTimels", "timeouts vs ls", 1000,0,3000);
-  herrorOverls = fs->make<TH1D>( "herrorOverls", "overflows vs ls",1000,0,3000);
-  herrorTimels1 = fs->make<TH1D>("herrorTimels1","timeouts vs ls", 1000,0,3000);
-  herrorOverls1 = fs->make<TH1D>("herrorOverls1","overflows vs ls",1000,0,3000);
-  herrorTimels2 = fs->make<TH1D>("herrorTimels2","timeouts vs ls", 1000,0,3000);
-  herrorOverls2 = fs->make<TH1D>("herrorOverls2","overflows vs ls",1000,0,3000);
-  herrorTimels3 = fs->make<TH1D>("herrorTimels3","timeouts vs ls", 1000,0,3000);
-  herrorOverls3 = fs->make<TH1D>("herrorOverls3","overflows vs ls",1000,0,3000);
-  herrorTimels0 = fs->make<TH1D>("herrorTimels0","timeouts vs ls", 1000,0,3000);
-  herrorOverls0 = fs->make<TH1D>("herrorOverls0","overflows vs ls",1000,0,3000);
+  herrorTimels = fs->make<TH1D>("herrorTimels", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls = fs->make<TH1D>("herrorOverls", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels1 = fs->make<TH1D>("herrorTimels1", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls1 = fs->make<TH1D>("herrorOverls1", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels2 = fs->make<TH1D>("herrorTimels2", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls2 = fs->make<TH1D>("herrorOverls2", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels3 = fs->make<TH1D>("herrorTimels3", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls3 = fs->make<TH1D>("herrorOverls3", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels0 = fs->make<TH1D>("herrorTimels0", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls0 = fs->make<TH1D>("herrorOverls0", "overflows vs ls", 1000, 0, 3000);
 
-  hfed2DErrorsType1 = fs->make<TH2F>("hfed2DErrorsType1", "errors type 1 per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrorsType2 = fs->make<TH2F>("hfed2DErrorsType2", "errors type 2 per FED", 40,-0.5,39.5,37, -0.5, 36.5);
+  hfed2DErrorsType1 = fs->make<TH2F>("hfed2DErrorsType1", "errors type 1 per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrorsType2 = fs->make<TH2F>("hfed2DErrorsType2", "errors type 2 per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
 
-  hfed2DErrors1 = fs->make<TH2F>("hfed2DErrors1", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
+  hfed2DErrors1 = fs->make<TH2F>("hfed2DErrors1", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
   //hfed2DErrors2 = fs->make<TH2F>("hfed2DErrors2", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors3 = fs->make<TH2F>("hfed2DErrors3", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors4 = fs->make<TH2F>("hfed2DErrors4", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors5 = fs->make<TH2F>("hfed2DErrors5", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors6 = fs->make<TH2F>("hfed2DErrors6", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
+  hfed2DErrors3 = fs->make<TH2F>("hfed2DErrors3", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors4 = fs->make<TH2F>("hfed2DErrors4", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors5 = fs->make<TH2F>("hfed2DErrors5", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors6 = fs->make<TH2F>("hfed2DErrors6", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
   //hfed2DErrors7 = fs->make<TH2F>("hfed2DErrors7", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
   //hfed2DErrors8 = fs->make<TH2F>("hfed2DErrors8", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
   //hfed2DErrors9 = fs->make<TH2F>("hfed2DErrors9", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors10 = fs->make<TH2F>("hfed2DErrors10", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors11 = fs->make<TH2F>("hfed2DErrors11", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors12 = fs->make<TH2F>("hfed2DErrors12", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors13 = fs->make<TH2F>("hfed2DErrors13", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors14 = fs->make<TH2F>("hfed2DErrors14", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors15 = fs->make<TH2F>("hfed2DErrors15", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors16 = fs->make<TH2F>("hfed2DErrors16", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
+  hfed2DErrors10 = fs->make<TH2F>("hfed2DErrors10", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors11 = fs->make<TH2F>("hfed2DErrors11", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors12 = fs->make<TH2F>("hfed2DErrors12", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors13 = fs->make<TH2F>("hfed2DErrors13", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors14 = fs->make<TH2F>("hfed2DErrors14", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors15 = fs->make<TH2F>("hfed2DErrors15", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors16 = fs->make<TH2F>("hfed2DErrors16", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
 
+  hfedErrorType1ls = fs->make<TH2F>("hfedErrorType1ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfedErrorType2ls = fs->make<TH2F>("hfedErrorType2ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
 
-  hfedErrorType1ls = fs->make<TH2F>( "hfedErrorType1ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); // 
-  hfedErrorType2ls = fs->make<TH2F>( "hfedErrorType2ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-
-  hfed2DErrors1ls  = fs->make<TH2F>("hfed2DErrors1ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
+  hfed2DErrors1ls = fs->make<TH2F>("hfed2DErrors1ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
   //hfed2DErrors2ls  = fs->make<TH2F>("hfed2DErrors2ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors3ls  = fs->make<TH2F>("hfed2DErrors3ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors4ls  = fs->make<TH2F>("hfed2DErrors4ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors5ls  = fs->make<TH2F>("hfed2DErrors5ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors6ls  = fs->make<TH2F>("hfed2DErrors6ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
+  hfed2DErrors3ls = fs->make<TH2F>("hfed2DErrors3ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors4ls = fs->make<TH2F>("hfed2DErrors4ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors5ls = fs->make<TH2F>("hfed2DErrors5ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors6ls = fs->make<TH2F>("hfed2DErrors6ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
   //hfed2DErrors7ls  = fs->make<TH2F>("hfed2DErrors7ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
   //hfed2DErrors8ls  = fs->make<TH2F>("hfed2DErrors8ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
   //hfed2DErrors9ls  = fs->make<TH2F>("hfed2DErrors9ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors10ls = fs->make<TH2F>("hfed2DErrors10ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors11ls = fs->make<TH2F>("hfed2DErrors11ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors12ls = fs->make<TH2F>("hfed2DErrors12ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors13ls = fs->make<TH2F>("hfed2DErrors13ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors14ls = fs->make<TH2F>("hfed2DErrors14ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors15ls = fs->make<TH2F>("hfed2DErrors15ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors16ls = fs->make<TH2F>("hfed2DErrors16ls","errors vs lumi",300,0,3000, 40,-0.5,39.5); //
+  hfed2DErrors10ls = fs->make<TH2F>("hfed2DErrors10ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors11ls = fs->make<TH2F>("hfed2DErrors11ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors12ls = fs->make<TH2F>("hfed2DErrors12ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors13ls = fs->make<TH2F>("hfed2DErrors13ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors14ls = fs->make<TH2F>("hfed2DErrors14ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors15ls = fs->make<TH2F>("hfed2DErrors15ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors16ls = fs->make<TH2F>("hfed2DErrors16ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
 
+  hsizels = fs->make<TProfile>("hsizels", " bpix fed size vs ls", 300, 0, 3000, 0, 200000.);
+  htotPixelsls = fs->make<TProfile>("htotPixelsls", " tot pixels vs ls", 300, 0, 3000, 0, 300000.);
+  havsizels = fs->make<TProfile>("havsizels", "av. bpix fed size vs ls", 300, 0, 3000, 0, 300000.);
 
-  hsizels = fs->make<TProfile>("hsizels"," bpix fed size vs ls",300,0,3000,0,200000.);
-  htotPixelsls = fs->make<TProfile>("htotPixelsls"," tot pixels vs ls",300,0,3000,0,300000.);
-  havsizels = fs->make<TProfile>("havsizels","av. bpix fed size vs ls",300,0,3000,0,300000.);
+  herrorType1ls = fs->make<TProfile>("herrorType1ls", "error type 1 vs ls", 300, 0, 3000, 0, 1000.);
+  herrorType2ls = fs->make<TProfile>("herrorType2ls", "error type 2 vs ls", 300, 0, 3000, 0, 1000.);
 
-  herrorType1ls = fs->make<TProfile>("herrorType1ls","error type 1 vs ls",300,0,3000,0,1000.);
-  herrorType2ls = fs->make<TProfile>("herrorType2ls","error type 2 vs ls",300,0,3000,0,1000.);
-
-  herror1ls = fs->make<TProfile>("herror1ls","error 1 vs ls",300,0,3000,0,1000.);
+  herror1ls = fs->make<TProfile>("herror1ls", "error 1 vs ls", 300, 0, 3000, 0, 1000.);
   //herror2ls = fs->make<TProfile>("herror2ls","error 2 vs ls",300,0,3000,0,1000.);
-  herror3ls = fs->make<TProfile>("herror3ls","error 3 vs ls",300,0,3000,0,1000.);
-  herror4ls = fs->make<TProfile>("herror4ls","error 4 vs ls",300,0,3000,0,1000.);
-  herror5ls = fs->make<TProfile>("herror5ls","error 5 vs ls",300,0,3000,0,1000.);
-  herror6ls = fs->make<TProfile>("herror6ls","error 6 vs ls",300,0,3000,0,1000.);
+  herror3ls = fs->make<TProfile>("herror3ls", "error 3 vs ls", 300, 0, 3000, 0, 1000.);
+  herror4ls = fs->make<TProfile>("herror4ls", "error 4 vs ls", 300, 0, 3000, 0, 1000.);
+  herror5ls = fs->make<TProfile>("herror5ls", "error 5 vs ls", 300, 0, 3000, 0, 1000.);
+  herror6ls = fs->make<TProfile>("herror6ls", "error 6 vs ls", 300, 0, 3000, 0, 1000.);
   //herror7ls = fs->make<TProfile>("herror7ls","error 7 vs ls",300,0,3000,0,1000.);
   //herror8ls = fs->make<TProfile>("herror8ls","error 8 vs ls",300,0,3000,0,1000.);
   //herror9ls = fs->make<TProfile>("herror9ls","error 9 vs ls",300,0,3000,0,1000.);
-  herror10ls = fs->make<TProfile>("herror10ls","error 10 vs ls",300,0,3000,0,1000.);
-  herror11ls = fs->make<TProfile>("herror11ls","error 11 vs ls",300,0,3000,0,1000.);
-  herror12ls = fs->make<TProfile>("herror12ls","error 12 vs ls",300,0,3000,0,1000.);
-  herror13ls = fs->make<TProfile>("herror13ls","error 13 vs ls",300,0,3000,0,1000.);
-  herror14ls = fs->make<TProfile>("herror14ls","error 14 vs ls",300,0,3000,0,1000.);
-  herror15ls = fs->make<TProfile>("herror15ls","error 15 vs ls",300,0,3000,0,1000.);
-  herror16ls = fs->make<TProfile>("herror16ls","error 16 vs ls",300,0,3000,0,1000.);
-  
-  htotPixelsbx = fs->make<TProfile>("htotPixelsbx"," tot pixels vs bx",4000,-0.5,3999.5,0,300000.);
-  havsizebx = fs->make<TProfile>("havsizebx"," ave bpix fed size vs bx",4000,-0.5,3999.5,0,300000.);
-  herrorType1bx = fs->make<TProfile>("herrorType1bx"," error type 1 vs bx",4000,-0.5,3999.5,0,300000.);
-  herrorType2bx = fs->make<TProfile>("herrorType2bx"," error type 2 vs bx",4000,-0.5,3999.5,0,300000.);
+  herror10ls = fs->make<TProfile>("herror10ls", "error 10 vs ls", 300, 0, 3000, 0, 1000.);
+  herror11ls = fs->make<TProfile>("herror11ls", "error 11 vs ls", 300, 0, 3000, 0, 1000.);
+  herror12ls = fs->make<TProfile>("herror12ls", "error 12 vs ls", 300, 0, 3000, 0, 1000.);
+  herror13ls = fs->make<TProfile>("herror13ls", "error 13 vs ls", 300, 0, 3000, 0, 1000.);
+  herror14ls = fs->make<TProfile>("herror14ls", "error 14 vs ls", 300, 0, 3000, 0, 1000.);
+  herror15ls = fs->make<TProfile>("herror15ls", "error 15 vs ls", 300, 0, 3000, 0, 1000.);
+  herror16ls = fs->make<TProfile>("herror16ls", "error 16 vs ls", 300, 0, 3000, 0, 1000.);
+
+  htotPixelsbx = fs->make<TProfile>("htotPixelsbx", " tot pixels vs bx", 4000, -0.5, 3999.5, 0, 300000.);
+  havsizebx = fs->make<TProfile>("havsizebx", " ave bpix fed size vs bx", 4000, -0.5, 3999.5, 0, 300000.);
+  herrorType1bx = fs->make<TProfile>("herrorType1bx", " error type 1 vs bx", 4000, -0.5, 3999.5, 0, 300000.);
+  herrorType2bx = fs->make<TProfile>("herrorType2bx", " error type 2 vs bx", 4000, -0.5, 3999.5, 0, 300000.);
 
   //hintgl  = fs->make<TProfile>("hintgl", "inst lumi vs ls ",1000,0.,3000.,0.0,1000.);
   //hinstl  = fs->make<TProfile>("hinstl", "intg lumi vs ls ",1000,0.,3000.,0.0,10.);
 
-  hfedchannelsize  = fs->make<TProfile2D>("hfedchannelsize", "pixels per fed/channel",40,-0.5,39.5,37,-0.5,36.5, 0.0,10000.);
+  hfedchannelsize =
+      fs->make<TProfile2D>("hfedchannelsize", "pixels per fed/channel", 40, -0.5, 39.5, 37, -0.5, 36.5, 0.0, 10000.);
 
-  hfedchannelsizeb   = fs->make<TH1D>("hfedchannelsizeb", "pixels per bpix channel",200,0.0,maxLink);
-  hfedchannelsizeb1  = fs->make<TH1D>("hfedchannelsizeb1", "pixels per bpix1 channel",200,0.0,maxLink);
-  hfedchannelsizeb2  = fs->make<TH1D>("hfedchannelsizeb2", "pixels per bpix2 channel",200,0.0,maxLink);
-  hfedchannelsizeb3  = fs->make<TH1D>("hfedchannelsizeb3", "pixels per bpix3 channel",200,0.0,maxLink);
-  hfedchannelsizef   = fs->make<TH1D>("hfedchannelsizef", "pixels per fpix channel",200,0.0,maxLink);
-
+  hfedchannelsizeb = fs->make<TH1D>("hfedchannelsizeb", "pixels per bpix channel", 200, 0.0, maxLink);
+  hfedchannelsizeb1 = fs->make<TH1D>("hfedchannelsizeb1", "pixels per bpix1 channel", 200, 0.0, maxLink);
+  hfedchannelsizeb2 = fs->make<TH1D>("hfedchannelsizeb2", "pixels per bpix2 channel", 200, 0.0, maxLink);
+  hfedchannelsizeb3 = fs->make<TH1D>("hfedchannelsizeb3", "pixels per bpix3 channel", 200, 0.0, maxLink);
+  hfedchannelsizef = fs->make<TH1D>("hfedchannelsizef", "pixels per fpix channel", 200, 0.0, maxLink);
 
 #ifdef OUTFILE
   outfile.open("pixfed.csv");
-  for(int i=0;i<40;++i) {if(i<39) outfile<<i<<","; else outfile<<i<<endl;}
+  for (int i = 0; i < 40; ++i) {
+    if (i < 39)
+      outfile << i << ",";
+    else
+      outfile << i << endl;
+  }
 #endif
-
 }
 //-----------------------------------------------------------------------
-void SiPixelRawDumper::analyze(const  edm::Event& ev, const edm::EventSetup& es) {
-
+void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
   // Access event information
-  int run       = ev.id().run();
-  int event     = ev.id().event();
+  int run = ev.id().run();
+  int event = ev.id().event();
   int lumiBlock = ev.luminosityBlock();
-  int bx        = ev.bunchCrossing();
+  int bx = ev.bunchCrossing();
   //int orbit     = ev.orbitNumber();
 
   hevent->Fill(float(event));
@@ -944,50 +998,48 @@ void SiPixelRawDumper::analyze(const  edm::Event& ev, const edm::EventSetup& es)
 #ifdef L1
   // Get L1
   edm::Handle<L1GlobalTriggerReadoutRecord> L1GTRR;
-  ev.getByLabel("gtDigis",L1GTRR);
+  ev.getByLabel("gtDigis", L1GTRR);
 
   if (L1GTRR.isValid()) {
     bool l1a = L1GTRR->decision();
-    cout<<" L1 status :"<<l1a<<endl;
+    cout << " L1 status :" << l1a << endl;
   } else {
-    cout<<" NO L1 status "<<endl;
-  } // if l1a
+    cout << " NO L1 status " << endl;
+  }  // if l1a
 #endif
 
-
   // Get lumi info (does not work for raw)
-//  edm::LuminosityBlock const& iLumi = ev.getLuminosityBlock();
-//   edm::Handle<LumiSummary> lumi;
-//   iLumi.getByLabel("lumiProducer", lumi);
-//   edm::Handle<edm::ConditionsInLumiBlock> cond;
-//   float intlumi = 0, instlumi=0;
-//   int beamint1=0, beamint2=0;
-//   iLumi.getByLabel("conditionsInEdm", cond);
-//   // This will only work when running on RECO until (if) they fix it in the FW
-//   // When running on RAW and reconstructing, the LumiSummary will not appear
-//   // in the event before reaching endLuminosityBlock(). Therefore, it is not
-//   // possible to get this info in the event
-//   if (lumi.isValid()) {
-//     intlumi =(lumi->intgRecLumi())/1000.; // integrated lumi per LS in -pb
-//     instlumi=(lumi->avgInsDelLumi())/1000.; //ave. inst lumi per LS in -pb
-//     beamint1=(cond->totalIntensityBeam1)/1000;
-//     beamint2=(cond->totalIntensityBeam2)/1000;
-//   } else {
-//     std::cout << "** ERROR: Event does not get lumi info\n";
-//   }
-//   cout<<instlumi<<" "<<intlumi<<" "<<lumiBlock<<endl;
+  //  edm::LuminosityBlock const& iLumi = ev.getLuminosityBlock();
+  //   edm::Handle<LumiSummary> lumi;
+  //   iLumi.getByLabel("lumiProducer", lumi);
+  //   edm::Handle<edm::ConditionsInLumiBlock> cond;
+  //   float intlumi = 0, instlumi=0;
+  //   int beamint1=0, beamint2=0;
+  //   iLumi.getByLabel("conditionsInEdm", cond);
+  //   // This will only work when running on RECO until (if) they fix it in the FW
+  //   // When running on RAW and reconstructing, the LumiSummary will not appear
+  //   // in the event before reaching endLuminosityBlock(). Therefore, it is not
+  //   // possible to get this info in the event
+  //   if (lumi.isValid()) {
+  //     intlumi =(lumi->intgRecLumi())/1000.; // integrated lumi per LS in -pb
+  //     instlumi=(lumi->avgInsDelLumi())/1000.; //ave. inst lumi per LS in -pb
+  //     beamint1=(cond->totalIntensityBeam1)/1000;
+  //     beamint2=(cond->totalIntensityBeam2)/1000;
+  //   } else {
+  //     std::cout << "** ERROR: Event does not get lumi info\n";
+  //   }
+  //   cout<<instlumi<<" "<<intlumi<<" "<<lumiBlock<<endl;
 
-//   hinstl->Fill(float(lumiBlock),float(instlumi));
-//   hintgl->Fill(float(lumiBlock),float(intlumi));
-
+  //   hinstl->Fill(float(lumiBlock),float(instlumi));
+  //   hintgl->Fill(float(lumiBlock),float(intlumi));
 
   edm::Handle<FEDRawDataCollection> buffers;
   //static std::string label = theConfig.getUntrackedParameter<std::string>("InputLabel","source");
-  //static std::string instance = theConfig.getUntrackedParameter<std::string>("InputInstance","");  
+  //static std::string instance = theConfig.getUntrackedParameter<std::string>("InputInstance","");
   //ev.getByLabel( label, instance, buffers);
-  ev.getByToken(rawData , buffers);  // the new bytoken 
+  ev.getByToken(rawData, buffers);  // the new bytoken
 
-  std::pair<int,int> fedIds(FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID);
+  std::pair<int, int> fedIds(FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID);
 
   //PixelDataFormatter formatter(0);  // only for digis
   //bool dummyErrorBool;
@@ -996,277 +1048,309 @@ void SiPixelRawDumper::analyze(const  edm::Event& ev, const edm::EventSetup& es)
   //typedef long long Word64;
   typedef uint32_t Word32;
   typedef uint64_t Word64;
-  int status=0;
-  int countPixels=0;
+  int status = 0;
+  int countPixels = 0;
   int eventId = -1;
-  int countErrorsPerEvent=0;
-  int countErrorsPerEvent1=0;
-  int countErrorsPerEvent2=0;
+  int countErrorsPerEvent = 0;
+  int countErrorsPerEvent1 = 0;
+  int countErrorsPerEvent2 = 0;
   double aveFedSize = 0.;
-  int stat1=-1, stat2=-1;
+  int stat1 = -1, stat2 = -1;
   int fedchannelsize[36];
 
-  int countErrors[20] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+  int countErrors[20] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
   countAllEvents++;
 
-  if(printHeaders || printLocal>0) cout<<"Event = "<<countEvents<<" Event number "<<event<<" Run "<<run<<" LS "<<lumiBlock<<endl;
+  if (printHeaders || printLocal > 0)
+    cout << "Event = " << countEvents << " Event number " << event << " Run " << run << " LS " << lumiBlock << endl;
 
   // Loop over FEDs
   for (int fedId = fedIds.first; fedId <= fedIds.second; fedId++) {
-
     //edm::DetSetVector<PixelDigi> collection;
     PixelDataFormatter::Errors errors;
 
     //get event data for this fed
-    const FEDRawData& rawData = buffers->FEDData( fedId );
+    const FEDRawData &rawData = buffers->FEDData(fedId);
 
-    if(printHeaders) cout<<"Get data For FED = "<<fedId<<" size in bytes "<<rawData.size()<<endl;
-    if(rawData.size()==0) continue;  // skip if not data for this fed
+    if (printHeaders)
+      cout << "Get data For FED = " << fedId << " size in bytes " << rawData.size() << endl;
+    if (rawData.size() == 0)
+      continue;  // skip if not data for this fed
 
-    for(int i=0;i<36;++i) fedchannelsize[i]=0;
+    for (int i = 0; i < 36; ++i)
+      fedchannelsize[i] = 0;
 
-    int nWords = rawData.size()/sizeof(Word64);
+    int nWords = rawData.size() / sizeof(Word64);
     //cout<<" size "<<nWords<<endl;
 
-    sumFedSize += float(nWords);    
-    if(fedId<32) aveFedSize += double(2.*nWords);
+    sumFedSize += float(nWords);
+    if (fedId < 32)
+      aveFedSize += double(2. * nWords);
 
-    hsize->Fill(float(2*nWords)); // fed buffer size in words (32bit)
-    hsize0->Fill(float(2*nWords)); // fed buffer size in words (32bit)
-    if(fedId<32) hsize1->Fill(float(2*nWords)); // bpix fed buffer size in words (32bit)
-    else hsize2->Fill(float(2*nWords)); // fpix fed buffer size in words (32bit)
+    hsize->Fill(float(2 * nWords));   // fed buffer size in words (32bit)
+    hsize0->Fill(float(2 * nWords));  // fed buffer size in words (32bit)
+    if (fedId < 32)
+      hsize1->Fill(float(2 * nWords));  // bpix fed buffer size in words (32bit)
+    else
+      hsize2->Fill(float(2 * nWords));  // fpix fed buffer size in words (32bit)
 
 #ifdef IND_FEDS
-    hsizeFeds[fedId]->Fill(float(2*nWords)); // size, includes errors and dummy words
+    hsizeFeds[fedId]->Fill(float(2 * nWords));  // size, includes errors and dummy words
 #endif
-    hsize2d->Fill(float(fedId),float(2*nWords));  // 2d 
-    hsizep->Fill(float(fedId),float(2*nWords)); // profile 
-    if(fedId<32) hsizels->Fill(float(lumiBlock),float(2*nWords)); // bpix versu sls
+    hsize2d->Fill(float(fedId), float(2 * nWords));  // 2d
+    hsizep->Fill(float(fedId), float(2 * nWords));   // profile
+    if (fedId < 32)
+      hsizels->Fill(float(lumiBlock), float(2 * nWords));  // bpix versu sls
 
     // check headers
-    const Word64* header = reinterpret_cast<const Word64* >(rawData.data()); 
+    const Word64 *header = reinterpret_cast<const Word64 *>(rawData.data());
     //cout<<hex<<*header<<dec<<endl;
 
     unsigned int bxid = 0;
     eventId = MyDecode::header(*header, fedId, printHeaders, bxid);
-    //if(fedId = fedIds.first) 
-    if(bx != int(bxid) ) cout<<" Inconsistent BX: from event "<<bx<<" from FED "<<bxid<<endl;
+    //if(fedId = fedIds.first)
+    if (bx != int(bxid))
+      cout << " Inconsistent BX: from event " << bx << " from FED " << bxid << endl;
 
-
-    const Word64* trailer = reinterpret_cast<const Word64* >(rawData.data())+(nWords-1);
+    const Word64 *trailer = reinterpret_cast<const Word64 *>(rawData.data()) + (nWords - 1);
     //cout<<hex<<*trailer<<dec<<endl;
-    status = MyDecode::trailer(*trailer,fedId, printHeaders);
+    status = MyDecode::trailer(*trailer, fedId, printHeaders);
 
-    int countPixelsInFed=0;
-    int countErrorsInFed=0;
-    int countErrorsInFed1=0;
-    int countErrorsInFed2=0;
+    int countPixelsInFed = 0;
+    int countErrorsInFed = 0;
+    int countErrorsInFed1 = 0;
+    int countErrorsInFed2 = 0;
     int fedChannel = 0;
-    int num=0;
+    int num = 0;
 
     // Loop over payload words
-    for (const Word64* word = header+1; word != trailer; word++) {
-      static const Word64 WORD32_mask  = 0xffffffff;
+    for (const Word64 *word = header + 1; word != trailer; word++) {
+      static const Word64 WORD32_mask = 0xffffffff;
 
-      for(int ipart=0;ipart<2;++ipart) {
-	Word32 w = 0;
-	if(ipart==0) {
-	  w =  *word       & WORD32_mask;  // 1st word
-	  //w1=w;
-	} else if(ipart==1) {
-	  w =  *word >> 32 & WORD32_mask;  // 2nd word
-	}
+      for (int ipart = 0; ipart < 2; ++ipart) {
+        Word32 w = 0;
+        if (ipart == 0) {
+          w = *word & WORD32_mask;  // 1st word
+          //w1=w;
+        } else if (ipart == 1) {
+          w = *word >> 32 & WORD32_mask;  // 2nd word
+        }
 
-	num++;
-	if(printLocal>3) cout<<" "<<num<<" "<<hex<<w<<dec<<endl;
+        num++;
+        if (printLocal > 3)
+          cout << " " << num << " " << hex << w << dec << endl;
 
-	status = MyDecode::data(w,fedChannel, fedId, stat1, stat2, printData);
-	int layer = MyDecode::checkLayerLink(fedId, fedChannel); // get bpix layer 
-	if(layer>10) layer = layer-10; // ignore 1/2 modules 
-	if(status>0) {  // data
-	  countPixels++;
-	  countPixelsInFed++;
-	  fedchannelsize[fedChannel-1]++;
+        status = MyDecode::data(w, fedChannel, fedId, stat1, stat2, printData);
+        int layer = MyDecode::checkLayerLink(fedId, fedChannel);  // get bpix layer
+        if (layer > 10)
+          layer = layer - 10;  // ignore 1/2 modules
+        if (status > 0) {      // data
+          countPixels++;
+          countPixelsInFed++;
+          fedchannelsize[fedChannel - 1]++;
 
-	} else if(status<0) {  // error word
-	  countErrorsInFed++;
-	  //if( status == -6 || status == -5) 
-	  if(printErrors) cout<<" Bad stats for FED "<<fedId<<" Event "<<eventId<<"/"
-			      <<countAllEvents<<" chan "<<fedChannel<<" status "<<status<<endl;
-	  status=abs(status);
-	  // 2 - wrong channel
-	  // 3 - wrong pix or dcol 
-	  // 4 - wrong roc
-	  // 5 - pix=0
-	  // 6 - double pixel
-	  // 10 - timeout ()
-	  // 11 - ene ()
-	  // 12 - mum pf rocs error ()
-	  // 13 - fsm ()
-	  // 14 - overflow ()
-	  // 15 - trailer ()
-	  // 16 - fifo  (30)
-	  // 17 - reset/resync NOT INCLUDED YET
-	  
-	  switch(status) {
+        } else if (status < 0) {  // error word
+          countErrorsInFed++;
+          //if( status == -6 || status == -5)
+          if (printErrors)
+            cout << " Bad stats for FED " << fedId << " Event " << eventId << "/" << countAllEvents << " chan "
+                 << fedChannel << " status " << status << endl;
+          status = abs(status);
+          // 2 - wrong channel
+          // 3 - wrong pix or dcol
+          // 4 - wrong roc
+          // 5 - pix=0
+          // 6 - double pixel
+          // 10 - timeout ()
+          // 11 - ene ()
+          // 12 - mum pf rocs error ()
+          // 13 - fsm ()
+          // 14 - overflow ()
+          // 15 - trailer ()
+          // 16 - fifo  (30)
+          // 17 - reset/resync NOT INCLUDED YET
 
-	  case(10) : { // Timeout
+          switch (status) {
+            case (10): {  // Timeout
 
-	    countErrors[10]++;
-	    fedErrorsTime[fedId][(fedChannel-1)]++;
-	    hfed2DErrors10->Fill(float(fedId),float(fedChannel));
-	    hfed2DErrors10ls->Fill(float(lumiBlock),float(fedId)); //errors
+              countErrors[10]++;
+              fedErrorsTime[fedId][(fedChannel - 1)]++;
+              hfed2DErrors10->Fill(float(fedId), float(fedChannel));
+              hfed2DErrors10ls->Fill(float(lumiBlock), float(fedId));  //errors
 
-	    herrorTimels->Fill(float(lumiBlock));
-	    if(layer==1)      herrorTimels1->Fill(float(lumiBlock));
-	    else if(layer==2) herrorTimels2->Fill(float(lumiBlock));
-	    else if(layer==3) herrorTimels3->Fill(float(lumiBlock));
-	    else if(layer==0) herrorTimels0->Fill(float(lumiBlock));
+              herrorTimels->Fill(float(lumiBlock));
+              if (layer == 1)
+                herrorTimels1->Fill(float(lumiBlock));
+              else if (layer == 2)
+                herrorTimels2->Fill(float(lumiBlock));
+              else if (layer == 3)
+                herrorTimels3->Fill(float(lumiBlock));
+              else if (layer == 0)
+                herrorTimels0->Fill(float(lumiBlock));
 
-	    //hbx1->Fill(float(bx));
-	    break; } 
+              //hbx1->Fill(float(bx));
+              break;
+            }
 
-	  case(14) : {  // OVER
+            case (14): {  // OVER
 
-	    countErrors[14]++;
-	    fedErrorsOver[fedId][(fedChannel-1)]++;
-	    hfed2DErrors14->Fill(float(fedId),float(fedChannel));
-	    hfed2DErrors14ls->Fill(float(lumiBlock),float(fedId)); //errors
+              countErrors[14]++;
+              fedErrorsOver[fedId][(fedChannel - 1)]++;
+              hfed2DErrors14->Fill(float(fedId), float(fedChannel));
+              hfed2DErrors14ls->Fill(float(lumiBlock), float(fedId));  //errors
 
-	    herrorOverls->Fill(float(lumiBlock));
-	    if(layer==1)      herrorOverls1->Fill(float(lumiBlock));
-	    else if(layer==2) herrorOverls2->Fill(float(lumiBlock));
-	    else if(layer==3) herrorOverls3->Fill(float(lumiBlock));
-	    else if(layer==0) herrorOverls0->Fill(float(lumiBlock));
-	    //hbx2->Fill(float(bx));
-	    break; }
+              herrorOverls->Fill(float(lumiBlock));
+              if (layer == 1)
+                herrorOverls1->Fill(float(lumiBlock));
+              else if (layer == 2)
+                herrorOverls2->Fill(float(lumiBlock));
+              else if (layer == 3)
+                herrorOverls3->Fill(float(lumiBlock));
+              else if (layer == 0)
+                herrorOverls0->Fill(float(lumiBlock));
+              //hbx2->Fill(float(bx));
+              break;
+            }
 
-	  case(11) : {  // ENE
+            case (11): {  // ENE
 
-	    countErrors[11]++;
-	    hfed2DErrors11->Fill(float(fedId),float(fedChannel));
-	    hfed2DErrors11ls->Fill(float(lumiBlock),float(fedId)); //errors
-	    //hbx3->Fill(float(bx));
-	    fedErrorsENE[fedId][(fedChannel-1)]++;
-	    break; }
+              countErrors[11]++;
+              hfed2DErrors11->Fill(float(fedId), float(fedChannel));
+              hfed2DErrors11ls->Fill(float(lumiBlock), float(fedId));  //errors
+              //hbx3->Fill(float(bx));
+              fedErrorsENE[fedId][(fedChannel - 1)]++;
+              break;
+            }
 
-	  case(16) : { //FIFO
+            case (16): {  //FIFO
 
-	    countErrors[16]++;
-	    hfed2DErrors16->Fill(float(fedId),float(fedChannel));
-	    hfed2DErrors16ls->Fill(float(lumiBlock),float(fedId)); //errors
-	    break; }
+              countErrors[16]++;
+              hfed2DErrors16->Fill(float(fedId), float(fedChannel));
+              hfed2DErrors16ls->Fill(float(lumiBlock), float(fedId));  //errors
+              break;
+            }
 
-	  case(12) : {  // NOR
+            case (12): {  // NOR
 
-	    countErrors[12]++;
-	    hfed2DErrors12->Fill(float(fedId),float(fedChannel));
-	    hfed2DErrors12ls->Fill(float(lumiBlock),float(fedId)); //errors
-	    //hbx5->Fill(float(bx));
-	    break; }
+              countErrors[12]++;
+              hfed2DErrors12->Fill(float(fedId), float(fedChannel));
+              hfed2DErrors12ls->Fill(float(lumiBlock), float(fedId));  //errors
+              //hbx5->Fill(float(bx));
+              break;
+            }
 
-	  case(15) : {  // TBM Trailer
+            case (15): {  // TBM Trailer
 
-	    countErrors[15]++;
-	    hfed2DErrors15->Fill(float(fedId),float(fedChannel));
-	    hfed2DErrors15ls->Fill(float(lumiBlock),float(fedId)); //errors
-	    break; }
+              countErrors[15]++;
+              hfed2DErrors15->Fill(float(fedId), float(fedChannel));
+              hfed2DErrors15ls->Fill(float(lumiBlock), float(fedId));  //errors
+              break;
+            }
 
-	  case(13) : {  // FSM
+            case (13): {  // FSM
 
-	    countErrors[13]++;
-	    hfed2DErrors13->Fill(float(fedId),float(fedChannel));
-	    hfed2DErrors13ls->Fill(float(lumiBlock),float(fedId)); //errors
-	    break; }
+              countErrors[13]++;
+              hfed2DErrors13->Fill(float(fedId), float(fedChannel));
+              hfed2DErrors13ls->Fill(float(lumiBlock), float(fedId));  //errors
+              break;
+            }
 
-	  case(3) : {  //  inv. pix-dcol
+            case (3): {  //  inv. pix-dcol
 
-	    countErrors[3]++;
-	    hfed2DErrors3->Fill(float(fedId),float(fedChannel));
-	    hfed2DErrors3ls->Fill(float(lumiBlock),float(fedId)); //errors
-	    //hbx8->Fill(float(bx));
-	    break; }
+              countErrors[3]++;
+              hfed2DErrors3->Fill(float(fedId), float(fedChannel));
+              hfed2DErrors3ls->Fill(float(lumiBlock), float(fedId));  //errors
+              //hbx8->Fill(float(bx));
+              break;
+            }
 
-	  case(4) : {  // inv roc
-	    countErrors[4]++;
-	    hfed2DErrors4->Fill(float(fedId),float(fedChannel));
-	    hfed2DErrors4ls->Fill(float(lumiBlock),float(fedId)); //errors
-	    //hbx9->Fill(float(bx));
-	    break; }
+            case (4): {  // inv roc
+              countErrors[4]++;
+              hfed2DErrors4->Fill(float(fedId), float(fedChannel));
+              hfed2DErrors4ls->Fill(float(lumiBlock), float(fedId));  //errors
+              //hbx9->Fill(float(bx));
+              break;
+            }
 
-	  case(5) : {  // pix=0
-	    countErrors[5]++;
-	    hfed2DErrors5->Fill(float(fedId),float(fedChannel));
-	    hfed2DErrors5ls->Fill(float(lumiBlock),float(fedId)); //errors
-	    //hbx10->Fill(float(bx));
+            case (5): {  // pix=0
+              countErrors[5]++;
+              hfed2DErrors5->Fill(float(fedId), float(fedChannel));
+              hfed2DErrors5ls->Fill(float(lumiBlock), float(fedId));  //errors
+              //hbx10->Fill(float(bx));
 
-	    hroc000->Fill(float(stat1)); // count rocs
-	    hcount000->Fill(float(stat2));
-	    hcount0002->Fill(float(fedId),float(stat2));
-	    break; }
+              hroc000->Fill(float(stat1));  // count rocs
+              hcount000->Fill(float(stat2));
+              hcount0002->Fill(float(fedId), float(stat2));
+              break;
+            }
 
-	  case(6) : {  // double pix
+            case (6): {  // double pix
 
-	    countErrors[6]++;
-	    hfed2DErrors6->Fill(float(fedId),float(fedChannel));
-	    hfed2DErrors6ls->Fill(float(lumiBlock),float(fedId)); //errors
-	    //hbx12->Fill(float(bx));
+              countErrors[6]++;
+              hfed2DErrors6->Fill(float(fedId), float(fedChannel));
+              hfed2DErrors6ls->Fill(float(lumiBlock), float(fedId));  //errors
+              //hbx12->Fill(float(bx));
 
-	    hrocDouble->Fill(float(stat1)); // count rocs
-	    hcountDouble->Fill(float(stat2));
-	    hcountDouble2->Fill(float(fedId),float(stat2));
-	    break; }
+              hrocDouble->Fill(float(stat1));  // count rocs
+              hcountDouble->Fill(float(stat2));
+              hcountDouble2->Fill(float(fedId), float(stat2));
+              break;
+            }
 
-	  case(1) : {  // unknown
-	    countErrors[1]++;
-	    hfed2DErrors1->Fill(float(fedId),float(fedChannel));
-	    hfed2DErrors1ls->Fill(float(lumiBlock),float(fedId)); //errors
-	    break; }
+            case (1): {  // unknown
+              countErrors[1]++;
+              hfed2DErrors1->Fill(float(fedId), float(fedChannel));
+              hfed2DErrors1ls->Fill(float(lumiBlock), float(fedId));  //errors
+              break;
+            }
 
-	  }  // end switch
-	  
-	  if(status<20) errorType[status]++;
+          }  // end switch
 
-	  //herrorType0->Fill(float(status));
-	  //herrorFed0->Fill(float(fedId));
-	  //herrorChan0->Fill(float(fedChannel));
+          if (status < 20)
+            errorType[status]++;
 
-	  hfed2d->Fill(float(fedId),float(status));
-	  
-	  if(status>=10) {  // hard errors
-	    // Type - 1 Errors
+          //herrorType0->Fill(float(status));
+          //herrorFed0->Fill(float(fedId));
+          //herrorChan0->Fill(float(fedChannel));
 
-	    countErrorsInFed1++;
-	    hfedErrorType1ls->Fill(float(lumiBlock),float(fedId)); // hard errors
-	    hfed2DErrorsType1->Fill(float(fedId),float(fedChannel));
+          hfed2d->Fill(float(fedId), float(status));
 
-	    herrorType1->Fill(float(status));
-	    herrorType1Fed->Fill(float(fedId));
-	    herrorType1Chan->Fill(float(fedChannel));
+          if (status >= 10) {  // hard errors
+            // Type - 1 Errors
 
-	    fedErrors[fedId][(fedChannel-1)]++;
+            countErrorsInFed1++;
+            hfedErrorType1ls->Fill(float(lumiBlock), float(fedId));  // hard errors
+            hfed2DErrorsType1->Fill(float(fedId), float(fedChannel));
 
-	  } else if(status>0) {  // decode errors
-	    // Type 2 errprs
+            herrorType1->Fill(float(status));
+            herrorType1Fed->Fill(float(fedId));
+            herrorType1Chan->Fill(float(fedChannel));
 
-	    countErrorsInFed2++;
-	    hfedErrorType2ls->Fill(float(lumiBlock),float(fedId)); // decode errors
-	    hfed2DErrorsType2->Fill(float(fedId),float(fedChannel));
+            fedErrors[fedId][(fedChannel - 1)]++;
 
-	    herrorType2->Fill(float(status));
-	    herrorType2Fed->Fill(float(fedId));
-	    herrorType2Chan->Fill(float(fedChannel));
+          } else if (status > 0) {  // decode errors
+            // Type 2 errprs
 
-	    if(status==5)      decodeErrors000[fedId][(fedChannel-1)]++;
-	    else if(status==6) decodeErrorsDouble[fedId][(fedChannel-1)]++;
-	    else               decodeErrors[fedId][(fedChannel-1)]++;
-	  }
+            countErrorsInFed2++;
+            hfedErrorType2ls->Fill(float(lumiBlock), float(fedId));  // decode errors
+            hfed2DErrorsType2->Fill(float(fedId), float(fedChannel));
 
-	}
-      } // for  1/2 word
+            herrorType2->Fill(float(status));
+            herrorType2Fed->Fill(float(fedId));
+            herrorType2Chan->Fill(float(fedChannel));
 
-    } // loop over longlong  words
+            if (status == 5)
+              decodeErrors000[fedId][(fedChannel - 1)]++;
+            else if (status == 6)
+              decodeErrorsDouble[fedId][(fedChannel - 1)]++;
+            else
+              decodeErrors[fedId][(fedChannel - 1)]++;
+          }
+        }
+      }  // for  1/2 word
+
+    }  // loop over longlong  words
 
     countTotErrors += countErrorsInFed;
     countErrorsPerEvent += countErrorsInFed;
@@ -1277,79 +1361,88 @@ void SiPixelRawDumper::analyze(const  edm::Event& ev, const edm::EventSetup& es)
     //formatter.interpretRawData( dummyErrorBool, fedId, rawData, collection, errors);
     //cout<<dummyErrorBool<<" "<<digis.size()<<" "<<errors.size()<<endl;
 
-    if(countPixelsInFed>0)  {
+    if (countPixelsInFed > 0) {
       sumFedPixels[fedId] += countPixelsInFed;
     }
 
     hpixels->Fill(float(countPixelsInFed));
     hpixels0->Fill(float(countPixelsInFed));
-    if(countPixelsInFed>0) hpixels1->Fill(float(countPixelsInFed));
-    if(countPixelsInFed>0 && fedId<32)  hpixels2->Fill(float(countPixelsInFed));
-    if(countPixelsInFed>0 && fedId>=32) hpixels3->Fill(float(countPixelsInFed));
+    if (countPixelsInFed > 0)
+      hpixels1->Fill(float(countPixelsInFed));
+    if (countPixelsInFed > 0 && fedId < 32)
+      hpixels2->Fill(float(countPixelsInFed));
+    if (countPixelsInFed > 0 && fedId >= 32)
+      hpixels3->Fill(float(countPixelsInFed));
     herrors->Fill(float(countErrorsInFed));
 
-    for(int i=0;i<36;++i) { 
-      hfedchannelsize->Fill( float(fedId), float(i+1), float(fedchannelsize[i]) );
-      if(fedId<32) {
-	hfedchannelsizeb->Fill( float(fedchannelsize[i]) );
-	int layer = MyDecode::checkLayerLink(fedId, i); // get bpix layer 
-	if(layer>10) layer = layer-10; // ignore 1/2 modules 
-	if(layer==3)      hfedchannelsizeb3->Fill( float(fedchannelsize[i]) );  // layer 3
-	else if(layer==2) hfedchannelsizeb2->Fill( float(fedchannelsize[i]) );  // layer 2
-	else if(layer==1) hfedchannelsizeb1->Fill( float(fedchannelsize[i]) );  // layer 1
-	else cout<<" Cannot be "<<layer<<" "<<fedId<<" "<<i<<endl;
-      } else         hfedchannelsizef->Fill( float(fedchannelsize[i]) );  // fpix
+    for (int i = 0; i < 36; ++i) {
+      hfedchannelsize->Fill(float(fedId), float(i + 1), float(fedchannelsize[i]));
+      if (fedId < 32) {
+        hfedchannelsizeb->Fill(float(fedchannelsize[i]));
+        int layer = MyDecode::checkLayerLink(fedId, i);  // get bpix layer
+        if (layer > 10)
+          layer = layer - 10;  // ignore 1/2 modules
+        if (layer == 3)
+          hfedchannelsizeb3->Fill(float(fedchannelsize[i]));  // layer 3
+        else if (layer == 2)
+          hfedchannelsizeb2->Fill(float(fedchannelsize[i]));  // layer 2
+        else if (layer == 1)
+          hfedchannelsizeb1->Fill(float(fedchannelsize[i]));  // layer 1
+        else
+          cout << " Cannot be " << layer << " " << fedId << " " << i << endl;
+      } else
+        hfedchannelsizef->Fill(float(fedchannelsize[i]));  // fpix
     }
     //    if(fedId == fedIds.first || countPixelsInFed>0 || countErrorsInFed>0 )  {
     //       eventId = MyDecode::header(*header, true);
     //       if(countPixelsInFed>0 || countErrorsInFed>0 ) cout<<"fed "<<fedId<<" pix "<<countPixelsInFed<<" err "<<countErrorsInFed<<endl;
     //       status = MyDecode::trailer(*trailer,true);
     //     }
-    
 
 #ifdef OUTFILE
     // print number of bytes per fed, CSV
-    if(fedId == fedIds.second) outfile<<(nWords*8)<<endl;
-    else                       outfile<<(nWords*8)<<",";  
+    if (fedId == fedIds.second)
+      outfile << (nWords * 8) << endl;
+    else
+      outfile << (nWords * 8) << ",";
 #endif
 
-  } // loop over feds
+  }  // loop over feds
 
   htotPixels->Fill(float(countPixels));
   htotPixels0->Fill(float(countPixels));
   htotErrors->Fill(float(countErrorsPerEvent));
 
-  htotPixelsls->Fill(float(lumiBlock),float(countPixels));
-  htotPixelsbx->Fill(float(bx),float(countPixels));
+  htotPixelsls->Fill(float(lumiBlock), float(countPixels));
+  htotPixelsbx->Fill(float(bx), float(countPixels));
 
-  herrorType1ls->Fill(float(lumiBlock),float(countErrorsPerEvent1));
-  herrorType2ls->Fill(float(lumiBlock),float(countErrorsPerEvent2));
+  herrorType1ls->Fill(float(lumiBlock), float(countErrorsPerEvent1));
+  herrorType2ls->Fill(float(lumiBlock), float(countErrorsPerEvent2));
 
-  herror1ls->Fill(float(lumiBlock),float(countErrors[1]));
-  herror3ls->Fill(float(lumiBlock),float(countErrors[3]));
-  herror4ls->Fill(float(lumiBlock),float(countErrors[4]));
-  herror5ls->Fill(float(lumiBlock),float(countErrors[5]));
-  herror6ls->Fill(float(lumiBlock),float(countErrors[6]));
-  herror10ls->Fill(float(lumiBlock),float(countErrors[10]));
-  herror11ls->Fill(float(lumiBlock),float(countErrors[11]));
-  herror12ls->Fill(float(lumiBlock),float(countErrors[12]));
-  herror13ls->Fill(float(lumiBlock),float(countErrors[13]));
-  herror14ls->Fill(float(lumiBlock),float(countErrors[14]));
-  herror15ls->Fill(float(lumiBlock),float(countErrors[15]));
-  herror16ls->Fill(float(lumiBlock),float(countErrors[16]));
+  herror1ls->Fill(float(lumiBlock), float(countErrors[1]));
+  herror3ls->Fill(float(lumiBlock), float(countErrors[3]));
+  herror4ls->Fill(float(lumiBlock), float(countErrors[4]));
+  herror5ls->Fill(float(lumiBlock), float(countErrors[5]));
+  herror6ls->Fill(float(lumiBlock), float(countErrors[6]));
+  herror10ls->Fill(float(lumiBlock), float(countErrors[10]));
+  herror11ls->Fill(float(lumiBlock), float(countErrors[11]));
+  herror12ls->Fill(float(lumiBlock), float(countErrors[12]));
+  herror13ls->Fill(float(lumiBlock), float(countErrors[13]));
+  herror14ls->Fill(float(lumiBlock), float(countErrors[14]));
+  herror15ls->Fill(float(lumiBlock), float(countErrors[15]));
+  herror16ls->Fill(float(lumiBlock), float(countErrors[16]));
 
-
-  herrorType1bx->Fill(float(bx),float(countErrorsPerEvent1));
-  herrorType2bx->Fill(float(bx),float(countErrorsPerEvent2));
+  herrorType1bx->Fill(float(bx), float(countErrorsPerEvent1));
+  herrorType2bx->Fill(float(bx), float(countErrorsPerEvent2));
 
   aveFedSize /= 32.;
   hsize3->Fill(aveFedSize);
   //hsize2dls->Fill(float(lumiBlock),aveFedSize);
 
-  havsizels->Fill(float(lumiBlock),aveFedSize);
-  havsizebx->Fill(float(bx),aveFedSize);
+  havsizels->Fill(float(lumiBlock), aveFedSize);
+  havsizebx->Fill(float(bx), aveFedSize);
 
-  if(countPixels>0) {
+  if (countPixels > 0) {
     hlumi->Fill(float(lumiBlock));
     hbx->Fill(float(bx));
     htotPixels1->Fill(float(countPixels));
@@ -1362,22 +1455,21 @@ void SiPixelRawDumper::analyze(const  edm::Event& ev, const edm::EventSetup& es)
     //cin>>dummy;
   }  // end if
 
- 
-} // end analyze
+}  // end analyze
 
 // 2 - wrong channel
 // 4 - wrong roc
-// 3 - wrong pix or dcol 
+// 3 - wrong pix or dcol
 // 5 - pix=0
 // 6 - double pix
-  // 10 - timeout ()
-  // 11 - ene ()
-  // 12 - mum pf rocs error ()
-  // 13 - fsm ()
-  // 14 - overflow ()
-  // 15 - trailer ()
-  // 16 - fifo  (30)
-  // 17 - reset/resync NOT INCLUDED YET
+// 10 - timeout ()
+// 11 - ene ()
+// 12 - mum pf rocs error ()
+// 13 - fsm ()
+// 14 - overflow ()
+// 15 - trailer ()
+// 16 - fifo  (30)
+// 17 - reset/resync NOT INCLUDED YET
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SiPixelRawDumper);

--- a/EventFilter/SiPixelRawToDigi/test/SiPixelRawDumper.cc
+++ b/EventFilter/SiPixelRawToDigi/test/SiPixelRawDumper.cc
@@ -1,5 +1,5 @@
 /** \class SiPixelRawDumper_H
- *  Plug-in module that dump raw data file 
+ *  Plug-in module that dump raw data file
  *  for pixel subdetector
  *  Added class to interpret the data d.k. 30/10/08
  *  Add histograms. Add pix 0 detection.
@@ -12,9 +12,9 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
@@ -22,10 +22,13 @@
 
 // For L1  NOT IN RAW
 //#include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
-//#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
+//#include
+//"DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
 //#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
-//#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
-//#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapRecord.h"
+//#include
+//"DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
+//#include
+//"DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapRecord.h"
 
 // For luminisoty NOT IN RAW
 //#include "FWCore/Framework/interface/LuminosityBlock.h"
@@ -33,21 +36,21 @@
 //#include "DataFormats/Common/interface/ConditionsInEdm.h"
 
 // To use root histos
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 
 // For ROOT
 #include <TROOT.h>
 //#include <TChain.h>
-#include <TFile.h>
 #include <TF1.h>
-#include <TH2F.h>
+#include <TFile.h>
 #include <TH1D.h>
+#include <TH2F.h>
 #include <TProfile.h>
 #include <TProfile2D.h>
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 using namespace std;
 
@@ -55,15 +58,15 @@ using namespace std;
 //#define OUTFILE
 
 namespace {
-  bool printErrors = true;
-  bool printData = false;
-  bool printHeaders = false;
-  const bool CHECK_PIXELS = true;
-  const bool PRINT_BASELINE = false;
-  // to store the previous pixel
-  int fed0 = -1, chan0 = -1, roc0 = -1, dcol0 = -1, pix0 = -1, count0 = -1;
-  int countDecodeErrors1 = 0, countDecodeErrors2 = 0;
-}  // namespace
+bool printErrors = true;
+bool printData = false;
+bool printHeaders = false;
+const bool CHECK_PIXELS = true;
+const bool PRINT_BASELINE = false;
+// to store the previous pixel
+int fed0 = -1, chan0 = -1, roc0 = -1, dcol0 = -1, pix0 = -1, count0 = -1;
+int countDecodeErrors1 = 0, countDecodeErrors2 = 0;
+} // namespace
 
 // Include the helper decoding class
 /////////////////////////////////////////////////////////////////////////////
@@ -71,9 +74,12 @@ class MyDecode {
 public:
   MyDecode() {}
   ~MyDecode() {}
-  static int error(int error, int &fedChannel, int fed, int &stat1, int &stat2, bool print = false);
-  static int data(int error, int &fedChannel, int fed, int &stat1, int &stat2, bool print = false);
-  static int header(unsigned long long word64, int fed, bool print, unsigned int &bx);
+  static int error(int error, int &fedChannel, int fed, int &stat1, int &stat2,
+                   bool print = false);
+  static int data(int error, int &fedChannel, int fed, int &stat1, int &stat2,
+                  bool print = false);
+  static int header(unsigned long long word64, int fed, bool print,
+                    unsigned int &bx);
   static int trailer(unsigned long long word64, int fed, bool print);
   static int convertToCol(int dcol, int pix);
   static int convertToRow(int pix);
@@ -82,31 +88,31 @@ public:
 private:
 };
 /////////////////////////////////////////////////////////////////////////////
-//Returns 1,2,3 for layer 1,2,3 full modules, 11,12,13 for 1/2 modules
+// Returns 1,2,3 for layer 1,2,3 full modules, 11,12,13 for 1/2 modules
 // 0 for fpix
 // needs fedid 0-31, and channel 1-36.
 int MyDecode::checkLayerLink(int fed, int chan) {
   int layer = 0;
   if (fed < 0 || fed > 31)
-    return layer;  // return 0 for invalid of fpix
+    return layer; // return 0 for invalid of fpix
 
-  if (chan > 24) {  // layer 3
+  if (chan > 24) { // layer 3
 
-    if (fed == 0 || fed == 8) {  // Type A
+    if (fed == 0 || fed == 8) { // Type A
 
       if (chan == 28 || chan == 34 || chan == 35 || chan == 36)
-        layer = 13;  // 1/2 module
+        layer = 13; // 1/2 module
       else
         layer = 3;
 
-    } else if (fed == 23 || fed == 31) {  // Type A
+    } else if (fed == 23 || fed == 31) { // Type A
 
       if (chan == 27 || chan == 31 || chan == 32 || chan == 33)
-        layer = 13;  // 1/2 module
+        layer = 13; // 1/2 module
       else
         layer = 3;
 
-    } else if (fed == 7 || fed == 15 || fed == 16 || fed == 24) {  // Type D
+    } else if (fed == 7 || fed == 15 || fed == 16 || fed == 24) { // Type D
 
       if (chan == 25 || chan == 26 || chan == 29 || chan == 30)
         layer = 13;
@@ -117,66 +123,72 @@ int MyDecode::checkLayerLink(int fed, int chan) {
       layer = 3;
     }
 
-    return layer;  // layer 3
+    return layer; // layer 3
 
   } else if ((chan >= 13 && chan <= 19) || chan == 24) {
-    return 2;  //layer 2
+    return 2; // layer 2
 
   } else {
-    if (fed == 0 || fed == 8 || fed == 16 || fed == 24) {  // Type A   WRONG AFTER FIBER SWAP
+    if (fed == 0 || fed == 8 || fed == 16 ||
+        fed == 24) { // Type A   WRONG AFTER FIBER SWAP
 
       if (chan == 5 || chan == 6 || chan == 22 || chan == 23)
-        layer = 12;  // 1/2 module
+        layer = 12; // 1/2 module
       else if (chan == 4 || chan == 10 || chan == 11 || chan == 12)
-        layer = 11;  // 1/2 module
+        layer = 11; // 1/2 module
       else
         layer = 1;
 
-    } else if (fed == 7 || fed == 15 || fed == 23 || fed == 31) {  // Type D
+    } else if (fed == 7 || fed == 15 || fed == 23 || fed == 31) { // Type D
 
       if (chan == 1 || chan == 2 || chan == 20 || chan == 21)
-        layer = 12;  // 1/2
+        layer = 12; // 1/2
       else if (chan == 3 || chan == 7 || chan == 8 || chan == 9)
-        layer = 11;  // 1/2
+        layer = 11; // 1/2
       else
         layer = 1;
 
-    } else if (fed == 1 || fed == 2 || fed == 3 || fed == 9 || fed == 10 || fed == 11 || fed == 17 || fed == 18 ||
-               fed == 19 || fed == 25 || fed == 26 || fed == 27) {  // Type B
+    } else if (fed == 1 || fed == 2 || fed == 3 || fed == 9 || fed == 10 ||
+               fed == 11 || fed == 17 || fed == 18 || fed == 19 || fed == 25 ||
+               fed == 26 || fed == 27) { // Type B
 
-      if ((chan >= 4 && chan <= 6) || (chan >= 10 && chan <= 12) || (chan >= 22 && chan <= 23))
+      if ((chan >= 4 && chan <= 6) || (chan >= 10 && chan <= 12) ||
+          (chan >= 22 && chan <= 23))
         layer = 2;
       else
         layer = 1;
 
-    } else if (fed == 4 || fed == 5 || fed == 6 || fed == 12 || fed == 13 || fed == 14 || fed == 20 || fed == 21 ||
-               fed == 22 || fed == 28 || fed == 29 || fed == 30) {  // Type C
+    } else if (fed == 4 || fed == 5 || fed == 6 || fed == 12 || fed == 13 ||
+               fed == 14 || fed == 20 || fed == 21 || fed == 22 || fed == 28 ||
+               fed == 29 || fed == 30) { // Type C
 
-      if ((chan >= 1 && chan <= 3) || (chan >= 7 && chan <= 9) || (chan >= 20 && chan <= 21))
+      if ((chan >= 1 && chan <= 3) || (chan >= 7 && chan <= 9) ||
+          (chan >= 20 && chan <= 21))
         layer = 2;
       else
         layer = 1;
 
     } else {
       cout << "unknown fed " << fed << endl;
-    }  // if fed
+    } // if fed
 
     return layer;
 
-  }  // if chan
+  } // if chan
 }
 
 int MyDecode::convertToCol(int dcol, int pix) {
   // First find if we are in the first or 2nd col of a dcol.
-  int colEvenOdd = pix % 2;  // module(2), 0-1st sol, 1-2nd col.
+  int colEvenOdd = pix % 2; // module(2), 0-1st sol, 1-2nd col.
   // Transform
-  return (dcol * 2 + colEvenOdd);  // col address, starts from 0
+  return (dcol * 2 + colEvenOdd); // col address, starts from 0
 }
 int MyDecode::convertToRow(int pix) {
-  return abs(int(pix / 2) - 80);  // row addres, starts from 0
+  return abs(int(pix / 2) - 80); // row addres, starts from 0
 }
 
-int MyDecode::header(unsigned long long word64, int fed, bool print, unsigned int &bx) {
+int MyDecode::header(unsigned long long word64, int fed, bool print,
+                     unsigned int &bx) {
   int fed_id = (word64 >> 8) & 0xfff;
   int event_id = (word64 >> 32) & 0xffffff;
   bx = (word64 >> 20) & 0xfff;
@@ -189,8 +201,9 @@ int MyDecode::header(unsigned long long word64, int fed, bool print, unsigned in
   //   }
   if (print)
     cout << "Header "
-         << " for FED " << fed_id << " event " << event_id << " bx " << bx << endl;
-  fed0 = -1;  // reset the previous hit fed id
+         << " for FED " << fed_id << " event " << event_id << " bx " << bx
+         << endl;
+  fed0 = -1; // reset the previous hit fed id
   return event_id;
 }
 //
@@ -201,13 +214,15 @@ int MyDecode::trailer(unsigned long long word64, int fed, bool print) {
   int slinkError = int((word64 & 0xf00) >> 8);
   if (print)
     cout << "Trailer "
-         << " len " << slinkLength << " tts " << tts << " error " << slinkError << " crc " << hex << crc << dec << endl;
+         << " len " << slinkLength << " tts " << tts << " error " << slinkError
+         << " crc " << hex << crc << dec << endl;
   return slinkLength;
 }
 //
 // Decode error FIFO
 // Works for both, the error FIFO and the SLink error words. d.k. 25/04/07
-int MyDecode::error(int word, int &fedChannel, int fed, int &stat1, int &stat2, bool print) {
+int MyDecode::error(int word, int &fedChannel, int fed, int &stat1, int &stat2,
+                    bool print) {
   int status = -1;
   print = print || printErrors;
 
@@ -219,69 +234,71 @@ int MyDecode::error(int word, int &fedChannel, int fed, int &stat1, int &stat2, 
   const unsigned int trailError = 0x3c00000;
   const unsigned int fifoError = 0x3800000;
 
-  //  const unsigned int  timeOutChannelMask = 0x1f;  // channel mask for timeouts
-  //const unsigned int  eventNumMask = 0x1fe000; // event number mask
-  const unsigned int channelMask = 0xfc000000;  // channel num mask
-  const unsigned int tbmEventMask = 0xff;       // tbm event num mask
-  const unsigned int overflowMask = 0x100;      // data overflow
-  const unsigned int tbmStatusMask = 0xff;      //TBM trailer info
-  const unsigned int BlkNumMask = 0x700;        //pointer to error fifo #
-  const unsigned int FsmErrMask = 0x600;        //pointer to FSM errors
-  const unsigned int RocErrMask = 0x800;        //pointer to #Roc errors
-  const unsigned int ChnFifMask = 0x1f;         //channel mask for fifo error
-  const unsigned int Fif2NFMask = 0x40;         //mask for fifo2 NF
-  const unsigned int TrigNFMask = 0x80;         //mask for trigger fifo NF
+  //  const unsigned int  timeOutChannelMask = 0x1f;  // channel mask for
+  //  timeouts
+  // const unsigned int  eventNumMask = 0x1fe000; // event number mask
+  const unsigned int channelMask = 0xfc000000; // channel num mask
+  const unsigned int tbmEventMask = 0xff;      // tbm event num mask
+  const unsigned int overflowMask = 0x100;     // data overflow
+  const unsigned int tbmStatusMask = 0xff;     // TBM trailer info
+  const unsigned int BlkNumMask = 0x700;       // pointer to error fifo #
+  const unsigned int FsmErrMask = 0x600;       // pointer to FSM errors
+  const unsigned int RocErrMask = 0x800;       // pointer to #Roc errors
+  const unsigned int ChnFifMask = 0x1f;        // channel mask for fifo error
+  const unsigned int Fif2NFMask = 0x40;        // mask for fifo2 NF
+  const unsigned int TrigNFMask = 0x80;        // mask for trigger fifo NF
 
   const int offsets[8] = {0, 4, 9, 13, 18, 22, 27, 31};
   unsigned int channel = 0;
 
-  //cout<<"error word "<<hex<<word<<dec<<endl;
+  // cout<<"error word "<<hex<<word<<dec<<endl;
 
-  if ((word & errorMask) == dummyMask) {  // DUMMY WORD
-    //cout<<" Dummy word";
+  if ((word & errorMask) == dummyMask) { // DUMMY WORD
+    // cout<<" Dummy word";
     return 0;
 
-  } else if ((word & errorMask) == gapMask) {  // GAP WORD
-    //cout<<" Gap word";
+  } else if ((word & errorMask) == gapMask) { // GAP WORD
+    // cout<<" Gap word";
     return 0;
 
-  } else if ((word & errorMask) == timeOut) {  // TIMEOUT
+  } else if ((word & errorMask) == timeOut) { // TIMEOUT
 
-    unsigned int bit20 = (word & 0x100000) >> 20;  // works only for slink format
+    unsigned int bit20 = (word & 0x100000) >> 20; // works only for slink format
 
-    if (bit20 == 0) {  // 2nd word
+    if (bit20 == 0) { // 2nd word
 
-      unsigned int timeoutCnt = (word & 0x7f800) >> 11;  // only for slink
-      // unsigned int timeoutCnt = ((word&0xfc000000)>>24) + ((word&0x1800)>>11); // only for fifo
-      // More than 1 channel within a group can have a timeout error
-      // More than 1 channel within a group can have a timeout error
+      unsigned int timeoutCnt = (word & 0x7f800) >> 11; // only for slink
+      // unsigned int timeoutCnt = ((word&0xfc000000)>>24) +
+      // ((word&0x1800)>>11); // only for fifo More than 1 channel within a
+      // group can have a timeout error More than 1 channel within a group can
+      // have a timeout error
 
-      unsigned int index = (word & 0x1F);  // index within a group of 4/5
+      unsigned int index = (word & 0x1F); // index within a group of 4/5
       unsigned int chip = (word & BlkNumMask) >> 8;
       int offset = offsets[chip];
       if (print)
         cout << "Timeout Error- channel: ";
-      //cout<<"Timeout Error- channel: ";
+      // cout<<"Timeout Error- channel: ";
       for (int i = 0; i < 5; i++) {
         if ((index & 0x1) != 0) {
           channel = offset + i + 1;
           if (print)
             cout << channel << " ";
-          //cout<<channel<<" ";
+          // cout<<channel<<" ";
         }
         index = index >> 1;
       }
 
       if (print)
         cout << " TimeoutCount: " << timeoutCnt;
-      //cout << " TimeoutCount: " << timeoutCnt<<endl;;
+      // cout << " TimeoutCount: " << timeoutCnt<<endl;;
 
-      //if(print) cout<<" for Fed "<<fed<<endl;
+      // if(print) cout<<" for Fed "<<fed<<endl;
       status = -10;
       fedChannel = channel;
-      //end of timeout  chip and channel decoding
+      // end of timeout  chip and channel decoding
 
-    } else {  // this is the 1st timout word with the baseline correction
+    } else { // this is the 1st timout word with the baseline correction
 
       int baselineCorr = 0;
       if (word & 0x200) {
@@ -292,27 +309,29 @@ int MyDecode::error(int word, int &fedChannel, int fed, int &stat1, int &stat2, 
 
       if (PRINT_BASELINE && print)
         cout << "Timeout BaselineCorr: " << baselineCorr << endl;
-      //cout<<"Timeout BaselineCorr: "<<baselineCorr<<endl;
+      // cout<<"Timeout BaselineCorr: "<<baselineCorr<<endl;
       status = 0;
     }
 
-  } else if ((word & errorMask) == eventNumError) {  // EVENT NUMBER ERROR
+  } else if ((word & errorMask) == eventNumError) { // EVENT NUMBER ERROR
     channel = (word & channelMask) >> 26;
     unsigned int tbm_event = (word & tbmEventMask);
 
     if (print)
-      cout << " Event Number Error- channel: " << channel << " tbm event nr. " << tbm_event << " ";
+      cout << " Event Number Error- channel: " << channel << " tbm event nr. "
+           << tbm_event << " ";
     status = -11;
     fedChannel = channel;
 
-  } else if (((word & errorMask) == trailError)) {  // TRAILER
+  } else if (((word & errorMask) == trailError)) { // TRAILER
     channel = (word & channelMask) >> 26;
     unsigned int tbm_status = (word & tbmStatusMask);
 
     if (tbm_status != 0) {
       if (print)
         cout << " Trailer Error- "
-             << "channel: " << channel << " TBM status:0x" << hex << tbm_status << dec << " ";  // <<endl;
+             << "channel: " << channel << " TBM status:0x" << hex << tbm_status
+             << dec << " "; // <<endl;
       status = -15;
       // implement the resync/reset 17
     }
@@ -320,28 +339,28 @@ int MyDecode::error(int word, int &fedChannel, int fed, int &stat1, int &stat2, 
     if (word & RocErrMask) {
       if (print)
         cout << "Number of Rocs Error- "
-             << "channel: " << channel << " ";  // <<endl;
+             << "channel: " << channel << " "; // <<endl;
       status = -12;
     }
 
     if (word & overflowMask) {
       if (print)
         cout << "Overflow Error- "
-             << "channel: " << channel << " ";  // <<endl;
+             << "channel: " << channel << " "; // <<endl;
       status = -14;
     }
 
     if (word & FsmErrMask) {
       if (print)
         cout << "Finite State Machine Error- "
-             << "channel: " << channel << " Error status:0x" << hex << ((word & FsmErrMask) >> 9) << dec
-             << " ";  // <<endl;
+             << "channel: " << channel << " Error status:0x" << hex
+             << ((word & FsmErrMask) >> 9) << dec << " "; // <<endl;
       status = -13;
     }
 
     fedChannel = channel;
 
-  } else if ((word & errorMask) == fifoError) {  // FIFO
+  } else if ((word & errorMask) == fifoError) { // FIFO
     if (print) {
       if (word & Fif2NFMask)
         cout << "A fifo 2 is Nearly full- ";
@@ -349,7 +368,7 @@ int MyDecode::error(int word, int &fedChannel, int fed, int &stat1, int &stat2, 
         cout << "The trigger fifo is nearly Full - ";
       if (word & ChnFifMask)
         cout << "fifo-1 is nearly full for channel" << (word & ChnFifMask);
-      //cout<<endl;
+      // cout<<endl;
       status = -16;
     }
 
@@ -364,23 +383,24 @@ int MyDecode::error(int word, int &fedChannel, int fed, int &stat1, int &stat2, 
   return status;
 }
 ///////////////////////////////////////////////////////////////////////////
-int MyDecode::data(int word, int &fedChannel, int fed, int &stat1, int &stat2, bool print) {
-  //const int ROCMAX = 24;
-  const unsigned int plsmsk = 0xff;    // pulse height
-  const unsigned int pxlmsk = 0xff00;  // pixel index
+int MyDecode::data(int word, int &fedChannel, int fed, int &stat1, int &stat2,
+                   bool print) {
+  // const int ROCMAX = 24;
+  const unsigned int plsmsk = 0xff;   // pulse height
+  const unsigned int pxlmsk = 0xff00; // pixel index
   const unsigned int dclmsk = 0x1f0000;
   const unsigned int rocmsk = 0x3e00000;
   const unsigned int chnlmsk = 0xfc000000;
   int status = 0;
 
-  int roc = ((word & rocmsk) >> 21);  // rocs start from 1
+  int roc = ((word & rocmsk) >> 21); // rocs start from 1
   // Check for embeded special words
-  if (roc > 0 && roc < 25) {  // valid ROCs go from 1-24
-    //if(print) cout<<"data "<<hex<<word<<dec;
+  if (roc > 0 && roc < 25) { // valid ROCs go from 1-24
+    // if(print) cout<<"data "<<hex<<word<<dec;
     int channel = ((word & chnlmsk) >> 26);
 
-    if (channel > 0 && channel < 37) {  // valid channels 1-36
-      //cout<<hex<<word<<dec;
+    if (channel > 0 && channel < 37) { // valid channels 1-36
+      // cout<<hex<<word<<dec;
       int dcol = (word & dclmsk) >> 16;
       int pix = (word & pxlmsk) >> 8;
       int adc = (word & plsmsk);
@@ -391,57 +411,66 @@ int MyDecode::data(int word, int &fedChannel, int fed, int &stat1, int &stat2, b
 
       // print the roc number according to the online 0-15 scheme
       if (print)
-        cout << " Fed " << fed << " Channel- " << channel << " ROC- " << (roc - 1) << " DCOL- " << dcol << " Pixel- "
-             << pix << " (" << col << "," << row << ") ADC- " << adc << endl;
+        cout << " Fed " << fed << " Channel- " << channel << " ROC- "
+             << (roc - 1) << " DCOL- " << dcol << " Pixel- " << pix << " ("
+             << col << "," << row << ") ADC- " << adc << endl;
       status++;
 
       if (CHECK_PIXELS) {
         // invalid roc number
-        if ((fed > 31 && roc > 24) || (fed <= 31 && roc > 16)) {  //inv ROC
-                                                                  //if(printErrors)
-          cout << " Fed " << fed << " wrong roc number chan/roc/dcol/pix/adc = " << channel << "/" << roc - 1 << "/"
-               << dcol << "/" << pix << "/" << adc << endl;
+        if ((fed > 31 && roc > 24) ||
+            (fed <= 31 && roc > 16)) { // inv ROC
+                                       // if(printErrors)
+          cout << " Fed " << fed
+               << " wrong roc number chan/roc/dcol/pix/adc = " << channel << "/"
+               << roc - 1 << "/" << dcol << "/" << pix << "/" << adc << endl;
           status = -4;
 
         } else if (fed <= 31 && channel <= 24 && roc > 8) {
           // Check invalid ROC numbers
 
           // protect for rerouted signals
-          if (!((fed == 13 && channel == 17) || (fed == 15 && channel == 5) || (fed == 31 && channel == 10) ||
-                (fed == 27 && channel == 15))) {
-            //if(printErrors)
-            cout << " Fed " << fed << " wrong roc number, chan/roc/dcol/pix/adc = " << channel << "/" << roc - 1 << "/"
-                 << dcol << "/" << pix << "/" << adc << endl;
+          if (!((fed == 13 && channel == 17) || (fed == 15 && channel == 5) ||
+                (fed == 31 && channel == 10) || (fed == 27 && channel == 15))) {
+            // if(printErrors)
+            cout << " Fed " << fed
+                 << " wrong roc number, chan/roc/dcol/pix/adc = " << channel
+                 << "/" << roc - 1 << "/" << dcol << "/" << pix << "/" << adc
+                 << endl;
             status = -4;
           }
         }
 
         // Check pixels
-        if (pix == 0) {  // PIX=0
-                         // Detect pixel 0 events
+        if (pix == 0) { // PIX=0
+                        // Detect pixel 0 events
           if (printErrors)
-            cout << " Fed " << fed << " pix=0 chan/roc/dcol/pix/adc = " << channel << "/" << roc - 1 << "/" << dcol
-                 << "/" << pix << "/" << adc << " (" << col << "," << row << ")" << endl;
+            cout << " Fed " << fed
+                 << " pix=0 chan/roc/dcol/pix/adc = " << channel << "/"
+                 << roc - 1 << "/" << dcol << "/" << pix << "/" << adc << " ("
+                 << col << "," << row << ")" << endl;
           count0++;
           stat1 = roc - 1;
           stat2 = count0;
           status = -5;
 
-        } else if (fed == fed0 && channel == chan0 && roc == roc0 && dcol == dcol0 && pix == pix0) {
+        } else if (fed == fed0 && channel == chan0 && roc == roc0 &&
+                   dcol == dcol0 && pix == pix0) {
           // detect multiple pixels
 
           count0++;
           if (printErrors)
             cout << " Fed "
                  << fed
-                 //cout<<" Fed "<<fed
-                 << " double pixel  chan/roc/dcol/pix/adc = " << channel << "/" << roc - 1 << "/" << dcol << "/" << pix
-                 << "/" << adc << " (" << col << "," << row << ") " << count0 << endl;
+                 // cout<<" Fed "<<fed
+                 << " double pixel  chan/roc/dcol/pix/adc = " << channel << "/"
+                 << roc - 1 << "/" << dcol << "/" << pix << "/" << adc << " ("
+                 << col << "," << row << ") " << count0 << endl;
           stat1 = roc - 1;
           stat2 = count0;
           status = -6;
 
-        } else {  // normal
+        } else { // normal
 
           count0 = 0;
 
@@ -452,51 +481,57 @@ int MyDecode::data(int word, int &fedChannel, int fed, int &stat1, int &stat2, b
           pix0 = pix;
 
           // Decode errors
-          if (pix < 2 || pix > 161) {  // inv PIX
+          if (pix < 2 || pix > 161) { // inv PIX
             if (printErrors)
-              cout << " Fed " << fed << " wrong pix number chan/roc/dcol/pix/adc = " << channel << "/" << roc - 1 << "/"
-                   << dcol << "/" << pix << "/" << adc << " (" << col << "," << row << ")" << endl;
+              cout << " Fed " << fed
+                   << " wrong pix number chan/roc/dcol/pix/adc = " << channel
+                   << "/" << roc - 1 << "/" << dcol << "/" << pix << "/" << adc
+                   << " (" << col << "," << row << ")" << endl;
             status = -3;
           }
 
-          if (dcol < 0 || dcol > 25) {  // inv DCOL
+          if (dcol < 0 || dcol > 25) { // inv DCOL
             if (printErrors)
-              cout << " Fed " << fed << " wrong dcol number chan/roc/dcol/pix/adc = " << channel << "/" << roc - 1
-                   << "/" << dcol << "/" << pix << "/" << adc << " (" << col << "," << row << ")" << endl;
+              cout << " Fed " << fed
+                   << " wrong dcol number chan/roc/dcol/pix/adc = " << channel
+                   << "/" << roc - 1 << "/" << dcol << "/" << pix << "/" << adc
+                   << " (" << col << "," << row << ")" << endl;
             status = -3;
           }
 
-        }  // check pixels
+        } // check pixels
 
         // Summary error count (for testing only)
         if (pix < 2 || pix > 161 || dcol < 0 || dcol > 25) {
-          countDecodeErrors2++;  // count pixels with errors
+          countDecodeErrors2++; // count pixels with errors
           if (pix < 2 || pix > 161)
-            countDecodeErrors1++;  // count errors
+            countDecodeErrors1++; // count errors
           if (dcol < 0 || dcol > 25)
-            countDecodeErrors1++;  // count errors
-          //if(fed==6 && channel==35 ) cout<<" Fed "<<fed<<" wrong dcol number chan/roc/dcol/pix/adc = "<<channel<<"/"
-          //			 <<roc-1<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<" ("<<col<<","<<row<<")"<<endl;
+            countDecodeErrors1++; // count errors
+          // if(fed==6 && channel==35 ) cout<<" Fed "<<fed<<" wrong dcol number
+          // chan/roc/dcol/pix/adc = "<<channel<<"/"
+          //			 <<roc-1<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<"
+          //("<<col<<","<<row<<")"<<endl;
         }
 
-      }  // if CHECK_PIXELS
+      } // if CHECK_PIXELS
 
-    } else {  // channel
+    } else { // channel
 
       cout << " Wrong channel " << channel << " : ";
       cout << " for FED " << fed << " Word " << hex << word << dec << endl;
       return -2;
     }
 
-  } else if (roc == 25) {  // ROC?
+  } else if (roc == 25) { // ROC?
     unsigned int channel = ((word & chnlmsk) >> 26);
     cout << "Wrong roc 25 "
          << " in fed/chan " << fed << "/" << channel << endl;
     status = -4;
 
-  } else {  // error word
+  } else { // error word
 
-    //cout<<"error word "<<hex<<word<<dec;
+    // cout<<"error word "<<hex<<word<<dec;
     status = error(word, fedChannel, fed, stat1, stat2, print);
   }
 
@@ -509,15 +544,15 @@ public:
   /// ctor
   explicit SiPixelRawDumper(const edm::ParameterSet &cfg);
 
-  //explicit SiPixelRawDumper( const edm::ParameterSet& cfg) : theConfig(cfg) {
-  //consumes<FEDRawDataCollection>(theConfig.getUntrackedParameter<std::string>("InputLabel","source"));}
+  // explicit SiPixelRawDumper( const edm::ParameterSet& cfg) : theConfig(cfg) {
+  // consumes<FEDRawDataCollection>(theConfig.getUntrackedParameter<std::string>("InputLabel","source"));}
 
   /// dtor
   virtual ~SiPixelRawDumper() {}
 
   void beginJob();
 
-  //void beginRun( const edm::EventSetup& ) {}
+  // void beginRun( const edm::EventSetup& ) {}
 
   // end of job
   void endJob();
@@ -539,8 +574,8 @@ private:
   int fedErrorsTime[40][36];
   int fedErrorsOver[40][36];
   int decodeErrors[40][36];
-  int decodeErrors000[40][36];     // pix 0 problem
-  int decodeErrorsDouble[40][36];  // double pix  problem
+  int decodeErrors000[40][36];    // pix 0 problem
+  int decodeErrorsDouble[40][36]; // double pix  problem
   int errorType[20];
 
 #ifdef OUTFILE
@@ -554,55 +589,54 @@ private:
   TH1D *hpixels, *hpixels0, *hpixels1, *hpixels2, *hpixels3, *hpixels4;
   TH1D *htotPixels, *htotPixels0, *htotPixels1;
   TH1D *herrors, *htotErrors;
-  TH1D *herrorType1, *herrorType1Fed, *herrorType1Chan, *herrorType2, *herrorType2Fed, *herrorType2Chan;
+  TH1D *herrorType1, *herrorType1Fed, *herrorType1Chan, *herrorType2,
+      *herrorType2Fed, *herrorType2Chan;
   TH1D *hcountDouble, *hcount000, *hrocDouble, *hroc000;
 
   TH2F *hfed2DErrorsType1, *hfed2DErrorsType2;
-  TH2F *hfed2DErrors1, *hfed2DErrors2, *hfed2DErrors3, *hfed2DErrors4, *hfed2DErrors5, *hfed2DErrors6, *hfed2DErrors7,
-      *hfed2DErrors8, *hfed2DErrors9, *hfed2DErrors10, *hfed2DErrors11, *hfed2DErrors12, *hfed2DErrors13,
-      *hfed2DErrors14, *hfed2DErrors15, *hfed2DErrors16;
-  TH2F *hfed2d, *hsize2d, *hfedErrorType1ls, *hfedErrorType2ls, *hcountDouble2, *hcount0002;
-  TH2F *hfed2DErrors1ls, *hfed2DErrors2ls, *hfed2DErrors3ls, *hfed2DErrors4ls, *hfed2DErrors5ls, *hfed2DErrors6ls,
-      *hfed2DErrors7ls, *hfed2DErrors8ls, *hfed2DErrors9ls, *hfed2DErrors10ls, *hfed2DErrors11ls, *hfed2DErrors12ls,
-      *hfed2DErrors13ls, *hfed2DErrors14ls, *hfed2DErrors15ls, *hfed2DErrors16ls;
+  TH2F *hfed2DErrors1, *hfed2DErrors2, *hfed2DErrors3, *hfed2DErrors4,
+      *hfed2DErrors5, *hfed2DErrors6, *hfed2DErrors7, *hfed2DErrors8,
+      *hfed2DErrors9, *hfed2DErrors10, *hfed2DErrors11, *hfed2DErrors12,
+      *hfed2DErrors13, *hfed2DErrors14, *hfed2DErrors15, *hfed2DErrors16;
+  TH2F *hfed2d, *hsize2d, *hfedErrorType1ls, *hfedErrorType2ls, *hcountDouble2,
+      *hcount0002;
+  TH2F *hfed2DErrors1ls, *hfed2DErrors2ls, *hfed2DErrors3ls, *hfed2DErrors4ls,
+      *hfed2DErrors5ls, *hfed2DErrors6ls, *hfed2DErrors7ls, *hfed2DErrors8ls,
+      *hfed2DErrors9ls, *hfed2DErrors10ls, *hfed2DErrors11ls, *hfed2DErrors12ls,
+      *hfed2DErrors13ls, *hfed2DErrors14ls, *hfed2DErrors15ls,
+      *hfed2DErrors16ls;
 
   TH1D *hevent, *hlumi, *horbit, *hbx, *hlumi0, *hbx0;
-  //TH1D *hbx1,*hbx2,*hbx3,*hbx4,*hbx5,*hbx6,*hbx7,*hbx8,*hbx9,*hbx10,*hbx11,*hbx12;
-  TProfile *htotPixelsls, *hsizels, *herrorType1ls, *herrorType2ls, *havsizels, *htotPixelsbx, *herrorType1bx,
-      *herrorType2bx, *havsizebx, *hsizep;
-  TProfile *herror1ls, *herror2ls, *herror3ls, *herror4ls, *herror5ls, *herror6ls, *herror7ls, *herror8ls, *herror9ls,
-      *herror10ls, *herror11ls, *herror12ls, *herror13ls, *herror14ls, *herror15ls, *herror16ls;
+  // TH1D
+  // *hbx1,*hbx2,*hbx3,*hbx4,*hbx5,*hbx6,*hbx7,*hbx8,*hbx9,*hbx10,*hbx11,*hbx12;
+  TProfile *htotPixelsls, *hsizels, *herrorType1ls, *herrorType2ls, *havsizels,
+      *htotPixelsbx, *herrorType1bx, *herrorType2bx, *havsizebx, *hsizep;
+  TProfile *herror1ls, *herror2ls, *herror3ls, *herror4ls, *herror5ls,
+      *herror6ls, *herror7ls, *herror8ls, *herror9ls, *herror10ls, *herror11ls,
+      *herror12ls, *herror13ls, *herror14ls, *herror15ls, *herror16ls;
   TProfile2D *hfedchannelsize;
-  TH1D *herrorTimels, *herrorOverls, *herrorTimels1, *herrorOverls1, *herrorTimels2, *herrorOverls2, *herrorTimels3,
-      *herrorOverls3, *herrorTimels0, *herrorOverls0;
-  TH1D *hfedchannelsizeb, *hfedchannelsizeb1, *hfedchannelsizeb2, *hfedchannelsizeb3, *hfedchannelsizef;
+  TH1D *herrorTimels, *herrorOverls, *herrorTimels1, *herrorOverls1,
+      *herrorTimels2, *herrorOverls2, *herrorTimels3, *herrorOverls3,
+      *herrorTimels0, *herrorOverls0;
+  TH1D *hfedchannelsizeb, *hfedchannelsizeb1, *hfedchannelsizeb2,
+      *hfedchannelsizeb3, *hfedchannelsizef;
 };
 //----------------------------------------------------------------------------------
-SiPixelRawDumper::SiPixelRawDumper(const edm::ParameterSet &cfg) : theConfig(cfg) {
-  string label = theConfig.getUntrackedParameter<std::string>("InputLabel", "source");
+SiPixelRawDumper::SiPixelRawDumper(const edm::ParameterSet &cfg)
+    : theConfig(cfg) {
+  string label =
+      theConfig.getUntrackedParameter<std::string>("InputLabel", "source");
   // For the ByToken method
   rawData = consumes<FEDRawDataCollection>(label);
 }
 //----------------------------------------------------------------------------------------
 void SiPixelRawDumper::endJob() {
-  string errorName[18] = {" ",
-                          " ",
-                          "wrong channel",
-                          "wrong pix or dcol",
-                          "wrong roc",
-                          "pix=0",
-                          " double-pix",
-                          " ",
-                          " ",
-                          " ",
-                          "timeout",
-                          "ENE",
-                          "NOR",
-                          "FSM",
-                          "overflow",
-                          "trailer",
-                          "fifo",
-                          "reset/resync"};
+  string errorName[18] = {
+      " ",         " ",           "wrong channel", "wrong pix or dcol",
+      "wrong roc", "pix=0",       " double-pix",   " ",
+      " ",         " ",           "timeout",       "ENE",
+      "NOR",       "FSM",         "overflow",      "trailer",
+      "fifo",      "reset/resync"};
 
   // 2 - wrong channel
   // 3 - wrong pix or dcol
@@ -623,15 +657,16 @@ void SiPixelRawDumper::endJob() {
     sumFedSize /= float(countAllEvents);
     for (int i = 0; i < 40; ++i) {
       sumFedPixels[i] /= float(countEvents);
-      hpixels4->Fill(float(i), sumFedPixels[i]);  //pixels only
+      hpixels4->Fill(float(i), sumFedPixels[i]); // pixels only
     }
   }
 
-  cout << " Total/non-empty events " << countAllEvents << " / " << countEvents << " average number of pixels "
-       << sumPixels << endl;
+  cout << " Total/non-empty events " << countAllEvents << " / " << countEvents
+       << " average number of pixels " << sumPixels << endl;
 
-  cout << " Average Fed size per event for all events (in 4-words) " << (sumFedSize * 2. / 40.)
-       << " total for all feds " << (sumFedSize * 2.) << endl;
+  cout << " Average Fed size per event for all events (in 4-words) "
+       << (sumFedSize * 2. / 40.) << " total for all feds " << (sumFedSize * 2.)
+       << endl;
 
   cout << " Size for ech FED per event in units of hit pixels:" << endl;
 
@@ -639,34 +674,44 @@ void SiPixelRawDumper::endJob() {
     cout << sumFedPixels[i] << " ";
   cout << endl;
 
-  cout << " Total number of errors " << countTotErrors << " print threshold " << int(countEvents * printThreshold)
-       << " total errors per fed channel" << endl;
-  cout << " FED errors " << endl << "Fed Channel Tot-Errors ENE-Errors Time-Errors Over-Errors" << endl;
+  cout << " Total number of errors " << countTotErrors << " print threshold "
+       << int(countEvents * printThreshold) << " total errors per fed channel"
+       << endl;
+  cout << " FED errors " << endl
+       << "Fed Channel Tot-Errors ENE-Errors Time-Errors Over-Errors" << endl;
 
   for (int i = 0; i < 40; ++i) {
     for (int j = 0; j < 36; ++j)
-      if ((fedErrors[i][j]) > int(countEvents * printThreshold) || (fedErrorsENE[i][j] > 0)) {
-        cout << " " << i << "  -  " << (j + 1) << " -  " << fedErrors[i][j] << " - " << fedErrorsENE[i][j] << " -  "
-             << fedErrorsTime[i][j] << " - " << fedErrorsOver[i][j] << endl;
+      if ((fedErrors[i][j]) > int(countEvents * printThreshold) ||
+          (fedErrorsENE[i][j] > 0)) {
+        cout << " " << i << "  -  " << (j + 1) << " -  " << fedErrors[i][j]
+             << " - " << fedErrorsENE[i][j] << " -  " << fedErrorsTime[i][j]
+             << " - " << fedErrorsOver[i][j] << endl;
       }
   }
-  cout << " Decode errors " << endl << "Fed Channel Errors Pix_000 Double_Pix" << endl;
+  cout << " Decode errors " << endl
+       << "Fed Channel Errors Pix_000 Double_Pix" << endl;
   for (int i = 0; i < 40; ++i) {
     for (int j = 0; j < 36; ++j) {
-      int tmp = decodeErrors[i][j] + decodeErrors000[i][j] + decodeErrorsDouble[i][j];
+      int tmp =
+          decodeErrors[i][j] + decodeErrors000[i][j] + decodeErrorsDouble[i][j];
       if (tmp > 10)
-        cout << " " << i << " -  " << (j + 1) << "   -  " << decodeErrors[i][j] << "  -    " << decodeErrors000[i][j]
-             << "  -   " << decodeErrorsDouble[i][j] << endl;
+        cout << " " << i << " -  " << (j + 1) << "   -  " << decodeErrors[i][j]
+             << "  -    " << decodeErrors000[i][j] << "  -   "
+             << decodeErrorsDouble[i][j] << endl;
     }
   }
 
-  cout << " Total errors for all feds " << endl << " Type Name Num-Of-Errors" << endl;
+  cout << " Total errors for all feds " << endl
+       << " Type Name Num-Of-Errors" << endl;
   for (int i = 0; i < 20; ++i) {
     if (errorType[i] > 0)
-      cout << "   " << i << " - " << errorName[i] << " - " << errorType[i] << endl;
+      cout << "   " << i << " - " << errorName[i] << " - " << errorType[i]
+           << endl;
   }
 
-  cout << " Test decode errors " << countDecodeErrors1 << " " << countDecodeErrors2 << endl;
+  cout << " Test decode errors " << countDecodeErrors1 << " "
+       << countDecodeErrors2 << endl;
 
 #ifdef OUTFILE
   outfile.close();
@@ -675,8 +720,8 @@ void SiPixelRawDumper::endJob() {
 //----------------------------------------------------------------------
 void SiPixelRawDumper::beginJob() {
   printLocal = theConfig.getUntrackedParameter<int>("Verbosity", 1);
-  printThreshold =
-      theConfig.getUntrackedParameter<double>("PrintThreshold", 0.001);  // threshold per event for printing errors
+  printThreshold = theConfig.getUntrackedParameter<double>(
+      "PrintThreshold", 0.001); // threshold per event for printing errors
   cout << " beginjob " << printLocal << " " << printThreshold << endl;
 
   if (printLocal > 0)
@@ -716,99 +761,165 @@ void SiPixelRawDumper::beginJob() {
 
   edm::Service<TFileService> fs;
 
-  //const float pixMax = 5999.5;   // pp value
-  //const float totMax = 99999.5;  // pp value
-  //const float maxLink = 200.;    // pp value
+  // const float pixMax = 5999.5;   // pp value
+  // const float totMax = 99999.5;  // pp value
+  // const float maxLink = 200.;    // pp value
 
-  const float pixMax = 19999.5;   // hi value
-  const float totMax = 399999.5;  // hi value
-  const float maxLink = 1000.;    // hi value
+  const float pixMax = 19999.5;  // hi value
+  const float totMax = 399999.5; // hi value
+  const float maxLink = 1000.;   // hi value
 
-  hsize = fs->make<TH1D>("hsize", "FED event size in words-4", 6000, -0.5, pixMax);
-  hsize0 = fs->make<TH1D>("hsize0", "FED event size in words-4", 2000, -0.5, 19999.5);
-  hsize1 = fs->make<TH1D>("hsize1", "bpix FED event size in words-4", 6000, -0.5, pixMax);
-  hsize2 = fs->make<TH1D>("hsize2", "fpix FED event size in words-4", 6000, -0.5, pixMax);
-  hsize3 = fs->make<TH1D>("hsize3", "ave bpix FED event size in words-4", 6000, -0.5, pixMax);
+  hsize =
+      fs->make<TH1D>("hsize", "FED event size in words-4", 6000, -0.5, pixMax);
+  hsize0 = fs->make<TH1D>("hsize0", "FED event size in words-4", 2000, -0.5,
+                          19999.5);
+  hsize1 = fs->make<TH1D>("hsize1", "bpix FED event size in words-4", 6000,
+                          -0.5, pixMax);
+  hsize2 = fs->make<TH1D>("hsize2", "fpix FED event size in words-4", 6000,
+                          -0.5, pixMax);
+  hsize3 = fs->make<TH1D>("hsize3", "ave bpix FED event size in words-4", 6000,
+                          -0.5, pixMax);
 
   hpixels = fs->make<TH1D>("hpixels", "pixels per FED", 2000, -0.5, 19999.5);
   hpixels0 = fs->make<TH1D>("hpixels0", "pixels per FED", 6000, -0.5, pixMax);
-  hpixels1 = fs->make<TH1D>("hpixels1", "pixels >0 per FED", 6000, -0.5, pixMax);
-  hpixels2 = fs->make<TH1D>("hpixels2", "pixels >0 per BPix FED", 6000, -0.5, pixMax);
-  hpixels3 = fs->make<TH1D>("hpixels3", "pixels >0 per Fpix FED", 6000, -0.5, pixMax);
+  hpixels1 =
+      fs->make<TH1D>("hpixels1", "pixels >0 per FED", 6000, -0.5, pixMax);
+  hpixels2 =
+      fs->make<TH1D>("hpixels2", "pixels >0 per BPix FED", 6000, -0.5, pixMax);
+  hpixels3 =
+      fs->make<TH1D>("hpixels3", "pixels >0 per Fpix FED", 6000, -0.5, pixMax);
   hpixels4 = fs->make<TH1D>("hpixels4", "pixels per each FED", 40, -0.5, 39.5);
 
-  htotPixels = fs->make<TH1D>("htotPixels", "pixels per event", 10000, -0.5, totMax);
-  htotPixels0 = fs->make<TH1D>("htotPixels0", "pixels per event, zoom low region", 20000, -0.5, 19999.5);
-  htotPixels1 = fs->make<TH1D>("htotPixels1", "pixels >0 per event", 10000, -0.5, totMax);
+  htotPixels =
+      fs->make<TH1D>("htotPixels", "pixels per event", 10000, -0.5, totMax);
+  htotPixels0 = fs->make<TH1D>(
+      "htotPixels0", "pixels per event, zoom low region", 20000, -0.5, 19999.5);
+  htotPixels1 =
+      fs->make<TH1D>("htotPixels1", "pixels >0 per event", 10000, -0.5, totMax);
 
   herrors = fs->make<TH1D>("herrors", "errors per FED", 100, -0.5, 99.5);
-  htotErrors = fs->make<TH1D>("htotErrors", "errors per event", 1000, -0.5, 999.5);
+  htotErrors =
+      fs->make<TH1D>("htotErrors", "errors per event", 1000, -0.5, 999.5);
 
-  herrorType1 = fs->make<TH1D>("herrorType1", "errors 1 per type", 20, -0.5, 19.5);
-  herrorType1Fed = fs->make<TH1D>("herrorType1Fed", "errors 1 per FED", 40, -0.5, 39.5);
-  herrorType1Chan = fs->make<TH1D>("herrorType1Chan", "errors 1 per chan", 37, -0.5, 36.5);
-  herrorType2 = fs->make<TH1D>("herrorType2", "readout errors 2 per type", 20, -0.5, 19.5);
-  herrorType2Fed = fs->make<TH1D>("herrorType2Fed", "readout errors 2 per FED", 40, -0.5, 39.5);
-  herrorType2Chan = fs->make<TH1D>("herrorType2Chan", "readout errors 2 per chan", 37, -0.5, 36.5);
+  herrorType1 =
+      fs->make<TH1D>("herrorType1", "errors 1 per type", 20, -0.5, 19.5);
+  herrorType1Fed =
+      fs->make<TH1D>("herrorType1Fed", "errors 1 per FED", 40, -0.5, 39.5);
+  herrorType1Chan =
+      fs->make<TH1D>("herrorType1Chan", "errors 1 per chan", 37, -0.5, 36.5);
+  herrorType2 = fs->make<TH1D>("herrorType2", "readout errors 2 per type", 20,
+                               -0.5, 19.5);
+  herrorType2Fed = fs->make<TH1D>("herrorType2Fed", "readout errors 2 per FED",
+                                  40, -0.5, 39.5);
+  herrorType2Chan = fs->make<TH1D>("herrorType2Chan",
+                                   "readout errors 2 per chan", 37, -0.5, 36.5);
 
-  hcountDouble = fs->make<TH1D>("hcountDouble", "count double pixels", 100, -0.5, 99.5);
-  hcountDouble2 = fs->make<TH2F>("hcountDouble2", "count double pixels", 40, -0.5, 39.5, 10, 0., 10.);
+  hcountDouble =
+      fs->make<TH1D>("hcountDouble", "count double pixels", 100, -0.5, 99.5);
+  hcountDouble2 = fs->make<TH2F>("hcountDouble2", "count double pixels", 40,
+                                 -0.5, 39.5, 10, 0., 10.);
   hcount000 = fs->make<TH1D>("hcount000", "count 000 pixels", 100, -0.5, 99.5);
-  hcount0002 = fs->make<TH2F>("hcount0002", "count 000 pixels", 40, -0.5, 39.5, 10, 0., 10.);
-  hrocDouble = fs->make<TH1D>("hrocDouble", "double pixels rocs", 25, -0.5, 24.5);
+  hcount0002 = fs->make<TH2F>("hcount0002", "count 000 pixels", 40, -0.5, 39.5,
+                              10, 0., 10.);
+  hrocDouble =
+      fs->make<TH1D>("hrocDouble", "double pixels rocs", 25, -0.5, 24.5);
   hroc000 = fs->make<TH1D>("hroc000", "000 pixels rocs", 25, -0.5, 24.5);
 
-  hfed2d = fs->make<TH2F>("hfed2d", "errors", 40, -0.5, 39.5, 21, -0.5, 20.5);  // ALL
+  hfed2d =
+      fs->make<TH2F>("hfed2d", "errors", 40, -0.5, 39.5, 21, -0.5, 20.5); // ALL
 
-  hsize2d = fs->make<TH2F>("hsize2d", "size vs fed", 40, -0.5, 39.5, 50, 0, 500);   // ALL
-  hsizep = fs->make<TProfile>("hsizep", "size vs fed", 40, -0.5, 39.5, 0, 100000);  // ALL
-  //hsize2dls = fs->make<TH2F>( "hsize2dls", "size vs lumi",100,0,1000, 50,0.,500.); // ALL
+  hsize2d = fs->make<TH2F>("hsize2d", "size vs fed", 40, -0.5, 39.5, 50, 0,
+                           500); // ALL
+  hsizep = fs->make<TProfile>("hsizep", "size vs fed", 40, -0.5, 39.5, 0,
+                              100000); // ALL
+  // hsize2dls = fs->make<TH2F>( "hsize2dls", "size vs lumi",100,0,1000,
+  // 50,0.,500.); // ALL
 
 #ifdef IND_FEDS
-  hsizeFeds[0] = fs->make<TH1D>("hsizeFed0", "FED 0 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[1] = fs->make<TH1D>("hsizeFed1", "FED 1 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[2] = fs->make<TH1D>("hsizeFed2", "FED 2 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[3] = fs->make<TH1D>("hsizeFed3", "FED 3 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[4] = fs->make<TH1D>("hsizeFed4", "FED 4 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[5] = fs->make<TH1D>("hsizeFed5", "FED 5 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[6] = fs->make<TH1D>("hsizeFed6", "FED 6 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[7] = fs->make<TH1D>("hsizeFed7", "FED 7 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[8] = fs->make<TH1D>("hsizeFed8", "FED 8 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[9] = fs->make<TH1D>("hsizeFed9", "FED 9 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[10] = fs->make<TH1D>("hsizeFed10", "FED 10 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[11] = fs->make<TH1D>("hsizeFed11", "FED 11 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[12] = fs->make<TH1D>("hsizeFed12", "FED 12 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[13] = fs->make<TH1D>("hsizeFed13", "FED 13 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[14] = fs->make<TH1D>("hsizeFed14", "FED 14 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[15] = fs->make<TH1D>("hsizeFed15", "FED 15 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[16] = fs->make<TH1D>("hsizeFed16", "FED 16 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[17] = fs->make<TH1D>("hsizeFed17", "FED 17 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[18] = fs->make<TH1D>("hsizeFed18", "FED 18 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[19] = fs->make<TH1D>("hsizeFed19", "FED 19 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[20] = fs->make<TH1D>("hsizeFed20", "FED 20 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[21] = fs->make<TH1D>("hsizeFed21", "FED 21 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[22] = fs->make<TH1D>("hsizeFed22", "FED 22 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[23] = fs->make<TH1D>("hsizeFed23", "FED 23 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[24] = fs->make<TH1D>("hsizeFed24", "FED 24 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[25] = fs->make<TH1D>("hsizeFed25", "FED 25 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[26] = fs->make<TH1D>("hsizeFed26", "FED 26 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[27] = fs->make<TH1D>("hsizeFed27", "FED 27 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[28] = fs->make<TH1D>("hsizeFed28", "FED 28 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[29] = fs->make<TH1D>("hsizeFed29", "FED 29 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[30] = fs->make<TH1D>("hsizeFed30", "FED 30 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[31] = fs->make<TH1D>("hsizeFed31", "FED 31 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[32] = fs->make<TH1D>("hsizeFed32", "FED 32 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[33] = fs->make<TH1D>("hsizeFed33", "FED 33 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[34] = fs->make<TH1D>("hsizeFed34", "FED 34 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[35] = fs->make<TH1D>("hsizeFed35", "FED 35 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[36] = fs->make<TH1D>("hsizeFed36", "FED 36 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[37] = fs->make<TH1D>("hsizeFed37", "FED 37 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[38] = fs->make<TH1D>("hsizeFed38", "FED 38 event size ", 1000, -0.5, pixMax);
-  hsizeFeds[39] = fs->make<TH1D>("hsizeFed39", "FED 39 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[0] =
+      fs->make<TH1D>("hsizeFed0", "FED 0 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[1] =
+      fs->make<TH1D>("hsizeFed1", "FED 1 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[2] =
+      fs->make<TH1D>("hsizeFed2", "FED 2 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[3] =
+      fs->make<TH1D>("hsizeFed3", "FED 3 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[4] =
+      fs->make<TH1D>("hsizeFed4", "FED 4 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[5] =
+      fs->make<TH1D>("hsizeFed5", "FED 5 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[6] =
+      fs->make<TH1D>("hsizeFed6", "FED 6 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[7] =
+      fs->make<TH1D>("hsizeFed7", "FED 7 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[8] =
+      fs->make<TH1D>("hsizeFed8", "FED 8 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[9] =
+      fs->make<TH1D>("hsizeFed9", "FED 9 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[10] =
+      fs->make<TH1D>("hsizeFed10", "FED 10 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[11] =
+      fs->make<TH1D>("hsizeFed11", "FED 11 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[12] =
+      fs->make<TH1D>("hsizeFed12", "FED 12 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[13] =
+      fs->make<TH1D>("hsizeFed13", "FED 13 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[14] =
+      fs->make<TH1D>("hsizeFed14", "FED 14 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[15] =
+      fs->make<TH1D>("hsizeFed15", "FED 15 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[16] =
+      fs->make<TH1D>("hsizeFed16", "FED 16 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[17] =
+      fs->make<TH1D>("hsizeFed17", "FED 17 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[18] =
+      fs->make<TH1D>("hsizeFed18", "FED 18 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[19] =
+      fs->make<TH1D>("hsizeFed19", "FED 19 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[20] =
+      fs->make<TH1D>("hsizeFed20", "FED 20 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[21] =
+      fs->make<TH1D>("hsizeFed21", "FED 21 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[22] =
+      fs->make<TH1D>("hsizeFed22", "FED 22 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[23] =
+      fs->make<TH1D>("hsizeFed23", "FED 23 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[24] =
+      fs->make<TH1D>("hsizeFed24", "FED 24 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[25] =
+      fs->make<TH1D>("hsizeFed25", "FED 25 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[26] =
+      fs->make<TH1D>("hsizeFed26", "FED 26 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[27] =
+      fs->make<TH1D>("hsizeFed27", "FED 27 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[28] =
+      fs->make<TH1D>("hsizeFed28", "FED 28 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[29] =
+      fs->make<TH1D>("hsizeFed29", "FED 29 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[30] =
+      fs->make<TH1D>("hsizeFed30", "FED 30 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[31] =
+      fs->make<TH1D>("hsizeFed31", "FED 31 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[32] =
+      fs->make<TH1D>("hsizeFed32", "FED 32 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[33] =
+      fs->make<TH1D>("hsizeFed33", "FED 33 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[34] =
+      fs->make<TH1D>("hsizeFed34", "FED 34 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[35] =
+      fs->make<TH1D>("hsizeFed35", "FED 35 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[36] =
+      fs->make<TH1D>("hsizeFed36", "FED 36 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[37] =
+      fs->make<TH1D>("hsizeFed37", "FED 37 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[38] =
+      fs->make<TH1D>("hsizeFed38", "FED 38 event size ", 1000, -0.5, pixMax);
+  hsizeFeds[39] =
+      fs->make<TH1D>("hsizeFed39", "FED 39 event size ", 1000, -0.5, pixMax);
 #endif
 
   hevent = fs->make<TH1D>("hevent", "event", 1000, 0, 10000000.);
-  //horbit = fs->make<TH1D>("horbit","orbit",100, 0,100000000.);
+  // horbit = fs->make<TH1D>("horbit","orbit",100, 0,100000000.);
   hlumi = fs->make<TH1D>("hlumi", "lumi", 3000, 0, 3000.);
   hlumi0 = fs->make<TH1D>("hlumi0", "lumi", 3000, 0, 3000.);
 
@@ -828,148 +939,270 @@ void SiPixelRawDumper::beginJob() {
   //   hbx11    = fs->make<TH1D>("hbx11",   "bx",   4000,0,4000.);
   //   hbx12    = fs->make<TH1D>("hbx12",   "bx",   4000,0,4000.);
 
-  herrorTimels = fs->make<TH1D>("herrorTimels", "timeouts vs ls", 1000, 0, 3000);
-  herrorOverls = fs->make<TH1D>("herrorOverls", "overflows vs ls", 1000, 0, 3000);
-  herrorTimels1 = fs->make<TH1D>("herrorTimels1", "timeouts vs ls", 1000, 0, 3000);
-  herrorOverls1 = fs->make<TH1D>("herrorOverls1", "overflows vs ls", 1000, 0, 3000);
-  herrorTimels2 = fs->make<TH1D>("herrorTimels2", "timeouts vs ls", 1000, 0, 3000);
-  herrorOverls2 = fs->make<TH1D>("herrorOverls2", "overflows vs ls", 1000, 0, 3000);
-  herrorTimels3 = fs->make<TH1D>("herrorTimels3", "timeouts vs ls", 1000, 0, 3000);
-  herrorOverls3 = fs->make<TH1D>("herrorOverls3", "overflows vs ls", 1000, 0, 3000);
-  herrorTimels0 = fs->make<TH1D>("herrorTimels0", "timeouts vs ls", 1000, 0, 3000);
-  herrorOverls0 = fs->make<TH1D>("herrorOverls0", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels =
+      fs->make<TH1D>("herrorTimels", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls =
+      fs->make<TH1D>("herrorOverls", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels1 =
+      fs->make<TH1D>("herrorTimels1", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls1 =
+      fs->make<TH1D>("herrorOverls1", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels2 =
+      fs->make<TH1D>("herrorTimels2", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls2 =
+      fs->make<TH1D>("herrorOverls2", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels3 =
+      fs->make<TH1D>("herrorTimels3", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls3 =
+      fs->make<TH1D>("herrorOverls3", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels0 =
+      fs->make<TH1D>("herrorTimels0", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls0 =
+      fs->make<TH1D>("herrorOverls0", "overflows vs ls", 1000, 0, 3000);
 
-  hfed2DErrorsType1 = fs->make<TH2F>("hfed2DErrorsType1", "errors type 1 per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrorsType2 = fs->make<TH2F>("hfed2DErrorsType2", "errors type 2 per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrorsType1 =
+      fs->make<TH2F>("hfed2DErrorsType1", "errors type 1 per FED", 40, -0.5,
+                     39.5, 37, -0.5, 36.5);
+  hfed2DErrorsType2 =
+      fs->make<TH2F>("hfed2DErrorsType2", "errors type 2 per FED", 40, -0.5,
+                     39.5, 37, -0.5, 36.5);
 
-  hfed2DErrors1 = fs->make<TH2F>("hfed2DErrors1", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  //hfed2DErrors2 = fs->make<TH2F>("hfed2DErrors2", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors3 = fs->make<TH2F>("hfed2DErrors3", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors4 = fs->make<TH2F>("hfed2DErrors4", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors5 = fs->make<TH2F>("hfed2DErrors5", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors6 = fs->make<TH2F>("hfed2DErrors6", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  //hfed2DErrors7 = fs->make<TH2F>("hfed2DErrors7", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  //hfed2DErrors8 = fs->make<TH2F>("hfed2DErrors8", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  //hfed2DErrors9 = fs->make<TH2F>("hfed2DErrors9", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors10 = fs->make<TH2F>("hfed2DErrors10", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors11 = fs->make<TH2F>("hfed2DErrors11", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors12 = fs->make<TH2F>("hfed2DErrors12", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors13 = fs->make<TH2F>("hfed2DErrors13", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors14 = fs->make<TH2F>("hfed2DErrors14", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors15 = fs->make<TH2F>("hfed2DErrors15", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors16 = fs->make<TH2F>("hfed2DErrors16", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors1 = fs->make<TH2F>("hfed2DErrors1", "errors per FED", 40, -0.5,
+                                 39.5, 37, -0.5, 36.5);
+  // hfed2DErrors2 = fs->make<TH2F>("hfed2DErrors2", "errors per FED",
+  // 40,-0.5,39.5,37, -0.5, 36.5);
+  hfed2DErrors3 = fs->make<TH2F>("hfed2DErrors3", "errors per FED", 40, -0.5,
+                                 39.5, 37, -0.5, 36.5);
+  hfed2DErrors4 = fs->make<TH2F>("hfed2DErrors4", "errors per FED", 40, -0.5,
+                                 39.5, 37, -0.5, 36.5);
+  hfed2DErrors5 = fs->make<TH2F>("hfed2DErrors5", "errors per FED", 40, -0.5,
+                                 39.5, 37, -0.5, 36.5);
+  hfed2DErrors6 = fs->make<TH2F>("hfed2DErrors6", "errors per FED", 40, -0.5,
+                                 39.5, 37, -0.5, 36.5);
+  // hfed2DErrors7 = fs->make<TH2F>("hfed2DErrors7", "errors per FED",
+  // 40,-0.5,39.5,37, -0.5, 36.5); hfed2DErrors8 =
+  // fs->make<TH2F>("hfed2DErrors8", "errors per FED", 40,-0.5,39.5,37,
+  // -0.5, 36.5); hfed2DErrors9 = fs->make<TH2F>("hfed2DErrors9", "errors per
+  // FED", 40,-0.5,39.5,37, -0.5, 36.5);
+  hfed2DErrors10 = fs->make<TH2F>("hfed2DErrors10", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
+  hfed2DErrors11 = fs->make<TH2F>("hfed2DErrors11", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
+  hfed2DErrors12 = fs->make<TH2F>("hfed2DErrors12", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
+  hfed2DErrors13 = fs->make<TH2F>("hfed2DErrors13", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
+  hfed2DErrors14 = fs->make<TH2F>("hfed2DErrors14", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
+  hfed2DErrors15 = fs->make<TH2F>("hfed2DErrors15", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
+  hfed2DErrors16 = fs->make<TH2F>("hfed2DErrors16", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
 
-  hfedErrorType1ls = fs->make<TH2F>("hfedErrorType1ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfedErrorType2ls = fs->make<TH2F>("hfedErrorType2ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfedErrorType1ls = fs->make<TH2F>("hfedErrorType1ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfedErrorType2ls = fs->make<TH2F>("hfedErrorType2ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
 
-  hfed2DErrors1ls = fs->make<TH2F>("hfed2DErrors1ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  //hfed2DErrors2ls  = fs->make<TH2F>("hfed2DErrors2ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors3ls = fs->make<TH2F>("hfed2DErrors3ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors4ls = fs->make<TH2F>("hfed2DErrors4ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors5ls = fs->make<TH2F>("hfed2DErrors5ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors6ls = fs->make<TH2F>("hfed2DErrors6ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  //hfed2DErrors7ls  = fs->make<TH2F>("hfed2DErrors7ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  //hfed2DErrors8ls  = fs->make<TH2F>("hfed2DErrors8ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  //hfed2DErrors9ls  = fs->make<TH2F>("hfed2DErrors9ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors10ls = fs->make<TH2F>("hfed2DErrors10ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors11ls = fs->make<TH2F>("hfed2DErrors11ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors12ls = fs->make<TH2F>("hfed2DErrors12ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors13ls = fs->make<TH2F>("hfed2DErrors13ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors14ls = fs->make<TH2F>("hfed2DErrors14ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors15ls = fs->make<TH2F>("hfed2DErrors15ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors16ls = fs->make<TH2F>("hfed2DErrors16ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors1ls = fs->make<TH2F>("hfed2DErrors1ls", "errors vs lumi", 300, 0,
+                                   3000, 40, -0.5, 39.5); //
+  // hfed2DErrors2ls  = fs->make<TH2F>("hfed2DErrors2ls", "errors vs
+  // lumi",300,0,3000, 40,-0.5,39.5); //
+  hfed2DErrors3ls = fs->make<TH2F>("hfed2DErrors3ls", "errors vs lumi", 300, 0,
+                                   3000, 40, -0.5, 39.5); //
+  hfed2DErrors4ls = fs->make<TH2F>("hfed2DErrors4ls", "errors vs lumi", 300, 0,
+                                   3000, 40, -0.5, 39.5); //
+  hfed2DErrors5ls = fs->make<TH2F>("hfed2DErrors5ls", "errors vs lumi", 300, 0,
+                                   3000, 40, -0.5, 39.5); //
+  hfed2DErrors6ls = fs->make<TH2F>("hfed2DErrors6ls", "errors vs lumi", 300, 0,
+                                   3000, 40, -0.5, 39.5); //
+  // hfed2DErrors7ls  = fs->make<TH2F>("hfed2DErrors7ls", "errors vs
+  // lumi",300,0,3000, 40,-0.5,39.5); // hfed2DErrors8ls  =
+  // fs->make<TH2F>("hfed2DErrors8ls", "errors vs lumi",300,0,3000,
+  // 40,-0.5,39.5); // hfed2DErrors9ls  = fs->make<TH2F>("hfed2DErrors9ls",
+  // "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
+  hfed2DErrors10ls = fs->make<TH2F>("hfed2DErrors10ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfed2DErrors11ls = fs->make<TH2F>("hfed2DErrors11ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfed2DErrors12ls = fs->make<TH2F>("hfed2DErrors12ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfed2DErrors13ls = fs->make<TH2F>("hfed2DErrors13ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfed2DErrors14ls = fs->make<TH2F>("hfed2DErrors14ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfed2DErrors15ls = fs->make<TH2F>("hfed2DErrors15ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfed2DErrors16ls = fs->make<TH2F>("hfed2DErrors16ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
 
-  herrorTimels = fs->make<TH1D>("herrorTimels", "timeouts vs ls", 1000, 0, 3000);
-  herrorOverls = fs->make<TH1D>("herrorOverls", "overflows vs ls", 1000, 0, 3000);
-  herrorTimels1 = fs->make<TH1D>("herrorTimels1", "timeouts vs ls", 1000, 0, 3000);
-  herrorOverls1 = fs->make<TH1D>("herrorOverls1", "overflows vs ls", 1000, 0, 3000);
-  herrorTimels2 = fs->make<TH1D>("herrorTimels2", "timeouts vs ls", 1000, 0, 3000);
-  herrorOverls2 = fs->make<TH1D>("herrorOverls2", "overflows vs ls", 1000, 0, 3000);
-  herrorTimels3 = fs->make<TH1D>("herrorTimels3", "timeouts vs ls", 1000, 0, 3000);
-  herrorOverls3 = fs->make<TH1D>("herrorOverls3", "overflows vs ls", 1000, 0, 3000);
-  herrorTimels0 = fs->make<TH1D>("herrorTimels0", "timeouts vs ls", 1000, 0, 3000);
-  herrorOverls0 = fs->make<TH1D>("herrorOverls0", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels =
+      fs->make<TH1D>("herrorTimels", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls =
+      fs->make<TH1D>("herrorOverls", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels1 =
+      fs->make<TH1D>("herrorTimels1", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls1 =
+      fs->make<TH1D>("herrorOverls1", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels2 =
+      fs->make<TH1D>("herrorTimels2", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls2 =
+      fs->make<TH1D>("herrorOverls2", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels3 =
+      fs->make<TH1D>("herrorTimels3", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls3 =
+      fs->make<TH1D>("herrorOverls3", "overflows vs ls", 1000, 0, 3000);
+  herrorTimels0 =
+      fs->make<TH1D>("herrorTimels0", "timeouts vs ls", 1000, 0, 3000);
+  herrorOverls0 =
+      fs->make<TH1D>("herrorOverls0", "overflows vs ls", 1000, 0, 3000);
 
-  hfed2DErrorsType1 = fs->make<TH2F>("hfed2DErrorsType1", "errors type 1 per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrorsType2 = fs->make<TH2F>("hfed2DErrorsType2", "errors type 2 per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrorsType1 =
+      fs->make<TH2F>("hfed2DErrorsType1", "errors type 1 per FED", 40, -0.5,
+                     39.5, 37, -0.5, 36.5);
+  hfed2DErrorsType2 =
+      fs->make<TH2F>("hfed2DErrorsType2", "errors type 2 per FED", 40, -0.5,
+                     39.5, 37, -0.5, 36.5);
 
-  hfed2DErrors1 = fs->make<TH2F>("hfed2DErrors1", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  //hfed2DErrors2 = fs->make<TH2F>("hfed2DErrors2", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors3 = fs->make<TH2F>("hfed2DErrors3", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors4 = fs->make<TH2F>("hfed2DErrors4", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors5 = fs->make<TH2F>("hfed2DErrors5", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors6 = fs->make<TH2F>("hfed2DErrors6", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  //hfed2DErrors7 = fs->make<TH2F>("hfed2DErrors7", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  //hfed2DErrors8 = fs->make<TH2F>("hfed2DErrors8", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  //hfed2DErrors9 = fs->make<TH2F>("hfed2DErrors9", "errors per FED", 40,-0.5,39.5,37, -0.5, 36.5);
-  hfed2DErrors10 = fs->make<TH2F>("hfed2DErrors10", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors11 = fs->make<TH2F>("hfed2DErrors11", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors12 = fs->make<TH2F>("hfed2DErrors12", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors13 = fs->make<TH2F>("hfed2DErrors13", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors14 = fs->make<TH2F>("hfed2DErrors14", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors15 = fs->make<TH2F>("hfed2DErrors15", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
-  hfed2DErrors16 = fs->make<TH2F>("hfed2DErrors16", "errors per FED", 40, -0.5, 39.5, 37, -0.5, 36.5);
+  hfed2DErrors1 = fs->make<TH2F>("hfed2DErrors1", "errors per FED", 40, -0.5,
+                                 39.5, 37, -0.5, 36.5);
+  // hfed2DErrors2 = fs->make<TH2F>("hfed2DErrors2", "errors per FED",
+  // 40,-0.5,39.5,37, -0.5, 36.5);
+  hfed2DErrors3 = fs->make<TH2F>("hfed2DErrors3", "errors per FED", 40, -0.5,
+                                 39.5, 37, -0.5, 36.5);
+  hfed2DErrors4 = fs->make<TH2F>("hfed2DErrors4", "errors per FED", 40, -0.5,
+                                 39.5, 37, -0.5, 36.5);
+  hfed2DErrors5 = fs->make<TH2F>("hfed2DErrors5", "errors per FED", 40, -0.5,
+                                 39.5, 37, -0.5, 36.5);
+  hfed2DErrors6 = fs->make<TH2F>("hfed2DErrors6", "errors per FED", 40, -0.5,
+                                 39.5, 37, -0.5, 36.5);
+  // hfed2DErrors7 = fs->make<TH2F>("hfed2DErrors7", "errors per FED",
+  // 40,-0.5,39.5,37, -0.5, 36.5); hfed2DErrors8 =
+  // fs->make<TH2F>("hfed2DErrors8", "errors per FED", 40,-0.5,39.5,37,
+  // -0.5, 36.5); hfed2DErrors9 = fs->make<TH2F>("hfed2DErrors9", "errors per
+  // FED", 40,-0.5,39.5,37, -0.5, 36.5);
+  hfed2DErrors10 = fs->make<TH2F>("hfed2DErrors10", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
+  hfed2DErrors11 = fs->make<TH2F>("hfed2DErrors11", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
+  hfed2DErrors12 = fs->make<TH2F>("hfed2DErrors12", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
+  hfed2DErrors13 = fs->make<TH2F>("hfed2DErrors13", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
+  hfed2DErrors14 = fs->make<TH2F>("hfed2DErrors14", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
+  hfed2DErrors15 = fs->make<TH2F>("hfed2DErrors15", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
+  hfed2DErrors16 = fs->make<TH2F>("hfed2DErrors16", "errors per FED", 40, -0.5,
+                                  39.5, 37, -0.5, 36.5);
 
-  hfedErrorType1ls = fs->make<TH2F>("hfedErrorType1ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfedErrorType2ls = fs->make<TH2F>("hfedErrorType2ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfedErrorType1ls = fs->make<TH2F>("hfedErrorType1ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfedErrorType2ls = fs->make<TH2F>("hfedErrorType2ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
 
-  hfed2DErrors1ls = fs->make<TH2F>("hfed2DErrors1ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  //hfed2DErrors2ls  = fs->make<TH2F>("hfed2DErrors2ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors3ls = fs->make<TH2F>("hfed2DErrors3ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors4ls = fs->make<TH2F>("hfed2DErrors4ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors5ls = fs->make<TH2F>("hfed2DErrors5ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors6ls = fs->make<TH2F>("hfed2DErrors6ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  //hfed2DErrors7ls  = fs->make<TH2F>("hfed2DErrors7ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  //hfed2DErrors8ls  = fs->make<TH2F>("hfed2DErrors8ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  //hfed2DErrors9ls  = fs->make<TH2F>("hfed2DErrors9ls", "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
-  hfed2DErrors10ls = fs->make<TH2F>("hfed2DErrors10ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors11ls = fs->make<TH2F>("hfed2DErrors11ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors12ls = fs->make<TH2F>("hfed2DErrors12ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors13ls = fs->make<TH2F>("hfed2DErrors13ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors14ls = fs->make<TH2F>("hfed2DErrors14ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors15ls = fs->make<TH2F>("hfed2DErrors15ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
-  hfed2DErrors16ls = fs->make<TH2F>("hfed2DErrors16ls", "errors vs lumi", 300, 0, 3000, 40, -0.5, 39.5);  //
+  hfed2DErrors1ls = fs->make<TH2F>("hfed2DErrors1ls", "errors vs lumi", 300, 0,
+                                   3000, 40, -0.5, 39.5); //
+  // hfed2DErrors2ls  = fs->make<TH2F>("hfed2DErrors2ls", "errors vs
+  // lumi",300,0,3000, 40,-0.5,39.5); //
+  hfed2DErrors3ls = fs->make<TH2F>("hfed2DErrors3ls", "errors vs lumi", 300, 0,
+                                   3000, 40, -0.5, 39.5); //
+  hfed2DErrors4ls = fs->make<TH2F>("hfed2DErrors4ls", "errors vs lumi", 300, 0,
+                                   3000, 40, -0.5, 39.5); //
+  hfed2DErrors5ls = fs->make<TH2F>("hfed2DErrors5ls", "errors vs lumi", 300, 0,
+                                   3000, 40, -0.5, 39.5); //
+  hfed2DErrors6ls = fs->make<TH2F>("hfed2DErrors6ls", "errors vs lumi", 300, 0,
+                                   3000, 40, -0.5, 39.5); //
+  // hfed2DErrors7ls  = fs->make<TH2F>("hfed2DErrors7ls", "errors vs
+  // lumi",300,0,3000, 40,-0.5,39.5); // hfed2DErrors8ls  =
+  // fs->make<TH2F>("hfed2DErrors8ls", "errors vs lumi",300,0,3000,
+  // 40,-0.5,39.5); // hfed2DErrors9ls  = fs->make<TH2F>("hfed2DErrors9ls",
+  // "errors vs lumi",300,0,3000, 40,-0.5,39.5); //
+  hfed2DErrors10ls = fs->make<TH2F>("hfed2DErrors10ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfed2DErrors11ls = fs->make<TH2F>("hfed2DErrors11ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfed2DErrors12ls = fs->make<TH2F>("hfed2DErrors12ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfed2DErrors13ls = fs->make<TH2F>("hfed2DErrors13ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfed2DErrors14ls = fs->make<TH2F>("hfed2DErrors14ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfed2DErrors15ls = fs->make<TH2F>("hfed2DErrors15ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
+  hfed2DErrors16ls = fs->make<TH2F>("hfed2DErrors16ls", "errors vs lumi", 300,
+                                    0, 3000, 40, -0.5, 39.5); //
 
-  hsizels = fs->make<TProfile>("hsizels", " bpix fed size vs ls", 300, 0, 3000, 0, 200000.);
-  htotPixelsls = fs->make<TProfile>("htotPixelsls", " tot pixels vs ls", 300, 0, 3000, 0, 300000.);
-  havsizels = fs->make<TProfile>("havsizels", "av. bpix fed size vs ls", 300, 0, 3000, 0, 300000.);
+  hsizels = fs->make<TProfile>("hsizels", " bpix fed size vs ls", 300, 0, 3000,
+                               0, 200000.);
+  htotPixelsls = fs->make<TProfile>("htotPixelsls", " tot pixels vs ls", 300, 0,
+                                    3000, 0, 300000.);
+  havsizels = fs->make<TProfile>("havsizels", "av. bpix fed size vs ls", 300, 0,
+                                 3000, 0, 300000.);
 
-  herrorType1ls = fs->make<TProfile>("herrorType1ls", "error type 1 vs ls", 300, 0, 3000, 0, 1000.);
-  herrorType2ls = fs->make<TProfile>("herrorType2ls", "error type 2 vs ls", 300, 0, 3000, 0, 1000.);
+  herrorType1ls = fs->make<TProfile>("herrorType1ls", "error type 1 vs ls", 300,
+                                     0, 3000, 0, 1000.);
+  herrorType2ls = fs->make<TProfile>("herrorType2ls", "error type 2 vs ls", 300,
+                                     0, 3000, 0, 1000.);
 
-  herror1ls = fs->make<TProfile>("herror1ls", "error 1 vs ls", 300, 0, 3000, 0, 1000.);
-  //herror2ls = fs->make<TProfile>("herror2ls","error 2 vs ls",300,0,3000,0,1000.);
-  herror3ls = fs->make<TProfile>("herror3ls", "error 3 vs ls", 300, 0, 3000, 0, 1000.);
-  herror4ls = fs->make<TProfile>("herror4ls", "error 4 vs ls", 300, 0, 3000, 0, 1000.);
-  herror5ls = fs->make<TProfile>("herror5ls", "error 5 vs ls", 300, 0, 3000, 0, 1000.);
-  herror6ls = fs->make<TProfile>("herror6ls", "error 6 vs ls", 300, 0, 3000, 0, 1000.);
-  //herror7ls = fs->make<TProfile>("herror7ls","error 7 vs ls",300,0,3000,0,1000.);
-  //herror8ls = fs->make<TProfile>("herror8ls","error 8 vs ls",300,0,3000,0,1000.);
-  //herror9ls = fs->make<TProfile>("herror9ls","error 9 vs ls",300,0,3000,0,1000.);
-  herror10ls = fs->make<TProfile>("herror10ls", "error 10 vs ls", 300, 0, 3000, 0, 1000.);
-  herror11ls = fs->make<TProfile>("herror11ls", "error 11 vs ls", 300, 0, 3000, 0, 1000.);
-  herror12ls = fs->make<TProfile>("herror12ls", "error 12 vs ls", 300, 0, 3000, 0, 1000.);
-  herror13ls = fs->make<TProfile>("herror13ls", "error 13 vs ls", 300, 0, 3000, 0, 1000.);
-  herror14ls = fs->make<TProfile>("herror14ls", "error 14 vs ls", 300, 0, 3000, 0, 1000.);
-  herror15ls = fs->make<TProfile>("herror15ls", "error 15 vs ls", 300, 0, 3000, 0, 1000.);
-  herror16ls = fs->make<TProfile>("herror16ls", "error 16 vs ls", 300, 0, 3000, 0, 1000.);
+  herror1ls =
+      fs->make<TProfile>("herror1ls", "error 1 vs ls", 300, 0, 3000, 0, 1000.);
+  // herror2ls = fs->make<TProfile>("herror2ls","error 2 vs
+  // ls",300,0,3000,0,1000.);
+  herror3ls =
+      fs->make<TProfile>("herror3ls", "error 3 vs ls", 300, 0, 3000, 0, 1000.);
+  herror4ls =
+      fs->make<TProfile>("herror4ls", "error 4 vs ls", 300, 0, 3000, 0, 1000.);
+  herror5ls =
+      fs->make<TProfile>("herror5ls", "error 5 vs ls", 300, 0, 3000, 0, 1000.);
+  herror6ls =
+      fs->make<TProfile>("herror6ls", "error 6 vs ls", 300, 0, 3000, 0, 1000.);
+  // herror7ls = fs->make<TProfile>("herror7ls","error 7 vs
+  // ls",300,0,3000,0,1000.); herror8ls = fs->make<TProfile>("herror8ls","error
+  // 8 vs ls",300,0,3000,0,1000.); herror9ls =
+  // fs->make<TProfile>("herror9ls","error 9 vs ls",300,0,3000,0,1000.);
+  herror10ls = fs->make<TProfile>("herror10ls", "error 10 vs ls", 300, 0, 3000,
+                                  0, 1000.);
+  herror11ls = fs->make<TProfile>("herror11ls", "error 11 vs ls", 300, 0, 3000,
+                                  0, 1000.);
+  herror12ls = fs->make<TProfile>("herror12ls", "error 12 vs ls", 300, 0, 3000,
+                                  0, 1000.);
+  herror13ls = fs->make<TProfile>("herror13ls", "error 13 vs ls", 300, 0, 3000,
+                                  0, 1000.);
+  herror14ls = fs->make<TProfile>("herror14ls", "error 14 vs ls", 300, 0, 3000,
+                                  0, 1000.);
+  herror15ls = fs->make<TProfile>("herror15ls", "error 15 vs ls", 300, 0, 3000,
+                                  0, 1000.);
+  herror16ls = fs->make<TProfile>("herror16ls", "error 16 vs ls", 300, 0, 3000,
+                                  0, 1000.);
 
-  htotPixelsbx = fs->make<TProfile>("htotPixelsbx", " tot pixels vs bx", 4000, -0.5, 3999.5, 0, 300000.);
-  havsizebx = fs->make<TProfile>("havsizebx", " ave bpix fed size vs bx", 4000, -0.5, 3999.5, 0, 300000.);
-  herrorType1bx = fs->make<TProfile>("herrorType1bx", " error type 1 vs bx", 4000, -0.5, 3999.5, 0, 300000.);
-  herrorType2bx = fs->make<TProfile>("herrorType2bx", " error type 2 vs bx", 4000, -0.5, 3999.5, 0, 300000.);
+  htotPixelsbx = fs->make<TProfile>("htotPixelsbx", " tot pixels vs bx", 4000,
+                                    -0.5, 3999.5, 0, 300000.);
+  havsizebx = fs->make<TProfile>("havsizebx", " ave bpix fed size vs bx", 4000,
+                                 -0.5, 3999.5, 0, 300000.);
+  herrorType1bx = fs->make<TProfile>("herrorType1bx", " error type 1 vs bx",
+                                     4000, -0.5, 3999.5, 0, 300000.);
+  herrorType2bx = fs->make<TProfile>("herrorType2bx", " error type 2 vs bx",
+                                     4000, -0.5, 3999.5, 0, 300000.);
 
-  //hintgl  = fs->make<TProfile>("hintgl", "inst lumi vs ls ",1000,0.,3000.,0.0,1000.);
-  //hinstl  = fs->make<TProfile>("hinstl", "intg lumi vs ls ",1000,0.,3000.,0.0,10.);
+  // hintgl  = fs->make<TProfile>("hintgl", "inst lumi vs ls
+  // ",1000,0.,3000.,0.0,1000.); hinstl  = fs->make<TProfile>("hinstl", "intg
+  // lumi vs ls ",1000,0.,3000.,0.0,10.);
 
   hfedchannelsize =
-      fs->make<TProfile2D>("hfedchannelsize", "pixels per fed/channel", 40, -0.5, 39.5, 37, -0.5, 36.5, 0.0, 10000.);
+      fs->make<TProfile2D>("hfedchannelsize", "pixels per fed/channel", 40,
+                           -0.5, 39.5, 37, -0.5, 36.5, 0.0, 10000.);
 
-  hfedchannelsizeb = fs->make<TH1D>("hfedchannelsizeb", "pixels per bpix channel", 200, 0.0, maxLink);
-  hfedchannelsizeb1 = fs->make<TH1D>("hfedchannelsizeb1", "pixels per bpix1 channel", 200, 0.0, maxLink);
-  hfedchannelsizeb2 = fs->make<TH1D>("hfedchannelsizeb2", "pixels per bpix2 channel", 200, 0.0, maxLink);
-  hfedchannelsizeb3 = fs->make<TH1D>("hfedchannelsizeb3", "pixels per bpix3 channel", 200, 0.0, maxLink);
-  hfedchannelsizef = fs->make<TH1D>("hfedchannelsizef", "pixels per fpix channel", 200, 0.0, maxLink);
+  hfedchannelsizeb = fs->make<TH1D>(
+      "hfedchannelsizeb", "pixels per bpix channel", 200, 0.0, maxLink);
+  hfedchannelsizeb1 = fs->make<TH1D>(
+      "hfedchannelsizeb1", "pixels per bpix1 channel", 200, 0.0, maxLink);
+  hfedchannelsizeb2 = fs->make<TH1D>(
+      "hfedchannelsizeb2", "pixels per bpix2 channel", 200, 0.0, maxLink);
+  hfedchannelsizeb3 = fs->make<TH1D>(
+      "hfedchannelsizeb3", "pixels per bpix3 channel", 200, 0.0, maxLink);
+  hfedchannelsizef = fs->make<TH1D>(
+      "hfedchannelsizef", "pixels per fpix channel", 200, 0.0, maxLink);
 
 #ifdef OUTFILE
   outfile.open("pixfed.csv");
@@ -982,18 +1215,19 @@ void SiPixelRawDumper::beginJob() {
 #endif
 }
 //-----------------------------------------------------------------------
-void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) {
+void SiPixelRawDumper::analyze(const edm::Event &ev,
+                               const edm::EventSetup &es) {
   // Access event information
   int run = ev.id().run();
   int event = ev.id().event();
   int lumiBlock = ev.luminosityBlock();
   int bx = ev.bunchCrossing();
-  //int orbit     = ev.orbitNumber();
+  // int orbit     = ev.orbitNumber();
 
   hevent->Fill(float(event));
   hlumi0->Fill(float(lumiBlock));
   hbx0->Fill(float(bx));
-  //horbit->Fill(float(orbit));
+  // horbit->Fill(float(orbit));
 
 #ifdef L1
   // Get L1
@@ -1005,7 +1239,7 @@ void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) 
     cout << " L1 status :" << l1a << endl;
   } else {
     cout << " NO L1 status " << endl;
-  }  // if l1a
+  } // if l1a
 #endif
 
   // Get lumi info (does not work for raw)
@@ -1016,9 +1250,12 @@ void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) 
   //   float intlumi = 0, instlumi=0;
   //   int beamint1=0, beamint2=0;
   //   iLumi.getByLabel("conditionsInEdm", cond);
-  //   // This will only work when running on RECO until (if) they fix it in the FW
-  //   // When running on RAW and reconstructing, the LumiSummary will not appear
-  //   // in the event before reaching endLuminosityBlock(). Therefore, it is not
+  //   // This will only work when running on RECO until (if) they fix it in the
+  //   FW
+  //   // When running on RAW and reconstructing, the LumiSummary will not
+  //   appear
+  //   // in the event before reaching endLuminosityBlock(). Therefore, it is
+  //   not
   //   // possible to get this info in the event
   //   if (lumi.isValid()) {
   //     intlumi =(lumi->intgRecLumi())/1000.; // integrated lumi per LS in -pb
@@ -1034,18 +1271,21 @@ void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) 
   //   hintgl->Fill(float(lumiBlock),float(intlumi));
 
   edm::Handle<FEDRawDataCollection> buffers;
-  //static std::string label = theConfig.getUntrackedParameter<std::string>("InputLabel","source");
-  //static std::string instance = theConfig.getUntrackedParameter<std::string>("InputInstance","");
-  //ev.getByLabel( label, instance, buffers);
-  ev.getByToken(rawData, buffers);  // the new bytoken
+  // static std::string label =
+  // theConfig.getUntrackedParameter<std::string>("InputLabel","source"); static
+  // std::string instance =
+  // theConfig.getUntrackedParameter<std::string>("InputInstance","");
+  // ev.getByLabel( label, instance, buffers);
+  ev.getByToken(rawData, buffers); // the new bytoken
 
-  std::pair<int, int> fedIds(FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID);
+  std::pair<int, int> fedIds(FEDNumbering::MINSiPixelFEDID,
+                             FEDNumbering::MAXSiPixelFEDID);
 
-  //PixelDataFormatter formatter(0);  // only for digis
-  //bool dummyErrorBool;
+  // PixelDataFormatter formatter(0);  // only for digis
+  // bool dummyErrorBool;
 
-  //typedef unsigned int Word32;
-  //typedef long long Word64;
+  // typedef unsigned int Word32;
+  // typedef long long Word64;
   typedef uint32_t Word32;
   typedef uint64_t Word64;
   int status = 0;
@@ -1058,63 +1298,69 @@ void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) 
   int stat1 = -1, stat2 = -1;
   int fedchannelsize[36];
 
-  int countErrors[20] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  int countErrors[20] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
   countAllEvents++;
 
   if (printHeaders || printLocal > 0)
-    cout << "Event = " << countEvents << " Event number " << event << " Run " << run << " LS " << lumiBlock << endl;
+    cout << "Event = " << countEvents << " Event number " << event << " Run "
+         << run << " LS " << lumiBlock << endl;
 
   // Loop over FEDs
   for (int fedId = fedIds.first; fedId <= fedIds.second; fedId++) {
-    //edm::DetSetVector<PixelDigi> collection;
+    // edm::DetSetVector<PixelDigi> collection;
     PixelDataFormatter::Errors errors;
 
-    //get event data for this fed
+    // get event data for this fed
     const FEDRawData &rawData = buffers->FEDData(fedId);
 
     if (printHeaders)
-      cout << "Get data For FED = " << fedId << " size in bytes " << rawData.size() << endl;
+      cout << "Get data For FED = " << fedId << " size in bytes "
+           << rawData.size() << endl;
     if (rawData.size() == 0)
-      continue;  // skip if not data for this fed
+      continue; // skip if not data for this fed
 
     for (int i = 0; i < 36; ++i)
       fedchannelsize[i] = 0;
 
     int nWords = rawData.size() / sizeof(Word64);
-    //cout<<" size "<<nWords<<endl;
+    // cout<<" size "<<nWords<<endl;
 
     sumFedSize += float(nWords);
     if (fedId < 32)
       aveFedSize += double(2. * nWords);
 
-    hsize->Fill(float(2 * nWords));   // fed buffer size in words (32bit)
-    hsize0->Fill(float(2 * nWords));  // fed buffer size in words (32bit)
+    hsize->Fill(float(2 * nWords));  // fed buffer size in words (32bit)
+    hsize0->Fill(float(2 * nWords)); // fed buffer size in words (32bit)
     if (fedId < 32)
-      hsize1->Fill(float(2 * nWords));  // bpix fed buffer size in words (32bit)
+      hsize1->Fill(float(2 * nWords)); // bpix fed buffer size in words (32bit)
     else
-      hsize2->Fill(float(2 * nWords));  // fpix fed buffer size in words (32bit)
+      hsize2->Fill(float(2 * nWords)); // fpix fed buffer size in words (32bit)
 
 #ifdef IND_FEDS
-    hsizeFeds[fedId]->Fill(float(2 * nWords));  // size, includes errors and dummy words
+    hsizeFeds[fedId]->Fill(
+        float(2 * nWords)); // size, includes errors and dummy words
 #endif
-    hsize2d->Fill(float(fedId), float(2 * nWords));  // 2d
-    hsizep->Fill(float(fedId), float(2 * nWords));   // profile
+    hsize2d->Fill(float(fedId), float(2 * nWords)); // 2d
+    hsizep->Fill(float(fedId), float(2 * nWords));  // profile
     if (fedId < 32)
-      hsizels->Fill(float(lumiBlock), float(2 * nWords));  // bpix versu sls
+      hsizels->Fill(float(lumiBlock), float(2 * nWords)); // bpix versu sls
 
     // check headers
     const Word64 *header = reinterpret_cast<const Word64 *>(rawData.data());
-    //cout<<hex<<*header<<dec<<endl;
+    // cout<<hex<<*header<<dec<<endl;
 
     unsigned int bxid = 0;
     eventId = MyDecode::header(*header, fedId, printHeaders, bxid);
-    //if(fedId = fedIds.first)
+    // if(fedId = fedIds.first)
     if (bx != int(bxid))
-      cout << " Inconsistent BX: from event " << bx << " from FED " << bxid << endl;
+      cout << " Inconsistent BX: from event " << bx << " from FED " << bxid
+           << endl;
 
-    const Word64 *trailer = reinterpret_cast<const Word64 *>(rawData.data()) + (nWords - 1);
-    //cout<<hex<<*trailer<<dec<<endl;
+    const Word64 *trailer =
+        reinterpret_cast<const Word64 *>(rawData.data()) + (nWords - 1);
+    // cout<<hex<<*trailer<<dec<<endl;
     status = MyDecode::trailer(*trailer, fedId, printHeaders);
 
     int countPixelsInFed = 0;
@@ -1131,10 +1377,10 @@ void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) 
       for (int ipart = 0; ipart < 2; ++ipart) {
         Word32 w = 0;
         if (ipart == 0) {
-          w = *word & WORD32_mask;  // 1st word
-          //w1=w;
+          w = *word & WORD32_mask; // 1st word
+          // w1=w;
         } else if (ipart == 1) {
-          w = *word >> 32 & WORD32_mask;  // 2nd word
+          w = *word >> 32 & WORD32_mask; // 2nd word
         }
 
         num++;
@@ -1142,20 +1388,22 @@ void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) 
           cout << " " << num << " " << hex << w << dec << endl;
 
         status = MyDecode::data(w, fedChannel, fedId, stat1, stat2, printData);
-        int layer = MyDecode::checkLayerLink(fedId, fedChannel);  // get bpix layer
+        int layer =
+            MyDecode::checkLayerLink(fedId, fedChannel); // get bpix layer
         if (layer > 10)
-          layer = layer - 10;  // ignore 1/2 modules
-        if (status > 0) {      // data
+          layer = layer - 10; // ignore 1/2 modules
+        if (status > 0) {     // data
           countPixels++;
           countPixelsInFed++;
           fedchannelsize[fedChannel - 1]++;
 
-        } else if (status < 0) {  // error word
+        } else if (status < 0) { // error word
           countErrorsInFed++;
-          //if( status == -6 || status == -5)
+          // if( status == -6 || status == -5)
           if (printErrors)
-            cout << " Bad stats for FED " << fedId << " Event " << eventId << "/" << countAllEvents << " chan "
-                 << fedChannel << " status " << status << endl;
+            cout << " Bad stats for FED " << fedId << " Event " << eventId
+                 << "/" << countAllEvents << " chan " << fedChannel
+                 << " status " << status << endl;
           status = abs(status);
           // 2 - wrong channel
           // 3 - wrong pix or dcol
@@ -1172,155 +1420,156 @@ void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) 
           // 17 - reset/resync NOT INCLUDED YET
 
           switch (status) {
-            case (10): {  // Timeout
+          case (10): { // Timeout
 
-              countErrors[10]++;
-              fedErrorsTime[fedId][(fedChannel - 1)]++;
-              hfed2DErrors10->Fill(float(fedId), float(fedChannel));
-              hfed2DErrors10ls->Fill(float(lumiBlock), float(fedId));  //errors
+            countErrors[10]++;
+            fedErrorsTime[fedId][(fedChannel - 1)]++;
+            hfed2DErrors10->Fill(float(fedId), float(fedChannel));
+            hfed2DErrors10ls->Fill(float(lumiBlock), float(fedId)); // errors
 
-              herrorTimels->Fill(float(lumiBlock));
-              if (layer == 1)
-                herrorTimels1->Fill(float(lumiBlock));
-              else if (layer == 2)
-                herrorTimels2->Fill(float(lumiBlock));
-              else if (layer == 3)
-                herrorTimels3->Fill(float(lumiBlock));
-              else if (layer == 0)
-                herrorTimels0->Fill(float(lumiBlock));
+            herrorTimels->Fill(float(lumiBlock));
+            if (layer == 1)
+              herrorTimels1->Fill(float(lumiBlock));
+            else if (layer == 2)
+              herrorTimels2->Fill(float(lumiBlock));
+            else if (layer == 3)
+              herrorTimels3->Fill(float(lumiBlock));
+            else if (layer == 0)
+              herrorTimels0->Fill(float(lumiBlock));
 
-              //hbx1->Fill(float(bx));
-              break;
-            }
+            // hbx1->Fill(float(bx));
+            break;
+          }
 
-            case (14): {  // OVER
+          case (14): { // OVER
 
-              countErrors[14]++;
-              fedErrorsOver[fedId][(fedChannel - 1)]++;
-              hfed2DErrors14->Fill(float(fedId), float(fedChannel));
-              hfed2DErrors14ls->Fill(float(lumiBlock), float(fedId));  //errors
+            countErrors[14]++;
+            fedErrorsOver[fedId][(fedChannel - 1)]++;
+            hfed2DErrors14->Fill(float(fedId), float(fedChannel));
+            hfed2DErrors14ls->Fill(float(lumiBlock), float(fedId)); // errors
 
-              herrorOverls->Fill(float(lumiBlock));
-              if (layer == 1)
-                herrorOverls1->Fill(float(lumiBlock));
-              else if (layer == 2)
-                herrorOverls2->Fill(float(lumiBlock));
-              else if (layer == 3)
-                herrorOverls3->Fill(float(lumiBlock));
-              else if (layer == 0)
-                herrorOverls0->Fill(float(lumiBlock));
-              //hbx2->Fill(float(bx));
-              break;
-            }
+            herrorOverls->Fill(float(lumiBlock));
+            if (layer == 1)
+              herrorOverls1->Fill(float(lumiBlock));
+            else if (layer == 2)
+              herrorOverls2->Fill(float(lumiBlock));
+            else if (layer == 3)
+              herrorOverls3->Fill(float(lumiBlock));
+            else if (layer == 0)
+              herrorOverls0->Fill(float(lumiBlock));
+            // hbx2->Fill(float(bx));
+            break;
+          }
 
-            case (11): {  // ENE
+          case (11): { // ENE
 
-              countErrors[11]++;
-              hfed2DErrors11->Fill(float(fedId), float(fedChannel));
-              hfed2DErrors11ls->Fill(float(lumiBlock), float(fedId));  //errors
-              //hbx3->Fill(float(bx));
-              fedErrorsENE[fedId][(fedChannel - 1)]++;
-              break;
-            }
+            countErrors[11]++;
+            hfed2DErrors11->Fill(float(fedId), float(fedChannel));
+            hfed2DErrors11ls->Fill(float(lumiBlock), float(fedId)); // errors
+            // hbx3->Fill(float(bx));
+            fedErrorsENE[fedId][(fedChannel - 1)]++;
+            break;
+          }
 
-            case (16): {  //FIFO
+          case (16): { // FIFO
 
-              countErrors[16]++;
-              hfed2DErrors16->Fill(float(fedId), float(fedChannel));
-              hfed2DErrors16ls->Fill(float(lumiBlock), float(fedId));  //errors
-              break;
-            }
+            countErrors[16]++;
+            hfed2DErrors16->Fill(float(fedId), float(fedChannel));
+            hfed2DErrors16ls->Fill(float(lumiBlock), float(fedId)); // errors
+            break;
+          }
 
-            case (12): {  // NOR
+          case (12): { // NOR
 
-              countErrors[12]++;
-              hfed2DErrors12->Fill(float(fedId), float(fedChannel));
-              hfed2DErrors12ls->Fill(float(lumiBlock), float(fedId));  //errors
-              //hbx5->Fill(float(bx));
-              break;
-            }
+            countErrors[12]++;
+            hfed2DErrors12->Fill(float(fedId), float(fedChannel));
+            hfed2DErrors12ls->Fill(float(lumiBlock), float(fedId)); // errors
+            // hbx5->Fill(float(bx));
+            break;
+          }
 
-            case (15): {  // TBM Trailer
+          case (15): { // TBM Trailer
 
-              countErrors[15]++;
-              hfed2DErrors15->Fill(float(fedId), float(fedChannel));
-              hfed2DErrors15ls->Fill(float(lumiBlock), float(fedId));  //errors
-              break;
-            }
+            countErrors[15]++;
+            hfed2DErrors15->Fill(float(fedId), float(fedChannel));
+            hfed2DErrors15ls->Fill(float(lumiBlock), float(fedId)); // errors
+            break;
+          }
 
-            case (13): {  // FSM
+          case (13): { // FSM
 
-              countErrors[13]++;
-              hfed2DErrors13->Fill(float(fedId), float(fedChannel));
-              hfed2DErrors13ls->Fill(float(lumiBlock), float(fedId));  //errors
-              break;
-            }
+            countErrors[13]++;
+            hfed2DErrors13->Fill(float(fedId), float(fedChannel));
+            hfed2DErrors13ls->Fill(float(lumiBlock), float(fedId)); // errors
+            break;
+          }
 
-            case (3): {  //  inv. pix-dcol
+          case (3): { //  inv. pix-dcol
 
-              countErrors[3]++;
-              hfed2DErrors3->Fill(float(fedId), float(fedChannel));
-              hfed2DErrors3ls->Fill(float(lumiBlock), float(fedId));  //errors
-              //hbx8->Fill(float(bx));
-              break;
-            }
+            countErrors[3]++;
+            hfed2DErrors3->Fill(float(fedId), float(fedChannel));
+            hfed2DErrors3ls->Fill(float(lumiBlock), float(fedId)); // errors
+            // hbx8->Fill(float(bx));
+            break;
+          }
 
-            case (4): {  // inv roc
-              countErrors[4]++;
-              hfed2DErrors4->Fill(float(fedId), float(fedChannel));
-              hfed2DErrors4ls->Fill(float(lumiBlock), float(fedId));  //errors
-              //hbx9->Fill(float(bx));
-              break;
-            }
+          case (4): { // inv roc
+            countErrors[4]++;
+            hfed2DErrors4->Fill(float(fedId), float(fedChannel));
+            hfed2DErrors4ls->Fill(float(lumiBlock), float(fedId)); // errors
+            // hbx9->Fill(float(bx));
+            break;
+          }
 
-            case (5): {  // pix=0
-              countErrors[5]++;
-              hfed2DErrors5->Fill(float(fedId), float(fedChannel));
-              hfed2DErrors5ls->Fill(float(lumiBlock), float(fedId));  //errors
-              //hbx10->Fill(float(bx));
+          case (5): { // pix=0
+            countErrors[5]++;
+            hfed2DErrors5->Fill(float(fedId), float(fedChannel));
+            hfed2DErrors5ls->Fill(float(lumiBlock), float(fedId)); // errors
+            // hbx10->Fill(float(bx));
 
-              hroc000->Fill(float(stat1));  // count rocs
-              hcount000->Fill(float(stat2));
-              hcount0002->Fill(float(fedId), float(stat2));
-              break;
-            }
+            hroc000->Fill(float(stat1)); // count rocs
+            hcount000->Fill(float(stat2));
+            hcount0002->Fill(float(fedId), float(stat2));
+            break;
+          }
 
-            case (6): {  // double pix
+          case (6): { // double pix
 
-              countErrors[6]++;
-              hfed2DErrors6->Fill(float(fedId), float(fedChannel));
-              hfed2DErrors6ls->Fill(float(lumiBlock), float(fedId));  //errors
-              //hbx12->Fill(float(bx));
+            countErrors[6]++;
+            hfed2DErrors6->Fill(float(fedId), float(fedChannel));
+            hfed2DErrors6ls->Fill(float(lumiBlock), float(fedId)); // errors
+            // hbx12->Fill(float(bx));
 
-              hrocDouble->Fill(float(stat1));  // count rocs
-              hcountDouble->Fill(float(stat2));
-              hcountDouble2->Fill(float(fedId), float(stat2));
-              break;
-            }
+            hrocDouble->Fill(float(stat1)); // count rocs
+            hcountDouble->Fill(float(stat2));
+            hcountDouble2->Fill(float(fedId), float(stat2));
+            break;
+          }
 
-            case (1): {  // unknown
-              countErrors[1]++;
-              hfed2DErrors1->Fill(float(fedId), float(fedChannel));
-              hfed2DErrors1ls->Fill(float(lumiBlock), float(fedId));  //errors
-              break;
-            }
+          case (1): { // unknown
+            countErrors[1]++;
+            hfed2DErrors1->Fill(float(fedId), float(fedChannel));
+            hfed2DErrors1ls->Fill(float(lumiBlock), float(fedId)); // errors
+            break;
+          }
 
-          }  // end switch
+          } // end switch
 
           if (status < 20)
             errorType[status]++;
 
-          //herrorType0->Fill(float(status));
-          //herrorFed0->Fill(float(fedId));
-          //herrorChan0->Fill(float(fedChannel));
+          // herrorType0->Fill(float(status));
+          // herrorFed0->Fill(float(fedId));
+          // herrorChan0->Fill(float(fedChannel));
 
           hfed2d->Fill(float(fedId), float(status));
 
-          if (status >= 10) {  // hard errors
+          if (status >= 10) { // hard errors
             // Type - 1 Errors
 
             countErrorsInFed1++;
-            hfedErrorType1ls->Fill(float(lumiBlock), float(fedId));  // hard errors
+            hfedErrorType1ls->Fill(float(lumiBlock),
+                                   float(fedId)); // hard errors
             hfed2DErrorsType1->Fill(float(fedId), float(fedChannel));
 
             herrorType1->Fill(float(status));
@@ -1329,11 +1578,12 @@ void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) 
 
             fedErrors[fedId][(fedChannel - 1)]++;
 
-          } else if (status > 0) {  // decode errors
+          } else if (status > 0) { // decode errors
             // Type 2 errprs
 
             countErrorsInFed2++;
-            hfedErrorType2ls->Fill(float(lumiBlock), float(fedId));  // decode errors
+            hfedErrorType2ls->Fill(float(lumiBlock),
+                                   float(fedId)); // decode errors
             hfed2DErrorsType2->Fill(float(fedId), float(fedChannel));
 
             herrorType2->Fill(float(status));
@@ -1348,18 +1598,19 @@ void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) 
               decodeErrors[fedId][(fedChannel - 1)]++;
           }
         }
-      }  // for  1/2 word
+      } // for  1/2 word
 
-    }  // loop over longlong  words
+    } // loop over longlong  words
 
     countTotErrors += countErrorsInFed;
     countErrorsPerEvent += countErrorsInFed;
     countErrorsPerEvent1 += countErrorsInFed1;
     countErrorsPerEvent2 += countErrorsInFed2;
 
-    //convert data to digi (dummy for the moment)
-    //formatter.interpretRawData( dummyErrorBool, fedId, rawData, collection, errors);
-    //cout<<dummyErrorBool<<" "<<digis.size()<<" "<<errors.size()<<endl;
+    // convert data to digi (dummy for the moment)
+    // formatter.interpretRawData( dummyErrorBool, fedId, rawData, collection,
+    // errors); cout<<dummyErrorBool<<" "<<digis.size()<<"
+    // "<<errors.size()<<endl;
 
     if (countPixelsInFed > 0) {
       sumFedPixels[fedId] += countPixelsInFed;
@@ -1376,27 +1627,31 @@ void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) 
     herrors->Fill(float(countErrorsInFed));
 
     for (int i = 0; i < 36; ++i) {
-      hfedchannelsize->Fill(float(fedId), float(i + 1), float(fedchannelsize[i]));
+      hfedchannelsize->Fill(float(fedId), float(i + 1),
+                            float(fedchannelsize[i]));
       if (fedId < 32) {
         hfedchannelsizeb->Fill(float(fedchannelsize[i]));
-        int layer = MyDecode::checkLayerLink(fedId, i);  // get bpix layer
+        int layer = MyDecode::checkLayerLink(fedId, i); // get bpix layer
         if (layer > 10)
-          layer = layer - 10;  // ignore 1/2 modules
+          layer = layer - 10; // ignore 1/2 modules
         if (layer == 3)
-          hfedchannelsizeb3->Fill(float(fedchannelsize[i]));  // layer 3
+          hfedchannelsizeb3->Fill(float(fedchannelsize[i])); // layer 3
         else if (layer == 2)
-          hfedchannelsizeb2->Fill(float(fedchannelsize[i]));  // layer 2
+          hfedchannelsizeb2->Fill(float(fedchannelsize[i])); // layer 2
         else if (layer == 1)
-          hfedchannelsizeb1->Fill(float(fedchannelsize[i]));  // layer 1
+          hfedchannelsizeb1->Fill(float(fedchannelsize[i])); // layer 1
         else
           cout << " Cannot be " << layer << " " << fedId << " " << i << endl;
       } else
-        hfedchannelsizef->Fill(float(fedchannelsize[i]));  // fpix
+        hfedchannelsizef->Fill(float(fedchannelsize[i])); // fpix
     }
-    //    if(fedId == fedIds.first || countPixelsInFed>0 || countErrorsInFed>0 )  {
+    //    if(fedId == fedIds.first || countPixelsInFed>0 || countErrorsInFed>0 )
+    //    {
     //       eventId = MyDecode::header(*header, true);
-    //       if(countPixelsInFed>0 || countErrorsInFed>0 ) cout<<"fed "<<fedId<<" pix "<<countPixelsInFed<<" err "<<countErrorsInFed<<endl;
-    //       status = MyDecode::trailer(*trailer,true);
+    //       if(countPixelsInFed>0 || countErrorsInFed>0 ) cout<<"fed
+    //       "<<fedId<<" pix "<<countPixelsInFed<<" err
+    //       "<<countErrorsInFed<<endl; status =
+    //       MyDecode::trailer(*trailer,true);
     //     }
 
 #ifdef OUTFILE
@@ -1407,7 +1662,7 @@ void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) 
       outfile << (nWords * 8) << ",";
 #endif
 
-  }  // loop over feds
+  } // loop over feds
 
   htotPixels->Fill(float(countPixels));
   htotPixels0->Fill(float(countPixels));
@@ -1437,7 +1692,7 @@ void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) 
 
   aveFedSize /= 32.;
   hsize3->Fill(aveFedSize);
-  //hsize2dls->Fill(float(lumiBlock),aveFedSize);
+  // hsize2dls->Fill(float(lumiBlock),aveFedSize);
 
   havsizels->Fill(float(lumiBlock), aveFedSize);
   havsizebx->Fill(float(bx), aveFedSize);
@@ -1447,15 +1702,16 @@ void SiPixelRawDumper::analyze(const edm::Event &ev, const edm::EventSetup &es) 
     hbx->Fill(float(bx));
     htotPixels1->Fill(float(countPixels));
 
-    //cout<<"EVENT: "<<countEvents<<" "<<eventId<<" pixels "<<countPixels<<" errors "<<countTotErrors<<endl;
+    // cout<<"EVENT: "<<countEvents<<" "<<eventId<<" pixels "<<countPixels<<"
+    // errors "<<countTotErrors<<endl;
     sumPixels += countPixels;
     countEvents++;
-    //int dummy=0;
-    //cout<<" : ";
-    //cin>>dummy;
-  }  // end if
+    // int dummy=0;
+    // cout<<" : ";
+    // cin>>dummy;
+  } // end if
 
-}  // end analyze
+} // end analyze
 
 // 2 - wrong channel
 // 4 - wrong roc

--- a/EventFilter/SiPixelRawToDigi/test/findHotPixels.cc
+++ b/EventFilter/SiPixelRawToDigi/test/findHotPixels.cc
@@ -7,7 +7,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 #include "DataFormats/Common/interface/Handle.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -25,11 +24,11 @@
 #include <iomanip>
 
 namespace {
-  const bool printErrors  = true;
-  const bool printData    = false;
+  const bool printErrors = true;
+  const bool printData = false;
   const bool printHeaders = false;
-  int count1=0, count2=0, count3=0;
-}
+  int count1 = 0, count2 = 0, count3 = 0;
+}  // namespace
 
 using namespace std;
 
@@ -39,37 +38,40 @@ class MyDecode {
 public:
   MyDecode() {}
   ~MyDecode() {}
-  static int error(int error, bool print=false);
-  static int data(int error, int &channel, int &roc, int &dcol, int &pix, bool print=false);
+  static int error(int error, bool print = false);
+  static int data(int error, int &channel, int &roc, int &dcol, int &pix, bool print = false);
   static int header(unsigned long long word64, bool print);
   static int trailer(unsigned long long word64, bool print);
+
 private:
 };
 /////////////////////////////////////////////////////////////////////////////
 int MyDecode::header(unsigned long long word64, bool printFlag) {
-  int fed_id=(word64>>8)&0xfff;
-  int event_id=(word64>>32)&0xffffff;
-  unsigned int bx_id=(word64>>20)&0xfff;
-//   if(bx_id!=101) {
-//     cout<<" Header "<<" for FED "
-//   <<fed_id<<" event "<<event_id<<" bx "<<bx_id<<endl;
-//     int dummy=0;
-//     cout<<" : ";
-//     cin>>dummy;
-//   }
-  if(printFlag) cout<<" Header "<<" for FED "
-             <<fed_id<<" event "<<event_id<<" bx "<<bx_id<<endl;
-  
+  int fed_id = (word64 >> 8) & 0xfff;
+  int event_id = (word64 >> 32) & 0xffffff;
+  unsigned int bx_id = (word64 >> 20) & 0xfff;
+  //   if(bx_id!=101) {
+  //     cout<<" Header "<<" for FED "
+  //   <<fed_id<<" event "<<event_id<<" bx "<<bx_id<<endl;
+  //     int dummy=0;
+  //     cout<<" : ";
+  //     cin>>dummy;
+  //   }
+  if (printFlag)
+    cout << " Header "
+         << " for FED " << fed_id << " event " << event_id << " bx " << bx_id << endl;
+
   return event_id;
 }
 //
 int MyDecode::trailer(unsigned long long word64, bool printFlag) {
-  int slinkLength = int( (word64>>32) & 0xffffff );
-  int crc         = int( (word64&0xffff0000)>>16 );
-  int tts         = int( (word64&0xf0)>>4);
-  int slinkError  = int( (word64&0xf00)>>8);
-  if(printFlag) cout<<" Trailer "<<" len "<<slinkLength
-             <<" tts "<<tts<<" error "<<slinkError<<" crc "<<hex<<crc<<dec<<endl;
+  int slinkLength = int((word64 >> 32) & 0xffffff);
+  int crc = int((word64 & 0xffff0000) >> 16);
+  int tts = int((word64 & 0xf0) >> 4);
+  int slinkError = int((word64 & 0xf00) >> 8);
+  if (printFlag)
+    cout << " Trailer "
+         << " len " << slinkLength << " tts " << tts << " error " << slinkError << " crc " << hex << crc << dec << endl;
   return slinkLength;
 }
 //
@@ -77,86 +79,95 @@ int MyDecode::trailer(unsigned long long word64, bool printFlag) {
 // Works for both, the error FIFO and the SLink error words. d.k. 25/04/07
 int MyDecode::error(int word, bool printFlag) {
   int status = -1;
-  const unsigned int  errorMask      = 0x3e00000;
-  const unsigned int  dummyMask      = 0x03600000;
-  const unsigned int  gapMask        = 0x03400000;
-  const unsigned int  timeOut        = 0x3a00000;
-  const unsigned int  eventNumError  = 0x3e00000;
-  const unsigned int  trailError     = 0x3c00000;
-  const unsigned int  fifoError      = 0x3800000;
+  const unsigned int errorMask = 0x3e00000;
+  const unsigned int dummyMask = 0x03600000;
+  const unsigned int gapMask = 0x03400000;
+  const unsigned int timeOut = 0x3a00000;
+  const unsigned int eventNumError = 0x3e00000;
+  const unsigned int trailError = 0x3c00000;
+  const unsigned int fifoError = 0x3800000;
 
-//  const unsigned int  timeOutChannelMask = 0x1f;  // channel mask for timeouts
+  //  const unsigned int  timeOutChannelMask = 0x1f;  // channel mask for timeouts
   //const unsigned int  eventNumMask = 0x1fe000; // event number mask
-  const unsigned int  channelMask = 0xfc000000; // channel num mask
-  const unsigned int  tbmEventMask = 0xff;    // tbm event num mask
-  const unsigned int  overflowMask = 0x100;   // data overflow
-  const unsigned int  tbmStatusMask = 0xff;   //TBM trailer info
-  const unsigned int  BlkNumMask = 0x700;   //pointer to error fifo #
-  const unsigned int  FsmErrMask = 0x600;   //pointer to FSM errors
-  const unsigned int  RocErrMask = 0x800;   //pointer to #Roc errors
-  const unsigned int  ChnFifMask = 0x1f;   //channel mask for fifo error
-  const unsigned int  Fif2NFMask = 0x40;   //mask for fifo2 NF
-  const unsigned int  TrigNFMask = 0x80;   //mask for trigger fifo NF
+  const unsigned int channelMask = 0xfc000000;  // channel num mask
+  const unsigned int tbmEventMask = 0xff;       // tbm event num mask
+  const unsigned int overflowMask = 0x100;      // data overflow
+  const unsigned int tbmStatusMask = 0xff;      //TBM trailer info
+  const unsigned int BlkNumMask = 0x700;        //pointer to error fifo #
+  const unsigned int FsmErrMask = 0x600;        //pointer to FSM errors
+  const unsigned int RocErrMask = 0x800;        //pointer to #Roc errors
+  const unsigned int ChnFifMask = 0x1f;         //channel mask for fifo error
+  const unsigned int Fif2NFMask = 0x40;         //mask for fifo2 NF
+  const unsigned int TrigNFMask = 0x80;         //mask for trigger fifo NF
 
- const int offsets[8] = {0,4,9,13,18,22,27,31};
+  const int offsets[8] = {0, 4, 9, 13, 18, 22, 27, 31};
 
- //cout<<"error word "<<hex<<word<<dec<<endl;
+  //cout<<"error word "<<hex<<word<<dec<<endl;
 
-  if( (word&errorMask) == dummyMask ) { // DUMMY WORD
+  if ((word & errorMask) == dummyMask) {  // DUMMY WORD
     //cout<<" Dummy word";
     return 0;
-  } else if( (word&errorMask) == gapMask ) { // GAP WORD
+  } else if ((word & errorMask) == gapMask) {  // GAP WORD
     //cout<<" Gap word";
     return 0;
-  } else if( (word&errorMask)==timeOut ) { // TIMEOUT
-     // More than 1 channel within a group can have a timeout error
-     unsigned int index = (word & 0x1F);  // index within a group of 4/5
-     unsigned int chip = (word& BlkNumMask)>>8;
-     int offset = offsets[chip];
-     if(printErrors) {
-       cout<<"Timeout Error- channels: ";
-       for(int i=0;i<5;i++) {
-      if( (index & 0x1) != 0) {
-        int chan = offset + i + 1;
-        cout<<chan<<" ";
+  } else if ((word & errorMask) == timeOut) {  // TIMEOUT
+    // More than 1 channel within a group can have a timeout error
+    unsigned int index = (word & 0x1F);  // index within a group of 4/5
+    unsigned int chip = (word & BlkNumMask) >> 8;
+    int offset = offsets[chip];
+    if (printErrors) {
+      cout << "Timeout Error- channels: ";
+      for (int i = 0; i < 5; i++) {
+        if ((index & 0x1) != 0) {
+          int chan = offset + i + 1;
+          cout << chan << " ";
+        }
+        index = index >> 1;
       }
-      index = index >> 1;
-       }
-       cout<<endl;
-     }
-     //end of timeout  chip and channel decoding
-     
-  } else if( (word&errorMask) == eventNumError ) { // EVENT NUMBER ERROR
-    unsigned int channel =  (word & channelMask) >>26;
-    unsigned int tbm_event   =  (word & tbmEventMask);
-    
-    if(printErrors) cout<<"Event Number Error- channel: "<<channel<<" tbm event nr. "
-                     <<tbm_event<<endl;
-    
-  } else if( ((word&errorMask) == trailError)) {
-    unsigned int channel =  (word & channelMask) >>26;
-    unsigned int tbm_status   =  (word & tbmStatusMask);
-    if(word & RocErrMask)
-      if(printErrors) cout<<"Number of Rocs Error- "<<"channel: "<<channel<<" "<<endl;
-    if(word & FsmErrMask)
-      if(printErrors) cout<<"Finite State Machine Error- "<<"channel: "<<channel
-                       <<" Error status:0x"<<hex<< ((word & FsmErrMask)>>9)<<dec<<" "<<endl;
-    if(word & overflowMask)
-      if(printErrors) cout<<"Overflow Error- "<<"channel: "<<channel<<" "<<endl;
-    //if(!((word & RocErrMask)|(word & FsmErrMask)|(word & overflowMask)))
-    if(tbm_status!=0)
-      if(printErrors) cout<<"Trailer Error- "<<"channel: "<<channel<<" TBM status:0x"
-                       <<hex<<tbm_status<<dec<<" "<<endl;
+      cout << endl;
+    }
+    //end of timeout  chip and channel decoding
 
-  } else if((word&errorMask)==fifoError) {
-    if(printErrors) { 
-      if(word & Fif2NFMask) cout<<"A fifo 2 is Nearly full- ";
-      if(word & TrigNFMask) cout<<"The trigger fifo is nearly Full - ";
-      if(word & ChnFifMask) cout<<"fifo-1 is nearly full for channel"<<(word & ChnFifMask);
-      cout<<endl;
+  } else if ((word & errorMask) == eventNumError) {  // EVENT NUMBER ERROR
+    unsigned int channel = (word & channelMask) >> 26;
+    unsigned int tbm_event = (word & tbmEventMask);
+
+    if (printErrors)
+      cout << "Event Number Error- channel: " << channel << " tbm event nr. " << tbm_event << endl;
+
+  } else if (((word & errorMask) == trailError)) {
+    unsigned int channel = (word & channelMask) >> 26;
+    unsigned int tbm_status = (word & tbmStatusMask);
+    if (word & RocErrMask)
+      if (printErrors)
+        cout << "Number of Rocs Error- "
+             << "channel: " << channel << " " << endl;
+    if (word & FsmErrMask)
+      if (printErrors)
+        cout << "Finite State Machine Error- "
+             << "channel: " << channel << " Error status:0x" << hex << ((word & FsmErrMask) >> 9) << dec << " " << endl;
+    if (word & overflowMask)
+      if (printErrors)
+        cout << "Overflow Error- "
+             << "channel: " << channel << " " << endl;
+    //if(!((word & RocErrMask)|(word & FsmErrMask)|(word & overflowMask)))
+    if (tbm_status != 0)
+      if (printErrors)
+        cout << "Trailer Error- "
+             << "channel: " << channel << " TBM status:0x" << hex << tbm_status << dec << " " << endl;
+
+  } else if ((word & errorMask) == fifoError) {
+    if (printErrors) {
+      if (word & Fif2NFMask)
+        cout << "A fifo 2 is Nearly full- ";
+      if (word & TrigNFMask)
+        cout << "The trigger fifo is nearly Full - ";
+      if (word & ChnFifMask)
+        cout << "fifo-1 is nearly full for channel" << (word & ChnFifMask);
+      cout << endl;
     }
   } else {
-    cout<<" Unknown error?";
+    cout << " Unknown error?";
   }
 
   //unsigned int event   =  (word & eventNumMask) >>13;
@@ -168,52 +179,53 @@ int MyDecode::error(int word, bool printFlag) {
 }
 // ///////////////////////////////////////////////////////////////////////////
 int MyDecode::data(int word, int &c, int &r, int &d, int &p, bool printFlag) {
-  
   const bool CHECK_PIXELS = true;
   //const bool PRINT_PIXELS = printData;
   const bool PRINT_PIXELS = false;
-  
+
   const int ROCMAX = 24;
-  const unsigned int plsmsk = 0xff;   // pulse height
-  const unsigned int pxlmsk = 0xff00; // pixel index
+  const unsigned int plsmsk = 0xff;    // pulse height
+  const unsigned int pxlmsk = 0xff00;  // pixel index
   const unsigned int dclmsk = 0x1f0000;
   const unsigned int rocmsk = 0x3e00000;
   const unsigned int chnlmsk = 0xfc000000;
   int status = 0;
 
-  int roc = ((word&rocmsk)>>21);
+  int roc = ((word & rocmsk) >> 21);
   // Check for embeded special words
-  if(roc>0 && roc<25) {  // valid ROCs go from 1-24
+  if (roc > 0 && roc < 25) {  // valid ROCs go from 1-24
     //if(PRINT_PIXELS) cout<<"data "<<hex<<word<<dec;
-    unsigned int channel = ((word&chnlmsk)>>26);
-    if(channel>0 && channel<37) {  // valid channels 1-36
+    unsigned int channel = ((word & chnlmsk) >> 26);
+    if (channel > 0 && channel < 37) {  // valid channels 1-36
       //cout<<hex<<word<<dec;
-      int dcol=(word&dclmsk)>>16;
-      int pix=(word&pxlmsk)>>8;
-      int adc=(word&plsmsk);
+      int dcol = (word & dclmsk) >> 16;
+      int pix = (word & pxlmsk) >> 8;
+      int adc = (word & plsmsk);
       // print the roc number according to the online 0-15 scheme
-      if(PRINT_PIXELS) cout<<" Channel- "<<channel<<" ROC- "<<(roc-1)<<" DCOL- "<<dcol<<" Pixel- "
-          <<pix<<" ADC- "<<adc<<endl;
-      if(CHECK_PIXELS) {
-        if(roc>ROCMAX)
-          cout<<" wrong roc number "<<channel<<"/"<<roc<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<endl;
-        if(dcol<0 || dcol>25)
-          cout<<" wrong dcol number "<<channel<<"/"<<roc<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<endl;
-        if(pix<2 || pix>181)
-          cout<<" wrong pix number chan/roc/dcol/pix/adc = "<<channel<<"/"<<roc<<"/"<<dcol<<"/"<<pix<<"/"<<adc<<endl;
+      if (PRINT_PIXELS)
+        cout << " Channel- " << channel << " ROC- " << (roc - 1) << " DCOL- " << dcol << " Pixel- " << pix << " ADC- "
+             << adc << endl;
+      if (CHECK_PIXELS) {
+        if (roc > ROCMAX)
+          cout << " wrong roc number " << channel << "/" << roc << "/" << dcol << "/" << pix << "/" << adc << endl;
+        if (dcol < 0 || dcol > 25)
+          cout << " wrong dcol number " << channel << "/" << roc << "/" << dcol << "/" << pix << "/" << adc << endl;
+        if (pix < 2 || pix > 181)
+          cout << " wrong pix number chan/roc/dcol/pix/adc = " << channel << "/" << roc << "/" << dcol << "/" << pix
+               << "/" << adc << endl;
       }
       c = channel;
-      r = roc-1; // start roc counting from 0
+      r = roc - 1;  // start roc counting from 0
       d = dcol;
       p = pix;
       status++;
     } else {
-      cout<<"Wrong channel "<<channel<<endl;
+      cout << "Wrong channel " << channel << endl;
       return -2;
     }
   } else {  // error word
     //cout<<"error word "<<hex<<word<<dec;
-    status=error(word);
+    status = error(word);
   }
 
   return status;
@@ -224,79 +236,83 @@ class MyConvert {
 public:
   MyConvert() {}
   ~MyConvert() {}
-  static string moduleNameFromFedChan(int fed,int fedChan, string & tbm);
+  static string moduleNameFromFedChan(int fed, int fedChan, string &tbm);
+
 private:
 };
 
 // Method returns the module name and the tbm type as strings
 // input: int fed, fedChan
 // output: string name, tbm ("A" or "B")
-string MyConvert::moduleNameFromFedChan(int fed0,int fedChan0, string & tbm0) {
-  if(fed0<0 || fed0>31) return " ";
-  if(fedChan0<1 || fedChan0>36) return " ";
+string MyConvert::moduleNameFromFedChan(int fed0, int fedChan0, string &tbm0) {
+  if (fed0 < 0 || fed0 > 31)
+    return " ";
+  if (fedChan0 < 1 || fedChan0 > 36)
+    return " ";
 
-  ifstream infile; //input file, name data_file uniqe
-  infile.open("translation_bpix.dat",ios::in); // open data file
+  ifstream infile;                               //input file, name data_file uniqe
+  infile.open("translation_bpix.dat", ios::in);  // open data file
 
   //cout << infile.eof() << " " << infile.bad() << " "
   //   << infile.fail() << " " << infile.good()<<endl;
 
   if (infile.fail()) {
     cout << " File not found " << endl;
-    return(" "); // signal error
+    return (" ");  // signal error
   }
 
   //string line;
   char line[500];
-  infile.getline(line,500,'\n');
+  infile.getline(line, 500, '\n');
 
-  string name, modName=" ";
-  int fec,mfec,mfecChan,hub,port,rocId,fed,fedChan,rocOrder;
+  string name, modName = " ";
+  int fec, mfec, mfecChan, hub, port, rocId, fed, fedChan, rocOrder;
   string tbm = " ";
-  int fedOld=-1, fedChanOld=-1;
+  int fedOld = -1, fedChanOld = -1;
   bool found = false;
-  for(int i=0;i<100000;++i) {
+  for (int i = 0; i < 100000; ++i) {
     //bool print = false;
 
-    infile>>name>>tbm>>fec>>mfec>>mfecChan>>hub>>port>>rocId>>fed>>fedChan>>rocOrder;
-    
-    if(name==" ")continue;
-    
-    if ( infile.eof() != 0 ) {
-      cout<< " end of file " << endl;
-      break;;
-    } else if (infile.fail()) { // check for errors
+    infile >> name >> tbm >> fec >> mfec >> mfecChan >> hub >> port >> rocId >> fed >> fedChan >> rocOrder;
+
+    if (name == " ")
+      continue;
+
+    if (infile.eof() != 0) {
+      cout << " end of file " << endl;
+      break;
+      ;
+    } else if (infile.fail()) {  // check for errors
       cout << "Cannot read data file" << endl;
-      return(" ");
+      return (" ");
     }
-    
-    if(fed==fedOld && fedChanOld==fedChan) continue;
+
+    if (fed == fedOld && fedChanOld == fedChan)
+      continue;
     fedOld = fed;
     fedChanOld = fedChan;
 
-
-    if(fed==fed0 && fedChan==fedChan0) {  // found
+    if (fed == fed0 && fedChan == fedChan0) {  // found
       found = true;
-      tbm0=tbm;
+      tbm0 = tbm;
 
       string::size_type idx;
       idx = name.find("_ROC");
-      if(idx != string::npos) {
+      if (idx != string::npos) {
         //      cout<<" ROC0 "<<idx<<endl;
         //name.replace(idx,idx+4,"     ");
-        modName = name.substr(0,(idx));
+        modName = name.substr(0, (idx));
       }
-
 
       break;
     }
   }  // end line loop
-  
-  infile.close();  
-  if(!found) cout<<" Module not found "<<fed0<<" "<<fedChan0<<endl;
+
+  infile.close();
+  if (!found)
+    cout << " Module not found " << fed0 << " " << fedChan0 << endl;
 
   return modName;
-
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -304,12 +320,19 @@ string MyConvert::moduleNameFromFedChan(int fed0,int fedChan0, string & tbm0) {
 const int NumPixels = 100000;
 class HotPixels {
 public:
-  HotPixels() {count=0; for(int i=0;i<NumPixels;++i) {array[i]=0; data[i]=0;}}
+  HotPixels() {
+    count = 0;
+    for (int i = 0; i < NumPixels; ++i) {
+      array[i] = 0;
+      data[i] = 0;
+    }
+  }
   ~HotPixels() {}
-  void update(int channel, int roc, int dcol, int pix); 
-  int code(int channel, int roc, int dcol, int pix); 
-  void decode(int index, int &channel, int &roc, int &dcol, int &pix); 
+  void update(int channel, int roc, int dcol, int pix);
+  int code(int channel, int roc, int dcol, int pix);
+  void decode(int index, int &channel, int &roc, int &dcol, int &pix);
   void print(int, int);
+
 private:
   int count;
   int array[NumPixels];
@@ -323,97 +346,93 @@ int HotPixels::code(int channel, int roc, int dcol, int pix) {
 }
 void HotPixels::decode(int index, int &channel, int &roc, int &dcol, int &pix) {
   //int index = pix + 1000 * dcol + 100000 * roc + 10000000 * channel;
-  channel =  index/10000000;
-  roc     = (index%10000000)/100000;
-  dcol    = (index%100000)/1000;
-  pix     = (index%1000);
+  channel = index / 10000000;
+  roc = (index % 10000000) / 100000;
+  dcol = (index % 100000) / 1000;
+  pix = (index % 1000);
 }
 void HotPixels::update(int channel, int roc, int dcol, int pix) {
   int index = code(channel, roc, dcol, pix);
   //cout<<channel<<"   "<<roc<<"    "<<dcol<<"    "<<pix<<"    "<<index<<endl;
   bool found = false;
-  for(int i=0;i<count;++i) {
-    if(index == array[i]) {
+  for (int i = 0; i < count; ++i) {
+    if (index == array[i]) {
       data[i]++;
-      found=true;
+      found = true;
       break;
     }
   }
-  if(!found) {
-    if(count>=NumPixels) {
-      cout<<" array too small "<<count<<" "<<endl;
+  if (!found) {
+    if (count >= NumPixels) {
+      cout << " array too small " << count << " " << endl;
     } else {
-      data[count] =1;
-      array[count]=index;
+      data[count] = 1;
+      array[count] = index;
       count++;
     }
   }
-
 }
 void HotPixels::print(int events, int fed_id) {
-  int channel=0, roc=0, dcol=0, pix=0;
-  int num =0;
-  int cut1 = events/100;
-  int cut2 = events/1000;
-  int cut3 = events/10000;
+  int channel = 0, roc = 0, dcol = 0, pix = 0;
+  int num = 0;
+  int cut1 = events / 100;
+  int cut2 = events / 1000;
+  int cut3 = events / 10000;
 
-  int cut = events/1000;
+  int cut = events / 1000;
   //int cut = 2;
-  if(cut<2) cut=10;
+  if (cut < 2)
+    cut = 10;
 
-
-
-  if(fed_id==0) {
-    cout<<" Threshold of "<<cut<<endl;
-    cout<<"fed chan     module                  tbm roc dcol  pix  colR ";   
-    cout<<"rowR count  num roc-local"<<endl;   
+  if (fed_id == 0) {
+    cout << " Threshold of " << cut << endl;
+    cout << "fed chan     module                  tbm roc dcol  pix  colR ";
+    cout << "rowR count  num roc-local" << endl;
   }
-  for(int i=0;i<count;++i) {
+  for (int i = 0; i < count; ++i) {
+    if (data[i] > cut1)
+      count1++;
+    if (data[i] > cut2)
+      count2++;
+    if (data[i] > cut3)
+      count3++;
 
-    if(data[i]>cut1) count1++;
-    if(data[i]>cut2) count2++;
-    if(data[i]>cut3) count3++;
-
-    if(data[i]>cut) {
+    if (data[i] > cut) {
       num++;
       int index = array[i];
       decode(index, channel, roc, dcol, pix);
 
-
       // First find if we are in the first or 2nd col of a dcol.
-      int colEvenOdd = pix%2;  // module(2), 0-1st sol, 1-2nd col.
+      int colEvenOdd = pix % 2;  // module(2), 0-1st sol, 1-2nd col.
       // Transform
-      int colROC = dcol * 2 + colEvenOdd; // col address, starts from 0
-      int rowROC = abs( int(pix/2) - 80); // row addres, starts from 0
+      int colROC = dcol * 2 + colEvenOdd;   // col address, starts from 0
+      int rowROC = abs(int(pix / 2) - 80);  // row addres, starts from 0
       //cout<<index<<" ";
 
-      // Get the module name and tbm type 
-      string modName = " ",tbm=" ";
-      modName = MyConvert::moduleNameFromFedChan(fed_id,channel,tbm);
+      // Get the module name and tbm type
+      string modName = " ", tbm = " ";
+      modName = MyConvert::moduleNameFromFedChan(fed_id, channel, tbm);
       int realRocNum = roc;
-      if(tbm=="B") realRocNum = roc + 8; // shift for TBM-N
-      cout<<setw(3)<<fed_id<<" "<<setw(3)<<channel<<" "<<setw(30)<<modName<<" "
-          <<tbm<<" "<<setw(3)
-          <<realRocNum<<"  "<<setw(3)<<dcol<<"  "<<setw(3)<<pix<<"   "
-          <<setw(3)<<colROC<<"  "<<setw(3)<<rowROC<<"  "<<setw(4)<<data[i]<<"  "
-          <<setw(3)<<num<<"  "<<setw(3)<<roc<<endl;
+      if (tbm == "B")
+        realRocNum = roc + 8;  // shift for TBM-N
+      cout << setw(3) << fed_id << " " << setw(3) << channel << " " << setw(30) << modName << " " << tbm << " "
+           << setw(3) << realRocNum << "  " << setw(3) << dcol << "  " << setw(3) << pix << "   " << setw(3) << colROC
+           << "  " << setw(3) << rowROC << "  " << setw(4) << data[i] << "  " << setw(3) << num << "  " << setw(3)
+           << roc << endl;
     }
   }
   //cout<<num<<" total 'noisy' pixels above the cut = "<<cut<<endl;
-
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Main program
 class findHotPixels : public edm::EDAnalyzer {
 public:
-
   /// ctor
-  explicit findHotPixels( const edm::ParameterSet& cfg) : theConfig(cfg) {
-  consumes<FEDRawDataCollection>(theConfig.getUntrackedParameter<std::string>("InputLabel","source"));
+  explicit findHotPixels(const edm::ParameterSet &cfg) : theConfig(cfg) {
+    consumes<FEDRawDataCollection>(theConfig.getUntrackedParameter<std::string>("InputLabel", "source"));
+  }
 
-} 
-  
   /// dtor
   virtual ~findHotPixels() {}
 
@@ -421,12 +440,12 @@ public:
 
   //void beginRun( const edm::EventSetup& ) {}
 
-  // end of job 
+  // end of job
   void endJob();
 
   /// get data, convert to digis attach againe to Event
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  
+  virtual void analyze(const edm::Event &, const edm::EventSetup &);
+
 private:
   edm::ParameterSet theConfig;
   int countEvents, countAllEvents;
@@ -435,126 +454,128 @@ private:
 };
 
 void findHotPixels::endJob() {
-  if(countEvents>0) {
+  if (countEvents > 0) {
     sumPixels /= float(countEvents);
-    for(int i=0;i<40;++i) sumFedPixels[i] /= float(countEvents);
+    for (int i = 0; i < 40; ++i)
+      sumFedPixels[i] /= float(countEvents);
   }
-  
-  cout<<" Total/non-empty events " <<countAllEvents<<" / "<<countEvents<<" average number of pixels "<<sumPixels<<endl;
+
+  cout << " Total/non-empty events " << countAllEvents << " / " << countEvents << " average number of pixels "
+       << sumPixels << endl;
 
   //for(int i=0;i<40;++i) cout<<sumFedPixels[i]<<" ";
   //cout<<endl;
 
-  for(int i=0;i<40;++i) {
-    hotPixels[i].print(countAllEvents,i);
+  for (int i = 0; i < 40; ++i) {
+    hotPixels[i].print(countAllEvents, i);
   }
-  cout<<" Number of noisy pixels: 1% "<<count1<<" 0.1% "<<count2<<" 0.01% "<<count3<<endl;
-
-
+  cout << " Number of noisy pixels: 1% " << count1 << " 0.1% " << count2 << " 0.01% " << count3 << endl;
 }
 
 void findHotPixels::beginJob() {
-  countEvents=0;
-  countAllEvents=0;
-  sumPixels=0.;
-  for(int i=0;i<40;++i) sumFedPixels[i]=0;
+  countEvents = 0;
+  countAllEvents = 0;
+  sumPixels = 0.;
+  for (int i = 0; i < 40; ++i)
+    sumFedPixels[i] = 0;
 }
 
-void findHotPixels::analyze(const  edm::Event& ev, const edm::EventSetup& es) {
-
+void findHotPixels::analyze(const edm::Event &ev, const edm::EventSetup &es) {
   edm::Handle<FEDRawDataCollection> buffers;
-  static std::string label = theConfig.getUntrackedParameter<std::string>("InputLabel","source");
-  static std::string instance = theConfig.getUntrackedParameter<std::string>("InputInstance","");
-  
-  ev.getByLabel( label, instance, buffers);
+  static std::string label = theConfig.getUntrackedParameter<std::string>("InputLabel", "source");
+  static std::string instance = theConfig.getUntrackedParameter<std::string>("InputInstance", "");
 
-  std::pair<int,int> fedIds(FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID);
-  
+  ev.getByLabel(label, instance, buffers);
+
+  std::pair<int, int> fedIds(FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID);
+
   //PixelDataFormatter formatter(0); // to get digis
   //bool dummyErrorBool;
-  
+
   typedef uint32_t Word32;
   typedef uint64_t Word64;
-  int status=0;
-  int countPixels=0;
-  int countErrors=0;
+  int status = 0;
+  int countPixels = 0;
+  int countErrors = 0;
   int eventId = -1;
-  int channel=-1, roc=-1, dcol=-1, pix=-1;
-  
-  countAllEvents++;
-  if(printHeaders) cout<<" Event = "<<countEvents<<endl;
-  
-  //edm::DetSetVector<PixelDigi> collection; // for digis only
+  int channel = -1, roc = -1, dcol = -1, pix = -1;
 
+  countAllEvents++;
+  if (printHeaders)
+    cout << " Event = " << countEvents << endl;
+
+  //edm::DetSetVector<PixelDigi> collection; // for digis only
 
   // Loop over FEDs
   for (int fedId = fedIds.first; fedId <= fedIds.second; fedId++) {
-    LogDebug("findHotPixels")<< " GET DATA FOR FED: " <<  fedId ;
-    if(printHeaders) cout<<" For FED = "<<fedId<<endl;
+    LogDebug("findHotPixels") << " GET DATA FOR FED: " << fedId;
+    if (printHeaders)
+      cout << " For FED = " << fedId << endl;
 
-     PixelDataFormatter::Errors errors;
-    
+    PixelDataFormatter::Errors errors;
+
     //get event data for this fed
-    const FEDRawData& rawData = buffers->FEDData( fedId );
-    
-    int nWords = rawData.size()/sizeof(Word64);
+    const FEDRawData &rawData = buffers->FEDData(fedId);
+
+    int nWords = rawData.size() / sizeof(Word64);
     //cout<<" size "<<nWords<<endl;
-    
+
     // check headers
-    const Word64* header = reinterpret_cast<const Word64* >(rawData.data()); 
+    const Word64 *header = reinterpret_cast<const Word64 *>(rawData.data());
     //cout<<hex<<*header<<dec<<endl;
     eventId = MyDecode::header(*header, printHeaders);
-    //if(fedId = fedIds.first) 
+    //if(fedId = fedIds.first)
 
-    const Word64* trailer = reinterpret_cast<const Word64* >(rawData.data())+(nWords-1);
+    const Word64 *trailer = reinterpret_cast<const Word64 *>(rawData.data()) + (nWords - 1);
     //cout<<hex<<*trailer<<dec<<endl;
-    status = MyDecode::trailer(*trailer,printHeaders);
+    status = MyDecode::trailer(*trailer, printHeaders);
 
-    int countPixelsInFed=0;
-    int countErrorsInFed=0;
+    int countPixelsInFed = 0;
+    int countErrorsInFed = 0;
     // Loop over payload words
-    for (const Word64* word = header+1; word != trailer; word++) {
-      static const Word64 WORD32_mask  = 0xffffffff;
-      Word32 w1 =  *word       & WORD32_mask;
+    for (const Word64 *word = header + 1; word != trailer; word++) {
+      static const Word64 WORD32_mask = 0xffffffff;
+      Word32 w1 = *word & WORD32_mask;
       status = MyDecode::data(w1, channel, roc, dcol, pix, printData);
-      if(status>0) {
-	countPixels++;
-	countPixelsInFed++;
-        hotPixels[fedId].update(channel,roc,dcol,pix);
-      } else if(status<0) countErrorsInFed++;
-      Word32 w2 =  *word >> 32 & WORD32_mask;
+      if (status > 0) {
+        countPixels++;
+        countPixelsInFed++;
+        hotPixels[fedId].update(channel, roc, dcol, pix);
+      } else if (status < 0)
+        countErrorsInFed++;
+      Word32 w2 = *word >> 32 & WORD32_mask;
       status = MyDecode::data(w2, channel, roc, dcol, pix, printData);
-      if(status>0) {
-	countPixels++;
-	countPixelsInFed++;
-        hotPixels[fedId].update(channel,roc,dcol,pix);
-      } else if(status<0) countErrorsInFed++;
+      if (status > 0) {
+        countPixels++;
+        countPixelsInFed++;
+        hotPixels[fedId].update(channel, roc, dcol, pix);
+      } else if (status < 0)
+        countErrorsInFed++;
       //cout<<hex<<w1<<" "<<w2<<dec<<endl;
-    } // loop over words
-    
+    }  // loop over words
+
     countErrors += countErrorsInFed;
-    
+
     //convert data to digi (dummy for the moment)
     //formatter.interpretRawData( dummyErrorBool, fedId, rawData,  collection, errors);
     //cout<<dummyErrorBool<<" "<<digis.size()<<" "<<errors.size()<<endl;
-    
-    if(countPixelsInFed>0)  {
+
+    if (countPixelsInFed > 0) {
       sumFedPixels[fedId] += countPixelsInFed;
     }
 
-  } // loop over feds
+  }  // loop over feds
 
-  if(countPixels>0) {
-    cout<<"EVENT: "<<countEvents<<" "<<eventId<<" pixels "<<countPixels<<" errors "<<countErrors<<endl;
+  if (countPixels > 0) {
+    cout << "EVENT: " << countEvents << " " << eventId << " pixels " << countPixels << " errors " << countErrors
+         << endl;
     sumPixels += countPixels;
     countEvents++;
     //int dummy=0;
     //cout<<" : ";
     //cin>>dummy;
   }
-  
 }
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(findHotPixels);

--- a/EventFilter/SiPixelRawToDigi/test/findHotPixels.cc
+++ b/EventFilter/SiPixelRawToDigi/test/findHotPixels.cc
@@ -9,26 +9,26 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
 #include "EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h"
 
-#include <iostream>
 #include <fstream>
+#include <iomanip>
+#include <iostream>
 #include <sstream>
 #include <string>
-#include <iomanip>
 
 namespace {
-  const bool printErrors = true;
-  const bool printData = false;
-  const bool printHeaders = false;
-  int count1 = 0, count2 = 0, count3 = 0;
-}  // namespace
+const bool printErrors = true;
+const bool printData = false;
+const bool printHeaders = false;
+int count1 = 0, count2 = 0, count3 = 0;
+} // namespace
 
 using namespace std;
 
@@ -39,7 +39,8 @@ public:
   MyDecode() {}
   ~MyDecode() {}
   static int error(int error, bool print = false);
-  static int data(int error, int &channel, int &roc, int &dcol, int &pix, bool print = false);
+  static int data(int error, int &channel, int &roc, int &dcol, int &pix,
+                  bool print = false);
   static int header(unsigned long long word64, bool print);
   static int trailer(unsigned long long word64, bool print);
 
@@ -59,7 +60,8 @@ int MyDecode::header(unsigned long long word64, bool printFlag) {
   //   }
   if (printFlag)
     cout << " Header "
-         << " for FED " << fed_id << " event " << event_id << " bx " << bx_id << endl;
+         << " for FED " << fed_id << " event " << event_id << " bx " << bx_id
+         << endl;
 
   return event_id;
 }
@@ -71,7 +73,8 @@ int MyDecode::trailer(unsigned long long word64, bool printFlag) {
   int slinkError = int((word64 & 0xf00) >> 8);
   if (printFlag)
     cout << " Trailer "
-         << " len " << slinkLength << " tts " << tts << " error " << slinkError << " crc " << hex << crc << dec << endl;
+         << " len " << slinkLength << " tts " << tts << " error " << slinkError
+         << " crc " << hex << crc << dec << endl;
   return slinkLength;
 }
 //
@@ -87,32 +90,33 @@ int MyDecode::error(int word, bool printFlag) {
   const unsigned int trailError = 0x3c00000;
   const unsigned int fifoError = 0x3800000;
 
-  //  const unsigned int  timeOutChannelMask = 0x1f;  // channel mask for timeouts
-  //const unsigned int  eventNumMask = 0x1fe000; // event number mask
-  const unsigned int channelMask = 0xfc000000;  // channel num mask
-  const unsigned int tbmEventMask = 0xff;       // tbm event num mask
-  const unsigned int overflowMask = 0x100;      // data overflow
-  const unsigned int tbmStatusMask = 0xff;      //TBM trailer info
-  const unsigned int BlkNumMask = 0x700;        //pointer to error fifo #
-  const unsigned int FsmErrMask = 0x600;        //pointer to FSM errors
-  const unsigned int RocErrMask = 0x800;        //pointer to #Roc errors
-  const unsigned int ChnFifMask = 0x1f;         //channel mask for fifo error
-  const unsigned int Fif2NFMask = 0x40;         //mask for fifo2 NF
-  const unsigned int TrigNFMask = 0x80;         //mask for trigger fifo NF
+  //  const unsigned int  timeOutChannelMask = 0x1f;  // channel mask for
+  //  timeouts
+  // const unsigned int  eventNumMask = 0x1fe000; // event number mask
+  const unsigned int channelMask = 0xfc000000; // channel num mask
+  const unsigned int tbmEventMask = 0xff;      // tbm event num mask
+  const unsigned int overflowMask = 0x100;     // data overflow
+  const unsigned int tbmStatusMask = 0xff;     // TBM trailer info
+  const unsigned int BlkNumMask = 0x700;       // pointer to error fifo #
+  const unsigned int FsmErrMask = 0x600;       // pointer to FSM errors
+  const unsigned int RocErrMask = 0x800;       // pointer to #Roc errors
+  const unsigned int ChnFifMask = 0x1f;        // channel mask for fifo error
+  const unsigned int Fif2NFMask = 0x40;        // mask for fifo2 NF
+  const unsigned int TrigNFMask = 0x80;        // mask for trigger fifo NF
 
   const int offsets[8] = {0, 4, 9, 13, 18, 22, 27, 31};
 
-  //cout<<"error word "<<hex<<word<<dec<<endl;
+  // cout<<"error word "<<hex<<word<<dec<<endl;
 
-  if ((word & errorMask) == dummyMask) {  // DUMMY WORD
-    //cout<<" Dummy word";
+  if ((word & errorMask) == dummyMask) { // DUMMY WORD
+    // cout<<" Dummy word";
     return 0;
-  } else if ((word & errorMask) == gapMask) {  // GAP WORD
-    //cout<<" Gap word";
+  } else if ((word & errorMask) == gapMask) { // GAP WORD
+    // cout<<" Gap word";
     return 0;
-  } else if ((word & errorMask) == timeOut) {  // TIMEOUT
+  } else if ((word & errorMask) == timeOut) { // TIMEOUT
     // More than 1 channel within a group can have a timeout error
-    unsigned int index = (word & 0x1F);  // index within a group of 4/5
+    unsigned int index = (word & 0x1F); // index within a group of 4/5
     unsigned int chip = (word & BlkNumMask) >> 8;
     int offset = offsets[chip];
     if (printErrors) {
@@ -126,14 +130,15 @@ int MyDecode::error(int word, bool printFlag) {
       }
       cout << endl;
     }
-    //end of timeout  chip and channel decoding
+    // end of timeout  chip and channel decoding
 
-  } else if ((word & errorMask) == eventNumError) {  // EVENT NUMBER ERROR
+  } else if ((word & errorMask) == eventNumError) { // EVENT NUMBER ERROR
     unsigned int channel = (word & channelMask) >> 26;
     unsigned int tbm_event = (word & tbmEventMask);
 
     if (printErrors)
-      cout << "Event Number Error- channel: " << channel << " tbm event nr. " << tbm_event << endl;
+      cout << "Event Number Error- channel: " << channel << " tbm event nr. "
+           << tbm_event << endl;
 
   } else if (((word & errorMask) == trailError)) {
     unsigned int channel = (word & channelMask) >> 26;
@@ -145,16 +150,18 @@ int MyDecode::error(int word, bool printFlag) {
     if (word & FsmErrMask)
       if (printErrors)
         cout << "Finite State Machine Error- "
-             << "channel: " << channel << " Error status:0x" << hex << ((word & FsmErrMask) >> 9) << dec << " " << endl;
+             << "channel: " << channel << " Error status:0x" << hex
+             << ((word & FsmErrMask) >> 9) << dec << " " << endl;
     if (word & overflowMask)
       if (printErrors)
         cout << "Overflow Error- "
              << "channel: " << channel << " " << endl;
-    //if(!((word & RocErrMask)|(word & FsmErrMask)|(word & overflowMask)))
+    // if(!((word & RocErrMask)|(word & FsmErrMask)|(word & overflowMask)))
     if (tbm_status != 0)
       if (printErrors)
         cout << "Trailer Error- "
-             << "channel: " << channel << " TBM status:0x" << hex << tbm_status << dec << " " << endl;
+             << "channel: " << channel << " TBM status:0x" << hex << tbm_status
+             << dec << " " << endl;
 
   } else if ((word & errorMask) == fifoError) {
     if (printErrors) {
@@ -170,22 +177,22 @@ int MyDecode::error(int word, bool printFlag) {
     cout << " Unknown error?";
   }
 
-  //unsigned int event   =  (word & eventNumMask) >>13;
-  //unsigned int tbm_status   =  (word & tbmStatusMask);
-  //if(event>0) cout<<":event: "<<event;
-  //cout<<endl;
+  // unsigned int event   =  (word & eventNumMask) >>13;
+  // unsigned int tbm_status   =  (word & tbmStatusMask);
+  // if(event>0) cout<<":event: "<<event;
+  // cout<<endl;
 
   return status;
 }
 // ///////////////////////////////////////////////////////////////////////////
 int MyDecode::data(int word, int &c, int &r, int &d, int &p, bool printFlag) {
   const bool CHECK_PIXELS = true;
-  //const bool PRINT_PIXELS = printData;
+  // const bool PRINT_PIXELS = printData;
   const bool PRINT_PIXELS = false;
 
   const int ROCMAX = 24;
-  const unsigned int plsmsk = 0xff;    // pulse height
-  const unsigned int pxlmsk = 0xff00;  // pixel index
+  const unsigned int plsmsk = 0xff;   // pulse height
+  const unsigned int pxlmsk = 0xff00; // pixel index
   const unsigned int dclmsk = 0x1f0000;
   const unsigned int rocmsk = 0x3e00000;
   const unsigned int chnlmsk = 0xfc000000;
@@ -193,29 +200,31 @@ int MyDecode::data(int word, int &c, int &r, int &d, int &p, bool printFlag) {
 
   int roc = ((word & rocmsk) >> 21);
   // Check for embeded special words
-  if (roc > 0 && roc < 25) {  // valid ROCs go from 1-24
-    //if(PRINT_PIXELS) cout<<"data "<<hex<<word<<dec;
+  if (roc > 0 && roc < 25) { // valid ROCs go from 1-24
+    // if(PRINT_PIXELS) cout<<"data "<<hex<<word<<dec;
     unsigned int channel = ((word & chnlmsk) >> 26);
-    if (channel > 0 && channel < 37) {  // valid channels 1-36
-      //cout<<hex<<word<<dec;
+    if (channel > 0 && channel < 37) { // valid channels 1-36
+      // cout<<hex<<word<<dec;
       int dcol = (word & dclmsk) >> 16;
       int pix = (word & pxlmsk) >> 8;
       int adc = (word & plsmsk);
       // print the roc number according to the online 0-15 scheme
       if (PRINT_PIXELS)
-        cout << " Channel- " << channel << " ROC- " << (roc - 1) << " DCOL- " << dcol << " Pixel- " << pix << " ADC- "
-             << adc << endl;
+        cout << " Channel- " << channel << " ROC- " << (roc - 1) << " DCOL- "
+             << dcol << " Pixel- " << pix << " ADC- " << adc << endl;
       if (CHECK_PIXELS) {
         if (roc > ROCMAX)
-          cout << " wrong roc number " << channel << "/" << roc << "/" << dcol << "/" << pix << "/" << adc << endl;
+          cout << " wrong roc number " << channel << "/" << roc << "/" << dcol
+               << "/" << pix << "/" << adc << endl;
         if (dcol < 0 || dcol > 25)
-          cout << " wrong dcol number " << channel << "/" << roc << "/" << dcol << "/" << pix << "/" << adc << endl;
+          cout << " wrong dcol number " << channel << "/" << roc << "/" << dcol
+               << "/" << pix << "/" << adc << endl;
         if (pix < 2 || pix > 181)
-          cout << " wrong pix number chan/roc/dcol/pix/adc = " << channel << "/" << roc << "/" << dcol << "/" << pix
-               << "/" << adc << endl;
+          cout << " wrong pix number chan/roc/dcol/pix/adc = " << channel << "/"
+               << roc << "/" << dcol << "/" << pix << "/" << adc << endl;
       }
       c = channel;
-      r = roc - 1;  // start roc counting from 0
+      r = roc - 1; // start roc counting from 0
       d = dcol;
       p = pix;
       status++;
@@ -223,8 +232,8 @@ int MyDecode::data(int word, int &c, int &r, int &d, int &p, bool printFlag) {
       cout << "Wrong channel " << channel << endl;
       return -2;
     }
-  } else {  // error word
-    //cout<<"error word "<<hex<<word<<dec;
+  } else { // error word
+    // cout<<"error word "<<hex<<word<<dec;
     status = error(word);
   }
 
@@ -250,18 +259,18 @@ string MyConvert::moduleNameFromFedChan(int fed0, int fedChan0, string &tbm0) {
   if (fedChan0 < 1 || fedChan0 > 36)
     return " ";
 
-  ifstream infile;                               //input file, name data_file uniqe
-  infile.open("translation_bpix.dat", ios::in);  // open data file
+  ifstream infile; // input file, name data_file uniqe
+  infile.open("translation_bpix.dat", ios::in); // open data file
 
-  //cout << infile.eof() << " " << infile.bad() << " "
+  // cout << infile.eof() << " " << infile.bad() << " "
   //   << infile.fail() << " " << infile.good()<<endl;
 
   if (infile.fail()) {
     cout << " File not found " << endl;
-    return (" ");  // signal error
+    return (" "); // signal error
   }
 
-  //string line;
+  // string line;
   char line[500];
   infile.getline(line, 500, '\n');
 
@@ -271,9 +280,10 @@ string MyConvert::moduleNameFromFedChan(int fed0, int fedChan0, string &tbm0) {
   int fedOld = -1, fedChanOld = -1;
   bool found = false;
   for (int i = 0; i < 100000; ++i) {
-    //bool print = false;
+    // bool print = false;
 
-    infile >> name >> tbm >> fec >> mfec >> mfecChan >> hub >> port >> rocId >> fed >> fedChan >> rocOrder;
+    infile >> name >> tbm >> fec >> mfec >> mfecChan >> hub >> port >> rocId >>
+        fed >> fedChan >> rocOrder;
 
     if (name == " ")
       continue;
@@ -282,7 +292,7 @@ string MyConvert::moduleNameFromFedChan(int fed0, int fedChan0, string &tbm0) {
       cout << " end of file " << endl;
       break;
       ;
-    } else if (infile.fail()) {  // check for errors
+    } else if (infile.fail()) { // check for errors
       cout << "Cannot read data file" << endl;
       return (" ");
     }
@@ -292,7 +302,7 @@ string MyConvert::moduleNameFromFedChan(int fed0, int fedChan0, string &tbm0) {
     fedOld = fed;
     fedChanOld = fedChan;
 
-    if (fed == fed0 && fedChan == fedChan0) {  // found
+    if (fed == fed0 && fedChan == fedChan0) { // found
       found = true;
       tbm0 = tbm;
 
@@ -300,13 +310,13 @@ string MyConvert::moduleNameFromFedChan(int fed0, int fedChan0, string &tbm0) {
       idx = name.find("_ROC");
       if (idx != string::npos) {
         //      cout<<" ROC0 "<<idx<<endl;
-        //name.replace(idx,idx+4,"     ");
+        // name.replace(idx,idx+4,"     ");
         modName = name.substr(0, (idx));
       }
 
       break;
     }
-  }  // end line loop
+  } // end line loop
 
   infile.close();
   if (!found)
@@ -345,7 +355,7 @@ int HotPixels::code(int channel, int roc, int dcol, int pix) {
   return index;
 }
 void HotPixels::decode(int index, int &channel, int &roc, int &dcol, int &pix) {
-  //int index = pix + 1000 * dcol + 100000 * roc + 10000000 * channel;
+  // int index = pix + 1000 * dcol + 100000 * roc + 10000000 * channel;
   channel = index / 10000000;
   roc = (index % 10000000) / 100000;
   dcol = (index % 100000) / 1000;
@@ -353,7 +363,7 @@ void HotPixels::decode(int index, int &channel, int &roc, int &dcol, int &pix) {
 }
 void HotPixels::update(int channel, int roc, int dcol, int pix) {
   int index = code(channel, roc, dcol, pix);
-  //cout<<channel<<"   "<<roc<<"    "<<dcol<<"    "<<pix<<"    "<<index<<endl;
+  // cout<<channel<<"   "<<roc<<"    "<<dcol<<"    "<<pix<<"    "<<index<<endl;
   bool found = false;
   for (int i = 0; i < count; ++i) {
     if (index == array[i]) {
@@ -380,7 +390,7 @@ void HotPixels::print(int events, int fed_id) {
   int cut3 = events / 10000;
 
   int cut = events / 1000;
-  //int cut = 2;
+  // int cut = 2;
   if (cut < 2)
     cut = 10;
 
@@ -403,25 +413,26 @@ void HotPixels::print(int events, int fed_id) {
       decode(index, channel, roc, dcol, pix);
 
       // First find if we are in the first or 2nd col of a dcol.
-      int colEvenOdd = pix % 2;  // module(2), 0-1st sol, 1-2nd col.
+      int colEvenOdd = pix % 2; // module(2), 0-1st sol, 1-2nd col.
       // Transform
-      int colROC = dcol * 2 + colEvenOdd;   // col address, starts from 0
-      int rowROC = abs(int(pix / 2) - 80);  // row addres, starts from 0
-      //cout<<index<<" ";
+      int colROC = dcol * 2 + colEvenOdd;  // col address, starts from 0
+      int rowROC = abs(int(pix / 2) - 80); // row addres, starts from 0
+      // cout<<index<<" ";
 
       // Get the module name and tbm type
       string modName = " ", tbm = " ";
       modName = MyConvert::moduleNameFromFedChan(fed_id, channel, tbm);
       int realRocNum = roc;
       if (tbm == "B")
-        realRocNum = roc + 8;  // shift for TBM-N
-      cout << setw(3) << fed_id << " " << setw(3) << channel << " " << setw(30) << modName << " " << tbm << " "
-           << setw(3) << realRocNum << "  " << setw(3) << dcol << "  " << setw(3) << pix << "   " << setw(3) << colROC
-           << "  " << setw(3) << rowROC << "  " << setw(4) << data[i] << "  " << setw(3) << num << "  " << setw(3)
-           << roc << endl;
+        realRocNum = roc + 8; // shift for TBM-N
+      cout << setw(3) << fed_id << " " << setw(3) << channel << " " << setw(30)
+           << modName << " " << tbm << " " << setw(3) << realRocNum << "  "
+           << setw(3) << dcol << "  " << setw(3) << pix << "   " << setw(3)
+           << colROC << "  " << setw(3) << rowROC << "  " << setw(4) << data[i]
+           << "  " << setw(3) << num << "  " << setw(3) << roc << endl;
     }
   }
-  //cout<<num<<" total 'noisy' pixels above the cut = "<<cut<<endl;
+  // cout<<num<<" total 'noisy' pixels above the cut = "<<cut<<endl;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -430,7 +441,8 @@ class findHotPixels : public edm::EDAnalyzer {
 public:
   /// ctor
   explicit findHotPixels(const edm::ParameterSet &cfg) : theConfig(cfg) {
-    consumes<FEDRawDataCollection>(theConfig.getUntrackedParameter<std::string>("InputLabel", "source"));
+    consumes<FEDRawDataCollection>(
+        theConfig.getUntrackedParameter<std::string>("InputLabel", "source"));
   }
 
   /// dtor
@@ -438,7 +450,7 @@ public:
 
   void beginJob();
 
-  //void beginRun( const edm::EventSetup& ) {}
+  // void beginRun( const edm::EventSetup& ) {}
 
   // end of job
   void endJob();
@@ -460,16 +472,17 @@ void findHotPixels::endJob() {
       sumFedPixels[i] /= float(countEvents);
   }
 
-  cout << " Total/non-empty events " << countAllEvents << " / " << countEvents << " average number of pixels "
-       << sumPixels << endl;
+  cout << " Total/non-empty events " << countAllEvents << " / " << countEvents
+       << " average number of pixels " << sumPixels << endl;
 
-  //for(int i=0;i<40;++i) cout<<sumFedPixels[i]<<" ";
-  //cout<<endl;
+  // for(int i=0;i<40;++i) cout<<sumFedPixels[i]<<" ";
+  // cout<<endl;
 
   for (int i = 0; i < 40; ++i) {
     hotPixels[i].print(countAllEvents, i);
   }
-  cout << " Number of noisy pixels: 1% " << count1 << " 0.1% " << count2 << " 0.01% " << count3 << endl;
+  cout << " Number of noisy pixels: 1% " << count1 << " 0.1% " << count2
+       << " 0.01% " << count3 << endl;
 }
 
 void findHotPixels::beginJob() {
@@ -482,15 +495,18 @@ void findHotPixels::beginJob() {
 
 void findHotPixels::analyze(const edm::Event &ev, const edm::EventSetup &es) {
   edm::Handle<FEDRawDataCollection> buffers;
-  static std::string label = theConfig.getUntrackedParameter<std::string>("InputLabel", "source");
-  static std::string instance = theConfig.getUntrackedParameter<std::string>("InputInstance", "");
+  static std::string label =
+      theConfig.getUntrackedParameter<std::string>("InputLabel", "source");
+  static std::string instance =
+      theConfig.getUntrackedParameter<std::string>("InputInstance", "");
 
   ev.getByLabel(label, instance, buffers);
 
-  std::pair<int, int> fedIds(FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID);
+  std::pair<int, int> fedIds(FEDNumbering::MINSiPixelFEDID,
+                             FEDNumbering::MAXSiPixelFEDID);
 
-  //PixelDataFormatter formatter(0); // to get digis
-  //bool dummyErrorBool;
+  // PixelDataFormatter formatter(0); // to get digis
+  // bool dummyErrorBool;
 
   typedef uint32_t Word32;
   typedef uint64_t Word64;
@@ -504,7 +520,7 @@ void findHotPixels::analyze(const edm::Event &ev, const edm::EventSetup &es) {
   if (printHeaders)
     cout << " Event = " << countEvents << endl;
 
-  //edm::DetSetVector<PixelDigi> collection; // for digis only
+  // edm::DetSetVector<PixelDigi> collection; // for digis only
 
   // Loop over FEDs
   for (int fedId = fedIds.first; fedId <= fedIds.second; fedId++) {
@@ -514,20 +530,21 @@ void findHotPixels::analyze(const edm::Event &ev, const edm::EventSetup &es) {
 
     PixelDataFormatter::Errors errors;
 
-    //get event data for this fed
+    // get event data for this fed
     const FEDRawData &rawData = buffers->FEDData(fedId);
 
     int nWords = rawData.size() / sizeof(Word64);
-    //cout<<" size "<<nWords<<endl;
+    // cout<<" size "<<nWords<<endl;
 
     // check headers
     const Word64 *header = reinterpret_cast<const Word64 *>(rawData.data());
-    //cout<<hex<<*header<<dec<<endl;
+    // cout<<hex<<*header<<dec<<endl;
     eventId = MyDecode::header(*header, printHeaders);
-    //if(fedId = fedIds.first)
+    // if(fedId = fedIds.first)
 
-    const Word64 *trailer = reinterpret_cast<const Word64 *>(rawData.data()) + (nWords - 1);
-    //cout<<hex<<*trailer<<dec<<endl;
+    const Word64 *trailer =
+        reinterpret_cast<const Word64 *>(rawData.data()) + (nWords - 1);
+    // cout<<hex<<*trailer<<dec<<endl;
     status = MyDecode::trailer(*trailer, printHeaders);
 
     int countPixelsInFed = 0;
@@ -551,29 +568,30 @@ void findHotPixels::analyze(const edm::Event &ev, const edm::EventSetup &es) {
         hotPixels[fedId].update(channel, roc, dcol, pix);
       } else if (status < 0)
         countErrorsInFed++;
-      //cout<<hex<<w1<<" "<<w2<<dec<<endl;
-    }  // loop over words
+      // cout<<hex<<w1<<" "<<w2<<dec<<endl;
+    } // loop over words
 
     countErrors += countErrorsInFed;
 
-    //convert data to digi (dummy for the moment)
-    //formatter.interpretRawData( dummyErrorBool, fedId, rawData,  collection, errors);
-    //cout<<dummyErrorBool<<" "<<digis.size()<<" "<<errors.size()<<endl;
+    // convert data to digi (dummy for the moment)
+    // formatter.interpretRawData( dummyErrorBool, fedId, rawData,  collection,
+    // errors); cout<<dummyErrorBool<<" "<<digis.size()<<"
+    // "<<errors.size()<<endl;
 
     if (countPixelsInFed > 0) {
       sumFedPixels[fedId] += countPixelsInFed;
     }
 
-  }  // loop over feds
+  } // loop over feds
 
   if (countPixels > 0) {
-    cout << "EVENT: " << countEvents << " " << eventId << " pixels " << countPixels << " errors " << countErrors
-         << endl;
+    cout << "EVENT: " << countEvents << " " << eventId << " pixels "
+         << countPixels << " errors " << countErrors << endl;
     sumPixels += countPixels;
     countEvents++;
-    //int dummy=0;
-    //cout<<" : ";
-    //cin>>dummy;
+    // int dummy=0;
+    // cout<<" : ";
+    // cin>>dummy;
   }
 }
 


### PR DESCRIPTION
#### PR description:

The FED raw data format for phase 0 and phase 1 detectors are essentially the same with small differences for the bit-packing of the pixel hit information in layer 1. There is a difference also in the error assignment by the front-end (*). The former case has been treated in the PixelDataFormatter by setting the 'phase1' variable through python configuration files. The error decoding class, called ErrorChecker, however was not made aware of the difference, instead, was just simply updated to phase 1. 
This PR fixes that: a base class is defined for the ErrorChecker, the present default code is kept with the same name deriving from this base, and a new derived class ErrorCheckerPhase0 is introduced to restore the phase 0 treatment. The proper error checker is instantiated by the PixelDataFormatter based on the value of 'phase1', so no change needs to be made in the python configurations.

FED error 25: in phase 1, FED error type 25 has been reinterpreted and used by the FED firmware to signal "dead" links. It is used to flag stuck TBMs. This error has a totally different meaning in phase 0. In this PR, the special treatment of this error type by raw-to-digi and digi-to-raw is cancelled for phase 0. 

(*) Few error codes have different interpretation; and in phase 0 FPix, the error association with detId is ambiguous. 

#### PR validation:

During the reconstruction of phase 0 data, when a rare type 25 error was encountered, the tracking code crashed. This PR fixes that. The FED25 error packing in simulation, and unpacking in simulation and data for phase 1 should be unchanged, are being validated by @tsusa. 

@tsusa @mmusich @dkotlins 