### PR TITLE
Fix dressed lepton constituents, add tau ghosts

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -123,6 +123,7 @@ void ParticleLevelProducer::produce(edm::Event& event, const edm::EventSetup& ev
 
   // Prompt leptons
   int iConstituent = -1;
+  int iTag = -1;
   for ( auto const & lepton : rivetAnalysis_->leptons() ) {
     reco::GenJet lepJet;
     lepJet.setP4(p4(lepton));
@@ -130,13 +131,18 @@ void ParticleLevelProducer::produce(edm::Event& event, const edm::EventSetup& ev
     lepJet.setPdgId(lepton.pdgId());
     lepJet.setCharge(lepton.charge());
     
-    const auto& cl = lepton.constituentLepton();
-    consts->push_back(reco::GenParticle(cl.charge(), p4(cl), genVertex_, cl.pdgId(), 1, true));
-    lepJet.addDaughter(edm::refToPtr(reco::GenParticleRef(constsRefHandle, ++iConstituent)));
-    
-    for ( auto const & p : lepton.constituentPhotons()) {
-      consts->push_back(reco::GenParticle(p.charge(), p4(p), genVertex_, p.pdgId(), 1, true));
-      lepJet.addDaughter(edm::refToPtr(reco::GenParticleRef(constsRefHandle, ++iConstituent)));
+    for ( auto const & p : lepton.constituents()) {
+      // ghost taus (momentum scaled with 10e-20 in RivetAnalysis.h already)
+      if (p.abspid() == 15) {
+        std::cout << "Adding ghost: " << p << std::endl;
+        tags->push_back(reco::GenParticle(p.charge(), p4(p), genVertex_, p.pdgId(), 2, true));
+        lepJet.addDaughter(edm::refToPtr(reco::GenParticleRef(tagsRefHandle, ++iTag)));
+      }
+      // electrons, muons, photons
+      else {
+        consts->push_back(reco::GenParticle(p.charge(), p4(p), genVertex_, p.pdgId(), 1, true));
+        lepJet.addDaughter(edm::refToPtr(reco::GenParticleRef(constsRefHandle, ++iConstituent)));
+      }
     }
     
     leptons->push_back(lepJet);
@@ -144,7 +150,6 @@ void ParticleLevelProducer::produce(edm::Event& event, const edm::EventSetup& ev
   std::sort(leptons->begin(), leptons->end(), GreaterByPt<reco::GenJet>());
 
   // Jets with constituents and tag particles
-  int iTag = -1;
   for ( auto jet : rivetAnalysis_->jets() ) {
     addGenJet(jet, jets, consts, constsRefHandle, iConstituent, tags, tagsRefHandle, iTag);
   }

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -134,7 +134,6 @@ void ParticleLevelProducer::produce(edm::Event& event, const edm::EventSetup& ev
     for ( auto const & p : lepton.constituents()) {
       // ghost taus (momentum scaled with 10e-20 in RivetAnalysis.h already)
       if (p.abspid() == 15) {
-        std::cout << "Adding ghost: " << p << std::endl;
         tags->push_back(reco::GenParticle(p.charge(), p4(p), genVertex_, p.pdgId(), 2, true));
         lepJet.addDaughter(edm::refToPtr(reco::GenParticleRef(tagsRefHandle, ++iTag)));
       }


### PR DESCRIPTION
#### PR description:

* Rivet 2.7.0 requires changes to access dressed lepton constituents (= bare lepton + photons). This did not impact any calculations done with the dressed lepton as a whole.
* Added ghost tau ancestors to identify electrons/muons from tau decays.

#### PR validation:

Tested on ttbar sample, number of dressed lepton constituents has entries >1 as expected again. Tau ghosts increase number of constituents and show up in the `tags` collection.
