### PR TITLE
BugFix for the reconstruction_fromReco sequences: https://github.com/cms-sw/cmssw/issues/26500

### DIFF
--- a/Configuration/ProcessModifiers/python/recoFromReco_cff.py
+++ b/Configuration/ProcessModifiers/python/recoFromReco_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier sets the flag used to run the showerDigiInfo off in the reco from reco step4
+recoFromReco = cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2742,6 +2742,7 @@ steps['RECOFROMRECO']=merge([{'-s':'RECO,EI',
                               '--process':'reRECO',
                               '--datatier':'AODSIM',
                               '--eventcontent':'AODSIM',
+                              '--procModifiers':'recoFromReco', 
                               },
                              stCond,step3Defaults])
 

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
@@ -18,9 +18,7 @@ RecoLocalMuonRECO = cms.PSet(
         'keep *_dt4DCosmicSegments_*_*',
         'keep *_csc2DRecHits_*_*', 
         'keep *_cscSegments_*_*', 
-        'keep *_rpcRecHits_*_*',
-        'keep *_muonDTDigis_*_*',
-        'keep *_muonCSCDigis_MuonCSCStripDigi_*')
+        'keep *_rpcRecHits_*_*')
 )
 # AOD content
 RecoLocalMuonAOD = cms.PSet(

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -102,7 +102,7 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toModify(muons1stStep, minPt = 0.8)
 
 from Configuration.ProcessModifiers.recoFromReco_cff import recoFromReco
-recoFromReco.toModify(muons1stStep,fillShowerDigis = cms.bool(False))
+recoFromReco.toModify(muons1stStep,fillShowerDigis = False)
 
 
 

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -100,3 +100,11 @@ muonEcalDetIds = cms.EDProducer("InterestingEcalDetIdProducer",
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toModify(muons1stStep, minPt = 0.8)
+
+from Configuration.ProcessModifiers.recoFromReco_cff import recoFromReco
+recoFromReco.toModify(muons1stStep,fillShowerDigis = cms.bool(False))
+
+
+
+
+   


### PR DESCRIPTION
#### PR description:

This PR follows up the #26602 (fix has been implemented). In addition to #26602 it reverts the #26501.

#### PR validation:
Validation of the process runTheMatrix.py -l 1102.0 has been successfully done.

