### PR TITLE
[PPS] Timing detectors tracks window reduced to 25 ns in lite tracks format

### DIFF
--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -7,16 +7,16 @@
  *
  ****************************************************************************/
 
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/CTPPSReco/interface/TotemRPLocalTrack.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h"
+#include "DataFormats/CTPPSReco/interface/TotemRPLocalTrack.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
 
 #include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLiteFwd.h"
@@ -30,23 +30,24 @@
  **/
 class CTPPSLocalTrackLiteProducer : public edm::stream::EDProducer<> {
 public:
-  explicit CTPPSLocalTrackLiteProducer(const edm::ParameterSet&);
+  explicit CTPPSLocalTrackLiteProducer(const edm::ParameterSet &);
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  static void fillDescriptions(edm::ConfigurationDescriptions&);
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &);
 
 private:
   /// HPTDC time slice width, in ns
   static constexpr float HPTDC_TIME_SLICE_WIDTH = 25.;
 
   bool includeStrips_;
-  edm::EDGetTokenT<edm::DetSetVector<TotemRPLocalTrack> > siStripTrackToken_;
+  edm::EDGetTokenT<edm::DetSetVector<TotemRPLocalTrack>> siStripTrackToken_;
 
   bool includeDiamonds_;
-  edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondLocalTrack> > diamondTrackToken_;
+  edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondLocalTrack>>
+      diamondTrackToken_;
 
   bool includePixels_;
-  edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelLocalTrack> > pixelTrackToken_;
+  edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelLocalTrack>> pixelTrackToken_;
 
   double pixelTrackTxMin_, pixelTrackTxMax_, pixelTrackTyMin_, pixelTrackTyMax_;
   double timingTrackTMin_, timingTrackTMax_;
@@ -54,7 +55,8 @@ private:
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(const edm::ParameterSet& iConfig)
+CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(
+    const edm::ParameterSet &iConfig)
     : includeStrips_(iConfig.getParameter<bool>("includeStrips")),
       includeDiamonds_(iConfig.getParameter<bool>("includeDiamonds")),
       includePixels_(iConfig.getParameter<bool>("includePixels")),
@@ -66,22 +68,26 @@ CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(const edm::ParameterSet
       timingTrackTMax_(iConfig.getParameter<double>("timingTrackTMax")) {
   auto tagSiStripTrack = iConfig.getParameter<edm::InputTag>("tagSiStripTrack");
   if (!tagSiStripTrack.label().empty())
-    siStripTrackToken_ = consumes<edm::DetSetVector<TotemRPLocalTrack> >(tagSiStripTrack);
+    siStripTrackToken_ =
+        consumes<edm::DetSetVector<TotemRPLocalTrack>>(tagSiStripTrack);
 
   auto tagDiamondTrack = iConfig.getParameter<edm::InputTag>("tagDiamondTrack");
   if (!tagDiamondTrack.label().empty())
-    diamondTrackToken_ = consumes<edm::DetSetVector<CTPPSDiamondLocalTrack> >(tagDiamondTrack);
+    diamondTrackToken_ =
+        consumes<edm::DetSetVector<CTPPSDiamondLocalTrack>>(tagDiamondTrack);
 
   auto tagPixelTrack = iConfig.getParameter<edm::InputTag>("tagPixelTrack");
   if (!tagPixelTrack.label().empty())
-    pixelTrackToken_ = consumes<edm::DetSetVector<CTPPSPixelLocalTrack> >(tagPixelTrack);
+    pixelTrackToken_ =
+        consumes<edm::DetSetVector<CTPPSPixelLocalTrack>>(tagPixelTrack);
 
   produces<CTPPSLocalTrackLiteCollection>();
 }
 
 //----------------------------------------------------------------------------------------------------
 
-void CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
+void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent,
+                                          const edm::EventSetup &) {
   // prepare output
   auto pOut = std::make_unique<CTPPSLocalTrackLiteCollection>();
 
@@ -89,45 +95,51 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSe
 
   // get input from Si strips
   if (includeStrips_) {
-    edm::Handle<edm::DetSetVector<TotemRPLocalTrack> > inputSiStripTracks;
+    edm::Handle<edm::DetSetVector<TotemRPLocalTrack>> inputSiStripTracks;
     iEvent.getByToken(siStripTrackToken_, inputSiStripTracks);
 
     // process tracks from Si strips
-    for (const auto& rpv : *inputSiStripTracks) {
+    for (const auto &rpv : *inputSiStripTracks) {
       const uint32_t rpId = rpv.detId();
-      for (const auto& trk : rpv) {
+      for (const auto &trk : rpv) {
         if (!trk.isValid())
           continue;
 
-        float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<14>(trk.getX0());
-        float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getX0Sigma());
-        float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
-        float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getY0Sigma());
-        float roundedTx = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTx());
-        float roundedTxSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTxSigma());
-        float roundedTy = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTy());
-        float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTySigma());
+        float roundedX0 =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<14>(trk.getX0());
+        float roundedX0Sigma =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
+                trk.getX0Sigma());
+        float roundedY0 =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
+        float roundedY0Sigma =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
+                trk.getY0Sigma());
+        float roundedTx =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTx());
+        float roundedTxSigma =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
+                trk.getTxSigma());
+        float roundedTy =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTy());
+        float roundedTySigma =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
+                trk.getTySigma());
         float roundedChiSquaredOverNDF =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
+            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
+                trk.getChiSquaredOverNDF());
 
-        pOut->emplace_back(rpId,  // detector info
-                           // spatial info
-                           roundedX0,
-                           roundedX0Sigma,
-                           roundedY0,
-                           roundedY0Sigma,
+        pOut->emplace_back(rpId, // detector info
+                                 // spatial info
+                           roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma,
                            // angular info
-                           roundedTx,
-                           roundedTxSigma,
-                           roundedTy,
-                           roundedTySigma,
+                           roundedTx, roundedTxSigma, roundedTy, roundedTySigma,
                            // reconstruction info
                            roundedChiSquaredOverNDF,
                            CTPPSpixelLocalTrackReconstructionInfo::invalid,
                            trk.getNumberOfPointsUsedForFit(),
                            // timing info
-                           0.,
-                           0.);
+                           0., 0.);
       }
     }
   }
@@ -136,45 +148,47 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSe
 
   if (includeDiamonds_) {
     // get input from diamond detectors
-    edm::Handle<edm::DetSetVector<CTPPSDiamondLocalTrack> > inputDiamondTracks;
+    edm::Handle<edm::DetSetVector<CTPPSDiamondLocalTrack>> inputDiamondTracks;
     iEvent.getByToken(diamondTrackToken_, inputDiamondTracks);
 
     // process tracks from diamond detectors
-    for (const auto& rpv : *inputDiamondTracks) {
+    for (const auto &rpv : *inputDiamondTracks) {
       const unsigned int rpId = rpv.detId();
-      for (const auto& trk : rpv) {
+      for (const auto &trk : rpv) {
         if (!trk.isValid())
           continue;
 
-        const float abs_time = trk.getT() + trk.getOOTIndex() * HPTDC_TIME_SLICE_WIDTH;
+        const float abs_time =
+            trk.getT() + trk.getOOTIndex() * HPTDC_TIME_SLICE_WIDTH;
         if (abs_time < timingTrackTMin_ || abs_time > timingTrackTMax_)
           continue;
 
-        float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(trk.getX0());
-        float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getX0Sigma());
-        float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
-        float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getY0Sigma());
-        float roundedT = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(abs_time);
-        float roundedTSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getTSigma());
+        float roundedX0 =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<16>(trk.getX0());
+        float roundedX0Sigma =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
+                trk.getX0Sigma());
+        float roundedY0 =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
+        float roundedY0Sigma =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
+                trk.getY0Sigma());
+        float roundedT =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<16>(abs_time);
+        float roundedTSigma =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<13>(
+                trk.getTSigma());
 
-        pOut->emplace_back(rpId,  // detector info
-                           // spatial info
-                           roundedX0,
-                           roundedX0Sigma,
-                           roundedY0,
-                           roundedY0Sigma,
+        pOut->emplace_back(rpId, // detector info
+                                 // spatial info
+                           roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma,
                            // angular info
-                           0.,
-                           0.,
-                           0.,
-                           0.,
+                           0., 0., 0., 0.,
                            // reconstruction info
-                           0.,
-                           CTPPSpixelLocalTrackReconstructionInfo::invalid,
+                           0., CTPPSpixelLocalTrackReconstructionInfo::invalid,
                            trk.getNumOfPlanes(),
                            // timing info
-                           roundedT,
-                           roundedTSigma);
+                           roundedT, roundedTSigma);
       }
     }
   }
@@ -182,47 +196,59 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSe
   //----- pixel detectors
 
   if (includePixels_) {
-    edm::Handle<edm::DetSetVector<CTPPSPixelLocalTrack> > inputPixelTracks;
+    edm::Handle<edm::DetSetVector<CTPPSPixelLocalTrack>> inputPixelTracks;
     if (!pixelTrackToken_.isUninitialized()) {
       iEvent.getByToken(pixelTrackToken_, inputPixelTracks);
 
       // process tracks from pixels
-      for (const auto& rpv : *inputPixelTracks) {
+      for (const auto &rpv : *inputPixelTracks) {
         const uint32_t rpId = rpv.detId();
-        for (const auto& trk : rpv) {
+        for (const auto &trk : rpv) {
           if (!trk.isValid())
             continue;
-          if (trk.getTx() > pixelTrackTxMin_ && trk.getTx() < pixelTrackTxMax_ && trk.getTy() > pixelTrackTyMin_ &&
+          if (trk.getTx() > pixelTrackTxMin_ &&
+              trk.getTx() < pixelTrackTxMax_ &&
+              trk.getTy() > pixelTrackTyMin_ &&
               trk.getTy() < pixelTrackTyMax_) {
-            float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(trk.getX0());
-            float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getX0Sigma());
-            float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
-            float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getY0Sigma());
-            float roundedTx = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTx());
-            float roundedTxSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTxSigma());
-            float roundedTy = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTy());
-            float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTySigma());
+            float roundedX0 =
+                MiniFloatConverter::reduceMantissaToNbitsRounding<16>(
+                    trk.getX0());
+            float roundedX0Sigma =
+                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
+                    trk.getX0Sigma());
+            float roundedY0 =
+                MiniFloatConverter::reduceMantissaToNbitsRounding<13>(
+                    trk.getY0());
+            float roundedY0Sigma =
+                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
+                    trk.getY0Sigma());
+            float roundedTx =
+                MiniFloatConverter::reduceMantissaToNbitsRounding<11>(
+                    trk.getTx());
+            float roundedTxSigma =
+                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
+                    trk.getTxSigma());
+            float roundedTy =
+                MiniFloatConverter::reduceMantissaToNbitsRounding<11>(
+                    trk.getTy());
+            float roundedTySigma =
+                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
+                    trk.getTySigma());
             float roundedChiSquaredOverNDF =
-                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
+                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
+                    trk.getChiSquaredOverNDF());
 
-            pOut->emplace_back(rpId,  // detector info
-                               // spatial info
-                               roundedX0,
-                               roundedX0Sigma,
-                               roundedY0,
-                               roundedY0Sigma,
-                               // angular info
-                               roundedTx,
-                               roundedTxSigma,
-                               roundedTy,
-                               roundedTySigma,
-                               // reconstruction info
-                               roundedChiSquaredOverNDF,
-                               trk.getRecoInfo(),
-                               trk.getNumberOfPointsUsedForFit(),
-                               // timing info
-                               0.,
-                               0.);
+            pOut->emplace_back(
+                rpId, // detector info
+                      // spatial info
+                roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma,
+                // angular info
+                roundedTx, roundedTxSigma, roundedTy, roundedTySigma,
+                // reconstruction info
+                roundedChiSquaredOverNDF, trk.getRecoInfo(),
+                trk.getNumberOfPointsUsedForFit(),
+                // timing info
+                0., 0.);
           }
         }
       }
@@ -235,26 +261,38 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSe
 
 //----------------------------------------------------------------------------------------------------
 
-void CTPPSLocalTrackLiteProducer::fillDescriptions(edm::ConfigurationDescriptions& descr) {
+void CTPPSLocalTrackLiteProducer::fillDescriptions(
+    edm::ConfigurationDescriptions &descr) {
   edm::ParameterSetDescription desc;
 
   // By default: all includeXYZ flags set to false.
-  // The includeXYZ are switched on when the "ctpps_2016" era is declared in python config, see:
+  // The includeXYZ are switched on when the "ctpps_2016" era is declared in
+  // python config, see:
   // RecoCTPPS/TotemRPLocal/python/ctppsLocalTrackLiteProducer_cff.py
 
-  desc.add<bool>("includeStrips", false)->setComment("whether tracks from Si strips should be included");
-  desc.add<edm::InputTag>("tagSiStripTrack", edm::InputTag("totemRPLocalTrackFitter"))
+  desc.add<bool>("includeStrips", false)
+      ->setComment("whether tracks from Si strips should be included");
+  desc.add<edm::InputTag>("tagSiStripTrack",
+                          edm::InputTag("totemRPLocalTrackFitter"))
       ->setComment("input TOTEM strips' local tracks collection to retrieve");
 
-  desc.add<bool>("includeDiamonds", false)->setComment("whether tracks from diamonds strips should be included");
-  desc.add<edm::InputTag>("tagDiamondTrack", edm::InputTag("ctppsDiamondLocalTracks"))
-      ->setComment("input diamond detectors' local tracks collection to retrieve");
+  desc.add<bool>("includeDiamonds", false)
+      ->setComment("whether tracks from diamonds strips should be included");
+  desc.add<edm::InputTag>("tagDiamondTrack",
+                          edm::InputTag("ctppsDiamondLocalTracks"))
+      ->setComment(
+          "input diamond detectors' local tracks collection to retrieve");
 
-  desc.add<bool>("includePixels", false)->setComment("whether tracks from pixels should be included");
-  desc.add<edm::InputTag>("tagPixelTrack", edm::InputTag("ctppsPixelLocalTracks"))
-      ->setComment("input pixel detectors' local tracks collection to retrieve");
-  desc.add<double>("timingTrackTMin", -12.5)->setComment("minimal track time selection for timing detectors, in ns");
-  desc.add<double>("timingTrackTMax", +12.5)->setComment("maximal track time selection for timing detectors, in ns");
+  desc.add<bool>("includePixels", false)
+      ->setComment("whether tracks from pixels should be included");
+  desc.add<edm::InputTag>("tagPixelTrack",
+                          edm::InputTag("ctppsPixelLocalTracks"))
+      ->setComment(
+          "input pixel detectors' local tracks collection to retrieve");
+  desc.add<double>("timingTrackTMin", -12.5)
+      ->setComment("minimal track time selection for timing detectors, in ns");
+  desc.add<double>("timingTrackTMax", +12.5)
+      ->setComment("maximal track time selection for timing detectors, in ns");
 
   desc.add<double>("pixelTrackTxMin", -10.0);
   desc.add<double>("pixelTrackTxMax", 10.0);

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -29,70 +29,69 @@
 class CTPPSLocalTrackLiteProducer : public edm::stream::EDProducer<>
 {
 public:
-  explicit CTPPSLocalTrackLiteProducer( const edm::ParameterSet& );
-  ~CTPPSLocalTrackLiteProducer() override {}
+  explicit CTPPSLocalTrackLiteProducer(const edm::ParameterSet&);
 
-  void produce( edm::Event&, const edm::EventSetup& ) override;
-  static void fillDescriptions( edm::ConfigurationDescriptions& );
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
   /// HPTDC time slice width, in ns
   static constexpr float HPTDC_TIME_SLICE_WIDTH = 25.;
   bool includeStrips_;
-  edm::EDGetTokenT< edm::DetSetVector<TotemRPLocalTrack> > siStripTrackToken_;
+  edm::EDGetTokenT<edm::DetSetVector<TotemRPLocalTrack> > siStripTrackToken_;
 
   bool includeDiamonds_;
-  edm::EDGetTokenT< edm::DetSetVector<CTPPSDiamondLocalTrack> > diamondTrackToken_;
+  edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondLocalTrack> > diamondTrackToken_;
 
   bool includePixels_;
-  edm::EDGetTokenT< edm::DetSetVector<CTPPSPixelLocalTrack> > pixelTrackToken_;
+  edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelLocalTrack> > pixelTrackToken_;
 
-  double pixelTrackTxMin_,pixelTrackTxMax_,pixelTrackTyMin_,pixelTrackTyMax_;
-/// if true, this module will do nothing
-/// needed for consistency with CTPPS-less workflows
+  double pixelTrackTxMin_, pixelTrackTxMax_, pixelTrackTyMin_, pixelTrackTyMax_;
+  /// if true, this module will do nothing
+  /// \note needed for consistency with CTPPS-less workflows
   bool doNothing_;
   double timingTrackTMin_, timingTrackTMax_;
 };
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer( const edm::ParameterSet& iConfig ) :
-  doNothing_( iConfig.getParameter<bool>( "doNothing" ) )
+CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(const edm::ParameterSet& iConfig) :
+  doNothing_(iConfig.getParameter<bool>("doNothing"))
 {
-  if ( doNothing_ ) return;
+  if (doNothing_)
+    return;
 
   includeStrips_ = iConfig.getParameter<bool>("includeStrips");
-  siStripTrackToken_ = consumes< edm::DetSetVector<TotemRPLocalTrack> >     ( iConfig.getParameter<edm::InputTag>("tagSiStripTrack") );
+  siStripTrackToken_ = consumes<edm::DetSetVector<TotemRPLocalTrack> >(iConfig.getParameter<edm::InputTag>("tagSiStripTrack"));
 
   includeDiamonds_ = iConfig.getParameter<bool>("includeDiamonds");
-  diamondTrackToken_ = consumes< edm::DetSetVector<CTPPSDiamondLocalTrack> >( iConfig.getParameter<edm::InputTag>("tagDiamondTrack") );
+  diamondTrackToken_ = consumes<edm::DetSetVector<CTPPSDiamondLocalTrack> >(iConfig.getParameter<edm::InputTag>("tagDiamondTrack"));
 
-  timingTrackTMin_ = iConfig.getParameter<double>( "timingTrackTMin" );
-  timingTrackTMax_ = iConfig.getParameter<double>( "timingTrackTMax" );
+  timingTrackTMin_ = iConfig.getParameter<double>("timingTrackTMin");
+  timingTrackTMax_ = iConfig.getParameter<double>("timingTrackTMax");
 
   includePixels_ = iConfig.getParameter<bool>("includePixels");
   auto tagPixelTrack = iConfig.getParameter<edm::InputTag>("tagPixelTrack");
-  if (not tagPixelTrack.label().empty()){
-    pixelTrackToken_   = consumes< edm::DetSetVector<CTPPSPixelLocalTrack> >  (tagPixelTrack);
-  }
+  if (!tagPixelTrack.label().empty())
+    pixelTrackToken_ = consumes<edm::DetSetVector<CTPPSPixelLocalTrack> >(tagPixelTrack);
 
   pixelTrackTxMin_ = iConfig.getParameter<double>("pixelTrackTxMin");
   pixelTrackTxMax_ = iConfig.getParameter<double>("pixelTrackTxMax");
   pixelTrackTyMin_ = iConfig.getParameter<double>("pixelTrackTyMin");
   pixelTrackTyMax_ = iConfig.getParameter<double>("pixelTrackTyMax");
-  produces< std::vector<CTPPSLocalTrackLite> >();
+  produces<std::vector<CTPPSLocalTrackLite> >();
 }
 
 //----------------------------------------------------------------------------------------------------
 
 void
-CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup& )
+CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
 {
-  if ( doNothing_ )
+  if (doNothing_)
     return;
 
   // prepare output
-  std::unique_ptr< std::vector<CTPPSLocalTrackLite> > pOut( new std::vector<CTPPSLocalTrackLite>() );
+  auto pOut = std::make_unique<std::vector<CTPPSLocalTrackLite> >();
 
   //----- TOTEM strips
 
@@ -100,13 +99,14 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
   if (includeStrips_)
   {
     edm::Handle< edm::DetSetVector<TotemRPLocalTrack> > inputSiStripTracks;
-    iEvent.getByToken( siStripTrackToken_, inputSiStripTracks );
+    iEvent.getByToken(siStripTrackToken_, inputSiStripTracks);
 
     // process tracks from Si strips
-    for ( const auto& rpv : *inputSiStripTracks ) {
+    for (const auto& rpv : *inputSiStripTracks) {
       const uint32_t rpId = rpv.detId();
-      for ( const auto& trk : rpv ) {
-        if ( !trk.isValid() ) continue;
+      for (const auto& trk : rpv) {
+        if (!trk.isValid())
+          continue;
 
           float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<14>(trk.getX0());
           float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getX0Sigma());
@@ -118,8 +118,8 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
           float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTySigma());
           float roundedChiSquaredOverNDF = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
 
-        pOut->emplace_back( rpId, roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma, roundedTx, roundedTxSigma, roundedTy, roundedTySigma,
-        roundedChiSquaredOverNDF, CTPPSpixelLocalTrackReconstructionInfo::invalid, trk.getNumberOfPointsUsedForFit(),0,0 );
+        pOut->emplace_back(rpId, roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma, roundedTx, roundedTxSigma, roundedTy, roundedTySigma,
+          roundedChiSquaredOverNDF, CTPPSpixelLocalTrackReconstructionInfo::invalid, trk.getNumberOfPointsUsedForFit(), 0, 0);
       }
     }
   }
@@ -130,16 +130,17 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
   {
     // get input from diamond detectors
     edm::Handle< edm::DetSetVector<CTPPSDiamondLocalTrack> > inputDiamondTracks;
-    iEvent.getByToken( diamondTrackToken_, inputDiamondTracks );
+    iEvent.getByToken(diamondTrackToken_, inputDiamondTracks);
 
     // process tracks from diamond detectors
-    for ( const auto& rpv : *inputDiamondTracks ) {
+    for (const auto& rpv : *inputDiamondTracks) {
       const unsigned int rpId = rpv.detId();
-      for ( const auto& trk : rpv ) {
-        if ( !trk.isValid() ) continue;
+      for (const auto& trk : rpv) {
+        if (!trk.isValid())
+          continue;
 
         const float abs_time = trk.getT()+trk.getOOTIndex()*HPTDC_TIME_SLICE_WIDTH;
-        if ( abs_time < timingTrackTMin_ || abs_time > timingTrackTMax_ ) continue;
+        if (abs_time < timingTrackTMin_ || abs_time > timingTrackTMax_) continue;
 
         float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(trk.getX0());
         float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getX0Sigma());
@@ -165,14 +166,14 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
   if (includePixels_)
   {
     edm::Handle< edm::DetSetVector<CTPPSPixelLocalTrack> > inputPixelTracks;
-    if (not pixelTrackToken_.isUninitialized()){
-      iEvent.getByToken( pixelTrackToken_, inputPixelTracks );
+    if (!pixelTrackToken_.isUninitialized()){
+      iEvent.getByToken(pixelTrackToken_, inputPixelTracks);
 
     // process tracks from pixels
-      for ( const auto& rpv : *inputPixelTracks ) {
+      for (const auto& rpv : *inputPixelTracks) {
         const uint32_t rpId = rpv.detId();
-        for ( const auto& trk : rpv ) {
-          if ( !trk.isValid() ) continue;
+        for (const auto& trk : rpv) {
+          if (!trk.isValid()) continue;
           if(trk.getTx()>pixelTrackTxMin_ && trk.getTx()<pixelTrackTxMax_
              && trk.getTy()>pixelTrackTyMin_ && trk.getTy()<pixelTrackTyMax_){
             float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(trk.getX0());
@@ -185,8 +186,8 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
             float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTySigma());
             float roundedChiSquaredOverNDF = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
 
-            pOut->emplace_back( rpId, roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma, roundedTx, roundedTxSigma, roundedTy, roundedTySigma,
-            roundedChiSquaredOverNDF, trk.getRecoInfo(), trk.getNumberOfPointsUsedForFit(),0.,0. );
+            pOut->emplace_back(rpId, roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma, roundedTx, roundedTxSigma, roundedTy, roundedTySigma,
+              roundedChiSquaredOverNDF, trk.getRecoInfo(), trk.getNumberOfPointsUsedForFit(), 0., 0.);
           }
         }
       }
@@ -194,13 +195,13 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
   }
 
   // save output to event
-  iEvent.put( std::move( pOut ) );
+  iEvent.put(std::move(pOut));
 }
 
 //----------------------------------------------------------------------------------------------------
 
 void
-CTPPSLocalTrackLiteProducer::fillDescriptions( edm::ConfigurationDescriptions& descr )
+CTPPSLocalTrackLiteProducer::fillDescriptions(edm::ConfigurationDescriptions& descr)
 {
   edm::ParameterSetDescription desc;
 
@@ -209,32 +210,32 @@ CTPPSLocalTrackLiteProducer::fillDescriptions( edm::ConfigurationDescriptions& d
   // RecoCTPPS/TotemRPLocal/python/ctppsLocalTrackLiteProducer_cff.py
 
   desc.add<bool>("includeStrips", false)->setComment("whether tracks from Si strips should be included");
-  desc.add<edm::InputTag>( "tagSiStripTrack", edm::InputTag( "totemRPLocalTrackFitter" ) )
-    ->setComment( "input TOTEM strips' local tracks collection to retrieve" );
+  desc.add<edm::InputTag>("tagSiStripTrack", edm::InputTag("totemRPLocalTrackFitter"))
+    ->setComment("input TOTEM strips' local tracks collection to retrieve");
 
   desc.add<bool>("includeDiamonds", false)->setComment("whether tracks from diamonds strips should be included");
-  desc.add<edm::InputTag>( "tagDiamondTrack", edm::InputTag( "ctppsDiamondLocalTracks" ) )
-    ->setComment( "input diamond detectors' local tracks collection to retrieve" );
+  desc.add<edm::InputTag>("tagDiamondTrack", edm::InputTag("ctppsDiamondLocalTracks"))
+    ->setComment("input diamond detectors' local tracks collection to retrieve");
 
   desc.add<bool>("includePixels", false)->setComment("whether tracks from pixels should be included");
-  desc.add<edm::InputTag>( "tagPixelTrack", edm::InputTag( "ctppsPixelLocalTracks"   ) )
-    ->setComment( "input pixel detectors' local tracks collection to retrieve" );
-  desc.add<bool>( "doNothing", false ) // enable the module by default
-    ->setComment( "disable the module" );
-  desc.add<double>( "timingTrackTMin", -12.5 )
-    ->setComment( "minimal track time selection for timing detectors, in ns" );
-  desc.add<double>( "timingTrackTMax", +12.5 )
-    ->setComment( "maximal track time selection for timing detectors, in ns" );
+  desc.add<edm::InputTag>("tagPixelTrack", edm::InputTag("ctppsPixelLocalTracks"))
+    ->setComment("input pixel detectors' local tracks collection to retrieve");
+  desc.add<bool>("doNothing", false) // enable the module by default
+    ->setComment("disable the module");
+  desc.add<double>("timingTrackTMin", -12.5)
+    ->setComment("minimal track time selection for timing detectors, in ns");
+  desc.add<double>("timingTrackTMax", +12.5)
+    ->setComment("maximal track time selection for timing detectors, in ns");
 
   desc.add<double>("pixelTrackTxMin",-10.0);
   desc.add<double>("pixelTrackTxMax", 10.0);
   desc.add<double>("pixelTrackTyMin",-10.0);
   desc.add<double>("pixelTrackTyMax", 10.0);
 
-  descr.add( "ctppsLocalTrackLiteDefaultProducer", desc );
+  descr.add("ctppsLocalTrackLiteDefaultProducer", desc);
 }
 
 //----------------------------------------------------------------------------------------------------
 
-DEFINE_FWK_MODULE( CTPPSLocalTrackLiteProducer );
+DEFINE_FWK_MODULE(CTPPSLocalTrackLiteProducer);
 

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -221,9 +221,9 @@ CTPPSLocalTrackLiteProducer::fillDescriptions( edm::ConfigurationDescriptions& d
     ->setComment( "input pixel detectors' local tracks collection to retrieve" );
   desc.add<bool>( "doNothing", false ) // enable the module by default
     ->setComment( "disable the module" );
-  desc.add<double>( "timingTrackTMin", -1000. )
+  desc.add<double>( "timingTrackTMin", -12.5 )
     ->setComment( "minimal track time selection for timing detectors, in ns" );
-  desc.add<double>( "timingTrackTMax", +1000. )
+  desc.add<double>( "timingTrackTMax", +12.5 )
     ->setComment( "maximal track time selection for timing detectors, in ns" );
 
   desc.add<double>("pixelTrackTxMin",-10.0);

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -55,9 +55,9 @@ private:
 //----------------------------------------------------------------------------------------------------
 
 CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(const edm::ParameterSet& iConfig)
-    : includeStrips_  (iConfig.getParameter<bool>("includeStrips")),
+    : includeStrips_(iConfig.getParameter<bool>("includeStrips")),
       includeDiamonds_(iConfig.getParameter<bool>("includeDiamonds")),
-      includePixels_  (iConfig.getParameter<bool>("includePixels")),
+      includePixels_(iConfig.getParameter<bool>("includePixels")),
       pixelTrackTxMin_(iConfig.getParameter<double>("pixelTrackTxMin")),
       pixelTrackTxMax_(iConfig.getParameter<double>("pixelTrackTxMax")),
       pixelTrackTyMin_(iConfig.getParameter<double>("pixelTrackTyMin")),
@@ -127,8 +127,7 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSe
                            trk.getNumberOfPointsUsedForFit(),
                            // timing info
                            0.,
-                           0.
-        );
+                           0.);
       }
     }
   }
@@ -175,8 +174,7 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSe
                            trk.getNumOfPlanes(),
                            // timing info
                            roundedT,
-                           roundedTSigma
-        );
+                           roundedTSigma);
       }
     }
   }
@@ -224,8 +222,7 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSe
                                trk.getNumberOfPointsUsedForFit(),
                                // timing info
                                0.,
-                               0.
-            );
+                               0.);
           }
         }
       }
@@ -270,4 +267,3 @@ void CTPPSLocalTrackLiteProducer::fillDescriptions(edm::ConfigurationDescription
 //----------------------------------------------------------------------------------------------------
 
 DEFINE_FWK_MODULE(CTPPSLocalTrackLiteProducer);
-

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -28,8 +28,7 @@
 /**
  * \brief Distills the essential track data from all RPs.
  **/
-class CTPPSLocalTrackLiteProducer : public edm::stream::EDProducer<>
-{
+class CTPPSLocalTrackLiteProducer : public edm::stream::EDProducer<> {
 public:
   explicit CTPPSLocalTrackLiteProducer(const edm::ParameterSet&);
 
@@ -55,17 +54,16 @@ private:
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(const edm::ParameterSet& iConfig) :
-  includeStrips_  (iConfig.getParameter<bool>("includeStrips")),
-  includeDiamonds_(iConfig.getParameter<bool>("includeDiamonds")),
-  includePixels_  (iConfig.getParameter<bool>("includePixels")),
-  pixelTrackTxMin_(iConfig.getParameter<double>("pixelTrackTxMin")),
-  pixelTrackTxMax_(iConfig.getParameter<double>("pixelTrackTxMax")),
-  pixelTrackTyMin_(iConfig.getParameter<double>("pixelTrackTyMin")),
-  pixelTrackTyMax_(iConfig.getParameter<double>("pixelTrackTyMax")),
-  timingTrackTMin_(iConfig.getParameter<double>("timingTrackTMin")),
-  timingTrackTMax_(iConfig.getParameter<double>("timingTrackTMax"))
-{
+CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(const edm::ParameterSet& iConfig)
+    : includeStrips_(iConfig.getParameter<bool>("includeStrips")),
+      includeDiamonds_(iConfig.getParameter<bool>("includeDiamonds")),
+      includePixels_(iConfig.getParameter<bool>("includePixels")),
+      pixelTrackTxMin_(iConfig.getParameter<double>("pixelTrackTxMin")),
+      pixelTrackTxMax_(iConfig.getParameter<double>("pixelTrackTxMax")),
+      pixelTrackTyMin_(iConfig.getParameter<double>("pixelTrackTyMin")),
+      pixelTrackTyMax_(iConfig.getParameter<double>("pixelTrackTyMax")),
+      timingTrackTMin_(iConfig.getParameter<double>("timingTrackTMin")),
+      timingTrackTMax_(iConfig.getParameter<double>("timingTrackTMax")) {
   auto tagSiStripTrack = iConfig.getParameter<edm::InputTag>("tagSiStripTrack");
   if (!tagSiStripTrack.label().empty())
     siStripTrackToken_ = consumes<edm::DetSetVector<TotemRPLocalTrack> >(tagSiStripTrack);
@@ -83,9 +81,7 @@ CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(const edm::ParameterSet
 
 //----------------------------------------------------------------------------------------------------
 
-void
-CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
-{
+void CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
   // prepare output
   auto pOut = std::make_unique<CTPPSLocalTrackLiteCollection>();
 
@@ -111,14 +107,23 @@ CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
         float roundedTxSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTxSigma());
         float roundedTy = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTy());
         float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTySigma());
-        float roundedChiSquaredOverNDF = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
+        float roundedChiSquaredOverNDF =
+            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
 
-        pOut->emplace_back(
-          rpId, // detector info
-          roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma, // spatial info
-          roundedTx, roundedTxSigma, roundedTy, roundedTySigma, // angular info
-          roundedChiSquaredOverNDF, CTPPSpixelLocalTrackReconstructionInfo::invalid, trk.getNumberOfPointsUsedForFit(), // reconstruction info
-          0., 0. // timing info
+        pOut->emplace_back(rpId,  // detector info
+                           roundedX0,
+                           roundedX0Sigma,
+                           roundedY0,
+                           roundedY0Sigma,  // spatial info
+                           roundedTx,
+                           roundedTxSigma,
+                           roundedTy,
+                           roundedTySigma,  // angular info
+                           roundedChiSquaredOverNDF,
+                           CTPPSpixelLocalTrackReconstructionInfo::invalid,
+                           trk.getNumberOfPointsUsedForFit(),  // reconstruction info
+                           0.,
+                           0.  // timing info
         );
       }
     }
@@ -138,7 +143,7 @@ CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
         if (!trk.isValid())
           continue;
 
-        const float abs_time = trk.getT()+trk.getOOTIndex()*HPTDC_TIME_SLICE_WIDTH;
+        const float abs_time = trk.getT() + trk.getOOTIndex() * HPTDC_TIME_SLICE_WIDTH;
         if (abs_time < timingTrackTMin_ || abs_time > timingTrackTMax_)
           continue;
 
@@ -149,34 +154,40 @@ CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
         float roundedT = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(abs_time);
         float roundedTSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getTSigma());
 
-        pOut->emplace_back(
-          rpId, // detector info
-          roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma, // spatial info
-          0., 0., 0., 0., // angular info
-          0., CTPPSpixelLocalTrackReconstructionInfo::invalid, trk.getNumOfPlanes(), // reconstruction info
-          roundedT, roundedTSigma // timing info
+        pOut->emplace_back(rpId,  // detector info
+                           roundedX0,
+                           roundedX0Sigma,
+                           roundedY0,
+                           roundedY0Sigma,  // spatial info
+                           0.,
+                           0.,
+                           0.,
+                           0.,  // angular info
+                           0.,
+                           CTPPSpixelLocalTrackReconstructionInfo::invalid,
+                           trk.getNumOfPlanes(),  // reconstruction info
+                           roundedT,
+                           roundedTSigma  // timing info
         );
       }
     }
   }
 
-
   //----- pixel detectors
 
   if (includePixels_) {
     edm::Handle<edm::DetSetVector<CTPPSPixelLocalTrack> > inputPixelTracks;
-    if (!pixelTrackToken_.isUninitialized()){
+    if (!pixelTrackToken_.isUninitialized()) {
       iEvent.getByToken(pixelTrackToken_, inputPixelTracks);
 
-    // process tracks from pixels
+      // process tracks from pixels
       for (const auto& rpv : *inputPixelTracks) {
         const uint32_t rpId = rpv.detId();
         for (const auto& trk : rpv) {
           if (!trk.isValid())
             continue;
-          if (trk.getTx() > pixelTrackTxMin_ && trk.getTx() < pixelTrackTxMax_
-           && trk.getTy() > pixelTrackTyMin_ && trk.getTy() < pixelTrackTyMax_) {
-
+          if (trk.getTx() > pixelTrackTxMin_ && trk.getTx() < pixelTrackTxMax_ && trk.getTy() > pixelTrackTyMin_ &&
+              trk.getTy() < pixelTrackTyMax_) {
             float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(trk.getX0());
             float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getX0Sigma());
             float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
@@ -185,14 +196,23 @@ CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
             float roundedTxSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTxSigma());
             float roundedTy = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTy());
             float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTySigma());
-            float roundedChiSquaredOverNDF = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
+            float roundedChiSquaredOverNDF =
+                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
 
-            pOut->emplace_back(
-              rpId, // detector info
-              roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma, // spatial info
-              roundedTx, roundedTxSigma, roundedTy, roundedTySigma, // angular info
-              roundedChiSquaredOverNDF, trk.getRecoInfo(), trk.getNumberOfPointsUsedForFit(), // reconstruction info
-              0., 0. // timing info
+            pOut->emplace_back(rpId,  // detector info
+                               roundedX0,
+                               roundedX0Sigma,
+                               roundedY0,
+                               roundedY0Sigma,  // spatial info
+                               roundedTx,
+                               roundedTxSigma,
+                               roundedTy,
+                               roundedTySigma,  // angular info
+                               roundedChiSquaredOverNDF,
+                               trk.getRecoInfo(),
+                               trk.getNumberOfPointsUsedForFit(),  // reconstruction info
+                               0.,
+                               0.  // timing info
             );
           }
         }
@@ -206,9 +226,7 @@ CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSetup&)
 
 //----------------------------------------------------------------------------------------------------
 
-void
-CTPPSLocalTrackLiteProducer::fillDescriptions(edm::ConfigurationDescriptions& descr)
-{
+void CTPPSLocalTrackLiteProducer::fillDescriptions(edm::ConfigurationDescriptions& descr) {
   edm::ParameterSetDescription desc;
 
   // By default: all includeXYZ flags set to false.
@@ -217,23 +235,21 @@ CTPPSLocalTrackLiteProducer::fillDescriptions(edm::ConfigurationDescriptions& de
 
   desc.add<bool>("includeStrips", false)->setComment("whether tracks from Si strips should be included");
   desc.add<edm::InputTag>("tagSiStripTrack", edm::InputTag("totemRPLocalTrackFitter"))
-    ->setComment("input TOTEM strips' local tracks collection to retrieve");
+      ->setComment("input TOTEM strips' local tracks collection to retrieve");
 
   desc.add<bool>("includeDiamonds", false)->setComment("whether tracks from diamonds strips should be included");
   desc.add<edm::InputTag>("tagDiamondTrack", edm::InputTag("ctppsDiamondLocalTracks"))
-    ->setComment("input diamond detectors' local tracks collection to retrieve");
+      ->setComment("input diamond detectors' local tracks collection to retrieve");
 
   desc.add<bool>("includePixels", false)->setComment("whether tracks from pixels should be included");
   desc.add<edm::InputTag>("tagPixelTrack", edm::InputTag("ctppsPixelLocalTracks"))
-    ->setComment("input pixel detectors' local tracks collection to retrieve");
-  desc.add<double>("timingTrackTMin", -12.5)
-    ->setComment("minimal track time selection for timing detectors, in ns");
-  desc.add<double>("timingTrackTMax", +12.5)
-    ->setComment("maximal track time selection for timing detectors, in ns");
+      ->setComment("input pixel detectors' local tracks collection to retrieve");
+  desc.add<double>("timingTrackTMin", -12.5)->setComment("minimal track time selection for timing detectors, in ns");
+  desc.add<double>("timingTrackTMax", +12.5)->setComment("maximal track time selection for timing detectors, in ns");
 
-  desc.add<double>("pixelTrackTxMin",-10.0);
+  desc.add<double>("pixelTrackTxMin", -10.0);
   desc.add<double>("pixelTrackTxMax", 10.0);
-  desc.add<double>("pixelTrackTyMin",-10.0);
+  desc.add<double>("pixelTrackTyMin", -10.0);
   desc.add<double>("pixelTrackTyMax", 10.0);
 
   descr.add("ctppsLocalTrackLiteDefaultProducer", desc);
@@ -242,4 +258,3 @@ CTPPSLocalTrackLiteProducer::fillDescriptions(edm::ConfigurationDescriptions& de
 //----------------------------------------------------------------------------------------------------
 
 DEFINE_FWK_MODULE(CTPPSLocalTrackLiteProducer);
-

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -55,9 +55,9 @@ private:
 //----------------------------------------------------------------------------------------------------
 
 CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(const edm::ParameterSet& iConfig)
-    : includeStrips_(iConfig.getParameter<bool>("includeStrips")),
+    : includeStrips_  (iConfig.getParameter<bool>("includeStrips")),
       includeDiamonds_(iConfig.getParameter<bool>("includeDiamonds")),
-      includePixels_(iConfig.getParameter<bool>("includePixels")),
+      includePixels_  (iConfig.getParameter<bool>("includePixels")),
       pixelTrackTxMin_(iConfig.getParameter<double>("pixelTrackTxMin")),
       pixelTrackTxMax_(iConfig.getParameter<double>("pixelTrackTxMax")),
       pixelTrackTyMin_(iConfig.getParameter<double>("pixelTrackTyMin")),
@@ -111,19 +111,23 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSe
             MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
 
         pOut->emplace_back(rpId,  // detector info
+                           // spatial info
                            roundedX0,
                            roundedX0Sigma,
                            roundedY0,
-                           roundedY0Sigma,  // spatial info
+                           roundedY0Sigma,
+                           // angular info
                            roundedTx,
                            roundedTxSigma,
                            roundedTy,
-                           roundedTySigma,  // angular info
+                           roundedTySigma,
+                           // reconstruction info
                            roundedChiSquaredOverNDF,
                            CTPPSpixelLocalTrackReconstructionInfo::invalid,
-                           trk.getNumberOfPointsUsedForFit(),  // reconstruction info
+                           trk.getNumberOfPointsUsedForFit(),
+                           // timing info
                            0.,
-                           0.  // timing info
+                           0.
         );
       }
     }
@@ -155,19 +159,23 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSe
         float roundedTSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getTSigma());
 
         pOut->emplace_back(rpId,  // detector info
+                           // spatial info
                            roundedX0,
                            roundedX0Sigma,
                            roundedY0,
-                           roundedY0Sigma,  // spatial info
+                           roundedY0Sigma,
+                           // angular info
                            0.,
                            0.,
                            0.,
-                           0.,  // angular info
+                           0.,
+                           // reconstruction info
                            0.,
                            CTPPSpixelLocalTrackReconstructionInfo::invalid,
-                           trk.getNumOfPlanes(),  // reconstruction info
+                           trk.getNumOfPlanes(),
+                           // timing info
                            roundedT,
-                           roundedTSigma  // timing info
+                           roundedTSigma
         );
       }
     }
@@ -200,19 +208,23 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event& iEvent, const edm::EventSe
                 MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
 
             pOut->emplace_back(rpId,  // detector info
+                               // spatial info
                                roundedX0,
                                roundedX0Sigma,
                                roundedY0,
-                               roundedY0Sigma,  // spatial info
+                               roundedY0Sigma,
+                               // angular info
                                roundedTx,
                                roundedTxSigma,
                                roundedTy,
-                               roundedTySigma,  // angular info
+                               roundedTySigma,
+                               // reconstruction info
                                roundedChiSquaredOverNDF,
                                trk.getRecoInfo(),
-                               trk.getNumberOfPointsUsedForFit(),  // reconstruction info
+                               trk.getNumberOfPointsUsedForFit(),
+                               // timing info
                                0.,
-                               0.  // timing info
+                               0.
             );
           }
         }
@@ -258,3 +270,4 @@ void CTPPSLocalTrackLiteProducer::fillDescriptions(edm::ConfigurationDescription
 //----------------------------------------------------------------------------------------------------
 
 DEFINE_FWK_MODULE(CTPPSLocalTrackLiteProducer);
+

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -222,9 +222,9 @@ CTPPSLocalTrackLiteProducer::fillDescriptions( edm::ConfigurationDescriptions& d
   desc.add<bool>( "doNothing", false ) // enable the module by default
     ->setComment( "disable the module" );
   desc.add<double>( "timingTrackTMin", -1000. )
-    ->setComment( "minimal track time selection for timing detectors" );
+    ->setComment( "minimal track time selection for timing detectors, in ns" );
   desc.add<double>( "timingTrackTMax", +1000. )
-    ->setComment( "maximal track time selection for timing detectors" );
+    ->setComment( "maximal track time selection for timing detectors, in ns" );
 
   desc.add<double>("pixelTrackTxMin",-10.0);
   desc.add<double>("pixelTrackTxMax", 10.0);

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -52,26 +52,29 @@ private:
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(const edm::ParameterSet& iConfig)
+CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(const edm::ParameterSet& iConfig) :
+  includeStrips_    (iConfig.getParameter<bool>("includeStrips")),
+  includeDiamonds_  (iConfig.getParameter<bool>("includeDiamonds")),
+  includePixels_    (iConfig.getParameter<bool>("includePixels")),
+  pixelTrackTxMin_  (iConfig.getParameter<double>("pixelTrackTxMin")),
+  pixelTrackTxMax_  (iConfig.getParameter<double>("pixelTrackTxMax")),
+  pixelTrackTyMin_  (iConfig.getParameter<double>("pixelTrackTyMin")),
+  pixelTrackTyMax_  (iConfig.getParameter<double>("pixelTrackTyMax")),
+  timingTrackTMin_  (iConfig.getParameter<double>("timingTrackTMin")),
+  timingTrackTMax_  (iConfig.getParameter<double>("timingTrackTMax"))
 {
-  includeStrips_ = iConfig.getParameter<bool>("includeStrips");
-  siStripTrackToken_ = consumes<edm::DetSetVector<TotemRPLocalTrack> >(iConfig.getParameter<edm::InputTag>("tagSiStripTrack"));
+  auto tagSiStripTrack = iConfig.getParameter<edm::InputTag>("tagSiStripTrack");
+  if (!tagSiStripTrack.label().empty())
+    siStripTrackToken_ = consumes<edm::DetSetVector<TotemRPLocalTrack> >(tagSiStripTrack);
 
-  includeDiamonds_ = iConfig.getParameter<bool>("includeDiamonds");
-  diamondTrackToken_ = consumes<edm::DetSetVector<CTPPSDiamondLocalTrack> >(iConfig.getParameter<edm::InputTag>("tagDiamondTrack"));
+  auto tagDiamondTrack = iConfig.getParameter<edm::InputTag>("tagDiamondTrack");
+  if (!tagDiamondTrack.label().empty())
+    diamondTrackToken_ = consumes<edm::DetSetVector<CTPPSDiamondLocalTrack> >(tagDiamondTrack);
 
-  timingTrackTMin_ = iConfig.getParameter<double>("timingTrackTMin");
-  timingTrackTMax_ = iConfig.getParameter<double>("timingTrackTMax");
-
-  includePixels_ = iConfig.getParameter<bool>("includePixels");
   auto tagPixelTrack = iConfig.getParameter<edm::InputTag>("tagPixelTrack");
   if (!tagPixelTrack.label().empty())
     pixelTrackToken_ = consumes<edm::DetSetVector<CTPPSPixelLocalTrack> >(tagPixelTrack);
 
-  pixelTrackTxMin_ = iConfig.getParameter<double>("pixelTrackTxMin");
-  pixelTrackTxMax_ = iConfig.getParameter<double>("pixelTrackTxMax");
-  pixelTrackTyMin_ = iConfig.getParameter<double>("pixelTrackTyMin");
-  pixelTrackTyMax_ = iConfig.getParameter<double>("pixelTrackTyMax");
   produces<std::vector<CTPPSLocalTrackLite> >();
 }
 


### PR DESCRIPTION
#### PR description:

The size of the time slice for tracks in PPS diamond timing detectors is reduced to the one 25 ns window of interest at the `miniAOD` lite data format level.

#### PR validation:

Compiles, and runs for the 2017-2018 periods where PPS diamond were in place and calibrated.

#### if this PR is a backport please specify the original PR: N/A

Before submitting your pull requests, make sure you followed this checklist:
- [x] verify that the PR is really intended for the chosen branch
- [x] verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- [x] verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
