### PR TITLE
Running code-format for simulation

### DIFF
--- a/SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.cc
@@ -1,45 +1,45 @@
-#include "SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include<iostream>
+#include "SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.h"
+#include <iostream>
 
-
-CastorDigiAnalyzer::CastorDigiAnalyzer(edm::ParameterSet const& conf) 
-: hitReadoutName_("CastorHits"),
-  simParameterMap_(),
-  castorHitAnalyzer_("CASTORDigi", 1., &simParameterMap_, &castorFilter_),
-  castorDigiStatistics_("CASTORDigi", 3, 10., 6., 0.1, 0.5, castorHitAnalyzer_),
-  castorDigiCollectionTag_(conf.getParameter<edm::InputTag>("castorDigiCollectionTag"))
-{
-}
-
+CastorDigiAnalyzer::CastorDigiAnalyzer(edm::ParameterSet const &conf)
+    : hitReadoutName_("CastorHits"), simParameterMap_(),
+      castorHitAnalyzer_("CASTORDigi", 1., &simParameterMap_, &castorFilter_),
+      castorDigiStatistics_("CASTORDigi", 3, 10., 6., 0.1, 0.5,
+                            castorHitAnalyzer_),
+      castorDigiCollectionTag_(
+          conf.getParameter<edm::InputTag>("castorDigiCollectionTag")) {}
 
 namespace CastorDigiAnalyzerImpl {
-  template<class Collection>
-  void analyze(edm::Event const& e, CastorDigiStatistics & statistics, edm::InputTag& tag) {
-    edm::Handle<Collection> digis;
-    e.getByLabel(tag, digis);
-    if (!digis.isValid()) {
-      edm::LogError("CastorDigiAnalyzer") << "Could not find Castor Digi Container ";
-    } else {
-      for(unsigned i = 0; i < digis->size(); ++i) {
-        statistics.analyze((*digis)[i]);
-      }
+template <class Collection>
+void analyze(edm::Event const &e, CastorDigiStatistics &statistics,
+             edm::InputTag &tag) {
+  edm::Handle<Collection> digis;
+  e.getByLabel(tag, digis);
+  if (!digis.isValid()) {
+    edm::LogError("CastorDigiAnalyzer")
+        << "Could not find Castor Digi Container ";
+  } else {
+    for (unsigned i = 0; i < digis->size(); ++i) {
+      statistics.analyze((*digis)[i]);
     }
   }
 }
+} // namespace CastorDigiAnalyzerImpl
 
-
-void CastorDigiAnalyzer::analyze(edm::Event const& e, edm::EventSetup const& c) {
+void CastorDigiAnalyzer::analyze(edm::Event const &e,
+                                 edm::EventSetup const &c) {
   //  edm::Handle<edm::PCaloHitContainer> hits;
-edm::Handle<CrossingFrame<PCaloHit> > castorcf;
+  edm::Handle<CrossingFrame<PCaloHit>> castorcf;
 
-e.getByLabel("mix", "g4SimHitsCastorFI", castorcf);
+  e.getByLabel("mix", "g4SimHitsCastorFI", castorcf);
 
-
-//access to SimHits
-std::unique_ptr<MixCollection<PCaloHit> > hits(new MixCollection<PCaloHit>(castorcf.product()));
-//  if (hits.isValid()) {
-    castorHitAnalyzer_.fillHits(*hits);
-    CastorDigiAnalyzerImpl::analyze<CastorDigiCollection>(e, castorDigiStatistics_, castorDigiCollectionTag_);
-  }
+  // access to SimHits
+  std::unique_ptr<MixCollection<PCaloHit>> hits(
+      new MixCollection<PCaloHit>(castorcf.product()));
+  //  if (hits.isValid()) {
+  castorHitAnalyzer_.fillHits(*hits);
+  CastorDigiAnalyzerImpl::analyze<CastorDigiCollection>(
+      e, castorDigiStatistics_, castorDigiCollectionTag_);
+}

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.h
@@ -1,30 +1,26 @@
 #ifndef CastorSim_CastorDigiAnalyzer_h
 #define CastorSim_CastorDigiAnalyzer_h
 
-#include "SimCalorimetry/CaloSimAlgos/interface/CaloHitAnalyzer.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "SimCalorimetry/CastorSim/src/CastorSimParameterMap.h"
-#include "SimCalorimetry/CastorSim/src/CastorHitFilter.h"
-#include "SimCalorimetry/CastorSim/plugins/CastorDigiStatistics.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloHitAnalyzer.h"
+#include "SimCalorimetry/CastorSim/plugins/CastorDigiStatistics.h"
+#include "SimCalorimetry/CastorSim/src/CastorHitFilter.h"
+#include "SimCalorimetry/CastorSim/src/CastorSimParameterMap.h"
 #include <string>
 
 /**  Castor digis
  Author: Panos Katsas
 */
 
-
-class CastorDigiAnalyzer : public edm::one::EDAnalyzer<>
-{
+class CastorDigiAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-
-  explicit CastorDigiAnalyzer(edm::ParameterSet const& conf);
-  void analyze(edm::Event const& e, edm::EventSetup const& c) override;
-
+  explicit CastorDigiAnalyzer(edm::ParameterSet const &conf);
+  void analyze(edm::Event const &e, edm::EventSetup const &c) override;
 
 private:
   std::string hitReadoutName_;
@@ -36,5 +32,3 @@ private:
 };
 
 #endif
-
-

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
@@ -1,45 +1,44 @@
-#include "SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h"
+#include "CalibFormats/CastorObjects/interface/CastorDbRecord.h"
+#include "CalibFormats/CastorObjects/interface/CastorDbService.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
-#include "SimCalorimetry/CaloSimAlgos/interface/CaloShapeIntegrator.h"
-#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "CalibFormats/CastorObjects/interface/CastorDbService.h"
-#include "CalibFormats/CastorObjects/interface/CastorDbRecord.h"
-#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
-#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloShapeIntegrator.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
+#include "SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h"
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
-CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet& ps, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC)
-: theParameterMap(new CastorSimParameterMap(ps)),
-  theCastorShape(new CastorShape()),
-  theCastorIntegratedShape(new CaloShapeIntegrator(theCastorShape)),
-  theCastorResponse(new CaloHitResponse(theParameterMap, theCastorIntegratedShape)),
-  theAmplifier(nullptr),
-  theCoderFactory(nullptr),
-  theElectronicsSim(nullptr),
-  theHitCorrection(nullptr),
-  theCastorDigitizer(nullptr),
-  theCastorHits()
-{
+CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet &ps,
+                                       edm::ProducerBase &mixMod,
+                                       edm::ConsumesCollector &iC)
+    : theParameterMap(new CastorSimParameterMap(ps)),
+      theCastorShape(new CastorShape()),
+      theCastorIntegratedShape(new CaloShapeIntegrator(theCastorShape)),
+      theCastorResponse(
+          new CaloHitResponse(theParameterMap, theCastorIntegratedShape)),
+      theAmplifier(nullptr), theCoderFactory(nullptr),
+      theElectronicsSim(nullptr), theHitCorrection(nullptr),
+      theCastorDigitizer(nullptr), theCastorHits() {
   theHitsProducerTag = ps.getParameter<edm::InputTag>("hitsProducer");
-  iC.consumes<std::vector<PCaloHit> >(theHitsProducerTag);
-  
+  iC.consumes<std::vector<PCaloHit>>(theHitsProducerTag);
+
   mixMod.produces<CastorDigiCollection>();
 
   theCastorResponse->setHitFilter(&theCastorHitFilter);
 
   bool doTimeSlew = ps.getParameter<bool>("doTimeSlew");
-  if(doTimeSlew) {
+  if (doTimeSlew) {
     // no time slewing for HF
     theCastorResponse->setHitCorrection(theHitCorrection);
   }
@@ -49,17 +48,18 @@ CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet& ps, edm::Produce
   theCoderFactory = new CastorCoderFactory(CastorCoderFactory::DB);
   theElectronicsSim = new CastorElectronicsSim(theAmplifier, theCoderFactory);
 
-  theCastorDigitizer = new CastorDigitizer(theCastorResponse, theElectronicsSim, doNoise);
+  theCastorDigitizer =
+      new CastorDigitizer(theCastorResponse, theElectronicsSim, doNoise);
 
   edm::Service<edm::RandomNumberGenerator> rng;
-  if ( ! rng.isAvailable()) {
+  if (!rng.isAvailable()) {
     throw cms::Exception("Configuration")
-      << "CastorDigiProducer requires the RandomNumberGeneratorService\n"
-         "which is not present in the configuration file.  You must add the service\n"
-         "in the configuration file or remove the modules that require it.";
+        << "CastorDigiProducer requires the RandomNumberGeneratorService\n"
+           "which is not present in the configuration file.  You must add the "
+           "service\n"
+           "in the configuration file or remove the modules that require it.";
   }
 }
-
 
 CastorDigiProducer::~CastorDigiProducer() {
   delete theCastorDigitizer;
@@ -73,7 +73,8 @@ CastorDigiProducer::~CastorDigiProducer() {
   delete theHitCorrection;
 }
 
-void CastorDigiProducer::initializeEvent(edm::Event const& event, edm::EventSetup const& eventSetup) {
+void CastorDigiProducer::initializeEvent(edm::Event const &event,
+                                         edm::EventSetup const &eventSetup) {
   // get the appropriate gains, noises, & widths for this event
   edm::ESHandle<CastorDbService> conditions;
   eventSetup.get<CastorDbRecord>().get(conditions);
@@ -89,46 +90,53 @@ void CastorDigiProducer::initializeEvent(edm::Event const& event, edm::EventSetu
 
   // get the correct geometry
   checkGeometry(eventSetup);
-  
+
   theCastorHits.clear();
 
   theCastorDigitizer->initializeHits();
 }
 
-void CastorDigiProducer::accumulateCaloHits(std::vector<PCaloHit> const& hcalHits, int bunchCrossing) {
-  //fillFakeHits();
+void CastorDigiProducer::accumulateCaloHits(
+    std::vector<PCaloHit> const &hcalHits, int bunchCrossing) {
+  // fillFakeHits();
 
-  if(theHitCorrection != nullptr) {
+  if (theHitCorrection != nullptr) {
     theHitCorrection->fillChargeSums(hcalHits);
   }
   theCastorDigitizer->add(hcalHits, bunchCrossing, randomEngine_);
 }
 
-void CastorDigiProducer::accumulate(edm::Event const& e, edm::EventSetup const&) {
-  // Step A: Get and accumulate digitized hits 
-  edm::Handle<std::vector<PCaloHit> > castorHandle;
+void CastorDigiProducer::accumulate(edm::Event const &e,
+                                    edm::EventSetup const &) {
+  // Step A: Get and accumulate digitized hits
+  edm::Handle<std::vector<PCaloHit>> castorHandle;
   e.getByLabel(theHitsProducerTag, castorHandle);
 
   accumulateCaloHits(*castorHandle.product(), 0);
 }
 
-void CastorDigiProducer::accumulate(PileUpEventPrincipal const& e, edm::EventSetup const&, edm::StreamID const& streamID) {
-  // Step A: Get and accumulate digitized hits 
-  edm::Handle<std::vector<PCaloHit> > castorHandle;
+void CastorDigiProducer::accumulate(PileUpEventPrincipal const &e,
+                                    edm::EventSetup const &,
+                                    edm::StreamID const &streamID) {
+  // Step A: Get and accumulate digitized hits
+  edm::Handle<std::vector<PCaloHit>> castorHandle;
   e.getByLabel(theHitsProducerTag, castorHandle);
 
   accumulateCaloHits(*castorHandle.product(), e.bunchCrossing());
 }
 
-void CastorDigiProducer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSetup) {
+void CastorDigiProducer::finalizeEvent(edm::Event &e,
+                                       const edm::EventSetup &eventSetup) {
   // Step B: Create empty output
 
-  std::unique_ptr<CastorDigiCollection> castorResult(new CastorDigiCollection());
+  std::unique_ptr<CastorDigiCollection> castorResult(
+      new CastorDigiCollection());
 
   // Step C: Invoke the algorithm, getting back outputs.
   theCastorDigitizer->run(*castorResult, randomEngine_);
 
-  edm::LogInfo("CastorDigiProducer") << "HCAL/Castor digis   : " << castorResult->size();
+  edm::LogInfo("CastorDigiProducer")
+      << "HCAL/Castor digis   : " << castorResult->size();
 
   // Step D: Put outputs into event
   e.put(std::move(castorResult));
@@ -136,35 +144,36 @@ void CastorDigiProducer::finalizeEvent(edm::Event& e, const edm::EventSetup& eve
   randomEngine_ = nullptr; // to prevent access outside event
 }
 
-
-void CastorDigiProducer::sortHits(const edm::PCaloHitContainer & hits){
-  for(edm::PCaloHitContainer::const_iterator hitItr = hits.begin();
-      hitItr != hits.end(); ++hitItr){
+void CastorDigiProducer::sortHits(const edm::PCaloHitContainer &hits) {
+  for (edm::PCaloHitContainer::const_iterator hitItr = hits.begin();
+       hitItr != hits.end(); ++hitItr) {
     DetId detId = hitItr->id();
-    if (detId.det()==DetId::Calo && detId.subdetId()==HcalCastorDetId::SubdetectorId){
+    if (detId.det() == DetId::Calo &&
+        detId.subdetId() == HcalCastorDetId::SubdetectorId) {
       theCastorHits.push_back(*hitItr);
+    } else {
+      edm::LogError("CastorDigiProducer")
+          << "Bad Hit subdetector " << detId.subdetId();
     }
-      else {
-	edm::LogError("CastorDigiProducer") << "Bad Hit subdetector " << detId.subdetId();
-      }
   }
 }
 
 void CastorDigiProducer::fillFakeHits() {
-  HcalCastorDetId castorDetId(HcalCastorDetId::Section(2),true,1,1);
+  HcalCastorDetId castorDetId(HcalCastorDetId::Section(2), true, 1, 1);
 
   theCastorHits.emplace_back(castorDetId.rawId(), 50.0, 0.);
 }
 
-
-void CastorDigiProducer::checkGeometry(const edm::EventSetup & eventSetup) {
+void CastorDigiProducer::checkGeometry(const edm::EventSetup &eventSetup) {
   // TODO find a way to avoid doing this every event
   edm::ESHandle<CaloGeometry> geometry;
   eventSetup.get<CaloGeometryRecord>().get(geometry);
   theCastorResponse->setGeometry(&*geometry);
 
-  const std::vector<DetId>& castorCells = geometry->getValidDetIds(DetId::Calo, HcalCastorDetId::SubdetectorId);
+  const std::vector<DetId> &castorCells =
+      geometry->getValidDetIds(DetId::Calo, HcalCastorDetId::SubdetectorId);
 
-  //std::cout<<"CastorDigiProducer::CheckGeometry number of cells: "<<castorCells.size()<<std::endl;
+  // std::cout<<"CastorDigiProducer::CheckGeometry number of cells:
+  // "<<castorCells.size()<<std::endl;
   theCastorDigitizer->setDetIds(castorCells);
 }

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
@@ -1,32 +1,32 @@
 #ifndef CastorDigiProducer_h
 #define CastorDigiProducer_h
 
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "SimCalorimetry/CastorSim/src/CastorDigitizerTraits.h"
-#include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
-#include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
-#include "SimCalorimetry/CastorSim/src/CastorSimParameterMap.h"
-#include "SimCalorimetry/CastorSim/src/CastorShape.h"
-#include "SimCalorimetry/CastorSim/src/CastorElectronicsSim.h"
-#include "SimCalorimetry/CastorSim/src/CastorHitFilter.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
 #include "SimCalorimetry/CastorSim/src/CastorAmplifier.h"
 #include "SimCalorimetry/CastorSim/src/CastorCoderFactory.h"
+#include "SimCalorimetry/CastorSim/src/CastorDigitizerTraits.h"
+#include "SimCalorimetry/CastorSim/src/CastorElectronicsSim.h"
 #include "SimCalorimetry/CastorSim/src/CastorHitCorrection.h"
+#include "SimCalorimetry/CastorSim/src/CastorHitFilter.h"
+#include "SimCalorimetry/CastorSim/src/CastorShape.h"
+#include "SimCalorimetry/CastorSim/src/CastorSimParameterMap.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 
 #include <vector>
 
 namespace edm {
-  class StreamID;
-  class ConsumesCollector;
-}
+class StreamID;
+class ConsumesCollector;
+} // namespace edm
 
 namespace CLHEP {
-  class HepRandomEngine;
+class HepRandomEngine;
 }
 
 class PCaloHit;
@@ -34,53 +34,52 @@ class PileUpEventPrincipal;
 
 class CastorDigiProducer : public DigiAccumulatorMixMod {
 public:
-
-  explicit CastorDigiProducer(const edm::ParameterSet& ps, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
+  explicit CastorDigiProducer(const edm::ParameterSet &ps,
+                              edm::ProducerBase &mixMod,
+                              edm::ConsumesCollector &iC);
   ~CastorDigiProducer() override;
 
-  void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;
-  void accumulate(edm::Event const& e, edm::EventSetup const& c) override;
-  void accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& c, edm::StreamID const&) override;
-  void finalizeEvent(edm::Event& e, edm::EventSetup const& c) override;
+  void initializeEvent(edm::Event const &e, edm::EventSetup const &c) override;
+  void accumulate(edm::Event const &e, edm::EventSetup const &c) override;
+  void accumulate(PileUpEventPrincipal const &e, edm::EventSetup const &c,
+                  edm::StreamID const &) override;
+  void finalizeEvent(edm::Event &e, edm::EventSetup const &c) override;
 
 private:
-  
-
-  void accumulateCaloHits(std::vector<PCaloHit> const&, int bunchCrossing);
+  void accumulateCaloHits(std::vector<PCaloHit> const &, int bunchCrossing);
 
   /// fills the vectors for each subdetector
-  void sortHits(const edm::PCaloHitContainer & hits);
+  void sortHits(const edm::PCaloHitContainer &hits);
   /// some hits in each subdetector, just for testing purposes
   void fillFakeHits();
   /// make sure the digitizer has the correct list of all cells that
   /// exist in the geometry
-  void checkGeometry(const edm::EventSetup& eventSetup);
+  void checkGeometry(const edm::EventSetup &eventSetup);
 
   edm::InputTag theHitsProducerTag;
 
   /** Reconstruction algorithm*/
   typedef CaloTDigitizer<CastorDigitizerTraits> CastorDigitizer;
- 
-  CastorSimParameterMap * theParameterMap;
-  CaloVShape * theCastorShape;
-  CaloVShape * theCastorIntegratedShape;
 
-  CaloHitResponse * theCastorResponse;
+  CastorSimParameterMap *theParameterMap;
+  CaloVShape *theCastorShape;
+  CaloVShape *theCastorIntegratedShape;
 
-  CastorAmplifier * theAmplifier;
-  CastorCoderFactory * theCoderFactory;
-  CastorElectronicsSim * theElectronicsSim;
+  CaloHitResponse *theCastorResponse;
+
+  CastorAmplifier *theAmplifier;
+  CastorCoderFactory *theCoderFactory;
+  CastorElectronicsSim *theElectronicsSim;
 
   CastorHitFilter theCastorHitFilter;
 
-  CastorHitCorrection * theHitCorrection;
+  CastorHitCorrection *theHitCorrection;
 
-  CastorDigitizer* theCastorDigitizer;
+  CastorDigitizer *theCastorDigitizer;
 
   std::vector<PCaloHit> theCastorHits;
 
-  CLHEP::HepRandomEngine* randomEngine_ = nullptr;
+  CLHEP::HepRandomEngine *randomEngine_ = nullptr;
 };
 
 #endif
-

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiStatistics.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiStatistics.h
@@ -2,31 +2,23 @@
 #define CastorSim_CastorDigiStatistics_h
 
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
-#include "SimCalorimetry/CaloSimAlgos/interface/CaloValidationStatistics.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloHitAnalyzer.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloValidationStatistics.h"
 #include <string>
 
-class CastorDigiStatistics
-{
+class CastorDigiStatistics {
 public:
-  CastorDigiStatistics(std::string name,
-                     int maxBin,
-                     float amplitudeThreshold,
-                     float expectedPedestal,
-                     float binPrevToBinMax,
-                     float binNextToBinMax,
-                     CaloHitAnalyzer & amplitudeAnalyzer)
-:  maxBin_(maxBin),
-   amplitudeThreshold_(amplitudeThreshold),
-   pedestal_(name+" pedestal", expectedPedestal, 0.),
-   binPrevToBinMax_(name+" binPrevToBinMax", binPrevToBinMax, 0.),
-   binNextToBinMax_(name+" binNextToBinMax", binNextToBinMax, 0.),
-   amplitudeAnalyzer_(amplitudeAnalyzer)
-{
-}
+  CastorDigiStatistics(std::string name, int maxBin, float amplitudeThreshold,
+                       float expectedPedestal, float binPrevToBinMax,
+                       float binNextToBinMax,
+                       CaloHitAnalyzer &amplitudeAnalyzer)
+      : maxBin_(maxBin), amplitudeThreshold_(amplitudeThreshold),
+        pedestal_(name + " pedestal", expectedPedestal, 0.),
+        binPrevToBinMax_(name + " binPrevToBinMax", binPrevToBinMax, 0.),
+        binNextToBinMax_(name + " binNextToBinMax", binNextToBinMax, 0.),
+        amplitudeAnalyzer_(amplitudeAnalyzer) {}
 
-  template<class Digi>
-  void analyze(const Digi & digi);
+  template <class Digi> void analyze(const Digi &digi);
 
 private:
   int maxBin_;
@@ -34,41 +26,32 @@ private:
   CaloValidationStatistics pedestal_;
   CaloValidationStatistics binPrevToBinMax_;
   CaloValidationStatistics binNextToBinMax_;
-  CaloHitAnalyzer & amplitudeAnalyzer_;
+  CaloHitAnalyzer &amplitudeAnalyzer_;
 };
 
+template <class Digi> void CastorDigiStatistics::analyze(const Digi &digi) {
+  pedestal_.addEntry(digi[0].adc());
+  pedestal_.addEntry(digi[1].adc());
 
-template<class Digi>
-void CastorDigiStatistics::analyze(const Digi & digi) {
-   pedestal_.addEntry(digi[0].adc());
-   pedestal_.addEntry(digi[1].adc());
-                                                                               
-                                                                               
-   double pedestal_fC = 0.5*(digi[0].nominal_fC() + digi[1].nominal_fC());
-                                                                               
-                                                                              
-  double maxAmplitude = digi[maxBin_].nominal_fC()   - pedestal_fC;
-                                                                              
-  if(maxAmplitude > amplitudeThreshold_) {
-                                                                              
-    double binPrevToBinMax = (digi[maxBin_-1].nominal_fC() - pedestal_fC)
-                           / maxAmplitude;
+  double pedestal_fC = 0.5 * (digi[0].nominal_fC() + digi[1].nominal_fC());
+
+  double maxAmplitude = digi[maxBin_].nominal_fC() - pedestal_fC;
+
+  if (maxAmplitude > amplitudeThreshold_) {
+
+    double binPrevToBinMax =
+        (digi[maxBin_ - 1].nominal_fC() - pedestal_fC) / maxAmplitude;
     binPrevToBinMax_.addEntry(binPrevToBinMax);
-                                                                              
-                                                                              
-    double binNextToBinMax = (digi[maxBin_+1].nominal_fC() - pedestal_fC)
-                           / maxAmplitude;
+
+    double binNextToBinMax =
+        (digi[maxBin_ + 1].nominal_fC() - pedestal_fC) / maxAmplitude;
     binNextToBinMax_.addEntry(binNextToBinMax);
-                                                                              
-    double amplitude = digi[maxBin_].nominal_fC()
-                   + digi[maxBin_+1].nominal_fC()
-                   - 2*pedestal_fC;
-                                                                                
-                                                                                
+
+    double amplitude = digi[maxBin_].nominal_fC() +
+                       digi[maxBin_ + 1].nominal_fC() - 2 * pedestal_fC;
+
     amplitudeAnalyzer_.analyze(digi.id().rawId(), amplitude);
-                                                                                
   }
 }
 
 #endif
-

--- a/SimCalorimetry/CastorSim/plugins/CastorHitAnalyzer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorHitAnalyzer.cc
@@ -1,45 +1,39 @@
-#include "SimCalorimetry/CastorSim/plugins/CastorHitAnalyzer.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include<iostream>
+#include "SimCalorimetry/CastorSim/plugins/CastorHitAnalyzer.h"
+#include <iostream>
 
-
-CastorHitAnalyzer::CastorHitAnalyzer(edm::ParameterSet const& conf) 
-  : hitReadoutName_("CastorHits"),
-  simParameterMap_(),
-  castorFilter_(),
-  castorAnalyzer_("CASTOR", 1., &simParameterMap_, &castorFilter_),
-  castorRecHitCollectionTag_(conf.getParameter<edm::InputTag>("castorRecHitCollectionTag"))
-{
-}
-
+CastorHitAnalyzer::CastorHitAnalyzer(edm::ParameterSet const &conf)
+    : hitReadoutName_("CastorHits"), simParameterMap_(), castorFilter_(),
+      castorAnalyzer_("CASTOR", 1., &simParameterMap_, &castorFilter_),
+      castorRecHitCollectionTag_(
+          conf.getParameter<edm::InputTag>("castorRecHitCollectionTag")) {}
 
 namespace CastorHitAnalyzerImpl {
-  template<class Collection>
-  void analyze(edm::Event const& e, CaloHitAnalyzer & analyzer, edm::InputTag& tag) {
-    edm::Handle<Collection> recHits;
-    e.getByLabel(tag, recHits);
-    if (!recHits.isValid()) {
-      edm::LogError("CastorHitAnalyzer") << "Could not find Castor RecHitContainer ";
-    } else {
-      for(unsigned i = 0 ; i < recHits->size(); ++i) {
-        analyzer.analyze((*recHits)[i].id().rawId(), (*recHits)[i].energy());
-      }
+template <class Collection>
+void analyze(edm::Event const &e, CaloHitAnalyzer &analyzer,
+             edm::InputTag &tag) {
+  edm::Handle<Collection> recHits;
+  e.getByLabel(tag, recHits);
+  if (!recHits.isValid()) {
+    edm::LogError("CastorHitAnalyzer")
+        << "Could not find Castor RecHitContainer ";
+  } else {
+    for (unsigned i = 0; i < recHits->size(); ++i) {
+      analyzer.analyze((*recHits)[i].id().rawId(), (*recHits)[i].energy());
     }
   }
 }
+} // namespace CastorHitAnalyzerImpl
 
-
-void CastorHitAnalyzer::analyze(edm::Event const& e, edm::EventSetup const& c) {
-edm::Handle<CrossingFrame<PCaloHit> > castorcf;
-e.getByLabel("mix", "g4SimHitsCastorFI", castorcf);  
-
+void CastorHitAnalyzer::analyze(edm::Event const &e, edm::EventSetup const &c) {
+  edm::Handle<CrossingFrame<PCaloHit>> castorcf;
+  e.getByLabel("mix", "g4SimHitsCastorFI", castorcf);
 
   // access to SimHits
-std::unique_ptr<MixCollection<PCaloHit> > hits(new MixCollection<PCaloHit>(castorcf.product()));
-    castorAnalyzer_.fillHits(*hits);
-    CastorHitAnalyzerImpl::analyze<CastorRecHitCollection>(e, castorAnalyzer_, castorRecHitCollectionTag_);
-  }
-
-
-
+  std::unique_ptr<MixCollection<PCaloHit>> hits(
+      new MixCollection<PCaloHit>(castorcf.product()));
+  castorAnalyzer_.fillHits(*hits);
+  CastorHitAnalyzerImpl::analyze<CastorRecHitCollection>(
+      e, castorAnalyzer_, castorRecHitCollectionTag_);
+}

--- a/SimCalorimetry/CastorSim/plugins/CastorHitAnalyzer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorHitAnalyzer.h
@@ -1,14 +1,14 @@
 #ifndef CastorSim_CastorHitAnalyzer_h
 #define CastorSim_CastorHitAnalyzer_h
 
-#include "SimCalorimetry/CaloSimAlgos/interface/CaloHitAnalyzer.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "SimCalorimetry/CastorSim/src/CastorSimParameterMap.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloHitAnalyzer.h"
 #include "SimCalorimetry/CastorSim/src/CastorHitFilter.h"
+#include "SimCalorimetry/CastorSim/src/CastorSimParameterMap.h"
 #include <string>
 
 /** Compares RecHits to SimHit
@@ -16,13 +16,10 @@
   \Author P. Katsas, Univ. of Athens
 */
 
-class CastorHitAnalyzer : public edm::one::EDAnalyzer<>
-{
+class CastorHitAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-
-  explicit CastorHitAnalyzer(edm::ParameterSet const& conf);
-  void analyze(edm::Event const& e, edm::EventSetup const& c) override;
-
+  explicit CastorHitAnalyzer(edm::ParameterSet const &conf);
+  void analyze(edm::Event const &e, edm::EventSetup const &c) override;
 
 private:
   std::string hitReadoutName_;
@@ -33,5 +30,3 @@ private:
 };
 
 #endif
-
-

--- a/SimCalorimetry/CastorSim/plugins/SealModule.cc
+++ b/SimCalorimetry/CastorSim/plugins/SealModule.cc
@@ -1,10 +1,9 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.h"
 #include "SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h"
 #include "SimCalorimetry/CastorSim/plugins/CastorHitAnalyzer.h"
-#include "SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
 
 DEFINE_DIGI_ACCUMULATOR(CastorDigiProducer);
 DEFINE_FWK_MODULE(CastorHitAnalyzer);
 DEFINE_FWK_MODULE(CastorDigiAnalyzer);
-

--- a/SimCalorimetry/CastorSim/src/CastorAmplifier.cc
+++ b/SimCalorimetry/CastorSim/src/CastorAmplifier.cc
@@ -1,53 +1,52 @@
-#include "SimCalorimetry/CastorSim/src/CastorAmplifier.h"
-#include "SimCalorimetry/CastorSim/src/CastorSimParameters.h"
-#include "CalibFormats/CastorObjects/interface/CastorDbService.h"
-#include "CondFormats/CastorObjects/interface/CastorPedestal.h"
-#include "CondFormats/CastorObjects/interface/CastorGain.h"
-#include "CondFormats/CastorObjects/interface/CastorPedestalWidth.h"
-#include "CondFormats/CastorObjects/interface/CastorGainWidth.h"
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
+#include "CalibFormats/CastorObjects/interface/CastorDbService.h"
+#include "CondFormats/CastorObjects/interface/CastorGain.h"
+#include "CondFormats/CastorObjects/interface/CastorGainWidth.h"
+#include "CondFormats/CastorObjects/interface/CastorPedestal.h"
+#include "CondFormats/CastorObjects/interface/CastorPedestalWidth.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimCalorimetry/CastorSim/src/CastorAmplifier.h"
+#include "SimCalorimetry/CastorSim/src/CastorSimParameters.h"
 
 #include "CLHEP/Random/RandGaussQ.h"
 
-#include<iostream>
+#include <iostream>
 
-CastorAmplifier::CastorAmplifier(const CastorSimParameterMap * parameters, bool addNoise) :
-  theDbService(nullptr),
-  theParameterMap(parameters),
-  theStartingCapId(0),
-  addNoise_(addNoise)
-{
-}
+CastorAmplifier::CastorAmplifier(const CastorSimParameterMap *parameters,
+                                 bool addNoise)
+    : theDbService(nullptr), theParameterMap(parameters), theStartingCapId(0),
+      addNoise_(addNoise) {}
 
-void CastorAmplifier::amplify(CaloSamples & frame, CLHEP::HepRandomEngine* engine) const {
-  const CastorSimParameters & parameters = theParameterMap->castorParameters();
+void CastorAmplifier::amplify(CaloSamples &frame,
+                              CLHEP::HepRandomEngine *engine) const {
+  const CastorSimParameters &parameters = theParameterMap->castorParameters();
   assert(theDbService != nullptr);
   HcalGenericDetId hcalGenDetId(frame.id());
-  const CastorPedestal* peds = theDbService->getPedestal(hcalGenDetId);
-  const CastorPedestalWidth* pwidths = theDbService->getPedestalWidth(hcalGenDetId);
-  if (!peds || !pwidths )
-  {
-    edm::LogError("CastorAmplifier") 
-      << "Could not fetch HCAL/CASTOR conditions for channel " << hcalGenDetId;
-  }
-  else 
-  {
-    double gauss [32]; //big enough
-    double noise [32]; //big enough
+  const CastorPedestal *peds = theDbService->getPedestal(hcalGenDetId);
+  const CastorPedestalWidth *pwidths =
+      theDbService->getPedestalWidth(hcalGenDetId);
+  if (!peds || !pwidths) {
+    edm::LogError("CastorAmplifier")
+        << "Could not fetch HCAL/CASTOR conditions for channel "
+        << hcalGenDetId;
+  } else {
+    double gauss[32]; // big enough
+    double noise[32]; // big enough
     double fCperPE = parameters.photoelectronsToAnalog(frame.id());
     double nominalfCperPE = parameters.getNominalfCperPE();
 
-    for (int i = 0; i < frame.size(); i++) { gauss[i] = CLHEP::RandGaussQ::shoot(engine, 0., 1.); }
-    if(addNoise_) {
-      pwidths->makeNoise (frame.size(), gauss, noise);
+    for (int i = 0; i < frame.size(); i++) {
+      gauss[i] = CLHEP::RandGaussQ::shoot(engine, 0., 1.);
     }
-    for(int tbin = 0; tbin < frame.size(); ++tbin) {
-      int capId = (theStartingCapId + tbin)%4;
+    if (addNoise_) {
+      pwidths->makeNoise(frame.size(), gauss, noise);
+    }
+    for (int tbin = 0; tbin < frame.size(); ++tbin) {
+      int capId = (theStartingCapId + tbin) % 4;
       double pedestal = peds->getValue(capId);
-      if(addNoise_) {
-	pedestal += noise [tbin]*(fCperPE/nominalfCperPE);
+      if (addNoise_) {
+        pedestal += noise[tbin] * (fCperPE / nominalfCperPE);
       }
       frame[tbin] *= fCperPE;
       frame[tbin] += pedestal;

--- a/SimCalorimetry/CastorSim/src/CastorAmplifier.h
+++ b/SimCalorimetry/CastorSim/src/CastorAmplifier.h
@@ -1,32 +1,31 @@
 #ifndef CastorSim_CastorAmplifier_h
 #define CastorSim_CastorAmplifier_h
-  
+
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
 #include "SimCalorimetry/CastorSim/src/CastorSimParameterMap.h"
 
 class CastorDbService;
 
 namespace CLHEP {
-  class HepRandomEngine;
+class HepRandomEngine;
 }
 
 class CastorAmplifier {
 public:
-  CastorAmplifier(const CastorSimParameterMap * parameters, bool addNoise);
-  virtual ~CastorAmplifier(){ }
+  CastorAmplifier(const CastorSimParameterMap *parameters, bool addNoise);
+  virtual ~CastorAmplifier() {}
 
   /// the Producer will probably update this every event
-  void setDbService(const CastorDbService * service) {
-    theDbService = service;
-  }
+  void setDbService(const CastorDbService *service) { theDbService = service; }
 
-  virtual void amplify(CaloSamples & linearFrame, CLHEP::HepRandomEngine*) const;
+  virtual void amplify(CaloSamples &linearFrame,
+                       CLHEP::HepRandomEngine *) const;
 
-  void setStartingCapId(int capId) {theStartingCapId = capId;}
+  void setStartingCapId(int capId) { theStartingCapId = capId; }
 
 private:
-  const CastorDbService * theDbService;
-  const CastorSimParameterMap * theParameterMap;
+  const CastorDbService *theDbService;
+  const CastorSimParameterMap *theParameterMap;
 
   unsigned theStartingCapId;
   bool addNoise_;

--- a/SimCalorimetry/CastorSim/src/CastorCoderFactory.cc
+++ b/SimCalorimetry/CastorSim/src/CastorCoderFactory.cc
@@ -1,23 +1,17 @@
-#include "SimCalorimetry/CastorSim/src/CastorCoderFactory.h"
 #include "CalibFormats/CastorObjects/interface/CastorCoderDb.h"
 #include "CalibFormats/CastorObjects/interface/CastorNominalCoder.h"
+#include "SimCalorimetry/CastorSim/src/CastorCoderFactory.h"
 
+CastorCoderFactory::CastorCoderFactory(CoderType coderType)
+    : theCoderType(coderType), theDbService(nullptr) {}
 
-
-CastorCoderFactory::CastorCoderFactory(CoderType coderType) 
-: theCoderType(coderType),
-  theDbService(nullptr)
-{
-}
-
-
-std::unique_ptr<CastorCoder> CastorCoderFactory::coder(const DetId & id) const {
-  CastorCoder * result = nullptr;
-  if(theCoderType == DB) {
+std::unique_ptr<CastorCoder> CastorCoderFactory::coder(const DetId &id) const {
+  CastorCoder *result = nullptr;
+  if (theCoderType == DB) {
     assert(theDbService != nullptr);
     HcalGenericDetId hcalGenDetId(id);
-    const CastorQIECoder * qieCoder = theDbService->getCastorCoder(hcalGenDetId );
-    const CastorQIEShape * qieShape = theDbService->getCastorShape();
+    const CastorQIECoder *qieCoder = theDbService->getCastorCoder(hcalGenDetId);
+    const CastorQIEShape *qieShape = theDbService->getCastorShape();
     result = new CastorCoderDb(*qieCoder, *qieShape);
   }
 
@@ -26,4 +20,3 @@ std::unique_ptr<CastorCoder> CastorCoderFactory::coder(const DetId & id) const {
   }
   return std::unique_ptr<CastorCoder>(result);
 }
-

--- a/SimCalorimetry/CastorSim/src/CastorCoderFactory.h
+++ b/SimCalorimetry/CastorSim/src/CastorCoderFactory.h
@@ -1,27 +1,24 @@
 #ifndef CastorSim_CastorCoderFactory_h
 #define CastorSim_CastorCoderFactory_h
 
-#include <memory>
-#include "CalibFormats/CastorObjects/interface/CastorDbService.h"
 #include "CalibFormats/CastorObjects/interface/CastorCoder.h"
+#include "CalibFormats/CastorObjects/interface/CastorDbService.h"
+#include <memory>
 
-class CastorCoderFactory
-{
+class CastorCoderFactory {
 public:
-  enum CoderType {DB, NOMINAL};
+  enum CoderType { DB, NOMINAL };
 
   CastorCoderFactory(CoderType coderType);
 
-  void setDbService(const CastorDbService * service) {theDbService = service;}
+  void setDbService(const CastorDbService *service) { theDbService = service; }
 
   /// user gets control of the pointer
-  std::unique_ptr<CastorCoder> coder(const DetId & detId) const;
+  std::unique_ptr<CastorCoder> coder(const DetId &detId) const;
 
 private:
-
   CoderType theCoderType;
-  const CastorDbService * theDbService;
+  const CastorDbService *theDbService;
 };
 
 #endif
-

--- a/SimCalorimetry/CastorSim/src/CastorDigitizerTraits.h
+++ b/SimCalorimetry/CastorSim/src/CastorDigitizerTraits.h
@@ -11,6 +11,4 @@ public:
   typedef CastorElectronicsSim ElectronicsSim;
 };
 
-
 #endif
-

--- a/SimCalorimetry/CastorSim/src/CastorElectronicsSim.cc
+++ b/SimCalorimetry/CastorSim/src/CastorElectronicsSim.cc
@@ -1,36 +1,32 @@
-#include "SimCalorimetry/CastorSim/src/CastorElectronicsSim.h"
+#include "DataFormats/HcalDigi/interface/CastorDataFrame.h"
 #include "SimCalorimetry/CastorSim/src/CastorAmplifier.h"
 #include "SimCalorimetry/CastorSim/src/CastorCoderFactory.h"
-#include "DataFormats/HcalDigi/interface/CastorDataFrame.h"
+#include "SimCalorimetry/CastorSim/src/CastorElectronicsSim.h"
 
 #include "CLHEP/Random/RandFlat.h"
 
+CastorElectronicsSim::CastorElectronicsSim(
+    CastorAmplifier *amplifier, const CastorCoderFactory *coderFactory)
+    : theAmplifier(amplifier), theCoderFactory(coderFactory),
+      theStartingCapId(0) {}
 
+CastorElectronicsSim::~CastorElectronicsSim() {}
 
-CastorElectronicsSim::CastorElectronicsSim(CastorAmplifier * amplifier, const CastorCoderFactory * coderFactory)
-  : theAmplifier(amplifier),
-    theCoderFactory(coderFactory),
-    theStartingCapId(0)
-{
-}
-
-
-CastorElectronicsSim::~CastorElectronicsSim()
-{
-}
-
-template<class Digi> 
-void CastorElectronicsSim::convert(CaloSamples & frame, Digi & result, CLHEP::HepRandomEngine* engine) {
+template <class Digi>
+void CastorElectronicsSim::convert(CaloSamples &frame, Digi &result,
+                                   CLHEP::HepRandomEngine *engine) {
   result.setSize(frame.size());
   theAmplifier->amplify(frame, engine);
   theCoderFactory->coder(frame.id())->fC2adc(frame, result, theStartingCapId);
 }
 
-void CastorElectronicsSim::analogToDigital(CLHEP::HepRandomEngine* engine, CaloSamples & lf, CastorDataFrame & result) {
+void CastorElectronicsSim::analogToDigital(CLHEP::HepRandomEngine *engine,
+                                           CaloSamples &lf,
+                                           CastorDataFrame &result) {
   convert<CastorDataFrame>(lf, result, engine);
 }
 
-void CastorElectronicsSim::newEvent(CLHEP::HepRandomEngine* engine) {
+void CastorElectronicsSim::newEvent(CLHEP::HepRandomEngine *engine) {
   // pick a new starting Capacitor ID
   theStartingCapId = CLHEP::RandFlat::shootInt(engine, 4);
   theAmplifier->setStartingCapId(theStartingCapId);

--- a/SimCalorimetry/CastorSim/src/CastorElectronicsSim.h
+++ b/SimCalorimetry/CastorSim/src/CastorElectronicsSim.h
@@ -1,10 +1,10 @@
 #ifndef CastorSim_CastorElectronicsSim_h
 #define CastorSim_CastorElectronicsSim_h
-  
-  /** This class turns a CaloSamples, representing the analog
-      signal input to the readout electronics, into a
-      digitized data frame
-   */
+
+/** This class turns a CaloSamples, representing the analog
+    signal input to the readout electronics, into a
+    digitized data frame
+ */
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
 
 class CastorDataFrame;
@@ -13,29 +13,29 @@ class CastorAmplifier;
 class CastorCoderFactory;
 
 namespace CLHEP {
-  class HepRandomEngine;
+class HepRandomEngine;
 }
 
 class CastorElectronicsSim {
 public:
-  CastorElectronicsSim(CastorAmplifier * amplifier, 
-                     const CastorCoderFactory * coderFactory);
+  CastorElectronicsSim(CastorAmplifier *amplifier,
+                       const CastorCoderFactory *coderFactory);
   ~CastorElectronicsSim();
 
-  void analogToDigital(CLHEP::HepRandomEngine*, CaloSamples & linearFrame, CastorDataFrame & result);
+  void analogToDigital(CLHEP::HepRandomEngine *, CaloSamples &linearFrame,
+                       CastorDataFrame &result);
 
   /// Things that need to be initialized every event
-  void newEvent(CLHEP::HepRandomEngine*);
+  void newEvent(CLHEP::HepRandomEngine *);
 
 private:
-  template<class Digi> void convert(CaloSamples & frame, Digi & result, CLHEP::HepRandomEngine*);
+  template <class Digi>
+  void convert(CaloSamples &frame, Digi &result, CLHEP::HepRandomEngine *);
 
-  CastorAmplifier * theAmplifier;
-  const CastorCoderFactory * theCoderFactory;
+  CastorAmplifier *theAmplifier;
+  const CastorCoderFactory *theCoderFactory;
 
   int theStartingCapId;
 };
 
-  
 #endif
-  

--- a/SimCalorimetry/CastorSim/src/CastorHitCorrection.cc
+++ b/SimCalorimetry/CastorSim/src/CastorHitCorrection.cc
@@ -1,115 +1,106 @@
-#include "SimCalorimetry/CastorSim/src/CastorHitCorrection.h"
-#include "SimCalorimetry/CaloSimAlgos/interface/CaloSimParameters.h"
 #include "CalibCalorimetry/CastorCalib/interface/CastorTimeSlew.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
-#include "FWCore/Utilities/interface/Exception.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloSimParameters.h"
+#include "SimCalorimetry/CastorSim/src/CastorHitCorrection.h"
 
-CastorHitCorrection::CastorHitCorrection(const CaloVSimParameterMap * parameterMap)
-: theParameterMap(parameterMap)
-{
-}
+CastorHitCorrection::CastorHitCorrection(
+    const CaloVSimParameterMap *parameterMap)
+    : theParameterMap(parameterMap) {}
 
-
-void CastorHitCorrection::fillChargeSums(MixCollection<PCaloHit> & hits)
-{
+void CastorHitCorrection::fillChargeSums(MixCollection<PCaloHit> &hits) {
   //  clear();
-  for(MixCollection<PCaloHit>::MixItr hitItr = hits.begin();
-      hitItr != hits.end(); ++hitItr)
-  {
-    LogDebug("CastorHitCorrection") << "CastorHitCorrection::Hit 0x" << std::hex << hitItr->id() << std::dec;
+  for (MixCollection<PCaloHit>::MixItr hitItr = hits.begin();
+       hitItr != hits.end(); ++hitItr) {
+    LogDebug("CastorHitCorrection") << "CastorHitCorrection::Hit 0x" << std::hex
+                                    << hitItr->id() << std::dec;
     int tbin = timeBin(*hitItr);
     LogDebug("CastorHitCorrection") << "CastorHitCorrection::Hit tbin" << tbin;
-    if(tbin >= 0 && tbin < 10) 
-    {  
+    if (tbin >= 0 && tbin < 10) {
       theChargeSumsForTimeBin[tbin][DetId(hitItr->id())] += charge(*hitItr);
     }
   }
 }
 
-void CastorHitCorrection::fillChargeSums(const std::vector<PCaloHit> & hits)
-{
+void CastorHitCorrection::fillChargeSums(const std::vector<PCaloHit> &hits) {
   //  clear();
-  for(std::vector<PCaloHit>::const_iterator hitItr = hits.begin();
-      hitItr != hits.end(); ++hitItr)
-  {
-    LogDebug("CastorHitCorrection") << "CastorHitCorrection::Hit 0x" << std::hex << hitItr->id() << std::dec;
+  for (std::vector<PCaloHit>::const_iterator hitItr = hits.begin();
+       hitItr != hits.end(); ++hitItr) {
+    LogDebug("CastorHitCorrection") << "CastorHitCorrection::Hit 0x" << std::hex
+                                    << hitItr->id() << std::dec;
     int tbin = timeBin(*hitItr);
     LogDebug("CastorHitCorrection") << "CastorHitCorrection::Hit tbin" << tbin;
-    if(tbin >= 0 && tbin < 10) 
-    {  
+    if (tbin >= 0 && tbin < 10) {
       theChargeSumsForTimeBin[tbin][DetId(hitItr->id())] += charge(*hitItr);
     }
   }
 }
 
-
-void CastorHitCorrection::clear()
-{
-  for(int i = 0; i < 10; ++i)
-  {
+void CastorHitCorrection::clear() {
+  for (int i = 0; i < 10; ++i) {
     theChargeSumsForTimeBin[i].clear();
   }
 }
 
-double CastorHitCorrection::charge(const PCaloHit & hit) const
-{
+double CastorHitCorrection::charge(const PCaloHit &hit) const {
   DetId detId(hit.id());
-  const CaloSimParameters & parameters = theParameterMap->simParameters(detId);
-  double simHitToCharge = parameters.simHitToPhotoelectrons()
-                        * parameters.photoelectronsToAnalog();
+  const CaloSimParameters &parameters = theParameterMap->simParameters(detId);
+  double simHitToCharge =
+      parameters.simHitToPhotoelectrons() * parameters.photoelectronsToAnalog();
   return hit.energy() * simHitToCharge;
 }
 
-double CastorHitCorrection::delay(const PCaloHit & hit, CLHEP::HepRandomEngine*) const
-{
+double CastorHitCorrection::delay(const PCaloHit &hit,
+                                  CLHEP::HepRandomEngine *) const {
   // HO goes slow, HF shouldn't be used at all
-  //Castor not used for the moment
+  // Castor not used for the moment
 
   DetId detId(hit.id());
-  if(detId.det()==DetId::Calo && (detId.subdetId()==HcalCastorDetId::SubdetectorId)) return 0;
+  if (detId.det() == DetId::Calo &&
+      (detId.subdetId() == HcalCastorDetId::SubdetectorId))
+    return 0;
 
   HcalDetId hcalDetId(hit.id());
-  if(hcalDetId.subdet() == HcalForward) return 0;  
-  CastorTimeSlew::BiasSetting biasSetting = (hcalDetId.subdet() == HcalOuter) ?
-                                          CastorTimeSlew::Slow :
-                                          CastorTimeSlew::Medium;
+  if (hcalDetId.subdet() == HcalForward)
+    return 0;
+  CastorTimeSlew::BiasSetting biasSetting = (hcalDetId.subdet() == HcalOuter)
+                                                ? CastorTimeSlew::Slow
+                                                : CastorTimeSlew::Medium;
   double delay = 0.;
   int tbin = timeBin(hit);
-  if(tbin >= 0 && tbin < 10)
-  {
-    ChargeSumsByChannel::const_iterator totalChargeItr = theChargeSumsForTimeBin[tbin].find(detId);
-    if(totalChargeItr == theChargeSumsForTimeBin[tbin].end())
-    {
-      throw cms::Exception("CastorHitCorrection") << "Cannot find HCAL/CASTOR charge sum for hit " << hit;
+  if (tbin >= 0 && tbin < 10) {
+    ChargeSumsByChannel::const_iterator totalChargeItr =
+        theChargeSumsForTimeBin[tbin].find(detId);
+    if (totalChargeItr == theChargeSumsForTimeBin[tbin].end()) {
+      throw cms::Exception("CastorHitCorrection")
+          << "Cannot find HCAL/CASTOR charge sum for hit " << hit;
     }
     double totalCharge = totalChargeItr->second;
     delay = CastorTimeSlew::delay(totalCharge, biasSetting);
-    LogDebug("CastorHitCorrection") << "TIMESLEWcharge " << charge(hit) 
-				  << "  totalcharge " << totalCharge 
-				  << " olddelay "  << CastorTimeSlew::delay(charge(hit), biasSetting) 
-				  << " newdelay " << delay;
+    LogDebug("CastorHitCorrection")
+        << "TIMESLEWcharge " << charge(hit) << "  totalcharge " << totalCharge
+        << " olddelay " << CastorTimeSlew::delay(charge(hit), biasSetting)
+        << " newdelay " << delay;
   }
 
   return delay;
 }
 
-
-int CastorHitCorrection::timeBin(const PCaloHit & hit) const
-{
-  const CaloSimParameters & parameters = theParameterMap->simParameters(DetId(hit.id()));
-  double t = hit.time() - timeOfFlight(DetId(hit.id())) + parameters.timePhase();
-  return static_cast<int> (t / 25) + parameters.binOfMaximum() - 1;
+int CastorHitCorrection::timeBin(const PCaloHit &hit) const {
+  const CaloSimParameters &parameters =
+      theParameterMap->simParameters(DetId(hit.id()));
+  double t =
+      hit.time() - timeOfFlight(DetId(hit.id())) + parameters.timePhase();
+  return static_cast<int>(t / 25) + parameters.binOfMaximum() - 1;
 }
 
-
-double CastorHitCorrection::timeOfFlight(const DetId & detId) const
-{
-    if(detId.det()==DetId::Calo && detId.subdetId()==HcalCastorDetId::SubdetectorId)
-	return 37.666;
-    else
-	throw cms::Exception("not HcalCastorDetId"); 
+double CastorHitCorrection::timeOfFlight(const DetId &detId) const {
+  if (detId.det() == DetId::Calo &&
+      detId.subdetId() == HcalCastorDetId::SubdetectorId)
+    return 37.666;
+  else
+    throw cms::Exception("not HcalCastorDetId");
 }
-

--- a/SimCalorimetry/CastorSim/src/CastorHitCorrection.h
+++ b/SimCalorimetry/CastorSim/src/CastorHitCorrection.h
@@ -3,55 +3,50 @@
 
 /** Applies a correction for time slewing
     Makes bigger signals come at a delayed time
-  
+
  */
 
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloVHitCorrection.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloVSimParameterMap.h"
-#include "DataFormats/HcalDetId/interface/HcalDetId.h"
-#include "DataFormats/DetId/interface/DetId.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include <map>
 #include <vector>
 
 namespace CLHEP {
-  class HepRandomEngine;
+class HepRandomEngine;
 }
 
-
-class CastorHitCorrection : public CaloVHitCorrection
-{
+class CastorHitCorrection : public CaloVHitCorrection {
 public:
   typedef std::map<DetId, double> ChargeSumsByChannel;
 
-  CastorHitCorrection(const CaloVSimParameterMap * parameterMap);
+  CastorHitCorrection(const CaloVSimParameterMap *parameterMap);
   ~CastorHitCorrection() override {}
 
-  void fillChargeSums(MixCollection<PCaloHit> & hits);
+  void fillChargeSums(MixCollection<PCaloHit> &hits);
 
-  void fillChargeSums(const std::vector<PCaloHit> & hits);
+  void fillChargeSums(const std::vector<PCaloHit> &hits);
 
   void clear();
 
   /// how much charge we expect from this hit
-  double charge(const PCaloHit & hit) const;
+  double charge(const PCaloHit &hit) const;
 
   /// how much delay this hit will get
-  double delay(const PCaloHit & hit, CLHEP::HepRandomEngine*) const override;
+  double delay(const PCaloHit &hit, CLHEP::HepRandomEngine *) const override;
 
   /// which time bin the peak of the signal will fall in
-  int timeBin(const PCaloHit & hit) const;
+  int timeBin(const PCaloHit &hit) const;
 
   /// simple average approximation
-  double timeOfFlight(const DetId & id) const;
+  double timeOfFlight(const DetId &id) const;
 
 private:
-
-  const CaloVSimParameterMap * theParameterMap;
+  const CaloVSimParameterMap *theParameterMap;
 
   ChargeSumsByChannel theChargeSumsForTimeBin[10];
-
 };
 
 #endif
-

--- a/SimCalorimetry/CastorSim/src/CastorHitFilter.h
+++ b/SimCalorimetry/CastorSim/src/CastorHitFilter.h
@@ -1,16 +1,16 @@
 #ifndef CastorSim_CastorHitFilter_h
 #define CastorSim_CastorHitFilter_h
 
-#include "SimCalorimetry/CaloSimAlgos/interface/CaloVHitFilter.h"
-#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloVHitFilter.h"
 
 class CastorHitFilter : public CaloVHitFilter {
-  bool accepts(const PCaloHit & hit) const override {
+  bool accepts(const PCaloHit &hit) const override {
     DetId detId(hit.id());
-    return (detId.det()==DetId::Calo && detId.subdetId()==HcalCastorDetId::SubdetectorId);
+    return (detId.det() == DetId::Calo &&
+            detId.subdetId() == HcalCastorDetId::SubdetectorId);
   }
 };
 
 #endif
-

--- a/SimCalorimetry/CastorSim/src/CastorShape.cc
+++ b/SimCalorimetry/CastorSim/src/CastorShape.cc
@@ -1,61 +1,45 @@
 #include "SimCalorimetry/CastorSim/src/CastorShape.h"
 #include <cmath>
-  
-CastorShape::CastorShape()
-: nbin_(256),
-  nt_(nbin_, 0.)
-{   
+
+CastorShape::CastorShape() : nbin_(256), nt_(nbin_, 0.) {
   computeShapeCastor();
 }
 
+CastorShape::CastorShape(const CastorShape &d)
+    : CaloVShape(d), nbin_(d.nbin_), nt_(d.nt_) {}
 
-CastorShape::CastorShape(const CastorShape&d)
-: CaloVShape(d),
-  nbin_(d.nbin_),
-  nt_(d.nt_)
-{
-}
-
-  
-void CastorShape::computeShapeCastor()
-{
+void CastorShape::computeShapeCastor() {
 
   //  cout << endl << " ===== computeShapeCastor  !!! " << endl << endl;
 
-  const float ts = 3.0;           // time constant in   t * exp(-(t/ts)**2)
-
+  const float ts = 3.0; // time constant in   t * exp(-(t/ts)**2)
 
   int j;
   float norm;
 
   // HF SHAPE
   norm = 0.0;
-  for( j = 0; j < 3 * ts && j < nbin_; j++){
-    //nt_[j] = ((float)j)*exp(-((float)(j*j))/(ts*ts));
-    nt_[j] = j * exp(-(j*j)/(ts*ts));
+  for (j = 0; j < 3 * ts && j < nbin_; j++) {
+    // nt_[j] = ((float)j)*exp(-((float)(j*j))/(ts*ts));
+    nt_[j] = j * exp(-(j * j) / (ts * ts));
     norm += nt_[j];
   }
   // normalize pulse area to 1.0
-  for( j = 0; j < 3 * ts && j < nbin_; j++){
+  for (j = 0; j < 3 * ts && j < nbin_; j++) {
     nt_[j] /= norm;
   }
 }
 
-double CastorShape::operator () (double time) const
-{
+double CastorShape::operator()(double time) const {
 
   // return pulse amplitude for request time in ns
   int jtime;
-  jtime = static_cast<int>(time+0.5);
+  jtime = static_cast<int>(time + 0.5);
 
-  if(jtime >= 0 && jtime < nbin_)
+  if (jtime >= 0 && jtime < nbin_)
     return nt_[jtime];
-  else 
+  else
     return 0.0;
 }
 
-double
-CastorShape::timeToRise() const
-{
-   return 0.0 ;
-}  
+double CastorShape::timeToRise() const { return 0.0; }

--- a/SimCalorimetry/CastorSim/src/CastorShape.h
+++ b/SimCalorimetry/CastorSim/src/CastorShape.h
@@ -1,37 +1,32 @@
 #ifndef CastorSim_CastorShape_h
 #define CastorSim_CastorShape_h
-#include<vector>
-  
+#include <vector>
+
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloVShape.h"
-  
+
 /**
-  
+
    \class CastorShape
-  
+
    \brief  shaper for Castor
-     
+
 */
-  
 
-class CastorShape : public CaloVShape
-{
+class CastorShape : public CaloVShape {
 public:
-  
   CastorShape();
-  CastorShape(const CastorShape&d);
+  CastorShape(const CastorShape &d);
 
-  ~CastorShape() override{}
-  
-  double operator () (double time) const override;
-  double timeToRise()              const override ;
+  ~CastorShape() override {}
 
- private:
+  double operator()(double time) const override;
+  double timeToRise() const override;
+
+private:
   void computeShapeCastor();
-  
+
   int nbin_;
   std::vector<float> nt_;
-  
 };
 
 #endif
-  

--- a/SimCalorimetry/CastorSim/src/CastorSimParameterMap.cc
+++ b/SimCalorimetry/CastorSim/src/CastorSimParameterMap.cc
@@ -1,18 +1,13 @@
-#include "SimCalorimetry/CastorSim/src/CastorSimParameterMap.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
-#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "SimCalorimetry/CastorSim/src/CastorSimParameterMap.h"
 #include <iostream>
 
-
-//some arbitrary numbers for now
-CastorSimParameterMap::CastorSimParameterMap() :
-  theCastorParameters(1., 4.3333,
-                   2.09 , -4.,
-                   false)
-{
-}
+// some arbitrary numbers for now
+CastorSimParameterMap::CastorSimParameterMap()
+    : theCastorParameters(1., 4.3333, 2.09, -4., false) {}
 /*
   CaloSimParameters(double photomultiplierGain, double amplifierGain,
                  double samplingFactor, double timePhase,
@@ -20,27 +15,23 @@ CastorSimParameterMap::CastorSimParameterMap() :
                  bool doPhotostatistics);
 */
 
-CastorSimParameterMap::CastorSimParameterMap(const edm::ParameterSet & p)
-:  theCastorParameters( p.getParameter<edm::ParameterSet>("castor") ) 
-{
+CastorSimParameterMap::CastorSimParameterMap(const edm::ParameterSet &p)
+    : theCastorParameters(p.getParameter<edm::ParameterSet>("castor")) {}
+
+const CaloSimParameters &
+CastorSimParameterMap::simParameters(const DetId &detId) const {
+  HcalGenericDetId genericId(detId);
+
+  //  if(detId.det()==DetId::Calo &&
+  //  detId.subdetId()==HcalCastorDetId::SubdetectorId)
+
+  if (genericId.isHcalCastorDetId())
+    return theCastorParameters;
+
+  else
+    throw cms::Exception("not HcalCastorDetId");
 }
 
-const CaloSimParameters& CastorSimParameterMap::simParameters(const DetId & detId) const 
-{
-    HcalGenericDetId genericId(detId);
-
-    //  if(detId.det()==DetId::Calo && detId.subdetId()==HcalCastorDetId::SubdetectorId)
-    
-    if(genericId.isHcalCastorDetId())
-	return theCastorParameters;
-    
-    else
-	throw cms::Exception("not HcalCastorDetId"); 
-    
+void CastorSimParameterMap::setDbService(const CastorDbService *dbService) {
+  theCastorParameters.setDbService(dbService);
 }
-
-void CastorSimParameterMap::setDbService(const CastorDbService * dbService)
-{
-theCastorParameters.setDbService(dbService);
-}
-

--- a/SimCalorimetry/CastorSim/src/CastorSimParameterMap.h
+++ b/SimCalorimetry/CastorSim/src/CastorSimParameterMap.h
@@ -1,37 +1,30 @@
 #ifndef CastorSim_CastorSimParameterMap_h
 #define CastorSim_CastorSimParameterMap_h
 
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloVSimParameterMap.h"
 #include "SimCalorimetry/CastorSim/src/CastorSimParameters.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
-class CastorSimParameterMap : public CaloVSimParameterMap
-{
+class CastorSimParameterMap : public CaloVSimParameterMap {
 public:
   /// hardcoded default parameters
   CastorSimParameterMap();
   /// configurable parameters
-  CastorSimParameterMap(const edm::ParameterSet & p);
+  CastorSimParameterMap(const edm::ParameterSet &p);
 
   ~CastorSimParameterMap() override {}
 
-  const CaloSimParameters & simParameters(const DetId & id) const override;
+  const CaloSimParameters &simParameters(const DetId &id) const override;
 
   /// accessors
-  //CaloSimParameters castorParameters() const  {return theCastorParameters;}
-    CastorSimParameters castorParameters() const 
-	{
-	    return theCastorParameters;
-	}
-    
-    
+  // CaloSimParameters castorParameters() const  {return theCastorParameters;}
+  CastorSimParameters castorParameters() const { return theCastorParameters; }
 
-  void setDbService(const CastorDbService * service);
+  void setDbService(const CastorDbService *service);
 
 private:
   CastorSimParameters theCastorParameters;
 };
 
 #endif
-

--- a/SimCalorimetry/CastorSim/src/CastorSimParameters.cc
+++ b/SimCalorimetry/CastorSim/src/CastorSimParameters.cc
@@ -1,57 +1,47 @@
-#include "SimCalorimetry/CastorSim/src/CastorSimParameters.h"
-#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
-#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
-#include "DataFormats/HcalDetId/interface/HcalDetId.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CLHEP/Random/RandGaussQ.h"
 #include "CondFormats/CastorObjects/interface/CastorGain.h"
 #include "CondFormats/CastorObjects/interface/CastorGainWidth.h"
-#include "CLHEP/Random/RandGaussQ.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimCalorimetry/CastorSim/src/CastorSimParameters.h"
 
+CastorSimParameters::CastorSimParameters(double simHitToPhotoelectrons,
+                                         double photoelectronsToAnalog,
+                                         double samplingFactor,
+                                         double timePhase, bool syncPhase)
+    : CaloSimParameters(simHitToPhotoelectrons, photoelectronsToAnalog,
+                        samplingFactor, timePhase, 6, 4, false, syncPhase),
+      theDbService(nullptr), theSamplingFactor(samplingFactor),
+      nominalfCperPE(1) {}
 
-CastorSimParameters::CastorSimParameters(double simHitToPhotoelectrons, double photoelectronsToAnalog,double samplingFactor, double timePhase, bool syncPhase)
-: CaloSimParameters(simHitToPhotoelectrons, photoelectronsToAnalog, samplingFactor, timePhase, 6, 4, false, syncPhase),
-  theDbService(nullptr),
-  theSamplingFactor( samplingFactor ),
-  nominalfCperPE( 1)
-{
-}
+CastorSimParameters::CastorSimParameters(const edm::ParameterSet &p)
+    : CaloSimParameters(p), theDbService(nullptr),
+      theSamplingFactor(p.getParameter<double>("samplingFactor")),
+      nominalfCperPE(p.getParameter<double>("photoelectronsToAnalog")) {}
 
-
-CastorSimParameters::CastorSimParameters(const edm::ParameterSet & p)
-:  CaloSimParameters(p),
-   theDbService(nullptr),
-   theSamplingFactor( p.getParameter<double>("samplingFactor") ),
-   nominalfCperPE( p.getParameter<double>("photoelectronsToAnalog") )
-{
-}
-
-double CastorSimParameters::getNominalfCperPE() const 
-{
+double CastorSimParameters::getNominalfCperPE() const {
   // return the nominal PMT gain value of CASTOR from the config file.
   return nominalfCperPE;
 }
 
-double CastorSimParameters::photoelectronsToAnalog(const DetId & detId) const
-{
-  // calculate factor (PMT gain) using sampling factor value & available electron gain
-  return theSamplingFactor/fCtoGeV(detId);
+double CastorSimParameters::photoelectronsToAnalog(const DetId &detId) const {
+  // calculate factor (PMT gain) using sampling factor value & available
+  // electron gain
+  return theSamplingFactor / fCtoGeV(detId);
 }
 
-
-
-double CastorSimParameters::fCtoGeV(const DetId & detId) const
-{
+double CastorSimParameters::fCtoGeV(const DetId &detId) const {
   assert(theDbService != nullptr);
   HcalGenericDetId hcalGenDetId(detId);
-  const CastorGain* gains = theDbService->getGain(hcalGenDetId);
-  const CastorGainWidth* gwidths = theDbService->getGainWidth(hcalGenDetId);
+  const CastorGain *gains = theDbService->getGain(hcalGenDetId);
+  const CastorGainWidth *gwidths = theDbService->getGainWidth(hcalGenDetId);
   double result = 0.0;
-  if (!gains || !gwidths )
-  {
-    edm::LogError("CastorAmplifier") << "Could not fetch HCAL conditions for channel " << hcalGenDetId;
-  }
-  else 
-  {
+  if (!gains || !gwidths) {
+    edm::LogError("CastorAmplifier")
+        << "Could not fetch HCAL conditions for channel " << hcalGenDetId;
+  } else {
     // only one gain will be recorded per channel, so just use capID 0 for now
     result = gains->getValue(0);
   }

--- a/SimCalorimetry/CastorSim/src/CastorSimParameters.h
+++ b/SimCalorimetry/CastorSim/src/CastorSimParameters.h
@@ -1,32 +1,31 @@
 #ifndef CastorSim_CastorSimParameters_h
 #define CastorSim_CastorSimParameters_h
 
-#include "SimCalorimetry/CaloSimAlgos/interface/CaloSimParameters.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CalibFormats/CastorObjects/interface/CastorDbService.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloSimParameters.h"
 
-class CastorSimParameters : public CaloSimParameters
-{
+class CastorSimParameters : public CaloSimParameters {
 public:
+  CastorSimParameters(double simHitToPhotoelectrons,
+                      double photoelectronsToAnalog, double samplingFactor,
+                      double timePhase, bool syncPhase);
+  CastorSimParameters(const edm::ParameterSet &p);
 
-CastorSimParameters(double simHitToPhotoelectrons, double photoelectronsToAnalog, double samplingFactor, double timePhase, bool syncPhase);
-CastorSimParameters(const edm::ParameterSet & p);
+  ~CastorSimParameters() override {}
 
-~CastorSimParameters() override {}
+  void setDbService(const CastorDbService *service) { theDbService = service; }
 
-void setDbService(const CastorDbService * service) {theDbService = service;}
+  double getNominalfCperPE() const;
 
-double getNominalfCperPE() const;
+  double photoelectronsToAnalog(const DetId &detId) const override;
 
-double photoelectronsToAnalog(const DetId & detId) const override;
-
-double fCtoGeV(const DetId & detId) const;
-
+  double fCtoGeV(const DetId &detId) const;
 
 private:
-const CastorDbService * theDbService;
-double theSamplingFactor;
-double nominalfCperPE;
+  const CastorDbService *theDbService;
+  double theSamplingFactor;
+  double nominalfCperPE;
 };
 
 #endif

--- a/SimCalorimetry/CastorSim/test/CastorDigitizerTest.cpp
+++ b/SimCalorimetry/CastorSim/test/CastorDigitizerTest.cpp
@@ -1,47 +1,48 @@
-#include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
-#include "DataFormats/HcalDigi/interface/CastorDataFrame.h"
-#include "SimDataFormats/CaloHit/interface/PCaloHit.h"
-#include "SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h"
-#include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
-#include "SimCalorimetry/CaloSimAlgos/interface/CaloShapeIntegrator.h"
-#include "SimCalorimetry/CastorSim/src/CastorSimParameterMap.h"
-#include "SimCalorimetry/CastorSim/src/CastorShape.h"
-#include "SimCalorimetry/CastorSim/src/CastorElectronicsSim.h"
 #include "CalibCalorimetry/CastorCalib/interface/CastorDbHardcode.h"
 #include "CalibFormats/CastorObjects/interface/CastorDbService.h"
+#include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
+#include "DataFormats/HcalDigi/interface/CastorDataFrame.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloShapeIntegrator.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
+#include "SimCalorimetry/CastorSim/src/CastorElectronicsSim.h"
+#include "SimCalorimetry/CastorSim/src/CastorShape.h"
+#include "SimCalorimetry/CastorSim/src/CastorSimParameterMap.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 //#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CLHEP/Random/JamesRandom.h"
+#include "CondFormats/CastorObjects/interface/CastorGainWidths.h"
+#include "CondFormats/CastorObjects/interface/CastorGains.h"
+#include "CondFormats/CastorObjects/interface/CastorPedestalWidths.h"
+#include "CondFormats/CastorObjects/interface/CastorPedestals.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/ForwardGeometry/interface/CastorHardcodeGeometryLoader.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalHardcodeGeometryLoader.h"
 #include "SimCalorimetry/CastorSim/src/CastorAmplifier.h"
 #include "SimCalorimetry/CastorSim/src/CastorCoderFactory.h"
-#include "SimCalorimetry/CastorSim/src/CastorHitFilter.h"
-#include "CondFormats/CastorObjects/interface/CastorPedestals.h"
-#include "CondFormats/CastorObjects/interface/CastorPedestalWidths.h"
-#include "CondFormats/CastorObjects/interface/CastorGains.h"
-#include "CondFormats/CastorObjects/interface/CastorGainWidths.h"
 #include "SimCalorimetry/CastorSim/src/CastorDigitizerTraits.h"
 #include "SimCalorimetry/CastorSim/src/CastorHitCorrection.h"
-#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
-#include "Geometry/HcalTowerAlgo/interface/HcalHardcodeGeometryLoader.h"
-#include "Geometry/ForwardGeometry/interface/CastorHardcodeGeometryLoader.h"
-#include "CLHEP/Random/JamesRandom.h"
+#include "SimCalorimetry/CastorSim/src/CastorHitFilter.h"
+#include <iostream>
+#include <iterator>
 #include <vector>
-#include<iostream>
-#include<iterator>
 using namespace std;
 using namespace cms;
 
-void testHitCorrection(CastorHitCorrection * correction, std::vector<PCaloHit> & hits)
-{
+void testHitCorrection(CastorHitCorrection *correction,
+                       std::vector<PCaloHit> &hits) {
   correction->fillChargeSums(hits);
-  for(PCaloHit& hit : hits)
-    {
-      DetId detId(hit.id());
-      if (detId.det()==DetId::Calo && detId.subdetId()==HcalCastorDetId::SubdetectorId){
-	std::cout<<"Castor -- ";
-    } 
-      std::cout << "HIT charge " << correction->charge(hit) << " delay " 
-		//<< correction->delay(*hitItr)
-		<< " Timebin " << correction->timeBin(hit) <<std::endl;
+  for (PCaloHit &hit : hits) {
+    DetId detId(hit.id());
+    if (detId.det() == DetId::Calo &&
+        detId.subdetId() == HcalCastorDetId::SubdetectorId) {
+      std::cout << "Castor -- ";
     }
+    std::cout << "HIT charge " << correction->charge(hit)
+              << " delay "
+              //<< correction->delay(*hitItr)
+              << " Timebin " << correction->timeBin(hit) << std::endl;
+  }
 }
 
 int main() {
@@ -51,10 +52,10 @@ int main() {
   HcalCastorDetId castorDetId(HcalCastorDetId::Section(2), true, 1, 1);
   PCaloHit castorHit(castorDetId.rawId(), 50.0, 0.123);
 
-  //assert(castorDetId.zside() == true);
-   
-  std::cout<<castorDetId<<std::endl;
-  std::cout<<castorHit<<std::endl;
+  // assert(castorDetId.zside() == true);
+
+  std::cout << castorDetId << std::endl;
+  std::cout << castorHit << std::endl;
 
   vector<DetId> hcastorDetIds;
   hcastorDetIds.push_back(castorDetId);
@@ -65,11 +66,12 @@ int main() {
 
   std::cout<<"generic Id "<< genericId <<std::endl;
   std::cout<< genericId.det() <<" "<< genericId.subdetId() <<std::endl;
- 
+
   std::cout<<"castor id "<< castorDetId <<std::endl;
   std::cout<< castorDetId.det() <<" "<< castorDetId.subdetId() <<std::endl;
 
-  std::cout<<"should be: "<< DetId::Calo <<" "<< HcalCastorDetId::SubdetectorId <<std::endl;
+  std::cout<<"should be: "<< DetId::Calo <<" "<< HcalCastorDetId::SubdetectorId
+  <<std::endl;
   */
   /*
     DEBUG
@@ -78,8 +80,8 @@ int main() {
 
   vector<HcalCastorDetId>::iterator testDetId = hcastorDetIds.begin();
   std::cout<< (*testDetId).zside() <<" "
-	   << (*testDetId).sector() <<" "
-	   << (*testDetId).module() <<std::endl;
+           << (*testDetId).sector() <<" "
+           << (*testDetId).module() <<std::endl;
   */
 
   vector<DetId> allDetIds;
@@ -90,7 +92,7 @@ int main() {
   string hitsName = "CastorHits";
   vector<string> caloDets;
 
-  CrossingFrame<PCaloHit> crossingFrame(-5, 5, 25,  hitsName, 0);
+  CrossingFrame<PCaloHit> crossingFrame(-5, 5, 25, hitsName, 0);
   edm::EventID eventId;
   crossingFrame.addSignals(&hits, eventId);
 
@@ -121,41 +123,43 @@ int main() {
   CastorGainWidths gainWidths;
 
   // make a calibration service by hand
-  for(vector<DetId>::const_iterator detItr = allDetIds.begin(); 
-      detItr != allDetIds.end(); ++detItr) 
-  {
-/* check CastorCondObjectContainer!
-      pedestals.addValues(*detItr, CastorDbHardcode::makePedestal(*detItr).getValues ());
-      *pedestalWidths.setWidth(*detItr) = CastorDbHardcode::makePedestalWidth(*detItr);
-      gains.addValues(*detItr, CastorDbHardcode::makeGain(*detItr).getValues ());
-      gainWidths.addValues(*detItr, CastorDbHardcode::makeGainWidth(*detItr).getValues ());
-*/
-      pedestals.addValues(CastorDbHardcode::makePedestal(*detItr));
-      pedestalWidths.addValues(CastorDbHardcode::makePedestalWidth(*detItr));
-      gains.addValues(CastorDbHardcode::makeGain(*detItr));
-      gainWidths.addValues(CastorDbHardcode::makeGainWidth(*detItr));
-
+  for (vector<DetId>::const_iterator detItr = allDetIds.begin();
+       detItr != allDetIds.end(); ++detItr) {
+    /* check CastorCondObjectContainer!
+          pedestals.addValues(*detItr,
+       CastorDbHardcode::makePedestal(*detItr).getValues ());
+          *pedestalWidths.setWidth(*detItr) =
+       CastorDbHardcode::makePedestalWidth(*detItr); gains.addValues(*detItr,
+       CastorDbHardcode::makeGain(*detItr).getValues ());
+          gainWidths.addValues(*detItr,
+       CastorDbHardcode::makeGainWidth(*detItr).getValues ());
+    */
+    pedestals.addValues(CastorDbHardcode::makePedestal(*detItr));
+    pedestalWidths.addValues(CastorDbHardcode::makePedestalWidth(*detItr));
+    gains.addValues(CastorDbHardcode::makeGain(*detItr));
+    gainWidths.addValues(CastorDbHardcode::makeGainWidth(*detItr));
   }
 
-/* obsolete stuff 
+  /* obsolete stuff
 
-  pedestals.sort();
-  pedestalWidths.sort();
-  gains.sort();
-  gainWidths.sort();
+    pedestals.sort();
+    pedestalWidths.sort();
+    gains.sort();
+    gainWidths.sort();
 
 
-//  std::cout << "TEST Pedestal " << pedestals.getValue(barrelDetId,  1) << std::endl;
-  std::cout << "Castor pedestals " << pedestals.getValue(castorDetId,  1) << std::endl;
-  std::cout << "Castor pedestal widths " << pedestalWidths.getWidth(castorDetId,  1) << std::endl;
-  std::cout << "Castor gains " << gains.getValue(castorDetId,  1) << std::endl;
-  std::cout << "Castor gain widths " << gainWidths.getValue(castorDetId,  1) << std::endl;
+  //  std::cout << "TEST Pedestal " << pedestals.getValue(barrelDetId,  1) <<
+  std::endl; std::cout << "Castor pedestals " << pedestals.getValue(castorDetId,
+  1) << std::endl; std::cout << "Castor pedestal widths " <<
+  pedestalWidths.getWidth(castorDetId,  1) << std::endl; std::cout << "Castor
+  gains " << gains.getValue(castorDetId,  1) << std::endl; std::cout << "Castor
+  gain widths " << gainWidths.getValue(castorDetId,  1) << std::endl;
 
-*/
+  */
 
   CastorDbService calibratorHandle;
 
-//  CastorDbService calibratorHandle;
+  //  CastorDbService calibratorHandle;
   calibratorHandle.setData(&pedestals);
   calibratorHandle.setData(&pedestalWidths);
   calibratorHandle.setData(&gains);
@@ -171,29 +175,27 @@ int main() {
   amplifier.setDbService(&calibratorHandle);
   parameterMap.setDbService(&calibratorHandle);
 
-  CaloTDigitizer<CastorDigitizerTraits> castorDigitizer(&castorResponse, &electronicsSim, addNoise);
+  CaloTDigitizer<CastorDigitizerTraits> castorDigitizer(
+      &castorResponse, &electronicsSim, addNoise);
 
   castorDigitizer.setDetIds(hcastorDetIds);
   cout << "setDetIds" << std::endl;
   unique_ptr<CastorDigiCollection> castorResult(new CastorDigiCollection);
   cout << "castorResult" << std::endl;
   cout << "test hit correction" << std::endl;
-  //something breaks here!
+  // something breaks here!
   testHitCorrection(&hitCorrection, hits);
   castorDigitizer.add(hits, 0, &randomEngine);
   // TODO Add pileups
-  //testHitCorrection(&hitCorrection, pileups);
-  //castorDigitizer.add(pileups, -3);
- 
+  // testHitCorrection(&hitCorrection, pileups);
+  // castorDigitizer.add(pileups, -3);
 
   cout << "castordigitizer.run" << std::endl;
   castorDigitizer.run(*castorResult, &randomEngine);
 
   cout << "Castor Frames" << std::endl;
-  copy(castorResult->begin(), castorResult->end(), std::ostream_iterator<CastorDataFrame>(std::cout, "\n"));
-  
+  copy(castorResult->begin(), castorResult->end(),
+       std::ostream_iterator<CastorDataFrame>(std::cout, "\n"));
+
   return 0;
 }
-
-
- 

--- a/SimCalorimetry/EcalElectronicsEmulation/bin/GenABIO.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/bin/GenABIO.cc
@@ -7,13 +7,13 @@
  * Run 'GenABIO -h' for usage.
  */
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <vector>
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <vector>
 
 #include "ecalDccMap.h"
 
@@ -22,87 +22,77 @@
 /* getline implementation is copied from glibc. */
 
 #ifndef SIZE_MAX
-# define SIZE_MAX ((size_t) -1)
+#define SIZE_MAX ((size_t)-1)
 #endif
 #ifndef SSIZE_MAX
-# define SSIZE_MAX ((ssize_t) (SIZE_MAX / 2))
+#define SSIZE_MAX ((ssize_t)(SIZE_MAX / 2))
 #endif
 namespace {
-ssize_t getline (char **lineptr, size_t *n, FILE *fp)
-{
-    ssize_t result;
-    size_t cur_len = 0;
+ssize_t getline(char **lineptr, size_t *n, FILE *fp) {
+  ssize_t result;
+  size_t cur_len = 0;
 
-    if (lineptr == NULL || n == NULL || fp == NULL)
-    {
-        errno = EINVAL;
-        return -1;
-   }
+  if (lineptr == NULL || n == NULL || fp == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
 
-    if (*lineptr == NULL || *n == 0)
-    {
-        *n = 120;
-        *lineptr = (char *) malloc (*n);
-        if (*lineptr == NULL)
-        {
-            result = -1;
-            goto end;
-        }
+  if (*lineptr == NULL || *n == 0) {
+    *n = 120;
+    *lineptr = (char *)malloc(*n);
+    if (*lineptr == NULL) {
+      result = -1;
+      goto end;
+    }
+  }
+
+  for (;;) {
+    int i;
+
+    i = getc(fp);
+    if (i == EOF) {
+      result = -1;
+      break;
     }
 
-    for (;;)
-    {
-        int i;
+    /* Make enough space for len+1 (for final NUL) bytes.  */
+    if (cur_len + 1 >= *n) {
+      size_t needed_max =
+          SSIZE_MAX < SIZE_MAX ? (size_t)SSIZE_MAX + 1 : SIZE_MAX;
+      size_t needed = 2 * *n + 1; /* Be generous. */
+      char *new_lineptr;
 
-        i = getc (fp);
-        if (i == EOF)
-        {
-            result = -1;
-            break;
-        }
+      if (needed_max < needed)
+        needed = needed_max;
+      if (cur_len + 1 >= needed) {
+        result = -1;
+        goto end;
+      }
 
-        /* Make enough space for len+1 (for final NUL) bytes.  */
-        if (cur_len + 1 >= *n)
-        {
-            size_t needed_max =
-                SSIZE_MAX < SIZE_MAX ? (size_t) SSIZE_MAX + 1 : SIZE_MAX;
-            size_t needed = 2 * *n + 1;   /* Be generous. */
-            char *new_lineptr;
+      new_lineptr = (char *)realloc(*lineptr, needed);
+      if (new_lineptr == NULL) {
+        result = -1;
+        goto end;
+      }
 
-            if (needed_max < needed)
-                needed = needed_max;
-            if (cur_len + 1 >= needed)
-            {
-                result = -1;
-                goto end;
-            }
-
-            new_lineptr = (char *) realloc (*lineptr, needed);
-            if (new_lineptr == NULL)
-            {
-                result = -1;
-                goto end;
-            }
-
-            *lineptr = new_lineptr;
-            *n = needed;
-        }
-
-        (*lineptr)[cur_len] = i;
-        cur_len++;
-
-        if (i == '\n')
-            break;
+      *lineptr = new_lineptr;
+      *n = needed;
     }
-    (*lineptr)[cur_len] = '\0';
-    result = cur_len ? (ssize_t) cur_len : result;
+
+    (*lineptr)[cur_len] = i;
+    cur_len++;
+
+    if (i == '\n')
+      break;
+  }
+  (*lineptr)[cur_len] = '\0';
+  result = cur_len ? (ssize_t)cur_len : result;
 
 end:
-    return result;
+  return result;
 }
-}
+} // namespace
 #endif
-
 
 using namespace std;
 
@@ -117,10 +107,10 @@ const static int nEndcapYBins = 100;
 const static int supercrystalEdge = 5;
 /** Range of endcap supercrystal x-index (xmax-xmin+1)
  */
-const static int nSupercrystalXBins = nEndcapXBins/supercrystalEdge;
+const static int nSupercrystalXBins = nEndcapXBins / supercrystalEdge;
 /** Range of endcap supercrystal y-index (ymay-ymin+1)
  */
-const static int nSupercrystalYBins = nEndcapYBins/supercrystalEdge;
+const static int nSupercrystalYBins = nEndcapYBins / supercrystalEdge;
 /** Number of endcap, obviously tow
  */
 const static int nEndcaps = 2;
@@ -132,363 +122,385 @@ const static int nEndcapTTInEta = 11;
 const static int nBarrelTTInEta = 34;
 /** Number of trigger towers along eta for the whole ECAL
  */
-const static int nTTInEta =
-2*nEndcapTTInEta+nBarrelTTInEta;
+const static int nTTInEta = 2 * nEndcapTTInEta + nBarrelTTInEta;
 /** Number of trigger towers in an eta ring
  */
 const static int nTTInPhi = 72;
 /** Number of ABs in a phi-sector
  */
-const int nABInEta=4;
+const int nABInEta = 4;
 /** Number of ABs in an eta slice
  */
-const int nABInPhi=3;
+const int nABInPhi = 3;
 /** Number of DCCs in an endcap
  */
 const int nDCCEE = 9;
-const int nABABCh = 8;//nbr of AB input/output ch. on an AB
-const int nABTCCCh = 12;//nbr of TCC inputs on an AB
-const int nDCCCh = 12;//nbr of DCC outputs on an AB
-const int nTCCInEta = 6; //nbr of TCC bins along eta
-const int nAB = nABInPhi*nABInEta;
-const int nTTInABAlongPhi=nTTInPhi/nABInPhi;
-const int iTTEtaMin[nABInEta] = {0,11,28,45};
-const int iTTEtaMax[nABInEta] = {10,27,44,55};
-const int iTTEtaSign[nABInEta] = {-1,-1,1,1};
+const int nABABCh = 8;   // nbr of AB input/output ch. on an AB
+const int nABTCCCh = 12; // nbr of TCC inputs on an AB
+const int nDCCCh = 12;   // nbr of DCC outputs on an AB
+const int nTCCInEta = 6; // nbr of TCC bins along eta
+const int nAB = nABInPhi * nABInEta;
+const int nTTInABAlongPhi = nTTInPhi / nABInPhi;
+const int iTTEtaMin[nABInEta] = {0, 11, 28, 45};
+const int iTTEtaMax[nABInEta] = {10, 27, 44, 55};
+const int iTTEtaSign[nABInEta] = {-1, -1, 1, 1};
 
-//Eta bounds for TCC partionning
-//a TCC covers from iTCCEtaBounds[iTCCEta] included to
-//iTCCEtaBounds[iTCCEta+1] excluded.
-const int iTCCEtaBounds[nTCCInEta+1] = {0,7,11,28,45,49,56};
+// Eta bounds for TCC partionning
+// a TCC covers from iTCCEtaBounds[iTCCEta] included to
+// iTCCEtaBounds[iTCCEta+1] excluded.
+const int iTCCEtaBounds[nTCCInEta + 1] = {0, 7, 11, 28, 45, 49, 56};
 
-const char* abTTFFilePrefix = "TTF_AB";
-const char* abTTFFilePostfix = ".txt";
-const char* abSRFFilePrefix = "AF_AB";
-const char* abSRFFilePostfix = ".txt";
-const char* abIOFilePrefix = "IO_AB";
-const char* abIOFilePostfix = ".txt";
+const char *abTTFFilePrefix = "TTF_AB";
+const char *abTTFFilePostfix = ".txt";
+const char *abSRFFilePrefix = "AF_AB";
+const char *abSRFFilePostfix = ".txt";
+const char *abIOFilePrefix = "IO_AB";
+const char *abIOFilePostfix = ".txt";
 
-const char* srfFilename = "SRF.txt";
-const char* ttfFilename = "TTF.txt";
-const char* xconnectFilename = "xconnect_universal.txt";
+const char *srfFilename = "SRF.txt";
+const char *ttfFilename = "TTF.txt";
+const char *xconnectFilename = "xconnect_universal.txt";
 
-const char srpFlagMarker[] = {'.', 'S', 'N', 'C', '4','5','6','7'};
+const char srpFlagMarker[] = {'.', 'S', 'N', 'C', '4', '5', '6', '7'};
 const char tccFlagMarker[] = {'.', 'S', '?', 'C', '4', '5', '6', '7'};
 
 char srp2roFlags[128];
 
-typedef enum {suppress=0, sr2, sr1, full, fsuppress, fsr2, fsr1, ffull} roAction_t;
-char roFlagMarker[] = {/*suppress*/'.', /*sr1*/'z', /*sr1*/'Z', /*full*/'F',
-		       /*fsuppress*/'4', /*fsr2*/'5', /*fsr1*/'6', /*ffull*/'7'
-};
+typedef enum {
+  suppress = 0,
+  sr2,
+  sr1,
+  full,
+  fsuppress,
+  fsr2,
+  fsr1,
+  ffull
+} roAction_t;
+char roFlagMarker[] = {
+    /*suppress*/ '.',  /*sr1*/ 'z',  /*sr1*/ 'Z',  /*full*/ 'F',
+    /*fsuppress*/ '4', /*fsr2*/ '5', /*fsr1*/ '6', /*ffull*/ '7'};
 
 const int nactions = 8;
-//can be overwritten according by cmd line arguments
-roAction_t actions[nactions] = {/*LI->*/sr2,/*S->*/full,/*N->*/ full,/*C->*/full,
-				/*fLI->*/sr2,/*fS->*/sr2,/*fN->*/sr2,/*fC->*/sr2}; 
+// can be overwritten according by cmd line arguments
+roAction_t actions[nactions] = {
+    /*LI->*/ sr2,  /*S->*/ full, /*N->*/ full, /*C->*/ full,
+    /*fLI->*/ sr2, /*fS->*/ sr2, /*fN->*/ sr2, /*fC->*/ sr2};
 
-//list of SC deserves by an endcap DCC [0(EE-)|1(EE+)][iDCCPhi]
-vector<pair<int, int> > ecalDccSC[nEndcaps][nDCCEE];
+// list of SC deserves by an endcap DCC [0(EE-)|1(EE+)][iDCCPhi]
+vector<pair<int, int>> ecalDccSC[nEndcaps][nDCCEE];
 
-void fillABTTFFiles(const char ttFlags[nTTInEta][nTTInPhi],
-                    ofstream files[]);
-void fillABSRPFiles(const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-                    const char endcapSrFlags[nEndcaps][nSupercrystalXBins]
-                    [nSupercrystalYBins],
-                    ofstream files[]);
-void fillABIOFiles(const char ttFlags[nTTInEta][nTTInPhi],
-                   const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-                   const char endcapSrFlags[nEndcaps][nSupercrystalXBins]
-                   [nSupercrystalYBins],
-                   ofstream files[]);
-inline int abNum(int iABEta, int iABPhi){return 3*iABEta+iABPhi;}
+void fillABTTFFiles(const char ttFlags[nTTInEta][nTTInPhi], ofstream files[]);
+void fillABSRPFiles(
+    const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
+    ofstream files[]);
+void fillABIOFiles(
+    const char ttFlags[nTTInEta][nTTInPhi],
+    const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
+    ofstream files[]);
+inline int abNum(int iABEta, int iABPhi) { return 3 * iABEta + iABPhi; }
 
-bool readTTF(FILE* file, char ttFlags[nTTInEta][nTTInPhi]);
-bool readSRF(FILE* file,
-	     char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-	     char endcapSrFlags[nEndcaps][nSupercrystalXBins]
-	     [nSupercrystalYBins]);
+bool readTTF(FILE *file, char ttFlags[nTTInEta][nTTInPhi]);
+bool readSRF(
+    FILE *file, char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+    char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins]);
 
-void writeABTTFFileHeader(ofstream& f, int abNum);
-void writeABSRFFileHeader(ofstream& f, int abNum);
-void writeABIOFileHeader(ofstream& f, int abNum);
+void writeABTTFFileHeader(ofstream &f, int abNum);
+void writeABSRFFileHeader(ofstream &f, int abNum);
+void writeABIOFileHeader(ofstream &f, int abNum);
 string getFlagStream(char flags[nTTInEta][nTTInPhi], int iEtaMin, int iEtaMax,
                      int iPhiMin, int iPhiMax);
-string getABTCCInputStream(const char tccFlags[nTTInEta][nTTInPhi],
-                           int iABEta, int iABPhi, int iTCCCh);
-void getABTTPhiBounds(int iABPhi, int& iTTPhiMin, int& iTTPhiMax);
-string getABABOutputStream(const char tccFlags[nTTInEta][nTTInPhi],
-                           int iABEta, int iABPhi, int iABCh);
-string getABABInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta, 
-			  int iABPhi, int iABCh);
-string getABDCCOutputStream(const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-                            const char endcapSrFlags[nEndcaps][nSupercrystalXBins]
-                            [nSupercrystalYBins],
-                            int iABEta, int iABPhi, int DCCCh);
-void abConnect(int iAB,int iABCh,int& iOtherAB,int& iOtherABCh);
+string getABTCCInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta,
+                           int iABPhi, int iTCCCh);
+void getABTTPhiBounds(int iABPhi, int &iTTPhiMin, int &iTTPhiMax);
+string getABABOutputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta,
+                           int iABPhi, int iABCh);
+string getABABInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta,
+                          int iABPhi, int iABCh);
+string getABDCCOutputStream(
+    const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
+    int iABEta, int iABPhi, int DCCCh);
+void abConnect(int iAB, int iABCh, int &iOtherAB, int &iOtherABCh);
 
 int iEvent = 0;
 
 int theAB = -1;
 
-int main(int argc, char* argv[]){
+int main(int argc, char *argv[]) {
   char barrelSrFlags[nBarrelTTInEta][nTTInPhi];
-  char endcapSrFlags[nEndcaps][nEndcapXBins/5][nEndcapYBins/5];
+  char endcapSrFlags[nEndcaps][nEndcapXBins / 5][nEndcapYBins / 5];
   char ttFlags[nTTInEta][nTTInPhi];
   ofstream abTTFFiles[nAB];
   ofstream abSRFFiles[nAB];
   ofstream abIOFiles[nAB];
 
   int iarg = 0;
-  while(++iarg<argc){
-    if(strcmp(argv[iarg],"-h")==0||strcmp(argv[iarg],"--help")==0){
-      cout << "Usage: GenABIO [OPTIONS]\n\n"
-	"Produces TT and SR flag files for each SRP board from TTF.txt and "
-	"SRF.txt global flag files. Requires the SRP cross-connect description"
-	" description file (xconnect_universal.txt). TTF.txt, SRF.txt and "
-	"xconnect_universal.txt must be in the directory the command is "
-	"launched.\n\n"
-	"OPTIONS:\n"
-        "  -A, --actions IJKLMNOP. IJKLMNOP I..P integers from 0 to 7.\n"
-	"                I: action flag for low interest RUs\n"
-	"                J: action flag for single RUs\n"
-	"                K: action flag for neighbour RUs\n"
-	"                L: action flag for centers RUs\n"
-	"                M: action flag for forced low interest RUs\n"
-	"                N: action flag for forced single RUs\n"
-	"                O: action flag for forced neighbour RUs\n"
-	"                P: action flag for forced centers RUs\n\n"
-	" -h, --help display this help\n"
-	" -a n, --ab n specifies indices of the AB whose file must be "
-	"produced. The ab number runs from 1 to 12. Use -1 to produce files "
-	"for every AB\n\n"
-	;
-      
+  while (++iarg < argc) {
+    if (strcmp(argv[iarg], "-h") == 0 || strcmp(argv[iarg], "--help") == 0) {
+      cout
+          << "Usage: GenABIO [OPTIONS]\n\n"
+             "Produces TT and SR flag files for each SRP board from TTF.txt "
+             "and "
+             "SRF.txt global flag files. Requires the SRP cross-connect "
+             "description"
+             " description file (xconnect_universal.txt). TTF.txt, SRF.txt and "
+             "xconnect_universal.txt must be in the directory the command is "
+             "launched.\n\n"
+             "OPTIONS:\n"
+             "  -A, --actions IJKLMNOP. IJKLMNOP I..P integers from 0 to 7.\n"
+             "                I: action flag for low interest RUs\n"
+             "                J: action flag for single RUs\n"
+             "                K: action flag for neighbour RUs\n"
+             "                L: action flag for centers RUs\n"
+             "                M: action flag for forced low interest RUs\n"
+             "                N: action flag for forced single RUs\n"
+             "                O: action flag for forced neighbour RUs\n"
+             "                P: action flag for forced centers RUs\n\n"
+             " -h, --help display this help\n"
+             " -a n, --ab n specifies indices of the AB whose file must be "
+             "produced. The ab number runs from 1 to 12. Use -1 to produce "
+             "files "
+             "for every AB\n\n";
+
       return 0;
     }
-    
-    if(!strcmp(argv[iarg],"-A") || !strcmp(argv[iarg],"-A")){//actions
-      if(++iarg>=argc){ cout << "Option error. Try -h\n"; return 1; }
-      for(int i=0; i<8; ++i){
-	int act = argv[iarg][i]-'0';
-	if(act<0 || act>=nactions){
-	  cout << "Error. Action argument is invalid.\n";
-	  return 1;
-	} else{
-	  actions[i] = (roAction_t)act;
-	}
+
+    if (!strcmp(argv[iarg], "-A") || !strcmp(argv[iarg], "-A")) { // actions
+      if (++iarg >= argc) {
+        cout << "Option error. Try -h\n";
+        return 1;
+      }
+      for (int i = 0; i < 8; ++i) {
+        int act = argv[iarg][i] - '0';
+        if (act < 0 || act >= nactions) {
+          cout << "Error. Action argument is invalid.\n";
+          return 1;
+        } else {
+          actions[i] = (roAction_t)act;
+        }
       }
       continue;
     }
-    if(!strcmp(argv[iarg],"-a")||!strcmp(argv[iarg],"--ab")){
-      if(++iarg>=argc){ cout << "Option error. Try -h\n"; return 1; }
+    if (!strcmp(argv[iarg], "-a") || !strcmp(argv[iarg], "--ab")) {
+      if (++iarg >= argc) {
+        cout << "Option error. Try -h\n";
+        return 1;
+      }
       theAB = strtoul(argv[iarg], nullptr, 0);
-      if(theAB>=0) --theAB;
-      if(theAB<-1 || theAB>11){
-	cout << "AB number is incorrect. Try -h option to get help.\n";
+      if (theAB >= 0)
+        --theAB;
+      if (theAB < -1 || theAB > 11) {
+        cout << "AB number is incorrect. Try -h option to get help.\n";
       }
       continue;
     }
   }
 
-  for(size_t i=0; i<sizeof(srp2roFlags)/sizeof(srp2roFlags[0]); srp2roFlags[i++]='?');
-  for(size_t i=0; i<sizeof(actions)/sizeof(actions[0]); ++i){
+  for (size_t i = 0; i < sizeof(srp2roFlags) / sizeof(srp2roFlags[0]);
+       srp2roFlags[i++] = '?')
+    ;
+  for (size_t i = 0; i < sizeof(actions) / sizeof(actions[0]); ++i) {
     srp2roFlags[(int)srpFlagMarker[i]] = roFlagMarker[actions[i]];
   }
 
-  for(int iEE=0; iEE < nEndcaps; ++iEE){
-    for(int iY = 0; iY < nSupercrystalXBins; ++iY){
-      for(int iX = 0; iX < nSupercrystalYBins; ++iX){
-	int iDCCPhi = dccPhiIndexOfRU(iEE==0?0:2,iX,iY);
-	if(iDCCPhi>=0){//SC exists
-	  ecalDccSC[iEE][iDCCPhi].push_back(pair<int,int>(iX,iY));
-	}
+  for (int iEE = 0; iEE < nEndcaps; ++iEE) {
+    for (int iY = 0; iY < nSupercrystalXBins; ++iY) {
+      for (int iX = 0; iX < nSupercrystalYBins; ++iX) {
+        int iDCCPhi = dccPhiIndexOfRU(iEE == 0 ? 0 : 2, iX, iY);
+        if (iDCCPhi >= 0) { // SC exists
+          ecalDccSC[iEE][iDCCPhi].push_back(pair<int, int>(iX, iY));
+        }
       }
     }
   }
-  
+
   stringstream s;
-  for(int iAB=0; iAB< nAB; ++iAB){
-    if(theAB!=-1 && theAB!=iAB) continue;
+  for (int iAB = 0; iAB < nAB; ++iAB) {
+    if (theAB != -1 && theAB != iAB)
+      continue;
     s.str("");
-    s << abTTFFilePrefix << (iAB<9?"0":"") << iAB+1 << abTTFFilePostfix;
+    s << abTTFFilePrefix << (iAB < 9 ? "0" : "") << iAB + 1 << abTTFFilePostfix;
     abTTFFiles[iAB].open(s.str().c_str(), ios::out);
     writeABTTFFileHeader(abTTFFiles[iAB], iAB);
     s.str("");
-    s << abSRFFilePrefix << (iAB<9?"0":"") << iAB+1 << abSRFFilePostfix;
+    s << abSRFFilePrefix << (iAB < 9 ? "0" : "") << iAB + 1 << abSRFFilePostfix;
     abSRFFiles[iAB].open(s.str().c_str(), ios::out);
     writeABSRFFileHeader(abSRFFiles[iAB], iAB);
     s.str("");
-    s << abIOFilePrefix << (iAB<9?"0":"") << iAB+1 << abIOFilePostfix;
+    s << abIOFilePrefix << (iAB < 9 ? "0" : "") << iAB + 1 << abIOFilePostfix;
     abIOFiles[iAB].open(s.str().c_str(), ios::out);
     writeABIOFileHeader(abIOFiles[iAB], iAB);
   }
 
-  FILE* srfFile = fopen(srfFilename, "r");
-  if(srfFile==nullptr){
+  FILE *srfFile = fopen(srfFilename, "r");
+  if (srfFile == nullptr) {
     cerr << "Failed to open SRF file, " << srfFilename << endl;
     exit(EXIT_FAILURE);
   }
 
-  FILE* ttfFile = fopen(ttfFilename, "r");
-  if(ttfFile==nullptr){
+  FILE *ttfFile = fopen(ttfFilename, "r");
+  if (ttfFile == nullptr) {
     cerr << "Failed to open TTF file, " << ttfFilename << endl;
     exit(EXIT_FAILURE);
   }
-  
+
   iEvent = 0;
-  while(readSRF(srfFile,barrelSrFlags,endcapSrFlags)
-	&& readTTF(ttfFile,ttFlags)){
-    if(iEvent%100==0){
+  while (readSRF(srfFile, barrelSrFlags, endcapSrFlags) &&
+         readTTF(ttfFile, ttFlags)) {
+    if (iEvent % 100 == 0) {
       cout << "Event " << iEvent << endl;
     }
-    fillABTTFFiles(ttFlags,abTTFFiles);
+    fillABTTFFiles(ttFlags, abTTFFiles);
     fillABSRPFiles(barrelSrFlags, endcapSrFlags, abSRFFiles);
-    fillABIOFiles(ttFlags,barrelSrFlags,endcapSrFlags,abIOFiles);
+    fillABIOFiles(ttFlags, barrelSrFlags, endcapSrFlags, abIOFiles);
     ++iEvent;
   }
-  
+
   return 0;
 }
 
 /** Produces one file per AB. Each file contains the TT flags
  * the AB receives from its inputs.
  */
-void  fillABTTFFiles(const char ttFlags[nTTInEta][nTTInPhi],
-		     ofstream files[]){
-  for(int iABEta=0; iABEta<nABInEta; ++iABEta){
-    for(int iABPhi=0; iABPhi<nABInPhi; ++iABPhi){
-      int iAB = abNum(iABEta,iABPhi);
+void fillABTTFFiles(const char ttFlags[nTTInEta][nTTInPhi], ofstream files[]) {
+  for (int iABEta = 0; iABEta < nABInEta; ++iABEta) {
+    for (int iABPhi = 0; iABPhi < nABInPhi; ++iABPhi) {
+      int iAB = abNum(iABEta, iABPhi);
       int iTTPhiMin;
       int iTTPhiMax;
       getABTTPhiBounds(iABPhi, iTTPhiMin, iTTPhiMax);
       //      writeEventHeader(files[iAB], iEvent, nTTInABAlongPhi);
       files[iAB] << "# Event " << iEvent << "\n";
-      
-      for(int i = 0 ; i <= iTTEtaMax[iABEta]-iTTEtaMin[iABEta];
-	  ++i){
-	int iTTEta;
-	if(iTTEtaSign[iABEta]>0){
-	  iTTEta = iTTEtaMin[iABEta] + i;
-	} else{
-	  iTTEta = iTTEtaMax[iABEta] - i;
-	}
-	for(int iTTPhi = iTTPhiMin;
-	    mod(iTTPhiMax-iTTPhi,nTTInPhi) < nTTInABAlongPhi;
-	    iTTPhi = mod(++iTTPhi, nTTInPhi)){
-	  files[iAB] << ttFlags[iTTEta][iTTPhi];
-	}
-	files[iAB] << "\n";
+
+      for (int i = 0; i <= iTTEtaMax[iABEta] - iTTEtaMin[iABEta]; ++i) {
+        int iTTEta;
+        if (iTTEtaSign[iABEta] > 0) {
+          iTTEta = iTTEtaMin[iABEta] + i;
+        } else {
+          iTTEta = iTTEtaMax[iABEta] - i;
+        }
+        for (int iTTPhi = iTTPhiMin;
+             mod(iTTPhiMax - iTTPhi, nTTInPhi) < nTTInABAlongPhi;
+             iTTPhi = mod(++iTTPhi, nTTInPhi)) {
+          files[iAB] << ttFlags[iTTEta][iTTPhi];
+        }
+        files[iAB] << "\n";
       }
       files[iAB] << "#\n";
-      //writeEventTrailer(files[iAB], nTTInABAlongPhi);
+      // writeEventTrailer(files[iAB], nTTInABAlongPhi);
     }
-  }  
+  }
 }
 
-void  fillABSRPFiles(const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-		     const char endcapSrFlags[nEndcaps][nSupercrystalXBins]
-		     [nSupercrystalYBins],
-		     ofstream files[nAB]){
-  //event headers:
-  for(int iAB=0; iAB < nAB; ++iAB){
+void fillABSRPFiles(
+    const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
+    ofstream files[nAB]) {
+  // event headers:
+  for (int iAB = 0; iAB < nAB; ++iAB) {
     files[iAB] << "# Event " << iEvent << "\n";
   }
-  
+
   bool lineAppended[nAB];
-  for(int i=0; i< nAB; lineAppended[i++]=false)/*empty*/;
-  
-  //EE:
-  for(int iEE = 0; iEE < nEndcaps; ++iEE){
-    for(int iX = 0; iX < nSupercrystalXBins; ++iX){
-      for(int iY=0; iY < nSupercrystalYBins; ++iY){
-	//        int iDCC = dccIndex(iEE==0?0:2,iX*5,iY*5);
-	int iDCC = dccIndexOfRU(iEE==0?0:2,iX,iY);
-	if(iDCC>=0){
-	  int iAB = abOfDcc(iDCC);
-	  if(!lineAppended[iAB]){
-	    for(int i=0; i< iY; ++i) files[iAB] << ' ';
-	  }
-	  files[iAB] << srp2roFlags[(int)endcapSrFlags[iEE][iX][iY]];
-	  lineAppended[iAB] = true;
-	}
-      }//next iY
-      for(int iFile=0; iFile< nAB; ++iFile){
-	if(lineAppended[iFile]){
-	  files[iFile] << "\n";
-	  lineAppended[iFile] = false;
-	}
+  for (int i = 0; i < nAB; lineAppended[i++] = false) /*empty*/
+    ;
+
+  // EE:
+  for (int iEE = 0; iEE < nEndcaps; ++iEE) {
+    for (int iX = 0; iX < nSupercrystalXBins; ++iX) {
+      for (int iY = 0; iY < nSupercrystalYBins; ++iY) {
+        //        int iDCC = dccIndex(iEE==0?0:2,iX*5,iY*5);
+        int iDCC = dccIndexOfRU(iEE == 0 ? 0 : 2, iX, iY);
+        if (iDCC >= 0) {
+          int iAB = abOfDcc(iDCC);
+          if (!lineAppended[iAB]) {
+            for (int i = 0; i < iY; ++i)
+              files[iAB] << ' ';
+          }
+          files[iAB] << srp2roFlags[(int)endcapSrFlags[iEE][iX][iY]];
+          lineAppended[iAB] = true;
+        }
+      } // next iY
+      for (int iFile = 0; iFile < nAB; ++iFile) {
+        if (lineAppended[iFile]) {
+          files[iFile] << "\n";
+          lineAppended[iFile] = false;
+        }
       }
-    }//next iX
+    } // next iX
   }
-  
-  //EB:
-  for(int iABEta=1; iABEta<3; ++iABEta){
-    for(int iABPhi=0; iABPhi<nABInPhi; ++iABPhi){
-      int iAB = abNum(iABEta,iABPhi);
+
+  // EB:
+  for (int iABEta = 1; iABEta < 3; ++iABEta) {
+    for (int iABPhi = 0; iABPhi < nABInPhi; ++iABPhi) {
+      int iAB = abNum(iABEta, iABPhi);
       int iTTPhiMin;
       int iTTPhiMax;
       getABTTPhiBounds(iABPhi, iTTPhiMin, iTTPhiMax);
-      //writeEventHeader(files[iAB], iEvent, nTTInABAlongPhi);
-      for(int i = 0 ; i <= iTTEtaMax[iABEta]-iTTEtaMin[iABEta];
-	  ++i){
-	int iTTEta;
-	if(iTTEtaSign[iABEta]>0){
-	  iTTEta = iTTEtaMin[iABEta] + i;
-	} else{
-	  iTTEta = iTTEtaMax[iABEta] - i;
-	}
-	for(int iTTPhi = iTTPhiMin;
-	    mod(iTTPhiMax-iTTPhi,nTTInPhi) < nTTInABAlongPhi;
-	    iTTPhi = mod(++iTTPhi, nTTInPhi)){
-	  files[iAB] << srp2roFlags[(int)barrelSrFlags[iTTEta-nEndcapTTInEta][iTTPhi]];
-	}
-	files[iAB] << "\n";
+      // writeEventHeader(files[iAB], iEvent, nTTInABAlongPhi);
+      for (int i = 0; i <= iTTEtaMax[iABEta] - iTTEtaMin[iABEta]; ++i) {
+        int iTTEta;
+        if (iTTEtaSign[iABEta] > 0) {
+          iTTEta = iTTEtaMin[iABEta] + i;
+        } else {
+          iTTEta = iTTEtaMax[iABEta] - i;
+        }
+        for (int iTTPhi = iTTPhiMin;
+             mod(iTTPhiMax - iTTPhi, nTTInPhi) < nTTInABAlongPhi;
+             iTTPhi = mod(++iTTPhi, nTTInPhi)) {
+          files[iAB] << srp2roFlags[(
+              int)barrelSrFlags[iTTEta - nEndcapTTInEta][iTTPhi]];
+        }
+        files[iAB] << "\n";
       }
       //      writeEventTrailer(files[iAB], nTTInABAlongPhi);
       files[iAB] << "#\n";
     }
   }
 
-  //file trailers
-  for(int iAB=0; iAB < nAB; ++iAB){
+  // file trailers
+  for (int iAB = 0; iAB < nAB; ++iAB) {
     files[iAB] << "#\n";
   }
 }
 
-void  fillABIOFiles(const char ttFlags[nTTInEta][nTTInPhi],
-		    const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-		    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
-		    ofstream files[]){
-  for(int iABEta=0; iABEta < nABInEta; ++iABEta){
-    for(int iABPhi=0; iABPhi < nABInPhi; ++iABPhi){
+void fillABIOFiles(
+    const char ttFlags[nTTInEta][nTTInPhi],
+    const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
+    ofstream files[]) {
+  for (int iABEta = 0; iABEta < nABInEta; ++iABEta) {
+    for (int iABPhi = 0; iABPhi < nABInPhi; ++iABPhi) {
       int iAB = abNum(iABEta, iABPhi);
       //      writeABIOFileHeader(files[iAB], iAB);
-      files[iAB] << "# Event " << iEvent << "\n"; 
-      //TCC inputs:
-      for(int iTCC=0; iTCC< nABTCCCh; ++iTCC){
-	files[iAB] << "ITCC" << iTCC+1 << ":"
-		   << getABTCCInputStream(ttFlags, iABEta, iABPhi, iTCC)
-		   << "\n";
+      files[iAB] << "# Event " << iEvent << "\n";
+      // TCC inputs:
+      for (int iTCC = 0; iTCC < nABTCCCh; ++iTCC) {
+        files[iAB] << "ITCC" << iTCC + 1 << ":"
+                   << getABTCCInputStream(ttFlags, iABEta, iABPhi, iTCC)
+                   << "\n";
       }
-      //AB inputs:
-      for(int iABCh=0; iABCh<nABABCh; ++iABCh){
-	files[iAB] << "IAB" <<  iABCh+1 << ":"
-		   << getABABInputStream(ttFlags, iABEta, iABPhi, iABCh)
-		   << "\n";
+      // AB inputs:
+      for (int iABCh = 0; iABCh < nABABCh; ++iABCh) {
+        files[iAB] << "IAB" << iABCh + 1 << ":"
+                   << getABABInputStream(ttFlags, iABEta, iABPhi, iABCh)
+                   << "\n";
       }
-      //AB outputs:
-      for(int iABCh=0; iABCh<nABABCh; ++iABCh){
-	files[iAB] << "OAB" <<  iABCh+1 << ":"
-		   << getABABOutputStream(ttFlags, iABEta, iABPhi, iABCh)
-		   << "\n";
+      // AB outputs:
+      for (int iABCh = 0; iABCh < nABABCh; ++iABCh) {
+        files[iAB] << "OAB" << iABCh + 1 << ":"
+                   << getABABOutputStream(ttFlags, iABEta, iABPhi, iABCh)
+                   << "\n";
       }
-      //DCC output:
-      for(int iDCCCh=0; iDCCCh<nDCCCh; ++iDCCCh){
-	files[iAB] << "ODCC";
-	files[iAB]<< (iDCCCh<=8?"0":"") << iDCCCh+1 << ":"
-		  << getABDCCOutputStream(barrelSrFlags, endcapSrFlags, iABEta, iABPhi,iDCCCh)
-		  << "\n";
+      // DCC output:
+      for (int iDCCCh = 0; iDCCCh < nDCCCh; ++iDCCCh) {
+        files[iAB] << "ODCC";
+        files[iAB] << (iDCCCh <= 8 ? "0" : "") << iDCCCh + 1 << ":"
+                   << getABDCCOutputStream(barrelSrFlags, endcapSrFlags, iABEta,
+                                           iABPhi, iDCCCh)
+                   << "\n";
       }
       files[iAB] << "#\n";
     }
@@ -503,106 +515,111 @@ void  fillABIOFiles(const char ttFlags[nTTInEta][nTTInPhi],
 
 */
 
-bool readTTF(FILE* f, char ttFlags[nTTInEta][nTTInPhi]){
-  char* buffer = nullptr;
+bool readTTF(FILE *f, char ttFlags[nTTInEta][nTTInPhi]) {
+  char *buffer = nullptr;
   size_t bufferSize = 0;
   int read;
-  if(f==nullptr) exit(EXIT_FAILURE);
-  int line=0;
+  if (f == nullptr)
+    exit(EXIT_FAILURE);
+  int line = 0;
   int iEta = 0;
-  while(iEta<nTTInEta && (read=getline(&buffer, &bufferSize,f))!=-1){
+  while (iEta < nTTInEta && (read = getline(&buffer, &bufferSize, f)) != -1) {
     ++line;
-    char* pos = buffer;
-    while(*pos==' ' || *pos=='\t') ++pos; //skip spaces
-    if(*pos!='#' && *pos!='\n'){//not a comment line nor an empty line
-      if(read-1!=nTTInPhi){
-	cerr << "Error: line " << line
-	     << " of file "<< ttfFilename << " has incorrect length"
-	  //             << " (" << read-1 << " instead of " << nTTInPhi << ")"
-	     << endl;
-	exit(EXIT_FAILURE);
+    char *pos = buffer;
+    while (*pos == ' ' || *pos == '\t')
+      ++pos;                           // skip spaces
+    if (*pos != '#' && *pos != '\n') { // not a comment line nor an empty line
+      if (read - 1 != nTTInPhi) {
+        cerr << "Error: line " << line << " of file " << ttfFilename
+             << " has incorrect length"
+             //             << " (" << read-1 << " instead of " << nTTInPhi <<
+             //             ")"
+             << endl;
+        exit(EXIT_FAILURE);
       }
-      for(int iPhi=0; iPhi<nTTInPhi; ++iPhi){
-	ttFlags[iEta][iPhi] = buffer[iPhi];
-	//         if(ttFlags[iEta][iPhi]!='.'){
-	//           cout << __FILE__ << ":" << __LINE__ << ": "
-	//                << iEta << "," << iPhi
-	//                << " " << ttFlags[iEta][iPhi] << "\n";
-	//         }
+      for (int iPhi = 0; iPhi < nTTInPhi; ++iPhi) {
+        ttFlags[iEta][iPhi] = buffer[iPhi];
+        //         if(ttFlags[iEta][iPhi]!='.'){
+        //           cout << __FILE__ << ":" << __LINE__ << ": "
+        //                << iEta << "," << iPhi
+        //                << " " << ttFlags[iEta][iPhi] << "\n";
+        //         }
       }
       ++iEta;
     }
   }
-  //returns true if all TT were read (not at end of file)
-  return (iEta==nTTInEta)?true:false;
+  // returns true if all TT were read (not at end of file)
+  return (iEta == nTTInEta) ? true : false;
 }
 
-bool readSRF(FILE* f,
-	     char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-	     char endcapSrFlags[nEndcaps][nSupercrystalXBins]
-	     [nSupercrystalYBins]){
-  char* buffer = nullptr;
+bool readSRF(
+    FILE *f, char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+    char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins]) {
+  char *buffer = nullptr;
   size_t bufferSize = 0;
   int read;
-  if(f==nullptr) exit(EXIT_FAILURE);
-  int line=0;
+  if (f == nullptr)
+    exit(EXIT_FAILURE);
+  int line = 0;
   int iEta = 0;
   int iXm = 0;
   int iXp = 0;
-  int iReadLine = 0;//number of read line, comment lines excluded
-  //number of non-comment lines to read:
-  const int nReadLine = nBarrelTTInEta + nEndcaps*nSupercrystalXBins; 
-  while(iReadLine<nReadLine && (read=getline(&buffer, &bufferSize,f))!=-1){
+  int iReadLine = 0; // number of read line, comment lines excluded
+  // number of non-comment lines to read:
+  const int nReadLine = nBarrelTTInEta + nEndcaps * nSupercrystalXBins;
+  while (iReadLine < nReadLine &&
+         (read = getline(&buffer, &bufferSize, f)) != -1) {
     ++line;
-    char* pos = buffer;
-    while(*pos==' ' || *pos=='\t') ++pos; //skip spaces
-    if(*pos!='#' && *pos!='\n'){//not a comment line nor an empty line
-      //go back to beginning of line:
+    char *pos = buffer;
+    while (*pos == ' ' || *pos == '\t')
+      ++pos;                           // skip spaces
+    if (*pos != '#' && *pos != '\n') { // not a comment line nor an empty line
+      // go back to beginning of line:
       pos = buffer;
-      if(iReadLine<nSupercrystalXBins){//EE- reading
-	if(read-1!=nSupercrystalYBins){
-	  cerr << "Error: line " << line
-	       << " of file "<< srfFilename << " has incorrect length"
-	       << " (" << read-1 << " instead of " << nSupercrystalYBins << ")"
-	       << endl;
-	  exit(EXIT_FAILURE);
-	}
-	for(int iY=0; iY<nSupercrystalYBins; ++iY){
-	  endcapSrFlags[0][iXm][iY] = buffer[iY];
-	}
-	++iXm;
-      } else if(iReadLine<nSupercrystalYBins+nBarrelTTInEta){//EB reading
-	if(read-1!=nTTInPhi){
-	  cerr << "Error: line " << line
-	       << " of file "<< srfFilename << " has incorrect length"
-	       << " (" << read-1 << " instead of " << nTTInPhi << ")"
-	       << endl;
-	  exit(EXIT_FAILURE);
-	}
-	for(int iPhi=0; iPhi<nTTInPhi; ++iPhi){
-	  barrelSrFlags[iEta][iPhi] = buffer[iPhi];
-	}
-	++iEta;
-      } else if(iReadLine<2*nSupercrystalXBins+nBarrelTTInEta){ //EE+ reading
-	if(read-1!=nSupercrystalYBins){
-	  cerr << "Error: line " << line
-	       << " of file "<< srfFilename << " has incorrect length"
-	       << " (" << read-1 << " instead of " << nSupercrystalYBins << ")"
-	       << endl;
-	  exit(EXIT_FAILURE);
-	}
-	for(int iY=0; iY<nSupercrystalYBins; ++iY){
-	  endcapSrFlags[1][iXp][iY] = buffer[iY];
-	}
-	++iXp;
+      if (iReadLine < nSupercrystalXBins) { // EE- reading
+        if (read - 1 != nSupercrystalYBins) {
+          cerr << "Error: line " << line << " of file " << srfFilename
+               << " has incorrect length"
+               << " (" << read - 1 << " instead of " << nSupercrystalYBins
+               << ")" << endl;
+          exit(EXIT_FAILURE);
+        }
+        for (int iY = 0; iY < nSupercrystalYBins; ++iY) {
+          endcapSrFlags[0][iXm][iY] = buffer[iY];
+        }
+        ++iXm;
+      } else if (iReadLine < nSupercrystalYBins + nBarrelTTInEta) { // EB
+                                                                    // reading
+        if (read - 1 != nTTInPhi) {
+          cerr << "Error: line " << line << " of file " << srfFilename
+               << " has incorrect length"
+               << " (" << read - 1 << " instead of " << nTTInPhi << ")" << endl;
+          exit(EXIT_FAILURE);
+        }
+        for (int iPhi = 0; iPhi < nTTInPhi; ++iPhi) {
+          barrelSrFlags[iEta][iPhi] = buffer[iPhi];
+        }
+        ++iEta;
+      } else if (iReadLine <
+                 2 * nSupercrystalXBins + nBarrelTTInEta) { // EE+ reading
+        if (read - 1 != nSupercrystalYBins) {
+          cerr << "Error: line " << line << " of file " << srfFilename
+               << " has incorrect length"
+               << " (" << read - 1 << " instead of " << nSupercrystalYBins
+               << ")" << endl;
+          exit(EXIT_FAILURE);
+        }
+        for (int iY = 0; iY < nSupercrystalYBins; ++iY) {
+          endcapSrFlags[1][iXp][iY] = buffer[iY];
+        }
+        ++iXp;
       }
-      ++iReadLine;      
-    }//not a comment or empty line
+      ++iReadLine;
+    } // not a comment or empty line
   }
-  //returns 0 if all TT were read:
-  return (iReadLine==nReadLine)?true:false;
+  // returns 0 if all TT were read:
+  return (iReadLine == nReadLine) ? true : false;
 }
-
 
 // void writeEventHeader(ofstream& f, int iEvent, int nPhi){
 //   //event header:
@@ -627,189 +644,242 @@ bool readSRF(FILE* f,
 //   f << "+\n";
 // }
 
-void writeABTTFFileHeader(ofstream& f, int abNum){
+void writeABTTFFileHeader(ofstream &f, int abNum) {
   time_t t;
   time(&t);
-  const char* date = ctime(&t);
-  f << "# TTF flag map covered by AB " << abNum+1 <<"\n#\n"
-    "# Generated on : " << date << "#\n"
-    "# +---> Phi          " << srpFlagMarker[0] << ": 000 (low interest)\n"
-    "# |                  " << srpFlagMarker[1] << ": 001 (single)\n"     
-    "# |                  " << srpFlagMarker[2] << ": 010 (neighbour)\n"    
-    "# V |Eta|            " << srpFlagMarker[3] << ": 011 (center)\n"     
-    "#\n";
+  const char *date = ctime(&t);
+  f << "# TTF flag map covered by AB " << abNum + 1
+    << "\n#\n"
+       "# Generated on : "
+    << date
+    << "#\n"
+       "# +---> Phi          "
+    << srpFlagMarker[0]
+    << ": 000 (low interest)\n"
+       "# |                  "
+    << srpFlagMarker[1]
+    << ": 001 (single)\n"
+       "# |                  "
+    << srpFlagMarker[2]
+    << ": 010 (neighbour)\n"
+       "# V |Eta|            "
+    << srpFlagMarker[3]
+    << ": 011 (center)\n"
+       "#\n";
 }
 
-void writeABSRFFileHeader(ofstream& f, int abNum){
+void writeABSRFFileHeader(ofstream &f, int abNum) {
   time_t t;
   time(&t);
-  const char* date = ctime(&t);
-  const char* xLabel;
-  const char* yLabel;
-  if(abNum<3 || abNum>8){//endcap
+  const char *date = ctime(&t);
+  const char *xLabel;
+  const char *yLabel;
+  if (abNum < 3 || abNum > 8) { // endcap
     xLabel = "Y  ";
     yLabel = "X    ";
-  } else{//barrel
+  } else { // barrel
     xLabel = "Phi";
     yLabel = "|Eta|";
   }
-  f << "# SRF flag map covered by AB " << abNum+1 <<"\n#\n"
-    "# Generated on : " << date << "#\n"
-    "# +---> " << xLabel << "          " << roFlagMarker[0] << ": 000 (suppress)\n"          
-    "# |                  "              << roFlagMarker[1] << ": 010 (SR Threshold 2)\n"     
-    "# |                  "              << roFlagMarker[2] << ": 001 (SR Threshold 1)\n"     
-    "# V " << yLabel << "            "   << roFlagMarker[3] << ": 011 (Full readout)\n"     
-    "#\n"
-    "# action table (when forced):\n"
-    "# LI-> " << roFlagMarker[actions[0]] << " (" << roFlagMarker[actions[4]]<< ")" << "\n"
-    "# S -> " << roFlagMarker[actions[1]] << " (" << roFlagMarker[actions[5]]<< ")" << "\n"
-    "# N -> " << roFlagMarker[actions[2]] << " (" << roFlagMarker[actions[6]]<< ")" << "\n"
-    "# C -> " << roFlagMarker[actions[3]] << " (" << roFlagMarker[actions[7]]<< ")" << "\n";
+  f << "# SRF flag map covered by AB " << abNum + 1
+    << "\n#\n"
+       "# Generated on : "
+    << date
+    << "#\n"
+       "# +---> "
+    << xLabel << "          " << roFlagMarker[0]
+    << ": 000 (suppress)\n"
+       "# |                  "
+    << roFlagMarker[1]
+    << ": 010 (SR Threshold 2)\n"
+       "# |                  "
+    << roFlagMarker[2]
+    << ": 001 (SR Threshold 1)\n"
+       "# V "
+    << yLabel << "            " << roFlagMarker[3]
+    << ": 011 (Full readout)\n"
+       "#\n"
+       "# action table (when forced):\n"
+       "# LI-> "
+    << roFlagMarker[actions[0]] << " (" << roFlagMarker[actions[4]] << ")"
+    << "\n"
+       "# S -> "
+    << roFlagMarker[actions[1]] << " (" << roFlagMarker[actions[5]] << ")"
+    << "\n"
+       "# N -> "
+    << roFlagMarker[actions[2]] << " (" << roFlagMarker[actions[6]] << ")"
+    << "\n"
+       "# C -> "
+    << roFlagMarker[actions[3]] << " (" << roFlagMarker[actions[7]] << ")"
+    << "\n";
 }
 
-void writeABIOFileHeader(ofstream& f, int abNum){
+void writeABIOFileHeader(ofstream &f, int abNum) {
   time_t t;
   time(&t);
-  const char* date = ctime(&t);
-  f << "# AB " << abNum+1 <<" I/O \n#\n"
-    "# Generated on : " << date << "#\n"
-    "# " << srpFlagMarker[0] << ": 000 (low interest)   " << tccFlagMarker[0] << ": 000 (low interest)   " << roFlagMarker[0] << ": 000 (suppress)\n"
-    "# " << srpFlagMarker[1] << ": 001 (single)         " << tccFlagMarker[1] << ": 001 (mid interest)   " << roFlagMarker[1] << ": 010 (SR Threshold 2)\n"
-    "# " << srpFlagMarker[2] << ": 010 (neighbour)      " << tccFlagMarker[2] << ": 010 (not valid)      " << roFlagMarker[2] << ": 001 (SR Threshold 1)\n"   
-    "# " << srpFlagMarker[3] << ": 011 (center)         " << tccFlagMarker[3] << ": 011 (high interest)  " <<	roFlagMarker[3] << ": 011 (Full readout)\n"
-    "#\n"
-    "# action table (when forced):\n"
-    "# LI-> " << roFlagMarker[actions[0]] << " (" << roFlagMarker[actions[4]]<< ")" << "\n"
-    "# S -> " << roFlagMarker[actions[1]] << " (" << roFlagMarker[actions[5]]<< ")" << "\n"
-    "# N -> " << roFlagMarker[actions[2]] << " (" << roFlagMarker[actions[6]]<< ")" << "\n"
-    "# C -> " << roFlagMarker[actions[3]] << " (" << roFlagMarker[actions[7]]<< ")" << "\n"
-    "#\n"; 
+  const char *date = ctime(&t);
+  f << "# AB " << abNum + 1
+    << " I/O \n#\n"
+       "# Generated on : "
+    << date
+    << "#\n"
+       "# "
+    << srpFlagMarker[0] << ": 000 (low interest)   " << tccFlagMarker[0]
+    << ": 000 (low interest)   " << roFlagMarker[0]
+    << ": 000 (suppress)\n"
+       "# "
+    << srpFlagMarker[1] << ": 001 (single)         " << tccFlagMarker[1]
+    << ": 001 (mid interest)   " << roFlagMarker[1]
+    << ": 010 (SR Threshold 2)\n"
+       "# "
+    << srpFlagMarker[2] << ": 010 (neighbour)      " << tccFlagMarker[2]
+    << ": 010 (not valid)      " << roFlagMarker[2]
+    << ": 001 (SR Threshold 1)\n"
+       "# "
+    << srpFlagMarker[3] << ": 011 (center)         " << tccFlagMarker[3]
+    << ": 011 (high interest)  " << roFlagMarker[3]
+    << ": 011 (Full readout)\n"
+       "#\n"
+       "# action table (when forced):\n"
+       "# LI-> "
+    << roFlagMarker[actions[0]] << " (" << roFlagMarker[actions[4]] << ")"
+    << "\n"
+       "# S -> "
+    << roFlagMarker[actions[1]] << " (" << roFlagMarker[actions[5]] << ")"
+    << "\n"
+       "# N -> "
+    << roFlagMarker[actions[2]] << " (" << roFlagMarker[actions[6]] << ")"
+    << "\n"
+       "# C -> "
+    << roFlagMarker[actions[3]] << " (" << roFlagMarker[actions[7]] << ")"
+    << "\n"
+       "#\n";
 }
 
 string getFlagStream(const char flags[nTTInEta][nTTInPhi], int iEtaMin,
-		     int iEtaMax, int iPhiMin, int iPhiMax){
-  assert(0<=iEtaMin && iEtaMin<=iEtaMax && iEtaMax<nTTInEta);
-  if(iEtaMin<=nTTInEta/2 && iEtaMax>nTTInEta){
-    cerr << "Implementation Errror:"
-	 << __FILE__ << ":" << __LINE__ 
-	 << ": A flag stream cannot covers parts of both half-ECAL!"
-	 << endl;
+                     int iEtaMax, int iPhiMin, int iPhiMax) {
+  assert(0 <= iEtaMin && iEtaMin <= iEtaMax && iEtaMax < nTTInEta);
+  if (iEtaMin <= nTTInEta / 2 && iEtaMax > nTTInEta) {
+    cerr << "Implementation Errror:" << __FILE__ << ":" << __LINE__
+         << ": A flag stream cannot covers parts of both half-ECAL!" << endl;
     exit(EXIT_FAILURE);
   }
 
-  bool zPos = (iEtaMin>=nTTInEta/2);
+  bool zPos = (iEtaMin >= nTTInEta / 2);
 
   stringstream buffer;
   buffer.str("");
-  for(int jEta = 0; jEta <= iEtaMax-iEtaMin; ++jEta){
-    //loops on iEta in |eta| increasing order:
+  for (int jEta = 0; jEta <= iEtaMax - iEtaMin; ++jEta) {
+    // loops on iEta in |eta| increasing order:
     int iEta;
-    if(zPos){
+    if (zPos) {
       iEta = iEtaMin + jEta;
-    } else{
+    } else {
       iEta = iEtaMax - jEta;
     }
 
-    for(int iPhi = mod(iPhiMin,nTTInPhi);
-	mod(iPhiMax+1-iPhi,nTTInPhi) != 0;
-	iPhi = mod(++iPhi, nTTInPhi)){
+    for (int iPhi = mod(iPhiMin, nTTInPhi);
+         mod(iPhiMax + 1 - iPhi, nTTInPhi) != 0; iPhi = mod(++iPhi, nTTInPhi)) {
       buffer << flags[iEta][iPhi];
     }
   }
-  
+
   return buffer.str();
 }
 
-string getABTCCInputStream(const char tccFlags[nTTInEta][nTTInPhi],
-			   int iABEta, int iABPhi, int iTCCCh){
-  //gets eta bounds for this tcc channel:
+string getABTCCInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta,
+                           int iABPhi, int iTCCCh) {
+  // gets eta bounds for this tcc channel:
   int iTCCEta;
-  if(iABEta==1 || iABEta==2){//barrel
-    if(iTCCCh>5) return ""; //only 6 TCCs per AB for barrel
-    iTCCEta =  1 + iABEta;
-  } else{//endcap
-    if(iABEta==0){//EE-
-      iTCCEta = (iTCCCh<6)?1:0;
-    } else{//EE+
-      iTCCEta = (iTCCCh<6)?4:5;
+  if (iABEta == 1 || iABEta == 2) { // barrel
+    if (iTCCCh > 5)
+      return ""; // only 6 TCCs per AB for barrel
+    iTCCEta = 1 + iABEta;
+  } else {             // endcap
+    if (iABEta == 0) { // EE-
+      iTCCEta = (iTCCCh < 6) ? 1 : 0;
+    } else { // EE+
+      iTCCEta = (iTCCCh < 6) ? 4 : 5;
     }
-  }      
+  }
   int iEtaMin = iTCCEtaBounds[iTCCEta];
-  int iEtaMax = iTCCEtaBounds[iTCCEta+1]-1;
+  int iEtaMax = iTCCEtaBounds[iTCCEta + 1] - 1;
 
-  //gets phi bounds:
+  // gets phi bounds:
   int iPhiMin;
   int iPhiMax;
   getABTTPhiBounds(iABPhi, iPhiMin, iPhiMax);
-  //phi is increasing with TTC channel number
-  //a TTC covers a 4TT-wide phi-sector
-  //=>iPhiMin(iTTCCh) = iPhiMin(AB) + 4*iTTCCh for iTCCCh<6 
-  iPhiMin += 4*(iTCCCh%6);
+  // phi is increasing with TTC channel number
+  // a TTC covers a 4TT-wide phi-sector
+  //=>iPhiMin(iTTCCh) = iPhiMin(AB) + 4*iTTCCh for iTCCCh<6
+  iPhiMin += 4 * (iTCCCh % 6);
   iPhiMax = iPhiMin + 4 - 1;
-  
+
   return getFlagStream(tccFlags, iEtaMin, iEtaMax, iPhiMin, iPhiMax);
 }
 
-string getABABOutputStream(const char tccFlags[nTTInEta][nTTInPhi],
-			   int iABEta, int iABPhi, int iABCh){
+string getABABOutputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta,
+                           int iABPhi, int iABCh) {
   stringstream buffer;
   buffer.str("");
-  bool barrel = (iABEta==1 || iABEta==2); //true for barrel, false for endcap
-  switch(iABCh){
+  bool barrel =
+      (iABEta == 1 || iABEta == 2); // true for barrel, false for endcap
+  switch (iABCh) {
   case 0:
-    //to AB ch #0 are sent the 16 1st TCC flags received on TCC input Ch. 0
-    buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 0).substr(0,16);
+    // to AB ch #0 are sent the 16 1st TCC flags received on TCC input Ch. 0
+    buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 0).substr(0, 16);
     break;
   case 1:
-    //to AB ch #1 are sent the 16 1st TCC flags received on TCC input Ch. 0 to 5:
-    for(int iTCCCh=0; iTCCCh<6; ++iTCCCh){
-      buffer <<
-	getABTCCInputStream(tccFlags, iABEta, iABPhi, iTCCCh).substr(0,16);
+    // to AB ch #1 are sent the 16 1st TCC flags received on TCC input Ch. 0 to
+    // 5:
+    for (int iTCCCh = 0; iTCCCh < 6; ++iTCCCh) {
+      buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, iTCCCh)
+                    .substr(0, 16);
     }
     break;
   case 2:
-    //to AB ch #2 are sent the 16 1st TCC flags received on TCC input Ch. 5:
-    buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 5).substr(0,16);
+    // to AB ch #2 are sent the 16 1st TCC flags received on TCC input Ch. 5:
+    buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 5).substr(0, 16);
     break;
   case 3:
-    //to AB ch #3 are sent TCC flags received on TCC input Ch. 0 and 6:
+    // to AB ch #3 are sent TCC flags received on TCC input Ch. 0 and 6:
     buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 0);
     buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 6);
     break;
   case 4:
-    //to AB ch #4 are sent TCC flags received on TCC input Ch 5 and 11:
+    // to AB ch #4 are sent TCC flags received on TCC input Ch 5 and 11:
     buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 5);
     buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 11);
     break;
   case 5:
-    //for endcaps AB output ch 5 is not used.
-    //for barrel, to AB ch #5 are sent the 16 last TCC flags received on TCC
-    //input Ch. 0:
-    if(barrel){//in barrel
+    // for endcaps AB output ch 5 is not used.
+    // for barrel, to AB ch #5 are sent the 16 last TCC flags received on TCC
+    // input Ch. 0:
+    if (barrel) { // in barrel
       string s = getABTCCInputStream(tccFlags, iABEta, iABPhi, 0);
-      assert(s.size()>=16);
-      buffer << s.substr(s.size()-16,16);
+      assert(s.size() >= 16);
+      buffer << s.substr(s.size() - 16, 16);
     }
     break;
   case 6:
-    //for endcaps AB output ch 6 is not used.
-    //for barrel, to AB ch #6 are sent the 16 last TCC flags received on TCC
-    //input Ch. 0 to 5:
-    if(barrel){//in barrel
-      for(int iTCCCh=0; iTCCCh<6; ++iTCCCh){
-	string s = getABTCCInputStream(tccFlags, iABEta, iABPhi, iTCCCh); 
-	buffer << s.substr(s.size()-16,16);
+    // for endcaps AB output ch 6 is not used.
+    // for barrel, to AB ch #6 are sent the 16 last TCC flags received on TCC
+    // input Ch. 0 to 5:
+    if (barrel) { // in barrel
+      for (int iTCCCh = 0; iTCCCh < 6; ++iTCCCh) {
+        string s = getABTCCInputStream(tccFlags, iABEta, iABPhi, iTCCCh);
+        buffer << s.substr(s.size() - 16, 16);
       }
     }
     break;
   case 7:
-    //for endcaps AB output ch 7 is not used.
-    //for barrel, to AB ch #7 are sent the 16 last TCC flags received on TCC
-    //input Ch. 5:
-    if(barrel){//in barrel
+    // for endcaps AB output ch 7 is not used.
+    // for barrel, to AB ch #7 are sent the 16 last TCC flags received on TCC
+    // input Ch. 5:
+    if (barrel) { // in barrel
       string s = getABTCCInputStream(tccFlags, iABEta, iABPhi, 5);
-      assert(s.size()>=16);
-      buffer << s.substr(s.size()-16,16);
+      assert(s.size() >= 16);
+      buffer << s.substr(s.size() - 16, 16);
     }
     break;
   default:
@@ -818,54 +888,53 @@ string getABABOutputStream(const char tccFlags[nTTInEta][nTTInPhi],
   return buffer.str();
 }
 
-string getABABInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta, 
-			  int iABPhi, int iABCh){
+string getABABInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta,
+                          int iABPhi, int iABCh) {
   int iAB = abNum(iABEta, iABPhi);
-  int iOtherAB; //AB which this channel is connected to
-  int iOtherABCh; //ch # on the other side of the AB-AB link
-  abConnect(iAB,iABCh,iOtherAB,iOtherABCh);
-  int iOtherABEta = iOtherAB/3;
-  int iOtherABPhi = iOtherAB%3;
+  int iOtherAB;   // AB which this channel is connected to
+  int iOtherABCh; // ch # on the other side of the AB-AB link
+  abConnect(iAB, iABCh, iOtherAB, iOtherABCh);
+  int iOtherABEta = iOtherAB / 3;
+  int iOtherABPhi = iOtherAB % 3;
   return getABABOutputStream(tccFlags, iOtherABEta, iOtherABPhi, iOtherABCh);
 }
 
-
-void getABTTPhiBounds(int iABPhi, int& iTTPhiMin, int& iTTPhiMax){
-  iTTPhiMin = mod(-6+iABPhi*nTTInABAlongPhi,nTTInPhi);
-  iTTPhiMax = mod(iTTPhiMin+nTTInABAlongPhi-1, nTTInPhi);
+void getABTTPhiBounds(int iABPhi, int &iTTPhiMin, int &iTTPhiMax) {
+  iTTPhiMin = mod(-6 + iABPhi * nTTInABAlongPhi, nTTInPhi);
+  iTTPhiMax = mod(iTTPhiMin + nTTInABAlongPhi - 1, nTTInPhi);
 }
 
-void abConnect(int iAB,int iABCh,int& iOtherAB,int& iOtherABCh){
+void abConnect(int iAB, int iABCh, int &iOtherAB, int &iOtherABCh) {
   static bool firstCall = true;
   static int xconnectMap[nAB][nABABCh][2];
-  if(firstCall){
-    FILE* f = fopen(xconnectFilename, "r");
-    if(f==nullptr){
+  if (firstCall) {
+    FILE *f = fopen(xconnectFilename, "r");
+    if (f == nullptr) {
       cerr << "Error. Failed to open xconnect definition file,"
-	   << xconnectFilename << endl;
+           << xconnectFilename << endl;
       exit(EXIT_FAILURE);
     }
-    //skips two first lines:
-    for(int i=0; i<2; ++i){
+    // skips two first lines:
+    for (int i = 0; i < 2; ++i) {
       int c;
-      while((c=getc(f))!='\n' && c >=0);
+      while ((c = getc(f)) != '\n' && c >= 0)
+        ;
     }
-    int ilink = 0 ;
-    while(!feof(f)){
+    int ilink = 0;
+    while (!feof(f)) {
       int abIn;
       int pinIn;
       int abOut;
       int pinOut;
-      if(4==fscanf(f, "%d\t%d\t%d\t%d", &abIn, &pinIn, &abOut, &pinOut)){
-	xconnectMap[abIn][pinIn][0] = abOut;
-	xconnectMap[abIn][pinIn][1] = pinOut;
-	++ilink;
+      if (4 == fscanf(f, "%d\t%d\t%d\t%d", &abIn, &pinIn, &abOut, &pinOut)) {
+        xconnectMap[abIn][pinIn][0] = abOut;
+        xconnectMap[abIn][pinIn][1] = pinOut;
+        ++ilink;
       }
     }
-    if(ilink!=nAB*nABABCh){
+    if (ilink != nAB * nABABCh) {
       cerr << "Error cross-connect definition file " << xconnectFilename
-	   << " contains an unexpected number of link definition."
-	   << endl;
+           << " contains an unexpected number of link definition." << endl;
       exit(EXIT_FAILURE);
     }
     firstCall = false;
@@ -875,33 +944,34 @@ void abConnect(int iAB,int iABCh,int& iOtherAB,int& iOtherABCh){
   iOtherABCh = xconnectMap[iAB][iABCh][1];
 }
 
-string getABDCCOutputStream(const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-			    const char endcapSrFlags[nEndcaps][nSupercrystalXBins]
-			    [nSupercrystalYBins],
-			    int iABEta, int iABPhi, int iDCCCh){
-  bool barrel = (iABEta==1||iABEta==2);
-  if(barrel){
-    //same as TCC with same ch number but with TCC flags replaced by SRP flags:
-    string stream = getABTCCInputStream(barrelSrFlags-nEndcapTTInEta, iABEta, iABPhi, iDCCCh);
-    //converts srp flags to readout flags:
-    for(size_t i=0; i< stream.size(); ++i){
+string getABDCCOutputStream(
+    const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
+    int iABEta, int iABPhi, int iDCCCh) {
+  bool barrel = (iABEta == 1 || iABEta == 2);
+  if (barrel) {
+    // same as TCC with same ch number but with TCC flags replaced by SRP flags:
+    string stream = getABTCCInputStream(barrelSrFlags - nEndcapTTInEta, iABEta,
+                                        iABPhi, iDCCCh);
+    // converts srp flags to readout flags:
+    for (size_t i = 0; i < stream.size(); ++i) {
       stream[i] = srp2roFlags[(int)stream[i]];
     }
     return stream;
-  } else{//endcap
-    if(iDCCCh<3){//used DCC output channel
-      //endcap index:
-      int iEE=(iABEta==0)?0:1;
+  } else {            // endcap
+    if (iDCCCh < 3) { // used DCC output channel
+      // endcap index:
+      int iEE = (iABEta == 0) ? 0 : 1;
       stringstream buffer("");
-      //3 DCC per AB and AB DCC output channel in
-      //increasing DCC phi position:
-      int iDCCPhi = iABPhi*3+iDCCCh;
-      for(size_t iSC=0; iSC < ecalDccSC[iEE][iDCCPhi].size(); ++iSC){
-	pair<int,int> sc = ecalDccSC[iEE][iDCCPhi][iSC];
-	buffer << srp2roFlags[(int)endcapSrFlags[iEE][sc.first][sc.second]];
+      // 3 DCC per AB and AB DCC output channel in
+      // increasing DCC phi position:
+      int iDCCPhi = iABPhi * 3 + iDCCCh;
+      for (size_t iSC = 0; iSC < ecalDccSC[iEE][iDCCPhi].size(); ++iSC) {
+        pair<int, int> sc = ecalDccSC[iEE][iDCCPhi][iSC];
+        buffer << srp2roFlags[(int)endcapSrFlags[iEE][sc.first][sc.second]];
       }
       return buffer.str();
-    } else{//unused output channel
+    } else { // unused output channel
       return "";
     }
   }

--- a/SimCalorimetry/EcalElectronicsEmulation/bin/ecalDccMap.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/bin/ecalDccMap.h
@@ -1,32 +1,30 @@
 #include <iostream>
 
-template<class T>
-T mod(const T& a, const T& b){
-  T c = a%b;
-  return c<0?c+b:c;
+template <class T> T mod(const T &a, const T &b) {
+  T c = a % b;
+  return c < 0 ? c + b : c;
 }
 
-static const char endcapDccMap[401] = {
-  "       777777       "      
-  "    666777777888    "      
-  "   66667777778888   "      
-  "  6666667777888888  "
-  " 666666677778888888 "
-  " 566666677778888880 "             //    Z          
-  " 555666667788888000 "             //     x-----> X 
-  "55555566677888000000"             //     |         
-  "555555566  880000000"             //     |         
-  "55555555    00000000"//_          //     |         
-  "55555554    10000000"             //     V Y       
-  "554444444  111111100"
-  "44444444332211111111"
-  " 444444333222111111 "
-  " 444443333222211111 "
-  " 444433333222221111 "
-  "  4443333322222111  "
-  "   43333332222221   "
-  "    333333222222    "
-  "       333222       "};
+static const char endcapDccMap[401] = {"       777777       "
+                                       "    666777777888    "
+                                       "   66667777778888   "
+                                       "  6666667777888888  "
+                                       " 666666677778888888 "
+                                       " 566666677778888880 " //    Z
+                                       " 555666667788888000 " //     x-----> X
+                                       "55555566677888000000" //     |
+                                       "555555566  880000000" //     |
+                                       "55555555    00000000" //_          // |
+                                       "55555554    10000000" //     V Y
+                                       "554444444  111111100"
+                                       "44444444332211111111"
+                                       " 444444333222111111 "
+                                       " 444443333222211111 "
+                                       " 444433333222221111 "
+                                       "  4443333322222111  "
+                                       "   43333332222221   "
+                                       "    333333222222    "
+                                       "       333222       "};
 
 /** Gets the phi index of the DCC reading a RU (SC or TT)
  * @param iDet 0 for EE-, 1 for EB, 2 for EE+
@@ -35,16 +33,15 @@ static const char endcapDccMap[401] = {
  * @return DCC phi index between 0 and 8 for EE
  * and between 0 and 17 for EB
  */
-inline int dccPhiIndexOfRU(int iDet, int i, int j){
-  if(iDet==1){//barrel
-    //iEta=i, iPhi=j
-    //phi edge of a SM is 4 TT
-    return j/4;
+inline int dccPhiIndexOfRU(int iDet, int i, int j) {
+  if (iDet == 1) { // barrel
+    // iEta=i, iPhi=j
+    // phi edge of a SM is 4 TT
+    return j / 4;
   }
-  char flag=endcapDccMap[i+j*20];
-  return (flag==' ')?-1:(flag-'0');
+  char flag = endcapDccMap[i + j * 20];
+  return (flag == ' ') ? -1 : (flag - '0');
 }
-
 
 /** Gets the phi index of the DCC reading a crystal
  * @param iDet 0 for EE-, 1 for EB, 2 for EE+
@@ -53,73 +50,76 @@ inline int dccPhiIndexOfRU(int iDet, int i, int j){
  * @return DCC phi index between 0 and 8 for EE
  * and between 0 and 17 for EB
  */
-inline int dccPhiIndex(int iDet, int i, int j){
-  return dccPhiIndexOfRU(iDet, i/5, j/5);
+inline int dccPhiIndex(int iDet, int i, int j) {
+  return dccPhiIndexOfRU(iDet, i / 5, j / 5);
 }
 
 /** Gets the index of the DCC reading a crystal
  * @param iDet 0 for EE-, 1 for EB, 2 for EE+
  * @param i iEta or iX
  * @param j iPhi or iY
- * @return DCC index between 0 and 53 
+ * @return DCC index between 0 and 53
  */
-inline int dccIndex(int iDet, int i, int j){
-  if(iDet==1){//barrel
-    //a SM is 85 crystal long:
-    int iEtaSM = i/85;
-    //a SM is 20 crystal wide:
-    int iPhiSM = j/20;
-    //DCC numbers start at 9 in the barrel and there 18 DCC/SM
-    return 9+18*iEtaSM+iPhiSM;
+inline int dccIndex(int iDet, int i, int j) {
+  if (iDet == 1) { // barrel
+    // a SM is 85 crystal long:
+    int iEtaSM = i / 85;
+    // a SM is 20 crystal wide:
+    int iPhiSM = j / 20;
+    // DCC numbers start at 9 in the barrel and there 18 DCC/SM
+    return 9 + 18 * iEtaSM + iPhiSM;
   }
   int iPhi = dccPhiIndex(iDet, i, j);
-  if(iPhi<0) return -1;
-  //34 DCCs in barrel and 8 in EE-=>in EE+ DCC numbering starts at 45,
-  //iDet/2 is 0 for EE- and 1 for EE+:
-  return iPhi+iDet/2*45;
+  if (iPhi < 0)
+    return -1;
+  // 34 DCCs in barrel and 8 in EE-=>in EE+ DCC numbering starts at 45,
+  // iDet/2 is 0 for EE- and 1 for EE+:
+  return iPhi + iDet / 2 * 45;
 }
 
 /** Gets the index of the DCC reading a crystal
  * @param iDet 0 for EE-, 1 for EB, 2 for EE+
  * @param i iEta (staring at eta=-1.48)  or iX
  * @param j iPhi or iY
- * @return DCC index between 0 and 53 
+ * @return DCC index between 0 and 53
  */
-inline int dccIndexOfRU(int iDet, int i, int j){
-  if(iDet==1){//barrel
-    //a SM is 17 RU long:
-    int iEtaSM = i/17;
-    //a SM is 4 RU wide:
-    int iPhiSM = j/4;
-    //DCC numbers start at 9 in the barrel and there 18 DCC/SM
-    return 9+18*iEtaSM+iPhiSM;
+inline int dccIndexOfRU(int iDet, int i, int j) {
+  if (iDet == 1) { // barrel
+    // a SM is 17 RU long:
+    int iEtaSM = i / 17;
+    // a SM is 4 RU wide:
+    int iPhiSM = j / 4;
+    // DCC numbers start at 9 in the barrel and there 18 DCC/SM
+    return 9 + 18 * iEtaSM + iPhiSM;
   }
   int iPhi = dccPhiIndexOfRU(iDet, i, j);
-  if(iPhi<0) return -1;
-  //34 DCCs in barrel and 8 in EE-=>in EE+ DCC numbering starts at 45,
-  //iDet/2 is 0 for EE- and 1 for EE+:
-  return iPhi+iDet/2*45;
+  if (iPhi < 0)
+    return -1;
+  // 34 DCCs in barrel and 8 in EE-=>in EE+ DCC numbering starts at 45,
+  // iDet/2 is 0 for EE- and 1 for EE+:
+  return iPhi + iDet / 2 * 45;
 }
 
-inline int abOfDcc(int iDCC){
-  if(iDCC<0||iDCC>54) return -1;
-  if(iDCC<9){//EE-
-    return iDCC/3;
-  } else if(iDCC<27){//EB-
-    //an EB AB is made of 6 DCCs,
-    //first EB- AB is numbered 3
-    //and "1st" DCC of AB 3 is DCC 26
+inline int abOfDcc(int iDCC) {
+  if (iDCC < 0 || iDCC > 54)
+    return -1;
+  if (iDCC < 9) { // EE-
+    return iDCC / 3;
+  } else if (iDCC < 27) { // EB-
+    // an EB AB is made of 6 DCCs,
+    // first EB- AB is numbered 3
+    // and "1st" DCC of AB 3 is DCC 26
     //(AB 3 made of DCCs 26,9,10,11,12,13):
-    return 3+mod(iDCC-26,18)/6;
-  } else if(iDCC<45){//EB+
-    //an EB AB is made of 6 DCCs,
-    //first EB+ AB is numbered 6
-    //and "1st" DCC of AB6 is DCC 44
+    return 3 + mod(iDCC - 26, 18) / 6;
+  } else if (iDCC < 45) { // EB+
+    // an EB AB is made of 6 DCCs,
+    // first EB+ AB is numbered 6
+    // and "1st" DCC of AB6 is DCC 44
     //(AB 6 made of DCCs 44,27,28,29,30,31):
-    return 6+mod(iDCC-44,18)/6;
-  } else{//EE+
-    //AB numbering starts at DCC=45 and runs along phi in increasing phi
-    //first EE+ AB is numbered 9:
-    return 9+(iDCC-45)/3;
+    return 6 + mod(iDCC - 44, 18) / 6;
+  } else { // EE+
+    // AB numbering starts at DCC=45 and runs along phi in increasing phi
+    // first EE+ AB is numbered 9:
+    return 9 + (iDCC - 45) / 3;
   }
 }

--- a/SimCalorimetry/EcalElectronicsEmulation/interface/EcalFEtoDigi.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/EcalFEtoDigi.h
@@ -8,50 +8,50 @@
  * Created:  Thu Feb 22 11:32:53 CET 2007
  */
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
-//#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h" 
+//#include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
 
-#include <memory>
-#include <iostream>
 #include <fstream>
-#include <vector>
 #include <iomanip>
+#include <iostream>
+#include <memory>
+#include <vector>
 
 #include "SimCalorimetry/EcalElectronicsEmulation/interface/TCCinput.h"
 
-struct TCCinput; 
+struct TCCinput;
 typedef std::vector<TCCinput> TCCInputData;
-static const int N_SM = 36; //number of ecal barrel supermodules
+static const int N_SM = 36; // number of ecal barrel supermodules
 
 class EcalFEtoDigi : public edm::one::EDProducer<> {
 
 public:
+  explicit EcalFEtoDigi(const edm::ParameterSet &);
+  ~EcalFEtoDigi() override {}
 
-  explicit EcalFEtoDigi(const edm::ParameterSet&);
-  ~EcalFEtoDigi() override{}
-  
 private:
-
-  void beginJob() override ;
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginJob() override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
   void endJob() override;
 
   void readInput();
-  EcalTrigTowerDetId         create_TTDetId (TCCinput);
-  EcalTriggerPrimitiveSample create_TPSample(TCCinput, const edm::EventSetup&);
-  EcalTriggerPrimitiveSample create_TPSampleTcp(TCCinput, const edm::EventSetup&);
+  EcalTrigTowerDetId create_TTDetId(TCCinput);
+  EcalTriggerPrimitiveSample create_TPSample(TCCinput, const edm::EventSetup &);
+  EcalTriggerPrimitiveSample create_TPSampleTcp(TCCinput,
+                                                const edm::EventSetup &);
   int SMidToTCCid(const int) const;
-  void getLUT(unsigned int * lut, const int towerId,  const edm::EventSetup&) const ;
+  void getLUT(unsigned int *lut, const int towerId,
+              const edm::EventSetup &) const;
 
   TCCInputData inputdata_[N_SM];
 
@@ -63,7 +63,6 @@ private:
   int fileEventOffset_;
   bool debug_;
   std::ofstream outfile;
-
 };
 
 #endif

--- a/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimRawData.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimRawData.h
@@ -1,16 +1,15 @@
-/*  
+/*
  */
 
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
 #include "SimCalorimetry/EcalSelectiveReadoutAlgos/src/EcalSelectiveReadout.h"
-#include <string>
 #include <fstream>
+#include <string>
 
 /** The EcalSimRawData CMSSW module produces raw data from digis. The raw data
  * are written into files which can be loaded into the TCC DCC and SRP boards
@@ -25,25 +24,27 @@
  *    <LI>string EBSrFlagCollection: EB SR flags product instance name</LI>
  *    <LI>string EESrFlagCollection: EE SR flags product instance name</LI>
  *    <LI>string trigPrimProducer: trigger primitive digi label"</LI>
- *    <LI>string trigPrimDigiCollection: trigger primitive digi product instance name</LI>
- *    <LI>string tcpPrimDigiCollection: TCP FENIX output trigger primitive digi product instance name</LI>
- *    <LI>string writeMode: output format. "write", "littleEndian", "bigEndian"
- *    <LI>untracked bool tpVerbose: make verbose the trigger primitive processing</LI>
- *    <LI>untracked bool xtalVerbose: make verbose the crystal digi processing</LI>
- *    <LI>untracked int32 dccNum: Id of the dcc raw data must be produced for. -1 means every DCC</LI>
- *    <LI>untracked int32 tccNum: Id of the tcc raw data must be produced for. -1 means every TCC</LI>
- *    <LI>untracked bool tcc2dccData: switch for TCC->DCC data stream production</LI>
- *    <LI>untracked bool srp2dccData: switch for SRP->DCC data stream production</LI>
- *    <LI>untracked int32 tccInDefaultVal: default TriggerPrimitive values if the trigger tower is abscent</LI>
+ *    <LI>string trigPrimDigiCollection: trigger primitive digi product instance
+ * name</LI> <LI>string tcpPrimDigiCollection: TCP FENIX output trigger
+ * primitive digi product instance name</LI> <LI>string writeMode: output
+ * format. "write", "littleEndian", "bigEndian" <LI>untracked bool tpVerbose:
+ * make verbose the trigger primitive processing</LI> <LI>untracked bool
+ * xtalVerbose: make verbose the crystal digi processing</LI> <LI>untracked
+ * int32 dccNum: Id of the dcc raw data must be produced for. -1 means every
+ * DCC</LI> <LI>untracked int32 tccNum: Id of the tcc raw data must be produced
+ * for. -1 means every TCC</LI> <LI>untracked bool tcc2dccData: switch for
+ * TCC->DCC data stream production</LI> <LI>untracked bool srp2dccData: switch
+ * for SRP->DCC data stream production</LI> <LI>untracked int32 tccInDefaultVal:
+ * default TriggerPrimitive values if the trigger tower is abscent</LI>
  *    <LI>untracked string outputBaseName: basename for output files</LI>
  *    </UL>
  */
-class EcalSimRawData: public edm::one::EDAnalyzer<> {
-  public:
+class EcalSimRawData : public edm::one::EDAnalyzer<> {
+public:
   /** Constructor
    * @param pset CMSSW configuration
    */
-  explicit EcalSimRawData(const edm::ParameterSet& pset);
+  explicit EcalSimRawData(const edm::ParameterSet &pset);
 
   /** Destructor
    */
@@ -52,10 +53,9 @@ class EcalSimRawData: public edm::one::EDAnalyzer<> {
   /** Main method. Called back for each event. This method produced the
    * raw data and write them to disk.
    */
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:
-
   int iEvent;
 
   /** Number of crystals in ECAL barrel along eta
@@ -91,7 +91,7 @@ private:
   static const int nScY = 20;
 
   /* Edge size of a barrel TT in num. of crystals
-  */
+   */
   static const int ttEdge = 5;
 
   /** Number of TTs along SM phi
@@ -104,11 +104,11 @@ private:
 
   /** Number of TTs along Ecal Phi
    */
-  static const int nTtPhi = nEbPhi/ttEdge;//72
+  static const int nTtPhi = nEbPhi / ttEdge; // 72
 
   /** Number of TTs along Ecal barrel eta
    */
-  static const int nEbTtEta = nEbEta/ttEdge;//34
+  static const int nEbTtEta = nEbEta / ttEdge; // 34
 
   /** Number of TTs along eta for one endcap.
    */
@@ -116,7 +116,7 @@ private:
 
   /** Number of TTs along ECAL eta
    */
-  static const int nTtEta = nEbTtEta+2*nEeTtEta;//56
+  static const int nTtEta = nEbTtEta + 2 * nEeTtEta; // 56
 
   /** Number of barrel DCCs along Phi
    */
@@ -143,11 +143,11 @@ private:
   static const int ebDccPhiEdge = 20;
 
   /** Number of trigger towers alng phi covered by a DCC
-   */ 
+   */
   static const int nTtPhisPerEbDcc = 4;
 
   /** Number of trigger towers alng phi covered by a TCC
-   */ 
+   */
   static const int nTtPhisPerEbTcc = 4;
 
   /** Number of barrel trigger tower types (in term of VFE card orientation)
@@ -182,44 +182,41 @@ private:
    * control software.</I>
    * </UL>
    */
-  enum writeMode_t {littleEndian, bigEndian, ascii};
-  
+  enum writeMode_t { littleEndian, bigEndian, ascii };
+
 private:
   /*
   const EBDigiCollection*
   getEBDigis(const edm::Event& event) const;
-  
+
   const EEDigiCollection*
   getEEDigis(const edm::Event& event) const;
 
   const EcalTrigPrimDigiCollection*
   getTrigPrims(const edm::Event& event) const;
   */
-  
+
   /// call these once an event, to make sure everything
   /// is up-to-date
-  void
-  checkGeometry(const edm::EventSetup& eventSetup);
-  void
-  checkTriggerMap(const edm::EventSetup& eventSetup);
+  void checkGeometry(const edm::EventSetup &eventSetup);
+  void checkTriggerMap(const edm::EventSetup &eventSetup);
 
   /** Converts std CMSSW crystal eta index into a c-index (contiguous integer
    * starting from 0 and increasing with pseudo-rapidity).
    * @param iEta std CMSSW crystal eta index
    * @return the c-array index
    */
-  int iEta2cIndex(int iEta) const{
-    return (iEta<0)?iEta+85:iEta+84;
-  }
+  int iEta2cIndex(int iEta) const { return (iEta < 0) ? iEta + 85 : iEta + 84; }
 
   /** Converts std CMSSW crystal phi index into a c-index (contiguous integer
    * starting from 0 at phi=0deg and increasing with phi).
    * @param iPhi std CMSSW crystal phi index
    * @return the c-array index
    */
-  int iPhi2cIndex(int iPhi) const{
-    int iPhi0 = iPhi -11;
-    if(iPhi0<0) iPhi0+=nEbPhi;
+  int iPhi2cIndex(int iPhi) const {
+    int iPhi0 = iPhi - 11;
+    if (iPhi0 < 0)
+      iPhi0 += nEbPhi;
     return iPhi0;
   }
 
@@ -229,34 +226,30 @@ private:
    * @param iEta std CMSSW trigger tower eta index
    * @return the c-array index
    */
-  int iTtEta2cIndex(int iTtEta) const{
-    return (iTtEta<0)?(iTtEta+28):(iTtEta+27);
+  int iTtEta2cIndex(int iTtEta) const {
+    return (iTtEta < 0) ? (iTtEta + 28) : (iTtEta + 27);
   }
 
   /** Converse of iTtEta2cIndex
    * @param iTtEta0 c eta index of TT
    * @param std CMSSW TT eta index
    */
-  int cIndex2iTtEta(int iTtEta0) const{
-    return (iTtEta0<28)?(iTtEta0-28):(iTtEta0-27);
+  int cIndex2iTtEta(int iTtEta0) const {
+    return (iTtEta0 < 28) ? (iTtEta0 - 28) : (iTtEta0 - 27);
   }
 
   /** Converse of iTtPhi2cIndex
    * @param iTtPhi0 phi index of TT
    * @return std CMSS TT index
    */
-  int cIndex2TtPhi(int iTtPhi0) const{
-    return iTtPhi0+1;
-  }
-  
+  int cIndex2TtPhi(int iTtPhi0) const { return iTtPhi0 + 1; }
+
   /** Converts std CMSSW ECAL trigger tower phi index into a c-index
    * (contiguous integer starting from 0 at phi=0deg and increasing with phi).
    * @param iPhi std CMSSW ECAL trigger tower phi index
    * @return the c-array index
    */
-  int iTtPhi2cIndex(int iTtPhi) const{
-    return iTtPhi-1;
-  }
+  int iTtPhi2cIndex(int iTtPhi) const { return iTtPhi - 1; }
 
   /*
     int iXY2cIndex(int iX) const{
@@ -273,13 +266,13 @@ private:
    * @param [out] iEta0 eta c index of the channel
    * @param [out] iPhi0 eta c index of the channel
    */
-  void elec2GeomNum(int ittEta0, int ittPhi0, int strip1,
-		    int ch1, int& iEta0, int& iPhi0) const;
+  void elec2GeomNum(int ittEta0, int ittPhi0, int strip1, int ch1, int &iEta0,
+                    int &iPhi0) const;
 
   /* Set horizontal parity of a 16-bit word of FE data
    * @param a the word whose parity must be set.
    */
-  void setHParity(uint16_t& a) const;
+  void setHParity(uint16_t &a) const;
 
   /** Generates FE crystal data
    * @param basename base for the output file name. DCC number is appended to
@@ -288,8 +281,7 @@ private:
    * @param adcCount the payload, the ADC count of the channels.
    */
   void genFeData(std::string basename, int iEvent,
-		 const std::vector<uint16_t> adcCount[nEbEta][nEbPhi]) const;
-
+                 const std::vector<uint16_t> adcCount[nEbEta][nEbPhi]) const;
 
   /** Generates FE trigger primitives data
    * @param basename base for the output file name. DCC number is appended to
@@ -298,7 +290,7 @@ private:
    * @param tps the payload, the trigger primitives
    */
   void genTccIn(std::string basename, int iEvent,
-		const int tps[nTtEta][nTtPhi]) const;
+                const int tps[nTtEta][nTtPhi]) const;
 
   /** Generates TCC->DCC data
    * @param basename base for the output file name. DCC number is appended to
@@ -307,17 +299,14 @@ private:
    * @param tps the payload, the trigger primitives
    */
   void genTccOut(std::string basename, int iEvent,
-		 const int tps[nTtEta][nTtPhi]) const;
+                 const int tps[nTtEta][nTtPhi]) const;
 
-
-  
   /** Retrieves barrel digis (APD ADC count).
    * @param event CMS event
-   * @param adc [out] the adc counts: adc[iEta0][iPhi0][iTimeSample0] 
+   * @param adc [out] the adc counts: adc[iEta0][iPhi0][iTimeSample0]
    */
-  void getEbDigi(const edm::Event& event,
-		 std::vector<uint16_t> adc[nEbEta][nEbPhi]) const;
-
+  void getEbDigi(const edm::Event &event,
+                 std::vector<uint16_t> adc[nEbEta][nEbPhi]) const;
 
   /** Extracts the trigger primitive (TP). The collection name
    * parameter permits to select either the TCP Fenix output
@@ -327,10 +316,9 @@ private:
    * @param collName label of the EDM collection containing the TP.
    * @param tp [out] the trigger primitives
    */
-  void getTp(const edm::Event& event, const std::string& collName,
-	     int tp[nTtEta][nTtPhi]) const;
+  void getTp(const edm::Event &event, const std::string &collName,
+             int tp[nTtEta][nTtPhi]) const;
 
-  
   /** Help function to get the file extension which depends on the output
    * formats.
    */
@@ -345,17 +333,16 @@ private:
    * @param hpar if true the horizontal odd word parity is set before writing
    * the word into the file.
    */
-  void fwrite(std::ofstream& f, uint16_t data, int& iword,
-	      bool hpar = true) const;
-
+  void fwrite(std::ofstream &f, uint16_t data, int &iword,
+              bool hpar = true) const;
 
   /** Computes the selective readout flags.
    * @param [in] event CMS event
    * @param [out] ebSrf the computed SR flags for barrel
    * @param [out] eeSrf the computed SR flags for endcaps
    */
-  void getSrfs(const edm::Event& event, int ebSrf[nTtEta][nTtPhi],
-	       int eeSrf[nEndcaps][nScX][nScY]) const;
+  void getSrfs(const edm::Event &event, int ebSrf[nTtEta][nTtPhi],
+               int eeSrf[nEndcaps][nScX][nScY]) const;
 
   /** Generates SR flags
    * @param basename base for the output file name. DCC number is appended to
@@ -364,8 +351,8 @@ private:
    * @param the trigger tower flags
    */
   void genSrData(std::string basename, int iEvent,
-		 int ttf[nEbTtEta][nTtPhi]) const;
-  
+                 int ttf[nEbTtEta][nTtPhi]) const;
+
 private:
   /** Name of module/plugin/producer making digis
    */
@@ -379,12 +366,11 @@ private:
    */
   std::string eeDigiCollection_;
 
-
   /** Label of SR flags and suppressed digis
    */
   std::string srDigiProducer_;
-  
-   /** EB SRP flag digi product instance name
+
+  /** EB SRP flag digi product instance name
    */
   std::string ebSrFlagCollection_;
 
@@ -394,15 +380,15 @@ private:
 
   /** Trigger primitive digi product instance name
    */
-  std::string tpDigiCollection_; 
+  std::string tpDigiCollection_;
 
   /** TCP Fenix output digi product instance name
    */
-  std::string tcpDigiCollection_; 
-  
+  std::string tcpDigiCollection_;
+
   /** Calorimeter geometry
    */
-  const CaloGeometry * theGeometry;
+  const CaloGeometry *theGeometry;
 
   /** Name of the trigger primitive label
    */
@@ -438,7 +424,7 @@ private:
 
   /** ECAL endcap trigger tower map
    */
-  const EcalTrigTowerConstituentsMap * theTriggerTowerMap;
+  const EcalTrigTowerConstituentsMap *theTriggerTowerMap;
 
   /** Selective readout simulator
    */
@@ -455,17 +441,16 @@ private:
   /** Index of the TCC, FE data must be produced for. -1 for all TTCs
    */
   int tccNum_;
-  
+
   /** Index of the DCC, FE data must be produced for. -1 for all TTCs
    */
   int dccNum_;
-  
+
   /** default TriggerPrimitive values if the trigger tower is abscent
    */
   int tccInDefaultVal_;
-  
+
   /** basename for output files
    */
   std::string basename_;
 };
-

--- a/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimpleProducer.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimpleProducer.h
@@ -2,8 +2,8 @@
 #define SimCalorimetry_EcalElectronicsEmulationEcalSimpleProducer_h
 
 #include "FWCore/Framework/interface/one/EDProducer.h"
-#include <memory>
 #include <TFormula.h>
+#include <memory>
 #include <string>
 
 /** This edm producer generates Ecal Digis (data frames and TPGs)
@@ -18,15 +18,15 @@
  * </UL>
  * The crystal ADC formula is parametrized with the following variables:
  * <UL><LI>ieta0: crystal eta index starting from 0 at eta- end of barrel</LI>
- *     <LI>iphi0: crystal phi index starting at Phi=0deg. in std CMS coordinates</LI>
- *     <LI>ievt0 event sequence number within the job run starting from 0</LI> 
- *     <LI>isample0 sample time position starting from 0</LI>
+ *     <LI>iphi0: crystal phi index starting at Phi=0deg. in std CMS
+ * coordinates</LI> <LI>ievt0 event sequence number within the job run starting
+ * from 0</LI> <LI>isample0 sample time position starting from 0</LI>
  * </UL>
  * The trigger primitive formula is parametrized with the following variables:
- * <UL><LI>ieta0: trigger tower eta index starting from 0 at eta- end of barrel</LI>
- *     <LI>iphi0: trigger tower index starting at Phi=0deg. in std CMS coordinates</LI>
- *     <LI>ievt0 event sequence number within the job run starting from 0</LI> 
- *     <LI>isample0 sample time position starting from 0</LI>
+ * <UL><LI>ieta0: trigger tower eta index starting from 0 at eta- end of
+ * barrel</LI> <LI>iphi0: trigger tower index starting at Phi=0deg. in std CMS
+ * coordinates</LI> <LI>ievt0 event sequence number within the job run starting
+ * from 0</LI> <LI>isample0 sample time position starting from 0</LI>
  * </UL>
  * In both formulae 'itt0' shortcut can be used for the trigger tower index
  * within the SM starting at 0 from lowest relative eta and lowest phi and
@@ -35,15 +35,15 @@
  * TFormula</A>
  *
  */
-class EcalSimpleProducer: public edm::one::EDProducer<> {
+class EcalSimpleProducer : public edm::one::EDProducer<> {
 
-  //constructor(s) and destructor(s)
+  // constructor(s) and destructor(s)
 public:
   /** Constructs an EcalSimpleProducer
    * @param pset CMSSW configuration
    * @param sdesc description of this input source
    */
-  EcalSimpleProducer(const edm::ParameterSet& pset);
+  EcalSimpleProducer(const edm::ParameterSet &pset);
 
   /**Destructor
    */
@@ -57,9 +57,9 @@ public:
   /** The main method. It produces the event.
    * @param evt [out] produced event.
    */
-  void produce(edm::Event& evt, const edm::EventSetup&) override;
-  
-  //method(s)
+  void produce(edm::Event &evt, const edm::EventSetup &) override;
+
+  // method(s)
 public:
 private:
   /** Help function to replace a pattern within a string. Every occurance
@@ -68,46 +68,42 @@ private:
    * @param pattern to replace.
    * @param string to substitute to the pattern
    */
-  void replaceAll(std::string& s, const std::string& from,
-		  const std::string& to) const;
+  void replaceAll(std::string &s, const std::string &from,
+                  const std::string &to) const;
 
   /** Converts c-array index (contiguous integer starting from 0) to
    * std CMSSW ECAL crystal eta index.
    * @param iEta0 c-array index. '0' postfix reminds the index starts from 0
    * @return std CMSSW ECAL crystal index.
    */
-  int cIndex2iEta(int iEta0) const{
-    return (iEta0<85)?iEta0-85:iEta0-84;
+  int cIndex2iEta(int iEta0) const {
+    return (iEta0 < 85) ? iEta0 - 85 : iEta0 - 84;
   }
-  
+
   /** Converts c-array index (contiguous integer starting from 0) to
    * std CMSSW ECAL crystal phi index.
    * @param iPhi0 c-array index. '0' postfix reminds the index starts from 0
    * @return std CMSSW ECAL crystal index.
    */
-  int cIndex2iPhi(int iPhi0) const{
-    return (iPhi0+10)%360+1;
-  }
-  
+  int cIndex2iPhi(int iPhi0) const { return (iPhi0 + 10) % 360 + 1; }
+
   /** Converts c-array index (contiguous integer starting from 0) to
    * std CMSSW ECAL trigger tower eta index.
    * @param iEta0 c-array index. '0' postfix reminds the index starts from 0
    * @return std CMSSW ECAL trigger tower index.
    */
-  int cIndex2iTtEta(int iEta0) const{
-    return (iEta0<28)?iEta0-28:iEta0-27;
+  int cIndex2iTtEta(int iEta0) const {
+    return (iEta0 < 28) ? iEta0 - 28 : iEta0 - 27;
   }
-  
+
   /** Converts c-array index (contiguous integer starting from 0) to
    * std CMSSW ECAL trigger tower phi index.
    * @param iPhi0 c-array index. '0' postfix reminds the index starts from 0
    * @return std CMSSW ECAL trigger tower index.
    */
-  int cIndex2iTtPhi(int iPhi0) const{
-    return iPhi0+1;
-  }
-  
-  //attribute(s)
+  int cIndex2iTtPhi(int iPhi0) const { return iPhi0 + 1; }
+
+  // attribute(s)
 protected:
 private:
   /** Formula defining the data frame samples
@@ -121,7 +117,7 @@ private:
   /** Formula defining the sim hits
    */
   std::unique_ptr<TFormula> simHitFormula_;
-  
+
   /** Verbosity switch
    */
   bool verbose_;

--- a/SimCalorimetry/EcalElectronicsEmulation/interface/TCCinput.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/TCCinput.h
@@ -7,57 +7,48 @@
  *\date February 2007
  */
 
-#include <iostream> 
+#include <iostream>
 
 struct TCCinput {
-  
-  int tower;         //tower number in SM
-  int bunchCrossing; 
-  unsigned input;    //11 bit value input (10 energy, 1 fg)
-  
-  TCCinput(int tt=0, int bx=0, unsigned val=0x0) : 
-    tower(tt), bunchCrossing(bx), input(val) {
-    if (input>0x7ff)  {
-      std::cout << "[TCCinput] saturated value 0x" 
-		<< std::hex << input << std::dec
-		<< std::endl;
+
+  int tower; // tower number in SM
+  int bunchCrossing;
+  unsigned input; // 11 bit value input (10 energy, 1 fg)
+
+  TCCinput(int tt = 0, int bx = 0, unsigned val = 0x0)
+      : tower(tt), bunchCrossing(bx), input(val) {
+    if (input > 0x7ff) {
+      std::cout << "[TCCinput] saturated value 0x" << std::hex << input
+                << std::dec << std::endl;
       input &= 0x7ff;
     }
-  }; 
- 
+  };
+
   int get_energy() const {
-    return input & 0x3ff; //get bits 9:0
-  }
-  
-  int get_fg() const {
-    return input & 0x400; //get bit number 10
+    return input & 0x3ff; // get bits 9:0
   }
 
-  bool is_current (int n) const {
-    return (n==bunchCrossing);
+  int get_fg() const {
+    return input & 0x400; // get bit number 10
   }
+
+  bool is_current(int n) const { return (n == bunchCrossing); }
 
   bool operator<(const TCCinput &) const;
-  
-  std::ostream& operator<<(std::ostream&);
 
+  std::ostream &operator<<(std::ostream &);
 };
 
-inline 
-std::ostream& TCCinput::operator<<(std::ostream& os) {
-  os << " tcc input " 
-     << " bx:"     << bunchCrossing 
-     << " tt:"     << tower 
-     << " raw:0x"  << std::hex  << input << std::dec  
-     << " fg:"     << this->get_fg()
-     << " energy:" << this->get_energy()
-     << std::endl;
+inline std::ostream &TCCinput::operator<<(std::ostream &os) {
+  os << " tcc input "
+     << " bx:" << bunchCrossing << " tt:" << tower << " raw:0x" << std::hex
+     << input << std::dec << " fg:" << this->get_fg()
+     << " energy:" << this->get_energy() << std::endl;
   return os;
 }
 
-inline
-bool TCCinput::operator< (const TCCinput &k) const {
+inline bool TCCinput::operator<(const TCCinput &k) const {
   return (bunchCrossing < k.bunchCrossing);
 }
 
-#endif 
+#endif

--- a/SimCalorimetry/EcalElectronicsEmulation/src/EcalFEtoDigi.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/src/EcalFEtoDigi.cc
@@ -1,345 +1,345 @@
-#include "CondFormats/EcalObjects/interface/EcalTPGLutIdMap.h"
-#include "CondFormats/EcalObjects/interface/EcalTPGLutGroup.h"
-#include "CondFormats/DataRecord/interface/EcalTPGLutIdMapRcd.h"
 #include "CondFormats/DataRecord/interface/EcalTPGLutGroupRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGLutIdMapRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGLutGroup.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGLutIdMap.h"
 #include "SimCalorimetry/EcalElectronicsEmulation/interface/EcalFEtoDigi.h"
 
-EcalFEtoDigi::EcalFEtoDigi(const edm::ParameterSet& iConfig) {
-  basename_           = iConfig.getUntrackedParameter<std::string>("FlatBaseName","ecal_tcc_");
-  sm_                 = iConfig.getUntrackedParameter<int>("SuperModuleId",-1);
-  fileEventOffset_    = iConfig.getUntrackedParameter<int>("FileEventOffset",0);
-  useIdentityLUT_     = iConfig.getUntrackedParameter<bool>("UseIdentityLUT",false);
-  debug_              = iConfig.getUntrackedParameter<bool>("debugPrintFlag", false);
+EcalFEtoDigi::EcalFEtoDigi(const edm::ParameterSet &iConfig) {
+  basename_ =
+      iConfig.getUntrackedParameter<std::string>("FlatBaseName", "ecal_tcc_");
+  sm_ = iConfig.getUntrackedParameter<int>("SuperModuleId", -1);
+  fileEventOffset_ = iConfig.getUntrackedParameter<int>("FileEventOffset", 0);
+  useIdentityLUT_ =
+      iConfig.getUntrackedParameter<bool>("UseIdentityLUT", false);
+  debug_ = iConfig.getUntrackedParameter<bool>("debugPrintFlag", false);
 
-  singlefile = (sm_==-1)?false:true;
+  singlefile = (sm_ == -1) ? false : true;
 
   produces<EcalTrigPrimDigiCollection>();
-  produces<EcalTrigPrimDigiCollection >("formatTCP");
- 
+  produces<EcalTrigPrimDigiCollection>("formatTCP");
 }
 
 /// method called to produce the data
-void
-EcalFEtoDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void EcalFEtoDigi::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
 
   /// event counter
   static int current_bx = -1;
   current_bx++;
 
   /// re-read input (needed in case of event-by-event input production)
-  //readInput();
+  // readInput();
 
-  if(debug_)
-    std::cout << "[EcalFEtoDigi::produce] producing event " << current_bx << std::endl;
-  
-  std::unique_ptr<EcalTrigPrimDigiCollection>
-    e_tpdigis (new EcalTrigPrimDigiCollection);
-  std::unique_ptr<EcalTrigPrimDigiCollection>
-    e_tpdigisTcp (new EcalTrigPrimDigiCollection);
+  if (debug_)
+    std::cout << "[EcalFEtoDigi::produce] producing event " << current_bx
+              << std::endl;
+
+  std::unique_ptr<EcalTrigPrimDigiCollection> e_tpdigis(
+      new EcalTrigPrimDigiCollection);
+  std::unique_ptr<EcalTrigPrimDigiCollection> e_tpdigisTcp(
+      new EcalTrigPrimDigiCollection);
 
   std::vector<TCCinput>::const_iterator it;
 
-  for(int i=0; i<N_SM; i++) {
+  for (int i = 0; i < N_SM; i++) {
 
-    if(!singlefile)
-      sm_=i+1;
+    if (!singlefile)
+      sm_ = i + 1;
 
-    for(it = inputdata_[i].begin(); it != inputdata_[i].end(); it++) {
+    for (it = inputdata_[i].begin(); it != inputdata_[i].end(); it++) {
 
-      if(!(*it).is_current(current_bx+fileEventOffset_)) 
-	continue;
-      else
-      	if(debug_ && (*it).input!=0 )
-	  std::cout << "[EcalFEtoDigi] " 
-	       << "\tsupermodule:" << sm_ 
-	       << "\tevent: "      << current_bx 
-	       << "\tbx: "         << (*it).bunchCrossing
-	       << "\tvalue:0x"     << std::setfill('0') << std::setw(4) 
-	       << std::hex << (*it).input << std::setfill(' ') << std::dec 
-	       << std::endl;
+      if (!(*it).is_current(current_bx + fileEventOffset_))
+        continue;
+      else if (debug_ && (*it).input != 0)
+        std::cout << "[EcalFEtoDigi] "
+                  << "\tsupermodule:" << sm_ << "\tevent: " << current_bx
+                  << "\tbx: " << (*it).bunchCrossing << "\tvalue:0x"
+                  << std::setfill('0') << std::setw(4) << std::hex
+                  << (*it).input << std::setfill(' ') << std::dec << std::endl;
 
-      
       /// create EcalTrigTowerDetId
-      const EcalTrigTowerDetId  e_id = create_TTDetId(*it);
-      
-      //EcalElectronicsMapping theMapping;
-      //const EcalTrigTowerDetId  e_id 
+      const EcalTrigTowerDetId e_id = create_TTDetId(*it);
+
+      // EcalElectronicsMapping theMapping;
+      // const EcalTrigTowerDetId  e_id
       //= theMapping.getTrigTowerDetId(SMidToTCCid(sm_),(*it).tower);
-      //EcalElectronicsMapping::getTrigTowerDetId(int TCCid, int iTT)
-      
+      // EcalElectronicsMapping::getTrigTowerDetId(int TCCid, int iTT)
+
       /// create EcalTriggerPrimitiveDigi
       EcalTriggerPrimitiveDigi *e_digi = new EcalTriggerPrimitiveDigi(e_id);
       EcalTriggerPrimitiveDigi *e_digiTcp = new EcalTriggerPrimitiveDigi(e_id);
-      
+
       /// create EcalTriggerPrimitiveSample
       EcalTriggerPrimitiveSample e_sample = create_TPSample(*it, iSetup);
       EcalTriggerPrimitiveSample e_sampleTcp = create_TPSampleTcp(*it, iSetup);
 
       /// set sample
-      e_digi->setSize(1); //set sampleOfInterest to 0
-      e_digi->setSample(0,e_sample);
-      
-      /// add to EcalTrigPrimDigiCollection 
+      e_digi->setSize(1); // set sampleOfInterest to 0
+      e_digi->setSample(0, e_sample);
+
+      /// add to EcalTrigPrimDigiCollection
       e_tpdigis->push_back(*e_digi);
-    
+
       /// set sample (uncompressed format)
-      e_digiTcp->setSize(1); //set sampleOfInterest to 0
-      e_digiTcp->setSample(0,e_sampleTcp);
-      
-      /// add to EcalTrigPrimDigiCollection (uncompressed format) 
+      e_digiTcp->setSize(1); // set sampleOfInterest to 0
+      e_digiTcp->setSample(0, e_sampleTcp);
+
+      /// add to EcalTrigPrimDigiCollection (uncompressed format)
       e_tpdigisTcp->push_back(*e_digiTcp);
 
-      if(debug_) 
-	outfile << (*it).tower << '\t' 
-		<< (*it).bunchCrossing << '\t'<< std::setfill('0') << std::hex
-		<< "0x" << std::setw(4) << (*it).input << '\t'
-		<< "0"	<< std::dec << std::setfill(' ') 
-		<< std::endl;
+      if (debug_)
+        outfile << (*it).tower << '\t' << (*it).bunchCrossing << '\t'
+                << std::setfill('0') << std::hex << "0x" << std::setw(4)
+                << (*it).input << '\t' << "0" << std::dec << std::setfill(' ')
+                << std::endl;
 
       /// print & debug
-      if(debug_ && (*it).input!=0 )
-	std::cout << "[EcalFEtoDigi] debug id: " << e_digi->id() << "\n\t" 
-		  << std::dec 
-		  << "\tieta: "     << e_digi->id().ieta()
-		  << "\tiphi: "     << e_digi->id().iphi()
-		  << "\tsize: "     << e_digi->size()
-		  << "\tfg: "       <<(e_digi->fineGrain()?1:0)    
-		  << std::hex 	 
-		  << "\tEt: 0x"     << e_digi->compressedEt() 
-		  << " (0x"         << (*it).get_energy() << ")" 
-		  << "\tttflag: 0x" << e_digi->ttFlag()
-		  << std::dec
-		  << std::endl;
+      if (debug_ && (*it).input != 0)
+        std::cout << "[EcalFEtoDigi] debug id: " << e_digi->id() << "\n\t"
+                  << std::dec << "\tieta: " << e_digi->id().ieta()
+                  << "\tiphi: " << e_digi->id().iphi()
+                  << "\tsize: " << e_digi->size()
+                  << "\tfg: " << (e_digi->fineGrain() ? 1 : 0) << std::hex
+                  << "\tEt: 0x" << e_digi->compressedEt() << " (0x"
+                  << (*it).get_energy() << ")"
+                  << "\tttflag: 0x" << e_digi->ttFlag() << std::dec
+                  << std::endl;
 
       delete e_digi;
       delete e_digiTcp;
-
     }
-    
-    if(singlefile)
+
+    if (singlefile)
       break;
   }
 
-  ///in case no info was found for the event:need to create something
-  if(e_tpdigis->empty()) {
+  /// in case no info was found for the event:need to create something
+  if (e_tpdigis->empty()) {
     std::cout << "[EcalFEtoDigi] creating empty collection for the event!\n";
     EcalTriggerPrimitiveDigi *e_digi = new EcalTriggerPrimitiveDigi();
     e_tpdigis->push_back(*e_digi);
   }
 
   iEvent.put(std::move(e_tpdigis));
-  iEvent.put(std::move(e_tpdigisTcp),"formatTCP");
-
+  iEvent.put(std::move(e_tpdigisTcp), "formatTCP");
 }
 
-
 /// open and read in input (flat) data file
-void 
-EcalFEtoDigi::readInput() {
+void EcalFEtoDigi::readInput() {
 
-  if(debug_)
+  if (debug_)
     std::cout << "\n[EcalFEtoDigi::readInput] Reading input data\n";
-  
-  if(!singlefile)
-    sm_=-1;
-  for(int i=0; i<N_SM; i++)
+
+  if (!singlefile)
+    sm_ = -1;
+  for (int i = 0; i < N_SM; i++)
     inputdata_[i].clear();
 
   std::stringstream s;
   int tcc;
 
-  for (int i=0; i<N_SM; i++) {
+  for (int i = 0; i < N_SM; i++) {
 
-    tcc = (sm_==-1)?SMidToTCCid(i+1):SMidToTCCid(sm_);
+    tcc = (sm_ == -1) ? SMidToTCCid(i + 1) : SMidToTCCid(sm_);
 
     s.str("");
-    s << basename_ << tcc << ".txt"; 
+    s << basename_ << tcc << ".txt";
 
     std::ifstream f(s.str().c_str());
-    
-    if(debug_) {
-      std::cout << "  opening " << s.str().c_str() << "..." << std::endl;
-      if(!f.good())
-	std::cout << " skipped!"; 
-      std::cout << std::endl;       
-    }
-    //if (!f.good() || f.eof()) 
-    //  throw cms::Exception("BadInputFile") 
-    //	<< "EcalFEtoDigi: cannot open file " << s.str().c_str() << std::endl; 
-    
-    int n_bx=0;
-    int tt; int bx; unsigned val; int dummy;
 
-    while(f.good()) {
-      if(f.eof()) break;
-      tt=0; bx=-1; val=0x0; dummy=0;
+    if (debug_) {
+      std::cout << "  opening " << s.str().c_str() << "..." << std::endl;
+      if (!f.good())
+        std::cout << " skipped!";
+      std::cout << std::endl;
+    }
+    // if (!f.good() || f.eof())
+    //  throw cms::Exception("BadInputFile")
+    //	<< "EcalFEtoDigi: cannot open file " << s.str().c_str() << std::endl;
+
+    int n_bx = 0;
+    int tt;
+    int bx;
+    unsigned val;
+    int dummy;
+
+    while (f.good()) {
+      if (f.eof())
+        break;
+      tt = 0;
+      bx = -1;
+      val = 0x0;
+      dummy = 0;
       f >> tt >> bx >> std::hex >> val >> std::dec >> dummy;
-      if(bx==-1 || bx < fileEventOffset_ ) continue;
-      if( !n_bx || (bx!=(inputdata_[i].back()).bunchCrossing) )
-	n_bx++;
-      TCCinput ttdata(tt,bx,val);
+      if (bx == -1 || bx < fileEventOffset_)
+        continue;
+      if (!n_bx || (bx != (inputdata_[i].back()).bunchCrossing))
+        n_bx++;
+      TCCinput ttdata(tt, bx, val);
       inputdata_[i].push_back(ttdata);
-      
-      if(debug_&&val!=0)
-	printf("\treading tower:%d  bx:%d input:0x%x dummy:%2d\n", 
-	       tt, bx, val, dummy);
-    } 
-    
+
+      if (debug_ && val != 0)
+        printf("\treading tower:%d  bx:%d input:0x%x dummy:%2d\n", tt, bx, val,
+               dummy);
+    }
+
     f.close();
-    
-    if(sm_!=-1)
-      break;    
+
+    if (sm_ != -1)
+      break;
   }
 
-  if(debug_)
+  if (debug_)
     std::cout << "[EcalFEtoDigi::readInput] Done reading." << std::endl;
 
-  return; 
+  return;
 }
 
 /// create EcalTrigTowerDetId from input data (line)
-EcalTrigTowerDetId 
-EcalFEtoDigi::create_TTDetId(TCCinput data) {
+EcalTrigTowerDetId EcalFEtoDigi::create_TTDetId(TCCinput data) {
 
   // (EcalBarrel only)
   static const int kTowersInPhi = 4;
-  
-  int iTT   = data.tower;
-  int zside = (sm_>18)?-1:+1;
-  int SMid  = sm_;
 
-  int jtower = iTT-1;
-  int etaTT  = jtower / kTowersInPhi +1;
+  int iTT = data.tower;
+  int zside = (sm_ > 18) ? -1 : +1;
+  int SMid = sm_;
+
+  int jtower = iTT - 1;
+  int etaTT = jtower / kTowersInPhi + 1;
   int phiTT;
-  if (zside < 0) 
-    phiTT = (SMid-19) * kTowersInPhi + jtower % kTowersInPhi;
-  else 
-    phiTT = (SMid- 1) * kTowersInPhi + kTowersInPhi-(jtower % kTowersInPhi)-1;
+  if (zside < 0)
+    phiTT = (SMid - 19) * kTowersInPhi + jtower % kTowersInPhi;
+  else
+    phiTT =
+        (SMid - 1) * kTowersInPhi + kTowersInPhi - (jtower % kTowersInPhi) - 1;
 
-  phiTT ++;
-  //needed as phi=0 (iphi=1) is at middle of lower SMs (1 and 19), need shift by 2
-  phiTT = phiTT -2; 
-  if (phiTT <= 0) phiTT = 72+phiTT;
+  phiTT++;
+  // needed as phi=0 (iphi=1) is at middle of lower SMs (1 and 19), need shift
+  // by 2
+  phiTT = phiTT - 2;
+  if (phiTT <= 0)
+    phiTT = 72 + phiTT;
 
   /// construct the EcalTrigTowerDetId object
-  if(debug_&&data.get_energy()!=0)
-    printf("[EcalFEtoDigi] Creating EcalTrigTowerDetId (SMid,itt)=(%d,%d)->(eta,phi)=(%d,%d) \n", SMid, iTT, etaTT, phiTT);
-  
-  EcalTrigTowerDetId 
-    e_id( zside , EcalBarrel, etaTT, phiTT, 0);
-  
+  if (debug_ && data.get_energy() != 0)
+    printf("[EcalFEtoDigi] Creating EcalTrigTowerDetId "
+           "(SMid,itt)=(%d,%d)->(eta,phi)=(%d,%d) \n",
+           SMid, iTT, etaTT, phiTT);
+
+  EcalTrigTowerDetId e_id(zside, EcalBarrel, etaTT, phiTT, 0);
+
   return e_id;
 }
 
 /// create EcalTriggerPrimitiveSample from input data (line)
-EcalTriggerPrimitiveSample 
-EcalFEtoDigi::create_TPSample(TCCinput data, const edm::EventSetup& evtSetup) {
+EcalTriggerPrimitiveSample
+EcalFEtoDigi::create_TPSample(TCCinput data, const edm::EventSetup &evtSetup) {
 
-  int tower      = create_TTDetId(data).rawId() ; 
-  int  Et        = data.get_energy();
-  bool tt_fg     = data.get_fg();
-  //unsigned input = data.input;
-  //int  Et    = input & 0x3ff; //get bits 0-9
-  //bool tt_fg = input & 0x400; //get bit number 10
+  int tower = create_TTDetId(data).rawId();
+  int Et = data.get_energy();
+  bool tt_fg = data.get_fg();
+  // unsigned input = data.input;
+  // int  Et    = input & 0x3ff; //get bits 0-9
+  // bool tt_fg = input & 0x400; //get bit number 10
 
   /// setup look up table
-  unsigned int lut_[1024] ;
-  if(!useIdentityLUT_)
-    getLUT(lut_, tower, evtSetup) ;
+  unsigned int lut_[1024];
+  if (!useIdentityLUT_)
+    getLUT(lut_, tower, evtSetup);
   else
-    for(int i=0; i<1024; i++) lut_[i] = i ; //identity lut!
-  
+    for (int i = 0; i < 1024; i++)
+      lut_[i] = i; // identity lut!
+
   /// compress energy 10 -> 8  bit
   int lut_out = lut_[Et];
-  int ttFlag  = (lut_out & 0x700) >> 8;
-  int cEt     = (lut_out & 0xff );
+  int ttFlag = (lut_out & 0x700) >> 8;
+  int cEt = (lut_out & 0xff);
 
-  ///crate sample
-  if(debug_&&data.get_energy()!=0)
-    printf("[EcalFEtoDigi] Creating sample; input:0x%X (Et:0x%x) cEt:0x%x fg:%d ttflag:0x%x \n",
-	   data.input, Et, cEt, tt_fg, ttFlag);
-  
+  /// crate sample
+  if (debug_ && data.get_energy() != 0)
+    printf("[EcalFEtoDigi] Creating sample; input:0x%X (Et:0x%x) cEt:0x%x "
+           "fg:%d ttflag:0x%x \n",
+           data.input, Et, cEt, tt_fg, ttFlag);
+
   EcalTriggerPrimitiveSample e_sample(cEt, tt_fg, ttFlag);
-  
+
   return e_sample;
 }
 
 /// create EcalTriggerPrimitiveSample in tcp format (uncomrpessed energy)
-EcalTriggerPrimitiveSample 
-EcalFEtoDigi::create_TPSampleTcp(TCCinput data, const edm::EventSetup& evtSetup) {
+EcalTriggerPrimitiveSample
+EcalFEtoDigi::create_TPSampleTcp(TCCinput data,
+                                 const edm::EventSetup &evtSetup) {
 
-  int tower      = create_TTDetId(data).rawId() ; 
-  int  Et        = data.get_energy();
-  bool tt_fg     = data.get_fg();
+  int tower = create_TTDetId(data).rawId();
+  int Et = data.get_energy();
+  bool tt_fg = data.get_fg();
 
   /// setup look up table
-  unsigned int lut_[1024] ;
-  if(!useIdentityLUT_)
-    getLUT(lut_, tower, evtSetup) ;
+  unsigned int lut_[1024];
+  if (!useIdentityLUT_)
+    getLUT(lut_, tower, evtSetup);
   else
-    for(int i=0; i<1024; i++) lut_[i] = i ; //identity lut!
-  
+    for (int i = 0; i < 1024; i++)
+      lut_[i] = i; // identity lut!
+
   int lut_out = lut_[Et];
-  int ttFlag  = (lut_out & 0x700) >> 8;
-  int tcpdata = ((ttFlag&0x7)<<11) | ((tt_fg & 0x1)<<10) |  (Et & 0x3ff) ;
+  int ttFlag = (lut_out & 0x700) >> 8;
+  int tcpdata = ((ttFlag & 0x7) << 11) | ((tt_fg & 0x1) << 10) | (Et & 0x3ff);
 
   EcalTriggerPrimitiveSample e_sample(tcpdata);
-  
+
   return e_sample;
 }
 
-
 /// method called once each job just before starting event loop
-void 
-EcalFEtoDigi::beginJob(){
+void EcalFEtoDigi::beginJob() {
 
-  ///check SM numbering convetion: 1-38 
+  /// check SM numbering convetion: 1-38
   /// [or -1 flag to indicate all sm's are to be read in]
-  if(sm_!=-1 && (sm_<1 || sm_>36)) 
-    throw cms::Exception("EcalFEtoDigiInvalidDetId") 
-      << "EcalFEtoDigi: Adapt SM numbering convention.\n";
+  if (sm_ != -1 && (sm_ < 1 || sm_ > 36))
+    throw cms::Exception("EcalFEtoDigiInvalidDetId")
+        << "EcalFEtoDigi: Adapt SM numbering convention.\n";
 
-  ///debug: open file for recreating input copy
-  if(debug_)
+  /// debug: open file for recreating input copy
+  if (debug_)
     outfile.open("inputcopy.txt");
 
   readInput();
-  
-}  
-
+}
 
 /// method called once each job just after ending the event loop
-void 
-EcalFEtoDigi::endJob() {
-  if(outfile.is_open())
+void EcalFEtoDigi::endJob() {
+  if (outfile.is_open())
     outfile.close();
 }
 
 /// translate input supermodule id into TCC id (barrel)
-int 
-EcalFEtoDigi::SMidToTCCid( const int smid ) const {
+int EcalFEtoDigi::SMidToTCCid(const int smid) const {
 
-  return (smid<=18) ? smid+55-1 : smid+37-19;
-
+  return (smid <= 18) ? smid + 55 - 1 : smid + 37 - 19;
 }
 
 /// return the LUT from eventSetup
-void EcalFEtoDigi::getLUT(unsigned int * lut, const int towerId,  const edm::EventSetup& evtSetup) const 
-{
+void EcalFEtoDigi::getLUT(unsigned int *lut, const int towerId,
+                          const edm::EventSetup &evtSetup) const {
   edm::ESHandle<EcalTPGLutGroup> lutGrpHandle;
-  evtSetup.get<EcalTPGLutGroupRcd>().get( lutGrpHandle );
-  const EcalTPGGroups::EcalTPGGroupsMap & lutGrpMap = lutGrpHandle.product()->getMap() ;  
-  EcalTPGGroups::EcalTPGGroupsMapItr itgrp = lutGrpMap.find(towerId) ;
-  uint32_t lutGrp = 999 ;
-  if (itgrp != lutGrpMap.end()) lutGrp = itgrp->second ;
-  
+  evtSetup.get<EcalTPGLutGroupRcd>().get(lutGrpHandle);
+  const EcalTPGGroups::EcalTPGGroupsMap &lutGrpMap =
+      lutGrpHandle.product()->getMap();
+  EcalTPGGroups::EcalTPGGroupsMapItr itgrp = lutGrpMap.find(towerId);
+  uint32_t lutGrp = 999;
+  if (itgrp != lutGrpMap.end())
+    lutGrp = itgrp->second;
+
   edm::ESHandle<EcalTPGLutIdMap> lutMapHandle;
-  evtSetup.get<EcalTPGLutIdMapRcd>().get( lutMapHandle );
-  const EcalTPGLutIdMap::EcalTPGLutMap & lutMap = lutMapHandle.product()->getMap() ;  
-  EcalTPGLutIdMap::EcalTPGLutMapItr itLut = lutMap.find(lutGrp) ;
+  evtSetup.get<EcalTPGLutIdMapRcd>().get(lutMapHandle);
+  const EcalTPGLutIdMap::EcalTPGLutMap &lutMap =
+      lutMapHandle.product()->getMap();
+  EcalTPGLutIdMap::EcalTPGLutMapItr itLut = lutMap.find(lutGrp);
   if (itLut != lutMap.end()) {
-    const unsigned int * theLut = (itLut->second).getLut() ;
-    for (unsigned int i=0 ; i<1024 ; i++) lut[i] = theLut[i] ;
+    const unsigned int *theLut = (itLut->second).getLut();
+    for (unsigned int i = 0; i < 1024; i++)
+      lut[i] = theLut[i];
   }
 }

--- a/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimRawData.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimRawData.cc
@@ -1,59 +1,58 @@
-#include "SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimRawData.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimRawData.h"
 
 #include <memory>
 
-#include <fstream> //used for debugging
-#include <iostream>
-#include <iomanip>
-#include <cmath>
 #include "DataFormats/EcalDigi/interface/EcalMGPASample.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include <cmath>
+#include <fstream> //used for debugging
+#include <iomanip>
+#include <iostream>
 
 using namespace std;
 using namespace edm;
 
 const int EcalSimRawData::ttType[nEbTtEta] = {
-  0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,1, //EE-
-  0,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1//EE+
+    0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, // EE-
+    0, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1  // EE+
 };
 
 const int EcalSimRawData::stripCh2Phi[nTtTypes][ttEdge][ttEdge] = {
-  //TT type 0:
-  /*ch-->*/
-  {{4,3,2,1,0}, /*strip*/		
-   {0,1,2,3,4}, /*|*/
-   {4,3,2,1,0}, /*|*/
-   {0,1,2,3,4}, /*|*/
-   {4,3,2,1,0}},/*V*/
-  //TT type 1:
-  {{0,1,2,3,4},
-   {4,3,2,1,0},
-   {0,1,2,3,4},
-   {4,3,2,1,0},
-   {0,1,2,3,4}}
-};
+    // TT type 0:
+    /*ch-->*/
+    {{4, 3, 2, 1, 0},  /*strip*/
+     {0, 1, 2, 3, 4},  /*|*/
+     {4, 3, 2, 1, 0},  /*|*/
+     {0, 1, 2, 3, 4},  /*|*/
+     {4, 3, 2, 1, 0}}, /*V*/
+    // TT type 1:
+    {{0, 1, 2, 3, 4},
+     {4, 3, 2, 1, 0},
+     {0, 1, 2, 3, 4},
+     {4, 3, 2, 1, 0},
+     {0, 1, 2, 3, 4}}};
 
 const int EcalSimRawData::strip2Eta[nTtTypes][ttEdge] = {
-  {4,3,2,1,0}, //TT type 0
-  {0,1,2,3,4}  //TT type 1
+    {4, 3, 2, 1, 0}, // TT type 0
+    {0, 1, 2, 3, 4}  // TT type 1
 };
 
-EcalSimRawData::EcalSimRawData(const edm::ParameterSet& params){
-  //sets up parameters:
+EcalSimRawData::EcalSimRawData(const edm::ParameterSet &params) {
+  // sets up parameters:
   digiProducer_ = params.getParameter<string>("unsuppressedDigiProducer");
   ebDigiCollection_ = params.getParameter<std::string>("EBdigiCollection");
   eeDigiCollection_ = params.getParameter<std::string>("EEdigiCollection");
   srDigiProducer_ = params.getParameter<string>("srProducer");
   ebSrFlagCollection_ = params.getParameter<std::string>("EBSrFlagCollection");
   eeSrFlagCollection_ = params.getParameter<std::string>("EESrFlagCollection");
-  tpDigiCollection_
-    = params.getParameter<std::string>("trigPrimDigiCollection");
+  tpDigiCollection_ =
+      params.getParameter<std::string>("trigPrimDigiCollection");
   tcpDigiCollection_ = params.getParameter<std::string>("tcpDigiCollection");
   tpProducer_ = params.getParameter<string>("trigPrimProducer");
   xtalVerbose_ = params.getUntrackedParameter<bool>("xtalVerbose", false);
@@ -64,112 +63,108 @@ EcalSimRawData::EcalSimRawData(const edm::ParameterSet& params){
   fe2tcc_ = params.getUntrackedParameter<bool>("fe2tccData", true);
   dccNum_ = params.getUntrackedParameter<int>("dccNum", -1);
   tccNum_ = params.getUntrackedParameter<int>("tccNum", -1);
-  tccInDefaultVal_ = params.getUntrackedParameter<int>("tccInDefaultVal", 0xffff);
+  tccInDefaultVal_ =
+      params.getUntrackedParameter<int>("tccInDefaultVal", 0xffff);
   basename_ = params.getUntrackedParameter<std::string>("outputBaseName");
 
   iEvent = 0;
 
   string writeMode = params.getParameter<string>("writeMode");
 
-  if(writeMode==string("littleEndian")){
+  if (writeMode == string("littleEndian")) {
     writeMode_ = littleEndian;
-  } else if(writeMode==string("bigEndian")){
+  } else if (writeMode == string("bigEndian")) {
     writeMode_ = bigEndian;
-  } else{
+  } else {
     writeMode_ = ascii;
   }
 }
 
-void
-EcalSimRawData::analyze(const edm::Event& event,
-			const edm::EventSetup& es){
-  //Event counter:
-  ++iEvent; 
-    
-  if(xtalVerbose_ | tpVerbose_){
-    cout << "======================================================================\n"
-	 << " Event " << iEvent << "\n"
-	 << "----------------------------------------------------------------------\n";
+void EcalSimRawData::analyze(const edm::Event &event,
+                             const edm::EventSetup &es) {
+  // Event counter:
+  ++iEvent;
+
+  if (xtalVerbose_ | tpVerbose_) {
+    cout << "=================================================================="
+            "====\n"
+         << " Event " << iEvent << "\n"
+         << "------------------------------------------------------------------"
+            "----\n";
   }
 
-  if(fe2dcc_){
+  if (fe2dcc_) {
     vector<uint16_t> adc[nEbEta][nEbPhi];
     getEbDigi(event, adc);
     genFeData(basename_, iEvent, adc);
   }
 
-  if(fe2tcc_){
-    int tcp[nTtEta][nTtPhi]={{0}};
+  if (fe2tcc_) {
+    int tcp[nTtEta][nTtPhi] = {{0}};
     getTp(event, tcpDigiCollection_, tcp);
     genTccIn(basename_, iEvent, tcp);
   }
-  
-  if(tcc2dcc_){
-    int tp[nTtEta][nTtPhi]={{0}};
-    getTp(event, tpDigiCollection_, tp); 
+
+  if (tcc2dcc_) {
+    int tp[nTtEta][nTtPhi] = {{0}};
+    getTp(event, tpDigiCollection_, tp);
     genTccOut(basename_, iEvent, tp);
   }
-  
-  //SR flags:
+
+  // SR flags:
   int ebSrf[nTtEta][nTtPhi];
   int eeSrf[nEndcaps][nScX][nScY];
 
-  if(srp2dcc_){
+  if (srp2dcc_) {
     getSrfs(event, ebSrf, eeSrf);
     genSrData(basename_, iEvent, ebSrf);
   }
-  
 }
 
-void EcalSimRawData::elec2GeomNum(int ittEta0, int ittPhi0, int strip1,
-				  int ch1, int& iEta0, int& iPhi0) const{
-  assert(0<=ittEta0 && ittEta0<nEbTtEta);
-  assert(0<=ittPhi0 && ittPhi0<nTtPhi);
-  assert(1<=strip1&& strip1<=ttEdge);
-  assert(1<=ch1 && ch1<=ttEdge);
+void EcalSimRawData::elec2GeomNum(int ittEta0, int ittPhi0, int strip1, int ch1,
+                                  int &iEta0, int &iPhi0) const {
+  assert(0 <= ittEta0 && ittEta0 < nEbTtEta);
+  assert(0 <= ittPhi0 && ittPhi0 < nTtPhi);
+  assert(1 <= strip1 && strip1 <= ttEdge);
+  assert(1 <= ch1 && ch1 <= ttEdge);
   const int type = ttType[ittEta0];
-  iEta0 = ittEta0*ttEdge + strip2Eta[type][strip1-1];
-  iPhi0 = ittPhi0*ttEdge + stripCh2Phi[type][strip1-1][ch1-1];
-  assert(0<=iEta0 && iEta0<nEbEta);
-  assert(0<=iPhi0 && iPhi0<nEbPhi);
+  iEta0 = ittEta0 * ttEdge + strip2Eta[type][strip1 - 1];
+  iPhi0 = ittPhi0 * ttEdge + stripCh2Phi[type][strip1 - 1][ch1 - 1];
+  assert(0 <= iEta0 && iEta0 < nEbEta);
+  assert(0 <= iPhi0 && iPhi0 < nEbPhi);
 }
 
-void EcalSimRawData::fwrite(ofstream& f, uint16_t data,
-			    int& iWord, bool hpar) const{
+void EcalSimRawData::fwrite(ofstream &f, uint16_t data, int &iWord,
+                            bool hpar) const {
 
-  if(hpar){
-    //set horizontal odd parity bit:
+  if (hpar) {
+    // set horizontal odd parity bit:
     setHParity(data);
   }
-  
-  switch(writeMode_){
-  case littleEndian:
-    {
-      char c = data & 0x00FF;
-      f.write(&c, sizeof(c));
-      c = (data >>8) & 0x00FF;
-      f.write(&c, sizeof(c));
-    }
-    break;
-  case bigEndian:
-    {
-      char c = (data >>8) & 0x00FF; 
-      f.write(&c, sizeof(c));
-      c = data & 0x00FF;
-      f.write(&c, sizeof(c));
-    }
-    break;
+
+  switch (writeMode_) {
+  case littleEndian: {
+    char c = data & 0x00FF;
+    f.write(&c, sizeof(c));
+    c = (data >> 8) & 0x00FF;
+    f.write(&c, sizeof(c));
+  } break;
+  case bigEndian: {
+    char c = (data >> 8) & 0x00FF;
+    f.write(&c, sizeof(c));
+    c = data & 0x00FF;
+    f.write(&c, sizeof(c));
+  } break;
   case ascii:
-    f << ((iWord%8==0&&iWord!=0)?"\n":"")
-      << "0x" << setfill('0') << setw(4) << hex << data << "\t"
-      << dec << setfill(' ');
+    f << ((iWord % 8 == 0 && iWord != 0) ? "\n" : "") << "0x" << setfill('0')
+      << setw(4) << hex << data << "\t" << dec << setfill(' ');
     break;
   }
   ++iWord;
 }
 
-string EcalSimRawData::getExt() const{
-  switch(writeMode_){
+string EcalSimRawData::getExt() const {
+  switch (writeMode_) {
   case littleEndian:
     return ".le";
   case bigEndian:
@@ -177,468 +172,464 @@ string EcalSimRawData::getExt() const{
   case ascii:
     return ".txt";
   default:
-    return".?";
-  }  
+    return ".?";
+  }
 }
 
-void EcalSimRawData::genFeData(string basename, int iEvent,
-			       const vector<uint16_t> adcCount[nEbEta][nEbPhi]
-			       ) const{
+void EcalSimRawData::genFeData(
+    string basename, int iEvent,
+    const vector<uint16_t> adcCount[nEbEta][nEbPhi]) const {
   int smf = 0;
   int gmf = 0;
   int nPendingEvt = 0;
   int monitorFlag = 0;
   int chFrameLen = adcCount[0][0].size() + 1;
-  
-  int iWord = 0;
-  
-  for(int iZ0 = 0; iZ0<2; ++iZ0){
-    for(int iDccPhi0 = 0; iDccPhi0<nDccInPhi; ++iDccPhi0){
-      int iDcc1 = iDccPhi0 + iZ0*nDccInPhi + nDccEndcap + 1;
 
-      if(dccNum_!=-1  && dccNum_!=iDcc1) continue;
-      
+  int iWord = 0;
+
+  for (int iZ0 = 0; iZ0 < 2; ++iZ0) {
+    for (int iDccPhi0 = 0; iDccPhi0 < nDccInPhi; ++iDccPhi0) {
+      int iDcc1 = iDccPhi0 + iZ0 * nDccInPhi + nDccEndcap + 1;
+
+      if (dccNum_ != -1 && dccNum_ != iDcc1)
+        continue;
+
       stringstream s;
       s.str("");
-      const string& ext = getExt();
+      const string &ext = getExt();
       s << basename << "_fe2dcc" << setfill('0') << setw(2) << iDcc1
-	<< setfill(' ') << ext;
-      ofstream f(s.str().c_str(), (iEvent==1?ios::ate:ios::app));
+        << setfill(' ') << ext;
+      ofstream f(s.str().c_str(), (iEvent == 1 ? ios::ate : ios::app));
 
-      if(f.fail()) return;
+      if (f.fail())
+        return;
 
-
-      if(writeMode_==ascii){
-	f << (iEvent==1?"":"\n") << "[Event:" << iEvent << "]\n";
+      if (writeMode_ == ascii) {
+        f << (iEvent == 1 ? "" : "\n") << "[Event:" << iEvent << "]\n";
       }
-      
-      for(int iTtEtaInSm0 = 0; iTtEtaInSm0 < nTtSmEta; ++iTtEtaInSm0){
-	int iTtEta0 = iZ0*nTtSmEta + iTtEtaInSm0;
-	for(int iTtPhiInSm0 = 0; iTtPhiInSm0 < nTtSmPhi; ++iTtPhiInSm0){
-	  //phi=0deg at middle of 1st barrel DCC:
-	  int iTtPhi0 = -nTtPhisPerEbDcc/2 + iDccPhi0*nTtPhisPerEbDcc
-	    + iTtPhiInSm0;
-	  if(iTtPhi0<0) iTtPhi0 += nTtPhi;
-	  for(int stripId1 = 1; stripId1 <= ttEdge; ++stripId1){
-	    uint16_t stripHeader =
-	      0xF << 11
-	      | (nPendingEvt & 0x3F) << 5
-	      | (gmf & 0x1) << 4
-	      | (smf & 0x1) << 3
-	      | (stripId1 & 0x7);
-	    ///	    stripHeader |= parity(stripHeader) << 15;
-	    fwrite(f,stripHeader, iWord);
 
-	    for(int xtalId1 = 1; xtalId1 <= ttEdge; ++xtalId1){
-	      
-	      uint16_t crystalHeader =
-		1 <<14
-		| (chFrameLen & 0xFF) <<4
-		| (monitorFlag & 0x1) <<3
-		| (xtalId1 & 0x7);
-	      //	      crystalHeader |=parity(crystalHeader) << 15;
-	      fwrite(f, crystalHeader, iWord);
-	      
-	      int iEta0;
-	      int iPhi0;
-	      elec2GeomNum(iTtEta0, iTtPhi0, stripId1, xtalId1,
-			   iEta0, iPhi0);
-	      if(xtalVerbose_){
-		cout << dec
-		     << "iDcc1 = " << iDcc1 << "\t"
-		     << "iEbTtEta0 = " << iTtEta0 << "\t"
-		     << "iEbTtPhi0 = " << iTtPhi0 << "\t"
-		     << "stripId1 = " << stripId1 << "\t"
-		     << "xtalId1 = " << xtalId1 << "\t"
-		     << "iEta0 = " << iEta0 << "\t"
-		     << "iPhi0 = " << iPhi0 << "\t"
-		     << "adc[5] = 0x" << hex << adcCount[iEta0][iPhi0][5]
-		     << dec << "\n";
-	      }
-	      
+      for (int iTtEtaInSm0 = 0; iTtEtaInSm0 < nTtSmEta; ++iTtEtaInSm0) {
+        int iTtEta0 = iZ0 * nTtSmEta + iTtEtaInSm0;
+        for (int iTtPhiInSm0 = 0; iTtPhiInSm0 < nTtSmPhi; ++iTtPhiInSm0) {
+          // phi=0deg at middle of 1st barrel DCC:
+          int iTtPhi0 =
+              -nTtPhisPerEbDcc / 2 + iDccPhi0 * nTtPhisPerEbDcc + iTtPhiInSm0;
+          if (iTtPhi0 < 0)
+            iTtPhi0 += nTtPhi;
+          for (int stripId1 = 1; stripId1 <= ttEdge; ++stripId1) {
+            uint16_t stripHeader = 0xF << 11 | (nPendingEvt & 0x3F) << 5 |
+                                   (gmf & 0x1) << 4 | (smf & 0x1) << 3 |
+                                   (stripId1 & 0x7);
+            ///	    stripHeader |= parity(stripHeader) << 15;
+            fwrite(f, stripHeader, iWord);
 
-	      const vector<uint16_t>& adc = adcCount[iEta0][iPhi0];
-	      for(unsigned iSample=0; iSample  < adc.size(); ++iSample){
-		uint16_t data = adc[iSample] & 0x3FFF;
-		//		data |= parity(data);
-		fwrite(f, data, iWord);
-	      } //next time sample
-	    } //next crystal in strip
-	  } //next strip in TT
-	} //next TT along phi
-      } //next TT along eta
-    } //next DCC
-  } //next half-barrel
+            for (int xtalId1 = 1; xtalId1 <= ttEdge; ++xtalId1) {
+
+              uint16_t crystalHeader = 1 << 14 | (chFrameLen & 0xFF) << 4 |
+                                       (monitorFlag & 0x1) << 3 |
+                                       (xtalId1 & 0x7);
+              //	      crystalHeader |=parity(crystalHeader) << 15;
+              fwrite(f, crystalHeader, iWord);
+
+              int iEta0;
+              int iPhi0;
+              elec2GeomNum(iTtEta0, iTtPhi0, stripId1, xtalId1, iEta0, iPhi0);
+              if (xtalVerbose_) {
+                cout << dec << "iDcc1 = " << iDcc1 << "\t"
+                     << "iEbTtEta0 = " << iTtEta0 << "\t"
+                     << "iEbTtPhi0 = " << iTtPhi0 << "\t"
+                     << "stripId1 = " << stripId1 << "\t"
+                     << "xtalId1 = " << xtalId1 << "\t"
+                     << "iEta0 = " << iEta0 << "\t"
+                     << "iPhi0 = " << iPhi0 << "\t"
+                     << "adc[5] = 0x" << hex << adcCount[iEta0][iPhi0][5] << dec
+                     << "\n";
+              }
+
+              const vector<uint16_t> &adc = adcCount[iEta0][iPhi0];
+              for (unsigned iSample = 0; iSample < adc.size(); ++iSample) {
+                uint16_t data = adc[iSample] & 0x3FFF;
+                //		data |= parity(data);
+                fwrite(f, data, iWord);
+              } // next time sample
+            }   // next crystal in strip
+          }     // next strip in TT
+        }       // next TT along phi
+      }         // next TT along eta
+    }           // next DCC
+  }             // next half-barrel
 }
 
 void EcalSimRawData::genSrData(string basename, int iEvent,
-			       int srf[nEbTtEta][nTtPhi]) const{
-  for(int iZ0 = 0; iZ0<2; ++iZ0){
-    for(int iDccPhi0 = 0; iDccPhi0<nDccInPhi; ++iDccPhi0){
-      int iDcc1 = iDccPhi0 + iZ0*nDccInPhi + nDccEndcap + 1;
-      if(dccNum_!=-1  && dccNum_!=iDcc1) continue;
+                               int srf[nEbTtEta][nTtPhi]) const {
+  for (int iZ0 = 0; iZ0 < 2; ++iZ0) {
+    for (int iDccPhi0 = 0; iDccPhi0 < nDccInPhi; ++iDccPhi0) {
+      int iDcc1 = iDccPhi0 + iZ0 * nDccInPhi + nDccEndcap + 1;
+      if (dccNum_ != -1 && dccNum_ != iDcc1)
+        continue;
       stringstream s;
       s.str("");
       s << basename << "_ab2dcc" << setfill('0') << setw(2) << iDcc1
-	<< setfill(' ') << getExt();
-      ofstream f(s.str().c_str(), (iEvent==1?ios::ate:ios::app));
-      
-      if(f.fail()) throw cms::Exception(string("Cannot create/open file ")
-				  + s.str() + ".");
-      
+        << setfill(' ') << getExt();
+      ofstream f(s.str().c_str(), (iEvent == 1 ? ios::ate : ios::app));
+
+      if (f.fail())
+        throw cms::Exception(string("Cannot create/open file ") + s.str() +
+                             ".");
+
       int iWord = 0;
-  
-      if(writeMode_==ascii){
-	f << (iEvent==1?"":"\n")<< "[Event:" << iEvent << "]\n";
+
+      if (writeMode_ == ascii) {
+        f << (iEvent == 1 ? "" : "\n") << "[Event:" << iEvent << "]\n";
       }
 
       const uint16_t le1 = 0;
       const uint16_t le0 = 0;
       const uint16_t h1 = 1;
       const uint16_t nFlags = 68;
-      uint16_t data =  (h1 & 0x1)<< 14
-	| (le1 & 0x1) << 12
-	| (le0 & 0x1) << 11
-	| (nFlags & 0x7F);
-      
+      uint16_t data = (h1 & 0x1) << 14 | (le1 & 0x1) << 12 | (le0 & 0x1) << 11 |
+                      (nFlags & 0x7F);
+
       fwrite(f, data, iWord, true);
-      
+
       int iFlag = 0;
       data = 0;
 
-      for(int iTtEtaInSm0 = 0; iTtEtaInSm0 < nTtSmEta; ++iTtEtaInSm0){
-	//	int iTtEbEta0 = iZ0*nTtSmEta + iTtEtaInSm0;
-	int iTtEta0 = nEeTtEta + iZ0*nTtSmEta + iTtEtaInSm0;
-	for(int iTtPhiInSm0 = 0; iTtPhiInSm0 < nTtSmPhi; ++iTtPhiInSm0){
-	  //phi=0deg at middle of 1st barrel DCC:
-	  int iTtPhi0 = -nTtPhisPerEbDcc/2 + iDccPhi0*nTtPhisPerEbDcc
-	    + iTtPhiInSm0;
-	  if(iTtPhi0<0) iTtPhi0 += nTtPhi;
-	  //flags are packed by four:
-	  //|15 |14 |13-12 |11      9|8      6|5      3|2      0| 
-	  //| P | 0 | X  X |  srf i+3| srf i+2| srf i+1| srf i  |
-	  //|   |   |      | field 3 |field 2 | field 1| field 0|
-	  const int field = iFlag%4;
-	  //cout << "TtEta0: " << iTtEta0 << "\tTtPhi0: " << iTtPhi0 << "\n";
-	  //cout << "#" << oct << (int)srf[iTtEta0][iTtPhi0] << "o ****> #" << oct << (srf[iTtEta0][iTtPhi0] << (field*3)) << "o\n" << dec;
-	  
-	  data |= srf[iTtEta0][iTtPhi0] << (field*3);
+      for (int iTtEtaInSm0 = 0; iTtEtaInSm0 < nTtSmEta; ++iTtEtaInSm0) {
+        //	int iTtEbEta0 = iZ0*nTtSmEta + iTtEtaInSm0;
+        int iTtEta0 = nEeTtEta + iZ0 * nTtSmEta + iTtEtaInSm0;
+        for (int iTtPhiInSm0 = 0; iTtPhiInSm0 < nTtSmPhi; ++iTtPhiInSm0) {
+          // phi=0deg at middle of 1st barrel DCC:
+          int iTtPhi0 =
+              -nTtPhisPerEbDcc / 2 + iDccPhi0 * nTtPhisPerEbDcc + iTtPhiInSm0;
+          if (iTtPhi0 < 0)
+            iTtPhi0 += nTtPhi;
+          // flags are packed by four:
+          //|15 |14 |13-12 |11      9|8      6|5      3|2      0|
+          //| P | 0 | X  X |  srf i+3| srf i+2| srf i+1| srf i  |
+          //|   |   |      | field 3 |field 2 | field 1| field 0|
+          const int field = iFlag % 4;
+          // cout << "TtEta0: " << iTtEta0 << "\tTtPhi0: " << iTtPhi0 << "\n";
+          // cout << "#" << oct << (int)srf[iTtEta0][iTtPhi0] << "o ****> #" <<
+          // oct << (srf[iTtEta0][iTtPhi0] << (field*3)) << "o\n" << dec;
 
-	  if(field==3){
-	    //cout <<  srf[iTtEta0][iTtPhi0] << "----> 0x" << hex << data << "\n";
-	    fwrite(f, data, iWord, true);
-	    data = 0;
-	  }
-	  ++iFlag;
-	} //next TT along phi
-      } //next TT along eta
-    } //next DCC
-  } //next half-barrel
+          data |= srf[iTtEta0][iTtPhi0] << (field * 3);
+
+          if (field == 3) {
+            // cout <<  srf[iTtEta0][iTtPhi0] << "----> 0x" << hex << data <<
+            // "\n";
+            fwrite(f, data, iWord, true);
+            data = 0;
+          }
+          ++iFlag;
+        } // next TT along phi
+      }   // next TT along eta
+    }     // next DCC
+  }       // next half-barrel
 }
-
 
 void EcalSimRawData::genTccIn(string basename, int iEvent,
-			      const int tcp[nTtEta][nTtPhi]) const{
-  for(int iZ0 = 0; iZ0<2; ++iZ0){
-    for(int iTccPhi0 = 0; iTccPhi0<nTccInPhi; ++iTccPhi0){
-      int iTcc1 = iTccPhi0 + iZ0*nTccInPhi + nTccEndcap + 1;
-      
-      if(tccNum_!=-1  && tccNum_!=iTcc1) continue;
-      
+                              const int tcp[nTtEta][nTtPhi]) const {
+  for (int iZ0 = 0; iZ0 < 2; ++iZ0) {
+    for (int iTccPhi0 = 0; iTccPhi0 < nTccInPhi; ++iTccPhi0) {
+      int iTcc1 = iTccPhi0 + iZ0 * nTccInPhi + nTccEndcap + 1;
+
+      if (tccNum_ != -1 && tccNum_ != iTcc1)
+        continue;
+
       stringstream s;
       s.str("");
-      const char* ext = ".txt"; //only ascii mode supported for TCP
+      const char *ext = ".txt"; // only ascii mode supported for TCP
 
       s << basename << "_tcc" << setfill('0') << setw(2) << iTcc1
-	<< setfill(' ') << ext;
-      ofstream fe2tcc(s.str().c_str(), (iEvent==1?ios::ate:ios::app));
+        << setfill(' ') << ext;
+      ofstream fe2tcc(s.str().c_str(), (iEvent == 1 ? ios::ate : ios::app));
 
-      if(fe2tcc.fail()) throw cms::Exception(string("Failed to create file ")
-				       + s.str() + ".");
-      
-      int memPos = iEvent-1;
+      if (fe2tcc.fail())
+        throw cms::Exception(string("Failed to create file ") + s.str() + ".");
+
+      int memPos = iEvent - 1;
       int iCh1 = 1;
-      for(int iTtEtaInSm0 = 0; iTtEtaInSm0 < nTtSmEta; ++iTtEtaInSm0){
-	int iTtEta0 = (iZ0==0) ? 27 - iTtEtaInSm0 : 28 + iTtEtaInSm0; 
-	for(int iTtPhiInSm0 = 0; iTtPhiInSm0 < nTtSmPhi; ++iTtPhiInSm0){
-	  //phi=0deg at middle of 1st barrel DCC:
-	  int iTtPhi0 = -nTtPhisPerEbTcc/2 + iTccPhi0*nTtPhisPerEbTcc
-	    + iTtPhiInSm0;
-	  iTtPhi0 += nTtPhisPerEbTcc*iTccPhi0;
-	  if(iTtPhi0<0) iTtPhi0 += nTtPhi;
-	  uint16_t tp_fe2tcc = (tcp[iTtEta0][iTtPhi0] & 0x7ff) ; //keep only Et (9:0) and FineGrain (10)
- 	  
-	  if(tpVerbose_ && tp_fe2tcc!=0){
-	    cout << dec
-		 << "iTcc1 = " << iTcc1 << "\t"
-		 << "iTtEta0 = " << iTtEta0 << "\t"
-		 << "iTtPhi0 = " << iTtPhi0 << "\t"
-		 << "iCh1 = " << iCh1 << "\t"
-		 << "memPos = " << memPos << "\t" 
-		 << "tp = 0x" << setfill('0') << hex << setw(3)
-		 << tp_fe2tcc
-		 << dec << setfill(' ') << "\n";
-	  }
-	  fe2tcc << iCh1 << "\t"
-		 << memPos << "\t"
-		 << setfill('0') << hex
-		 << "0x" << setw(4) << tp_fe2tcc << "\t"
-		 << "0"
-		 << dec << setfill(' ') << "\n";
-	  ++iCh1;
-	} //next TT along phi
-      } //next TT along eta
+      for (int iTtEtaInSm0 = 0; iTtEtaInSm0 < nTtSmEta; ++iTtEtaInSm0) {
+        int iTtEta0 = (iZ0 == 0) ? 27 - iTtEtaInSm0 : 28 + iTtEtaInSm0;
+        for (int iTtPhiInSm0 = 0; iTtPhiInSm0 < nTtSmPhi; ++iTtPhiInSm0) {
+          // phi=0deg at middle of 1st barrel DCC:
+          int iTtPhi0 =
+              -nTtPhisPerEbTcc / 2 + iTccPhi0 * nTtPhisPerEbTcc + iTtPhiInSm0;
+          iTtPhi0 += nTtPhisPerEbTcc * iTccPhi0;
+          if (iTtPhi0 < 0)
+            iTtPhi0 += nTtPhi;
+          uint16_t tp_fe2tcc = (tcp[iTtEta0][iTtPhi0] &
+                                0x7ff); // keep only Et (9:0) and FineGrain (10)
+
+          if (tpVerbose_ && tp_fe2tcc != 0) {
+            cout << dec << "iTcc1 = " << iTcc1 << "\t"
+                 << "iTtEta0 = " << iTtEta0 << "\t"
+                 << "iTtPhi0 = " << iTtPhi0 << "\t"
+                 << "iCh1 = " << iCh1 << "\t"
+                 << "memPos = " << memPos << "\t"
+                 << "tp = 0x" << setfill('0') << hex << setw(3) << tp_fe2tcc
+                 << dec << setfill(' ') << "\n";
+          }
+          fe2tcc << iCh1 << "\t" << memPos << "\t" << setfill('0') << hex
+                 << "0x" << setw(4) << tp_fe2tcc << "\t"
+                 << "0" << dec << setfill(' ') << "\n";
+          ++iCh1;
+        } // next TT along phi
+      }   // next TT along eta
       fe2tcc << std::flush;
       fe2tcc.close();
-    } //next TCC
-  } //next half-barrel
+    } // next TCC
+  }   // next half-barrel
 }
 
-
 void EcalSimRawData::genTccOut(string basename, int iEvent,
-			       const int tps[nTtEta][nTtPhi]) const{
+                               const int tps[nTtEta][nTtPhi]) const {
   int iDccWord = 0;
 
-  for(int iZ0 = 0; iZ0<2; ++iZ0){
-    for(int iTccPhi0 = 0; iTccPhi0<nTccInPhi; ++iTccPhi0){
-      int iTcc1 = iTccPhi0 + iZ0*nTccInPhi + nTccEndcap + 1;
+  for (int iZ0 = 0; iZ0 < 2; ++iZ0) {
+    for (int iTccPhi0 = 0; iTccPhi0 < nTccInPhi; ++iTccPhi0) {
+      int iTcc1 = iTccPhi0 + iZ0 * nTccInPhi + nTccEndcap + 1;
 
-      if(tccNum_!=-1  && tccNum_!=iTcc1) continue;
-      
+      if (tccNum_ != -1 && tccNum_ != iTcc1)
+        continue;
+
       stringstream s;
       s.str("");
-      const char* ext = ".txt"; //only ascii mode supported for TCP
+      const char *ext = ".txt"; // only ascii mode supported for TCP
 
       s << basename << "_tcc" << setfill('0') << setw(2) << iTcc1
-	<< setfill(' ') << ext;
+        << setfill(' ') << ext;
 
       s.str("");
       s << basename << "_tcc2dcc" << setfill('0') << setw(2) << iTcc1
-	<< setfill(' ') << getExt();
-      ofstream dccF(s.str().c_str(), (iEvent==1?ios::ate:ios::app));
-      
-      if(dccF.fail()){
-	cout << "Warning: failed to create or open file " << s.str() << ".\n";
-	return;
+        << setfill(' ') << getExt();
+      ofstream dccF(s.str().c_str(), (iEvent == 1 ? ios::ate : ios::app));
+
+      if (dccF.fail()) {
+        cout << "Warning: failed to create or open file " << s.str() << ".\n";
+        return;
       }
-      
+
       const uint16_t h1 = 1;
       const uint16_t le1 = 0;
       const uint16_t le0 = 0;
       const uint16_t nSamples = 1;
       const uint16_t nTts = 68;
-      const uint16_t data = (h1 & 0x1) << 14
-	| (le1 & 0x1) << 12
-	| (le0 & 0x1) << 11
-	| (nSamples & 0xF) << 7
-	| (nTts & 0x7F);	
-      dccF << (iEvent==1?"":"\n") << "[Event:" << iEvent << "]\n";
+      const uint16_t data = (h1 & 0x1) << 14 | (le1 & 0x1) << 12 |
+                            (le0 & 0x1) << 11 | (nSamples & 0xF) << 7 |
+                            (nTts & 0x7F);
+      dccF << (iEvent == 1 ? "" : "\n") << "[Event:" << iEvent << "]\n";
       fwrite(dccF, data, iDccWord, false);
-      
-      int memPos = iEvent-1;
+
+      int memPos = iEvent - 1;
       int iCh1 = 1;
-      for(int iTtEtaInSm0 = 0; iTtEtaInSm0 < nTtSmEta; ++iTtEtaInSm0){
-	int iTtEta0 = nEeTtEta + iZ0*nTtSmEta + iTtEtaInSm0;
-	for(int iTtPhiInSm0 = 0; iTtPhiInSm0 < nTtSmPhi; ++iTtPhiInSm0){
-	  //phi=0deg at middle of 1st barrel DCC:
-	  int iTtPhi0 = -nTtPhisPerEbTcc/2 + iTccPhi0*nTtPhisPerEbTcc
-	    + iTtPhiInSm0;
-	  if(iTtPhi0<0) iTtPhi0 += nTtPhi;
-	  
-	  if(tpVerbose_){
-	    cout << dec
-		 << "iTcc1 = " << iTcc1 << "\t"
-		 << "iTtEta0 = " << iTtEta0 << "\t"
-		 << "iTtPhi0 = " << iTtPhi0 << "\t"
-		 << "iCh1 = " << iCh1 << "\t"
-		 << "memPos = " << memPos << "\t" 
-		 << "tp = 0x" << hex << tps[iTtEta0][iTtPhi0]
-		 << dec << "\n";
-	  }
-	  fwrite(dccF, tps[iTtEta0][iTtPhi0], iDccWord, false);
-	  ++iCh1;
-	} //next TT along phi
-      } //next TT along eta
-    } //next TCC
-  } //next half-barrel
+      for (int iTtEtaInSm0 = 0; iTtEtaInSm0 < nTtSmEta; ++iTtEtaInSm0) {
+        int iTtEta0 = nEeTtEta + iZ0 * nTtSmEta + iTtEtaInSm0;
+        for (int iTtPhiInSm0 = 0; iTtPhiInSm0 < nTtSmPhi; ++iTtPhiInSm0) {
+          // phi=0deg at middle of 1st barrel DCC:
+          int iTtPhi0 =
+              -nTtPhisPerEbTcc / 2 + iTccPhi0 * nTtPhisPerEbTcc + iTtPhiInSm0;
+          if (iTtPhi0 < 0)
+            iTtPhi0 += nTtPhi;
+
+          if (tpVerbose_) {
+            cout << dec << "iTcc1 = " << iTcc1 << "\t"
+                 << "iTtEta0 = " << iTtEta0 << "\t"
+                 << "iTtPhi0 = " << iTtPhi0 << "\t"
+                 << "iCh1 = " << iCh1 << "\t"
+                 << "memPos = " << memPos << "\t"
+                 << "tp = 0x" << hex << tps[iTtEta0][iTtPhi0] << dec << "\n";
+          }
+          fwrite(dccF, tps[iTtEta0][iTtPhi0], iDccWord, false);
+          ++iCh1;
+        } // next TT along phi
+      }   // next TT along eta
+    }     // next TCC
+  }       // next half-barrel
 }
 
-
-void EcalSimRawData::setHParity(uint16_t& a) const{
-  const int odd = 1 <<15;
+void EcalSimRawData::setHParity(uint16_t &a) const {
+  const int odd = 1 << 15;
   const int even = 0;
-  //parity bit of numbers from 0x0 to 0xF:
-  //                    0   1   2    3   4    5    6   7   8    9    A   B    C   D   E    F           
-  const int p[16] = {even,odd,odd,even,odd,even,even,odd,odd,even,even,odd,even,odd,odd,even};
-  //inverts parity bit (LSB) of 'a' in case of even parity:
-  a ^= p[a&0xF] ^ p[(a>>4)&0xF] ^ p[(a>>8)&0xF] ^ p[a>>12&0xF] ^ odd;   
+  // parity bit of numbers from 0x0 to 0xF:
+  //                    0   1   2    3   4    5    6   7   8    9    A   B    C
+  //                    D   E    F
+  const int p[16] = {even, odd,  odd,  even, odd,  even, even, odd,
+                     odd,  even, even, odd,  even, odd,  odd,  even};
+  // inverts parity bit (LSB) of 'a' in case of even parity:
+  a ^= p[a & 0xF] ^ p[(a >> 4) & 0xF] ^ p[(a >> 8) & 0xF] ^ p[a >> 12 & 0xF] ^
+       odd;
 }
 
-void EcalSimRawData::getSrfs(const edm::Event& event,
-			     int ebSrf[nTtEta][nTtPhi],
-			     int eeSrf[nEndcaps][nScX][nScY]) const{
+void EcalSimRawData::getSrfs(const edm::Event &event, int ebSrf[nTtEta][nTtPhi],
+                             int eeSrf[nEndcaps][nScX][nScY]) const {
 
-  //EE
+  // EE
   edm::Handle<EESrFlagCollection> hEeSrFlags;
   event.getByLabel(srDigiProducer_, eeSrFlagCollection_, hEeSrFlags);
-  for(size_t i=0; i < (nEndcaps*nScX*nScY); ((int*)eeSrf)[i++] = -1){};
-  if(hEeSrFlags.isValid()){
-    for(EESrFlagCollection::const_iterator it = hEeSrFlags->begin();
-	it != hEeSrFlags->end(); ++it){
-      const EESrFlag& flag = *it;
-      int iZ0 = flag.id().zside()>0?1:0;
-      int iX0 = flag.id().ix()-1;
-      int iY0 = flag.id().iy()-1;
-      assert(iZ0>=0 && iZ0<nEndcaps);
-      assert(iX0>=0 && iX0<nScX);
-      assert(iY0>=0 && iY0<nScY);
+  for (size_t i = 0; i < (nEndcaps * nScX * nScY); ((int *)eeSrf)[i++] = -1) {
+  };
+  if (hEeSrFlags.isValid()) {
+    for (EESrFlagCollection::const_iterator it = hEeSrFlags->begin();
+         it != hEeSrFlags->end(); ++it) {
+      const EESrFlag &flag = *it;
+      int iZ0 = flag.id().zside() > 0 ? 1 : 0;
+      int iX0 = flag.id().ix() - 1;
+      int iY0 = flag.id().iy() - 1;
+      assert(iZ0 >= 0 && iZ0 < nEndcaps);
+      assert(iX0 >= 0 && iX0 < nScX);
+      assert(iY0 >= 0 && iY0 < nScY);
       eeSrf[iZ0][iX0][iY0] = flag.value();
     }
-  } else{
-    LogWarning("EcalSimRawData") << "EE SR flag not found ("
-				 << "Product label: " << srDigiProducer_
-				 << "Producet instance: "
-				 << eeSrFlagCollection_ << ")";
+  } else {
+    LogWarning("EcalSimRawData")
+        << "EE SR flag not found ("
+        << "Product label: " << srDigiProducer_
+        << "Producet instance: " << eeSrFlagCollection_ << ")";
   }
 
-  //EB
+  // EB
   edm::Handle<EBSrFlagCollection> hEbSrFlags;
   event.getByLabel(srDigiProducer_, ebSrFlagCollection_, hEbSrFlags);
-  for(size_t i=0; i<(nTtEta*nTtPhi); ((int*)ebSrf)[i++] = -1){};
-  if(hEbSrFlags.isValid()){
-    for(EBSrFlagCollection::const_iterator it = hEbSrFlags->begin();
-	it != hEbSrFlags->end(); ++it){
-      
-      const EBSrFlag& flag = *it;
+  for (size_t i = 0; i < (nTtEta * nTtPhi); ((int *)ebSrf)[i++] = -1) {
+  };
+  if (hEbSrFlags.isValid()) {
+    for (EBSrFlagCollection::const_iterator it = hEbSrFlags->begin();
+         it != hEbSrFlags->end(); ++it) {
+
+      const EBSrFlag &flag = *it;
       int iEta = flag.id().ieta();
-      int iEta0 = iEta + nTtEta/2 - (iEta>=0?1:0); //0->55 from eta=-3 to eta=3
-      int iEbEta0 = iEta0 - nEeTtEta;//0->33 from eta=-1.48 to eta=1.48
+      int iEta0 =
+          iEta + nTtEta / 2 - (iEta >= 0 ? 1 : 0); // 0->55 from eta=-3 to eta=3
+      int iEbEta0 = iEta0 - nEeTtEta; // 0->33 from eta=-1.48 to eta=1.48
       int iPhi0 = flag.id().iphi() - 1;
 
-      assert(iEbEta0>=0 && iEbEta0<nEbTtEta);
-      assert(iPhi0>=0 && iPhi0<nTtPhi);
-      
+      assert(iEbEta0 >= 0 && iEbEta0 < nEbTtEta);
+      assert(iPhi0 >= 0 && iPhi0 < nTtPhi);
+
       ebSrf[iEbEta0][iPhi0] = flag.value();
     }
-  } else{
-    LogWarning("EcalSimRawData") << "EB SR flag not found ("
-				 << "Product label: " << srDigiProducer_
-				 << "Producet instance: "
-				 << ebSrFlagCollection_ << ")";
+  } else {
+    LogWarning("EcalSimRawData")
+        << "EB SR flag not found ("
+        << "Product label: " << srDigiProducer_
+        << "Producet instance: " << ebSrFlagCollection_ << ")";
   }
 }
 
-void EcalSimRawData::getEbDigi(const edm::Event& event,
-			       vector<uint16_t> adc[nEbEta][nEbPhi]) const{
+void EcalSimRawData::getEbDigi(const edm::Event &event,
+                               vector<uint16_t> adc[nEbEta][nEbPhi]) const {
 
   edm::Handle<EBDigiCollection> hEbDigis;
   event.getByLabel(digiProducer_, ebDigiCollection_, hEbDigis);
 
   int nSamples = 0;
-  if(hEbDigis.isValid() && !hEbDigis->empty()){//there is at least one digi
-    nSamples  = hEbDigis->begin()->size();//gets the sample count from 1st digi
+  if (hEbDigis.isValid() && !hEbDigis->empty()) { // there is at least one digi
+    nSamples = hEbDigis->begin()->size(); // gets the sample count from 1st digi
   }
-
 
   const uint16_t suppressed = 0xFFFF;
 
   adc[0][0] = vector<uint16_t>(nSamples, suppressed);
-  
-  for(int iEbEta=0; iEbEta<nEbEta; ++iEbEta){
-    for(int iEbPhi=0; iEbPhi<nEbPhi; ++iEbPhi){
+
+  for (int iEbEta = 0; iEbEta < nEbEta; ++iEbEta) {
+    for (int iEbPhi = 0; iEbPhi < nEbPhi; ++iEbPhi) {
       adc[iEbEta][iEbPhi] = adc[0][0];
     }
   }
-  if(hEbDigis.isValid()){
-    if(xtalVerbose_) cout << setfill('0');
-    for(EBDigiCollection::const_iterator it = hEbDigis->begin();
-	it != hEbDigis->end(); ++it){
-      const EBDataFrame& frame = *it;
-      
+  if (hEbDigis.isValid()) {
+    if (xtalVerbose_)
+      cout << setfill('0');
+    for (EBDigiCollection::const_iterator it = hEbDigis->begin();
+         it != hEbDigis->end(); ++it) {
+      const EBDataFrame &frame = *it;
+
       int iEta0 = iEta2cIndex((frame.id()).ieta());
       int iPhi0 = iPhi2cIndex((frame.id()).iphi());
-      
+
       //     cout << "xtl indices conv: (" << frame.id().ieta() << ","
       // 	 << frame.id().iphi() << ") -> ("
       // 	 << iEta0 << "," << iPhi0 << ")\n";
-    
-      if(iEta0<0 || iEta0>=nEbEta){
-	cout << "iEta0 (= " << iEta0 << ") is out of range ("
-	     << "[0," << nEbEta -1 << "])\n";
+
+      if (iEta0 < 0 || iEta0 >= nEbEta) {
+        cout << "iEta0 (= " << iEta0 << ") is out of range ("
+             << "[0," << nEbEta - 1 << "])\n";
       }
-      if(iPhi0<0 || iPhi0>=nEbPhi){
-	cout << "iPhi0 (= " << iPhi0 << ") is out of range ("
-	     << "[0," << nEbPhi -1 << "])\n";
+      if (iPhi0 < 0 || iPhi0 >= nEbPhi) {
+        cout << "iPhi0 (= " << iPhi0 << ") is out of range ("
+             << "[0," << nEbPhi - 1 << "])\n";
       }
-    
-      if(xtalVerbose_){
-	cout << iEta0 << "\t" << iPhi0 << ":\t";
-	cout << hex;
+
+      if (xtalVerbose_) {
+        cout << iEta0 << "\t" << iPhi0 << ":\t";
+        cout << hex;
       }
-      
-      if(nSamples!=frame.size()){
-	throw cms::Exception("EcalSimRawData", "Found EB digis with different sample count! This is not supported by EcalSimRawData.");
+
+      if (nSamples != frame.size()) {
+        throw cms::Exception("EcalSimRawData",
+                             "Found EB digis with different sample count! This "
+                             "is not supported by EcalSimRawData.");
       }
-    
-      for(int iSample=0; iSample<nSamples; ++iSample){
-	const EcalMGPASample& sample = frame.sample(iSample);
-	uint16_t encodedAdc = sample.raw();
-	adc[iEta0][iPhi0][iSample] = encodedAdc;  
-	if(xtalVerbose_){
-	  cout << (iSample>0?" ":"") << "0x" << setw(4) 
-	       << encodedAdc;
-	}
+
+      for (int iSample = 0; iSample < nSamples; ++iSample) {
+        const EcalMGPASample &sample = frame.sample(iSample);
+        uint16_t encodedAdc = sample.raw();
+        adc[iEta0][iPhi0][iSample] = encodedAdc;
+        if (xtalVerbose_) {
+          cout << (iSample > 0 ? " " : "") << "0x" << setw(4) << encodedAdc;
+        }
       }
-      if(xtalVerbose_) cout << "\n" << dec;
+      if (xtalVerbose_)
+        cout << "\n" << dec;
     }
-    if(xtalVerbose_) cout << setfill(' ');
+    if (xtalVerbose_)
+      cout << setfill(' ');
   }
 }
-  
 
-void EcalSimRawData::getTp(const edm::Event& event,
-			   const std::string& collName,
-			   int tcp[nTtEta][nTtPhi]) const{
+void EcalSimRawData::getTp(const edm::Event &event, const std::string &collName,
+                           int tcp[nTtEta][nTtPhi]) const {
   edm::Handle<EcalTrigPrimDigiCollection> hTpDigis;
   event.getByLabel(tpProducer_, collName, hTpDigis);
-  if(hTpDigis.isValid() && !hTpDigis->empty()){
-    const EcalTrigPrimDigiCollection& tpDigis = *hTpDigis.product();
+  if (hTpDigis.isValid() && !hTpDigis->empty()) {
+    const EcalTrigPrimDigiCollection &tpDigis = *hTpDigis.product();
 
     //    EcalSelectiveReadout::ttFlag_t ttf[nTtEta][nTtPhi];
-    for(int iTtEta0=0; iTtEta0 < nTtEta; ++iTtEta0){
-      for(int iTtPhi0=0; iTtPhi0 < nTtPhi; ++iTtPhi0){
-	tcp[iTtEta0][iTtPhi0] = tccInDefaultVal_ ;
+    for (int iTtEta0 = 0; iTtEta0 < nTtEta; ++iTtEta0) {
+      for (int iTtPhi0 = 0; iTtPhi0 < nTtPhi; ++iTtPhi0) {
+        tcp[iTtEta0][iTtPhi0] = tccInDefaultVal_;
       }
     }
-    if(tpVerbose_){
+    if (tpVerbose_) {
       cout << setfill('0');
     }
-    for(EcalTrigPrimDigiCollection::const_iterator it = tpDigis.begin();
-	it != tpDigis.end(); ++it){
-      const EcalTriggerPrimitiveDigi& tp = *it;
+    for (EcalTrigPrimDigiCollection::const_iterator it = tpDigis.begin();
+         it != tpDigis.end(); ++it) {
+      const EcalTriggerPrimitiveDigi &tp = *it;
       int iTtEta0 = iTtEta2cIndex(tp.id().ieta());
       int iTtPhi0 = iTtPhi2cIndex(tp.id().iphi());
-      if(iTtEta0<0 || iTtEta0>=nTtEta){
-	cout << "iTtEta0 (= " << iTtEta0 << ") is out of range ("
-	     << "[0," << nEbTtEta -1 << "])\n";
+      if (iTtEta0 < 0 || iTtEta0 >= nTtEta) {
+        cout << "iTtEta0 (= " << iTtEta0 << ") is out of range ("
+             << "[0," << nEbTtEta - 1 << "])\n";
       }
-      if(iTtPhi0<0 || iTtPhi0>=nTtPhi){
-	cout << "iTtPhi0 (= " << iTtPhi0 << ") is out of range ("
-	     << "[0," << nTtPhi -1 << "])\n";
+      if (iTtPhi0 < 0 || iTtPhi0 >= nTtPhi) {
+        cout << "iTtPhi0 (= " << iTtPhi0 << ") is out of range ("
+             << "[0," << nTtPhi - 1 << "])\n";
       }
 
       tcp[iTtEta0][iTtPhi0] = tp[tp.sampleOfInterest()].raw();
 
-      if(tpVerbose_){
-	if(tcp[iTtEta0][iTtPhi0]!=0) //print non-zero values only
-	cout << collName << (collName.empty()?"":" ")
-	     << "TP(" << setw(2) << iTtEta0 << "," << iTtPhi0 << ") = "
-	     << "0x" << setw(4) 
-	     << tcp[iTtEta0][iTtPhi0]
-	     << "\tcmssw indices: "
-	     << tp.id().ieta() << " " << tp.id().iphi() << "\n";
+      if (tpVerbose_) {
+        if (tcp[iTtEta0][iTtPhi0] != 0) // print non-zero values only
+          cout << collName << (collName.empty() ? "" : " ") << "TP(" << setw(2)
+               << iTtEta0 << "," << iTtPhi0 << ") = "
+               << "0x" << setw(4) << tcp[iTtEta0][iTtPhi0]
+               << "\tcmssw indices: " << tp.id().ieta() << " " << tp.id().iphi()
+               << "\n";
       }
-    }//next TP
-    if(tpVerbose_) cout << setfill(' ');
+    } // next TP
+    if (tpVerbose_)
+      cout << setfill(' ');
   }
 }

--- a/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimpleProducer.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimpleProducer.cc
@@ -1,107 +1,115 @@
-#include "SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimpleProducer.h"
-#include "TFormula.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
-#include "DataFormats/EcalDigi/interface/EBDataFrame.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "DataFormats/EcalDigi/interface/EBDataFrame.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimpleProducer.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
+#include "TFormula.h"
 #include <iostream>
 #include <string>
 
 using namespace std;
 using namespace edm;
 
-void EcalSimpleProducer::produce(edm::Event& evt, const edm::EventSetup&){
+void EcalSimpleProducer::produce(edm::Event &evt, const edm::EventSetup &) {
   const int ievt = evt.id().event();
-  if(formula_.get()!=nullptr){
+  if (formula_.get() != nullptr) {
     unique_ptr<EBDigiCollection> digis(new EBDigiCollection);
-    
-    digis->reserve(170*360);
-    
+
+    digis->reserve(170 * 360);
+
     const int nSamples = digis->stride();
-    for(int iEta0=0; iEta0<170; ++iEta0){
-      for(int iPhi0=0; iPhi0<360; ++iPhi0){
-	int iEta1 = cIndex2iEta(iEta0);
-	int iPhi = cIndex2iPhi(iPhi0);
-	if(verbose_) cout << "(" << iEta0 << "," << iPhi0 << "): ";
-	digis->push_back(EBDetId(iEta1,iPhi));
-	DataFrame dframe(digis->back());
-	
-	for(int t = 0; t < nSamples; ++t){
-	  uint16_t encodedAdc = (uint16_t)formula_->Eval(iEta0, iPhi0, ievt-1, t);
-	  if(verbose_) cout << encodedAdc << ((t<(nSamples-1))?"\t":"\n");
-	  dframe[t]=encodedAdc;
-	}
+    for (int iEta0 = 0; iEta0 < 170; ++iEta0) {
+      for (int iPhi0 = 0; iPhi0 < 360; ++iPhi0) {
+        int iEta1 = cIndex2iEta(iEta0);
+        int iPhi = cIndex2iPhi(iPhi0);
+        if (verbose_)
+          cout << "(" << iEta0 << "," << iPhi0 << "): ";
+        digis->push_back(EBDetId(iEta1, iPhi));
+        DataFrame dframe(digis->back());
+
+        for (int t = 0; t < nSamples; ++t) {
+          uint16_t encodedAdc =
+              (uint16_t)formula_->Eval(iEta0, iPhi0, ievt - 1, t);
+          if (verbose_)
+            cout << encodedAdc << ((t < (nSamples - 1)) ? "\t" : "\n");
+          dframe[t] = encodedAdc;
+        }
       }
     }
     evt.put(std::move(digis));
-    //puts an empty digi collecion for endcap:
+    // puts an empty digi collecion for endcap:
     evt.put(unique_ptr<EEDigiCollection>(new EEDigiCollection()));
   }
-  if(tpFormula_.get()!=nullptr){
-    unique_ptr<EcalTrigPrimDigiCollection> tps
-      = unique_ptr<EcalTrigPrimDigiCollection>(new EcalTrigPrimDigiCollection);
-    tps->reserve(56*72);
+  if (tpFormula_.get() != nullptr) {
+    unique_ptr<EcalTrigPrimDigiCollection> tps =
+        unique_ptr<EcalTrigPrimDigiCollection>(new EcalTrigPrimDigiCollection);
+    tps->reserve(56 * 72);
     const int nSamples = 5;
-    for(int iTtEta0=0; iTtEta0<56; ++iTtEta0){
-      for(int iTtPhi0=0; iTtPhi0<72; ++iTtPhi0){
-	int iTtEta1 = cIndex2iTtEta(iTtEta0);
-	int iTtPhi = cIndex2iTtPhi(iTtPhi0);
-	
-	if(verbose_) cout << "(" << iTtEta0 << "," << iTtPhi0 << "): ";
-	int zside = iTtEta1<0?-1:1;
-	EcalTriggerPrimitiveDigi
-	  tpframe(EcalTrigTowerDetId(zside, EcalTriggerTower,
-				     abs(iTtEta1), iTtPhi));
-	
-	tpframe.setSize(nSamples);
-	
-	if(verbose_) cout << "TP: ";
-	for(int t = 0; t < nSamples; ++t){
-	  uint16_t encodedTp = (uint16_t)tpFormula_->Eval(iTtEta0, iTtPhi0, ievt-1, t);
-	  
-	  if(verbose_) cout << "TP(" << iTtEta0 << "," << iTtPhi0 << ") = "
-			    << encodedTp << ((t<(nSamples-1))?"\t":"\n");
-	  tpframe.setSample(t, EcalTriggerPrimitiveSample(encodedTp));
-	}
-	tps->push_back(tpframe);
+    for (int iTtEta0 = 0; iTtEta0 < 56; ++iTtEta0) {
+      for (int iTtPhi0 = 0; iTtPhi0 < 72; ++iTtPhi0) {
+        int iTtEta1 = cIndex2iTtEta(iTtEta0);
+        int iTtPhi = cIndex2iTtPhi(iTtPhi0);
+
+        if (verbose_)
+          cout << "(" << iTtEta0 << "," << iTtPhi0 << "): ";
+        int zside = iTtEta1 < 0 ? -1 : 1;
+        EcalTriggerPrimitiveDigi tpframe(
+            EcalTrigTowerDetId(zside, EcalTriggerTower, abs(iTtEta1), iTtPhi));
+
+        tpframe.setSize(nSamples);
+
+        if (verbose_)
+          cout << "TP: ";
+        for (int t = 0; t < nSamples; ++t) {
+          uint16_t encodedTp =
+              (uint16_t)tpFormula_->Eval(iTtEta0, iTtPhi0, ievt - 1, t);
+
+          if (verbose_)
+            cout << "TP(" << iTtEta0 << "," << iTtPhi0 << ") = " << encodedTp
+                 << ((t < (nSamples - 1)) ? "\t" : "\n");
+          tpframe.setSample(t, EcalTriggerPrimitiveSample(encodedTp));
+        }
+        tps->push_back(tpframe);
       }
     }
     evt.put(std::move(tps));
   }
-  if(simHitFormula_.get()!=nullptr){//generation of barrel sim hits
-    unique_ptr<PCaloHitContainer> hits
-      = unique_ptr<PCaloHitContainer>(new PCaloHitContainer);
-    for(int iEta0=0; iEta0<170; ++iEta0){
-      for(int iPhi0=0; iPhi0<360; ++iPhi0){
-	int iEta1 = cIndex2iEta(iEta0);
-	int iPhi = cIndex2iPhi(iPhi0);
-	if(verbose_) cout << "(" << iEta0 << "," << iPhi0 << "): ";
-	
-	double em = simHitFormula_->Eval(iEta0, iPhi0, ievt-1);
+  if (simHitFormula_.get() != nullptr) { // generation of barrel sim hits
+    unique_ptr<PCaloHitContainer> hits =
+        unique_ptr<PCaloHitContainer>(new PCaloHitContainer);
+    for (int iEta0 = 0; iEta0 < 170; ++iEta0) {
+      for (int iPhi0 = 0; iPhi0 < 360; ++iPhi0) {
+        int iEta1 = cIndex2iEta(iEta0);
+        int iPhi = cIndex2iPhi(iPhi0);
+        if (verbose_)
+          cout << "(" << iEta0 << "," << iPhi0 << "): ";
+
+        double em = simHitFormula_->Eval(iEta0, iPhi0, ievt - 1);
         double eh = 0.;
-	double t = 0.;
-	const PCaloHit hit(EBDetId(iEta1,iPhi).rawId(), em, eh, t, 0);
-	hits->push_back(hit);
+        double t = 0.;
+        const PCaloHit hit(EBDetId(iEta1, iPhi).rawId(), em, eh, t, 0);
+        hits->push_back(hit);
       }
     }
     evt.put(std::move(hits), "EcalHitsEB");
-    //puts an empty digi collecion for endcap:
+    // puts an empty digi collecion for endcap:
     evt.put(unique_ptr<PCaloHitContainer>(new PCaloHitContainer()),
-	    "EcalHitsEE");
+            "EcalHitsEE");
   }
 }
 
-EcalSimpleProducer::EcalSimpleProducer(const edm::ParameterSet& pset):
-  EDProducer(){
+EcalSimpleProducer::EcalSimpleProducer(const edm::ParameterSet &pset)
+    : EDProducer() {
   string formula = pset.getParameter<string>("formula");
   string tpFormula = pset.getParameter<string>("tpFormula");
   string simHitFormula = pset.getParameter<string>("simHitFormula");
-  
+
   verbose_ = pset.getUntrackedParameter<bool>("verbose", false);
-  //  replaceAll(formula, "itt0", "((((ieta0<85)*(84-ieta0)+(ieta0>=85)*(ieta0-85))/5-18)*4+((iphi0/5+2)%4))");
+  //  replaceAll(formula, "itt0",
+  //  "((((ieta0<85)*(84-ieta0)+(ieta0>=85)*(ieta0-85))/5-18)*4+((iphi0/5+2)%4))");
   replaceAll(formula, "ebm", "(ieta0<85)");
   replaceAll(formula, "ebp", "(ieta0>84)");
   replaceAll(formula, "ieta0", "x");
@@ -109,8 +117,9 @@ EcalSimpleProducer::EcalSimpleProducer(const edm::ParameterSet& pset):
   replaceAll(formula, "ievt0", "z");
   replaceAll(formula, "isample0", "t");
   //  cout << "----------> " << formula << endl;
-  
-  replaceAll(tpFormula, "itt0", "((ieta0<28)*(27-ieta0)+(ieta0>=28)*(ieta0-28))*4+(iphi0+2)%4");
+
+  replaceAll(tpFormula, "itt0",
+             "((ieta0<28)*(27-ieta0)+(ieta0>=28)*(ieta0-28))*4+(iphi0+2)%4");
   replaceAll(tpFormula, "eb", "(ieta0>10 && ieta0<45)");
   replaceAll(tpFormula, "ebm", "(ieta0>10 && ieta0<28)");
   replaceAll(tpFormula, "ebp", "(ieta0>27 && ieta0<45)");
@@ -121,53 +130,53 @@ EcalSimpleProducer::EcalSimpleProducer(const edm::ParameterSet& pset):
   replaceAll(tpFormula, "iphi0", "y");
   replaceAll(tpFormula, "ievt0", "z");
   replaceAll(tpFormula, "isample0", "t");
-  //cout << "----------> " << tpFormula << endl;
-  
+  // cout << "----------> " << tpFormula << endl;
 
-  //replaceAll(simHitormula, "itt0", "((((ieta0<85)*(84-ieta0)+(ieta0>=85)*(ieta0-85))/5-18)*4+((iphi0/5+2)%4))");
+  // replaceAll(simHitormula, "itt0",
+  // "((((ieta0<85)*(84-ieta0)+(ieta0>=85)*(ieta0-85))/5-18)*4+((iphi0/5+2)%4))");
   replaceAll(simHitFormula, "ebm", "(ieta0<85)");
   replaceAll(simHitFormula, "ebp", "(ieta0>84)");
   replaceAll(simHitFormula, "ieta0", "x");
   replaceAll(simHitFormula, "iphi0", "y");
   replaceAll(simHitFormula, "ievt0", "z");
-  
-  if(!formula.empty()){
+
+  if (!formula.empty()) {
     formula_ = unique_ptr<TFormula>(new TFormula("f", formula.c_str()));
     Int_t err = formula_->Compile();
-    if(err!=0){
+    if (err != 0) {
       throw cms::Exception("Error in EcalSimpleProducer 'formula' config.");
     }
     produces<EBDigiCollection>();
     produces<EEDigiCollection>();
   }
-  if(!tpFormula.empty()){
+  if (!tpFormula.empty()) {
     tpFormula_ = unique_ptr<TFormula>(new TFormula("f", tpFormula.c_str()));
     Int_t err = tpFormula_->Compile();
-    if(err!=0){
+    if (err != 0) {
       throw cms::Exception("Error in EcalSimpleProducer 'tpFormula' config.");
     }
     produces<EcalTrigPrimDigiCollection>();
   }
-  if(!simHitFormula.empty()){
-    simHitFormula_
-      = unique_ptr<TFormula>(new TFormula("f", simHitFormula.c_str()));
+  if (!simHitFormula.empty()) {
+    simHitFormula_ =
+        unique_ptr<TFormula>(new TFormula("f", simHitFormula.c_str()));
     Int_t err = simHitFormula_->Compile();
-    if(err!=0){
+    if (err != 0) {
       throw cms::Exception("Error in EcalSimpleProducer "
-			   "'simHitFormula' config.");
+                           "'simHitFormula' config.");
     }
     produces<edm::PCaloHitContainer>("EcalHitsEB");
     produces<edm::PCaloHitContainer>("EcalHitsEE");
   }
 }
 
-void EcalSimpleProducer::replaceAll(std::string& s, const std::string& from,
-				  const std::string& to) const{
+void EcalSimpleProducer::replaceAll(std::string &s, const std::string &from,
+                                    const std::string &to) const {
   string::size_type pos = 0;
   //  cout << "replaceAll(" << s << "," << from << "," << to << ")\n";
-  while((pos=s.find(from, pos))!=string::npos){
+  while ((pos = s.find(from, pos)) != string::npos) {
     // cout << "replace(" << pos << "," << from.size() << "," << to << ")\n";
     s.replace(pos, from.size(), to);
-    //   cout << " -> " << s << "\n"; 
+    //   cout << " -> " << s << "\n";
   }
 }

--- a/SimCalorimetry/EcalElectronicsEmulation/src/SealModules.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/src/SealModules.cc
@@ -1,9 +1,8 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimpleProducer.h"
-#include "SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimRawData.h"
 #include "SimCalorimetry/EcalElectronicsEmulation/interface/EcalFEtoDigi.h"
-
+#include "SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimRawData.h"
+#include "SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimpleProducer.h"
 
 DEFINE_FWK_MODULE(EcalSimpleProducer);
 DEFINE_FWK_MODULE(EcalSimRawData);

--- a/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
@@ -1,153 +1,162 @@
 #ifndef SimCalorimetry_EcalSimProducers_EcalDigiProducer_h
 #define SimCalorimetry_EcalSimProducers_EcalDigiProducer_h
 
+#include "DataFormats/Math/interface/Error.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/APDShape.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EBShape.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EEShape.h"
-#include "SimCalorimetry/EcalSimAlgos/interface/ESShape.h"
-#include "DataFormats/Math/interface/Error.h"
-#include "SimGeneral/NoiseGenerators/interface/CorrelatedNoisifier.h"
-#include "SimCalorimetry/EcalSimAlgos/interface/EcalCorrelatedNoiseMatrix.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/ESElectronicsSim.h"
+#include "SimCalorimetry/EcalSimAlgos/interface/ESShape.h"
+#include "SimCalorimetry/EcalSimAlgos/interface/EcalCorrelatedNoiseMatrix.h"
+#include "SimGeneral/NoiseGenerators/interface/CorrelatedNoisifier.h"
 
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
-#include "SimCalorimetry/EcalSimAlgos/interface/EcalTDigitizer.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalDigitizerTraits.h"
+#include "SimCalorimetry/EcalSimAlgos/interface/EcalTDigitizer.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
-
 
 #include <vector>
 
-typedef EcalTDigitizer<EBDigitizerTraits> EBDigitizer  ;
-typedef EcalTDigitizer<EEDigitizerTraits> EEDigitizer  ;
-typedef CaloTDigitizer<ESOldDigitizerTraits> ESOldDigitizer  ;
+typedef EcalTDigitizer<EBDigitizerTraits> EBDigitizer;
+typedef EcalTDigitizer<EEDigitizerTraits> EEDigitizer;
+typedef CaloTDigitizer<ESOldDigitizerTraits> ESOldDigitizer;
 
-class ESDigitizer ;
+class ESDigitizer;
 
-class APDSimParameters ;
-class EBHitResponse ;
-class EEHitResponse ;
-class ESHitResponse ;
-class CaloHitResponse ;
-class EcalSimParameterMap ;
-class EcalCoder ;
-class EcalElectronicsSim ;
-class ESElectronicsSim ;
-class ESElectronicsSimFast ;
+class APDSimParameters;
+class EBHitResponse;
+class EEHitResponse;
+class ESHitResponse;
+class CaloHitResponse;
+class EcalSimParameterMap;
+class EcalCoder;
+class EcalElectronicsSim;
+class ESElectronicsSim;
+class ESElectronicsSimFast;
 class EcalBaseSignalGenerator;
-class CaloGeometry ;
-class EBDigiCollection ;
-class EEDigiCollection ;
-class ESDigiCollection ;
-class PileUpEventPrincipal ;
+class CaloGeometry;
+class EBDigiCollection;
+class EEDigiCollection;
+class ESDigiCollection;
+class PileUpEventPrincipal;
 
 namespace edm {
-  class ConsumesCollector;
-  class ProducerBase;
-  class Event;
-  class EventSetup;
-  template<typename T> class Handle;
-  class ParameterSet;
-  class StreamID;
-}
+class ConsumesCollector;
+class ProducerBase;
+class Event;
+class EventSetup;
+template <typename T> class Handle;
+class ParameterSet;
+class StreamID;
+} // namespace edm
 
 namespace CLHEP {
-  class HepRandomEngine;
+class HepRandomEngine;
 }
 
 class EcalDigiProducer : public DigiAccumulatorMixMod {
-   public:
+public:
+  EcalDigiProducer(const edm::ParameterSet &params, edm::ProducerBase &mixMod,
+                   edm::ConsumesCollector &iC);
+  EcalDigiProducer(const edm::ParameterSet &params, edm::ConsumesCollector &iC);
+  ~EcalDigiProducer() override;
 
-      EcalDigiProducer( const edm::ParameterSet& params , edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
-      EcalDigiProducer( const edm::ParameterSet& params , edm::ConsumesCollector& iC);
-      ~EcalDigiProducer() override;
+  void initializeEvent(edm::Event const &e, edm::EventSetup const &c) override;
+  void accumulate(edm::Event const &e, edm::EventSetup const &c) override;
+  void accumulate(PileUpEventPrincipal const &e, edm::EventSetup const &c,
+                  edm::StreamID const &) override;
+  void finalizeEvent(edm::Event &e, edm::EventSetup const &c) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const &lumi,
+                            edm::EventSetup const &setup) override;
+  void beginRun(edm::Run const &run, edm::EventSetup const &setup) override;
 
-      void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;
-      void accumulate(edm::Event const& e, edm::EventSetup const& c) override;
-      void accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& c, edm::StreamID const&) override;
-      void finalizeEvent(edm::Event& e, edm::EventSetup const& c) override;
-      void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) override;
-      void beginRun(edm::Run const& run, edm::EventSetup const& setup) override;
+  void setEBNoiseSignalGenerator(EcalBaseSignalGenerator *noiseGenerator);
+  void setEENoiseSignalGenerator(EcalBaseSignalGenerator *noiseGenerator);
+  void setESNoiseSignalGenerator(EcalBaseSignalGenerator *noiseGenerator);
 
-      void setEBNoiseSignalGenerator(EcalBaseSignalGenerator * noiseGenerator);
-      void setEENoiseSignalGenerator(EcalBaseSignalGenerator * noiseGenerator);
-      void setESNoiseSignalGenerator(EcalBaseSignalGenerator * noiseGenerator);
+private:
+  virtual void cacheEBDigis(const EBDigiCollection *ebDigiPtr) const {}
+  virtual void cacheEEDigis(const EEDigiCollection *eeDigiPtr) const {}
 
-   private:
+  typedef edm::Handle<std::vector<PCaloHit>> HitsHandle;
+  void accumulateCaloHits(HitsHandle const &ebHandle,
+                          HitsHandle const &eeHandle,
+                          HitsHandle const &esHandle, int bunchCrossing);
 
-      virtual void cacheEBDigis( const EBDigiCollection* ebDigiPtr ) const { }
-      virtual void cacheEEDigis( const EEDigiCollection* eeDigiPtr ) const { }
+  void checkGeometry(const edm::EventSetup &eventSetup);
 
-      typedef edm::Handle<std::vector<PCaloHit> > HitsHandle;
-      void accumulateCaloHits(HitsHandle const& ebHandle, HitsHandle const& eeHandle, HitsHandle const& esHandle, int bunchCrossing);
+  void updateGeometry();
 
-      void checkGeometry(const edm::EventSetup& eventSetup) ;
+  void checkCalibrations(const edm::Event &event,
+                         const edm::EventSetup &eventSetup);
 
-      void updateGeometry() ;
+  APDShape m_APDShape;
+  EBShape m_EBShape;
+  EEShape m_EEShape;
+  ESShape m_ESShape; // no const because gain must be set
 
-      void checkCalibrations(const edm::Event& event, const edm::EventSetup& eventSetup) ;
+  const std::string m_EBdigiCollection;
+  const std::string m_EEdigiCollection;
+  const std::string m_ESdigiCollection;
+  const std::string m_hitsProducerTag;
 
-      APDShape m_APDShape ;
-      EBShape  m_EBShape  ;
-      EEShape  m_EEShape  ;
-      ESShape        m_ESShape  ; // no const because gain must be set
+  bool m_useLCcorrection;
 
-      const std::string m_EBdigiCollection ;
-      const std::string m_EEdigiCollection ;
-      const std::string m_ESdigiCollection ;
-      const std::string m_hitsProducerTag  ;
+  const bool m_apdSeparateDigi;
 
-      bool  m_useLCcorrection;
+  const double m_EBs25notCont;
+  const double m_EEs25notCont;
 
-      const bool m_apdSeparateDigi ;
+  const unsigned int m_readoutFrameSize;
 
-      const double m_EBs25notCont ;
-      const double m_EEs25notCont ;
+protected:
+  std::unique_ptr<const EcalSimParameterMap> m_ParameterMap;
 
-      const unsigned int         m_readoutFrameSize ;
-   protected:
-      std::unique_ptr<const EcalSimParameterMap> m_ParameterMap  ;
-   private:
-      const std::string          m_apdDigiTag    ;
-      std::unique_ptr<const APDSimParameters>    m_apdParameters ;
+private:
+  const std::string m_apdDigiTag;
+  std::unique_ptr<const APDSimParameters> m_apdParameters;
 
-      std::unique_ptr<EBHitResponse> m_APDResponse ;
-   protected:
-      std::unique_ptr<EBHitResponse> m_EBResponse ;
-      std::unique_ptr<EEHitResponse> m_EEResponse ;
-   private:
-      std::unique_ptr<ESHitResponse> m_ESResponse ;
-      std::unique_ptr<CaloHitResponse> m_ESOldResponse ;
+  std::unique_ptr<EBHitResponse> m_APDResponse;
 
-      const bool m_addESNoise ;
-      const bool m_PreMix1 ;
-      const bool m_PreMix2 ;
+protected:
+  std::unique_ptr<EBHitResponse> m_EBResponse;
+  std::unique_ptr<EEHitResponse> m_EEResponse;
 
-      const bool m_doFastES   ;
+private:
+  std::unique_ptr<ESHitResponse> m_ESResponse;
+  std::unique_ptr<CaloHitResponse> m_ESOldResponse;
 
-      const bool m_doEB, m_doEE, m_doES;
+  const bool m_addESNoise;
+  const bool m_PreMix1;
+  const bool m_PreMix2;
 
-      std::unique_ptr<ESElectronicsSim>     m_ESElectronicsSim     ;
-      std::unique_ptr<ESOldDigitizer>       m_ESOldDigitizer       ;
-      std::unique_ptr<ESElectronicsSimFast> m_ESElectronicsSimFast ;
-      std::unique_ptr<ESDigitizer>          m_ESDigitizer          ;
+  const bool m_doFastES;
 
-      std::unique_ptr<EBDigitizer>          m_APDDigitizer ;
-      std::unique_ptr<EBDigitizer>          m_BarrelDigitizer ;
-      std::unique_ptr<EEDigitizer>          m_EndcapDigitizer ;
+  const bool m_doEB, m_doEE, m_doES;
 
-      std::unique_ptr<EcalElectronicsSim>   m_ElectronicsSim ;
-      std::unique_ptr<EcalCoder>            m_Coder ;
+  std::unique_ptr<ESElectronicsSim> m_ESElectronicsSim;
+  std::unique_ptr<ESOldDigitizer> m_ESOldDigitizer;
+  std::unique_ptr<ESElectronicsSimFast> m_ESElectronicsSimFast;
+  std::unique_ptr<ESDigitizer> m_ESDigitizer;
 
-      std::unique_ptr<EcalElectronicsSim>   m_APDElectronicsSim ;
-      std::unique_ptr<EcalCoder>            m_APDCoder ;
+  std::unique_ptr<EBDigitizer> m_APDDigitizer;
+  std::unique_ptr<EBDigitizer> m_BarrelDigitizer;
+  std::unique_ptr<EEDigitizer> m_EndcapDigitizer;
 
-      const CaloGeometry*   m_Geometry ;
+  std::unique_ptr<EcalElectronicsSim> m_ElectronicsSim;
+  std::unique_ptr<EcalCoder> m_Coder;
 
-      std::array< std::unique_ptr<CorrelatedNoisifier<EcalCorrMatrix> >, 3 > m_EBCorrNoise ;
-      std::array< std::unique_ptr<CorrelatedNoisifier<EcalCorrMatrix> >, 3 > m_EECorrNoise ;
+  std::unique_ptr<EcalElectronicsSim> m_APDElectronicsSim;
+  std::unique_ptr<EcalCoder> m_APDCoder;
 
-      CLHEP::HepRandomEngine* randomEngine_ = nullptr;
+  const CaloGeometry *m_Geometry;
+
+  std::array<std::unique_ptr<CorrelatedNoisifier<EcalCorrMatrix>>, 3>
+      m_EBCorrNoise;
+  std::array<std::unique_ptr<CorrelatedNoisifier<EcalCorrMatrix>>, 3>
+      m_EECorrNoise;
+
+  CLHEP::HepRandomEngine *randomEngine_ = nullptr;
 };
 
-#endif 
+#endif

--- a/SimCalorimetry/EcalSimProducers/interface/EcalTimeDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalTimeDigiProducer.h
@@ -1,68 +1,68 @@
 #ifndef SimCalorimetry_EcalSimProducers_EcalTimeDigiProducer_h
 #define SimCalorimetry_EcalSimProducers_EcalTimeDigiProducer_h
 
-
 #include "DataFormats/Math/interface/Error.h"
 
-#include "SimCalorimetry/EcalSimAlgos/interface/EcalDigitizerTraits.h"
-#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
-#include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "SimCalorimetry/EcalSimAlgos/interface/EcalDigitizerTraits.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHit.h"
+#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 
 #include "FWCore/Framework/interface/ProducerBase.h"
 
 #include <vector>
 
-class ESDigitizer ;
+class ESDigitizer;
 
-class CaloGeometry ;
-class EcalSimParameterMap ;
-class PileUpEventPrincipal ;
+class CaloGeometry;
+class EcalSimParameterMap;
+class PileUpEventPrincipal;
 class EcalTimeMapDigitizer;
 
 namespace edm {
-  class Event;
-  class EventSetup;
-  template<typename T> class Handle;
-  class ParameterSet;
-}
+class Event;
+class EventSetup;
+template <typename T> class Handle;
+class ParameterSet;
+} // namespace edm
 
 class EcalTimeDigiProducer : public DigiAccumulatorMixMod {
-   public:
+public:
+  EcalTimeDigiProducer(const edm::ParameterSet &params,
+                       edm::ProducerBase &mixMod, edm::ConsumesCollector &);
+  ~EcalTimeDigiProducer() override;
 
-  EcalTimeDigiProducer( const edm::ParameterSet& params , edm::ProducerBase& mixMod, edm::ConsumesCollector&);
-      ~EcalTimeDigiProducer() override;
+  void initializeEvent(edm::Event const &e, edm::EventSetup const &c) override;
+  void accumulate(edm::Event const &e, edm::EventSetup const &c) override;
+  void accumulate(PileUpEventPrincipal const &e, edm::EventSetup const &c,
+                  edm::StreamID const &) override;
+  void finalizeEvent(edm::Event &e, edm::EventSetup const &c) override;
 
-      void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;
-      void accumulate(edm::Event const& e, edm::EventSetup const& c) override;
-      void accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& c, edm::StreamID const&) override;
-      void finalizeEvent(edm::Event& e, edm::EventSetup const& c) override;
+private:
+  typedef edm::Handle<std::vector<PCaloHit>> HitsHandle;
+  void accumulateCaloHits(HitsHandle const &ebHandle,
+                          HitsHandle const &eeHandle, int bunchCrossing);
 
-   private:
+  void checkGeometry(const edm::EventSetup &eventSetup);
 
-      typedef edm::Handle<std::vector<PCaloHit> > HitsHandle;
-      void accumulateCaloHits(HitsHandle const& ebHandle, HitsHandle const& eeHandle,  int bunchCrossing);
+  void updateGeometry();
 
-      void checkGeometry(const edm::EventSetup& eventSetup) ;
+  const std::string m_EBdigiCollection;
+  const std::string m_EEdigiCollection;
+  const edm::InputTag m_hitsProducerTagEB;
+  const edm::InputTag m_hitsProducerTagEE;
+  const edm::EDGetTokenT<std::vector<PCaloHit>> m_hitsProducerTokenEB;
+  const edm::EDGetTokenT<std::vector<PCaloHit>> m_hitsProducerTokenEE;
 
-      void updateGeometry() ;
+private:
+  int m_timeLayerEB;
+  int m_timeLayerEE;
+  const CaloGeometry *m_Geometry;
 
-      const std::string m_EBdigiCollection ;
-      const std::string m_EEdigiCollection ;
-      const edm::InputTag m_hitsProducerTagEB  ;
-      const edm::InputTag m_hitsProducerTagEE  ;
-      const edm::EDGetTokenT<std::vector<PCaloHit> > m_hitsProducerTokenEB  ;
-      const edm::EDGetTokenT<std::vector<PCaloHit> > m_hitsProducerTokenEE  ;
-
-   private:
-      int m_timeLayerEB;
-      int m_timeLayerEE;
-      const CaloGeometry*   m_Geometry ;
-
-      EcalTimeMapDigitizer* m_BarrelDigitizer;
-      EcalTimeMapDigitizer* m_EndcapDigitizer;
+  EcalTimeMapDigitizer *m_BarrelDigitizer;
+  EcalTimeMapDigitizer *m_EndcapDigitizer;
 };
 
-#endif 
+#endif

--- a/SimCalorimetry/EcalSimProducers/plugins/PreMixingEcalWorker.cc
+++ b/SimCalorimetry/EcalSimProducers/plugins/PreMixingEcalWorker.cc
@@ -1,45 +1,52 @@
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/ProducerBase.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/EcalDigi/interface/EBDataFrame.h"
 #include "DataFormats/EcalDigi/interface/EEDataFrame.h"
 #include "DataFormats/EcalDigi/interface/ESDataFrame.h"
-#include "SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h"
+#include "SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h"
 
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorker.h"
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
 
-class PreMixingEcalWorker: public PreMixingWorker {
+class PreMixingEcalWorker : public PreMixingWorker {
 public:
-  PreMixingEcalWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
+  PreMixingEcalWorker(const edm::ParameterSet &ps, edm::ProducerBase &producer,
+                      edm::ConsumesCollector &&iC);
   ~PreMixingEcalWorker() override = default;
 
-  PreMixingEcalWorker(const PreMixingEcalWorker&) = delete;
-  PreMixingEcalWorker& operator=(const PreMixingEcalWorker&) = delete;
+  PreMixingEcalWorker(const PreMixingEcalWorker &) = delete;
+  PreMixingEcalWorker &operator=(const PreMixingEcalWorker &) = delete;
 
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const &lumi,
+                            edm::EventSetup const &setup) override;
 
-  void initializeEvent(edm::Event const& e, edm::EventSetup const& ES) override;
-  void addSignals(edm::Event const& e, edm::EventSetup const& ES) override;
-  void addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& es) override;
-  void put(edm::Event &e, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bs) override;
+  void initializeEvent(edm::Event const &e, edm::EventSetup const &ES) override;
+  void addSignals(edm::Event const &e, edm::EventSetup const &ES) override;
+  void addPileups(PileUpEventPrincipal const &pep,
+                  edm::EventSetup const &es) override;
+  void put(edm::Event &e, edm::EventSetup const &iSetup,
+           std::vector<PileupSummaryInfo> const &ps, int bs) override;
 
 private:
   edm::InputTag EBPileInputTag_; // InputTag for Pileup Digis collection
-  edm::InputTag EEPileInputTag_  ; // InputTag for Pileup Digis collection
-  edm::InputTag ESPileInputTag_  ; // InputTag for Pileup Digis collection
+  edm::InputTag EEPileInputTag_; // InputTag for Pileup Digis collection
+  edm::InputTag ESPileInputTag_; // InputTag for Pileup Digis collection
 
-  std::string EBDigiCollectionDM_; // secondary name to be given to collection of digis
-  std::string EEDigiCollectionDM_  ; // secondary name to be given to collection of digis
-  std::string ESDigiCollectionDM_  ; // secondary name to be given to collection of digis
+  std::string
+      EBDigiCollectionDM_; // secondary name to be given to collection of digis
+  std::string
+      EEDigiCollectionDM_; // secondary name to be given to collection of digis
+  std::string
+      ESDigiCollectionDM_; // secondary name to be given to collection of digis
 
   edm::EDGetTokenT<EBDigitizerTraits::DigiCollection> tok_eb_;
   edm::EDGetTokenT<EEDigitizerTraits::DigiCollection> tok_ee_;
@@ -56,48 +63,56 @@ private:
   EcalDigiProducer myEcalDigitizer_;
 };
 
-
 // Constructor
-PreMixingEcalWorker::PreMixingEcalWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC) : 
-  EBPileInputTag_(ps.getParameter<edm::InputTag>("EBPileInputTag")),
-  EEPileInputTag_(ps.getParameter<edm::InputTag>("EEPileInputTag")),
-  ESPileInputTag_(ps.getParameter<edm::InputTag>("ESPileInputTag")),
-  tok_eb_(iC.consumes<EBDigitizerTraits::DigiCollection>(EBPileInputTag_)),
-  tok_ee_(iC.consumes<EEDigitizerTraits::DigiCollection>(EEPileInputTag_)),
-  tok_es_(iC.consumes<ESDigitizerTraits::DigiCollection>(ESPileInputTag_)),
-  m_EBs25notCont(ps.getParameter<double>("EBs25notContainment") ) ,
-  m_EEs25notCont(ps.getParameter<double>("EEs25notContainment") ) ,
-  m_peToABarrel(ps.getParameter<double>("photoelectronsToAnalogBarrel") ) ,
-  m_peToAEndcap(ps.getParameter<double>("photoelectronsToAnalogEndcap") ),
-  theEBSignalGenerator(EBPileInputTag_,tok_eb_, m_EBs25notCont, m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
-  theEESignalGenerator(EEPileInputTag_,tok_ee_, m_EBs25notCont, m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
-  theESSignalGenerator(ESPileInputTag_,tok_es_, m_EBs25notCont, m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
-  myEcalDigitizer_(ps, iC)
-{
-  EBDigiCollectionDM_   = ps.getParameter<std::string>("EBDigiCollectionDM");
-  EEDigiCollectionDM_   = ps.getParameter<std::string>("EEDigiCollectionDM");
-  ESDigiCollectionDM_   = ps.getParameter<std::string>("ESDigiCollectionDM");
+PreMixingEcalWorker::PreMixingEcalWorker(const edm::ParameterSet &ps,
+                                         edm::ProducerBase &producer,
+                                         edm::ConsumesCollector &&iC)
+    : EBPileInputTag_(ps.getParameter<edm::InputTag>("EBPileInputTag")),
+      EEPileInputTag_(ps.getParameter<edm::InputTag>("EEPileInputTag")),
+      ESPileInputTag_(ps.getParameter<edm::InputTag>("ESPileInputTag")),
+      tok_eb_(iC.consumes<EBDigitizerTraits::DigiCollection>(EBPileInputTag_)),
+      tok_ee_(iC.consumes<EEDigitizerTraits::DigiCollection>(EEPileInputTag_)),
+      tok_es_(iC.consumes<ESDigitizerTraits::DigiCollection>(ESPileInputTag_)),
+      m_EBs25notCont(ps.getParameter<double>("EBs25notContainment")),
+      m_EEs25notCont(ps.getParameter<double>("EEs25notContainment")),
+      m_peToABarrel(ps.getParameter<double>("photoelectronsToAnalogBarrel")),
+      m_peToAEndcap(ps.getParameter<double>("photoelectronsToAnalogEndcap")),
+      theEBSignalGenerator(EBPileInputTag_, tok_eb_, m_EBs25notCont,
+                           m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
+      theEESignalGenerator(EEPileInputTag_, tok_ee_, m_EBs25notCont,
+                           m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
+      theESSignalGenerator(ESPileInputTag_, tok_es_, m_EBs25notCont,
+                           m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
+      myEcalDigitizer_(ps, iC) {
+  EBDigiCollectionDM_ = ps.getParameter<std::string>("EBDigiCollectionDM");
+  EEDigiCollectionDM_ = ps.getParameter<std::string>("EEDigiCollectionDM");
+  ESDigiCollectionDM_ = ps.getParameter<std::string>("ESDigiCollectionDM");
 
-  producer.produces< EBDigiCollection >(EBDigiCollectionDM_);
-  producer.produces< EEDigiCollection >(EEDigiCollectionDM_);
-  producer.produces< ESDigiCollection >(ESDigiCollectionDM_);
+  producer.produces<EBDigiCollection>(EBDigiCollectionDM_);
+  producer.produces<EEDigiCollection>(EEDigiCollectionDM_);
+  producer.produces<ESDigiCollection>(ESDigiCollectionDM_);
 
-  myEcalDigitizer_.setEBNoiseSignalGenerator( & theEBSignalGenerator );
-  myEcalDigitizer_.setEENoiseSignalGenerator( & theEESignalGenerator );
-  myEcalDigitizer_.setESNoiseSignalGenerator( & theESSignalGenerator );
+  myEcalDigitizer_.setEBNoiseSignalGenerator(&theEBSignalGenerator);
+  myEcalDigitizer_.setEENoiseSignalGenerator(&theEESignalGenerator);
+  myEcalDigitizer_.setESNoiseSignalGenerator(&theESSignalGenerator);
 }
 
-void PreMixingEcalWorker::initializeEvent(const edm::Event &e, const edm::EventSetup& ES) {
+void PreMixingEcalWorker::initializeEvent(const edm::Event &e,
+                                          const edm::EventSetup &ES) {
   myEcalDigitizer_.initializeEvent(e, ES);
 }
 
-void PreMixingEcalWorker::addSignals(const edm::Event &e,const edm::EventSetup& ES) { 
+void PreMixingEcalWorker::addSignals(const edm::Event &e,
+                                     const edm::EventSetup &ES) {
   myEcalDigitizer_.accumulate(e, ES);
 }
 
-void PreMixingEcalWorker::addPileups(const PileUpEventPrincipal& pep, const edm::EventSetup& ES) {
+void PreMixingEcalWorker::addPileups(const PileUpEventPrincipal &pep,
+                                     const edm::EventSetup &ES) {
 
-  LogDebug("PreMixingEcalWorker") <<"\n===============> adding pileups from event  "<<pep.principal().id()<<" for bunchcrossing "<<pep.bunchCrossing();
+  LogDebug("PreMixingEcalWorker")
+      << "\n===============> adding pileups from event  "
+      << pep.principal().id() << " for bunchcrossing " << pep.bunchCrossing();
 
   theEBSignalGenerator.initializeEvent(&pep.principal(), &ES);
   theEESignalGenerator.initializeEvent(&pep.principal(), &ES);
@@ -109,12 +124,15 @@ void PreMixingEcalWorker::addPileups(const PileUpEventPrincipal& pep, const edm:
   theESSignalGenerator.fill(pep.moduleCallingContext());
 }
 
-void PreMixingEcalWorker::put(edm::Event &e,const edm::EventSetup& ES, std::vector<PileupSummaryInfo> const& ps, int bs) {
-  myEcalDigitizer_.finalizeEvent( e, ES );
+void PreMixingEcalWorker::put(edm::Event &e, const edm::EventSetup &ES,
+                              std::vector<PileupSummaryInfo> const &ps,
+                              int bs) {
+  myEcalDigitizer_.finalizeEvent(e, ES);
 }
 
-void PreMixingEcalWorker::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) {
-  myEcalDigitizer_.beginLuminosityBlock(lumi,setup);
+void PreMixingEcalWorker::beginLuminosityBlock(edm::LuminosityBlock const &lumi,
+                                               edm::EventSetup const &setup) {
+  myEcalDigitizer_.beginLuminosityBlock(lumi, setup);
 }
 
 DEFINE_PREMIXING_WORKER(PreMixingEcalWorker);

--- a/SimCalorimetry/EcalSimProducers/plugins/SealModule.cc
+++ b/SimCalorimetry/EcalSimProducers/plugins/SealModule.cc
@@ -1,8 +1,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
 #include "SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h"
 #include "SimCalorimetry/EcalSimProducers/interface/EcalTimeDigiProducer.h"
+#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
 
 DEFINE_DIGI_ACCUMULATOR(EcalDigiProducer);
 DEFINE_DIGI_ACCUMULATOR(EcalTimeDigiProducer);
-

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -1,336 +1,318 @@
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h"
+#include "SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h"
+#include "SimCalorimetry/EcalSimAlgos/interface/APDSimParameters.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EBHitResponse.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EEHitResponse.h"
+#include "SimCalorimetry/EcalSimAlgos/interface/ESElectronicsSim.h"
+#include "SimCalorimetry/EcalSimAlgos/interface/ESElectronicsSimFast.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/ESHitResponse.h"
-#include "SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h"
-#include "SimCalorimetry/EcalSimAlgos/interface/EcalSimParameterMap.h"
-#include "SimCalorimetry/EcalSimAlgos/interface/APDSimParameters.h"
-#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalCoder.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalElectronicsSim.h"
-#include "SimCalorimetry/EcalSimAlgos/interface/ESElectronicsSimFast.h"
-#include "SimCalorimetry/EcalSimAlgos/interface/ESElectronicsSim.h"
+#include "SimCalorimetry/EcalSimAlgos/interface/EcalSimParameterMap.h"
+#include "SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h"
 //#include "SimCalorimetry/EcalSimAlgos/interface/ESFastTDigitizer.h"
-#include "SimCalorimetry/EcalSimAlgos/interface/ESDigitizer.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecord.h"
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h"
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
-#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "CondFormats/DataRecord/interface/EcalADCToGeVConstantRcd.h"
+#include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
+#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsMCRcd.h"
+#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
+#include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
+#include "CondFormats/EcalObjects/interface/EcalIntercalibConstantsMC.h"
+#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-#include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
-#include "SimDataFormats/CaloHit/interface/PCaloHit.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
-#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalIntercalibConstantsMC.h"
-#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsMCRcd.h"
-#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h"
-#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecord.h"
-#include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
-#include "CondFormats/DataRecord/interface/EcalADCToGeVConstantRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
-#include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
+#include "SimCalorimetry/EcalSimAlgos/interface/ESDigitizer.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHit.h"
+#include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
-#include "CondFormats/ESObjects/interface/ESIntercalibConstants.h"
-#include "CondFormats/DataRecord/interface/ESIntercalibConstantsRcd.h"
-#include "CondFormats/ESObjects/interface/ESMIPToGeVConstant.h"
-#include "CondFormats/DataRecord/interface/ESMIPToGeVConstantRcd.h"
-#include "CondFormats/ESObjects/interface/ESGain.h"
 #include "CondFormats/DataRecord/interface/ESGainRcd.h"
-#include "CondFormats/ESObjects/interface/ESPedestals.h"
+#include "CondFormats/DataRecord/interface/ESIntercalibConstantsRcd.h"
+#include "CondFormats/DataRecord/interface/ESMIPToGeVConstantRcd.h"
 #include "CondFormats/DataRecord/interface/ESPedestalsRcd.h"
+#include "CondFormats/ESObjects/interface/ESGain.h"
+#include "CondFormats/ESObjects/interface/ESIntercalibConstants.h"
+#include "CondFormats/ESObjects/interface/ESMIPToGeVConstant.h"
+#include "CondFormats/ESObjects/interface/ESPedestals.h"
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
 
+EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params,
+                                   edm::ProducerBase &mixMod,
+                                   edm::ConsumesCollector &iC)
+    : EcalDigiProducer(params, iC) {
+  if (m_apdSeparateDigi)
+    mixMod.produces<EBDigiCollection>(m_apdDigiTag);
 
-EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) :
-  EcalDigiProducer(params, iC)
-{
-   if(m_apdSeparateDigi) mixMod.produces<EBDigiCollection>(m_apdDigiTag);
-     
-   mixMod.produces<EBDigiCollection>(m_EBdigiCollection);
-   mixMod.produces<EEDigiCollection>(m_EEdigiCollection);
-   mixMod.produces<ESDigiCollection>(m_ESdigiCollection);
+  mixMod.produces<EBDigiCollection>(m_EBdigiCollection);
+  mixMod.produces<EEDigiCollection>(m_EEdigiCollection);
+  mixMod.produces<ESDigiCollection>(m_ESdigiCollection);
 }
 
 // version for Pre-Mixing, for use outside of MixingModule
-EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params,  edm::ConsumesCollector& iC) :
-   DigiAccumulatorMixMod(),
-   m_APDShape         ( true ) ,
-   m_EBShape          ( true ) ,
-   m_EEShape          ( true ) ,
-   m_ESShape          (   ) ,
-   m_EBdigiCollection ( params.getParameter<std::string>("EBdigiCollection") ) ,
-   m_EEdigiCollection ( params.getParameter<std::string>("EEdigiCollection") ) ,
-   m_ESdigiCollection ( params.getParameter<std::string>("ESdigiCollection") ) ,
-   m_hitsProducerTag  ( params.getParameter<std::string>("hitsProducer"    ) ) ,
-   m_useLCcorrection  ( params.getUntrackedParameter<bool>("UseLCcorrection") ) ,
-   m_apdSeparateDigi  ( params.getParameter<bool>       ("apdSeparateDigi") ) ,
+EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params,
+                                   edm::ConsumesCollector &iC)
+    : DigiAccumulatorMixMod(), m_APDShape(true), m_EBShape(true),
+      m_EEShape(true), m_ESShape(),
+      m_EBdigiCollection(params.getParameter<std::string>("EBdigiCollection")),
+      m_EEdigiCollection(params.getParameter<std::string>("EEdigiCollection")),
+      m_ESdigiCollection(params.getParameter<std::string>("ESdigiCollection")),
+      m_hitsProducerTag(params.getParameter<std::string>("hitsProducer")),
+      m_useLCcorrection(params.getUntrackedParameter<bool>("UseLCcorrection")),
+      m_apdSeparateDigi(params.getParameter<bool>("apdSeparateDigi")),
 
-   m_EBs25notCont     ( params.getParameter<double>     ("EBs25notContainment") ) ,
-   m_EEs25notCont     ( params.getParameter<double>     ("EEs25notContainment") ) ,
+      m_EBs25notCont(params.getParameter<double>("EBs25notContainment")),
+      m_EEs25notCont(params.getParameter<double>("EEs25notContainment")),
 
-   m_readoutFrameSize ( params.getParameter<int>       ("readoutFrameSize") ) ,
-   m_ParameterMap     ( new EcalSimParameterMap(
-			   params.getParameter<double> ("simHitToPhotoelectronsBarrel") ,
-			   params.getParameter<double> ("simHitToPhotoelectronsEndcap") , 
-			   params.getParameter<double> ("photoelectronsToAnalogBarrel") ,
-			   params.getParameter<double> ("photoelectronsToAnalogEndcap") , 
-			   params.getParameter<double> ("samplingFactor") ,
-			   params.getParameter<double> ("timePhase") ,
-			   m_readoutFrameSize ,
-			   params.getParameter<int>    ("binOfMaximum") , 
-			   params.getParameter<bool>   ("doPhotostatistics") ,
-			   params.getParameter<bool>   ("syncPhase") ) ) ,
-   
-   m_apdDigiTag    ( params.getParameter<std::string> ("apdDigiTag"  )      ) ,
-   m_apdParameters ( new APDSimParameters( 
-			params.getParameter<bool>        ("apdAddToBarrel"  ) ,
-			m_apdSeparateDigi ,
-			params.getParameter<double>      ("apdSimToPELow"   ) ,
-			params.getParameter<double>      ("apdSimToPEHigh"  ) ,
-			params.getParameter<double>      ("apdTimeOffset"   ) ,
-			params.getParameter<double>      ("apdTimeOffWidth" ) ,
-			params.getParameter<bool>        ("apdDoPEStats"    ) ,
-			m_apdDigiTag ,
-			params.getParameter<std::vector<double> > ( "apdNonlParms" ) ) ) ,
+      m_readoutFrameSize(params.getParameter<int>("readoutFrameSize")),
+      m_ParameterMap(new EcalSimParameterMap(
+          params.getParameter<double>("simHitToPhotoelectronsBarrel"),
+          params.getParameter<double>("simHitToPhotoelectronsEndcap"),
+          params.getParameter<double>("photoelectronsToAnalogBarrel"),
+          params.getParameter<double>("photoelectronsToAnalogEndcap"),
+          params.getParameter<double>("samplingFactor"),
+          params.getParameter<double>("timePhase"), m_readoutFrameSize,
+          params.getParameter<int>("binOfMaximum"),
+          params.getParameter<bool>("doPhotostatistics"),
+          params.getParameter<bool>("syncPhase"))),
 
-   m_APDResponse ( !m_apdSeparateDigi ? nullptr :
-		   new EBHitResponse( m_ParameterMap.get()  ,
-				      &m_EBShape      ,
-				      true            ,
-				      m_apdParameters.get() ,
-				      &m_APDShape       ) ) ,
-   
-   m_EBResponse ( new EBHitResponse( m_ParameterMap.get()  ,
-				     &m_EBShape      ,
-				     false           , // barrel
-				     m_apdParameters.get() ,
-				     &m_APDShape       ) ) ,
+      m_apdDigiTag(params.getParameter<std::string>("apdDigiTag")),
+      m_apdParameters(new APDSimParameters(
+          params.getParameter<bool>("apdAddToBarrel"), m_apdSeparateDigi,
+          params.getParameter<double>("apdSimToPELow"),
+          params.getParameter<double>("apdSimToPEHigh"),
+          params.getParameter<double>("apdTimeOffset"),
+          params.getParameter<double>("apdTimeOffWidth"),
+          params.getParameter<bool>("apdDoPEStats"), m_apdDigiTag,
+          params.getParameter<std::vector<double>>("apdNonlParms"))),
 
-   m_EEResponse ( new EEHitResponse( m_ParameterMap.get(),
-				     &m_EEShape       ) ) ,
-   m_ESResponse ( new ESHitResponse( m_ParameterMap.get(), &m_ESShape ) ) ,
-   m_ESOldResponse ( new CaloHitResponse( m_ParameterMap.get(), &m_ESShape ) ) ,
+      m_APDResponse(!m_apdSeparateDigi
+                        ? nullptr
+                        : new EBHitResponse(m_ParameterMap.get(), &m_EBShape,
+                                            true, m_apdParameters.get(),
+                                            &m_APDShape)),
 
-   m_addESNoise           ( params.getParameter<bool> ("doESNoise") ) ,
-   m_PreMix1              ( params.getParameter<bool> ("EcalPreMixStage1") ) ,
-   m_PreMix2              ( params.getParameter<bool> ("EcalPreMixStage2") ) ,
+      m_EBResponse(new EBHitResponse(m_ParameterMap.get(), &m_EBShape,
+                                     false, // barrel
+                                     m_apdParameters.get(), &m_APDShape)),
 
-   m_doFastES             ( params.getParameter<bool> ("doFast"   ) ) ,
+      m_EEResponse(new EEHitResponse(m_ParameterMap.get(), &m_EEShape)),
+      m_ESResponse(new ESHitResponse(m_ParameterMap.get(), &m_ESShape)),
+      m_ESOldResponse(new CaloHitResponse(m_ParameterMap.get(), &m_ESShape)),
 
-   m_doEB                 ( params.getParameter<bool> ("doEB"     ) ) ,
-   m_doEE                 ( params.getParameter<bool> ("doEE"     ) ) ,
-   m_doES                 ( params.getParameter<bool> ("doES"     ) ) ,
+      m_addESNoise(params.getParameter<bool>("doESNoise")),
+      m_PreMix1(params.getParameter<bool>("EcalPreMixStage1")),
+      m_PreMix2(params.getParameter<bool>("EcalPreMixStage2")),
 
-   m_ESElectronicsSim     ( m_doFastES ? nullptr :
-			    new ESElectronicsSim( m_addESNoise ) ) ,
-	 
-   m_ESOldDigitizer       ( m_doFastES ? nullptr :
-			    new ESOldDigitizer( m_ESOldResponse.get()    , 
-						m_ESElectronicsSim.get() ,
-						m_addESNoise         ) ) ,
-   
-   m_ESElectronicsSimFast ( !m_doFastES ? nullptr :
-			    new ESElectronicsSimFast( m_addESNoise, 
-						      m_PreMix1      ) ) ,
+      m_doFastES(params.getParameter<bool>("doFast")),
 
-   m_ESDigitizer          ( !m_doFastES ? nullptr :
-			    new ESDigitizer( m_ESResponse.get()           ,
-					     m_ESElectronicsSimFast.get() ,
-					     m_addESNoise            ) ) ,
+      m_doEB(params.getParameter<bool>("doEB")),
+      m_doEE(params.getParameter<bool>("doEE")),
+      m_doES(params.getParameter<bool>("doES")),
 
-   m_APDDigitizer      ( nullptr ) ,
-   m_BarrelDigitizer   ( nullptr ) ,
-   m_EndcapDigitizer   ( nullptr ) ,
-   m_ElectronicsSim    ( nullptr ) ,
-   m_Coder             ( nullptr ) ,
-   m_APDElectronicsSim ( nullptr ) ,
-   m_APDCoder          ( nullptr ) ,
-   m_Geometry          ( nullptr ) ,
-   m_EBCorrNoise       ( { {nullptr, nullptr, nullptr} } ) ,
-   m_EECorrNoise       ( { {nullptr, nullptr, nullptr} } ) 
-{
+      m_ESElectronicsSim(m_doFastES ? nullptr
+                                    : new ESElectronicsSim(m_addESNoise)),
+
+      m_ESOldDigitizer(m_doFastES ? nullptr
+                                  : new ESOldDigitizer(m_ESOldResponse.get(),
+                                                       m_ESElectronicsSim.get(),
+                                                       m_addESNoise)),
+
+      m_ESElectronicsSimFast(
+          !m_doFastES ? nullptr
+                      : new ESElectronicsSimFast(m_addESNoise, m_PreMix1)),
+
+      m_ESDigitizer(!m_doFastES ? nullptr
+                                : new ESDigitizer(m_ESResponse.get(),
+                                                  m_ESElectronicsSimFast.get(),
+                                                  m_addESNoise)),
+
+      m_APDDigitizer(nullptr), m_BarrelDigitizer(nullptr),
+      m_EndcapDigitizer(nullptr), m_ElectronicsSim(nullptr), m_Coder(nullptr),
+      m_APDElectronicsSim(nullptr), m_APDCoder(nullptr), m_Geometry(nullptr),
+      m_EBCorrNoise({{nullptr, nullptr, nullptr}}),
+      m_EECorrNoise({{nullptr, nullptr, nullptr}}) {
   // "produces" statements taken care of elsewhere.
   //   if(m_apdSeparateDigi) mixMod.produces<EBDigiCollection>(m_apdDigiTag);
   // mixMod.produces<EBDigiCollection>(m_EBdigiCollection);
   // mixMod.produces<EEDigiCollection>(m_EEdigiCollection);
   // mixMod.produces<ESDigiCollection>(m_ESdigiCollection);
-   if ( m_doEB ) iC.consumes<std::vector<PCaloHit> >(edm::InputTag(m_hitsProducerTag, "EcalHitsEB"));   
-   if ( m_doEE ) iC.consumes<std::vector<PCaloHit> >(edm::InputTag(m_hitsProducerTag, "EcalHitsEE"));
-   if ( m_doES ) iC.consumes<std::vector<PCaloHit> >(edm::InputTag(m_hitsProducerTag, "EcalHitsES"));
+  if (m_doEB)
+    iC.consumes<std::vector<PCaloHit>>(
+        edm::InputTag(m_hitsProducerTag, "EcalHitsEB"));
+  if (m_doEE)
+    iC.consumes<std::vector<PCaloHit>>(
+        edm::InputTag(m_hitsProducerTag, "EcalHitsEE"));
+  if (m_doES)
+    iC.consumes<std::vector<PCaloHit>>(
+        edm::InputTag(m_hitsProducerTag, "EcalHitsES"));
 
-   const std::vector<double> ebCorMatG12 = params.getParameter< std::vector<double> >("EBCorrNoiseMatrixG12");
-   const std::vector<double> eeCorMatG12 = params.getParameter< std::vector<double> >("EECorrNoiseMatrixG12");
-   const std::vector<double> ebCorMatG06 = params.getParameter< std::vector<double> >("EBCorrNoiseMatrixG06");
-   const std::vector<double> eeCorMatG06 = params.getParameter< std::vector<double> >("EECorrNoiseMatrixG06");
-   const std::vector<double> ebCorMatG01 = params.getParameter< std::vector<double> >("EBCorrNoiseMatrixG01");
-   const std::vector<double> eeCorMatG01 = params.getParameter< std::vector<double> >("EECorrNoiseMatrixG01");
+  const std::vector<double> ebCorMatG12 =
+      params.getParameter<std::vector<double>>("EBCorrNoiseMatrixG12");
+  const std::vector<double> eeCorMatG12 =
+      params.getParameter<std::vector<double>>("EECorrNoiseMatrixG12");
+  const std::vector<double> ebCorMatG06 =
+      params.getParameter<std::vector<double>>("EBCorrNoiseMatrixG06");
+  const std::vector<double> eeCorMatG06 =
+      params.getParameter<std::vector<double>>("EECorrNoiseMatrixG06");
+  const std::vector<double> ebCorMatG01 =
+      params.getParameter<std::vector<double>>("EBCorrNoiseMatrixG01");
+  const std::vector<double> eeCorMatG01 =
+      params.getParameter<std::vector<double>>("EECorrNoiseMatrixG01");
 
-   const bool applyConstantTerm          = params.getParameter<bool>       ("applyConstantTerm");
-   const double rmsConstantTerm          = params.getParameter<double>     ("ConstantTerm");
+  const bool applyConstantTerm = params.getParameter<bool>("applyConstantTerm");
+  const double rmsConstantTerm = params.getParameter<double>("ConstantTerm");
 
-   const bool addNoise                   = params.getParameter<bool>       ("doENoise"); 
-   const bool cosmicsPhase               = params.getParameter<bool>       ("cosmicsPhase");
-   const double cosmicsShift             = params.getParameter<double>     ("cosmicsShift");
+  const bool addNoise = params.getParameter<bool>("doENoise");
+  const bool cosmicsPhase = params.getParameter<bool>("cosmicsPhase");
+  const double cosmicsShift = params.getParameter<double>("cosmicsShift");
 
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-   // further phase for cosmics studies
-   if( cosmicsPhase ) 
-   {
-     if( m_doEB ) m_EBResponse->setPhaseShift( 1. + cosmicsShift ) ;
-     if( m_doEE ) m_EEResponse->setPhaseShift( 1. + cosmicsShift ) ;
-   }
+  // further phase for cosmics studies
+  if (cosmicsPhase) {
+    if (m_doEB)
+      m_EBResponse->setPhaseShift(1. + cosmicsShift);
+    if (m_doEE)
+      m_EEResponse->setPhaseShift(1. + cosmicsShift);
+  }
 
-   EcalCorrMatrix ebMatrix[ 3 ] ;
-   EcalCorrMatrix eeMatrix[ 3 ] ;
+  EcalCorrMatrix ebMatrix[3];
+  EcalCorrMatrix eeMatrix[3];
 
-   assert( ebCorMatG12.size() == m_readoutFrameSize ) ;
-   assert( eeCorMatG12.size() == m_readoutFrameSize ) ;
-   assert( ebCorMatG06.size() == m_readoutFrameSize ) ;
-   assert( eeCorMatG06.size() == m_readoutFrameSize ) ;
-   assert( ebCorMatG01.size() == m_readoutFrameSize ) ;
-   assert( eeCorMatG01.size() == m_readoutFrameSize ) ;
+  assert(ebCorMatG12.size() == m_readoutFrameSize);
+  assert(eeCorMatG12.size() == m_readoutFrameSize);
+  assert(ebCorMatG06.size() == m_readoutFrameSize);
+  assert(eeCorMatG06.size() == m_readoutFrameSize);
+  assert(ebCorMatG01.size() == m_readoutFrameSize);
+  assert(eeCorMatG01.size() == m_readoutFrameSize);
 
-   assert( 1.e-7 > fabs( ebCorMatG12[0] - 1.0 ) ) ;
-   assert( 1.e-7 > fabs( ebCorMatG06[0] - 1.0 ) ) ;
-   assert( 1.e-7 > fabs( ebCorMatG01[0] - 1.0 ) ) ;
-   assert( 1.e-7 > fabs( eeCorMatG12[0] - 1.0 ) ) ;
-   assert( 1.e-7 > fabs( eeCorMatG06[0] - 1.0 ) ) ;
-   assert( 1.e-7 > fabs( eeCorMatG01[0] - 1.0 ) ) ;
+  assert(1.e-7 > fabs(ebCorMatG12[0] - 1.0));
+  assert(1.e-7 > fabs(ebCorMatG06[0] - 1.0));
+  assert(1.e-7 > fabs(ebCorMatG01[0] - 1.0));
+  assert(1.e-7 > fabs(eeCorMatG12[0] - 1.0));
+  assert(1.e-7 > fabs(eeCorMatG06[0] - 1.0));
+  assert(1.e-7 > fabs(eeCorMatG01[0] - 1.0));
 
-   for ( unsigned int row ( 0 ) ; row != m_readoutFrameSize ; ++row )
-   {
-      assert( 0 == row || 1. >= ebCorMatG12[row] ) ;
-      assert( 0 == row || 1. >= ebCorMatG06[row] ) ;
-      assert( 0 == row || 1. >= ebCorMatG01[row] ) ;
-      assert( 0 == row || 1. >= eeCorMatG12[row] ) ;
-      assert( 0 == row || 1. >= eeCorMatG06[row] ) ;
-      assert( 0 == row || 1. >= eeCorMatG01[row] ) ;
-      for ( unsigned int column ( 0 ) ; column <= row ; ++column )
-      {
-	 const unsigned int index ( row - column ) ;
-	 ebMatrix[0]( row, column ) = ebCorMatG12[ index ] ;
-	 eeMatrix[0]( row, column ) = eeCorMatG12[ index ] ;
-	 ebMatrix[1]( row, column ) = ebCorMatG06[ index ] ;
-	 eeMatrix[1]( row, column ) = eeCorMatG06[ index ] ;
-	 ebMatrix[2]( row, column ) = ebCorMatG01[ index ] ;
-	 eeMatrix[2]( row, column ) = eeCorMatG01[ index ] ;
-      }
-   }
-			  
-   m_EBCorrNoise[0].reset( new CorrelatedNoisifier<EcalCorrMatrix>( ebMatrix[0] ) );
-   m_EECorrNoise[0].reset( new CorrelatedNoisifier<EcalCorrMatrix>( eeMatrix[0] ) );
-   m_EBCorrNoise[1].reset( new CorrelatedNoisifier<EcalCorrMatrix>( ebMatrix[1] ) );
-   m_EECorrNoise[1].reset( new CorrelatedNoisifier<EcalCorrMatrix>( eeMatrix[1] ) );
-   m_EBCorrNoise[2].reset( new CorrelatedNoisifier<EcalCorrMatrix>( ebMatrix[2] ) );
-   m_EECorrNoise[2].reset( new CorrelatedNoisifier<EcalCorrMatrix>( eeMatrix[2] ) );
+  for (unsigned int row(0); row != m_readoutFrameSize; ++row) {
+    assert(0 == row || 1. >= ebCorMatG12[row]);
+    assert(0 == row || 1. >= ebCorMatG06[row]);
+    assert(0 == row || 1. >= ebCorMatG01[row]);
+    assert(0 == row || 1. >= eeCorMatG12[row]);
+    assert(0 == row || 1. >= eeCorMatG06[row]);
+    assert(0 == row || 1. >= eeCorMatG01[row]);
+    for (unsigned int column(0); column <= row; ++column) {
+      const unsigned int index(row - column);
+      ebMatrix[0](row, column) = ebCorMatG12[index];
+      eeMatrix[0](row, column) = eeCorMatG12[index];
+      ebMatrix[1](row, column) = ebCorMatG06[index];
+      eeMatrix[1](row, column) = eeCorMatG06[index];
+      ebMatrix[2](row, column) = ebCorMatG01[index];
+      eeMatrix[2](row, column) = eeCorMatG01[index];
+    }
+  }
 
-   m_Coder.reset( new EcalCoder( addNoise         , 
-                                 m_PreMix1        ,
-                                 m_EBCorrNoise[0].get() ,
-                                 m_EECorrNoise[0].get() ,
-                                 m_EBCorrNoise[1].get() ,
-                                 m_EECorrNoise[1].get() ,
-                                 m_EBCorrNoise[2].get() ,
-                                 m_EECorrNoise[2].get()   ) );
+  m_EBCorrNoise[0].reset(new CorrelatedNoisifier<EcalCorrMatrix>(ebMatrix[0]));
+  m_EECorrNoise[0].reset(new CorrelatedNoisifier<EcalCorrMatrix>(eeMatrix[0]));
+  m_EBCorrNoise[1].reset(new CorrelatedNoisifier<EcalCorrMatrix>(ebMatrix[1]));
+  m_EECorrNoise[1].reset(new CorrelatedNoisifier<EcalCorrMatrix>(eeMatrix[1]));
+  m_EBCorrNoise[2].reset(new CorrelatedNoisifier<EcalCorrMatrix>(ebMatrix[2]));
+  m_EECorrNoise[2].reset(new CorrelatedNoisifier<EcalCorrMatrix>(eeMatrix[2]));
 
-   m_ElectronicsSim.reset( new EcalElectronicsSim( m_ParameterMap.get()    ,
-                                                   m_Coder.get()           ,
-                                                   applyConstantTerm ,
-                                                   rmsConstantTerm     ) );
-				  
-   if( m_apdSeparateDigi )
-   {
-     m_APDCoder.reset( new EcalCoder( false            , 
-                                      m_PreMix1        ,
-                                      m_EBCorrNoise[0].get() ,
-                                      m_EECorrNoise[0].get() ,
-                                      m_EBCorrNoise[1].get() ,
-                                      m_EECorrNoise[1].get() ,
-                                      m_EBCorrNoise[2].get() ,
-                                      m_EECorrNoise[2].get()   ) );
-     
-     m_APDElectronicsSim.reset( new EcalElectronicsSim( m_ParameterMap.get()    ,
-                                                        m_APDCoder.get()        ,
-                                                        applyConstantTerm ,
-                                                        rmsConstantTerm     ) );
-     
-     m_APDDigitizer.reset( new EBDigitizer( m_APDResponse.get()       , 
-                                            m_APDElectronicsSim.get() ,
-                                            false                 ) );
-   }
+  m_Coder.reset(new EcalCoder(addNoise, m_PreMix1, m_EBCorrNoise[0].get(),
+                              m_EECorrNoise[0].get(), m_EBCorrNoise[1].get(),
+                              m_EECorrNoise[1].get(), m_EBCorrNoise[2].get(),
+                              m_EECorrNoise[2].get()));
 
-   if( m_doEB ) {
-     m_BarrelDigitizer.reset( new EBDigitizer( m_EBResponse.get()     , 
-                                               m_ElectronicsSim.get() ,
-                                               addNoise            ) );
-   }
+  m_ElectronicsSim.reset(new EcalElectronicsSim(
+      m_ParameterMap.get(), m_Coder.get(), applyConstantTerm, rmsConstantTerm));
 
-   if( m_doEE ) {
-     m_EndcapDigitizer.reset( new EEDigitizer( m_EEResponse.get()     ,
-                                               m_ElectronicsSim.get() , 
-                                               addNoise            ) );
-   }
+  if (m_apdSeparateDigi) {
+    m_APDCoder.reset(new EcalCoder(
+        false, m_PreMix1, m_EBCorrNoise[0].get(), m_EECorrNoise[0].get(),
+        m_EBCorrNoise[1].get(), m_EECorrNoise[1].get(), m_EBCorrNoise[2].get(),
+        m_EECorrNoise[2].get()));
+
+    m_APDElectronicsSim.reset(
+        new EcalElectronicsSim(m_ParameterMap.get(), m_APDCoder.get(),
+                               applyConstantTerm, rmsConstantTerm));
+
+    m_APDDigitizer.reset(
+        new EBDigitizer(m_APDResponse.get(), m_APDElectronicsSim.get(), false));
+  }
+
+  if (m_doEB) {
+    m_BarrelDigitizer.reset(
+        new EBDigitizer(m_EBResponse.get(), m_ElectronicsSim.get(), addNoise));
+  }
+
+  if (m_doEE) {
+    m_EndcapDigitizer.reset(
+        new EEDigitizer(m_EEResponse.get(), m_ElectronicsSim.get(), addNoise));
+  }
 }
 
+EcalDigiProducer::~EcalDigiProducer() {}
 
-EcalDigiProducer::~EcalDigiProducer() 
-{}
-
-void
-EcalDigiProducer::initializeEvent(edm::Event const& event, edm::EventSetup const& eventSetup) {
+void EcalDigiProducer::initializeEvent(edm::Event const &event,
+                                       edm::EventSetup const &eventSetup) {
   edm::Service<edm::RandomNumberGenerator> rng;
   randomEngine_ = &rng->getEngine(event.streamID());
 
-   checkGeometry( eventSetup );
-   checkCalibrations( event, eventSetup );
-   if( m_doEB ) {
-     m_BarrelDigitizer->initializeHits();
-     if(m_apdSeparateDigi) {
-       m_APDDigitizer->initializeHits();
-     }
-   }
-   if( m_doEE ) {
-     m_EndcapDigitizer->initializeHits();
-   }
-   if( m_doES ) {
-     if(m_doFastES) {
-       m_ESDigitizer->initializeHits();
-     } else {
-       m_ESOldDigitizer->initializeHits();
-     }
-   }
+  checkGeometry(eventSetup);
+  checkCalibrations(event, eventSetup);
+  if (m_doEB) {
+    m_BarrelDigitizer->initializeHits();
+    if (m_apdSeparateDigi) {
+      m_APDDigitizer->initializeHits();
+    }
+  }
+  if (m_doEE) {
+    m_EndcapDigitizer->initializeHits();
+  }
+  if (m_doES) {
+    if (m_doFastES) {
+      m_ESDigitizer->initializeHits();
+    } else {
+      m_ESOldDigitizer->initializeHits();
+    }
+  }
 }
 
-void
-EcalDigiProducer::accumulateCaloHits(HitsHandle const& ebHandle, HitsHandle const& eeHandle, HitsHandle const& esHandle, int bunchCrossing) {
-  if(m_doEB && ebHandle.isValid()) {
+void EcalDigiProducer::accumulateCaloHits(HitsHandle const &ebHandle,
+                                          HitsHandle const &eeHandle,
+                                          HitsHandle const &esHandle,
+                                          int bunchCrossing) {
+  if (m_doEB && ebHandle.isValid()) {
     m_BarrelDigitizer->add(*ebHandle.product(), bunchCrossing, randomEngine_);
 
-    if(m_apdSeparateDigi) {
+    if (m_apdSeparateDigi) {
       m_APDDigitizer->add(*ebHandle.product(), bunchCrossing, randomEngine_);
     }
   }
 
-  if(m_doEE && eeHandle.isValid()) {
+  if (m_doEE && eeHandle.isValid()) {
     m_EndcapDigitizer->add(*eeHandle.product(), bunchCrossing, randomEngine_);
   }
 
-  if(m_doES && esHandle.isValid()) {
-    if(m_doFastES) {
+  if (m_doES && esHandle.isValid()) {
+    if (m_doFastES) {
       m_ESDigitizer->add(*esHandle.product(), bunchCrossing, randomEngine_);
     } else {
       m_ESOldDigitizer->add(*esHandle.product(), bunchCrossing, randomEngine_);
@@ -338,26 +320,30 @@ EcalDigiProducer::accumulateCaloHits(HitsHandle const& ebHandle, HitsHandle cons
   }
 }
 
-void
-EcalDigiProducer::accumulate(edm::Event const& e, edm::EventSetup const& eventSetup) {
+void EcalDigiProducer::accumulate(edm::Event const &e,
+                                  edm::EventSetup const &eventSetup) {
   // Step A: Get Inputs
-  edm::Handle<std::vector<PCaloHit> > ebHandle;
-  if(m_doEB) {
-    m_EBShape.setEventSetup(eventSetup);  // need to set the eventSetup here, otherwise pre-mixing module will not wrk
+  edm::Handle<std::vector<PCaloHit>> ebHandle;
+  if (m_doEB) {
+    m_EBShape.setEventSetup(
+        eventSetup); // need to set the eventSetup here, otherwise pre-mixing
+                     // module will not wrk
     m_APDShape.setEventSetup(eventSetup); //
     edm::InputTag ebTag(m_hitsProducerTag, "EcalHitsEB");
     e.getByLabel(ebTag, ebHandle);
   }
 
-  edm::Handle<std::vector<PCaloHit> > eeHandle;
-  if(m_doEE) {
-    m_EEShape.setEventSetup(eventSetup); // need to set the eventSetup here, otherwise pre-mixing module will not work
+  edm::Handle<std::vector<PCaloHit>> eeHandle;
+  if (m_doEE) {
+    m_EEShape.setEventSetup(
+        eventSetup); // need to set the eventSetup here, otherwise pre-mixing
+                     // module will not work
     edm::InputTag eeTag(m_hitsProducerTag, "EcalHitsEE");
     e.getByLabel(eeTag, eeHandle);
   }
 
-  edm::Handle<std::vector<PCaloHit> > esHandle;
-  if(m_doES) {
+  edm::Handle<std::vector<PCaloHit>> esHandle;
+  if (m_doES) {
     edm::InputTag esTag(m_hitsProducerTag, "EcalHitsES");
     e.getByLabel(esTag, esHandle);
   }
@@ -365,23 +351,24 @@ EcalDigiProducer::accumulate(edm::Event const& e, edm::EventSetup const& eventSe
   accumulateCaloHits(ebHandle, eeHandle, esHandle, 0);
 }
 
-void
-EcalDigiProducer::accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& eventSetup, edm::StreamID const& streamID) {
+void EcalDigiProducer::accumulate(PileUpEventPrincipal const &e,
+                                  edm::EventSetup const &eventSetup,
+                                  edm::StreamID const &streamID) {
   // Step A: Get Inputs
-  edm::Handle<std::vector<PCaloHit> > ebHandle;
-  if(m_doEB) {
+  edm::Handle<std::vector<PCaloHit>> ebHandle;
+  if (m_doEB) {
     edm::InputTag ebTag(m_hitsProducerTag, "EcalHitsEB");
     e.getByLabel(ebTag, ebHandle);
   }
 
-  edm::Handle<std::vector<PCaloHit> > eeHandle;
-  if(m_doEE) {
+  edm::Handle<std::vector<PCaloHit>> eeHandle;
+  if (m_doEE) {
     edm::InputTag eeTag(m_hitsProducerTag, "EcalHitsEE");
     e.getByLabel(eeTag, eeHandle);
   }
 
-  edm::Handle<std::vector<PCaloHit> > esHandle;
-  if(m_doES) {
+  edm::Handle<std::vector<PCaloHit>> esHandle;
+  if (m_doES) {
     edm::InputTag esTag(m_hitsProducerTag, "EcalHitsES");
     e.getByLabel(esTag, esHandle);
   }
@@ -389,271 +376,267 @@ EcalDigiProducer::accumulate(PileUpEventPrincipal const& e, edm::EventSetup cons
   accumulateCaloHits(ebHandle, eeHandle, esHandle, e.bunchCrossing());
 }
 
-void 
-EcalDigiProducer::finalizeEvent(edm::Event& event, edm::EventSetup const& eventSetup) {
-   // Step B: Create empty output
-   std::unique_ptr<EBDigiCollection> apdResult      ( !m_apdSeparateDigi || !m_doEB ? nullptr :
-						    new EBDigiCollection() ) ;
-   std::unique_ptr<EBDigiCollection> barrelResult   ( new EBDigiCollection() ) ;
-   std::unique_ptr<EEDigiCollection> endcapResult   ( new EEDigiCollection() ) ;
-   std::unique_ptr<ESDigiCollection> preshowerResult( new ESDigiCollection() ) ;
-   
-   // run the algorithm
+void EcalDigiProducer::finalizeEvent(edm::Event &event,
+                                     edm::EventSetup const &eventSetup) {
+  // Step B: Create empty output
+  std::unique_ptr<EBDigiCollection> apdResult(
+      !m_apdSeparateDigi || !m_doEB ? nullptr : new EBDigiCollection());
+  std::unique_ptr<EBDigiCollection> barrelResult(new EBDigiCollection());
+  std::unique_ptr<EEDigiCollection> endcapResult(new EEDigiCollection());
+  std::unique_ptr<ESDigiCollection> preshowerResult(new ESDigiCollection());
 
-   if( m_doEB ) {
-     m_BarrelDigitizer->run( *barrelResult, randomEngine_ ) ;
-     cacheEBDigis( &*barrelResult ) ;
-     
-     edm::LogInfo("DigiInfo") << "EB Digis: " << barrelResult->size() ;
-     
-     if( m_apdSeparateDigi ) {
-       m_APDDigitizer->run( *apdResult, randomEngine_ ) ;
-       edm::LogInfo("DigiInfo") << "APD Digis: " << apdResult->size() ;
-     }
-   }
+  // run the algorithm
 
-   if( m_doEE ) {
-     m_EndcapDigitizer->run( *endcapResult, randomEngine_ ) ;
-     edm::LogInfo("EcalDigi") << "EE Digis: " << endcapResult->size() ;
-     cacheEEDigis( &*endcapResult ) ;
-   }
-   if( m_doES ) {
-     if(m_doFastES) {
-       m_ESDigitizer->run( *preshowerResult, randomEngine_ ) ;
-     } else {
-       m_ESOldDigitizer->run( *preshowerResult, randomEngine_ ) ;
-     }
-     edm::LogInfo("EcalDigi") << "ES Digis: " << preshowerResult->size();
-   }
+  if (m_doEB) {
+    m_BarrelDigitizer->run(*barrelResult, randomEngine_);
+    cacheEBDigis(&*barrelResult);
 
+    edm::LogInfo("DigiInfo") << "EB Digis: " << barrelResult->size();
 
-   // Step D: Put outputs into event
-   if( m_apdSeparateDigi ) {
-     //event.put(std::move(apdResult),    m_apdDigiTag         ) ;
-   }
+    if (m_apdSeparateDigi) {
+      m_APDDigitizer->run(*apdResult, randomEngine_);
+      edm::LogInfo("DigiInfo") << "APD Digis: " << apdResult->size();
+    }
+  }
 
-   event.put(std::move(barrelResult),    m_EBdigiCollection ) ;
-   event.put(std::move(endcapResult),    m_EEdigiCollection ) ;
-   event.put(std::move(preshowerResult), m_ESdigiCollection ) ;
+  if (m_doEE) {
+    m_EndcapDigitizer->run(*endcapResult, randomEngine_);
+    edm::LogInfo("EcalDigi") << "EE Digis: " << endcapResult->size();
+    cacheEEDigis(&*endcapResult);
+  }
+  if (m_doES) {
+    if (m_doFastES) {
+      m_ESDigitizer->run(*preshowerResult, randomEngine_);
+    } else {
+      m_ESOldDigitizer->run(*preshowerResult, randomEngine_);
+    }
+    edm::LogInfo("EcalDigi") << "ES Digis: " << preshowerResult->size();
+  }
 
-   randomEngine_ = nullptr; // to prevent access outside event
+  // Step D: Put outputs into event
+  if (m_apdSeparateDigi) {
+    // event.put(std::move(apdResult),    m_apdDigiTag         ) ;
+  }
+
+  event.put(std::move(barrelResult), m_EBdigiCollection);
+  event.put(std::move(endcapResult), m_EEdigiCollection);
+  event.put(std::move(preshowerResult), m_ESdigiCollection);
+
+  randomEngine_ = nullptr; // to prevent access outside event
 }
 
-void
-EcalDigiProducer::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup)
-{
-   edm::Service<edm::RandomNumberGenerator> rng;
-   if ( ! rng.isAvailable() ) {
-      throw cms::Exception("Configuration") <<
-         "RandomNumberGenerator service is not available.\n"
-         "You must add the service in the configuration file\n"
-         "or remove the module that requires it.";
-   }
-   CLHEP::HepRandomEngine* engine = &rng->getEngine(lumi.index());
+void EcalDigiProducer::beginLuminosityBlock(edm::LuminosityBlock const &lumi,
+                                            edm::EventSetup const &setup) {
+  edm::Service<edm::RandomNumberGenerator> rng;
+  if (!rng.isAvailable()) {
+    throw cms::Exception("Configuration")
+        << "RandomNumberGenerator service is not available.\n"
+           "You must add the service in the configuration file\n"
+           "or remove the module that requires it.";
+  }
+  CLHEP::HepRandomEngine *engine = &rng->getEngine(lumi.index());
 
-   if( m_doEB ) {
-     if( nullptr != m_APDResponse ) m_APDResponse->initialize(engine);
-     m_EBResponse->initialize(engine);
-   }
+  if (m_doEB) {
+    if (nullptr != m_APDResponse)
+      m_APDResponse->initialize(engine);
+    m_EBResponse->initialize(engine);
+  }
 }
 
-void  
-EcalDigiProducer::checkCalibrations(const edm::Event& event, const edm::EventSetup& eventSetup ) 
-{
-   // Pedestals from event setup
+void EcalDigiProducer::checkCalibrations(const edm::Event &event,
+                                         const edm::EventSetup &eventSetup) {
+  // Pedestals from event setup
 
-   edm::ESHandle<EcalPedestals>            dbPed   ;
-   eventSetup.get<EcalPedestalsRcd>().get( dbPed ) ;
-   const EcalPedestals* pedestals        ( dbPed.product() ) ;
-  
-   m_Coder->setPedestals( pedestals ) ;
-   if( nullptr != m_APDCoder ) m_APDCoder->setPedestals( pedestals ) ;
+  edm::ESHandle<EcalPedestals> dbPed;
+  eventSetup.get<EcalPedestalsRcd>().get(dbPed);
+  const EcalPedestals *pedestals(dbPed.product());
 
-   // Ecal Intercalibration Constants
-   edm::ESHandle<EcalIntercalibConstantsMC>            pIcal   ;
-   eventSetup.get<EcalIntercalibConstantsMCRcd>().get( pIcal ) ;
-   const EcalIntercalibConstantsMC* ical             ( pIcal.product() ) ;
-  
-   m_Coder->setIntercalibConstants( ical ) ;
-   if( nullptr != m_APDCoder) m_APDCoder->setIntercalibConstants( ical ) ;
+  m_Coder->setPedestals(pedestals);
+  if (nullptr != m_APDCoder)
+    m_APDCoder->setPedestals(pedestals);
 
-   m_EBResponse->setIntercal( ical ) ;
-   if( nullptr != m_APDResponse ) m_APDResponse->setIntercal( ical ) ;
+  // Ecal Intercalibration Constants
+  edm::ESHandle<EcalIntercalibConstantsMC> pIcal;
+  eventSetup.get<EcalIntercalibConstantsMCRcd>().get(pIcal);
+  const EcalIntercalibConstantsMC *ical(pIcal.product());
 
-   // Ecal LaserCorrection Constants                                
-   edm::ESHandle<EcalLaserDbService> laser;
-   eventSetup.get<EcalLaserDbRecord>().get(laser);
-   const edm::TimeValue_t eventTimeValue = event.time().value();
+  m_Coder->setIntercalibConstants(ical);
+  if (nullptr != m_APDCoder)
+    m_APDCoder->setIntercalibConstants(ical);
 
-   m_EBResponse->setEventTime(eventTimeValue);
-   m_EBResponse->setLaserConstants(laser.product(), m_useLCcorrection);
+  m_EBResponse->setIntercal(ical);
+  if (nullptr != m_APDResponse)
+    m_APDResponse->setIntercal(ical);
 
-   m_EEResponse->setEventTime(eventTimeValue);
-   m_EEResponse->setLaserConstants(laser.product(), m_useLCcorrection);
+  // Ecal LaserCorrection Constants
+  edm::ESHandle<EcalLaserDbService> laser;
+  eventSetup.get<EcalLaserDbRecord>().get(laser);
+  const edm::TimeValue_t eventTimeValue = event.time().value();
 
-   // ADC -> GeV Scale
-   edm::ESHandle<EcalADCToGeVConstant> pAgc;
-   eventSetup.get<EcalADCToGeVConstantRcd>().get(pAgc);
-   const EcalADCToGeVConstant* agc = pAgc.product();
-  
-   // Gain Ratios
-   edm::ESHandle<EcalGainRatios> pRatio;
-   eventSetup.get<EcalGainRatiosRcd>().get(pRatio);
-   const EcalGainRatios* gr = pRatio.product();
+  m_EBResponse->setEventTime(eventTimeValue);
+  m_EBResponse->setLaserConstants(laser.product(), m_useLCcorrection);
 
-   m_Coder->setGainRatios( gr );
-   if( nullptr != m_APDCoder) m_APDCoder->setGainRatios( gr );
+  m_EEResponse->setEventTime(eventTimeValue);
+  m_EEResponse->setLaserConstants(laser.product(), m_useLCcorrection);
 
-   EcalMGPAGainRatio * defaultRatios = new EcalMGPAGainRatio();
+  // ADC -> GeV Scale
+  edm::ESHandle<EcalADCToGeVConstant> pAgc;
+  eventSetup.get<EcalADCToGeVConstantRcd>().get(pAgc);
+  const EcalADCToGeVConstant *agc = pAgc.product();
 
-   double theGains[m_Coder->NGAINS+1];
-   theGains[0] = 0.;
-   theGains[3] = 1.;
-   theGains[2] = defaultRatios->gain6Over1() ;
-   theGains[1] = theGains[2]*(defaultRatios->gain12Over6()) ;
+  // Gain Ratios
+  edm::ESHandle<EcalGainRatios> pRatio;
+  eventSetup.get<EcalGainRatiosRcd>().get(pRatio);
+  const EcalGainRatios *gr = pRatio.product();
 
-   LogDebug("EcalDigi") << " Gains: " << "\n" << " g1 = " << theGains[1] 
-			<< "\n" << " g2 = " << theGains[2] 
-			<< "\n" << " g3 = " << theGains[3] ;
+  m_Coder->setGainRatios(gr);
+  if (nullptr != m_APDCoder)
+    m_APDCoder->setGainRatios(gr);
 
-   delete defaultRatios;
+  EcalMGPAGainRatio *defaultRatios = new EcalMGPAGainRatio();
 
-   const double EBscale (
-      ( agc->getEBValue())*theGains[1]*(m_Coder->MAXADC)*m_EBs25notCont ) ;
+  double theGains[m_Coder->NGAINS + 1];
+  theGains[0] = 0.;
+  theGains[3] = 1.;
+  theGains[2] = defaultRatios->gain6Over1();
+  theGains[1] = theGains[2] * (defaultRatios->gain12Over6());
 
-   LogDebug("EcalDigi") << " GeV/ADC = " << agc->getEBValue() 
-			<< "\n" << " notCont = " << m_EBs25notCont 
-			<< "\n" << " saturation for EB = " << EBscale 
-			<< ", " << m_EBs25notCont ;
+  LogDebug("EcalDigi") << " Gains: "
+                       << "\n"
+                       << " g1 = " << theGains[1] << "\n"
+                       << " g2 = " << theGains[2] << "\n"
+                       << " g3 = " << theGains[3];
 
-   const double EEscale (
-      (agc->getEEValue())*theGains[1]*(m_Coder->MAXADC)*m_EEs25notCont ) ;
+  delete defaultRatios;
 
-   LogDebug("EcalDigi") << " GeV/ADC = " << agc->getEEValue() 
-			<< "\n" << " notCont = " << m_EEs25notCont 
-			<< "\n" << " saturation for EB = " << EEscale 
-			<< ", " << m_EEs25notCont ;
+  const double EBscale((agc->getEBValue()) * theGains[1] * (m_Coder->MAXADC) *
+                       m_EBs25notCont);
 
-   m_Coder->setFullScaleEnergy( EBscale , 
-				EEscale   ) ;
-   if( nullptr != m_APDCoder ) m_APDCoder->setFullScaleEnergy( EBscale ,
-							 EEscale   ) ;
+  LogDebug("EcalDigi") << " GeV/ADC = " << agc->getEBValue() << "\n"
+                       << " notCont = " << m_EBs25notCont << "\n"
+                       << " saturation for EB = " << EBscale << ", "
+                       << m_EBs25notCont;
 
-   if( nullptr != m_ESOldDigitizer ||
-       nullptr != m_ESDigitizer       )
-   {
-      // ES condition objects
-      edm::ESHandle<ESGain>                hesgain      ;
-      edm::ESHandle<ESMIPToGeVConstant>    hesMIPToGeV  ;
-      edm::ESHandle<ESPedestals>           hesPedestals ;
-      edm::ESHandle<ESIntercalibConstants> hesMIPs      ;
+  const double EEscale((agc->getEEValue()) * theGains[1] * (m_Coder->MAXADC) *
+                       m_EEs25notCont);
 
-      eventSetup.get<ESGainRcd>().               get( hesgain      ) ;
-      eventSetup.get<ESMIPToGeVConstantRcd>().   get( hesMIPToGeV  ) ;
-      eventSetup.get<ESPedestalsRcd>().          get( hesPedestals ) ;
-      eventSetup.get<ESIntercalibConstantsRcd>().get( hesMIPs      ) ;
+  LogDebug("EcalDigi") << " GeV/ADC = " << agc->getEEValue() << "\n"
+                       << " notCont = " << m_EEs25notCont << "\n"
+                       << " saturation for EB = " << EEscale << ", "
+                       << m_EEs25notCont;
 
-      const ESGain*                esgain     ( hesgain.product()      ) ;
-      const ESPedestals*           espeds     ( hesPedestals.product() ) ;
-      const ESIntercalibConstants* esmips     ( hesMIPs.product()      ) ;
-      const ESMIPToGeVConstant*    esMipToGeV ( hesMIPToGeV.product()  ) ;
-      const int ESGain ( 1.1 > esgain->getESGain() ? 1 : 2 ) ;
-      const double ESMIPToGeV ( ( 1 == ESGain ) ?
-				esMipToGeV->getESValueLow()  :
-				esMipToGeV->getESValueHigh()   ) ; 
-   
-      if( m_doES ) {
-        m_ESShape.setGain( ESGain );      
-        if( !m_doFastES )
-          {
-            m_ESElectronicsSim->setGain(      ESGain     ) ;
-            m_ESElectronicsSim->setPedestals( espeds     ) ;
-            m_ESElectronicsSim->setMIPs(      esmips     ) ;
-            m_ESElectronicsSim->setMIPToGeV(  ESMIPToGeV ) ;
-          }
-        else
-          {
-            m_ESDigitizer->setGain(               ESGain     ) ;
-            m_ESElectronicsSimFast->setPedestals( espeds     ) ;
-            m_ESElectronicsSimFast->setMIPs(      esmips     ) ;
-            m_ESElectronicsSimFast->setMIPToGeV(  ESMIPToGeV ) ;
-          }
+  m_Coder->setFullScaleEnergy(EBscale, EEscale);
+  if (nullptr != m_APDCoder)
+    m_APDCoder->setFullScaleEnergy(EBscale, EEscale);
+
+  if (nullptr != m_ESOldDigitizer || nullptr != m_ESDigitizer) {
+    // ES condition objects
+    edm::ESHandle<ESGain> hesgain;
+    edm::ESHandle<ESMIPToGeVConstant> hesMIPToGeV;
+    edm::ESHandle<ESPedestals> hesPedestals;
+    edm::ESHandle<ESIntercalibConstants> hesMIPs;
+
+    eventSetup.get<ESGainRcd>().get(hesgain);
+    eventSetup.get<ESMIPToGeVConstantRcd>().get(hesMIPToGeV);
+    eventSetup.get<ESPedestalsRcd>().get(hesPedestals);
+    eventSetup.get<ESIntercalibConstantsRcd>().get(hesMIPs);
+
+    const ESGain *esgain(hesgain.product());
+    const ESPedestals *espeds(hesPedestals.product());
+    const ESIntercalibConstants *esmips(hesMIPs.product());
+    const ESMIPToGeVConstant *esMipToGeV(hesMIPToGeV.product());
+    const int ESGain(1.1 > esgain->getESGain() ? 1 : 2);
+    const double ESMIPToGeV((1 == ESGain) ? esMipToGeV->getESValueLow()
+                                          : esMipToGeV->getESValueHigh());
+
+    if (m_doES) {
+      m_ESShape.setGain(ESGain);
+      if (!m_doFastES) {
+        m_ESElectronicsSim->setGain(ESGain);
+        m_ESElectronicsSim->setPedestals(espeds);
+        m_ESElectronicsSim->setMIPs(esmips);
+        m_ESElectronicsSim->setMIPToGeV(ESMIPToGeV);
+      } else {
+        m_ESDigitizer->setGain(ESGain);
+        m_ESElectronicsSimFast->setPedestals(espeds);
+        m_ESElectronicsSimFast->setMIPs(esmips);
+        m_ESElectronicsSimFast->setMIPToGeV(ESMIPToGeV);
       }
-   }
+    }
+  }
 }
 
-void 
-EcalDigiProducer::checkGeometry( const edm::EventSetup & eventSetup ) 
-{
-   // TODO find a way to avoid doing this every event
-   edm::ESHandle<CaloGeometry>               hGeometry   ;
-   eventSetup.get<CaloGeometryRecord>().get( hGeometry ) ;
+void EcalDigiProducer::checkGeometry(const edm::EventSetup &eventSetup) {
+  // TODO find a way to avoid doing this every event
+  edm::ESHandle<CaloGeometry> hGeometry;
+  eventSetup.get<CaloGeometryRecord>().get(hGeometry);
 
-   const CaloGeometry* pGeometry = &*hGeometry;
+  const CaloGeometry *pGeometry = &*hGeometry;
 
-   if( pGeometry != m_Geometry )
-   {
-      m_Geometry = pGeometry;
-      updateGeometry();
-   }
+  if (pGeometry != m_Geometry) {
+    m_Geometry = pGeometry;
+    updateGeometry();
+  }
 }
 
-void
-EcalDigiProducer::updateGeometry() 
-{
-  if( m_doEB ) {
-    if( nullptr != m_APDResponse ) m_APDResponse->setGeometry(
-      m_Geometry->getSubdetectorGeometry( DetId::Ecal, EcalBarrel    ) ) ;
+void EcalDigiProducer::updateGeometry() {
+  if (m_doEB) {
+    if (nullptr != m_APDResponse)
+      m_APDResponse->setGeometry(
+          m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
     m_EBResponse->setGeometry(
-      m_Geometry->getSubdetectorGeometry( DetId::Ecal, EcalBarrel    ) ) ;
+        m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
   }
-  if( m_doEE ) {
+  if (m_doEE) {
     m_EEResponse->setGeometry(
-      m_Geometry->getSubdetectorGeometry( DetId::Ecal, EcalEndcap    ) ) ;
+        m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalEndcap));
   }
-  if( m_doES ) {
+  if (m_doES) {
     m_ESResponse->setGeometry(
-      m_Geometry->getSubdetectorGeometry( DetId::Ecal, EcalPreshower    ) ) ;
-    m_ESOldResponse->setGeometry( m_Geometry ) ;
-   
-   const std::vector<DetId>* theESDets ( 
-      nullptr != m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalPreshower) ?
-      &m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalPreshower)->getValidDetIds() : nullptr ) ;
+        m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalPreshower));
+    m_ESOldResponse->setGeometry(m_Geometry);
 
-   if( !m_doFastES ) 
-   {
-      if( nullptr != m_ESOldDigitizer &&
-	  nullptr != theESDets             )
-	 m_ESOldDigitizer->setDetIds( *theESDets ) ;
-   }
-   else
-   {
-      if( nullptr != m_ESDigitizer &&
-	  nullptr != theESDets         )
-	 m_ESDigitizer->setDetIds( *theESDets ) ; 
-   }
+    const std::vector<DetId> *theESDets(
+        nullptr !=
+                m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalPreshower)
+            ? &m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalPreshower)
+                   ->getValidDetIds()
+            : nullptr);
+
+    if (!m_doFastES) {
+      if (nullptr != m_ESOldDigitizer && nullptr != theESDets)
+        m_ESOldDigitizer->setDetIds(*theESDets);
+    } else {
+      if (nullptr != m_ESDigitizer && nullptr != theESDets)
+        m_ESDigitizer->setDetIds(*theESDets);
+    }
   }
 }
 
-void EcalDigiProducer::setEBNoiseSignalGenerator(EcalBaseSignalGenerator * noiseGenerator) {
-  //noiseGenerator->setParameterMap(theParameterMap);
-  if(nullptr != m_BarrelDigitizer) m_BarrelDigitizer->setNoiseSignalGenerator(noiseGenerator);
+void EcalDigiProducer::setEBNoiseSignalGenerator(
+    EcalBaseSignalGenerator *noiseGenerator) {
+  // noiseGenerator->setParameterMap(theParameterMap);
+  if (nullptr != m_BarrelDigitizer)
+    m_BarrelDigitizer->setNoiseSignalGenerator(noiseGenerator);
 }
 
-void EcalDigiProducer::setEENoiseSignalGenerator(EcalBaseSignalGenerator * noiseGenerator) {
-  //noiseGenerator->setParameterMap(theParameterMap);
-  if(nullptr != m_EndcapDigitizer) m_EndcapDigitizer->setNoiseSignalGenerator(noiseGenerator);
+void EcalDigiProducer::setEENoiseSignalGenerator(
+    EcalBaseSignalGenerator *noiseGenerator) {
+  // noiseGenerator->setParameterMap(theParameterMap);
+  if (nullptr != m_EndcapDigitizer)
+    m_EndcapDigitizer->setNoiseSignalGenerator(noiseGenerator);
 }
 
-void EcalDigiProducer::setESNoiseSignalGenerator(EcalBaseSignalGenerator * noiseGenerator) {
-  //noiseGenerator->setParameterMap(theParameterMap);
-  if(nullptr != m_ESDigitizer) m_ESDigitizer->setNoiseSignalGenerator(noiseGenerator);  
+void EcalDigiProducer::setESNoiseSignalGenerator(
+    EcalBaseSignalGenerator *noiseGenerator) {
+  // noiseGenerator->setParameterMap(theParameterMap);
+  if (nullptr != m_ESDigitizer)
+    m_ESDigitizer->setNoiseSignalGenerator(noiseGenerator);
 }
 
-
-void EcalDigiProducer::beginRun(edm::Run const& run, edm::EventSetup const& setup) {
-   m_EBShape.setEventSetup(setup); 
-   m_EEShape.setEventSetup(setup);
-   m_APDShape.setEventSetup(setup);
+void EcalDigiProducer::beginRun(edm::Run const &run,
+                                edm::EventSetup const &setup) {
+  m_EBShape.setEventSetup(setup);
+  m_EEShape.setEventSetup(setup);
+  m_APDShape.setEventSetup(setup);
 }
-

--- a/SimCalorimetry/EcalSimProducers/src/EcalTimeDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalTimeDigiProducer.cc
@@ -1,85 +1,90 @@
 #include "FWCore/Framework/interface/Event.h"
-#include "SimCalorimetry/EcalSimProducers/interface/EcalTimeDigiProducer.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalTimeMapDigitizer.h"
+#include "SimCalorimetry/EcalSimProducers/interface/EcalTimeDigiProducer.h"
 
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
 
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
-
 
 //#define ecal_time_debug 1
 
-EcalTimeDigiProducer::EcalTimeDigiProducer( const edm::ParameterSet& params, edm::ProducerBase& mixMod,edm::ConsumesCollector& sumes) :
-   DigiAccumulatorMixMod(),
-   m_EBdigiCollection ( params.getParameter<std::string>("EBtimeDigiCollection") ) ,
-   m_EEdigiCollection ( params.getParameter<std::string>("EEtimeDigiCollection") ) ,
-   m_hitsProducerTagEB  ( params.getParameter<edm::InputTag>("hitsProducerEB"    ) ) ,
-   m_hitsProducerTagEE  ( params.getParameter<edm::InputTag>("hitsProducerEE"    ) ) ,
-   m_hitsProducerTokenEB  ( sumes.consumes<std::vector<PCaloHit> >( m_hitsProducerTagEB) ) ,
-   m_hitsProducerTokenEE  ( sumes.consumes<std::vector<PCaloHit> >( m_hitsProducerTagEE) ) ,
-   m_timeLayerEB     (  params.getParameter<int> ("timeLayerBarrel") ),
-   m_timeLayerEE     (  params.getParameter<int> ("timeLayerEndcap") ),
-   m_Geometry          ( nullptr ) 
-{
-   mixMod.produces<EcalTimeDigiCollection>(m_EBdigiCollection);
-   mixMod.produces<EcalTimeDigiCollection>(m_EEdigiCollection);
+EcalTimeDigiProducer::EcalTimeDigiProducer(const edm::ParameterSet &params,
+                                           edm::ProducerBase &mixMod,
+                                           edm::ConsumesCollector &sumes)
+    : DigiAccumulatorMixMod(),
+      m_EBdigiCollection(
+          params.getParameter<std::string>("EBtimeDigiCollection")),
+      m_EEdigiCollection(
+          params.getParameter<std::string>("EEtimeDigiCollection")),
+      m_hitsProducerTagEB(params.getParameter<edm::InputTag>("hitsProducerEB")),
+      m_hitsProducerTagEE(params.getParameter<edm::InputTag>("hitsProducerEE")),
+      m_hitsProducerTokenEB(
+          sumes.consumes<std::vector<PCaloHit>>(m_hitsProducerTagEB)),
+      m_hitsProducerTokenEE(
+          sumes.consumes<std::vector<PCaloHit>>(m_hitsProducerTagEE)),
+      m_timeLayerEB(params.getParameter<int>("timeLayerBarrel")),
+      m_timeLayerEE(params.getParameter<int>("timeLayerEndcap")),
+      m_Geometry(nullptr) {
+  mixMod.produces<EcalTimeDigiCollection>(m_EBdigiCollection);
+  mixMod.produces<EcalTimeDigiCollection>(m_EEdigiCollection);
 
-   m_BarrelDigitizer = new EcalTimeMapDigitizer(EcalBarrel);
-   m_EndcapDigitizer = new EcalTimeMapDigitizer(EcalEndcap);
+  m_BarrelDigitizer = new EcalTimeMapDigitizer(EcalBarrel);
+  m_EndcapDigitizer = new EcalTimeMapDigitizer(EcalEndcap);
 
 #ifdef ecal_time_debug
-   std::cout << "[EcalTimeDigiProducer]::Create EB " << m_EBdigiCollection << " and EE " << m_EEdigiCollection << " collections and digitizers" << std::endl;
+  std::cout << "[EcalTimeDigiProducer]::Create EB " << m_EBdigiCollection
+            << " and EE " << m_EEdigiCollection << " collections and digitizers"
+            << std::endl;
 #endif
 
-   m_BarrelDigitizer->setTimeLayerId(m_timeLayerEB);
-   m_EndcapDigitizer->setTimeLayerId(m_timeLayerEE);
+  m_BarrelDigitizer->setTimeLayerId(m_timeLayerEB);
+  m_EndcapDigitizer->setTimeLayerId(m_timeLayerEE);
 }
 
-EcalTimeDigiProducer::~EcalTimeDigiProducer() 
-{
+EcalTimeDigiProducer::~EcalTimeDigiProducer() {}
+
+void EcalTimeDigiProducer::initializeEvent(edm::Event const &event,
+                                           edm::EventSetup const &eventSetup) {
+  checkGeometry(eventSetup);
+  //    checkCalibrations( event, eventSetup );
+  // here the methods to clean the maps
+  m_BarrelDigitizer->initializeMap();
+  m_EndcapDigitizer->initializeMap();
 }
 
-void
-EcalTimeDigiProducer::initializeEvent(edm::Event const& event, edm::EventSetup const& eventSetup) {
-   checkGeometry( eventSetup );
-   //    checkCalibrations( event, eventSetup );
-   // here the methods to clean the maps
-   m_BarrelDigitizer->initializeMap();
-   m_EndcapDigitizer->initializeMap();
-}
-
-void
-EcalTimeDigiProducer::accumulateCaloHits(HitsHandle const& ebHandle, HitsHandle const& eeHandle, int bunchCrossing) {
-  // accumulate the simHits and do the averages in a given layer per bunch crossing
-  if(ebHandle.isValid()) {
+void EcalTimeDigiProducer::accumulateCaloHits(HitsHandle const &ebHandle,
+                                              HitsHandle const &eeHandle,
+                                              int bunchCrossing) {
+  // accumulate the simHits and do the averages in a given layer per bunch
+  // crossing
+  if (ebHandle.isValid()) {
     m_BarrelDigitizer->add(*ebHandle.product(), bunchCrossing);
   }
 
-  if(eeHandle.isValid()) {
+  if (eeHandle.isValid()) {
     m_EndcapDigitizer->add(*eeHandle.product(), bunchCrossing);
   }
-
 }
 
-void
-EcalTimeDigiProducer::accumulate(edm::Event const& e, edm::EventSetup const& eventSetup) {
+void EcalTimeDigiProducer::accumulate(edm::Event const &e,
+                                      edm::EventSetup const &eventSetup) {
   // Step A: Get Inputs
-  edm::Handle<std::vector<PCaloHit> > ebHandle;
+  edm::Handle<std::vector<PCaloHit>> ebHandle;
   e.getByToken(m_hitsProducerTokenEB, ebHandle);
 
-  edm::Handle<std::vector<PCaloHit> > eeHandle;
+  edm::Handle<std::vector<PCaloHit>> eeHandle;
   e.getByToken(m_hitsProducerTokenEE, eeHandle);
 
 #ifdef ecal_time_debug
@@ -89,75 +94,77 @@ EcalTimeDigiProducer::accumulate(edm::Event const& e, edm::EventSetup const& eve
   accumulateCaloHits(ebHandle, eeHandle, 0);
 }
 
-void
-EcalTimeDigiProducer::accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& eventSetup, edm::StreamID const&) {
-  edm::Handle<std::vector<PCaloHit> > ebHandle;
+void EcalTimeDigiProducer::accumulate(PileUpEventPrincipal const &e,
+                                      edm::EventSetup const &eventSetup,
+                                      edm::StreamID const &) {
+  edm::Handle<std::vector<PCaloHit>> ebHandle;
   e.getByLabel(m_hitsProducerTagEB, ebHandle);
 
-  edm::Handle<std::vector<PCaloHit> > eeHandle;
+  edm::Handle<std::vector<PCaloHit>> eeHandle;
   e.getByLabel(m_hitsProducerTagEE, eeHandle);
 
 #ifdef ecal_time_debug
-  std::cout << "[EcalTimeDigiProducer]::Accumulate Hits for BC " << e.bunchCrossing() << std::endl;
+  std::cout << "[EcalTimeDigiProducer]::Accumulate Hits for BC "
+            << e.bunchCrossing() << std::endl;
 #endif
   accumulateCaloHits(ebHandle, eeHandle, e.bunchCrossing());
 }
 
-void 
-EcalTimeDigiProducer::finalizeEvent(edm::Event& event, edm::EventSetup const& eventSetup) {
-   std::unique_ptr<EcalTimeDigiCollection> barrelResult   ( new EcalTimeDigiCollection() ) ;
-   std::unique_ptr<EcalTimeDigiCollection> endcapResult   ( new EcalTimeDigiCollection() ) ;
+void EcalTimeDigiProducer::finalizeEvent(edm::Event &event,
+                                         edm::EventSetup const &eventSetup) {
+  std::unique_ptr<EcalTimeDigiCollection> barrelResult(
+      new EcalTimeDigiCollection());
+  std::unique_ptr<EcalTimeDigiCollection> endcapResult(
+      new EcalTimeDigiCollection());
 
 #ifdef ecal_time_debug
-   std::cout << "[EcalTimeDigiProducer]::finalizeEvent" << std::endl;
+  std::cout << "[EcalTimeDigiProducer]::finalizeEvent" << std::endl;
 #endif
 
-   // here basically just put everything in the final collections
-   m_BarrelDigitizer->run( *barrelResult ) ;
+  // here basically just put everything in the final collections
+  m_BarrelDigitizer->run(*barrelResult);
 
 #ifdef ecal_time_debug
-   std::cout << "[EcalTimeDigiProducer]::EB Digi size " <<  barrelResult->size() << std::endl;
+  std::cout << "[EcalTimeDigiProducer]::EB Digi size " << barrelResult->size()
+            << std::endl;
 #endif
 
-   edm::LogInfo("TimeDigiInfo") << "EB time Digis: " << barrelResult->size() ;
+  edm::LogInfo("TimeDigiInfo") << "EB time Digis: " << barrelResult->size();
 
-   m_EndcapDigitizer->run( *endcapResult ) ;
+  m_EndcapDigitizer->run(*endcapResult);
 
 #ifdef ecal_time_debug
-   std::cout << "[EcalTimeDigiProducer]::EE Digi size " <<  endcapResult->size() << std::endl;
+  std::cout << "[EcalTimeDigiProducer]::EE Digi size " << endcapResult->size()
+            << std::endl;
 #endif
 
-    edm::LogInfo("TimeDigiInfo") << "EE Digis: " << endcapResult->size() ;
+  edm::LogInfo("TimeDigiInfo") << "EE Digis: " << endcapResult->size();
 
 #ifdef ecal_time_debug
-    std::cout << "[EcalTimeDigiProducer]::putting collections into the event " << std::endl;
+  std::cout << "[EcalTimeDigiProducer]::putting collections into the event "
+            << std::endl;
 #endif
 
-    event.put( std::move(barrelResult),    m_EBdigiCollection ) ;
-    event.put( std::move(endcapResult),    m_EEdigiCollection ) ;
+  event.put(std::move(barrelResult), m_EBdigiCollection);
+  event.put(std::move(endcapResult), m_EEdigiCollection);
 }
 
-void 
-EcalTimeDigiProducer::checkGeometry( const edm::EventSetup & eventSetup ) 
-{
-   // TODO find a way to avoid doing this every event
-   edm::ESHandle<CaloGeometry>               hGeometry   ;
-   eventSetup.get<CaloGeometryRecord>().get( hGeometry ) ;
+void EcalTimeDigiProducer::checkGeometry(const edm::EventSetup &eventSetup) {
+  // TODO find a way to avoid doing this every event
+  edm::ESHandle<CaloGeometry> hGeometry;
+  eventSetup.get<CaloGeometryRecord>().get(hGeometry);
 
-   const CaloGeometry* pGeometry = &*hGeometry;
+  const CaloGeometry *pGeometry = &*hGeometry;
 
-   if( pGeometry != m_Geometry )
-   {
-      m_Geometry = pGeometry;
-      updateGeometry();
-   }
+  if (pGeometry != m_Geometry) {
+    m_Geometry = pGeometry;
+    updateGeometry();
+  }
 }
 
-void
-EcalTimeDigiProducer::updateGeometry() 
-{
-   m_BarrelDigitizer->setGeometry(
-      m_Geometry->getSubdetectorGeometry( DetId::Ecal, EcalBarrel    ) ) ;
-   m_EndcapDigitizer->setGeometry(
-      m_Geometry->getSubdetectorGeometry( DetId::Ecal, EcalEndcap    ) ) ;
+void EcalTimeDigiProducer::updateGeometry() {
+  m_BarrelDigitizer->setGeometry(
+      m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
+  m_EndcapDigitizer->setGeometry(
+      m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalEndcap));
 }

--- a/SimCalorimetry/EcalSimProducers/test/ESDigisReferenceDistrib.cc
+++ b/SimCalorimetry/EcalSimProducers/test/ESDigisReferenceDistrib.cc
@@ -2,95 +2,113 @@
  * \file ESDigisReferenceDistrib.cc
  * \ creating reference distribuitons for ES digitization
  *
-*/
+ */
 
 #include <SimCalorimetry/EcalSimProducers/test/ESDigisReferenceDistrib.h>
 
-ESDigisReferenceDistrib::ESDigisReferenceDistrib(const edm::ParameterSet& ps):
-  ESdigiCollection_(ps.getParameter<edm::InputTag>("ESdigiCollection"))
-{
+ESDigisReferenceDistrib::ESDigisReferenceDistrib(const edm::ParameterSet &ps)
+    : ESdigiCollection_(ps.getParameter<edm::InputTag>("ESdigiCollection")) {
   // root and txt outputs
   outputRootFile_ = ps.getUntrackedParameter<std::string>("outputRootFile", "");
-  outputTxtFile_  = ps.getUntrackedParameter<std::string>("outputTxtFile", "");
-  
+  outputTxtFile_ = ps.getUntrackedParameter<std::string>("outputTxtFile", "");
+
   // histos
   char histo[200];
-  for (int ii = 0; ii<3 ; ii++) {
-    sprintf (histo, "esRefHistos%02d", ii) ;
-    meESDigiADC_[ii] = new TH1F(histo, histo, 80, 960.5, 1040.5) ;
+  for (int ii = 0; ii < 3; ii++) {
+    sprintf(histo, "esRefHistos%02d", ii);
+    meESDigiADC_[ii] = new TH1F(histo, histo, 80, 960.5, 1040.5);
   }
-  
-  meESDigi3D_ = new TH3F("meESDigi3D_", "meESDigi3D_", 80, 960.5, 1040.5, 80, 960.5, 1040.5, 80, 960.5, 1040.5) ;
+
+  meESDigi3D_ = new TH3F("meESDigi3D_", "meESDigi3D_", 80, 960.5, 1040.5, 80,
+                         960.5, 1040.5, 80, 960.5, 1040.5);
 }
 
-ESDigisReferenceDistrib::~ESDigisReferenceDistrib(){ 
+ESDigisReferenceDistrib::~ESDigisReferenceDistrib() {
 
   // preparing the txt file with the histo infos
-   std::ofstream *outFile_ = new std::ofstream(outputTxtFile_.c_str(),std::ios::out);
-  *outFile_ << "# number of bin"                         << std::endl;
-  *outFile_ << "# axis inf (common to the three axes"    << std::endl;
-  *outFile_ << "# axis sup (common to the three axes"    << std::endl;
-  *outFile_ << "# bin x bin content"                     << std::endl;
-  *outFile_ << "# "                                      << std::endl;
-  
-  if(!meESDigi3D_) throw cms::Exception("ESDigisReferenceDistrib: problems with the reference histo");
+  std::ofstream *outFile_ =
+      new std::ofstream(outputTxtFile_.c_str(), std::ios::out);
+  *outFile_ << "# number of bin" << std::endl;
+  *outFile_ << "# axis inf (common to the three axes" << std::endl;
+  *outFile_ << "# axis sup (common to the three axes" << std::endl;
+  *outFile_ << "# bin x bin content" << std::endl;
+  *outFile_ << "# " << std::endl;
+
+  if (!meESDigi3D_)
+    throw cms::Exception(
+        "ESDigisReferenceDistrib: problems with the reference histo");
   else {
     float histoBin_ = meESDigi3D_->GetNbinsX();
-    float histoInf_ = meESDigi3D_->GetBinLowEdge(1); 
-    float histoSup_ = meESDigi3D_->GetBinLowEdge((int)histoBin_)+meESDigi3D_->GetBinWidth((int)histoBin_);
-    
-    *outFile_ << histoBin_  << std::endl;  
-    *outFile_ << histoInf_  << std::endl;
-    *outFile_ << histoSup_  << std::endl;
-    
-    for (int thisBinZ = 1; thisBinZ <= meESDigi3D_->GetNbinsZ(); thisBinZ++){                  // sample2
-      for (int thisBinY = 1; thisBinY <= meESDigi3D_->GetNbinsY(); thisBinY++){                // sample1
-	for (int thisBinX = 1; thisBinX <= meESDigi3D_->GetNbinsX(); thisBinX++){	       // sample0    
-	  *outFile_ << meESDigi3D_->GetBinContent(thisBinX, thisBinY, thisBinZ) << std::endl;
-	}
+    float histoInf_ = meESDigi3D_->GetBinLowEdge(1);
+    float histoSup_ = meESDigi3D_->GetBinLowEdge((int)histoBin_) +
+                      meESDigi3D_->GetBinWidth((int)histoBin_);
+
+    *outFile_ << histoBin_ << std::endl;
+    *outFile_ << histoInf_ << std::endl;
+    *outFile_ << histoSup_ << std::endl;
+
+    for (int thisBinZ = 1; thisBinZ <= meESDigi3D_->GetNbinsZ();
+         thisBinZ++) { // sample2
+      for (int thisBinY = 1; thisBinY <= meESDigi3D_->GetNbinsY();
+           thisBinY++) { // sample1
+        for (int thisBinX = 1; thisBinX <= meESDigi3D_->GetNbinsX();
+             thisBinX++) { // sample0
+          *outFile_ << meESDigi3D_->GetBinContent(thisBinX, thisBinY, thisBinZ)
+                    << std::endl;
+        }
       }
     }
   }
-  
+
   // saving and deleting
-  TFile file(outputRootFile_.c_str(),"RECREATE");
-  for (int ii=0; ii<3 ; ii++) { meESDigiADC_[ii] -> Write(); }  
-  meESDigi3D_ -> Write();
+  TFile file(outputRootFile_.c_str(), "RECREATE");
+  for (int ii = 0; ii < 3; ii++) {
+    meESDigiADC_[ii]->Write();
+  }
+  meESDigi3D_->Write();
   file.Close();
 
-  for (int ii=0; ii<3; ii++) { if (meESDigiADC_[ii]){ delete meESDigiADC_[ii]; }}
-  if (meESDigi3D_) delete meESDigi3D_;
+  for (int ii = 0; ii < 3; ii++) {
+    if (meESDigiADC_[ii]) {
+      delete meESDigiADC_[ii];
+    }
+  }
+  if (meESDigi3D_)
+    delete meESDigi3D_;
 }
 
-void ESDigisReferenceDistrib::beginJob(){ }
+void ESDigisReferenceDistrib::beginJob() {}
 
-void ESDigisReferenceDistrib::endJob(){ }
+void ESDigisReferenceDistrib::endJob() {}
 
-void ESDigisReferenceDistrib::analyze(const edm::Event& e, const edm::EventSetup& c){
+void ESDigisReferenceDistrib::analyze(const edm::Event &e,
+                                      const edm::EventSetup &c) {
 
-   edm::Handle<ESDigiCollection> EcalDigiES;  
-  e.getByLabel( ESdigiCollection_ , EcalDigiES );
-  
+  edm::Handle<ESDigiCollection> EcalDigiES;
+  e.getByLabel(ESdigiCollection_, EcalDigiES);
+
   // loop over Digis
-  const ESDigiCollection * preshowerDigi = EcalDigiES.product () ;
-  
-  std::vector<double> esADCCounts ;
+  const ESDigiCollection *preshowerDigi = EcalDigiES.product();
+
+  std::vector<double> esADCCounts;
   esADCCounts.reserve(ESDataFrame::MAXSAMPLES);
-  
-  for (unsigned int digis=0; digis<EcalDigiES->size(); ++digis) {
 
-    ESDataFrame esdf=(*preshowerDigi)[digis];
-    int nrSamples=esdf.size();
+  for (unsigned int digis = 0; digis < EcalDigiES->size(); ++digis) {
 
-    if ( meESDigi3D_ ) meESDigi3D_ -> Fill(esdf[0].adc(),esdf[1].adc(),esdf[2].adc());
-    for (int sample = 0 ; sample < nrSamples; ++sample) {
+    ESDataFrame esdf = (*preshowerDigi)[digis];
+    int nrSamples = esdf.size();
+
+    if (meESDigi3D_)
+      meESDigi3D_->Fill(esdf[0].adc(), esdf[1].adc(), esdf[2].adc());
+    for (int sample = 0; sample < nrSamples; ++sample) {
       ESSample mySample = esdf[sample];
-      if (meESDigiADC_[sample]) { meESDigiADC_[sample] ->Fill(mySample.adc()); }
+      if (meESDigiADC_[sample]) {
+        meESDigiADC_[sample]->Fill(mySample.adc());
+      }
     }
   }
 }
 
-
-//define this as a plug-in
+// define this as a plug-in
 
 DEFINE_FWK_MODULE(ESDigisReferenceDistrib);

--- a/SimCalorimetry/EcalSimProducers/test/ESDigisReferenceDistrib.h
+++ b/SimCalorimetry/EcalSimProducers/test/ESDigisReferenceDistrib.h
@@ -1,60 +1,57 @@
 #ifndef ESDigisReferenceDistrib_H
 #define ESDigisReferenceDistrib_H
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "DataFormats/EcalDigi/interface/ESDataFrame.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 #include "TFile.h"
 #include "TH1F.h"
 #include "TH3F.h"
 
-class ESDigisReferenceDistrib: public edm::EDAnalyzer{
-  
- public:
-  
+class ESDigisReferenceDistrib : public edm::EDAnalyzer {
+
+public:
   /// Constructor
-  ESDigisReferenceDistrib(const edm::ParameterSet& ps);
-  
+  ESDigisReferenceDistrib(const edm::ParameterSet &ps);
+
   /// Destructor
   ~ESDigisReferenceDistrib() override;
-  
- protected:
-  
+
+protected:
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-  
+  void analyze(const edm::Event &e, const edm::EventSetup &c) override;
+
   // BeginJob
   void beginJob() override;
-  
+
   // EndJob
   void endJob(void) override;
-  
- private:
-  
+
+private:
   bool verbose_;
-  
+
   std::string outputRootFile_;
   std::string outputTxtFile_;
-  
+
   edm::InputTag ESdigiCollection_;
-  
-  TH3F* meESDigi3D_;  
-  TH1F* meESDigiADC_[3];
+
+  TH3F *meESDigi3D_;
+  TH1F *meESDigiADC_[3];
 };
 
 #endif

--- a/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
+++ b/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
@@ -1,62 +1,59 @@
 #ifndef SimCalorimetry_EcalTestBeam_EcalTBDigiProducer_h
 #define SimCalorimetry_EcalTestBeam_EcalTBDigiProducer_h
 
-#include "SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h"
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
-#include "SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h"
 #include "RecoTBCalo/EcalTBTDCReconstructor/interface/EcalTBTDCRecInfoAlgo.h"
+#include "SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h"
+#include "SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h"
 #include "TBDataFormats/EcalTBObjects/interface/EcalTBTDCRawInfo.h"
 
 namespace edm {
-  class ConsumesCollector;
-  class ProducerBase;
-  class Event;
-  class EventSetup;
-  class ParameterSet;
-}
+class ConsumesCollector;
+class ProducerBase;
+class Event;
+class EventSetup;
+class ParameterSet;
+} // namespace edm
 class PEcalTBInfo;
 class PileUpEventPrincipal;
 
-class EcalTBDigiProducer : public EcalDigiProducer
-{
-   public:
+class EcalTBDigiProducer : public EcalDigiProducer {
+public:
+  EcalTBDigiProducer(const edm::ParameterSet &params, edm::ProducerBase &mixMod,
+                     edm::ConsumesCollector &iC);
+  ~EcalTBDigiProducer() override;
 
-      EcalTBDigiProducer( const edm::ParameterSet& params, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) ;
-      ~EcalTBDigiProducer() override ;
+  void initializeEvent(edm::Event const &, edm::EventSetup const &) override;
+  void finalizeEvent(edm::Event &, edm::EventSetup const &) override;
 
+private:
+  void cacheEBDigis(const EBDigiCollection *ebDigiPtr) const override;
+  void cacheEEDigis(const EEDigiCollection *eeDigiPtr) const override;
 
-      void initializeEvent(edm::Event const&, edm::EventSetup const&) override;
-      void finalizeEvent(edm::Event&, edm::EventSetup const&) override;
+  void setPhaseShift(const DetId &detId);
 
-   private:
+  void fillTBTDCRawInfo(EcalTBTDCRawInfo &theTBTDCRawInfo);
 
-      void cacheEBDigis( const EBDigiCollection* ebDigiPtr ) const override ;
-      void cacheEEDigis( const EEDigiCollection* eeDigiPtr ) const override ; 
+  const EcalTrigTowerConstituentsMap m_theTTmap;
+  EcalTBReadout *m_theTBReadout;
 
-      void setPhaseShift( const DetId& detId ) ;
+  std::string m_ecalTBInfoLabel;
+  std::string m_EBdigiFinalTag;
+  std::string m_EBdigiTempTag;
 
-      void fillTBTDCRawInfo( EcalTBTDCRawInfo& theTBTDCRawInfo ) ;
+  bool m_doPhaseShift;
+  double m_thisPhaseShift;
 
-      const EcalTrigTowerConstituentsMap m_theTTmap        ;
-      EcalTBReadout*                     m_theTBReadout    ;
+  bool m_doReadout;
 
-      std::string m_ecalTBInfoLabel ;
-      std::string m_EBdigiFinalTag  ;
-      std::string m_EBdigiTempTag   ;
+  std::vector<EcalTBTDCRecInfoAlgo::EcalTBTDCRanges> m_tdcRanges;
+  bool m_use2004OffsetConvention;
 
-      bool   m_doPhaseShift   ;
-      double m_thisPhaseShift ;
+  double m_tunePhaseShift;
 
-      bool   m_doReadout      ;
-
-      std::vector<EcalTBTDCRecInfoAlgo::EcalTBTDCRanges> m_tdcRanges ;
-      bool   m_use2004OffsetConvention ;
-      
-      double m_tunePhaseShift ;
-
-      mutable std::unique_ptr<EBDigiCollection> m_ebDigis ;
-      mutable std::unique_ptr<EEDigiCollection> m_eeDigis ;
-      mutable std::unique_ptr<EcalTBTDCRawInfo> m_TDCproduct ;
+  mutable std::unique_ptr<EBDigiCollection> m_ebDigis;
+  mutable std::unique_ptr<EEDigiCollection> m_eeDigis;
+  mutable std::unique_ptr<EcalTBTDCRawInfo> m_TDCproduct;
 };
 
-#endif 
+#endif

--- a/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
+++ b/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
@@ -1,181 +1,163 @@
 
-#include "SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h"
-#include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
+#include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "SimCalorimetry/EcalSimAlgos/interface/EcalSimParameterMap.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EBHitResponse.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EEHitResponse.h"
+#include "SimCalorimetry/EcalSimAlgos/interface/EcalSimParameterMap.h"
+#include "SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h"
+#include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
 
-EcalTBDigiProducer::EcalTBDigiProducer( const edm::ParameterSet& params, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) :
-   EcalDigiProducer(params, mixMod, iC)
-{
-   std::string const instance("simEcalUnsuppressedDigis");
-   m_EBdigiFinalTag = params.getParameter<std::string>( "EBdigiFinalCollection" ) ;
-   m_EBdigiTempTag  = params.getParameter<std::string>( "EBdigiCollection");
+EcalTBDigiProducer::EcalTBDigiProducer(const edm::ParameterSet &params,
+                                       edm::ProducerBase &mixMod,
+                                       edm::ConsumesCollector &iC)
+    : EcalDigiProducer(params, mixMod, iC) {
+  std::string const instance("simEcalUnsuppressedDigis");
+  m_EBdigiFinalTag = params.getParameter<std::string>("EBdigiFinalCollection");
+  m_EBdigiTempTag = params.getParameter<std::string>("EBdigiCollection");
 
-   mixMod.produces<EBDigiCollection>(instance + m_EBdigiFinalTag) ; // after selective readout
-   mixMod.produces<EcalTBTDCRawInfo>(instance) ;
+  mixMod.produces<EBDigiCollection>(
+      instance + m_EBdigiFinalTag); // after selective readout
+  mixMod.produces<EcalTBTDCRawInfo>(instance);
 
-   const bool syncPhase ( params.getParameter<bool>("syncPhase") ) ;
+  const bool syncPhase(params.getParameter<bool>("syncPhase"));
 
-   // possible phase shift for asynchronous trigger (e.g. test-beam)
+  // possible phase shift for asynchronous trigger (e.g. test-beam)
 
-   m_doPhaseShift = !syncPhase ;
-   m_thisPhaseShift = 1. ;
+  m_doPhaseShift = !syncPhase;
+  m_thisPhaseShift = 1.;
 
-   typedef std::vector< edm::ParameterSet > Parameters;
-   Parameters ranges=params.getParameter<Parameters>( "tdcRanges" ) ;
-   for( Parameters::iterator itRanges = ranges.begin(); 
-	itRanges != ranges.end(); ++itRanges )
-   {
-      EcalTBTDCRecInfoAlgo::EcalTBTDCRanges aRange;
-      aRange.runRanges.first = itRanges->getParameter<int>("startRun");
-      aRange.runRanges.second = itRanges->getParameter<int>("endRun");
-      aRange.tdcMin = itRanges->getParameter< std::vector<double> >("tdcMin");
-      aRange.tdcMax = itRanges->getParameter< std::vector<double> >("tdcMax");
-      m_tdcRanges.push_back(std::move(aRange));
-   }
+  typedef std::vector<edm::ParameterSet> Parameters;
+  Parameters ranges = params.getParameter<Parameters>("tdcRanges");
+  for (Parameters::iterator itRanges = ranges.begin(); itRanges != ranges.end();
+       ++itRanges) {
+    EcalTBTDCRecInfoAlgo::EcalTBTDCRanges aRange;
+    aRange.runRanges.first = itRanges->getParameter<int>("startRun");
+    aRange.runRanges.second = itRanges->getParameter<int>("endRun");
+    aRange.tdcMin = itRanges->getParameter<std::vector<double>>("tdcMin");
+    aRange.tdcMax = itRanges->getParameter<std::vector<double>>("tdcMax");
+    m_tdcRanges.push_back(std::move(aRange));
+  }
 
-   m_use2004OffsetConvention = 
-      params.getUntrackedParameter< bool >("use2004OffsetConvention",
-					   false ) ;
+  m_use2004OffsetConvention =
+      params.getUntrackedParameter<bool>("use2004OffsetConvention", false);
 
-   m_ecalTBInfoLabel =
-      params.getUntrackedParameter<std::string>( "EcalTBInfoLabel" ,
-						 "SimEcalTBG4Object" ) ;
+  m_ecalTBInfoLabel = params.getUntrackedParameter<std::string>(
+      "EcalTBInfoLabel", "SimEcalTBG4Object");
 
-   m_doReadout = params.getParameter<bool>( "doReadout" ) ;
+  m_doReadout = params.getParameter<bool>("doReadout");
 
-   m_theTBReadout = new EcalTBReadout( m_ecalTBInfoLabel ) ;
+  m_theTBReadout = new EcalTBReadout(m_ecalTBInfoLabel);
 
-   m_tunePhaseShift =  params.getParameter<double>( "tunePhaseShift" ) ;
+  m_tunePhaseShift = params.getParameter<double>("tunePhaseShift");
 
-   if( m_doPhaseShift )
-   {
-     iC.consumes<PEcalTBInfo>(edm::InputTag(params.getUntrackedParameter<std::string>("EcalTBInfoLabel","SimEcalTBG4Object")));
-   }
+  if (m_doPhaseShift) {
+    iC.consumes<PEcalTBInfo>(
+        edm::InputTag(params.getUntrackedParameter<std::string>(
+            "EcalTBInfoLabel", "SimEcalTBG4Object")));
+  }
 }
 
-EcalTBDigiProducer::~EcalTBDigiProducer()
-{
+EcalTBDigiProducer::~EcalTBDigiProducer() {}
+
+void EcalTBDigiProducer::initializeEvent(edm::Event const &event,
+                                         edm::EventSetup const &eventSetup) {
+  std::cout << "====****Entering EcalTBDigiProducer produce()" << std::endl;
+  edm::ESHandle<CaloGeometry> hGeometry;
+  eventSetup.get<CaloGeometryRecord>().get(hGeometry);
+  const std::vector<DetId> &theBarrelDets(
+      hGeometry->getValidDetIds(DetId::Ecal, EcalBarrel));
+
+  m_theTBReadout->setDetIds(theBarrelDets);
+
+  m_TDCproduct.reset(new EcalTBTDCRawInfo(1));
+  if (m_doPhaseShift) {
+    edm::Handle<PEcalTBInfo> theEcalTBInfo;
+    event.getByLabel(m_ecalTBInfoLabel, theEcalTBInfo);
+    m_thisPhaseShift = theEcalTBInfo->phaseShift();
+
+    DetId detId(DetId::Ecal, 1);
+    setPhaseShift(detId);
+
+    fillTBTDCRawInfo(*m_TDCproduct); // fill the TDC info in the event
+  }
+  EcalDigiProducer::initializeEvent(event, eventSetup);
 }
 
-void EcalTBDigiProducer::initializeEvent(edm::Event const& event, edm::EventSetup const& eventSetup) {
-  std::cout<<"====****Entering EcalTBDigiProducer produce()"<<std::endl ;
-   edm::ESHandle<CaloGeometry>               hGeometry ;
-   eventSetup.get<CaloGeometryRecord>().get( hGeometry ) ;
-   const std::vector<DetId>& theBarrelDets (
-      hGeometry->getValidDetIds(DetId::Ecal, EcalBarrel) ) ;
+void EcalTBDigiProducer::finalizeEvent(edm::Event &event,
+                                       const edm::EventSetup &eventSetup) {
+  m_ebDigis.reset(new EBDigiCollection);
 
-   m_theTBReadout->setDetIds( theBarrelDets ) ;
+  EcalDigiProducer::finalizeEvent(event, eventSetup);
 
-   m_TDCproduct.reset( new EcalTBTDCRawInfo(1) ) ;
-   if( m_doPhaseShift ) 
-   {
-      edm::Handle<PEcalTBInfo>             theEcalTBInfo   ;
-      event.getByLabel( m_ecalTBInfoLabel, theEcalTBInfo ) ;
-      m_thisPhaseShift = theEcalTBInfo->phaseShift() ;
+  const EBDigiCollection *barrelResult(&*m_ebDigis);
 
-      DetId detId( DetId::Ecal, 1 ) ;
-      setPhaseShift( detId ) ;
+  std::unique_ptr<EBDigiCollection> barrelReadout(new EBDigiCollection());
+  if (m_doReadout) {
+    m_theTBReadout->performReadout(event, m_theTTmap, *barrelResult,
+                                   *barrelReadout);
+  } else {
+    *barrelReadout = *barrelResult;
+  }
 
-      fillTBTDCRawInfo( *m_TDCproduct ) ; // fill the TDC info in the event    
-   }
-   EcalDigiProducer::initializeEvent( event, eventSetup ) ;
+  std::cout << "===**** EcalTBDigiProducer: number of barrel digis = "
+            << barrelReadout->size() << std::endl;
+
+  std::string const instance("simEcalUnsuppressedDigis");
+  event.put(std::move(barrelReadout), instance + m_EBdigiFinalTag);
+  event.put(std::move(m_TDCproduct), instance);
+
+  m_ebDigis.reset(); // release memory
+  m_eeDigis.reset(); // release memory
 }
 
-void EcalTBDigiProducer::finalizeEvent( edm::Event& event, const edm::EventSetup& eventSetup ) {
-   m_ebDigis.reset( new EBDigiCollection ) ;
+void EcalTBDigiProducer::setPhaseShift(const DetId &detId) {
+  const CaloSimParameters &parameters(
+      EcalDigiProducer::m_ParameterMap->simParameters(detId));
 
-   EcalDigiProducer::finalizeEvent( event, eventSetup ) ;
+  if (!parameters.syncPhase()) {
+    const int myDet(detId.subdetId());
 
-   const EBDigiCollection* barrelResult ( &*m_ebDigis ) ;
+    LogDebug("EcalDigi") << "Setting the phase shift " << m_thisPhaseShift
+                         << " and the offset " << m_tunePhaseShift
+                         << " for the subdetector " << myDet;
 
-   std::unique_ptr<EBDigiCollection> barrelReadout( new EBDigiCollection() ) ;
-   if( m_doReadout ) 
-   {
-      m_theTBReadout->performReadout( event,
-				      m_theTTmap,
-				      *barrelResult,
-				      *barrelReadout ) ;
-   }
-   else 
-   {
-      *barrelReadout = *barrelResult ;
-   }
-
-   std::cout<< "===**** EcalTBDigiProducer: number of barrel digis = "
-	    << barrelReadout->size()<<std::endl ;
-
-   std::string const instance("simEcalUnsuppressedDigis");
-   event.put(std::move(barrelReadout), instance + m_EBdigiFinalTag) ;
-   event.put(std::move(m_TDCproduct), instance) ;
-
-   m_ebDigis.reset(); // release memory
-   m_eeDigis.reset(); // release memory
+    if (myDet == 1) {
+      double passPhaseShift(m_thisPhaseShift + m_tunePhaseShift);
+      if (m_use2004OffsetConvention)
+        passPhaseShift = 1. - passPhaseShift;
+      EcalDigiProducer::m_EBResponse->setPhaseShift(passPhaseShift);
+      EcalDigiProducer::m_EEResponse->setPhaseShift(passPhaseShift);
+    }
+  }
 }
 
-void 
-EcalTBDigiProducer::setPhaseShift( const DetId& detId ) 
-{  
-   const CaloSimParameters& parameters ( 
-      EcalDigiProducer::m_ParameterMap->simParameters( detId ) ) ;
+void EcalTBDigiProducer::fillTBTDCRawInfo(EcalTBTDCRawInfo &theTBTDCRawInfo) {
+  const unsigned int thisChannel(1);
 
-   if ( !parameters.syncPhase() ) 
-   {
-      const int myDet ( detId.subdetId() ) ;
+  const unsigned int thisCount(
+      (unsigned int)(m_thisPhaseShift *
+                         (m_tdcRanges[0].tdcMax[0] - m_tdcRanges[0].tdcMin[0]) +
+                     m_tdcRanges[0].tdcMin[0]));
 
-      LogDebug("EcalDigi") << "Setting the phase shift " 
-			   << m_thisPhaseShift 
-			   << " and the offset " 
-			   << m_tunePhaseShift 
-			   << " for the subdetector " 
-			   << myDet;
+  EcalTBTDCSample theTBTDCSample(thisChannel, thisCount);
 
-      if( myDet == 1 ) 
-      {
-	 double passPhaseShift ( m_thisPhaseShift + m_tunePhaseShift ) ;
-	 if( m_use2004OffsetConvention ) passPhaseShift = 1. - passPhaseShift ;
-	 EcalDigiProducer::m_EBResponse->setPhaseShift( passPhaseShift ) ;
-	 EcalDigiProducer::m_EEResponse->setPhaseShift( passPhaseShift ) ;
-      }
-   }
+  const unsigned int sampleIndex(0);
+  theTBTDCRawInfo.setSample(sampleIndex, theTBTDCSample);
+
+  LogDebug("EcalDigi") << theTBTDCSample << "\n" << theTBTDCRawInfo;
 }
 
-void 
-EcalTBDigiProducer::fillTBTDCRawInfo( EcalTBTDCRawInfo& theTBTDCRawInfo ) 
-{
-   const unsigned int thisChannel ( 1 ) ;
-  
-   const unsigned int thisCount ( 
-      (unsigned int)( m_thisPhaseShift*( m_tdcRanges[0].tdcMax[0]
-					 - m_tdcRanges[0].tdcMin[0] ) 
-		      + m_tdcRanges[0].tdcMin[0] ) ) ;
-
-   EcalTBTDCSample theTBTDCSample ( thisChannel, thisCount ) ;
-
-   const unsigned int sampleIndex ( 0 ) ;
-   theTBTDCRawInfo.setSample( sampleIndex, theTBTDCSample ) ;
-
-   LogDebug("EcalDigi") << theTBTDCSample << "\n" << theTBTDCRawInfo ;
+void EcalTBDigiProducer::cacheEBDigis(const EBDigiCollection *ebDigiPtr) const {
+  m_ebDigis.reset(new EBDigiCollection);
+  *m_ebDigis = *ebDigiPtr;
 }
 
-void 
-EcalTBDigiProducer::cacheEBDigis( const EBDigiCollection* ebDigiPtr ) const
-{
-   m_ebDigis.reset( new EBDigiCollection ) ;
-   *m_ebDigis = *ebDigiPtr ;
-}
-
-void 
-EcalTBDigiProducer::cacheEEDigis( const EEDigiCollection* eeDigiPtr ) const
-{
-   std::cout<< "===**** EcalTBDigiProducer: number of endcap digis = "
-	    << eeDigiPtr->size()<<std::endl ;
+void EcalTBDigiProducer::cacheEEDigis(const EEDigiCollection *eeDigiPtr) const {
+  std::cout << "===**** EcalTBDigiProducer: number of endcap digis = "
+            << eeDigiPtr->size() << std::endl;
 }

--- a/SimCalorimetry/EcalTestBeam/src/SealModule.cc
+++ b/SimCalorimetry/EcalTestBeam/src/SealModule.cc
@@ -1,6 +1,5 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
 #include "SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h"
+#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
 
 DEFINE_DIGI_ACCUMULATOR(EcalTBDigiProducer);
-

--- a/SimG4Core/GFlash/interface/GFlash.h
+++ b/SimG4Core/GFlash/interface/GFlash.h
@@ -3,22 +3,19 @@
 // Joanna Weng 08.2005
 // modifed by Soon Yung Jun, Dongwook Jang
 
-#include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
+#include "SimG4Core/Physics/interface/PhysicsList.h"
+
 class GflashHistogram;
 
-class GFlash : public PhysicsList
-{
+class GFlash : public PhysicsList {
 public:
-  GFlash(const edm::ParameterSet & p);
+  GFlash(const edm::ParameterSet &p);
   ~GFlash() override;
 
 private:
-  GflashHistogram* theHisto;
+  GflashHistogram *theHisto;
   edm::ParameterSet thePar;
-
 };
 
 #endif
-

--- a/SimG4Core/GFlash/interface/GflashEMShowerModel.h
+++ b/SimG4Core/GFlash/interface/GflashEMShowerModel.h
@@ -15,44 +15,41 @@
 #ifndef GflashEMShowerModel_h
 #define GflashEMShowerModel_h
 
-#include "G4VFastSimulationModel.hh"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "G4VFastSimulationModel.hh"
 
-#include "G4TouchableHandle.hh"
 #include "G4Navigator.hh"
 #include "G4Step.hh"
+#include "G4TouchableHandle.hh"
 
 class GflashEMShowerProfile;
 class G4Region;
 
 class GflashEMShowerModel : public G4VFastSimulationModel {
 
- public:
-  
-  GflashEMShowerModel (const G4String& name, G4Envelope* env, 
-		       const edm::ParameterSet& parSet);
-  ~GflashEMShowerModel () override;  
+public:
+  GflashEMShowerModel(const G4String &name, G4Envelope *env,
+                      const edm::ParameterSet &parSet);
+  ~GflashEMShowerModel() override;
 
-  G4bool ModelTrigger(const G4FastTrack &) override; 
-  G4bool IsApplicable(const G4ParticleDefinition&) override;
-  void DoIt(const G4FastTrack&, G4FastStep&) override;
-
-private:
-  G4bool excludeDetectorRegion(const G4FastTrack& fastTrack);
-  void makeHits(const G4FastTrack& fastTrack);
-  void updateGflashStep(const G4ThreeVector& position, G4double time);
+  G4bool ModelTrigger(const G4FastTrack &) override;
+  G4bool IsApplicable(const G4ParticleDefinition &) override;
+  void DoIt(const G4FastTrack &, G4FastStep &) override;
 
 private:
+  G4bool excludeDetectorRegion(const G4FastTrack &fastTrack);
+  void makeHits(const G4FastTrack &fastTrack);
+  void updateGflashStep(const G4ThreeVector &position, G4double time);
 
+private:
   edm::ParameterSet theParSet;
 
   GflashEMShowerProfile *theProfile;
 
-  const G4Region* theRegion;
+  const G4Region *theRegion;
 
   G4Step *theGflashStep;
   G4Navigator *theGflashNavigator;
-  G4TouchableHandle  theGflashTouchableHandle;
-
+  G4TouchableHandle theGflashTouchableHandle;
 };
 #endif

--- a/SimG4Core/GFlash/interface/GflashG4Watcher.h
+++ b/SimG4Core/GFlash/interface/GflashG4Watcher.h
@@ -1,14 +1,14 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "SimG4Core/Watcher/interface/SimWatcher.h"
 #include "SimG4Core/Notification/interface/Observer.h"
+#include "SimG4Core/Watcher/interface/SimWatcher.h"
 
+#include "G4ThreeVector.hh"
+#include "globals.hh"
 #include <TFile.h>
-#include <TTree.h>
 #include <TH1F.h>
 #include <TH2F.h>
 #include <TProfile.h>
-#include "globals.hh"
-#include "G4ThreeVector.hh"
+#include <TTree.h>
 #include <string>
 
 //
@@ -19,28 +19,26 @@ class BeginOfEvent;
 class EndOfEvent;
 class G4Step;
 
-
 class GflashG4Watcher : public SimWatcher,
-  public Observer<const BeginOfEvent*>,
-  public Observer<const EndOfEvent*>,
-  public Observer<const G4Step*> {
+                        public Observer<const BeginOfEvent *>,
+                        public Observer<const EndOfEvent *>,
+                        public Observer<const G4Step *> {
 
- public:
-  GflashG4Watcher(const edm::ParameterSet& p);
+public:
+  GflashG4Watcher(const edm::ParameterSet &p);
   ~GflashG4Watcher() override;
-  
- private:
 
-  G4bool        inc_flag;
-  G4double      inc_energy;
-  G4double      out_energy;
+private:
+  G4bool inc_flag;
+  G4double inc_energy;
+  G4double out_energy;
   G4ThreeVector inc_vertex;
   G4ThreeVector inc_direction;
   G4ThreeVector inc_position;
 
-  void update(const BeginOfEvent* ) override;
-  void update(const EndOfEvent* ) override;
-  void update(const G4Step* ) override;
+  void update(const BeginOfEvent *) override;
+  void update(const EndOfEvent *) override;
+  void update(const G4Step *) override;
 
   // histograms for GflashG4Watcher
 
@@ -48,27 +46,25 @@ class GflashG4Watcher : public SimWatcher,
   double recoEnergyScaleEB_;
   double recoEnergyScaleEE_;
 
-  TFile*    histFile_;
+  TFile *histFile_;
 
-  TH1F*     em_incE;
-  TH1F*     em_vtx_rho;
-  TH1F*     em_vtx_z;
+  TH1F *em_incE;
+  TH1F *em_vtx_rho;
+  TH1F *em_vtx_z;
 
-  TH1F*     eb_ssp_rho;
-  TH1F*     eb_hit_long;
-  TH1F*     eb_hit_lat;
-  TH2F*     eb_hit_rz;
-  TH1F*     eb_hit_long_sd;
-  TH1F*     eb_hit_lat_sd;
-  TH2F*     eb_hit_rz_sd;
+  TH1F *eb_ssp_rho;
+  TH1F *eb_hit_long;
+  TH1F *eb_hit_lat;
+  TH2F *eb_hit_rz;
+  TH1F *eb_hit_long_sd;
+  TH1F *eb_hit_lat_sd;
+  TH2F *eb_hit_rz_sd;
 
-  TH1F*     ee_ssp_z;
-  TH1F*     ee_hit_long;
-  TH1F*     ee_hit_lat;
-  TH2F*     ee_hit_rz;
-  TH1F*     ee_hit_long_sd;
-  TH1F*     ee_hit_lat_sd;
-  TH2F*     ee_hit_rz_sd;
-
+  TH1F *ee_ssp_z;
+  TH1F *ee_hit_long;
+  TH1F *ee_hit_lat;
+  TH2F *ee_hit_rz;
+  TH1F *ee_hit_long_sd;
+  TH1F *ee_hit_lat_sd;
+  TH2F *ee_hit_rz_sd;
 };
-

--- a/SimG4Core/GFlash/interface/GflashHadronShowerModel.h
+++ b/SimG4Core/GFlash/interface/GflashHadronShowerModel.h
@@ -4,9 +4,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "G4VFastSimulationModel.hh"
 
-#include "G4TouchableHandle.hh"
 #include "G4Navigator.hh"
 #include "G4Step.hh"
+#include "G4TouchableHandle.hh"
 
 class GflashHadronShowerProfile;
 class GflashPiKShowerProfile;
@@ -16,31 +16,30 @@ class GflashProtonShowerProfile;
 class GflashAntiProtonShowerProfile;
 class GflashHistogram;
 
-class GflashHadronShowerModel : public G4VFastSimulationModel 
-{
+class GflashHadronShowerModel : public G4VFastSimulationModel {
 public:
   //-------------------------
   // Constructor, destructor
   //-------------------------
-  GflashHadronShowerModel (G4String modelName, G4Region* envelope, const edm::ParameterSet& parSet);
-  ~GflashHadronShowerModel () override;
+  GflashHadronShowerModel(G4String modelName, G4Region *envelope,
+                          const edm::ParameterSet &parSet);
+  ~GflashHadronShowerModel() override;
 
   //------------------------------------------------------------------------
   // Virtual methods that should be implemented for this hadron shower model
   //------------------------------------------------------------------------
 
-  G4bool IsApplicable(const G4ParticleDefinition&) override;
+  G4bool IsApplicable(const G4ParticleDefinition &) override;
   G4bool ModelTrigger(const G4FastTrack &) override;
-  void DoIt(const G4FastTrack&, G4FastStep&) override;
+  void DoIt(const G4FastTrack &, G4FastStep &) override;
 
 private:
-  G4bool isFirstInelasticInteraction(const G4FastTrack& fastTrack);
-  G4bool excludeDetectorRegion(const G4FastTrack& fastTrack);
-  void makeHits(const G4FastTrack& fastTrack);
-  void updateGflashStep(const G4ThreeVector& position, G4double time);
+  G4bool isFirstInelasticInteraction(const G4FastTrack &fastTrack);
+  G4bool excludeDetectorRegion(const G4FastTrack &fastTrack);
+  void makeHits(const G4FastTrack &fastTrack);
+  void updateGflashStep(const G4ThreeVector &position, G4double time);
 
-private:  
-
+private:
   G4bool theWatcherOn;
   edm::ParameterSet theParSet;
   GflashHadronShowerProfile *theProfile;
@@ -52,11 +51,10 @@ private:
 
   G4Step *theGflashStep;
   G4Navigator *theGflashNavigator;
-  G4TouchableHandle  theGflashTouchableHandle;
+  G4TouchableHandle theGflashTouchableHandle;
 
-  //debugging histograms
-  GflashHistogram* theHisto;
-
+  // debugging histograms
+  GflashHistogram *theHisto;
 };
 
 #endif

--- a/SimG4Core/GFlash/interface/GflashHadronWrapperProcess.h
+++ b/SimG4Core/GFlash/interface/GflashHadronWrapperProcess.h
@@ -12,28 +12,28 @@ class G4ProcessVector;
 class G4VProcess;
 
 class GflashHadronWrapperProcess : public G4WrapperProcess {
-  
-public:
 
-  GflashHadronWrapperProcess(G4String processName);	
-  //  GflashHadronWrapperProcess();	
-  
-  ~GflashHadronWrapperProcess() override;	
-  
+public:
+  GflashHadronWrapperProcess(G4String processName);
+  //  GflashHadronWrapperProcess();
+
+  ~GflashHadronWrapperProcess() override;
+
   // Override PostStepDoIt  method
-  G4VParticleChange* PostStepDoIt(const G4Track& track, const G4Step& step) override;
+  G4VParticleChange *PostStepDoIt(const G4Track &track,
+                                  const G4Step &step) override;
 
   G4String GetName() { return theProcessName; };
 
-  void Print(const G4Step& astep);
+  void Print(const G4Step &astep);
 
 private:
   G4String theProcessName;
 
-  G4VParticleChange* particleChange;
-  G4ProcessManager*  pmanager;
-  G4ProcessVector*   fProcessVector;
-  G4VProcess*        fProcess;
+  G4VParticleChange *particleChange;
+  G4ProcessManager *pmanager;
+  G4ProcessVector *fProcessVector;
+  G4VProcess *fProcess;
 };
 
 #endif

--- a/SimG4Core/GFlash/interface/ParametrisedPhysics.h
+++ b/SimG4Core/GFlash/interface/ParametrisedPhysics.h
@@ -1,27 +1,26 @@
 #ifndef SimG4Core_GFlash_ParametrisedPhysics_H
 #define SimG4Core_GFlash_ParametrisedPhysics_H
 
-#include "G4VPhysicsConstructor.hh"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "G4FastSimulationManagerProcess.hh"
+#include "G4VPhysicsConstructor.hh"
 #include "SimG4Core/GFlash/interface/GflashEMShowerModel.h"
 #include "SimG4Core/GFlash/interface/GflashHadronShowerModel.h"
-#include "G4FastSimulationManagerProcess.hh"
 
 // Joanna Weng 08.2005
 // Physics process for Gflash parameterisation
 // modified by Soon Yung Jun, Dongwook Jang
 
-class ParametrisedPhysics : public G4VPhysicsConstructor
-{
- public:
-  ParametrisedPhysics(std::string name, const edm::ParameterSet & p);
+class ParametrisedPhysics : public G4VPhysicsConstructor {
+public:
+  ParametrisedPhysics(std::string name, const edm::ParameterSet &p);
   ~ParametrisedPhysics() override;
-	
- protected:
+
+protected:
   void ConstructParticle() override;
   void ConstructProcess() override;
 
- private:
+private:
   edm::ParameterSet theParSet;
   struct ThreadPrivate {
     GflashEMShowerModel *theEMShowerModel;
@@ -29,8 +28,7 @@ class ParametrisedPhysics : public G4VPhysicsConstructor
     GflashHadronShowerModel *theHadronShowerModel;
     G4FastSimulationManagerProcess *theFastSimulationManagerProcess;
   };
-  static G4ThreadLocal ThreadPrivate* tpdata;    
+  static G4ThreadLocal ThreadPrivate *tpdata;
 };
 
 #endif
-

--- a/SimG4Core/GFlash/plugins/GFlash.cc
+++ b/SimG4Core/GFlash/plugins/GFlash.cc
@@ -1,90 +1,88 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimG4Core/GFlash/interface/GFlash.h"
 #include "SimG4Core/GFlash/interface/ParametrisedPhysics.h"
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics95msc93.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4DecayPhysics.hh"
 #include "G4EmExtraPhysics.hh"
-#include "G4IonPhysics.hh"
-#include "G4StoppingPhysics.hh"
-#include "G4HadronElasticPhysics.hh" 
-#include "G4NeutronTrackingCut.hh"
+#include "G4HadronElasticPhysics.hh"
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
+#include "G4IonPhysics.hh"
+#include "G4NeutronTrackingCut.hh"
+#include "G4StoppingPhysics.hh"
 
 #include "G4DataQuestionaire.hh"
 #include "SimGeneral/GFlash/interface/GflashHistogram.h"
 
 #include <string>
 
-GFlash::GFlash(const edm::ParameterSet & p) 
-  : PhysicsList(p), 
-    thePar(p.getParameter<edm::ParameterSet>("GFlash")) {
+GFlash::GFlash(const edm::ParameterSet &p)
+    : PhysicsList(p), thePar(p.getParameter<edm::ParameterSet>("GFlash")) {
 
   G4DataQuestionaire it(photon);
 
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
   std::string region = p.getParameter<std::string>("Region");
 
-  edm::LogInfo("PhysicsList") << "You are using the obsolete simulation engine: "
-			      << " GFlash with Flags for EM Physics "
-                              << emPhys << ", for Hadronic Physics "
-			      << hadPhys
-                              << " and tracking cut " << tracking
-                              << " with special region " << region;
+  edm::LogInfo("PhysicsList")
+      << "You are using the obsolete simulation engine: "
+      << " GFlash with Flags for EM Physics " << emPhys
+      << ", for Hadronic Physics " << hadPhys << " and tracking cut "
+      << tracking << " with special region " << region;
 
-  RegisterPhysics(new ParametrisedPhysics("parametrised",thePar)); 
+  RegisterPhysics(new ParametrisedPhysics("parametrised", thePar));
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysics95msc93("EM standard msc93",ver,region));
+    RegisterPhysics(
+        new CMSEmStandardPhysics95msc93("EM standard msc93", ver, region));
 
     // Synchroton Radiation & GN Physics
-    RegisterPhysics( new G4EmExtraPhysics(ver));
+    RegisterPhysics(new G4EmExtraPhysics(ver));
   }
 
   // Decays
-  RegisterPhysics( new G4DecayPhysics(ver) );
+  RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics( new G4HadronPhysicsQGSP_FTFP_BERT(ver));   
+    RegisterPhysics(new G4HadronPhysicsQGSP_FTFP_BERT(ver));
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      RegisterPhysics(new G4NeutronTrackingCut(ver));
     }
   }
   // singleton histogram object
-  if(thePar.getParameter<bool>("GflashHistogram")) {
+  if (thePar.getParameter<bool>("GflashHistogram")) {
     theHisto = GflashHistogram::instance();
     theHisto->setStoreFlag(true);
-    theHisto->bookHistogram(thePar.getParameter<std::string>("GflashHistogramName"));
+    theHisto->bookHistogram(
+        thePar.getParameter<std::string>("GflashHistogramName"));
   }
 }
 
 GFlash::~GFlash() {
 
-  if(thePar.getParameter<bool>("GflashHistogram")) {
-    if(theHisto) delete theHisto;
+  if (thePar.getParameter<bool>("GflashHistogram")) {
+    if (theHisto)
+      delete theHisto;
   }
-
 }
 
-//define this as a plug-in
+// define this as a plug-in
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "SimG4Core/Physics/interface/PhysicsListFactory.h"
 
-
 DEFINE_PHYSICSLIST(GFlash);
-

--- a/SimG4Core/GFlash/plugins/GflashG4Watcher.cc
+++ b/SimG4Core/GFlash/plugins/GflashG4Watcher.cc
@@ -1,10 +1,10 @@
-#include "G4Step.hh"
 #include "G4Electron.hh"
 #include "G4Positron.hh"
-#include "G4VProcess.hh"
-#include "G4SDManager.hh"
 #include "G4PrimaryParticle.hh"
 #include "G4PrimaryVertex.hh"
+#include "G4SDManager.hh"
+#include "G4Step.hh"
+#include "G4VProcess.hh"
 
 #include "SimG4CMS/Calo/interface/CaloG4HitCollection.h"
 #include "SimG4Core/Notification/interface/BeginOfEvent.h"
@@ -18,41 +18,84 @@ using namespace CLHEP;
 
 // constructors and destructor
 //
-GflashG4Watcher::GflashG4Watcher(const edm::ParameterSet& p) {
+GflashG4Watcher::GflashG4Watcher(const edm::ParameterSet &p) {
 
   edm::ParameterSet myP = p.getParameter<edm::ParameterSet>("GflashG4Watcher");
   histFileName_ = myP.getParameter<std::string>("histFileName");
   recoEnergyScaleEB_ = myP.getParameter<double>("recoEnergyScaleEB");
   recoEnergyScaleEE_ = myP.getParameter<double>("recoEnergyScaleEE");
 
-
-  histFile_ = new TFile(histFileName_.c_str(),"RECREATE");
+  histFile_ = new TFile(histFileName_.c_str(), "RECREATE");
 
   TH1::AddDirectory(kTRUE);
 
+  em_incE =
+      new TH1F("em_incE", "Incoming energy at Ecal;E (GeV);Number of Events",
+               500, 0.0, 500.0);
+  em_vtx_rho =
+      new TH1F("em_vtx_rho", "vertex position;#rho (cm);Number of Events", 100,
+               0.0, 10.0);
+  em_vtx_z = new TH1F("em_vtx_z", "vertex position;z (cm);Number of Events",
+                      100, -10.0, 10.0);
 
-  em_incE        = new TH1F("em_incE","Incoming energy at Ecal;E (GeV);Number of Events",500,0.0,500.0);
-  em_vtx_rho     = new TH1F("em_vtx_rho","vertex position;#rho (cm);Number of Events",100,0.0,10.0);
-  em_vtx_z       = new TH1F("em_vtx_z","vertex position;z (cm);Number of Events",100,-10.0,10.0);
+  eb_ssp_rho = new TH1F("eb_ssp_rho",
+                        "Shower starting position;#rho (cm);Number of Events",
+                        200, 0.0, 200.0);
+  eb_hit_long = new TH1F("eb_hit_long",
+                         "longitudinal hit position;shower depth (cm);Number "
+                         "of energy weighted hits",
+                         400, 0.0, 200.0);
+  eb_hit_lat =
+      new TH1F("eb_hit_lat",
+               "lateral hit position;arm (cm);Number of energy weighted hits",
+               100, 0.0, 5.0);
+  eb_hit_rz = new TH2F(
+      "eb_hit_rz",
+      "hit position along the shower direction;shower depth (cm);arm (cm)", 400,
+      0.0, 200.0, 100, 0.0, 5.0);
+  eb_hit_long_sd =
+      new TH1F("eb_hit_long_sd",
+               "longitudinal hit position in Sensitive Detector;shower depth "
+               "(cm);Number of energy weighted hits",
+               400, 0.0, 200.0);
+  eb_hit_lat_sd = new TH1F("eb_hit_lat_sd",
+                           "lateral hit position in Sensitive Detector;arm "
+                           "(cm);Number of energy weighted hits",
+                           100, 0.0, 5.0);
+  eb_hit_rz_sd = new TH2F("eb_hit_rz_sd",
+                          "hit position along the shower direction in "
+                          "Sensitive Detector;shower depth (cm);arm (cm)",
+                          400, 0.0, 200.0, 100, 0.0, 5.0);
 
-  eb_ssp_rho     = new TH1F("eb_ssp_rho","Shower starting position;#rho (cm);Number of Events",200,0.0,200.0);
-  eb_hit_long    = new TH1F("eb_hit_long","longitudinal hit position;shower depth (cm);Number of energy weighted hits",400,0.0,200.0);
-  eb_hit_lat     = new TH1F("eb_hit_lat","lateral hit position;arm (cm);Number of energy weighted hits",100,0.0,5.0);
-  eb_hit_rz      = new TH2F("eb_hit_rz","hit position along the shower direction;shower depth (cm);arm (cm)",400,0.0,200.0,100,0.0,5.0);
-  eb_hit_long_sd = new TH1F("eb_hit_long_sd","longitudinal hit position in Sensitive Detector;shower depth (cm);Number of energy weighted hits",400,0.0,200.0);
-  eb_hit_lat_sd  = new TH1F("eb_hit_lat_sd","lateral hit position in Sensitive Detector;arm (cm);Number of energy weighted hits",100,0.0,5.0);
-  eb_hit_rz_sd   = new TH2F("eb_hit_rz_sd","hit position along the shower direction in Sensitive Detector;shower depth (cm);arm (cm)",400,0.0,200.0,100,0.0,5.0);
-
-  ee_ssp_z       = new TH1F("ee_ssp_z","Shower starting position;z (cm);Number of Events",800,-400.0,400.0);
-  ee_hit_long    = new TH1F("ee_hit_long","longitudinal hit position;shower depth (cm);Number of energy weighted hits",800,0.0,400.0);
-  ee_hit_lat     = new TH1F("ee_hit_lat","lateral hit position;arm (cm);Number of energy weighted hits",100,0.0,5.0);
-  ee_hit_rz      = new TH2F("ee_hit_rz","hit position along the shower direction;shower depth (cm);arm (cm)",800,0.0,400.0,100,0.0,5.0);
-  ee_hit_long_sd = new TH1F("ee_hit_long_sd","longitudinal hit position in Sensitive Detector;shower depth (cm);Number of energy weighted hits",800,0.0,400.0);
-  ee_hit_lat_sd  = new TH1F("ee_hit_lat_sd","lateral hit position in Sensitive Detector;arm (cm);Number of energy weighted hits",100,0.0,5.0);
-  ee_hit_rz_sd   = new TH2F("ee_hit_rz_sd","hit position along the shower direction in Sensitive Detector;shower depth (cm);arm (cm)",800,0.0,400.0,100,0.0,5.0);
-
+  ee_ssp_z =
+      new TH1F("ee_ssp_z", "Shower starting position;z (cm);Number of Events",
+               800, -400.0, 400.0);
+  ee_hit_long = new TH1F("ee_hit_long",
+                         "longitudinal hit position;shower depth (cm);Number "
+                         "of energy weighted hits",
+                         800, 0.0, 400.0);
+  ee_hit_lat =
+      new TH1F("ee_hit_lat",
+               "lateral hit position;arm (cm);Number of energy weighted hits",
+               100, 0.0, 5.0);
+  ee_hit_rz = new TH2F(
+      "ee_hit_rz",
+      "hit position along the shower direction;shower depth (cm);arm (cm)", 800,
+      0.0, 400.0, 100, 0.0, 5.0);
+  ee_hit_long_sd =
+      new TH1F("ee_hit_long_sd",
+               "longitudinal hit position in Sensitive Detector;shower depth "
+               "(cm);Number of energy weighted hits",
+               800, 0.0, 400.0);
+  ee_hit_lat_sd = new TH1F("ee_hit_lat_sd",
+                           "lateral hit position in Sensitive Detector;arm "
+                           "(cm);Number of energy weighted hits",
+                           100, 0.0, 5.0);
+  ee_hit_rz_sd = new TH2F("ee_hit_rz_sd",
+                          "hit position along the shower direction in "
+                          "Sensitive Detector;shower depth (cm);arm (cm)",
+                          800, 0.0, 400.0, 100, 0.0, 5.0);
 }
-
 
 GflashG4Watcher::~GflashG4Watcher() {
   histFile_->cd();
@@ -60,38 +103,38 @@ GflashG4Watcher::~GflashG4Watcher() {
   histFile_->Close();
 }
 
-
-void GflashG4Watcher::update(const BeginOfEvent* g4Event){
+void GflashG4Watcher::update(const BeginOfEvent *g4Event) {
 
   inc_flag = false;
 
-  const G4Event* evt = (*g4Event)();
+  const G4Event *evt = (*g4Event)();
   inc_vertex = evt->GetPrimaryVertex(0)->GetPosition();
   inc_position = inc_vertex;
   inc_direction = evt->GetPrimaryVertex(0)->GetPrimary(0)->GetMomentum().unit();
   inc_energy = evt->GetPrimaryVertex(0)->GetPrimary(0)->GetMomentum().mag();
   out_energy = 0;
 
-  em_incE->Fill(inc_energy/GeV);
-  em_vtx_rho->Fill(inc_vertex.rho()/cm);
-  em_vtx_z->Fill(inc_vertex.z()/cm);
+  em_incE->Fill(inc_energy / GeV);
+  em_vtx_rho->Fill(inc_vertex.rho() / cm);
+  em_vtx_z->Fill(inc_vertex.z() / cm);
 
-  if(std::abs(inc_direction.eta()) < 1.5) eb_ssp_rho->Fill(inc_position.rho()/cm);
-  else ee_ssp_z->Fill(inc_position.z()/cm);
-
+  if (std::abs(inc_direction.eta()) < 1.5)
+    eb_ssp_rho->Fill(inc_position.rho() / cm);
+  else
+    ee_ssp_z->Fill(inc_position.z() / cm);
 }
 
+void GflashG4Watcher::update(const EndOfEvent *g4Event) {}
 
-void GflashG4Watcher::update(const EndOfEvent* g4Event){ }
+void GflashG4Watcher::update(const G4Step *aStep) {
 
-
-void GflashG4Watcher::update(const G4Step* aStep){
-
-  if(aStep == nullptr) return;
+  if (aStep == nullptr)
+    return;
 
   double hitEnergy = aStep->GetTotalEnergyDeposit();
 
-  if(hitEnergy < 1.0e-6) return;
+  if (hitEnergy < 1.0e-6)
+    return;
 
   bool inEB = std::abs(inc_direction.eta()) < 1.5;
 
@@ -104,39 +147,34 @@ void GflashG4Watcher::update(const G4Step* aStep){
   double diff_z = std::abs(diff.mag() * std::cos(angle));
   double diff_r = std::abs(diff.mag() * std::sin(angle));
 
-  G4VSensitiveDetector* aSensitive = aStep->GetPreStepPoint()->GetSensitiveDetector();
+  G4VSensitiveDetector *aSensitive =
+      aStep->GetPreStepPoint()->GetSensitiveDetector();
 
-  if(inEB){ // showers in barrel crystals
+  if (inEB) { // showers in barrel crystals
     hitEnergy *= recoEnergyScaleEB_;
-    eb_hit_long->Fill(diff_z/cm,hitEnergy/GeV);
-    eb_hit_lat->Fill(diff_r/cm,hitEnergy/GeV);
-    eb_hit_rz->Fill(diff_z/cm,diff_r/cm,hitEnergy/GeV);
-    if(aSensitive){
-      eb_hit_long_sd->Fill(diff_z/cm,hitEnergy/GeV);
-      eb_hit_lat_sd->Fill(diff_r/cm,hitEnergy/GeV);
-      eb_hit_rz_sd->Fill(diff_z/cm,diff_r/cm,hitEnergy/GeV);
+    eb_hit_long->Fill(diff_z / cm, hitEnergy / GeV);
+    eb_hit_lat->Fill(diff_r / cm, hitEnergy / GeV);
+    eb_hit_rz->Fill(diff_z / cm, diff_r / cm, hitEnergy / GeV);
+    if (aSensitive) {
+      eb_hit_long_sd->Fill(diff_z / cm, hitEnergy / GeV);
+      eb_hit_lat_sd->Fill(diff_r / cm, hitEnergy / GeV);
+      eb_hit_rz_sd->Fill(diff_z / cm, diff_r / cm, hitEnergy / GeV);
     }
-  }
-  else{ // showers in endcap crystals
+  } else { // showers in endcap crystals
     hitEnergy *= recoEnergyScaleEE_;
-    ee_hit_long->Fill(diff_z/cm,hitEnergy/GeV);
-    ee_hit_lat->Fill(diff_r/cm,hitEnergy/GeV);
-    ee_hit_rz->Fill(diff_z/cm,diff_r/cm,hitEnergy/GeV);
-    if(aSensitive){
-      ee_hit_long_sd->Fill(diff_z/cm,hitEnergy/GeV);
-      ee_hit_lat_sd->Fill(diff_r/cm,hitEnergy/GeV);
-      ee_hit_rz_sd->Fill(diff_z/cm,diff_r/cm,hitEnergy/GeV);
+    ee_hit_long->Fill(diff_z / cm, hitEnergy / GeV);
+    ee_hit_lat->Fill(diff_r / cm, hitEnergy / GeV);
+    ee_hit_rz->Fill(diff_z / cm, diff_r / cm, hitEnergy / GeV);
+    if (aSensitive) {
+      ee_hit_long_sd->Fill(diff_z / cm, hitEnergy / GeV);
+      ee_hit_lat_sd->Fill(diff_r / cm, hitEnergy / GeV);
+      ee_hit_rz_sd->Fill(diff_z / cm, diff_r / cm, hitEnergy / GeV);
     }
   }
-
-
 }
 
-
-//define this as a plug-in
-#include "SimG4Core/Watcher/interface/SimWatcherFactory.h"
+// define this as a plug-in
 #include "FWCore/PluginManager/interface/ModuleDef.h"
-
+#include "SimG4Core/Watcher/interface/SimWatcherFactory.h"
 
 DEFINE_SIMWATCHER(GflashG4Watcher);
-

--- a/SimG4Core/GFlash/src/GflashEMShowerModel.cc
+++ b/SimG4Core/GFlash/src/GflashEMShowerModel.cc
@@ -1,5 +1,5 @@
 //
-// initial setup : E.Barberio & Joanna Weng 
+// initial setup : E.Barberio & Joanna Weng
 // big changes : Soon Jun & Dongwook Jang
 //
 #include "SimG4Core/Application/interface/SteppingAction.h"
@@ -9,30 +9,29 @@
 #include "SimGeneral/GFlash/interface/GflashHit.h"
 
 #include "G4Electron.hh"
-#include "G4Positron.hh"
-#include "G4VProcess.hh"
-#include "G4VPhysicalVolume.hh" 
-#include "G4LogicalVolume.hh"
-#include "G4TransportationManager.hh"
 #include "G4EventManager.hh"
 #include "G4FastSimulationManager.hh"
+#include "G4LogicalVolume.hh"
+#include "G4Positron.hh"
 #include "G4TouchableHandle.hh"
+#include "G4TransportationManager.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4VProcess.hh"
 #include "G4VSensitiveDetector.hh"
 
 using namespace CLHEP;
 
-GflashEMShowerModel::GflashEMShowerModel(const G4String& modelName, 
-					 G4Envelope* envelope, 
-					 const edm::ParameterSet& parSet)
-  : G4VFastSimulationModel(modelName, envelope), theParSet(parSet) {
+GflashEMShowerModel::GflashEMShowerModel(const G4String &modelName,
+                                         G4Envelope *envelope,
+                                         const edm::ParameterSet &parSet)
+    : G4VFastSimulationModel(modelName, envelope), theParSet(parSet) {
 
   theProfile = new GflashEMShowerProfile(parSet);
-  theRegion  = const_cast<const G4Region*>(envelope); 
+  theRegion = const_cast<const G4Region *>(envelope);
 
   theGflashStep = new G4Step();
   theGflashTouchableHandle = new G4TouchableHistory();
   theGflashNavigator = new G4Navigator();
-
 }
 
 // -----------------------------------------------------------------------------------
@@ -43,111 +42,143 @@ GflashEMShowerModel::~GflashEMShowerModel() {
   delete theGflashStep;
 }
 
-G4bool GflashEMShowerModel::IsApplicable(const G4ParticleDefinition& particleType) { 
+G4bool
+GflashEMShowerModel::IsApplicable(const G4ParticleDefinition &particleType) {
 
-  return ( &particleType == G4Electron::ElectronDefinition() ||
-	   &particleType == G4Positron::PositronDefinition() ); 
-
+  return (&particleType == G4Electron::ElectronDefinition() ||
+          &particleType == G4Positron::PositronDefinition());
 }
 
 // -----------------------------------------------------------------------------------
-G4bool GflashEMShowerModel::ModelTrigger(const G4FastTrack & fastTrack ) {
+G4bool GflashEMShowerModel::ModelTrigger(const G4FastTrack &fastTrack) {
 
   // Mininum energy cutoff to parameterize
-  if(fastTrack.GetPrimaryTrack()->GetKineticEnergy() < GeV) { return false; }
-  if(excludeDetectorRegion(fastTrack)) { return false; }
+  if (fastTrack.GetPrimaryTrack()->GetKineticEnergy() < GeV) {
+    return false;
+  }
+  if (excludeDetectorRegion(fastTrack)) {
+    return false;
+  }
 
-  // This will be changed accordingly when the way 
+  // This will be changed accordingly when the way
   // dealing with CaloRegion changes later.
-  G4VPhysicalVolume* pCurrentVolume = (fastTrack.GetPrimaryTrack()->GetTouchable())->GetVolume();
-  if( pCurrentVolume == nullptr) { return false; }
+  G4VPhysicalVolume *pCurrentVolume =
+      (fastTrack.GetPrimaryTrack()->GetTouchable())->GetVolume();
+  if (pCurrentVolume == nullptr) {
+    return false;
+  }
 
-  G4LogicalVolume* lv = pCurrentVolume->GetLogicalVolume();
-  if(lv->GetRegion() != theRegion) { return false; }
+  G4LogicalVolume *lv = pCurrentVolume->GetLogicalVolume();
+  if (lv->GetRegion() != theRegion) {
+    return false;
+  }
   return true;
 }
 
 // -----------------------------------------------------------------------------------
-void GflashEMShowerModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastStep) {
+void GflashEMShowerModel::DoIt(const G4FastTrack &fastTrack,
+                               G4FastStep &fastStep) {
 
   // Kill the parameterised particle:
   fastStep.KillPrimaryTrack();
   fastStep.ProposePrimaryTrackPathLength(0.0);
 
-  //input variables for GflashEMShowerProfile with showerType = 1,5 (shower starts inside crystals)
-  G4double energy = fastTrack.GetPrimaryTrack()->GetKineticEnergy()/GeV;
-  G4double globalTime = fastTrack.GetPrimaryTrack()->GetStep()->GetPostStepPoint()->GetGlobalTime();
-  G4double charge = fastTrack.GetPrimaryTrack()->GetStep()->GetPreStepPoint()->GetCharge();
+  // input variables for GflashEMShowerProfile with showerType = 1,5 (shower
+  // starts inside crystals)
+  G4double energy = fastTrack.GetPrimaryTrack()->GetKineticEnergy() / GeV;
+  G4double globalTime = fastTrack.GetPrimaryTrack()
+                            ->GetStep()
+                            ->GetPostStepPoint()
+                            ->GetGlobalTime();
+  G4double charge =
+      fastTrack.GetPrimaryTrack()->GetStep()->GetPreStepPoint()->GetCharge();
   G4ThreeVector position = fastTrack.GetPrimaryTrack()->GetPosition() / cm;
-  G4ThreeVector momentum = fastTrack.GetPrimaryTrack()->GetMomentum()/GeV;
+  G4ThreeVector momentum = fastTrack.GetPrimaryTrack()->GetMomentum() / GeV;
   G4int showerType = Gflash::findShowerType(position);
 
   // Do actual parameterization. The result of parameterization is gflashHitList
-  theProfile->initialize(showerType,energy,globalTime,charge,position,momentum);
+  theProfile->initialize(showerType, energy, globalTime, charge, position,
+                         momentum);
   theProfile->parameterization();
 
-  //make hits
+  // make hits
   makeHits(fastTrack);
 }
 
-void GflashEMShowerModel::makeHits(const G4FastTrack& fastTrack) {
+void GflashEMShowerModel::makeHits(const G4FastTrack &fastTrack) {
 
-  std::vector<GflashHit>& gflashHitList = theProfile->getGflashHitList();
+  std::vector<GflashHit> &gflashHitList = theProfile->getGflashHitList();
 
-  theGflashStep->SetTrack(const_cast<G4Track*>(fastTrack.GetPrimaryTrack()));
+  theGflashStep->SetTrack(const_cast<G4Track *>(fastTrack.GetPrimaryTrack()));
 
-  theGflashStep->GetPostStepPoint()->SetProcessDefinedStep(const_cast<G4VProcess*>
-    (fastTrack.GetPrimaryTrack()->GetStep()->GetPostStepPoint()->GetProcessDefinedStep()));
-  theGflashNavigator->SetWorldVolume(G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume());
+  theGflashStep->GetPostStepPoint()->SetProcessDefinedStep(
+      const_cast<G4VProcess *>(fastTrack.GetPrimaryTrack()
+                                   ->GetStep()
+                                   ->GetPostStepPoint()
+                                   ->GetProcessDefinedStep()));
+  theGflashNavigator->SetWorldVolume(
+      G4TransportationManager::GetTransportationManager()
+          ->GetNavigatorForTracking()
+          ->GetWorldVolume());
 
-  std::vector<GflashHit>::const_iterator spotIter    = gflashHitList.begin();
+  std::vector<GflashHit>::const_iterator spotIter = gflashHitList.begin();
   std::vector<GflashHit>::const_iterator spotIterEnd = gflashHitList.end();
 
-  for( ; spotIter != spotIterEnd; spotIter++){
+  for (; spotIter != spotIterEnd; spotIter++) {
 
-      //put touchable for each hit so that touchable history keeps track of each step.
-      theGflashNavigator->LocateGlobalPointAndUpdateTouchableHandle(spotIter->getPosition(),G4ThreeVector(0,0,0),
-								    theGflashTouchableHandle, false);
-      updateGflashStep(spotIter->getPosition(),spotIter->getTime());
+    // put touchable for each hit so that touchable history keeps track of each
+    // step.
+    theGflashNavigator->LocateGlobalPointAndUpdateTouchableHandle(
+        spotIter->getPosition(), G4ThreeVector(0, 0, 0),
+        theGflashTouchableHandle, false);
+    updateGflashStep(spotIter->getPosition(), spotIter->getTime());
 
-      // Send G4Step information to Hit/Digi if the volume is sensitive
-      // Copied from G4SteppingManager.cc
-    
-      G4VPhysicalVolume* aCurrentVolume = theGflashStep->GetPreStepPoint()->GetPhysicalVolume();
-      if( aCurrentVolume == nullptr ) continue;
+    // Send G4Step information to Hit/Digi if the volume is sensitive
+    // Copied from G4SteppingManager.cc
 
-      G4LogicalVolume* lv = aCurrentVolume->GetLogicalVolume();
-      if(lv->GetRegion() != theRegion) continue;
+    G4VPhysicalVolume *aCurrentVolume =
+        theGflashStep->GetPreStepPoint()->GetPhysicalVolume();
+    if (aCurrentVolume == nullptr)
+      continue;
 
-      theGflashStep->GetPreStepPoint()->SetSensitiveDetector(aCurrentVolume->GetLogicalVolume()->GetSensitiveDetector());
-      G4VSensitiveDetector* aSensitive = theGflashStep->GetPreStepPoint()->GetSensitiveDetector();
-      
-      if( aSensitive == nullptr ) continue;
+    G4LogicalVolume *lv = aCurrentVolume->GetLogicalVolume();
+    if (lv->GetRegion() != theRegion)
+      continue;
 
-      theGflashStep->SetTotalEnergyDeposit(spotIter->getEnergy());
-      aSensitive->Hit(theGflashStep);
+    theGflashStep->GetPreStepPoint()->SetSensitiveDetector(
+        aCurrentVolume->GetLogicalVolume()->GetSensitiveDetector());
+    G4VSensitiveDetector *aSensitive =
+        theGflashStep->GetPreStepPoint()->GetSensitiveDetector();
+
+    if (aSensitive == nullptr)
+      continue;
+
+    theGflashStep->SetTotalEnergyDeposit(spotIter->getEnergy());
+    aSensitive->Hit(theGflashStep);
   }
-
 }
 
-void GflashEMShowerModel::updateGflashStep(const G4ThreeVector& spotPosition, 
-					   G4double timeGlobal)
-{
+void GflashEMShowerModel::updateGflashStep(const G4ThreeVector &spotPosition,
+                                           G4double timeGlobal) {
   theGflashStep->GetPostStepPoint()->SetGlobalTime(timeGlobal);
   theGflashStep->GetPreStepPoint()->SetPosition(spotPosition);
   theGflashStep->GetPostStepPoint()->SetPosition(spotPosition);
-  theGflashStep->GetPreStepPoint()->SetTouchableHandle(theGflashTouchableHandle);
+  theGflashStep->GetPreStepPoint()->SetTouchableHandle(
+      theGflashTouchableHandle);
 }
 
 // -----------------------------------------------------------------------------------
-G4bool GflashEMShowerModel::excludeDetectorRegion(const G4FastTrack& fastTrack) {
+G4bool
+GflashEMShowerModel::excludeDetectorRegion(const G4FastTrack &fastTrack) {
 
-  G4bool isExcluded=false;
+  G4bool isExcluded = false;
 
-  //exclude regions where geometry are complicated
-  //+- one supermodule around the EB/EE boundary: 1.479 +- 0.0174*5 
-  G4double eta =   fastTrack.GetPrimaryTrack()->GetPosition().pseudoRapidity() ;
-  if(std::fabs(eta) > 1.392 && std::fabs(eta) < 1.566) { return true; }
+  // exclude regions where geometry are complicated
+  //+- one supermodule around the EB/EE boundary: 1.479 +- 0.0174*5
+  G4double eta = fastTrack.GetPrimaryTrack()->GetPosition().pseudoRapidity();
+  if (std::fabs(eta) > 1.392 && std::fabs(eta) < 1.566) {
+    return true;
+  }
 
   return isExcluded;
 }
@@ -169,7 +200,8 @@ G4int GflashEMShowerModel::findShowerType(const G4FastTrack& fastTrack)
   // showerType =  6 : ssp after  EFRY before HE
   // showerType =  7 : ssp inside HE
 
-  G4TouchableHistory* touch = (G4TouchableHistory*)(fastTrack.GetPrimaryTrack()->GetTouchable());
+  G4TouchableHistory* touch =
+(G4TouchableHistory*)(fastTrack.GetPrimaryTrack()->GetTouchable());
   G4LogicalVolume* lv = touch->GetVolume()->GetLogicalVolume();
 
   std::size_t pos1  = lv->GetName().find("EBRY");
@@ -187,13 +219,14 @@ G4int GflashEMShowerModel::findShowerType(const G4FastTrack& fastTrack)
 
     G4double posRho = position.getRho();
 
-    if(pos1 != std::string::npos || pos11 != std::string::npos || pos12 != std::string::npos ) {
-      showerType = 1;
+    if(pos1 != std::string::npos || pos11 != std::string::npos || pos12 !=
+std::string::npos ) { showerType = 1;
     }
     else {
       if(kCalor == Gflash::kESPM) {
         showerType = 2;
-        if( posRho < Gflash::Rmin[Gflash::kESPM]+ Gflash::ROffCrystalEB ) showerType = 0;
+        if( posRho < Gflash::Rmin[Gflash::kESPM]+ Gflash::ROffCrystalEB )
+showerType = 0;
       }
       else showerType = 3;
     }
@@ -207,7 +240,8 @@ G4int GflashEMShowerModel::findShowerType(const G4FastTrack& fastTrack)
     else {
       if(kCalor == Gflash::kENCA) {
         showerType = 6;
-        if(fabs(position.getZ()) < Gflash::Zmin[Gflash::kENCA] + Gflash::ZOffCrystalEE) showerType = 4;
+        if(fabs(position.getZ()) < Gflash::Zmin[Gflash::kENCA] +
+Gflash::ZOffCrystalEE) showerType = 4;
       }
       else showerType = 7;
     }

--- a/SimG4Core/GFlash/src/GflashHadronShowerModel.cc
+++ b/SimG4Core/GFlash/src/GflashHadronShowerModel.cc
@@ -1,40 +1,40 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "SimG4Core/GFlash/interface/GflashHadronShowerModel.h"
 #include "SimG4Core/Application/interface/SteppingAction.h"
+#include "SimG4Core/GFlash/interface/GflashHadronShowerModel.h"
 
-#include "SimGeneral/GFlash/interface/GflashHadronShowerProfile.h"
-#include "SimGeneral/GFlash/interface/GflashPiKShowerProfile.h"
-#include "SimGeneral/GFlash/interface/GflashKaonPlusShowerProfile.h"
-#include "SimGeneral/GFlash/interface/GflashKaonMinusShowerProfile.h"
-#include "SimGeneral/GFlash/interface/GflashProtonShowerProfile.h"
 #include "SimGeneral/GFlash/interface/GflashAntiProtonShowerProfile.h"
-#include "SimGeneral/GFlash/interface/GflashNameSpace.h"
+#include "SimGeneral/GFlash/interface/GflashHadronShowerProfile.h"
 #include "SimGeneral/GFlash/interface/GflashHistogram.h"
 #include "SimGeneral/GFlash/interface/GflashHit.h"
+#include "SimGeneral/GFlash/interface/GflashKaonMinusShowerProfile.h"
+#include "SimGeneral/GFlash/interface/GflashKaonPlusShowerProfile.h"
+#include "SimGeneral/GFlash/interface/GflashNameSpace.h"
+#include "SimGeneral/GFlash/interface/GflashPiKShowerProfile.h"
+#include "SimGeneral/GFlash/interface/GflashProtonShowerProfile.h"
 
-#include "G4FastSimulationManager.hh"
-#include "G4TransportationManager.hh"
-#include "G4TouchableHandle.hh"
-#include "G4VSensitiveDetector.hh"
-#include "G4VPhysicalVolume.hh"
 #include "G4EventManager.hh"
+#include "G4FastSimulationManager.hh"
+#include "G4TouchableHandle.hh"
+#include "G4TransportationManager.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4VSensitiveDetector.hh"
 
-#include "G4PionMinus.hh"
-#include "G4PionPlus.hh"
+#include "G4AntiProton.hh"
 #include "G4KaonMinus.hh"
 #include "G4KaonPlus.hh"
+#include "G4PionMinus.hh"
+#include "G4PionPlus.hh"
 #include "G4Proton.hh"
-#include "G4AntiProton.hh"
 #include "G4VProcess.hh"
 
 #include <vector>
 
 using namespace CLHEP;
 
-GflashHadronShowerModel::GflashHadronShowerModel(G4String modelName, G4Region* envelope, const edm::ParameterSet& parSet)
-  : G4VFastSimulationModel(modelName, envelope), theParSet(parSet)
-{
+GflashHadronShowerModel::GflashHadronShowerModel(
+    G4String modelName, G4Region *envelope, const edm::ParameterSet &parSet)
+    : G4VFastSimulationModel(modelName, envelope), theParSet(parSet) {
   theWatcherOn = parSet.getParameter<bool>("watcherOn");
 
   theProfile = new GflashHadronShowerProfile(parSet);
@@ -48,250 +48,301 @@ GflashHadronShowerModel::GflashHadronShowerModel(G4String modelName, G4Region* e
   theGflashStep = new G4Step();
   theGflashTouchableHandle = new G4TouchableHistory();
   theGflashNavigator = new G4Navigator();
-
 }
 
-GflashHadronShowerModel::~GflashHadronShowerModel()
-{
-  if(theProfile) delete theProfile;
-  if(theGflashStep) delete theGflashStep;
+GflashHadronShowerModel::~GflashHadronShowerModel() {
+  if (theProfile)
+    delete theProfile;
+  if (theGflashStep)
+    delete theGflashStep;
 }
 
-G4bool GflashHadronShowerModel::IsApplicable(const G4ParticleDefinition& particleType)
-{
-  return 
-    &particleType == G4PionMinus::PionMinusDefinition() ||
-    &particleType == G4PionPlus::PionPlusDefinition() ||
-    &particleType == G4KaonMinus::KaonMinusDefinition() ||
-    &particleType == G4KaonPlus::KaonPlusDefinition() ||
-    &particleType == G4AntiProton::AntiProtonDefinition() ||
-    &particleType == G4Proton::ProtonDefinition() ;
+G4bool GflashHadronShowerModel::IsApplicable(
+    const G4ParticleDefinition &particleType) {
+  return &particleType == G4PionMinus::PionMinusDefinition() ||
+         &particleType == G4PionPlus::PionPlusDefinition() ||
+         &particleType == G4KaonMinus::KaonMinusDefinition() ||
+         &particleType == G4KaonPlus::KaonPlusDefinition() ||
+         &particleType == G4AntiProton::AntiProtonDefinition() ||
+         &particleType == G4Proton::ProtonDefinition();
 }
 
-G4bool GflashHadronShowerModel::ModelTrigger(const G4FastTrack& fastTrack)
-{
+G4bool GflashHadronShowerModel::ModelTrigger(const G4FastTrack &fastTrack) {
   // ModelTrigger returns false for Gflash Hadronic Shower Model if it is not
-  // tested from the corresponding wrapper process, GflashHadronWrapperProcess. 
+  // tested from the corresponding wrapper process, GflashHadronWrapperProcess.
   // Temporarily the track status is set to fPostponeToNextEvent at the wrapper
-  // process before ModelTrigger is really tested for the second time through 
-  // PostStepGPIL of enviaged parameterization processes.  The better 
+  // process before ModelTrigger is really tested for the second time through
+  // PostStepGPIL of enviaged parameterization processes.  The better
   // implmentation may be using via G4VUserTrackInformation of each track, which
   // requires to modify a geant source code of stepping (G4SteppingManager2)
 
   G4bool trigger = false;
 
   // mininum energy cutoff to parameterize
-  if (fastTrack.GetPrimaryTrack()->GetKineticEnergy()/GeV < Gflash::energyCutOff) return trigger;
+  if (fastTrack.GetPrimaryTrack()->GetKineticEnergy() / GeV <
+      Gflash::energyCutOff)
+    return trigger;
 
-  // check whether this is called from the normal GPIL or the wrapper process GPIL
-  if(fastTrack.GetPrimaryTrack()->GetTrackStatus() == fPostponeToNextEvent ) {
+  // check whether this is called from the normal GPIL or the wrapper process
+  // GPIL
+  if (fastTrack.GetPrimaryTrack()->GetTrackStatus() == fPostponeToNextEvent) {
 
     // Shower pameterization start at the first inelastic interaction point
-    G4bool isInelastic  = isFirstInelasticInteraction(fastTrack);
-    
+    G4bool isInelastic = isFirstInelasticInteraction(fastTrack);
+
     // Other conditions
-    if(isInelastic) {
+    if (isInelastic) {
       trigger = (!excludeDetectorRegion(fastTrack));
     }
   }
 
   return trigger;
-
 }
 
-void GflashHadronShowerModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastStep)
-{
+void GflashHadronShowerModel::DoIt(const G4FastTrack &fastTrack,
+                                   G4FastStep &fastStep) {
   // kill the particle
   fastStep.KillPrimaryTrack();
   fastStep.ProposePrimaryTrackPathLength(0.0);
 
   // parameterize energy depostion by the particle type
-  G4ParticleDefinition* particleType = fastTrack.GetPrimaryTrack()->GetDefinition();
-  
-  theProfile = thePiKProfile;
-  if(particleType == G4KaonMinus::KaonMinusDefinition()) theProfile = theKaonMinusProfile;
-  else if(particleType == G4KaonPlus::KaonPlusDefinition()) theProfile = theKaonPlusProfile;
-  else if(particleType == G4AntiProton::AntiProtonDefinition()) theProfile = theAntiProtonProfile;
-  else if(particleType == G4Proton::ProtonDefinition()) theProfile = theProtonProfile;
+  G4ParticleDefinition *particleType =
+      fastTrack.GetPrimaryTrack()->GetDefinition();
 
-  //input variables for GflashHadronShowerProfile
-  G4double energy = fastTrack.GetPrimaryTrack()->GetKineticEnergy()/GeV;
-  G4double globalTime = fastTrack.GetPrimaryTrack()->GetStep()->GetPostStepPoint()->GetGlobalTime();
-  G4double charge = fastTrack.GetPrimaryTrack()->GetStep()->GetPreStepPoint()->GetCharge();
-  G4ThreeVector position = fastTrack.GetPrimaryTrack()->GetPosition()/cm;
-  G4ThreeVector momentum = fastTrack.GetPrimaryTrack()->GetMomentum()/GeV;
+  theProfile = thePiKProfile;
+  if (particleType == G4KaonMinus::KaonMinusDefinition())
+    theProfile = theKaonMinusProfile;
+  else if (particleType == G4KaonPlus::KaonPlusDefinition())
+    theProfile = theKaonPlusProfile;
+  else if (particleType == G4AntiProton::AntiProtonDefinition())
+    theProfile = theAntiProtonProfile;
+  else if (particleType == G4Proton::ProtonDefinition())
+    theProfile = theProtonProfile;
+
+  // input variables for GflashHadronShowerProfile
+  G4double energy = fastTrack.GetPrimaryTrack()->GetKineticEnergy() / GeV;
+  G4double globalTime = fastTrack.GetPrimaryTrack()
+                            ->GetStep()
+                            ->GetPostStepPoint()
+                            ->GetGlobalTime();
+  G4double charge =
+      fastTrack.GetPrimaryTrack()->GetStep()->GetPreStepPoint()->GetCharge();
+  G4ThreeVector position = fastTrack.GetPrimaryTrack()->GetPosition() / cm;
+  G4ThreeVector momentum = fastTrack.GetPrimaryTrack()->GetMomentum() / GeV;
   G4int showerType = Gflash::findShowerType(position);
 
-  theProfile->initialize(showerType,energy,globalTime,charge,position,momentum);
+  theProfile->initialize(showerType, energy, globalTime, charge, position,
+                         momentum);
   theProfile->loadParameters();
   theProfile->hadronicParameterization();
 
   // make hits
   makeHits(fastTrack);
-
 }
 
-void GflashHadronShowerModel::makeHits(const G4FastTrack& fastTrack) {
+void GflashHadronShowerModel::makeHits(const G4FastTrack &fastTrack) {
 
-  std::vector<GflashHit>& gflashHitList = theProfile->getGflashHitList();
+  std::vector<GflashHit> &gflashHitList = theProfile->getGflashHitList();
 
-  theGflashStep->SetTrack(const_cast<G4Track*>(fastTrack.GetPrimaryTrack()));
-  theGflashStep->GetPostStepPoint()->SetProcessDefinedStep(const_cast<G4VProcess*>
-    (fastTrack.GetPrimaryTrack()->GetStep()->GetPostStepPoint()->GetProcessDefinedStep()));
-  theGflashNavigator->SetWorldVolume(G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume());
+  theGflashStep->SetTrack(const_cast<G4Track *>(fastTrack.GetPrimaryTrack()));
+  theGflashStep->GetPostStepPoint()->SetProcessDefinedStep(
+      const_cast<G4VProcess *>(fastTrack.GetPrimaryTrack()
+                                   ->GetStep()
+                                   ->GetPostStepPoint()
+                                   ->GetProcessDefinedStep()));
+  theGflashNavigator->SetWorldVolume(
+      G4TransportationManager::GetTransportationManager()
+          ->GetNavigatorForTracking()
+          ->GetWorldVolume());
 
-  std::vector<GflashHit>::const_iterator spotIter    = gflashHitList.begin();
+  std::vector<GflashHit>::const_iterator spotIter = gflashHitList.begin();
   std::vector<GflashHit>::const_iterator spotIterEnd = gflashHitList.end();
 
-  for( ; spotIter != spotIterEnd; spotIter++){
+  for (; spotIter != spotIterEnd; spotIter++) {
 
-    theGflashNavigator->LocateGlobalPointAndUpdateTouchableHandle(spotIter->getPosition(),G4ThreeVector(0,0,0),
-								  theGflashTouchableHandle, false);
-    updateGflashStep(spotIter->getPosition(),spotIter->getTime());
+    theGflashNavigator->LocateGlobalPointAndUpdateTouchableHandle(
+        spotIter->getPosition(), G4ThreeVector(0, 0, 0),
+        theGflashTouchableHandle, false);
+    updateGflashStep(spotIter->getPosition(), spotIter->getTime());
 
     // if there is a watcher defined in a job and the flag is turned on
-    if(theWatcherOn) {
+    if (theWatcherOn) {
       theGflashStep->SetTotalEnergyDeposit(spotIter->getEnergy());
-      SteppingAction* userSteppingAction = (SteppingAction*) G4EventManager::GetEventManager()->GetUserSteppingAction();
+      SteppingAction *userSteppingAction =
+          (SteppingAction *)G4EventManager::GetEventManager()
+              ->GetUserSteppingAction();
       userSteppingAction->m_g4StepSignal(theGflashStep);
     }
 
-    G4VPhysicalVolume* aCurrentVolume = theGflashStep->GetPreStepPoint()->GetPhysicalVolume();
-    if( aCurrentVolume == nullptr ) continue;
+    G4VPhysicalVolume *aCurrentVolume =
+        theGflashStep->GetPreStepPoint()->GetPhysicalVolume();
+    if (aCurrentVolume == nullptr)
+      continue;
 
-    G4LogicalVolume* lv = aCurrentVolume->GetLogicalVolume();
-    if(lv->GetRegion()->GetName() != "CaloRegion") continue;
-	  
-    theGflashStep->GetPreStepPoint()->SetSensitiveDetector(aCurrentVolume->GetLogicalVolume()->GetSensitiveDetector());
-    G4VSensitiveDetector* aSensitive = theGflashStep->GetPreStepPoint()->GetSensitiveDetector();
+    G4LogicalVolume *lv = aCurrentVolume->GetLogicalVolume();
+    if (lv->GetRegion()->GetName() != "CaloRegion")
+      continue;
 
-    if( aSensitive == nullptr ) continue;
-    
+    theGflashStep->GetPreStepPoint()->SetSensitiveDetector(
+        aCurrentVolume->GetLogicalVolume()->GetSensitiveDetector());
+    G4VSensitiveDetector *aSensitive =
+        theGflashStep->GetPreStepPoint()->GetSensitiveDetector();
+
+    if (aSensitive == nullptr)
+      continue;
+
     G4String nameCalor = aCurrentVolume->GetName();
-    nameCalor.assign(nameCalor,0,2);
-    G4double samplingWeight = 1.0; 
-    if(nameCalor == "HB" ) {
+    nameCalor.assign(nameCalor, 0, 2);
+    G4double samplingWeight = 1.0;
+    if (nameCalor == "HB") {
       samplingWeight = Gflash::scaleSensitiveHB;
-    }
-    else if(nameCalor=="HE" || nameCalor == "HT") {
+    } else if (nameCalor == "HE" || nameCalor == "HT") {
       samplingWeight = Gflash::scaleSensitiveHE;
     }
-    theGflashStep->SetTotalEnergyDeposit(spotIter->getEnergy()*samplingWeight);
+    theGflashStep->SetTotalEnergyDeposit(spotIter->getEnergy() *
+                                         samplingWeight);
 
     aSensitive->Hit(theGflashStep);
-
   }
 }
 
-void GflashHadronShowerModel::updateGflashStep(const G4ThreeVector& spotPosition, G4double timeGlobal)
-{
+void GflashHadronShowerModel::updateGflashStep(
+    const G4ThreeVector &spotPosition, G4double timeGlobal) {
   theGflashStep->GetPostStepPoint()->SetGlobalTime(timeGlobal);
   theGflashStep->GetPreStepPoint()->SetPosition(spotPosition);
   theGflashStep->GetPostStepPoint()->SetPosition(spotPosition);
-  theGflashStep->GetPreStepPoint()->SetTouchableHandle(theGflashTouchableHandle);
+  theGflashStep->GetPreStepPoint()->SetTouchableHandle(
+      theGflashTouchableHandle);
 }
 
-G4bool GflashHadronShowerModel::isFirstInelasticInteraction(const G4FastTrack& fastTrack)
-{
-  G4bool isFirst=false;
+G4bool GflashHadronShowerModel::isFirstInelasticInteraction(
+    const G4FastTrack &fastTrack) {
+  G4bool isFirst = false;
 
-  G4StepPoint* preStep = fastTrack.GetPrimaryTrack()->GetStep()->GetPreStepPoint();
-  G4StepPoint* postStep = fastTrack.GetPrimaryTrack()->GetStep()->GetPostStepPoint();
+  G4StepPoint *preStep =
+      fastTrack.GetPrimaryTrack()->GetStep()->GetPreStepPoint();
+  G4StepPoint *postStep =
+      fastTrack.GetPrimaryTrack()->GetStep()->GetPostStepPoint();
 
-  G4String procName = postStep->GetProcessDefinedStep()->GetProcessName();  
-  G4ParticleDefinition* particleType = fastTrack.GetPrimaryTrack()->GetDefinition();
+  G4String procName = postStep->GetProcessDefinedStep()->GetProcessName();
+  G4ParticleDefinition *particleType =
+      fastTrack.GetPrimaryTrack()->GetDefinition();
 
-  //@@@ this part is still temporary and the cut for the variable ratio should be optimized later
+  //@@@ this part is still temporary and the cut for the variable ratio should
+  // be optimized later
 
-  if((particleType == G4PionPlus::PionPlusDefinition() && procName == "WrappedPionPlusInelastic") || 
-     (particleType == G4PionMinus::PionMinusDefinition() && procName == "WrappedPionMinusInelastic") ||
-     (particleType == G4KaonPlus::KaonPlusDefinition() && procName == "WrappedKaonPlusInelastic") ||
-     (particleType == G4KaonMinus::KaonMinusDefinition() && procName == "WrappedKaonMinusInelastic") ||
-     (particleType == G4AntiProton::AntiProtonDefinition() && procName == "WrappedAntiProtonInelastic") ||
-     (particleType == G4Proton::ProtonDefinition() && procName == "WrappedProtonInelastic")) {
+  if ((particleType == G4PionPlus::PionPlusDefinition() &&
+       procName == "WrappedPionPlusInelastic") ||
+      (particleType == G4PionMinus::PionMinusDefinition() &&
+       procName == "WrappedPionMinusInelastic") ||
+      (particleType == G4KaonPlus::KaonPlusDefinition() &&
+       procName == "WrappedKaonPlusInelastic") ||
+      (particleType == G4KaonMinus::KaonMinusDefinition() &&
+       procName == "WrappedKaonMinusInelastic") ||
+      (particleType == G4AntiProton::AntiProtonDefinition() &&
+       procName == "WrappedAntiProtonInelastic") ||
+      (particleType == G4Proton::ProtonDefinition() &&
+       procName == "WrappedProtonInelastic")) {
 
-    //skip to the second interaction if the first inelastic is a quasi-elastic like interaction
+    // skip to the second interaction if the first inelastic is a quasi-elastic
+    // like interaction
     //@@@ the cut may be optimized later
 
-    const G4TrackVector* fSecondaryVector = fastTrack.GetPrimaryTrack()->GetStep()->GetSecondary();
+    const G4TrackVector *fSecondaryVector =
+        fastTrack.GetPrimaryTrack()->GetStep()->GetSecondary();
     G4double leadingEnergy = 0.0;
 
-    //loop over 'all' secondaries including those produced by continuous processes.
-    //@@@may require an additional condition only for hadron interaction with the process name,
-    //but it will not change the result anyway
+    // loop over 'all' secondaries including those produced by continuous
+    // processes.
+    //@@@may require an additional condition only for hadron interaction with
+    // the process name, but it will not change the result anyway
 
-    for (unsigned int isec = 0 ; isec < fSecondaryVector->size() ; isec++) {
-      G4Track* fSecondaryTrack = (*fSecondaryVector)[isec];
+    for (unsigned int isec = 0; isec < fSecondaryVector->size(); isec++) {
+      G4Track *fSecondaryTrack = (*fSecondaryVector)[isec];
       G4double secondaryEnergy = fSecondaryTrack->GetKineticEnergy();
 
-      if(secondaryEnergy > leadingEnergy ) {
+      if (secondaryEnergy > leadingEnergy) {
         leadingEnergy = secondaryEnergy;
       }
     }
 
-    if((preStep->GetTotalEnergy()!=0) && 
-       (leadingEnergy/preStep->GetTotalEnergy() < Gflash::QuasiElasticLike)) isFirst = true;
+    if ((preStep->GetTotalEnergy() != 0) &&
+        (leadingEnergy / preStep->GetTotalEnergy() < Gflash::QuasiElasticLike))
+      isFirst = true;
 
-    //Fill debugging histograms and check information on secondaries -
-    //remove after final implimentation
+    // Fill debugging histograms and check information on secondaries -
+    // remove after final implimentation
 
-    if(theHisto->getStoreFlag()) {
-      theHisto->preStepPosition->Fill(preStep->GetPosition().getRho()/cm);
-      theHisto->postStepPosition->Fill(postStep->GetPosition().getRho()/cm);
-      theHisto->deltaStep->Fill((postStep->GetPosition() - preStep->GetPosition()).getRho()/cm);
-      theHisto->kineticEnergy->Fill(fastTrack.GetPrimaryTrack()->GetKineticEnergy()/GeV);
-      theHisto->energyLoss->Fill(fabs(fastTrack.GetPrimaryTrack()->GetStep()->GetDeltaEnergy()/GeV));
-      theHisto->energyRatio->Fill(leadingEnergy/preStep->GetTotalEnergy());
+    if (theHisto->getStoreFlag()) {
+      theHisto->preStepPosition->Fill(preStep->GetPosition().getRho() / cm);
+      theHisto->postStepPosition->Fill(postStep->GetPosition().getRho() / cm);
+      theHisto->deltaStep->Fill(
+          (postStep->GetPosition() - preStep->GetPosition()).getRho() / cm);
+      theHisto->kineticEnergy->Fill(
+          fastTrack.GetPrimaryTrack()->GetKineticEnergy() / GeV);
+      theHisto->energyLoss->Fill(
+          fabs(fastTrack.GetPrimaryTrack()->GetStep()->GetDeltaEnergy() / GeV));
+      theHisto->energyRatio->Fill(leadingEnergy / preStep->GetTotalEnergy());
     }
-
- }
-  return isFirst;
-} 
-
-G4bool GflashHadronShowerModel::excludeDetectorRegion(const G4FastTrack& fastTrack)
-{
-  G4bool isExcluded=false;
-  int verbosity = theParSet.getUntrackedParameter<int>("Verbosity");
-  
-  //exclude regions where geometry are complicated
-  //+- one supermodule around the EB/EE boundary: 1.479 +- 0.0174*5
-  G4double eta =   fastTrack.GetPrimaryTrack()->GetPosition().pseudoRapidity() ;
-  if(std::fabs(eta) > 1.392 && std::fabs(eta) < 1.566) {
-    if(verbosity>0) {
-       edm::LogInfo("SimGeneralGFlash") << "GflashHadronShowerModel: excluding region of eta = " << eta;
-    }
-    return true;  
   }
-  else {
-    G4StepPoint* postStep = fastTrack.GetPrimaryTrack()->GetStep()->GetPostStepPoint();
+  return isFirst;
+}
 
-    Gflash::CalorimeterNumber kCalor = Gflash::getCalorimeterNumber(postStep->GetPosition()/cm);
+G4bool
+GflashHadronShowerModel::excludeDetectorRegion(const G4FastTrack &fastTrack) {
+  G4bool isExcluded = false;
+  int verbosity = theParSet.getUntrackedParameter<int>("Verbosity");
+
+  // exclude regions where geometry are complicated
+  //+- one supermodule around the EB/EE boundary: 1.479 +- 0.0174*5
+  G4double eta = fastTrack.GetPrimaryTrack()->GetPosition().pseudoRapidity();
+  if (std::fabs(eta) > 1.392 && std::fabs(eta) < 1.566) {
+    if (verbosity > 0) {
+      edm::LogInfo("SimGeneralGFlash")
+          << "GflashHadronShowerModel: excluding region of eta = " << eta;
+    }
+    return true;
+  } else {
+    G4StepPoint *postStep =
+        fastTrack.GetPrimaryTrack()->GetStep()->GetPostStepPoint();
+
+    Gflash::CalorimeterNumber kCalor =
+        Gflash::getCalorimeterNumber(postStep->GetPosition() / cm);
     G4double distOut = 9999.0;
 
-    //exclude the region where the shower starting point is inside the preshower
-    if( std::fabs(eta) > Gflash::EtaMin[Gflash::kENCA] &&
-        std::fabs((postStep->GetPosition()).getZ()/cm) < Gflash::Zmin[Gflash::kENCA]) {
+    // exclude the region where the shower starting point is inside the
+    // preshower
+    if (std::fabs(eta) > Gflash::EtaMin[Gflash::kENCA] &&
+        std::fabs((postStep->GetPosition()).getZ() / cm) <
+            Gflash::Zmin[Gflash::kENCA]) {
       return true;
     }
 
     //<---the shower starting point is always inside envelopes
-    //@@@exclude the region where the shower starting point is too close to the end of
-    //the hadronic envelopes (may need to be optimized further!)
-    //@@@if we extend parameterization including Magnet/HO, we need to change this strategy
-    if(kCalor == Gflash::kHB) {
-      distOut =  Gflash::Rmax[Gflash::kHB] - postStep->GetPosition().getRho()/cm;
-      if (distOut < Gflash::MinDistanceToOut ) isExcluded = true;
-    }
-    else if(kCalor == Gflash::kHE) {
-      distOut =  Gflash::Zmax[Gflash::kHE] - std::fabs(postStep->GetPosition().getZ()/cm);
-      if (distOut < Gflash::MinDistanceToOut ) isExcluded = true;
+    //@@@exclude the region where the shower starting point is too close to the
+    // end of the hadronic envelopes (may need to be optimized further!)
+    //@@@if we extend parameterization including Magnet/HO, we need to change
+    // this strategy
+    if (kCalor == Gflash::kHB) {
+      distOut =
+          Gflash::Rmax[Gflash::kHB] - postStep->GetPosition().getRho() / cm;
+      if (distOut < Gflash::MinDistanceToOut)
+        isExcluded = true;
+    } else if (kCalor == Gflash::kHE) {
+      distOut = Gflash::Zmax[Gflash::kHE] -
+                std::fabs(postStep->GetPosition().getZ() / cm);
+      if (distOut < Gflash::MinDistanceToOut)
+        isExcluded = true;
     }
 
     //@@@remove this print statement later
-    if(isExcluded && verbosity > 0) {
-      std::cout << "GflashHadronShowerModel: skipping kCalor = " << kCalor << 
-	" DistanceToOut " << distOut << " from (" <<  (postStep->GetPosition()).getRho()/cm << 
-	":" << (postStep->GetPosition()).getZ()/cm << ") of KE = " << fastTrack.GetPrimaryTrack()->GetKineticEnergy()/GeV << std::endl;
+    if (isExcluded && verbosity > 0) {
+      std::cout << "GflashHadronShowerModel: skipping kCalor = " << kCalor
+                << " DistanceToOut " << distOut << " from ("
+                << (postStep->GetPosition()).getRho() / cm << ":"
+                << (postStep->GetPosition()).getZ() / cm << ") of KE = "
+                << fastTrack.GetPrimaryTrack()->GetKineticEnergy() / GeV
+                << std::endl;
     }
   }
 

--- a/SimG4Core/GFlash/src/GflashHadronWrapperProcess.cc
+++ b/SimG4Core/GFlash/src/GflashHadronWrapperProcess.cc
@@ -3,85 +3,84 @@
 //
 #include "SimG4Core/GFlash/interface/GflashHadronWrapperProcess.h"
 
-#include "G4Track.hh"
-#include "G4VParticleChange.hh"
+#include "G4GPILSelection.hh"
 #include "G4ProcessManager.hh"
 #include "G4ProcessVector.hh"
+#include "G4Track.hh"
+#include "G4VParticleChange.hh"
 #include "G4VProcess.hh"
-#include "G4GPILSelection.hh"
 
 using namespace CLHEP;
 
-GflashHadronWrapperProcess::GflashHadronWrapperProcess(G4String processName) :
-  particleChange(nullptr), 
-  pmanager(nullptr), 
-  fProcessVector(nullptr),
-  fProcess(nullptr) 
-{
+GflashHadronWrapperProcess::GflashHadronWrapperProcess(G4String processName)
+    : particleChange(nullptr), pmanager(nullptr), fProcessVector(nullptr),
+      fProcess(nullptr) {
   theProcessName = processName;
 }
 
-GflashHadronWrapperProcess::~GflashHadronWrapperProcess() {
-}
+GflashHadronWrapperProcess::~GflashHadronWrapperProcess() {}
 
-G4VParticleChange* GflashHadronWrapperProcess::PostStepDoIt(const G4Track& track, const G4Step& step)
-{
+G4VParticleChange *
+GflashHadronWrapperProcess::PostStepDoIt(const G4Track &track,
+                                         const G4Step &step) {
   // process PostStepDoIt for the original process
 
   particleChange = pRegProcess->PostStepDoIt(track, step);
 
-  // specific actions of the wrapper process 
+  // specific actions of the wrapper process
 
-  // update step/track information after PostStep of the original process is done
-  // these steps will be repeated again without additional conflicts even if the 
-  // parameterized physics process doesn't take over the original process
+  // update step/track information after PostStep of the original process is
+  // done these steps will be repeated again without additional conflicts even
+  // if the parameterized physics process doesn't take over the original process
 
-  particleChange->UpdateStepForPostStep(const_cast<G4Step *> (&step));
+  particleChange->UpdateStepForPostStep(const_cast<G4Step *>(&step));
 
   // we may not want to update G4Track during this wrapper process if
   // G4Track accessors are not used in the G4VFastSimulationModel model
   //  (const_cast<G4Step *> (&step))->UpdateTrack();
 
   // update safety after each invocation of PostStepDoIts
-  // G4double safety = std::max(endpointSafety - (endpointSafOrigin - fPostStepPoint->GetPosition()).mag(),0.);
+  // G4double safety = std::max(endpointSafety - (endpointSafOrigin -
+  // fPostStepPoint->GetPosition()).mag(),0.);
   // step.GetPostStepPoint()->SetSafety(safety);
 
-  // the secondaries from the original process are also created at the wrapper 
-  // process, but they must be deleted whether the parameterized physics is  
-  // an 'ExclusivelyForced' process or not.  Normally the secondaries will be 
+  // the secondaries from the original process are also created at the wrapper
+  // process, but they must be deleted whether the parameterized physics is
+  // an 'ExclusivelyForced' process or not.  Normally the secondaries will be
   // created after this wrapper process in G4SteppingManager::InvokePSDIP
 
   // store the secondaries from ParticleChange to SecondaryList
-	
-  G4TrackVector* fSecondary = (const_cast<G4Step *> (&step))->GetfSecondary();
+
+  G4TrackVector *fSecondary = (const_cast<G4Step *>(&step))->GetfSecondary();
   G4int nSecondarySave = fSecondary->size();
 
   G4int num2ndaries = particleChange->GetNumberOfSecondaries();
-  G4Track* tempSecondaryTrack;
+  G4Track *tempSecondaryTrack;
 
-  for(G4int DSecLoop=0 ; DSecLoop< num2ndaries; DSecLoop++){
+  for (G4int DSecLoop = 0; DSecLoop < num2ndaries; DSecLoop++) {
     tempSecondaryTrack = particleChange->GetSecondary(DSecLoop);
-    
+
     // Set the process pointer which created this track
-    tempSecondaryTrack->SetCreatorProcess( pRegProcess );
+    tempSecondaryTrack->SetCreatorProcess(pRegProcess);
 
-    //add secondaries from this wrapper process to the existing list
-    fSecondary->push_back( tempSecondaryTrack );
+    // add secondaries from this wrapper process to the existing list
+    fSecondary->push_back(tempSecondaryTrack);
 
-  } //end of loop on secondary
+  } // end of loop on secondary
 
   // Now we can still impose conditions on the secondaries from ModelTrigger,
-  // such as the number of secondaries produced by the original process as well as
-  // those by other continuous processes - for the hadronic inelastic interaction, 
-  // it is always true that particleChange->GetNumberOfSecondaries() > 0
+  // such as the number of secondaries produced by the original process as well
+  // as those by other continuous processes - for the hadronic inelastic
+  // interaction, it is always true that
+  // particleChange->GetNumberOfSecondaries() > 0
 
-  // at this stage, updated step information after all processes involved 
+  // at this stage, updated step information after all processes involved
   // should be available
 
   //  Print(step);
 
   // call ModelTrigger for the second time - the primary loop of PostStepGPIL
-  // is inside G4SteppingManager::DefinePhysicalStepLength().    
+  // is inside G4SteppingManager::DefinePhysicalStepLength().
 
   pmanager = track.GetDefinition()->GetProcessManager();
 
@@ -99,88 +98,94 @@ G4VParticleChange* GflashHadronWrapperProcess::PostStepDoIt(const G4Track& track
 
   const G4TrackStatus keepStatus = track.GetTrackStatus();
 
-  (const_cast<G4Track *> (&track))->SetTrackStatus(fPostponeToNextEvent);
-  
-  for(G4int ipm = 0 ; ipm < fProcessVector->entries() ; ipm++) {
-    fProcess = (*fProcessVector)(ipm);  
+  (const_cast<G4Track *>(&track))->SetTrackStatus(fPostponeToNextEvent);
 
-    if ( fProcess->GetProcessType() == fParameterisation ) {
+  for (G4int ipm = 0; ipm < fProcessVector->entries(); ipm++) {
+    fProcess = (*fProcessVector)(ipm);
+
+    if (fProcess->GetProcessType() == fParameterisation) {
       // test ModelTrigger via PostStepGPIL
 
-      testGPIL = fProcess->PostStepGPIL(track,fStepLength,&fForceCondition );
+      testGPIL = fProcess->PostStepGPIL(track, fStepLength, &fForceCondition);
 
-      // if G4FastSimulationModel:: ModelTrigger is true, then the parameterized 
-      // physics process takes over the current process 
-      
-      if( fForceCondition == ExclusivelyForced) {     
+      // if G4FastSimulationModel:: ModelTrigger is true, then the parameterized
+      // physics process takes over the current process
 
-	// clean up memory for changing the process - counter clean up for
-	// the secondaries created by new G4Track in G4HadronicProcess::FillTotalResult 
-	G4int nsec = particleChange->GetNumberOfSecondaries();
-	for(G4int DSecLoop=0 ; DSecLoop< nsec ; DSecLoop++){
-	  G4Track* tempSecondaryTrack = particleChange->GetSecondary(DSecLoop);
-	  delete tempSecondaryTrack;
-	} 
-	particleChange->Clear();
+      if (fForceCondition == ExclusivelyForced) {
 
-	// updating G4Step between PostStepGPIL and PostStepDoIt for the parameterized 
-        // process may not be necessary, but do it anyway
+        // clean up memory for changing the process - counter clean up for
+        // the secondaries created by new G4Track in
+        // G4HadronicProcess::FillTotalResult
+        G4int nsec = particleChange->GetNumberOfSecondaries();
+        for (G4int DSecLoop = 0; DSecLoop < nsec; DSecLoop++) {
+          G4Track *tempSecondaryTrack = particleChange->GetSecondary(DSecLoop);
+          delete tempSecondaryTrack;
+        }
+        particleChange->Clear();
 
-	(const_cast<G4Step *> (&step))->SetStepLength(testGPIL);
-        (const_cast<G4Track *> (&track))->SetStepLength(testGPIL);
+        // updating G4Step between PostStepGPIL and PostStepDoIt for the
+        // parameterized process may not be necessary, but do it anyway
 
-	step.GetPostStepPoint()->SetStepStatus(fExclusivelyForcedProc);;
-	step.GetPostStepPoint()->SetProcessDefinedStep(fProcess);
+        (const_cast<G4Step *>(&step))->SetStepLength(testGPIL);
+        (const_cast<G4Track *>(&track))->SetStepLength(testGPIL);
+
+        step.GetPostStepPoint()->SetStepStatus(fExclusivelyForcedProc);
+        ;
+        step.GetPostStepPoint()->SetProcessDefinedStep(fProcess);
         step.GetPostStepPoint()->SetSafety(0.0);
 
-	// invoke PostStepDoIt: equivalent steps for G4SteppingManager::InvokePSDIP 
-        particleChange = fProcess->PostStepDoIt(track,step);
+        // invoke PostStepDoIt: equivalent steps for
+        // G4SteppingManager::InvokePSDIP
+        particleChange = fProcess->PostStepDoIt(track, step);
 
-	// update PostStepPoint of Step according to ParticleChange
-	particleChange->UpdateStepForPostStep(const_cast<G4Step *> (&step));
+        // update PostStepPoint of Step according to ParticleChange
+        particleChange->UpdateStepForPostStep(const_cast<G4Step *>(&step));
 
-	// update G4Track according to ParticleChange after each PostStepDoIt
-        (const_cast<G4Step *> (&step))->UpdateTrack();
+        // update G4Track according to ParticleChange after each PostStepDoIt
+        (const_cast<G4Step *>(&step))->UpdateTrack();
 
-	// update safety after each invocation of PostStepDoIts - acutally this
-	// is not necessary for the parameterized physics process, but do it anyway
+        // update safety after each invocation of PostStepDoIts - acutally this
+        // is not necessary for the parameterized physics process, but do it
+        // anyway
         step.GetPostStepPoint()->SetSafety(0.0);
-	
-	// additional nullification 
-	(const_cast<G4Track *> (&track))->SetTrackStatus( particleChange->GetTrackStatus() );
-      }
-      else {
-	//restore TrackStatus if fForceCondition !=  ExclusivelyForced
-	(const_cast<G4Track *> (&track))->SetTrackStatus(keepStatus);
+
+        // additional nullification
+        (const_cast<G4Track *>(&track))
+            ->SetTrackStatus(particleChange->GetTrackStatus());
+      } else {
+        // restore TrackStatus if fForceCondition !=  ExclusivelyForced
+        (const_cast<G4Track *>(&track))->SetTrackStatus(keepStatus);
       }
       // assume that there is one and only one parameterized physics
       break;
     }
   }
 
-  // remove secondaries of this wrapper process that were added to the secondary list
-  // since they will be added in the normal stepping procedure after this->PostStepDoIt 
-  // in G4SteppingManager::InvokePSDIP
+  // remove secondaries of this wrapper process that were added to the secondary
+  // list since they will be added in the normal stepping procedure after
+  // this->PostStepDoIt in G4SteppingManager::InvokePSDIP
 
-  //move the iterator to the (nSecondarySave+1)th element in the secondary list
+  // move the iterator to the (nSecondarySave+1)th element in the secondary list
   G4TrackVector::iterator itv = fSecondary->begin();
   itv += nSecondarySave;
 
-  //delete next num2ndaries tracks from the secondary list
-  fSecondary->erase(itv,itv+num2ndaries);
+  // delete next num2ndaries tracks from the secondary list
+  fSecondary->erase(itv, itv + num2ndaries);
 
-  //end of specific actions of this wrapper process
+  // end of specific actions of this wrapper process
 
   return particleChange;
 }
 
-void GflashHadronWrapperProcess::Print(const G4Step& step) {
+void GflashHadronWrapperProcess::Print(const G4Step &step) {
 
-  std::cout << " GflashHadronWrapperProcess ProcessName, PreStepPosition, preStepPoint KE, PostStepPoint KE, DeltaEnergy Nsec \n " 
-         << step.GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName() << " " 
-         << step.GetPostStepPoint()->GetPosition() << " "  
-         << step.GetPreStepPoint()->GetKineticEnergy()/GeV  << " "  
-         << step.GetPostStepPoint()->GetKineticEnergy()/GeV  << " " 
-         << step.GetDeltaEnergy()/GeV << " "
-         << particleChange->GetNumberOfSecondaries() << std::endl;
+  std::cout
+      << " GflashHadronWrapperProcess ProcessName, PreStepPosition, "
+         "preStepPoint KE, PostStepPoint KE, DeltaEnergy Nsec \n "
+      << step.GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName()
+      << " " << step.GetPostStepPoint()->GetPosition() << " "
+      << step.GetPreStepPoint()->GetKineticEnergy() / GeV << " "
+      << step.GetPostStepPoint()->GetKineticEnergy() / GeV << " "
+      << step.GetDeltaEnergy() / GeV << " "
+      << particleChange->GetNumberOfSecondaries() << std::endl;
 }

--- a/SimG4Core/GFlash/src/ParametrisedPhysics.cc
+++ b/SimG4Core/GFlash/src/ParametrisedPhysics.cc
@@ -4,23 +4,24 @@
 #include "G4Electron.hh"
 #include "G4ProcessManager.hh"
 
+#include "G4BaryonConstructor.hh"
+#include "G4IonConstructor.hh"
 #include "G4LeptonConstructor.hh"
 #include "G4MesonConstructor.hh"
-#include "G4BaryonConstructor.hh"
-#include "G4ShortLivedConstructor.hh"
-#include "G4IonConstructor.hh"
 #include "G4RegionStore.hh"
+#include "G4ShortLivedConstructor.hh"
 
 using namespace CLHEP;
 
-G4ThreadLocal ParametrisedPhysics::ThreadPrivate* ParametrisedPhysics::tpdata = nullptr;
+G4ThreadLocal ParametrisedPhysics::ThreadPrivate *ParametrisedPhysics::tpdata =
+    nullptr;
 
-ParametrisedPhysics::ParametrisedPhysics(std::string name, const edm::ParameterSet & p) :
-  G4VPhysicsConstructor(name), theParSet(p) 
-{}
+ParametrisedPhysics::ParametrisedPhysics(std::string name,
+                                         const edm::ParameterSet &p)
+    : G4VPhysicsConstructor(name), theParSet(p) {}
 
 ParametrisedPhysics::~ParametrisedPhysics() {
-  if(nullptr != tpdata) {
+  if (nullptr != tpdata) {
     delete tpdata->theEMShowerModel;
     delete tpdata->theHadShowerModel;
     delete tpdata->theHadronShowerModel;
@@ -29,22 +30,21 @@ ParametrisedPhysics::~ParametrisedPhysics() {
   }
 }
 
-void ParametrisedPhysics::ConstructParticle() 
-{
-    G4LeptonConstructor pLeptonConstructor;
-    pLeptonConstructor.ConstructParticle();
+void ParametrisedPhysics::ConstructParticle() {
+  G4LeptonConstructor pLeptonConstructor;
+  pLeptonConstructor.ConstructParticle();
 
-    G4MesonConstructor pMesonConstructor;
-    pMesonConstructor.ConstructParticle();
+  G4MesonConstructor pMesonConstructor;
+  pMesonConstructor.ConstructParticle();
 
-    G4BaryonConstructor pBaryonConstructor;
-    pBaryonConstructor.ConstructParticle();
+  G4BaryonConstructor pBaryonConstructor;
+  pBaryonConstructor.ConstructParticle();
 
-    G4ShortLivedConstructor pShortLivedConstructor;
-    pShortLivedConstructor.ConstructParticle();  
-    
-    G4IonConstructor pConstructor;
-    pConstructor.ConstructParticle();  
+  G4ShortLivedConstructor pShortLivedConstructor;
+  pShortLivedConstructor.ConstructParticle();
+
+  G4IonConstructor pConstructor;
+  pConstructor.ConstructParticle();
 }
 
 void ParametrisedPhysics::ConstructProcess() {
@@ -55,52 +55,52 @@ void ParametrisedPhysics::ConstructProcess() {
   tpdata->theHadronShowerModel = nullptr;
   tpdata->theFastSimulationManagerProcess = nullptr;
 
-  bool gem  = theParSet.getParameter<bool>("GflashEcal");
+  bool gem = theParSet.getParameter<bool>("GflashEcal");
   bool ghad = theParSet.getParameter<bool>("GflashHcal");
   G4cout << "GFlash Construct: " << gem << "  " << ghad << G4endl;
 
-  if(gem || ghad) {
+  if (gem || ghad) {
     tpdata->theFastSimulationManagerProcess =
-      new G4FastSimulationManagerProcess();
+        new G4FastSimulationManagerProcess();
 
-    G4ParticleTable* table = G4ParticleTable::GetParticleTable();
+    G4ParticleTable *table = G4ParticleTable::GetParticleTable();
     EmParticleList emList;
-    for(const auto& particleName : emList.PartNames()) {
-      G4ParticleDefinition* particle = table->FindParticle(particleName);
-      G4ProcessManager * pmanager = particle->GetProcessManager();
-      const G4String& pname = particle->GetParticleName();
-      if(pname == "e-" || pname == "e+") {
-	pmanager->AddDiscreteProcess(tpdata->theFastSimulationManagerProcess);
+    for (const auto &particleName : emList.PartNames()) {
+      G4ParticleDefinition *particle = table->FindParticle(particleName);
+      G4ProcessManager *pmanager = particle->GetProcessManager();
+      const G4String &pname = particle->GetParticleName();
+      if (pname == "e-" || pname == "e+") {
+        pmanager->AddDiscreteProcess(tpdata->theFastSimulationManagerProcess);
       }
     }
 
-    if(gem) {
-      G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("EcalRegion");
+    if (gem) {
+      G4Region *aRegion = G4RegionStore::GetInstance()->GetRegion("EcalRegion");
 
-      if(!aRegion){
-	G4cout << "EcalRegion is not defined !!!" << G4endl;
-	G4cout << "This means that GFlash will not be turned on." << G4endl;
-	
+      if (!aRegion) {
+        G4cout << "EcalRegion is not defined !!!" << G4endl;
+        G4cout << "This means that GFlash will not be turned on." << G4endl;
+
       } else {
 
-	//Electromagnetic Shower Model for ECAL
-	tpdata->theEMShowerModel = 
-	  new GflashEMShowerModel("GflashEMShowerModel",aRegion,theParSet);
-	G4cout << "GFlash is defined for EcalRegion" << G4endl;
-      }    
+        // Electromagnetic Shower Model for ECAL
+        tpdata->theEMShowerModel =
+            new GflashEMShowerModel("GflashEMShowerModel", aRegion, theParSet);
+        G4cout << "GFlash is defined for EcalRegion" << G4endl;
+      }
     }
-    if(ghad) {
-      G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("HcalRegion");
-      if(!aRegion) {
-	G4cout << "HcalRegion is not defined !!!" << G4endl;
-	G4cout << "This means that GFlash will not be turned on." << G4endl;
-	
+    if (ghad) {
+      G4Region *aRegion = G4RegionStore::GetInstance()->GetRegion("HcalRegion");
+      if (!aRegion) {
+        G4cout << "HcalRegion is not defined !!!" << G4endl;
+        G4cout << "This means that GFlash will not be turned on." << G4endl;
+
       } else {
 
-	//Electromagnetic Shower Model for HCAL
-	tpdata->theHadShowerModel = 
-	  new GflashEMShowerModel("GflashHadShowerModel",aRegion,theParSet);
-	G4cout << "GFlash is defined for HcalRegion" << G4endl;    
+        // Electromagnetic Shower Model for HCAL
+        tpdata->theHadShowerModel =
+            new GflashEMShowerModel("GflashHadShowerModel", aRegion, theParSet);
+        G4cout << "GFlash is defined for HcalRegion" << G4endl;
       }
     }
   }

--- a/SimGeneral/TrackingAnalysis/interface/EncodedTruthId.h
+++ b/SimGeneral/TrackingAnalysis/interface/EncodedTruthId.h
@@ -1,60 +1,44 @@
 #ifndef TrackingAnalysis_EncodedTruthId_h
 #define TrackingAnalysis_EncodedTruthId_h
 
-#include <iosfwd>
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
+#include <iosfwd>
 
-class EncodedTruthId : public EncodedEventId
-{
+class EncodedTruthId : public EncodedEventId {
 
-    friend std::ostream& operator<< (std::ostream& os, const EncodedTruthId & id);
+  friend std::ostream &operator<<(std::ostream &os, const EncodedTruthId &id);
 
 public:
+  // Constructors
+  EncodedTruthId();
+  EncodedTruthId(EncodedEventId eid, int index);
 
-// Constructors
-    EncodedTruthId();
-    EncodedTruthId(EncodedEventId eid, int index);
+  // Getters
+  int index() const { return index_; }
 
-// Getters
-    int index() const
-    {
-        return index_;
+  // Operators
+  int operator==(const EncodedTruthId &id) const {
+    if (EncodedEventId::operator==(id)) {
+      return index_ == id.index_;
+    } else {
+      return EncodedEventId::operator==(id);
     }
+  }
 
-// Operators
-    int operator==(const EncodedTruthId& id) const
-    {
-        if (EncodedEventId::operator==(id))
-        {
-            return index_ == id.index_;
-        }
-        else
-        {
-            return EncodedEventId::operator==(id);
-        }
-    }
+  int operator!=(const EncodedTruthId &id) const { return !(operator==(id)); }
 
-    int operator!=(const EncodedTruthId& id) const
-    {
-        return !(operator==(id));
+  int operator<(const EncodedTruthId &id) const {
+    if (EncodedEventId::operator==(id)) {
+      return index_ < id.index_;
+    } else {
+      return (EncodedEventId::operator<(id));
     }
-
-    int operator<( const EncodedTruthId& id) const
-    {
-        if (EncodedEventId::operator==(id))
-        {
-            return index_ < id.index_;
-        }
-        else
-        {
-            return (EncodedEventId::operator<(id));
-        }
-    }
+  }
 
 private:
-    int index_;
+  int index_;
 };
 
-std::ostream& operator<<(std::ostream & os , EncodedTruthId& id);
+std::ostream &operator<<(std::ostream &os, EncodedTruthId &id);
 
 #endif

--- a/SimGeneral/TrackingAnalysis/interface/MuonPSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/MuonPSimHitSelector.h
@@ -4,21 +4,20 @@
 #include "SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h"
 
 //! MuonPSimHitSelector class
-class MuonPSimHitSelector : public PSimHitSelector
-{
+class MuonPSimHitSelector : public PSimHitSelector {
 
 public:
+  //! Constructor by pset.
+  /* Creates a MuonPSimHitSelector with association given by pset.
 
-    //! Constructor by pset.
-    /* Creates a MuonPSimHitSelector with association given by pset.
+     /param[in] pset with the configuration values
+  */
+  MuonPSimHitSelector(edm::ParameterSet const &config)
+      : PSimHitSelector(config) {}
 
-       /param[in] pset with the configuration values
-    */
-    MuonPSimHitSelector(edm::ParameterSet const & config) : PSimHitSelector(config) {}
-
-    //! Pre-process event information
-    void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const override;
-
+  //! Pre-process event information
+  void select(PSimHitCollection &, edm::Event const &,
+              edm::EventSetup const &) const override;
 };
 
 #endif

--- a/SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h
@@ -12,32 +12,30 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
 //! PSimHitSelector class
-class PSimHitSelector
-{
+class PSimHitSelector {
 
 public:
+  typedef std::vector<PSimHit> PSimHitCollection;
 
-    typedef std::vector<PSimHit> PSimHitCollection;
+  //! Constructor by pset.
+  /* Creates a MuonPSimHitSelector with association given by pset.
 
-    //! Constructor by pset.
-    /* Creates a MuonPSimHitSelector with association given by pset.
+     /param[in] pset with the configuration values
+  */
+  PSimHitSelector(edm::ParameterSet const &);
+  std::string mixLabel_;
 
-       /param[in] pset with the configuration values
-    */
-    PSimHitSelector(edm::ParameterSet const &);
-    std::string mixLabel_;
+  //! Virtual destructor.
+  virtual ~PSimHitSelector() {}
 
-    //! Virtual destructor.
-    virtual ~PSimHitSelector() {}
-
-    //! Select the psimhit add them to a PSimHitCollection
-    virtual void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const;
+  //! Select the psimhit add them to a PSimHitCollection
+  virtual void select(PSimHitCollection &, edm::Event const &,
+                      edm::EventSetup const &) const;
 
 protected:
+  typedef std::map<std::string, std::vector<std::string>> PSimHitCollectionMap;
 
-    typedef std::map<std::string, std::vector<std::string> > PSimHitCollectionMap;
-
-    PSimHitCollectionMap pSimHitCollectionMap_;
+  PSimHitCollectionMap pSimHitCollectionMap_;
 };
 
 #endif

--- a/SimGeneral/TrackingAnalysis/interface/PixelPSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/PixelPSimHitSelector.h
@@ -4,21 +4,20 @@
 #include "SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h"
 
 //! PixelPSimHitSelector class
-class PixelPSimHitSelector : public PSimHitSelector
-{
+class PixelPSimHitSelector : public PSimHitSelector {
 
 public:
+  //! Constructor by pset.
+  /* Creates a PixelPSimHitSelector with association given by pset.
 
-    //! Constructor by pset.
-    /* Creates a PixelPSimHitSelector with association given by pset.
+     /param[in] pset with the configuration values
+  */
+  PixelPSimHitSelector(edm::ParameterSet const &config)
+      : PSimHitSelector(config) {}
 
-       /param[in] pset with the configuration values
-    */
-    PixelPSimHitSelector(edm::ParameterSet const & config) : PSimHitSelector(config) {}
-
-    //! Pre-process event information
-    void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const override;
-
+  //! Pre-process event information
+  void select(PSimHitCollection &, edm::Event const &,
+              edm::EventSetup const &) const override;
 };
 
 #endif

--- a/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
+++ b/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
@@ -1,9 +1,9 @@
 #ifndef SimGeneral_TrackingAnalysis_SimHitTPAssociationProducer_h
 #define SimGeneral_TrackingAnalysis_SimHitTPAssociationProducer_h
 
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
@@ -12,22 +12,23 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-class SimHitTPAssociationProducer : public edm::global::EDProducer<>
-{
+class SimHitTPAssociationProducer : public edm::global::EDProducer<> {
 public:
-
   typedef std::pair<TrackingParticleRef, TrackPSimHitRef> SimHitTPPair;
   typedef std::vector<SimHitTPPair> SimHitTPAssociationList;
 
-  explicit SimHitTPAssociationProducer(const edm::ParameterSet&);
+  explicit SimHitTPAssociationProducer(const edm::ParameterSet &);
   ~SimHitTPAssociationProducer() override;
 
-  static bool simHitTPAssociationListGreater(SimHitTPPair i,SimHitTPPair j) { return (i.first.key()>j.first.key()); }
+  static bool simHitTPAssociationListGreater(SimHitTPPair i, SimHitTPPair j) {
+    return (i.first.key() > j.first.key());
+  }
 
 private:
-  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event &,
+               const edm::EventSetup &) const override;
 
-  std::vector<edm::EDGetTokenT<edm::PSimHitContainer> > _simHitSrc;
+  std::vector<edm::EDGetTokenT<edm::PSimHitContainer>> _simHitSrc;
   edm::EDGetTokenT<TrackingParticleCollection> _trackingParticleSrc;
 };
 #endif

--- a/SimGeneral/TrackingAnalysis/interface/TrackerPSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/TrackerPSimHitSelector.h
@@ -4,21 +4,20 @@
 #include "SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h"
 
 //! TrackerPSimHitSelector class
-class TrackerPSimHitSelector : public PSimHitSelector
-{
+class TrackerPSimHitSelector : public PSimHitSelector {
 
 public:
+  //! Constructor by pset.
+  /* Creates a TrackerPSimHitSelector with association given by pset.
 
-    //! Constructor by pset.
-    /* Creates a TrackerPSimHitSelector with association given by pset.
+     /param[in] pset with the configuration values
+  */
+  TrackerPSimHitSelector(edm::ParameterSet const &config)
+      : PSimHitSelector(config) {}
 
-       /param[in] pset with the configuration values
-    */
-    TrackerPSimHitSelector(edm::ParameterSet const & config) : PSimHitSelector(config) {}
-
-    //! Pre-process event information
-    void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const override;
-
+  //! Pre-process event information
+  void select(PSimHitCollection &, edm::Event const &,
+              edm::EventSetup const &) const override;
 };
 
 #endif

--- a/SimGeneral/TrackingAnalysis/interface/TrackingParticleNumberOfLayers.h
+++ b/SimGeneral/TrackingAnalysis/interface/TrackingParticleNumberOfLayers.h
@@ -4,8 +4,8 @@
 #include "FWCore/Framework/interface/Event.h"
 
 #include "DataFormats/Common/interface/ValueMap.h"
-#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
 /**
  * This class calculates the number of tracker layers, pixel layers,
@@ -43,17 +43,16 @@
  */
 class TrackingParticleNumberOfLayers {
 public:
-  TrackingParticleNumberOfLayers(const edm::Event& iEvent, const std::vector<edm::EDGetTokenT<std::vector<PSimHit> > >& simHitTokens);
+  TrackingParticleNumberOfLayers(
+      const edm::Event &iEvent,
+      const std::vector<edm::EDGetTokenT<std::vector<PSimHit>>> &simHitTokens);
 
-  enum {
-    nTrackerLayers = 0,
-    nPixelLayers = 1,
-    nStripMonoAndStereoLayers = 2
-  };
+  enum { nTrackerLayers = 0, nPixelLayers = 1, nStripMonoAndStereoLayers = 2 };
   std::tuple<std::unique_ptr<edm::ValueMap<unsigned int>>,
              std::unique_ptr<edm::ValueMap<unsigned int>>,
              std::unique_ptr<edm::ValueMap<unsigned int>>>
-  calculate(const edm::Handle<TrackingParticleCollection>& tps, const edm::EventSetup& iSetup) const;
+  calculate(const edm::Handle<TrackingParticleCollection> &tps,
+            const edm::EventSetup &iSetup) const;
 
 private:
   // used as multimap, but faster

--- a/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackerDigiSimLinkWorkers.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackerDigiSimLinkWorkers.cc
@@ -1,11 +1,13 @@
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 #include "SimGeneral/PreMixingModule/interface/PreMixingDigiSimLinkWorker.h"
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
-#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
-#include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
 
-using PreMixingPixelDigiSimLinkWorker = PreMixingDigiSimLinkWorker<edm::DetSetVector<PixelDigiSimLink> >;
-using PreMixingStripDigiSimLinkWorker = PreMixingDigiSimLinkWorker<edm::DetSetVector<StripDigiSimLink> >;
+using PreMixingPixelDigiSimLinkWorker =
+    PreMixingDigiSimLinkWorker<edm::DetSetVector<PixelDigiSimLink>>;
+using PreMixingStripDigiSimLinkWorker =
+    PreMixingDigiSimLinkWorker<edm::DetSetVector<StripDigiSimLink>>;
 
 DEFINE_PREMIXING_WORKER(PreMixingPixelDigiSimLinkWorker);
 DEFINE_PREMIXING_WORKER(PreMixingStripDigiSimLinkWorker);

--- a/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackingParticleWorker.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackingParticleWorker.cc
@@ -1,8 +1,8 @@
-#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ProducerBase.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
 #include "DataFormats/Common/interface/Handle.h"
@@ -12,26 +12,35 @@
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorker.h"
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
 
-class PreMixingTrackingParticleWorker: public PreMixingWorker {
+class PreMixingTrackingParticleWorker : public PreMixingWorker {
 public:
-  PreMixingTrackingParticleWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector && iC);
+  PreMixingTrackingParticleWorker(const edm::ParameterSet &ps,
+                                  edm::ProducerBase &producer,
+                                  edm::ConsumesCollector &&iC);
   ~PreMixingTrackingParticleWorker() override = default;
-    
-  void initializeEvent(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
-  void addSignals(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
-  void addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& iSetup) override;
-  void put(edm::Event& iEvent, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bunchSpacing) override;
+
+  void initializeEvent(edm::Event const &iEvent,
+                       edm::EventSetup const &iSetup) override;
+  void addSignals(edm::Event const &iEvent,
+                  edm::EventSetup const &iSetup) override;
+  void addPileups(PileUpEventPrincipal const &pep,
+                  edm::EventSetup const &iSetup) override;
+  void put(edm::Event &iEvent, edm::EventSetup const &iSetup,
+           std::vector<PileupSummaryInfo> const &ps, int bunchSpacing) override;
 
 private:
-  void add(const std::vector<TrackingParticle>& particles, const std::vector<TrackingVertex>& vertices);
-    
-  edm::EDGetTokenT<std::vector<TrackingParticle> > TrackSigToken_;  // Token to retrieve information  
-  edm::EDGetTokenT<std::vector<TrackingVertex> > VtxSigToken_;  // Token to retrieve information  
+  void add(const std::vector<TrackingParticle> &particles,
+           const std::vector<TrackingVertex> &vertices);
 
-  edm::InputTag TrackingParticlePileInputTag_ ;    // InputTag for pileup tracks
+  edm::EDGetTokenT<std::vector<TrackingParticle>>
+      TrackSigToken_; // Token to retrieve information
+  edm::EDGetTokenT<std::vector<TrackingVertex>>
+      VtxSigToken_; // Token to retrieve information
 
-  std::string TrackingParticleCollectionDM_; // secondary name to be given to new TrackingParticle
+  edm::InputTag TrackingParticlePileInputTag_; // InputTag for pileup tracks
 
+  std::string TrackingParticleCollectionDM_; // secondary name to be given to
+                                             // new TrackingParticle
 
   std::unique_ptr<std::vector<TrackingParticle>> NewTrackList_;
   std::unique_ptr<std::vector<TrackingVertex>> NewVertexList_;
@@ -39,41 +48,56 @@ private:
   TrackingVertexRefProd VertexListRef_;
 };
 
-PreMixingTrackingParticleWorker::PreMixingTrackingParticleWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector && iC):
-  TrackSigToken_(iC.consumes<std::vector<TrackingParticle> >(ps.getParameter<edm::InputTag>("labelSig"))),
-  VtxSigToken_  (iC.consumes<std::vector<TrackingVertex>   >(ps.getParameter<edm::InputTag>("labelSig"))),
-  TrackingParticlePileInputTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
-  TrackingParticleCollectionDM_(ps.getParameter<std::string>("collectionDM"))
-{
-  producer.produces< std::vector<TrackingParticle> >(TrackingParticleCollectionDM_);
-  producer.produces< std::vector<TrackingVertex> >(TrackingParticleCollectionDM_);
+PreMixingTrackingParticleWorker::PreMixingTrackingParticleWorker(
+    const edm::ParameterSet &ps, edm::ProducerBase &producer,
+    edm::ConsumesCollector &&iC)
+    : TrackSigToken_(iC.consumes<std::vector<TrackingParticle>>(
+          ps.getParameter<edm::InputTag>("labelSig"))),
+      VtxSigToken_(iC.consumes<std::vector<TrackingVertex>>(
+          ps.getParameter<edm::InputTag>("labelSig"))),
+      TrackingParticlePileInputTag_(
+          ps.getParameter<edm::InputTag>("pileInputTag")),
+      TrackingParticleCollectionDM_(
+          ps.getParameter<std::string>("collectionDM")) {
+  producer.produces<std::vector<TrackingParticle>>(
+      TrackingParticleCollectionDM_);
+  producer.produces<std::vector<TrackingVertex>>(TrackingParticleCollectionDM_);
 }
 
-
-void PreMixingTrackingParticleWorker::initializeEvent(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
+void PreMixingTrackingParticleWorker::initializeEvent(
+    edm::Event const &iEvent, edm::EventSetup const &iSetup) {
   NewTrackList_ = std::make_unique<std::vector<TrackingParticle>>();
   NewVertexList_ = std::make_unique<std::vector<TrackingVertex>>();
 
   // need RefProds in order to re-key the particle<->vertex refs
-  // TODO: try to remove const_cast, requires making Event non-const in BMixingModule::initializeEvent
-  TrackListRef_  = const_cast<edm::Event&>(iEvent).getRefBeforePut< std::vector<TrackingParticle> >(TrackingParticleCollectionDM_);
-  VertexListRef_ = const_cast<edm::Event&>(iEvent).getRefBeforePut< std::vector<TrackingVertex> >(TrackingParticleCollectionDM_);    
+  // TODO: try to remove const_cast, requires making Event non-const in
+  // BMixingModule::initializeEvent
+  TrackListRef_ = const_cast<edm::Event &>(iEvent)
+                      .getRefBeforePut<std::vector<TrackingParticle>>(
+                          TrackingParticleCollectionDM_);
+  VertexListRef_ = const_cast<edm::Event &>(iEvent)
+                       .getRefBeforePut<std::vector<TrackingVertex>>(
+                           TrackingParticleCollectionDM_);
 }
 
-void PreMixingTrackingParticleWorker::addSignals(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
+void PreMixingTrackingParticleWorker::addSignals(
+    edm::Event const &iEvent, edm::EventSetup const &iSetup) {
   edm::Handle<std::vector<TrackingParticle>> tracks;
   iEvent.getByToken(TrackSigToken_, tracks);
 
   edm::Handle<std::vector<TrackingVertex>> vtxs;
   iEvent.getByToken(VtxSigToken_, vtxs);
 
-  if(tracks.isValid() && vtxs.isValid()) {
+  if (tracks.isValid() && vtxs.isValid()) {
     add(*tracks, *vtxs);
   }
 }
 
-void PreMixingTrackingParticleWorker::addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& iSetup) {
-  LogDebug("PreMixingTrackingParticleWorker") <<"\n===============> adding pileups from event  "<<pep.principal().id()<<" for bunchcrossing "<<pep.bunchCrossing();
+void PreMixingTrackingParticleWorker::addPileups(
+    PileUpEventPrincipal const &pep, edm::EventSetup const &iSetup) {
+  LogDebug("PreMixingTrackingParticleWorker")
+      << "\n===============> adding pileups from event  "
+      << pep.principal().id() << " for bunchcrossing " << pep.bunchCrossing();
 
   edm::Handle<std::vector<TrackingParticle>> inputHandle;
   pep.getByLabel(TrackingParticlePileInputTag_, inputHandle);
@@ -81,62 +105,71 @@ void PreMixingTrackingParticleWorker::addPileups(PileUpEventPrincipal const& pep
   edm::Handle<std::vector<TrackingVertex>> inputVHandle;
   pep.getByLabel(TrackingParticlePileInputTag_, inputVHandle);
 
-  if(inputHandle.isValid() && inputVHandle.isValid()) {
+  if (inputHandle.isValid() && inputVHandle.isValid()) {
     add(*inputHandle, *inputVHandle);
   }
 }
 
-void PreMixingTrackingParticleWorker::add(const std::vector<TrackingParticle>& particles, const std::vector<TrackingVertex>& vertices) {
+void PreMixingTrackingParticleWorker::add(
+    const std::vector<TrackingParticle> &particles,
+    const std::vector<TrackingVertex> &vertices) {
   const size_t StartingIndexV = NewVertexList_->size();
   const size_t StartingIndexT = NewTrackList_->size();
 
-  // grab Vertices, store copy, preserving indices.  Easier to loop over vertices first - fewer links
-  for(const auto& vtx: vertices) {
+  // grab Vertices, store copy, preserving indices.  Easier to loop over
+  // vertices first - fewer links
+  for (const auto &vtx : vertices) {
     NewVertexList_->push_back(vtx);
   }
 
   // grab tracks, store copy
-  for(const auto& track: particles) {
-    const auto& oldRef=track.parentVertex();
-    auto newRef=TrackingVertexRef( VertexListRef_, oldRef.index()+StartingIndexV );
+  for (const auto &track : particles) {
+    const auto &oldRef = track.parentVertex();
+    auto newRef =
+        TrackingVertexRef(VertexListRef_, oldRef.index() + StartingIndexV);
     NewTrackList_->push_back(track);
 
-    auto & Ntrack = NewTrackList_->back();  //modify copy
+    auto &Ntrack = NewTrackList_->back(); // modify copy
 
-    Ntrack.setParentVertex( newRef );
+    Ntrack.setParentVertex(newRef);
     Ntrack.clearDecayVertices();
 
     // next, loop over daughter vertices, same strategy
-    for( auto const& vertexRef : track.decayVertices() ) {
-      auto newRef=TrackingVertexRef( VertexListRef_, vertexRef.index()+StartingIndexV );
+    for (auto const &vertexRef : track.decayVertices()) {
+      auto newRef =
+          TrackingVertexRef(VertexListRef_, vertexRef.index() + StartingIndexV);
       Ntrack.addDecayVertex(newRef);
     }
   }
 
   // Now that tracks are handled, go back and put correct Refs in vertices
-  // Operate only on the added pileup vertices, and leave the already-existing vertices untouched
+  // Operate only on the added pileup vertices, and leave the already-existing
+  // vertices untouched
   std::vector<decltype(TrackingParticleRef().index())> sourceTrackIndices;
   std::vector<decltype(TrackingParticleRef().index())> daughterTrackIndices;
-  for(size_t iVertex = StartingIndexV; iVertex != NewVertexList_->size(); ++iVertex) {
-    auto& vertex = (*NewVertexList_)[iVertex];
+  for (size_t iVertex = StartingIndexV; iVertex != NewVertexList_->size();
+       ++iVertex) {
+    auto &vertex = (*NewVertexList_)[iVertex];
 
     // Need to copy the indices before clearing the vectors
     sourceTrackIndices.reserve(vertex.sourceTracks().size());
     daughterTrackIndices.reserve(vertex.daughterTracks().size());
-    for(auto const& ref: vertex.sourceTracks()) sourceTrackIndices.push_back(ref.index());
-    for(auto const& ref: vertex.daughterTracks()) daughterTrackIndices.push_back(ref.index());
+    for (auto const &ref : vertex.sourceTracks())
+      sourceTrackIndices.push_back(ref.index());
+    for (auto const &ref : vertex.daughterTracks())
+      daughterTrackIndices.push_back(ref.index());
 
     vertex.clearParentTracks();
     vertex.clearDaughterTracks();
 
-    for( auto index : sourceTrackIndices ) {
-      auto newRef=TrackingParticleRef( TrackListRef_, index+StartingIndexT );
+    for (auto index : sourceTrackIndices) {
+      auto newRef = TrackingParticleRef(TrackListRef_, index + StartingIndexT);
       vertex.addParentTrack(newRef);
     }
 
-    // next, loop over daughter tracks, same strategy                                                                 
-    for( auto index : daughterTrackIndices ) {
-      auto newRef=TrackingParticleRef( TrackListRef_, index+StartingIndexT );
+    // next, loop over daughter tracks, same strategy
+    for (auto index : daughterTrackIndices) {
+      auto newRef = TrackingParticleRef(TrackListRef_, index + StartingIndexT);
       vertex.addDaughterTrack(newRef);
     }
 
@@ -144,9 +177,12 @@ void PreMixingTrackingParticleWorker::add(const std::vector<TrackingParticle>& p
     daughterTrackIndices.clear();
   }
 }
-  
-void PreMixingTrackingParticleWorker::put(edm::Event& iEvent, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bunchSpacing) {
-  edm::LogInfo("PreMixingTrackingParticleWorker") << "total # Merged Tracks: " << NewTrackList_->size() ;
+
+void PreMixingTrackingParticleWorker::put(
+    edm::Event &iEvent, edm::EventSetup const &iSetup,
+    std::vector<PileupSummaryInfo> const &ps, int bunchSpacing) {
+  edm::LogInfo("PreMixingTrackingParticleWorker")
+      << "total # Merged Tracks: " << NewTrackList_->size();
   iEvent.put(std::move(NewTrackList_), TrackingParticleCollectionDM_);
   iEvent.put(std::move(NewVertexList_), TrackingParticleCollectionDM_);
 }

--- a/SimGeneral/TrackingAnalysis/plugins/SimHitTPAssociationProducer.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/SimHitTPAssociationProducer.cc
@@ -1,8 +1,8 @@
-#include <memory>
-#include <vector>
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <memory>
 #include <utility>
+#include <vector>
 
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -14,60 +14,67 @@
 
 #include "SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h"
 
-SimHitTPAssociationProducer::SimHitTPAssociationProducer(const edm::ParameterSet & cfg) 
-  : _simHitSrc(),
-    _trackingParticleSrc(consumes<TrackingParticleCollection>(cfg.getParameter<edm::InputTag>("trackingParticleSrc")))
-{
+SimHitTPAssociationProducer::SimHitTPAssociationProducer(
+    const edm::ParameterSet &cfg)
+    : _simHitSrc(),
+      _trackingParticleSrc(consumes<TrackingParticleCollection>(
+          cfg.getParameter<edm::InputTag>("trackingParticleSrc"))) {
   produces<SimHitTPAssociationList>();
-  std::vector<edm::InputTag> tags = cfg.getParameter<std::vector<edm::InputTag> >("simHitSrc");
+  std::vector<edm::InputTag> tags =
+      cfg.getParameter<std::vector<edm::InputTag>>("simHitSrc");
   _simHitSrc.reserve(tags.size());
-  for(auto const& tag  : tags) {
+  for (auto const &tag : tags) {
     _simHitSrc.emplace_back(consumes<edm::PSimHitContainer>(tag));
   }
 }
 
-SimHitTPAssociationProducer::~SimHitTPAssociationProducer() {
-}
-		
-void SimHitTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& es) const {
-  std::unique_ptr<SimHitTPAssociationList> simHitTPList(new SimHitTPAssociationList);
- 
+SimHitTPAssociationProducer::~SimHitTPAssociationProducer() {}
+
+void SimHitTPAssociationProducer::produce(edm::StreamID, edm::Event &iEvent,
+                                          const edm::EventSetup &es) const {
+  std::unique_ptr<SimHitTPAssociationList> simHitTPList(
+      new SimHitTPAssociationList);
+
   // TrackingParticle
-  edm::Handle<TrackingParticleCollection>  TPCollectionH;
-  iEvent.getByToken(_trackingParticleSrc,  TPCollectionH);
+  edm::Handle<TrackingParticleCollection> TPCollectionH;
+  iEvent.getByToken(_trackingParticleSrc, TPCollectionH);
 
   // prepare temporary map between SimTrackId and TrackingParticle index
   std::map<std::pair<size_t, EncodedEventId>, TrackingParticleRef> mapping;
-  for (TrackingParticleCollection::size_type itp = 0; itp < TPCollectionH.product()->size(); ++itp) {
+  for (TrackingParticleCollection::size_type itp = 0;
+       itp < TPCollectionH.product()->size(); ++itp) {
     TrackingParticleRef trackingParticle(TPCollectionH, itp);
     // SimTracks inside TrackingParticle
     EncodedEventId eid(trackingParticle->eventId());
-    for (auto itrk  = trackingParticle->g4Track_begin(); itrk != trackingParticle->g4Track_end(); ++itrk) {
+    for (auto itrk = trackingParticle->g4Track_begin();
+         itrk != trackingParticle->g4Track_end(); ++itrk) {
       std::pair<uint32_t, EncodedEventId> trkid(itrk->trackId(), eid);
       mapping.insert(std::make_pair(trkid, trackingParticle));
     }
   }
 
   // PSimHits
-  for (auto const& psit : _simHitSrc ) {
-    edm::Handle<edm::PSimHitContainer>  PSimHitCollectionH;
-    iEvent.getByToken(psit,  PSimHitCollectionH);
-    for (unsigned int psimHit = 0;psimHit != PSimHitCollectionH->size();++psimHit) {
-      TrackPSimHitRef pSimHitRef(PSimHitCollectionH,psimHit);
-      std::pair<uint32_t, EncodedEventId> simTkIds(pSimHitRef->trackId(),pSimHitRef->eventId()); 
+  for (auto const &psit : _simHitSrc) {
+    edm::Handle<edm::PSimHitContainer> PSimHitCollectionH;
+    iEvent.getByToken(psit, PSimHitCollectionH);
+    for (unsigned int psimHit = 0; psimHit != PSimHitCollectionH->size();
+         ++psimHit) {
+      TrackPSimHitRef pSimHitRef(PSimHitCollectionH, psimHit);
+      std::pair<uint32_t, EncodedEventId> simTkIds(pSimHitRef->trackId(),
+                                                   pSimHitRef->eventId());
       auto ipos = mapping.find(simTkIds);
       if (ipos != mapping.end()) {
-	simHitTPList->push_back(std::make_pair(ipos->second,pSimHitRef));
+        simHitTPList->push_back(std::make_pair(ipos->second, pSimHitRef));
       }
     }
-  } 
-  
-  std::sort(simHitTPList->begin(),simHitTPList->end(),simHitTPAssociationListGreater);
-  iEvent.put(std::move(simHitTPList));
+  }
 
+  std::sort(simHitTPList->begin(), simHitTPList->end(),
+            simHitTPAssociationListGreater);
+  iEvent.put(std::move(simHitTPList));
 }
 
-#include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
 
 DEFINE_FWK_MODULE(SimHitTPAssociationProducer);

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingParticleNumberOfLayersProducer.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingParticleNumberOfLayersProducer.cc
@@ -1,34 +1,38 @@
-#include "FWCore/Framework/interface/global/EDProducer.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "SimGeneral/TrackingAnalysis/interface/TrackingParticleNumberOfLayers.h"
 
 /**
- * The purpose of this producer is to create a ValueMap<pair<unsigned int, unsigned int>>
- * for the number of pixel and strip stereo tracker layers the TrackingParticle has hits on.
+ * The purpose of this producer is to create a ValueMap<pair<unsigned int,
+ * unsigned int>> for the number of pixel and strip stereo tracker layers the
+ * TrackingParticle has hits on.
  */
-class TrackingParticleNumberOfLayersProducer: public edm::global::EDProducer<> {
+class TrackingParticleNumberOfLayersProducer
+    : public edm::global::EDProducer<> {
 public:
-  TrackingParticleNumberOfLayersProducer(const edm::ParameterSet& iConfig);
+  TrackingParticleNumberOfLayersProducer(const edm::ParameterSet &iConfig);
 
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
-  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+  void produce(edm::StreamID, edm::Event &iEvent,
+               const edm::EventSetup &iSetup) const override;
 
 private:
   edm::EDGetTokenT<TrackingParticleCollection> tpToken_;
   std::vector<edm::EDGetTokenT<std::vector<PSimHit>>> simHitTokens_;
 };
 
-
-TrackingParticleNumberOfLayersProducer::TrackingParticleNumberOfLayersProducer(const edm::ParameterSet& iConfig):
-  tpToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("trackingParticles")))
-{
-  for(const auto& tag: iConfig.getParameter<std::vector<edm::InputTag>>("simHits")) {
+TrackingParticleNumberOfLayersProducer::TrackingParticleNumberOfLayersProducer(
+    const edm::ParameterSet &iConfig)
+    : tpToken_(consumes<TrackingParticleCollection>(
+          iConfig.getParameter<edm::InputTag>("trackingParticles"))) {
+  for (const auto &tag :
+       iConfig.getParameter<std::vector<edm::InputTag>>("simHits")) {
     simHitTokens_.push_back(consumes<std::vector<PSimHit>>(tag));
   }
 
@@ -37,37 +41,47 @@ TrackingParticleNumberOfLayersProducer::TrackingParticleNumberOfLayersProducer(c
   produces<edm::ValueMap<unsigned int>>("stripStereoLayers");
 }
 
-void TrackingParticleNumberOfLayersProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void TrackingParticleNumberOfLayersProducer::fillDescriptions(
+    edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("trackingParticles", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.add<edm::InputTag>("trackingParticles",
+                          edm::InputTag("mix", "MergedTrackTruth"));
 
-  desc.add<std::vector<edm::InputTag> >("simHits", {
-      edm::InputTag("g4SimHits", "TrackerHitsPixelBarrelLowTof"),
-      edm::InputTag("g4SimHits", "TrackerHitsPixelBarrelHighTof"),
-      edm::InputTag("g4SimHits", "TrackerHitsPixelEndcapLowTof"),
-      edm::InputTag("g4SimHits", "TrackerHitsPixelEndcapHighTof"),
-      edm::InputTag("g4SimHits", "TrackerHitsTIBLowTof"),
-      edm::InputTag("g4SimHits", "TrackerHitsTIBHighTof"),
-      edm::InputTag("g4SimHits", "TrackerHitsTIDLowTof"),
-      edm::InputTag("g4SimHits", "TrackerHitsTIDHighTof"),
-      edm::InputTag("g4SimHits", "TrackerHitsTOBLowTof"),
-      edm::InputTag("g4SimHits", "TrackerHitsTOBHighTof"),
-      edm::InputTag("g4SimHits", "TrackerHitsTECLowTof"),
-      edm::InputTag("g4SimHits", "TrackerHitsTECHighTof")
-    });
+  desc.add<std::vector<edm::InputTag>>(
+      "simHits", {edm::InputTag("g4SimHits", "TrackerHitsPixelBarrelLowTof"),
+                  edm::InputTag("g4SimHits", "TrackerHitsPixelBarrelHighTof"),
+                  edm::InputTag("g4SimHits", "TrackerHitsPixelEndcapLowTof"),
+                  edm::InputTag("g4SimHits", "TrackerHitsPixelEndcapHighTof"),
+                  edm::InputTag("g4SimHits", "TrackerHitsTIBLowTof"),
+                  edm::InputTag("g4SimHits", "TrackerHitsTIBHighTof"),
+                  edm::InputTag("g4SimHits", "TrackerHitsTIDLowTof"),
+                  edm::InputTag("g4SimHits", "TrackerHitsTIDHighTof"),
+                  edm::InputTag("g4SimHits", "TrackerHitsTOBLowTof"),
+                  edm::InputTag("g4SimHits", "TrackerHitsTOBHighTof"),
+                  edm::InputTag("g4SimHits", "TrackerHitsTECLowTof"),
+                  edm::InputTag("g4SimHits", "TrackerHitsTECHighTof")});
 
   descriptions.add("trackingParticleNumberOfLayersProducer", desc);
 }
 
-void TrackingParticleNumberOfLayersProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void TrackingParticleNumberOfLayersProducer::produce(
+    edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   edm::Handle<TrackingParticleCollection> htps;
   iEvent.getByToken(tpToken_, htps);
 
   TrackingParticleNumberOfLayers algo(iEvent, simHitTokens_);
   auto ret = algo.calculate(htps, iSetup);
-  iEvent.put(std::move(std::get<TrackingParticleNumberOfLayers::nTrackerLayers>(ret)), "trackerLayers");
-  iEvent.put(std::move(std::get<TrackingParticleNumberOfLayers::nPixelLayers>(ret)), "pixelLayers");
-  iEvent.put(std::move(std::get<TrackingParticleNumberOfLayers::nStripMonoAndStereoLayers>(ret)), "stripStereoLayers");
+  iEvent.put(
+      std::move(std::get<TrackingParticleNumberOfLayers::nTrackerLayers>(ret)),
+      "trackerLayers");
+  iEvent.put(
+      std::move(std::get<TrackingParticleNumberOfLayers::nPixelLayers>(ret)),
+      "pixelLayers");
+  iEvent.put(
+      std::move(
+          std::get<TrackingParticleNumberOfLayers::nStripMonoAndStereoLayers>(
+              ret)),
+      "stripStereoLayers");
 }
 
 DEFINE_FWK_MODULE(TrackingParticleNumberOfLayersProducer);

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -1,1268 +1,1513 @@
 /** @file
  * @brief Definitions of the TrackingTruthAccumulator methods.
  *
- * There are a lot of utility classes and functions in this file. This makes it quite long but
- * I didn't want to confuse the directory structure with lots of extra files. My reasoning was
- * that lots of people look at the directory contents but only the really interested ones will
- * look in this particular file, and the utility stuff isn't used elsewhere.
+ * There are a lot of utility classes and functions in this file. This makes it
+ * quite long but I didn't want to confuse the directory structure with lots of
+ * extra files. My reasoning was that lots of people look at the directory
+ * contents but only the really interested ones will look in this particular
+ * file, and the utility stuff isn't used elsewhere.
  *
  * There are three main sections to this file, from top to bottom:
- * 1 - Declarations of extra utility stuff not in the header file. All in the unnamed namespace.
- * 2 - Definitions of the TrackingTruthAccumulator methods.
+ * 1 - Declarations of extra utility stuff not in the header file. All in the
+ * unnamed namespace. 2 - Definitions of the TrackingTruthAccumulator methods.
  * 3 - Definitions of the utility classes and functions declared in (1).
  *
  * @author Mark Grimes (mark.grimes@bristol.ac.uk)
  * @date circa Oct/2012 to Feb/2013
  *
  * Changelog:
- * 05/May/2015 Mark Grimes - Added functionality to add a collection of just the initial vertices
- * for FastTimer studies.
+ * 05/May/2015 Mark Grimes - Added functionality to add a collection of just the
+ * initial vertices for FastTimer studies.
  *
- * 17/Jul/2014 Dominik Nowatschin (dominik.nowatschin@cern.ch) - added SimVertex and a ref to
- * HepMC::Genvertex to TrackingVertex in TrackingParticleFactory::createTrackingVertex; handle to
- * edm::HepMCProduct is created directly in TrackingTruthAccumulator::accumulate and not in 
- * accumulateEvent as edm::Event and PileUpEventPrincipal have different getByLabel() functions
- * 
- * 07/Feb/2013 Mark Grimes - Reorganised and added a bit more documentation. Still not enough
- * though.
- * 12/Mar/2012 Mark Grimes - Updated TrackingParticle creation to fit in with Subir Sarkar's
- * re-implementation of TrackingParticle.
+ * 17/Jul/2014 Dominik Nowatschin (dominik.nowatschin@cern.ch) - added SimVertex
+ * and a ref to HepMC::Genvertex to TrackingVertex in
+ * TrackingParticleFactory::createTrackingVertex; handle to edm::HepMCProduct is
+ * created directly in TrackingTruthAccumulator::accumulate and not in
+ * accumulateEvent as edm::Event and PileUpEventPrincipal have different
+ * getByLabel() functions
+ *
+ * 07/Feb/2013 Mark Grimes - Reorganised and added a bit more documentation.
+ * Still not enough though. 12/Mar/2012 Mark Grimes - Updated TrackingParticle
+ * creation to fit in with Subir Sarkar's re-implementation of TrackingParticle.
  */
 #include "SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h"
 
-#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 #include "FWCore/Framework/interface/ProducerBase.h"
-#include "SimGeneral/TrackingAnalysis/interface/EncodedTruthId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertex.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
+#include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
+#include "SimGeneral/TrackingAnalysis/interface/EncodedTruthId.h"
 
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/isFinite.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-//Turn on integrity checking
+// Turn on integrity checking
 //#define DO_DEBUG_TESTING
 
+//---------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------
+//------ ------
+//------  Declarations for utility classes and functions in the unnamed ------
+//------  namespace. The definitions are right at the bottom of the file. ------
+//------ ------
+//---------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------
 
-//---------------------------------------------------------------------------------
-//---------------------------------------------------------------------------------
-//---------------------------------------------------------------------------------
-//------                                                                     ------
-//------  Declarations for utility classes and functions in the unnamed      ------
-//------  namespace. The definitions are right at the bottom of the file.    ------
-//------                                                                     ------
-//---------------------------------------------------------------------------------
-//---------------------------------------------------------------------------------
-//---------------------------------------------------------------------------------
+namespace {
+/** @brief Class to represent tracks in the decay chain.
+ * @author Mark Grimes (mark.grimes@bristol.ac.uk)
+ * @date 30/Oct/2012
+ */
+struct DecayChainTrack {
+  int simTrackIndex;
+  struct DecayChainVertex *pParentVertex;
+  // Some things have multiple decay vertices. Not sure how that works but it
+  // seems to be mostly electrons and some photons.
+  std::vector<struct DecayChainVertex *> daughterVertices;
+  DecayChainTrack *pMergedBremSource;
+  DecayChainTrack()
+      : simTrackIndex(-1), pParentVertex(nullptr), pMergedBremSource(nullptr) {}
+  DecayChainTrack(int newSimTrackIndex)
+      : simTrackIndex(newSimTrackIndex), pParentVertex(nullptr),
+        pMergedBremSource() {}
+};
 
-namespace
-{
-	/** @brief Class to represent tracks in the decay chain.
-	 * @author Mark Grimes (mark.grimes@bristol.ac.uk)
-	 * @date 30/Oct/2012
-	 */
-	struct DecayChainTrack
-	{
-		int simTrackIndex;
-		struct DecayChainVertex* pParentVertex;
-		// Some things have multiple decay vertices. Not sure how that works but it seems to be mostly electrons and some photons.
-		std::vector<struct DecayChainVertex*> daughterVertices;
-		DecayChainTrack* pMergedBremSource;
-		DecayChainTrack() : simTrackIndex(-1), pParentVertex(nullptr), pMergedBremSource(nullptr) {}
-		DecayChainTrack( int newSimTrackIndex ) : simTrackIndex(newSimTrackIndex), pParentVertex(nullptr), pMergedBremSource() {}
-	};
+/** @brief Class to represent a vertex in the decay chain, and it's relationship
+ * with parents and daughters.
+ * @author Mark Grimes (mark.grimes@bristol.ac.uk)
+ * @date 30/Oct/2012
+ */
+struct DecayChainVertex {
+  int simVertexIndex;
+  DecayChainTrack *pParentTrack;
+  std::vector<DecayChainTrack *> daughterTracks;
+  DecayChainVertex *pMergedBremSource;
+  DecayChainVertex()
+      : simVertexIndex(-1), pParentTrack(nullptr), pMergedBremSource(nullptr) {}
+  DecayChainVertex(int newIndex)
+      : simVertexIndex(newIndex), pParentTrack(nullptr),
+        pMergedBremSource(nullptr) {}
+};
 
-	/** @brief Class to represent a vertex in the decay chain, and it's relationship with parents and daughters.
-	 * @author Mark Grimes (mark.grimes@bristol.ac.uk)
-	 * @date 30/Oct/2012
-	 */
-	struct DecayChainVertex
-	{
-		int simVertexIndex;
-		DecayChainTrack* pParentTrack;
-		std::vector<DecayChainTrack*> daughterTracks;
-		DecayChainVertex* pMergedBremSource;
-		DecayChainVertex() : simVertexIndex(-1), pParentTrack(nullptr), pMergedBremSource(nullptr) {}
-		DecayChainVertex( int newIndex ) : simVertexIndex(newIndex), pParentTrack(nullptr), pMergedBremSource(nullptr) {}
-	};
-
-	/** @brief Intermediary class. Mainly here to handle memory safely.
-	 *
-	 * Reconstructs the parent and child information from SimVertex and SimTracks to create the decay chain.
-	 * SimVertex and SimTrack only have information about their parent, so to get information about the children the
-	 * whole collection has to be analysed. This function does that and returns a tree of DecayChainTrack and
-	 * DecayChainVertex classes that represent the full decay chain.
-	 *
-	 * @author Mark Grimes (mark.grimes@bristol.ac.uk)
-	 * @date 31/Oct/2012
-	 */
-	struct DecayChain
-	{
-	public:
-		DecayChain( const std::vector<SimTrack>& trackCollection, const std::vector<SimVertex>& vertexCollection );
-		const size_t decayTracksSize;
-		const size_t decayVerticesSize;
+/** @brief Intermediary class. Mainly here to handle memory safely.
+ *
+ * Reconstructs the parent and child information from SimVertex and SimTracks to
+ * create the decay chain. SimVertex and SimTrack only have information about
+ * their parent, so to get information about the children the whole collection
+ * has to be analysed. This function does that and returns a tree of
+ * DecayChainTrack and DecayChainVertex classes that represent the full decay
+ * chain.
+ *
+ * @author Mark Grimes (mark.grimes@bristol.ac.uk)
+ * @date 31/Oct/2012
+ */
+struct DecayChain {
+public:
+  DecayChain(const std::vector<SimTrack> &trackCollection,
+             const std::vector<SimVertex> &vertexCollection);
+  const size_t decayTracksSize;
+  const size_t decayVerticesSize;
 
 #if defined(DO_DEBUG_TESTING)
-		/** @brief Testing check. Won't actually be called when the code becomes production.
-		 *
-		 * Checks that there are no dangling objects not associated in the decay chain.
-		 */
-		void integrityCheck();
+  /** @brief Testing check. Won't actually be called when the code becomes
+   * production.
+   *
+   * Checks that there are no dangling objects not associated in the decay
+   * chain.
+   */
+  void integrityCheck();
 #endif
-		const SimTrack& getSimTrack( const ::DecayChainTrack* pDecayTrack ) const { return simTrackCollection_.at( pDecayTrack->simTrackIndex ); }
-		const SimVertex& getSimVertex( const ::DecayChainVertex* pDecayVertex ) const { return simVertexCollection_.at( pDecayVertex->simVertexIndex ); }
-	private:
-		void findBrem( const std::vector<SimTrack>& trackCollection, const std::vector<SimVertex>& vertexCollection );
-		std::unique_ptr< ::DecayChainTrack[]> decayTracks_;
-		std::unique_ptr< ::DecayChainVertex[]> decayVertices_;
+  const SimTrack &getSimTrack(const ::DecayChainTrack *pDecayTrack) const {
+    return simTrackCollection_.at(pDecayTrack->simTrackIndex);
+  }
+  const SimVertex &getSimVertex(const ::DecayChainVertex *pDecayVertex) const {
+    return simVertexCollection_.at(pDecayVertex->simVertexIndex);
+  }
 
-		/// The vertices at the top of the decay chain. These are a subset of the ones in the decayVertices member. Don't delete them.
-		std::vector< ::DecayChainVertex*> rootVertices_;
+private:
+  void findBrem(const std::vector<SimTrack> &trackCollection,
+                const std::vector<SimVertex> &vertexCollection);
+  std::unique_ptr<::DecayChainTrack[]> decayTracks_;
+  std::unique_ptr<::DecayChainVertex[]> decayVertices_;
 
-		// Keep a record of the constructor parameters
-		const std::vector<SimTrack>& simTrackCollection_;
-		const std::vector<SimVertex>& simVertexCollection_;
-	public:
-		const std::unique_ptr< ::DecayChainTrack[]>& decayTracks; ///< Reference maps to decayTracks_ for easy external const access.
-		const std::unique_ptr< ::DecayChainVertex[]>& decayVertices; ///< Reference maps to decayVertices_ for easy external const access.
-		const std::vector< ::DecayChainVertex*>& rootVertices; ///< Reference maps to rootVertices_ for easy external const access.
-	};
+  /// The vertices at the top of the decay chain. These are a subset of the ones
+  /// in the decayVertices member. Don't delete them.
+  std::vector<::DecayChainVertex *> rootVertices_;
 
-	/** @brief Class to create TrackingParticle and TrackingVertex objects.
-	 * @author Mark Grimes (mark.grimes@bristol.ac.uk)
-	 * @date 12/Nov/2012
-	 */
-	class TrackingParticleFactory
-	{
-	public:
-		TrackingParticleFactory( const ::DecayChain& decayChain, const edm::Handle< std::vector<reco::GenParticle> >& hGenParticles,
-				const edm::Handle< edm::HepMCProduct >& hepMCproduct, const edm::Handle< std::vector<int> >& hHepMCGenParticleIndices,
-				const std::vector<const PSimHit*>& simHits, double volumeRadius, double volumeZ, double vertexDistanceCut, bool allowDifferentProcessTypes );
-		TrackingParticle createTrackingParticle( const DecayChainTrack* pTrack, const TrackerTopology *tTopo ) const;
-		TrackingVertex createTrackingVertex( const DecayChainVertex* pVertex) const;
-		bool vectorIsInsideVolume( const math::XYZTLorentzVectorD& vector ) const;
-	private:
-		const ::DecayChain& decayChain_;
-		const edm::Handle< std::vector<reco::GenParticle> >& hGenParticles_;
-		const edm::Handle< edm::HepMCProduct >& hepMCproduct_;
-		std::vector<int> genParticleIndices_;
-		const std::vector<const PSimHit*>& simHits_;
-		const double volumeRadius_;
-		const double volumeZ_;
-		const double vertexDistanceCut2_; // distance based on which HepMC::GenVertexs are added to SimVertexs
-		std::multimap<unsigned int, size_t> trackIdToHitIndex_; ///< A multimap linking SimTrack::trackId() to the hit index in pSimHits_
-		bool allowDifferentProcessTypeForDifferentDetectors_; ///< See the comment for the same member in TrackingTruthAccumulator
-	};
+  // Keep a record of the constructor parameters
+  const std::vector<SimTrack> &simTrackCollection_;
+  const std::vector<SimVertex> &simVertexCollection_;
 
-	/** @brief Handles adding objects to the output collections correctly, and checks to see if a particular object already exists.
-	 * @author Mark Grimes (mark.grimes@bristol.ac.uk)
-	 * @date 09/Nov/2012
-	 */
-	class OutputCollectionWrapper
-	{
-	public:
-		OutputCollectionWrapper( const DecayChain& decayChain, TrackingTruthAccumulator::OutputCollections& outputCollections );
-		TrackingParticle* addTrackingParticle( const ::DecayChainTrack* pDecayTrack, const TrackingParticle& trackingParticle );
-		TrackingVertex* addTrackingVertex( const ::DecayChainVertex* pDecayVertex, const TrackingVertex& trackingVertex );
-		TrackingParticle* getTrackingParticle( const ::DecayChainTrack* pDecayTrack );
-		/// @brief After this call, any call to getTrackingParticle or getRef with pOriginalTrack will return the TrackingParticle for pProxyTrack instead.
-		void setProxy( const ::DecayChainTrack* pOriginalTrack, const ::DecayChainTrack* pProxyTrack );
-		void setProxy( const ::DecayChainVertex* pOriginalVertex, const ::DecayChainVertex* pProxyVertex );
-		TrackingVertex* getTrackingVertex( const ::DecayChainVertex* pDecayVertex );
-		TrackingParticleRef getRef( const ::DecayChainTrack* pDecayTrack );
-		TrackingVertexRef getRef( const ::DecayChainVertex* pDecayVertex );
-	private:
-		void associateToExistingObjects( const ::DecayChainVertex* pChainVertex );
-		void associateToExistingObjects( const ::DecayChainTrack* pChainTrack );
-		TrackingTruthAccumulator::OutputCollections& output_;
-		std::vector<int> trackingParticleIndices_;
-		std::vector<int> trackingVertexIndices_;
-	};
+public:
+  const std::unique_ptr<::DecayChainTrack[]>
+      &decayTracks; ///< Reference maps to decayTracks_ for easy external const
+                    ///< access.
+  const std::unique_ptr<::DecayChainVertex[]>
+      &decayVertices; ///< Reference maps to decayVertices_ for easy external
+                      ///< const access.
+  const std::vector<::DecayChainVertex *>
+      &rootVertices; ///< Reference maps to rootVertices_ for easy external
+                     ///< const access.
+};
 
-	/** @brief Adds the supplied TrackingParticle and its parent TrackingVertex to the output collection. Checks to make sure they don't already exist first.
-	 * @author Mark Grimes (mark.grimes@bristol.ac.uk)
-	 * @date 12/Nov/2012
-	 */
-	TrackingParticle* addTrackAndParentVertex( ::DecayChainTrack* pDecayTrack, const TrackingParticle& trackingParticle, ::OutputCollectionWrapper* pOutput );
+/** @brief Class to create TrackingParticle and TrackingVertex objects.
+ * @author Mark Grimes (mark.grimes@bristol.ac.uk)
+ * @date 12/Nov/2012
+ */
+class TrackingParticleFactory {
+public:
+  TrackingParticleFactory(
+      const ::DecayChain &decayChain,
+      const edm::Handle<std::vector<reco::GenParticle>> &hGenParticles,
+      const edm::Handle<edm::HepMCProduct> &hepMCproduct,
+      const edm::Handle<std::vector<int>> &hHepMCGenParticleIndices,
+      const std::vector<const PSimHit *> &simHits, double volumeRadius,
+      double volumeZ, double vertexDistanceCut,
+      bool allowDifferentProcessTypes);
+  TrackingParticle createTrackingParticle(const DecayChainTrack *pTrack,
+                                          const TrackerTopology *tTopo) const;
+  TrackingVertex createTrackingVertex(const DecayChainVertex *pVertex) const;
+  bool vectorIsInsideVolume(const math::XYZTLorentzVectorD &vector) const;
 
-	/** @brief Creates a TrackingParticle for the supplied DecayChainTrack and adds it to the output if it passes selection. Gets called recursively if adding parents.
-	 * @author Mark Grimes (mark.grimes@bristol.ac.uk)
-	 * @date 05/Nov/2012
-	 */
-	void addTrack( ::DecayChainTrack* pDecayChainTrack, const TrackingParticleSelector* pSelector, ::OutputCollectionWrapper* pUnmergedOutput, ::OutputCollectionWrapper* pMergedOutput, const ::TrackingParticleFactory& objectFactory, bool addAncestors, const TrackerTopology *tTopo);
+private:
+  const ::DecayChain &decayChain_;
+  const edm::Handle<std::vector<reco::GenParticle>> &hGenParticles_;
+  const edm::Handle<edm::HepMCProduct> &hepMCproduct_;
+  std::vector<int> genParticleIndices_;
+  const std::vector<const PSimHit *> &simHits_;
+  const double volumeRadius_;
+  const double volumeZ_;
+  const double vertexDistanceCut2_; // distance based on which HepMC::GenVertexs
+                                    // are added to SimVertexs
+  std::multimap<unsigned int, size_t>
+      trackIdToHitIndex_; ///< A multimap linking SimTrack::trackId() to the hit
+                          ///< index in pSimHits_
+  bool
+      allowDifferentProcessTypeForDifferentDetectors_; ///< See the comment for
+                                                       ///< the same member in
+                                                       ///< TrackingTruthAccumulator
+};
 
-} // end of the unnamed namespace
+/** @brief Handles adding objects to the output collections correctly, and
+ * checks to see if a particular object already exists.
+ * @author Mark Grimes (mark.grimes@bristol.ac.uk)
+ * @date 09/Nov/2012
+ */
+class OutputCollectionWrapper {
+public:
+  OutputCollectionWrapper(
+      const DecayChain &decayChain,
+      TrackingTruthAccumulator::OutputCollections &outputCollections);
+  TrackingParticle *
+  addTrackingParticle(const ::DecayChainTrack *pDecayTrack,
+                      const TrackingParticle &trackingParticle);
+  TrackingVertex *addTrackingVertex(const ::DecayChainVertex *pDecayVertex,
+                                    const TrackingVertex &trackingVertex);
+  TrackingParticle *getTrackingParticle(const ::DecayChainTrack *pDecayTrack);
+  /// @brief After this call, any call to getTrackingParticle or getRef with
+  /// pOriginalTrack will return the TrackingParticle for pProxyTrack instead.
+  void setProxy(const ::DecayChainTrack *pOriginalTrack,
+                const ::DecayChainTrack *pProxyTrack);
+  void setProxy(const ::DecayChainVertex *pOriginalVertex,
+                const ::DecayChainVertex *pProxyVertex);
+  TrackingVertex *getTrackingVertex(const ::DecayChainVertex *pDecayVertex);
+  TrackingParticleRef getRef(const ::DecayChainTrack *pDecayTrack);
+  TrackingVertexRef getRef(const ::DecayChainVertex *pDecayVertex);
 
+private:
+  void associateToExistingObjects(const ::DecayChainVertex *pChainVertex);
+  void associateToExistingObjects(const ::DecayChainTrack *pChainTrack);
+  TrackingTruthAccumulator::OutputCollections &output_;
+  std::vector<int> trackingParticleIndices_;
+  std::vector<int> trackingVertexIndices_;
+};
 
+/** @brief Adds the supplied TrackingParticle and its parent TrackingVertex to
+ * the output collection. Checks to make sure they don't already exist first.
+ * @author Mark Grimes (mark.grimes@bristol.ac.uk)
+ * @date 12/Nov/2012
+ */
+TrackingParticle *
+addTrackAndParentVertex(::DecayChainTrack *pDecayTrack,
+                        const TrackingParticle &trackingParticle,
+                        ::OutputCollectionWrapper *pOutput);
 
+/** @brief Creates a TrackingParticle for the supplied DecayChainTrack and adds
+ * it to the output if it passes selection. Gets called recursively if adding
+ * parents.
+ * @author Mark Grimes (mark.grimes@bristol.ac.uk)
+ * @date 05/Nov/2012
+ */
+void addTrack(::DecayChainTrack *pDecayChainTrack,
+              const TrackingParticleSelector *pSelector,
+              ::OutputCollectionWrapper *pUnmergedOutput,
+              ::OutputCollectionWrapper *pMergedOutput,
+              const ::TrackingParticleFactory &objectFactory, bool addAncestors,
+              const TrackerTopology *tTopo);
+
+} // namespace
 
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
-//------                                                                     ------
-//------  Definitions for the TrackingTruthAccumulator methods               ------
-//------  are below.                                                         ------
-//------                                                                     ------
+//------ ------
+//------  Definitions for the TrackingTruthAccumulator methods ------
+//------  are below. ------
+//------ ------
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
 
-TrackingTruthAccumulator::TrackingTruthAccumulator( const edm::ParameterSet & config, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) :
-		messageCategory_("TrackingTruthAccumulator"),
-		volumeRadius_( config.getParameter<double>("volumeRadius") ),
-		volumeZ_( config.getParameter<double>("volumeZ") ),
-		vertexDistanceCut_( config.getParameter<double>("vertexDistanceCut") ),
-		ignoreTracksOutsideVolume_( config.getParameter<bool>("ignoreTracksOutsideVolume") ),
-		maximumPreviousBunchCrossing_( config.getParameter<unsigned int>("maximumPreviousBunchCrossing") ),
-		maximumSubsequentBunchCrossing_( config.getParameter<unsigned int>("maximumSubsequentBunchCrossing") ),
-		createUnmergedCollection_( config.getParameter<bool>("createUnmergedCollection") ),
-		createMergedCollection_(config.getParameter<bool>("createMergedBremsstrahlung") ),
-		createInitialVertexCollection_(config.getParameter<bool>("createInitialVertexCollection") ),
-		addAncestors_( config.getParameter<bool>("alwaysAddAncestors") ),
-		removeDeadModules_( config.getParameter<bool>("removeDeadModules") ),
-		simTrackLabel_( config.getParameter<edm::InputTag>("simTrackCollection") ),
-		simVertexLabel_( config.getParameter<edm::InputTag>("simVertexCollection") ),
-		collectionTags_( ),
-		genParticleLabel_( config.getParameter<edm::InputTag>("genParticleCollection") ),
-		hepMCproductLabel_( config.getParameter<edm::InputTag>("HepMCProductLabel") ),
-		allowDifferentProcessTypeForDifferentDetectors_( config.getParameter<bool>("allowDifferentSimHitProcesses") )
-{
-	//
-	// Make sure at least one of the merged and unmerged collections have been set
-	// to be created.
-	//
-	if( !createUnmergedCollection_ && !createMergedCollection_ )
-		edm::LogError(messageCategory_) << "Both \"createUnmergedCollection\" and \"createMergedBremsstrahlung\" have been"
-			<< "set to false, which means no collections will be created";
+TrackingTruthAccumulator::TrackingTruthAccumulator(
+    const edm::ParameterSet &config, edm::ProducerBase &mixMod,
+    edm::ConsumesCollector &iC)
+    : messageCategory_("TrackingTruthAccumulator"),
+      volumeRadius_(config.getParameter<double>("volumeRadius")),
+      volumeZ_(config.getParameter<double>("volumeZ")),
+      vertexDistanceCut_(config.getParameter<double>("vertexDistanceCut")),
+      ignoreTracksOutsideVolume_(
+          config.getParameter<bool>("ignoreTracksOutsideVolume")),
+      maximumPreviousBunchCrossing_(
+          config.getParameter<unsigned int>("maximumPreviousBunchCrossing")),
+      maximumSubsequentBunchCrossing_(
+          config.getParameter<unsigned int>("maximumSubsequentBunchCrossing")),
+      createUnmergedCollection_(
+          config.getParameter<bool>("createUnmergedCollection")),
+      createMergedCollection_(
+          config.getParameter<bool>("createMergedBremsstrahlung")),
+      createInitialVertexCollection_(
+          config.getParameter<bool>("createInitialVertexCollection")),
+      addAncestors_(config.getParameter<bool>("alwaysAddAncestors")),
+      removeDeadModules_(config.getParameter<bool>("removeDeadModules")),
+      simTrackLabel_(config.getParameter<edm::InputTag>("simTrackCollection")),
+      simVertexLabel_(
+          config.getParameter<edm::InputTag>("simVertexCollection")),
+      collectionTags_(), genParticleLabel_(config.getParameter<edm::InputTag>(
+                             "genParticleCollection")),
+      hepMCproductLabel_(
+          config.getParameter<edm::InputTag>("HepMCProductLabel")),
+      allowDifferentProcessTypeForDifferentDetectors_(
+          config.getParameter<bool>("allowDifferentSimHitProcesses")) {
+  //
+  // Make sure at least one of the merged and unmerged collections have been set
+  // to be created.
+  //
+  if (!createUnmergedCollection_ && !createMergedCollection_)
+    edm::LogError(messageCategory_)
+        << "Both \"createUnmergedCollection\" and "
+           "\"createMergedBremsstrahlung\" have been"
+        << "set to false, which means no collections will be created";
 
-	// Initialize selection for building TrackingParticles
-	//
-	if( config.exists( "select" ) )
-	{
-		edm::ParameterSet param=config.getParameter<edm::ParameterSet>("select");
-		selector_=TrackingParticleSelector( param.getParameter<double>( "ptMinTP" ),
-				param.getParameter<double>( "ptMaxTP" ),
-				param.getParameter<double>( "minRapidityTP" ),
-				param.getParameter<double>( "maxRapidityTP" ),
-				param.getParameter<double>( "tipTP" ),
-				param.getParameter<double>( "lipTP" ),
-				param.getParameter<int>( "minHitTP" ),
-				param.getParameter<bool>( "signalOnlyTP" ),
-				param.getParameter<bool>( "intimeOnlyTP" ),
-				param.getParameter<bool>( "chargedOnlyTP" ),
-				param.getParameter<bool>( "stableOnlyTP" ),
-				param.getParameter<std::vector<int> >("pdgIdTP") );
-		selectorFlag_=true;
+  // Initialize selection for building TrackingParticles
+  //
+  if (config.exists("select")) {
+    edm::ParameterSet param = config.getParameter<edm::ParameterSet>("select");
+    selector_ = TrackingParticleSelector(
+        param.getParameter<double>("ptMinTP"),
+        param.getParameter<double>("ptMaxTP"),
+        param.getParameter<double>("minRapidityTP"),
+        param.getParameter<double>("maxRapidityTP"),
+        param.getParameter<double>("tipTP"),
+        param.getParameter<double>("lipTP"),
+        param.getParameter<int>("minHitTP"),
+        param.getParameter<bool>("signalOnlyTP"),
+        param.getParameter<bool>("intimeOnlyTP"),
+        param.getParameter<bool>("chargedOnlyTP"),
+        param.getParameter<bool>("stableOnlyTP"),
+        param.getParameter<std::vector<int>>("pdgIdTP"));
+    selectorFlag_ = true;
 
-		// Also set these two variables, which are used to drop out early if the SimTrack doesn't conform.
-		// The selector_ requires a full TrackingParticle object, but these two variables can veto things early.
-		chargedOnly_=param.getParameter<bool>( "chargedOnlyTP" );
-		signalOnly_=param.getParameter<bool>( "signalOnlyTP" );
-	}
-	else
-	{
-		selectorFlag_=false;
-		chargedOnly_=false;
-		signalOnly_=false;
-	}
+    // Also set these two variables, which are used to drop out early if the
+    // SimTrack doesn't conform. The selector_ requires a full TrackingParticle
+    // object, but these two variables can veto things early.
+    chargedOnly_ = param.getParameter<bool>("chargedOnlyTP");
+    signalOnly_ = param.getParameter<bool>("signalOnlyTP");
+  } else {
+    selectorFlag_ = false;
+    chargedOnly_ = false;
+    signalOnly_ = false;
+  }
 
-	//
-	// Need to state what collections are going to be added to the event. This
-	// depends on which of the merged and unmerged collections have been configured
-	// to be created.
-	//
-	if( createUnmergedCollection_ )
-	{
-		mixMod.produces<TrackingVertexCollection>();
-		mixMod.produces<TrackingParticleCollection>();
-	}
+  //
+  // Need to state what collections are going to be added to the event. This
+  // depends on which of the merged and unmerged collections have been
+  // configured to be created.
+  //
+  if (createUnmergedCollection_) {
+    mixMod.produces<TrackingVertexCollection>();
+    mixMod.produces<TrackingParticleCollection>();
+  }
 
-	if( createMergedCollection_ )
-	{
-		mixMod.produces<TrackingParticleCollection>("MergedTrackTruth");
-		mixMod.produces<TrackingVertexCollection>("MergedTrackTruth");
-	}
+  if (createMergedCollection_) {
+    mixMod.produces<TrackingParticleCollection>("MergedTrackTruth");
+    mixMod.produces<TrackingVertexCollection>("MergedTrackTruth");
+  }
 
-	if( createInitialVertexCollection_ )
-	{
-		mixMod.produces<TrackingVertexCollection>("InitialVertices");
-	}
+  if (createInitialVertexCollection_) {
+    mixMod.produces<TrackingVertexCollection>("InitialVertices");
+  }
 
-	iC.consumes<std::vector<SimTrack> >(simTrackLabel_);
-	iC.consumes<std::vector<SimVertex> >(simVertexLabel_);
-	iC.consumes<std::vector<reco::GenParticle> >(genParticleLabel_);
-	iC.consumes<std::vector<int> >(genParticleLabel_);
-	iC.consumes<std::vector<int> >(hepMCproductLabel_);
+  iC.consumes<std::vector<SimTrack>>(simTrackLabel_);
+  iC.consumes<std::vector<SimVertex>>(simVertexLabel_);
+  iC.consumes<std::vector<reco::GenParticle>>(genParticleLabel_);
+  iC.consumes<std::vector<int>>(genParticleLabel_);
+  iC.consumes<std::vector<int>>(hepMCproductLabel_);
 
-	// Fill the collection tags
-        const edm::ParameterSet& simHitCollectionConfig=config.getParameterSet("simHitCollections");
-	std::vector<std::string> parameterNames=simHitCollectionConfig.getParameterNames();
+  // Fill the collection tags
+  const edm::ParameterSet &simHitCollectionConfig =
+      config.getParameterSet("simHitCollections");
+  std::vector<std::string> parameterNames =
+      simHitCollectionConfig.getParameterNames();
 
-	for( const auto& parameterName : parameterNames )
-	{
-           std::vector<edm::InputTag> tags=simHitCollectionConfig.getParameter<std::vector<edm::InputTag> >(parameterName);
-           collectionTags_.insert(collectionTags_.end(), tags.begin(), tags.end());
-        }
+  for (const auto &parameterName : parameterNames) {
+    std::vector<edm::InputTag> tags =
+        simHitCollectionConfig.getParameter<std::vector<edm::InputTag>>(
+            parameterName);
+    collectionTags_.insert(collectionTags_.end(), tags.begin(), tags.end());
+  }
 
-	for( const auto& collectionTag : collectionTags_ ) {
-	  iC.consumes<std::vector<PSimHit> >(collectionTag);
-        }
-
+  for (const auto &collectionTag : collectionTags_) {
+    iC.consumes<std::vector<PSimHit>>(collectionTag);
+  }
 }
 
-void TrackingTruthAccumulator::initializeEvent( edm::Event const& event, edm::EventSetup const& setup )
-{
-	if( createUnmergedCollection_ )
-	{
-		unmergedOutput_.pTrackingParticles.reset( new TrackingParticleCollection );
-		unmergedOutput_.pTrackingVertices.reset( new TrackingVertexCollection );
-		unmergedOutput_.refTrackingParticles=const_cast<edm::Event&>( event ).getRefBeforePut<TrackingParticleCollection>();
-		unmergedOutput_.refTrackingVertexes=const_cast<edm::Event&>( event ).getRefBeforePut<TrackingVertexCollection>();
-	}
+void TrackingTruthAccumulator::initializeEvent(edm::Event const &event,
+                                               edm::EventSetup const &setup) {
+  if (createUnmergedCollection_) {
+    unmergedOutput_.pTrackingParticles.reset(new TrackingParticleCollection);
+    unmergedOutput_.pTrackingVertices.reset(new TrackingVertexCollection);
+    unmergedOutput_.refTrackingParticles =
+        const_cast<edm::Event &>(event)
+            .getRefBeforePut<TrackingParticleCollection>();
+    unmergedOutput_.refTrackingVertexes =
+        const_cast<edm::Event &>(event)
+            .getRefBeforePut<TrackingVertexCollection>();
+  }
 
-	if( createMergedCollection_ )
-	{
-		mergedOutput_.pTrackingParticles.reset( new TrackingParticleCollection );
-		mergedOutput_.pTrackingVertices.reset( new TrackingVertexCollection );
-		mergedOutput_.refTrackingParticles=const_cast<edm::Event&>( event ).getRefBeforePut<TrackingParticleCollection>("MergedTrackTruth");
-		mergedOutput_.refTrackingVertexes=const_cast<edm::Event&>( event ).getRefBeforePut<TrackingVertexCollection>("MergedTrackTruth");
-	}
+  if (createMergedCollection_) {
+    mergedOutput_.pTrackingParticles.reset(new TrackingParticleCollection);
+    mergedOutput_.pTrackingVertices.reset(new TrackingVertexCollection);
+    mergedOutput_.refTrackingParticles =
+        const_cast<edm::Event &>(event)
+            .getRefBeforePut<TrackingParticleCollection>("MergedTrackTruth");
+    mergedOutput_.refTrackingVertexes =
+        const_cast<edm::Event &>(event)
+            .getRefBeforePut<TrackingVertexCollection>("MergedTrackTruth");
+  }
 
-	if( createInitialVertexCollection_ )
-	{
-		pInitialVertices_.reset( new TrackingVertexCollection );
-	}
+  if (createInitialVertexCollection_) {
+    pInitialVertices_.reset(new TrackingVertexCollection);
+  }
 }
 
-/// create handle to edm::HepMCProduct here because event.getByLabel with edm::HepMCProduct only works for edm::Event
-/// but not for PileUpEventPrincipal; PileUpEventPrincipal::getByLabel tries to call T::value_type and T::iterator
-/// (where T is the type of the object one wants to get a handle to) which is only implemented for container-like objects
+/// create handle to edm::HepMCProduct here because event.getByLabel with
+/// edm::HepMCProduct only works for edm::Event but not for
+/// PileUpEventPrincipal; PileUpEventPrincipal::getByLabel tries to call
+/// T::value_type and T::iterator (where T is the type of the object one wants
+/// to get a handle to) which is only implemented for container-like objects
 /// like std::vector but not for edm::HepMCProduct!
 
-void TrackingTruthAccumulator::accumulate( edm::Event const& event, edm::EventSetup const& setup )
-{
-	// Call the templated version that does the same for both signal and pileup events
-	
-	edm::Handle< edm::HepMCProduct > hepmc;
-	event.getByLabel(hepMCproductLabel_, hepmc);
-	
-	accumulateEvent( event, setup, hepmc );
+void TrackingTruthAccumulator::accumulate(edm::Event const &event,
+                                          edm::EventSetup const &setup) {
+  // Call the templated version that does the same for both signal and pileup
+  // events
+
+  edm::Handle<edm::HepMCProduct> hepmc;
+  event.getByLabel(hepMCproductLabel_, hepmc);
+
+  accumulateEvent(event, setup, hepmc);
 }
 
-void TrackingTruthAccumulator::accumulate( PileUpEventPrincipal const& event, edm::EventSetup const& setup, edm::StreamID const& )
-{
-	// If this bunch crossing is outside the user configured limit, don't do anything.
-	if( event.bunchCrossing()>=-static_cast<int>(maximumPreviousBunchCrossing_) && event.bunchCrossing()<=static_cast<int>(maximumSubsequentBunchCrossing_) )
-	{
-		//edm::LogInfo(messageCategory_) << "Analysing pileup event for bunch crossing " << event.bunchCrossing();
-		
-		//simply create empty handle as we do not have a HepMCProduct in PU anyway
-		edm::Handle< edm::HepMCProduct > hepmc;
-		accumulateEvent( event, setup, hepmc );
-	}
-	else edm::LogInfo(messageCategory_) << "Skipping pileup event for bunch crossing " << event.bunchCrossing();
+void TrackingTruthAccumulator::accumulate(PileUpEventPrincipal const &event,
+                                          edm::EventSetup const &setup,
+                                          edm::StreamID const &) {
+  // If this bunch crossing is outside the user configured limit, don't do
+  // anything.
+  if (event.bunchCrossing() >=
+          -static_cast<int>(maximumPreviousBunchCrossing_) &&
+      event.bunchCrossing() <=
+          static_cast<int>(maximumSubsequentBunchCrossing_)) {
+    // edm::LogInfo(messageCategory_) << "Analysing pileup event for bunch
+    // crossing " << event.bunchCrossing();
+
+    // simply create empty handle as we do not have a HepMCProduct in PU anyway
+    edm::Handle<edm::HepMCProduct> hepmc;
+    accumulateEvent(event, setup, hepmc);
+  } else
+    edm::LogInfo(messageCategory_)
+        << "Skipping pileup event for bunch crossing " << event.bunchCrossing();
 }
 
-void TrackingTruthAccumulator::finalizeEvent( edm::Event& event, edm::EventSetup const& setup )
-{
+void TrackingTruthAccumulator::finalizeEvent(edm::Event &event,
+                                             edm::EventSetup const &setup) {
 
-	if( createUnmergedCollection_ )
-	{
-		edm::LogInfo("TrackingTruthAccumulator") << "Adding " << unmergedOutput_.pTrackingParticles->size() << " TrackingParticles and " << unmergedOutput_.pTrackingVertices->size()
-				<< " TrackingVertexs to the event.";
+  if (createUnmergedCollection_) {
+    edm::LogInfo("TrackingTruthAccumulator")
+        << "Adding " << unmergedOutput_.pTrackingParticles->size()
+        << " TrackingParticles and "
+        << unmergedOutput_.pTrackingVertices->size()
+        << " TrackingVertexs to the event.";
 
-		event.put(std::move(unmergedOutput_.pTrackingParticles));
-		event.put(std::move(unmergedOutput_.pTrackingVertices));
-	}
+    event.put(std::move(unmergedOutput_.pTrackingParticles));
+    event.put(std::move(unmergedOutput_.pTrackingVertices));
+  }
 
-	if( createMergedCollection_ )
-	{
-		edm::LogInfo("TrackingTruthAccumulator") << "Adding " << mergedOutput_.pTrackingParticles->size() << " merged TrackingParticles and " << mergedOutput_.pTrackingVertices->size()
-				<< " merged TrackingVertexs to the event.";
+  if (createMergedCollection_) {
+    edm::LogInfo("TrackingTruthAccumulator")
+        << "Adding " << mergedOutput_.pTrackingParticles->size()
+        << " merged TrackingParticles and "
+        << mergedOutput_.pTrackingVertices->size()
+        << " merged TrackingVertexs to the event.";
 
-		event.put(std::move(mergedOutput_.pTrackingParticles), "MergedTrackTruth" );
-		event.put(std::move(mergedOutput_.pTrackingVertices), "MergedTrackTruth" );
-	}
+    event.put(std::move(mergedOutput_.pTrackingParticles), "MergedTrackTruth");
+    event.put(std::move(mergedOutput_.pTrackingVertices), "MergedTrackTruth");
+  }
 
-	if( createInitialVertexCollection_ )
-	{
-		edm::LogInfo("TrackingTruthAccumulator") << "Adding " << pInitialVertices_->size() << " initial TrackingVertexs to the event.";
+  if (createInitialVertexCollection_) {
+    edm::LogInfo("TrackingTruthAccumulator")
+        << "Adding " << pInitialVertices_->size()
+        << " initial TrackingVertexs to the event.";
 
-		event.put(std::move(pInitialVertices_), "InitialVertices" );
-	}
+    event.put(std::move(pInitialVertices_), "InitialVertices");
+  }
 }
 
-template<class T> void TrackingTruthAccumulator::accumulateEvent( const T& event, const edm::EventSetup& setup, const edm::Handle< edm::HepMCProduct >& hepMCproduct)
-{
-	//
-	// Get the collections
-	//
-	edm::Handle<std::vector<SimTrack> > hSimTracks;
-	edm::Handle<std::vector<SimVertex> > hSimVertices;
-	edm::Handle< std::vector<reco::GenParticle> > hGenParticles;
-	edm::Handle< std::vector<int> > hGenParticleIndices;
+template <class T>
+void TrackingTruthAccumulator::accumulateEvent(
+    const T &event, const edm::EventSetup &setup,
+    const edm::Handle<edm::HepMCProduct> &hepMCproduct) {
+  //
+  // Get the collections
+  //
+  edm::Handle<std::vector<SimTrack>> hSimTracks;
+  edm::Handle<std::vector<SimVertex>> hSimVertices;
+  edm::Handle<std::vector<reco::GenParticle>> hGenParticles;
+  edm::Handle<std::vector<int>> hGenParticleIndices;
 
-	event.getByLabel( simTrackLabel_, hSimTracks );
-	event.getByLabel( simVertexLabel_, hSimVertices );
+  event.getByLabel(simTrackLabel_, hSimTracks);
+  event.getByLabel(simVertexLabel_, hSimVertices);
 
-	try
-	{
-		event.getByLabel( genParticleLabel_, hGenParticles );
-		event.getByLabel( genParticleLabel_, hGenParticleIndices );
-	}
-	catch( cms::Exception& exception )
-	{
-		//
-		// The Monte Carlo is not always available, e.g. for pileup events. The information
-		// is only used if it's available, but for some reason the PileUpEventPrincipal
-		// wrapper throws an exception here rather than waiting to see if the handle is
-		// used (as is the case for edm::Event). So I just want to catch this exception
-		// and use the normal handle checking later on.
-		//
-	}
+  try {
+    event.getByLabel(genParticleLabel_, hGenParticles);
+    event.getByLabel(genParticleLabel_, hGenParticleIndices);
+  } catch (cms::Exception &exception) {
+    //
+    // The Monte Carlo is not always available, e.g. for pileup events. The
+    // information is only used if it's available, but for some reason the
+    // PileUpEventPrincipal wrapper throws an exception here rather than waiting
+    // to see if the handle is used (as is the case for edm::Event). So I just
+    // want to catch this exception and use the normal handle checking later on.
+    //
+  }
 
-	//Retrieve tracker topology from geometry
-	edm::ESHandle<TrackerTopology> tTopoHandle;
-	setup.get<TrackerTopologyRcd>().get(tTopoHandle);
-	const TrackerTopology* const tTopo = tTopoHandle.product();
+  // Retrieve tracker topology from geometry
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  setup.get<TrackerTopologyRcd>().get(tTopoHandle);
+  const TrackerTopology *const tTopo = tTopoHandle.product();
 
+  // Run through the collections and work out the decay chain of each
+  // track/vertex. The information in SimTrack and SimVertex only allows
+  // traversing upwards, but this will allow traversal in both directions. This
+  // is required for things like grouping electrons that bremsstrahlung as one
+  // TrackingParticle if "mergedBremsstrahlung" is set in the config file.
+  DecayChain decayChain(*hSimTracks, *hSimVertices);
 
-	// Run through the collections and work out the decay chain of each track/vertex. The
-	// information in SimTrack and SimVertex only allows traversing upwards, but this will
-	// allow traversal in both directions. This is required for things like grouping electrons
-	// that bremsstrahlung as one TrackingParticle if "mergedBremsstrahlung" is set in the
-	// config file.
-	DecayChain decayChain( *hSimTracks, *hSimVertices );
+  // I only want to create these collections if they're actually required
+  std::unique_ptr<::OutputCollectionWrapper> pUnmergedCollectionWrapper;
+  std::unique_ptr<::OutputCollectionWrapper> pMergedCollectionWrapper;
+  if (createUnmergedCollection_)
+    pUnmergedCollectionWrapper.reset(
+        new ::OutputCollectionWrapper(decayChain, unmergedOutput_));
+  if (createMergedCollection_)
+    pMergedCollectionWrapper.reset(
+        new ::OutputCollectionWrapper(decayChain, mergedOutput_));
 
-	// I only want to create these collections if they're actually required
-	std::unique_ptr< ::OutputCollectionWrapper> pUnmergedCollectionWrapper;
-	std::unique_ptr< ::OutputCollectionWrapper> pMergedCollectionWrapper;
-	if( createUnmergedCollection_ ) pUnmergedCollectionWrapper.reset( new ::OutputCollectionWrapper( decayChain, unmergedOutput_ ) );
-	if( createMergedCollection_ ) pMergedCollectionWrapper.reset( new ::OutputCollectionWrapper( decayChain, mergedOutput_ ) );
-
-	std::vector<const PSimHit*> simHitPointers;
-	fillSimHits( simHitPointers, event, setup );
-	TrackingParticleFactory objectFactory( decayChain, hGenParticles, hepMCproduct, hGenParticleIndices, simHitPointers, volumeRadius_, volumeZ_, vertexDistanceCut_, allowDifferentProcessTypeForDifferentDetectors_ );
+  std::vector<const PSimHit *> simHitPointers;
+  fillSimHits(simHitPointers, event, setup);
+  TrackingParticleFactory objectFactory(
+      decayChain, hGenParticles, hepMCproduct, hGenParticleIndices,
+      simHitPointers, volumeRadius_, volumeZ_, vertexDistanceCut_,
+      allowDifferentProcessTypeForDifferentDetectors_);
 
 #if defined(DO_DEBUG_TESTING)
-	// While I'm testing, perform some checks.
-	// TODO - drop this call once I'm happy it works in all situations.
-	decayChain.integrityCheck();
+  // While I'm testing, perform some checks.
+  // TODO - drop this call once I'm happy it works in all situations.
+  decayChain.integrityCheck();
 #endif
 
-	TrackingParticleSelector* pSelector=nullptr;
-	if( selectorFlag_ ) pSelector=&selector_;
+  TrackingParticleSelector *pSelector = nullptr;
+  if (selectorFlag_)
+    pSelector = &selector_;
 
-	// Run over all of the SimTracks, but because I'm interested in the decay hierarchy
-	// do it through the DecayChainTrack objects. These are looped over in sequence here
-	// but they have the hierarchy information for the functions called to traverse the
-	// decay chain.
+  // Run over all of the SimTracks, but because I'm interested in the decay
+  // hierarchy do it through the DecayChainTrack objects. These are looped over
+  // in sequence here but they have the hierarchy information for the functions
+  // called to traverse the decay chain.
 
-	for( size_t index=0; index<decayChain.decayTracksSize; ++index )
-	{
-		::DecayChainTrack* pDecayTrack=&decayChain.decayTracks[index];
-		const SimTrack& simTrack=hSimTracks->at(pDecayTrack->simTrackIndex);
+  for (size_t index = 0; index < decayChain.decayTracksSize; ++index) {
+    ::DecayChainTrack *pDecayTrack = &decayChain.decayTracks[index];
+    const SimTrack &simTrack = hSimTracks->at(pDecayTrack->simTrackIndex);
 
+    // Perform some quick checks to see if we can drop out early. Note that
+    // these are a subset of the cuts in the selector_ so the created
+    // TrackingParticle could still fail. The selector_ requires the full
+    // TrackingParticle to be made however, which can be computationally
+    // expensive.
+    if (chargedOnly_ && simTrack.charge() == 0)
+      continue;
+    if (signalOnly_ && (simTrack.eventId().bunchCrossing() != 0 ||
+                        simTrack.eventId().event() != 0))
+      continue;
 
-		// Perform some quick checks to see if we can drop out early. Note that these are
-		// a subset of the cuts in the selector_ so the created TrackingParticle could still
-		// fail. The selector_ requires the full TrackingParticle to be made however, which
-		// can be computationally expensive.
-		if( chargedOnly_ && simTrack.charge()==0 ) continue;
-		if( signalOnly_ && (simTrack.eventId().bunchCrossing()!=0 || simTrack.eventId().event()!=0) ) continue;
+    // Also perform a check to see if the production vertex is inside the
+    // tracker volume (if required).
+    if (ignoreTracksOutsideVolume_) {
+      const SimVertex &simVertex =
+          hSimVertices->at(pDecayTrack->pParentVertex->simVertexIndex);
+      if (!objectFactory.vectorIsInsideVolume(simVertex.position()))
+        continue;
+    }
 
-		// Also perform a check to see if the production vertex is inside the tracker volume (if required).
-		if( ignoreTracksOutsideVolume_ )
-		{
-			const SimVertex& simVertex=hSimVertices->at( pDecayTrack->pParentVertex->simVertexIndex );
-			if( !objectFactory.vectorIsInsideVolume( simVertex.position() ) ) continue;
-		}
+    // This function creates the TrackinParticle and adds it to the collection
+    // if it passes the selection criteria specified in the configuration. If
+    // the config specifies adding ancestors, the function is called recursively
+    // to do that.
+    ::addTrack(pDecayTrack, pSelector, pUnmergedCollectionWrapper.get(),
+               pMergedCollectionWrapper.get(), objectFactory, addAncestors_,
+               tTopo);
+  }
 
+  // If configured to create a collection of initial vertices, add them from
+  // this bunch crossing. No selection is applied on this collection, but it
+  // also has no links to the TrackingParticle decay products. There are a lot
+  // of "initial vertices", I'm not entirely sure what they all are (nuclear
+  // interactions in the detector maybe?), but the one for the main event is the
+  // one with vertexId==0.
+  if (createInitialVertexCollection_) {
+    // Pretty sure the one with vertexId==0 is always the first one, but doesn't
+    // hurt to check
+    for (const auto &pRootVertex : decayChain.rootVertices) {
+      const SimVertex &vertex =
+          hSimVertices->at(decayChain.rootVertices[0]->simVertexIndex);
+      if (vertex.vertexId() != 0)
+        continue;
 
-		// This function creates the TrackinParticle and adds it to the collection if it
-		// passes the selection criteria specified in the configuration. If the config
-		// specifies adding ancestors, the function is called recursively to do that.
-		::addTrack( pDecayTrack, pSelector, pUnmergedCollectionWrapper.get(), pMergedCollectionWrapper.get(), objectFactory, addAncestors_, tTopo );
-	}
-
-	// If configured to create a collection of initial vertices, add them from this bunch
-	// crossing. No selection is applied on this collection, but it also has no links to
-	// the TrackingParticle decay products.
-	// There are a lot of "initial vertices", I'm not entirely sure what they all are
-	// (nuclear interactions in the detector maybe?), but the one for the main event is
-	// the one with vertexId==0.
-	if( createInitialVertexCollection_ )
-	{
-		// Pretty sure the one with vertexId==0 is always the first one, but doesn't hurt to check
-		for( const auto& pRootVertex : decayChain.rootVertices )
-		{
-			const SimVertex& vertex=hSimVertices->at(decayChain.rootVertices[0]->simVertexIndex);
-			if( vertex.vertexId()!=0 ) continue;
-
-			pInitialVertices_->push_back( objectFactory.createTrackingVertex(pRootVertex) );
-			break;
-		}
-	}
+      pInitialVertices_->push_back(
+          objectFactory.createTrackingVertex(pRootVertex));
+      break;
+    }
+  }
 }
 
-template<class T> void TrackingTruthAccumulator::fillSimHits( std::vector<const PSimHit*>& returnValue, const T& event, const edm::EventSetup& setup )
-{
-	// loop over the collections
-	for( const auto& collectionTag : collectionTags_ )
-	{
-		edm::Handle< std::vector<PSimHit> > hSimHits;
-		event.getByLabel( collectionTag, hSimHits );
+template <class T>
+void TrackingTruthAccumulator::fillSimHits(
+    std::vector<const PSimHit *> &returnValue, const T &event,
+    const edm::EventSetup &setup) {
+  // loop over the collections
+  for (const auto &collectionTag : collectionTags_) {
+    edm::Handle<std::vector<PSimHit>> hSimHits;
+    event.getByLabel(collectionTag, hSimHits);
 
-		// TODO - implement removing the dead modules
-		for( const auto& simHit : *hSimHits )
-		{
-			returnValue.push_back( &simHit );
-		}
+    // TODO - implement removing the dead modules
+    for (const auto &simHit : *hSimHits) {
+      returnValue.push_back(&simHit);
+    }
 
-	} // end of loop over InputTags
+  } // end of loop over InputTags
 
-        // sort the SimHits according to their time of flight,
-        // necessary for looping over them "in order" in
-        // TrackingParticleFactory::createTrackingParticle()
-        std::sort(returnValue.begin(), returnValue.end(), [](const PSimHit *a, const PSimHit *b) {
-            const auto atof = edm::isFinite(a->timeOfFlight()) ? a->timeOfFlight() : std::numeric_limits<decltype(a->timeOfFlight())>::max();
-            const auto btof = edm::isFinite(b->timeOfFlight()) ? b->timeOfFlight() : std::numeric_limits<decltype(b->timeOfFlight())>::max();
-            return atof < btof;
-          });
+  // sort the SimHits according to their time of flight,
+  // necessary for looping over them "in order" in
+  // TrackingParticleFactory::createTrackingParticle()
+  std::sort(returnValue.begin(), returnValue.end(),
+            [](const PSimHit *a, const PSimHit *b) {
+              const auto atof =
+                  edm::isFinite(a->timeOfFlight())
+                      ? a->timeOfFlight()
+                      : std::numeric_limits<decltype(a->timeOfFlight())>::max();
+              const auto btof =
+                  edm::isFinite(b->timeOfFlight())
+                      ? b->timeOfFlight()
+                      : std::numeric_limits<decltype(b->timeOfFlight())>::max();
+              return atof < btof;
+            });
 }
 
-
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
-//------                                                                     ------
-//------  End of the definitions for the TrackingTruthAccumulator methods.   ------
-//------  Definitions for the functions and classes declared in the unnamed  ------
-//------  namespace are below. Documentation for those is above, where       ------
-//------  they're declared.                                                  ------
-//------                                                                     ------
+//------ ------
+//------  End of the definitions for the TrackingTruthAccumulator methods.
+//------
+//------  Definitions for the functions and classes declared in the unnamed
+//------
+//------  namespace are below. Documentation for those is above, where ------
+//------  they're declared. ------
+//------ ------
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
-
 
 namespace // Unnamed namespace for things only used in this file
 {
-	//---------------------------------------------------------------------------------
-	//---------------------------------------------------------------------------------
-	//----   TrackingParticleFactory methods   ----------------------------------------
-	//---------------------------------------------------------------------------------
-	//---------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------
+//----   TrackingParticleFactory methods
+//----------------------------------------
+//---------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------
 
-	::TrackingParticleFactory::TrackingParticleFactory( const ::DecayChain& decayChain, const edm::Handle< std::vector<reco::GenParticle> >& hGenParticles,
-			const edm::Handle< edm::HepMCProduct >& hepMCproduct, const edm::Handle< std::vector<int> >& hHepMCGenParticleIndices, const std::vector<const PSimHit*>& simHits,
-			double volumeRadius, double volumeZ, double vertexDistanceCut, bool allowDifferentProcessTypes )
-		: decayChain_(decayChain), hGenParticles_(hGenParticles), hepMCproduct_(hepMCproduct), simHits_(simHits), volumeRadius_(volumeRadius),
-		  volumeZ_(volumeZ), vertexDistanceCut2_(vertexDistanceCut*vertexDistanceCut), allowDifferentProcessTypeForDifferentDetectors_(allowDifferentProcessTypes)
-	{
-		// Need to create a multimap to get from a SimTrackId to all of the hits in it. The SimTrackId
-		// is an unsigned int.
-		for( size_t index=0; index<simHits_.size(); ++index )
-		{
-			trackIdToHitIndex_.insert( std::make_pair( simHits_[index]->trackId(), index ) );
-		}
+::TrackingParticleFactory::TrackingParticleFactory(
+    const ::DecayChain &decayChain,
+    const edm::Handle<std::vector<reco::GenParticle>> &hGenParticles,
+    const edm::Handle<edm::HepMCProduct> &hepMCproduct,
+    const edm::Handle<std::vector<int>> &hHepMCGenParticleIndices,
+    const std::vector<const PSimHit *> &simHits, double volumeRadius,
+    double volumeZ, double vertexDistanceCut, bool allowDifferentProcessTypes)
+    : decayChain_(decayChain), hGenParticles_(hGenParticles),
+      hepMCproduct_(hepMCproduct), simHits_(simHits),
+      volumeRadius_(volumeRadius), volumeZ_(volumeZ),
+      vertexDistanceCut2_(vertexDistanceCut * vertexDistanceCut),
+      allowDifferentProcessTypeForDifferentDetectors_(
+          allowDifferentProcessTypes) {
+  // Need to create a multimap to get from a SimTrackId to all of the hits in
+  // it. The SimTrackId is an unsigned int.
+  for (size_t index = 0; index < simHits_.size(); ++index) {
+    trackIdToHitIndex_.insert(
+        std::make_pair(simHits_[index]->trackId(), index));
+  }
 
-		if( hHepMCGenParticleIndices.isValid() ) // Monte Carlo might not be available for the pileup events
-		{
-			genParticleIndices_.resize( hHepMCGenParticleIndices->size()+1 );
+  if (hHepMCGenParticleIndices.isValid()) // Monte Carlo might not be available
+                                          // for the pileup events
+  {
+    genParticleIndices_.resize(hHepMCGenParticleIndices->size() + 1);
 
-			// What I need is the reverse mapping of this vector. The sizes are already equivalent because I set
-			// the size in the initialiser list.
-			for( size_t recoGenParticleIndex=0; recoGenParticleIndex<hHepMCGenParticleIndices->size(); ++recoGenParticleIndex )
-			{
-				size_t hepMCGenParticleIndex=(*hHepMCGenParticleIndices)[recoGenParticleIndex];
+    // What I need is the reverse mapping of this vector. The sizes are already
+    // equivalent because I set the size in the initialiser list.
+    for (size_t recoGenParticleIndex = 0;
+         recoGenParticleIndex < hHepMCGenParticleIndices->size();
+         ++recoGenParticleIndex) {
+      size_t hepMCGenParticleIndex =
+          (*hHepMCGenParticleIndices)[recoGenParticleIndex];
 
-				// They should be the same size, give or take a fencepost error, so this should never happen - but just in case
-				if( genParticleIndices_.size()<=hepMCGenParticleIndex ) genParticleIndices_.resize(hepMCGenParticleIndex+1);
+      // They should be the same size, give or take a fencepost error, so this
+      // should never happen - but just in case
+      if (genParticleIndices_.size() <= hepMCGenParticleIndex)
+        genParticleIndices_.resize(hepMCGenParticleIndex + 1);
 
-				genParticleIndices_[ hepMCGenParticleIndex ]=recoGenParticleIndex;
-			}
-		}
-	}
+      genParticleIndices_[hepMCGenParticleIndex] = recoGenParticleIndex;
+    }
+  }
+}
 
-	TrackingParticle TrackingParticleFactory::createTrackingParticle( const ::DecayChainTrack* pChainTrack, const TrackerTopology *tTopo ) const
-	{
-		typedef math::XYZTLorentzVectorD LorentzVector;
-		typedef math::XYZPoint Vector;
+TrackingParticle TrackingParticleFactory::createTrackingParticle(
+    const ::DecayChainTrack *pChainTrack, const TrackerTopology *tTopo) const {
+  typedef math::XYZTLorentzVectorD LorentzVector;
+  typedef math::XYZPoint Vector;
 
-		const SimTrack& simTrack=decayChain_.getSimTrack( pChainTrack );
-		const SimVertex& parentSimVertex=decayChain_.getSimVertex( pChainTrack->pParentVertex );
+  const SimTrack &simTrack = decayChain_.getSimTrack(pChainTrack);
+  const SimVertex &parentSimVertex =
+      decayChain_.getSimVertex(pChainTrack->pParentVertex);
 
-		LorentzVector position( 0, 0, 0, 0 );
-		if( !simTrack.noVertex() ) position=parentSimVertex.position();
+  LorentzVector position(0, 0, 0, 0);
+  if (!simTrack.noVertex())
+    position = parentSimVertex.position();
 
-		int pdgId=simTrack.type();
+  int pdgId = simTrack.type();
 
-		TrackingParticle returnValue;
-		// N.B. The sim track is added a few lines below, the parent and decay vertices are added in
-		// another function later on.
+  TrackingParticle returnValue;
+  // N.B. The sim track is added a few lines below, the parent and decay
+  // vertices are added in another function later on.
 
-		//
-		// If there is some valid Monte Carlo for this track, take some information from that.
-		// Only do so if it is from the signal event however. Not sure why but that's what the
-		// old code did.
-		//
-		if( simTrack.eventId().event()==0 && simTrack.eventId().bunchCrossing()==0 ) // if this is a track in the signal event
-		{
-			int hepMCGenParticleIndex=simTrack.genpartIndex();
-			if( hepMCGenParticleIndex>=0 && hepMCGenParticleIndex<static_cast<int>(genParticleIndices_.size()) && hGenParticles_.isValid() )
-			{
-				int recoGenParticleIndex=genParticleIndices_[hepMCGenParticleIndex];
-				reco::GenParticleRef generatorParticleRef( hGenParticles_, recoGenParticleIndex );
-				pdgId=generatorParticleRef->pdgId();
-				returnValue.addGenParticle( generatorParticleRef );
-			}
-		}
+  //
+  // If there is some valid Monte Carlo for this track, take some information
+  // from that. Only do so if it is from the signal event however. Not sure why
+  // but that's what the old code did.
+  //
+  if (simTrack.eventId().event() == 0 &&
+      simTrack.eventId().bunchCrossing() ==
+          0) // if this is a track in the signal event
+  {
+    int hepMCGenParticleIndex = simTrack.genpartIndex();
+    if (hepMCGenParticleIndex >= 0 &&
+        hepMCGenParticleIndex < static_cast<int>(genParticleIndices_.size()) &&
+        hGenParticles_.isValid()) {
+      int recoGenParticleIndex = genParticleIndices_[hepMCGenParticleIndex];
+      reco::GenParticleRef generatorParticleRef(hGenParticles_,
+                                                recoGenParticleIndex);
+      pdgId = generatorParticleRef->pdgId();
+      returnValue.addGenParticle(generatorParticleRef);
+    }
+  }
 
-		returnValue.addG4Track( simTrack );
+  returnValue.addG4Track(simTrack);
 
-		// I need to run over the sim hits and count up the different types of hits. To be honest
-		// I don't fully understand this next section of code, I copied it from the old TrackingTruthProducer
-		// to provide the same results. The different types of hits that I need to count are:
-		size_t matchedHits=0; // As far as I can tell, this is the number of tracker layers with hits on them, i.e. taking account of overlaps.
-		size_t numberOfHits=0; // The total number of hits not taking account of overlaps.
-		size_t numberOfTrackerHits=0; // The number of tracker hits not taking account of overlaps.
+  // I need to run over the sim hits and count up the different types of hits.
+  // To be honest I don't fully understand this next section of code, I copied
+  // it from the old TrackingTruthProducer to provide the same results. The
+  // different types of hits that I need to count are:
+  size_t matchedHits =
+      0; // As far as I can tell, this is the number of tracker layers with hits
+         // on them, i.e. taking account of overlaps.
+  size_t numberOfHits =
+      0; // The total number of hits not taking account of overlaps.
+  size_t numberOfTrackerHits =
+      0; // The number of tracker hits not taking account of overlaps.
 
-		bool init=true;
-		int processType=0;
-		int particleType=0;
-		int oldLayer = 0;
-		int newLayer = 0;
-		DetId oldDetector;
-		DetId newDetector;
+  bool init = true;
+  int processType = 0;
+  int particleType = 0;
+  int oldLayer = 0;
+  int newLayer = 0;
+  DetId oldDetector;
+  DetId newDetector;
 
-		// Loop over the SimHits associated to this SimTrack
-		// in the order defined by time of flight, which is
-		// probably the best quantity available for going
-		// through the hits "in order" (ok, most important is
-		// to get the first hit right because processType and
-		// particleType are taken from it)
-		for( auto iHitIndex=trackIdToHitIndex_.lower_bound( simTrack.trackId() ), end=trackIdToHitIndex_.upper_bound( simTrack.trackId() );
-				iHitIndex!=end;
-				++iHitIndex )
-		{
-			const auto& pSimHit=simHits_[ iHitIndex->second ];
+  // Loop over the SimHits associated to this SimTrack
+  // in the order defined by time of flight, which is
+  // probably the best quantity available for going
+  // through the hits "in order" (ok, most important is
+  // to get the first hit right because processType and
+  // particleType are taken from it)
+  for (auto iHitIndex = trackIdToHitIndex_.lower_bound(simTrack.trackId()),
+            end = trackIdToHitIndex_.upper_bound(simTrack.trackId());
+       iHitIndex != end; ++iHitIndex) {
+    const auto &pSimHit = simHits_[iHitIndex->second];
 
-                        // Skip hits with particle type different from SimTrack pdgId
-                        if(pSimHit->particleType() != pdgId)
-                          continue;
+    // Skip hits with particle type different from SimTrack pdgId
+    if (pSimHit->particleType() != pdgId)
+      continue;
 
-			// Initial condition for consistent simhit selection
-			if( init )
-			{
-				processType=pSimHit->processType();
-				particleType=pSimHit->particleType();
-				newDetector=DetId( pSimHit->detUnitId() );
-				init=false;
-			}
+    // Initial condition for consistent simhit selection
+    if (init) {
+      processType = pSimHit->processType();
+      particleType = pSimHit->particleType();
+      newDetector = DetId(pSimHit->detUnitId());
+      init = false;
+    }
 
-			oldDetector=newDetector;
-			newDetector=DetId( pSimHit->detUnitId() );
+    oldDetector = newDetector;
+    newDetector = DetId(pSimHit->detUnitId());
 
-			// Fast sim seems to have different processType between tracker and muons, so if this flag
-			// has been set allow the processType to change if the detector changes.
-			if( allowDifferentProcessTypeForDifferentDetectors_ && newDetector.det()!=oldDetector.det() ) processType=pSimHit->processType();
+    // Fast sim seems to have different processType between tracker and muons,
+    // so if this flag has been set allow the processType to change if the
+    // detector changes.
+    if (allowDifferentProcessTypeForDifferentDetectors_ &&
+        newDetector.det() != oldDetector.det())
+      processType = pSimHit->processType();
 
-			// Check for delta and interaction products discards
-			if( processType==pSimHit->processType() && particleType==pSimHit->particleType() )
-			{
-				++numberOfHits;
-				oldLayer=newLayer;
-                                newLayer=0;
-				if( newDetector.det() == DetId::Tracker ) {
-                                  ++numberOfTrackerHits;
+    // Check for delta and interaction products discards
+    if (processType == pSimHit->processType() &&
+        particleType == pSimHit->particleType()) {
+      ++numberOfHits;
+      oldLayer = newLayer;
+      newLayer = 0;
+      if (newDetector.det() == DetId::Tracker) {
+        ++numberOfTrackerHits;
 
-                                  newLayer=tTopo->layer( newDetector );
+        newLayer = tTopo->layer(newDetector);
 
-                                  // Count hits using layers for glued detectors
-                                  if( (oldLayer!=newLayer || (oldLayer==newLayer && oldDetector.subdetId()!=newDetector.subdetId())) ) ++matchedHits;
-                                }
-			}
-		} // end of loop over the sim hits for this sim track
+        // Count hits using layers for glued detectors
+        if ((oldLayer != newLayer ||
+             (oldLayer == newLayer &&
+              oldDetector.subdetId() != newDetector.subdetId())))
+          ++matchedHits;
+      }
+    }
+  } // end of loop over the sim hits for this sim track
 
-		returnValue.setNumberOfTrackerLayers( matchedHits );
-		returnValue.setNumberOfHits( numberOfHits );
-		returnValue.setNumberOfTrackerHits( numberOfTrackerHits );
+  returnValue.setNumberOfTrackerLayers(matchedHits);
+  returnValue.setNumberOfHits(numberOfHits);
+  returnValue.setNumberOfTrackerHits(numberOfTrackerHits);
 
-		return returnValue;
-	}
+  return returnValue;
+}
 
-	TrackingVertex TrackingParticleFactory::createTrackingVertex( const ::DecayChainVertex* pChainVertex) const
-	{
-                
-		typedef math::XYZTLorentzVectorD LorentzVector;
-		typedef math::XYZPoint Vector;
-		typedef edm::Ref<edm::HepMCProduct, HepMC::GenVertex >   GenVertexRef;
-		
-		const SimVertex& simVertex=decayChain_.getSimVertex( pChainVertex );
+TrackingVertex TrackingParticleFactory::createTrackingVertex(
+    const ::DecayChainVertex *pChainVertex) const {
 
-		bool isInVolume=this->vectorIsInsideVolume( simVertex.position() );
+  typedef math::XYZTLorentzVectorD LorentzVector;
+  typedef math::XYZPoint Vector;
+  typedef edm::Ref<edm::HepMCProduct, HepMC::GenVertex> GenVertexRef;
 
-		TrackingVertex returnValue( simVertex.position(), isInVolume, simVertex.eventId() );
-		
-		// add the SimVertex to the TrackingVertex
-		returnValue.addG4Vertex(simVertex);
-                
-		// also add refs to nearby HepMC::GenVertexs; the way this is done (i.e. based on the position) is transcribed over from the old TrackingTruthProducer
-		if( simVertex.eventId().event()==0 && simVertex.eventId().bunchCrossing()==0 && hepMCproduct_.isValid()) // if this is a track in the signal event
-		{
-			const HepMC::GenEvent* genEvent = hepMCproduct_->GetEvent();
-			
-			if (genEvent != nullptr)
-			{
-				Vector tvPosition(returnValue.position().x(), returnValue.position().y(), returnValue.position().z());
-                
-				for (HepMC::GenEvent::vertex_const_iterator iGenVertex = genEvent->vertices_begin(); iGenVertex != genEvent->vertices_end(); ++iGenVertex)
-				{
-					HepMC::ThreeVector rawPosition = (*iGenVertex)->position();
-                    
-					Vector genPosition(rawPosition.x()*0.1, rawPosition.y()*0.1, rawPosition.z()*0.1);
-                    
-					auto distance2 = (tvPosition - genPosition).mag2();
-                    
-					if (distance2 < vertexDistanceCut2_)
-						returnValue.addGenVertex( GenVertexRef(hepMCproduct_, (*iGenVertex)->barcode()) );
-				}
-			}
-		}
-                
-		return returnValue;
-	}
+  const SimVertex &simVertex = decayChain_.getSimVertex(pChainVertex);
 
-	bool ::TrackingParticleFactory::vectorIsInsideVolume( const math::XYZTLorentzVectorD& vector ) const
-	{
-		return ( vector.Pt()<volumeRadius_ && std::abs( vector.z() )<volumeZ_ );
-	}
+  bool isInVolume = this->vectorIsInsideVolume(simVertex.position());
 
-	//---------------------------------------------------------------------------------
-	//---------------------------------------------------------------------------------
-	//----   DecayChain methods   -----------------------------------------------------
-	//---------------------------------------------------------------------------------
-	//---------------------------------------------------------------------------------
+  TrackingVertex returnValue(simVertex.position(), isInVolume,
+                             simVertex.eventId());
 
-	::DecayChain::DecayChain( const std::vector<SimTrack>& trackCollection, const std::vector<SimVertex>& vertexCollection )
-		: decayTracksSize( trackCollection.size() ),
-		  decayVerticesSize( vertexCollection.size() ),
-		  decayTracks_( new DecayChainTrack[decayTracksSize] ),
-		  decayVertices_( new DecayChainVertex[decayVerticesSize] ),
-		  simTrackCollection_( trackCollection ),
-		  simVertexCollection_( vertexCollection ),
-		  decayTracks( decayTracks_ ), // These const references map onto the actual members for public const access
-		  decayVertices( decayVertices_ ),
-		  rootVertices( rootVertices_ )
-	{
-		// I need some maps to be able to get object pointers from the track/vertex ID
-		std::map<int,::DecayChainTrack*> trackIdToDecayTrack;
-		std::map<int,::DecayChainVertex*> vertexIdToDecayVertex;
+  // add the SimVertex to the TrackingVertex
+  returnValue.addG4Vertex(simVertex);
 
-		// First create a DecayChainTrack for every SimTrack and make a note of the
-		// trackIds in the map. Also add a pointer to the daughter list of the parent
-		// DecayChainVertex, which might include creating the vertex object if it
-		// doesn't already exist.
-		size_t decayVertexIndex=0; // The index of the next free slot in the DecayChainVertex array.
-		for( size_t index=0; index<trackCollection.size(); ++index )
-		{
-			::DecayChainTrack* pDecayTrack=&decayTracks_[index]; // Get a pointer for ease of use
+  // also add refs to nearby HepMC::GenVertexs; the way this is done (i.e. based
+  // on the position) is transcribed over from the old TrackingTruthProducer
+  if (simVertex.eventId().event() == 0 &&
+      simVertex.eventId().bunchCrossing() == 0 &&
+      hepMCproduct_.isValid()) // if this is a track in the signal event
+  {
+    const HepMC::GenEvent *genEvent = hepMCproduct_->GetEvent();
 
-			// This is the array index of the SimTrack that this DecayChainTrack corresponds to. At
-			// the moment this is a 1 to 1 relationship with the DecayChainTrack index, but they won't
-			// necessarily be accessed through the array later so it's still required to store it.
-			pDecayTrack->simTrackIndex=index;
+    if (genEvent != nullptr) {
+      Vector tvPosition(returnValue.position().x(), returnValue.position().y(),
+                        returnValue.position().z());
 
-			trackIdToDecayTrack[ trackCollection[index].trackId() ]=pDecayTrack;
+      for (HepMC::GenEvent::vertex_const_iterator iGenVertex =
+               genEvent->vertices_begin();
+           iGenVertex != genEvent->vertices_end(); ++iGenVertex) {
+        HepMC::ThreeVector rawPosition = (*iGenVertex)->position();
 
-			int parentVertexIndex=trackCollection[index].vertIndex();
-			if( parentVertexIndex>=0 )
-			{
-				// Get the DecayChainVertex corresponding to this SimVertex, or initialise it if it hasn't been done already.
-				::DecayChainVertex*& pParentVertex=vertexIdToDecayVertex[parentVertexIndex];
-				if( pParentVertex==nullptr )
-				{
-					// Note that I'm using a reference, so changing pParentVertex will change the entry in the map too.
-					pParentVertex=&decayVertices_[decayVertexIndex];
-					++decayVertexIndex;
-					pParentVertex->simVertexIndex=parentVertexIndex;
-				}
-				pParentVertex->daughterTracks.push_back(pDecayTrack);
-				pDecayTrack->pParentVertex=pParentVertex;
-			}
-			else throw std::runtime_error( "TrackingTruthAccumulator: Found a track with an invalid parent vertex index." );
-		}
+        Vector genPosition(rawPosition.x() * 0.1, rawPosition.y() * 0.1,
+                           rawPosition.z() * 0.1);
 
-		// This assert was originally in to check the internal consistency of the decay chain. Fast sim
-		// pileup seems to have a load of vertices with no tracks pointing to them though, so fast sim fails
-		// this assert if pileup is added. I don't think the problem is vital however, so if the assert is
-		// taken out these extra vertices are ignored.
-		//assert( vertexIdToDecayVertex.size()==vertexCollection.size() && vertexCollection.size()==decayVertexIndex );
+        auto distance2 = (tvPosition - genPosition).mag2();
 
-		// I still need to set DecayChainTrack::daughterVertices and DecayChainVertex::pParentTrack.
-		// The information to do this comes from SimVertex::parentIndex. I couldn't do this before
-		// because I need all of the DecayChainTracks initialised.
-		for( auto& decayVertexMapPair : vertexIdToDecayVertex )
-		{
-			::DecayChainVertex* pDecayVertex=decayVertexMapPair.second;
-			int parentTrackIndex=vertexCollection[pDecayVertex->simVertexIndex].parentIndex();
-			if( parentTrackIndex!=-1 )
-			{
-				std::map<int,::DecayChainTrack*>::iterator iParentTrackMapPair=trackIdToDecayTrack.find(parentTrackIndex);
-				if( iParentTrackMapPair==trackIdToDecayTrack.end() )
-				{
-					std::stringstream errorStream;
-					errorStream << "TrackingTruthAccumulator: Something has gone wrong with the indexing. Parent track index is " << parentTrackIndex << ".";
-					throw std::runtime_error( errorStream.str() );
-				}
+        if (distance2 < vertexDistanceCut2_)
+          returnValue.addGenVertex(
+              GenVertexRef(hepMCproduct_, (*iGenVertex)->barcode()));
+      }
+    }
+  }
 
-				::DecayChainTrack* pParentTrackHierarchy=iParentTrackMapPair->second;
+  return returnValue;
+}
 
-				pParentTrackHierarchy->daughterVertices.push_back( pDecayVertex );
-				pDecayVertex->pParentTrack=pParentTrackHierarchy;
-			}
-			else rootVertices_.push_back(pDecayVertex); // Has no parent so is at the top of the decay chain.
-		} // end of loop over the vertexIdToDecayVertex map
+bool ::TrackingParticleFactory::vectorIsInsideVolume(
+    const math::XYZTLorentzVectorD &vector) const {
+  return (vector.Pt() < volumeRadius_ && std::abs(vector.z()) < volumeZ_);
+}
 
-		findBrem( trackCollection, vertexCollection );
+//---------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------
+//----   DecayChain methods
+//-----------------------------------------------------
+//---------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------
 
-	} // end of ::DecayChain constructor
+::DecayChain::DecayChain(const std::vector<SimTrack> &trackCollection,
+                         const std::vector<SimVertex> &vertexCollection)
+    : decayTracksSize(trackCollection.size()),
+      decayVerticesSize(vertexCollection.size()),
+      decayTracks_(new DecayChainTrack[decayTracksSize]),
+      decayVertices_(new DecayChainVertex[decayVerticesSize]),
+      simTrackCollection_(trackCollection),
+      simVertexCollection_(vertexCollection),
+      decayTracks(decayTracks_), // These const references map onto the actual
+                                 // members for public const access
+      decayVertices(decayVertices_), rootVertices(rootVertices_) {
+  // I need some maps to be able to get object pointers from the track/vertex ID
+  std::map<int, ::DecayChainTrack *> trackIdToDecayTrack;
+  std::map<int, ::DecayChainVertex *> vertexIdToDecayVertex;
+
+  // First create a DecayChainTrack for every SimTrack and make a note of the
+  // trackIds in the map. Also add a pointer to the daughter list of the parent
+  // DecayChainVertex, which might include creating the vertex object if it
+  // doesn't already exist.
+  size_t decayVertexIndex =
+      0; // The index of the next free slot in the DecayChainVertex array.
+  for (size_t index = 0; index < trackCollection.size(); ++index) {
+    ::DecayChainTrack *pDecayTrack =
+        &decayTracks_[index]; // Get a pointer for ease of use
+
+    // This is the array index of the SimTrack that this DecayChainTrack
+    // corresponds to. At the moment this is a 1 to 1 relationship with the
+    // DecayChainTrack index, but they won't necessarily be accessed through the
+    // array later so it's still required to store it.
+    pDecayTrack->simTrackIndex = index;
+
+    trackIdToDecayTrack[trackCollection[index].trackId()] = pDecayTrack;
+
+    int parentVertexIndex = trackCollection[index].vertIndex();
+    if (parentVertexIndex >= 0) {
+      // Get the DecayChainVertex corresponding to this SimVertex, or initialise
+      // it if it hasn't been done already.
+      ::DecayChainVertex *&pParentVertex =
+          vertexIdToDecayVertex[parentVertexIndex];
+      if (pParentVertex == nullptr) {
+        // Note that I'm using a reference, so changing pParentVertex will
+        // change the entry in the map too.
+        pParentVertex = &decayVertices_[decayVertexIndex];
+        ++decayVertexIndex;
+        pParentVertex->simVertexIndex = parentVertexIndex;
+      }
+      pParentVertex->daughterTracks.push_back(pDecayTrack);
+      pDecayTrack->pParentVertex = pParentVertex;
+    } else
+      throw std::runtime_error("TrackingTruthAccumulator: Found a track with "
+                               "an invalid parent vertex index.");
+  }
+
+  // This assert was originally in to check the internal consistency of the
+  // decay chain. Fast sim pileup seems to have a load of vertices with no
+  // tracks pointing to them though, so fast sim fails this assert if pileup is
+  // added. I don't think the problem is vital however, so if the assert is
+  // taken out these extra vertices are ignored.
+  // assert( vertexIdToDecayVertex.size()==vertexCollection.size() &&
+  // vertexCollection.size()==decayVertexIndex );
+
+  // I still need to set DecayChainTrack::daughterVertices and
+  // DecayChainVertex::pParentTrack. The information to do this comes from
+  // SimVertex::parentIndex. I couldn't do this before because I need all of the
+  // DecayChainTracks initialised.
+  for (auto &decayVertexMapPair : vertexIdToDecayVertex) {
+    ::DecayChainVertex *pDecayVertex = decayVertexMapPair.second;
+    int parentTrackIndex =
+        vertexCollection[pDecayVertex->simVertexIndex].parentIndex();
+    if (parentTrackIndex != -1) {
+      std::map<int, ::DecayChainTrack *>::iterator iParentTrackMapPair =
+          trackIdToDecayTrack.find(parentTrackIndex);
+      if (iParentTrackMapPair == trackIdToDecayTrack.end()) {
+        std::stringstream errorStream;
+        errorStream << "TrackingTruthAccumulator: Something has gone wrong "
+                       "with the indexing. Parent track index is "
+                    << parentTrackIndex << ".";
+        throw std::runtime_error(errorStream.str());
+      }
+
+      ::DecayChainTrack *pParentTrackHierarchy = iParentTrackMapPair->second;
+
+      pParentTrackHierarchy->daughterVertices.push_back(pDecayVertex);
+      pDecayVertex->pParentTrack = pParentTrackHierarchy;
+    } else
+      rootVertices_.push_back(
+          pDecayVertex); // Has no parent so is at the top of the decay chain.
+  }                      // end of loop over the vertexIdToDecayVertex map
+
+  findBrem(trackCollection, vertexCollection);
+
+} // end of ::DecayChain constructor
 
 #if defined(DO_DEBUG_TESTING)
-	// Function documentation is with the declaration above. This function is only used for testing.
-	void ::DecayChain::integrityCheck()
-	{
-		//
-		// Start off checking the tracks
-		//
-		for( size_t index=0; index<decayTracksSize; ++index )
-		{
-			const auto& decayTrack=decayTracks[index];
-			//
-			// Tracks should always have a production vertex
-			//
-			if( decayTrack.pParentVertex==NULL ) throw std::runtime_error( "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainTrack with no parent vertex." );
+// Function documentation is with the declaration above. This function is only
+// used for testing.
+void ::DecayChain::integrityCheck() {
+  //
+  // Start off checking the tracks
+  //
+  for (size_t index = 0; index < decayTracksSize; ++index) {
+    const auto &decayTrack = decayTracks[index];
+    //
+    // Tracks should always have a production vertex
+    //
+    if (decayTrack.pParentVertex == NULL)
+      throw std::runtime_error("TrackingTruthAccumulator.cc integrityCheck(): "
+                               "Found DecayChainTrack with no parent vertex.");
 
-			//
-			// Make sure the parent has this as a child. Also make sure it's only listed once.
-			//
-			size_t numberOfTimesListed=0;
-			for( const auto pSiblingTrack : decayTrack.pParentVertex->daughterTracks )
-			{
-				if( pSiblingTrack==&decayTrack ) ++numberOfTimesListed;
-			}
-			if( numberOfTimesListed!=1 ) throw std::runtime_error( "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainTrack whose parent does not have it listed once and only once as a child." );
+    //
+    // Make sure the parent has this as a child. Also make sure it's only listed
+    // once.
+    //
+    size_t numberOfTimesListed = 0;
+    for (const auto pSiblingTrack : decayTrack.pParentVertex->daughterTracks) {
+      if (pSiblingTrack == &decayTrack)
+        ++numberOfTimesListed;
+    }
+    if (numberOfTimesListed != 1)
+      throw std::runtime_error("TrackingTruthAccumulator.cc integrityCheck(): "
+                               "Found DecayChainTrack whose parent does not "
+                               "have it listed once and only once as a child.");
 
-			//
-			// Make sure all of the children have this listed as a parent.
-			//
-			for( const auto pDaughterVertex : decayTrack.daughterVertices )
-			{
-				if( pDaughterVertex->pParentTrack!=&decayTrack ) throw std::runtime_error( "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainTrack whose child does not have it listed as the parent." );
-			}
+    //
+    // Make sure all of the children have this listed as a parent.
+    //
+    for (const auto pDaughterVertex : decayTrack.daughterVertices) {
+      if (pDaughterVertex->pParentTrack != &decayTrack)
+        throw std::runtime_error(
+            "TrackingTruthAccumulator.cc integrityCheck(): Found "
+            "DecayChainTrack whose child does not have it listed as the "
+            "parent.");
+    }
 
-			//
-			// Follow the chain up to the root vertex, and make sure that is listed in rootVertices
-			//
-			const DecayChainVertex* pAncestorVertex=decayTrack.pParentVertex;
-			while( pAncestorVertex->pParentTrack!=NULL )
-			{
-				if( pAncestorVertex->pParentTrack->pParentVertex==NULL ) throw std::runtime_error( "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainTrack with no parent vertex higher in the decay chain." );
-				pAncestorVertex=pAncestorVertex->pParentTrack->pParentVertex;
-			}
-			if( std::find( rootVertices.begin(), rootVertices.end(), pAncestorVertex )==rootVertices.end() )
-			{
-				throw std::runtime_error( "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainTrack whose root vertex is not recorded anywhere." );
-			}
-		} // end of loop over decayTracks
+    //
+    // Follow the chain up to the root vertex, and make sure that is listed in
+    // rootVertices
+    //
+    const DecayChainVertex *pAncestorVertex = decayTrack.pParentVertex;
+    while (pAncestorVertex->pParentTrack != NULL) {
+      if (pAncestorVertex->pParentTrack->pParentVertex == NULL)
+        throw std::runtime_error(
+            "TrackingTruthAccumulator.cc integrityCheck(): Found "
+            "DecayChainTrack with no parent vertex higher in the decay chain.");
+      pAncestorVertex = pAncestorVertex->pParentTrack->pParentVertex;
+    }
+    if (std::find(rootVertices.begin(), rootVertices.end(), pAncestorVertex) ==
+        rootVertices.end()) {
+      throw std::runtime_error(
+          "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainTrack "
+          "whose root vertex is not recorded anywhere.");
+    }
+  } // end of loop over decayTracks
 
-		//
-		// Now check the vertices
-		//
-		for( size_t index=0; index<decayVerticesSize; ++index )
-		{
-			const auto& decayVertex=decayVertices[index];
+  //
+  // Now check the vertices
+  //
+  for (size_t index = 0; index < decayVerticesSize; ++index) {
+    const auto &decayVertex = decayVertices[index];
 
-			//
-			// Make sure this, or a vertex higher in the chain, is in the list of root vertices.
-			//
-			const DecayChainVertex* pAncestorVertex=&decayVertex;
-			while( pAncestorVertex->pParentTrack!=NULL )
-			{
-				if( pAncestorVertex->pParentTrack->pParentVertex==NULL ) throw std::runtime_error( "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainTrack with no parent vertex higher in the vertex decay chain." );
-				pAncestorVertex=pAncestorVertex->pParentTrack->pParentVertex;
-			}
-			if( std::find( rootVertices.begin(), rootVertices.end(), pAncestorVertex )==rootVertices.end() )
-			{
-				throw std::runtime_error( "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainTrack whose root vertex is not recorded anywhere." );
-			}
+    //
+    // Make sure this, or a vertex higher in the chain, is in the list of root
+    // vertices.
+    //
+    const DecayChainVertex *pAncestorVertex = &decayVertex;
+    while (pAncestorVertex->pParentTrack != NULL) {
+      if (pAncestorVertex->pParentTrack->pParentVertex == NULL)
+        throw std::runtime_error(
+            "TrackingTruthAccumulator.cc integrityCheck(): Found "
+            "DecayChainTrack with no parent vertex higher in the vertex decay "
+            "chain.");
+      pAncestorVertex = pAncestorVertex->pParentTrack->pParentVertex;
+    }
+    if (std::find(rootVertices.begin(), rootVertices.end(), pAncestorVertex) ==
+        rootVertices.end()) {
+      throw std::runtime_error(
+          "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainTrack "
+          "whose root vertex is not recorded anywhere.");
+    }
 
-			//
-			// Make sure the parent has this listed in its daughters once and only once.
-			//
-			if( decayVertex.pParentTrack!=NULL )
-			{
-				size_t numberOfTimesListed=0;
-				for( const auto pSibling : decayVertex.pParentTrack->daughterVertices )
-				{
-					if( pSibling==&decayVertex ) ++numberOfTimesListed;
-				}
-				if( numberOfTimesListed!=1 ) throw std::runtime_error( "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainVertex whose parent does not have it listed once and only once as a child." );
-			}
+    //
+    // Make sure the parent has this listed in its daughters once and only once.
+    //
+    if (decayVertex.pParentTrack != NULL) {
+      size_t numberOfTimesListed = 0;
+      for (const auto pSibling : decayVertex.pParentTrack->daughterVertices) {
+        if (pSibling == &decayVertex)
+          ++numberOfTimesListed;
+      }
+      if (numberOfTimesListed != 1)
+        throw std::runtime_error(
+            "TrackingTruthAccumulator.cc integrityCheck(): Found "
+            "DecayChainVertex whose parent does not have it listed once and "
+            "only once as a child.");
+    }
 
-			//
-			// Make sure all of the children have this listed as the parent
-			//
-			for( const auto pDaughter : decayVertex.daughterTracks )
-			{
-				if( pDaughter->pParentVertex!=&decayVertex ) throw std::runtime_error( "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainVertex whose child does not have it listed as the parent." );
-			}
-		} // end of loop over decay vertices
+    //
+    // Make sure all of the children have this listed as the parent
+    //
+    for (const auto pDaughter : decayVertex.daughterTracks) {
+      if (pDaughter->pParentVertex != &decayVertex)
+        throw std::runtime_error(
+            "TrackingTruthAccumulator.cc integrityCheck(): Found "
+            "DecayChainVertex whose child does not have it listed as the "
+            "parent.");
+    }
+  } // end of loop over decay vertices
 
-		std::cout << "TrackingTruthAccumulator.cc integrityCheck() completed successfully" << std::endl;
-	} // end of ::DecayChain::integrityCheck()
+  std::cout
+      << "TrackingTruthAccumulator.cc integrityCheck() completed successfully"
+      << std::endl;
+} // end of ::DecayChain::integrityCheck()
 #endif
 
-	void ::DecayChain::findBrem( const std::vector<SimTrack>& trackCollection, const std::vector<SimVertex>& vertexCollection )
-	{
-		for( size_t index=0; index<decayVerticesSize; ++index )
-		{
-			auto& vertex=decayVertices_[index];
+void ::DecayChain::findBrem(const std::vector<SimTrack> &trackCollection,
+                            const std::vector<SimVertex> &vertexCollection) {
+  for (size_t index = 0; index < decayVerticesSize; ++index) {
+    auto &vertex = decayVertices_[index];
 
-			// Make sure parent is an electron
-			if( vertex.pParentTrack==nullptr ) continue;
-			int parentTrackPDG=trackCollection[vertex.pParentTrack->simTrackIndex].type();
-			if( std::abs( parentTrackPDG )!=11 ) continue;
+    // Make sure parent is an electron
+    if (vertex.pParentTrack == nullptr)
+      continue;
+    int parentTrackPDG =
+        trackCollection[vertex.pParentTrack->simTrackIndex].type();
+    if (std::abs(parentTrackPDG) != 11)
+      continue;
 
-			size_t numberOfElectrons=0;
-			size_t numberOfNonElectronsOrPhotons=0;
-			for( auto& pDaughterTrack : vertex.daughterTracks )
-			{
-				const auto& simTrack=trackCollection[pDaughterTrack->simTrackIndex];
-				if( simTrack.type()==11 || simTrack.type()==-11 ) ++numberOfElectrons;
-				else if( simTrack.type()!=22 ) ++numberOfNonElectronsOrPhotons;
-			}
-			if( numberOfElectrons==1 && numberOfNonElectronsOrPhotons==0 )
-			{
-				// This is a valid brem, run through and tell all daughters to use the parent
-				// as the brem
-				for( auto& pDaughterTrack : vertex.daughterTracks ) pDaughterTrack->pMergedBremSource=vertex.pParentTrack;
-				vertex.pMergedBremSource=vertex.pParentTrack->pParentVertex;
-			}
-		}
-	} // end of ::DecayChain::findBrem()
+    size_t numberOfElectrons = 0;
+    size_t numberOfNonElectronsOrPhotons = 0;
+    for (auto &pDaughterTrack : vertex.daughterTracks) {
+      const auto &simTrack = trackCollection[pDaughterTrack->simTrackIndex];
+      if (simTrack.type() == 11 || simTrack.type() == -11)
+        ++numberOfElectrons;
+      else if (simTrack.type() != 22)
+        ++numberOfNonElectronsOrPhotons;
+    }
+    if (numberOfElectrons == 1 && numberOfNonElectronsOrPhotons == 0) {
+      // This is a valid brem, run through and tell all daughters to use the
+      // parent as the brem
+      for (auto &pDaughterTrack : vertex.daughterTracks)
+        pDaughterTrack->pMergedBremSource = vertex.pParentTrack;
+      vertex.pMergedBremSource = vertex.pParentTrack->pParentVertex;
+    }
+  }
+} // end of ::DecayChain::findBrem()
 
+//---------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------
+//----   OutputCollectionWrapper methods
+//----------------------------------------
+//---------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------
 
-	//---------------------------------------------------------------------------------
-	//---------------------------------------------------------------------------------
-	//----   OutputCollectionWrapper methods   ----------------------------------------
-	//---------------------------------------------------------------------------------
-	//---------------------------------------------------------------------------------
+::OutputCollectionWrapper::OutputCollectionWrapper(
+    const ::DecayChain &decayChain,
+    TrackingTruthAccumulator::OutputCollections &outputCollections)
+    : output_(outputCollections),
+      trackingParticleIndices_(decayChain.decayTracksSize, -1),
+      trackingVertexIndices_(decayChain.decayVerticesSize, -1) {
+  // No operation besides the initialiser list
+}
 
-	::OutputCollectionWrapper::OutputCollectionWrapper( const ::DecayChain& decayChain, TrackingTruthAccumulator::OutputCollections& outputCollections )
-		: output_(outputCollections),
-		  trackingParticleIndices_(decayChain.decayTracksSize,-1),
-		  trackingVertexIndices_(decayChain.decayVerticesSize,-1)
-	{
-		// No operation besides the initialiser list
-	}
+TrackingParticle * ::OutputCollectionWrapper::addTrackingParticle(
+    const ::DecayChainTrack *pDecayTrack,
+    const TrackingParticle &trackingParticle) {
+  if (trackingParticleIndices_[pDecayTrack->simTrackIndex] != -1)
+    throw std::runtime_error("OutputCollectionWrapper::addTrackingParticle - "
+                             "trying to add a particle twice");
 
-	TrackingParticle* ::OutputCollectionWrapper::addTrackingParticle( const ::DecayChainTrack* pDecayTrack, const TrackingParticle& trackingParticle )
-	{
-		if( trackingParticleIndices_[pDecayTrack->simTrackIndex]!=-1 ) throw std::runtime_error( "OutputCollectionWrapper::addTrackingParticle - trying to add a particle twice" );
+  trackingParticleIndices_[pDecayTrack->simTrackIndex] =
+      output_.pTrackingParticles->size();
+  output_.pTrackingParticles->push_back(trackingParticle);
 
-		trackingParticleIndices_[pDecayTrack->simTrackIndex]=output_.pTrackingParticles->size();
-		output_.pTrackingParticles->push_back( trackingParticle );
+  // Clear any associations in case there were any beforehand
+  output_.pTrackingParticles->back().clearDecayVertices();
+  output_.pTrackingParticles->back().clearParentVertex();
 
-		// Clear any associations in case there were any beforehand
-		output_.pTrackingParticles->back().clearDecayVertices();
-		output_.pTrackingParticles->back().clearParentVertex();
+  // Associate to the objects that are already in the output collections
+  associateToExistingObjects(pDecayTrack);
 
-		// Associate to the objects that are already in the output collections
-		associateToExistingObjects( pDecayTrack );
+  return &output_.pTrackingParticles->back();
+}
 
-		return &output_.pTrackingParticles->back();
-	}
+TrackingVertex * ::OutputCollectionWrapper::addTrackingVertex(
+    const ::DecayChainVertex *pDecayVertex,
+    const TrackingVertex &trackingVertex) {
+  if (trackingVertexIndices_[pDecayVertex->simVertexIndex] != -1)
+    throw std::runtime_error("OutputCollectionWrapper::addTrackingVertex - "
+                             "trying to add a vertex twice");
 
-	TrackingVertex* ::OutputCollectionWrapper::addTrackingVertex( const ::DecayChainVertex* pDecayVertex, const TrackingVertex& trackingVertex )
-	{
-		if( trackingVertexIndices_[pDecayVertex->simVertexIndex]!=-1 ) throw std::runtime_error( "OutputCollectionWrapper::addTrackingVertex - trying to add a vertex twice" );
+  trackingVertexIndices_[pDecayVertex->simVertexIndex] =
+      output_.pTrackingVertices->size();
+  output_.pTrackingVertices->push_back(trackingVertex);
 
-		trackingVertexIndices_[pDecayVertex->simVertexIndex]=output_.pTrackingVertices->size();
-		output_.pTrackingVertices->push_back( trackingVertex );
+  // Associate the new vertex to any parents or children that are already in the
+  // output collections
+  associateToExistingObjects(pDecayVertex);
 
-		// Associate the new vertex to any parents or children that are already in the output collections
-		associateToExistingObjects( pDecayVertex );
+  return &output_.pTrackingVertices->back();
+}
 
-		return &output_.pTrackingVertices->back();
-	}
+TrackingParticle * ::OutputCollectionWrapper::getTrackingParticle(
+    const ::DecayChainTrack *pDecayTrack) {
+  const int index = trackingParticleIndices_[pDecayTrack->simTrackIndex];
+  if (index == -1)
+    return nullptr;
+  else
+    return &(*output_.pTrackingParticles)[index];
+}
 
-	TrackingParticle* ::OutputCollectionWrapper::getTrackingParticle( const ::DecayChainTrack* pDecayTrack )
-	{
-		const int index=trackingParticleIndices_[pDecayTrack->simTrackIndex];
-		if( index==-1 ) return nullptr;
-		else return &(*output_.pTrackingParticles)[index];
-	}
+TrackingVertex * ::OutputCollectionWrapper::getTrackingVertex(
+    const ::DecayChainVertex *pDecayVertex) {
+  const int index = trackingVertexIndices_[pDecayVertex->simVertexIndex];
+  if (index == -1)
+    return nullptr;
+  else
+    return &(*output_.pTrackingVertices)[index];
+}
 
-	TrackingVertex* ::OutputCollectionWrapper::getTrackingVertex( const ::DecayChainVertex* pDecayVertex )
-	{
-		const int index=trackingVertexIndices_[pDecayVertex->simVertexIndex];
-		if( index==-1 ) return nullptr;
-		else return &(*output_.pTrackingVertices)[index];
-	}
+TrackingParticleRef
+OutputCollectionWrapper::getRef(const ::DecayChainTrack *pDecayTrack) {
+  const int index = trackingParticleIndices_[pDecayTrack->simTrackIndex];
+  if (index == -1)
+    throw std::runtime_error(
+        "OutputCollectionWrapper::getRefTrackingParticle - ref requested for a "
+        "non existent TrackingParticle");
+  else
+    return TrackingParticleRef(output_.refTrackingParticles, index);
+}
 
-	TrackingParticleRef OutputCollectionWrapper::getRef( const ::DecayChainTrack* pDecayTrack )
-	{
-		const int index=trackingParticleIndices_[pDecayTrack->simTrackIndex];
-		if( index==-1 ) throw std::runtime_error( "OutputCollectionWrapper::getRefTrackingParticle - ref requested for a non existent TrackingParticle" );
-		else return TrackingParticleRef( output_.refTrackingParticles, index );
-	}
+TrackingVertexRef
+OutputCollectionWrapper::getRef(const ::DecayChainVertex *pDecayVertex) {
+  const int index = trackingVertexIndices_[pDecayVertex->simVertexIndex];
+  if (index == -1)
+    throw std::runtime_error(
+        "OutputCollectionWrapper::getRefTrackingParticle - ref requested for a "
+        "non existent TrackingVertex");
+  else
+    return TrackingVertexRef(output_.refTrackingVertexes, index);
+}
 
-	TrackingVertexRef OutputCollectionWrapper::getRef( const ::DecayChainVertex* pDecayVertex )
-	{
-		const int index=trackingVertexIndices_[pDecayVertex->simVertexIndex];
-		if( index==-1 ) throw std::runtime_error( "OutputCollectionWrapper::getRefTrackingParticle - ref requested for a non existent TrackingVertex" );
-		else return TrackingVertexRef( output_.refTrackingVertexes, index );
-	}
+void ::OutputCollectionWrapper::setProxy(
+    const ::DecayChainTrack *pOriginalTrack,
+    const ::DecayChainTrack *pProxyTrack) {
+  int &index = trackingParticleIndices_[pOriginalTrack->simTrackIndex];
+  if (index != -1)
+    throw std::runtime_error(
+        "OutputCollectionWrapper::setProxy() was called for a TrackingParticle "
+        "that has already been created");
+  // Note that index is a reference so this call changes the value in the vector
+  // too
+  index = trackingParticleIndices_[pProxyTrack->simTrackIndex];
+}
 
-	void ::OutputCollectionWrapper::setProxy( const ::DecayChainTrack* pOriginalTrack, const ::DecayChainTrack* pProxyTrack )
-	{
-		int& index=trackingParticleIndices_[pOriginalTrack->simTrackIndex];
-		if( index!=-1 ) throw std::runtime_error( "OutputCollectionWrapper::setProxy() was called for a TrackingParticle that has already been created" );
-		// Note that index is a reference so this call changes the value in the vector too
-		index=trackingParticleIndices_[pProxyTrack->simTrackIndex];
-	}
+void ::OutputCollectionWrapper::setProxy(
+    const ::DecayChainVertex *pOriginalVertex,
+    const ::DecayChainVertex *pProxyVertex) {
+  int &index = trackingVertexIndices_[pOriginalVertex->simVertexIndex];
+  const int newIndex = trackingVertexIndices_[pProxyVertex->simVertexIndex];
 
-	void ::OutputCollectionWrapper::setProxy( const ::DecayChainVertex* pOriginalVertex, const ::DecayChainVertex* pProxyVertex )
-	{
-		int& index=trackingVertexIndices_[pOriginalVertex->simVertexIndex];
-		const int newIndex=trackingVertexIndices_[pProxyVertex->simVertexIndex];
+  if (index != -1 && index != newIndex)
+    throw std::runtime_error(
+        "OutputCollectionWrapper::setProxy() was called for a TrackingVertex "
+        "that has already been created");
 
-		if( index!=-1 && index!=newIndex ) throw std::runtime_error( "OutputCollectionWrapper::setProxy() was called for a TrackingVertex that has already been created" );
+  // Note that index is a reference so this call changes the value in the vector
+  // too
+  index = newIndex;
+}
 
-		// Note that index is a reference so this call changes the value in the vector too
-		index=newIndex;
-	}
+void ::OutputCollectionWrapper::associateToExistingObjects(
+    const ::DecayChainVertex *pChainVertex) {
+  // First make sure the DecayChainVertex supplied has been turned into a
+  // TrackingVertex
+  TrackingVertex *pTrackingVertex = getTrackingVertex(pChainVertex);
+  if (pTrackingVertex == nullptr)
+    throw std::runtime_error(
+        "associateToExistingObjects was passed a non existent TrackingVertex");
 
-	void ::OutputCollectionWrapper::associateToExistingObjects( const ::DecayChainVertex* pChainVertex )
-	{
-		// First make sure the DecayChainVertex supplied has been turned into a TrackingVertex
-		TrackingVertex* pTrackingVertex=getTrackingVertex( pChainVertex );
-		if( pTrackingVertex==nullptr ) throw std::runtime_error( "associateToExistingObjects was passed a non existent TrackingVertex" );
+  //
+  // Associate to the parent track (if there is one)
+  //
+  ::DecayChainTrack *pParentChainTrack = pChainVertex->pParentTrack;
+  if (pParentChainTrack != nullptr) // Make sure there is a parent track first
+  {
+    // There is a parent track, but it might not have been turned into a
+    // TrackingParticle yet
+    TrackingParticle *pParentTrackingParticle =
+        getTrackingParticle(pParentChainTrack);
+    if (pParentTrackingParticle != nullptr) {
+      pParentTrackingParticle->addDecayVertex(getRef(pChainVertex));
+      pTrackingVertex->addParentTrack(getRef(pParentChainTrack));
+    }
+    // Don't worry about the "else" case - the parent track might not
+    // necessarily get added to the output collection at all. A check is done on
+    // daughter vertices when tracks are added, so the association will be
+    // picked up then.
+  }
 
-		//
-		// Associate to the parent track (if there is one)
-		//
-		::DecayChainTrack* pParentChainTrack=pChainVertex->pParentTrack;
-		if( pParentChainTrack!=nullptr ) // Make sure there is a parent track first
-		{
-			// There is a parent track, but it might not have been turned into a TrackingParticle yet
-			TrackingParticle* pParentTrackingParticle=getTrackingParticle(pParentChainTrack);
-			if( pParentTrackingParticle!=nullptr )
-			{
-				pParentTrackingParticle->addDecayVertex( getRef(pChainVertex) );
-				pTrackingVertex->addParentTrack( getRef(pParentChainTrack) );
-			}
-			// Don't worry about the "else" case - the parent track might not necessarily get added
-			// to the output collection at all. A check is done on daughter vertices when tracks
-			// are added, so the association will be picked up then.
-		}
+  //
+  // A parent TrackingVertex is always associated to a daughter TrackingParticle
+  // when the TrackingParticle is created. Hence there is no need to check the
+  // list of daughter tracks.
+  //
+}
 
-		//
-		// A parent TrackingVertex is always associated to a daughter TrackingParticle when
-		// the TrackingParticle is created. Hence there is no need to check the list of
-		// daughter tracks.
-		//
-	}
+void ::OutputCollectionWrapper::associateToExistingObjects(
+    const ::DecayChainTrack *pChainTrack) {
+  //
+  // First make sure this DecayChainTrack has been turned into a
+  // TrackingParticle
+  //
+  TrackingParticle *pTrackingParticle = getTrackingParticle(pChainTrack);
+  if (pTrackingParticle == nullptr)
+    throw std::runtime_error("associateToExistingObjects was passed a non "
+                             "existent TrackingParticle");
 
-	void ::OutputCollectionWrapper::associateToExistingObjects( const ::DecayChainTrack* pChainTrack )
-	{
-		//
-		// First make sure this DecayChainTrack has been turned into a TrackingParticle
-		//
-		TrackingParticle* pTrackingParticle=getTrackingParticle( pChainTrack );
-		if( pTrackingParticle==nullptr ) throw std::runtime_error( "associateToExistingObjects was passed a non existent TrackingParticle" );
+  // Get the parent vertex. This should always already have been turned into a
+  // TrackingVertex, and there should always be a parent DecayChainVertex.
+  ::DecayChainVertex *pParentChainVertex = pChainTrack->pParentVertex;
+  TrackingVertex *pParentTrackingVertex = getTrackingVertex(pParentChainVertex);
 
-		// Get the parent vertex. This should always already have been turned into a TrackingVertex, and
-		// there should always be a parent DecayChainVertex.
-		::DecayChainVertex* pParentChainVertex=pChainTrack->pParentVertex;
-		TrackingVertex* pParentTrackingVertex=getTrackingVertex( pParentChainVertex );
+  //
+  // First associate to the parent vertex.
+  //
+  pTrackingParticle->setParentVertex(getRef(pParentChainVertex));
+  pParentTrackingVertex->addDaughterTrack(getRef(pChainTrack));
 
-		//
-		// First associate to the parent vertex.
-		//
-		pTrackingParticle->setParentVertex( getRef(pParentChainVertex) );
-		pParentTrackingVertex->addDaughterTrack( getRef(pChainTrack) );
+  // If there are any daughter vertices that have already been made into a
+  // TrackingVertex make sure they know about each other. If the daughter
+  // vertices haven't been made into TrackingVertexs yet, I won't do anything
+  // and create the association when the vertex is made.
+  for (auto pDaughterChainVertex : pChainTrack->daughterVertices) {
+    TrackingVertex *pDaughterTrackingVertex =
+        getTrackingVertex(pDaughterChainVertex);
+    if (pDaughterTrackingVertex != nullptr) {
+      pTrackingParticle->addDecayVertex(getRef(pDaughterChainVertex));
+      pDaughterTrackingVertex->addParentTrack(getRef(pChainTrack));
+    }
+  }
+}
 
-		// If there are any daughter vertices that have already been made into a TrackingVertex
-		// make sure they know about each other. If the daughter vertices haven't been made into
-		// TrackingVertexs yet, I won't do anything and create the association when the vertex is
-		// made.
-		for( auto pDaughterChainVertex : pChainTrack->daughterVertices )
-		{
-			TrackingVertex* pDaughterTrackingVertex=getTrackingVertex( pDaughterChainVertex );
-			if( pDaughterTrackingVertex!=nullptr )
-			{
-				pTrackingParticle->addDecayVertex( getRef(pDaughterChainVertex) );
-				pDaughterTrackingVertex->addParentTrack( getRef(pChainTrack) );
-			}
-		}
-	}
+TrackingParticle *
+addTrackAndParentVertex(::DecayChainTrack *pDecayTrack,
+                        const TrackingParticle &trackingParticle,
+                        ::OutputCollectionWrapper *pOutput) {
+  // See if this TrackingParticle has already been created (could be if the
+  // DecayChainTracks are looped over in a funny order). If it has then there's
+  // no need to do anything.
+  TrackingParticle *pTrackingParticle =
+      pOutput->getTrackingParticle(pDecayTrack);
+  if (pTrackingParticle == nullptr) {
+    // Need to make sure the production vertex has been created first
+    if (pOutput->getTrackingVertex(pDecayTrack->pParentVertex) == nullptr) {
+      // TrackingVertex doesn't exist in the output collection yet. However,
+      // it's already been created in the addTrack() function and a temporary
+      // reference to it set in the TrackingParticle. I'll use that reference to
+      // create a copy in the output collection. When the TrackingParticle is
+      // added to the output collection a few lines below the temporary
+      // reference to the parent vertex will be cleared, and the correct one
+      // referring to the output collection will be set.
+      pOutput->addTrackingVertex(pDecayTrack->pParentVertex,
+                                 *trackingParticle.parentVertex());
+    }
 
+    pTrackingParticle =
+        pOutput->addTrackingParticle(pDecayTrack, trackingParticle);
+  }
 
-	TrackingParticle* addTrackAndParentVertex( ::DecayChainTrack* pDecayTrack, const TrackingParticle& trackingParticle, ::OutputCollectionWrapper* pOutput )
-	{
-		// See if this TrackingParticle has already been created (could be if the DecayChainTracks are
-		// looped over in a funny order). If it has then there's no need to do anything.
-		TrackingParticle* pTrackingParticle=pOutput->getTrackingParticle( pDecayTrack );
-		if( pTrackingParticle==nullptr )
-		{
-			// Need to make sure the production vertex has been created first
-			if( pOutput->getTrackingVertex( pDecayTrack->pParentVertex ) == nullptr )
-			{
-				// TrackingVertex doesn't exist in the output collection yet. However, it's already been
-				// created in the addTrack() function and a temporary reference to it set in the TrackingParticle.
-				// I'll use that reference to create a copy in the output collection. When the TrackingParticle
-				// is added to the output collection a few lines below the temporary reference to the parent
-				// vertex will be cleared, and the correct one referring to the output collection will be set.
-				pOutput->addTrackingVertex( pDecayTrack->pParentVertex, *trackingParticle.parentVertex() );
-			}
+  return pTrackingParticle;
+}
 
+void addTrack(::DecayChainTrack *pDecayChainTrack,
+              const TrackingParticleSelector *pSelector,
+              ::OutputCollectionWrapper *pUnmergedOutput,
+              ::OutputCollectionWrapper *pMergedOutput,
+              const ::TrackingParticleFactory &objectFactory, bool addAncestors,
+              const TrackerTopology *tTopo) {
+  if (pDecayChainTrack == nullptr)
+    return; // This is required for when the addAncestors_ recursive call
+            // reaches the top of the chain
 
-			pTrackingParticle=pOutput->addTrackingParticle( pDecayTrack, trackingParticle );
-		}
+  // Check to see if this particle has already been processed while traversing
+  // up the parents of another split in the decay chain. The check in the line
+  // above only stops when the top of the chain is reached, whereas this will
+  // stop when a previously traversed split is reached.
+  { // block to limit the scope of temporary variables
+    bool alreadyProcessed = true;
+    if (pUnmergedOutput != nullptr) {
+      if (pUnmergedOutput->getTrackingParticle(pDecayChainTrack) == nullptr)
+        alreadyProcessed = false;
+    }
+    if (pMergedOutput != nullptr) {
+      if (pMergedOutput->getTrackingParticle(pDecayChainTrack) == nullptr)
+        alreadyProcessed = false;
+    }
+    if (alreadyProcessed)
+      return;
+  }
 
-		return pTrackingParticle;
-	}
+  // Create a TrackingParticle.
+  TrackingParticle newTrackingParticle =
+      objectFactory.createTrackingParticle(pDecayChainTrack, tTopo);
 
-	void addTrack( ::DecayChainTrack* pDecayChainTrack, const TrackingParticleSelector* pSelector, ::OutputCollectionWrapper* pUnmergedOutput, ::OutputCollectionWrapper* pMergedOutput, const ::TrackingParticleFactory& objectFactory, bool addAncestors, const TrackerTopology *tTopo )
-	{
-		if( pDecayChainTrack==nullptr ) return; // This is required for when the addAncestors_ recursive call reaches the top of the chain
+  // The selector checks the impact parameters from the vertex, so I need to
+  // have a valid reference to the parent vertex in the TrackingParticle before
+  // that can be called. TrackingParticle needs an edm::Ref for the parent
+  // TrackingVertex though. I still don't know if this is going to be added to
+  // the collection so I can't take it from there, so I need to create a
+  // temporary one. When the addTrackAndParentVertex() is called (assuming it
+  // passes selection) it will use the temporary reference to create a copy of
+  // the parent vertex, put that in the output collection, and then set the
+  // reference in the TrackingParticle properly.
+  TrackingVertexCollection dummyCollection; // Only needed to create an edm::Ref
+  dummyCollection.push_back(
+      objectFactory.createTrackingVertex(pDecayChainTrack->pParentVertex));
+  TrackingVertexRef temporaryRef(&dummyCollection, 0);
+  newTrackingParticle.setParentVertex(temporaryRef);
 
-		// Check to see if this particle has already been processed while traversing up the parents
-		// of another split in the decay chain. The check in the line above only stops when the top
-		// of the chain is reached, whereas this will stop when a previously traversed split is reached.
-		{ // block to limit the scope of temporary variables
-			bool alreadyProcessed=true;
-			if( pUnmergedOutput!=nullptr )
-			{
-				if( pUnmergedOutput->getTrackingParticle( pDecayChainTrack )==nullptr ) alreadyProcessed=false;
-			}
-			if( pMergedOutput!=nullptr )
-			{
-				if( pMergedOutput->getTrackingParticle( pDecayChainTrack )==nullptr ) alreadyProcessed=false;
-			}
-			if( alreadyProcessed ) return;
-		}
+  // If a selector has been supplied apply it on the new TrackingParticle and
+  // return if it fails.
+  if (pSelector) {
+    if (!(*pSelector)(newTrackingParticle))
+      return; // Return if the TrackingParticle fails selection
+  }
 
-		// Create a TrackingParticle.
-		TrackingParticle newTrackingParticle=objectFactory.createTrackingParticle( pDecayChainTrack, tTopo );
+  // Add the ancestors first (if required) so that the collection has some kind
+  // of chronological order. I don't know how important that is but other code
+  // might assume chronological order. If adding ancestors, no selection is
+  // applied. Note that I've already checked that all DecayChainTracks have a
+  // pParentVertex.
+  if (addAncestors)
+    addTrack(pDecayChainTrack->pParentVertex->pParentTrack, nullptr,
+             pUnmergedOutput, pMergedOutput, objectFactory, addAncestors,
+             tTopo);
 
-		// The selector checks the impact parameters from the vertex, so I need to have a valid reference
-		// to the parent vertex in the TrackingParticle before that can be called. TrackingParticle needs
-		// an edm::Ref for the parent TrackingVertex though. I still don't know if this is going to be
-		// added to the collection so I can't take it from there, so I need to create a temporary one.
-		// When the addTrackAndParentVertex() is called (assuming it passes selection) it will use the
-		// temporary reference to create a copy of the parent vertex, put that in the output collection,
-		// and then set the reference in the TrackingParticle properly.
-		TrackingVertexCollection dummyCollection; // Only needed to create an edm::Ref
-		dummyCollection.push_back( objectFactory.createTrackingVertex( pDecayChainTrack->pParentVertex) );
-		TrackingVertexRef temporaryRef( &dummyCollection, 0 );
-		newTrackingParticle.setParentVertex( temporaryRef );
+  // If creation of the unmerged collection has been turned off in the config
+  // this pointer will be null.
+  if (pUnmergedOutput != nullptr)
+    addTrackAndParentVertex(pDecayChainTrack, newTrackingParticle,
+                            pUnmergedOutput);
 
-		// If a selector has been supplied apply it on the new TrackingParticle and return if it fails.
-		if( pSelector )
-		{
-			if( !(*pSelector)( newTrackingParticle ) ) return; // Return if the TrackingParticle fails selection
-		}
+  // If creation of the merged collection has been turned off in the config this
+  // pointer will be null.
+  if (pMergedOutput != nullptr) {
+    ::DecayChainTrack *pBremParentChainTrack = pDecayChainTrack;
+    while (pBremParentChainTrack->pMergedBremSource != nullptr)
+      pBremParentChainTrack = pBremParentChainTrack->pMergedBremSource;
 
-		// Add the ancestors first (if required) so that the collection has some kind of chronological
-		// order. I don't know how important that is but other code might assume chronological order.
-		// If adding ancestors, no selection is applied. Note that I've already checked that all
-		// DecayChainTracks have a pParentVertex.
-		if( addAncestors ) addTrack( pDecayChainTrack->pParentVertex->pParentTrack, nullptr, pUnmergedOutput, pMergedOutput, objectFactory, addAncestors, tTopo );
+    if (pBremParentChainTrack != pDecayChainTrack) {
+      TrackingParticle *pBremParentTrackingParticle = addTrackAndParentVertex(
+          pBremParentChainTrack, newTrackingParticle, pMergedOutput);
+      // The original particle in the bremsstrahlung decay chain has been
+      // created (or retrieved if it already existed), now copy in the
+      // extra information.
+      // TODO - copy extra information.
 
-		// If creation of the unmerged collection has been turned off in the config this pointer
-		// will be null.
-		if( pUnmergedOutput!=nullptr ) addTrackAndParentVertex( pDecayChainTrack, newTrackingParticle, pUnmergedOutput );
+      if (std::abs(newTrackingParticle.pdgId()) == 22) {
+        // Photons are added as separate TrackingParticles, but with the
+        // production vertex changed to be the production vertex of the original
+        // electron.
 
-		// If creation of the merged collection has been turned off in the config this pointer
-		// will be null.
-		if( pMergedOutput!=nullptr )
-		{
-			::DecayChainTrack* pBremParentChainTrack=pDecayChainTrack;
-			while( pBremParentChainTrack->pMergedBremSource!=nullptr ) pBremParentChainTrack=pBremParentChainTrack->pMergedBremSource;
+        // Set up a proxy, so that all requests for the parent TrackingVertex
+        // get redirected to the brem parent's TrackingVertex.
+        pMergedOutput->setProxy(pDecayChainTrack->pParentVertex,
+                                pBremParentChainTrack->pParentVertex);
 
-			if( pBremParentChainTrack!=pDecayChainTrack )
-			{
-				TrackingParticle* pBremParentTrackingParticle=addTrackAndParentVertex( pBremParentChainTrack, newTrackingParticle, pMergedOutput );
-				// The original particle in the bremsstrahlung decay chain has been
-				// created (or retrieved if it already existed), now copy in the
-				// extra information.
-				// TODO - copy extra information.
+        // Now that pMergedOutput thinks the parent vertex is the brem parent's
+        // vertex I can call this and it will set the TrackingParticle parent
+        // vertex correctly to the brem parent vertex.
+        addTrackAndParentVertex(pDecayChainTrack, newTrackingParticle,
+                                pMergedOutput);
+      } else if (std::abs(newTrackingParticle.pdgId()) == 11) {
+        // Electrons have their G4 tracks and SimHits copied to the parent
+        // TrackingParticle.
+        for (const auto &trackSegment : newTrackingParticle.g4Tracks()) {
+          pBremParentTrackingParticle->addG4Track(trackSegment);
+        }
 
-				if( std::abs( newTrackingParticle.pdgId() ) == 22 )
-				{
-					// Photons are added as separate TrackingParticles, but with the production
-					// vertex changed to be the production vertex of the original electron.
+        // Also copy the generator particle references
+        for (const auto &genParticleRef : newTrackingParticle.genParticles()) {
+          pBremParentTrackingParticle->addGenParticle(genParticleRef);
+        }
 
-					// Set up a proxy, so that all requests for the parent TrackingVertex get
-					// redirected to the brem parent's TrackingVertex.
-					pMergedOutput->setProxy( pDecayChainTrack->pParentVertex, pBremParentChainTrack->pParentVertex );
+        pBremParentTrackingParticle->setNumberOfHits(
+            pBremParentTrackingParticle->numberOfHits() +
+            newTrackingParticle.numberOfHits());
+        pBremParentTrackingParticle->setNumberOfTrackerHits(
+            pBremParentTrackingParticle->numberOfTrackerHits() +
+            newTrackingParticle.numberOfTrackerHits());
+        pBremParentTrackingParticle->setNumberOfTrackerLayers(
+            pBremParentTrackingParticle->numberOfTrackerLayers() +
+            newTrackingParticle.numberOfTrackerLayers());
 
-					// Now that pMergedOutput thinks the parent vertex is the brem parent's vertex I can
-					// call this and it will set the TrackingParticle parent vertex correctly to the brem
-					// parent vertex.
-					addTrackAndParentVertex( pDecayChainTrack, newTrackingParticle, pMergedOutput );
-				}
-				else if( std::abs( newTrackingParticle.pdgId() ) == 11 )
-				{
-					// Electrons have their G4 tracks and SimHits copied to the parent TrackingParticle.
-					for( const auto& trackSegment : newTrackingParticle.g4Tracks() )
-					{
-						pBremParentTrackingParticle->addG4Track( trackSegment );
-					}
+        // Set a proxy in the output collection wrapper so that any attempt to
+        // get objects for this DecayChainTrack again get redirected to the brem
+        // parent.
+        pMergedOutput->setProxy(pDecayChainTrack, pBremParentChainTrack);
+      }
+    } else {
+      // This is not the result of bremsstrahlung so add to the collection as
+      // normal.
+      addTrackAndParentVertex(pDecayChainTrack, newTrackingParticle,
+                              pMergedOutput);
+    }
+  } // end of "if( pMergedOutput!=NULL )", i.e. end of "if bremsstrahlung
+    // merging is turned on"
 
-					// Also copy the generator particle references
-					for( const auto& genParticleRef : newTrackingParticle.genParticles() )
-					{
-						pBremParentTrackingParticle->addGenParticle( genParticleRef );
-					}
+} // end of addTrack function
 
-					pBremParentTrackingParticle->setNumberOfHits(pBremParentTrackingParticle->numberOfHits()+newTrackingParticle.numberOfHits());
-					pBremParentTrackingParticle->setNumberOfTrackerHits(pBremParentTrackingParticle->numberOfTrackerHits()+newTrackingParticle.numberOfTrackerHits());
-					pBremParentTrackingParticle->setNumberOfTrackerLayers(pBremParentTrackingParticle->numberOfTrackerLayers()+newTrackingParticle.numberOfTrackerLayers());
-
-					// Set a proxy in the output collection wrapper so that any attempt to get objects for
-					// this DecayChainTrack again get redirected to the brem parent.
-					pMergedOutput->setProxy( pDecayChainTrack, pBremParentChainTrack );
-				}
-			}
-			else
-			{
-				// This is not the result of bremsstrahlung so add to the collection as normal.
-				addTrackAndParentVertex( pDecayChainTrack, newTrackingParticle, pMergedOutput );
-			}
-		} // end of "if( pMergedOutput!=NULL )", i.e. end of "if bremsstrahlung merging is turned on"
-
-	} // end of addTrack function
-
-} // end of the unnamed namespace
+} // namespace
 
 // Register with the framework
-DEFINE_DIGI_ACCUMULATOR (TrackingTruthAccumulator);
+DEFINE_DIGI_ACCUMULATOR(TrackingTruthAccumulator);

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
@@ -1,27 +1,23 @@
 #ifndef TrackingAnalysis_TrackingTruthAccumulator_h
 #define TrackingAnalysis_TrackingTruthAccumulator_h
 
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "SimTracker/Common/interface/TrackingParticleSelector.h"
 #include <memory> // required for std::unique_ptr
-#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
-#include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
-
 
 // Forward declarations
-namespace edm
-{
-	class ParameterSet;
-        class ConsumesCollector;
-	class ProducerBase;
-	class Event;
-	class EventSetup;
-        class StreamID;
-}
+namespace edm {
+class ParameterSet;
+class ConsumesCollector;
+class ProducerBase;
+class Event;
+class EventSetup;
+class StreamID;
+} // namespace edm
 class PileUpEventPrincipal;
 class PSimHit;
-
-
 
 /** @brief Replacement for TrackingTruthProducer in the new pileup mixing setup.
  *
@@ -29,123 +25,167 @@ class PSimHit;
  *
  * <table>
  * <tr>
- *     <th>Parameter name                  </th><th> Type              </th><th> Description </th>
+ *     <th>Parameter name                  </th><th> Type              </th><th>
+ * Description </th>
  * </tr>
- * <tr><td> volumeRadius                   </td><td> double            </td><td> The volume radius in cm used if ignoreTracksOutsideVolume is true. </td></tr>
- * <tr><td> volumeZ                        </td><td> double            </td><td> The volume z in cm used if ignoreTracksOutsideVolume is true. </td></tr>
- * <tr><td> ignoreTracksOutsideVolume      </td><td> bool              </td><td> If true, sim tracks that have a production vertex outside the volume specified by
- *                                                                               volumeRadius and volumeZ won't be turned into TrackingParticles. Doesn't make much
- *                                                                               difference to be honest, over a huge range of volume sizes so there must be a cut
- *                                                                               earlier in the simulation. </td></tr>
- * <tr><td> maximumPreviousBunchCrossing   </td><td> unsigned int      </td><td> Bunch crossings before this number (inclusive; use positive integer) won't be included.
- *                                                                               Setting to zero means only in-time. </td></tr>
- * <tr><td> maximumSubsequentBunchCrossing </td><td> unsigned int      </td><td> Bunch crossings after this won't create any TrackingParticles. </td></tr>
- * <tr><td> createUnmergedCollection       </td><td> bool              </td><td> Whether to create the TrackingParticle collection without bremsstrahlung merged. </td></tr>
- * <tr><td> createMergedBremsstrahlung     </td><td> bool              </td><td> Whether to create the TrackingParticle collection with bremsstrahlung merged. At
- *                                                                               least one of createUnmergedCollection or createMergedBremsstrahlung should be true
- *                                                                               otherwise nothing will be produced. </td></tr>
- * <tr><td> createInitialVertexCollection  </td><td> bool              </td><td> Whether to create a collection of just the initial vertices. You can usually get this
- *                                                                               information from one of the other collections (merged or unmerged bremsstrahlung), but
- *                                                                               for this collection no selection is applied. Hence you will always have all of the initial
- *                                                                               vertices regardless of how tightly you select TrackingParticles with the "select" parameter.
- *                                                                               Note that <b>the collection will have no links to the products of these vertices<b>.  If you
- *                                                                               want to know what came off these vertices you will have to look in one of the other
- *                                                                               collections. The name of the collection will be "InitialVertices".</td></tr>
- * <tr><td> alwaysAddAncestors             </td><td> bool              </td><td> If a sim track passes selection and is turned into a TrackingParticle, all of it's
- *                                                                               parents will also be created even if they fail the selection. This was the default
- *                                                                               behaviour for the old TrackingParticleProducer. </td></tr>
- * <tr><td> removeDeadModules              </td><td> bool              </td><td> Hasn't been implemented yet (as of 22/May/2013). </td></tr>
- * <tr><td> simTrackCollection             </td><td> edm::InputTag     </td><td> The input SimTrack collection </td></tr>
- * <tr><td> simVertexCollection            </td><td> edm::InputTag     </td><td> The input SimVerted collection </td></tr>
- * <tr><td> simHitCollections              </td><td> edm::ParameterSet </td><td> A ParameterSet of vectors of InputTags that are the input PSimHits </td></tr>
- * <tr><td> genParticleCollection          </td><td> edm::InputTag     </td><td> The input reco::GenParticle collection. Note that there's a difference between
- *                                                                               reco::GenParticle and HepMC::GenParticle; the old TrackingTruthProducer used to
- *                                                                               use HepMC::GenParticle. </td></tr>
- * <tr><td> allowDifferentSimHitProcesses  </td><td> bool              </td><td> Should be false for FullSim and true for FastSim. There's more documentation in
- *                                                                               the code if you're really interested. </td></tr>
- * <tr><td> select                         </td><td> edm::ParameterSet </td><td> A ParameterSet used to configure a TrackingParticleSelector. If the TrackingParticle
- *                                                                               doesn't pass this selector then it's not added to the output. </td></tr>
+ * <tr><td> volumeRadius                   </td><td> double            </td><td>
+ * The volume radius in cm used if ignoreTracksOutsideVolume is true. </td></tr>
+ * <tr><td> volumeZ                        </td><td> double            </td><td>
+ * The volume z in cm used if ignoreTracksOutsideVolume is true. </td></tr>
+ * <tr><td> ignoreTracksOutsideVolume      </td><td> bool              </td><td>
+ * If true, sim tracks that have a production vertex outside the volume
+ * specified by volumeRadius and volumeZ won't be turned into TrackingParticles.
+ * Doesn't make much difference to be honest, over a huge range of volume sizes
+ * so there must be a cut earlier in the simulation. </td></tr> <tr><td>
+ * maximumPreviousBunchCrossing   </td><td> unsigned int      </td><td> Bunch
+ * crossings before this number (inclusive; use positive integer) won't be
+ * included. Setting to zero means only in-time. </td></tr> <tr><td>
+ * maximumSubsequentBunchCrossing </td><td> unsigned int      </td><td> Bunch
+ * crossings after this won't create any TrackingParticles. </td></tr> <tr><td>
+ * createUnmergedCollection       </td><td> bool              </td><td> Whether
+ * to create the TrackingParticle collection without bremsstrahlung merged.
+ * </td></tr> <tr><td> createMergedBremsstrahlung     </td><td> bool </td><td>
+ * Whether to create the TrackingParticle collection with bremsstrahlung merged.
+ * At least one of createUnmergedCollection or createMergedBremsstrahlung should
+ * be true otherwise nothing will be produced. </td></tr> <tr><td>
+ * createInitialVertexCollection  </td><td> bool              </td><td> Whether
+ * to create a collection of just the initial vertices. You can usually get this
+ *                                                                               information
+ * from one of the other collections (merged or unmerged bremsstrahlung), but
+ *                                                                               for
+ * this collection no selection is applied. Hence you will always have all of
+ * the initial vertices regardless of how tightly you select TrackingParticles
+ * with the "select" parameter. Note that <b>the collection will have no links
+ * to the products of these vertices<b>.  If you want to know what came off
+ * these vertices you will have to look in one of the other collections. The
+ * name of the collection will be "InitialVertices".</td></tr> <tr><td>
+ * alwaysAddAncestors             </td><td> bool              </td><td> If a sim
+ * track passes selection and is turned into a TrackingParticle, all of it's
+ *                                                                               parents
+ * will also be created even if they fail the selection. This was the default
+ *                                                                               behaviour
+ * for the old TrackingParticleProducer. </td></tr> <tr><td> removeDeadModules
+ * </td><td> bool              </td><td> Hasn't been implemented yet (as of
+ * 22/May/2013). </td></tr> <tr><td> simTrackCollection             </td><td>
+ * edm::InputTag     </td><td> The input SimTrack collection </td></tr> <tr><td>
+ * simVertexCollection            </td><td> edm::InputTag     </td><td> The
+ * input SimVerted collection </td></tr> <tr><td> simHitCollections </td><td>
+ * edm::ParameterSet </td><td> A ParameterSet of vectors of InputTags that are
+ * the input PSimHits </td></tr> <tr><td> genParticleCollection </td><td>
+ * edm::InputTag     </td><td> The input reco::GenParticle collection. Note that
+ * there's a difference between reco::GenParticle and HepMC::GenParticle; the
+ * old TrackingTruthProducer used to use HepMC::GenParticle. </td></tr> <tr><td>
+ * allowDifferentSimHitProcesses  </td><td> bool              </td><td> Should
+ * be false for FullSim and true for FastSim. There's more documentation in the
+ * code if you're really interested. </td></tr> <tr><td> select </td><td>
+ * edm::ParameterSet </td><td> A ParameterSet used to configure a
+ * TrackingParticleSelector. If the TrackingParticle doesn't pass this selector
+ * then it's not added to the output. </td></tr>
  * </table>
  *
  * @author Mark Grimes (mark.grimes@bristol.ac.uk)
  * @date 11/Oct/2012
  */
-class TrackingTruthAccumulator : public DigiAccumulatorMixMod
-{
+class TrackingTruthAccumulator : public DigiAccumulatorMixMod {
 public:
-	explicit TrackingTruthAccumulator( const edm::ParameterSet& config, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
+  explicit TrackingTruthAccumulator(const edm::ParameterSet &config,
+                                    edm::ProducerBase &mixMod,
+                                    edm::ConsumesCollector &iC);
+
 private:
-	void initializeEvent( const edm::Event& event, const edm::EventSetup& setup ) override;
-	void accumulate( const edm::Event& event, const edm::EventSetup& setup ) override;
-	void accumulate( const PileUpEventPrincipal& event, const edm::EventSetup& setup, edm::StreamID const& ) override;
-	void finalizeEvent( edm::Event& event, const edm::EventSetup& setup ) override;
+  void initializeEvent(const edm::Event &event,
+                       const edm::EventSetup &setup) override;
+  void accumulate(const edm::Event &event,
+                  const edm::EventSetup &setup) override;
+  void accumulate(const PileUpEventPrincipal &event,
+                  const edm::EventSetup &setup, edm::StreamID const &) override;
+  void finalizeEvent(edm::Event &event, const edm::EventSetup &setup) override;
 
-	/** @brief Both forms of accumulate() delegate to this templated method. */
-	template<class T> void accumulateEvent( const T& event, const edm::EventSetup& setup, const edm::Handle< edm::HepMCProduct >& hepMCproduct );
+  /** @brief Both forms of accumulate() delegate to this templated method. */
+  template <class T>
+  void accumulateEvent(const T &event, const edm::EventSetup &setup,
+                       const edm::Handle<edm::HepMCProduct> &hepMCproduct);
 
-	/** @brief Fills the supplied vector with pointers to the SimHits, checking for bad modules if required */
-	template<class T> void fillSimHits( std::vector<const PSimHit*>& returnValue, const T& event, const edm::EventSetup& setup );
+  /** @brief Fills the supplied vector with pointers to the SimHits, checking
+   * for bad modules if required */
+  template <class T>
+  void fillSimHits(std::vector<const PSimHit *> &returnValue, const T &event,
+                   const edm::EventSetup &setup);
 
-	const std::string messageCategory_; ///< The message category used to send messages to MessageLogger
+  const std::string messageCategory_; ///< The message category used to send
+                                      ///< messages to MessageLogger
 
-	const double volumeRadius_;
-	const double volumeZ_;
-	/// maximum distance for HepMC::GenVertex to be added to SimVertex
-	const double vertexDistanceCut_;
-	const bool ignoreTracksOutsideVolume_;
+  const double volumeRadius_;
+  const double volumeZ_;
+  /// maximum distance for HepMC::GenVertex to be added to SimVertex
+  const double vertexDistanceCut_;
+  const bool ignoreTracksOutsideVolume_;
 
-	/** The maximum bunch crossing BEFORE the signal crossing to create TrackinParticles for. Use positive values. If set to zero no
-	 * previous bunches are added and only in-time, signal and after bunches (defined by maximumSubsequentBunchCrossing_) are used.*/
-	const unsigned int maximumPreviousBunchCrossing_;
-	/** The maximum bunch crossing AFTER the signal crossing to create TrackinParticles for. E.g. if set to zero only
-	 * uses the signal and in time pileup (and previous bunches defined by the maximumPreviousBunchCrossing_ parameter). */
-	const unsigned int maximumSubsequentBunchCrossing_;
-	/// If bremsstrahlung merging, whether to also add the unmerged collection to the event or not.
-	const bool createUnmergedCollection_;
-	const bool createMergedCollection_;
-	/// Whether or not to create a separate collection for just the initial interaction vertices
-	const bool createInitialVertexCollection_;
-	/// Whether or not to add the full parentage of any TrackingParticle that is inserted in the collection.
-	const bool addAncestors_;
+  /** The maximum bunch crossing BEFORE the signal crossing to create
+   * TrackinParticles for. Use positive values. If set to zero no previous
+   * bunches are added and only in-time, signal and after bunches (defined by
+   * maximumSubsequentBunchCrossing_) are used.*/
+  const unsigned int maximumPreviousBunchCrossing_;
+  /** The maximum bunch crossing AFTER the signal crossing to create
+   * TrackinParticles for. E.g. if set to zero only
+   * uses the signal and in time pileup (and previous bunches defined by the
+   * maximumPreviousBunchCrossing_ parameter). */
+  const unsigned int maximumSubsequentBunchCrossing_;
+  /// If bremsstrahlung merging, whether to also add the unmerged collection to
+  /// the event or not.
+  const bool createUnmergedCollection_;
+  const bool createMergedCollection_;
+  /// Whether or not to create a separate collection for just the initial
+  /// interaction vertices
+  const bool createInitialVertexCollection_;
+  /// Whether or not to add the full parentage of any TrackingParticle that is
+  /// inserted in the collection.
+  const bool addAncestors_;
 
-	/// As of 11/Feb/2013 this option hasn't been implemented yet.
-	const bool removeDeadModules_;
-	const edm::InputTag simTrackLabel_;
-	const edm::InputTag simVertexLabel_;
-        std::vector<edm::InputTag> collectionTags_;
-	edm::InputTag genParticleLabel_;
-	/// Needed to add HepMC::GenVertex to SimVertex
-	edm::InputTag hepMCproductLabel_;
+  /// As of 11/Feb/2013 this option hasn't been implemented yet.
+  const bool removeDeadModules_;
+  const edm::InputTag simTrackLabel_;
+  const edm::InputTag simVertexLabel_;
+  std::vector<edm::InputTag> collectionTags_;
+  edm::InputTag genParticleLabel_;
+  /// Needed to add HepMC::GenVertex to SimVertex
+  edm::InputTag hepMCproductLabel_;
 
-	bool selectorFlag_;
-	TrackingParticleSelector selector_;
-	/// Uses the same config as selector_, but can be used to drop out early since selector_ requires the TrackingParticle to be created first.
-	bool chargedOnly_;
-	/// Uses the same config as selector_, but can be used to drop out early since selector_ requires the TrackingParticle to be created first.
-	bool signalOnly_;
+  bool selectorFlag_;
+  TrackingParticleSelector selector_;
+  /// Uses the same config as selector_, but can be used to drop out early since
+  /// selector_ requires the TrackingParticle to be created first.
+  bool chargedOnly_;
+  /// Uses the same config as selector_, but can be used to drop out early since
+  /// selector_ requires the TrackingParticle to be created first.
+  bool signalOnly_;
 
-	/** @brief When counting hits, allows hits in different detectors to have a different process type.
-	 *
-	 * Fast sim PSimHits seem to have a peculiarity where the process type (as reported by PSimHit::processType()) is
-	 * different for the tracker than the muons. When counting how many hits there are, the code usually only counts
-	 * the number of hits that have the same process type as the first hit. Setting this to true will also count hits
-	 * that have the same process type as the first hit in the second detector.<br/>
-	 */
-	bool allowDifferentProcessTypeForDifferentDetectors_;
+  /** @brief When counting hits, allows hits in different detectors to have a
+   * different process type.
+   *
+   * Fast sim PSimHits seem to have a peculiarity where the process type (as
+   * reported by PSimHit::processType()) is different for the tracker than the
+   * muons. When counting how many hits there are, the code usually only counts
+   * the number of hits that have the same process type as the first hit.
+   * Setting this to true will also count hits that have the same process type
+   * as the first hit in the second detector.<br/>
+   */
+  bool allowDifferentProcessTypeForDifferentDetectors_;
+
 public:
-	// These always go hand in hand, and I need to pass them around in the internal
-	// functions, so I might as well package them up in a struct.
-	struct OutputCollections
-	{
-		std::unique_ptr<TrackingParticleCollection> pTrackingParticles;
-		std::unique_ptr<TrackingVertexCollection> pTrackingVertices;
-		TrackingParticleRefProd refTrackingParticles;
-		TrackingVertexRefProd refTrackingVertexes;
-	};
+  // These always go hand in hand, and I need to pass them around in the
+  // internal functions, so I might as well package them up in a struct.
+  struct OutputCollections {
+    std::unique_ptr<TrackingParticleCollection> pTrackingParticles;
+    std::unique_ptr<TrackingVertexCollection> pTrackingVertices;
+    TrackingParticleRefProd refTrackingParticles;
+    TrackingVertexRefProd refTrackingVertexes;
+  };
+
 private:
-	OutputCollections unmergedOutput_;
-	OutputCollections mergedOutput_;
-	std::unique_ptr<TrackingVertexCollection> pInitialVertices_;
+  OutputCollections unmergedOutput_;
+  OutputCollections mergedOutput_;
+  std::unique_ptr<TrackingVertexCollection> pInitialVertices_;
 };
 
 #endif // end of "#ifndef TrackingAnalysis_TrackingTruthAccumulator_h"

--- a/SimGeneral/TrackingAnalysis/src/EncodedTruthId.cc
+++ b/SimGeneral/TrackingAnalysis/src/EncodedTruthId.cc
@@ -2,13 +2,10 @@
 
 EncodedTruthId::EncodedTruthId() {}
 
-EncodedTruthId::EncodedTruthId(EncodedEventId eid, int index):
-        EncodedEventId(eid), index_(index) {}
+EncodedTruthId::EncodedTruthId(EncodedEventId eid, int index)
+    : EncodedEventId(eid), index_(index) {}
 
-std::ostream& operator<<(std::ostream & os , EncodedTruthId& id)
-{
-    return os  << "(" << id.bunchCrossing() << ","
-           << id.event()         << ","
-           << id.index()         << ")";
+std::ostream &operator<<(std::ostream &os, EncodedTruthId &id) {
+  return os << "(" << id.bunchCrossing() << "," << id.event() << ","
+            << id.index() << ")";
 }
-

--- a/SimGeneral/TrackingAnalysis/src/MuonPSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/MuonPSimHitSelector.cc
@@ -11,44 +11,44 @@
 
 // #include "SimTracker/Common/interface/SimHitSelectorFromDB.h"
 
+void MuonPSimHitSelector::select(PSimHitCollection &selection,
+                                 edm::Event const &event,
+                                 edm::EventSetup const &setup) const {
+  // Look for psimhit collection associated to the muon system
+  PSimHitCollectionMap::const_iterator pSimHitCollections =
+      pSimHitCollectionMap_.find("muon");
 
-void MuonPSimHitSelector::select(PSimHitCollection & selection, edm::Event const & event, edm::EventSetup const & setup) const
-{
-    // Look for psimhit collection associated to the muon system
-    PSimHitCollectionMap::const_iterator pSimHitCollections = pSimHitCollectionMap_.find("muon");
+  // Check that there are psimhit collections defined for the tracker
+  if (pSimHitCollections == pSimHitCollectionMap_.end())
+    return;
 
-    // Check that there are psimhit collections defined for the tracker
-    if (pSimHitCollections == pSimHitCollectionMap_.end()) return;
+  // Grab all the PSimHit from the different sencitive volumes
+  edm::Handle<CrossingFrame<PSimHit>> cfPSimHits;
+  std::vector<const CrossingFrame<PSimHit> *> cfPSimHitProductPointers;
 
-    // Grab all the PSimHit from the different sencitive volumes
-    edm::Handle<CrossingFrame<PSimHit> > cfPSimHits;
-    std::vector<const CrossingFrame<PSimHit> *> cfPSimHitProductPointers;
+  // Collect the product pointers to the different psimhit collection
+  for (std::size_t i = 0; i < pSimHitCollections->second.size(); ++i) {
+    event.getByLabel("mix", pSimHitCollections->second[i], cfPSimHits);
+    cfPSimHitProductPointers.push_back(cfPSimHits.product());
+  }
 
-    // Collect the product pointers to the different psimhit collection
-    for (std::size_t i = 0; i < pSimHitCollections->second.size(); ++i)
-    {
-        event.getByLabel("mix", pSimHitCollections->second[i], cfPSimHits);
-        cfPSimHitProductPointers.push_back(cfPSimHits.product());
-    }
+  // Create a mix collection from the different psimhit collections
+  std::unique_ptr<MixCollection<PSimHit>> pSimHits(
+      new MixCollection<PSimHit>(cfPSimHitProductPointers));
 
-    // Create a mix collection from the different psimhit collections
-    std::unique_ptr<MixCollection<PSimHit> > pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
+  // Get CSC Bad Chambers (ME4/2)
+  edm::ESHandle<CSCBadChambers> cscBadChambers;
+  setup.get<CSCBadChambersRcd>().get(cscBadChambers);
 
-    // Get CSC Bad Chambers (ME4/2)
-    edm::ESHandle<CSCBadChambers> cscBadChambers;
-    setup.get<CSCBadChambersRcd>().get(cscBadChambers);
+  // Select only psimhits from alive modules
+  for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin();
+       pSimHit != pSimHits->end(); ++pSimHit) {
+    DetId dId = DetId(pSimHit->detUnitId());
 
-    // Select only psimhits from alive modules
-    for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin(); pSimHit != pSimHits->end(); ++pSimHit)
-    {
-        DetId dId = DetId( pSimHit->detUnitId() );
-
-        if (dId.det() == DetId::Muon && dId.subdetId() == MuonSubdetId::CSC)
-        {
-            if ( !cscBadChambers->isInBadChamber(CSCDetId(dId)) )
-                selection.push_back(*pSimHit);
-        }
-        else
-            selection.push_back(*pSimHit);
-    }
+    if (dId.det() == DetId::Muon && dId.subdetId() == MuonSubdetId::CSC) {
+      if (!cscBadChambers->isInBadChamber(CSCDetId(dId)))
+        selection.push_back(*pSimHit);
+    } else
+      selection.push_back(*pSimHit);
+  }
 }

--- a/SimGeneral/TrackingAnalysis/src/PSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/PSimHitSelector.cc
@@ -4,53 +4,54 @@
 
 #include "SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h"
 
-PSimHitSelector::PSimHitSelector(edm::ParameterSet const & config)
-{
-    // Initilize psimhit collection discriminated by sub systems
-    edm::ParameterSet pSimHitCollections = config.getParameter<edm::ParameterSet>("simHitCollections");
+PSimHitSelector::PSimHitSelector(edm::ParameterSet const &config) {
+  // Initilize psimhit collection discriminated by sub systems
+  edm::ParameterSet pSimHitCollections =
+      config.getParameter<edm::ParameterSet>("simHitCollections");
 
-    std::vector<std::string> subdetectors( pSimHitCollections.getParameterNames() );
+  std::vector<std::string> subdetectors(pSimHitCollections.getParameterNames());
 
-    mixLabel_ = config.getParameter<std::string>("mixLabel");
+  mixLabel_ = config.getParameter<std::string>("mixLabel");
 
-    for (size_t i = 0; i < subdetectors.size(); ++i)
-    {
-        pSimHitCollectionMap_.insert(
-            std::pair<std::string, std::vector<std::string> >(
-                subdetectors[i],
-                pSimHitCollections.getParameter<std::vector<std::string> >(subdetectors[i])
-            )
-        );
-    }
+  for (size_t i = 0; i < subdetectors.size(); ++i) {
+    pSimHitCollectionMap_.insert(
+        std::pair<std::string, std::vector<std::string>>(
+            subdetectors[i],
+            pSimHitCollections.getParameter<std::vector<std::string>>(
+                subdetectors[i])));
+  }
 }
 
+void PSimHitSelector::select(PSimHitCollection &selection,
+                             edm::Event const &event,
+                             edm::EventSetup const &setup) const {
+  // Look for all psimhit collections
+  PSimHitCollectionMap::const_iterator pSimHitCollections =
+      pSimHitCollectionMap_.begin();
 
-void PSimHitSelector::select(PSimHitCollection & selection, edm::Event const & event, edm::EventSetup const & setup) const
-{
-    // Look for all psimhit collections
-    PSimHitCollectionMap::const_iterator pSimHitCollections = pSimHitCollectionMap_.begin();
+  std::vector<const CrossingFrame<PSimHit> *> cfPSimHitProductPointers;
 
-    std::vector<const CrossingFrame<PSimHit> *> cfPSimHitProductPointers;
+  for (; pSimHitCollections != pSimHitCollectionMap_.end();
+       ++pSimHitCollections) {
+    // Grab all the PSimHit from the different sencitive volumes
+    edm::Handle<CrossingFrame<PSimHit>> cfPSimHits;
 
-    for (; pSimHitCollections != pSimHitCollectionMap_.end(); ++pSimHitCollections)
-    {
-        // Grab all the PSimHit from the different sencitive volumes
-        edm::Handle<CrossingFrame<PSimHit> > cfPSimHits;
-
-        // Collect the product pointers to the different psimhit collection
-        for (std::size_t i = 0; i < pSimHitCollections->second.size(); ++i)
-        {
-            event.getByLabel(mixLabel_, pSimHitCollections->second[i], cfPSimHits);
-            cfPSimHitProductPointers.push_back(cfPSimHits.product());
-        }
+    // Collect the product pointers to the different psimhit collection
+    for (std::size_t i = 0; i < pSimHitCollections->second.size(); ++i) {
+      event.getByLabel(mixLabel_, pSimHitCollections->second[i], cfPSimHits);
+      cfPSimHitProductPointers.push_back(cfPSimHits.product());
     }
+  }
 
-    if (cfPSimHitProductPointers.empty()) return;
+  if (cfPSimHitProductPointers.empty())
+    return;
 
-    // Create a mix collection from the different psimhit collections
-    std::unique_ptr<MixCollection<PSimHit> > pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
+  // Create a mix collection from the different psimhit collections
+  std::unique_ptr<MixCollection<PSimHit>> pSimHits(
+      new MixCollection<PSimHit>(cfPSimHitProductPointers));
 
-    // Select all psimhits
-    for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin(); pSimHit != pSimHits->end(); ++pSimHit)
-        selection.push_back(*pSimHit);
+  // Select all psimhits
+  for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin();
+       pSimHit != pSimHits->end(); ++pSimHit)
+    selection.push_back(*pSimHit);
 }

--- a/SimGeneral/TrackingAnalysis/src/PixelPSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/PixelPSimHitSelector.cc
@@ -1,6 +1,6 @@
 
-#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
 #include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
@@ -9,41 +9,44 @@
 
 #include "SimGeneral/TrackingAnalysis/interface/PixelPSimHitSelector.h"
 
+void PixelPSimHitSelector::select(PSimHitCollection &selection,
+                                  edm::Event const &event,
+                                  edm::EventSetup const &setup) const {
+  // Look for psimhit collection associated o the tracker
+  PSimHitCollectionMap::const_iterator pSimHitCollections =
+      pSimHitCollectionMap_.find("pixel");
 
-void PixelPSimHitSelector::select(PSimHitCollection & selection, edm::Event const & event, edm::EventSetup const & setup) const
-{
-    // Look for psimhit collection associated o the tracker
-    PSimHitCollectionMap::const_iterator pSimHitCollections = pSimHitCollectionMap_.find("pixel");
+  // Check that there are psimhit collections defined for the tracker
+  if (pSimHitCollections == pSimHitCollectionMap_.end())
+    return;
 
-    // Check that there are psimhit collections defined for the tracker
-    if (pSimHitCollections == pSimHitCollectionMap_.end()) return;
+  // Grab all the PSimHit from the different sencitive volumes
+  edm::Handle<CrossingFrame<PSimHit>> cfPSimHits;
+  std::vector<const CrossingFrame<PSimHit> *> cfPSimHitProductPointers;
 
-    // Grab all the PSimHit from the different sencitive volumes
-    edm::Handle<CrossingFrame<PSimHit> > cfPSimHits;
-    std::vector<const CrossingFrame<PSimHit> *> cfPSimHitProductPointers;
+  // Collect the product pointers to the different psimhit collection
+  for (std::size_t i = 0; i < pSimHitCollections->second.size(); ++i) {
+    event.getByLabel("mix", pSimHitCollections->second[i], cfPSimHits);
+    cfPSimHitProductPointers.push_back(cfPSimHits.product());
+  }
 
-    // Collect the product pointers to the different psimhit collection
-    for (std::size_t i = 0; i < pSimHitCollections->second.size(); ++i)
-    {
-        event.getByLabel("mix", pSimHitCollections->second[i], cfPSimHits);
-        cfPSimHitProductPointers.push_back(cfPSimHits.product());
-    }
+  // Create a mix collection from the different psimhit collections
+  std::unique_ptr<MixCollection<PSimHit>> pSimHits(
+      new MixCollection<PSimHit>(cfPSimHitProductPointers));
 
-    // Create a mix collection from the different psimhit collections
-    std::unique_ptr<MixCollection<PSimHit> > pSimHits( new MixCollection<PSimHit>(cfPSimHitProductPointers) );
+  // Accessing dead pixel modules from DB:
+  edm::ESHandle<SiPixelQuality> siPixelBadModule;
+  setup.get<SiPixelQualityRcd>().get(siPixelBadModule);
 
-    // Accessing dead pixel modules from DB:
-    edm::ESHandle<SiPixelQuality> siPixelBadModule;
-    setup.get<SiPixelQualityRcd>().get(siPixelBadModule);
+  // Reading the DB information
+  std::vector<SiPixelQuality::disabledModuleType> badModules(
+      siPixelBadModule->getBadComponentList());
+  SiPixelQuality pixelQuality(badModules);
 
-    // Reading the DB information
-    std::vector<SiPixelQuality::disabledModuleType> badModules( siPixelBadModule->getBadComponentList() );
-    SiPixelQuality pixelQuality(badModules);
-
-    // Select only psimhits from alive modules
-    for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin(); pSimHit != pSimHits->end(); ++pSimHit)
-    {
-        if ( !pixelQuality.IsModuleBad(pSimHit->detUnitId()) )
-            selection.push_back(*pSimHit);
-    }
+  // Select only psimhits from alive modules
+  for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin();
+       pSimHit != pSimHits->end(); ++pSimHit) {
+    if (!pixelQuality.IsModuleBad(pSimHit->detUnitId()))
+      selection.push_back(*pSimHit);
+  }
 }

--- a/SimGeneral/TrackingAnalysis/src/TrackerPSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/TrackerPSimHitSelector.cc
@@ -12,39 +12,42 @@
 
 #include "SimTracker/Common/interface/SimHitSelectorFromDB.h"
 
+void TrackerPSimHitSelector::select(PSimHitCollection &selection,
+                                    edm::Event const &event,
+                                    edm::EventSetup const &setup) const {
+  // Look for psimhit collection associated o the tracker
+  PSimHitCollectionMap::const_iterator pSimHitCollections =
+      pSimHitCollectionMap_.find("tracker");
 
-void TrackerPSimHitSelector::select(PSimHitCollection & selection, edm::Event const & event, edm::EventSetup const & setup) const
-{
-    // Look for psimhit collection associated o the tracker
-    PSimHitCollectionMap::const_iterator pSimHitCollections = pSimHitCollectionMap_.find("tracker");
+  // Check that there are psimhit collections defined for the tracker
+  if (pSimHitCollections == pSimHitCollectionMap_.end())
+    return;
 
-    // Check that there are psimhit collections defined for the tracker
-    if (pSimHitCollections == pSimHitCollectionMap_.end()) return;
+  // Grab all the PSimHit from the different sencitive volumes
+  edm::Handle<CrossingFrame<PSimHit>> cfPSimHits;
+  std::vector<const CrossingFrame<PSimHit> *> cfPSimHitProductPointers;
 
-    // Grab all the PSimHit from the different sencitive volumes
-    edm::Handle<CrossingFrame<PSimHit> > cfPSimHits;
-    std::vector<const CrossingFrame<PSimHit> *> cfPSimHitProductPointers;
+  // Collect the product pointers to the different psimhit collection
+  for (std::size_t i = 0; i < pSimHitCollections->second.size(); ++i) {
+    event.getByLabel(mixLabel_, pSimHitCollections->second[i], cfPSimHits);
+    cfPSimHitProductPointers.push_back(cfPSimHits.product());
+  }
 
-    // Collect the product pointers to the different psimhit collection
-    for (std::size_t i = 0; i < pSimHitCollections->second.size(); ++i)
-    {
-      event.getByLabel(mixLabel_, pSimHitCollections->second[i], cfPSimHits);
-      cfPSimHitProductPointers.push_back(cfPSimHits.product());
-    }
+  // Create a mix collection from the different psimhit collections
+  std::unique_ptr<MixCollection<PSimHit>> pSimHits(
+      new MixCollection<PSimHit>(cfPSimHitProductPointers));
 
-    // Create a mix collection from the different psimhit collections
-    std::unique_ptr<MixCollection<PSimHit> > pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
+  // Setup the cabling mapping
+  std::map<uint32_t, std::vector<int>> theDetIdList;
+  edm::ESHandle<SiStripDetCabling> detCabling;
+  setup.get<SiStripDetCablingRcd>().get(detCabling);
+  detCabling->addConnected(theDetIdList);
 
-    // Setup the cabling mapping
-    std::map<uint32_t, std::vector<int> > theDetIdList;
-    edm::ESHandle<SiStripDetCabling> detCabling;
-    setup.get<SiStripDetCablingRcd>().get( detCabling );
-    detCabling->addConnected(theDetIdList);
+  // Select only psimhits from alive modules
+  std::vector<std::pair<const PSimHit *, int>> psimhits(
+      SimHitSelectorFromDB().getSimHit(pSimHits, theDetIdList));
 
-    // Select only psimhits from alive modules
-    std::vector<std::pair<const PSimHit*,int> > psimhits(SimHitSelectorFromDB().getSimHit(pSimHits, theDetIdList));
-
-    // Add the selected psimhit to the main list
-    for (std::size_t i = 0; i < psimhits.size(); ++i)
-        selection.push_back( *(const_cast<PSimHit*>(psimhits[i].first)) );
+  // Add the selected psimhit to the main list
+  for (std::size_t i = 0; i < psimhits.size(); ++i)
+    selection.push_back(*(const_cast<PSimHit *>(psimhits[i].first)));
 }

--- a/SimGeneral/TrackingAnalysis/src/TrackingParticleNumberOfLayers.cc
+++ b/SimGeneral/TrackingAnalysis/src/TrackingParticleNumberOfLayers.cc
@@ -3,59 +3,73 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "FWCore/Utilities/interface/isFinite.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 namespace {
-  bool trackIdHitPairLess(const std::pair<unsigned int, const PSimHit*>& a, const std::pair<unsigned int, const PSimHit*>& b) {
-    return a.first < b.first;
-  }
-
-  bool trackIdHitPairLessSort(const std::pair<unsigned int, const PSimHit*>& a, const std::pair<unsigned int, const PSimHit*>& b) {
-    if(a.first == b.first) {
-      const auto atof = edm::isFinite(a.second->timeOfFlight()) ? a.second->timeOfFlight() : std::numeric_limits<decltype(a.second->timeOfFlight())>::max();
-      const auto btof = edm::isFinite(b.second->timeOfFlight()) ? b.second->timeOfFlight() : std::numeric_limits<decltype(b.second->timeOfFlight())>::max();
-      return atof < btof;
-    }
-    return a.first < b.first;
-  }
+bool trackIdHitPairLess(const std::pair<unsigned int, const PSimHit *> &a,
+                        const std::pair<unsigned int, const PSimHit *> &b) {
+  return a.first < b.first;
 }
 
-TrackingParticleNumberOfLayers::TrackingParticleNumberOfLayers(const edm::Event& iEvent, const std::vector<edm::EDGetTokenT<std::vector<PSimHit> > >& simHitTokens) {
+bool trackIdHitPairLessSort(const std::pair<unsigned int, const PSimHit *> &a,
+                            const std::pair<unsigned int, const PSimHit *> &b) {
+  if (a.first == b.first) {
+    const auto atof =
+        edm::isFinite(a.second->timeOfFlight())
+            ? a.second->timeOfFlight()
+            : std::numeric_limits<decltype(a.second->timeOfFlight())>::max();
+    const auto btof =
+        edm::isFinite(b.second->timeOfFlight())
+            ? b.second->timeOfFlight()
+            : std::numeric_limits<decltype(b.second->timeOfFlight())>::max();
+    return atof < btof;
+  }
+  return a.first < b.first;
+}
+} // namespace
+
+TrackingParticleNumberOfLayers::TrackingParticleNumberOfLayers(
+    const edm::Event &iEvent,
+    const std::vector<edm::EDGetTokenT<std::vector<PSimHit>>> &simHitTokens) {
 
   // A multimap linking SimTrack::trackId() to a pointer to PSimHit
   // Similar to TrackingTruthAccumulator
-  for(const auto& simHitToken: simHitTokens) {
-    edm::Handle<std::vector<PSimHit> > hsimhits;
+  for (const auto &simHitToken : simHitTokens) {
+    edm::Handle<std::vector<PSimHit>> hsimhits;
     iEvent.getByToken(simHitToken, hsimhits);
-    trackIdToHitPtr_.reserve(trackIdToHitPtr_.size()+hsimhits->size());
-    for(const auto& simHit: *hsimhits) {
+    trackIdToHitPtr_.reserve(trackIdToHitPtr_.size() + hsimhits->size());
+    for (const auto &simHit : *hsimhits) {
       trackIdToHitPtr_.emplace_back(simHit.trackId(), &simHit);
     }
   }
-  std::stable_sort(trackIdToHitPtr_.begin(), trackIdToHitPtr_.end(), trackIdHitPairLessSort);
+  std::stable_sort(trackIdToHitPtr_.begin(), trackIdToHitPtr_.end(),
+                   trackIdHitPairLessSort);
 }
 
 std::tuple<std::unique_ptr<edm::ValueMap<unsigned int>>,
            std::unique_ptr<edm::ValueMap<unsigned int>>,
            std::unique_ptr<edm::ValueMap<unsigned int>>>
-TrackingParticleNumberOfLayers::calculate(const edm::Handle<TrackingParticleCollection>& htps, const edm::EventSetup& iSetup) const {
-  //Retrieve tracker topology from geometry
+TrackingParticleNumberOfLayers::calculate(
+    const edm::Handle<TrackingParticleCollection> &htps,
+    const edm::EventSetup &iSetup) const {
+  // Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology& tTopo = *tTopoHandle;
+  const TrackerTopology &tTopo = *tTopoHandle;
 
-  const TrackingParticleCollection& tps = *htps;
+  const TrackingParticleCollection &tps = *htps;
   std::vector<unsigned int> valuesLayers(tps.size(), 0);
   std::vector<unsigned int> valuesPixelLayers(tps.size(), 0);
   std::vector<unsigned int> valuesStripMonoAndStereoLayers(tps.size(), 0);
-  for(size_t iTP=0; iTP<tps.size(); ++iTP) {
-    const TrackingParticle& tp = tps[iTP];
+  for (size_t iTP = 0; iTP < tps.size(); ++iTP) {
+    const TrackingParticle &tp = tps[iTP];
     const auto pdgId = tp.pdgId();
 
     // I would prefer a better way...
-    constexpr unsigned int maxSubdet = static_cast<unsigned>(StripSubdetector::TEC)+1;
-    constexpr unsigned int maxLayer = 0xF+1; // as in HitPattern.h
+    constexpr unsigned int maxSubdet =
+        static_cast<unsigned>(StripSubdetector::TEC) + 1;
+    constexpr unsigned int maxLayer = 0xF + 1; // as in HitPattern.h
     bool hasHit[maxSubdet][maxLayer];
     bool hasPixel[maxSubdet][maxLayer];
     bool hasMono[maxSubdet][maxLayer];
@@ -65,36 +79,42 @@ TrackingParticleNumberOfLayers::calculate(const edm::Handle<TrackingParticleColl
     memset(hasMono, 0, sizeof(hasMono));
     memset(hasStereo, 0, sizeof(hasStereo));
 
-    for(const SimTrack& simTrack: tp.g4Tracks()) {
+    for (const SimTrack &simTrack : tp.g4Tracks()) {
       // Logic is from TrackingTruthAccumulator
-      auto range = std::equal_range(trackIdToHitPtr_.begin(), trackIdToHitPtr_.end(), std::pair<unsigned int, const PSimHit *>(simTrack.trackId(), nullptr), trackIdHitPairLess);
-      if(range.first == range.second) continue;
+      auto range = std::equal_range(
+          trackIdToHitPtr_.begin(), trackIdToHitPtr_.end(),
+          std::pair<unsigned int, const PSimHit *>(simTrack.trackId(), nullptr),
+          trackIdHitPairLess);
+      if (range.first == range.second)
+        continue;
 
       auto iHitPtr = range.first;
-      for(; iHitPtr != range.second; ++iHitPtr) {
+      for (; iHitPtr != range.second; ++iHitPtr) {
         // prevent simhits with particleType != pdgId from being the "first hit"
-        if(iHitPtr->second->particleType() == pdgId)
+        if (iHitPtr->second->particleType() == pdgId)
           break;
       }
-      if(iHitPtr == range.second) // no simhits with particleType == pdgId
+      if (iHitPtr == range.second) // no simhits with particleType == pdgId
         continue;
       int processType = iHitPtr->second->processType();
       int particleType = iHitPtr->second->particleType();
 
-      for(; iHitPtr != range.second; ++iHitPtr) {
-        const PSimHit& simHit = *(iHitPtr->second);
-        if(simHit.eventId() != tp.eventId())
+      for (; iHitPtr != range.second; ++iHitPtr) {
+        const PSimHit &simHit = *(iHitPtr->second);
+        if (simHit.eventId() != tp.eventId())
           continue;
-        DetId newDetector = DetId( simHit.detUnitId() );
+        DetId newDetector = DetId(simHit.detUnitId());
 
         // Check for delta and interaction products discards
-        if( processType == simHit.processType() && particleType == simHit.particleType() && pdgId == simHit.particleType() ) {
+        if (processType == simHit.processType() &&
+            particleType == simHit.particleType() &&
+            pdgId == simHit.particleType()) {
           // The logic of this piece follows HitPattern
           bool isPixel = false;
           bool isStripStereo = false;
           bool isStripMono = false;
 
-          switch(newDetector.subdetId()) {
+          switch (newDetector.subdetId()) {
           case PixelSubdetector::PixelBarrel:
           case PixelSubdetector::PixelEndcap:
             isPixel = true;
@@ -118,22 +138,24 @@ TrackingParticleNumberOfLayers::calculate(const edm::Handle<TrackingParticleColl
           }
 
           const auto subdet = newDetector.subdetId();
-          const auto layer = tTopo.layer( newDetector );
+          const auto layer = tTopo.layer(newDetector);
 
           hasHit[subdet][layer] = true;
-          if(isPixel)            hasPixel[subdet][layer]  = isPixel;
-          else if(isStripMono)   hasMono[subdet][layer]   = isStripMono;
-          else if(isStripStereo) hasStereo[subdet][layer] = isStripStereo;
+          if (isPixel)
+            hasPixel[subdet][layer] = isPixel;
+          else if (isStripMono)
+            hasMono[subdet][layer] = isStripMono;
+          else if (isStripStereo)
+            hasStereo[subdet][layer] = isStripStereo;
         }
       }
     }
 
-
     unsigned int nLayers = 0;
     unsigned int nPixelLayers = 0;
     unsigned int nStripMonoAndStereoLayers = 0;
-    for(unsigned int i=0; i<maxSubdet; ++i) {
-      for(unsigned int j=0; j<maxLayer; ++j) {
+    for (unsigned int i = 0; i < maxSubdet; ++i) {
+      for (unsigned int j = 0; j < maxLayer; ++j) {
         nLayers += hasHit[i][j];
         nPixelLayers += hasPixel[i][j];
         nStripMonoAndStereoLayers += (hasMono[i][j] && hasStereo[i][j]);
@@ -160,7 +182,8 @@ TrackingParticleNumberOfLayers::calculate(const edm::Handle<TrackingParticleColl
   auto ret2 = std::make_unique<edm::ValueMap<unsigned int>>();
   {
     edm::ValueMap<unsigned int>::Filler filler(*ret2);
-    filler.insert(htps, valuesStripMonoAndStereoLayers.begin(), valuesStripMonoAndStereoLayers.end());
+    filler.insert(htps, valuesStripMonoAndStereoLayers.begin(),
+                  valuesStripMonoAndStereoLayers.end());
     filler.fill();
   }
 

--- a/SimGeneral/TrackingAnalysis/src/classes.h
+++ b/SimGeneral/TrackingAnalysis/src/classes.h
@@ -5,19 +5,27 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 namespace SimGeneral_TrackingAnalysis {
-  struct dictionary {
-    edm::Ptr< TrackingParticle >                  TP;
-    std::vector< edm::Ptr< TrackingParticle > > V_TP;
-    std::pair<TrackingParticleRef, TrackPSimHitRef> dummy13;
-    edm::Wrapper<std::pair<TrackingParticleRef, TrackPSimHitRef> > dummy14;
-    std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef> > dummy07;
-    edm::Wrapper<std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef> > > dummy08;
-    
-    std::pair< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > >, edm::Ptr< TrackingParticle > >                P_TAM_S_TP_PD;
-    std::pair< edm::Ptr< TrackingParticle >, std::vector< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > > > P_TAM_TP_S_PD;
+struct dictionary {
+  edm::Ptr<TrackingParticle> TP;
+  std::vector<edm::Ptr<TrackingParticle>> V_TP;
+  std::pair<TrackingParticleRef, TrackPSimHitRef> dummy13;
+  edm::Wrapper<std::pair<TrackingParticleRef, TrackPSimHitRef>> dummy14;
+  std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef>> dummy07;
+  edm::Wrapper<std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef>>>
+      dummy08;
 
-    std::map< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > >, edm::Ptr< TrackingParticle > >                M_TAM_S_TP_PD;
-    std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > > > M_TAM_TP_S_PD;
-    
-  };
-}
+  std::pair<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>,
+            edm::Ptr<TrackingParticle>>
+      P_TAM_S_TP_PD;
+  std::pair<edm::Ptr<TrackingParticle>,
+            std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>>>
+      P_TAM_TP_S_PD;
+
+  std::map<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>,
+           edm::Ptr<TrackingParticle>>
+      M_TAM_S_TP_PD;
+  std::map<edm::Ptr<TrackingParticle>,
+           std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>>>
+      M_TAM_TP_S_PD;
+};
+} // namespace SimGeneral_TrackingAnalysis

--- a/SimGeneral/TrackingAnalysis/test/TrackingTruthOutputTest.cc
+++ b/SimGeneral/TrackingAnalysis/test/TrackingTruthOutputTest.cc
@@ -1,11 +1,10 @@
-#include "SimGeneral/TrackingAnalysis/test/TrackingTruthOutputTest.h"
+#include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "SimGeneral/TrackingAnalysis/test/TrackingTruthOutputTest.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -16,57 +15,56 @@
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
-typedef edm::RefVector< std::vector<TrackingParticle> > TrackingParticleContainer;
-typedef std::vector<TrackingParticle>                   TrackingParticleCollection;
+typedef edm::RefVector<std::vector<TrackingParticle>> TrackingParticleContainer;
+typedef std::vector<TrackingParticle> TrackingParticleCollection;
 
-typedef TrackingParticleRefVector::iterator               tp_iterator;
-typedef TrackingVertex::genv_iterator                   genv_iterator;
-typedef TrackingVertex::g4v_iterator                     g4v_iterator;
+typedef TrackingParticleRefVector::iterator tp_iterator;
+typedef TrackingVertex::genv_iterator genv_iterator;
+typedef TrackingVertex::g4v_iterator g4v_iterator;
 
-TrackingTruthOutputTest::TrackingTruthOutputTest(const edm::ParameterSet& conf){
+TrackingTruthOutputTest::TrackingTruthOutputTest(
+    const edm::ParameterSet &conf) {
   conf_ = conf;
 }
 
-void TrackingTruthOutputTest::analyze(const edm::Event& event, const edm::EventSetup& c){
+void TrackingTruthOutputTest::analyze(const edm::Event &event,
+                                      const edm::EventSetup &c) {
   using namespace std;
 
   edm::Handle<TrackingParticleCollection> mergedPH;
-  edm::Handle<TrackingVertexCollection>   mergedVH;
+  edm::Handle<TrackingVertexCollection> mergedVH;
 
-  edm::InputTag trackingTruth = conf_.getUntrackedParameter<edm::InputTag>("trackingTruth");
+  edm::InputTag trackingTruth =
+      conf_.getUntrackedParameter<edm::InputTag>("trackingTruth");
 
   event.getByLabel(trackingTruth, mergedPH);
   event.getByLabel(trackingTruth, mergedVH);
 
-  if ( conf_.getUntrackedParameter<bool>("dumpVertexes") )
-  {
+  if (conf_.getUntrackedParameter<bool>("dumpVertexes")) {
     std::cout << std::endl << "Dumping merged vertices: " << std::endl;
-    for (TrackingVertexCollection::const_iterator iVertex = mergedVH->begin(); iVertex != mergedVH->end(); ++iVertex) 
-    {
+    for (TrackingVertexCollection::const_iterator iVertex = mergedVH->begin();
+         iVertex != mergedVH->end(); ++iVertex) {
       std::cout << std::endl << *iVertex;
       std::cout << "Daughters of this vertex:" << std::endl;
-      for (tp_iterator iTrack = iVertex->daughterTracks_begin(); iTrack != iVertex->daughterTracks_end(); ++iTrack) 
+      for (tp_iterator iTrack = iVertex->daughterTracks_begin();
+           iTrack != iVertex->daughterTracks_end(); ++iTrack)
         std::cout << **iTrack;
     }
     std::cout << std::endl;
   }
 
-  if ( conf_.getUntrackedParameter<bool>("dumpOnlyBremsstrahlung") )
-  {
-     std::cout << std::endl << "Dumping only merged tracks: " << std::endl;
-     for (TrackingParticleCollection::const_iterator iTrack = mergedPH->begin(); iTrack != mergedPH->end(); ++iTrack)
-        if (iTrack->g4Tracks().size() > 1)
-            std::cout << *iTrack << std::endl;
-  }
-  else
-  {
-    std::cout << std::endl << "Dump of merged tracks: " << std::endl;
-    for (TrackingParticleCollection::const_iterator iTrack = mergedPH->begin(); iTrack != mergedPH->end(); ++iTrack)
+  if (conf_.getUntrackedParameter<bool>("dumpOnlyBremsstrahlung")) {
+    std::cout << std::endl << "Dumping only merged tracks: " << std::endl;
+    for (TrackingParticleCollection::const_iterator iTrack = mergedPH->begin();
+         iTrack != mergedPH->end(); ++iTrack)
+      if (iTrack->g4Tracks().size() > 1)
         std::cout << *iTrack << std::endl;
+  } else {
+    std::cout << std::endl << "Dump of merged tracks: " << std::endl;
+    for (TrackingParticleCollection::const_iterator iTrack = mergedPH->begin();
+         iTrack != mergedPH->end(); ++iTrack)
+      std::cout << *iTrack << std::endl;
   }
 }
 
-
 DEFINE_FWK_MODULE(TrackingTruthOutputTest);
-
-

--- a/SimGeneral/TrackingAnalysis/test/TrackingTruthOutputTest.h
+++ b/SimGeneral/TrackingAnalysis/test/TrackingTruthOutputTest.h
@@ -3,18 +3,16 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class TrackingTruthOutputTest  : public edm::EDAnalyzer {
- public:
+class TrackingTruthOutputTest : public edm::EDAnalyzer {
+public:
+  explicit TrackingTruthOutputTest(const edm::ParameterSet &conf);
 
-  explicit TrackingTruthOutputTest(const edm::ParameterSet& conf);
+  ~TrackingTruthOutputTest() override {}
 
-  ~TrackingTruthOutputTest() override{}
+  void analyze(const edm::Event &e, const edm::EventSetup &c) override;
 
-  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-
- private:
+private:
   edm::ParameterSet conf_;
-
 };
 
 #endif

--- a/SimMuon/MCTruth/interface/CSCHitAssociator.h
+++ b/SimMuon/MCTruth/interface/CSCHitAssociator.h
@@ -1,50 +1,48 @@
 #ifndef MCTruth_CSCHitAssociator_h
 #define MCTruth_CSCHitAssociator_h
 
-#include "DataFormats/CSCRecHit/interface/CSCRecHit2D.h"
-#include "DataFormats/CSCDigi/interface/CSCStripDigi.h"
-#include "DataFormats/CSCDigi/interface/CSCWireDigi.h"
-#include "SimDataFormats/Track/interface/SimTrackContainer.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
-#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
-#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
-#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
-#include "Geometry/CSCGeometry/interface/CSCLayerGeometry.h"
 #include "CondFormats/CSCObjects/interface/CSCBadChambers.h"
 #include "CondFormats/DataRecord/interface/CSCBadChambersRcd.h"
+#include "DataFormats/CSCDigi/interface/CSCStripDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCWireDigi.h"
+#include "DataFormats/CSCRecHit/interface/CSCRecHit2D.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/CSCGeometry/interface/CSCLayerGeometry.h"
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-class CSCHitAssociator
-{
+class CSCHitAssociator {
 public:
   typedef edm::DetSetVector<StripDigiSimLink> DigiSimLinks;
   typedef edm::DetSetVector<StripDigiSimLink> WireDigiSimLinks;
   typedef edm::DetSet<StripDigiSimLink> LayerLinks;
-  typedef std::pair <uint32_t, EncodedEventId> SimHitIdpr;
+  typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
 
-  CSCHitAssociator(const edm::Event&, const edm::EventSetup&, const edm::ParameterSet&); 
-  CSCHitAssociator(const edm::ParameterSet&, edm::ConsumesCollector && iC);
- 
-  void initEvent(const edm::Event &, const edm::EventSetup& );
+  CSCHitAssociator(const edm::Event &, const edm::EventSetup &,
+                   const edm::ParameterSet &);
+  CSCHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&iC);
+
+  void initEvent(const edm::Event &, const edm::EventSetup &);
 
   std::vector<SimHitIdpr> associateHitId(const TrackingRecHit &) const;
   std::vector<SimHitIdpr> associateCSCHitId(const CSCRecHit2D *) const;
 
-
 private:
-
-  const DigiSimLinks  * theDigiSimLinks;
+  const DigiSimLinks *theDigiSimLinks;
 
   edm::InputTag linksTag;
 
-  const CSCGeometry* cscgeom;
+  const CSCGeometry *cscgeom;
 };
 
 #endif

--- a/SimMuon/MCTruth/interface/CSCTruthTest.h
+++ b/SimMuon/MCTruth/interface/CSCTruthTest.h
@@ -8,14 +8,12 @@
 class CSCTruthTest : public edm::stream::EDAnalyzer<> {
 
 public:
-  explicit CSCTruthTest(const edm::ParameterSet&);
+  explicit CSCTruthTest(const edm::ParameterSet &);
   ~CSCTruthTest() override;
 
 private:
-
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
-  const edm::ParameterSet& conf_;
-
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+  const edm::ParameterSet &conf_;
 };
 
 #endif

--- a/SimMuon/MCTruth/interface/DTHitAssociator.h
+++ b/SimMuon/MCTruth/interface/DTHitAssociator.h
@@ -1,69 +1,66 @@
 #ifndef MCTruth_DTHitAssociator_h
 #define MCTruth_DTHitAssociator_h
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/DTDigi/interface/DTDigiCollection.h"
+#include "DataFormats/DTRecHit/interface/DTRecHit1D.h"
+#include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
+#include "DataFormats/MuonDetId/interface/DTWireId.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "SimDataFormats/DigiSimLinks/interface/DTDigiSimLinkCollection.h"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
-#include "DataFormats/DTRecHit/interface/DTRecHit1D.h"
-#include "DataFormats/MuonDetId/interface/DTWireId.h"
-#include "DataFormats/DTDigi/interface/DTDigiCollection.h"
-#include "SimDataFormats/DigiSimLinks/interface/DTDigiSimLinkCollection.h"
-#include "Geometry/DTGeometry/interface/DTGeometry.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 
-#include <vector>
 #include <map>
+#include <vector>
 
 class DTHitAssociator {
 
- public:
-  typedef std::pair <uint32_t, EncodedEventId> SimHitIdpr;
-  typedef std::pair<PSimHit,bool> PSimHit_withFlag;
-  typedef std::map<DTWireId, std::vector<PSimHit_withFlag> > SimHitMap;
-  typedef std::map<DTWireId, std::vector<DTRecHit1DPair> > RecHitMap;
-  typedef std::map<DTWireId, std::vector<DTDigi> > DigiMap;
-  typedef std::map<DTWireId, std::vector<DTDigiSimLink> > LinksMap;
+public:
+  typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
+  typedef std::pair<PSimHit, bool> PSimHit_withFlag;
+  typedef std::map<DTWireId, std::vector<PSimHit_withFlag>> SimHitMap;
+  typedef std::map<DTWireId, std::vector<DTRecHit1DPair>> RecHitMap;
+  typedef std::map<DTWireId, std::vector<DTDigi>> DigiMap;
+  typedef std::map<DTWireId, std::vector<DTDigiSimLink>> LinksMap;
 
-  DTHitAssociator(const edm::Event&, const edm::EventSetup&, const edm::ParameterSet&, bool printRtS); 
-  DTHitAssociator(const edm::ParameterSet&, edm::ConsumesCollector && iC); 
+  DTHitAssociator(const edm::Event &, const edm::EventSetup &,
+                  const edm::ParameterSet &, bool printRtS);
+  DTHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&iC);
 
-  void initEvent(const edm::Event&, const edm::EventSetup& );
+  void initEvent(const edm::Event &, const edm::EventSetup &);
 
-  virtual ~DTHitAssociator(){}
+  virtual ~DTHitAssociator() {}
 
-  std::vector<SimHitIdpr> associateHitId(const TrackingRecHit & hit) const;
-  std::vector<SimHitIdpr> associateDTHitId(const DTRecHit1D * dtrechit) const;
-  
-  std::vector<PSimHit> associateHit(const TrackingRecHit & hit) const;
+  std::vector<SimHitIdpr> associateHitId(const TrackingRecHit &hit) const;
+  std::vector<SimHitIdpr> associateDTHitId(const DTRecHit1D *dtrechit) const;
+
+  std::vector<PSimHit> associateHit(const TrackingRecHit &hit) const;
 
   SimHitMap mapOfSimHit;
   RecHitMap mapOfRecHit;
   DigiMap mapOfDigi;
   LinksMap mapOfLinks;
 
- private:
+private:
   edm::InputTag DTsimhitsTag;
   edm::InputTag DTsimhitsXFTag;
   edm::InputTag DTdigiTag;
   edm::InputTag DTdigisimlinkTag;
   edm::InputTag DTrechitTag;
-  
+
   bool dumpDT;
   bool crossingframe;
   bool links_exist;
   bool associatorByWire;
-  
+
   bool SimHitOK(const edm::ESHandle<DTGeometry> &, const PSimHit &);
   bool printRtS;
-
 };
 
 #endif
-
-
-

--- a/SimMuon/MCTruth/interface/GEMHitAssociator.h
+++ b/SimMuon/MCTruth/interface/GEMHitAssociator.h
@@ -1,71 +1,68 @@
 #ifndef MCTruth_GEMHitAssociator_h
 #define MCTruth_GEMHitAssociator_h
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "DataFormats/MuonDetId/interface/GEMDetId.h"
-#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 
-#include <vector>
 #include <map>
-#include <string>
 #include <set>
+#include <string>
+#include <vector>
 
-#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
-#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
 #include "DataFormats/GEMRecHit/interface/GEMSegmentCollection.h"
+#include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 
 class GEMHitAssociator {
 
- public:
+public:
+  typedef edm::DetSetVector<StripDigiSimLink> DigiSimLinks;
+  typedef edm::DetSet<StripDigiSimLink> LayerLinks;
+  typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
 
-   typedef edm::DetSetVector<StripDigiSimLink> DigiSimLinks;
-   typedef edm::DetSet<StripDigiSimLink> LayerLinks;
-   typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
+  // Constructor with configurable parameters
+  GEMHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&ic);
+  GEMHitAssociator(const edm::Event &e, const edm::EventSetup &eventSetup,
+                   const edm::ParameterSet &conf);
 
-   // Constructor with configurable parameters
-   GEMHitAssociator(const edm::ParameterSet&, edm::ConsumesCollector && ic);
-   GEMHitAssociator(const edm::Event& e, const edm::EventSetup& eventSetup, const edm::ParameterSet& conf);
-    
-   void initEvent(const edm::Event&, const edm::EventSetup&);
+  void initEvent(const edm::Event &, const edm::EventSetup &);
 
-   // Destructor
-   ~GEMHitAssociator(){}
+  // Destructor
+  ~GEMHitAssociator() {}
 
-   std::vector<SimHitIdpr> associateRecHit(const GEMRecHit * gemrechit) const;
+  std::vector<SimHitIdpr> associateRecHit(const GEMRecHit *gemrechit) const;
 
- private:
-    
-   const DigiSimLinks * theDigiSimLinks;
-   edm::InputTag GEMdigisimlinkTag;
- 
-   bool crossingframe;
-   bool useGEMs_;
-   edm::InputTag GEMsimhitsTag;
-   edm::InputTag GEMsimhitsXFTag;
-    
-   edm::EDGetTokenT<CrossingFrame<PSimHit> > GEMsimhitsXFToken_;
-   edm::EDGetTokenT<edm::PSimHitContainer> GEMsimhitsToken_;
-   edm::EDGetTokenT<edm::DetSetVector<StripDigiSimLink> > GEMdigisimlinkToken_;
+private:
+  const DigiSimLinks *theDigiSimLinks;
+  edm::InputTag GEMdigisimlinkTag;
 
-   std::map<unsigned int, edm::PSimHitContainer> _SimHitMap;
+  bool crossingframe;
+  bool useGEMs_;
+  edm::InputTag GEMsimhitsTag;
+  edm::InputTag GEMsimhitsXFTag;
 
- };
+  edm::EDGetTokenT<CrossingFrame<PSimHit>> GEMsimhitsXFToken_;
+  edm::EDGetTokenT<edm::PSimHitContainer> GEMsimhitsToken_;
+  edm::EDGetTokenT<edm::DetSetVector<StripDigiSimLink>> GEMdigisimlinkToken_;
+
+  std::map<unsigned int, edm::PSimHitContainer> _SimHitMap;
+};
 
 #endif
-

--- a/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
@@ -1,16 +1,16 @@
 #ifndef MuonAssociatorByHits_h
 #define MuonAssociatorByHits_h
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/Common/interface/Ref.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
 #include "SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h"
@@ -19,61 +19,66 @@
 #include <memory>
 
 namespace muonAssociatorByHitsDiagnostics {
-  class InputDumper;
+class InputDumper;
 }
 
 class MuonAssociatorByHits {
-  
- public:
-  
-  MuonAssociatorByHits (const edm::ParameterSet& conf, edm::ConsumesCollector && iC);   
+
+public:
+  MuonAssociatorByHits(const edm::ParameterSet &conf,
+                       edm::ConsumesCollector &&iC);
   virtual ~MuonAssociatorByHits();
-  
-  // Originally from TrackAssociatorBase from where this class used to inherit from
-  reco::RecoToSimCollection associateRecoToSim(edm::Handle<edm::View<reco::Track> >& tCH,
-						       edm::Handle<TrackingParticleCollection>& tPCH,
-						       const edm::Event * event ,
-                                                       const edm::EventSetup * setup ) const {
+
+  // Originally from TrackAssociatorBase from where this class used to inherit
+  // from
+  reco::RecoToSimCollection
+  associateRecoToSim(edm::Handle<edm::View<reco::Track>> &tCH,
+                     edm::Handle<TrackingParticleCollection> &tPCH,
+                     const edm::Event *event,
+                     const edm::EventSetup *setup) const {
     edm::RefToBaseVector<reco::Track> tc;
-    for (unsigned int j=0; j<tCH->size();j++)
+    for (unsigned int j = 0; j < tCH->size(); j++)
       tc.push_back(tCH->refAt(j));
 
     edm::RefVector<TrackingParticleCollection> tpc(tPCH.id());
-    for (unsigned int j=0; j<tPCH->size();j++)
-      tpc.push_back(edm::Ref<TrackingParticleCollection>(tPCH,j));
+    for (unsigned int j = 0; j < tPCH->size(); j++)
+      tpc.push_back(edm::Ref<TrackingParticleCollection>(tPCH, j));
 
-    return associateRecoToSim(tc,tpc,event,setup);
+    return associateRecoToSim(tc, tpc, event, setup);
   }
 
-  virtual reco::SimToRecoCollection associateSimToReco(edm::Handle<edm::View<reco::Track> >& tCH,
-						       edm::Handle<TrackingParticleCollection>& tPCH,
-						       const edm::Event * event ,
-                                                       const edm::EventSetup * setup ) const {
+  virtual reco::SimToRecoCollection
+  associateSimToReco(edm::Handle<edm::View<reco::Track>> &tCH,
+                     edm::Handle<TrackingParticleCollection> &tPCH,
+                     const edm::Event *event,
+                     const edm::EventSetup *setup) const {
     edm::RefToBaseVector<reco::Track> tc;
-    for (unsigned int j=0; j<tCH->size();j++)
+    for (unsigned int j = 0; j < tCH->size(); j++)
       tc.push_back(tCH->refAt(j));
 
     edm::RefVector<TrackingParticleCollection> tpc(tPCH.id());
-    for (unsigned int j=0; j<tPCH->size();j++)
-      tpc.push_back(edm::Ref<TrackingParticleCollection>(tPCH,j));
+    for (unsigned int j = 0; j < tPCH->size(); j++)
+      tpc.push_back(edm::Ref<TrackingParticleCollection>(tPCH, j));
 
-    return associateSimToReco(tc,tpc,event,setup);
+    return associateSimToReco(tc, tpc, event, setup);
   }
 
- 
   /* Associate SimTracks to RecoTracks By Hits */
   /// Association Reco To Sim with Collections
-  reco::RecoToSimCollection associateRecoToSim(const edm::RefToBaseVector<reco::Track>&,
-					       const edm::RefVector<TrackingParticleCollection>&,
-					       const edm::Event * event = nullptr, const edm::EventSetup * setup = nullptr) const;
-  
-  /// Association Sim To Reco with Collections
-  reco::SimToRecoCollection associateSimToReco(const edm::RefToBaseVector<reco::Track>&,
-					       const edm::RefVector<TrackingParticleCollection>&,
-					       const edm::Event * event = nullptr, const edm::EventSetup * setup = nullptr) const;
+  reco::RecoToSimCollection
+  associateRecoToSim(const edm::RefToBaseVector<reco::Track> &,
+                     const edm::RefVector<TrackingParticleCollection> &,
+                     const edm::Event *event = nullptr,
+                     const edm::EventSetup *setup = nullptr) const;
 
- 
- private:
+  /// Association Sim To Reco with Collections
+  reco::SimToRecoCollection
+  associateSimToReco(const edm::RefToBaseVector<reco::Track> &,
+                     const edm::RefVector<TrackingParticleCollection> &,
+                     const edm::Event *event = nullptr,
+                     const edm::EventSetup *setup = nullptr) const;
+
+private:
   MuonAssociatorByHitsHelper helper_;
   edm::ParameterSet const conf_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;

--- a/SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h
@@ -1,23 +1,23 @@
 #ifndef MuonAssociatorByHitsHelper_h
 #define MuonAssociatorByHitsHelper_h
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/Ref.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/RecoCandidate/interface/TrackAssociation.h"
-#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
-#include "SimMuon/MCTruth/interface/DTHitAssociator.h"
-#include "SimMuon/MCTruth/interface/CSCHitAssociator.h"
-#include "SimMuon/MCTruth/interface/RPCHitAssociator.h"
-#include "SimMuon/MCTruth/interface/GEMHitAssociator.h"
-#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
+#include "SimMuon/MCTruth/interface/CSCHitAssociator.h"
+#include "SimMuon/MCTruth/interface/DTHitAssociator.h"
+#include "SimMuon/MCTruth/interface/GEMHitAssociator.h"
+#include "SimMuon/MCTruth/interface/RPCHitAssociator.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <functional>
@@ -25,68 +25,83 @@
 class TrackerTopology;
 
 class MuonAssociatorByHitsHelper {
-  
- public:
-  typedef std::pair <uint32_t, EncodedEventId> SimHitIdpr;
-  //typedef std::map<unsigned int, std::vector<SimHitIdpr> > MapOfMatchedIds;
-  typedef std::pair<unsigned int,std::vector<SimHitIdpr> > uint_SimHitIdpr_pair;
+
+public:
+  typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
+  // typedef std::map<unsigned int, std::vector<SimHitIdpr> > MapOfMatchedIds;
+  typedef std::pair<unsigned int, std::vector<SimHitIdpr>> uint_SimHitIdpr_pair;
   typedef boost::ptr_vector<uint_SimHitIdpr_pair> MapOfMatchedIds;
-  typedef std::vector<std::pair<trackingRecHit_iterator, trackingRecHit_iterator> > TrackHitsCollection;
-  
-  MuonAssociatorByHitsHelper (const edm::ParameterSet& conf);   
+  typedef std::vector<
+      std::pair<trackingRecHit_iterator, trackingRecHit_iterator>>
+      TrackHitsCollection;
+
+  MuonAssociatorByHitsHelper(const edm::ParameterSet &conf);
 
   struct Resources {
-    TrackerTopology const* tTopo_;
-    TrackerHitAssociator const* trackerHitAssoc_;
-    CSCHitAssociator const* cscHitAssoc_;
-    DTHitAssociator const* dtHitAssoc_;
-    RPCHitAssociator const* rpcHitAssoc_;
-    GEMHitAssociator const* gemHitAssoc_;
-    std::function<void(const TrackHitsCollection&, const TrackingParticleCollection&)> diagnostics_;
+    TrackerTopology const *tTopo_;
+    TrackerHitAssociator const *trackerHitAssoc_;
+    CSCHitAssociator const *cscHitAssoc_;
+    DTHitAssociator const *dtHitAssoc_;
+    RPCHitAssociator const *rpcHitAssoc_;
+    GEMHitAssociator const *gemHitAssoc_;
+    std::function<void(const TrackHitsCollection &,
+                       const TrackingParticleCollection &)>
+        diagnostics_;
   };
-  
- 
+
   struct IndexMatch {
-      IndexMatch(size_t index, double global_quality) : idx(index), quality(global_quality) {}
-      size_t idx; double quality; 
-      bool operator<(const IndexMatch &other) const { return other.quality < quality; } 
+    IndexMatch(size_t index, double global_quality)
+        : idx(index), quality(global_quality) {}
+    size_t idx;
+    double quality;
+    bool operator<(const IndexMatch &other) const {
+      return other.quality < quality;
+    }
   };
-  typedef std::map<size_t, std::vector<IndexMatch> > IndexAssociation;
- 
-  IndexAssociation associateSimToRecoIndices(const TrackHitsCollection &, 
-                                             const edm::RefVector<TrackingParticleCollection>&,
-                                             Resources const&) const;
+  typedef std::map<size_t, std::vector<IndexMatch>> IndexAssociation;
 
-  IndexAssociation associateRecoToSimIndices(const TrackHitsCollection &, 
-                                             const edm::RefVector<TrackingParticleCollection>&,
-                                             Resources const&) const;
-  
+  IndexAssociation
+  associateSimToRecoIndices(const TrackHitsCollection &,
+                            const edm::RefVector<TrackingParticleCollection> &,
+                            Resources const &) const;
 
+  IndexAssociation
+  associateRecoToSimIndices(const TrackHitsCollection &,
+                            const edm::RefVector<TrackingParticleCollection> &,
+                            Resources const &) const;
 
- private:
-  void getMatchedIds
-    (MapOfMatchedIds & tracker_matchedIds_valid, MapOfMatchedIds & muon_matchedIds_valid,
-     MapOfMatchedIds & tracker_matchedIds_INVALID, MapOfMatchedIds & muon_matchedIds_INVALID,
-     int& n_tracker_valid, int& n_dt_valid, int& n_csc_valid, int& n_rpc_valid, int& n_gem_valid,
-     int& n_tracker_matched_valid, int& n_dt_matched_valid, int& n_csc_matched_valid, int& n_rpc_matched_valid, int& n_gem_matched_valid,
-     int& n_tracker_INVALID, int& n_dt_INVALID, int& n_csc_INVALID, int& n_rpc_INVALID, int& n_gem_INVALID,
-     int& n_tracker_matched_INVALID, int& n_dt_matched_INVALID, int& n_csc_matched_INVALID, int& n_rpc_matched_INVALID, int& n_gem_matched_INVALID,
-     trackingRecHit_iterator begin, trackingRecHit_iterator end,
-     const TrackerHitAssociator* trackertruth, const DTHitAssociator& dttruth, const CSCHitAssociator& csctruth, const RPCHitAssociator& rpctruth, const GEMHitAssociator& gemtruth,
-     bool printRts, const TrackerTopology *) const;
-  
-  int getShared(MapOfMatchedIds & matchedIds, TrackingParticleCollection::const_iterator trpart) const;
+private:
+  void getMatchedIds(
+      MapOfMatchedIds &tracker_matchedIds_valid,
+      MapOfMatchedIds &muon_matchedIds_valid,
+      MapOfMatchedIds &tracker_matchedIds_INVALID,
+      MapOfMatchedIds &muon_matchedIds_INVALID, int &n_tracker_valid,
+      int &n_dt_valid, int &n_csc_valid, int &n_rpc_valid, int &n_gem_valid,
+      int &n_tracker_matched_valid, int &n_dt_matched_valid,
+      int &n_csc_matched_valid, int &n_rpc_matched_valid,
+      int &n_gem_matched_valid, int &n_tracker_INVALID, int &n_dt_INVALID,
+      int &n_csc_INVALID, int &n_rpc_INVALID, int &n_gem_INVALID,
+      int &n_tracker_matched_INVALID, int &n_dt_matched_INVALID,
+      int &n_csc_matched_INVALID, int &n_rpc_matched_INVALID,
+      int &n_gem_matched_INVALID, trackingRecHit_iterator begin,
+      trackingRecHit_iterator end, const TrackerHitAssociator *trackertruth,
+      const DTHitAssociator &dttruth, const CSCHitAssociator &csctruth,
+      const RPCHitAssociator &rpctruth, const GEMHitAssociator &gemtruth,
+      bool printRts, const TrackerTopology *) const;
 
-  const bool includeZeroHitMuons;    
+  int getShared(MapOfMatchedIds &matchedIds,
+                TrackingParticleCollection::const_iterator trpart) const;
+
+  const bool includeZeroHitMuons;
   const bool acceptOneStubMatchings;
   bool UseTracker;
   bool UseMuon;
   const bool AbsoluteNumberOfHits_track;
-  unsigned int NHitCut_track;    
+  unsigned int NHitCut_track;
   double EfficiencyCut_track;
   double PurityCut_track;
   const bool AbsoluteNumberOfHits_muon;
-  unsigned int NHitCut_muon;    
+  unsigned int NHitCut_muon;
   double EfficiencyCut_muon;
   double PurityCut_muon;
   const bool UsePixels;
@@ -95,12 +110,16 @@ class MuonAssociatorByHitsHelper {
   const bool ThreeHitTracksAreSpecial;
   const bool dumpDT;
 
-  int LayerFromDetid(const DetId&) const;
-  const TrackingRecHit* getHitPtr(edm::OwnVector<TrackingRecHit>::const_iterator iter) const {return &*iter;}
-  const TrackingRecHit* getHitPtr(const trackingRecHit_iterator& iter) const {return &**iter;}
+  int LayerFromDetid(const DetId &) const;
+  const TrackingRecHit *
+  getHitPtr(edm::OwnVector<TrackingRecHit>::const_iterator iter) const {
+    return &*iter;
+  }
+  const TrackingRecHit *getHitPtr(const trackingRecHit_iterator &iter) const {
+    return &**iter;
+  }
 
-  std::string write_matched_simtracks(const std::vector<SimHitIdpr>&) const;
-
+  std::string write_matched_simtracks(const std::vector<SimHitIdpr> &) const;
 };
 
 #endif

--- a/SimMuon/MCTruth/interface/MuonToSimAssociatorBase.h
+++ b/SimMuon/MCTruth/interface/MuonToSimAssociatorBase.h
@@ -1,46 +1,54 @@
 #ifndef MuonToSimAssociatorBase_h
 #define MuonToSimAssociatorBase_h
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
-
 
 class TrackerTopology;
 
-class MuonToSimAssociatorBase  {
-  
- public:
-  
-  MuonToSimAssociatorBase ();
+class MuonToSimAssociatorBase {
+
+public:
+  MuonToSimAssociatorBase();
   virtual ~MuonToSimAssociatorBase();
-  
+
   enum MuonTrackType { InnerTk, OuterTk, GlobalTk, Segments };
 
-  struct RefToBaseSort { 
-    template<typename T> bool operator()(const edm::RefToBase<T> &r1, const edm::RefToBase<T> &r2) const { 
-        return (r1.id() == r2.id() ? r1.key() < r2.key() : r1.id() < r2.id()); 
+  struct RefToBaseSort {
+    template <typename T>
+    bool operator()(const edm::RefToBase<T> &r1,
+                    const edm::RefToBase<T> &r2) const {
+      return (r1.id() == r2.id() ? r1.key() < r2.key() : r1.id() < r2.id());
     }
   };
-  typedef std::map<edm::RefToBase<reco::Muon>, std::vector<std::pair<TrackingParticleRef, double> >, RefToBaseSort> MuonToSimCollection;
-  typedef std::map<TrackingParticleRef, std::vector<std::pair<edm::RefToBase<reco::Muon>, double> > >               SimToMuonCollection;
+  typedef std::map<edm::RefToBase<reco::Muon>,
+                   std::vector<std::pair<TrackingParticleRef, double>>,
+                   RefToBaseSort>
+      MuonToSimCollection;
+  typedef std::map<TrackingParticleRef,
+                   std::vector<std::pair<edm::RefToBase<reco::Muon>, double>>>
+      SimToMuonCollection;
 
+  virtual void
+  associateMuons(MuonToSimCollection &recoToSim, SimToMuonCollection &simToReco,
+                 const edm::RefToBaseVector<reco::Muon> &, MuonTrackType,
+                 const edm::RefVector<TrackingParticleCollection> &,
+                 const edm::Event *event = nullptr,
+                 const edm::EventSetup *setup = nullptr) const = 0;
 
-  virtual void associateMuons(MuonToSimCollection & recoToSim, SimToMuonCollection & simToReco,
-                              const edm::RefToBaseVector<reco::Muon> &, MuonTrackType ,
-                              const edm::RefVector<TrackingParticleCollection>&,
-                              const edm::Event * event = nullptr, const edm::EventSetup * setup = nullptr) const = 0; 
-
-  virtual void associateMuons(MuonToSimCollection & recoToSim, SimToMuonCollection & simToReco,
-                              const edm::Handle<edm::View<reco::Muon> > &, MuonTrackType , 
-                              const edm::Handle<TrackingParticleCollection>&,
-                              const edm::Event * event = nullptr, const edm::EventSetup * setup = nullptr) const = 0;
-
+  virtual void associateMuons(MuonToSimCollection &recoToSim,
+                              SimToMuonCollection &simToReco,
+                              const edm::Handle<edm::View<reco::Muon>> &,
+                              MuonTrackType,
+                              const edm::Handle<TrackingParticleCollection> &,
+                              const edm::Event *event = nullptr,
+                              const edm::EventSetup *setup = nullptr) const = 0;
 };
 
 #endif

--- a/SimMuon/MCTruth/interface/MuonToSimAssociatorByHits.h
+++ b/SimMuon/MCTruth/interface/MuonToSimAssociatorByHits.h
@@ -1,38 +1,38 @@
 #ifndef MuonToSimAssociatorByHits_h
 #define MuonToSimAssociatorByHits_h
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimMuon/MCTruth/interface/MuonToSimAssociatorBase.h"
 
 #include "SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h"
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
 class MuonToSimAssociatorByHits : public MuonToSimAssociatorBase {
-  
- public:
-  
-  MuonToSimAssociatorByHits (const edm::ParameterSet& conf, edm::ConsumesCollector && iC);   
+
+public:
+  MuonToSimAssociatorByHits(const edm::ParameterSet &conf,
+                            edm::ConsumesCollector &&iC);
   ~MuonToSimAssociatorByHits() override;
 
+  void associateMuons(MuonToSimCollection &recoToSim,
+                      SimToMuonCollection &simToReco,
+                      const edm::RefToBaseVector<reco::Muon> &, MuonTrackType,
+                      const edm::RefVector<TrackingParticleCollection> &,
+                      const edm::Event *event = nullptr,
+                      const edm::EventSetup *setup = nullptr) const override;
 
+  void associateMuons(MuonToSimCollection &recoToSim,
+                      SimToMuonCollection &simToReco,
+                      const edm::Handle<edm::View<reco::Muon>> &, MuonTrackType,
+                      const edm::Handle<TrackingParticleCollection> &,
+                      const edm::Event *event = nullptr,
+                      const edm::EventSetup *setup = nullptr) const override;
 
-  void associateMuons(MuonToSimCollection & recoToSim, SimToMuonCollection & simToReco,
-                      const edm::RefToBaseVector<reco::Muon> &, MuonTrackType ,
-                      const edm::RefVector<TrackingParticleCollection>&,
-                      const edm::Event * event = nullptr, const edm::EventSetup * setup = nullptr) const override ; 
-
-  void associateMuons(MuonToSimCollection & recoToSim, SimToMuonCollection & simToReco,
-                      const edm::Handle<edm::View<reco::Muon> > &, MuonTrackType , 
-                      const edm::Handle<TrackingParticleCollection>&,
-                      const edm::Event * event = nullptr, const edm::EventSetup * setup = nullptr) const override;
-
- private:
-
+private:
   MuonAssociatorByHitsHelper helper_;
   edm::ParameterSet const conf_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
-
 };
 
 #endif

--- a/SimMuon/MCTruth/interface/MuonTruth.h
+++ b/SimMuon/MCTruth/interface/MuonTruth.h
@@ -1,42 +1,44 @@
 #ifndef MCTruth_MuonTruth_h
 #define MCTruth_MuonTruth_h
 
-#include "DataFormats/CSCRecHit/interface/CSCRecHit2D.h"
-#include "DataFormats/CSCDigi/interface/CSCStripDigi.h"
-#include "DataFormats/CSCDigi/interface/CSCWireDigi.h"
-#include "SimDataFormats/Track/interface/SimTrackContainer.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
-#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
-#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
-#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
-#include "Geometry/CSCGeometry/interface/CSCLayerGeometry.h"
 #include "CondFormats/CSCObjects/interface/CSCBadChambers.h"
 #include "CondFormats/DataRecord/interface/CSCBadChambersRcd.h"
+#include "DataFormats/CSCDigi/interface/CSCStripDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCWireDigi.h"
+#include "DataFormats/CSCRecHit/interface/CSCRecHit2D.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/CSCGeometry/interface/CSCLayerGeometry.h"
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-class MuonTruth
-{
+class MuonTruth {
 public:
   typedef edm::DetSetVector<StripDigiSimLink> DigiSimLinks;
   typedef edm::DetSetVector<StripDigiSimLink> WireDigiSimLinks;
   typedef edm::DetSet<StripDigiSimLink> LayerLinks;
-  typedef std::pair <uint32_t, EncodedEventId> SimHitIdpr;
+  typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
 
-  MuonTruth(const edm::Event&, const edm::EventSetup&, const edm::ParameterSet&); 
-  MuonTruth(const edm::ParameterSet&, edm::ConsumesCollector && iC);
- 
-  void initEvent(const edm::Event &, const edm::EventSetup& );
+  MuonTruth(const edm::Event &, const edm::EventSetup &,
+            const edm::ParameterSet &);
+  MuonTruth(const edm::ParameterSet &, edm::ConsumesCollector &&iC);
 
-  void analyze(const CSCRecHit2D & recHit);
-  void analyze(const CSCStripDigi & stripDigi, int rawDetIdCorrespondingToCSCLayer);
-  void analyze(const CSCWireDigi & wireDigi  , int rawDetIdCorrespondingToCSCLayer);
+  void initEvent(const edm::Event &, const edm::EventSetup &);
+
+  void analyze(const CSCRecHit2D &recHit);
+  void analyze(const CSCStripDigi &stripDigi,
+               int rawDetIdCorrespondingToCSCLayer);
+  void analyze(const CSCWireDigi &wireDigi,
+               int rawDetIdCorrespondingToCSCLayer);
 
   /// analyze() must be called before any of the following
   float muonFraction();
@@ -45,23 +47,22 @@ public:
 
   std::vector<PSimHit> simHits();
 
-  const CSCBadChambers* cscBadChambers;
+  const CSCBadChambers *cscBadChambers;
 
 private:
-
-  std::vector<PSimHit> hitsFromSimTrack(SimHitIdpr truthId) ;
+  std::vector<PSimHit> hitsFromSimTrack(SimHitIdpr truthId);
   // goes to SimHits for information
   int particleType(SimHitIdpr truthId);
 
-  void addChannel(const LayerLinks &layerLinks, int channel, float weight=1.);
+  void addChannel(const LayerLinks &layerLinks, int channel, float weight = 1.);
 
   std::map<SimHitIdpr, float> theChargeMap;
   float theTotalCharge;
 
   unsigned int theDetId;
 
-  const DigiSimLinks  * theDigiSimLinks;
-  const DigiSimLinks  * theWireDigiSimLinks;
+  const DigiSimLinks *theDigiSimLinks;
+  const DigiSimLinks *theWireDigiSimLinks;
 
   edm::InputTag linksTag;
   edm::InputTag wireLinksTag;
@@ -72,7 +73,7 @@ private:
 
   std::map<unsigned int, edm::PSimHitContainer> theSimHitMap;
 
-  const CSCGeometry* cscgeom;
+  const CSCGeometry *cscgeom;
 };
 
 #endif

--- a/SimMuon/MCTruth/interface/PSimHitMap.h
+++ b/SimMuon/MCTruth/interface/PSimHitMap.h
@@ -1,33 +1,31 @@
 #ifndef MCTruth_PSimHitMap_h
 #define MCTruth_PSimHitMap_h
 
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include <map>
 
-class PSimHitMap
-{
- public:
-  PSimHitMap(const edm::InputTag & iT, edm::ConsumesCollector && iC)
-    :  theMap(), theEmptyContainer()
-  {
-    sh_token = iC.consumes<CrossingFrame<PSimHit> >(iT);
+class PSimHitMap {
+public:
+  PSimHitMap(const edm::InputTag &iT, edm::ConsumesCollector &&iC)
+      : theMap(), theEmptyContainer() {
+    sh_token = iC.consumes<CrossingFrame<PSimHit>>(iT);
   }
 
-  void fill(const edm::Event & e);
+  void fill(const edm::Event &e);
 
-  const edm::PSimHitContainer & hits(int detId) const;
+  const edm::PSimHitContainer &hits(int detId) const;
 
   std::vector<int> detsWithHits() const;
 
- private:
+private:
   std::map<int, edm::PSimHitContainer> theMap;
   edm::PSimHitContainer theEmptyContainer;
   //  edm::InputTag simHitsTag;
-  edm::EDGetTokenT<CrossingFrame<PSimHit> > sh_token;
+  edm::EDGetTokenT<CrossingFrame<PSimHit>> sh_token;
 };
 
 #endif

--- a/SimMuon/MCTruth/interface/RPCHitAssociator.h
+++ b/SimMuon/MCTruth/interface/RPCHitAssociator.h
@@ -1,71 +1,68 @@
 #ifndef MCTruth_RPCHitAssociator_h
 #define MCTruth_RPCHitAssociator_h
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/MuonDetId/interface/RPCDetId.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
+#include "SimDataFormats/RPCDigiSimLink/interface/RPCDigiSimLink.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "DataFormats/MuonDetId/interface/RPCDetId.h"
-#include "SimDataFormats/RPCDigiSimLink/interface/RPCDigiSimLink.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 
-#include <vector>
 #include <map>
-#include <string>
 #include <set>
+#include <string>
+#include <vector>
 
-#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
-#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 
 class RPCHitAssociator {
 
- public:
-   typedef edm::DetSetVector<RPCDigiSimLink> RPCDigiSimLinks;
-   typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
+public:
+  typedef edm::DetSetVector<RPCDigiSimLink> RPCDigiSimLinks;
+  typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
 
   // Constructor with configurable parameters
-   RPCHitAssociator(const edm::ParameterSet&, edm::ConsumesCollector && ic); 
-   RPCHitAssociator(const edm::Event& e, const edm::EventSetup& eventSetup, const edm::ParameterSet& conf );
+  RPCHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&ic);
+  RPCHitAssociator(const edm::Event &e, const edm::EventSetup &eventSetup,
+                   const edm::ParameterSet &conf);
 
-   void initEvent(const edm::Event&, const edm::EventSetup&);
-  
+  void initEvent(const edm::Event &, const edm::EventSetup &);
+
   // Destructor
-  ~RPCHitAssociator(){}
+  ~RPCHitAssociator() {}
 
-   std::vector<SimHitIdpr> associateRecHit(const TrackingRecHit & hit) const;
-   std::set<RPCDigiSimLink> findRPCDigiSimLink(uint32_t rpcDetId, int strip, int bx) const;
-   //   const PSimHit* linkToSimHit(RPCDigiSimLink link);
+  std::vector<SimHitIdpr> associateRecHit(const TrackingRecHit &hit) const;
+  std::set<RPCDigiSimLink> findRPCDigiSimLink(uint32_t rpcDetId, int strip,
+                                              int bx) const;
+  //   const PSimHit* linkToSimHit(RPCDigiSimLink link);
 
+private:
+  edm::Handle<edm::DetSetVector<RPCDigiSimLink>> _thelinkDigis;
+  edm::InputTag RPCdigisimlinkTag;
 
- private:
-   edm::Handle< edm::DetSetVector<RPCDigiSimLink> > _thelinkDigis;
-   edm::InputTag RPCdigisimlinkTag;
- 
-   bool crossingframe;
-   edm::InputTag RPCsimhitsTag;
-   edm::InputTag RPCsimhitsXFTag;
+  bool crossingframe;
+  edm::InputTag RPCsimhitsTag;
+  edm::InputTag RPCsimhitsXFTag;
 
-   edm::EDGetTokenT<CrossingFrame<PSimHit> > RPCsimhitsXFToken_;
-   edm::EDGetTokenT<edm::PSimHitContainer> RPCsimhitsToken_;
-   edm::EDGetTokenT<edm::DetSetVector<RPCDigiSimLink> > RPCdigisimlinkToken_; 
+  edm::EDGetTokenT<CrossingFrame<PSimHit>> RPCsimhitsXFToken_;
+  edm::EDGetTokenT<edm::PSimHitContainer> RPCsimhitsToken_;
+  edm::EDGetTokenT<edm::DetSetVector<RPCDigiSimLink>> RPCdigisimlinkToken_;
 
-   std::map<unsigned int, edm::PSimHitContainer> _SimHitMap;
-
- };
+  std::map<unsigned int, edm::PSimHitContainer> _SimHitMap;
+};
 
 #endif
-
-
-

--- a/SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h
+++ b/SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h
@@ -1,36 +1,38 @@
 //
 // modified & integrated by Giovanni Abbiendi
-// from code by Arun Luthra: UserCode/luthra/MuonTrackSelector/src/MuonTrackSelector.cc
+// from code by Arun Luthra:
+// UserCode/luthra/MuonTrackSelector/src/MuonTrackSelector.cc
 //
 #ifndef MCTruth_TrackerMuonHitExtractor_h
 #define MCTruth_TrackerMuonHitExtractor_h
 
-#include <memory>
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/MuonReco/interface/MuonFwd.h"
-#include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include <memory>
 
 class TrackerMuonHitExtractor {
-  public:
-    explicit TrackerMuonHitExtractor(const edm::ParameterSet&, edm::ConsumesCollector && ic);
-    explicit TrackerMuonHitExtractor(const edm::ParameterSet& );
-    ~TrackerMuonHitExtractor();
+public:
+  explicit TrackerMuonHitExtractor(const edm::ParameterSet &,
+                                   edm::ConsumesCollector &&ic);
+  explicit TrackerMuonHitExtractor(const edm::ParameterSet &);
+  ~TrackerMuonHitExtractor();
 
-    void init(const edm::Event&, const edm::EventSetup&);
-    std::vector<const TrackingRecHit *> getMuonHits(const reco::Muon &mu) const ;
-  private:
-    edm::Handle<DTRecSegment4DCollection> dtSegmentCollectionH_;
-    edm::Handle<CSCSegmentCollection> cscSegmentCollectionH_;
+  void init(const edm::Event &, const edm::EventSetup &);
+  std::vector<const TrackingRecHit *> getMuonHits(const reco::Muon &mu) const;
 
-    edm::EDGetTokenT<DTRecSegment4DCollection> inputDTRecSegment4DToken_;
-    edm::EDGetTokenT<CSCSegmentCollection> inputCSCSegmentToken_;
-    edm::InputTag inputDTRecSegment4DCollection_;
-    edm::InputTag inputCSCSegmentCollection_;
+private:
+  edm::Handle<DTRecSegment4DCollection> dtSegmentCollectionH_;
+  edm::Handle<CSCSegmentCollection> cscSegmentCollectionH_;
 
+  edm::EDGetTokenT<DTRecSegment4DCollection> inputDTRecSegment4DToken_;
+  edm::EDGetTokenT<CSCSegmentCollection> inputCSCSegmentToken_;
+  edm::InputTag inputDTRecSegment4DCollection_;
+  edm::InputTag inputCSCSegmentCollection_;
 };
 
 #endif

--- a/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.cc
@@ -1,120 +1,143 @@
-#include <memory>
-#include "SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/RecoCandidate/interface/TrackAssociation.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.h"
+#include <memory>
 
-MuonAssociatorEDProducer::MuonAssociatorEDProducer(const edm::ParameterSet& parset):
-  tracksTag(parset.getParameter< edm::InputTag >("tracksTag")),
-  tpTag(parset.getParameter< edm::InputTag >("tpTag")),
-  ignoreMissingTrackCollection(parset.getUntrackedParameter<bool>("ignoreMissingTrackCollection",false)),
-  parset_(parset)
-{
-  
-  edm::LogVerbatim("MuonAssociatorEDProducer") << "constructing  MuonAssociatorEDProducer";
+MuonAssociatorEDProducer::MuonAssociatorEDProducer(
+    const edm::ParameterSet &parset)
+    : tracksTag(parset.getParameter<edm::InputTag>("tracksTag")),
+      tpTag(parset.getParameter<edm::InputTag>("tpTag")),
+      ignoreMissingTrackCollection(parset.getUntrackedParameter<bool>(
+          "ignoreMissingTrackCollection", false)),
+      parset_(parset) {
+
+  edm::LogVerbatim("MuonAssociatorEDProducer")
+      << "constructing  MuonAssociatorEDProducer";
   produces<reco::RecoToSimCollection>();
   produces<reco::SimToRecoCollection>();
-  tpToken_=consumes<TrackingParticleCollection>(tpTag);
-  tracksToken_=consumes<edm::View<reco::Track> >(tracksTag);
+  tpToken_ = consumes<TrackingParticleCollection>(tpTag);
+  tracksToken_ = consumes<edm::View<reco::Track>>(tracksTag);
 
   /// Perform some sanity checks of the configuration
-  LogTrace("MuonAssociatorEDProducer") << "constructing  MuonAssociatorByHits" << parset_.dump();
-  edm::LogVerbatim("MuonAssociatorEDProducer") << "\n MuonAssociatorByHits will associate reco::Tracks with "<<tracksTag
-					   << "\n\t\t and TrackingParticles with "<<tpTag;
+  LogTrace("MuonAssociatorEDProducer")
+      << "constructing  MuonAssociatorByHits" << parset_.dump();
+  edm::LogVerbatim("MuonAssociatorEDProducer")
+      << "\n MuonAssociatorByHits will associate reco::Tracks with "
+      << tracksTag << "\n\t\t and TrackingParticles with " << tpTag;
   const std::string recoTracksLabel = tracksTag.label();
   const std::string recoTracksInstance = tracksTag.instance();
 
   // check and fix inconsistent input settings
   // tracks with hits only on muon detectors
-  if (recoTracksLabel == "standAloneMuons" || recoTracksLabel == "standAloneSETMuons" ||
+  if (recoTracksLabel == "standAloneMuons" ||
+      recoTracksLabel == "standAloneSETMuons" ||
       recoTracksLabel == "cosmicMuons" || recoTracksLabel == "hltL2Muons") {
     if (parset_.getParameter<bool>("UseTracker")) {
-      edm::LogWarning("MuonAssociatorEDProducer") 
-	<<"\n*** WARNING : inconsistent input tracksTag = "<<tracksTag
-	<<"\n with UseTracker = true"<<"\n ---> setting UseTracker = false ";
-      parset_.addParameter<bool>("UseTracker",false);
+      edm::LogWarning("MuonAssociatorEDProducer")
+          << "\n*** WARNING : inconsistent input tracksTag = " << tracksTag
+          << "\n with UseTracker = true"
+          << "\n ---> setting UseTracker = false ";
+      parset_.addParameter<bool>("UseTracker", false);
     }
     if (!parset_.getParameter<bool>("UseMuon")) {
-      edm::LogWarning("MuonAssociatorEDProducer") 
-	<<"\n*** WARNING : inconsistent input tracksTag = "<<tracksTag
-	<<"\n with UseMuon = false"<<"\n ---> setting UseMuon = true ";
-      parset_.addParameter<bool>("UseMuon",true);
+      edm::LogWarning("MuonAssociatorEDProducer")
+          << "\n*** WARNING : inconsistent input tracksTag = " << tracksTag
+          << "\n with UseMuon = false"
+          << "\n ---> setting UseMuon = true ";
+      parset_.addParameter<bool>("UseMuon", true);
     }
   }
   // tracks with hits only on tracker
-  if (recoTracksLabel == "generalTracks" || recoTracksLabel == "ctfWithMaterialTracksP5LHCNavigation" ||
-      recoTracksLabel == "hltL3TkTracksFromL2" || 
+  if (recoTracksLabel == "generalTracks" ||
+      recoTracksLabel == "ctfWithMaterialTracksP5LHCNavigation" ||
+      recoTracksLabel == "hltL3TkTracksFromL2" ||
       (recoTracksLabel == "hltL3Muons" && recoTracksInstance == "L2Seeded")) {
     if (parset_.getParameter<bool>("UseMuon")) {
-      edm::LogWarning("MuonAssociatorEDProducer") 
-	<<"\n*** WARNING : inconsistent input tracksTag = "<<tracksTag
-	<<"\n with UseMuon = true"<<"\n ---> setting UseMuon = false ";
-      parset_.addParameter<bool>("UseMuon",false);
+      edm::LogWarning("MuonAssociatorEDProducer")
+          << "\n*** WARNING : inconsistent input tracksTag = " << tracksTag
+          << "\n with UseMuon = true"
+          << "\n ---> setting UseMuon = false ";
+      parset_.addParameter<bool>("UseMuon", false);
     }
     if (!parset_.getParameter<bool>("UseTracker")) {
-      edm::LogWarning("MuonAssociatorEDProducer") 
-	<<"\n*** WARNING : inconsistent input tracksTag = "<<tracksTag
-	<<"\n with UseTracker = false"<<"\n ---> setting UseTracker = true ";
-      parset_.addParameter<bool>("UseTracker",true);
+      edm::LogWarning("MuonAssociatorEDProducer")
+          << "\n*** WARNING : inconsistent input tracksTag = " << tracksTag
+          << "\n with UseTracker = false"
+          << "\n ---> setting UseTracker = true ";
+      parset_.addParameter<bool>("UseTracker", true);
     }
   }
 
-  LogTrace("MuonAssociatorEDProducer") << "MuonAssociatorEDProducer::beginJob : constructing MuonAssociatorByHits";
-  associatorByHits = new MuonAssociatorByHits(parset_,consumesCollector());
+  LogTrace("MuonAssociatorEDProducer") << "MuonAssociatorEDProducer::beginJob "
+                                          ": constructing MuonAssociatorByHits";
+  associatorByHits = new MuonAssociatorByHits(parset_, consumesCollector());
 }
 
 MuonAssociatorEDProducer::~MuonAssociatorEDProducer() {}
 
-void MuonAssociatorEDProducer::beginJob() {
-}
+void MuonAssociatorEDProducer::beginJob() {}
 
 void MuonAssociatorEDProducer::endJob() {}
 
-void MuonAssociatorEDProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
-   using namespace edm;
+void MuonAssociatorEDProducer::produce(edm::Event &event,
+                                       const edm::EventSetup &setup) {
+  using namespace edm;
 
-   Handle<TrackingParticleCollection>  TPCollection ;
-   LogTrace("MuonAssociatorEDProducer") <<"getting TrackingParticle collection - "<<tpTag;
-   event.getByToken(tpToken_, TPCollection);
-   LogTrace("MuonAssociatorEDProducer") <<"\t... size = "<<TPCollection->size();
+  Handle<TrackingParticleCollection> TPCollection;
+  LogTrace("MuonAssociatorEDProducer")
+      << "getting TrackingParticle collection - " << tpTag;
+  event.getByToken(tpToken_, TPCollection);
+  LogTrace("MuonAssociatorEDProducer")
+      << "\t... size = " << TPCollection->size();
 
-   Handle<edm::View<reco::Track> > trackCollection;
-   LogTrace("MuonAssociatorEDProducer") <<"getting reco::Track collection - "<<tracksTag;
-   bool trackAvailable = event.getByToken (tracksToken_, trackCollection);
-   if (trackAvailable) LogTrace("MuonAssociatorEDProducer") <<"\t... size = "<<trackCollection->size();
-   else LogTrace("MuonAssociatorEDProducer") <<"\t... NOT FOUND.";
+  Handle<edm::View<reco::Track>> trackCollection;
+  LogTrace("MuonAssociatorEDProducer")
+      << "getting reco::Track collection - " << tracksTag;
+  bool trackAvailable = event.getByToken(tracksToken_, trackCollection);
+  if (trackAvailable)
+    LogTrace("MuonAssociatorEDProducer")
+        << "\t... size = " << trackCollection->size();
+  else
+    LogTrace("MuonAssociatorEDProducer") << "\t... NOT FOUND.";
 
-   std::unique_ptr<reco::RecoToSimCollection> rts;
-   std::unique_ptr<reco::SimToRecoCollection> str;
+  std::unique_ptr<reco::RecoToSimCollection> rts;
+  std::unique_ptr<reco::SimToRecoCollection> str;
 
-   if (ignoreMissingTrackCollection && !trackAvailable) {
-     //the track collection is not in the event and we're being told to ignore this.
-     //do not output anything to the event, other wise this would be considered as inefficiency.
-     LogTrace("MuonAssociatorEDProducer") << "\n ignoring missing track collection." << "\n";
-   }   
-   else {
-     edm::LogVerbatim("MuonAssociatorEDProducer") 
-       <<"\n >>> RecoToSim association <<< \n"
-       <<"     Track collection : "
-       <<tracksTag.label()<<":"<<tracksTag.instance()<<" (size = "<<trackCollection->size()<<") \n"
-       <<"     TrackingParticle collection : "
-       <<tpTag.label()<<":"<<tpTag.instance()<<" (size = "<<TPCollection->size()<<")";
-     
-     reco::RecoToSimCollection recSimColl = associatorByHits->associateRecoToSim(trackCollection,TPCollection,&event,&setup);
-     
-     edm::LogVerbatim("MuonAssociatorEDProducer") 
-       <<"\n >>> SimToReco association <<< \n"
-       <<"     TrackingParticle collection : "
-       <<tpTag.label()<<":"<<tpTag.instance()<<" (size = "<<TPCollection->size()<<") \n"
-       <<"     Track collection : "
-       <<tracksTag.label()<<":"<<tracksTag.instance()<<" (size = "<<trackCollection->size()<<")";
-     
-     reco::SimToRecoCollection simRecColl = associatorByHits->associateSimToReco(trackCollection,TPCollection,&event,&setup);
-     
-     rts.reset(new reco::RecoToSimCollection(recSimColl));
-     str.reset(new reco::SimToRecoCollection(simRecColl));
-     
-     event.put(std::move(rts));
-     event.put(std::move(str));
-   }
+  if (ignoreMissingTrackCollection && !trackAvailable) {
+    // the track collection is not in the event and we're being told to ignore
+    // this. do not output anything to the event, other wise this would be
+    // considered as inefficiency.
+    LogTrace("MuonAssociatorEDProducer")
+        << "\n ignoring missing track collection."
+        << "\n";
+  } else {
+    edm::LogVerbatim("MuonAssociatorEDProducer")
+        << "\n >>> RecoToSim association <<< \n"
+        << "     Track collection : " << tracksTag.label() << ":"
+        << tracksTag.instance() << " (size = " << trackCollection->size()
+        << ") \n"
+        << "     TrackingParticle collection : " << tpTag.label() << ":"
+        << tpTag.instance() << " (size = " << TPCollection->size() << ")";
+
+    reco::RecoToSimCollection recSimColl = associatorByHits->associateRecoToSim(
+        trackCollection, TPCollection, &event, &setup);
+
+    edm::LogVerbatim("MuonAssociatorEDProducer")
+        << "\n >>> SimToReco association <<< \n"
+        << "     TrackingParticle collection : " << tpTag.label() << ":"
+        << tpTag.instance() << " (size = " << TPCollection->size() << ") \n"
+        << "     Track collection : " << tracksTag.label() << ":"
+        << tracksTag.instance() << " (size = " << trackCollection->size()
+        << ")";
+
+    reco::SimToRecoCollection simRecColl = associatorByHits->associateSimToReco(
+        trackCollection, TPCollection, &event, &setup);
+
+    rts.reset(new reco::RecoToSimCollection(recSimColl));
+    str.reset(new reco::SimToRecoCollection(simRecColl));
+
+    event.put(std::move(rts));
+    event.put(std::move(str));
+  }
 }

--- a/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.h
+++ b/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.h
@@ -1,33 +1,33 @@
 #ifndef MCTruth_MuonAssociatorEDProducer_h
 #define MCTruth_MuonAssociatorEDProducer_h
 
-#include <memory>
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "DataFormats/RecoCandidate/interface/TrackAssociation.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "SimMuon/MCTruth/interface/MuonAssociatorByHits.h"
-#include "DataFormats/RecoCandidate/interface/TrackAssociation.h"
+#include <memory>
 
 class MuonAssociatorEDProducer : public edm::stream::EDProducer<> {
 public:
-  explicit MuonAssociatorEDProducer(const edm::ParameterSet&);
+  explicit MuonAssociatorEDProducer(const edm::ParameterSet &);
   ~MuonAssociatorEDProducer() override;
-  
+
 private:
-  virtual void beginJob() ;
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void beginJob();
+  void produce(edm::Event &, const edm::EventSetup &) override;
   virtual void endJob();
 
   edm::InputTag tracksTag;
   edm::InputTag tpTag;
   edm::EDGetTokenT<TrackingParticleCollection> tpToken_;
-  edm::EDGetTokenT<edm::View<reco::Track> > tracksToken_;
+  edm::EDGetTokenT<edm::View<reco::Track>> tracksToken_;
 
   bool ignoreMissingTrackCollection;
   edm::ParameterSet parset_;
-  MuonAssociatorByHits * associatorByHits;
+  MuonAssociatorByHits *associatorByHits;
 };
 
 #endif

--- a/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
+++ b/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
@@ -7,22 +7,26 @@
 
 
  CLASSIFICATION: For each RECO Muon, match to SIM particle, and then:
-  - If the SIM is not a Muon, label as Punchthrough (1) except if it is an electron or positron (11)
+  - If the SIM is not a Muon, label as Punchthrough (1) except if it is an
+ electron or positron (11)
   - If the SIM is a Muon, then look at it's provenance.
-     A) the SIM muon is also a GEN muon, whose parent is NOT A HADRON AND NOT A TAU
+     A) the SIM muon is also a GEN muon, whose parent is NOT A HADRON AND NOT A
+ TAU
         -> classify as "primary" (4).
-     B) the SIM muon is also a GEN muon, whose parent is HEAVY FLAVOURED HADRON OR A TAU
+     B) the SIM muon is also a GEN muon, whose parent is HEAVY FLAVOURED HADRON
+ OR A TAU
         -> classify as "heavy flavour" (3)
      C) classify as "light flavour/decay" (2)
 
-  In any case, if the TP is not preferentially matched back to the same RECO muon,
-  label as Ghost (flip the classification)
+  In any case, if the TP is not preferentially matched back to the same RECO
+ muon, label as Ghost (flip the classification)
 
 
  FLAVOUR:
   - for non-muons: 0
   - for primary muons: 13
-  - for non primary muons: flavour of the mother: std::abs(pdgId) of heaviest quark, or 15 for tau
+  - for non primary muons: flavour of the mother: std::abs(pdgId) of heaviest
+ quark, or 15 for tau
 
 */
 //
@@ -30,7 +34,6 @@
 //         Created:  Sun Nov 16 16:14:09 CET 2008
 //         revised:  3/Aug/2017
 //
-
 
 // system include files
 #include <memory>
@@ -40,541 +43,641 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DataFormats/Common/interface/View.h"
-#include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/Association.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Common/interface/View.h"
 
-#include "DataFormats/MuonReco/interface/Muon.h"
-#include "DataFormats/MuonReco/interface/MuonSimInfo.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonSimInfo.h"
 
 #include "SimDataFormats/Associations/interface/MuonToTrackingParticleAssociator.h"
-#include "SimTracker/Records/interface/TrackAssociatorRecord.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertex.h"
+#include "SimTracker/Records/interface/TrackAssociatorRecord.h"
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
 //
 // class decleration
 class MuonSimClassifier : public edm::stream::EDProducer<> {
-    public:
-        explicit MuonSimClassifier(const edm::ParameterSet&);
-        ~MuonSimClassifier() override;
+public:
+  explicit MuonSimClassifier(const edm::ParameterSet &);
+  ~MuonSimClassifier() override;
 
-    private:
-        void produce(edm::Event&, const edm::EventSetup&) override;
-        /// The RECO objects
-        edm::EDGetTokenT<edm::View<reco::Muon> > muonsToken_;
+private:
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  /// The RECO objects
+  edm::EDGetTokenT<edm::View<reco::Muon>> muonsToken_;
 
-        /// Track to use
-        reco::MuonTrackType trackType_;
+  /// Track to use
+  reco::MuonTrackType trackType_;
 
-        /// The TrackingParticle objects
-        edm::EDGetTokenT<TrackingParticleCollection> trackingParticlesToken_;
+  /// The TrackingParticle objects
+  edm::EDGetTokenT<TrackingParticleCollection> trackingParticlesToken_;
 
-        /// The Associations
-        edm::InputTag associatorLabel_;
-        edm::EDGetTokenT<reco::MuonToTrackingParticleAssociator> muAssocToken_;
+  /// The Associations
+  edm::InputTag associatorLabel_;
+  edm::EDGetTokenT<reco::MuonToTrackingParticleAssociator> muAssocToken_;
 
-        /// Cylinder to use to decide if a decay is early or late
-        double decayRho_, decayAbsZ_;
+  /// Cylinder to use to decide if a decay is early or late
+  double decayRho_, decayAbsZ_;
 
-        /// Create a link to the generator level particles
-        bool linkToGenParticles_;
-        edm::InputTag genParticles_;
-        edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
+  /// Create a link to the generator level particles
+  bool linkToGenParticles_;
+  edm::InputTag genParticles_;
+  edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
 
-        /// Returns the flavour given a pdg id code
-        int flavour(int pdgId) const ;
+  /// Returns the flavour given a pdg id code
+  int flavour(int pdgId) const;
 
-        /// Write a ValueMap<int> in the event
-        template<typename T>
-        void writeValueMap(edm::Event &iEvent,
-                const edm::Handle<edm::View<reco::Muon> > & handle,
-                const std::vector<T> & values,
-                const std::string    & label) const ;
+  /// Write a ValueMap<int> in the event
+  template <typename T>
+  void writeValueMap(edm::Event &iEvent,
+                     const edm::Handle<edm::View<reco::Muon>> &handle,
+                     const std::vector<T> &values,
+                     const std::string &label) const;
 
-        TrackingParticleRef getTpMother(TrackingParticleRef tp) {
-            if (tp.isNonnull() && tp->parentVertex().isNonnull() && !tp->parentVertex()->sourceTracks().empty()) {
-                return tp->parentVertex()->sourceTracks()[0];
-            } else {
-                return TrackingParticleRef();
-            }
-        }
+  TrackingParticleRef getTpMother(TrackingParticleRef tp) {
+    if (tp.isNonnull() && tp->parentVertex().isNonnull() &&
+        !tp->parentVertex()->sourceTracks().empty()) {
+      return tp->parentVertex()->sourceTracks()[0];
+    } else {
+      return TrackingParticleRef();
+    }
+  }
 
-        /// Convert TrackingParticle into GenParticle, save into output collection,
-        /// if mother is primary set reference to it,
-        /// return index in output collection
-        int convertAndPush(const TrackingParticle &tp,
-                           reco::GenParticleCollection &out,
-                           const TrackingParticleRef &momRef,
-                           const edm::Handle<reco::GenParticleCollection> & genParticles) const ;
+  /// Convert TrackingParticle into GenParticle, save into output collection,
+  /// if mother is primary set reference to it,
+  /// return index in output collection
+  int convertAndPush(
+      const TrackingParticle &tp, reco::GenParticleCollection &out,
+      const TrackingParticleRef &momRef,
+      const edm::Handle<reco::GenParticleCollection> &genParticles) const;
 };
 
-
-MuonSimClassifier::MuonSimClassifier(const edm::ParameterSet &iConfig) :
-    muonsToken_(consumes<edm::View<reco::Muon> >(iConfig.getParameter<edm::InputTag>("muons"))),
-    trackingParticlesToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("trackingParticles"))),
-    muAssocToken_(consumes<reco::MuonToTrackingParticleAssociator>(iConfig.getParameter<edm::InputTag>("associatorLabel"))),
-    decayRho_(iConfig.getParameter<double>("decayRho")),
-    decayAbsZ_(iConfig.getParameter<double>("decayAbsZ")),
-    linkToGenParticles_(iConfig.getParameter<bool>("linkToGenParticles")),
-    genParticles_(linkToGenParticles_ ? iConfig.getParameter<edm::InputTag>("genParticles") : edm::InputTag())
+MuonSimClassifier::MuonSimClassifier(const edm::ParameterSet &iConfig)
+    : muonsToken_(consumes<edm::View<reco::Muon>>(
+          iConfig.getParameter<edm::InputTag>("muons"))),
+      trackingParticlesToken_(consumes<TrackingParticleCollection>(
+          iConfig.getParameter<edm::InputTag>("trackingParticles"))),
+      muAssocToken_(consumes<reco::MuonToTrackingParticleAssociator>(
+          iConfig.getParameter<edm::InputTag>("associatorLabel"))),
+      decayRho_(iConfig.getParameter<double>("decayRho")),
+      decayAbsZ_(iConfig.getParameter<double>("decayAbsZ")),
+      linkToGenParticles_(iConfig.getParameter<bool>("linkToGenParticles")),
+      genParticles_(linkToGenParticles_
+                        ? iConfig.getParameter<edm::InputTag>("genParticles")
+                        : edm::InputTag())
 
 {
-    std::string trackType = iConfig.getParameter< std::string >("trackType");
-    if (trackType == "inner") trackType_ = reco::InnerTk;
-    else if (trackType == "outer") trackType_ = reco::OuterTk;
-    else if (trackType == "global") trackType_ = reco::GlobalTk;
-    else if (trackType == "segments") trackType_ = reco::Segments;
-    else if (trackType == "glb_or_trk") trackType_ = reco::GlbOrTrk;
-    else throw cms::Exception("Configuration") << "Track type '" << trackType << "' not supported.\n";
-    if (linkToGenParticles_) {
-      genParticlesToken_ = consumes<reco::GenParticleCollection>(genParticles_);
-    }
+  std::string trackType = iConfig.getParameter<std::string>("trackType");
+  if (trackType == "inner")
+    trackType_ = reco::InnerTk;
+  else if (trackType == "outer")
+    trackType_ = reco::OuterTk;
+  else if (trackType == "global")
+    trackType_ = reco::GlobalTk;
+  else if (trackType == "segments")
+    trackType_ = reco::Segments;
+  else if (trackType == "glb_or_trk")
+    trackType_ = reco::GlbOrTrk;
+  else
+    throw cms::Exception("Configuration")
+        << "Track type '" << trackType << "' not supported.\n";
+  if (linkToGenParticles_) {
+    genParticlesToken_ = consumes<reco::GenParticleCollection>(genParticles_);
+  }
 
-    produces<edm::ValueMap<reco::MuonSimInfo> >();
-    if (linkToGenParticles_) {
-        produces<reco::GenParticleCollection>("secondaries");
-        produces<edm::Association<reco::GenParticleCollection> >("toPrimaries");
-        produces<edm::Association<reco::GenParticleCollection> >("toSecondaries");
-    }
+  produces<edm::ValueMap<reco::MuonSimInfo>>();
+  if (linkToGenParticles_) {
+    produces<reco::GenParticleCollection>("secondaries");
+    produces<edm::Association<reco::GenParticleCollection>>("toPrimaries");
+    produces<edm::Association<reco::GenParticleCollection>>("toSecondaries");
+  }
 }
 
-MuonSimClassifier::~MuonSimClassifier()
-{
-}
+MuonSimClassifier::~MuonSimClassifier() {}
 
-void dumpFormatedInfo(const reco::MuonSimInfo& simInfo){
+void dumpFormatedInfo(const reco::MuonSimInfo &simInfo) {
   return;
-  LogTrace("MuonSimClassifier") << 
-    "\t Particle pdgId = " << simInfo.pdgId << 
-    ", (Event,Bx) = "<< "(" << simInfo.tpEvent << "," << simInfo.tpBX << ")" <<
-    "\n\t   q*p = " << simInfo.charge*simInfo.p4.P() << 
-    ", pT = " << simInfo.p4.pt() << ", eta = " << simInfo.p4.eta() << ", phi = " << simInfo.p4.phi() <<
-    "\n\t   produced at vertex rho = " << simInfo.vertex.Rho() << ", z = " << simInfo.vertex.Z() <<
-    ", (GEANT4 process = " << simInfo.g4processType << ")\n";
+  LogTrace("MuonSimClassifier")
+      << "\t Particle pdgId = " << simInfo.pdgId << ", (Event,Bx) = "
+      << "(" << simInfo.tpEvent << "," << simInfo.tpBX << ")"
+      << "\n\t   q*p = " << simInfo.charge * simInfo.p4.P()
+      << ", pT = " << simInfo.p4.pt() << ", eta = " << simInfo.p4.eta()
+      << ", phi = " << simInfo.p4.phi()
+      << "\n\t   produced at vertex rho = " << simInfo.vertex.Rho()
+      << ", z = " << simInfo.vertex.Z()
+      << ", (GEANT4 process = " << simInfo.g4processType << ")\n";
 }
 
-void
-MuonSimClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    edm::Handle<edm::View<reco::Muon> > muons;
-    iEvent.getByToken(muonsToken_, muons);
+void MuonSimClassifier::produce(edm::Event &iEvent,
+                                const edm::EventSetup &iSetup) {
+  edm::Handle<edm::View<reco::Muon>> muons;
+  iEvent.getByToken(muonsToken_, muons);
 
-    edm::Handle<TrackingParticleCollection> trackingParticles;
-    iEvent.getByToken(trackingParticlesToken_, trackingParticles);
+  edm::Handle<TrackingParticleCollection> trackingParticles;
+  iEvent.getByToken(trackingParticlesToken_, trackingParticles);
 
-    edm::Handle<reco::GenParticleCollection> genParticles;
-    if (linkToGenParticles_) {
-        iEvent.getByToken(genParticlesToken_, genParticles);
+  edm::Handle<reco::GenParticleCollection> genParticles;
+  if (linkToGenParticles_) {
+    iEvent.getByToken(genParticlesToken_, genParticles);
+  }
+
+  edm::Handle<reco::MuonToTrackingParticleAssociator> associatorBase;
+  iEvent.getByToken(muAssocToken_, associatorBase);
+  const reco::MuonToTrackingParticleAssociator *assoByHits =
+      associatorBase.product();
+
+  reco::MuonToSimCollection recSimColl;
+  reco::SimToMuonCollection simRecColl;
+  LogTrace("MuonSimClassifier")
+      << "\n "
+         "***************************************************************** ";
+  LogTrace("MuonSimClassifier")
+      << " RECO MUON association, type:  " << trackType_;
+  LogTrace("MuonSimClassifier") << " ******************************************"
+                                   "*********************** \n";
+
+  edm::RefToBaseVector<reco::Muon> allMuons;
+  for (size_t i = 0, n = muons->size(); i < n; ++i) {
+    allMuons.push_back(muons->refAt(i));
+  }
+
+  edm::RefVector<TrackingParticleCollection> allTPs;
+  for (size_t i = 0, n = trackingParticles->size(); i < n; ++i) {
+    allTPs.push_back(TrackingParticleRef(trackingParticles, i));
+  }
+
+  assoByHits->associateMuons(recSimColl, simRecColl, allMuons, trackType_,
+                             allTPs);
+
+  // for global muons without hits on muon detectors, look at the linked
+  // standalone muon
+  reco::MuonToSimCollection updSTA_recSimColl;
+  reco::SimToMuonCollection updSTA_simRecColl;
+  if (trackType_ == reco::GlobalTk) {
+    LogTrace("MuonSimClassifier")
+        << "\n "
+           "***************************************************************** ";
+    LogTrace("MuonSimClassifier") << " STANDALONE (UpdAtVtx) MUON association ";
+    LogTrace("MuonSimClassifier") << " ****************************************"
+                                     "************************* \n";
+    assoByHits->associateMuons(updSTA_recSimColl, updSTA_simRecColl, allMuons,
+                               reco::OuterTk, allTPs);
+  }
+
+  typedef reco::MuonToSimCollection::const_iterator r2s_it;
+  typedef reco::SimToMuonCollection::const_iterator s2r_it;
+
+  size_t nmu = muons->size();
+  LogTrace("MuonSimClassifier") << "\n There are " << nmu << " reco::Muons.";
+
+  std::vector<reco::MuonSimInfo> simInfo;
+
+  std::unique_ptr<reco::GenParticleCollection>
+      secondaries; // output collection of secondary muons
+  std::map<TrackingParticleRef, int>
+      tpToSecondaries; // map from tp to (index+1) in output collection
+  std::vector<int> muToPrimary(nmu, -1),
+      muToSecondary(nmu,
+                    -1); // map from input into (index) in output, -1 for null
+  if (linkToGenParticles_)
+    secondaries.reset(new reco::GenParticleCollection());
+
+  // loop on reco muons
+  for (size_t i = 0; i < nmu; ++i) {
+    simInfo.push_back(reco::MuonSimInfo());
+    LogTrace("MuonSimClassifier") << "\n reco::Muon # " << i;
+
+    TrackingParticleRef tp;
+    edm::RefToBase<reco::Muon> muMatchBack;
+    r2s_it match = recSimColl.find(allMuons.at(i));
+    s2r_it matchback;
+    if (match != recSimColl.end()) {
+      // match->second is vector, front is first element, first is the ref
+      // (second would be the quality)
+      tp = match->second.front().first;
+      simInfo[i].tpId =
+          tp.isNonnull()
+              ? tp.key()
+              : -1; // we check, even if null refs should not appear here at all
+      simInfo[i].tpAssoQuality = match->second.front().second;
+      s2r_it matchback = simRecColl.find(tp);
+      if (matchback != simRecColl.end()) {
+        muMatchBack = matchback->second.front().first;
+      } else {
+        LogTrace("MuonSimClassifier")
+            << "\n***WARNING:  This I do NOT understand: why no match back? "
+               "*** \n";
+      }
+    } else {
+      if ((trackType_ == reco::GlobalTk) && allMuons.at(i)->isGlobalMuon()) {
+        // perform a second attempt, matching with the standalone muon
+        r2s_it matchSta = updSTA_recSimColl.find(allMuons.at(i));
+        if (matchSta != updSTA_recSimColl.end()) {
+          tp = matchSta->second.front().first;
+          simInfo[i].tpId =
+              tp.isNonnull() ? tp.key() : -1; // we check, even if null refs
+                                              // should not appear here at all
+          simInfo[i].tpAssoQuality = matchSta->second.front().second;
+          s2r_it matchback = updSTA_simRecColl.find(tp);
+          if (matchback != updSTA_simRecColl.end()) {
+            muMatchBack = matchback->second.front().first;
+          } else {
+            LogTrace("MuonSimClassifier")
+                << "\n***WARNING:  This I do NOT understand: why no match back "
+                   "in updSTA? *** \n";
+          }
+        }
+      } else {
+        LogTrace("MuonSimClassifier")
+            << "\t No matching TrackingParticle is found ";
+      }
     }
 
-    edm::Handle<reco::MuonToTrackingParticleAssociator> associatorBase;
-    iEvent.getByToken(muAssocToken_, associatorBase);
-    const reco::MuonToTrackingParticleAssociator * assoByHits = associatorBase.product();
+    if (tp.isNonnull()) {
+      bool isGhost = muMatchBack != allMuons.at(i);
+      if (isGhost)
+        LogTrace("MuonSimClassifier") << "\t *** This seems a Duplicate muon ! "
+                                         "classif[i] will be < 0 ***";
 
-    reco::MuonToSimCollection recSimColl;
-    reco::SimToMuonCollection simRecColl;
-    LogTrace("MuonSimClassifier") <<"\n ***************************************************************** ";
-    LogTrace("MuonSimClassifier") <<  " RECO MUON association, type:  "<< trackType_;
-    LogTrace("MuonSimClassifier") <<  " ***************************************************************** \n";
+      // identify signal and pileup TP
+      simInfo[i].tpBX = tp->eventId().bunchCrossing();
+      simInfo[i].tpEvent = tp->eventId().event();
 
-    edm::RefToBaseVector<reco::Muon> allMuons;
-    for (size_t i = 0, n = muons->size(); i < n; ++i) {
-      allMuons.push_back(muons->refAt(i));
-    }
-    
-    edm::RefVector<TrackingParticleCollection> allTPs;
-    for (size_t i = 0, n = trackingParticles->size(); i < n; ++i) {
-        allTPs.push_back(TrackingParticleRef(trackingParticles,i));
-    }
+      simInfo[i].pdgId = tp->pdgId();
+      simInfo[i].vertex = tp->vertex();
 
-    assoByHits->associateMuons(recSimColl, simRecColl, allMuons, trackType_, allTPs);
+      // added info on GEANT process producing the TrackingParticle
+      const std::vector<SimVertex> &g4Vs = tp->parentVertex()->g4Vertices();
+      simInfo[i].g4processType = g4Vs[0].processType();
 
-    // for global muons without hits on muon detectors, look at the linked standalone muon
-    reco::MuonToSimCollection updSTA_recSimColl;
-    reco::SimToMuonCollection updSTA_simRecColl;
-    if (trackType_ == reco::GlobalTk) {
-      LogTrace("MuonSimClassifier") <<"\n ***************************************************************** ";
-      LogTrace("MuonSimClassifier") <<  " STANDALONE (UpdAtVtx) MUON association ";
-      LogTrace("MuonSimClassifier") <<  " ***************************************************************** \n";
-      assoByHits->associateMuons(updSTA_recSimColl, updSTA_simRecColl, allMuons, reco::OuterTk, allTPs);
-    }
+      simInfo[i].charge = tp->charge();
+      simInfo[i].p4 = tp->p4();
 
-    typedef reco::MuonToSimCollection::const_iterator r2s_it;
-    typedef reco::SimToMuonCollection::const_iterator s2r_it;
+      // Try to extract mother and grand mother of this muon.
+      // Unfortunately, SIM and GEN histories require diffent code :-(
+      if (!tp->genParticles().empty()) { // Muon is in GEN
+        reco::GenParticleRef genp = tp->genParticles()[0];
+        reco::GenParticleRef genMom = genp->numberOfMothers() > 0
+                                          ? genp->motherRef()
+                                          : reco::GenParticleRef();
+        reco::GenParticleRef mMom = genMom;
 
-    size_t nmu = muons->size();
-    LogTrace("MuonSimClassifier") <<"\n There are "<<nmu<<" reco::Muons.";
+        if (genMom.isNonnull()) {
+          if (genMom->pdgId() != tp->pdgId()) {
+            simInfo[i].motherPdgId = genMom->pdgId();
+            simInfo[i].motherStatus = genMom->status();
+            simInfo[i].motherVertex = genMom->vertex();
+          } else {
+            // if mother has the same identity look backwards for the real
+            // mother (it may happen in radiative decays)
+            int jm = 0;
+            while (mMom->pdgId() == tp->pdgId()) {
+              jm++;
+              if (mMom->numberOfMothers() > 0) {
+                mMom = mMom->motherRef();
+              }
+              LogTrace("MuonSimClassifier") << "\t\t backtracking mother " << jm
+                                            << ", pdgId = " << mMom->pdgId()
+                                            << ", status= " << mMom->status();
+            }
+            genMom = mMom; // redefine genMom
+            simInfo[i].motherPdgId = genMom->pdgId();
+            simInfo[i].motherStatus = genMom->status();
+            simInfo[i].motherVertex = genMom->vertex();
+          }
+          dumpFormatedInfo(simInfo[i]);
+          LogTrace("MuonSimClassifier")
+              << "\t   has GEN mother pdgId = " << simInfo[i].motherPdgId
+              << " (status = " << simInfo[i].motherStatus << ")";
 
-    std::vector<reco::MuonSimInfo> simInfo;
+          reco::GenParticleRef genGMom = genMom->numberOfMothers() > 0
+                                             ? genMom->motherRef()
+                                             : reco::GenParticleRef();
 
-    std::unique_ptr<reco::GenParticleCollection> secondaries;     // output collection of secondary muons
-    std::map<TrackingParticleRef, int>         tpToSecondaries; // map from tp to (index+1) in output collection
-    std::vector<int> muToPrimary(nmu, -1), muToSecondary(nmu, -1); // map from input into (index) in output, -1 for null
-    if (linkToGenParticles_) secondaries.reset(new reco::GenParticleCollection());
-    
-    // loop on reco muons
-    for(size_t i = 0; i < nmu; ++i) {
-      simInfo.push_back(reco::MuonSimInfo());
-      LogTrace("MuonSimClassifier") <<"\n reco::Muon # "<<i;
+          if (genGMom.isNonnull()) {
+            simInfo[i].grandMotherPdgId = genGMom->pdgId();
+            LogTrace("MuonSimClassifier")
+                << "\t\t mother prod. vertex rho = "
+                << simInfo[i].motherVertex.Rho()
+                << ", z = " << simInfo[i].motherVertex.Z()
+                << ", grand-mom pdgId = " << simInfo[i].grandMotherPdgId;
+          }
+          // in this case, we might want to know the heaviest mom flavour
+          for (reco::GenParticleRef nMom = genMom;
+               nMom.isNonnull() &&
+               std::abs(nMom->pdgId()) >= 100; // stop when we're no longer
+                                               // looking at hadrons or mesons
+               nMom = nMom->numberOfMothers() > 0 ? nMom->motherRef()
+                                                  : reco::GenParticleRef()) {
+            int flav = flavour(nMom->pdgId());
+            if (simInfo[i].heaviestMotherFlavour < flav)
+              simInfo[i].heaviestMotherFlavour = flav;
+            LogTrace("MuonSimClassifier")
+                << "\t\t backtracking flavour: mom pdgId = " << nMom->pdgId()
+                << ", flavour = " << flav
+                << ", heaviest so far = " << simInfo[i].heaviestMotherFlavour;
+          }
+        } else { // mother is null ??
+          dumpFormatedInfo(simInfo[i]);
+          LogTrace("MuonSimClassifier") << "\t   has NO mother!";
+        }
+      } else { // Muon is in SIM Only
+        TrackingParticleRef simMom = getTpMother(tp);
+        if (simMom.isNonnull()) {
+          simInfo[i].motherPdgId = simMom->pdgId();
+          simInfo[i].motherVertex = simMom->vertex();
+          dumpFormatedInfo(simInfo[i]);
+          LogTrace("MuonSimClassifier")
+              << "\t   has SIM mother pdgId = " << simInfo[i].motherPdgId
+              << " produced at rho = " << simMom->vertex().Rho()
+              << ", z = " << simMom->vertex().Z();
 
-        TrackingParticleRef        tp;
-        edm::RefToBase<reco::Muon> muMatchBack;
-        r2s_it match = recSimColl.find(allMuons.at(i));
-        s2r_it matchback;
-        if (match != recSimColl.end()) {
-	  // match->second is vector, front is first element, first is the ref (second would be the quality)
-	  tp = match->second.front().first;
-	  simInfo[i].tpId = tp.isNonnull() ? tp.key() : -1; // we check, even if null refs should not appear here at all
-	  simInfo[i].tpAssoQuality = match->second.front().second;
-	  s2r_it matchback = simRecColl.find(tp);
-	  if (matchback != simRecColl.end()) {
-	    muMatchBack = matchback->second.front().first;
-	  } else {
-	    LogTrace("MuonSimClassifier") << "\n***WARNING:  This I do NOT understand: why no match back? *** \n";
-	  }
+          if (!simMom->genParticles().empty()) {
+            simInfo[i].motherStatus = simMom->genParticles()[0]->status();
+            reco::GenParticleRef genGMom =
+                (simMom->genParticles()[0]->numberOfMothers() > 0
+                     ? simMom->genParticles()[0]->motherRef()
+                     : reco::GenParticleRef());
+            if (genGMom.isNonnull())
+              simInfo[i].grandMotherPdgId = genGMom->pdgId();
+            LogTrace("MuonSimClassifier")
+                << "\t\t SIM mother is in GEN (status "
+                << simInfo[i].motherStatus
+                << "), grand-mom id = " << simInfo[i].grandMotherPdgId;
+          } else {
+            simInfo[i].motherStatus = -1;
+            TrackingParticleRef simGMom = getTpMother(simMom);
+            if (simGMom.isNonnull())
+              simInfo[i].grandMotherPdgId = simGMom->pdgId();
+            LogTrace("MuonSimClassifier")
+                << "\t\t SIM mother is in SIM only, grand-mom id = "
+                << simInfo[i].grandMotherPdgId;
+          }
         } else {
-	  if ((trackType_ == reco::GlobalTk) && allMuons.at(i)->isGlobalMuon()) {
-	    // perform a second attempt, matching with the standalone muon
-	    r2s_it matchSta = updSTA_recSimColl.find(allMuons.at(i));
-	    if (matchSta != updSTA_recSimColl.end()) {
-	      tp    = matchSta->second.front().first;
-	      simInfo[i].tpId = tp.isNonnull() ? tp.key() : -1; // we check, even if null refs should not appear here at all
-	      simInfo[i].tpAssoQuality = matchSta->second.front().second;
-	      s2r_it matchback = updSTA_simRecColl.find(tp);
-	      if (matchback != updSTA_simRecColl.end()) {
-		muMatchBack = matchback->second.front().first;
-	      } else {
-		LogTrace("MuonSimClassifier") << 
-		  "\n***WARNING:  This I do NOT understand: why no match back in updSTA? *** \n";
-	      }
-	    }
-	  } else {
-	    LogTrace("MuonSimClassifier") <<"\t No matching TrackingParticle is found ";
-	  }
-	}
-	
-        if (tp.isNonnull()) {
-	  bool isGhost = muMatchBack != allMuons.at(i);
-	  if (isGhost) LogTrace("MuonSimClassifier") <<"\t *** This seems a Duplicate muon ! classif[i] will be < 0 ***";
+          dumpFormatedInfo(simInfo[i]);
+          LogTrace("MuonSimClassifier") << "\t   has NO mother!";
+        }
+      }
+      simInfo[i].motherFlavour = flavour(simInfo[i].motherPdgId);
+      simInfo[i].grandMotherFlavour = flavour(simInfo[i].grandMotherPdgId);
 
-	  // identify signal and pileup TP
-	  simInfo[i].tpBX      = tp->eventId().bunchCrossing();
-	  simInfo[i].tpEvent   = tp->eventId().event();
+      // Check first IF this is a muon at all
+      if (std::abs(tp->pdgId()) != 13) {
+        if (std::abs(tp->pdgId()) == 11) {
+          simInfo[i].primaryClass = isGhost
+                                        ? reco::MuonSimType::GhostElectron
+                                        : reco::MuonSimType::MatchedElectron;
+          simInfo[i].extendedClass =
+              isGhost ? reco::ExtendedMuonSimType::ExtGhostElectron
+                      : reco::ExtendedMuonSimType::ExtMatchedElectron;
+          LogTrace("MuonSimClassifier")
+              << "\t This is electron/positron. classif[i] = "
+              << simInfo[i].primaryClass;
+        } else {
+          simInfo[i].primaryClass =
+              isGhost ? reco::MuonSimType::GhostPunchthrough
+                      : reco::MuonSimType::MatchedPunchthrough;
+          simInfo[i].extendedClass =
+              isGhost ? reco::ExtendedMuonSimType::ExtGhostPunchthrough
+                      : reco::ExtendedMuonSimType::ExtMatchedPunchthrough;
+          LogTrace("MuonSimClassifier")
+              << "\t This is not a muon. Sorry. classif[i] = "
+              << simInfo[i].primaryClass;
+        }
+        continue;
+      }
 
-	  simInfo[i].pdgId = tp->pdgId();
-	  simInfo[i].vertex = tp->vertex();
+      // Is this SIM muon also a GEN muon, with a mother?
+      if (!tp->genParticles().empty() && (simInfo[i].motherPdgId != 0)) {
+        if (std::abs(simInfo[i].motherPdgId) < 100 &&
+            (std::abs(simInfo[i].motherPdgId) != 15)) {
+          simInfo[i].primaryClass = isGhost
+                                        ? reco::MuonSimType::GhostPrimaryMuon
+                                        : reco::MuonSimType::MatchedPrimaryMuon;
+          simInfo[i].flavour = 13;
+          simInfo[i].extendedClass =
+              isGhost
+                  ? reco::ExtendedMuonSimType::GhostMuonFromGaugeOrHiggsBoson
+                  : reco::ExtendedMuonSimType::MatchedMuonFromGaugeOrHiggsBoson;
+          LogTrace("MuonSimClassifier")
+              << "\t This seems PRIMARY MUON ! classif[i] = "
+              << simInfo[i].primaryClass;
+        } else if (simInfo[i].motherFlavour == 4 ||
+                   simInfo[i].motherFlavour == 5 ||
+                   simInfo[i].motherFlavour == 15) {
+          simInfo[i].primaryClass =
+              isGhost ? reco::MuonSimType::GhostMuonFromHeavyFlavour
+                      : reco::MuonSimType::MatchedMuonFromHeavyFlavour;
+          simInfo[i].flavour = simInfo[i].motherFlavour;
+          if (simInfo[i].motherFlavour == 15)
+            simInfo[i].extendedClass =
+                isGhost ? reco::ExtendedMuonSimType::GhostMuonFromTau
+                        : reco::ExtendedMuonSimType::MatchedMuonFromTau;
+          else if (simInfo[i].motherFlavour == 5)
+            simInfo[i].extendedClass =
+                isGhost ? reco::ExtendedMuonSimType::GhostMuonFromB
+                        : reco::ExtendedMuonSimType::MatchedMuonFromB;
+          else if (simInfo[i].heaviestMotherFlavour == 5)
+            simInfo[i].extendedClass =
+                isGhost ? reco::ExtendedMuonSimType::GhostMuonFromBtoC
+                        : reco::ExtendedMuonSimType::MatchedMuonFromBtoC;
+          else
+            simInfo[i].extendedClass =
+                isGhost ? reco::ExtendedMuonSimType::GhostMuonFromC
+                        : reco::ExtendedMuonSimType::MatchedMuonFromC;
+          LogTrace("MuonSimClassifier")
+              << "\t This seems HEAVY FLAVOUR ! classif[i] = "
+              << simInfo[i].primaryClass;
+        } else {
+          simInfo[i].primaryClass =
+              isGhost ? reco::MuonSimType::GhostMuonFromLightFlavour
+                      : reco::MuonSimType::MatchedMuonFromLightFlavour;
+          simInfo[i].flavour = simInfo[i].motherFlavour;
+          LogTrace("MuonSimClassifier")
+              << "\t This seems LIGHT FLAVOUR ! classif[i] = "
+              << simInfo[i].primaryClass;
+        }
+      } else {
+        simInfo[i].primaryClass =
+            isGhost ? reco::MuonSimType::GhostMuonFromLightFlavour
+                    : reco::MuonSimType::MatchedMuonFromLightFlavour;
+        simInfo[i].flavour = simInfo[i].motherFlavour;
+        LogTrace("MuonSimClassifier")
+            << "\t This seems LIGHT FLAVOUR ! classif[i] = "
+            << simInfo[i].primaryClass;
+      }
 
-	  // added info on GEANT process producing the TrackingParticle
-	  const std::vector<SimVertex> & g4Vs = tp->parentVertex()->g4Vertices();
-	  simInfo[i].g4processType = g4Vs[0].processType();
-	  
-	  simInfo[i].charge = tp->charge();
-	  simInfo[i].p4 = tp->p4();
+      // extended classification
+      // don't we override previous decisions?
+      if (simInfo[i].motherPdgId == 0)
+        // if it has no mom, it's not a primary particle so it won't be in ppMuX
+        simInfo[i].extendedClass =
+            isGhost
+                ? reco::ExtendedMuonSimType::GhostMuonFromNonPrimaryParticle
+                : reco::ExtendedMuonSimType::MatchedMuonFromNonPrimaryParticle;
+      else if (std::abs(simInfo[i].motherPdgId) < 100) {
+        if (simInfo[i].motherFlavour == 15)
+          simInfo[i].extendedClass =
+              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromTau
+                      : reco::ExtendedMuonSimType::MatchedMuonFromTau;
+        else
+          simInfo[i].extendedClass =
+              isGhost
+                  ? reco::ExtendedMuonSimType::GhostMuonFromGaugeOrHiggsBoson
+                  : reco::ExtendedMuonSimType::MatchedMuonFromGaugeOrHiggsBoson;
+      } else if (simInfo[i].motherFlavour == 5)
+        simInfo[i].extendedClass =
+            isGhost ? reco::ExtendedMuonSimType::GhostMuonFromB
+                    : reco::ExtendedMuonSimType::MatchedMuonFromB;
+      else if (simInfo[i].motherFlavour == 4) {
+        if (simInfo[i].heaviestMotherFlavour == 5)
+          simInfo[i].extendedClass =
+              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromBtoC
+                      : reco::ExtendedMuonSimType::MatchedMuonFromBtoC;
+        else
+          simInfo[i].extendedClass =
+              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromC
+                      : reco::ExtendedMuonSimType::MatchedMuonFromC;
+      } else if (simInfo[i].motherStatus != -1) { // primary light particle
+        int id = std::abs(simInfo[i].motherPdgId);
+        if (id != /*pi+*/ 211 && id != /*K+*/ 321 && id != 130 /*K0L*/)
+          // other light particle, possibly short-lived
+          simInfo[i].extendedClass =
+              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromOtherLight
+                      : reco::ExtendedMuonSimType::MatchedMuonFromOtherLight;
+        else if (simInfo[i].vertex.Rho() < decayRho_ &&
+                 std::abs(simInfo[i].vertex.Z()) < decayAbsZ_)
+          // decay a la ppMuX (primary pi/K within a cylinder)
+          simInfo[i].extendedClass =
+              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromPiKppMuX
+                      : reco::ExtendedMuonSimType::MatchedMuonFromPiKppMuX;
+        else
+          // late decay that wouldn't be in ppMuX
+          simInfo[i].extendedClass =
+              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromPiKNotppMuX
+                      : reco::ExtendedMuonSimType::MatchedMuonFromPiKNotppMuX;
+      } else
+        // decay of non-primary particle, would not be in ppMuX
+        simInfo[i].extendedClass =
+            isGhost
+                ? reco::ExtendedMuonSimType::GhostMuonFromNonPrimaryParticle
+                : reco::ExtendedMuonSimType::MatchedMuonFromNonPrimaryParticle;
 
-	  // Try to extract mother and grand mother of this muon.
-	  // Unfortunately, SIM and GEN histories require diffent code :-(
-	  if (!tp->genParticles().empty()) { // Muon is in GEN
-	    reco::GenParticleRef genp   = tp->genParticles()[0];
-	    reco::GenParticleRef genMom = genp->numberOfMothers() > 0 ? genp->motherRef() : reco::GenParticleRef();
-	    reco::GenParticleRef mMom = genMom;
-	      
-	    if (genMom.isNonnull()) {
-	      if (genMom->pdgId() != tp->pdgId()) {
-		simInfo[i].motherPdgId  = genMom->pdgId();
-		simInfo[i].motherStatus = genMom->status();
-		simInfo[i].motherVertex = genMom->vertex(); 
-	      } else {
-		// if mother has the same identity look backwards for the real mother (it may happen in radiative decays) 
-		int jm = 0;
-		while (mMom->pdgId() == tp->pdgId()) {
-		  jm++;
-		  if (mMom->numberOfMothers() > 0) {
-		    mMom = mMom->motherRef();
-		  }
-		  LogTrace("MuonSimClassifier") 
-		    << "\t\t backtracking mother "<<jm<<", pdgId = "<<mMom->pdgId()<<", status= " <<mMom->status();
-		}
-		genMom = mMom; // redefine genMom
-		simInfo[i].motherPdgId  = genMom->pdgId();
-		simInfo[i].motherStatus = genMom->status();
-		simInfo[i].motherVertex = genMom->vertex(); 
-	      }
-	      dumpFormatedInfo(simInfo[i]);
-	      LogTrace("MuonSimClassifier") << 
-		"\t   has GEN mother pdgId = " << simInfo[i].motherPdgId << 
-		" (status = " << simInfo[i].motherStatus << ")";
-		
-	      reco::GenParticleRef genGMom = genMom->numberOfMothers() > 0 ? genMom->motherRef() : reco::GenParticleRef();
-	      
-	      if (genGMom.isNonnull()) {
-		simInfo[i].grandMotherPdgId = genGMom->pdgId();
-		LogTrace("MuonSimClassifier") << 
-		  "\t\t mother prod. vertex rho = " << simInfo[i].motherVertex.Rho() << ", z = " << simInfo[i].motherVertex.Z() << 
-		  ", grand-mom pdgId = " << simInfo[i].grandMotherPdgId;
-	      }
-	      // in this case, we might want to know the heaviest mom flavour
-	      for (reco::GenParticleRef nMom = genMom;
-		   nMom.isNonnull() && std::abs(nMom->pdgId()) >= 100; // stop when we're no longer looking at hadrons or mesons
-		   nMom = nMom->numberOfMothers() > 0 ? nMom->motherRef() : reco::GenParticleRef()) {
-		int flav = flavour(nMom->pdgId());
-		if (simInfo[i].heaviestMotherFlavour < flav) simInfo[i].heaviestMotherFlavour = flav;
-		LogTrace("MuonSimClassifier") 
-		  << "\t\t backtracking flavour: mom pdgId = " << nMom->pdgId()
-		  << ", flavour = " << flav << ", heaviest so far = " << simInfo[i].heaviestMotherFlavour;
-	      }
-	    } else {   // mother is null ??
-	      dumpFormatedInfo(simInfo[i]);
-	      LogTrace("MuonSimClassifier") <<"\t   has NO mother!";
-	    }
-	  } else { // Muon is in SIM Only
-	    TrackingParticleRef simMom = getTpMother(tp);
-	    if (simMom.isNonnull()) {
-	      simInfo[i].motherPdgId = simMom->pdgId();
-	      simInfo[i].motherVertex = simMom->vertex();
-	      dumpFormatedInfo(simInfo[i]);
-	      LogTrace("MuonSimClassifier") <<
-		"\t   has SIM mother pdgId = " << simInfo[i].motherPdgId << 
-		" produced at rho = " << simMom->vertex().Rho() << ", z = " << simMom->vertex().Z();
-	      
-	      if (!simMom->genParticles().empty()) {
-		simInfo[i].motherStatus = simMom->genParticles()[0]->status();
-		reco::GenParticleRef genGMom = (simMom->genParticles()[0]->numberOfMothers() > 0 ? 
-						simMom->genParticles()[0]->motherRef() : 
-						reco::GenParticleRef());
-		if (genGMom.isNonnull()) simInfo[i].grandMotherPdgId = genGMom->pdgId();
-		LogTrace("MuonSimClassifier") << 
-		  "\t\t SIM mother is in GEN (status " << simInfo[i].motherStatus << 
-		  "), grand-mom id = " << simInfo[i].grandMotherPdgId;
-	      } else {
-		simInfo[i].motherStatus = -1;
-		TrackingParticleRef simGMom = getTpMother(simMom);
-		if (simGMom.isNonnull()) simInfo[i].grandMotherPdgId = simGMom->pdgId();
-		LogTrace("MuonSimClassifier") << 
-		  "\t\t SIM mother is in SIM only, grand-mom id = " << simInfo[i].grandMotherPdgId;
-	      }
-	    } else {
-	      dumpFormatedInfo(simInfo[i]);
-	      LogTrace("MuonSimClassifier") <<"\t   has NO mother!";
-	    }
-	  }
-	  simInfo[i].motherFlavour = flavour(simInfo[i].motherPdgId);
-	  simInfo[i].grandMotherFlavour = flavour(simInfo[i].grandMotherPdgId);
-
-	  // Check first IF this is a muon at all
-	  if (std::abs(tp->pdgId()) != 13) {
-	    if (std::abs(tp->pdgId()) == 11) {
-	      simInfo[i].primaryClass  = isGhost ? reco::MuonSimType::GhostElectron : reco::MuonSimType::MatchedElectron;
-	      simInfo[i].extendedClass = isGhost ? reco::ExtendedMuonSimType::ExtGhostElectron : reco::ExtendedMuonSimType::ExtMatchedElectron;
-	      LogTrace("MuonSimClassifier") <<"\t This is electron/positron. classif[i] = " << simInfo[i].primaryClass;
-	    } else {
-	      simInfo[i].primaryClass  = isGhost ? reco::MuonSimType::GhostPunchthrough : reco::MuonSimType::MatchedPunchthrough;
-	      simInfo[i].extendedClass = isGhost ? reco::ExtendedMuonSimType::ExtGhostPunchthrough : reco::ExtendedMuonSimType::ExtMatchedPunchthrough;
-	      LogTrace("MuonSimClassifier") <<"\t This is not a muon. Sorry. classif[i] = " << simInfo[i].primaryClass;
-	    }
-	    continue;
-	  }
-
-	  // Is this SIM muon also a GEN muon, with a mother?
-	  if (!tp->genParticles().empty() && (simInfo[i].motherPdgId != 0)) {
-	    if (std::abs(simInfo[i].motherPdgId) < 100 && (std::abs(simInfo[i].motherPdgId) != 15)) {
-	      simInfo[i].primaryClass = isGhost ? 
-		reco::MuonSimType::GhostPrimaryMuon : 
-		reco::MuonSimType::MatchedPrimaryMuon;
-	      simInfo[i].flavour = 13;
-	      simInfo[i].extendedClass  = isGhost ?
-		reco::ExtendedMuonSimType::GhostMuonFromGaugeOrHiggsBoson :
-		reco::ExtendedMuonSimType::MatchedMuonFromGaugeOrHiggsBoson;
-	      LogTrace("MuonSimClassifier") <<"\t This seems PRIMARY MUON ! classif[i] = " << simInfo[i].primaryClass;
-	    } else if (simInfo[i].motherFlavour == 4 || simInfo[i].motherFlavour == 5 || simInfo[i].motherFlavour == 15) {
-	      simInfo[i].primaryClass = isGhost ? 
-		reco::MuonSimType::GhostMuonFromHeavyFlavour : 
-		reco::MuonSimType::MatchedMuonFromHeavyFlavour;
-	      simInfo[i].flavour    = simInfo[i].motherFlavour;
-	      if (simInfo[i].motherFlavour == 15)      
-		simInfo[i].extendedClass = isGhost ? 
-		  reco::ExtendedMuonSimType::GhostMuonFromTau :
-		  reco::ExtendedMuonSimType::MatchedMuonFromTau;
-	      else if (simInfo[i].motherFlavour == 5)  
-		simInfo[i].extendedClass = isGhost ? 
-		  reco::ExtendedMuonSimType::GhostMuonFromB :
-		  reco::ExtendedMuonSimType::MatchedMuonFromB;
-	      else if (simInfo[i].heaviestMotherFlavour == 5) 
-		simInfo[i].extendedClass = isGhost ? 
-		  reco::ExtendedMuonSimType::GhostMuonFromBtoC :
-		  reco::ExtendedMuonSimType::MatchedMuonFromBtoC;
-	      else 
-		simInfo[i].extendedClass = isGhost ? 
-		  reco::ExtendedMuonSimType::GhostMuonFromC :
-		  reco::ExtendedMuonSimType::MatchedMuonFromC;
-	      LogTrace("MuonSimClassifier") <<"\t This seems HEAVY FLAVOUR ! classif[i] = " << simInfo[i].primaryClass;
-	    } else {
-	      simInfo[i].primaryClass = isGhost ? 
-		reco::MuonSimType::GhostMuonFromLightFlavour : 
-		reco::MuonSimType::MatchedMuonFromLightFlavour;
-	      simInfo[i].flavour    = simInfo[i].motherFlavour;
-	      LogTrace("MuonSimClassifier") <<"\t This seems LIGHT FLAVOUR ! classif[i] = " << simInfo[i].primaryClass;
-	    }
-	  } else {
-	    simInfo[i].primaryClass = isGhost ? 
-	      reco::MuonSimType::GhostMuonFromLightFlavour : 
-	      reco::MuonSimType::MatchedMuonFromLightFlavour;
-	    simInfo[i].flavour    = simInfo[i].motherFlavour;
-	    LogTrace("MuonSimClassifier") <<"\t This seems LIGHT FLAVOUR ! classif[i] = " << simInfo[i].primaryClass;
-	  }
-	  
-	  // extended classification
-	  // don't we override previous decisions?
-	  if (simInfo[i].motherPdgId == 0)
-	    // if it has no mom, it's not a primary particle so it won't be in ppMuX 
-	    simInfo[i].extendedClass = isGhost ? 
-	      reco::ExtendedMuonSimType::GhostMuonFromNonPrimaryParticle : 
-	      reco::ExtendedMuonSimType::MatchedMuonFromNonPrimaryParticle; 
-	  else if (std::abs(simInfo[i].motherPdgId) < 100) {
-	    if (simInfo[i].motherFlavour == 15)
-		simInfo[i].extendedClass = isGhost ? 
-		  reco::ExtendedMuonSimType::GhostMuonFromTau :
-		  reco::ExtendedMuonSimType::MatchedMuonFromTau;
-	    else
-	      simInfo[i].extendedClass  = isGhost ?
-		reco::ExtendedMuonSimType::GhostMuonFromGaugeOrHiggsBoson :
-		reco::ExtendedMuonSimType::MatchedMuonFromGaugeOrHiggsBoson;
-	  }
-	  else if (simInfo[i].motherFlavour == 5) 
-	    simInfo[i].extendedClass = isGhost ? 
-	      reco::ExtendedMuonSimType::GhostMuonFromB :
-	      reco::ExtendedMuonSimType::MatchedMuonFromB;
-	  else if (simInfo[i].motherFlavour == 4) 
-	    {
-	      if (simInfo[i].heaviestMotherFlavour == 5) 
-		simInfo[i].extendedClass = isGhost ? 
-		  reco::ExtendedMuonSimType::GhostMuonFromBtoC :
-		  reco::ExtendedMuonSimType::MatchedMuonFromBtoC;
-	      else 
-		simInfo[i].extendedClass = isGhost ? 
-		  reco::ExtendedMuonSimType::GhostMuonFromC :
-		  reco::ExtendedMuonSimType::MatchedMuonFromC;
-	    }
-	  else if (simInfo[i].motherStatus != -1) { // primary light particle
-	    int id = std::abs(simInfo[i].motherPdgId);
-	    if (id != /*pi+*/211 && id != /*K+*/321 && id != 130 /*K0L*/)  
-	      // other light particle, possibly short-lived
-	      simInfo[i].extendedClass = isGhost ? 
-		reco::ExtendedMuonSimType::GhostMuonFromOtherLight :
-		reco::ExtendedMuonSimType::MatchedMuonFromOtherLight;
-	    else if (simInfo[i].vertex.Rho() < decayRho_ && std::abs(simInfo[i].vertex.Z()) < decayAbsZ_) 
-	      // decay a la ppMuX (primary pi/K within a cylinder)
-	      simInfo[i].extendedClass = isGhost ? 
-		reco::ExtendedMuonSimType::GhostMuonFromPiKppMuX :
-		reco::ExtendedMuonSimType::MatchedMuonFromPiKppMuX;
-	    else                                                           
-	      // late decay that wouldn't be in ppMuX
-	      simInfo[i].extendedClass = isGhost ? 
-		reco::ExtendedMuonSimType::GhostMuonFromPiKNotppMuX :
-		reco::ExtendedMuonSimType::MatchedMuonFromPiKNotppMuX;
-	  } else 
-	    // decay of non-primary particle, would not be in ppMuX
-	    simInfo[i].extendedClass = isGhost ? 
-		reco::ExtendedMuonSimType::GhostMuonFromNonPrimaryParticle :
-		reco::ExtendedMuonSimType::MatchedMuonFromNonPrimaryParticle;
-
-	  if (linkToGenParticles_ && std::abs(simInfo[i].extendedClass) >= 2) {
-	    // Link to the genParticle if possible, but not decays in flight (in ppMuX they're in GEN block, but they have wrong parameters)
-	    if (!tp->genParticles().empty() && std::abs(simInfo[i].extendedClass) >= 5) {
-	      if (genParticles.id() != tp->genParticles().id()) {
-		throw cms::Exception("Configuration") << "Product ID mismatch between the genParticle collection (" << 
-		  genParticles_ << ", id " << genParticles.id() << ") and the references in the TrackingParticles (id " << 
-		  tp->genParticles().id() << ")\n";
-	      }
-	      muToPrimary[i] = tp->genParticles()[0].key();
-	    } else {
-	      // Don't put the same trackingParticle twice!
-	      int &indexPlus1 = tpToSecondaries[tp]; // will create a 0 if the tp is not in the list already
-	      if (indexPlus1 == 0) indexPlus1 = convertAndPush(*tp, *secondaries, getTpMother(tp), genParticles) + 1;
-	      muToSecondary[i] = indexPlus1 - 1;
-	    }
-	  }
-	  LogTrace("MuonSimClassifier") <<"\t Extended classification code = " << simInfo[i].extendedClass;
-	} else { // if (tp.isNonnull())
-	  simInfo[i].primaryClass  = reco::MuonSimType::NotMatched;
-	  simInfo[i].extendedClass = reco::ExtendedMuonSimType::ExtNotMatched;
-	}
-    } // end loop on reco muons 
-
-    writeValueMap(iEvent, muons, simInfo,   "");
-
-    if (linkToGenParticles_) {
-        edm::OrphanHandle<reco::GenParticleCollection> secHandle = iEvent.put(std::move(secondaries), "secondaries");
-        edm::RefProd<reco::GenParticleCollection> priRP(genParticles);
-        edm::RefProd<reco::GenParticleCollection> secRP(secHandle);
-        std::unique_ptr<edm::Association<reco::GenParticleCollection> > outPri(new edm::Association<reco::GenParticleCollection>(priRP));
-        std::unique_ptr<edm::Association<reco::GenParticleCollection> > outSec(new edm::Association<reco::GenParticleCollection>(secRP));
-        edm::Association<reco::GenParticleCollection>::Filler fillPri(*outPri), fillSec(*outSec);
-        fillPri.insert(muons, muToPrimary.begin(),   muToPrimary.end());
-        fillSec.insert(muons, muToSecondary.begin(), muToSecondary.end());
-        fillPri.fill(); fillSec.fill();
-        iEvent.put(std::move(outPri), "toPrimaries");
-        iEvent.put(std::move(outSec), "toSecondaries");
+      if (linkToGenParticles_ && std::abs(simInfo[i].extendedClass) >= 2) {
+        // Link to the genParticle if possible, but not decays in flight (in
+        // ppMuX they're in GEN block, but they have wrong parameters)
+        if (!tp->genParticles().empty() &&
+            std::abs(simInfo[i].extendedClass) >= 5) {
+          if (genParticles.id() != tp->genParticles().id()) {
+            throw cms::Exception("Configuration")
+                << "Product ID mismatch between the genParticle collection ("
+                << genParticles_ << ", id " << genParticles.id()
+                << ") and the references in the TrackingParticles (id "
+                << tp->genParticles().id() << ")\n";
+          }
+          muToPrimary[i] = tp->genParticles()[0].key();
+        } else {
+          // Don't put the same trackingParticle twice!
+          int &indexPlus1 = tpToSecondaries[tp]; // will create a 0 if the tp is
+                                                 // not in the list already
+          if (indexPlus1 == 0)
+            indexPlus1 = convertAndPush(*tp, *secondaries, getTpMother(tp),
+                                        genParticles) +
+                         1;
+          muToSecondary[i] = indexPlus1 - 1;
+        }
+      }
+      LogTrace("MuonSimClassifier")
+          << "\t Extended classification code = " << simInfo[i].extendedClass;
+    } else { // if (tp.isNonnull())
+      simInfo[i].primaryClass = reco::MuonSimType::NotMatched;
+      simInfo[i].extendedClass = reco::ExtendedMuonSimType::ExtNotMatched;
     }
+  } // end loop on reco muons
 
+  writeValueMap(iEvent, muons, simInfo, "");
+
+  if (linkToGenParticles_) {
+    edm::OrphanHandle<reco::GenParticleCollection> secHandle =
+        iEvent.put(std::move(secondaries), "secondaries");
+    edm::RefProd<reco::GenParticleCollection> priRP(genParticles);
+    edm::RefProd<reco::GenParticleCollection> secRP(secHandle);
+    std::unique_ptr<edm::Association<reco::GenParticleCollection>> outPri(
+        new edm::Association<reco::GenParticleCollection>(priRP));
+    std::unique_ptr<edm::Association<reco::GenParticleCollection>> outSec(
+        new edm::Association<reco::GenParticleCollection>(secRP));
+    edm::Association<reco::GenParticleCollection>::Filler fillPri(*outPri),
+        fillSec(*outSec);
+    fillPri.insert(muons, muToPrimary.begin(), muToPrimary.end());
+    fillSec.insert(muons, muToSecondary.begin(), muToSecondary.end());
+    fillPri.fill();
+    fillSec.fill();
+    iEvent.put(std::move(outPri), "toPrimaries");
+    iEvent.put(std::move(outSec), "toSecondaries");
+  }
 }
 
-template<typename T>
-void
-MuonSimClassifier::writeValueMap(edm::Event &iEvent,
-	const edm::Handle<edm::View<reco::Muon> > & handle,
-        const std::vector<T> & values,
-        const std::string    & label) const
-{
-    using namespace edm;
-    using namespace std;
-    unique_ptr<ValueMap<T> > valMap(new ValueMap<T>());
-    typename edm::ValueMap<T>::Filler filler(*valMap);
-    filler.insert(handle, values.begin(), values.end());
-    filler.fill();
-    iEvent.put(std::move(valMap), label);
+template <typename T>
+void MuonSimClassifier::writeValueMap(
+    edm::Event &iEvent, const edm::Handle<edm::View<reco::Muon>> &handle,
+    const std::vector<T> &values, const std::string &label) const {
+  using namespace edm;
+  using namespace std;
+  unique_ptr<ValueMap<T>> valMap(new ValueMap<T>());
+  typename edm::ValueMap<T>::Filler filler(*valMap);
+  filler.insert(handle, values.begin(), values.end());
+  filler.fill();
+  iEvent.put(std::move(valMap), label);
 }
 
-int
-MuonSimClassifier::flavour(int pdgId) const {
-    int flav = std::abs(pdgId);
-    // for quarks, leptons and bosons except gluons, take their pdgId
-    // muons and taus have themselves as flavour
-    if (flav <= 37 && flav != 21) return flav;
-    // look for barions
-    int bflav = ((flav / 1000) % 10);
-    if (bflav != 0) return bflav;
-    // look for mesons
-    int mflav = ((flav / 100) % 10);
-    if (mflav != 0) return mflav;
-    return 0;
+int MuonSimClassifier::flavour(int pdgId) const {
+  int flav = std::abs(pdgId);
+  // for quarks, leptons and bosons except gluons, take their pdgId
+  // muons and taus have themselves as flavour
+  if (flav <= 37 && flav != 21)
+    return flav;
+  // look for barions
+  int bflav = ((flav / 1000) % 10);
+  if (bflav != 0)
+    return bflav;
+  // look for mesons
+  int mflav = ((flav / 100) % 10);
+  if (mflav != 0)
+    return mflav;
+  return 0;
 }
 
 // push secondary in collection.
 // if it has a primary mother link to it.
-int MuonSimClassifier::convertAndPush(const TrackingParticle &tp,
-                                     reco::GenParticleCollection &out,
-                                     const TrackingParticleRef & simMom,
-                                     const edm::Handle<reco::GenParticleCollection> & genParticles) const {
-    out.push_back(reco::GenParticle(tp.charge(), tp.p4(), tp.vertex(), tp.pdgId(), tp.status(), true));
-    if (simMom.isNonnull() && !simMom->genParticles().empty()) {
-         if (genParticles.id() != simMom->genParticles().id()) {
-            throw cms::Exception("Configuration") << "Product ID mismatch between the genParticle collection (" << genParticles_ << ", id " << genParticles.id() << ") and the references in the TrackingParticles (id " << simMom->genParticles().id() << ")\n";
-         }
-         out.back().addMother(simMom->genParticles()[0]);
+int MuonSimClassifier::convertAndPush(
+    const TrackingParticle &tp, reco::GenParticleCollection &out,
+    const TrackingParticleRef &simMom,
+    const edm::Handle<reco::GenParticleCollection> &genParticles) const {
+  out.push_back(reco::GenParticle(tp.charge(), tp.p4(), tp.vertex(), tp.pdgId(),
+                                  tp.status(), true));
+  if (simMom.isNonnull() && !simMom->genParticles().empty()) {
+    if (genParticles.id() != simMom->genParticles().id()) {
+      throw cms::Exception("Configuration")
+          << "Product ID mismatch between the genParticle collection ("
+          << genParticles_ << ", id " << genParticles.id()
+          << ") and the references in the TrackingParticles (id "
+          << simMom->genParticles().id() << ")\n";
     }
-    return out.size()-1;
+    out.back().addMother(simMom->genParticles()[0]);
+  }
+  return out.size() - 1;
 }
 
-//define this as a plug-in
+// define this as a plug-in
 DEFINE_FWK_MODULE(MuonSimClassifier);

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.cc
@@ -2,7 +2,7 @@
 //
 // Package:     SimMuon/MCTruth
 // Class  :     MuonToTrackingParticleAssociatorByHitsImpl
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -16,7 +16,6 @@
 #include "MuonToTrackingParticleAssociatorByHitsImpl.h"
 #include "SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h"
 
-
 //
 // constants, enums and typedefs
 //
@@ -28,15 +27,13 @@
 //
 // constructors and destructor
 //
-MuonToTrackingParticleAssociatorByHitsImpl::MuonToTrackingParticleAssociatorByHitsImpl(TrackerMuonHitExtractor const& iHitExtractor,
-									    MuonAssociatorByHitsHelper::Resources const& iResources,
-										          MuonAssociatorByHitsHelper const* iHelper):
-  m_hitExtractor(&iHitExtractor),
-  m_resources(iResources),
-  m_helper(iHelper)
-{
-}
-
+MuonToTrackingParticleAssociatorByHitsImpl::
+    MuonToTrackingParticleAssociatorByHitsImpl(
+        TrackerMuonHitExtractor const &iHitExtractor,
+        MuonAssociatorByHitsHelper::Resources const &iResources,
+        MuonAssociatorByHitsHelper const *iHelper)
+    : m_hitExtractor(&iHitExtractor), m_resources(iResources),
+      m_helper(iHelper) {}
 
 //
 // member functions
@@ -45,170 +42,210 @@ MuonToTrackingParticleAssociatorByHitsImpl::MuonToTrackingParticleAssociatorByHi
 //
 // const member functions
 //
-void 
-MuonToTrackingParticleAssociatorByHitsImpl::associateMuons(reco::MuonToSimCollection & recToSim, 
-                                                           reco::SimToMuonCollection & simToRec,
-                                                           const edm::RefToBaseVector<reco::Muon> & muons, 
-                                                           reco::MuonTrackType type,
-                                                           const edm::RefVector<TrackingParticleCollection>& tPC) const {
-    /// PART 1: Fill MuonToSimAssociatorByHits::TrackHitsCollection
-    MuonAssociatorByHitsHelper::TrackHitsCollection muonHitRefs;
-    edm::OwnVector<TrackingRecHit> allTMRecHits;  // this I will fill in only for tracker muon hits from segments
+void MuonToTrackingParticleAssociatorByHitsImpl::associateMuons(
+    reco::MuonToSimCollection &recToSim, reco::SimToMuonCollection &simToRec,
+    const edm::RefToBaseVector<reco::Muon> &muons, reco::MuonTrackType type,
+    const edm::RefVector<TrackingParticleCollection> &tPC) const {
+  /// PART 1: Fill MuonToSimAssociatorByHits::TrackHitsCollection
+  MuonAssociatorByHitsHelper::TrackHitsCollection muonHitRefs;
+  edm::OwnVector<TrackingRecHit>
+      allTMRecHits; // this I will fill in only for tracker muon hits from
+                    // segments
 
-    std::vector<edm::OwnVector<TrackingRecHit> > TMRecHits; // used for case GlbOrTrk
-    edm::OwnVector<TrackingRecHit> noTM;
+  std::vector<edm::OwnVector<TrackingRecHit>>
+      TMRecHits; // used for case GlbOrTrk
+  edm::OwnVector<TrackingRecHit> noTM;
 
-    switch (type) {
-        
-        case reco::InnerTk: 
-            for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
-                edm::RefToBase<reco::Muon> mur = *it;
-                if (mur->track().isNonnull()) { 
-                    muonHitRefs.push_back(std::make_pair(mur->track()->recHitsBegin(), mur->track()->recHitsEnd()));
-                } else {
-		  muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
-                }
-            }
-	    break;
-        case reco::OuterTk: 
-            for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
-                edm::RefToBase<reco::Muon> mur = *it;
-                if (mur->outerTrack().isNonnull()) { 
-                    muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(), mur->outerTrack()->recHitsEnd()));
-                } else {
-		  muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
-                }
-            }
-            break;
-        case reco::GlobalTk: 
-            for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
-                edm::RefToBase<reco::Muon> mur = *it;
-                if (mur->globalTrack().isNonnull()) { 
-                    muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(), mur->globalTrack()->recHitsEnd()));
-                } else {
-		  muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
-		}
-            }
-            break;
-        case reco::Segments: {
-                // puts hits in the vector, and record indices
-                std::vector<std::pair<size_t, size_t> >   muonHitIndices;
-                for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
-                    edm::RefToBase<reco::Muon> mur = *it;
-                    std::pair<size_t, size_t> indices(allTMRecHits.size(), allTMRecHits.size());
-                    if (mur->isTrackerMuon()) {
-                        std::vector<const TrackingRecHit *> hits = m_hitExtractor->getMuonHits(*mur);
-                        for (std::vector<const TrackingRecHit *>::const_iterator ith = hits.begin(), edh = hits.end(); ith != edh; ++ith) {
-                            allTMRecHits.push_back(**ith);
-                        }
-                        indices.second += hits.size();
-                    }
-                    muonHitIndices.push_back(indices);  
-                }
-                // convert indices into pairs of iterators to references
-                typedef std::pair<size_t, size_t> index_pair;
-                trackingRecHit_iterator hitRefBegin = allTMRecHits.data().begin();
-                for (std::vector<std::pair<size_t, size_t> >::const_iterator idxs = muonHitIndices.begin(), idxend = muonHitIndices.end(); idxs != idxend; ++idxs) {
-                    muonHitRefs.push_back(std::make_pair(hitRefBegin+idxs->first, 
-                                                         hitRefBegin+idxs->second));
-                }
-                
-            }
-            break;
-        case reco::GlbOrTrk: {
-	   edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
-	     <<"\n"<<"There are "<<muons.size()<<" selected reco::Muons.";
+  switch (type) {
 
-	   int isel = 0;
-	   for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
-	     edm::RefToBase<reco::Muon> mur = *it;
-
-	    edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
-	      <<" #"<<isel<<", reco::Muon key = " <<mur.key()
-	      <<", q*p = "<<mur->charge()*mur->p()<<", pT = "<<mur->pt()<<", eta = "<<mur->eta()<<", phi = "<<mur->phi();
-
-	     // Global muon with valid muon hits
-	     if (mur->isGlobalMuon() && mur->globalTrack()->hitPattern().numberOfValidMuonHits()>0) {
-	       edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
-		 <<"\t this is a Global Muon with valid muon hits";
-	       muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(), mur->globalTrack()->recHitsEnd()));
-	     }
-
-	     // Tracker Muon
-	     else if (mur->isTrackerMuon()) {
-	       edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
-		 <<"\t this is a Tracker Muon";
-	       edm::OwnVector<TrackingRecHit> TMvec;
-
-	       std::vector<const TrackingRecHit *> hits = m_hitExtractor->getMuonHits(*mur); 
-	       for (std::vector<const TrackingRecHit *>::const_iterator ith = hits.begin(), edh = hits.end(); ith != edh; ++ith) {
-		 TMvec.push_back(**ith);
-	       }
-	       
-	       TMRecHits.push_back(TMvec);
-	       
-	       muonHitRefs.push_back(std::make_pair(TMRecHits.rbegin()->data().begin(), TMRecHits.rbegin()->data().end()));
-	     }
-
-	     // Standalone muon or Global without valid muon hits
-	     else if (mur->outerTrack().isNonnull()) {
-	       edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
-		 <<"\t this is a Standalone muon";
-	       muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(), mur->outerTrack()->recHitsEnd()));
-	     }
-
-	     else {
-	       edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
-		 <<"\t what muon is this ?";
-	       edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
-		 <<"isMuon : "<<mur->isMuon()<<", isPFMuon : "<<mur->isPFMuon()<<", isTrackerMuon : "<<mur->isTrackerMuon()
-		 <<", isStandAloneMuon : "<<mur->isStandAloneMuon()<<", isGlobalMuon : "<<mur->isGlobalMuon()
-		 <<", isRPCMuon : "<<mur->isRPCMuon()<<", isGEMMuon : "<<mur->isGEMMuon()<<", isME0Muon : "<<mur->isME0Muon();
-	       muonHitRefs.push_back(std::make_pair(noTM.data().end(), noTM.data().end()));
-	     }
-	     
-	     isel++;
-	   } // loop on muons
-	   
+  case reco::InnerTk:
+    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
+                                                          ed = muons.end();
+         it != ed; ++it) {
+      edm::RefToBase<reco::Muon> mur = *it;
+      if (mur->track().isNonnull()) {
+        muonHitRefs.push_back(std::make_pair(mur->track()->recHitsBegin(),
+                                             mur->track()->recHitsEnd()));
+      } else {
+        muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(),
+                                             allTMRecHits.data().end()));
+      }
+    }
+    break;
+  case reco::OuterTk:
+    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
+                                                          ed = muons.end();
+         it != ed; ++it) {
+      edm::RefToBase<reco::Muon> mur = *it;
+      if (mur->outerTrack().isNonnull()) {
+        muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(),
+                                             mur->outerTrack()->recHitsEnd()));
+      } else {
+        muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(),
+                                             allTMRecHits.data().end()));
+      }
+    }
+    break;
+  case reco::GlobalTk:
+    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
+                                                          ed = muons.end();
+         it != ed; ++it) {
+      edm::RefToBase<reco::Muon> mur = *it;
+      if (mur->globalTrack().isNonnull()) {
+        muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(),
+                                             mur->globalTrack()->recHitsEnd()));
+      } else {
+        muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(),
+                                             allTMRecHits.data().end()));
+      }
+    }
+    break;
+  case reco::Segments: {
+    // puts hits in the vector, and record indices
+    std::vector<std::pair<size_t, size_t>> muonHitIndices;
+    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
+                                                          ed = muons.end();
+         it != ed; ++it) {
+      edm::RefToBase<reco::Muon> mur = *it;
+      std::pair<size_t, size_t> indices(allTMRecHits.size(),
+                                        allTMRecHits.size());
+      if (mur->isTrackerMuon()) {
+        std::vector<const TrackingRecHit *> hits =
+            m_hitExtractor->getMuonHits(*mur);
+        for (std::vector<const TrackingRecHit *>::const_iterator
+                 ith = hits.begin(),
+                 edh = hits.end();
+             ith != edh; ++ith) {
+          allTMRecHits.push_back(**ith);
         }
-	break;
+        indices.second += hits.size();
+      }
+      muonHitIndices.push_back(indices);
+    }
+    // convert indices into pairs of iterators to references
+    typedef std::pair<size_t, size_t> index_pair;
+    trackingRecHit_iterator hitRefBegin = allTMRecHits.data().begin();
+    for (std::vector<std::pair<size_t, size_t>>::const_iterator
+             idxs = muonHitIndices.begin(),
+             idxend = muonHitIndices.end();
+         idxs != idxend; ++idxs) {
+      muonHitRefs.push_back(std::make_pair(hitRefBegin + idxs->first,
+                                           hitRefBegin + idxs->second));
     }
 
-    /// PART 2: call the association routines 
-    auto recSimColl = m_helper->associateRecoToSimIndices(muonHitRefs,tPC, m_resources);
-    for (auto it = recSimColl.begin(), ed = recSimColl.end(); it != ed; ++it) {
-        edm::RefToBase<reco::Muon> rec = muons[it->first];
-        std::vector<std::pair<TrackingParticleRef, double> > & tpAss  = recToSim[rec];
-        for ( auto const & a : it->second) {
-            tpAss.push_back(std::make_pair(tPC[a.idx], a.quality));
+  } break;
+  case reco::GlbOrTrk: {
+    edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
+        << "\n"
+        << "There are " << muons.size() << " selected reco::Muons.";
+
+    int isel = 0;
+    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
+                                                          ed = muons.end();
+         it != ed; ++it) {
+      edm::RefToBase<reco::Muon> mur = *it;
+
+      edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
+          << " #" << isel << ", reco::Muon key = " << mur.key()
+          << ", q*p = " << mur->charge() * mur->p() << ", pT = " << mur->pt()
+          << ", eta = " << mur->eta() << ", phi = " << mur->phi();
+
+      // Global muon with valid muon hits
+      if (mur->isGlobalMuon() &&
+          mur->globalTrack()->hitPattern().numberOfValidMuonHits() > 0) {
+        edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
+            << "\t this is a Global Muon with valid muon hits";
+        muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(),
+                                             mur->globalTrack()->recHitsEnd()));
+      }
+
+      // Tracker Muon
+      else if (mur->isTrackerMuon()) {
+        edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
+            << "\t this is a Tracker Muon";
+        edm::OwnVector<TrackingRecHit> TMvec;
+
+        std::vector<const TrackingRecHit *> hits =
+            m_hitExtractor->getMuonHits(*mur);
+        for (std::vector<const TrackingRecHit *>::const_iterator
+                 ith = hits.begin(),
+                 edh = hits.end();
+             ith != edh; ++ith) {
+          TMvec.push_back(**ith);
         }
+
+        TMRecHits.push_back(TMvec);
+
+        muonHitRefs.push_back(std::make_pair(TMRecHits.rbegin()->data().begin(),
+                                             TMRecHits.rbegin()->data().end()));
+      }
+
+      // Standalone muon or Global without valid muon hits
+      else if (mur->outerTrack().isNonnull()) {
+        edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
+            << "\t this is a Standalone muon";
+        muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(),
+                                             mur->outerTrack()->recHitsEnd()));
+      }
+
+      else {
+        edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
+            << "\t what muon is this ?";
+        edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
+            << "isMuon : " << mur->isMuon()
+            << ", isPFMuon : " << mur->isPFMuon()
+            << ", isTrackerMuon : " << mur->isTrackerMuon()
+            << ", isStandAloneMuon : " << mur->isStandAloneMuon()
+            << ", isGlobalMuon : " << mur->isGlobalMuon()
+            << ", isRPCMuon : " << mur->isRPCMuon()
+            << ", isGEMMuon : " << mur->isGEMMuon()
+            << ", isME0Muon : " << mur->isME0Muon();
+        muonHitRefs.push_back(
+            std::make_pair(noTM.data().end(), noTM.data().end()));
+      }
+
+      isel++;
+    } // loop on muons
+
+  } break;
+  }
+
+  /// PART 2: call the association routines
+  auto recSimColl =
+      m_helper->associateRecoToSimIndices(muonHitRefs, tPC, m_resources);
+  for (auto it = recSimColl.begin(), ed = recSimColl.end(); it != ed; ++it) {
+    edm::RefToBase<reco::Muon> rec = muons[it->first];
+    std::vector<std::pair<TrackingParticleRef, double>> &tpAss = recToSim[rec];
+    for (auto const &a : it->second) {
+      tpAss.push_back(std::make_pair(tPC[a.idx], a.quality));
     }
-    auto simRecColl = m_helper->associateSimToRecoIndices(muonHitRefs,tPC,m_resources);
-    for (auto it = simRecColl.begin(), ed = simRecColl.end(); it != ed; ++it) {
-        TrackingParticleRef sim = tPC[it->first];
-        std::vector<std::pair<edm::RefToBase<reco::Muon>, double> > & recAss = simToRec[sim];
-        for ( auto const & a: it->second ) {
-            recAss.push_back(std::make_pair(muons[a.idx], a.quality));
-        }
+  }
+  auto simRecColl =
+      m_helper->associateSimToRecoIndices(muonHitRefs, tPC, m_resources);
+  for (auto it = simRecColl.begin(), ed = simRecColl.end(); it != ed; ++it) {
+    TrackingParticleRef sim = tPC[it->first];
+    std::vector<std::pair<edm::RefToBase<reco::Muon>, double>> &recAss =
+        simToRec[sim];
+    for (auto const &a : it->second) {
+      recAss.push_back(std::make_pair(muons[a.idx], a.quality));
     }
+  }
 }
-   
-void
-MuonToTrackingParticleAssociatorByHitsImpl::associateMuons(reco::MuonToSimCollection & recToSim, 
-                                                           reco::SimToMuonCollection & simToRec,
-                                                           const edm::Handle<edm::View<reco::Muon> > & tCH, 
-                                                           reco::MuonTrackType type, 
-                                                           const edm::Handle<TrackingParticleCollection>& tPCH) const {
 
-    edm::RefVector<TrackingParticleCollection> tpc(tPCH.id());
-    for (unsigned int j=0; j<tPCH->size();j++)
-      tpc.push_back(edm::Ref<TrackingParticleCollection>(tPCH,j));
-    
-    edm::RefToBaseVector<reco::Muon> muonBaseRefVector;
-    for (size_t i = 0; i < tCH->size(); ++i)
-      muonBaseRefVector.push_back(tCH->refAt(i));
+void MuonToTrackingParticleAssociatorByHitsImpl::associateMuons(
+    reco::MuonToSimCollection &recToSim, reco::SimToMuonCollection &simToRec,
+    const edm::Handle<edm::View<reco::Muon>> &tCH, reco::MuonTrackType type,
+    const edm::Handle<TrackingParticleCollection> &tPCH) const {
 
-    associateMuons(recToSim, simToRec, muonBaseRefVector,type,tpc);
+  edm::RefVector<TrackingParticleCollection> tpc(tPCH.id());
+  for (unsigned int j = 0; j < tPCH->size(); j++)
+    tpc.push_back(edm::Ref<TrackingParticleCollection>(tPCH, j));
+
+  edm::RefToBaseVector<reco::Muon> muonBaseRefVector;
+  for (size_t i = 0; i < tCH->size(); ++i)
+    muonBaseRefVector.push_back(tCH->refAt(i));
+
+  associateMuons(recToSim, simToRec, muonBaseRefVector, type, tpc);
 }
 
 //

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.h
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.h
@@ -4,8 +4,10 @@
 //
 // Package:     SimMuon/MCTruth
 // Class  :     MuonToTrackingParticleAssociatorByHitsImpl
-// 
-/**\class MuonToTrackingParticleAssociatorByHitsImpl MuonToTrackingParticleAssociatorByHitsImpl.h "MuonToTrackingParticleAssociatorByHitsImpl.h"
+//
+/**\class MuonToTrackingParticleAssociatorByHitsImpl
+ MuonToTrackingParticleAssociatorByHitsImpl.h
+ "MuonToTrackingParticleAssociatorByHitsImpl.h"
 
  Description: [one line class summary]
 
@@ -27,37 +29,45 @@
 // forward declarations
 class TrackerMuonHitExtractor;
 
-class MuonToTrackingParticleAssociatorByHitsImpl: public reco::MuonToTrackingParticleAssociatorBaseImpl
-{
+class MuonToTrackingParticleAssociatorByHitsImpl
+    : public reco::MuonToTrackingParticleAssociatorBaseImpl {
 
-   public:
-   MuonToTrackingParticleAssociatorByHitsImpl(TrackerMuonHitExtractor const& iHitExtractor,
-                                              MuonAssociatorByHitsHelper::Resources const& iResources,
-                                              MuonAssociatorByHitsHelper const* iHelper);
+public:
+  MuonToTrackingParticleAssociatorByHitsImpl(
+      TrackerMuonHitExtractor const &iHitExtractor,
+      MuonAssociatorByHitsHelper::Resources const &iResources,
+      MuonAssociatorByHitsHelper const *iHelper);
 
-   // ---------- const member functions ---------------------
-   void associateMuons(reco::MuonToSimCollection & recoToSim, reco::SimToMuonCollection & simToReco,
-                       const edm::RefToBaseVector<reco::Muon> & muons, reco::MuonTrackType type,
-                       const edm::RefVector<TrackingParticleCollection>& tpColl) const override;
-   
-   void associateMuons(reco::MuonToSimCollection & recoToSim, reco::SimToMuonCollection & simToReco,
-                       const edm::Handle<edm::View<reco::Muon> > & muons, reco::MuonTrackType type, 
-                       const edm::Handle<TrackingParticleCollection>& tpColl) const override;
-   
-   // ---------- static member functions --------------------
-   
-   // ---------- member functions ---------------------------
-   
- private:
-   MuonToTrackingParticleAssociatorByHitsImpl(const MuonToTrackingParticleAssociatorByHitsImpl&) = delete; // stop default
-   
-   const MuonToTrackingParticleAssociatorByHitsImpl& operator=(const MuonToTrackingParticleAssociatorByHitsImpl&) = delete; // stop default
-   
-      // ---------- member data --------------------------------
-   TrackerMuonHitExtractor const* m_hitExtractor;
-   MuonAssociatorByHitsHelper::Resources m_resources;
-   MuonAssociatorByHitsHelper const* m_helper;
+  // ---------- const member functions ---------------------
+  void associateMuons(
+      reco::MuonToSimCollection &recoToSim,
+      reco::SimToMuonCollection &simToReco,
+      const edm::RefToBaseVector<reco::Muon> &muons, reco::MuonTrackType type,
+      const edm::RefVector<TrackingParticleCollection> &tpColl) const override;
+
+  void associateMuons(
+      reco::MuonToSimCollection &recoToSim,
+      reco::SimToMuonCollection &simToReco,
+      const edm::Handle<edm::View<reco::Muon>> &muons, reco::MuonTrackType type,
+      const edm::Handle<TrackingParticleCollection> &tpColl) const override;
+
+  // ---------- static member functions --------------------
+
+  // ---------- member functions ---------------------------
+
+private:
+  MuonToTrackingParticleAssociatorByHitsImpl(
+      const MuonToTrackingParticleAssociatorByHitsImpl &) =
+      delete; // stop default
+
+  const MuonToTrackingParticleAssociatorByHitsImpl &
+  operator=(const MuonToTrackingParticleAssociatorByHitsImpl &) =
+      delete; // stop default
+
+  // ---------- member data --------------------------------
+  TrackerMuonHitExtractor const *m_hitExtractor;
+  MuonAssociatorByHitsHelper::Resources m_resources;
+  MuonAssociatorByHitsHelper const *m_helper;
 };
-
 
 #endif

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -2,8 +2,10 @@
 //
 // Package:    SimMuon/MCTruth
 // Class:      MuonToTrackingParticleAssociatorEDProducer
-// 
-/**\class MuonToTrackingParticleAssociatorEDProducer MuonToTrackingParticleAssociatorEDProducer.cc SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+//
+/**\class MuonToTrackingParticleAssociatorEDProducer
+ MuonToTrackingParticleAssociatorEDProducer.cc
+ SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
 
  Description: [one line class summary]
 
@@ -15,7 +17,6 @@
 //         Created:  Wed, 07 Jan 2015 21:30:14 GMT
 //
 //
-
 
 // system include files
 #include <memory>
@@ -29,156 +30,192 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h"
-#include "SimDataFormats/Associations/interface/MuonToTrackingParticleAssociator.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "MuonToTrackingParticleAssociatorByHitsImpl.h"
+#include "SimDataFormats/Associations/interface/MuonToTrackingParticleAssociator.h"
+#include "SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h"
 
 //
 // class declaration
 //
 namespace {
-  using TrackHitsCollection = MuonAssociatorByHitsHelper::TrackHitsCollection;
+using TrackHitsCollection = MuonAssociatorByHitsHelper::TrackHitsCollection;
 
-  class InputDumper {
-  public:
-    
-    InputDumper(const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :
-      simtracksTag(conf.getParameter<edm::InputTag>("simtracksTag")),
-      simtracksXFTag(conf.getParameter<edm::InputTag>("simtracksXFTag")),
-      crossingframe(conf.getParameter<bool>("crossingframe")) 
-    {
-      if (crossingframe) {
-        simtracksXFToken_ = iC.consumes<CrossingFrame<SimTrack> >(simtracksXFTag);
-        simvertsXFToken_ = iC.consumes<CrossingFrame<SimVertex> >(simtracksXFTag);
-      }
-      else{
-        simtracksToken_ = iC.consumes<edm::SimTrackContainer>(simtracksTag);
-        simvertsToken_ = iC.consumes<edm::SimVertexContainer>(simtracksTag);
-      }
-    }
-
-    void read(const edm::Event&);
-    void dump(const TrackHitsCollection&, const TrackingParticleCollection&) const;
-
-  private:
-    edm::InputTag simtracksTag;
-    edm::InputTag simtracksXFTag;
-    edm::EDGetTokenT<CrossingFrame<SimTrack> > simtracksXFToken_;
-    edm::EDGetTokenT<CrossingFrame<SimVertex> > simvertsXFToken_;
-    edm::EDGetTokenT<edm::SimTrackContainer> simtracksToken_;
-    edm::EDGetTokenT<edm::SimVertexContainer> simvertsToken_;
-
-    edm::Handle<CrossingFrame<SimTrack>> simtracksXF_;
-    edm::Handle<CrossingFrame<SimVertex>> simvertsXF_;
-    edm::Handle<edm::SimTrackContainer> simtracks_;
-    edm::Handle<edm::SimVertexContainer> simverts_;
-    bool const crossingframe;
-  };
-  
-  void
-  InputDumper::read(const edm::Event& iEvent) {
-    if(crossingframe) {
-      iEvent.getByToken(simtracksXFToken_, simtracksXF_);
-      iEvent.getByToken(simvertsXFToken_, simvertsXF_);
-    }else {
-      iEvent.getByToken(simtracksToken_, simtracks_);
-      iEvent.getByToken(simvertsToken_, simverts_);
-    }
-  }
-
-  void
-  InputDumper::dump(const TrackHitsCollection& tC, const TrackingParticleCollection& tPC) const {
-    using namespace std;
-    // reco::Track collection
-    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")<<"\n"<<"reco::Track collection --- size = "<<tC.size();
- 
-    // TrackingParticle collection
-    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")<<"\n"<<"TrackingParticle collection --- size = "<<tPC.size();
-    int j = 0;
-    for(TrackingParticleCollection::const_iterator ITER=tPC.begin(); ITER!=tPC.end(); ITER++, j++) {
-      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-        <<"TrackingParticle "<<j<<", q = "<<ITER->charge()<<", p = "<<ITER->p()
-        <<", pT = "<<ITER->pt()<<", eta = "<<ITER->eta()<<", phi = "<<ITER->phi();
-       
-      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-        <<"\t pdg code = "<<ITER->pdgId()<<", made of "<<ITER->numberOfHits()<<" PSimHit"
-        <<" (in "<<ITER->numberOfTrackerLayers()<<" layers)"
-        <<" from "<<ITER->g4Tracks().size()<<" SimTrack:";
-      for (TrackingParticle::g4t_iterator g4T=ITER->g4Track_begin(); g4T!=ITER->g4Track_end(); g4T++) {
-        edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-          <<"\t\t Id:"<<g4T->trackId()<<"/Evt:("<<g4T->eventId().event()<<","<<g4T->eventId().bunchCrossing()<<")";
-      }    
-    }
- 
+class InputDumper {
+public:
+  InputDumper(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
+      : simtracksTag(conf.getParameter<edm::InputTag>("simtracksTag")),
+        simtracksXFTag(conf.getParameter<edm::InputTag>("simtracksXFTag")),
+        crossingframe(conf.getParameter<bool>("crossingframe")) {
     if (crossingframe) {
-      std:: unique_ptr<MixCollection<SimTrack> > SimTk( new MixCollection<SimTrack>(simtracksXF_.product()) );
-      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-	<<"\n"<<"CrossingFrame<SimTrack> collection with InputTag = "<<simtracksXFTag<<" has size = "<<SimTk->size();
-      int k = 0;
-      for (MixCollection<SimTrack>::MixItr ITER=SimTk->begin(); ITER!=SimTk->end(); ITER++, k++) {
-        edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-          <<"SimTrack "<<k
-          <<" - Id:"<<ITER->trackId()<<"/Evt:("<<ITER->eventId().event()<<","<<ITER->eventId().bunchCrossing()<<")"
-          <<", q = "<<ITER->charge()<<", p = "<<ITER->momentum().P()
-          <<", pT = "<<ITER->momentum().Pt()<<", eta = "<<ITER->momentum().Eta()<<", phi = "<<ITER->momentum().Phi()
-	  <<"\n\t pdgId = "<<ITER->type()<<", Vertex index = "<<ITER->vertIndex()
-	  <<", Gen Particle index = "<< (ITER->genpartIndex()>0 ? ITER->genpartIndex()-1 : ITER->genpartIndex()) <<endl;
-      }
-
-      std::unique_ptr<MixCollection<SimVertex> > SimVtx( new MixCollection<SimVertex>(simvertsXF_.product()) );
-      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-	<<"\n"<<"CrossingFrame<SimVertex> collection with InputTag = "<<simtracksXFTag<<" has size = "<<SimVtx->size();
-      int kv = 0;
-      for (MixCollection<SimVertex>::MixItr VITER=SimVtx->begin(); VITER!=SimVtx->end(); VITER++, kv++){
-        edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-          <<"SimVertex "<<kv
-	  <<" - Id:"<<VITER->vertexId()<<", position = "<<VITER->position()<<", parent SimTrack Id = "<<VITER->parentIndex()
-	  <<", processType = "<<VITER->processType();
-      }
+      simtracksXFToken_ = iC.consumes<CrossingFrame<SimTrack>>(simtracksXFTag);
+      simvertsXFToken_ = iC.consumes<CrossingFrame<SimVertex>>(simtracksXFTag);
+    } else {
+      simtracksToken_ = iC.consumes<edm::SimTrackContainer>(simtracksTag);
+      simvertsToken_ = iC.consumes<edm::SimVertexContainer>(simtracksTag);
     }
-    else {
-      const edm::SimTrackContainer simTC = *(simtracks_.product());
-      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")<<"\n"<<"SimTrack collection with InputTag = "<<simtracksTag
-                                              <<" has size = "<<simTC.size()<<endl;
-      int k = 0;
-      for(edm::SimTrackContainer::const_iterator ITER=simTC.begin(); ITER!=simTC.end(); ITER++, k++){
-        edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-          <<"SimTrack "<<k
-          <<" - Id:"<<ITER->trackId()<<"/Evt:("<<ITER->eventId().event()<<","<<ITER->eventId().bunchCrossing()<<")"
-          <<", q = "<<ITER->charge()<<", p = "<<ITER->momentum().P()
-          <<", pT = "<<ITER->momentum().Pt()<<", eta = "<<ITER->momentum().Eta()<<", phi = "<<ITER->momentum().Phi()
-	  <<"\n\t pdgId = "<<ITER->type()<<", Vertex index = "<<ITER->vertIndex()
-	  <<", Gen Particle index = "<< (ITER->genpartIndex()>0 ? ITER->genpartIndex()-1 : ITER->genpartIndex()) <<endl;
-      }
-      const edm::SimVertexContainer simVC = *(simverts_.product());
-      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")<<"\n"<<"SimVertex collection with InputTag = "<<"g4SimHits"
-                                              <<" has size = "<<simVC.size()<<endl;
-      int kv = 0;
-      for (edm::SimVertexContainer::const_iterator VITER=simVC.begin(); VITER!=simVC.end(); VITER++, kv++){
-        edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-          <<"SimVertex "<<kv
-	  <<" - Id:"<<VITER->vertexId()<<", position = "<<VITER->position()<<", parent SimTrack Id = "<<VITER->parentIndex()
-	  <<", processType = "<<VITER->processType();
-      }
-    }
-
   }
 
+  void read(const edm::Event &);
+  void dump(const TrackHitsCollection &,
+            const TrackingParticleCollection &) const;
+
+private:
+  edm::InputTag simtracksTag;
+  edm::InputTag simtracksXFTag;
+  edm::EDGetTokenT<CrossingFrame<SimTrack>> simtracksXFToken_;
+  edm::EDGetTokenT<CrossingFrame<SimVertex>> simvertsXFToken_;
+  edm::EDGetTokenT<edm::SimTrackContainer> simtracksToken_;
+  edm::EDGetTokenT<edm::SimVertexContainer> simvertsToken_;
+
+  edm::Handle<CrossingFrame<SimTrack>> simtracksXF_;
+  edm::Handle<CrossingFrame<SimVertex>> simvertsXF_;
+  edm::Handle<edm::SimTrackContainer> simtracks_;
+  edm::Handle<edm::SimVertexContainer> simverts_;
+  bool const crossingframe;
+};
+
+void InputDumper::read(const edm::Event &iEvent) {
+  if (crossingframe) {
+    iEvent.getByToken(simtracksXFToken_, simtracksXF_);
+    iEvent.getByToken(simvertsXFToken_, simvertsXF_);
+  } else {
+    iEvent.getByToken(simtracksToken_, simtracks_);
+    iEvent.getByToken(simvertsToken_, simverts_);
+  }
 }
 
+void InputDumper::dump(const TrackHitsCollection &tC,
+                       const TrackingParticleCollection &tPC) const {
+  using namespace std;
+  // reco::Track collection
+  edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+      << "\n"
+      << "reco::Track collection --- size = " << tC.size();
 
-class MuonToTrackingParticleAssociatorEDProducer : public edm::stream::EDProducer<> {
+  // TrackingParticle collection
+  edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+      << "\n"
+      << "TrackingParticle collection --- size = " << tPC.size();
+  int j = 0;
+  for (TrackingParticleCollection::const_iterator ITER = tPC.begin();
+       ITER != tPC.end(); ITER++, j++) {
+    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+        << "TrackingParticle " << j << ", q = " << ITER->charge()
+        << ", p = " << ITER->p() << ", pT = " << ITER->pt()
+        << ", eta = " << ITER->eta() << ", phi = " << ITER->phi();
+
+    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+        << "\t pdg code = " << ITER->pdgId() << ", made of "
+        << ITER->numberOfHits() << " PSimHit"
+        << " (in " << ITER->numberOfTrackerLayers() << " layers)"
+        << " from " << ITER->g4Tracks().size() << " SimTrack:";
+    for (TrackingParticle::g4t_iterator g4T = ITER->g4Track_begin();
+         g4T != ITER->g4Track_end(); g4T++) {
+      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+          << "\t\t Id:" << g4T->trackId() << "/Evt:(" << g4T->eventId().event()
+          << "," << g4T->eventId().bunchCrossing() << ")";
+    }
+  }
+
+  if (crossingframe) {
+    std::unique_ptr<MixCollection<SimTrack>> SimTk(
+        new MixCollection<SimTrack>(simtracksXF_.product()));
+    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+        << "\n"
+        << "CrossingFrame<SimTrack> collection with InputTag = "
+        << simtracksXFTag << " has size = " << SimTk->size();
+    int k = 0;
+    for (MixCollection<SimTrack>::MixItr ITER = SimTk->begin();
+         ITER != SimTk->end(); ITER++, k++) {
+      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+          << "SimTrack " << k << " - Id:" << ITER->trackId() << "/Evt:("
+          << ITER->eventId().event() << "," << ITER->eventId().bunchCrossing()
+          << ")"
+          << ", q = " << ITER->charge() << ", p = " << ITER->momentum().P()
+          << ", pT = " << ITER->momentum().Pt()
+          << ", eta = " << ITER->momentum().Eta()
+          << ", phi = " << ITER->momentum().Phi()
+          << "\n\t pdgId = " << ITER->type()
+          << ", Vertex index = " << ITER->vertIndex()
+          << ", Gen Particle index = "
+          << (ITER->genpartIndex() > 0 ? ITER->genpartIndex() - 1
+                                       : ITER->genpartIndex())
+          << endl;
+    }
+
+    std::unique_ptr<MixCollection<SimVertex>> SimVtx(
+        new MixCollection<SimVertex>(simvertsXF_.product()));
+    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+        << "\n"
+        << "CrossingFrame<SimVertex> collection with InputTag = "
+        << simtracksXFTag << " has size = " << SimVtx->size();
+    int kv = 0;
+    for (MixCollection<SimVertex>::MixItr VITER = SimVtx->begin();
+         VITER != SimVtx->end(); VITER++, kv++) {
+      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+          << "SimVertex " << kv << " - Id:" << VITER->vertexId()
+          << ", position = " << VITER->position()
+          << ", parent SimTrack Id = " << VITER->parentIndex()
+          << ", processType = " << VITER->processType();
+    }
+  } else {
+    const edm::SimTrackContainer simTC = *(simtracks_.product());
+    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+        << "\n"
+        << "SimTrack collection with InputTag = " << simtracksTag
+        << " has size = " << simTC.size() << endl;
+    int k = 0;
+    for (edm::SimTrackContainer::const_iterator ITER = simTC.begin();
+         ITER != simTC.end(); ITER++, k++) {
+      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+          << "SimTrack " << k << " - Id:" << ITER->trackId() << "/Evt:("
+          << ITER->eventId().event() << "," << ITER->eventId().bunchCrossing()
+          << ")"
+          << ", q = " << ITER->charge() << ", p = " << ITER->momentum().P()
+          << ", pT = " << ITER->momentum().Pt()
+          << ", eta = " << ITER->momentum().Eta()
+          << ", phi = " << ITER->momentum().Phi()
+          << "\n\t pdgId = " << ITER->type()
+          << ", Vertex index = " << ITER->vertIndex()
+          << ", Gen Particle index = "
+          << (ITER->genpartIndex() > 0 ? ITER->genpartIndex() - 1
+                                       : ITER->genpartIndex())
+          << endl;
+    }
+    const edm::SimVertexContainer simVC = *(simverts_.product());
+    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+        << "\n"
+        << "SimVertex collection with InputTag = "
+        << "g4SimHits"
+        << " has size = " << simVC.size() << endl;
+    int kv = 0;
+    for (edm::SimVertexContainer::const_iterator VITER = simVC.begin();
+         VITER != simVC.end(); VITER++, kv++) {
+      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+          << "SimVertex " << kv << " - Id:" << VITER->vertexId()
+          << ", position = " << VITER->position()
+          << ", parent SimTrack Id = " << VITER->parentIndex()
+          << ", processType = " << VITER->processType();
+    }
+  }
+}
+
+} // namespace
+
+class MuonToTrackingParticleAssociatorEDProducer
+    : public edm::stream::EDProducer<> {
 public:
-  explicit MuonToTrackingParticleAssociatorEDProducer(const edm::ParameterSet&);
+  explicit MuonToTrackingParticleAssociatorEDProducer(
+      const edm::ParameterSet &);
   ~MuonToTrackingParticleAssociatorEDProducer() override;
-  
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
 private:
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  
+  void produce(edm::Event &, const edm::EventSetup &) override;
+
   // ----------member data ---------------------------
   edm::ParameterSet const config_;
   MuonAssociatorByHitsHelper helper_;
@@ -197,7 +234,6 @@ private:
 // constants, enums and typedefs
 //
 
-
 //
 // static data member definitions
 //
@@ -205,96 +241,100 @@ private:
 //
 // constructors and destructor
 //
-MuonToTrackingParticleAssociatorEDProducer::MuonToTrackingParticleAssociatorEDProducer(const edm::ParameterSet& iConfig):
-  config_(iConfig),
-  helper_(iConfig),
-  trackerHitAssociatorConfig_(iConfig,consumesCollector()),
-  hitExtractor_(iConfig,consumesCollector())
-{
-   //register your products
-   produces<reco::MuonToTrackingParticleAssociator>();
+MuonToTrackingParticleAssociatorEDProducer::
+    MuonToTrackingParticleAssociatorEDProducer(const edm::ParameterSet &iConfig)
+    : config_(iConfig), helper_(iConfig),
+      trackerHitAssociatorConfig_(iConfig, consumesCollector()),
+      hitExtractor_(iConfig, consumesCollector()) {
+  // register your products
+  produces<reco::MuonToTrackingParticleAssociator>();
 
-   //hack for consumes
-   RPCHitAssociator rpctruth(iConfig,consumesCollector());
-   GEMHitAssociator gemtruth(iConfig,consumesCollector());
-   DTHitAssociator dttruth(iConfig,consumesCollector());
-   CSCHitAssociator cscruth(iConfig,consumesCollector());
+  // hack for consumes
+  RPCHitAssociator rpctruth(iConfig, consumesCollector());
+  GEMHitAssociator gemtruth(iConfig, consumesCollector());
+  DTHitAssociator dttruth(iConfig, consumesCollector());
+  CSCHitAssociator cscruth(iConfig, consumesCollector());
 
-  if( iConfig.getUntrackedParameter<bool>("dumpInputCollections") ) {
-    diagnostics_.reset( new InputDumper(iConfig, consumesCollector()) );
+  if (iConfig.getUntrackedParameter<bool>("dumpInputCollections")) {
+    diagnostics_.reset(new InputDumper(iConfig, consumesCollector()));
   }
 }
 
+MuonToTrackingParticleAssociatorEDProducer::
+    ~MuonToTrackingParticleAssociatorEDProducer() {
 
-MuonToTrackingParticleAssociatorEDProducer::~MuonToTrackingParticleAssociatorEDProducer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-MuonToTrackingParticleAssociatorEDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void MuonToTrackingParticleAssociatorEDProducer::produce(
+    edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  using namespace edm;
 
-   hitExtractor_.init(iEvent, iSetup);
+  hitExtractor_.init(iEvent, iSetup);
 
-   //Retrieve tracker topology from geometry
-   edm::ESHandle<TrackerTopology> tTopoHand;
-   iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
-   const TrackerTopology *tTopo=tTopoHand.product();
-   
-   bool printRtS = true;
-   
-   //NOTE: This assumes that produce will not be called until the edm::Event used in the previous call
-   // has been deleted. This is true for now. In the future, we may have to have the resources own
-   // the memory.
+  // Retrieve tracker topology from geometry
+  edm::ESHandle<TrackerTopology> tTopoHand;
+  iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
+  const TrackerTopology *tTopo = tTopoHand.product();
 
-   // Tracker hit association  
-   trackertruth_.reset(new TrackerHitAssociator(iEvent, trackerHitAssociatorConfig_));
-   // CSC hit association
-   csctruth_.reset(new CSCHitAssociator(iEvent,iSetup,config_));
-   // DT hit association
-   printRtS = false;
-   dttruth_.reset(new DTHitAssociator(iEvent,iSetup,config_,printRtS));
-   // RPC hit association
-   rpctruth_.reset( new RPCHitAssociator(iEvent,iSetup,config_) );
-   // GEM hit association
-   gemtruth_.reset( new GEMHitAssociator(iEvent,iSetup,config_) );
-   
-   MuonAssociatorByHitsHelper::Resources resources = {tTopo, trackertruth_.get(), csctruth_.get(), dttruth_.get(), rpctruth_.get(), gemtruth_.get()};
+  bool printRtS = true;
 
-   if(diagnostics_) {
-     diagnostics_->read(iEvent);
-     resources.diagnostics_ = [this](const TrackHitsCollection& hC, const TrackingParticleCollection& pC) {
-       diagnostics_->dump(hC,pC);
-     };
-   }
+  // NOTE: This assumes that produce will not be called until the edm::Event
+  // used in the previous call
+  // has been deleted. This is true for now. In the future, we may have to have
+  // the resources own the memory.
 
-   std::unique_ptr<reco::MuonToTrackingParticleAssociatorBaseImpl> impl{ 
-     new MuonToTrackingParticleAssociatorByHitsImpl(hitExtractor_,resources, &helper_) }; 
-   std::unique_ptr<reco::MuonToTrackingParticleAssociator> toPut( new reco::MuonToTrackingParticleAssociator(std::move(impl)));
-   iEvent.put(std::move(toPut));
+  // Tracker hit association
+  trackertruth_.reset(
+      new TrackerHitAssociator(iEvent, trackerHitAssociatorConfig_));
+  // CSC hit association
+  csctruth_.reset(new CSCHitAssociator(iEvent, iSetup, config_));
+  // DT hit association
+  printRtS = false;
+  dttruth_.reset(new DTHitAssociator(iEvent, iSetup, config_, printRtS));
+  // RPC hit association
+  rpctruth_.reset(new RPCHitAssociator(iEvent, iSetup, config_));
+  // GEM hit association
+  gemtruth_.reset(new GEMHitAssociator(iEvent, iSetup, config_));
+
+  MuonAssociatorByHitsHelper::Resources resources = {
+      tTopo,          trackertruth_.get(), csctruth_.get(),
+      dttruth_.get(), rpctruth_.get(),     gemtruth_.get()};
+
+  if (diagnostics_) {
+    diagnostics_->read(iEvent);
+    resources.diagnostics_ = [this](const TrackHitsCollection &hC,
+                                    const TrackingParticleCollection &pC) {
+      diagnostics_->dump(hC, pC);
+    };
+  }
+
+  std::unique_ptr<reco::MuonToTrackingParticleAssociatorBaseImpl> impl{
+      new MuonToTrackingParticleAssociatorByHitsImpl(hitExtractor_, resources,
+                                                     &helper_)};
+  std::unique_ptr<reco::MuonToTrackingParticleAssociator> toPut(
+      new reco::MuonToTrackingParticleAssociator(std::move(impl)));
+  iEvent.put(std::move(toPut));
 }
 
- 
-// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-MuonToTrackingParticleAssociatorEDProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
+// ------------ method fills 'descriptions' with the allowed parameters for the
+// module  ------------
+void MuonToTrackingParticleAssociatorEDProducer::fillDescriptions(
+    edm::ConfigurationDescriptions &descriptions) {
+  // The following says we do not know what parameters are allowed so do no
+  // validation
+  // Please change this to state exactly what you do use, even if it is no
+  // parameters
   edm::ParameterSetDescription desc;
   desc.setUnknown();
   descriptions.addDefault(desc);
 }
 
-//define this as a plug-in
+// define this as a plug-in
 DEFINE_FWK_MODULE(MuonToTrackingParticleAssociatorEDProducer);

--- a/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
@@ -1,138 +1,161 @@
 //
 // modified & integrated by Giovanni Abbiendi
-// from code by Arun Luthra: UserCode/luthra/MuonTrackSelector/src/MuonTrackSelector.cc
+// from code by Arun Luthra:
+// UserCode/luthra/MuonTrackSelector/src/MuonTrackSelector.cc
 //
-#include "SimMuon/MCTruth/plugins/MuonTrackProducer.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimMuon/MCTruth/plugins/MuonTrackProducer.h"
 #include <sstream>
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-MuonTrackProducer::MuonTrackProducer(const edm::ParameterSet& parset) :
-  muonsToken(consumes<reco::MuonCollection>(parset.getParameter< edm::InputTag >("muonsTag"))),
-  inputDTRecSegment4DToken_(consumes<DTRecSegment4DCollection>(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"))),
-  inputCSCSegmentToken_(consumes<CSCSegmentCollection>(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))),
-  selectionTags(parset.getParameter< std::vector<std::string> >("selectionTags")),
-  trackType(parset.getParameter< std::string >("trackType")),
-  parset_(parset)
-{
-  edm::LogVerbatim("MuonTrackProducer") << "constructing  MuonTrackProducer" << parset_.dump();
+MuonTrackProducer::MuonTrackProducer(const edm::ParameterSet &parset)
+    : muonsToken(consumes<reco::MuonCollection>(
+          parset.getParameter<edm::InputTag>("muonsTag"))),
+      inputDTRecSegment4DToken_(consumes<DTRecSegment4DCollection>(
+          parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"))),
+      inputCSCSegmentToken_(consumes<CSCSegmentCollection>(
+          parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))),
+      selectionTags(
+          parset.getParameter<std::vector<std::string>>("selectionTags")),
+      trackType(parset.getParameter<std::string>("trackType")),
+      parset_(parset) {
+  edm::LogVerbatim("MuonTrackProducer")
+      << "constructing  MuonTrackProducer" << parset_.dump();
   produces<reco::TrackCollection>();
   produces<reco::TrackExtraCollection>();
   produces<TrackingRecHitCollection>();
 }
 
-MuonTrackProducer::~MuonTrackProducer() {
-}
+MuonTrackProducer::~MuonTrackProducer() {}
 
-void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
-{
-  iEvent.getByToken(muonsToken,muonCollectionH);
+void MuonTrackProducer::produce(edm::Event &iEvent,
+                                const edm::EventSetup &iSetup) {
+  iEvent.getByToken(muonsToken, muonCollectionH);
   iEvent.getByToken(inputDTRecSegment4DToken_, dtSegmentCollectionH_);
   iEvent.getByToken(inputCSCSegmentToken_, cscSegmentCollectionH_);
 
   edm::ESHandle<TrackerTopology> httopo;
   iSetup.get<TrackerTopologyRcd>().get(httopo);
-  const TrackerTopology& ttopo = *httopo;
+  const TrackerTopology &ttopo = *httopo;
 
-  std::unique_ptr<reco::TrackCollection> selectedTracks(new reco::TrackCollection);
-  std::unique_ptr<reco::TrackExtraCollection> selectedTrackExtras( new reco::TrackExtraCollection() );
-  std::unique_ptr<TrackingRecHitCollection> selectedTrackHits( new TrackingRecHitCollection() );
+  std::unique_ptr<reco::TrackCollection> selectedTracks(
+      new reco::TrackCollection);
+  std::unique_ptr<reco::TrackExtraCollection> selectedTrackExtras(
+      new reco::TrackExtraCollection());
+  std::unique_ptr<TrackingRecHitCollection> selectedTrackHits(
+      new TrackingRecHitCollection());
 
   reco::TrackRefProd rTracks = iEvent.getRefBeforePut<reco::TrackCollection>();
-  reco::TrackExtraRefProd rTrackExtras = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
-  TrackingRecHitRefProd rHits = iEvent.getRefBeforePut<TrackingRecHitCollection>();
+  reco::TrackExtraRefProd rTrackExtras =
+      iEvent.getRefBeforePut<reco::TrackExtraCollection>();
+  TrackingRecHitRefProd rHits =
+      iEvent.getRefBeforePut<TrackingRecHitCollection>();
 
   edm::Ref<reco::TrackExtraCollection>::key_type idx = 0;
   edm::Ref<reco::TrackExtraCollection>::key_type hidx = 0;
 
-  edm::LogVerbatim("MuonTrackProducer") <<"\nThere are "<< dtSegmentCollectionH_->size()<<" DT segments.";
+  edm::LogVerbatim("MuonTrackProducer")
+      << "\nThere are " << dtSegmentCollectionH_->size() << " DT segments.";
   unsigned int index_dt_segment = 0;
-  for(DTRecSegment4DCollection::const_iterator segment = dtSegmentCollectionH_->begin();
-      segment != dtSegmentCollectionH_->end(); ++segment , index_dt_segment++) {
-    LocalPoint  segmentLocalPosition       = segment->localPosition();
-    LocalVector segmentLocalDirection      = segment->localDirection();
-    LocalError  segmentLocalPositionError  = segment->localPositionError();
-    LocalError  segmentLocalDirectionError = segment->localDirectionError();
+  for (DTRecSegment4DCollection::const_iterator segment =
+           dtSegmentCollectionH_->begin();
+       segment != dtSegmentCollectionH_->end(); ++segment, index_dt_segment++) {
+    LocalPoint segmentLocalPosition = segment->localPosition();
+    LocalVector segmentLocalDirection = segment->localDirection();
+    LocalError segmentLocalPositionError = segment->localPositionError();
+    LocalError segmentLocalDirectionError = segment->localDirectionError();
     DetId geoid = segment->geographicalId();
     DTChamberId dtdetid = DTChamberId(geoid);
     int wheel = dtdetid.wheel();
     int station = dtdetid.station();
     int sector = dtdetid.sector();
-    
+
     float segmentX = segmentLocalPosition.x();
     float segmentY = segmentLocalPosition.y();
-    float segmentdXdZ = segmentLocalDirection.x()/segmentLocalDirection.z();
-    float segmentdYdZ = segmentLocalDirection.y()/segmentLocalDirection.z();
+    float segmentdXdZ = segmentLocalDirection.x() / segmentLocalDirection.z();
+    float segmentdYdZ = segmentLocalDirection.y() / segmentLocalDirection.z();
     float segmentXerr = sqrt(segmentLocalPositionError.xx());
     float segmentYerr = sqrt(segmentLocalPositionError.yy());
     float segmentdXdZerr = sqrt(segmentLocalDirectionError.xx());
     float segmentdYdZerr = sqrt(segmentLocalDirectionError.yy());
 
-    edm::LogVerbatim("MuonTrackProducer") 
-      <<"\nDT segment index :"<<index_dt_segment
-      <<"\nchamber Wh:"<<wheel<<",St:"<<station<<",Se:"<<sector
-      <<"\nLocal Position (X,Y)=("<<segmentX<<","<<segmentY<<") +/- ("<<segmentXerr<<","<<segmentYerr<<"), " 
-      <<"Local Direction (dXdZ,dYdZ)=("<<segmentdXdZ<<","<<segmentdYdZ<<") +/- ("<<segmentdXdZerr<<","<<segmentdYdZerr<<")"; 
+    edm::LogVerbatim("MuonTrackProducer")
+        << "\nDT segment index :" << index_dt_segment
+        << "\nchamber Wh:" << wheel << ",St:" << station << ",Se:" << sector
+        << "\nLocal Position (X,Y)=(" << segmentX << "," << segmentY
+        << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
+        << "Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ
+        << ") +/- (" << segmentdXdZerr << "," << segmentdYdZerr << ")";
   }
 
-  edm::LogVerbatim("MuonTrackProducer") <<"\nThere are "<< cscSegmentCollectionH_->size()<<" CSC segments.";
+  edm::LogVerbatim("MuonTrackProducer")
+      << "\nThere are " << cscSegmentCollectionH_->size() << " CSC segments.";
   unsigned int index_csc_segment = 0;
-  for(CSCSegmentCollection::const_iterator segment = cscSegmentCollectionH_->begin();
-      segment != cscSegmentCollectionH_->end(); ++segment , index_csc_segment++) {
-    LocalPoint  segmentLocalPosition       = segment->localPosition();
-    LocalVector segmentLocalDirection      = segment->localDirection();
-    LocalError  segmentLocalPositionError  = segment->localPositionError();
-    LocalError  segmentLocalDirectionError = segment->localDirectionError();
+  for (CSCSegmentCollection::const_iterator segment =
+           cscSegmentCollectionH_->begin();
+       segment != cscSegmentCollectionH_->end();
+       ++segment, index_csc_segment++) {
+    LocalPoint segmentLocalPosition = segment->localPosition();
+    LocalVector segmentLocalDirection = segment->localDirection();
+    LocalError segmentLocalPositionError = segment->localPositionError();
+    LocalError segmentLocalDirectionError = segment->localDirectionError();
 
     DetId geoid = segment->geographicalId();
     CSCDetId cscdetid = CSCDetId(geoid);
     int endcap = cscdetid.endcap();
     int station = cscdetid.station();
     int ring = cscdetid.ring();
-    int chamber = cscdetid.chamber(); 
-    
+    int chamber = cscdetid.chamber();
+
     float segmentX = segmentLocalPosition.x();
     float segmentY = segmentLocalPosition.y();
-    float segmentdXdZ = segmentLocalDirection.x()/segmentLocalDirection.z();
-    float segmentdYdZ = segmentLocalDirection.y()/segmentLocalDirection.z();
+    float segmentdXdZ = segmentLocalDirection.x() / segmentLocalDirection.z();
+    float segmentdYdZ = segmentLocalDirection.y() / segmentLocalDirection.z();
     float segmentXerr = sqrt(segmentLocalPositionError.xx());
     float segmentYerr = sqrt(segmentLocalPositionError.yy());
     float segmentdXdZerr = sqrt(segmentLocalDirectionError.xx());
     float segmentdYdZerr = sqrt(segmentLocalDirectionError.yy());
 
-    edm::LogVerbatim("MuonTrackProducer") 
-      <<"\nCSC segment index :"<<index_csc_segment
-      <<"\nchamber Endcap:"<<endcap<<",St:"<<station<<",Ri:"<<ring<<",Ch:"<<chamber
-      <<"\nLocal Position (X,Y)=("<<segmentX<<","<<segmentY<<") +/- ("<<segmentXerr<<","<<segmentYerr<<"), " 
-      <<"Local Direction (dXdZ,dYdZ)=("<<segmentdXdZ<<","<<segmentdYdZ<<") +/- ("<<segmentdXdZerr<<","<<segmentdYdZerr<<")"; 
+    edm::LogVerbatim("MuonTrackProducer")
+        << "\nCSC segment index :" << index_csc_segment
+        << "\nchamber Endcap:" << endcap << ",St:" << station << ",Ri:" << ring
+        << ",Ch:" << chamber << "\nLocal Position (X,Y)=(" << segmentX << ","
+        << segmentY << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
+        << "Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ
+        << ") +/- (" << segmentdXdZerr << "," << segmentdYdZerr << ")";
   }
 
-  edm::LogVerbatim("MuonTrackProducer") <<"\nThere are "<< muonCollectionH->size() <<" reco::Muons.";
+  edm::LogVerbatim("MuonTrackProducer")
+      << "\nThere are " << muonCollectionH->size() << " reco::Muons.";
   unsigned int muon_index = 0;
-  for(reco::MuonCollection::const_iterator muon = muonCollectionH->begin();
+  for (reco::MuonCollection::const_iterator muon = muonCollectionH->begin();
        muon != muonCollectionH->end(); ++muon, muon_index++) {
-    edm::LogVerbatim("MuonTrackProducer") <<"\n******* muon index : "<<muon_index;
-    
-    std::vector<bool> isGood;    
-    for(unsigned int index=0; index<selectionTags.size(); ++index) {
+    edm::LogVerbatim("MuonTrackProducer")
+        << "\n******* muon index : " << muon_index;
+
+    std::vector<bool> isGood;
+    for (unsigned int index = 0; index < selectionTags.size(); ++index) {
       isGood.push_back(false);
 
-      muon::SelectionType muonType = muon::selectionTypeFromString(selectionTags[index]);
+      muon::SelectionType muonType =
+          muon::selectionTypeFromString(selectionTags[index]);
       isGood[index] = muon::isGoodMuon(*muon, muonType);
     }
 
-    bool isGoodResult=true;
-    for(unsigned int index=0; index<isGood.size(); ++index) {
-      edm::LogVerbatim("MuonTrackProducer") << "selectionTag = "<<selectionTags[index]<< ": "<<isGood[index]<<"\n";
+    bool isGoodResult = true;
+    for (unsigned int index = 0; index < isGood.size(); ++index) {
+      edm::LogVerbatim("MuonTrackProducer")
+          << "selectionTag = " << selectionTags[index] << ": " << isGood[index]
+          << "\n";
       isGoodResult *= isGood[index];
     }
 
@@ -140,209 +163,254 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
       // new copy of Track
       reco::TrackRef trackref;
       if (trackType == "innerTrack") {
-        if (muon->innerTrack().isNonnull()) trackref = muon->innerTrack();
-        else continue;
-      } 
-      else if (trackType == "outerTrack") {
-        if (muon->outerTrack().isNonnull()) trackref = muon->outerTrack();
-        else continue;
-      } 
-      else if (trackType == "globalTrack") {
-        if (muon->globalTrack().isNonnull()) trackref = muon->globalTrack();
-        else continue;
-      }
-      else if (trackType == "innerTrackPlusSegments") {
-        if (muon->innerTrack().isNonnull()) trackref = muon->innerTrack();
-        else continue;
-      }
-      else if (trackType == "gemMuonTrack") {
-        if (muon->innerTrack().isNonnull() && muon->isGEMMuon()){
-            trackref = muon->innerTrack();
-        }
-        else continue;
-      }
-      else if (trackType == "me0MuonTrack") {
-        if (muon->innerTrack().isNonnull() && muon->isME0Muon()){
-            trackref = muon->innerTrack();
-        }
-        else continue;
+        if (muon->innerTrack().isNonnull())
+          trackref = muon->innerTrack();
+        else
+          continue;
+      } else if (trackType == "outerTrack") {
+        if (muon->outerTrack().isNonnull())
+          trackref = muon->outerTrack();
+        else
+          continue;
+      } else if (trackType == "globalTrack") {
+        if (muon->globalTrack().isNonnull())
+          trackref = muon->globalTrack();
+        else
+          continue;
+      } else if (trackType == "innerTrackPlusSegments") {
+        if (muon->innerTrack().isNonnull())
+          trackref = muon->innerTrack();
+        else
+          continue;
+      } else if (trackType == "gemMuonTrack") {
+        if (muon->innerTrack().isNonnull() && muon->isGEMMuon()) {
+          trackref = muon->innerTrack();
+        } else
+          continue;
+      } else if (trackType == "me0MuonTrack") {
+        if (muon->innerTrack().isNonnull() && muon->isME0Muon()) {
+          trackref = muon->innerTrack();
+        } else
+          continue;
       }
 
-      const reco::Track* trk = &(*trackref);
+      const reco::Track *trk = &(*trackref);
       // pointer to old track:
       std::unique_ptr<reco::Track> newTrk(new reco::Track(*trk));
 
-      newTrk->setExtra( reco::TrackExtraRef( rTrackExtras, idx++ ) );
+      newTrk->setExtra(reco::TrackExtraRef(rTrackExtras, idx++));
       PropagationDirection seedDir = trk->seedDirection();
       // new copy of track Extras
-      std::unique_ptr<reco::TrackExtra> newExtra(new reco::TrackExtra( trk->outerPosition(), trk->outerMomentum(), 
-								       trk->outerOk(), trk->innerPosition(), 
-								       trk->innerMomentum(), trk->innerOk(),
-								       trk->outerStateCovariance(), trk->outerDetId(),
-								       trk->innerStateCovariance(), trk->innerDetId() , seedDir )) ;
+      std::unique_ptr<reco::TrackExtra> newExtra(new reco::TrackExtra(
+          trk->outerPosition(), trk->outerMomentum(), trk->outerOk(),
+          trk->innerPosition(), trk->innerMomentum(), trk->innerOk(),
+          trk->outerStateCovariance(), trk->outerDetId(),
+          trk->innerStateCovariance(), trk->innerDetId(), seedDir));
 
-      // new copy of the silicon hits; add hit refs to Extra and hits to hit collection
-      
-      //      edm::LogVerbatim("MuonTrackProducer")<<"\n printing initial hit_pattern";
-      //      trk->hitPattern().print();
+      // new copy of the silicon hits; add hit refs to Extra and hits to hit
+      // collection
+
+      //      edm::LogVerbatim("MuonTrackProducer")<<"\n printing initial
+      //      hit_pattern"; trk->hitPattern().print();
       unsigned int nHitsToAdd = 0;
-      for (trackingRecHit_iterator iHit = trk->recHitsBegin(); iHit != trk->recHitsEnd(); iHit++) {
-        TrackingRecHit* hit = (*iHit)->clone();
-        selectedTrackHits->push_back( hit );
+      for (trackingRecHit_iterator iHit = trk->recHitsBegin();
+           iHit != trk->recHitsEnd(); iHit++) {
+        TrackingRecHit *hit = (*iHit)->clone();
+        selectedTrackHits->push_back(hit);
         ++nHitsToAdd;
       }
-      newExtra->setHits( rHits, hidx, nHitsToAdd );
+      newExtra->setHits(rHits, hidx, nHitsToAdd);
       hidx += nHitsToAdd;
-      if (trackType == "innerTrackPlusSegments") { 
-	
-	int wheel, station, sector;
-	int endcap, /*station, */ ring, chamber;
-	
-	edm::LogVerbatim("MuonTrackProducer") <<"Number of chambers: "<<muon->matches().size()
-					      <<", arbitrated: "<<muon->numberOfMatches(reco::Muon::SegmentAndTrackArbitration);
-	unsigned int index_chamber = 0;
-	
-	for(std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch = muon->matches().begin();
-	    chamberMatch != muon->matches().end(); ++chamberMatch, index_chamber++) {
-	  std::stringstream chamberStr;
-	  chamberStr <<"\nchamber index: "<<index_chamber; 
-	  
-	  int subdet = chamberMatch->detector();
-	  DetId did = chamberMatch->id;
-	  
-	  if (subdet == MuonSubdetId::DT) {
-	    DTChamberId dtdetid = DTChamberId(did);
-	    wheel = dtdetid.wheel();
-	    station = dtdetid.station();
-	    sector = dtdetid.sector();
-	    chamberStr << ", DT chamber Wh:"<<wheel<<",St:"<<station<<",Se:"<<sector;
-	  } 
-	  else if (subdet == MuonSubdetId::CSC) {
-	    CSCDetId cscdetid = CSCDetId(did);
-	    endcap = cscdetid.endcap();
-	    station = cscdetid.station();
-	    ring = cscdetid.ring();
-	    chamber = cscdetid.chamber();
-	    chamberStr << ", CSC chamber End:"<<endcap<<",St:"<<station<<",Ri:"<<ring<<",Ch:"<<chamber;
-	  }
-	  
-	  chamberStr << ", Number of segments: "<<chamberMatch->segmentMatches.size();
-	  edm::LogVerbatim("MuonTrackProducer") << chamberStr.str();
+      if (trackType == "innerTrackPlusSegments") {
 
-	  unsigned int index_segment = 0;
-	  
-	  for(std::vector<reco::MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
-	      segmentMatch != chamberMatch->segmentMatches.end(); ++segmentMatch, index_segment++) {
-	    
-	    float segmentX = segmentMatch->x;
-	    float segmentY = segmentMatch->y ;
-	    float segmentdXdZ = segmentMatch->dXdZ;
-	    float segmentdYdZ = segmentMatch->dYdZ;
-	    float segmentXerr = segmentMatch->xErr;
-	    float segmentYerr = segmentMatch->yErr;
-	    float segmentdXdZerr = segmentMatch->dXdZErr;
-	    float segmentdYdZerr = segmentMatch->dYdZErr;
-	    
-	    CSCSegmentRef segmentCSC = segmentMatch->cscSegmentRef;
-	    DTRecSegment4DRef segmentDT = segmentMatch->dtSegmentRef;
-	    
-	    bool segment_arbitrated_Ok = (segmentMatch->isMask(reco::MuonSegmentMatch::BestInChamberByDR) && 
-					  segmentMatch->isMask(reco::MuonSegmentMatch::BelongsToTrackByDR));
-	    
-	    std::string ARBITRATED(" ***Arbitrated Off*** ");
-	    if (segment_arbitrated_Ok) ARBITRATED = " ***ARBITRATED OK*** ";
+        int wheel, station, sector;
+        int endcap, /*station, */ ring, chamber;
 
-	    if (subdet == MuonSubdetId::DT) {	      
-	      edm::LogVerbatim("MuonTrackProducer")
-		<<"\n\t segment index: "<<index_segment << ARBITRATED
-		<<"\n\t  Local Position (X,Y)=("<<segmentX<<","<<segmentY<<") +/- ("<<segmentXerr<<","<<segmentYerr<<"), " 
-		<<"\n\t  Local Direction (dXdZ,dYdZ)=("<<segmentdXdZ<<","<<segmentdYdZ<<") +/- ("<<segmentdXdZerr<<","<<segmentdYdZerr<<")"; 
-	      
-	      if (!segment_arbitrated_Ok) continue;
-	      
-	      if (segmentDT.get() != nullptr) {
-		const DTRecSegment4D* segment = segmentDT.get();
-		
-		edm::LogVerbatim("MuonTrackProducer")<<"\t ===> MATCHING with DT segment with index = "<<segmentDT.key();
-		
-		if(segment->hasPhi()) {
-		  const DTChamberRecSegment2D* phiSeg = segment->phiSegment();
-		  std::vector<const TrackingRecHit*> phiHits = phiSeg->recHits();
+        edm::LogVerbatim("MuonTrackProducer")
+            << "Number of chambers: " << muon->matches().size()
+            << ", arbitrated: "
+            << muon->numberOfMatches(reco::Muon::SegmentAndTrackArbitration);
+        unsigned int index_chamber = 0;
+
+        for (std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch =
+                 muon->matches().begin();
+             chamberMatch != muon->matches().end();
+             ++chamberMatch, index_chamber++) {
+          std::stringstream chamberStr;
+          chamberStr << "\nchamber index: " << index_chamber;
+
+          int subdet = chamberMatch->detector();
+          DetId did = chamberMatch->id;
+
+          if (subdet == MuonSubdetId::DT) {
+            DTChamberId dtdetid = DTChamberId(did);
+            wheel = dtdetid.wheel();
+            station = dtdetid.station();
+            sector = dtdetid.sector();
+            chamberStr << ", DT chamber Wh:" << wheel << ",St:" << station
+                       << ",Se:" << sector;
+          } else if (subdet == MuonSubdetId::CSC) {
+            CSCDetId cscdetid = CSCDetId(did);
+            endcap = cscdetid.endcap();
+            station = cscdetid.station();
+            ring = cscdetid.ring();
+            chamber = cscdetid.chamber();
+            chamberStr << ", CSC chamber End:" << endcap << ",St:" << station
+                       << ",Ri:" << ring << ",Ch:" << chamber;
+          }
+
+          chamberStr << ", Number of segments: "
+                     << chamberMatch->segmentMatches.size();
+          edm::LogVerbatim("MuonTrackProducer") << chamberStr.str();
+
+          unsigned int index_segment = 0;
+
+          for (std::vector<reco::MuonSegmentMatch>::const_iterator
+                   segmentMatch = chamberMatch->segmentMatches.begin();
+               segmentMatch != chamberMatch->segmentMatches.end();
+               ++segmentMatch, index_segment++) {
+
+            float segmentX = segmentMatch->x;
+            float segmentY = segmentMatch->y;
+            float segmentdXdZ = segmentMatch->dXdZ;
+            float segmentdYdZ = segmentMatch->dYdZ;
+            float segmentXerr = segmentMatch->xErr;
+            float segmentYerr = segmentMatch->yErr;
+            float segmentdXdZerr = segmentMatch->dXdZErr;
+            float segmentdYdZerr = segmentMatch->dYdZErr;
+
+            CSCSegmentRef segmentCSC = segmentMatch->cscSegmentRef;
+            DTRecSegment4DRef segmentDT = segmentMatch->dtSegmentRef;
+
+            bool segment_arbitrated_Ok =
+                (segmentMatch->isMask(
+                     reco::MuonSegmentMatch::BestInChamberByDR) &&
+                 segmentMatch->isMask(
+                     reco::MuonSegmentMatch::BelongsToTrackByDR));
+
+            std::string ARBITRATED(" ***Arbitrated Off*** ");
+            if (segment_arbitrated_Ok)
+              ARBITRATED = " ***ARBITRATED OK*** ";
+
+            if (subdet == MuonSubdetId::DT) {
+              edm::LogVerbatim("MuonTrackProducer")
+                  << "\n\t segment index: " << index_segment << ARBITRATED
+                  << "\n\t  Local Position (X,Y)=(" << segmentX << ","
+                  << segmentY << ") +/- (" << segmentXerr << "," << segmentYerr
+                  << "), "
+                  << "\n\t  Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << ","
+                  << segmentdYdZ << ") +/- (" << segmentdXdZerr << ","
+                  << segmentdYdZerr << ")";
+
+              if (!segment_arbitrated_Ok)
+                continue;
+
+              if (segmentDT.get() != nullptr) {
+                const DTRecSegment4D *segment = segmentDT.get();
+
+                edm::LogVerbatim("MuonTrackProducer")
+                    << "\t ===> MATCHING with DT segment with index = "
+                    << segmentDT.key();
+
+                if (segment->hasPhi()) {
+                  const DTChamberRecSegment2D *phiSeg = segment->phiSegment();
+                  std::vector<const TrackingRecHit *> phiHits =
+                      phiSeg->recHits();
                   unsigned int nHitsAdded = 0;
-		  for(std::vector<const TrackingRecHit*>::const_iterator ihit = phiHits.begin();
-		      ihit != phiHits.end(); ++ihit) {
-		    TrackingRecHit* seghit = (*ihit)->clone();
-		    newTrk->appendHitPattern(*seghit, ttopo);
-		    //		    edm::LogVerbatim("MuonTrackProducer")<<"hit pattern for position "<<index_hit<<" set to:";
-		    //		    newTrk->hitPattern().printHitPattern(index_hit, std::cout);
-		    selectedTrackHits->push_back( seghit );
+                  for (std::vector<const TrackingRecHit *>::const_iterator
+                           ihit = phiHits.begin();
+                       ihit != phiHits.end(); ++ihit) {
+                    TrackingRecHit *seghit = (*ihit)->clone();
+                    newTrk->appendHitPattern(*seghit, ttopo);
+                    //		    edm::LogVerbatim("MuonTrackProducer")<<"hit
+                    // pattern for position "<<index_hit<<" set to:";
+                    //		    newTrk->hitPattern().printHitPattern(index_hit,
+                    // std::cout);
+                    selectedTrackHits->push_back(seghit);
                     ++nHitsAdded;
-		  }
-                  newExtra->setHits( rHits, hidx, nHitsAdded );
+                  }
+                  newExtra->setHits(rHits, hidx, nHitsAdded);
                   hidx += nHitsAdded;
-		}
-		
-		if(segment->hasZed()) {
-		  const DTSLRecSegment2D* zSeg = (*segment).zSegment();
-		  std::vector<const TrackingRecHit*> zedHits = zSeg->recHits();
-                  unsigned int nHitsAdded = 0;
-		  for(std::vector<const TrackingRecHit*>::const_iterator ihit = zedHits.begin();
-		      ihit != zedHits.end(); ++ihit) {
-		    TrackingRecHit* seghit = (*ihit)->clone();
-		    newTrk->appendHitPattern(*seghit, ttopo);
-		    //		    edm::LogVerbatim("MuonTrackProducer")<<"hit pattern for position "<<index_hit<<" set to:";
-		    //		    newTrk->hitPattern().printHitPattern(index_hit, std::cout);
-		    selectedTrackHits->push_back( seghit );
-                    ++nHitsAdded;
-		  }
-                  newExtra->setHits( rHits, hidx, nHitsAdded );
-                  hidx += nHitsAdded;
-		}
-	      } else edm::LogWarning("MuonTrackProducer")<<"\n***WARNING: UNMATCHED DT segment ! \n";
-	    } // if (subdet == MuonSubdetId::DT)
+                }
 
-	    else if (subdet == MuonSubdetId::CSC) {
-	      edm::LogVerbatim("MuonTrackProducer")
-		<<"\n\t segment index: "<<index_segment << ARBITRATED
-		<<"\n\t  Local Position (X,Y)=("<<segmentX<<","<<segmentY<<") +/- ("<<segmentXerr<<","<<segmentYerr<<"), " 
-		<<"\n\t  Local Direction (dXdZ,dYdZ)=("<<segmentdXdZ<<","<<segmentdYdZ<<") +/- ("<<segmentdXdZerr<<","<<segmentdYdZerr<<")"; 
-	      
-	      if (!segment_arbitrated_Ok) continue;
-	      
-	      if (segmentCSC.get() != nullptr) {
-		const CSCSegment* segment = segmentCSC.get();
-		
-		edm::LogVerbatim("MuonTrackProducer")<<"\t ===> MATCHING with CSC segment with index = "<<segmentCSC.key();
-		
-		std::vector<const TrackingRecHit*> hits = segment->recHits();
+                if (segment->hasZed()) {
+                  const DTSLRecSegment2D *zSeg = (*segment).zSegment();
+                  std::vector<const TrackingRecHit *> zedHits = zSeg->recHits();
+                  unsigned int nHitsAdded = 0;
+                  for (std::vector<const TrackingRecHit *>::const_iterator
+                           ihit = zedHits.begin();
+                       ihit != zedHits.end(); ++ihit) {
+                    TrackingRecHit *seghit = (*ihit)->clone();
+                    newTrk->appendHitPattern(*seghit, ttopo);
+                    //		    edm::LogVerbatim("MuonTrackProducer")<<"hit
+                    // pattern for position "<<index_hit<<" set to:";
+                    //		    newTrk->hitPattern().printHitPattern(index_hit,
+                    // std::cout);
+                    selectedTrackHits->push_back(seghit);
+                    ++nHitsAdded;
+                  }
+                  newExtra->setHits(rHits, hidx, nHitsAdded);
+                  hidx += nHitsAdded;
+                }
+              } else
+                edm::LogWarning("MuonTrackProducer")
+                    << "\n***WARNING: UNMATCHED DT segment ! \n";
+            } // if (subdet == MuonSubdetId::DT)
+
+            else if (subdet == MuonSubdetId::CSC) {
+              edm::LogVerbatim("MuonTrackProducer")
+                  << "\n\t segment index: " << index_segment << ARBITRATED
+                  << "\n\t  Local Position (X,Y)=(" << segmentX << ","
+                  << segmentY << ") +/- (" << segmentXerr << "," << segmentYerr
+                  << "), "
+                  << "\n\t  Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << ","
+                  << segmentdYdZ << ") +/- (" << segmentdXdZerr << ","
+                  << segmentdYdZerr << ")";
+
+              if (!segment_arbitrated_Ok)
+                continue;
+
+              if (segmentCSC.get() != nullptr) {
+                const CSCSegment *segment = segmentCSC.get();
+
+                edm::LogVerbatim("MuonTrackProducer")
+                    << "\t ===> MATCHING with CSC segment with index = "
+                    << segmentCSC.key();
+
+                std::vector<const TrackingRecHit *> hits = segment->recHits();
                 unsigned int nHitsAdded = 0;
-		for(std::vector<const TrackingRecHit*>::const_iterator ihit = hits.begin();
-		    ihit != hits.end(); ++ihit) {
-		  TrackingRecHit* seghit = (*ihit)->clone();
-		  newTrk->appendHitPattern(*seghit, ttopo);
-		  //		    edm::LogVerbatim("MuonTrackProducer")<<"hit pattern for position "<<index_hit<<" set to:";
-		  //		    newTrk->hitPattern().printHitPattern(index_hit, std::cout);
-		  selectedTrackHits->push_back( seghit );
+                for (std::vector<const TrackingRecHit *>::const_iterator ihit =
+                         hits.begin();
+                     ihit != hits.end(); ++ihit) {
+                  TrackingRecHit *seghit = (*ihit)->clone();
+                  newTrk->appendHitPattern(*seghit, ttopo);
+                  //		    edm::LogVerbatim("MuonTrackProducer")<<"hit
+                  // pattern for position "<<index_hit<<" set to:";
+                  //		    newTrk->hitPattern().printHitPattern(index_hit,
+                  // std::cout);
+                  selectedTrackHits->push_back(seghit);
                   ++nHitsAdded;
-		}
-                newExtra->setHits( rHits, hidx, nHitsAdded );
+                }
+                newExtra->setHits(rHits, hidx, nHitsAdded);
                 hidx += nHitsAdded;
-	      } else edm::LogWarning("MuonTrackProducer")<<"\n***WARNING: UNMATCHED CSC segment ! \n";
-	    }  //  else if (subdet == MuonSubdetId::CSC)
+              } else
+                edm::LogWarning("MuonTrackProducer")
+                    << "\n***WARNING: UNMATCHED CSC segment ! \n";
+            } //  else if (subdet == MuonSubdetId::CSC)
 
-	  } // loop on vector<MuonSegmentMatch>	  
-	} // loop on vector<MuonChamberMatch>	
-      } // if (trackType == "innerTrackPlusSegments")
-      
-      //      edm::LogVerbatim("MuonTrackProducer")<<"\n printing final hit_pattern";
-      //      newTrk->hitPattern().print();
-      
-      selectedTracks->push_back( *newTrk );
-      selectedTrackExtras->push_back( *newExtra );
+          } // loop on vector<MuonSegmentMatch>
+        }   // loop on vector<MuonChamberMatch>
+      }     // if (trackType == "innerTrackPlusSegments")
+
+      //      edm::LogVerbatim("MuonTrackProducer")<<"\n printing final
+      //      hit_pattern"; newTrk->hitPattern().print();
+
+      selectedTracks->push_back(*newTrk);
+      selectedTrackExtras->push_back(*newExtra);
 
     } // if (isGoodResult)
-  }  // loop on reco::MuonCollection
-  
+  }   // loop on reco::MuonCollection
+
   iEvent.put(std::move(selectedTracks));
   iEvent.put(std::move(selectedTrackExtras));
   iEvent.put(std::move(selectedTrackHits));

--- a/SimMuon/MCTruth/plugins/MuonTrackProducer.h
+++ b/SimMuon/MCTruth/plugins/MuonTrackProducer.h
@@ -1,38 +1,39 @@
 //
 // modified & integrated by Giovanni Abbiendi
-// from code by Arun Luthra: UserCode/luthra/MuonTrackSelector/src/MuonTrackSelector.cc
+// from code by Arun Luthra:
+// UserCode/luthra/MuonTrackSelector/src/MuonTrackSelector.cc
 //
 #ifndef MCTruth_MuonTrackProducer_h
 #define MCTruth_MuonTrackProducer_h
 
-#include <memory>
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/MuonReco/interface/MuonFwd.h"
-#include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include <memory>
 
 class MuonTrackProducer : public edm::stream::EDProducer<> {
-  public:
-    explicit MuonTrackProducer(const edm::ParameterSet&);
-    ~MuonTrackProducer() override;
+public:
+  explicit MuonTrackProducer(const edm::ParameterSet &);
+  ~MuonTrackProducer() override;
 
-  private:
-    void produce(edm::Event&, const edm::EventSetup&) override;
-  
-    edm::Handle<reco::MuonCollection> muonCollectionH;
-    edm::Handle<DTRecSegment4DCollection> dtSegmentCollectionH_;
-    edm::Handle<CSCSegmentCollection> cscSegmentCollectionH_;
+private:
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
-    edm::EDGetTokenT<reco::MuonCollection> muonsToken;
-    edm::EDGetTokenT<DTRecSegment4DCollection> inputDTRecSegment4DToken_;
-    edm::EDGetTokenT<CSCSegmentCollection> inputCSCSegmentToken_;
+  edm::Handle<reco::MuonCollection> muonCollectionH;
+  edm::Handle<DTRecSegment4DCollection> dtSegmentCollectionH_;
+  edm::Handle<CSCSegmentCollection> cscSegmentCollectionH_;
 
-    std::vector<std::string> selectionTags;
-    std::string trackType;
-    const edm::ParameterSet parset_;
+  edm::EDGetTokenT<reco::MuonCollection> muonsToken;
+  edm::EDGetTokenT<DTRecSegment4DCollection> inputDTRecSegment4DToken_;
+  edm::EDGetTokenT<CSCSegmentCollection> inputCSCSegmentToken_;
+
+  std::vector<std::string> selectionTags;
+  std::string trackType;
+  const edm::ParameterSet parset_;
 };
 
 #endif

--- a/SimMuon/MCTruth/plugins/SealModule.cc
+++ b/SimMuon/MCTruth/plugins/SealModule.cc
@@ -1,9 +1,8 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "SimMuon/MCTruth/interface/CSCTruthTest.h"
 #include "SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.h"
 #include "SimMuon/MCTruth/plugins/MuonTrackProducer.h"
-#include "SimMuon/MCTruth/interface/CSCTruthTest.h"
-#include "FWCore/PluginManager/interface/ModuleDef.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
 
 DEFINE_FWK_MODULE(MuonAssociatorEDProducer);
 DEFINE_FWK_MODULE(MuonTrackProducer);

--- a/SimMuon/MCTruth/plugins/SeedToTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/SeedToTrackProducer.cc
@@ -2,8 +2,9 @@
 //
 // Package:    SeedToTrackProducer
 // Class:      SeedToTrackProducer
-// 
-/**\class SeedToTrackProducer SeedToTrackProducer.cc hugues/SeedToTrackProducer/plugins/SeedToTrackProducer.cc
+//
+/**\class SeedToTrackProducer SeedToTrackProducer.cc
+ hugues/SeedToTrackProducer/plugins/SeedToTrackProducer.cc
 
  Description: [one line class summary]
 
@@ -25,138 +26,153 @@
 //
 // constructors and destructor
 //
-SeedToTrackProducer::SeedToTrackProducer(const edm::ParameterSet& iConfig)
-{
-    
-  L2seedsTagT_ = consumes<TrajectorySeedCollection>(iConfig.getParameter<edm::InputTag>("L2seedsCollection"));
-  L2seedsTagS_ = consumes<edm::View<TrajectorySeed> >(iConfig.getParameter<edm::InputTag>("L2seedsCollection"));
+SeedToTrackProducer::SeedToTrackProducer(const edm::ParameterSet &iConfig) {
 
-    produces<reco::TrackCollection>();
-    produces<reco::TrackExtraCollection>();
-    produces<TrackingRecHitCollection>();
+  L2seedsTagT_ = consumes<TrajectorySeedCollection>(
+      iConfig.getParameter<edm::InputTag>("L2seedsCollection"));
+  L2seedsTagS_ = consumes<edm::View<TrajectorySeed>>(
+      iConfig.getParameter<edm::InputTag>("L2seedsCollection"));
+
+  produces<reco::TrackCollection>();
+  produces<reco::TrackExtraCollection>();
+  produces<TrackingRecHitCollection>();
 }
 
-SeedToTrackProducer::~SeedToTrackProducer()
-{
-}
+SeedToTrackProducer::~SeedToTrackProducer() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-SeedToTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    using namespace edm;
-    using namespace std;
+void SeedToTrackProducer::produce(edm::Event &iEvent,
+                                  const edm::EventSetup &iSetup) {
+  using namespace edm;
+  using namespace std;
 
-    std::unique_ptr<reco::TrackCollection> selectedTracks(new reco::TrackCollection);
-    std::unique_ptr<reco::TrackExtraCollection> selectedTrackExtras( new reco::TrackExtraCollection() );
-    std::unique_ptr<TrackingRecHitCollection> selectedTrackHits( new TrackingRecHitCollection() );
-    
-    reco::TrackRefProd rTracks = iEvent.getRefBeforePut<reco::TrackCollection>();
-    reco::TrackExtraRefProd rTrackExtras = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
-    TrackingRecHitRefProd rHits = iEvent.getRefBeforePut<TrackingRecHitCollection>();
-    
-    edm::Ref<reco::TrackExtraCollection>::key_type hidx = 0;
-    edm::Ref<reco::TrackExtraCollection>::key_type idx = 0;
-    
-    // magnetic fied and detector geometry
-    iSetup.get<IdealMagneticFieldRecord>().get(theMGField);
-    iSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
+  std::unique_ptr<reco::TrackCollection> selectedTracks(
+      new reco::TrackCollection);
+  std::unique_ptr<reco::TrackExtraCollection> selectedTrackExtras(
+      new reco::TrackExtraCollection());
+  std::unique_ptr<TrackingRecHitCollection> selectedTrackHits(
+      new TrackingRecHitCollection());
 
-    edm::ESHandle<TrackerTopology> httopo;
-    iSetup.get<TrackerTopologyRcd>().get(httopo);
-    const TrackerTopology& ttopo = *httopo;
+  reco::TrackRefProd rTracks = iEvent.getRefBeforePut<reco::TrackCollection>();
+  reco::TrackExtraRefProd rTrackExtras =
+      iEvent.getRefBeforePut<reco::TrackExtraCollection>();
+  TrackingRecHitRefProd rHits =
+      iEvent.getRefBeforePut<TrackingRecHitCollection>();
 
-    // now read the L2 seeds collection :
-    edm::Handle<TrajectorySeedCollection> L2seedsCollection;
-    iEvent.getByToken(L2seedsTagT_,L2seedsCollection);
-    const std::vector<TrajectorySeed>* L2seeds = nullptr;
-    if (L2seedsCollection.isValid()) L2seeds = L2seedsCollection.product();
-    else  edm::LogError("SeedToTrackProducer") << "L2 seeds collection not found !! " << endl;
-    
-    edm::Handle<edm::View<TrajectorySeed> > seedHandle;
-    iEvent.getByToken(L2seedsTagS_, seedHandle);
-    
-    
-    int countRH = 0;
+  edm::Ref<reco::TrackExtraCollection>::key_type hidx = 0;
+  edm::Ref<reco::TrackExtraCollection>::key_type idx = 0;
 
-    // now  loop on the seeds :
-    for (unsigned int i = 0; i < L2seeds->size() ; i++){
-        
-        
-        //get the kinematic extrapolation from the seed
-        TrajectoryStateOnSurface theTrajectory = seedTransientState(L2seeds->at(i));
-        float seedEta =  theTrajectory.globalMomentum().eta();
-        float seedPhi =  theTrajectory.globalMomentum().phi();
-        float seedPt =  theTrajectory.globalMomentum().perp();
-        CovarianceMatrix matrixSeedErr = theTrajectory.curvilinearError().matrix();
-        edm::LogVerbatim("SeedToTrackProducer") <<  "seedPt=" << seedPt << " seedEta=" << seedEta << " seedPhi=" << seedPhi << endl;
-        /*AlgebraicSymMatrix66 errors = theTrajectory.cartesianError().matrix();
-        double partialPterror = errors(3,3)*pow(theTrajectory.globalMomentum().x(),2) + errors(4,4)*pow(theTrajectory.globalMomentum().y(),2);
-	edm::LogVerbatim("SeedToTrackProducer") <<  "seedPtError=" << sqrt(partialPterror)/theTrajectory.globalMomentum().perp() << "seedPhiError=" << theTrajectory.curvilinearError().matrix()(2,2) << endl;*/ 
-        //fill the track in a way that its pt, phi and eta will be the same as the seed
-        math::XYZPoint initPoint(0,0,0);
-        math::XYZVector initMom(seedPt*cos(seedPhi),seedPt*sin(seedPhi),seedPt*sinh(seedEta));
-        reco::Track theTrack(1, 1, //dummy Chi2 and ndof
-                             initPoint, initMom,
-                             1, matrixSeedErr,
-                             reco::TrackBase::TrackAlgorithm::globalMuon, reco::TrackBase::TrackQuality::tight);
+  // magnetic fied and detector geometry
+  iSetup.get<IdealMagneticFieldRecord>().get(theMGField);
+  iSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
 
-        //fill the extra track with dummy information
-        math::XYZPoint dummyFinalPoint(1,1,1);
-        math::XYZVector dummyFinalMom(0,0,10);
-        edm::RefToBase<TrajectorySeed> seed(seedHandle, i);
-        CovarianceMatrix matrixExtra = ROOT::Math::SMatrixIdentity();
-        reco::TrackExtra theTrackExtra(dummyFinalPoint, dummyFinalMom, true, initPoint, initMom, true,
-                                  matrixSeedErr, 1,
-                                  matrixExtra, 2,
-                                  (L2seeds->at(i)).direction(), seed);
-        theTrack.setExtra( reco::TrackExtraRef( rTrackExtras, idx++ ) );
-        edm::LogVerbatim("SeedToTrackProducer") << "trackPt=" << theTrack.pt() << " trackEta=" << theTrack.eta() << " trackPhi=" << theTrack.phi() << endl;
-        edm::LogVerbatim("SeedToTrackProducer") << "trackPtError=" << theTrack.ptError() << "trackPhiError=" << theTrack.phiError() << endl;
- 
-        //fill the seed segments in the track
-        unsigned int nHitsAdded = 0;
-        for(TrajectorySeed::recHitContainer::const_iterator itRecHits=(L2seeds->at(i)).recHits().first; itRecHits!=(L2seeds->at(i)).recHits().second; ++itRecHits, ++countRH) {
-            TrackingRecHit* hit = (itRecHits)->clone();
-            theTrack.appendHitPattern(*hit, ttopo);
-            selectedTrackHits->push_back(hit);
-            nHitsAdded++;
-        }
-        theTrackExtra.setHits( rHits, hidx, nHitsAdded );
-        hidx += nHitsAdded;
-        selectedTracks->push_back(theTrack);
-        selectedTrackExtras->push_back(theTrackExtra);
+  edm::ESHandle<TrackerTopology> httopo;
+  iSetup.get<TrackerTopologyRcd>().get(httopo);
+  const TrackerTopology &ttopo = *httopo;
 
+  // now read the L2 seeds collection :
+  edm::Handle<TrajectorySeedCollection> L2seedsCollection;
+  iEvent.getByToken(L2seedsTagT_, L2seedsCollection);
+  const std::vector<TrajectorySeed> *L2seeds = nullptr;
+  if (L2seedsCollection.isValid())
+    L2seeds = L2seedsCollection.product();
+  else
+    edm::LogError("SeedToTrackProducer")
+        << "L2 seeds collection not found !! " << endl;
+
+  edm::Handle<edm::View<TrajectorySeed>> seedHandle;
+  iEvent.getByToken(L2seedsTagS_, seedHandle);
+
+  int countRH = 0;
+
+  // now  loop on the seeds :
+  for (unsigned int i = 0; i < L2seeds->size(); i++) {
+
+    // get the kinematic extrapolation from the seed
+    TrajectoryStateOnSurface theTrajectory = seedTransientState(L2seeds->at(i));
+    float seedEta = theTrajectory.globalMomentum().eta();
+    float seedPhi = theTrajectory.globalMomentum().phi();
+    float seedPt = theTrajectory.globalMomentum().perp();
+    CovarianceMatrix matrixSeedErr = theTrajectory.curvilinearError().matrix();
+    edm::LogVerbatim("SeedToTrackProducer")
+        << "seedPt=" << seedPt << " seedEta=" << seedEta
+        << " seedPhi=" << seedPhi << endl;
+    /*AlgebraicSymMatrix66 errors = theTrajectory.cartesianError().matrix();
+    double partialPterror =
+    errors(3,3)*pow(theTrajectory.globalMomentum().x(),2) +
+    errors(4,4)*pow(theTrajectory.globalMomentum().y(),2);
+    edm::LogVerbatim("SeedToTrackProducer") <<  "seedPtError=" <<
+    sqrt(partialPterror)/theTrajectory.globalMomentum().perp() <<
+    "seedPhiError=" << theTrajectory.curvilinearError().matrix()(2,2) << endl;*/
+    // fill the track in a way that its pt, phi and eta will be the same as the
+    // seed
+    math::XYZPoint initPoint(0, 0, 0);
+    math::XYZVector initMom(seedPt * cos(seedPhi), seedPt * sin(seedPhi),
+                            seedPt * sinh(seedEta));
+    reco::Track theTrack(1, 1, // dummy Chi2 and ndof
+                         initPoint, initMom, 1, matrixSeedErr,
+                         reco::TrackBase::TrackAlgorithm::globalMuon,
+                         reco::TrackBase::TrackQuality::tight);
+
+    // fill the extra track with dummy information
+    math::XYZPoint dummyFinalPoint(1, 1, 1);
+    math::XYZVector dummyFinalMom(0, 0, 10);
+    edm::RefToBase<TrajectorySeed> seed(seedHandle, i);
+    CovarianceMatrix matrixExtra = ROOT::Math::SMatrixIdentity();
+    reco::TrackExtra theTrackExtra(
+        dummyFinalPoint, dummyFinalMom, true, initPoint, initMom, true,
+        matrixSeedErr, 1, matrixExtra, 2, (L2seeds->at(i)).direction(), seed);
+    theTrack.setExtra(reco::TrackExtraRef(rTrackExtras, idx++));
+    edm::LogVerbatim("SeedToTrackProducer")
+        << "trackPt=" << theTrack.pt() << " trackEta=" << theTrack.eta()
+        << " trackPhi=" << theTrack.phi() << endl;
+    edm::LogVerbatim("SeedToTrackProducer")
+        << "trackPtError=" << theTrack.ptError()
+        << "trackPhiError=" << theTrack.phiError() << endl;
+
+    // fill the seed segments in the track
+    unsigned int nHitsAdded = 0;
+    for (TrajectorySeed::recHitContainer::const_iterator itRecHits =
+             (L2seeds->at(i)).recHits().first;
+         itRecHits != (L2seeds->at(i)).recHits().second;
+         ++itRecHits, ++countRH) {
+      TrackingRecHit *hit = (itRecHits)->clone();
+      theTrack.appendHitPattern(*hit, ttopo);
+      selectedTrackHits->push_back(hit);
+      nHitsAdded++;
     }
-    iEvent.put(std::move(selectedTracks));
-    iEvent.put(std::move(selectedTrackExtras));
-    iEvent.put(std::move(selectedTrackHits));
-    
+    theTrackExtra.setHits(rHits, hidx, nHitsAdded);
+    hidx += nHitsAdded;
+    selectedTracks->push_back(theTrack);
+    selectedTrackExtras->push_back(theTrackExtra);
+  }
+  iEvent.put(std::move(selectedTracks));
+  iEvent.put(std::move(selectedTrackExtras));
+  iEvent.put(std::move(selectedTrackHits));
 }
 
-TrajectoryStateOnSurface SeedToTrackProducer::seedTransientState(const TrajectorySeed& tmpSeed){
-    
-    PTrajectoryStateOnDet tmpTSOD = tmpSeed.startingState();
-    DetId tmpDetId(tmpTSOD.detId());
-    const GeomDet* tmpGeomDet = theTrackingGeometry->idToDet(tmpDetId);
-    TrajectoryStateOnSurface tmpTSOS = trajectoryStateTransform::transientState(tmpTSOD, &(tmpGeomDet->surface()), &(*theMGField));
-    return tmpTSOS;
+TrajectoryStateOnSurface
+SeedToTrackProducer::seedTransientState(const TrajectorySeed &tmpSeed) {
+
+  PTrajectoryStateOnDet tmpTSOD = tmpSeed.startingState();
+  DetId tmpDetId(tmpTSOD.detId());
+  const GeomDet *tmpGeomDet = theTrackingGeometry->idToDet(tmpDetId);
+  TrajectoryStateOnSurface tmpTSOS = trajectoryStateTransform::transientState(
+      tmpTSOD, &(tmpGeomDet->surface()), &(*theMGField));
+  return tmpTSOS;
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-SeedToTrackProducer::beginJob()
-{
-}
+// ------------ method called once each job just before starting event loop
+// ------------
+void SeedToTrackProducer::beginJob() {}
 
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-SeedToTrackProducer::endJob() {
-}
+// ------------ method called once each job just after ending the event loop
+// ------------
+void SeedToTrackProducer::endJob() {}
 
-//define this as a plug-in
+// define this as a plug-in
 DEFINE_FWK_MODULE(SeedToTrackProducer);

--- a/SimMuon/MCTruth/plugins/SeedToTrackProducer.h
+++ b/SimMuon/MCTruth/plugins/SeedToTrackProducer.h
@@ -2,10 +2,11 @@
 //
 // Package:    SeedToTrackProducer
 // Class:      SeedToTrackProducer
-// 
-/**\class SeedToTrackProducer SeedToTrackProducer.cc hugues/SeedToTrackProducer/plugins/SeedToTrackProducer.cc
+//
+/**\class SeedToTrackProducer SeedToTrackProducer.cc
+ hugues/SeedToTrackProducer/plugins/SeedToTrackProducer.cc
 
- Description: 
+ Description:
 
 */
 //
@@ -18,27 +19,27 @@
 #include <memory>
 
 // user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
-#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 
-#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 //
 // class declaration
@@ -47,21 +48,20 @@
 typedef math::Error<5>::type CovarianceMatrix;
 
 class SeedToTrackProducer : public edm::one::EDProducer<> {
-   public:
-      explicit SeedToTrackProducer(const edm::ParameterSet&);
-      ~SeedToTrackProducer() override;
+public:
+  explicit SeedToTrackProducer(const edm::ParameterSet &);
+  ~SeedToTrackProducer() override;
 
-   private:
-      void beginJob() override;
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      void endJob() override;
-      virtual TrajectoryStateOnSurface seedTransientState(const TrajectorySeed&);
-      // ----------member data ---------------------------
-    
-    edm::EDGetTokenT<TrajectorySeedCollection> L2seedsTagT_;
-    edm::EDGetTokenT<edm::View<TrajectorySeed> > L2seedsTagS_;
-    
-    edm::ESHandle<MagneticField> theMGField;
-    edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
+private:
+  void beginJob() override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  void endJob() override;
+  virtual TrajectoryStateOnSurface seedTransientState(const TrajectorySeed &);
+  // ----------member data ---------------------------
+
+  edm::EDGetTokenT<TrajectorySeedCollection> L2seedsTagT_;
+  edm::EDGetTokenT<edm::View<TrajectorySeed>> L2seedsTagS_;
+
+  edm::ESHandle<MagneticField> theMGField;
+  edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
 };
-

--- a/SimMuon/MCTruth/plugins/SimMuFilter.cc
+++ b/SimMuon/MCTruth/plugins/SimMuFilter.cc
@@ -1,113 +1,112 @@
-#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-class SimMuFilter : public edm::stream::EDFilter<>
-{
- public:
+class SimMuFilter : public edm::stream::EDFilter<> {
+public:
+  explicit SimMuFilter(const edm::ParameterSet &);
+  ~SimMuFilter() override;
 
-   explicit SimMuFilter(const edm::ParameterSet&);
-   ~SimMuFilter() override;
+private:
+  virtual void beginJob();
+  virtual void endJob();
+  bool filter(edm::Event &, const edm::EventSetup &) override;
 
- private:
+private:
+  edm::EDGetTokenT<std::vector<SimTrack>> simTracksToken_;
+  edm::EDGetTokenT<edm::PSimHitContainer> simHitsMuonRPCToken_;
+  edm::EDGetTokenT<edm::PSimHitContainer> simHitsMuonCSCToken_;
+  edm::EDGetTokenT<edm::PSimHitContainer> simHitsMuonDTToken_;
 
-   virtual void beginJob();
-   virtual void endJob();
-   bool filter(edm::Event&, const edm::EventSetup&) override;
-   
- private:
-   
-   edm::EDGetTokenT<std::vector<SimTrack> > simTracksToken_;
-   edm::EDGetTokenT<edm::PSimHitContainer> simHitsMuonRPCToken_;
-   edm::EDGetTokenT<edm::PSimHitContainer> simHitsMuonCSCToken_;
-   edm::EDGetTokenT<edm::PSimHitContainer> simHitsMuonDTToken_;
-   
-   edm::Handle<std::vector<SimTrack> > simTracksHandle;
-   edm::Handle<edm::PSimHitContainer> simHitsMuonRPCHandle;
-   edm::Handle<edm::PSimHitContainer> simHitsMuonCSCHandle;
-   edm::Handle<edm::PSimHitContainer> simHitsMuonDTHandle;
-   
-   int nMuSel_;
+  edm::Handle<std::vector<SimTrack>> simTracksHandle;
+  edm::Handle<edm::PSimHitContainer> simHitsMuonRPCHandle;
+  edm::Handle<edm::PSimHitContainer> simHitsMuonCSCHandle;
+  edm::Handle<edm::PSimHitContainer> simHitsMuonDTHandle;
+
+  int nMuSel_;
 };
 
-SimMuFilter::SimMuFilter(const edm::ParameterSet& iConfig)
-{
-   simTracksToken_    = consumes<std::vector<SimTrack> >(iConfig.getParameter<edm::InputTag>("simTracksInput"));
-   simHitsMuonRPCToken_ = consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("simHitsMuonRPCInput"));
-   simHitsMuonCSCToken_ = consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("simHitsMuonCSCInput"));
-   simHitsMuonDTToken_ = consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("simHitsMuonDTInput"));
-   nMuSel_             = iConfig.getParameter<int>("nMuSel");
+SimMuFilter::SimMuFilter(const edm::ParameterSet &iConfig) {
+  simTracksToken_ = consumes<std::vector<SimTrack>>(
+      iConfig.getParameter<edm::InputTag>("simTracksInput"));
+  simHitsMuonRPCToken_ = consumes<edm::PSimHitContainer>(
+      iConfig.getParameter<edm::InputTag>("simHitsMuonRPCInput"));
+  simHitsMuonCSCToken_ = consumes<edm::PSimHitContainer>(
+      iConfig.getParameter<edm::InputTag>("simHitsMuonCSCInput"));
+  simHitsMuonDTToken_ = consumes<edm::PSimHitContainer>(
+      iConfig.getParameter<edm::InputTag>("simHitsMuonDTInput"));
+  nMuSel_ = iConfig.getParameter<int>("nMuSel");
 }
 
-SimMuFilter::~SimMuFilter()
-{
+SimMuFilter::~SimMuFilter() {}
+
+bool SimMuFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  using namespace edm;
+
+  iEvent.getByToken(simTracksToken_, simTracksHandle);
+  iEvent.getByToken(simHitsMuonRPCToken_, simHitsMuonRPCHandle);
+  iEvent.getByToken(simHitsMuonCSCToken_, simHitsMuonCSCHandle);
+  iEvent.getByToken(simHitsMuonDTToken_, simHitsMuonDTHandle);
+
+  const std::vector<SimTrack> &simTracks = *simTracksHandle.product();
+
+  int nTracks = simTracks.size();
+
+  int nPass = 0;
+
+  for (int it = 0; it < nTracks; it++) {
+    SimTrack simTrk = simTracks[it];
+
+    int pdgId = simTrk.type();
+    float pt = simTrk.momentum().pt();
+
+    if (abs(pdgId) != 13)
+      continue;
+    if (pt < 3.)
+      continue;
+
+    int nSimHitRPC = 0;
+    int nSimHitCSC = 0;
+    int nSimHitDT = 0;
+
+    for (PSimHitContainer::const_iterator simHitIt =
+             simHitsMuonRPCHandle->begin();
+         simHitIt != simHitsMuonRPCHandle->end(); simHitIt++) {
+      if (simHitIt->trackId() != simTrk.trackId())
+        continue;
+
+      nSimHitRPC++;
+    }
+
+    for (PSimHitContainer::const_iterator simHitIt =
+             simHitsMuonCSCHandle->begin();
+         simHitIt != simHitsMuonCSCHandle->end(); simHitIt++) {
+      if (simHitIt->trackId() != simTrk.trackId())
+        continue;
+
+      nSimHitCSC++;
+    }
+
+    for (PSimHitContainer::const_iterator simHitIt =
+             simHitsMuonDTHandle->begin();
+         simHitIt != simHitsMuonDTHandle->end(); simHitIt++) {
+      if (simHitIt->trackId() != simTrk.trackId())
+        continue;
+
+      nSimHitDT++;
+    }
+
+    if (nSimHitRPC + nSimHitCSC + nSimHitDT > 0)
+      nPass++;
+  }
+
+  return (nPass >= nMuSel_);
 }
 
-bool SimMuFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void SimMuFilter::beginJob() {}
 
-   iEvent.getByToken(simTracksToken_,simTracksHandle);
-   iEvent.getByToken(simHitsMuonRPCToken_,simHitsMuonRPCHandle);
-   iEvent.getByToken(simHitsMuonCSCToken_,simHitsMuonCSCHandle);
-   iEvent.getByToken(simHitsMuonDTToken_,simHitsMuonDTHandle);
-      
-   const std::vector<SimTrack> &simTracks = *simTracksHandle.product();
-   
-   int nTracks = simTracks.size();
+void SimMuFilter::endJob() {}
 
-   int nPass = 0;
-   
-   for(int it=0;it<nTracks;it++)
-     {
-	SimTrack simTrk = simTracks[it];
-	
-	int pdgId = simTrk.type();
-	float pt = simTrk.momentum().pt();
-	
-	if( abs(pdgId) != 13 ) continue;
-	if( pt < 3. ) continue;
-	
-	int nSimHitRPC = 0;
-	int nSimHitCSC = 0;
-	int nSimHitDT = 0;
-
-	for( PSimHitContainer::const_iterator simHitIt = simHitsMuonRPCHandle->begin();simHitIt!=simHitsMuonRPCHandle->end();simHitIt++ )
-	  {
-	     if( simHitIt->trackId() != simTrk.trackId() ) continue;
-	     
-	     nSimHitRPC++;
-	  }	     
-	
-	for( PSimHitContainer::const_iterator simHitIt = simHitsMuonCSCHandle->begin();simHitIt!=simHitsMuonCSCHandle->end();simHitIt++ )
-	  {
-	     if( simHitIt->trackId() != simTrk.trackId() ) continue;
-	     
-	     nSimHitCSC++;
-	  }
-	
-	for( PSimHitContainer::const_iterator simHitIt = simHitsMuonDTHandle->begin();simHitIt!=simHitsMuonDTHandle->end();simHitIt++ )
-	  {
-	     if( simHitIt->trackId() != simTrk.trackId() ) continue;
-	     
-	     nSimHitDT++;
-	  }
-	
-	if( nSimHitRPC+nSimHitCSC+nSimHitDT > 0 ) nPass++;
-     }   
-   
-   return (nPass >= nMuSel_);
-}
-
-void SimMuFilter::beginJob()
-{
-}
-
-void SimMuFilter::endJob()
-{
-}
-
-//define this as a plug-in
+// define this as a plug-in
 DEFINE_FWK_MODULE(SimMuFilter);
-

--- a/SimMuon/MCTruth/src/CSCHitAssociator.cc
+++ b/SimMuon/MCTruth/src/CSCHitAssociator.cc
@@ -1,108 +1,122 @@
-#include "SimMuon/MCTruth/interface/CSCHitAssociator.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
-#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
+#include "SimMuon/MCTruth/interface/CSCHitAssociator.h"
 
-CSCHitAssociator::CSCHitAssociator(const edm::Event& event, const edm::EventSetup& setup, const edm::ParameterSet& conf): 
-  theDigiSimLinks(nullptr),
-  linksTag(conf.getParameter<edm::InputTag>("CSClinksTag"))
-{
-  initEvent(event,setup);
+CSCHitAssociator::CSCHitAssociator(const edm::Event &event,
+                                   const edm::EventSetup &setup,
+                                   const edm::ParameterSet &conf)
+    : theDigiSimLinks(nullptr),
+      linksTag(conf.getParameter<edm::InputTag>("CSClinksTag")) {
+  initEvent(event, setup);
 }
 
-CSCHitAssociator::CSCHitAssociator( const edm::ParameterSet& conf, edm::ConsumesCollector && iC ): 
-  theDigiSimLinks(nullptr),
-  linksTag(conf.getParameter<edm::InputTag>("CSClinksTag"))
-{
+CSCHitAssociator::CSCHitAssociator(const edm::ParameterSet &conf,
+                                   edm::ConsumesCollector &&iC)
+    : theDigiSimLinks(nullptr),
+      linksTag(conf.getParameter<edm::InputTag>("CSClinksTag")) {
   iC.consumes<DigiSimLinks>(linksTag);
 }
 
-void CSCHitAssociator::initEvent(const edm::Event& event, const edm::EventSetup& setup) {
+void CSCHitAssociator::initEvent(const edm::Event &event,
+                                 const edm::EventSetup &setup) {
 
   edm::Handle<DigiSimLinks> digiSimLinks;
-  LogTrace("CSCHitAssociator") <<"getting CSC Strip DigiSimLink collection - "<<linksTag;
+  LogTrace("CSCHitAssociator")
+      << "getting CSC Strip DigiSimLink collection - " << linksTag;
   event.getByLabel(linksTag, digiSimLinks);
   theDigiSimLinks = digiSimLinks.product();
 
   // get CSC Geometry to use CSCLayer methods
   edm::ESHandle<CSCGeometry> mugeom;
-  setup.get<MuonGeometryRecord>().get( mugeom );
+  setup.get<MuonGeometryRecord>().get(mugeom);
   cscgeom = &*mugeom;
 }
 
-std::vector<CSCHitAssociator::SimHitIdpr> CSCHitAssociator::associateCSCHitId(const CSCRecHit2D * cscrechit) const {
+std::vector<CSCHitAssociator::SimHitIdpr>
+CSCHitAssociator::associateCSCHitId(const CSCRecHit2D *cscrechit) const {
   std::vector<SimHitIdpr> simtrackids;
-  
+
   unsigned int detId = cscrechit->geographicalId().rawId();
   int nchannels = cscrechit->nStrips();
-  const CSCLayerGeometry * laygeom = cscgeom->layer(cscrechit->cscDetId())->geometry();
-  
-  DigiSimLinks::const_iterator layerLinks = theDigiSimLinks->find(detId);    
-  
+  const CSCLayerGeometry *laygeom =
+      cscgeom->layer(cscrechit->cscDetId())->geometry();
+
+  DigiSimLinks::const_iterator layerLinks = theDigiSimLinks->find(detId);
+
   if (layerLinks != theDigiSimLinks->end()) {
-    
-    for(int idigi = 0; idigi < nchannels; ++idigi) {
+
+    for (int idigi = 0; idigi < nchannels; ++idigi) {
       // strip and readout channel numbers may differ in ME1/1A
       int istrip = cscrechit->channels(idigi);
       int channel = laygeom->channel(istrip);
-      
-      for (LayerLinks::const_iterator link=layerLinks->begin(); link!=layerLinks->end(); ++link) {
-	int ch = static_cast<int>(link->channel());
-	if (ch == channel) {
-	  SimHitIdpr currentId(link->SimTrackId(), link->eventId());
-	  if (find(simtrackids.begin(), simtrackids.end(), currentId) == simtrackids.end())
-	    simtrackids.push_back(currentId);
-	}
+
+      for (LayerLinks::const_iterator link = layerLinks->begin();
+           link != layerLinks->end(); ++link) {
+        int ch = static_cast<int>(link->channel());
+        if (ch == channel) {
+          SimHitIdpr currentId(link->SimTrackId(), link->eventId());
+          if (find(simtrackids.begin(), simtrackids.end(), currentId) ==
+              simtrackids.end())
+            simtrackids.push_back(currentId);
+        }
       }
     }
-    
-  } else LogTrace("CSCHitAssociator")
-    <<"*** WARNING in CSCHitAssociator::associateCSCHitId - CSC layer "<<detId<<" has no DigiSimLinks !"<<std::endl;   
-  
+
+  } else
+    LogTrace("CSCHitAssociator")
+        << "*** WARNING in CSCHitAssociator::associateCSCHitId - CSC layer "
+        << detId << " has no DigiSimLinks !" << std::endl;
+
   return simtrackids;
 }
 
-
-std::vector<CSCHitAssociator::SimHitIdpr> CSCHitAssociator::associateHitId(const TrackingRecHit & hit) const
-{
+std::vector<CSCHitAssociator::SimHitIdpr>
+CSCHitAssociator::associateHitId(const TrackingRecHit &hit) const {
   std::vector<SimHitIdpr> simtrackids;
-  
-  const TrackingRecHit * hitp = &hit;
-  const CSCRecHit2D * cscrechit = dynamic_cast<const CSCRecHit2D *>(hitp);
+
+  const TrackingRecHit *hitp = &hit;
+  const CSCRecHit2D *cscrechit = dynamic_cast<const CSCRecHit2D *>(hitp);
 
   if (cscrechit) {
-    
+
     unsigned int detId = cscrechit->geographicalId().rawId();
     int nchannels = cscrechit->nStrips();
-    const CSCLayerGeometry * laygeom = cscgeom->layer(cscrechit->cscDetId())->geometry();
+    const CSCLayerGeometry *laygeom =
+        cscgeom->layer(cscrechit->cscDetId())->geometry();
 
-    DigiSimLinks::const_iterator layerLinks = theDigiSimLinks->find(detId);    
+    DigiSimLinks::const_iterator layerLinks = theDigiSimLinks->find(detId);
 
     if (layerLinks != theDigiSimLinks->end()) {
-      
-      for(int idigi = 0; idigi < nchannels; ++idigi) {
-	// strip and readout channel numbers may differ in ME1/1A
-	int istrip = cscrechit->channels(idigi);
-	int channel = laygeom->channel(istrip);
-	
-	for (LayerLinks::const_iterator link=layerLinks->begin(); link!=layerLinks->end(); ++link) {
-	  int ch = static_cast<int>(link->channel());
-	  if (ch == channel) {
-	    SimHitIdpr currentId(link->SimTrackId(), link->eventId());
-	    if (find(simtrackids.begin(), simtrackids.end(), currentId) == simtrackids.end())
-	      simtrackids.push_back(currentId);
-	  }
-	}
+
+      for (int idigi = 0; idigi < nchannels; ++idigi) {
+        // strip and readout channel numbers may differ in ME1/1A
+        int istrip = cscrechit->channels(idigi);
+        int channel = laygeom->channel(istrip);
+
+        for (LayerLinks::const_iterator link = layerLinks->begin();
+             link != layerLinks->end(); ++link) {
+          int ch = static_cast<int>(link->channel());
+          if (ch == channel) {
+            SimHitIdpr currentId(link->SimTrackId(), link->eventId());
+            if (find(simtrackids.begin(), simtrackids.end(), currentId) ==
+                simtrackids.end())
+              simtrackids.push_back(currentId);
+          }
+        }
       }
-      
-    } else LogTrace("CSCHitAssociator")
-      <<"*** WARNING in CSCHitAssociator::associateHitId - CSC layer "<<detId<<" has no DigiSimLinks !"<<std::endl;   
-    
-  } else LogTrace("CSCHitAssociator")<<"*** WARNING in CSCHitAssociator::associateHitId, null dynamic_cast !";
-  
+
+    } else
+      LogTrace("CSCHitAssociator")
+          << "*** WARNING in CSCHitAssociator::associateHitId - CSC layer "
+          << detId << " has no DigiSimLinks !" << std::endl;
+
+  } else
+    LogTrace("CSCHitAssociator")
+        << "*** WARNING in CSCHitAssociator::associateHitId, null dynamic_cast "
+           "!";
+
   return simtrackids;
 }
-    
-

--- a/SimMuon/MCTruth/src/CSCTruthTest.cc
+++ b/SimMuon/MCTruth/src/CSCTruthTest.cc
@@ -1,35 +1,26 @@
-#include "SimMuon/MCTruth/interface/CSCTruthTest.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimMuon/MCTruth/interface/CSCTruthTest.h"
 
-CSCTruthTest::CSCTruthTest(const edm::ParameterSet& iConfig):
-  conf_(iConfig)
-{
-}
+CSCTruthTest::CSCTruthTest(const edm::ParameterSet &iConfig) : conf_(iConfig) {}
 
-CSCTruthTest::~CSCTruthTest()
-{
-}
+CSCTruthTest::~CSCTruthTest() {}
 
-void
-CSCTruthTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void CSCTruthTest::analyze(const edm::Event &iEvent,
+                           const edm::EventSetup &iSetup) {
   using namespace edm;
-  
+
   Handle<CSCRecHit2DCollection> cscRecHits;
-  iEvent.getByLabel("csc2DRecHits",cscRecHits);
+  iEvent.getByLabel("csc2DRecHits", cscRecHits);
 
-  MuonTruth theTruth(iEvent,iSetup,conf_);
+  MuonTruth theTruth(iEvent, iSetup, conf_);
 
-  for(CSCRecHit2DCollection::const_iterator recHitItr = cscRecHits->begin();
-      recHitItr != cscRecHits->end(); recHitItr++)
-  {
-     theTruth.analyze(*recHitItr);
-     edm::LogVerbatim("SimMuonCSCTruthTest") 
-       << theTruth.muonFraction() << " " << recHitItr->cscDetId();
+  for (CSCRecHit2DCollection::const_iterator recHitItr = cscRecHits->begin();
+       recHitItr != cscRecHits->end(); recHitItr++) {
+    theTruth.analyze(*recHitItr);
+    edm::LogVerbatim("SimMuonCSCTruthTest")
+        << theTruth.muonFraction() << " " << recHitItr->cscDetId();
   }
 }
-
-

--- a/SimMuon/MCTruth/src/DTHitAssociator.cc
+++ b/SimMuon/MCTruth/src/DTHitAssociator.cc
@@ -1,468 +1,508 @@
-#include "SimMuon/MCTruth/interface/DTHitAssociator.h"
-#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
-#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/DTGeometry/interface/DTLayer.h"
 #include "Geometry/DTGeometry/interface/DTTopology.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <string>
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "SimMuon/MCTruth/interface/DTHitAssociator.h"
 #include <sstream>
+#include <string>
 
 using namespace std;
 
 // Constructor
-DTHitAssociator::DTHitAssociator(const edm::ParameterSet& conf, 
-				 edm::ConsumesCollector && iC) :
-  DTsimhitsTag(conf.getParameter<edm::InputTag>("DTsimhitsTag")),
-  DTsimhitsXFTag(conf.getParameter<edm::InputTag>("DTsimhitsXFTag")),
-  DTdigiTag(conf.getParameter<edm::InputTag>("DTdigiTag")),
-  DTdigisimlinkTag(conf.getParameter<edm::InputTag>("DTdigisimlinkTag")),
-  DTrechitTag(conf.getParameter<edm::InputTag>("DTrechitTag")),
+DTHitAssociator::DTHitAssociator(const edm::ParameterSet &conf,
+                                 edm::ConsumesCollector &&iC)
+    : DTsimhitsTag(conf.getParameter<edm::InputTag>("DTsimhitsTag")),
+      DTsimhitsXFTag(conf.getParameter<edm::InputTag>("DTsimhitsXFTag")),
+      DTdigiTag(conf.getParameter<edm::InputTag>("DTdigiTag")),
+      DTdigisimlinkTag(conf.getParameter<edm::InputTag>("DTdigisimlinkTag")),
+      DTrechitTag(conf.getParameter<edm::InputTag>("DTrechitTag")),
 
-  // nice printout of DT hits
-  dumpDT(conf.getParameter<bool>("dumpDT")),
-  // CrossingFrame used or not ?
-  crossingframe(conf.getParameter<bool>("crossingframe")),
-  // Event contain the DTDigiSimLink collection ?
-  links_exist(conf.getParameter<bool>("links_exist")),
-  // associatorByWire links to a RecHit all the "valid" SimHits on the same DT wire
-  associatorByWire(conf.getParameter<bool>("associatorByWire")),
+      // nice printout of DT hits
+      dumpDT(conf.getParameter<bool>("dumpDT")),
+      // CrossingFrame used or not ?
+      crossingframe(conf.getParameter<bool>("crossingframe")),
+      // Event contain the DTDigiSimLink collection ?
+      links_exist(conf.getParameter<bool>("links_exist")),
+      // associatorByWire links to a RecHit all the "valid" SimHits on the same
+      // DT wire
+      associatorByWire(conf.getParameter<bool>("associatorByWire")),
 
-  printRtS(true)
-{
+      printRtS(true) {
 
-  if ( crossingframe) {
-    iC.consumes<CrossingFrame<PSimHit> >(DTsimhitsXFTag);
-  }
-  else if (!DTsimhitsTag.label().empty()) {
+  if (crossingframe) {
+    iC.consumes<CrossingFrame<PSimHit>>(DTsimhitsXFTag);
+  } else if (!DTsimhitsTag.label().empty()) {
     iC.consumes<edm::PSimHitContainer>(DTsimhitsTag);
   }
   iC.consumes<DTDigiCollection>(DTdigiTag);
   iC.consumes<DTDigiSimLinkCollection>(DTdigisimlinkTag);
 
-  if ( dumpDT && printRtS ) {
+  if (dumpDT && printRtS) {
     iC.consumes<DTRecHitCollection>(DTrechitTag);
   }
-
 }
 
+DTHitAssociator::DTHitAssociator(const edm::Event &iEvent,
+                                 const edm::EventSetup &iSetup,
+                                 const edm::ParameterSet &conf, bool printRtS)
+    : // input collection labels
+      DTsimhitsTag(conf.getParameter<edm::InputTag>("DTsimhitsTag")),
+      DTsimhitsXFTag(conf.getParameter<edm::InputTag>("DTsimhitsXFTag")),
+      DTdigiTag(conf.getParameter<edm::InputTag>("DTdigiTag")),
+      DTdigisimlinkTag(conf.getParameter<edm::InputTag>("DTdigisimlinkTag")),
+      DTrechitTag(conf.getParameter<edm::InputTag>("DTrechitTag")),
 
-DTHitAssociator::DTHitAssociator(const edm::Event& iEvent, const edm::EventSetup& iSetup, const edm::ParameterSet& conf, bool printRtS):
-  // input collection labels
-  DTsimhitsTag(conf.getParameter<edm::InputTag>("DTsimhitsTag")),
-  DTsimhitsXFTag(conf.getParameter<edm::InputTag>("DTsimhitsXFTag")),
-  DTdigiTag(conf.getParameter<edm::InputTag>("DTdigiTag")),
-  DTdigisimlinkTag(conf.getParameter<edm::InputTag>("DTdigisimlinkTag")),
-  DTrechitTag(conf.getParameter<edm::InputTag>("DTrechitTag")),
+      // nice printout of DT hits
+      dumpDT(conf.getParameter<bool>("dumpDT")),
+      // CrossingFrame used or not ?
+      crossingframe(conf.getParameter<bool>("crossingframe")),
+      // Event contain the DTDigiSimLink collection ?
+      links_exist(conf.getParameter<bool>("links_exist")),
+      // associatorByWire links to a RecHit all the "valid" SimHits on the same
+      // DT wire
+      associatorByWire(conf.getParameter<bool>("associatorByWire")),
 
-  // nice printout of DT hits
-  dumpDT(conf.getParameter<bool>("dumpDT")),
-  // CrossingFrame used or not ?
-  crossingframe(conf.getParameter<bool>("crossingframe")),
-  // Event contain the DTDigiSimLink collection ?
-  links_exist(conf.getParameter<bool>("links_exist")),
-  // associatorByWire links to a RecHit all the "valid" SimHits on the same DT wire
-  associatorByWire(conf.getParameter<bool>("associatorByWire")),
+      printRtS(true)
 
-  printRtS(true)
-  
-{  
-  initEvent(iEvent,iSetup);
+{
+  initEvent(iEvent, iSetup);
 }
 
-void DTHitAssociator::initEvent(const edm::Event &iEvent, const edm::EventSetup& iSetup) {
+void DTHitAssociator::initEvent(const edm::Event &iEvent,
+                                const edm::EventSetup &iSetup) {
 
-  LogTrace("DTHitAssociator") <<"DTHitAssociator constructor: dumpDT = "<<dumpDT
-                              <<", crossingframe = "<<crossingframe<<", links_exist = "<<links_exist
-                              <<", associatorByWire = "<<associatorByWire;
-  
+  LogTrace("DTHitAssociator")
+      << "DTHitAssociator constructor: dumpDT = " << dumpDT
+      << ", crossingframe = " << crossingframe
+      << ", links_exist = " << links_exist
+      << ", associatorByWire = " << associatorByWire;
+
   if (!links_exist && !associatorByWire) {
-    LogTrace("DTHitAssociator")<<"*** WARNING in DTHitAssociator::DTHitAssociator: associatorByWire reset to TRUE !"
-			       <<"    \t (missing DTDigiSimLinkCollection ?)";
+    LogTrace("DTHitAssociator")
+        << "*** WARNING in DTHitAssociator::DTHitAssociator: associatorByWire "
+           "reset to TRUE !"
+        << "    \t (missing DTDigiSimLinkCollection ?)";
     associatorByWire = true;
   }
-  
-  // need DT Geometry to discard hits for which the drift time parametrisation is not applicable
+
+  // need DT Geometry to discard hits for which the drift time parametrisation
+  // is not applicable
   edm::ESHandle<DTGeometry> muonGeom;
   iSetup.get<MuonGeometryRecord>().get(muonGeom);
-  
+
   // Get the DT SimHits from the event and map PSimHit by DTWireId
   mapOfSimHit.clear();
   bool takeHit(true);
- 
+
   if (crossingframe) {
-    edm::Handle<CrossingFrame<PSimHit> > xFrame;
-    LogTrace("DTHitAssociator") <<"getting CrossingFrame<PSimHit> collection - "<<DTsimhitsXFTag;
-    iEvent.getByLabel(DTsimhitsXFTag,xFrame);
-    unique_ptr<MixCollection<PSimHit> > 
-      DTsimhits( new MixCollection<PSimHit>(xFrame.product()) );
-    LogTrace("DTHitAssociator") <<"... size = "<<DTsimhits->size();
+    edm::Handle<CrossingFrame<PSimHit>> xFrame;
+    LogTrace("DTHitAssociator")
+        << "getting CrossingFrame<PSimHit> collection - " << DTsimhitsXFTag;
+    iEvent.getByLabel(DTsimhitsXFTag, xFrame);
+    unique_ptr<MixCollection<PSimHit>> DTsimhits(
+        new MixCollection<PSimHit>(xFrame.product()));
+    LogTrace("DTHitAssociator") << "... size = " << DTsimhits->size();
     MixCollection<PSimHit>::MixItr isimhit;
-    for (isimhit=DTsimhits->begin(); isimhit!= DTsimhits->end(); isimhit++) {
+    for (isimhit = DTsimhits->begin(); isimhit != DTsimhits->end(); isimhit++) {
       DTWireId wireid((*isimhit).detUnitId());
       takeHit = SimHitOK(muonGeom, *isimhit);
-      mapOfSimHit[wireid].push_back(make_pair(*isimhit,takeHit));
+      mapOfSimHit[wireid].push_back(make_pair(*isimhit, takeHit));
     }
-  }
-  else if (!DTsimhitsTag.label().empty()) {
+  } else if (!DTsimhitsTag.label().empty()) {
     edm::Handle<edm::PSimHitContainer> DTsimhits;
-    LogTrace("DTHitAssociator") <<"getting PSimHit collection - "<<DTsimhitsTag;
-    iEvent.getByLabel(DTsimhitsTag,DTsimhits);    
-    LogTrace("DTHitAssociator") <<"... size = "<<DTsimhits->size();
+    LogTrace("DTHitAssociator")
+        << "getting PSimHit collection - " << DTsimhitsTag;
+    iEvent.getByLabel(DTsimhitsTag, DTsimhits);
+    LogTrace("DTHitAssociator") << "... size = " << DTsimhits->size();
     edm::PSimHitContainer::const_iterator isimhit;
-    for (isimhit=DTsimhits->begin(); isimhit!= DTsimhits->end(); isimhit++) {
+    for (isimhit = DTsimhits->begin(); isimhit != DTsimhits->end(); isimhit++) {
       DTWireId wireid((*isimhit).detUnitId());
       takeHit = SimHitOK(muonGeom, *isimhit);
-      mapOfSimHit[wireid].push_back(make_pair(*isimhit,takeHit));
-    }    
+      mapOfSimHit[wireid].push_back(make_pair(*isimhit, takeHit));
+    }
   }
 
   // Get the DT Digi collection from the event
   mapOfDigi.clear();
   edm::Handle<DTDigiCollection> digis;
-  LogTrace("DTHitAssociator") <<"getting DTDigi collection - "<<DTdigiTag;
-  iEvent.getByLabel(DTdigiTag,digis);
-  
+  LogTrace("DTHitAssociator") << "getting DTDigi collection - " << DTdigiTag;
+  iEvent.getByLabel(DTdigiTag, digis);
+
   if (digis.isValid()) {
     // Map DTDigi by DTWireId
-    for (DTDigiCollection::DigiRangeIterator detUnit=digis->begin(); detUnit !=digis->end(); ++detUnit) {
-      const DTLayerId& layerid = (*detUnit).first;
-      const DTDigiCollection::Range& range = (*detUnit).second;
-      
+    for (DTDigiCollection::DigiRangeIterator detUnit = digis->begin();
+         detUnit != digis->end(); ++detUnit) {
+      const DTLayerId &layerid = (*detUnit).first;
+      const DTDigiCollection::Range &range = (*detUnit).second;
+
       DTDigiCollection::const_iterator digi;
-      for (digi = range.first; digi != range.second; ++digi){
-	DTWireId wireid(layerid,(*digi).wire());
-	mapOfDigi[wireid].push_back(*digi);
+      for (digi = range.first; digi != range.second; ++digi) {
+        DTWireId wireid(layerid, (*digi).wire());
+        mapOfDigi[wireid].push_back(*digi);
       }
     }
   } else {
-    LogTrace("DTHitAssociator") <<"... NO DTDigi collection found !";
+    LogTrace("DTHitAssociator") << "... NO DTDigi collection found !";
   }
-  
+
   mapOfLinks.clear();
   if (links_exist) {
-  // Get the DT DigiSimLink collection from the event and map DTDigiSimLink by DTWireId
+    // Get the DT DigiSimLink collection from the event and map DTDigiSimLink by
+    // DTWireId
     edm::Handle<DTDigiSimLinkCollection> digisimlinks;
-    LogTrace("DTHitAssociator") <<"getting DTDigiSimLink collection - "<<DTdigisimlinkTag;
-    iEvent.getByLabel(DTdigisimlinkTag,digisimlinks);
-    
-    for (DTDigiSimLinkCollection::DigiRangeIterator detUnit=digisimlinks->begin(); 
-	 detUnit !=digisimlinks->end(); 
-	 ++detUnit) {
-      const DTLayerId& layerid = (*detUnit).first;
-      const DTDigiSimLinkCollection::Range& range = (*detUnit).second;
-      
+    LogTrace("DTHitAssociator")
+        << "getting DTDigiSimLink collection - " << DTdigisimlinkTag;
+    iEvent.getByLabel(DTdigisimlinkTag, digisimlinks);
+
+    for (DTDigiSimLinkCollection::DigiRangeIterator detUnit =
+             digisimlinks->begin();
+         detUnit != digisimlinks->end(); ++detUnit) {
+      const DTLayerId &layerid = (*detUnit).first;
+      const DTDigiSimLinkCollection::Range &range = (*detUnit).second;
+
       DTDigiSimLinkCollection::const_iterator link;
-      for (link=range.first; link!=range.second; ++link){
-	DTWireId wireid(layerid,(*link).wire());
-	mapOfLinks[wireid].push_back(*link);
+      for (link = range.first; link != range.second; ++link) {
+        DTWireId wireid(layerid, (*link).wire());
+        mapOfLinks[wireid].push_back(*link);
       }
     }
   }
 
-  if(dumpDT && printRtS) {
-    
+  if (dumpDT && printRtS) {
+
     // Get the DT rechits from the event
-    edm::Handle<DTRecHitCollection> DTrechits; 
-    LogTrace("DTHitAssociator") <<"getting DTRecHit1DPair collection - "<<DTrechitTag;
-    iEvent.getByLabel(DTrechitTag,DTrechits);
-    LogTrace("DTHitAssociator") <<"... size = "<<DTrechits->size();
-    
+    edm::Handle<DTRecHitCollection> DTrechits;
+    LogTrace("DTHitAssociator")
+        << "getting DTRecHit1DPair collection - " << DTrechitTag;
+    iEvent.getByLabel(DTrechitTag, DTrechits);
+    LogTrace("DTHitAssociator") << "... size = " << DTrechits->size();
+
     // map DTRecHit1DPair by DTWireId
     mapOfRecHit.clear();
     DTRecHitCollection::const_iterator rechit;
-    for(rechit=DTrechits->begin(); rechit!=DTrechits->end(); ++rechit) {
+    for (rechit = DTrechits->begin(); rechit != DTrechits->end(); ++rechit) {
       DTWireId wireid = (*rechit).wireId();
       mapOfRecHit[wireid].push_back(*rechit);
     }
-    
+
     if (mapOfSimHit.end() != mapOfSimHit.begin()) {
-      LogTrace("DTHitAssociator")<<"\n *** Dump DT PSimHit's ***";
-      
+      LogTrace("DTHitAssociator") << "\n *** Dump DT PSimHit's ***";
+
       int jwire = 0;
       int ihit = 0;
-      
-      for(SimHitMap::const_iterator mapIT=mapOfSimHit.begin();
-	  mapIT!=mapOfSimHit.end();
-	  ++mapIT , jwire++) {
-	
-	DTWireId wireid = (*mapIT).first;
-	for (vector<PSimHit_withFlag>::const_iterator hitIT = mapOfSimHit[wireid].begin(); 
-	     hitIT != mapOfSimHit[wireid].end(); 
-	     hitIT++ , ihit++) {
-	  PSimHit hit = hitIT->first;
-	  LogTrace("DTHitAssociator")
-	    <<"PSimHit "<<ihit <<", wire "<<wireid //<<", detID = "<<hit.detUnitId()
-	    <<", SimTrack Id:"<<hit.trackId()<<"/Evt:(" <<hit.eventId().event()<<","<<hit.eventId().bunchCrossing()<<") "
-	    <<", pdg = "<<hit.particleType()<<", procs = "<<hit.processType();
-	}	
-      } 
-    } else {
-      LogTrace("DTHitAssociator")<<"\n *** There are NO DT PSimHit's ***";
-    }
 
-    if(mapOfDigi.end() != mapOfDigi.begin()) {
-      
-      int jwire = 0;
-      int ihit = 0;
-      
-      for(DigiMap::const_iterator mapIT=mapOfDigi.begin(); mapIT!=mapOfDigi.end(); ++mapIT , jwire++) {
-	LogTrace("DTHitAssociator")<<"\n *** Dump DT digis ***";
+      for (SimHitMap::const_iterator mapIT = mapOfSimHit.begin();
+           mapIT != mapOfSimHit.end(); ++mapIT, jwire++) {
 
-	DTWireId wireid = (*mapIT).first;
-	for (vector<DTDigi>::const_iterator hitIT = mapOfDigi[wireid].begin(); 
-	     hitIT != mapOfDigi[wireid].end(); 
-	     hitIT++ , ihit++) {
-	  LogTrace("DTHitAssociator")
-	    <<"DTDigi "<<ihit<<", wire "<<wireid<<", number = "<<hitIT->number()<<", TDC counts = "<<hitIT->countsTDC();
-	}	
+        DTWireId wireid = (*mapIT).first;
+        for (vector<PSimHit_withFlag>::const_iterator hitIT =
+                 mapOfSimHit[wireid].begin();
+             hitIT != mapOfSimHit[wireid].end(); hitIT++, ihit++) {
+          PSimHit hit = hitIT->first;
+          LogTrace("DTHitAssociator")
+              << "PSimHit " << ihit << ", wire "
+              << wireid //<<", detID = "<<hit.detUnitId()
+              << ", SimTrack Id:" << hit.trackId() << "/Evt:("
+              << hit.eventId().event() << "," << hit.eventId().bunchCrossing()
+              << ") "
+              << ", pdg = " << hit.particleType()
+              << ", procs = " << hit.processType();
+        }
       }
     } else {
-      LogTrace("DTHitAssociator")<<"\n *** There are NO DTDigi's ***";
+      LogTrace("DTHitAssociator") << "\n *** There are NO DT PSimHit's ***";
     }
-    
-    if (mapOfRecHit.end() != mapOfRecHit.begin()) 
-      LogTrace("DTHitAssociator")<<"\n *** Analyze DTRecHitCollection by DTWireId ***";
-    
+
+    if (mapOfDigi.end() != mapOfDigi.begin()) {
+
+      int jwire = 0;
+      int ihit = 0;
+
+      for (DigiMap::const_iterator mapIT = mapOfDigi.begin();
+           mapIT != mapOfDigi.end(); ++mapIT, jwire++) {
+        LogTrace("DTHitAssociator") << "\n *** Dump DT digis ***";
+
+        DTWireId wireid = (*mapIT).first;
+        for (vector<DTDigi>::const_iterator hitIT = mapOfDigi[wireid].begin();
+             hitIT != mapOfDigi[wireid].end(); hitIT++, ihit++) {
+          LogTrace("DTHitAssociator")
+              << "DTDigi " << ihit << ", wire " << wireid
+              << ", number = " << hitIT->number()
+              << ", TDC counts = " << hitIT->countsTDC();
+        }
+      }
+    } else {
+      LogTrace("DTHitAssociator") << "\n *** There are NO DTDigi's ***";
+    }
+
+    if (mapOfRecHit.end() != mapOfRecHit.begin())
+      LogTrace("DTHitAssociator")
+          << "\n *** Analyze DTRecHitCollection by DTWireId ***";
+
     int iwire = 0;
-    for(RecHitMap::const_iterator mapIT=mapOfRecHit.begin(); 
-	mapIT!=mapOfRecHit.end(); 
-	++mapIT , iwire++) {
-      
+    for (RecHitMap::const_iterator mapIT = mapOfRecHit.begin();
+         mapIT != mapOfRecHit.end(); ++mapIT, iwire++) {
+
       DTWireId wireid = (*mapIT).first;
-      LogTrace("DTHitAssociator")<<"\n==================================================================="; 
-      LogTrace("DTHitAssociator")<<"wire index = "<<iwire<<"  *** DTWireId = "<<" ("<<wireid<<")";
-      
-      if(mapOfSimHit.find(wireid) != mapOfSimHit.end()) {
-	LogTrace("DTHitAssociator")<<"\n"<<mapOfSimHit[wireid].size()<<" SimHits (PSimHit):";
-	
-	for (vector<PSimHit_withFlag>::const_iterator hitIT = mapOfSimHit[wireid].begin(); 
-	     hitIT != mapOfSimHit[wireid].end(); 
-	     ++hitIT) {
-	  stringstream tId;
-	  tId << (hitIT->first).trackId();
-	  string simhitlog = "\t SimTrack Id = "+tId.str();
-	  if (hitIT->second) simhitlog = simhitlog + "\t -VALID HIT-";
-	  else simhitlog = simhitlog + "\t -not valid hit-";
-	  LogTrace("DTHitAssociator")<<simhitlog;
-	}
+      LogTrace("DTHitAssociator") << "\n======================================="
+                                     "============================";
+      LogTrace("DTHitAssociator")
+          << "wire index = " << iwire << "  *** DTWireId = "
+          << " (" << wireid << ")";
+
+      if (mapOfSimHit.find(wireid) != mapOfSimHit.end()) {
+        LogTrace("DTHitAssociator")
+            << "\n"
+            << mapOfSimHit[wireid].size() << " SimHits (PSimHit):";
+
+        for (vector<PSimHit_withFlag>::const_iterator hitIT =
+                 mapOfSimHit[wireid].begin();
+             hitIT != mapOfSimHit[wireid].end(); ++hitIT) {
+          stringstream tId;
+          tId << (hitIT->first).trackId();
+          string simhitlog = "\t SimTrack Id = " + tId.str();
+          if (hitIT->second)
+            simhitlog = simhitlog + "\t -VALID HIT-";
+          else
+            simhitlog = simhitlog + "\t -not valid hit-";
+          LogTrace("DTHitAssociator") << simhitlog;
+        }
       }
-      
-      if(mapOfLinks.find(wireid) != mapOfLinks.end()) {
-	LogTrace("DTHitAssociator")<<"\n"<<mapOfLinks[wireid].size()<<" Links (DTDigiSimLink):";
-	
-	for (vector<DTDigiSimLink>::const_iterator hitIT = mapOfLinks[wireid].begin(); 
-	     hitIT != mapOfLinks[wireid].end(); 
-	     ++hitIT) {
-	  LogTrace("DTHitAssociator")
-	    <<"\t digi number = "<<hitIT->number()<<", time = "<<hitIT->time()<<", SimTrackId = "<<hitIT->SimTrackId();
-	}
+
+      if (mapOfLinks.find(wireid) != mapOfLinks.end()) {
+        LogTrace("DTHitAssociator")
+            << "\n"
+            << mapOfLinks[wireid].size() << " Links (DTDigiSimLink):";
+
+        for (vector<DTDigiSimLink>::const_iterator hitIT =
+                 mapOfLinks[wireid].begin();
+             hitIT != mapOfLinks[wireid].end(); ++hitIT) {
+          LogTrace("DTHitAssociator")
+              << "\t digi number = " << hitIT->number()
+              << ", time = " << hitIT->time()
+              << ", SimTrackId = " << hitIT->SimTrackId();
+        }
       }
-      
-      if(mapOfDigi.find(wireid) != mapOfDigi.end()) {
-	LogTrace("DTHitAssociator")<<"\n"<<mapOfDigi[wireid].size()<<" Digis (DTDigi):";
-	for (vector<DTDigi>::const_iterator hitIT = mapOfDigi[wireid].begin(); 
-	     hitIT != mapOfDigi[wireid].end(); 
-	     ++hitIT) {
-	  LogTrace("DTHitAssociator")<<"\t digi number = "<<hitIT->number()<<", time = "<<hitIT->time();
-	}
+
+      if (mapOfDigi.find(wireid) != mapOfDigi.end()) {
+        LogTrace("DTHitAssociator")
+            << "\n"
+            << mapOfDigi[wireid].size() << " Digis (DTDigi):";
+        for (vector<DTDigi>::const_iterator hitIT = mapOfDigi[wireid].begin();
+             hitIT != mapOfDigi[wireid].end(); ++hitIT) {
+          LogTrace("DTHitAssociator") << "\t digi number = " << hitIT->number()
+                                      << ", time = " << hitIT->time();
+        }
       }
-      
-      LogTrace("DTHitAssociator")<<"\n"<<(*mapIT).second.size()<<" RecHits (DTRecHit1DPair):";    
-      for(vector<DTRecHit1DPair>::const_iterator vIT =(*mapIT).second.begin(); 
-	  vIT !=(*mapIT).second.end(); 
-	  ++vIT) {
-	LogTrace("DTHitAssociator")<<"\t digi time = "<<vIT->digiTime();
+
+      LogTrace("DTHitAssociator")
+          << "\n"
+          << (*mapIT).second.size() << " RecHits (DTRecHit1DPair):";
+      for (vector<DTRecHit1DPair>::const_iterator vIT = (*mapIT).second.begin();
+           vIT != (*mapIT).second.end(); ++vIT) {
+        LogTrace("DTHitAssociator") << "\t digi time = " << vIT->digiTime();
       }
     }
   }
 }
 // end of constructor
 
-std::vector<DTHitAssociator::SimHitIdpr> DTHitAssociator::associateHitId(const TrackingRecHit & hit) const {
-  
+std::vector<DTHitAssociator::SimHitIdpr>
+DTHitAssociator::associateHitId(const TrackingRecHit &hit) const {
+
   std::vector<SimHitIdpr> simtrackids;
-  const TrackingRecHit * hitp = &hit;
-  const DTRecHit1D * dtrechit = dynamic_cast<const DTRecHit1D *>(hitp);
-  
+  const TrackingRecHit *hitp = &hit;
+  const DTRecHit1D *dtrechit = dynamic_cast<const DTRecHit1D *>(hitp);
+
   if (dtrechit) {
     simtrackids = associateDTHitId(dtrechit);
   } else {
-    LogTrace("DTHitAssociator")<<"*** WARNING in DTHitAssociator::associateHitId, null dynamic_cast !";
+    LogTrace("DTHitAssociator")
+        << "*** WARNING in DTHitAssociator::associateHitId, null dynamic_cast "
+           "!";
   }
   return simtrackids;
 }
 
-std::vector<DTHitAssociator::SimHitIdpr> DTHitAssociator::associateDTHitId(const DTRecHit1D * dtrechit) const {
-  
-  std::vector<SimHitIdpr> matched; 
+std::vector<DTHitAssociator::SimHitIdpr>
+DTHitAssociator::associateDTHitId(const DTRecHit1D *dtrechit) const {
+
+  std::vector<SimHitIdpr> matched;
 
   DTWireId wireid = dtrechit->wireId();
-  
-  if(associatorByWire) {
+
+  if (associatorByWire) {
     // matching based on DTWireId : take only "valid" SimHits on that wire
 
     auto found = mapOfSimHit.find(wireid);
-    if(found != mapOfSimHit.end()) {	
-      for (vector<PSimHit_withFlag>::const_iterator hitIT = found->second.begin(); 
-	   hitIT != found->second.end(); 
-	   ++hitIT) {
-	
-	bool valid_hit = hitIT->second;
-	PSimHit this_hit = hitIT->first;
+    if (found != mapOfSimHit.end()) {
+      for (vector<PSimHit_withFlag>::const_iterator hitIT =
+               found->second.begin();
+           hitIT != found->second.end(); ++hitIT) {
 
-	if (valid_hit) {
-	  SimHitIdpr currentId(this_hit.trackId(), this_hit.eventId());
-	  matched.push_back(currentId);
-	}
+        bool valid_hit = hitIT->second;
+        PSimHit this_hit = hitIT->first;
+
+        if (valid_hit) {
+          SimHitIdpr currentId(this_hit.trackId(), this_hit.eventId());
+          matched.push_back(currentId);
+        }
       }
     }
   }
 
   else {
     // matching based on DTDigiSimLink
-    
+
     float theTime = dtrechit->digiTime();
     int theNumber(-1);
-    
+
     auto found = mapOfLinks.find(wireid);
 
     if (found != mapOfLinks.end()) {
-      // DTDigiSimLink::time() is set equal to DTDigi::time() only for the DTDigiSimLink corresponding to the digitizied PSimHit
-      // other DTDigiSimLinks associated to the same DTDigi are identified by having the same DTDigiSimLink::number()
-      
+      // DTDigiSimLink::time() is set equal to DTDigi::time() only for the
+      // DTDigiSimLink corresponding to the digitizied PSimHit other
+      // DTDigiSimLinks associated to the same DTDigi are identified by having
+      // the same DTDigiSimLink::number()
+
       // first find the associated digi Number
-      for (vector<DTDigiSimLink>::const_iterator linkIT = found->second.begin(); 
-	   linkIT != found->second.end(); 
-	   ++linkIT ) {
-	float digitime = linkIT->time();
-	if (fabs(digitime-theTime)<0.1) {
+      for (vector<DTDigiSimLink>::const_iterator linkIT = found->second.begin();
+           linkIT != found->second.end(); ++linkIT) {
+        float digitime = linkIT->time();
+        if (fabs(digitime - theTime) < 0.1) {
           theNumber = linkIT->number();
-	}	
+        }
       }
-      
-      // then get all the DTDigiSimLinks with that digi Number (corresponding to valid SimHits  
-      //  within a time window of the order of the time resolution, specified in the DTDigitizer)
-      for (vector<DTDigiSimLink>::const_iterator linkIT = found->second.begin(); 
-	   linkIT != found->second.end(); 
-	   ++linkIT ) {
-	
+
+      // then get all the DTDigiSimLinks with that digi Number (corresponding to
+      // valid SimHits
+      //  within a time window of the order of the time resolution, specified in
+      //  the DTDigitizer)
+      for (vector<DTDigiSimLink>::const_iterator linkIT = found->second.begin();
+           linkIT != found->second.end(); ++linkIT) {
+
         int digiNr = linkIT->number();
-	if (digiNr == theNumber) {
-	  SimHitIdpr currentId(linkIT->SimTrackId(), linkIT->eventId());
-	  matched.push_back(currentId);
-	}
+        if (digiNr == theNumber) {
+          SimHitIdpr currentId(linkIT->SimTrackId(), linkIT->eventId());
+          matched.push_back(currentId);
+        }
       }
 
     } else {
-      LogTrace("DTHitAssociator")<<"*** ERROR in DTHitAssociator::associateDTHitId - DTRecHit1D: "
-				 <<*dtrechit<<" has no associated DTDigiSimLink !"<<endl;
-      return matched; 
+      LogTrace("DTHitAssociator")
+          << "*** ERROR in DTHitAssociator::associateDTHitId - DTRecHit1D: "
+          << *dtrechit << " has no associated DTDigiSimLink !" << endl;
+      return matched;
     }
   }
-  
+
   return matched;
 }
 
-std::vector<PSimHit> DTHitAssociator::associateHit(const TrackingRecHit & hit) const {
-  
-  std::vector<PSimHit> simhits;  
+std::vector<PSimHit>
+DTHitAssociator::associateHit(const TrackingRecHit &hit) const {
+
+  std::vector<PSimHit> simhits;
   std::vector<SimHitIdpr> simtrackids;
 
-  const TrackingRecHit * hitp = &hit;
-  const DTRecHit1D * dtrechit = dynamic_cast<const DTRecHit1D *>(hitp);
+  const TrackingRecHit *hitp = &hit;
+  const DTRecHit1D *dtrechit = dynamic_cast<const DTRecHit1D *>(hitp);
 
   if (dtrechit) {
     DTWireId wireid = dtrechit->wireId();
-    
+
     if (associatorByWire) {
-    // matching based on DTWireId : take only "valid" SimHits on that wire
+      // matching based on DTWireId : take only "valid" SimHits on that wire
 
       auto found = mapOfSimHit.find(wireid);
-      if(found != mapOfSimHit.end()) {	
-	for (vector<PSimHit_withFlag>::const_iterator hitIT = found->second.begin(); 
-	     hitIT != found->second.end(); 
-	     ++hitIT) {
-	  
-	  bool valid_hit = hitIT->second;
-	  if (valid_hit) simhits.push_back(hitIT->first);
-	}
+      if (found != mapOfSimHit.end()) {
+        for (vector<PSimHit_withFlag>::const_iterator hitIT =
+                 found->second.begin();
+             hitIT != found->second.end(); ++hitIT) {
+
+          bool valid_hit = hitIT->second;
+          if (valid_hit)
+            simhits.push_back(hitIT->first);
+        }
       }
-    }
-    else {
+    } else {
       // matching based on DTDigiSimLink
 
       simtrackids = associateDTHitId(dtrechit);
 
-      for (vector<SimHitIdpr>::const_iterator idIT =  simtrackids.begin(); idIT != simtrackids.end(); ++idIT) {
-	uint32_t trId = idIT->first;
-	EncodedEventId evId = idIT->second;
-	
+      for (vector<SimHitIdpr>::const_iterator idIT = simtrackids.begin();
+           idIT != simtrackids.end(); ++idIT) {
+        uint32_t trId = idIT->first;
+        EncodedEventId evId = idIT->second;
+
         auto found = mapOfSimHit.find(wireid);
-	if(found != mapOfSimHit.end()) {	
-	  for (vector<PSimHit_withFlag>::const_iterator hitIT = found->second.begin(); 
-	       hitIT != found->second.end(); 
-	       ++hitIT) {
-	    
-	    if (hitIT->first.trackId() == trId  && 
-		hitIT->first.eventId() == evId) 
-	      simhits.push_back(hitIT->first);	    
-	  }
-	}	
+        if (found != mapOfSimHit.end()) {
+          for (vector<PSimHit_withFlag>::const_iterator hitIT =
+                   found->second.begin();
+               hitIT != found->second.end(); ++hitIT) {
+
+            if (hitIT->first.trackId() == trId &&
+                hitIT->first.eventId() == evId)
+              simhits.push_back(hitIT->first);
+          }
+        }
       }
     }
 
   } else {
-    LogTrace("DTHitAssociator")<<"*** WARNING in DTHitAssociator::associateHit, null dynamic_cast !";
+    LogTrace("DTHitAssociator")
+        << "*** WARNING in DTHitAssociator::associateHit, null dynamic_cast !";
   }
   return simhits;
 }
 
-bool DTHitAssociator::SimHitOK(const edm::ESHandle<DTGeometry> & muongeom, 
-			       const PSimHit & simhit) {
+bool DTHitAssociator::SimHitOK(const edm::ESHandle<DTGeometry> &muongeom,
+                               const PSimHit &simhit) {
   bool result = true;
-  
+
   DTWireId wireid(simhit.detUnitId());
-  const DTLayer* dtlayer = muongeom->layer(wireid.layerId()); 
+  const DTLayer *dtlayer = muongeom->layer(wireid.layerId());
   LocalPoint entryP = simhit.entryPoint();
   LocalPoint exitP = simhit.exitPoint();
   const DTTopology &topo = dtlayer->specificTopology();
-  float xwire = topo.wirePosition(wireid.wire()); 
+  float xwire = topo.wirePosition(wireid.wire());
   float xEntry = entryP.x() - xwire;
-  float xExit  = exitP.x() - xwire;
-  DTTopology::Side entrySide = topo.onWhichBorder(xEntry,entryP.y(),entryP.z());
-  DTTopology::Side exitSide  = topo.onWhichBorder(xExit,exitP.y(),exitP.z());
-  
-  bool noParametrisation = 
-    (( entrySide == DTTopology::none || exitSide == DTTopology::none ) ||
-     (entrySide == exitSide) ||
-     ((entrySide == DTTopology::xMin && exitSide == DTTopology::xMax) || 
-      (entrySide == DTTopology::xMax && exitSide == DTTopology::xMin))   );
+  float xExit = exitP.x() - xwire;
+  DTTopology::Side entrySide =
+      topo.onWhichBorder(xEntry, entryP.y(), entryP.z());
+  DTTopology::Side exitSide = topo.onWhichBorder(xExit, exitP.y(), exitP.z());
+
+  bool noParametrisation =
+      ((entrySide == DTTopology::none || exitSide == DTTopology::none) ||
+       (entrySide == exitSide) ||
+       ((entrySide == DTTopology::xMin && exitSide == DTTopology::xMax) ||
+        (entrySide == DTTopology::xMax && exitSide == DTTopology::xMin)));
 
   // discard hits where parametrization can not be used
-  if (noParametrisation) 
-    {
-      result = false;
-      return result;
-    }  
-    
+  if (noParametrisation) {
+    result = false;
+    return result;
+  }
+
   float x;
-  LocalPoint hitPos = simhit.localPosition(); 
-  
-  if(fabs(hitPos.z()) < 0.002) {
+  LocalPoint hitPos = simhit.localPosition();
+
+  if (fabs(hitPos.z()) < 0.002) {
     // hit center within 20 um from z=0, no need to extrapolate.
     x = hitPos.x() - xwire;
   } else {
-    x = xEntry - (entryP.z()*(xExit-xEntry))/(exitP.z()-entryP.z());
+    x = xEntry - (entryP.z() * (xExit - xEntry)) / (exitP.z() - entryP.z());
   }
-  
+
   // discard hits where x is out of range of the parametrization (|x|>2.1 cm)
-  x *= 10.;  //cm -> mm 
-  if (fabs(x) > 21.) 
+  x *= 10.; // cm -> mm
+  if (fabs(x) > 21.)
     result = false;
-  
+
   return result;
 }

--- a/SimMuon/MCTruth/src/GEMHitAssociator.cc
+++ b/SimMuon/MCTruth/src/GEMHitAssociator.cc
@@ -3,121 +3,125 @@
 using namespace std;
 
 // Constructor
-GEMHitAssociator::GEMHitAssociator( const edm::ParameterSet& conf,
-				    edm::ConsumesCollector && iC):
-  GEMdigisimlinkTag(conf.getParameter<edm::InputTag>("GEMdigisimlinkTag")),
-  // CrossingFrame used or not ?
-  crossingframe(conf.getParameter<bool>("crossingframe")),
-  useGEMs_(conf.getParameter<bool>("useGEMs")),
-  GEMsimhitsTag(conf.getParameter<edm::InputTag>("GEMsimhitsTag")),
-  GEMsimhitsXFTag(conf.getParameter<edm::InputTag>("GEMsimhitsXFTag"))
-{
-  if (crossingframe){
-    GEMsimhitsXFToken_=iC.consumes<CrossingFrame<PSimHit> >(GEMsimhitsXFTag);
+GEMHitAssociator::GEMHitAssociator(const edm::ParameterSet &conf,
+                                   edm::ConsumesCollector &&iC)
+    : GEMdigisimlinkTag(conf.getParameter<edm::InputTag>("GEMdigisimlinkTag")),
+      // CrossingFrame used or not ?
+      crossingframe(conf.getParameter<bool>("crossingframe")),
+      useGEMs_(conf.getParameter<bool>("useGEMs")),
+      GEMsimhitsTag(conf.getParameter<edm::InputTag>("GEMsimhitsTag")),
+      GEMsimhitsXFTag(conf.getParameter<edm::InputTag>("GEMsimhitsXFTag")) {
+  if (crossingframe) {
+    GEMsimhitsXFToken_ = iC.consumes<CrossingFrame<PSimHit>>(GEMsimhitsXFTag);
   } else if (!GEMsimhitsTag.label().empty()) {
-    GEMsimhitsToken_=iC.consumes<edm::PSimHitContainer>(GEMsimhitsTag);
+    GEMsimhitsToken_ = iC.consumes<edm::PSimHitContainer>(GEMsimhitsTag);
   }
 
-  GEMdigisimlinkToken_=iC.consumes< edm::DetSetVector<StripDigiSimLink> >(GEMdigisimlinkTag);
+  GEMdigisimlinkToken_ =
+      iC.consumes<edm::DetSetVector<StripDigiSimLink>>(GEMdigisimlinkTag);
 }
 
-GEMHitAssociator::GEMHitAssociator(const edm::Event& e, const edm::EventSetup& eventSetup, const edm::ParameterSet& conf ):
-  GEMdigisimlinkTag(conf.getParameter<edm::InputTag>("GEMdigisimlinkTag")),
-  // CrossingFrame used or not ?
-  crossingframe(conf.getParameter<bool>("crossingframe")),
-  useGEMs_(conf.getParameter<bool>("useGEMs")),
-  GEMsimhitsTag(conf.getParameter<edm::InputTag>("GEMsimhitsTag")),
-  GEMsimhitsXFTag(conf.getParameter<edm::InputTag>("GEMsimhitsXFTag"))
-{
-  initEvent(e,eventSetup);
+GEMHitAssociator::GEMHitAssociator(const edm::Event &e,
+                                   const edm::EventSetup &eventSetup,
+                                   const edm::ParameterSet &conf)
+    : GEMdigisimlinkTag(conf.getParameter<edm::InputTag>("GEMdigisimlinkTag")),
+      // CrossingFrame used or not ?
+      crossingframe(conf.getParameter<bool>("crossingframe")),
+      useGEMs_(conf.getParameter<bool>("useGEMs")),
+      GEMsimhitsTag(conf.getParameter<edm::InputTag>("GEMsimhitsTag")),
+      GEMsimhitsXFTag(conf.getParameter<edm::InputTag>("GEMsimhitsXFTag")) {
+  initEvent(e, eventSetup);
 }
 
-void GEMHitAssociator::initEvent(const edm::Event& e, const edm::EventSetup& eventSetup)
-{
+void GEMHitAssociator::initEvent(const edm::Event &e,
+                                 const edm::EventSetup &eventSetup) {
 
-  if(useGEMs_){
+  if (useGEMs_) {
 
-	  if (crossingframe) {
-	    
-	    edm::Handle<CrossingFrame<PSimHit> > cf;
-	    LogTrace("GEMHitAssociator") <<"getting CrossingFrame<PSimHit> collection - "<<GEMsimhitsXFTag;
-	    e.getByLabel(GEMsimhitsXFTag, cf);
-	    
-	    std::unique_ptr<MixCollection<PSimHit> > 
-	      GEMsimhits( new MixCollection<PSimHit>(cf.product()) );
-	    LogTrace("GEMHitAssociator") <<"... size = "<<GEMsimhits->size();
+    if (crossingframe) {
 
-	    //   MixCollection<PSimHit> & simHits = *hits;
-	    
-	    for(MixCollection<PSimHit>::MixItr hitItr = GEMsimhits->begin();
-		hitItr != GEMsimhits->end(); ++hitItr) 
-	      {
-		_SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
-	      }
-	    
-	  } else if (!GEMsimhitsTag.label().empty()) {
-	    edm::Handle<edm::PSimHitContainer> GEMsimhits;
-	    LogTrace("GEMHitAssociator") <<"getting PSimHit collection - "<<GEMsimhitsTag;
-	    e.getByLabel(GEMsimhitsTag, GEMsimhits);    
-	    LogTrace("GEMHitAssociator") <<"... size = "<<GEMsimhits->size();
-	    
-	    // arrange the hits by detUnit
-	    for(edm::PSimHitContainer::const_iterator hitItr = GEMsimhits->begin();
-		hitItr != GEMsimhits->end(); ++hitItr)
-	      {
-		_SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
-	      }
-	  }
+      edm::Handle<CrossingFrame<PSimHit>> cf;
+      LogTrace("GEMHitAssociator")
+          << "getting CrossingFrame<PSimHit> collection - " << GEMsimhitsXFTag;
+      e.getByLabel(GEMsimhitsXFTag, cf);
 
-	  edm::Handle<DigiSimLinks> digiSimLinks;
-	  LogTrace("GEMHitAssociator") <<"getting GEM Strip DigiSimLink collection - "<<GEMdigisimlinkTag;
-	  e.getByLabel(GEMdigisimlinkTag, digiSimLinks);
-	  theDigiSimLinks = digiSimLinks.product();
+      std::unique_ptr<MixCollection<PSimHit>> GEMsimhits(
+          new MixCollection<PSimHit>(cf.product()));
+      LogTrace("GEMHitAssociator") << "... size = " << GEMsimhits->size();
 
+      //   MixCollection<PSimHit> & simHits = *hits;
+
+      for (MixCollection<PSimHit>::MixItr hitItr = GEMsimhits->begin();
+           hitItr != GEMsimhits->end(); ++hitItr) {
+        _SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
+      }
+
+    } else if (!GEMsimhitsTag.label().empty()) {
+      edm::Handle<edm::PSimHitContainer> GEMsimhits;
+      LogTrace("GEMHitAssociator")
+          << "getting PSimHit collection - " << GEMsimhitsTag;
+      e.getByLabel(GEMsimhitsTag, GEMsimhits);
+      LogTrace("GEMHitAssociator") << "... size = " << GEMsimhits->size();
+
+      // arrange the hits by detUnit
+      for (edm::PSimHitContainer::const_iterator hitItr = GEMsimhits->begin();
+           hitItr != GEMsimhits->end(); ++hitItr) {
+        _SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
+      }
+    }
+
+    edm::Handle<DigiSimLinks> digiSimLinks;
+    LogTrace("GEMHitAssociator")
+        << "getting GEM Strip DigiSimLink collection - " << GEMdigisimlinkTag;
+    e.getByLabel(GEMdigisimlinkTag, digiSimLinks);
+    theDigiSimLinks = digiSimLinks.product();
   }
-
 }
 // end of constructor
 
-std::vector<GEMHitAssociator::SimHitIdpr> GEMHitAssociator::associateRecHit(const GEMRecHit * gemrechit) const {
-  
+std::vector<GEMHitAssociator::SimHitIdpr>
+GEMHitAssociator::associateRecHit(const GEMRecHit *gemrechit) const {
+
   std::vector<SimHitIdpr> matched;
 
-  if(useGEMs_){
+  if (useGEMs_) {
     if (gemrechit) {
-	    
-	    GEMDetId gemDetId = gemrechit->gemId();
-	    int fstrip = gemrechit->firstClusterStrip();
-	    int cls = gemrechit->clusterSize();
-	    //int bx = gemrechit->BunchX();
 
-	    DigiSimLinks::const_iterator layerLinks = theDigiSimLinks->find(gemDetId);
+      GEMDetId gemDetId = gemrechit->gemId();
+      int fstrip = gemrechit->firstClusterStrip();
+      int cls = gemrechit->clusterSize();
+      // int bx = gemrechit->BunchX();
 
-	    if (layerLinks != theDigiSimLinks->end()) {
-	    
-		for(int i = fstrip; i < (fstrip+cls); ++i) {
-			      
-			for(LayerLinks::const_iterator itlink = layerLinks->begin(); itlink != layerLinks->end(); ++itlink) {
+      DigiSimLinks::const_iterator layerLinks = theDigiSimLinks->find(gemDetId);
 
-		  		int ch = static_cast<int>(itlink->channel());
-				if(ch != i) continue;
+      if (layerLinks != theDigiSimLinks->end()) {
 
-				SimHitIdpr currentId(itlink->SimTrackId(), itlink->eventId());
-				if(find(matched.begin(),matched.end(),currentId ) == matched.end())
-					matched.push_back(currentId);
+        for (int i = fstrip; i < (fstrip + cls); ++i) {
 
-			}
+          for (LayerLinks::const_iterator itlink = layerLinks->begin();
+               itlink != layerLinks->end(); ++itlink) {
 
-		}
+            int ch = static_cast<int>(itlink->channel());
+            if (ch != i)
+              continue;
 
-	    }else edm::LogWarning("GEMHitAssociator")
-	      <<"*** WARNING in GEMHitAssociator: GEM layer "<<gemDetId<<" has no DigiSimLinks !"<<std::endl;
-	    
-	  } else edm::LogWarning("GEMHitAssociator")<<"*** WARNING in GEMHitAssociator::associateRecHit, null dynamic_cast !";
+            SimHitIdpr currentId(itlink->SimTrackId(), itlink->eventId());
+            if (find(matched.begin(), matched.end(), currentId) ==
+                matched.end())
+              matched.push_back(currentId);
+          }
+        }
 
+      } else
+        edm::LogWarning("GEMHitAssociator")
+            << "*** WARNING in GEMHitAssociator: GEM layer " << gemDetId
+            << " has no DigiSimLinks !" << std::endl;
+
+    } else
+      edm::LogWarning("GEMHitAssociator")
+          << "*** WARNING in GEMHitAssociator::associateRecHit, null "
+             "dynamic_cast !";
   }
-  
-  return  matched;
 
+  return matched;
 }
-

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -1,15 +1,15 @@
-#include "SimMuon/MCTruth/interface/MuonAssociatorByHits.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "DataFormats/CSCRecHit/interface/CSCSegment.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4D.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include "DataFormats/DTRecHit/interface/DTRecSegment4D.h"
-#include "DataFormats/CSCRecHit/interface/CSCSegment.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "SimMuon/MCTruth/interface/MuonAssociatorByHits.h"
 #include "SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h"
 #include <sstream>
 
@@ -18,185 +18,210 @@ using namespace std;
 using namespace muonAssociatorByHitsDiagnostics;
 
 namespace muonAssociatorByHitsDiagnostics {
-  using TrackHitsCollection = MuonAssociatorByHitsHelper::TrackHitsCollection;
+using TrackHitsCollection = MuonAssociatorByHitsHelper::TrackHitsCollection;
 
-  class InputDumper {
-  public:
-    InputDumper(const edm::ParameterSet& conf) :
-      simtracksTag(conf.getParameter<edm::InputTag>("simtracksTag")),
-      simtracksXFTag(conf.getParameter<edm::InputTag>("simtracksXFTag")),
-      crossingframe(conf.getParameter<bool>("crossingframe")) {}
+class InputDumper {
+public:
+  InputDumper(const edm::ParameterSet &conf)
+      : simtracksTag(conf.getParameter<edm::InputTag>("simtracksTag")),
+        simtracksXFTag(conf.getParameter<edm::InputTag>("simtracksXFTag")),
+        crossingframe(conf.getParameter<bool>("crossingframe")) {}
 
-    InputDumper(const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :
-      InputDumper(conf)
-    {
-      if (crossingframe) {
-        iC.consumes<CrossingFrame<SimTrack> >(simtracksXFTag);
-        iC.consumes<CrossingFrame<SimVertex> >(simtracksXFTag);
-      }
-      else{
-        iC.consumes<edm::SimTrackContainer>(simtracksTag);
-        iC.consumes<edm::SimVertexContainer>(simtracksTag);
-      }
-    }
-
-    void dump(const TrackHitsCollection&, const TrackingParticleCollection&, const edm::Event&) const;
-
-  private:
-    edm::InputTag const simtracksTag;
-    edm::InputTag const simtracksXFTag;
-    bool const crossingframe;
-  };
-
-  void
-  InputDumper::dump(const TrackHitsCollection& tC, const TrackingParticleCollection& tPC, const edm::Event& event) const {
-    // reco::Track collection
-    edm::LogVerbatim("MuonAssociatorByHits")<<"\n"<<"reco::Track collection --- size = "<<tC.size();
- 
- 
-    // TrackingParticle collection
-    edm::LogVerbatim("MuonAssociatorByHits")<<"\n"<<"TrackingParticle collection --- size = "<<tPC.size();
-    int j = 0;
-    for(TrackingParticleCollection::const_iterator ITER=tPC.begin(); ITER!=tPC.end(); ITER++, j++) {
-      edm::LogVerbatim("MuonAssociatorByHits")
-        <<"TrackingParticle "<<j<<", q = "<<ITER->charge()<<", p = "<<ITER->p()
-        <<", pT = "<<ITER->pt()<<", eta = "<<ITER->eta()<<", phi = "<<ITER->phi();
-       
-      edm::LogVerbatim("MuonAssociatorByHits")
-        <<"\t pdg code = "<<ITER->pdgId()<<", made of "<<ITER->numberOfHits()<<" PSimHit"
-        <<" (in "<<ITER->numberOfTrackerLayers()<<" layers)"
-        <<" from "<<ITER->g4Tracks().size()<<" SimTrack:";
-      for (TrackingParticle::g4t_iterator g4T=ITER->g4Track_begin(); g4T!=ITER->g4Track_end(); g4T++) {
-        edm::LogVerbatim("MuonAssociatorByHits")
-          <<"\t\t Id:"<<g4T->trackId()<<"/Evt:("<<g4T->eventId().event()<<","<<g4T->eventId().bunchCrossing()<<")";
-      }    
-    }
- 
-    // SimTrack collection
-    edm::Handle<CrossingFrame<SimTrack> > cf_simtracks;
-    edm::Handle<edm::SimTrackContainer> simTrackCollection;
- 
-    // SimVertex collection
-    edm::Handle<CrossingFrame<SimVertex> > cf_simvertices;
-    edm::Handle<edm::SimVertexContainer> simVertexCollection;
-         
+  InputDumper(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
+      : InputDumper(conf) {
     if (crossingframe) {
-      event.getByLabel(simtracksXFTag,cf_simtracks);
-      unique_ptr<MixCollection<SimTrack> > SimTk( new MixCollection<SimTrack>(cf_simtracks.product()) );
-      edm::LogVerbatim("MuonAssociatorByHits")<<"\n"<<"CrossingFrame<SimTrack> collection with InputTag = "<<simtracksXFTag
-                                              <<" has size = "<<SimTk->size();
-      int k = 0;
-      for (MixCollection<SimTrack>::MixItr ITER=SimTk->begin(); ITER!=SimTk->end(); ITER++, k++) {
-        edm::LogVerbatim("MuonAssociatorByHits")
-          <<"SimTrack "<<k
-          <<" - Id:"<<ITER->trackId()<<"/Evt:("<<ITER->eventId().event()<<","<<ITER->eventId().bunchCrossing()<<")"
-          <<" pdgId = "<<ITER->type()<<", q = "<<ITER->charge()<<", p = "<<ITER->momentum().P()
-          <<", pT = "<<ITER->momentum().Pt()<<", eta = "<<ITER->momentum().Eta()<<", phi = "<<ITER->momentum().Phi()
-          <<"\n * "<<*ITER <<endl;
-      }
-      event.getByLabel(simtracksXFTag,cf_simvertices);
-      unique_ptr<MixCollection<SimVertex> > SimVtx( new MixCollection<SimVertex>(cf_simvertices.product()) );
-      edm::LogVerbatim("MuonAssociatorByHits")<<"\n"<<"CrossingFrame<SimVertex> collection with InputTag = "<<simtracksXFTag
-                                              <<" has size = "<<SimVtx->size();
-      int kv = 0;
-      for (MixCollection<SimVertex>::MixItr VITER=SimVtx->begin(); VITER!=SimVtx->end(); VITER++, kv++){
-        edm::LogVerbatim("MuonAssociatorByHits")
-          <<"SimVertex "<<kv
-          << " : "<< *VITER <<endl;
-      }
-    }
-    else {
-      event.getByLabel(simtracksTag,simTrackCollection);
-      const edm::SimTrackContainer simTC = *(simTrackCollection.product());
-      edm::LogVerbatim("MuonAssociatorByHits")<<"\n"<<"SimTrack collection with InputTag = "<<simtracksTag
-                                              <<" has size = "<<simTC.size()<<endl;
-      int k = 0;
-      for(edm::SimTrackContainer::const_iterator ITER=simTC.begin(); ITER!=simTC.end(); ITER++, k++){
-        edm::LogVerbatim("MuonAssociatorByHits")
-          <<"SimTrack "<<k
-          <<" - Id:"<<ITER->trackId()<<"/Evt:("<<ITER->eventId().event()<<","<<ITER->eventId().bunchCrossing()<<")"
-          <<" pdgId = "<<ITER->type()<<", q = "<<ITER->charge()<<", p = "<<ITER->momentum().P()
-          <<", pT = "<<ITER->momentum().Pt()<<", eta = "<<ITER->momentum().Eta()<<", phi = "<<ITER->momentum().Phi()
-          <<"\n * "<<*ITER <<endl;
-      }
-      event.getByLabel(simtracksTag,simVertexCollection);
-      const edm::SimVertexContainer simVC = *(simVertexCollection.product());
-      edm::LogVerbatim("MuonAssociatorByHits")<<"\n"<<"SimVertex collection with InputTag = "<<"g4SimHits"
-                                              <<" has size = "<<simVC.size()<<endl;
-      int kv = 0;
-      for (edm::SimVertexContainer::const_iterator VITER=simVC.begin(); VITER!=simVC.end(); VITER++, kv++){
-        edm::LogVerbatim("MuonAssociatorByHits")
-          <<"SimVertex "<<kv
-          << " : "<< *VITER <<endl;
-      }
+      iC.consumes<CrossingFrame<SimTrack>>(simtracksXFTag);
+      iC.consumes<CrossingFrame<SimVertex>>(simtracksXFTag);
+    } else {
+      iC.consumes<edm::SimTrackContainer>(simtracksTag);
+      iC.consumes<edm::SimVertexContainer>(simtracksTag);
     }
   }
 
-}
+  void dump(const TrackHitsCollection &, const TrackingParticleCollection &,
+            const edm::Event &) const;
 
+private:
+  edm::InputTag const simtracksTag;
+  edm::InputTag const simtracksXFTag;
+  bool const crossingframe;
+};
 
-MuonAssociatorByHits::MuonAssociatorByHits (const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :  
-  helper_(conf),
-  conf_(conf),
-  trackerHitAssociatorConfig_(conf, std::move(iC))
-{
-  //hack for consumes
-  RPCHitAssociator rpctruth(conf,std::move(iC));
-  GEMHitAssociator gemtruth(conf,std::move(iC));
-  DTHitAssociator dttruth(conf,std::move(iC));
-  CSCHitAssociator muonTruth(conf,std::move(iC));
-  if( conf.getUntrackedParameter<bool>("dumpInputCollections") ) {
-    diagnostics_.reset( new InputDumper(conf, std::move(iC)) );
+void InputDumper::dump(const TrackHitsCollection &tC,
+                       const TrackingParticleCollection &tPC,
+                       const edm::Event &event) const {
+  // reco::Track collection
+  edm::LogVerbatim("MuonAssociatorByHits")
+      << "\n"
+      << "reco::Track collection --- size = " << tC.size();
+
+  // TrackingParticle collection
+  edm::LogVerbatim("MuonAssociatorByHits")
+      << "\n"
+      << "TrackingParticle collection --- size = " << tPC.size();
+  int j = 0;
+  for (TrackingParticleCollection::const_iterator ITER = tPC.begin();
+       ITER != tPC.end(); ITER++, j++) {
+    edm::LogVerbatim("MuonAssociatorByHits")
+        << "TrackingParticle " << j << ", q = " << ITER->charge()
+        << ", p = " << ITER->p() << ", pT = " << ITER->pt()
+        << ", eta = " << ITER->eta() << ", phi = " << ITER->phi();
+
+    edm::LogVerbatim("MuonAssociatorByHits")
+        << "\t pdg code = " << ITER->pdgId() << ", made of "
+        << ITER->numberOfHits() << " PSimHit"
+        << " (in " << ITER->numberOfTrackerLayers() << " layers)"
+        << " from " << ITER->g4Tracks().size() << " SimTrack:";
+    for (TrackingParticle::g4t_iterator g4T = ITER->g4Track_begin();
+         g4T != ITER->g4Track_end(); g4T++) {
+      edm::LogVerbatim("MuonAssociatorByHits")
+          << "\t\t Id:" << g4T->trackId() << "/Evt:(" << g4T->eventId().event()
+          << "," << g4T->eventId().bunchCrossing() << ")";
+    }
+  }
+
+  // SimTrack collection
+  edm::Handle<CrossingFrame<SimTrack>> cf_simtracks;
+  edm::Handle<edm::SimTrackContainer> simTrackCollection;
+
+  // SimVertex collection
+  edm::Handle<CrossingFrame<SimVertex>> cf_simvertices;
+  edm::Handle<edm::SimVertexContainer> simVertexCollection;
+
+  if (crossingframe) {
+    event.getByLabel(simtracksXFTag, cf_simtracks);
+    unique_ptr<MixCollection<SimTrack>> SimTk(
+        new MixCollection<SimTrack>(cf_simtracks.product()));
+    edm::LogVerbatim("MuonAssociatorByHits")
+        << "\n"
+        << "CrossingFrame<SimTrack> collection with InputTag = "
+        << simtracksXFTag << " has size = " << SimTk->size();
+    int k = 0;
+    for (MixCollection<SimTrack>::MixItr ITER = SimTk->begin();
+         ITER != SimTk->end(); ITER++, k++) {
+      edm::LogVerbatim("MuonAssociatorByHits")
+          << "SimTrack " << k << " - Id:" << ITER->trackId() << "/Evt:("
+          << ITER->eventId().event() << "," << ITER->eventId().bunchCrossing()
+          << ")"
+          << " pdgId = " << ITER->type() << ", q = " << ITER->charge()
+          << ", p = " << ITER->momentum().P()
+          << ", pT = " << ITER->momentum().Pt()
+          << ", eta = " << ITER->momentum().Eta()
+          << ", phi = " << ITER->momentum().Phi() << "\n * " << *ITER << endl;
+    }
+    event.getByLabel(simtracksXFTag, cf_simvertices);
+    unique_ptr<MixCollection<SimVertex>> SimVtx(
+        new MixCollection<SimVertex>(cf_simvertices.product()));
+    edm::LogVerbatim("MuonAssociatorByHits")
+        << "\n"
+        << "CrossingFrame<SimVertex> collection with InputTag = "
+        << simtracksXFTag << " has size = " << SimVtx->size();
+    int kv = 0;
+    for (MixCollection<SimVertex>::MixItr VITER = SimVtx->begin();
+         VITER != SimVtx->end(); VITER++, kv++) {
+      edm::LogVerbatim("MuonAssociatorByHits")
+          << "SimVertex " << kv << " : " << *VITER << endl;
+    }
+  } else {
+    event.getByLabel(simtracksTag, simTrackCollection);
+    const edm::SimTrackContainer simTC = *(simTrackCollection.product());
+    edm::LogVerbatim("MuonAssociatorByHits")
+        << "\n"
+        << "SimTrack collection with InputTag = " << simtracksTag
+        << " has size = " << simTC.size() << endl;
+    int k = 0;
+    for (edm::SimTrackContainer::const_iterator ITER = simTC.begin();
+         ITER != simTC.end(); ITER++, k++) {
+      edm::LogVerbatim("MuonAssociatorByHits")
+          << "SimTrack " << k << " - Id:" << ITER->trackId() << "/Evt:("
+          << ITER->eventId().event() << "," << ITER->eventId().bunchCrossing()
+          << ")"
+          << " pdgId = " << ITER->type() << ", q = " << ITER->charge()
+          << ", p = " << ITER->momentum().P()
+          << ", pT = " << ITER->momentum().Pt()
+          << ", eta = " << ITER->momentum().Eta()
+          << ", phi = " << ITER->momentum().Phi() << "\n * " << *ITER << endl;
+    }
+    event.getByLabel(simtracksTag, simVertexCollection);
+    const edm::SimVertexContainer simVC = *(simVertexCollection.product());
+    edm::LogVerbatim("MuonAssociatorByHits")
+        << "\n"
+        << "SimVertex collection with InputTag = "
+        << "g4SimHits"
+        << " has size = " << simVC.size() << endl;
+    int kv = 0;
+    for (edm::SimVertexContainer::const_iterator VITER = simVC.begin();
+         VITER != simVC.end(); VITER++, kv++) {
+      edm::LogVerbatim("MuonAssociatorByHits")
+          << "SimVertex " << kv << " : " << *VITER << endl;
+    }
   }
 }
 
+} // namespace muonAssociatorByHitsDiagnostics
 
-
-MuonAssociatorByHits::~MuonAssociatorByHits()
-{
+MuonAssociatorByHits::MuonAssociatorByHits(const edm::ParameterSet &conf,
+                                           edm::ConsumesCollector &&iC)
+    : helper_(conf), conf_(conf),
+      trackerHitAssociatorConfig_(conf, std::move(iC)) {
+  // hack for consumes
+  RPCHitAssociator rpctruth(conf, std::move(iC));
+  GEMHitAssociator gemtruth(conf, std::move(iC));
+  DTHitAssociator dttruth(conf, std::move(iC));
+  CSCHitAssociator muonTruth(conf, std::move(iC));
+  if (conf.getUntrackedParameter<bool>("dumpInputCollections")) {
+    diagnostics_.reset(new InputDumper(conf, std::move(iC)));
+  }
 }
 
-RecoToSimCollection  
-MuonAssociatorByHits::associateRecoToSim( const edm::RefToBaseVector<reco::Track>& tC,
-					  const edm::RefVector<TrackingParticleCollection>& TPCollectionH,
-    					  const edm::Event * e, const edm::EventSetup * setup) const{
-  RecoToSimCollection  outputCollection(&e->productGetter());
+MuonAssociatorByHits::~MuonAssociatorByHits() {}
+
+RecoToSimCollection MuonAssociatorByHits::associateRecoToSim(
+    const edm::RefToBaseVector<reco::Track> &tC,
+    const edm::RefVector<TrackingParticleCollection> &TPCollectionH,
+    const edm::Event *e, const edm::EventSetup *setup) const {
+  RecoToSimCollection outputCollection(&e->productGetter());
 
   MuonAssociatorByHitsHelper::TrackHitsCollection tH;
   for (auto it = tC.begin(), ed = tC.end(); it != ed; ++it) {
     tH.push_back(std::make_pair((*it)->recHitsBegin(), (*it)->recHitsEnd()));
   }
 
-  //Retrieve tracker topology from geometry
+  // Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHand;
   setup->get<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology *tTopo=tTopoHand.product();
+  const TrackerTopology *tTopo = tTopoHand.product();
 
-
-  // Tracker hit association  
+  // Tracker hit association
   TrackerHitAssociator trackertruth(*e, trackerHitAssociatorConfig_);
   // CSC hit association
-  CSCHitAssociator csctruth(*e,*setup,conf_);
+  CSCHitAssociator csctruth(*e, *setup, conf_);
   // DT hit association
   bool printRtS(true);
-  DTHitAssociator dttruth(*e,*setup,conf_,printRtS);  
+  DTHitAssociator dttruth(*e, *setup, conf_, printRtS);
   // RPC hit association
-  RPCHitAssociator rpctruth(*e,*setup,conf_);
+  RPCHitAssociator rpctruth(*e, *setup, conf_);
   // GEM hit association
-  GEMHitAssociator gemtruth(*e,*setup,conf_);
-   
-  MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
+  GEMHitAssociator gemtruth(*e, *setup, conf_);
 
-  if(diagnostics_) {
-    resources.diagnostics_ = [this, e](const TrackHitsCollection& hC, const TrackingParticleCollection& pC) {
-      diagnostics_->dump(hC,pC, *e);
+  MuonAssociatorByHitsHelper::Resources resources = {
+      tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
+
+  if (diagnostics_) {
+    resources.diagnostics_ = [this, e](const TrackHitsCollection &hC,
+                                       const TrackingParticleCollection &pC) {
+      diagnostics_->dump(hC, pC, *e);
     };
   }
 
-  auto bareAssoc = helper_.associateRecoToSimIndices(tH, TPCollectionH, resources);
+  auto bareAssoc =
+      helper_.associateRecoToSimIndices(tH, TPCollectionH, resources);
   for (auto it = bareAssoc.begin(), ed = bareAssoc.end(); it != ed; ++it) {
-    for (auto itma = it->second.begin(), edma = it->second.end(); itma != edma; ++itma) {
-        outputCollection.insert(tC[it->first], std::make_pair(TPCollectionH[itma->idx], itma->quality));
+    for (auto itma = it->second.begin(), edma = it->second.end(); itma != edma;
+         ++itma) {
+      outputCollection.insert(
+          tC[it->first],
+          std::make_pair(TPCollectionH[itma->idx], itma->quality));
     }
   }
 
@@ -204,41 +229,44 @@ MuonAssociatorByHits::associateRecoToSim( const edm::RefToBaseVector<reco::Track
   return outputCollection;
 }
 
-SimToRecoCollection  
-MuonAssociatorByHits::associateSimToReco( const edm::RefToBaseVector<reco::Track>& tC, 
-					  const edm::RefVector<TrackingParticleCollection>& TPCollectionH,
-					  const edm::Event * e, const edm::EventSetup * setup) const{
+SimToRecoCollection MuonAssociatorByHits::associateSimToReco(
+    const edm::RefToBaseVector<reco::Track> &tC,
+    const edm::RefVector<TrackingParticleCollection> &TPCollectionH,
+    const edm::Event *e, const edm::EventSetup *setup) const {
 
-  SimToRecoCollection  outputCollection(&e->productGetter());
+  SimToRecoCollection outputCollection(&e->productGetter());
   MuonAssociatorByHitsHelper::TrackHitsCollection tH;
   for (auto it = tC.begin(), ed = tC.end(); it != ed; ++it) {
     tH.push_back(std::make_pair((*it)->recHitsBegin(), (*it)->recHitsEnd()));
   }
 
-  //Retrieve tracker topology from geometry
+  // Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHand;
   setup->get<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology *tTopo=tTopoHand.product();
+  const TrackerTopology *tTopo = tTopoHand.product();
 
-  // Tracker hit association  
+  // Tracker hit association
   TrackerHitAssociator trackertruth(*e, trackerHitAssociatorConfig_);
   // CSC hit association
-  CSCHitAssociator csctruth(*e,*setup,conf_);
+  CSCHitAssociator csctruth(*e, *setup, conf_);
   // DT hit association
   bool printRtS = false;
-  DTHitAssociator dttruth(*e,*setup,conf_,printRtS);  
+  DTHitAssociator dttruth(*e, *setup, conf_, printRtS);
   // RPC hit association
-  RPCHitAssociator rpctruth(*e,*setup,conf_);
+  RPCHitAssociator rpctruth(*e, *setup, conf_);
   // GEM hit association
-  GEMHitAssociator gemtruth(*e,*setup,conf_);
-   
-  MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
-  
-  auto bareAssoc = helper_.associateSimToRecoIndices(tH, TPCollectionH, resources);
+  GEMHitAssociator gemtruth(*e, *setup, conf_);
+
+  MuonAssociatorByHitsHelper::Resources resources = {
+      tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
+
+  auto bareAssoc =
+      helper_.associateSimToRecoIndices(tH, TPCollectionH, resources);
   for (auto it = bareAssoc.begin(), ed = bareAssoc.end(); it != ed; ++it) {
-    for (auto itma = it->second.begin(), edma = it->second.end(); itma != edma; ++itma) {
-        outputCollection.insert(TPCollectionH[ it->first],
-                                std::make_pair(tC[itma->idx], itma->quality));
+    for (auto itma = it->second.begin(), edma = it->second.end(); itma != edma;
+         ++itma) {
+      outputCollection.insert(TPCollectionH[it->first],
+                              std::make_pair(tC[itma->idx], itma->quality));
     }
   }
 

--- a/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
@@ -1,71 +1,89 @@
-#include "SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "DataFormats/CSCRecHit/interface/CSCSegment.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4D.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "DataFormats/DTRecHit/interface/DTRecSegment4D.h"
-#include "DataFormats/CSCRecHit/interface/CSCSegment.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h"
 #include <sstream>
 
 using namespace reco;
 using namespace std;
 
-MuonAssociatorByHitsHelper::MuonAssociatorByHitsHelper (const edm::ParameterSet& conf) :  
-  includeZeroHitMuons(conf.getParameter<bool>("includeZeroHitMuons")),
-  acceptOneStubMatchings(conf.getParameter<bool>("acceptOneStubMatchings")),
-  UseTracker(conf.getParameter<bool>("UseTracker")),
-  UseMuon(conf.getParameter<bool>("UseMuon")),
-  AbsoluteNumberOfHits_track(conf.getParameter<bool>("AbsoluteNumberOfHits_track")),
-  NHitCut_track(conf.getParameter<unsigned int>("NHitCut_track")),
-  EfficiencyCut_track(conf.getParameter<double>("EfficiencyCut_track")),
-  PurityCut_track(conf.getParameter<double>("PurityCut_track")),
-  AbsoluteNumberOfHits_muon(conf.getParameter<bool>("AbsoluteNumberOfHits_muon")),
-  NHitCut_muon(conf.getParameter<unsigned int>("NHitCut_muon")),
-  EfficiencyCut_muon(conf.getParameter<double>("EfficiencyCut_muon")),
-  PurityCut_muon(conf.getParameter<double>("PurityCut_muon")),
-  UsePixels(conf.getParameter<bool>("UsePixels")),
-  UseGrouped(conf.getParameter<bool>("UseGrouped")),
-  UseSplitting(conf.getParameter<bool>("UseSplitting")),
-  ThreeHitTracksAreSpecial(conf.getParameter<bool>("ThreeHitTracksAreSpecial")),
-  dumpDT(conf.getParameter<bool>("dumpDT"))
-{
-  edm::LogVerbatim("MuonAssociatorByHitsHelper") << "constructing  MuonAssociatorByHitsHelper" << conf.dump();
+MuonAssociatorByHitsHelper::MuonAssociatorByHitsHelper(
+    const edm::ParameterSet &conf)
+    : includeZeroHitMuons(conf.getParameter<bool>("includeZeroHitMuons")),
+      acceptOneStubMatchings(conf.getParameter<bool>("acceptOneStubMatchings")),
+      UseTracker(conf.getParameter<bool>("UseTracker")),
+      UseMuon(conf.getParameter<bool>("UseMuon")),
+      AbsoluteNumberOfHits_track(
+          conf.getParameter<bool>("AbsoluteNumberOfHits_track")),
+      NHitCut_track(conf.getParameter<unsigned int>("NHitCut_track")),
+      EfficiencyCut_track(conf.getParameter<double>("EfficiencyCut_track")),
+      PurityCut_track(conf.getParameter<double>("PurityCut_track")),
+      AbsoluteNumberOfHits_muon(
+          conf.getParameter<bool>("AbsoluteNumberOfHits_muon")),
+      NHitCut_muon(conf.getParameter<unsigned int>("NHitCut_muon")),
+      EfficiencyCut_muon(conf.getParameter<double>("EfficiencyCut_muon")),
+      PurityCut_muon(conf.getParameter<double>("PurityCut_muon")),
+      UsePixels(conf.getParameter<bool>("UsePixels")),
+      UseGrouped(conf.getParameter<bool>("UseGrouped")),
+      UseSplitting(conf.getParameter<bool>("UseSplitting")),
+      ThreeHitTracksAreSpecial(
+          conf.getParameter<bool>("ThreeHitTracksAreSpecial")),
+      dumpDT(conf.getParameter<bool>("dumpDT")) {
+  edm::LogVerbatim("MuonAssociatorByHitsHelper")
+      << "constructing  MuonAssociatorByHitsHelper" << conf.dump();
 
   // up to the user in the other cases - print a message
-  if (UseTracker) edm::LogVerbatim("MuonAssociatorByHitsHelper")<<"\n UseTracker = TRUE  : Tracker SimHits and RecHits WILL be counted";
-  else edm::LogVerbatim("MuonAssociatorByHitsHelper") <<"\n UseTracker = FALSE : Tracker SimHits and RecHits WILL NOT be counted";
-  
+  if (UseTracker)
+    edm::LogVerbatim("MuonAssociatorByHitsHelper")
+        << "\n UseTracker = TRUE  : Tracker SimHits and RecHits WILL be "
+           "counted";
+  else
+    edm::LogVerbatim("MuonAssociatorByHitsHelper")
+        << "\n UseTracker = FALSE : Tracker SimHits and RecHits WILL NOT be "
+           "counted";
+
   // up to the user in the other cases - print a message
-  if (UseMuon) edm::LogVerbatim("MuonAssociatorByHitsHelper")<<" UseMuon = TRUE  : Muon SimHits and RecHits WILL be counted";
-  else edm::LogVerbatim("MuonAssociatorByHitsHelper") <<" UseMuon = FALSE : Muon SimHits and RecHits WILL NOT be counted"<<endl;
-  
-  // check consistency of the configuration when allowing zero-hit muon matching (counting invalid hits)
+  if (UseMuon)
+    edm::LogVerbatim("MuonAssociatorByHitsHelper")
+        << " UseMuon = TRUE  : Muon SimHits and RecHits WILL be counted";
+  else
+    edm::LogVerbatim("MuonAssociatorByHitsHelper")
+        << " UseMuon = FALSE : Muon SimHits and RecHits WILL NOT be counted"
+        << endl;
+
+  // check consistency of the configuration when allowing zero-hit muon matching
+  // (counting invalid hits)
   if (includeZeroHitMuons) {
-    edm::LogVerbatim("MuonAssociatorByHitsHelper") 
-      <<"\n includeZeroHitMuons = TRUE"
-      <<"\n ==> (re)set NHitCut_muon = 0, PurityCut_muon = 0, EfficiencyCut_muon = 0"<<endl;
+    edm::LogVerbatim("MuonAssociatorByHitsHelper")
+        << "\n includeZeroHitMuons = TRUE"
+        << "\n ==> (re)set NHitCut_muon = 0, PurityCut_muon = 0, "
+           "EfficiencyCut_muon = 0"
+        << endl;
     NHitCut_muon = 0;
     PurityCut_muon = 0.;
     EfficiencyCut_muon = 0.;
   }
-
 }
 
 MuonAssociatorByHitsHelper::IndexAssociation
-MuonAssociatorByHitsHelper::associateRecoToSimIndices(const TrackHitsCollection & tC,
-                                                      const edm::RefVector<TrackingParticleCollection>& TPCollectionH,
-                                                      const Resources& resources) const {
+MuonAssociatorByHitsHelper::associateRecoToSimIndices(
+    const TrackHitsCollection &tC,
+    const edm::RefVector<TrackingParticleCollection> &TPCollectionH,
+    const Resources &resources) const {
 
   auto tTopo = resources.tTopo_;
   auto trackertruth = resources.trackerHitAssoc_;
-  auto const & csctruth = *resources.cscHitAssoc_;
-  auto const& dttruth = *resources.dtHitAssoc_;
-  auto const& rpctruth = *resources.rpcHitAssoc_;
-  auto const& gemtruth = *resources.gemHitAssoc_;
+  auto const &csctruth = *resources.cscHitAssoc_;
+  auto const &dttruth = *resources.dtHitAssoc_;
+  auto const &rpctruth = *resources.rpcHitAssoc_;
+  auto const &gemtruth = *resources.gemHitAssoc_;
 
   int tracker_nshared = 0;
   int muon_nshared = 0;
@@ -73,37 +91,43 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(const TrackHitsCollection 
 
   double tracker_quality = 0;
   double tracker_quality_cut;
-  if (AbsoluteNumberOfHits_track) tracker_quality_cut = static_cast<double>(NHitCut_track); 
-  else tracker_quality_cut = PurityCut_track;
+  if (AbsoluteNumberOfHits_track)
+    tracker_quality_cut = static_cast<double>(NHitCut_track);
+  else
+    tracker_quality_cut = PurityCut_track;
 
   double muon_quality = 0;
   double muon_quality_cut;
-  if (AbsoluteNumberOfHits_muon) muon_quality_cut = static_cast<double>(NHitCut_muon); 
-  else muon_quality_cut = PurityCut_muon;
+  if (AbsoluteNumberOfHits_muon)
+    muon_quality_cut = static_cast<double>(NHitCut_muon);
+  else
+    muon_quality_cut = PurityCut_muon;
 
   double global_quality = 0;
-  
+
   MapOfMatchedIds tracker_matchedIds_valid, muon_matchedIds_valid;
   MapOfMatchedIds tracker_matchedIds_INVALID, muon_matchedIds_INVALID;
 
-  IndexAssociation     outputCollection;
+  IndexAssociation outputCollection;
   bool printRtS(true);
 
   TrackingParticleCollection tPC;
   tPC.reserve(TPCollectionH.size());
-  for(auto const& ref: TPCollectionH) {
+  for (auto const &ref : TPCollectionH) {
     tPC.push_back(*ref);
   }
 
-  if(resources.diagnostics_) {
-    resources.diagnostics_(tC,tPC);
+  if (resources.diagnostics_) {
+    resources.diagnostics_(tC, tPC);
   }
 
-  int tindex=0;
-  for (TrackHitsCollection::const_iterator track=tC.begin(); track!=tC.end(); track++, tindex++) {
+  int tindex = 0;
+  for (TrackHitsCollection::const_iterator track = tC.begin();
+       track != tC.end(); track++, tindex++) {
     edm::LogVerbatim("MuonAssociatorByHitsHelper")
-      <<"\n"<<"reco::Track "<<tindex
-      <<", number of RecHits = "<< (track->second - track->first) << "\n";
+        << "\n"
+        << "reco::Track " << tindex
+        << ", number of RecHits = " << (track->second - track->first) << "\n";
     tracker_matchedIds_valid.clear();
     muon_matchedIds_valid.clear();
 
@@ -114,239 +138,304 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(const TrackHitsCollection 
     int n_matching_simhits = 0;
 
     // all hits = valid +INVALID
-    int n_all         = 0;        
+    int n_all = 0;
     int n_tracker_all = 0;
-    int n_dt_all      = 0;     
-    int n_csc_all     = 0;    
-    int n_rpc_all     = 0;
-    int n_gem_all     = 0;
+    int n_dt_all = 0;
+    int n_csc_all = 0;
+    int n_rpc_all = 0;
+    int n_gem_all = 0;
 
-    int n_valid         = 0;        
+    int n_valid = 0;
     int n_tracker_valid = 0;
-    int n_muon_valid    = 0;   
-    int n_dt_valid      = 0;     
-    int n_csc_valid     = 0;    
-    int n_rpc_valid     = 0;
-    int n_gem_valid     = 0;
+    int n_muon_valid = 0;
+    int n_dt_valid = 0;
+    int n_csc_valid = 0;
+    int n_rpc_valid = 0;
+    int n_gem_valid = 0;
 
     int n_tracker_matched_valid = 0;
-    int n_muon_matched_valid    = 0;   
-    int n_dt_matched_valid      = 0;     
-    int n_csc_matched_valid     = 0;    
-    int n_rpc_matched_valid     = 0;
-    int n_gem_matched_valid     = 0;
+    int n_muon_matched_valid = 0;
+    int n_dt_matched_valid = 0;
+    int n_csc_matched_valid = 0;
+    int n_rpc_matched_valid = 0;
+    int n_gem_matched_valid = 0;
 
-    int n_INVALID         = 0;        
+    int n_INVALID = 0;
     int n_tracker_INVALID = 0;
-    int n_muon_INVALID    = 0;   
-    int n_dt_INVALID      = 0;     
-    int n_csc_INVALID     = 0;    
-    int n_rpc_INVALID     = 0;
-    int n_gem_INVALID     = 0;
-    
+    int n_muon_INVALID = 0;
+    int n_dt_INVALID = 0;
+    int n_csc_INVALID = 0;
+    int n_rpc_INVALID = 0;
+    int n_gem_INVALID = 0;
+
     int n_tracker_matched_INVALID = 0;
-    int n_muon_matched_INVALID    = 0;     
-    int n_dt_matched_INVALID      = 0;     
-    int n_csc_matched_INVALID     = 0;    
-    int n_rpc_matched_INVALID     = 0;
-    int n_gem_matched_INVALID     = 0;
-    
+    int n_muon_matched_INVALID = 0;
+    int n_dt_matched_INVALID = 0;
+    int n_csc_matched_INVALID = 0;
+    int n_rpc_matched_INVALID = 0;
+    int n_gem_matched_INVALID = 0;
+
     printRtS = true;
     getMatchedIds(tracker_matchedIds_valid, muon_matchedIds_valid,
-		  tracker_matchedIds_INVALID, muon_matchedIds_INVALID,       
-		  n_tracker_valid, n_dt_valid, n_csc_valid, n_rpc_valid, n_gem_valid,
-		  n_tracker_matched_valid, n_dt_matched_valid, n_csc_matched_valid, n_rpc_matched_valid, n_gem_matched_valid,
-		  n_tracker_INVALID, n_dt_INVALID, n_csc_INVALID, n_rpc_INVALID, n_gem_INVALID,
-		  n_tracker_matched_INVALID, n_dt_matched_INVALID, n_csc_matched_INVALID, n_rpc_matched_INVALID, n_gem_matched_INVALID,
-                  track->first, track->second,
-		  trackertruth, dttruth, csctruth, rpctruth, gemtruth,
-		  printRtS,tTopo);
-    
-    n_matching_simhits = tracker_matchedIds_valid.size() + muon_matchedIds_valid.size() + 
-                         tracker_matchedIds_INVALID.size() +muon_matchedIds_INVALID.size(); 
+                  tracker_matchedIds_INVALID, muon_matchedIds_INVALID,
+                  n_tracker_valid, n_dt_valid, n_csc_valid, n_rpc_valid,
+                  n_gem_valid, n_tracker_matched_valid, n_dt_matched_valid,
+                  n_csc_matched_valid, n_rpc_matched_valid, n_gem_matched_valid,
+                  n_tracker_INVALID, n_dt_INVALID, n_csc_INVALID, n_rpc_INVALID,
+                  n_gem_INVALID, n_tracker_matched_INVALID,
+                  n_dt_matched_INVALID, n_csc_matched_INVALID,
+                  n_rpc_matched_INVALID, n_gem_matched_INVALID, track->first,
+                  track->second, trackertruth, dttruth, csctruth, rpctruth,
+                  gemtruth, printRtS, tTopo);
 
-    n_muon_valid   = n_dt_valid + n_csc_valid + n_rpc_valid + n_gem_valid;
-    n_valid        = n_tracker_valid + n_muon_valid;
-    n_muon_INVALID = n_dt_INVALID + n_csc_INVALID + n_rpc_INVALID + n_gem_INVALID;
-    n_INVALID      = n_tracker_INVALID + n_muon_INVALID;
+    n_matching_simhits =
+        tracker_matchedIds_valid.size() + muon_matchedIds_valid.size() +
+        tracker_matchedIds_INVALID.size() + muon_matchedIds_INVALID.size();
+
+    n_muon_valid = n_dt_valid + n_csc_valid + n_rpc_valid + n_gem_valid;
+    n_valid = n_tracker_valid + n_muon_valid;
+    n_muon_INVALID =
+        n_dt_INVALID + n_csc_INVALID + n_rpc_INVALID + n_gem_INVALID;
+    n_INVALID = n_tracker_INVALID + n_muon_INVALID;
 
     // all used hits (valid+INVALID), defined by UseTracker, UseMuon
     n_tracker_all = n_tracker_valid + n_tracker_INVALID;
-    n_dt_all      = n_dt_valid  + n_dt_INVALID;
-    n_csc_all     = n_csc_valid + n_csc_INVALID;
-    n_rpc_all     = n_rpc_valid + n_rpc_INVALID;
-    n_gem_all     = n_gem_valid + n_gem_INVALID;
-    n_all         = n_valid + n_INVALID;
+    n_dt_all = n_dt_valid + n_dt_INVALID;
+    n_csc_all = n_csc_valid + n_csc_INVALID;
+    n_rpc_all = n_rpc_valid + n_rpc_INVALID;
+    n_gem_all = n_gem_valid + n_gem_INVALID;
+    n_all = n_valid + n_INVALID;
 
-    n_muon_matched_valid   = n_dt_matched_valid + n_csc_matched_valid + n_rpc_matched_valid + n_gem_matched_valid;
-    n_muon_matched_INVALID = n_dt_matched_INVALID + n_csc_matched_INVALID + n_rpc_matched_INVALID + n_gem_matched_INVALID;
+    n_muon_matched_valid = n_dt_matched_valid + n_csc_matched_valid +
+                           n_rpc_matched_valid + n_gem_matched_valid;
+    n_muon_matched_INVALID = n_dt_matched_INVALID + n_csc_matched_INVALID +
+                             n_rpc_matched_INVALID + n_gem_matched_INVALID;
 
     // selected hits are set initially to valid hits
     int n_tracker_selected_hits = n_tracker_valid;
-    int n_muon_selected_hits    = n_muon_valid;
-    int n_dt_selected_hits      = n_dt_valid;
-    int n_csc_selected_hits     = n_csc_valid;
-    int n_rpc_selected_hits     = n_rpc_valid;
-    int n_gem_selected_hits     = n_gem_valid;
+    int n_muon_selected_hits = n_muon_valid;
+    int n_dt_selected_hits = n_dt_valid;
+    int n_csc_selected_hits = n_csc_valid;
+    int n_rpc_selected_hits = n_rpc_valid;
+    int n_gem_selected_hits = n_gem_valid;
 
     // matched hits are a subsample of the selected hits
     int n_tracker_matched = n_tracker_matched_valid;
-    int n_muon_matched    = n_muon_matched_valid;
-    int n_dt_matched      = n_dt_matched_valid;
-    int n_csc_matched     = n_csc_matched_valid;
-    int n_rpc_matched     = n_rpc_matched_valid;
-    int n_gem_matched     = n_gem_matched_valid;
+    int n_muon_matched = n_muon_matched_valid;
+    int n_dt_matched = n_dt_matched_valid;
+    int n_csc_matched = n_csc_matched_valid;
+    int n_rpc_matched = n_rpc_matched_valid;
+    int n_gem_matched = n_gem_matched_valid;
 
     std::string InvMuonHits, ZeroHitMuon;
-    
-    if (includeZeroHitMuons && n_muon_valid==0 && n_muon_INVALID!=0) {
-      // selected muon hits = INVALID when (useZeroHitMuons == True) and track has no valid muon hits
+
+    if (includeZeroHitMuons && n_muon_valid == 0 && n_muon_INVALID != 0) {
+      // selected muon hits = INVALID when (useZeroHitMuons == True) and track
+      // has no valid muon hits
 
       InvMuonHits = " ***INVALID MUON HITS***";
       ZeroHitMuon = " ***ZERO-HIT MUON***";
 
       n_muon_selected_hits = n_muon_INVALID;
-      n_dt_selected_hits   = n_dt_INVALID;
-      n_csc_selected_hits  = n_csc_INVALID;
-      n_rpc_selected_hits  = n_rpc_INVALID;
-      n_gem_selected_hits  = n_gem_INVALID;
+      n_dt_selected_hits = n_dt_INVALID;
+      n_csc_selected_hits = n_csc_INVALID;
+      n_rpc_selected_hits = n_rpc_INVALID;
+      n_gem_selected_hits = n_gem_INVALID;
 
       n_muon_matched = n_muon_matched_INVALID;
-      n_dt_matched   = n_dt_matched_INVALID;
-      n_csc_matched  = n_csc_matched_INVALID;
-      n_rpc_matched  = n_rpc_matched_INVALID;
-      n_gem_matched  = n_gem_matched_INVALID;
+      n_dt_matched = n_dt_matched_INVALID;
+      n_csc_matched = n_csc_matched_INVALID;
+      n_rpc_matched = n_rpc_matched_INVALID;
+      n_gem_matched = n_gem_matched_INVALID;
     }
 
     int n_selected_hits = n_tracker_selected_hits + n_muon_selected_hits;
     int n_matched = n_tracker_matched + n_muon_matched;
 
     edm::LogVerbatim("MuonAssociatorByHitsHelper")
-      <<"\n"<<"# TrackingRecHits: "<<(track->second - track->first) 
-      <<"\n"<< "# used RecHits     = " << n_all <<" ("<<n_tracker_all<<"/"
-      <<n_dt_all<<"/"<<n_csc_all<<"/"<<n_rpc_all<<"/"<<n_gem_all<<" in Tracker/DT/CSC/RPC/GEM)"<<", obtained from " << n_matching_simhits << " SimHits"
-      <<"\n"<< "# selected RecHits = " <<n_selected_hits <<" (" <<n_tracker_selected_hits<<"/"
-      <<n_dt_selected_hits<<"/"<<n_csc_selected_hits<<"/"<<n_rpc_selected_hits<<"/"<<n_gem_selected_hits<<" in Tracker/DT/CSC/RPC/GEM)"<<InvMuonHits
-      <<"\n"<< "# matched RecHits  = " <<n_matched<<" ("<<n_tracker_matched<<"/"
-      <<n_dt_matched<<"/"<<n_csc_matched<<"/"<<n_rpc_matched<<"/"<<n_gem_matched<<" in Tracker/DT/CSC/RPC/GEM)";
+        << "\n"
+        << "# TrackingRecHits: " << (track->second - track->first) << "\n"
+        << "# used RecHits     = " << n_all << " (" << n_tracker_all << "/"
+        << n_dt_all << "/" << n_csc_all << "/" << n_rpc_all << "/" << n_gem_all
+        << " in Tracker/DT/CSC/RPC/GEM)"
+        << ", obtained from " << n_matching_simhits << " SimHits"
+        << "\n"
+        << "# selected RecHits = " << n_selected_hits << " ("
+        << n_tracker_selected_hits << "/" << n_dt_selected_hits << "/"
+        << n_csc_selected_hits << "/" << n_rpc_selected_hits << "/"
+        << n_gem_selected_hits << " in Tracker/DT/CSC/RPC/GEM)" << InvMuonHits
+        << "\n"
+        << "# matched RecHits  = " << n_matched << " (" << n_tracker_matched
+        << "/" << n_dt_matched << "/" << n_csc_matched << "/" << n_rpc_matched
+        << "/" << n_gem_matched << " in Tracker/DT/CSC/RPC/GEM)";
 
-    if (n_all>0 && n_matching_simhits == 0)
+    if (n_all > 0 && n_matching_simhits == 0)
       edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	<<"*** WARNING in MuonAssociatorByHitsHelper::associateRecoToSim: no matching PSimHit found for this reco::Track !";
+          << "*** WARNING in MuonAssociatorByHitsHelper::associateRecoToSim: "
+             "no matching PSimHit found for this reco::Track !";
 
     if (n_matching_simhits != 0) {
       edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	<<"\n"<< "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
-	<<"\n"<< "reco::Track "<<tindex<<ZeroHitMuon
-	<<"\n\t"<< "made of "<<n_selected_hits<<" selected RecHits (tracker:"<<n_tracker_selected_hits<<"/muons:"<<n_muon_selected_hits<<")";
+          << "\n"
+          << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
+             "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
+          << "\n"
+          << "reco::Track " << tindex << ZeroHitMuon << "\n\t"
+          << "made of " << n_selected_hits
+          << " selected RecHits (tracker:" << n_tracker_selected_hits
+          << "/muons:" << n_muon_selected_hits << ")";
 
       int tpindex = 0;
-      for (TrackingParticleCollection::const_iterator trpart = tPC.begin(); trpart != tPC.end(); ++trpart, ++tpindex) {
-	tracker_nshared = getShared(tracker_matchedIds_valid, trpart);
-	muon_nshared = getShared(muon_matchedIds_valid, trpart);
+      for (TrackingParticleCollection::const_iterator trpart = tPC.begin();
+           trpart != tPC.end(); ++trpart, ++tpindex) {
+        tracker_nshared = getShared(tracker_matchedIds_valid, trpart);
+        muon_nshared = getShared(muon_matchedIds_valid, trpart);
 
-	if (includeZeroHitMuons && n_muon_valid==0 && n_muon_INVALID!=0) 
-	  muon_nshared = getShared(muon_matchedIds_INVALID, trpart);
+        if (includeZeroHitMuons && n_muon_valid == 0 && n_muon_INVALID != 0)
+          muon_nshared = getShared(muon_matchedIds_INVALID, trpart);
 
         global_nshared = tracker_nshared + muon_nshared;
 
-	if (AbsoluteNumberOfHits_track) tracker_quality = static_cast<double>(tracker_nshared);
-	else if(n_tracker_selected_hits != 0) tracker_quality = (static_cast<double>(tracker_nshared)/static_cast<double>(n_tracker_selected_hits));
-	else tracker_quality = 0;
+        if (AbsoluteNumberOfHits_track)
+          tracker_quality = static_cast<double>(tracker_nshared);
+        else if (n_tracker_selected_hits != 0)
+          tracker_quality = (static_cast<double>(tracker_nshared) /
+                             static_cast<double>(n_tracker_selected_hits));
+        else
+          tracker_quality = 0;
 
-	if (AbsoluteNumberOfHits_muon) muon_quality = static_cast<double>(muon_nshared);
-	else if(n_muon_selected_hits != 0) muon_quality = (static_cast<double>(muon_nshared)/static_cast<double>(n_muon_selected_hits));
-	else muon_quality = 0;
+        if (AbsoluteNumberOfHits_muon)
+          muon_quality = static_cast<double>(muon_nshared);
+        else if (n_muon_selected_hits != 0)
+          muon_quality = (static_cast<double>(muon_nshared) /
+                          static_cast<double>(n_muon_selected_hits));
+        else
+          muon_quality = 0;
 
-	// global_quality used to order the matching TPs
-	if (n_selected_hits != 0) {
-            if (AbsoluteNumberOfHits_muon && AbsoluteNumberOfHits_track) 
-                global_quality = global_nshared;
-            else
-                global_quality = (static_cast<double>(global_nshared)/static_cast<double>(n_selected_hits));
-        } else global_quality = 0;
+        // global_quality used to order the matching TPs
+        if (n_selected_hits != 0) {
+          if (AbsoluteNumberOfHits_muon && AbsoluteNumberOfHits_track)
+            global_quality = global_nshared;
+          else
+            global_quality = (static_cast<double>(global_nshared) /
+                              static_cast<double>(n_selected_hits));
+        } else
+          global_quality = 0;
 
-	bool trackerOk = false;
-	if (n_tracker_selected_hits != 0) {
-	  if (tracker_quality > tracker_quality_cut) trackerOk = true;
-	  //if a track has just 3 hits in the Tracker we require that all 3 hits are shared
-	  if (ThreeHitTracksAreSpecial && n_tracker_selected_hits==3 && tracker_nshared<3) trackerOk = false;
-	}
-	
-	bool muonOk = false;
-	if (n_muon_selected_hits != 0) {
-	  if (muon_quality > muon_quality_cut) muonOk = true;
-	}
-	
-	// (matchOk) has to account for different track types (tracker-only, standalone muons, global muons)
-	bool matchOk = trackerOk || muonOk;
+        bool trackerOk = false;
+        if (n_tracker_selected_hits != 0) {
+          if (tracker_quality > tracker_quality_cut)
+            trackerOk = true;
+          // if a track has just 3 hits in the Tracker we require that all 3
+          // hits are shared
+          if (ThreeHitTracksAreSpecial && n_tracker_selected_hits == 3 &&
+              tracker_nshared < 3)
+            trackerOk = false;
+        }
 
-	// only for global muons: match both tracker and muon stub unless (acceptOneStubMatchings==true)
-	if (!acceptOneStubMatchings && n_tracker_selected_hits!=0 && n_muon_selected_hits!=0)
-	  matchOk = trackerOk && muonOk;
-	
-	if (matchOk) {
+        bool muonOk = false;
+        if (n_muon_selected_hits != 0) {
+          if (muon_quality > muon_quality_cut)
+            muonOk = true;
+        }
 
-          outputCollection[tindex].push_back(IndexMatch(tpindex, global_quality));
-	  this_track_matched = true;
+        // (matchOk) has to account for different track types (tracker-only,
+        // standalone muons, global muons)
+        bool matchOk = trackerOk || muonOk;
 
-	  edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	    << "\n\t"<<" **MATCHED** with quality = "<<global_quality<<" (tracker: "<<tracker_quality<<" / muon: "<<muon_quality<<")"
-	    << "\n\t"<<"   N shared hits = "<<global_nshared<<" (tracker: "<<tracker_nshared<<" / muon: "<<muon_nshared<<")"
-	    <<"\n"<< "   to: TrackingParticle " <<tpindex<<", q = "<<(*trpart).charge()<<", p = "<<(*trpart).p()
-	    <<", pT = "<<(*trpart).pt()<<", eta = "<<(*trpart).eta()<<", phi = "<<(*trpart).phi()
-	    <<"\n\t"<< " pdg code = "<<(*trpart).pdgId()<<", made of "<<(*trpart).numberOfHits()<<" PSimHits"
-	    <<" from "<<(*trpart).g4Tracks().size()<<" SimTrack:";
-	  for(TrackingParticle::g4t_iterator g4T=(*trpart).g4Track_begin(); 
-	      g4T!=(*trpart).g4Track_end(); 
-	      ++g4T) {
-	    edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	      <<"\t"<< " Id:"<<(*g4T).trackId()<<"/Evt:("<<(*g4T).eventId().event()<<","<<(*g4T).eventId().bunchCrossing()<<")";	    
-	  }
-	}
-	else {
-	  // print something only if this TrackingParticle shares some hits with the current reco::Track
-	  if (global_nshared != 0) 
-	    edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	      <<"\n\t"<<" NOT matched to TrackingParticle "<<tpindex
-	      << " with quality = "<<global_quality<<" (tracker: "<<tracker_quality<<" / muon: "<<muon_quality<<")"
-	      << "\n"<< "   N shared hits = "<<global_nshared<<" (tracker: "<<tracker_nshared<<" / muon: "<<muon_nshared<<")";
-	}
-	
-      }    //  loop over TrackingParticle
+        // only for global muons: match both tracker and muon stub unless
+        // (acceptOneStubMatchings==true)
+        if (!acceptOneStubMatchings && n_tracker_selected_hits != 0 &&
+            n_muon_selected_hits != 0)
+          matchOk = trackerOk && muonOk;
+
+        if (matchOk) {
+
+          outputCollection[tindex].push_back(
+              IndexMatch(tpindex, global_quality));
+          this_track_matched = true;
+
+          edm::LogVerbatim("MuonAssociatorByHitsHelper")
+              << "\n\t"
+              << " **MATCHED** with quality = " << global_quality
+              << " (tracker: " << tracker_quality << " / muon: " << muon_quality
+              << ")"
+              << "\n\t"
+              << "   N shared hits = " << global_nshared
+              << " (tracker: " << tracker_nshared << " / muon: " << muon_nshared
+              << ")"
+              << "\n"
+              << "   to: TrackingParticle " << tpindex
+              << ", q = " << (*trpart).charge() << ", p = " << (*trpart).p()
+              << ", pT = " << (*trpart).pt() << ", eta = " << (*trpart).eta()
+              << ", phi = " << (*trpart).phi() << "\n\t"
+              << " pdg code = " << (*trpart).pdgId() << ", made of "
+              << (*trpart).numberOfHits() << " PSimHits"
+              << " from " << (*trpart).g4Tracks().size() << " SimTrack:";
+          for (TrackingParticle::g4t_iterator g4T = (*trpart).g4Track_begin();
+               g4T != (*trpart).g4Track_end(); ++g4T) {
+            edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                << "\t"
+                << " Id:" << (*g4T).trackId() << "/Evt:("
+                << (*g4T).eventId().event() << ","
+                << (*g4T).eventId().bunchCrossing() << ")";
+          }
+        } else {
+          // print something only if this TrackingParticle shares some hits with
+          // the current reco::Track
+          if (global_nshared != 0)
+            edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                << "\n\t"
+                << " NOT matched to TrackingParticle " << tpindex
+                << " with quality = " << global_quality
+                << " (tracker: " << tracker_quality
+                << " / muon: " << muon_quality << ")"
+                << "\n"
+                << "   N shared hits = " << global_nshared
+                << " (tracker: " << tracker_nshared
+                << " / muon: " << muon_nshared << ")";
+        }
+
+      } //  loop over TrackingParticle
 
       if (!this_track_matched) {
-	edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	  <<"\n"<<" NOT matched to any TrackingParticle";
+        edm::LogVerbatim("MuonAssociatorByHitsHelper")
+            << "\n"
+            << " NOT matched to any TrackingParticle";
       }
-      
+
       edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	<<"%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"<<"\n";
-     
-    }    //  if(n_matching_simhits != 0)
-    
-  }    // loop over reco::Track
+          << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
+             "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
+          << "\n";
 
-  if (tC.empty()) 
-    edm::LogVerbatim("MuonAssociatorByHitsHelper")<<"0 reconstructed tracks (-->> 0 associated !)";
+    } //  if(n_matching_simhits != 0)
 
-  for (IndexAssociation::iterator it = outputCollection.begin(), ed = outputCollection.end(); it != ed; ++it) {
+  } // loop over reco::Track
+
+  if (tC.empty())
+    edm::LogVerbatim("MuonAssociatorByHitsHelper")
+        << "0 reconstructed tracks (-->> 0 associated !)";
+
+  for (IndexAssociation::iterator it = outputCollection.begin(),
+                                  ed = outputCollection.end();
+       it != ed; ++it) {
     std::sort(it->second.begin(), it->second.end());
   }
   return outputCollection;
 }
 
-
 MuonAssociatorByHitsHelper::IndexAssociation
-MuonAssociatorByHitsHelper::associateSimToRecoIndices( const TrackHitsCollection & tC, 
-                                                       const edm::RefVector<TrackingParticleCollection>& TPCollectionH,
-                                                       const Resources& resources) const {
+MuonAssociatorByHitsHelper::associateSimToRecoIndices(
+    const TrackHitsCollection &tC,
+    const edm::RefVector<TrackingParticleCollection> &TPCollectionH,
+    const Resources &resources) const {
   auto tTopo = resources.tTopo_;
   auto trackertruth = resources.trackerHitAssoc_;
-  auto const & csctruth = *resources.cscHitAssoc_;
-  auto const& dttruth = *resources.dtHitAssoc_;
-  auto const& rpctruth = *resources.rpcHitAssoc_;
-  auto const& gemtruth = *resources.gemHitAssoc_;
+  auto const &csctruth = *resources.cscHitAssoc_;
+  auto const &dttruth = *resources.dtHitAssoc_;
+  auto const &rpctruth = *resources.rpcHitAssoc_;
+  auto const &gemtruth = *resources.gemHitAssoc_;
 
   int tracker_nshared = 0;
   int muon_nshared = 0;
@@ -354,42 +443,48 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices( const TrackHitsCollection
 
   double tracker_quality = 0;
   double tracker_quality_cut;
-  if (AbsoluteNumberOfHits_track) tracker_quality_cut = static_cast<double>(NHitCut_track); 
-  else tracker_quality_cut = EfficiencyCut_track;
-  
+  if (AbsoluteNumberOfHits_track)
+    tracker_quality_cut = static_cast<double>(NHitCut_track);
+  else
+    tracker_quality_cut = EfficiencyCut_track;
+
   double muon_quality = 0;
   double muon_quality_cut;
-  if (AbsoluteNumberOfHits_muon) muon_quality_cut = static_cast<double>(NHitCut_muon); 
-  else muon_quality_cut = EfficiencyCut_muon;
+  if (AbsoluteNumberOfHits_muon)
+    muon_quality_cut = static_cast<double>(NHitCut_muon);
+  else
+    muon_quality_cut = EfficiencyCut_muon;
 
   double global_quality = 0;
 
   double tracker_purity = 0;
   double muon_purity = 0;
   double global_purity = 0;
-  
+
   MapOfMatchedIds tracker_matchedIds_valid, muon_matchedIds_valid;
   MapOfMatchedIds tracker_matchedIds_INVALID, muon_matchedIds_INVALID;
 
-  IndexAssociation  outputCollection;
-
+  IndexAssociation outputCollection;
 
   bool printRtS(true);
 
   TrackingParticleCollection tPC;
   tPC.reserve(TPCollectionH.size());
-  for(auto const& ref: TPCollectionH) {
+  for (auto const &ref : TPCollectionH) {
     tPC.push_back(*ref);
   }
 
   bool any_trackingParticle_matched = false;
-  
-  int tindex=0;
-  for (TrackHitsCollection::const_iterator track=tC.begin(); track!=tC.end(); track++, tindex++) {
-    if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-      <<"\n"<<"reco::Track "<<tindex
-      <<", number of RecHits = "<< (track->second - track->first) << "\n";
-    
+
+  int tindex = 0;
+  for (TrackHitsCollection::const_iterator track = tC.begin();
+       track != tC.end(); track++, tindex++) {
+    if (printRtS)
+      edm::LogVerbatim("MuonAssociatorByHitsHelper")
+          << "\n"
+          << "reco::Track " << tindex
+          << ", number of RecHits = " << (track->second - track->first) << "\n";
+
     tracker_matchedIds_valid.clear();
     muon_matchedIds_valid.clear();
 
@@ -399,385 +494,484 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices( const TrackHitsCollection
     int n_matching_simhits = 0;
 
     // all hits = valid +INVALID
-    int n_all         = 0;        
+    int n_all = 0;
     int n_tracker_all = 0;
-    int n_dt_all      = 0;     
-    int n_csc_all     = 0;    
-    int n_rpc_all     = 0;
-    int n_gem_all     = 0;
+    int n_dt_all = 0;
+    int n_csc_all = 0;
+    int n_rpc_all = 0;
+    int n_gem_all = 0;
 
-    int n_valid         = 0;        
+    int n_valid = 0;
     int n_tracker_valid = 0;
-    int n_muon_valid    = 0;   
-    int n_dt_valid      = 0;     
-    int n_csc_valid     = 0;    
-    int n_rpc_valid     = 0;
-    int n_gem_valid     = 0;
+    int n_muon_valid = 0;
+    int n_dt_valid = 0;
+    int n_csc_valid = 0;
+    int n_rpc_valid = 0;
+    int n_gem_valid = 0;
 
     int n_tracker_matched_valid = 0;
-    int n_muon_matched_valid    = 0;   
-    int n_dt_matched_valid      = 0;     
-    int n_csc_matched_valid     = 0;    
-    int n_rpc_matched_valid     = 0;
-    int n_gem_matched_valid     = 0;
+    int n_muon_matched_valid = 0;
+    int n_dt_matched_valid = 0;
+    int n_csc_matched_valid = 0;
+    int n_rpc_matched_valid = 0;
+    int n_gem_matched_valid = 0;
 
-    int n_INVALID         = 0;        
+    int n_INVALID = 0;
     int n_tracker_INVALID = 0;
-    int n_muon_INVALID    = 0;   
-    int n_dt_INVALID      = 0;     
-    int n_csc_INVALID     = 0;    
-    int n_rpc_INVALID     = 0;
-    int n_gem_INVALID     = 0;
-    
+    int n_muon_INVALID = 0;
+    int n_dt_INVALID = 0;
+    int n_csc_INVALID = 0;
+    int n_rpc_INVALID = 0;
+    int n_gem_INVALID = 0;
+
     int n_tracker_matched_INVALID = 0;
-    int n_muon_matched_INVALID    = 0;     
-    int n_dt_matched_INVALID      = 0;     
-    int n_csc_matched_INVALID     = 0;    
-    int n_rpc_matched_INVALID     = 0;
-    int n_gem_matched_INVALID     = 0;
-    
+    int n_muon_matched_INVALID = 0;
+    int n_dt_matched_INVALID = 0;
+    int n_csc_matched_INVALID = 0;
+    int n_rpc_matched_INVALID = 0;
+    int n_gem_matched_INVALID = 0;
+
     printRtS = false;
     getMatchedIds(tracker_matchedIds_valid, muon_matchedIds_valid,
-		  tracker_matchedIds_INVALID, muon_matchedIds_INVALID,       
-		  n_tracker_valid, n_dt_valid, n_csc_valid, n_rpc_valid, n_gem_valid,
-		  n_tracker_matched_valid, n_dt_matched_valid, n_csc_matched_valid, n_rpc_matched_valid, n_gem_matched_valid,
-		  n_tracker_INVALID, n_dt_INVALID, n_csc_INVALID, n_rpc_INVALID, n_gem_INVALID,
-		  n_tracker_matched_INVALID, n_dt_matched_INVALID, n_csc_matched_INVALID, n_rpc_matched_INVALID, n_gem_matched_INVALID,
-                  track->first, track->second,
-		  trackertruth, dttruth, csctruth, rpctruth, gemtruth,
-		  printRtS,tTopo);
-    
-    n_matching_simhits = tracker_matchedIds_valid.size() + muon_matchedIds_valid.size() + 
-                         tracker_matchedIds_INVALID.size() +muon_matchedIds_INVALID.size(); 
+                  tracker_matchedIds_INVALID, muon_matchedIds_INVALID,
+                  n_tracker_valid, n_dt_valid, n_csc_valid, n_rpc_valid,
+                  n_gem_valid, n_tracker_matched_valid, n_dt_matched_valid,
+                  n_csc_matched_valid, n_rpc_matched_valid, n_gem_matched_valid,
+                  n_tracker_INVALID, n_dt_INVALID, n_csc_INVALID, n_rpc_INVALID,
+                  n_gem_INVALID, n_tracker_matched_INVALID,
+                  n_dt_matched_INVALID, n_csc_matched_INVALID,
+                  n_rpc_matched_INVALID, n_gem_matched_INVALID, track->first,
+                  track->second, trackertruth, dttruth, csctruth, rpctruth,
+                  gemtruth, printRtS, tTopo);
 
-    n_muon_valid   = n_dt_valid + n_csc_valid + n_rpc_valid + n_gem_valid;
-    n_valid        = n_tracker_valid + n_muon_valid;
-    n_muon_INVALID = n_dt_INVALID + n_csc_INVALID + n_rpc_INVALID + n_gem_INVALID;
-    n_INVALID      = n_tracker_INVALID + n_muon_INVALID;
+    n_matching_simhits =
+        tracker_matchedIds_valid.size() + muon_matchedIds_valid.size() +
+        tracker_matchedIds_INVALID.size() + muon_matchedIds_INVALID.size();
+
+    n_muon_valid = n_dt_valid + n_csc_valid + n_rpc_valid + n_gem_valid;
+    n_valid = n_tracker_valid + n_muon_valid;
+    n_muon_INVALID =
+        n_dt_INVALID + n_csc_INVALID + n_rpc_INVALID + n_gem_INVALID;
+    n_INVALID = n_tracker_INVALID + n_muon_INVALID;
 
     // all used hits (valid+INVALID), defined by UseTracker, UseMuon
     n_tracker_all = n_tracker_valid + n_tracker_INVALID;
-    n_dt_all      = n_dt_valid  + n_dt_INVALID;
-    n_csc_all     = n_csc_valid + n_csc_INVALID;
-    n_rpc_all     = n_rpc_valid + n_rpc_INVALID;
-    n_gem_all     = n_gem_valid + n_gem_INVALID;
-    n_all         = n_valid + n_INVALID;
+    n_dt_all = n_dt_valid + n_dt_INVALID;
+    n_csc_all = n_csc_valid + n_csc_INVALID;
+    n_rpc_all = n_rpc_valid + n_rpc_INVALID;
+    n_gem_all = n_gem_valid + n_gem_INVALID;
+    n_all = n_valid + n_INVALID;
 
-    n_muon_matched_valid   = n_dt_matched_valid + n_csc_matched_valid + n_rpc_matched_valid + n_gem_matched_valid;
-    n_muon_matched_INVALID = n_dt_matched_INVALID + n_csc_matched_INVALID + n_rpc_matched_INVALID + n_gem_matched_INVALID;
+    n_muon_matched_valid = n_dt_matched_valid + n_csc_matched_valid +
+                           n_rpc_matched_valid + n_gem_matched_valid;
+    n_muon_matched_INVALID = n_dt_matched_INVALID + n_csc_matched_INVALID +
+                             n_rpc_matched_INVALID + n_gem_matched_INVALID;
 
-     // selected hits are set initially to valid hits
+    // selected hits are set initially to valid hits
     int n_tracker_selected_hits = n_tracker_valid;
-    int n_muon_selected_hits    = n_muon_valid;
-    int n_dt_selected_hits      = n_dt_valid;
-    int n_csc_selected_hits     = n_csc_valid;
-    int n_rpc_selected_hits     = n_rpc_valid;
-    int n_gem_selected_hits     = n_gem_valid;
+    int n_muon_selected_hits = n_muon_valid;
+    int n_dt_selected_hits = n_dt_valid;
+    int n_csc_selected_hits = n_csc_valid;
+    int n_rpc_selected_hits = n_rpc_valid;
+    int n_gem_selected_hits = n_gem_valid;
 
     // matched hits are a subsample of the selected hits
     int n_tracker_matched = n_tracker_matched_valid;
-    int n_muon_matched    = n_muon_matched_valid;
-    int n_dt_matched      = n_dt_matched_valid;
-    int n_csc_matched     = n_csc_matched_valid;
-    int n_rpc_matched     = n_rpc_matched_valid;
-    int n_gem_matched     = n_gem_matched_valid;
+    int n_muon_matched = n_muon_matched_valid;
+    int n_dt_matched = n_dt_matched_valid;
+    int n_csc_matched = n_csc_matched_valid;
+    int n_rpc_matched = n_rpc_matched_valid;
+    int n_gem_matched = n_gem_matched_valid;
 
     std::string InvMuonHits, ZeroHitMuon;
 
-    if (includeZeroHitMuons && n_muon_valid==0 && n_muon_INVALID!=0) {
-      // selected muon hits = INVALID when (useZeroHitMuons == True) and track has no valid muon hits
-      
+    if (includeZeroHitMuons && n_muon_valid == 0 && n_muon_INVALID != 0) {
+      // selected muon hits = INVALID when (useZeroHitMuons == True) and track
+      // has no valid muon hits
+
       InvMuonHits = " ***INVALID MUON HITS***";
       ZeroHitMuon = " ***ZERO-HIT MUON***";
 
       n_muon_selected_hits = n_muon_INVALID;
-      n_dt_selected_hits   = n_dt_INVALID;
-      n_csc_selected_hits  = n_csc_INVALID;
-      n_rpc_selected_hits  = n_rpc_INVALID;
-      n_gem_selected_hits  = n_gem_INVALID;
+      n_dt_selected_hits = n_dt_INVALID;
+      n_csc_selected_hits = n_csc_INVALID;
+      n_rpc_selected_hits = n_rpc_INVALID;
+      n_gem_selected_hits = n_gem_INVALID;
 
       n_muon_matched = n_muon_matched_INVALID;
-      n_dt_matched   = n_dt_matched_INVALID;
-      n_csc_matched  = n_csc_matched_INVALID;
-      n_rpc_matched  = n_rpc_matched_INVALID;
-      n_gem_matched  = n_gem_matched_INVALID;
+      n_dt_matched = n_dt_matched_INVALID;
+      n_csc_matched = n_csc_matched_INVALID;
+      n_rpc_matched = n_rpc_matched_INVALID;
+      n_gem_matched = n_gem_matched_INVALID;
     }
 
     int n_selected_hits = n_tracker_selected_hits + n_muon_selected_hits;
     int n_matched = n_tracker_matched + n_muon_matched;
 
-    if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-      <<"\n"<<"# TrackingRecHits: "<<(track->second - track->first) 
-      <<"\n"<< "# used RecHits     = " <<n_all    <<" ("<<n_tracker_all<<"/"
-      <<n_dt_all<<"/"<<n_csc_all<<"/"<<n_rpc_all<<"/"<<n_gem_all<<" in Tracker/DT/CSC/RPC/GEM)"<<", obtained from " << n_matching_simhits << " SimHits"
-      <<"\n"<< "# selected RecHits = " <<n_selected_hits  <<" (" <<n_tracker_selected_hits<<"/"
-      <<n_dt_selected_hits<<"/"<<n_csc_selected_hits<<"/"<<n_rpc_selected_hits<<"/"<<n_gem_selected_hits<<" in Tracker/DT/CSC/RPC/GEM)"<<InvMuonHits
-      <<"\n"<< "# matched RecHits = " <<n_matched<<" ("<<n_tracker_matched<<"/"
-      <<n_dt_matched<<"/"<<n_csc_matched<<"/"<<n_rpc_matched<<"/"<<n_gem_matched<<" in Tracker/DT/CSC/RPC/GEM)";
-    
-    if (printRtS && n_all>0 && n_matching_simhits==0)
+    if (printRtS)
       edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	<<"*** WARNING in MuonAssociatorByHitsHelper::associateSimToReco: no matching PSimHit found for this reco::Track !";
-    
+          << "\n"
+          << "# TrackingRecHits: " << (track->second - track->first) << "\n"
+          << "# used RecHits     = " << n_all << " (" << n_tracker_all << "/"
+          << n_dt_all << "/" << n_csc_all << "/" << n_rpc_all << "/"
+          << n_gem_all << " in Tracker/DT/CSC/RPC/GEM)"
+          << ", obtained from " << n_matching_simhits << " SimHits"
+          << "\n"
+          << "# selected RecHits = " << n_selected_hits << " ("
+          << n_tracker_selected_hits << "/" << n_dt_selected_hits << "/"
+          << n_csc_selected_hits << "/" << n_rpc_selected_hits << "/"
+          << n_gem_selected_hits << " in Tracker/DT/CSC/RPC/GEM)" << InvMuonHits
+          << "\n"
+          << "# matched RecHits = " << n_matched << " (" << n_tracker_matched
+          << "/" << n_dt_matched << "/" << n_csc_matched << "/" << n_rpc_matched
+          << "/" << n_gem_matched << " in Tracker/DT/CSC/RPC/GEM)";
+
+    if (printRtS && n_all > 0 && n_matching_simhits == 0)
+      edm::LogVerbatim("MuonAssociatorByHitsHelper")
+          << "*** WARNING in MuonAssociatorByHitsHelper::associateSimToReco: "
+             "no matching PSimHit found for this reco::Track !";
+
     if (n_matching_simhits != 0) {
-      int tpindex =0;
-      for (TrackingParticleCollection::const_iterator trpart = tPC.begin(); trpart != tPC.end(); ++trpart, ++tpindex) {
+      int tpindex = 0;
+      for (TrackingParticleCollection::const_iterator trpart = tPC.begin();
+           trpart != tPC.end(); ++trpart, ++tpindex) {
 
-	//	int n_tracker_simhits = 0;
-	int n_tracker_recounted_simhits = 0; 
-	int n_muon_simhits = 0; 
-	int n_global_simhits = 0; 
-	//	std::vector<PSimHit> tphits;
+        //	int n_tracker_simhits = 0;
+        int n_tracker_recounted_simhits = 0;
+        int n_muon_simhits = 0;
+        int n_global_simhits = 0;
+        //	std::vector<PSimHit> tphits;
 
-	int n_tracker_selected_simhits = 0;
-	int n_muon_selected_simhits = 0; 
-	int n_global_selected_simhits = 0; 
+        int n_tracker_selected_simhits = 0;
+        int n_muon_selected_simhits = 0;
+        int n_global_selected_simhits = 0;
 
-	// shared hits are counted over the selected ones
-	tracker_nshared = getShared(tracker_matchedIds_valid, trpart);
-	muon_nshared = getShared(muon_matchedIds_valid, trpart);
+        // shared hits are counted over the selected ones
+        tracker_nshared = getShared(tracker_matchedIds_valid, trpart);
+        muon_nshared = getShared(muon_matchedIds_valid, trpart);
 
-        if (includeZeroHitMuons && n_muon_valid==0 && n_muon_INVALID!=0)
-	  muon_nshared = getShared(muon_matchedIds_INVALID, trpart);
-	
-        global_nshared = tracker_nshared + muon_nshared;	
-        if (global_nshared == 0) continue; // if this TP shares no hits with the current reco::Track loop over 
+        if (includeZeroHitMuons && n_muon_valid == 0 && n_muon_INVALID != 0)
+          muon_nshared = getShared(muon_matchedIds_INVALID, trpart);
 
-	// This does not work with the new TP interface 
-	/*
-	for(std::vector<PSimHit>::const_iterator TPhit = trpart->pSimHit_begin(); TPhit != trpart->pSimHit_end(); TPhit++) {
+        global_nshared = tracker_nshared + muon_nshared;
+        if (global_nshared == 0)
+          continue; // if this TP shares no hits with the current reco::Track
+                    // loop over
+
+        // This does not work with the new TP interface
+        /*
+        for(std::vector<PSimHit>::const_iterator TPhit =
+        trpart->pSimHit_begin(); TPhit != trpart->pSimHit_end(); TPhit++) {
           DetId dId = DetId(TPhit->detUnitId());
-	  DetId::Detector detector = dId.det();
-	  
-	  if (detector == DetId::Tracker) {
-	    n_tracker_simhits++;
+          DetId::Detector detector = dId.det();
 
-	    unsigned int subdetId = static_cast<unsigned int>(dId.subdetId());
-	    if (!UsePixels && (subdetId==PixelSubdetector::PixelBarrel || subdetId==PixelSubdetector::PixelEndcap) )
-	      continue;
+          if (detector == DetId::Tracker) {
+            n_tracker_simhits++;
 
-	    SiStripDetId* stripDetId = 0;
-	    if (subdetId==SiStripDetId::TIB||subdetId==SiStripDetId::TOB||
-		subdetId==SiStripDetId::TID||subdetId==SiStripDetId::TEC)
-	      stripDetId= new SiStripDetId(dId);
-	    
-	    bool newhit = true;
-	    for(std::vector<PSimHit>::const_iterator TPhitOK = tphits.begin(); TPhitOK != tphits.end(); TPhitOK++) {
-	      DetId dIdOK = DetId(TPhitOK->detUnitId());
-	      //no grouped, no splitting
-	      if (!UseGrouped && !UseSplitting)
-		if (tTopo->layer(dId)==tTopo->layer(dIdOK) &&
-		    dId.subdetId()==dIdOK.subdetId()) newhit = false;
-	      //no grouped, splitting
-	      if (!UseGrouped && UseSplitting)
-		if (tTopo->layer(dId)==tTopo->layer(dIdOK) &&
-		    dId.subdetId()==dIdOK.subdetId() &&
-		    (stripDetId==0 || stripDetId->partnerDetId()!=dIdOK.rawId()))
-		  newhit = false;
-	      //grouped, no splitting
-	      if (UseGrouped && !UseSplitting)
-		if ( tTopo->layer(dId)== tTopo->layer(dIdOK) &&
-		    dId.subdetId()==dIdOK.subdetId() &&
-		    stripDetId!=0 && stripDetId->partnerDetId()==dIdOK.rawId())
-		  newhit = false;
-	      //grouped, splitting
-	      if (UseGrouped && UseSplitting)
-		newhit = true;
-	    }
-	    if (newhit) {
-	      tphits.push_back(*TPhit);
-	    }
-	    delete stripDetId;
-	  }
-	  else if (detector == DetId::Muon) {
-	    n_muon_simhits++;
-	    
-	    // discard BAD CSC chambers (ME4/2) from hit counting
-	    if (dId.subdetId() == MuonSubdetId::CSC) {
+            unsigned int subdetId = static_cast<unsigned int>(dId.subdetId());
+            if (!UsePixels && (subdetId==PixelSubdetector::PixelBarrel ||
+        subdetId==PixelSubdetector::PixelEndcap) ) continue;
+
+            SiStripDetId* stripDetId = 0;
+            if (subdetId==SiStripDetId::TIB||subdetId==SiStripDetId::TOB||
+                subdetId==SiStripDetId::TID||subdetId==SiStripDetId::TEC)
+              stripDetId= new SiStripDetId(dId);
+
+            bool newhit = true;
+            for(std::vector<PSimHit>::const_iterator TPhitOK = tphits.begin();
+        TPhitOK != tphits.end(); TPhitOK++) { DetId dIdOK =
+        DetId(TPhitOK->detUnitId());
+              //no grouped, no splitting
+              if (!UseGrouped && !UseSplitting)
+                if (tTopo->layer(dId)==tTopo->layer(dIdOK) &&
+                    dId.subdetId()==dIdOK.subdetId()) newhit = false;
+              //no grouped, splitting
+              if (!UseGrouped && UseSplitting)
+                if (tTopo->layer(dId)==tTopo->layer(dIdOK) &&
+                    dId.subdetId()==dIdOK.subdetId() &&
+                    (stripDetId==0 ||
+        stripDetId->partnerDetId()!=dIdOK.rawId())) newhit = false;
+              //grouped, no splitting
+              if (UseGrouped && !UseSplitting)
+                if ( tTopo->layer(dId)== tTopo->layer(dIdOK) &&
+                    dId.subdetId()==dIdOK.subdetId() &&
+                    stripDetId!=0 && stripDetId->partnerDetId()==dIdOK.rawId())
+                  newhit = false;
+              //grouped, splitting
+              if (UseGrouped && UseSplitting)
+                newhit = true;
+            }
+            if (newhit) {
+              tphits.push_back(*TPhit);
+            }
+            delete stripDetId;
+          }
+          else if (detector == DetId::Muon) {
+            n_muon_simhits++;
+
+            // discard BAD CSC chambers (ME4/2) from hit counting
+            if (dId.subdetId() == MuonSubdetId::CSC) {
               if (csctruth.cscBadChambers->isInBadChamber(CSCDetId(dId))) {
-		// edm::LogVerbatim("MuonAssociatorByHitsHelper")<<"This PSimHit is in a BAD CSC chamber, CSCDetId = "<<CSCDetId(dId);
-		n_muon_simhits--;
-	      }
-	    }
-	    
-	  }
-	}
-	*/
-	//	n_tracker_recounted_simhits = tphits.size();
+                // edm::LogVerbatim("MuonAssociatorByHitsHelper")<<"This PSimHit
+        is in a BAD CSC chamber, CSCDetId = "<<CSCDetId(dId); n_muon_simhits--;
+              }
+            }
 
-        // adapt to new TP interface: this gives the total number of hits in tracker
+          }
+        }
+        */
+        //	n_tracker_recounted_simhits = tphits.size();
+
+        // adapt to new TP interface: this gives the total number of hits in
+        // tracker
         //   should reproduce the behaviour of UseGrouped=UseSplitting=.true.
-	n_tracker_recounted_simhits = trpart->numberOfTrackerHits();
+        n_tracker_recounted_simhits = trpart->numberOfTrackerHits();
         //   numberOfHits() gives the total number of hits (tracker + muons)
         n_muon_simhits = trpart->numberOfHits() - trpart->numberOfTrackerHits();
 
-        // Handle the case of TrackingParticles that don't have PSimHits inside, e.g. because they were made on RECOSIM only.
-        if (trpart->numberOfHits()==0) {
-	  // FIXME this can be made better, counting the digiSimLinks associated to this TP, but perhaps it's not worth it
-	  //n_tracker_recounted_simhits = tracker_nshared;
-	  //n_muon_simhits = muon_nshared;
-	  // ---> on RECOSIM when the AbsoluteNumberOfHits_muon=True this always obtains quality=1, 
-	  //      hence no sorting is possible in case of duplicate matchings
-	  // ---> reset these variables to 1 so to keep the number of shared hits as ranking criterion
-	  n_tracker_recounted_simhits = 1;
-	  n_muon_simhits = 1;
-        }	
-	n_global_simhits = n_tracker_recounted_simhits + n_muon_simhits;
+        // Handle the case of TrackingParticles that don't have PSimHits inside,
+        // e.g. because they were made on RECOSIM only.
+        if (trpart->numberOfHits() == 0) {
+          // FIXME this can be made better, counting the digiSimLinks associated
+          // to this TP, but perhaps it's not worth it
+          // n_tracker_recounted_simhits = tracker_nshared;
+          // n_muon_simhits = muon_nshared;
+          // ---> on RECOSIM when the AbsoluteNumberOfHits_muon=True this always
+          // obtains quality=1,
+          //      hence no sorting is possible in case of duplicate matchings
+          // ---> reset these variables to 1 so to keep the number of shared
+          // hits as ranking criterion
+          n_tracker_recounted_simhits = 1;
+          n_muon_simhits = 1;
+        }
+        n_global_simhits = n_tracker_recounted_simhits + n_muon_simhits;
 
-	if (UseMuon) {
-	  n_muon_selected_simhits = n_muon_simhits;
-	  n_global_selected_simhits = n_muon_selected_simhits;
-	}
-	if (UseTracker) {
-	  n_tracker_selected_simhits = n_tracker_recounted_simhits;
-	  n_global_selected_simhits += n_tracker_selected_simhits;
-	}
+        if (UseMuon) {
+          n_muon_selected_simhits = n_muon_simhits;
+          n_global_selected_simhits = n_muon_selected_simhits;
+        }
+        if (UseTracker) {
+          n_tracker_selected_simhits = n_tracker_recounted_simhits;
+          n_global_selected_simhits += n_tracker_selected_simhits;
+        }
 
-	if (AbsoluteNumberOfHits_track) tracker_quality = static_cast<double>(tracker_nshared);
-	else if (n_tracker_selected_simhits!=0) 
-	  tracker_quality = static_cast<double>(tracker_nshared)/static_cast<double>(n_tracker_selected_simhits);
-	else tracker_quality = 0;
-	
-	if (AbsoluteNumberOfHits_muon) muon_quality = static_cast<double>(muon_nshared);
-	else if (n_muon_selected_simhits!=0) 
-	  muon_quality = static_cast<double>(muon_nshared)/static_cast<double>(n_muon_selected_simhits);
-	else muon_quality = 0;
+        if (AbsoluteNumberOfHits_track)
+          tracker_quality = static_cast<double>(tracker_nshared);
+        else if (n_tracker_selected_simhits != 0)
+          tracker_quality = static_cast<double>(tracker_nshared) /
+                            static_cast<double>(n_tracker_selected_simhits);
+        else
+          tracker_quality = 0;
 
-	// global_quality used to order the matching tracks
-	if (n_global_selected_simhits != 0) {
-	  if (AbsoluteNumberOfHits_muon && AbsoluteNumberOfHits_track)
-	    global_quality = global_nshared;
-	  else 
-	    global_quality = static_cast<double>(global_nshared)/static_cast<double>(n_global_selected_simhits);
-	} 
-	else global_quality = 0;
+        if (AbsoluteNumberOfHits_muon)
+          muon_quality = static_cast<double>(muon_nshared);
+        else if (n_muon_selected_simhits != 0)
+          muon_quality = static_cast<double>(muon_nshared) /
+                         static_cast<double>(n_muon_selected_simhits);
+        else
+          muon_quality = 0;
 
-	// global purity
-	if (n_selected_hits != 0) {
-	  if (AbsoluteNumberOfHits_muon && AbsoluteNumberOfHits_track)
-	    global_purity = global_nshared;
-	  else
-	    global_purity = static_cast<double>(global_nshared)/static_cast<double>(n_selected_hits);
-	}
-	else global_purity = 0;
-	
-	bool trackerOk = false;
-	if (n_tracker_selected_hits != 0) {
-	  if (tracker_quality > tracker_quality_cut) trackerOk = true;
-	  
-	  tracker_purity = static_cast<double>(tracker_nshared)/static_cast<double>(n_tracker_selected_hits);
-	  if (AbsoluteNumberOfHits_track) tracker_purity = static_cast<double>(tracker_nshared);
+        // global_quality used to order the matching tracks
+        if (n_global_selected_simhits != 0) {
+          if (AbsoluteNumberOfHits_muon && AbsoluteNumberOfHits_track)
+            global_quality = global_nshared;
+          else
+            global_quality = static_cast<double>(global_nshared) /
+                             static_cast<double>(n_global_selected_simhits);
+        } else
+          global_quality = 0;
 
-	  if ((!AbsoluteNumberOfHits_track) && tracker_purity <= PurityCut_track) trackerOk = false;
-	  
-	  //if a track has just 3 hits in the Tracker we require that all 3 hits are shared
-	  if (ThreeHitTracksAreSpecial && n_tracker_selected_hits==3 && tracker_nshared<3) trackerOk = false;
-	}
-	
-	bool muonOk = false;
-	if (n_muon_selected_hits != 0) {
-	  if (muon_quality > muon_quality_cut) muonOk = true;
-	  
-	  muon_purity = static_cast<double>(muon_nshared)/static_cast<double>(n_muon_selected_hits);
-	  if (AbsoluteNumberOfHits_muon) muon_purity = static_cast<double>(muon_nshared);
+        // global purity
+        if (n_selected_hits != 0) {
+          if (AbsoluteNumberOfHits_muon && AbsoluteNumberOfHits_track)
+            global_purity = global_nshared;
+          else
+            global_purity = static_cast<double>(global_nshared) /
+                            static_cast<double>(n_selected_hits);
+        } else
+          global_purity = 0;
 
-	  if ((!AbsoluteNumberOfHits_muon) &&  muon_purity <= PurityCut_muon) muonOk = false;
-	}
+        bool trackerOk = false;
+        if (n_tracker_selected_hits != 0) {
+          if (tracker_quality > tracker_quality_cut)
+            trackerOk = true;
 
-	// (matchOk) has to account for different track types (tracker-only, standalone muons, global muons)
-	bool matchOk = trackerOk || muonOk;
+          tracker_purity = static_cast<double>(tracker_nshared) /
+                           static_cast<double>(n_tracker_selected_hits);
+          if (AbsoluteNumberOfHits_track)
+            tracker_purity = static_cast<double>(tracker_nshared);
 
-	// only for global muons: match both tracker and muon stub unless (acceptOneStubMatchings==true)
-	if (!acceptOneStubMatchings && n_tracker_selected_hits!=0 && n_muon_selected_hits!=0)
-	  matchOk = trackerOk && muonOk;
-	
-	if (matchOk) {
-	  
-          outputCollection[tpindex].push_back(IndexMatch(tindex,global_quality));
-	  any_trackingParticle_matched = true;
-	  
-	  edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	    <<"************************************************************************************************************************"  
-	    <<"\n"<< "TrackingParticle " << tpindex <<", q = "<<(*trpart).charge()<<", p = "<<(*trpart).p()
-	    <<", pT = "<<(*trpart).pt()<<", eta = "<<(*trpart).eta()<<", phi = "<<(*trpart).phi()
-	    <<"\n"<<" pdg code = "<<(*trpart).pdgId()
-	    <<", made of "<<(*trpart).numberOfHits()<<" PSimHits, recounted "<<n_global_simhits<<" PSimHits"
-	    <<" (tracker:"<<n_tracker_recounted_simhits<<"/muons:"<<n_muon_simhits<<")"
-	    <<", from "<<(*trpart).g4Tracks().size()<<" SimTrack:";
-	  for(TrackingParticle::g4t_iterator g4T=(*trpart).g4Track_begin(); 
-	      g4T!=(*trpart).g4Track_end(); 
-	      ++g4T) {
-	    edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	      <<" Id:"<<(*g4T).trackId()<<"/Evt:("<<(*g4T).eventId().event()<<","<<(*g4T).eventId().bunchCrossing()<<")";
-	  }
-	  edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	    <<"\t selected "<<n_global_selected_simhits<<" PSimHits"
-	    <<" (tracker:"<<n_tracker_selected_simhits<<"/muons:"<<n_muon_selected_simhits<<")"
-	    << "\n\t **MATCHED** with quality = "<<global_quality<<" (tracker: "<<tracker_quality<<" / muon: "<<muon_quality<<")"
-	    << "\n\t               and purity = "<<global_purity<<" (tracker: "<<tracker_purity<<" / muon: "<<muon_purity<<")"
-	    << "\n\t   N shared hits = "<<global_nshared<<" (tracker: "<<tracker_nshared<<" / muon: "<<muon_nshared<<")"
-	    <<"\n" <<"   to: reco::Track "<<tindex<<ZeroHitMuon
-	    <<"\n\t"<< " made of "<<n_selected_hits<<" RecHits (tracker:"<<n_tracker_valid<<"/muons:"<<n_muon_selected_hits<<")";
-	}
-	else {
-	  // print something only if this TrackingParticle shares some hits with the current reco::Track
-	  if (global_nshared != 0) {
-	    if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	      <<"************************************************************************************************************************"  
-	      <<"\n"<<"TrackingParticle " << tpindex <<", q = "<<(*trpart).charge()<<", p = "<<(*trpart).p()
-	      <<", pT = "<<(*trpart).pt()<<", eta = "<<(*trpart).eta()<<", phi = "<<(*trpart).phi()
-	      <<"\n"<<" pdg code = "<<(*trpart).pdgId()
-	      <<", made of "<<(*trpart).numberOfHits()<<" PSimHits, recounted "<<n_global_simhits<<" PSimHits"
-	      <<" (tracker:"<<n_tracker_recounted_simhits<<"/muons:"<<n_muon_simhits<<")"
-	      <<", from "<<(*trpart).g4Tracks().size()<<" SimTrack:";
-	    for(TrackingParticle::g4t_iterator g4T=(*trpart).g4Track_begin(); 
-		g4T!=(*trpart).g4Track_end(); 
-		++g4T) {
-	      if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-		<<" Id:"<<(*g4T).trackId()<<"/Evt:("<<(*g4T).eventId().event()<<","<<(*g4T).eventId().bunchCrossing()<<")";
-	    }
-	    if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	      <<"\t selected "<<n_global_selected_simhits<<" PSimHits"
-	      <<" (tracker:"<<n_tracker_selected_simhits<<"/muons:"<<n_muon_selected_simhits<<")"
-	      <<"\n\t NOT matched  to reco::Track "<<tindex<<ZeroHitMuon
-	      <<" with quality = "<<global_quality<<" (tracker: "<<tracker_quality<<" / muon: "<<muon_quality<<")"
-	      <<"\n\t and purity = "<<global_purity<<" (tracker: "<<tracker_purity<<" / muon: "<<muon_purity<<")"
-	      <<"\n\t     N shared hits = "<<global_nshared<<" (tracker: "<<tracker_nshared<<" / muon: "<<muon_nshared<<")";
-	  }
-	}
-      }  // loop over TrackingParticle's
+          if ((!AbsoluteNumberOfHits_track) &&
+              tracker_purity <= PurityCut_track)
+            trackerOk = false;
+
+          // if a track has just 3 hits in the Tracker we require that all 3
+          // hits are shared
+          if (ThreeHitTracksAreSpecial && n_tracker_selected_hits == 3 &&
+              tracker_nshared < 3)
+            trackerOk = false;
+        }
+
+        bool muonOk = false;
+        if (n_muon_selected_hits != 0) {
+          if (muon_quality > muon_quality_cut)
+            muonOk = true;
+
+          muon_purity = static_cast<double>(muon_nshared) /
+                        static_cast<double>(n_muon_selected_hits);
+          if (AbsoluteNumberOfHits_muon)
+            muon_purity = static_cast<double>(muon_nshared);
+
+          if ((!AbsoluteNumberOfHits_muon) && muon_purity <= PurityCut_muon)
+            muonOk = false;
+        }
+
+        // (matchOk) has to account for different track types (tracker-only,
+        // standalone muons, global muons)
+        bool matchOk = trackerOk || muonOk;
+
+        // only for global muons: match both tracker and muon stub unless
+        // (acceptOneStubMatchings==true)
+        if (!acceptOneStubMatchings && n_tracker_selected_hits != 0 &&
+            n_muon_selected_hits != 0)
+          matchOk = trackerOk && muonOk;
+
+        if (matchOk) {
+
+          outputCollection[tpindex].push_back(
+              IndexMatch(tindex, global_quality));
+          any_trackingParticle_matched = true;
+
+          edm::LogVerbatim("MuonAssociatorByHitsHelper")
+              << "*************************************************************"
+                 "***********************************************************"
+              << "\n"
+              << "TrackingParticle " << tpindex
+              << ", q = " << (*trpart).charge() << ", p = " << (*trpart).p()
+              << ", pT = " << (*trpart).pt() << ", eta = " << (*trpart).eta()
+              << ", phi = " << (*trpart).phi() << "\n"
+              << " pdg code = " << (*trpart).pdgId() << ", made of "
+              << (*trpart).numberOfHits() << " PSimHits, recounted "
+              << n_global_simhits << " PSimHits"
+              << " (tracker:" << n_tracker_recounted_simhits
+              << "/muons:" << n_muon_simhits << ")"
+              << ", from " << (*trpart).g4Tracks().size() << " SimTrack:";
+          for (TrackingParticle::g4t_iterator g4T = (*trpart).g4Track_begin();
+               g4T != (*trpart).g4Track_end(); ++g4T) {
+            edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                << " Id:" << (*g4T).trackId() << "/Evt:("
+                << (*g4T).eventId().event() << ","
+                << (*g4T).eventId().bunchCrossing() << ")";
+          }
+          edm::LogVerbatim("MuonAssociatorByHitsHelper")
+              << "\t selected " << n_global_selected_simhits << " PSimHits"
+              << " (tracker:" << n_tracker_selected_simhits
+              << "/muons:" << n_muon_selected_simhits << ")"
+              << "\n\t **MATCHED** with quality = " << global_quality
+              << " (tracker: " << tracker_quality << " / muon: " << muon_quality
+              << ")"
+              << "\n\t               and purity = " << global_purity
+              << " (tracker: " << tracker_purity << " / muon: " << muon_purity
+              << ")"
+              << "\n\t   N shared hits = " << global_nshared
+              << " (tracker: " << tracker_nshared << " / muon: " << muon_nshared
+              << ")"
+              << "\n"
+              << "   to: reco::Track " << tindex << ZeroHitMuon << "\n\t"
+              << " made of " << n_selected_hits
+              << " RecHits (tracker:" << n_tracker_valid
+              << "/muons:" << n_muon_selected_hits << ")";
+        } else {
+          // print something only if this TrackingParticle shares some hits with
+          // the current reco::Track
+          if (global_nshared != 0) {
+            if (printRtS)
+              edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                  << "*********************************************************"
+                     "*********************************************************"
+                     "******"
+                  << "\n"
+                  << "TrackingParticle " << tpindex
+                  << ", q = " << (*trpart).charge() << ", p = " << (*trpart).p()
+                  << ", pT = " << (*trpart).pt()
+                  << ", eta = " << (*trpart).eta()
+                  << ", phi = " << (*trpart).phi() << "\n"
+                  << " pdg code = " << (*trpart).pdgId() << ", made of "
+                  << (*trpart).numberOfHits() << " PSimHits, recounted "
+                  << n_global_simhits << " PSimHits"
+                  << " (tracker:" << n_tracker_recounted_simhits
+                  << "/muons:" << n_muon_simhits << ")"
+                  << ", from " << (*trpart).g4Tracks().size() << " SimTrack:";
+            for (TrackingParticle::g4t_iterator g4T = (*trpart).g4Track_begin();
+                 g4T != (*trpart).g4Track_end(); ++g4T) {
+              if (printRtS)
+                edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                    << " Id:" << (*g4T).trackId() << "/Evt:("
+                    << (*g4T).eventId().event() << ","
+                    << (*g4T).eventId().bunchCrossing() << ")";
+            }
+            if (printRtS)
+              edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                  << "\t selected " << n_global_selected_simhits << " PSimHits"
+                  << " (tracker:" << n_tracker_selected_simhits
+                  << "/muons:" << n_muon_selected_simhits << ")"
+                  << "\n\t NOT matched  to reco::Track " << tindex
+                  << ZeroHitMuon << " with quality = " << global_quality
+                  << " (tracker: " << tracker_quality
+                  << " / muon: " << muon_quality << ")"
+                  << "\n\t and purity = " << global_purity
+                  << " (tracker: " << tracker_purity
+                  << " / muon: " << muon_purity << ")"
+                  << "\n\t     N shared hits = " << global_nshared
+                  << " (tracker: " << tracker_nshared
+                  << " / muon: " << muon_nshared << ")";
+          }
+        }
+      } // loop over TrackingParticle's
     }   // if(n_matching_simhits != 0)
-  }    // loop over reco Tracks
-  
+  }     // loop over reco Tracks
+
   if (!any_trackingParticle_matched) {
     edm::LogVerbatim("MuonAssociatorByHitsHelper")
-      <<"\n"
-      <<"************************************************************************************************************************"
-      << "\n NO TrackingParticle associated to ANY input reco::Track ! \n"
-      <<"************************************************************************************************************************"<<"\n";  
+        << "\n"
+        << "*******************************************************************"
+           "*****************************************************"
+        << "\n NO TrackingParticle associated to ANY input reco::Track ! \n"
+        << "*******************************************************************"
+           "*****************************************************"
+        << "\n";
   } else {
     edm::LogVerbatim("MuonAssociatorByHitsHelper")
-      <<"************************************************************************************************************************"<<"\n";  
+        << "*******************************************************************"
+           "*****************************************************"
+        << "\n";
   }
-  
-  for (IndexAssociation::iterator it = outputCollection.begin(), ed = outputCollection.end(); it != ed; ++it) {
+
+  for (IndexAssociation::iterator it = outputCollection.begin(),
+                                  ed = outputCollection.end();
+       it != ed; ++it) {
     std::sort(it->second.begin(), it->second.end());
   }
   return outputCollection;
 }
 
-
-void MuonAssociatorByHitsHelper::getMatchedIds
-(MapOfMatchedIds & tracker_matchedIds_valid, MapOfMatchedIds & muon_matchedIds_valid,
- MapOfMatchedIds & tracker_matchedIds_INVALID, MapOfMatchedIds & muon_matchedIds_INVALID,       
- int& n_tracker_valid, int& n_dt_valid, int& n_csc_valid, int& n_rpc_valid, int& n_gem_valid,
- int& n_tracker_matched_valid, int& n_dt_matched_valid, int& n_csc_matched_valid, int& n_rpc_matched_valid, int& n_gem_matched_valid,
- int& n_tracker_INVALID, int& n_dt_INVALID, int& n_csc_INVALID, int& n_rpc_INVALID, int& n_gem_INVALID,
- int& n_tracker_matched_INVALID, int& n_dt_matched_INVALID, int& n_csc_matched_INVALID, int& n_rpc_matched_INVALID, int& n_gem_matched_INVALID,
- trackingRecHit_iterator begin, trackingRecHit_iterator end,
- const TrackerHitAssociator* trackertruth, 
- const DTHitAssociator& dttruth, const CSCHitAssociator& csctruth, const RPCHitAssociator& rpctruth, const GEMHitAssociator& gemtruth, bool printRtS,
- const TrackerTopology *tTopo) const
+void MuonAssociatorByHitsHelper::getMatchedIds(
+    MapOfMatchedIds &tracker_matchedIds_valid,
+    MapOfMatchedIds &muon_matchedIds_valid,
+    MapOfMatchedIds &tracker_matchedIds_INVALID,
+    MapOfMatchedIds &muon_matchedIds_INVALID, int &n_tracker_valid,
+    int &n_dt_valid, int &n_csc_valid, int &n_rpc_valid, int &n_gem_valid,
+    int &n_tracker_matched_valid, int &n_dt_matched_valid,
+    int &n_csc_matched_valid, int &n_rpc_matched_valid,
+    int &n_gem_matched_valid, int &n_tracker_INVALID, int &n_dt_INVALID,
+    int &n_csc_INVALID, int &n_rpc_INVALID, int &n_gem_INVALID,
+    int &n_tracker_matched_INVALID, int &n_dt_matched_INVALID,
+    int &n_csc_matched_INVALID, int &n_rpc_matched_INVALID,
+    int &n_gem_matched_INVALID, trackingRecHit_iterator begin,
+    trackingRecHit_iterator end, const TrackerHitAssociator *trackertruth,
+    const DTHitAssociator &dttruth, const CSCHitAssociator &csctruth,
+    const RPCHitAssociator &rpctruth, const GEMHitAssociator &gemtruth,
+    bool printRtS, const TrackerTopology *tTopo) const
 
 {
   tracker_matchedIds_valid.clear();
@@ -787,507 +981,587 @@ void MuonAssociatorByHitsHelper::getMatchedIds
   muon_matchedIds_INVALID.clear();
 
   n_tracker_valid = 0;
-  n_dt_valid  = 0;
+  n_dt_valid = 0;
   n_csc_valid = 0;
   n_rpc_valid = 0;
   n_gem_valid = 0;
 
   n_tracker_matched_valid = 0;
-  n_dt_matched_valid  = 0;
+  n_dt_matched_valid = 0;
   n_csc_matched_valid = 0;
   n_rpc_matched_valid = 0;
   n_gem_matched_valid = 0;
-  
+
   n_tracker_INVALID = 0;
-  n_dt_INVALID  = 0;
+  n_dt_INVALID = 0;
   n_csc_INVALID = 0;
   n_rpc_INVALID = 0;
   n_gem_INVALID = 0;
-  
+
   n_tracker_matched_INVALID = 0;
-  n_dt_matched_INVALID  = 0;
+  n_dt_matched_INVALID = 0;
   n_csc_matched_INVALID = 0;
   n_rpc_matched_INVALID = 0;
   n_gem_matched_INVALID = 0;
-  
+
   std::vector<SimHitIdpr> SimTrackIds;
 
   // main loop on TrackingRecHits
   int iloop = 0;
   int iH = -1;
-  for (trackingRecHit_iterator it = begin;  it != end; it++, iloop++) {
-    stringstream hit_index;     
-    hit_index<<iloop;
+  for (trackingRecHit_iterator it = begin; it != end; it++, iloop++) {
+    stringstream hit_index;
+    hit_index << iloop;
 
-    const TrackingRecHit * hitp = getHitPtr(it);
-    DetId geoid = hitp->geographicalId();    
+    const TrackingRecHit *hitp = getHitPtr(it);
+    DetId geoid = hitp->geographicalId();
 
-    unsigned int detid = geoid.rawId();    
+    unsigned int detid = geoid.rawId();
     stringstream detector_id;
-    detector_id<<detid;
+    detector_id << detid;
 
-    string hitlog = "TrackingRecHit "+hit_index.str();
+    string hitlog = "TrackingRecHit " + hit_index.str();
     string wireidlog;
     std::vector<string> DTSimHits;
-    
+
     DetId::Detector det = geoid.det();
     int subdet = geoid.subdetId();
-    
+
     bool valid_Hit = hitp->isValid();
-    
+
     // Si-Tracker Hits
     if (det == DetId::Tracker && UseTracker) {
       stringstream detector_id;
-      detector_id<< tTopo->print(detid);
-      
-      if (valid_Hit) hitlog = hitlog+" -Tracker - detID = "+detector_id.str();
-      else hitlog = hitlog+" *** INVALID ***"+" -Tracker - detID = "+detector_id.str();
-      
+      detector_id << tTopo->print(detid);
+
+      if (valid_Hit)
+        hitlog = hitlog + " -Tracker - detID = " + detector_id.str();
+      else
+        hitlog = hitlog + " *** INVALID ***" +
+                 " -Tracker - detID = " + detector_id.str();
+
       iH++;
       SimTrackIds = trackertruth->associateHitId(*hitp);
 
       if (valid_Hit) {
-	n_tracker_valid++;
-	
-	if(!SimTrackIds.empty()) {
-	  n_tracker_matched_valid++;
-	  //tracker_matchedIds_valid[iH] = SimTrackIds;
-          tracker_matchedIds_valid.push_back( new uint_SimHitIdpr_pair(iH, SimTrackIds));
-	}
+        n_tracker_valid++;
+
+        if (!SimTrackIds.empty()) {
+          n_tracker_matched_valid++;
+          // tracker_matchedIds_valid[iH] = SimTrackIds;
+          tracker_matchedIds_valid.push_back(
+              new uint_SimHitIdpr_pair(iH, SimTrackIds));
+        }
       } else {
-	n_tracker_INVALID++;
+        n_tracker_INVALID++;
 
-	if(!SimTrackIds.empty()) {
-	  n_tracker_matched_INVALID++;
-	  //tracker_matchedIds_INVALID[iH] = SimTrackIds;
-          tracker_matchedIds_INVALID.push_back( new uint_SimHitIdpr_pair(iH, SimTrackIds));
-	}
-      }
-    }  
-    // Muon detector Hits    
-    else if (det == DetId::Muon && UseMuon) {
-
-      // DT Hits      
-      if (subdet == MuonSubdetId::DT) {    
-	DTWireId dtdetid = DTWireId(detid);
-	stringstream dt_detector_id;
-	dt_detector_id << dtdetid;
-	if (valid_Hit) hitlog = hitlog+" -Muon DT - detID = "+dt_detector_id.str();	  
-	else hitlog = hitlog+" *** INVALID ***"+" -Muon DT - detID = "+dt_detector_id.str();	  
-	
-	const DTRecHit1D * dtrechit = dynamic_cast<const DTRecHit1D *>(hitp);
-	
-	// single DT hits
-	if (dtrechit) {
-	  iH++;
-	  SimTrackIds = dttruth.associateDTHitId(dtrechit);  
-	  
-	  if (valid_Hit) {
-	    n_dt_valid++;
-
-	    if (!SimTrackIds.empty()) {
-	      n_dt_matched_valid++;
-	      //muon_matchedIds_valid[iH] = SimTrackIds;
-              muon_matchedIds_valid.push_back (new uint_SimHitIdpr_pair(iH,SimTrackIds));
-	    }
-	  } else {
-	    n_dt_INVALID++;
-	    
-	    if (!SimTrackIds.empty()) {
-	      n_dt_matched_INVALID++;
-	      //muon_matchedIds_INVALID[iH] = SimTrackIds;
-              muon_matchedIds_INVALID.push_back (new uint_SimHitIdpr_pair(iH,SimTrackIds));
-	    }
-	  }
-
-	  if (dumpDT) {
-	    DTWireId wireid = dtrechit->wireId();
-	    stringstream wid; 
-	    wid<<wireid;
-	    std::vector<PSimHit> dtSimHits = dttruth.associateHit(*hitp);
-	    
-	    stringstream ndthits;
-	    ndthits<<dtSimHits.size();
-	    wireidlog = "\t DTWireId :"+wid.str()+", "+ndthits.str()+" associated PSimHit :";
-	    
-	    for (unsigned int j=0; j<dtSimHits.size(); j++) {
-	      stringstream index;
-	      index<<j;
-	      stringstream simhit;
-	      simhit<<dtSimHits[j];
-	      string simhitlog = "\t\t PSimHit "+index.str()+": "+simhit.str();
-	      DTSimHits.push_back(simhitlog);
-	    }
-	  }  // if (dumpDT)
-	}
-
-	// DT segments	
-	else {
-	  const DTRecSegment4D * dtsegment = dynamic_cast<const DTRecSegment4D *>(hitp);
-	  
-	  if (dtsegment) {
-	    
-	    std::vector<const TrackingRecHit *> componentHits, phiHits, zHits;
-	    if (dtsegment->hasPhi()) {
-	      phiHits = dtsegment->phiSegment()->recHits();
-	      componentHits.insert(componentHits.end(),phiHits.begin(),phiHits.end());
-	    }
-	    if (dtsegment->hasZed()) {
-	      zHits = dtsegment->zSegment()->recHits();
-	      componentHits.insert(componentHits.end(),zHits.begin(),zHits.end());
-	    }
-	    if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	      <<"\n\t this TrackingRecHit is a DTRecSegment4D with "
-	      <<componentHits.size()<<" hits (phi:"<<phiHits.size()<<", z:"<<zHits.size()<<")";
-	    
-	    SimTrackIds.clear();
-	    std::vector<SimHitIdpr> i_SimTrackIds;
-	    int i_compHit = 0;
-	    for (std::vector<const TrackingRecHit *>::const_iterator ithit =componentHits.begin(); 
-		 ithit != componentHits.end(); ++ithit) {
-	      i_compHit++;
-	      
-	      const DTRecHit1D * dtrechit1D = dynamic_cast<const DTRecHit1D *>(*ithit);
-	      
-	      i_SimTrackIds.clear();
-	      if (dtrechit1D) {
-		iH++;
-		i_SimTrackIds = dttruth.associateDTHitId(dtrechit1D);  
-		
-		if (valid_Hit) {
-		  // validity check is on the segment, but hits are counted one-by-one
-		  n_dt_valid++; 
-
-		  if (!i_SimTrackIds.empty()) {
-		    n_dt_matched_valid++;
-		    //muon_matchedIds_valid[iH] = i_SimTrackIds;
-                    muon_matchedIds_valid.push_back (new uint_SimHitIdpr_pair(iH,i_SimTrackIds));
-		  }
-		} else {
-		  n_dt_INVALID++;
-		  
-		  if (!i_SimTrackIds.empty()) {
-		    n_dt_matched_INVALID++;
-		    //muon_matchedIds_INVALID[iH] = i_SimTrackIds;
-                    muon_matchedIds_INVALID.push_back (new uint_SimHitIdpr_pair(iH,i_SimTrackIds));
-                    
-		  } 
-		}
-	      } else if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-		<<"*** WARNING in MuonAssociatorByHitsHelper::getMatchedIds, null dynamic_cast of a DT TrackingRecHit !";
-	      
-	      unsigned int i_detid = (*ithit)->geographicalId().rawId();
-	      DTWireId i_dtdetid = DTWireId(i_detid);
-
-	      stringstream i_dt_detector_id;
-	      i_dt_detector_id << i_dtdetid;
-
-	      stringstream i_ss;
-	      i_ss<<"\t\t hit "<<i_compHit<<" -Muon DT - detID = "<<i_dt_detector_id.str();
-
-	      string i_hitlog = i_ss.str();
-	      i_hitlog = i_hitlog + write_matched_simtracks(i_SimTrackIds);
-	      if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper") << i_hitlog;
-	      
-	      SimTrackIds.insert(SimTrackIds.end(),i_SimTrackIds.begin(),i_SimTrackIds.end());
-	    }	      
-	  }  // if (dtsegment)
-
-	  else if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	    <<"*** WARNING in MuonAssociatorByHitsHelper::getMatchedIds, DT TrackingRecHit is neither DTRecHit1D nor DTRecSegment4D ! ";	    
-	}
-      }
-      
-      // CSC Hits
-      else if (subdet == MuonSubdetId::CSC) {
-	CSCDetId cscdetid = CSCDetId(detid);
-	stringstream csc_detector_id;
-	csc_detector_id << cscdetid;
-	if (valid_Hit) hitlog = hitlog+" -Muon CSC- detID = "+csc_detector_id.str();	  
-	else hitlog = hitlog+" *** INVALID ***"+" -Muon CSC- detID = "+csc_detector_id.str();	  
-	
-	const CSCRecHit2D * cscrechit = dynamic_cast<const CSCRecHit2D *>(hitp);
-	
-	// single CSC hits
-	if (cscrechit) {
-	  iH++;
-	  SimTrackIds = csctruth.associateCSCHitId(cscrechit);
-	  
-	  if (valid_Hit) {
-	    n_csc_valid++;
-	    
-	    if (!SimTrackIds.empty()) {
-	      n_csc_matched_valid++;
-	      //muon_matchedIds_valid[iH] = SimTrackIds;
-              muon_matchedIds_valid.push_back (new uint_SimHitIdpr_pair(iH,SimTrackIds));
-	    }
-	  } else {
-	    n_csc_INVALID++;
-	    
-	    if (!SimTrackIds.empty()) {
-	      n_csc_matched_INVALID++;
-	      //muon_matchedIds_INVALID[iH] = SimTrackIds;
-              muon_matchedIds_INVALID.push_back (new uint_SimHitIdpr_pair(iH,SimTrackIds));
-	    }
-	  }
-	}
-	
-	// CSC segments
-	else {
-	  const CSCSegment * cscsegment = dynamic_cast<const CSCSegment *>(hitp);
-	  
-	  if (cscsegment) {
-	    
-	    std::vector<const TrackingRecHit *> componentHits = cscsegment->recHits();
-	    if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	      <<"\n\t this TrackingRecHit is a CSCSegment with "<<componentHits.size()<<" hits";
-	    
-	    SimTrackIds.clear();
-	    std::vector<SimHitIdpr> i_SimTrackIds;
-	    int i_compHit = 0;
-	    for (std::vector<const TrackingRecHit *>::const_iterator ithit =componentHits.begin(); 
-		 ithit != componentHits.end(); ++ithit) {
-	      i_compHit++;
-	      
-	      const CSCRecHit2D * cscrechit2D = dynamic_cast<const CSCRecHit2D *>(*ithit);
-	      
-	      i_SimTrackIds.clear();
-	      if (cscrechit2D) {
-		iH++;
-		i_SimTrackIds = csctruth.associateCSCHitId(cscrechit2D);
-
-		if (valid_Hit) {
-		  // validity check is on the segment, but hits are counted one-by-one
-		  n_csc_valid++;
-
-		  if (!i_SimTrackIds.empty()) {
-		    n_csc_matched_valid++;
-		    //muon_matchedIds_valid[iH] =  i_SimTrackIds;
-                    muon_matchedIds_valid.push_back (new uint_SimHitIdpr_pair(iH,i_SimTrackIds));
-		  }
-		} else {
-		  n_csc_INVALID++;
-		  
-		  if (!i_SimTrackIds.empty()) {
-		    n_csc_matched_INVALID++;
-		    //muon_matchedIds_INVALID[iH] =  i_SimTrackIds;
-                    muon_matchedIds_INVALID.push_back (new uint_SimHitIdpr_pair(iH,i_SimTrackIds));
-		  }
-		}
-	      } else if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-		<<"*** WARNING in MuonAssociatorByHitsHelper::getMatchedIds, null dynamic_cast of a CSC TrackingRecHit !";
-	      
-	      unsigned int i_detid = (*ithit)->geographicalId().rawId();
-	      CSCDetId i_cscdetid = CSCDetId(i_detid);
-
-	      stringstream i_csc_detector_id;
-	      i_csc_detector_id << i_cscdetid;
-
-	      stringstream i_ss;
-	      i_ss<<"\t\t hit "<<i_compHit<<" -Muon CSC- detID = "<<i_csc_detector_id.str();
-
-	      string i_hitlog = i_ss.str();
-	      i_hitlog = i_hitlog + write_matched_simtracks(i_SimTrackIds);
-	      if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper") << i_hitlog;
-	      
-	      SimTrackIds.insert(SimTrackIds.end(),i_SimTrackIds.begin(),i_SimTrackIds.end());
-	    }	    
-	  }  // if (cscsegment)
-
-	  else if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	    <<"*** WARNING in MuonAssociatorByHitsHelper::getMatchedIds, CSC TrackingRecHit is neither CSCRecHit2D nor CSCSegment ! ";
-	}
-      }
-      
-      // RPC Hits
-      else if (subdet == MuonSubdetId::RPC) {
-	RPCDetId rpcdetid = RPCDetId(detid);
-	stringstream rpc_detector_id;
-	rpc_detector_id << rpcdetid;
-	if (valid_Hit) hitlog = hitlog+" -Muon RPC- detID = "+rpc_detector_id.str();	  
-	else hitlog = hitlog+" *** INVALID ***"+" -Muon RPC- detID = "+rpc_detector_id.str();	  
-	
-	iH++;
-	SimTrackIds = rpctruth.associateRecHit(*hitp);
-	
-	if (valid_Hit) {
-	  n_rpc_valid++;
-
-	  if (!SimTrackIds.empty()) {
-	    n_rpc_matched_valid++;
-	    //muon_matchedIds_valid[iH] = SimTrackIds;
-            muon_matchedIds_valid.push_back (new uint_SimHitIdpr_pair(iH,SimTrackIds));
-            
-	  }
-	} else {
-	  n_rpc_INVALID++;
-	  
-	  if (!SimTrackIds.empty()) {
-	    n_rpc_matched_INVALID++;
-	    //muon_matchedIds_INVALID[iH] = SimTrackIds;
-            muon_matchedIds_INVALID.push_back (new uint_SimHitIdpr_pair(iH,SimTrackIds));
-	  }
-	}
-      }
-          
-      // GEM Hits
-      else if (subdet == MuonSubdetId::GEM) {
-	GEMDetId gemdetid = GEMDetId(detid);
-	stringstream gem_detector_id;
-	gem_detector_id << gemdetid;
-	if (valid_Hit) hitlog = hitlog+" -Muon GEM- detID = "+gem_detector_id.str();	  
-	else hitlog = hitlog+" *** INVALID ***"+" -Muon GEM- detID = "+gem_detector_id.str();	  
-
-	const GEMRecHit * gemrechit = dynamic_cast<const GEMRecHit *>(hitp);
-	if (gemrechit){
-	  iH++;
-	  SimTrackIds = gemtruth.associateRecHit(gemrechit);
-	
-	  if (valid_Hit) {
-	    n_gem_valid++;
-
-	    if (!SimTrackIds.empty()) {
-	      n_gem_matched_valid++;
-	      //muon_matchedIds_valid[iH] = SimTrackIds;
-	      muon_matchedIds_valid.push_back (new uint_SimHitIdpr_pair(iH,SimTrackIds));
-            
-	    }
-	  } else {
-	    n_gem_INVALID++;
-	  
-	    if (!SimTrackIds.empty()) {
-	      n_gem_matched_INVALID++;
-	      //muon_matchedIds_INVALID[iH] = SimTrackIds;
-	      muon_matchedIds_INVALID.push_back (new uint_SimHitIdpr_pair(iH,SimTrackIds));
-	    }
-	  }
-	}
-	else {
-	  const GEMSegment * gemsegment = dynamic_cast<const GEMSegment *>(hitp);
-	  if (gemsegment) {
-	    
-	    std::vector<const TrackingRecHit *> componentHits = gemsegment->recHits();
-	    if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-	      <<"\n\t this TrackingRecHit is a GEMSegment with "<<componentHits.size()<<" hits";
-	    
-	    SimTrackIds.clear();
-	    std::vector<SimHitIdpr> i_SimTrackIds;
-	    int i_compHit = 0;
-
-	    for ( auto const & ithit : componentHits) {
-	      
-	      i_compHit++;
-	      
-	      const GEMRecHit * gemrechitseg = dynamic_cast<const GEMRecHit *>(ithit);
-	      
-	      i_SimTrackIds.clear();
-	      if (gemrechitseg) {
-		iH++;
-		i_SimTrackIds = gemtruth.associateRecHit(gemrechitseg);
-
-		if (valid_Hit) {
-		  // validity check is on the segment, but hits are counted one-by-one
-		  n_gem_valid++;
-
-		  if (!i_SimTrackIds.empty()) {
-		    n_gem_matched_valid++;
-		    //muon_matchedIds_valid[iH] =  i_SimTrackIds;
-                    muon_matchedIds_valid.push_back (new uint_SimHitIdpr_pair(iH,i_SimTrackIds));
-		  }
-		} else {
-		  n_gem_INVALID++;
-		  
-		  if (!i_SimTrackIds.empty()) {
-		    n_gem_matched_INVALID++;
-		    //muon_matchedIds_INVALID[iH] =  i_SimTrackIds;
-                    muon_matchedIds_INVALID.push_back (new uint_SimHitIdpr_pair(iH,i_SimTrackIds));
-		  }
-		}
-	      } else if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-		<<"*** WARNING in MuonAssociatorByHitsHelper::getMatchedIds, null dynamic_cast of a GEM TrackingRecHit !";
-	      
-	      if (printRtS){
-		unsigned int i_detid = ithit->geographicalId().rawId();
-		GEMDetId i_gemdetid = GEMDetId(i_detid);
-
-		string i_hitlog = std::to_string(i_gemdetid);
-		i_hitlog = i_hitlog + write_matched_simtracks(i_SimTrackIds);
-		edm::LogVerbatim("MuonAssociatorByHitsHelper") << i_hitlog;
-	      }
-
-	      SimTrackIds.insert(SimTrackIds.end(),i_SimTrackIds.begin(),i_SimTrackIds.end());
-	    }	    
-	  }  // if (gemsegment)	  
-          
-	} // if (gemrechit
-      }
-      else if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
-			   <<"TrackingRecHit "<<iloop<<"  *** WARNING *** Unexpected Hit from Detector = "<<det;
-    } // end if (det == DetId::Muon && UseMuon)
-    else continue;
-    
-    hitlog = hitlog + write_matched_simtracks(SimTrackIds);
-    
-    if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper") << hitlog;
-    if (printRtS && dumpDT && det==DetId::Muon && subdet==MuonSubdetId::DT) {
-      edm::LogVerbatim("MuonAssociatorByHitsHelper") <<wireidlog;
-      for (unsigned int j=0; j<DTSimHits.size(); j++) {
-	edm::LogVerbatim("MuonAssociatorByHitsHelper") <<DTSimHits[j];
+        if (!SimTrackIds.empty()) {
+          n_tracker_matched_INVALID++;
+          // tracker_matchedIds_INVALID[iH] = SimTrackIds;
+          tracker_matchedIds_INVALID.push_back(
+              new uint_SimHitIdpr_pair(iH, SimTrackIds));
+        }
       }
     }
-    
-  } //trackingRecHit loop
+    // Muon detector Hits
+    else if (det == DetId::Muon && UseMuon) {
+
+      // DT Hits
+      if (subdet == MuonSubdetId::DT) {
+        DTWireId dtdetid = DTWireId(detid);
+        stringstream dt_detector_id;
+        dt_detector_id << dtdetid;
+        if (valid_Hit)
+          hitlog = hitlog + " -Muon DT - detID = " + dt_detector_id.str();
+        else
+          hitlog = hitlog + " *** INVALID ***" +
+                   " -Muon DT - detID = " + dt_detector_id.str();
+
+        const DTRecHit1D *dtrechit = dynamic_cast<const DTRecHit1D *>(hitp);
+
+        // single DT hits
+        if (dtrechit) {
+          iH++;
+          SimTrackIds = dttruth.associateDTHitId(dtrechit);
+
+          if (valid_Hit) {
+            n_dt_valid++;
+
+            if (!SimTrackIds.empty()) {
+              n_dt_matched_valid++;
+              // muon_matchedIds_valid[iH] = SimTrackIds;
+              muon_matchedIds_valid.push_back(
+                  new uint_SimHitIdpr_pair(iH, SimTrackIds));
+            }
+          } else {
+            n_dt_INVALID++;
+
+            if (!SimTrackIds.empty()) {
+              n_dt_matched_INVALID++;
+              // muon_matchedIds_INVALID[iH] = SimTrackIds;
+              muon_matchedIds_INVALID.push_back(
+                  new uint_SimHitIdpr_pair(iH, SimTrackIds));
+            }
+          }
+
+          if (dumpDT) {
+            DTWireId wireid = dtrechit->wireId();
+            stringstream wid;
+            wid << wireid;
+            std::vector<PSimHit> dtSimHits = dttruth.associateHit(*hitp);
+
+            stringstream ndthits;
+            ndthits << dtSimHits.size();
+            wireidlog = "\t DTWireId :" + wid.str() + ", " + ndthits.str() +
+                        " associated PSimHit :";
+
+            for (unsigned int j = 0; j < dtSimHits.size(); j++) {
+              stringstream index;
+              index << j;
+              stringstream simhit;
+              simhit << dtSimHits[j];
+              string simhitlog =
+                  "\t\t PSimHit " + index.str() + ": " + simhit.str();
+              DTSimHits.push_back(simhitlog);
+            }
+          } // if (dumpDT)
+        }
+
+        // DT segments
+        else {
+          const DTRecSegment4D *dtsegment =
+              dynamic_cast<const DTRecSegment4D *>(hitp);
+
+          if (dtsegment) {
+
+            std::vector<const TrackingRecHit *> componentHits, phiHits, zHits;
+            if (dtsegment->hasPhi()) {
+              phiHits = dtsegment->phiSegment()->recHits();
+              componentHits.insert(componentHits.end(), phiHits.begin(),
+                                   phiHits.end());
+            }
+            if (dtsegment->hasZed()) {
+              zHits = dtsegment->zSegment()->recHits();
+              componentHits.insert(componentHits.end(), zHits.begin(),
+                                   zHits.end());
+            }
+            if (printRtS)
+              edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                  << "\n\t this TrackingRecHit is a DTRecSegment4D with "
+                  << componentHits.size() << " hits (phi:" << phiHits.size()
+                  << ", z:" << zHits.size() << ")";
+
+            SimTrackIds.clear();
+            std::vector<SimHitIdpr> i_SimTrackIds;
+            int i_compHit = 0;
+            for (std::vector<const TrackingRecHit *>::const_iterator ithit =
+                     componentHits.begin();
+                 ithit != componentHits.end(); ++ithit) {
+              i_compHit++;
+
+              const DTRecHit1D *dtrechit1D =
+                  dynamic_cast<const DTRecHit1D *>(*ithit);
+
+              i_SimTrackIds.clear();
+              if (dtrechit1D) {
+                iH++;
+                i_SimTrackIds = dttruth.associateDTHitId(dtrechit1D);
+
+                if (valid_Hit) {
+                  // validity check is on the segment, but hits are counted
+                  // one-by-one
+                  n_dt_valid++;
+
+                  if (!i_SimTrackIds.empty()) {
+                    n_dt_matched_valid++;
+                    // muon_matchedIds_valid[iH] = i_SimTrackIds;
+                    muon_matchedIds_valid.push_back(
+                        new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
+                  }
+                } else {
+                  n_dt_INVALID++;
+
+                  if (!i_SimTrackIds.empty()) {
+                    n_dt_matched_INVALID++;
+                    // muon_matchedIds_INVALID[iH] = i_SimTrackIds;
+                    muon_matchedIds_INVALID.push_back(
+                        new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
+                  }
+                }
+              } else if (printRtS)
+                edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                    << "*** WARNING in "
+                       "MuonAssociatorByHitsHelper::getMatchedIds, null "
+                       "dynamic_cast of a DT TrackingRecHit !";
+
+              unsigned int i_detid = (*ithit)->geographicalId().rawId();
+              DTWireId i_dtdetid = DTWireId(i_detid);
+
+              stringstream i_dt_detector_id;
+              i_dt_detector_id << i_dtdetid;
+
+              stringstream i_ss;
+              i_ss << "\t\t hit " << i_compHit
+                   << " -Muon DT - detID = " << i_dt_detector_id.str();
+
+              string i_hitlog = i_ss.str();
+              i_hitlog = i_hitlog + write_matched_simtracks(i_SimTrackIds);
+              if (printRtS)
+                edm::LogVerbatim("MuonAssociatorByHitsHelper") << i_hitlog;
+
+              SimTrackIds.insert(SimTrackIds.end(), i_SimTrackIds.begin(),
+                                 i_SimTrackIds.end());
+            }
+          } // if (dtsegment)
+
+          else if (printRtS)
+            edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                << "*** WARNING in MuonAssociatorByHitsHelper::getMatchedIds, "
+                   "DT TrackingRecHit is neither DTRecHit1D nor DTRecSegment4D "
+                   "! ";
+        }
+      }
+
+      // CSC Hits
+      else if (subdet == MuonSubdetId::CSC) {
+        CSCDetId cscdetid = CSCDetId(detid);
+        stringstream csc_detector_id;
+        csc_detector_id << cscdetid;
+        if (valid_Hit)
+          hitlog = hitlog + " -Muon CSC- detID = " + csc_detector_id.str();
+        else
+          hitlog = hitlog + " *** INVALID ***" +
+                   " -Muon CSC- detID = " + csc_detector_id.str();
+
+        const CSCRecHit2D *cscrechit = dynamic_cast<const CSCRecHit2D *>(hitp);
+
+        // single CSC hits
+        if (cscrechit) {
+          iH++;
+          SimTrackIds = csctruth.associateCSCHitId(cscrechit);
+
+          if (valid_Hit) {
+            n_csc_valid++;
+
+            if (!SimTrackIds.empty()) {
+              n_csc_matched_valid++;
+              // muon_matchedIds_valid[iH] = SimTrackIds;
+              muon_matchedIds_valid.push_back(
+                  new uint_SimHitIdpr_pair(iH, SimTrackIds));
+            }
+          } else {
+            n_csc_INVALID++;
+
+            if (!SimTrackIds.empty()) {
+              n_csc_matched_INVALID++;
+              // muon_matchedIds_INVALID[iH] = SimTrackIds;
+              muon_matchedIds_INVALID.push_back(
+                  new uint_SimHitIdpr_pair(iH, SimTrackIds));
+            }
+          }
+        }
+
+        // CSC segments
+        else {
+          const CSCSegment *cscsegment = dynamic_cast<const CSCSegment *>(hitp);
+
+          if (cscsegment) {
+
+            std::vector<const TrackingRecHit *> componentHits =
+                cscsegment->recHits();
+            if (printRtS)
+              edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                  << "\n\t this TrackingRecHit is a CSCSegment with "
+                  << componentHits.size() << " hits";
+
+            SimTrackIds.clear();
+            std::vector<SimHitIdpr> i_SimTrackIds;
+            int i_compHit = 0;
+            for (std::vector<const TrackingRecHit *>::const_iterator ithit =
+                     componentHits.begin();
+                 ithit != componentHits.end(); ++ithit) {
+              i_compHit++;
+
+              const CSCRecHit2D *cscrechit2D =
+                  dynamic_cast<const CSCRecHit2D *>(*ithit);
+
+              i_SimTrackIds.clear();
+              if (cscrechit2D) {
+                iH++;
+                i_SimTrackIds = csctruth.associateCSCHitId(cscrechit2D);
+
+                if (valid_Hit) {
+                  // validity check is on the segment, but hits are counted
+                  // one-by-one
+                  n_csc_valid++;
+
+                  if (!i_SimTrackIds.empty()) {
+                    n_csc_matched_valid++;
+                    // muon_matchedIds_valid[iH] =  i_SimTrackIds;
+                    muon_matchedIds_valid.push_back(
+                        new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
+                  }
+                } else {
+                  n_csc_INVALID++;
+
+                  if (!i_SimTrackIds.empty()) {
+                    n_csc_matched_INVALID++;
+                    // muon_matchedIds_INVALID[iH] =  i_SimTrackIds;
+                    muon_matchedIds_INVALID.push_back(
+                        new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
+                  }
+                }
+              } else if (printRtS)
+                edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                    << "*** WARNING in "
+                       "MuonAssociatorByHitsHelper::getMatchedIds, null "
+                       "dynamic_cast of a CSC TrackingRecHit !";
+
+              unsigned int i_detid = (*ithit)->geographicalId().rawId();
+              CSCDetId i_cscdetid = CSCDetId(i_detid);
+
+              stringstream i_csc_detector_id;
+              i_csc_detector_id << i_cscdetid;
+
+              stringstream i_ss;
+              i_ss << "\t\t hit " << i_compHit
+                   << " -Muon CSC- detID = " << i_csc_detector_id.str();
+
+              string i_hitlog = i_ss.str();
+              i_hitlog = i_hitlog + write_matched_simtracks(i_SimTrackIds);
+              if (printRtS)
+                edm::LogVerbatim("MuonAssociatorByHitsHelper") << i_hitlog;
+
+              SimTrackIds.insert(SimTrackIds.end(), i_SimTrackIds.begin(),
+                                 i_SimTrackIds.end());
+            }
+          } // if (cscsegment)
+
+          else if (printRtS)
+            edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                << "*** WARNING in MuonAssociatorByHitsHelper::getMatchedIds, "
+                   "CSC TrackingRecHit is neither CSCRecHit2D nor CSCSegment "
+                   "! ";
+        }
+      }
+
+      // RPC Hits
+      else if (subdet == MuonSubdetId::RPC) {
+        RPCDetId rpcdetid = RPCDetId(detid);
+        stringstream rpc_detector_id;
+        rpc_detector_id << rpcdetid;
+        if (valid_Hit)
+          hitlog = hitlog + " -Muon RPC- detID = " + rpc_detector_id.str();
+        else
+          hitlog = hitlog + " *** INVALID ***" +
+                   " -Muon RPC- detID = " + rpc_detector_id.str();
+
+        iH++;
+        SimTrackIds = rpctruth.associateRecHit(*hitp);
+
+        if (valid_Hit) {
+          n_rpc_valid++;
+
+          if (!SimTrackIds.empty()) {
+            n_rpc_matched_valid++;
+            // muon_matchedIds_valid[iH] = SimTrackIds;
+            muon_matchedIds_valid.push_back(
+                new uint_SimHitIdpr_pair(iH, SimTrackIds));
+          }
+        } else {
+          n_rpc_INVALID++;
+
+          if (!SimTrackIds.empty()) {
+            n_rpc_matched_INVALID++;
+            // muon_matchedIds_INVALID[iH] = SimTrackIds;
+            muon_matchedIds_INVALID.push_back(
+                new uint_SimHitIdpr_pair(iH, SimTrackIds));
+          }
+        }
+      }
+
+      // GEM Hits
+      else if (subdet == MuonSubdetId::GEM) {
+        GEMDetId gemdetid = GEMDetId(detid);
+        stringstream gem_detector_id;
+        gem_detector_id << gemdetid;
+        if (valid_Hit)
+          hitlog = hitlog + " -Muon GEM- detID = " + gem_detector_id.str();
+        else
+          hitlog = hitlog + " *** INVALID ***" +
+                   " -Muon GEM- detID = " + gem_detector_id.str();
+
+        const GEMRecHit *gemrechit = dynamic_cast<const GEMRecHit *>(hitp);
+        if (gemrechit) {
+          iH++;
+          SimTrackIds = gemtruth.associateRecHit(gemrechit);
+
+          if (valid_Hit) {
+            n_gem_valid++;
+
+            if (!SimTrackIds.empty()) {
+              n_gem_matched_valid++;
+              // muon_matchedIds_valid[iH] = SimTrackIds;
+              muon_matchedIds_valid.push_back(
+                  new uint_SimHitIdpr_pair(iH, SimTrackIds));
+            }
+          } else {
+            n_gem_INVALID++;
+
+            if (!SimTrackIds.empty()) {
+              n_gem_matched_INVALID++;
+              // muon_matchedIds_INVALID[iH] = SimTrackIds;
+              muon_matchedIds_INVALID.push_back(
+                  new uint_SimHitIdpr_pair(iH, SimTrackIds));
+            }
+          }
+        } else {
+          const GEMSegment *gemsegment = dynamic_cast<const GEMSegment *>(hitp);
+          if (gemsegment) {
+
+            std::vector<const TrackingRecHit *> componentHits =
+                gemsegment->recHits();
+            if (printRtS)
+              edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                  << "\n\t this TrackingRecHit is a GEMSegment with "
+                  << componentHits.size() << " hits";
+
+            SimTrackIds.clear();
+            std::vector<SimHitIdpr> i_SimTrackIds;
+            int i_compHit = 0;
+
+            for (auto const &ithit : componentHits) {
+
+              i_compHit++;
+
+              const GEMRecHit *gemrechitseg =
+                  dynamic_cast<const GEMRecHit *>(ithit);
+
+              i_SimTrackIds.clear();
+              if (gemrechitseg) {
+                iH++;
+                i_SimTrackIds = gemtruth.associateRecHit(gemrechitseg);
+
+                if (valid_Hit) {
+                  // validity check is on the segment, but hits are counted
+                  // one-by-one
+                  n_gem_valid++;
+
+                  if (!i_SimTrackIds.empty()) {
+                    n_gem_matched_valid++;
+                    // muon_matchedIds_valid[iH] =  i_SimTrackIds;
+                    muon_matchedIds_valid.push_back(
+                        new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
+                  }
+                } else {
+                  n_gem_INVALID++;
+
+                  if (!i_SimTrackIds.empty()) {
+                    n_gem_matched_INVALID++;
+                    // muon_matchedIds_INVALID[iH] =  i_SimTrackIds;
+                    muon_matchedIds_INVALID.push_back(
+                        new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
+                  }
+                }
+              } else if (printRtS)
+                edm::LogVerbatim("MuonAssociatorByHitsHelper")
+                    << "*** WARNING in "
+                       "MuonAssociatorByHitsHelper::getMatchedIds, null "
+                       "dynamic_cast of a GEM TrackingRecHit !";
+
+              if (printRtS) {
+                unsigned int i_detid = ithit->geographicalId().rawId();
+                GEMDetId i_gemdetid = GEMDetId(i_detid);
+
+                string i_hitlog = std::to_string(i_gemdetid);
+                i_hitlog = i_hitlog + write_matched_simtracks(i_SimTrackIds);
+                edm::LogVerbatim("MuonAssociatorByHitsHelper") << i_hitlog;
+              }
+
+              SimTrackIds.insert(SimTrackIds.end(), i_SimTrackIds.begin(),
+                                 i_SimTrackIds.end());
+            }
+          } // if (gemsegment)
+
+        } // if (gemrechit
+      } else if (printRtS)
+        edm::LogVerbatim("MuonAssociatorByHitsHelper")
+            << "TrackingRecHit " << iloop
+            << "  *** WARNING *** Unexpected Hit from Detector = " << det;
+    } // end if (det == DetId::Muon && UseMuon)
+    else
+      continue;
+
+    hitlog = hitlog + write_matched_simtracks(SimTrackIds);
+
+    if (printRtS)
+      edm::LogVerbatim("MuonAssociatorByHitsHelper") << hitlog;
+    if (printRtS && dumpDT && det == DetId::Muon &&
+        subdet == MuonSubdetId::DT) {
+      edm::LogVerbatim("MuonAssociatorByHitsHelper") << wireidlog;
+      for (unsigned int j = 0; j < DTSimHits.size(); j++) {
+        edm::LogVerbatim("MuonAssociatorByHitsHelper") << DTSimHits[j];
+      }
+    }
+
+  } // trackingRecHit loop
 }
 
-int MuonAssociatorByHitsHelper::getShared(MapOfMatchedIds & matchedIds, TrackingParticleCollection::const_iterator trpart) const {
-    
-  int nshared = 0;
-  const std::vector<SimTrack>& g4Tracks = trpart->g4Tracks();
+int MuonAssociatorByHitsHelper::getShared(
+    MapOfMatchedIds &matchedIds,
+    TrackingParticleCollection::const_iterator trpart) const {
 
-  // map is indexed over the rechits of the reco::Track (no double-countings allowed)
-  for (MapOfMatchedIds::const_iterator iRecH=matchedIds.begin(); iRecH!=matchedIds.end(); ++iRecH) {
+  int nshared = 0;
+  const std::vector<SimTrack> &g4Tracks = trpart->g4Tracks();
+
+  // map is indexed over the rechits of the reco::Track (no double-countings
+  // allowed)
+  for (MapOfMatchedIds::const_iterator iRecH = matchedIds.begin();
+       iRecH != matchedIds.end(); ++iRecH) {
 
     // vector of associated simhits associated to the current rechit
-    std::vector<SimHitIdpr> const & SimTrackIds = (*iRecH).second;
-    
+    std::vector<SimHitIdpr> const &SimTrackIds = (*iRecH).second;
+
     bool found = false;
-    
-    for (const auto& iSimH : SimTrackIds) {
-        
+
+    for (const auto &iSimH : SimTrackIds) {
+
       uint32_t simtrackId = iSimH.first;
       EncodedEventId evtId = iSimH.second;
-      
-      // look for shared hits with the given TrackingParticle (looping over component SimTracks)
-      for (const auto& simtrack : g4Tracks) {
-          
-          if (simtrack.trackId() == simtrackId  &&  simtrack.eventId() == evtId) {
-            found = true;
-              break;
-          }
-      }
-      
-      if (found) {
-          nshared++;
+
+      // look for shared hits with the given TrackingParticle (looping over
+      // component SimTracks)
+      for (const auto &simtrack : g4Tracks) {
+
+        if (simtrack.trackId() == simtrackId && simtrack.eventId() == evtId) {
+          found = true;
           break;
+        }
+      }
+
+      if (found) {
+        nshared++;
+        break;
       }
     }
   }
-  
+
   return nshared;
 }
 
-std::string MuonAssociatorByHitsHelper::write_matched_simtracks(const std::vector<SimHitIdpr>& SimTrackIds) const {
+std::string MuonAssociatorByHitsHelper::write_matched_simtracks(
+    const std::vector<SimHitIdpr> &SimTrackIds) const {
   if (SimTrackIds.empty())
     return "  *** UNMATCHED ***";
 
   string hitlog(" matched to SimTrack");
-  
-  for(size_t j=0; j<SimTrackIds.size(); j++)
-  {
+
+  for (size_t j = 0; j < SimTrackIds.size(); j++) {
     char buf[64];
-    snprintf(buf, 64, " Id:%i/Evt:(%i,%i) ", SimTrackIds[j].first, SimTrackIds[j].second.event(), SimTrackIds[j].second.bunchCrossing());
+    snprintf(buf, 64, " Id:%i/Evt:(%i,%i) ", SimTrackIds[j].first,
+             SimTrackIds[j].second.event(),
+             SimTrackIds[j].second.bunchCrossing());
     hitlog += buf;
   }
   return hitlog;
 }
-

--- a/SimMuon/MCTruth/src/MuonToSimAssociatorBase.cc
+++ b/SimMuon/MCTruth/src/MuonToSimAssociatorBase.cc
@@ -2,7 +2,7 @@
 //
 // Package:     SimMuon/MCTruth
 // Class  :     MuonToSimAssociatorBase
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -13,9 +13,8 @@
 // system include files
 
 // user include files
-#include "SimMuon/MCTruth/interface/MuonToSimAssociatorBase.h"
 #include "FWCore/Utilities/interface/typelookup.h"
-
+#include "SimMuon/MCTruth/interface/MuonToSimAssociatorBase.h"
 
 //
 // constants, enums and typedefs
@@ -28,12 +27,8 @@
 //
 // constructors and destructor
 //
-MuonToSimAssociatorBase::MuonToSimAssociatorBase()
-{
-}
+MuonToSimAssociatorBase::MuonToSimAssociatorBase() {}
 
-MuonToSimAssociatorBase::~MuonToSimAssociatorBase()
-{
-}
+MuonToSimAssociatorBase::~MuonToSimAssociatorBase() {}
 
 TYPELOOKUP_DATA_REG(MuonToSimAssociatorBase);

--- a/SimMuon/MCTruth/src/MuonToSimAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonToSimAssociatorByHits.cc
@@ -1,162 +1,184 @@
-#include "SimMuon/MCTruth/interface/MuonToSimAssociatorByHits.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "DataFormats/CSCRecHit/interface/CSCSegment.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4D.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include "DataFormats/DTRecHit/interface/DTRecSegment4D.h"
-#include "DataFormats/CSCRecHit/interface/CSCSegment.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "SimMuon/MCTruth/interface/MuonToSimAssociatorByHits.h"
 #include "SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h"
 #include <sstream>
 
 using namespace reco;
 using namespace std;
 
-MuonToSimAssociatorByHits::MuonToSimAssociatorByHits (const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :
-  helper_(conf),
-  conf_(conf),
-  trackerHitAssociatorConfig_(conf,std::move(iC))
-{
-  TrackerMuonHitExtractor hitExtractor(conf_,std::move(iC)); 
+MuonToSimAssociatorByHits::MuonToSimAssociatorByHits(
+    const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
+    : helper_(conf), conf_(conf),
+      trackerHitAssociatorConfig_(conf, std::move(iC)) {
+  TrackerMuonHitExtractor hitExtractor(conf_, std::move(iC));
 
-  //hack for consumes
-  RPCHitAssociator rpctruth(conf,std::move(iC));
-  GEMHitAssociator gemtruth(conf,std::move(iC));
-  DTHitAssociator dttruth(conf,std::move(iC));
-  CSCHitAssociator muonTruth(conf,std::move(iC));
+  // hack for consumes
+  RPCHitAssociator rpctruth(conf, std::move(iC));
+  GEMHitAssociator gemtruth(conf, std::move(iC));
+  DTHitAssociator dttruth(conf, std::move(iC));
+  CSCHitAssociator muonTruth(conf, std::move(iC));
 }
 
+MuonToSimAssociatorByHits::~MuonToSimAssociatorByHits() {}
 
-MuonToSimAssociatorByHits::~MuonToSimAssociatorByHits()
-{
+void MuonToSimAssociatorByHits::associateMuons(
+    MuonToSimCollection &recToSim, SimToMuonCollection &simToRec,
+    const edm::Handle<edm::View<reco::Muon>> &tCH, MuonTrackType type,
+    const edm::Handle<TrackingParticleCollection> &tPCH,
+    const edm::Event *event, const edm::EventSetup *setup) const {
+
+  edm::RefVector<TrackingParticleCollection> tpc(tPCH.id());
+  for (unsigned int j = 0; j < tPCH->size(); j++)
+    tpc.push_back(edm::Ref<TrackingParticleCollection>(tPCH, j));
+
+  edm::RefToBaseVector<reco::Muon> muonBaseRefVector;
+  for (size_t i = 0; i < tCH->size(); ++i)
+    muonBaseRefVector.push_back(tCH->refAt(i));
+
+  associateMuons(recToSim, simToRec, muonBaseRefVector, type, tpc, event,
+                 setup);
 }
 
+void MuonToSimAssociatorByHits::associateMuons(
+    MuonToSimCollection &recToSim, SimToMuonCollection &simToRec,
+    const edm::RefToBaseVector<reco::Muon> &muons, MuonTrackType trackType,
+    const edm::RefVector<TrackingParticleCollection> &tPC,
+    const edm::Event *event, const edm::EventSetup *setup) const {
 
-
-void MuonToSimAssociatorByHits::associateMuons(MuonToSimCollection & recToSim, SimToMuonCollection & simToRec,
-                                          const edm::Handle<edm::View<reco::Muon> > &tCH, MuonTrackType type,
-                                          const edm::Handle<TrackingParticleCollection>&tPCH,
-                                          const edm::Event * event, const edm::EventSetup * setup) const  {
-
-    edm::RefVector<TrackingParticleCollection> tpc(tPCH.id());
-    for (unsigned int j=0; j<tPCH->size();j++)
-      tpc.push_back(edm::Ref<TrackingParticleCollection>(tPCH,j));
-    
-    edm::RefToBaseVector<reco::Muon> muonBaseRefVector;
-    for (size_t i = 0; i < tCH->size(); ++i)
-      muonBaseRefVector.push_back(tCH->refAt(i));
-
-    associateMuons(recToSim, simToRec, muonBaseRefVector,type,tpc,event,setup);
-}
-
-void MuonToSimAssociatorByHits::associateMuons(MuonToSimCollection & recToSim, SimToMuonCollection & simToRec,
-                      const edm::RefToBaseVector<reco::Muon> & muons, MuonTrackType trackType,
-                      const edm::RefVector<TrackingParticleCollection>& tPC,
-                      const edm::Event * event, const edm::EventSetup * setup) const {
-
-    /// PART 1: Fill MuonToSimAssociatorByHits::TrackHitsCollection
-    MuonAssociatorByHitsHelper::TrackHitsCollection muonHitRefs;
-    edm::OwnVector<TrackingRecHit> allTMRecHits;  // this I will fill in only for tracker muon hits from segments
-    switch (trackType) {
-        case InnerTk: 
-            for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
-                edm::RefToBase<reco::Muon> mur = *it;
-                if (mur->track().isNonnull()) { 
-                    muonHitRefs.push_back(std::make_pair(mur->track()->recHitsBegin(), mur->track()->recHitsEnd()));
-                } else {
-                    muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
-                }
-            }
-            break;
-        case OuterTk: 
-            for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
-                edm::RefToBase<reco::Muon> mur = *it;
-                if (mur->outerTrack().isNonnull()) { 
-                    muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(), mur->outerTrack()->recHitsEnd()));
-                } else {
-                    muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
-                }
-            }
-            break;
-        case GlobalTk: 
-            for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
-                edm::RefToBase<reco::Muon> mur = *it;
-                if (mur->globalTrack().isNonnull()) { 
-                    muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(), mur->globalTrack()->recHitsEnd()));
-                } else {
-                    muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
-               }
-            }
-            break;
-        case Segments: {
-                TrackerMuonHitExtractor hitExtractor(conf_); 
-                hitExtractor.init(*event, *setup);
-                // puts hits in the vector, and record indices
-                std::vector<std::pair<size_t, size_t> >   muonHitIndices;
-                for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
-                    edm::RefToBase<reco::Muon> mur = *it;
-                    std::pair<size_t, size_t> indices(allTMRecHits.size(), allTMRecHits.size());
-                    if (mur->isTrackerMuon()) {
-                        std::vector<const TrackingRecHit *> hits = hitExtractor.getMuonHits(*mur);
-                        for (std::vector<const TrackingRecHit *>::const_iterator ith = hits.begin(), edh = hits.end(); ith != edh; ++ith) {
-                            allTMRecHits.push_back(**ith);
-                        }
-                        indices.second += hits.size();
-                    }
-                    muonHitIndices.push_back(indices);  
-                }
-                // convert indices into pairs of iterators to references
-                typedef std::pair<size_t, size_t> index_pair;
-                trackingRecHit_iterator hitRefBegin = allTMRecHits.data().begin();
-                for (std::vector<std::pair<size_t, size_t> >::const_iterator idxs = muonHitIndices.begin(), idxend = muonHitIndices.end(); idxs != idxend; ++idxs) {
-                    muonHitRefs.push_back(std::make_pair(hitRefBegin+idxs->first, 
-                                                         hitRefBegin+idxs->second));
-                }
-                
-            }
-            break;
+  /// PART 1: Fill MuonToSimAssociatorByHits::TrackHitsCollection
+  MuonAssociatorByHitsHelper::TrackHitsCollection muonHitRefs;
+  edm::OwnVector<TrackingRecHit>
+      allTMRecHits; // this I will fill in only for tracker muon hits from
+                    // segments
+  switch (trackType) {
+  case InnerTk:
+    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
+                                                          ed = muons.end();
+         it != ed; ++it) {
+      edm::RefToBase<reco::Muon> mur = *it;
+      if (mur->track().isNonnull()) {
+        muonHitRefs.push_back(std::make_pair(mur->track()->recHitsBegin(),
+                                             mur->track()->recHitsEnd()));
+      } else {
+        muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(),
+                                             allTMRecHits.data().end()));
+      }
     }
-
-    /// PART 2: call the association routines 
-    //Retrieve tracker topology from geometry
-    edm::ESHandle<TrackerTopology> tTopoHand;
-    setup->get<TrackerTopologyRcd>().get(tTopoHand);
-    const TrackerTopology *tTopo=tTopoHand.product();
-    
-    
-    // Tracker hit association  
-    TrackerHitAssociator trackertruth(*event, trackerHitAssociatorConfig_);
-    // CSC hit association
-    CSCHitAssociator csctruth(*event,*setup,conf_);
-    // DT hit association
-    bool printRtS = true;
-    DTHitAssociator dttruth(*event,*setup,conf_,printRtS);  
-    // RPC hit association
-    RPCHitAssociator rpctruth(*event,*setup,conf_);
-    // GEM hit association
-    GEMHitAssociator gemtruth(*event,*setup,conf_);
-   
-    MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
-
-    auto recSimColl = helper_.associateRecoToSimIndices(muonHitRefs,tPC,resources);
-    for (auto it = recSimColl.begin(), ed = recSimColl.end(); it != ed; ++it) {
-        edm::RefToBase<reco::Muon> rec = muons[it->first];
-        std::vector<std::pair<TrackingParticleRef, double> > & tpAss  = recToSim[rec];
-        for ( auto const & a : it->second) {
-            tpAss.push_back(std::make_pair(tPC[a.idx], a.quality));
+    break;
+  case OuterTk:
+    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
+                                                          ed = muons.end();
+         it != ed; ++it) {
+      edm::RefToBase<reco::Muon> mur = *it;
+      if (mur->outerTrack().isNonnull()) {
+        muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(),
+                                             mur->outerTrack()->recHitsEnd()));
+      } else {
+        muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(),
+                                             allTMRecHits.data().end()));
+      }
+    }
+    break;
+  case GlobalTk:
+    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
+                                                          ed = muons.end();
+         it != ed; ++it) {
+      edm::RefToBase<reco::Muon> mur = *it;
+      if (mur->globalTrack().isNonnull()) {
+        muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(),
+                                             mur->globalTrack()->recHitsEnd()));
+      } else {
+        muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(),
+                                             allTMRecHits.data().end()));
+      }
+    }
+    break;
+  case Segments: {
+    TrackerMuonHitExtractor hitExtractor(conf_);
+    hitExtractor.init(*event, *setup);
+    // puts hits in the vector, and record indices
+    std::vector<std::pair<size_t, size_t>> muonHitIndices;
+    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
+                                                          ed = muons.end();
+         it != ed; ++it) {
+      edm::RefToBase<reco::Muon> mur = *it;
+      std::pair<size_t, size_t> indices(allTMRecHits.size(),
+                                        allTMRecHits.size());
+      if (mur->isTrackerMuon()) {
+        std::vector<const TrackingRecHit *> hits =
+            hitExtractor.getMuonHits(*mur);
+        for (std::vector<const TrackingRecHit *>::const_iterator
+                 ith = hits.begin(),
+                 edh = hits.end();
+             ith != edh; ++ith) {
+          allTMRecHits.push_back(**ith);
         }
+        indices.second += hits.size();
+      }
+      muonHitIndices.push_back(indices);
     }
-    auto simRecColl = helper_.associateSimToRecoIndices(muonHitRefs,tPC,resources);
-    for (auto it = simRecColl.begin(), ed = simRecColl.end(); it != ed; ++it) {
-        TrackingParticleRef sim = tPC[it->first];
-        std::vector<std::pair<edm::RefToBase<reco::Muon>, double> > & recAss = simToRec[sim];
-        for ( auto const & a: it->second ) {
-            recAss.push_back(std::make_pair(muons[a.idx], a.quality));
-        }
+    // convert indices into pairs of iterators to references
+    typedef std::pair<size_t, size_t> index_pair;
+    trackingRecHit_iterator hitRefBegin = allTMRecHits.data().begin();
+    for (std::vector<std::pair<size_t, size_t>>::const_iterator
+             idxs = muonHitIndices.begin(),
+             idxend = muonHitIndices.end();
+         idxs != idxend; ++idxs) {
+      muonHitRefs.push_back(std::make_pair(hitRefBegin + idxs->first,
+                                           hitRefBegin + idxs->second));
     }
 
+  } break;
+  }
+
+  /// PART 2: call the association routines
+  // Retrieve tracker topology from geometry
+  edm::ESHandle<TrackerTopology> tTopoHand;
+  setup->get<TrackerTopologyRcd>().get(tTopoHand);
+  const TrackerTopology *tTopo = tTopoHand.product();
+
+  // Tracker hit association
+  TrackerHitAssociator trackertruth(*event, trackerHitAssociatorConfig_);
+  // CSC hit association
+  CSCHitAssociator csctruth(*event, *setup, conf_);
+  // DT hit association
+  bool printRtS = true;
+  DTHitAssociator dttruth(*event, *setup, conf_, printRtS);
+  // RPC hit association
+  RPCHitAssociator rpctruth(*event, *setup, conf_);
+  // GEM hit association
+  GEMHitAssociator gemtruth(*event, *setup, conf_);
+
+  MuonAssociatorByHitsHelper::Resources resources = {
+      tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
+
+  auto recSimColl =
+      helper_.associateRecoToSimIndices(muonHitRefs, tPC, resources);
+  for (auto it = recSimColl.begin(), ed = recSimColl.end(); it != ed; ++it) {
+    edm::RefToBase<reco::Muon> rec = muons[it->first];
+    std::vector<std::pair<TrackingParticleRef, double>> &tpAss = recToSim[rec];
+    for (auto const &a : it->second) {
+      tpAss.push_back(std::make_pair(tPC[a.idx], a.quality));
+    }
+  }
+  auto simRecColl =
+      helper_.associateSimToRecoIndices(muonHitRefs, tPC, resources);
+  for (auto it = simRecColl.begin(), ed = simRecColl.end(); it != ed; ++it) {
+    TrackingParticleRef sim = tPC[it->first];
+    std::vector<std::pair<edm::RefToBase<reco::Muon>, double>> &recAss =
+        simToRec[sim];
+    for (auto const &a : it->second) {
+      recAss.push_back(std::make_pair(muons[a.idx], a.quality));
+    }
+  }
 }

--- a/SimMuon/MCTruth/src/MuonTruth.cc
+++ b/SimMuon/MCTruth/src/MuonTruth.cc
@@ -1,60 +1,61 @@
-#include "SimMuon/MCTruth/interface/MuonTruth.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
-#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
+#include "SimMuon/MCTruth/interface/MuonTruth.h"
 
-MuonTruth::MuonTruth(const edm::Event& event, const edm::EventSetup& setup, const edm::ParameterSet& conf): 
-  theDigiSimLinks(nullptr),
-  theWireDigiSimLinks(nullptr),
-  linksTag(conf.getParameter<edm::InputTag>("CSClinksTag")),
-  wireLinksTag(conf.getParameter<edm::InputTag>("CSCwireLinksTag")),
-  // CrossingFrame used or not ?
-  crossingframe(conf.getParameter<bool>("crossingframe")),
-  CSCsimHitsTag(conf.getParameter<edm::InputTag>("CSCsimHitsTag")),
-  CSCsimHitsXFTag(conf.getParameter<edm::InputTag>("CSCsimHitsXFTag"))
+MuonTruth::MuonTruth(const edm::Event &event, const edm::EventSetup &setup,
+                     const edm::ParameterSet &conf)
+    : theDigiSimLinks(nullptr), theWireDigiSimLinks(nullptr),
+      linksTag(conf.getParameter<edm::InputTag>("CSClinksTag")),
+      wireLinksTag(conf.getParameter<edm::InputTag>("CSCwireLinksTag")),
+      // CrossingFrame used or not ?
+      crossingframe(conf.getParameter<bool>("crossingframe")),
+      CSCsimHitsTag(conf.getParameter<edm::InputTag>("CSCsimHitsTag")),
+      CSCsimHitsXFTag(conf.getParameter<edm::InputTag>("CSCsimHitsXFTag"))
 
 {
-  initEvent(event,setup);
+  initEvent(event, setup);
 }
 
-MuonTruth::MuonTruth( const edm::ParameterSet& conf, edm::ConsumesCollector && iC ): 
-  theDigiSimLinks(nullptr),
-  theWireDigiSimLinks(nullptr),
-  linksTag(conf.getParameter<edm::InputTag>("CSClinksTag")),
-  wireLinksTag(conf.getParameter<edm::InputTag>("CSCwireLinksTag")),
-  // CrossingFrame used or not ?
-  crossingframe(conf.getParameter<bool>("crossingframe")),
-  CSCsimHitsTag(conf.getParameter<edm::InputTag>("CSCsimHitsTag")),
-  CSCsimHitsXFTag(conf.getParameter<edm::InputTag>("CSCsimHitsXFTag"))
+MuonTruth::MuonTruth(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
+    : theDigiSimLinks(nullptr), theWireDigiSimLinks(nullptr),
+      linksTag(conf.getParameter<edm::InputTag>("CSClinksTag")),
+      wireLinksTag(conf.getParameter<edm::InputTag>("CSCwireLinksTag")),
+      // CrossingFrame used or not ?
+      crossingframe(conf.getParameter<bool>("crossingframe")),
+      CSCsimHitsTag(conf.getParameter<edm::InputTag>("CSCsimHitsTag")),
+      CSCsimHitsXFTag(conf.getParameter<edm::InputTag>("CSCsimHitsXFTag"))
 
 {
   iC.consumes<DigiSimLinks>(linksTag);
   iC.consumes<DigiSimLinks>(wireLinksTag);
-  if ( crossingframe ) {
-    iC.consumes<CrossingFrame<PSimHit> >(CSCsimHitsXFTag);
-  } else if (!CSCsimHitsTag.label().empty()){
+  if (crossingframe) {
+    iC.consumes<CrossingFrame<PSimHit>>(CSCsimHitsXFTag);
+  } else if (!CSCsimHitsTag.label().empty()) {
     iC.consumes<edm::PSimHitContainer>(CSCsimHitsTag);
   }
-
 }
 
-void MuonTruth::initEvent(const edm::Event& event, const edm::EventSetup& setup) {
+void MuonTruth::initEvent(const edm::Event &event,
+                          const edm::EventSetup &setup) {
 
   edm::Handle<DigiSimLinks> digiSimLinks;
-  LogTrace("MuonTruth") <<"getting CSC Strip DigiSimLink collection - "<<linksTag;
+  LogTrace("MuonTruth") << "getting CSC Strip DigiSimLink collection - "
+                        << linksTag;
   event.getByLabel(linksTag, digiSimLinks);
   theDigiSimLinks = digiSimLinks.product();
 
   edm::Handle<DigiSimLinks> wireDigiSimLinks;
-  LogTrace("MuonTruth") <<"getting CSC Wire DigiSimLink collection - "<<wireLinksTag;
+  LogTrace("MuonTruth") << "getting CSC Wire DigiSimLink collection - "
+                        << wireLinksTag;
   event.getByLabel(wireLinksTag, wireDigiSimLinks);
   theWireDigiSimLinks = wireDigiSimLinks.product();
 
   // get CSC Geometry to use CSCLayer methods
   edm::ESHandle<CSCGeometry> mugeom;
-  setup.get<MuonGeometryRecord>().get( mugeom );
+  setup.get<MuonGeometryRecord>().get(mugeom);
   cscgeom = &*mugeom;
 
   // get CSC Bad Chambers (ME4/2)
@@ -65,46 +66,44 @@ void MuonTruth::initEvent(const edm::Event& event, const edm::EventSetup& setup)
   theSimHitMap.clear();
 
   if (crossingframe) {
-    
-    edm::Handle<CrossingFrame<PSimHit> > cf;
-    LogTrace("MuonTruth") <<"getting CrossingFrame<PSimHit> collection - "<<CSCsimHitsXFTag;
-    event.getByLabel(CSCsimHitsXFTag, cf);
-    
-    std::unique_ptr<MixCollection<PSimHit> > 
-      CSCsimhits( new MixCollection<PSimHit>(cf.product()) );
-    LogTrace("MuonTruth") <<"... size = "<<CSCsimhits->size();
 
-    for(MixCollection<PSimHit>::MixItr hitItr = CSCsimhits->begin();
-	hitItr != CSCsimhits->end(); ++hitItr) 
-      {
-	theSimHitMap[hitItr->detUnitId()].push_back(*hitItr);
-      }
-    
-  } else if (!CSCsimHitsTag.label().empty()){
+    edm::Handle<CrossingFrame<PSimHit>> cf;
+    LogTrace("MuonTruth") << "getting CrossingFrame<PSimHit> collection - "
+                          << CSCsimHitsXFTag;
+    event.getByLabel(CSCsimHitsXFTag, cf);
+
+    std::unique_ptr<MixCollection<PSimHit>> CSCsimhits(
+        new MixCollection<PSimHit>(cf.product()));
+    LogTrace("MuonTruth") << "... size = " << CSCsimhits->size();
+
+    for (MixCollection<PSimHit>::MixItr hitItr = CSCsimhits->begin();
+         hitItr != CSCsimhits->end(); ++hitItr) {
+      theSimHitMap[hitItr->detUnitId()].push_back(*hitItr);
+    }
+
+  } else if (!CSCsimHitsTag.label().empty()) {
 
     edm::Handle<edm::PSimHitContainer> CSCsimhits;
-    LogTrace("MuonTruth") <<"getting PSimHit collection - "<<CSCsimHitsTag;
-    event.getByLabel(CSCsimHitsTag, CSCsimhits);    
-    LogTrace("MuonTruth") <<"... size = "<<CSCsimhits->size();
-    
-    for(edm::PSimHitContainer::const_iterator hitItr = CSCsimhits->begin();
-	hitItr != CSCsimhits->end(); ++hitItr)
-      {
-	theSimHitMap[hitItr->detUnitId()].push_back(*hitItr);
-      }
+    LogTrace("MuonTruth") << "getting PSimHit collection - " << CSCsimHitsTag;
+    event.getByLabel(CSCsimHitsTag, CSCsimhits);
+    LogTrace("MuonTruth") << "... size = " << CSCsimhits->size();
+
+    for (edm::PSimHitContainer::const_iterator hitItr = CSCsimhits->begin();
+         hitItr != CSCsimhits->end(); ++hitItr) {
+      theSimHitMap[hitItr->detUnitId()].push_back(*hitItr);
+    }
   }
 }
 
-float MuonTruth::muonFraction()
-{
-  if(theChargeMap.empty()) return 0.;
+float MuonTruth::muonFraction() {
+  if (theChargeMap.empty())
+    return 0.;
 
   float muonCharge = 0.;
-  for(std::map<SimHitIdpr, float>::const_iterator chargeMapItr = theChargeMap.begin();
-      chargeMapItr != theChargeMap.end(); ++chargeMapItr)
-  {
-    if( abs(particleType(chargeMapItr->first)) == 13)
-    {
+  for (std::map<SimHitIdpr, float>::const_iterator chargeMapItr =
+           theChargeMap.begin();
+       chargeMapItr != theChargeMap.end(); ++chargeMapItr) {
+    if (abs(particleType(chargeMapItr->first)) == 13) {
       muonCharge += chargeMapItr->second;
     }
   }
@@ -112,156 +111,134 @@ float MuonTruth::muonFraction()
   return muonCharge / theTotalCharge;
 }
 
-
-std::vector<PSimHit> MuonTruth::simHits()
-{
+std::vector<PSimHit> MuonTruth::simHits() {
   std::vector<PSimHit> result;
-  for(std::map<SimHitIdpr, float>::const_iterator chargeMapItr = theChargeMap.begin();
-      chargeMapItr != theChargeMap.end(); ++chargeMapItr)
-  {
+  for (std::map<SimHitIdpr, float>::const_iterator chargeMapItr =
+           theChargeMap.begin();
+       chargeMapItr != theChargeMap.end(); ++chargeMapItr) {
     std::vector<PSimHit> trackHits = hitsFromSimTrack(chargeMapItr->first);
     result.insert(result.end(), trackHits.begin(), trackHits.end());
   }
-  
+
   return result;
 }
 
-
-std::vector<PSimHit> MuonTruth::muonHits()
-{
+std::vector<PSimHit> MuonTruth::muonHits() {
   std::vector<PSimHit> result;
   std::vector<PSimHit> allHits = simHits();
-  std::vector<PSimHit>::const_iterator hitItr = allHits.begin(), lastHit = allHits.end();
+  std::vector<PSimHit>::const_iterator hitItr = allHits.begin(),
+                                       lastHit = allHits.end();
 
-  for( ; hitItr != lastHit; ++hitItr)
-  {
-    if(abs((*hitItr).particleType()) == 13)
-    {
+  for (; hitItr != lastHit; ++hitItr) {
+    if (abs((*hitItr).particleType()) == 13) {
       result.push_back(*hitItr);
     }
   }
   return result;
 }
 
-
-
-std::vector<PSimHit> MuonTruth::hitsFromSimTrack(MuonTruth::SimHitIdpr truthId)
-{
+std::vector<PSimHit>
+MuonTruth::hitsFromSimTrack(MuonTruth::SimHitIdpr truthId) {
   std::vector<PSimHit> result;
 
   auto found = theSimHitMap.find(theDetId);
   if (found != theSimHitMap.end()) {
 
-    for(auto const& hit: found->second)
-      {
-        unsigned int hitTrack = hit.trackId();
-        EncodedEventId hitEvId = hit.eventId();
-        
-        if(hitTrack == truthId.first && hitEvId == truthId.second) 
-          {
-            result.push_back(hit);
-          }
+    for (auto const &hit : found->second) {
+      unsigned int hitTrack = hit.trackId();
+      EncodedEventId hitEvId = hit.eventId();
+
+      if (hitTrack == truthId.first && hitEvId == truthId.second) {
+        result.push_back(hit);
       }
+    }
   }
   return result;
 }
 
-
-int MuonTruth::particleType(MuonTruth::SimHitIdpr truthId)
-{
+int MuonTruth::particleType(MuonTruth::SimHitIdpr truthId) {
   int result = 0;
-  const std::vector<PSimHit>& hits = hitsFromSimTrack(truthId);
-  if(!hits.empty())
-  {
+  const std::vector<PSimHit> &hits = hitsFromSimTrack(truthId);
+  if (!hits.empty()) {
     result = hits[0].particleType();
   }
   return result;
 }
 
-
-void MuonTruth::analyze(const CSCRecHit2D & recHit)
-{
+void MuonTruth::analyze(const CSCRecHit2D &recHit) {
   theChargeMap.clear();
   theTotalCharge = 0.;
   theDetId = recHit.geographicalId().rawId();
 
   int nchannels = recHit.nStrips();
-  const CSCLayerGeometry * laygeom = cscgeom->layer(recHit.cscDetId())->geometry();
+  const CSCLayerGeometry *laygeom =
+      cscgeom->layer(recHit.cscDetId())->geometry();
 
-  for(int idigi = 0; idigi < nchannels; ++idigi)
-  {
+  for (int idigi = 0; idigi < nchannels; ++idigi) {
     // strip and readout channel numbers may differ in ME1/1A
     int istrip = recHit.channels(idigi);
     int channel = laygeom->channel(istrip);
-    float weight = recHit.adcs(idigi,0);//DL: I think this is wrong before and after...seems to assume one time binadcContainer[idigi];
+    float weight = recHit.adcs(
+        idigi, 0); // DL: I think this is wrong before and after...seems to
+                   // assume one time binadcContainer[idigi];
 
     DigiSimLinks::const_iterator layerLinks = theDigiSimLinks->find(theDetId);
 
-    if(layerLinks != theDigiSimLinks->end())
-    {
+    if (layerLinks != theDigiSimLinks->end()) {
       addChannel(*layerLinks, channel, weight);
     }
   }
 }
 
-
-void MuonTruth::analyze(const CSCStripDigi & stripDigi, int rawDetIdCorrespondingToCSCLayer)
-{
+void MuonTruth::analyze(const CSCStripDigi &stripDigi,
+                        int rawDetIdCorrespondingToCSCLayer) {
   theDetId = rawDetIdCorrespondingToCSCLayer;
   theChargeMap.clear();
   theTotalCharge = 0.;
 
   DigiSimLinks::const_iterator layerLinks = theDigiSimLinks->find(theDetId);
-  if(layerLinks != theDigiSimLinks->end())
-  {
+  if (layerLinks != theDigiSimLinks->end()) {
     addChannel(*layerLinks, stripDigi.getStrip(), 1.);
   }
 }
 
-
-void MuonTruth::analyze(const CSCWireDigi & wireDigi, int rawDetIdCorrespondingToCSCLayer) 
-{
+void MuonTruth::analyze(const CSCWireDigi &wireDigi,
+                        int rawDetIdCorrespondingToCSCLayer) {
   theDetId = rawDetIdCorrespondingToCSCLayer;
   theChargeMap.clear();
   theTotalCharge = 0.;
 
-  WireDigiSimLinks::const_iterator layerLinks = theWireDigiSimLinks->find(theDetId);
+  WireDigiSimLinks::const_iterator layerLinks =
+      theWireDigiSimLinks->find(theDetId);
 
-  if(layerLinks != theDigiSimLinks->end()) 
-  {
-    // In the simulation digis, the channel labels for wires and strips must be distinct, therefore:
+  if (layerLinks != theDigiSimLinks->end()) {
+    // In the simulation digis, the channel labels for wires and strips must be
+    // distinct, therefore:
     int wireDigiInSimulation = wireDigi.getWireGroup() + 100;
     //
     addChannel(*layerLinks, wireDigiInSimulation, 1.);
   }
 }
 
-
-void MuonTruth::addChannel(const LayerLinks &layerLinks, int channel, float weight)
-{
-  LayerLinks::const_iterator linkItr = layerLinks.begin(), 
+void MuonTruth::addChannel(const LayerLinks &layerLinks, int channel,
+                           float weight) {
+  LayerLinks::const_iterator linkItr = layerLinks.begin(),
                              lastLayerLink = layerLinks.end();
 
-  for ( ; linkItr != lastLayerLink; ++linkItr)
-  {
+  for (; linkItr != lastLayerLink; ++linkItr) {
     int linkChannel = linkItr->channel();
-    if(linkChannel == channel)
-    {
+    if (linkChannel == channel) {
       float charge = linkItr->fraction() * weight;
       theTotalCharge += charge;
       // see if it's in the map
-      SimHitIdpr truthId(linkItr->SimTrackId(),linkItr->eventId());
-      std::map<SimHitIdpr, float>::const_iterator chargeMapItr = theChargeMap.find(truthId);
-      if(chargeMapItr == theChargeMap.end())
-      {
-	theChargeMap[truthId] = charge;
-      }
-      else
-      {
-	theChargeMap[truthId] += charge;
+      SimHitIdpr truthId(linkItr->SimTrackId(), linkItr->eventId());
+      std::map<SimHitIdpr, float>::const_iterator chargeMapItr =
+          theChargeMap.find(truthId);
+      if (chargeMapItr == theChargeMap.end()) {
+        theChargeMap[truthId] = charge;
+      } else {
+        theChargeMap[truthId] += charge;
       }
     }
   }
 }
-    
-

--- a/SimMuon/MCTruth/src/PSimHitMap.cc
+++ b/SimMuon/MCTruth/src/PSimHitMap.cc
@@ -1,49 +1,40 @@
-#include "SimMuon/MCTruth/interface/PSimHitMap.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "SimMuon/MCTruth/interface/PSimHitMap.h"
 
-void PSimHitMap::fill(const edm::Event & e)
-{
+void PSimHitMap::fill(const edm::Event &e) {
   theMap.clear();
-  edm::Handle<CrossingFrame<PSimHit> > cf;
+  edm::Handle<CrossingFrame<PSimHit>> cf;
   LogTrace("PSimHitMap") << "getting CrossingFrame<PSimHit> collection ";
   e.getByToken(sh_token, cf);
 
   MixCollection<PSimHit> simHits(cf.product());
-  LogTrace("PSimHitMap") <<"... size = "<<simHits.size();
+  LogTrace("PSimHitMap") << "... size = " << simHits.size();
 
-  // arrange the hits by detUnit                                                                          
-  for(MixCollection<PSimHit>::MixItr hitItr = simHits.begin();
-      hitItr != simHits.end(); ++hitItr)
-    {
-      theMap[hitItr->detUnitId()].push_back(*hitItr);
-    }
+  // arrange the hits by detUnit
+  for (MixCollection<PSimHit>::MixItr hitItr = simHits.begin();
+       hitItr != simHits.end(); ++hitItr) {
+    theMap[hitItr->detUnitId()].push_back(*hitItr);
+  }
 }
 
-const edm::PSimHitContainer & PSimHitMap::hits(int detId) const
-{
-  std::map<int, edm::PSimHitContainer>::const_iterator mapItr
-    = theMap.find(detId);
-  if(mapItr != theMap.end())
-    {
-      return mapItr->second;
-    }
-  else
-    {
-      return theEmptyContainer;
-    }
+const edm::PSimHitContainer &PSimHitMap::hits(int detId) const {
+  std::map<int, edm::PSimHitContainer>::const_iterator mapItr =
+      theMap.find(detId);
+  if (mapItr != theMap.end()) {
+    return mapItr->second;
+  } else {
+    return theEmptyContainer;
+  }
 }
 
-
-std::vector<int> PSimHitMap::detsWithHits() const 
-{
+std::vector<int> PSimHitMap::detsWithHits() const {
   std::vector<int> result;
   result.reserve(theMap.size());
-  for(std::map<int, edm::PSimHitContainer>::const_iterator mapItr = theMap.begin(),
-	mapEnd = theMap.end();
-      mapItr != mapEnd;
-      ++mapItr)
-    {
-      result.push_back(mapItr->first);
-    }
+  for (std::map<int, edm::PSimHitContainer>::const_iterator
+           mapItr = theMap.begin(),
+           mapEnd = theMap.end();
+       mapItr != mapEnd; ++mapItr) {
+    result.push_back(mapItr->first);
+  }
   return result;
-} 
+}

--- a/SimMuon/MCTruth/src/RPCHitAssociator.cc
+++ b/SimMuon/MCTruth/src/RPCHitAssociator.cc
@@ -2,131 +2,142 @@
 
 using namespace std;
 
-
-
 // Constructor
-RPCHitAssociator::RPCHitAssociator( const edm::ParameterSet& conf, 
-				    edm::ConsumesCollector && iC):
-  RPCdigisimlinkTag(conf.getParameter<edm::InputTag>("RPCdigisimlinkTag")),
-  // CrossingFrame used or not ?
-  crossingframe(conf.getParameter<bool>("crossingframe")),
-  RPCsimhitsTag(conf.getParameter<edm::InputTag>("RPCsimhitsTag")),
-  RPCsimhitsXFTag(conf.getParameter<edm::InputTag>("RPCsimhitsXFTag"))
-{
-  if (crossingframe){
-    RPCsimhitsXFToken_=iC.consumes<CrossingFrame<PSimHit> >(RPCsimhitsXFTag);
+RPCHitAssociator::RPCHitAssociator(const edm::ParameterSet &conf,
+                                   edm::ConsumesCollector &&iC)
+    : RPCdigisimlinkTag(conf.getParameter<edm::InputTag>("RPCdigisimlinkTag")),
+      // CrossingFrame used or not ?
+      crossingframe(conf.getParameter<bool>("crossingframe")),
+      RPCsimhitsTag(conf.getParameter<edm::InputTag>("RPCsimhitsTag")),
+      RPCsimhitsXFTag(conf.getParameter<edm::InputTag>("RPCsimhitsXFTag")) {
+  if (crossingframe) {
+    RPCsimhitsXFToken_ = iC.consumes<CrossingFrame<PSimHit>>(RPCsimhitsXFTag);
   } else if (!RPCsimhitsTag.label().empty()) {
-    RPCsimhitsToken_=iC.consumes<edm::PSimHitContainer>(RPCsimhitsTag);
+    RPCsimhitsToken_ = iC.consumes<edm::PSimHitContainer>(RPCsimhitsTag);
   }
 
-  RPCdigisimlinkToken_=iC.consumes< edm::DetSetVector<RPCDigiSimLink> >(RPCdigisimlinkTag); 
+  RPCdigisimlinkToken_ =
+      iC.consumes<edm::DetSetVector<RPCDigiSimLink>>(RPCdigisimlinkTag);
 }
 
-RPCHitAssociator::RPCHitAssociator(const edm::Event& e, const edm::EventSetup& eventSetup, const edm::ParameterSet& conf ):
-  RPCdigisimlinkTag(conf.getParameter<edm::InputTag>("RPCdigisimlinkTag")),
-  // CrossingFrame used or not ?
-  crossingframe(conf.getParameter<bool>("crossingframe")),
-  RPCsimhitsTag(conf.getParameter<edm::InputTag>("RPCsimhitsTag")),
-  RPCsimhitsXFTag(conf.getParameter<edm::InputTag>("RPCsimhitsXFTag"))
-{
-  initEvent(e,eventSetup);
+RPCHitAssociator::RPCHitAssociator(const edm::Event &e,
+                                   const edm::EventSetup &eventSetup,
+                                   const edm::ParameterSet &conf)
+    : RPCdigisimlinkTag(conf.getParameter<edm::InputTag>("RPCdigisimlinkTag")),
+      // CrossingFrame used or not ?
+      crossingframe(conf.getParameter<bool>("crossingframe")),
+      RPCsimhitsTag(conf.getParameter<edm::InputTag>("RPCsimhitsTag")),
+      RPCsimhitsXFTag(conf.getParameter<edm::InputTag>("RPCsimhitsXFTag")) {
+  initEvent(e, eventSetup);
 }
 
-
-void RPCHitAssociator::initEvent(const edm::Event& e, const edm::EventSetup& eventSetup)
-
+void RPCHitAssociator::initEvent(const edm::Event &e,
+                                 const edm::EventSetup &eventSetup)
 
 {
   if (crossingframe) {
-    
-    edm::Handle<CrossingFrame<PSimHit> > cf;
-    LogTrace("RPCHitAssociator") <<"getting CrossingFrame<PSimHit> collection - "<<RPCsimhitsXFTag;
+
+    edm::Handle<CrossingFrame<PSimHit>> cf;
+    LogTrace("RPCHitAssociator")
+        << "getting CrossingFrame<PSimHit> collection - " << RPCsimhitsXFTag;
     e.getByLabel(RPCsimhitsXFTag, cf);
-    
-    std::unique_ptr<MixCollection<PSimHit> > 
-      RPCsimhits( new MixCollection<PSimHit>(cf.product()) );
-    LogTrace("RPCHitAssociator") <<"... size = "<<RPCsimhits->size();
+
+    std::unique_ptr<MixCollection<PSimHit>> RPCsimhits(
+        new MixCollection<PSimHit>(cf.product()));
+    LogTrace("RPCHitAssociator") << "... size = " << RPCsimhits->size();
 
     //   MixCollection<PSimHit> & simHits = *hits;
-    
-    for(MixCollection<PSimHit>::MixItr hitItr = RPCsimhits->begin();
-	hitItr != RPCsimhits->end(); ++hitItr) 
-      {
-	_SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
-      }
-    
+
+    for (MixCollection<PSimHit>::MixItr hitItr = RPCsimhits->begin();
+         hitItr != RPCsimhits->end(); ++hitItr) {
+      _SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
+    }
+
   } else if (!RPCsimhitsTag.label().empty()) {
     edm::Handle<edm::PSimHitContainer> RPCsimhits;
-    LogTrace("RPCHitAssociator") <<"getting PSimHit collection - "<<RPCsimhitsTag;
-    e.getByLabel(RPCsimhitsTag, RPCsimhits);    
-    LogTrace("RPCHitAssociator") <<"... size = "<<RPCsimhits->size();
-    
+    LogTrace("RPCHitAssociator")
+        << "getting PSimHit collection - " << RPCsimhitsTag;
+    e.getByLabel(RPCsimhitsTag, RPCsimhits);
+    LogTrace("RPCHitAssociator") << "... size = " << RPCsimhits->size();
+
     // arrange the hits by detUnit
-    for(edm::PSimHitContainer::const_iterator hitItr = RPCsimhits->begin();
-	hitItr != RPCsimhits->end(); ++hitItr)
-      {
-	_SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
-      }
+    for (edm::PSimHitContainer::const_iterator hitItr = RPCsimhits->begin();
+         hitItr != RPCsimhits->end(); ++hitItr) {
+      _SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
+    }
   }
 
-  edm::Handle< edm::DetSetVector<RPCDigiSimLink> > thelinkDigis;
-  LogTrace("RPCHitAssociator") <<"getting RPCDigiSimLink collection - "<<RPCdigisimlinkTag;
+  edm::Handle<edm::DetSetVector<RPCDigiSimLink>> thelinkDigis;
+  LogTrace("RPCHitAssociator")
+      << "getting RPCDigiSimLink collection - " << RPCdigisimlinkTag;
   e.getByLabel(RPCdigisimlinkTag, thelinkDigis);
   _thelinkDigis = thelinkDigis;
 }
 // end of constructor
 
-std::vector<RPCHitAssociator::SimHitIdpr> RPCHitAssociator::associateRecHit(const TrackingRecHit & hit) const {
-  
+std::vector<RPCHitAssociator::SimHitIdpr>
+RPCHitAssociator::associateRecHit(const TrackingRecHit &hit) const {
+
   std::vector<SimHitIdpr> matched;
 
-  const TrackingRecHit * hitp = &hit;
-  const RPCRecHit * rpcrechit = dynamic_cast<const RPCRecHit *>(hitp);
+  const TrackingRecHit *hitp = &hit;
+  const RPCRecHit *rpcrechit = dynamic_cast<const RPCRecHit *>(hitp);
 
   if (rpcrechit) {
-    
+
     RPCDetId rpcDetId = rpcrechit->rpcId();
     int fstrip = rpcrechit->firstClusterStrip();
     int cls = rpcrechit->clusterSize();
     int bx = rpcrechit->BunchX();
-    
-    for(int i = fstrip; i < fstrip+cls; ++i) {
-      std::set<RPCDigiSimLink> links = findRPCDigiSimLink(rpcDetId.rawId(),i,bx);
-      
-      if (links.empty()) LogTrace("RPCHitAssociator")
-	<<"*** WARNING in RPCHitAssociator::associateRecHit, RPCRecHit "<<*rpcrechit<<", strip "<<i<<" has no associated RPCDigiSimLink !"<<endl;
-      
-      for(std::set<RPCDigiSimLink>::iterator itlink = links.begin(); itlink != links.end(); ++itlink) {
-	SimHitIdpr currentId(itlink->getTrackId(),itlink->getEventId());
-	if(find(matched.begin(),matched.end(),currentId ) == matched.end())
-	  matched.push_back(currentId);
+
+    for (int i = fstrip; i < fstrip + cls; ++i) {
+      std::set<RPCDigiSimLink> links =
+          findRPCDigiSimLink(rpcDetId.rawId(), i, bx);
+
+      if (links.empty())
+        LogTrace("RPCHitAssociator")
+            << "*** WARNING in RPCHitAssociator::associateRecHit, RPCRecHit "
+            << *rpcrechit << ", strip " << i
+            << " has no associated RPCDigiSimLink !" << endl;
+
+      for (std::set<RPCDigiSimLink>::iterator itlink = links.begin();
+           itlink != links.end(); ++itlink) {
+        SimHitIdpr currentId(itlink->getTrackId(), itlink->getEventId());
+        if (find(matched.begin(), matched.end(), currentId) == matched.end())
+          matched.push_back(currentId);
       }
     }
-    
-  } else LogTrace("RPCHitAssociator")<<"*** WARNING in RPCHitAssociator::associateRecHit, null dynamic_cast !";
-  
-  return  matched;
+
+  } else
+    LogTrace("RPCHitAssociator")
+        << "*** WARNING in RPCHitAssociator::associateRecHit, null "
+           "dynamic_cast !";
+
+  return matched;
 }
-  
-std::set<RPCDigiSimLink>  RPCHitAssociator::findRPCDigiSimLink(uint32_t rpcDetId, int strip, int bx) const {
+
+std::set<RPCDigiSimLink> RPCHitAssociator::findRPCDigiSimLink(uint32_t rpcDetId,
+                                                              int strip,
+                                                              int bx) const {
 
   std::set<RPCDigiSimLink> links;
 
-  for (edm::DetSetVector<RPCDigiSimLink>::const_iterator itlink = _thelinkDigis->begin(); itlink != _thelinkDigis->end(); itlink++){
-    for(edm::DetSet<RPCDigiSimLink>::const_iterator digi_iter=itlink->data.begin();digi_iter != itlink->data.end();++digi_iter){
+  for (edm::DetSetVector<RPCDigiSimLink>::const_iterator itlink =
+           _thelinkDigis->begin();
+       itlink != _thelinkDigis->end(); itlink++) {
+    for (edm::DetSet<RPCDigiSimLink>::const_iterator digi_iter =
+             itlink->data.begin();
+         digi_iter != itlink->data.end(); ++digi_iter) {
 
       uint32_t detid = digi_iter->getDetUnitId();
       int str = digi_iter->getStrip();
       int bunchx = digi_iter->getBx();
 
-      if(detid == rpcDetId && str == strip && bunchx == bx){
+      if (detid == rpcDetId && str == strip && bunchx == bx) {
         links.insert(*digi_iter);
       }
-
     }
   }
 
   return links;
 }
-
-

--- a/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
+++ b/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
@@ -1,228 +1,269 @@
 //
 // modified & integrated by Giovanni Abbiendi
-// from code by Arun Luthra: UserCode/luthra/MuonTrackSelector/src/MuonTrackSelector.cc
+// from code by Arun Luthra:
+// UserCode/luthra/MuonTrackSelector/src/MuonTrackSelector.cc
 //
-#include "SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h"
 #include <sstream>
 
-TrackerMuonHitExtractor::TrackerMuonHitExtractor(const edm::ParameterSet& parset,
-						 edm::ConsumesCollector && ic) :
-  inputDTRecSegment4DToken_(ic.consumes<DTRecSegment4DCollection>(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"))),
-  inputCSCSegmentToken_(ic.consumes<CSCSegmentCollection>(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))),
-  inputDTRecSegment4DCollection_(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
-  inputCSCSegmentCollection_(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))
-{
-}
+TrackerMuonHitExtractor::TrackerMuonHitExtractor(
+    const edm::ParameterSet &parset, edm::ConsumesCollector &&ic)
+    : inputDTRecSegment4DToken_(ic.consumes<DTRecSegment4DCollection>(
+          parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"))),
+      inputCSCSegmentToken_(ic.consumes<CSCSegmentCollection>(
+          parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))),
+      inputDTRecSegment4DCollection_(
+          parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
+      inputCSCSegmentCollection_(
+          parset.getParameter<edm::InputTag>("inputCSCSegmentCollection")) {}
 
-TrackerMuonHitExtractor::TrackerMuonHitExtractor(const edm::ParameterSet& parset ) :
-  inputDTRecSegment4DCollection_(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
-  inputCSCSegmentCollection_(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))
-{
-}
+TrackerMuonHitExtractor::TrackerMuonHitExtractor(
+    const edm::ParameterSet &parset)
+    : inputDTRecSegment4DCollection_(
+          parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
+      inputCSCSegmentCollection_(
+          parset.getParameter<edm::InputTag>("inputCSCSegmentCollection")) {}
 
-TrackerMuonHitExtractor::~TrackerMuonHitExtractor() {
-}
+TrackerMuonHitExtractor::~TrackerMuonHitExtractor() {}
 
-void TrackerMuonHitExtractor::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
-{
+void TrackerMuonHitExtractor::init(const edm::Event &iEvent,
+                                   const edm::EventSetup &iSetup) {
   iEvent.getByLabel(inputDTRecSegment4DCollection_, dtSegmentCollectionH_);
   iEvent.getByLabel(inputCSCSegmentCollection_, cscSegmentCollectionH_);
 
-  edm::LogVerbatim("TrackerMuonHitExtractor") <<"\nThere are "<< dtSegmentCollectionH_->size()<<" DT segments.";
+  edm::LogVerbatim("TrackerMuonHitExtractor")
+      << "\nThere are " << dtSegmentCollectionH_->size() << " DT segments.";
   unsigned int index_dt_segment = 0;
-  for(DTRecSegment4DCollection::const_iterator segment = dtSegmentCollectionH_->begin();
-      segment != dtSegmentCollectionH_->end(); ++segment , index_dt_segment++) {
-    LocalPoint  segmentLocalPosition       = segment->localPosition();
-    LocalVector segmentLocalDirection      = segment->localDirection();
-    LocalError  segmentLocalPositionError  = segment->localPositionError();
-    LocalError  segmentLocalDirectionError = segment->localDirectionError();
+  for (DTRecSegment4DCollection::const_iterator segment =
+           dtSegmentCollectionH_->begin();
+       segment != dtSegmentCollectionH_->end(); ++segment, index_dt_segment++) {
+    LocalPoint segmentLocalPosition = segment->localPosition();
+    LocalVector segmentLocalDirection = segment->localDirection();
+    LocalError segmentLocalPositionError = segment->localPositionError();
+    LocalError segmentLocalDirectionError = segment->localDirectionError();
     DetId geoid = segment->geographicalId();
     DTChamberId dtdetid = DTChamberId(geoid);
     int wheel = dtdetid.wheel();
     int station = dtdetid.station();
     int sector = dtdetid.sector();
-    
+
     float segmentX = segmentLocalPosition.x();
     float segmentY = segmentLocalPosition.y();
-    float segmentdXdZ = segmentLocalDirection.x()/segmentLocalDirection.z();
-    float segmentdYdZ = segmentLocalDirection.y()/segmentLocalDirection.z();
+    float segmentdXdZ = segmentLocalDirection.x() / segmentLocalDirection.z();
+    float segmentdYdZ = segmentLocalDirection.y() / segmentLocalDirection.z();
     float segmentXerr = sqrt(segmentLocalPositionError.xx());
     float segmentYerr = sqrt(segmentLocalPositionError.yy());
     float segmentdXdZerr = sqrt(segmentLocalDirectionError.xx());
     float segmentdYdZerr = sqrt(segmentLocalDirectionError.yy());
 
-    edm::LogVerbatim("TrackerMuonHitExtractor") 
-      <<"\nDT segment index :"<<index_dt_segment
-      <<"\nchamber Wh:"<<wheel<<",St:"<<station<<",Se:"<<sector
-      <<"\nLocal Position (X,Y)=("<<segmentX<<","<<segmentY<<") +/- ("<<segmentXerr<<","<<segmentYerr<<"), " 
-      <<"Local Direction (dXdZ,dYdZ)=("<<segmentdXdZ<<","<<segmentdYdZ<<") +/- ("<<segmentdXdZerr<<","<<segmentdYdZerr<<")"; 
+    edm::LogVerbatim("TrackerMuonHitExtractor")
+        << "\nDT segment index :" << index_dt_segment
+        << "\nchamber Wh:" << wheel << ",St:" << station << ",Se:" << sector
+        << "\nLocal Position (X,Y)=(" << segmentX << "," << segmentY
+        << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
+        << "Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ
+        << ") +/- (" << segmentdXdZerr << "," << segmentdYdZerr << ")";
   }
 
-  edm::LogVerbatim("TrackerMuonHitExtractor") <<"\nThere are "<< cscSegmentCollectionH_->size()<<" CSC segments.";
+  edm::LogVerbatim("TrackerMuonHitExtractor")
+      << "\nThere are " << cscSegmentCollectionH_->size() << " CSC segments.";
   unsigned int index_csc_segment = 0;
-  for(CSCSegmentCollection::const_iterator segment = cscSegmentCollectionH_->begin();
-      segment != cscSegmentCollectionH_->end(); ++segment , index_csc_segment++) {
-    LocalPoint  segmentLocalPosition       = segment->localPosition();
-    LocalVector segmentLocalDirection      = segment->localDirection();
-    LocalError  segmentLocalPositionError  = segment->localPositionError();
-    LocalError  segmentLocalDirectionError = segment->localDirectionError();
+  for (CSCSegmentCollection::const_iterator segment =
+           cscSegmentCollectionH_->begin();
+       segment != cscSegmentCollectionH_->end();
+       ++segment, index_csc_segment++) {
+    LocalPoint segmentLocalPosition = segment->localPosition();
+    LocalVector segmentLocalDirection = segment->localDirection();
+    LocalError segmentLocalPositionError = segment->localPositionError();
+    LocalError segmentLocalDirectionError = segment->localDirectionError();
 
     DetId geoid = segment->geographicalId();
     CSCDetId cscdetid = CSCDetId(geoid);
     int endcap = cscdetid.endcap();
     int station = cscdetid.station();
     int ring = cscdetid.ring();
-    int chamber = cscdetid.chamber(); 
-    
+    int chamber = cscdetid.chamber();
+
     float segmentX = segmentLocalPosition.x();
     float segmentY = segmentLocalPosition.y();
-    float segmentdXdZ = segmentLocalDirection.x()/segmentLocalDirection.z();
-    float segmentdYdZ = segmentLocalDirection.y()/segmentLocalDirection.z();
+    float segmentdXdZ = segmentLocalDirection.x() / segmentLocalDirection.z();
+    float segmentdYdZ = segmentLocalDirection.y() / segmentLocalDirection.z();
     float segmentXerr = sqrt(segmentLocalPositionError.xx());
     float segmentYerr = sqrt(segmentLocalPositionError.yy());
     float segmentdXdZerr = sqrt(segmentLocalDirectionError.xx());
     float segmentdYdZerr = sqrt(segmentLocalDirectionError.yy());
 
-    edm::LogVerbatim("TrackerMuonHitExtractor") 
-      <<"\nCSC segment index :"<<index_csc_segment
-      <<"\nchamber Endcap:"<<endcap<<",St:"<<station<<",Ri:"<<ring<<",Ch:"<<chamber
-      <<"\nLocal Position (X,Y)=("<<segmentX<<","<<segmentY<<") +/- ("<<segmentXerr<<","<<segmentYerr<<"), " 
-      <<"Local Direction (dXdZ,dYdZ)=("<<segmentdXdZ<<","<<segmentdYdZ<<") +/- ("<<segmentdXdZerr<<","<<segmentdYdZerr<<")"; 
+    edm::LogVerbatim("TrackerMuonHitExtractor")
+        << "\nCSC segment index :" << index_csc_segment
+        << "\nchamber Endcap:" << endcap << ",St:" << station << ",Ri:" << ring
+        << ",Ch:" << chamber << "\nLocal Position (X,Y)=(" << segmentX << ","
+        << segmentY << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
+        << "Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ
+        << ") +/- (" << segmentdXdZerr << "," << segmentdYdZerr << ")";
   }
-
 }
 std::vector<const TrackingRecHit *>
 TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
-        std::vector<const TrackingRecHit *> ret;
+  std::vector<const TrackingRecHit *> ret;
 
-	int wheel, station, sector;
-	int endcap, /*station, */ ring, chamber;
-	
-	edm::LogVerbatim("TrackerMuonHitExtractor") <<"Number of chambers: "<<mu.matches().size()
-					      <<", arbitrated: "<<mu.numberOfMatches(reco::Muon::SegmentAndTrackArbitration)
-					      <<", tot (no arbitration): "<<mu.numberOfMatches(reco::Muon::NoArbitration);
-	unsigned int index_chamber = 0;
-	int n_segments_noArb = 0;
-	
-	for(std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch = mu.matches().begin();
-	    chamberMatch != mu.matches().end(); ++chamberMatch, index_chamber++) {
-	  std::stringstream chamberStr;
-	  chamberStr <<"\nchamber index: "<<index_chamber; 
-	  
-	  int subdet = chamberMatch->detector();
-	  DetId did = chamberMatch->id;
-	  
-	  if (subdet == MuonSubdetId::DT) {
-	    DTChamberId dtdetid = DTChamberId(did);
-	    wheel = dtdetid.wheel();
-	    station = dtdetid.station();
-	    sector = dtdetid.sector();
-	    chamberStr << ", DT chamber Wh:"<<wheel<<",St:"<<station<<",Se:"<<sector;
-	  } 
-	  else if (subdet == MuonSubdetId::CSC) {
-	    CSCDetId cscdetid = CSCDetId(did);
-	    endcap = cscdetid.endcap();
-	    station = cscdetid.station();
-	    ring = cscdetid.ring();
-	    chamber = cscdetid.chamber();
-	    chamberStr << ", CSC chamber End:"<<endcap<<",St:"<<station<<",Ri:"<<ring<<",Ch:"<<chamber;
-	  }
-	  
-	  chamberStr << ", Number of segments: "<<chamberMatch->segmentMatches.size();
-	  edm::LogVerbatim("TrackerMuonHitExtractor") << chamberStr.str();
-	  n_segments_noArb = n_segments_noArb + chamberMatch->segmentMatches.size();
+  int wheel, station, sector;
+  int endcap, /*station, */ ring, chamber;
 
-	  unsigned int index_segment = 0;
-	  
-	  for(std::vector<reco::MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
-	      segmentMatch != chamberMatch->segmentMatches.end(); ++segmentMatch, index_segment++) {
-	    
-	    float segmentX = segmentMatch->x;
-	    float segmentY = segmentMatch->y ;
-	    float segmentdXdZ = segmentMatch->dXdZ;
-	    float segmentdYdZ = segmentMatch->dYdZ;
-	    float segmentXerr = segmentMatch->xErr;
-	    float segmentYerr = segmentMatch->yErr;
-	    float segmentdXdZerr = segmentMatch->dXdZErr;
-	    float segmentdYdZerr = segmentMatch->dYdZErr;
-	    
-	    CSCSegmentRef segmentCSC = segmentMatch->cscSegmentRef;
-	    DTRecSegment4DRef segmentDT = segmentMatch->dtSegmentRef;
-	    
-	    bool segment_arbitrated_Ok = (segmentMatch->isMask(reco::MuonSegmentMatch::BestInChamberByDR) && 
-					  segmentMatch->isMask(reco::MuonSegmentMatch::BelongsToTrackByDR));
-	    
-	    std::string ARBITRATED(" ***Arbitrated Off*** ");
-	    if (segment_arbitrated_Ok) ARBITRATED = " ***ARBITRATED OK*** ";
+  edm::LogVerbatim("TrackerMuonHitExtractor")
+      << "Number of chambers: " << mu.matches().size() << ", arbitrated: "
+      << mu.numberOfMatches(reco::Muon::SegmentAndTrackArbitration)
+      << ", tot (no arbitration): "
+      << mu.numberOfMatches(reco::Muon::NoArbitration);
+  unsigned int index_chamber = 0;
+  int n_segments_noArb = 0;
 
-	    if (subdet == MuonSubdetId::DT) {	      
-	      edm::LogVerbatim("TrackerMuonHitExtractor")
-		<<"\n\t segment index: "<<index_segment << ARBITRATED
-		<<"\n\t  Local Position (X,Y)=("<<segmentX<<","<<segmentY<<") +/- ("<<segmentXerr<<","<<segmentYerr<<"), " 
-		<<"\n\t  Local Direction (dXdZ,dYdZ)=("<<segmentdXdZ<<","<<segmentdYdZ<<") +/- ("<<segmentdXdZerr<<","<<segmentdYdZerr<<")"; 
-	      
-	      // with the following line the DT segments failing standard arbitration are skipped 
-	      if (!segment_arbitrated_Ok) continue;
+  for (std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch =
+           mu.matches().begin();
+       chamberMatch != mu.matches().end(); ++chamberMatch, index_chamber++) {
+    std::stringstream chamberStr;
+    chamberStr << "\nchamber index: " << index_chamber;
 
-              if (segmentDT.get() != nullptr) {
-		const DTRecSegment4D* segment = segmentDT.get();
-		
-		edm::LogVerbatim("TrackerMuonHitExtractor")<<"\t ===> MATCHING with DT segment with index = "<<segmentDT.key();
-		
-		if(segment->hasPhi()) {
-		  const DTChamberRecSegment2D* phiSeg = segment->phiSegment();
-		  std::vector<const TrackingRecHit*> phiHits = phiSeg->recHits();
-		  for(std::vector<const TrackingRecHit*>::const_iterator ihit = phiHits.begin();
-		      ihit != phiHits.end(); ++ihit) {
-                    ret.push_back(*ihit);
-		  }
-		}
-		
-		if(segment->hasZed()) {
-		  const DTSLRecSegment2D* zSeg = (*segment).zSegment();
-		  std::vector<const TrackingRecHit*> zedHits = zSeg->recHits();
-		  for(std::vector<const TrackingRecHit*>::const_iterator ihit = zedHits.begin();
-		      ihit != zedHits.end(); ++ihit) {
-                    ret.push_back(*ihit);
-		  }
-		}
-	      } else edm::LogWarning("TrackerMuonHitExtractor")<<"\n***WARNING: UNMATCHED DT segment ! \n";
-            } // if (subdet == MuonSubdetId::DT)
-	    
-	    else if (subdet == MuonSubdetId::CSC) {
-	      edm::LogVerbatim("TrackerMuonHitExtractor")
-		<<"\n\t segment index: "<<index_segment << ARBITRATED
-		<<"\n\t  Local Position (X,Y)=("<<segmentX<<","<<segmentY<<") +/- ("<<segmentXerr<<","<<segmentYerr<<"), " 
-		<<"\n\t  Local Direction (dXdZ,dYdZ)=("<<segmentdXdZ<<","<<segmentdYdZ<<") +/- ("<<segmentdXdZerr<<","<<segmentdYdZerr<<")"; 
-	      
-	      // with the following line the CSC segments failing standard arbitration are skipped 
-	      if (!segment_arbitrated_Ok) continue;
+    int subdet = chamberMatch->detector();
+    DetId did = chamberMatch->id;
 
-              if (segmentCSC.get() != nullptr) {
-		const CSCSegment* segment = segmentCSC.get();
-		
-		edm::LogVerbatim("TrackerMuonHitExtractor")<<"\t ===> MATCHING with CSC segment with index = "<<segmentCSC.key();
-		
-		std::vector<const TrackingRecHit*> hits = segment->recHits();
-		for(std::vector<const TrackingRecHit*>::const_iterator ihit = hits.begin();
-		    ihit != hits.end(); ++ihit) {
-                  ret.push_back(*ihit);
-		}
-	      } else edm::LogWarning("TrackerMuonHitExtractor")<<"\n***WARNING: UNMATCHED CSC segment ! \n";
-	    }   // else if (subdet == MuonSubdetId::CSC)
-	    
-	  } // loop on vector<MuonSegmentMatch>	  
-	}  // loop on vector<MuonChamberMatch>	
+    if (subdet == MuonSubdetId::DT) {
+      DTChamberId dtdetid = DTChamberId(did);
+      wheel = dtdetid.wheel();
+      station = dtdetid.station();
+      sector = dtdetid.sector();
+      chamberStr << ", DT chamber Wh:" << wheel << ",St:" << station
+                 << ",Se:" << sector;
+    } else if (subdet == MuonSubdetId::CSC) {
+      CSCDetId cscdetid = CSCDetId(did);
+      endcap = cscdetid.endcap();
+      station = cscdetid.station();
+      ring = cscdetid.ring();
+      chamber = cscdetid.chamber();
+      chamberStr << ", CSC chamber End:" << endcap << ",St:" << station
+                 << ",Ri:" << ring << ",Ch:" << chamber;
+    }
 
-	edm::LogVerbatim("TrackerMuonHitExtractor")<<"\n N. matched Segments before arbitration = "<<n_segments_noArb;
+    chamberStr << ", Number of segments: "
+               << chamberMatch->segmentMatches.size();
+    edm::LogVerbatim("TrackerMuonHitExtractor") << chamberStr.str();
+    n_segments_noArb = n_segments_noArb + chamberMatch->segmentMatches.size();
 
-        return ret;
+    unsigned int index_segment = 0;
+
+    for (std::vector<reco::MuonSegmentMatch>::const_iterator segmentMatch =
+             chamberMatch->segmentMatches.begin();
+         segmentMatch != chamberMatch->segmentMatches.end();
+         ++segmentMatch, index_segment++) {
+
+      float segmentX = segmentMatch->x;
+      float segmentY = segmentMatch->y;
+      float segmentdXdZ = segmentMatch->dXdZ;
+      float segmentdYdZ = segmentMatch->dYdZ;
+      float segmentXerr = segmentMatch->xErr;
+      float segmentYerr = segmentMatch->yErr;
+      float segmentdXdZerr = segmentMatch->dXdZErr;
+      float segmentdYdZerr = segmentMatch->dYdZErr;
+
+      CSCSegmentRef segmentCSC = segmentMatch->cscSegmentRef;
+      DTRecSegment4DRef segmentDT = segmentMatch->dtSegmentRef;
+
+      bool segment_arbitrated_Ok =
+          (segmentMatch->isMask(reco::MuonSegmentMatch::BestInChamberByDR) &&
+           segmentMatch->isMask(reco::MuonSegmentMatch::BelongsToTrackByDR));
+
+      std::string ARBITRATED(" ***Arbitrated Off*** ");
+      if (segment_arbitrated_Ok)
+        ARBITRATED = " ***ARBITRATED OK*** ";
+
+      if (subdet == MuonSubdetId::DT) {
+        edm::LogVerbatim("TrackerMuonHitExtractor")
+            << "\n\t segment index: " << index_segment << ARBITRATED
+            << "\n\t  Local Position (X,Y)=(" << segmentX << "," << segmentY
+            << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
+            << "\n\t  Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << ","
+            << segmentdYdZ << ") +/- (" << segmentdXdZerr << ","
+            << segmentdYdZerr << ")";
+
+        // with the following line the DT segments failing standard arbitration
+        // are skipped
+        if (!segment_arbitrated_Ok)
+          continue;
+
+        if (segmentDT.get() != nullptr) {
+          const DTRecSegment4D *segment = segmentDT.get();
+
+          edm::LogVerbatim("TrackerMuonHitExtractor")
+              << "\t ===> MATCHING with DT segment with index = "
+              << segmentDT.key();
+
+          if (segment->hasPhi()) {
+            const DTChamberRecSegment2D *phiSeg = segment->phiSegment();
+            std::vector<const TrackingRecHit *> phiHits = phiSeg->recHits();
+            for (std::vector<const TrackingRecHit *>::const_iterator ihit =
+                     phiHits.begin();
+                 ihit != phiHits.end(); ++ihit) {
+              ret.push_back(*ihit);
+            }
+          }
+
+          if (segment->hasZed()) {
+            const DTSLRecSegment2D *zSeg = (*segment).zSegment();
+            std::vector<const TrackingRecHit *> zedHits = zSeg->recHits();
+            for (std::vector<const TrackingRecHit *>::const_iterator ihit =
+                     zedHits.begin();
+                 ihit != zedHits.end(); ++ihit) {
+              ret.push_back(*ihit);
+            }
+          }
+        } else
+          edm::LogWarning("TrackerMuonHitExtractor")
+              << "\n***WARNING: UNMATCHED DT segment ! \n";
+      } // if (subdet == MuonSubdetId::DT)
+
+      else if (subdet == MuonSubdetId::CSC) {
+        edm::LogVerbatim("TrackerMuonHitExtractor")
+            << "\n\t segment index: " << index_segment << ARBITRATED
+            << "\n\t  Local Position (X,Y)=(" << segmentX << "," << segmentY
+            << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
+            << "\n\t  Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << ","
+            << segmentdYdZ << ") +/- (" << segmentdXdZerr << ","
+            << segmentdYdZerr << ")";
+
+        // with the following line the CSC segments failing standard arbitration
+        // are skipped
+        if (!segment_arbitrated_Ok)
+          continue;
+
+        if (segmentCSC.get() != nullptr) {
+          const CSCSegment *segment = segmentCSC.get();
+
+          edm::LogVerbatim("TrackerMuonHitExtractor")
+              << "\t ===> MATCHING with CSC segment with index = "
+              << segmentCSC.key();
+
+          std::vector<const TrackingRecHit *> hits = segment->recHits();
+          for (std::vector<const TrackingRecHit *>::const_iterator ihit =
+                   hits.begin();
+               ihit != hits.end(); ++ihit) {
+            ret.push_back(*ihit);
+          }
+        } else
+          edm::LogWarning("TrackerMuonHitExtractor")
+              << "\n***WARNING: UNMATCHED CSC segment ! \n";
+      } // else if (subdet == MuonSubdetId::CSC)
+
+    } // loop on vector<MuonSegmentMatch>
+  }   // loop on vector<MuonChamberMatch>
+
+  edm::LogVerbatim("TrackerMuonHitExtractor")
+      << "\n N. matched Segments before arbitration = " << n_segments_noArb;
+
+  return ret;
 }
-

--- a/SimMuon/MCTruth/test/testAssociatorRecoMuon.cc
+++ b/SimMuon/MCTruth/test/testAssociatorRecoMuon.cc
@@ -1,156 +1,185 @@
-#include <memory>
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include <memory>
 
 #include "SimMuon/MCTruth/interface/MuonToSimAssociatorBase.h"
 #include "SimTracker/Records/interface/TrackAssociatorRecord.h"
 
 #include <iostream>
-#include <string>
 #include <map>
+#include <string>
 
 class testAssociatorRecoMuon : public edm::EDAnalyzer {
-  
- public:
-  testAssociatorRecoMuon(const edm::ParameterSet&);
+
+public:
+  testAssociatorRecoMuon(const edm::ParameterSet &);
   ~testAssociatorRecoMuon() override;
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
-  
- private:
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+
+private:
   edm::InputTag muonsTag;
   edm::InputTag tpTag;
 
   std::string associatorLabel_;
- 
+
   MuonToSimAssociatorBase::MuonTrackType trackType_;
 };
 
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/MuonReco/interface/Muon.h"
 
-testAssociatorRecoMuon::testAssociatorRecoMuon(const edm::ParameterSet& parset) :
-  muonsTag(parset.getParameter< edm::InputTag >("muonsTag")),
-  tpTag(parset.getParameter< edm::InputTag >("tpTag")),
-  associatorLabel_(parset.getParameter< std::string >("associatorLabel"))
-{
-    std::string trackType = parset.getParameter< std::string >("trackType");
-    if (trackType == "inner") trackType_ = MuonToSimAssociatorBase::InnerTk;
-    else if (trackType == "outer") trackType_ = MuonToSimAssociatorBase::OuterTk;
-    else if (trackType == "global") trackType_ = MuonToSimAssociatorBase::GlobalTk;
-    else if (trackType == "segments") trackType_ = MuonToSimAssociatorBase::Segments;
-    else throw cms::Exception("Configuration") << "Track type '" << trackType << "' not supported.\n";
+testAssociatorRecoMuon::testAssociatorRecoMuon(const edm::ParameterSet &parset)
+    : muonsTag(parset.getParameter<edm::InputTag>("muonsTag")),
+      tpTag(parset.getParameter<edm::InputTag>("tpTag")),
+      associatorLabel_(parset.getParameter<std::string>("associatorLabel")) {
+  std::string trackType = parset.getParameter<std::string>("trackType");
+  if (trackType == "inner")
+    trackType_ = MuonToSimAssociatorBase::InnerTk;
+  else if (trackType == "outer")
+    trackType_ = MuonToSimAssociatorBase::OuterTk;
+  else if (trackType == "global")
+    trackType_ = MuonToSimAssociatorBase::GlobalTk;
+  else if (trackType == "segments")
+    trackType_ = MuonToSimAssociatorBase::Segments;
+  else
+    throw cms::Exception("Configuration")
+        << "Track type '" << trackType << "' not supported.\n";
 }
 
-testAssociatorRecoMuon::~testAssociatorRecoMuon() {
-}
+testAssociatorRecoMuon::~testAssociatorRecoMuon() {}
 
-void testAssociatorRecoMuon::analyze(const edm::Event& event, const edm::EventSetup& setup)
-{  
+void testAssociatorRecoMuon::analyze(const edm::Event &event,
+                                     const edm::EventSetup &setup) {
   edm::ESHandle<MuonToSimAssociatorBase> associatorBase;
   setup.get<TrackAssociatorRecord>().get(associatorLabel_, associatorBase);
-  const MuonToSimAssociatorBase* assoByHits = associatorBase.product();
-  if (assoByHits == nullptr) throw cms::Exception("Configuration") << "The Track Associator with label '" << associatorLabel_ << "' is not a MuonAssociatorByHits.\n";
+  const MuonToSimAssociatorBase *assoByHits = associatorBase.product();
+  if (assoByHits == nullptr)
+    throw cms::Exception("Configuration")
+        << "The Track Associator with label '" << associatorLabel_
+        << "' is not a MuonAssociatorByHits.\n";
 
-  edm::Handle<edm::View<reco::Muon> > muonCollectionH;
-  LogTrace("testAssociatorRecoMuon") << "getting reco::Track collection "<<muonsTag;
-  event.getByLabel(muonsTag,muonCollectionH);
+  edm::Handle<edm::View<reco::Muon>> muonCollectionH;
+  LogTrace("testAssociatorRecoMuon")
+      << "getting reco::Track collection " << muonsTag;
+  event.getByLabel(muonsTag, muonCollectionH);
 
-  const edm::View<reco::Muon>  muonCollection = *(muonCollectionH.product()); 
-  LogTrace("testAssociatorRecoMuon") << "...size = "<<muonCollection.size();
+  const edm::View<reco::Muon> muonCollection = *(muonCollectionH.product());
+  LogTrace("testAssociatorRecoMuon") << "...size = " << muonCollection.size();
 
-  edm::Handle<TrackingParticleCollection>  TPCollectionH ;
-  LogTrace("testAssociatorRecoMuon") << "getting TrackingParticle collection "<<tpTag;
-  event.getByLabel(tpTag,TPCollectionH);
+  edm::Handle<TrackingParticleCollection> TPCollectionH;
+  LogTrace("testAssociatorRecoMuon")
+      << "getting TrackingParticle collection " << tpTag;
+  event.getByLabel(tpTag, TPCollectionH);
 
-  LogTrace("testAssociatorRecoMuon") << "...size = "<< TPCollectionH->size();
+  LogTrace("testAssociatorRecoMuon") << "...size = " << TPCollectionH->size();
 
-  edm::LogVerbatim("testAssociatorRecoMuon") <<"\n === Event ID = "<< event.id()<<" ===";
-    
-  //RECOTOSIM 
-  edm::LogVerbatim("testAssociatorRecoMuon") 
-    << "\n                      ****************** Reco To Sim ****************** ";
+  edm::LogVerbatim("testAssociatorRecoMuon")
+      << "\n === Event ID = " << event.id() << " ===";
+
+  // RECOTOSIM
+  edm::LogVerbatim("testAssociatorRecoMuon")
+      << "\n                      ****************** Reco To Sim "
+         "****************** ";
 
   MuonToSimAssociatorBase::MuonToSimCollection recSimColl;
   MuonToSimAssociatorBase::SimToMuonCollection simRecColl;
 
-  assoByHits->associateMuons(recSimColl, simRecColl, muonCollectionH, trackType_, TPCollectionH, &event, &setup);
-
+  assoByHits->associateMuons(recSimColl, simRecColl, muonCollectionH,
+                             trackType_, TPCollectionH, &event, &setup);
 
   edm::LogVerbatim("testAssociatorRecoMuon")
-    << "\n There are " << muonCollection.size() << " reco::Muon "<< "("<<recSimColl.size()<<" matched) \n";
+      << "\n There are " << muonCollection.size() << " reco::Muon "
+      << "(" << recSimColl.size() << " matched) \n";
 
-  for(edm::View<reco::Muon>::size_type i=0; i<muonCollection.size(); ++i) {
+  for (edm::View<reco::Muon>::size_type i = 0; i < muonCollection.size(); ++i) {
     edm::RefToBase<reco::Muon> track(muonCollectionH, i);
-    
-    if(recSimColl.find(track) != recSimColl.end()) {
-      std::vector<std::pair<TrackingParticleRef, double> > recSimAsso = recSimColl[track];
-      
-      for (std::vector<std::pair<TrackingParticleRef, double> >::const_iterator IT = recSimAsso.begin(); 
-	   IT != recSimAsso.end(); ++IT) {
-	TrackingParticleRef trpart = IT->first;
-	double purity = IT->second;
-	edm::LogVerbatim("testAssociatorRecoMuon") <<"reco::Muon #" << int(i) << " with pt = " << track->pt()
-					     << " associated to TrackingParticle #" << trpart.key()
-					     << " (pdgId = " << trpart->pdgId() << ", pt = " << trpart->pt() << ") with Quality = " << purity;
+
+    if (recSimColl.find(track) != recSimColl.end()) {
+      std::vector<std::pair<TrackingParticleRef, double>> recSimAsso =
+          recSimColl[track];
+
+      for (std::vector<std::pair<TrackingParticleRef, double>>::const_iterator
+               IT = recSimAsso.begin();
+           IT != recSimAsso.end(); ++IT) {
+        TrackingParticleRef trpart = IT->first;
+        double purity = IT->second;
+        edm::LogVerbatim("testAssociatorRecoMuon")
+            << "reco::Muon #" << int(i) << " with pt = " << track->pt()
+            << " associated to TrackingParticle #" << trpart.key()
+            << " (pdgId = " << trpart->pdgId() << ", pt = " << trpart->pt()
+            << ") with Quality = " << purity;
       }
     } else {
-      edm::LogVerbatim("testAssociatorRecoMuon") << "reco::Muon #" << int(i) << " with pt = " << track->pt()
-					   << " NOT associated to any TrackingParticle" << "\n";		   
-    } 
+      edm::LogVerbatim("testAssociatorRecoMuon")
+          << "reco::Muon #" << int(i) << " with pt = " << track->pt()
+          << " NOT associated to any TrackingParticle"
+          << "\n";
+    }
   }
 
-  //SIMTORECO
-  edm::LogVerbatim("testAssociatorRecoMuon") 
-    << "\n                      ****************** Sim To Reco ****************** ";
+  // SIMTORECO
+  edm::LogVerbatim("testAssociatorRecoMuon")
+      << "\n                      ****************** Sim To Reco "
+         "****************** ";
 
   edm::LogVerbatim("testAssociatorRecoMuon")
-    << "\n There are " << TPCollectionH->size() << " TrackingParticles "<<"("<<simRecColl.size()<<" matched) \n";
+      << "\n There are " << TPCollectionH->size() << " TrackingParticles "
+      << "(" << simRecColl.size() << " matched) \n";
 
   bool any_trackingParticle_matched = false;
 
-  for (TrackingParticleCollection::size_type i = 0; i < TPCollectionH->size(); i++) {
+  for (TrackingParticleCollection::size_type i = 0; i < TPCollectionH->size();
+       i++) {
     TrackingParticleRef trpart(TPCollectionH, i);
 
-    std::vector<std::pair<edm::RefToBase<reco::Muon>, double> > simRecAsso;
-    if(simRecColl.find(trpart) != simRecColl.end()) { 
+    std::vector<std::pair<edm::RefToBase<reco::Muon>, double>> simRecAsso;
+    if (simRecColl.find(trpart) != simRecColl.end()) {
       simRecAsso = simRecColl[trpart];
-      
-      for (std::vector<std::pair<edm::RefToBase<reco::Muon>, double> >::const_iterator IT = simRecAsso.begin(); 
-	   IT != simRecAsso.end(); ++IT) {
-	edm::RefToBase<reco::Muon> track = IT->first;
-	double quality = IT->second;
-	any_trackingParticle_matched = true;
 
-	// find the purity from RecoToSim association (set purity = -1 for unmatched recoToSim)
-	double purity = -1.;
-	if(recSimColl.find(track) != recSimColl.end()) {
-          std::vector<std::pair<TrackingParticleRef, double> > recSimAsso = recSimColl[track];
-	  for (std::vector<std::pair<TrackingParticleRef, double> >::const_iterator ITS = recSimAsso.begin(); 
-	       ITS != recSimAsso.end(); ++ITS) {
-	    TrackingParticleRef tp(ITS->first);
-	    if (tp == trpart) purity = ITS->second;
-	  }
-	}
+      for (std::vector<std::pair<edm::RefToBase<reco::Muon>, double>>::
+               const_iterator IT = simRecAsso.begin();
+           IT != simRecAsso.end(); ++IT) {
+        edm::RefToBase<reco::Muon> track = IT->first;
+        double quality = IT->second;
+        any_trackingParticle_matched = true;
 
-	edm::LogVerbatim("testAssociatorRecoMuon") <<"TrackingParticle #" << int(i)<< " with pdgId = " << trpart->pdgId() << ", pt = " << trpart->pt()
-					     << " associated to reco::Muon #" <<track.key()
-					     << " (pt = " << track->pt() << ") with Quality = " << quality
-	                                     << " and Purity = "<< purity;
+        // find the purity from RecoToSim association (set purity = -1 for
+        // unmatched recoToSim)
+        double purity = -1.;
+        if (recSimColl.find(track) != recSimColl.end()) {
+          std::vector<std::pair<TrackingParticleRef, double>> recSimAsso =
+              recSimColl[track];
+          for (std::vector<
+                   std::pair<TrackingParticleRef, double>>::const_iterator ITS =
+                   recSimAsso.begin();
+               ITS != recSimAsso.end(); ++ITS) {
+            TrackingParticleRef tp(ITS->first);
+            if (tp == trpart)
+              purity = ITS->second;
+          }
+        }
+
+        edm::LogVerbatim("testAssociatorRecoMuon")
+            << "TrackingParticle #" << int(i)
+            << " with pdgId = " << trpart->pdgId() << ", pt = " << trpart->pt()
+            << " associated to reco::Muon #" << track.key()
+            << " (pt = " << track->pt() << ") with Quality = " << quality
+            << " and Purity = " << purity;
       }
-    } 
-    
+    }
   }
   if (!any_trackingParticle_matched) {
-    edm::LogVerbatim("testAssociatorRecoMuon") << "NO TrackingParticle associated to ANY input reco::Muon !" << "\n";
+    edm::LogVerbatim("testAssociatorRecoMuon")
+        << "NO TrackingParticle associated to ANY input reco::Muon !"
+        << "\n";
   }
-  
 }
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(testAssociatorRecoMuon);

--- a/SimMuon/MCTruth/test/testReader.cc
+++ b/SimMuon/MCTruth/test/testReader.cc
@@ -1,151 +1,173 @@
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "SimMuon/MCTruth/test/testReader.h"
-#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/RecoCandidate/interface/TrackAssociation.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimMuon/MCTruth/test/testReader.h"
 
-testReader::testReader(const edm::ParameterSet& parset) :
-  tracksTag(parset.getParameter< edm::InputTag >("tracksTag")),
-  tpTag(parset.getParameter< edm::InputTag >("tpTag")),
-  assoMapsTag(parset.getParameter< edm::InputTag >("assoMapsTag"))
-{
-}
+testReader::testReader(const edm::ParameterSet &parset)
+    : tracksTag(parset.getParameter<edm::InputTag>("tracksTag")),
+      tpTag(parset.getParameter<edm::InputTag>("tpTag")),
+      assoMapsTag(parset.getParameter<edm::InputTag>("assoMapsTag")) {}
 
-testReader::~testReader() {
-}
+testReader::~testReader() {}
 
-void testReader::analyze(const edm::Event& event, const edm::EventSetup& setup)
-{  
-  edm::Handle<edm::View<reco::Track> > trackCollectionH;
+void testReader::analyze(const edm::Event &event,
+                         const edm::EventSetup &setup) {
+  edm::Handle<edm::View<reco::Track>> trackCollectionH;
   edm::View<reco::Track> trackCollection;
-  LogTrace("testReader") << "testReader::analyze : getting reco::Track collection, "<<tracksTag;
-  event.getByLabel(tracksTag,trackCollectionH);
-  if (trackCollectionH.isValid()) { 
-    trackCollection = *(trackCollectionH.product()); 
-    LogTrace("testReader") << "... size = "<<trackCollection.size();
-  }
-  else LogTrace("testReader") << "... NOT FOUND.";
+  LogTrace("testReader")
+      << "testReader::analyze : getting reco::Track collection, " << tracksTag;
+  event.getByLabel(tracksTag, trackCollectionH);
+  if (trackCollectionH.isValid()) {
+    trackCollection = *(trackCollectionH.product());
+    LogTrace("testReader") << "... size = " << trackCollection.size();
+  } else
+    LogTrace("testReader") << "... NOT FOUND.";
 
-  edm::Handle<TrackingParticleCollection>  TPCollectionH ;
+  edm::Handle<TrackingParticleCollection> TPCollectionH;
   TrackingParticleCollection tPC;
-  LogTrace("testReader") << "testReader::analyze : getting TrackingParticle collection, "<<tpTag;
-  event.getByLabel(tpTag,TPCollectionH);
+  LogTrace("testReader")
+      << "testReader::analyze : getting TrackingParticle collection, " << tpTag;
+  event.getByLabel(tpTag, TPCollectionH);
   if (TPCollectionH.isValid()) {
-    tPC   = *(TPCollectionH.product());
-    LogTrace("testReader") << "... size = "<<tPC.size();
-  }
-  else LogTrace("testReader") << "... NOT FOUND.";
-  
+    tPC = *(TPCollectionH.product());
+    LogTrace("testReader") << "... size = " << tPC.size();
+  } else
+    LogTrace("testReader") << "... NOT FOUND.";
+
   edm::Handle<reco::RecoToSimCollection> recSimH;
   reco::RecoToSimCollection recSimColl;
-  LogTrace("testReader") << "testReader::analyze : getting  RecoToSimCollection - "<<assoMapsTag;
-  event.getByLabel(assoMapsTag,recSimH);
+  LogTrace("testReader")
+      << "testReader::analyze : getting  RecoToSimCollection - " << assoMapsTag;
+  event.getByLabel(assoMapsTag, recSimH);
   if (recSimH.isValid()) {
     recSimColl = *(recSimH.product());
-    LogTrace("testReader") << "... size = "<<recSimColl.size();
+    LogTrace("testReader") << "... size = " << recSimColl.size();
   } else {
     LogTrace("testReader") << "... NOT FOUND.";
   }
 
   edm::Handle<reco::SimToRecoCollection> simRecH;
   reco::SimToRecoCollection simRecColl;
-  LogTrace("testReader") << "testReader::analyze : getting  SimToRecoCollection - "<<assoMapsTag;
-  event.getByLabel(assoMapsTag,simRecH);
+  LogTrace("testReader")
+      << "testReader::analyze : getting  SimToRecoCollection - " << assoMapsTag;
+  event.getByLabel(assoMapsTag, simRecH);
   if (simRecH.isValid()) {
     simRecColl = *(simRecH.product());
-    LogTrace("testReader") << "... size = "<<simRecColl.size();
+    LogTrace("testReader") << "... size = " << simRecColl.size();
   } else {
     LogTrace("testReader") << "... NOT FOUND.";
   }
 
-  edm::LogVerbatim("testReader") <<"\n === Event ID = "<< event.id()<<" ===";
-  
-  //RECOTOSIM 
-  edm::LogVerbatim("testReader") 
-    << "\n                      ****************** Reco To Sim ****************** ";
+  edm::LogVerbatim("testReader")
+      << "\n === Event ID = " << event.id() << " ===";
+
+  // RECOTOSIM
+  edm::LogVerbatim("testReader")
+      << "\n                      ****************** Reco To Sim "
+         "****************** ";
   if (recSimH.isValid()) {
-    
-  edm::LogVerbatim("testReader")
-    << "\n There are " << trackCollection.size() << " reco::Tracks "<< "("<<recSimColl.size()<<" matched) \n";
 
-  for(edm::View<reco::Track>::size_type i=0; i<trackCollection.size(); ++i) {
-    edm::RefToBase<reco::Track> track(trackCollectionH, i);
-    
-    if(recSimColl.find(track) != recSimColl.end()) {
-      std::vector<std::pair<TrackingParticleRef, double> > recSimAsso = recSimColl[track];
-      
-      for (std::vector<std::pair<TrackingParticleRef, double> >::const_iterator IT = recSimAsso.begin(); 
-	   IT != recSimAsso.end(); ++IT) {
-	TrackingParticleRef trpart = IT->first;
-	double purity = IT->second;
-	edm::LogVerbatim("testReader") <<"reco::Track #" << int(i) << " with pt = " << track->pt()
-				       << " associated to TrackingParticle #" <<trpart.key()
-				       << " (pt = " << trpart->pt() << ") with Quality = " << purity;
-      }
-    } else {
-      edm::LogVerbatim("testReader") << "reco::Track #" << int(i) << " with pt = " << track->pt()
-				     << " NOT associated to any TrackingParticle" << "\n";		   
-    } 
-  }
+    edm::LogVerbatim("testReader")
+        << "\n There are " << trackCollection.size() << " reco::Tracks "
+        << "(" << recSimColl.size() << " matched) \n";
 
-  } else  edm::LogVerbatim("testReader") << "\n RtS map not found in the Event.";
+    for (edm::View<reco::Track>::size_type i = 0; i < trackCollection.size();
+         ++i) {
+      edm::RefToBase<reco::Track> track(trackCollectionH, i);
 
-  //SIMTORECO
-  edm::LogVerbatim("testReader") 
-    << "\n                      ****************** Sim To Reco ****************** ";
-  if (simRecH.isValid()) {
+      if (recSimColl.find(track) != recSimColl.end()) {
+        std::vector<std::pair<TrackingParticleRef, double>> recSimAsso =
+            recSimColl[track];
 
-  edm::LogVerbatim("testReader")
-    << "\n There are " << tPC.size() << " TrackingParticles "<<"("<<simRecColl.size()<<" matched) \n";
-  bool any_trackingParticle_matched = false;
- 
-  for (TrackingParticleCollection::size_type i=0; i<tPC.size(); i++) {
-    TrackingParticleRef trpart(TPCollectionH, i);
-    
-    std::vector<std::pair<edm::RefToBase<reco::Track>, double> > simRecAsso;
-    
-    if(simRecColl.find(trpart) != simRecColl.end()) { 
-      simRecAsso = (std::vector<std::pair<edm::RefToBase<reco::Track>, double> >) simRecColl[trpart];
-      
-      for (std::vector<std::pair<edm::RefToBase<reco::Track>, double> >::const_iterator IT = simRecAsso.begin(); 
-	   IT != simRecAsso.end(); ++IT) {
-	edm::RefToBase<reco::Track> track = IT->first;
-	double quality = IT->second;
-	any_trackingParticle_matched = true;
-	
-	// find the purity from RecoToSim association (set purity = -1 for unmatched recoToSim)
-	double purity = -1.;
-	if(recSimColl.find(track) != recSimColl.end()) {
-	  std::vector<std::pair<TrackingParticleRef, double> > recSimAsso = recSimColl[track];
-	  for (std::vector<std::pair<TrackingParticleRef, double> >::const_iterator ITS = recSimAsso.begin(); 
-	       ITS != recSimAsso.end(); ++ITS) {
-	    TrackingParticleRef tp = ITS->first;
-	    if (tp == trpart) purity = ITS->second;
-	  }
-	}
-	
-	edm::LogVerbatim("testReader") <<"TrackingParticle #" << int(i)<< " with pt = " << trpart->pt()
-				       << " associated to reco::Track #" <<track.key()
-				       << " (pt = " << track->pt() << ") with Quality = " << quality
-	                               << " and Purity = "<< purity;
+        for (std::vector<std::pair<TrackingParticleRef, double>>::const_iterator
+                 IT = recSimAsso.begin();
+             IT != recSimAsso.end(); ++IT) {
+          TrackingParticleRef trpart = IT->first;
+          double purity = IT->second;
+          edm::LogVerbatim("testReader")
+              << "reco::Track #" << int(i) << " with pt = " << track->pt()
+              << " associated to TrackingParticle #" << trpart.key()
+              << " (pt = " << trpart->pt() << ") with Quality = " << purity;
+        }
+      } else {
+        edm::LogVerbatim("testReader")
+            << "reco::Track #" << int(i) << " with pt = " << track->pt()
+            << " NOT associated to any TrackingParticle"
+            << "\n";
       }
     }
-    
-    //    else 
-    //      {
-    //	LogTrace("testReader") << "TrackingParticle #" << int(i)<< " with pt = " << trpart->pt() 
-    //			       << " NOT associated to any reco::Track" ;
-    //      }    
-  }
-  
-  if (!any_trackingParticle_matched) {
-    edm::LogVerbatim("testReader") << "NO TrackingParticle associated to ANY input reco::Track !" << "\n";
-  }
 
-  } else edm::LogVerbatim("testReader") <<"\n StR map not found in the Event.";
-  
+  } else
+    edm::LogVerbatim("testReader") << "\n RtS map not found in the Event.";
+
+  // SIMTORECO
+  edm::LogVerbatim("testReader")
+      << "\n                      ****************** Sim To Reco "
+         "****************** ";
+  if (simRecH.isValid()) {
+
+    edm::LogVerbatim("testReader")
+        << "\n There are " << tPC.size() << " TrackingParticles "
+        << "(" << simRecColl.size() << " matched) \n";
+    bool any_trackingParticle_matched = false;
+
+    for (TrackingParticleCollection::size_type i = 0; i < tPC.size(); i++) {
+      TrackingParticleRef trpart(TPCollectionH, i);
+
+      std::vector<std::pair<edm::RefToBase<reco::Track>, double>> simRecAsso;
+
+      if (simRecColl.find(trpart) != simRecColl.end()) {
+        simRecAsso =
+            (std::vector<std::pair<edm::RefToBase<reco::Track>, double>>)
+                simRecColl[trpart];
+
+        for (std::vector<std::pair<edm::RefToBase<reco::Track>, double>>::
+                 const_iterator IT = simRecAsso.begin();
+             IT != simRecAsso.end(); ++IT) {
+          edm::RefToBase<reco::Track> track = IT->first;
+          double quality = IT->second;
+          any_trackingParticle_matched = true;
+
+          // find the purity from RecoToSim association (set purity = -1 for
+          // unmatched recoToSim)
+          double purity = -1.;
+          if (recSimColl.find(track) != recSimColl.end()) {
+            std::vector<std::pair<TrackingParticleRef, double>> recSimAsso =
+                recSimColl[track];
+            for (std::vector<std::pair<TrackingParticleRef, double>>::
+                     const_iterator ITS = recSimAsso.begin();
+                 ITS != recSimAsso.end(); ++ITS) {
+              TrackingParticleRef tp = ITS->first;
+              if (tp == trpart)
+                purity = ITS->second;
+            }
+          }
+
+          edm::LogVerbatim("testReader")
+              << "TrackingParticle #" << int(i) << " with pt = " << trpart->pt()
+              << " associated to reco::Track #" << track.key()
+              << " (pt = " << track->pt() << ") with Quality = " << quality
+              << " and Purity = " << purity;
+        }
+      }
+
+      //    else
+      //      {
+      //	LogTrace("testReader") << "TrackingParticle #" << int(i)<< "
+      // with pt = " << trpart->pt()
+      //			       << " NOT associated to any reco::Track" ;
+      //      }
+    }
+
+    if (!any_trackingParticle_matched) {
+      edm::LogVerbatim("testReader")
+          << "NO TrackingParticle associated to ANY input reco::Track !"
+          << "\n";
+    }
+
+  } else
+    edm::LogVerbatim("testReader") << "\n StR map not found in the Event.";
 }
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(testReader);
-
-

--- a/SimMuon/MCTruth/test/testReader.h
+++ b/SimMuon/MCTruth/test/testReader.h
@@ -1,22 +1,22 @@
 #ifndef testReader_h
 #define testReader_h
 
-#include <memory>
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include <memory>
 
 class testReader : public edm::EDAnalyzer {
-  
- public:
-  testReader(const edm::ParameterSet&);
+
+public:
+  testReader(const edm::ParameterSet &);
   ~testReader() override;
-  void beginJob() override {}  
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
-  
- private:
+  void beginJob() override {}
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+
+private:
   edm::InputTag tracksTag;
   edm::InputTag tpTag;
   edm::InputTag assoMapsTag;

--- a/SimTracker/TrackHistory/interface/CMSProcessTypes.h
+++ b/SimTracker/TrackHistory/interface/CMSProcessTypes.h
@@ -2,28 +2,26 @@
 #define SimTracker_TrackHistory_CMSProcessTypes_h
 
 //! Struct holding legacy CMS convention for process types
-struct CMS
-{
-    enum Process
-    {
-        Undefined = 0,
-        Unknown,
-        Primary,
-        Hadronic,
-        Decay,
-        Compton,
-        Annihilation,
-        EIoni,
-        HIoni,
-        MuIoni,
-        Photon,
-        MuPairProd,
-        Conversions,
-        EBrem,
-        SynchrotronRadiation,
-        MuBrem,
-        MuNucl
-    };
+struct CMS {
+  enum Process {
+    Undefined = 0,
+    Unknown,
+    Primary,
+    Hadronic,
+    Decay,
+    Compton,
+    Annihilation,
+    EIoni,
+    HIoni,
+    MuIoni,
+    Photon,
+    MuPairProd,
+    Conversions,
+    EBrem,
+    SynchrotronRadiation,
+    MuBrem,
+    MuNucl
+  };
 };
 
 #endif

--- a/SimTracker/TrackHistory/interface/CategoryCriteria.h
+++ b/SimTracker/TrackHistory/interface/CategoryCriteria.h
@@ -1,88 +1,73 @@
 #ifndef CategoryCriteria_h
 #define CategoryCriteria_h
 
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
 #include "DataFormats/Common/interface/Ref.h"
 
-
-//! Implement a selector given a track or vertex collection and track or vertex classifier.
-template <typename Collection, typename Classifier>
-class CategoryCriteria
-{
+//! Implement a selector given a track or vertex collection and track or vertex
+//! classifier.
+template <typename Collection, typename Classifier> class CategoryCriteria {
 
 public:
+  // Input collection type
+  typedef Collection collection;
 
-    // Input collection type
-    typedef Collection collection;
+  // Type of the collection elements
+  typedef typename Collection::value_type type;
 
-    // Type of the collection elements
-    typedef typename Collection::value_type type;
+  // Oumemberut collection type
+  typedef std::vector<const type *> container;
 
-    // Oumemberut collection type
-    typedef std::vector<const type *> container;
+  // Iterator over result collection type.
+  typedef typename container::const_iterator const_iterator;
 
-    // Iterator over result collection type.
-    typedef typename container::const_iterator const_iterator;
+  // Constructor from parameter set configurability
+  CategoryCriteria(const edm::ParameterSet &config, edm::ConsumesCollector &&iC)
+      : classifier_(config, std::move(iC)),
+        evaluate_(config.getParameter<std::string>("cut")) {}
 
-    // Constructor from parameter set configurability
-    CategoryCriteria(const edm::ParameterSet & config, edm::ConsumesCollector && iC) :
-            classifier_(config,std::move(iC)),
-            evaluate_( config.getParameter<std::string>("cut") ) {}
+  // Select object from a collection and possibly event content
+  void select(const edm::Handle<collection> &collectionHandler,
+              const edm::Event &event, const edm::EventSetup &setup) {
 
-    // Select object from a collection and possibly event content
-    void select(const edm::Handle<collection> & collectionHandler, const edm::Event & event, const edm::EventSetup & setup)
-    {
+    selected_.clear();
 
-        selected_.clear();
+    // const collection & collectionPointer = *(collectionHandler.product());
 
-        // const collection & collectionPointer = *(collectionHandler.product());
+    classifier_.newEvent(event, setup);
 
-        classifier_.newEvent(event, setup);
+    for (typename collection::size_type i = 0; i < collectionHandler->size();
+         ++i) {
+      edm::Ref<Collection> member(collectionHandler, i);
 
-        for (typename collection::size_type i = 0; i < collectionHandler->size(); ++i)
-        {
-            edm::Ref<Collection> member(collectionHandler, i);
+      classifier_.evaluate(member);
 
-            classifier_.evaluate(member);
-
-            // Classifier is evaluated using StringCutObjectSelector
-            if ( evaluate_(classifier_) )
-                selected_.push_back( &(*member) );
-        }
+      // Classifier is evaluated using StringCutObjectSelector
+      if (evaluate_(classifier_))
+        selected_.push_back(&(*member));
     }
+  }
 
-    // Iterators over selected objects: collection begin
-    const_iterator begin() const
-    {
-        return selected_.begin();
-    }
+  // Iterators over selected objects: collection begin
+  const_iterator begin() const { return selected_.begin(); }
 
-    // Iterators over selected objects: collection end
-    const_iterator end() const
-    {
-        return selected_.end();
-    }
+  // Iterators over selected objects: collection end
+  const_iterator end() const { return selected_.end(); }
 
-    // True if no object has been selected
-    std::size_t size() const
-    {
-        return selected_.size();
-    }
+  // True if no object has been selected
+  std::size_t size() const { return selected_.size(); }
 
 private:
+  container selected_;
 
-    container selected_;
+  Classifier classifier_;
 
-    Classifier classifier_;
-
-    StringCutObjectSelector<typename Classifier::Categories> evaluate_;
-
+  StringCutObjectSelector<typename Classifier::Categories> evaluate_;
 };
-
 
 #endif

--- a/SimTracker/TrackHistory/interface/HistoryBase.h
+++ b/SimTracker/TrackHistory/interface/HistoryBase.h
@@ -9,186 +9,162 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
 
 //! Base class to all the history types.
-class HistoryBase
-{
+class HistoryBase {
 
 public:
+  //! HepMC::GenParticle trail type.
+  typedef std::vector<const HepMC::GenParticle *> GenParticleTrail;
 
-    //! HepMC::GenParticle trail type.
-    typedef std::vector<const HepMC::GenParticle *> GenParticleTrail;
-    
-    //! reco::GenParticle trail type.
-    typedef std::vector<const reco::GenParticle *> RecoGenParticleTrail;
-    
-    //!reco::GenParticle trail helper type.
-    typedef std::set<const reco::GenParticle *> RecoGenParticleTrailHelper;
+  //! reco::GenParticle trail type.
+  typedef std::vector<const reco::GenParticle *> RecoGenParticleTrail;
 
-    //! GenVertex trail type.
-    typedef std::vector<const HepMC::GenVertex *> GenVertexTrail;
+  //! reco::GenParticle trail helper type.
+  typedef std::set<const reco::GenParticle *> RecoGenParticleTrailHelper;
 
-    //! GenVertex trail helper type.
-    typedef std::set<const HepMC::GenVertex *> GenVertexTrailHelper;
+  //! GenVertex trail type.
+  typedef std::vector<const HepMC::GenVertex *> GenVertexTrail;
 
-    //! SimParticle trail type.
-    typedef std::vector<TrackingParticleRef> SimParticleTrail;
+  //! GenVertex trail helper type.
+  typedef std::set<const HepMC::GenVertex *> GenVertexTrailHelper;
 
-    //! SimVertex trail type.
-    typedef std::vector<TrackingVertexRef> SimVertexTrail;
+  //! SimParticle trail type.
+  typedef std::vector<TrackingParticleRef> SimParticleTrail;
 
-    // Default constructor
-    HistoryBase()
-    {
-        // Default depth
-        depth_ = -1;
-    }
+  //! SimVertex trail type.
+  typedef std::vector<TrackingVertexRef> SimVertexTrail;
 
-    //! Set the depth of the history.
-    /* Set TrackHistory to given depth. Positive values
-       constrain the number of TrackingVertex visit in the history.
-       Negatives values set the limit of the iteration over generated
-       information i.e. (-1 -> status 1 or -2 -> status 2 particles).
+  // Default constructor
+  HistoryBase() {
+    // Default depth
+    depth_ = -1;
+  }
 
-       /param[in] depth the history
-    */
-    void depth(int d)
-    {
-        depth_ = d;
-    }
+  //! Set the depth of the history.
+  /* Set TrackHistory to given depth. Positive values
+     constrain the number of TrackingVertex visit in the history.
+     Negatives values set the limit of the iteration over generated
+     information i.e. (-1 -> status 1 or -2 -> status 2 particles).
 
-    //! Return all the simulated vertices in the history.
-    SimVertexTrail const & simVertexTrail() const
-    {
-        return simVertexTrail_;
-    }
+     /param[in] depth the history
+  */
+  void depth(int d) { depth_ = d; }
 
-    //! Return all the simulated particle in the history.
-    SimParticleTrail const & simParticleTrail() const
-    {
-        return simParticleTrail_;
-    }
+  //! Return all the simulated vertices in the history.
+  SimVertexTrail const &simVertexTrail() const { return simVertexTrail_; }
 
-    //! Return all generated vertex in the history.
-    GenVertexTrail const & genVertexTrail() const
-    {
-        return genVertexTrail_;
-    }
+  //! Return all the simulated particle in the history.
+  SimParticleTrail const &simParticleTrail() const { return simParticleTrail_; }
 
-    //! Return all generated particle (HepMC::GenParticle) in the history.
-    GenParticleTrail const & genParticleTrail() const
-    {
-        return genParticleTrail_;
-    }
-    
-     //! Return all reco::GenParticle in the history.
-    RecoGenParticleTrail const & recoGenParticleTrail() const
-    {
-        return recoGenParticleTrail_;
-    }
+  //! Return all generated vertex in the history.
+  GenVertexTrail const &genVertexTrail() const { return genVertexTrail_; }
 
-    //! Return the initial tracking particle from the history.
-    const TrackingParticleRef & simParticle() const
-    {
-        return simParticleTrail_[0];
-    }
+  //! Return all generated particle (HepMC::GenParticle) in the history.
+  GenParticleTrail const &genParticleTrail() const { return genParticleTrail_; }
 
-    //! Return the initial tracking vertex from the history.
-    const TrackingVertexRef & simVertex() const
-    {
-        return simVertexTrail_[0];
-    }
+  //! Return all reco::GenParticle in the history.
+  RecoGenParticleTrail const &recoGenParticleTrail() const {
+    return recoGenParticleTrail_;
+  }
 
-    //! Returns a pointer to most primitive status 1 or 2 particle in the genParticleTrail_.
-    const HepMC::GenParticle * genParticle() const
-    {
-        if ( genParticleTrail_.empty() ) return nullptr;
-        return genParticleTrail_[genParticleTrail_.size()-1];
-    }
-    
-    //! Returns a pointer to most primitive status 1 or 2 particle in the recoGenParticleTrail_.
-    const reco::GenParticle * recoGenParticle() const
-    {
-        if ( recoGenParticleTrail_.empty() ) return nullptr;
-        return recoGenParticleTrail_[recoGenParticleTrail_.size()-1];
-    }
+  //! Return the initial tracking particle from the history.
+  const TrackingParticleRef &simParticle() const {
+    return simParticleTrail_[0];
+  }
 
-    //! Evaluate track history using a TrackingParticleRef.
-    /* Return false when the history cannot be determined upto a given depth.
-       If not depth is pass to the function no restriction are apply to it.
+  //! Return the initial tracking vertex from the history.
+  const TrackingVertexRef &simVertex() const { return simVertexTrail_[0]; }
 
-       /param[in] TrackingParticleRef of a simulated track
-       /param[in] depth of the track history
-       /param[out] boolean that is true when history can be determined
-    */
-    bool evaluate(TrackingParticleRef tpr)
-    {
-        resetTrails(tpr);
-        return traceSimHistory(tpr, depth_);
-    }
+  //! Returns a pointer to most primitive status 1 or 2 particle in the
+  //! genParticleTrail_.
+  const HepMC::GenParticle *genParticle() const {
+    if (genParticleTrail_.empty())
+      return nullptr;
+    return genParticleTrail_[genParticleTrail_.size() - 1];
+  }
 
-    //! Evaluate track history using a TrackingParticleRef.
-    /* Return false when the history cannot be determined upto a given depth.
-       If not depth is pass to the function no restriction are apply to it.
+  //! Returns a pointer to most primitive status 1 or 2 particle in the
+  //! recoGenParticleTrail_.
+  const reco::GenParticle *recoGenParticle() const {
+    if (recoGenParticleTrail_.empty())
+      return nullptr;
+    return recoGenParticleTrail_[recoGenParticleTrail_.size() - 1];
+  }
 
-       /param[in] TrackingVertexRef of a simulated vertex
-       /param[in] depth of the track history
-       /param[out] boolean that is true when history can be determined
-    */
-    bool evaluate(TrackingVertexRef tvr)
-    {
-        resetTrails();
-        return traceSimHistory(tvr, depth_);
-    }
+  //! Evaluate track history using a TrackingParticleRef.
+  /* Return false when the history cannot be determined upto a given depth.
+     If not depth is pass to the function no restriction are apply to it.
+
+     /param[in] TrackingParticleRef of a simulated track
+     /param[in] depth of the track history
+     /param[out] boolean that is true when history can be determined
+  */
+  bool evaluate(TrackingParticleRef tpr) {
+    resetTrails(tpr);
+    return traceSimHistory(tpr, depth_);
+  }
+
+  //! Evaluate track history using a TrackingParticleRef.
+  /* Return false when the history cannot be determined upto a given depth.
+     If not depth is pass to the function no restriction are apply to it.
+
+     /param[in] TrackingVertexRef of a simulated vertex
+     /param[in] depth of the track history
+     /param[out] boolean that is true when history can be determined
+  */
+  bool evaluate(TrackingVertexRef tvr) {
+    resetTrails();
+    return traceSimHistory(tvr, depth_);
+  }
 
 protected:
+  // History cointainers
+  GenVertexTrail genVertexTrail_;
+  GenParticleTrail genParticleTrail_;
+  RecoGenParticleTrail recoGenParticleTrail_;
+  SimVertexTrail simVertexTrail_;
+  SimParticleTrail simParticleTrail_;
 
-    // History cointainers
-    GenVertexTrail genVertexTrail_;
-    GenParticleTrail genParticleTrail_;
-    RecoGenParticleTrail recoGenParticleTrail_;
-    SimVertexTrail simVertexTrail_;
-    SimParticleTrail simParticleTrail_;
-
-    // Helper function to speedup search
-    GenVertexTrailHelper genVertexTrailHelper_;
-    RecoGenParticleTrailHelper recoGenParticleTrailHelper_;
+  // Helper function to speedup search
+  GenVertexTrailHelper genVertexTrailHelper_;
+  RecoGenParticleTrailHelper recoGenParticleTrailHelper_;
 
 private:
+  int depth_;
 
-    int depth_;
+  //! Trace all the simulated information for a given reference to a
+  //! TrackingParticle.
+  bool traceSimHistory(TrackingParticleRef const &, int);
 
-    //! Trace all the simulated information for a given reference to a TrackingParticle.
-    bool traceSimHistory (TrackingParticleRef const &, int);
+  //! Trace all the simulated information for a given reference to a
+  //! TrackingVertex.
+  bool traceSimHistory(TrackingVertexRef const &, int);
 
-    //! Trace all the simulated information for a given reference to a TrackingVertex.
-    bool traceSimHistory (TrackingVertexRef const &, int);
+  //! Trace all the simulated information for a given pointer to a
+  //! HepMC::GenParticle.
+  void traceGenHistory(HepMC::GenParticle const *);
 
-    //! Trace all the simulated information for a given pointer to a HepMC::GenParticle.
-    void traceGenHistory (HepMC::GenParticle const *);
-    
-    //! Trace all the simulated information for a given pointer to a reco::GenParticle.
-    void traceRecoGenHistory (reco::GenParticle const *);
-    
+  //! Trace all the simulated information for a given pointer to a
+  //! reco::GenParticle.
+  void traceRecoGenHistory(reco::GenParticle const *);
 
-    //! Trace all the simulated information for a given pointer to a GenVertex.
-    void traceGenHistory (HepMC::GenVertex const *);
+  //! Trace all the simulated information for a given pointer to a GenVertex.
+  void traceGenHistory(HepMC::GenVertex const *);
 
-    //! Reset trail functions.
-    void resetTrails()
-    {
-        simParticleTrail_.clear();
-        simVertexTrail_.clear();
-        genVertexTrail_.clear();
-        genParticleTrail_.clear();
-        recoGenParticleTrail_.clear();
-        recoGenParticleTrailHelper_.clear();
-        genVertexTrailHelper_.clear();
-    }
+  //! Reset trail functions.
+  void resetTrails() {
+    simParticleTrail_.clear();
+    simVertexTrail_.clear();
+    genVertexTrail_.clear();
+    genParticleTrail_.clear();
+    recoGenParticleTrail_.clear();
+    recoGenParticleTrailHelper_.clear();
+    genVertexTrailHelper_.clear();
+  }
 
-    void resetTrails(TrackingParticleRef tpr)
-    {
-        resetTrails();
-        simParticleTrail_.push_back(tpr);
-    }
+  void resetTrails(TrackingParticleRef tpr) {
+    resetTrails();
+    simParticleTrail_.push_back(tpr);
+  }
 };
 
 #endif

--- a/SimTracker/TrackHistory/interface/JetVetoedTracksAssociatorDRVertex.h
+++ b/SimTracker/TrackHistory/interface/JetVetoedTracksAssociatorDRVertex.h
@@ -2,32 +2,28 @@
 #ifndef JetVetoedTracksAssociationDRVertex_h
 #define JetVetoedTracksAssociationDRVertex_h
 
-#include "DataFormats/Math/interface/deltaR.h"
-#include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/JetReco/interface/JetTracksAssociation.h"
+#include "DataFormats/Math/interface/Vector3D.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
 #include "SimTracker/TrackHistory/interface/TrackClassifier.h"
 
-class JetVetoedTracksAssociationDRVertex
-{
+class JetVetoedTracksAssociationDRVertex {
 
 public:
+  JetVetoedTracksAssociationDRVertex(double fDr);
+  ~JetVetoedTracksAssociationDRVertex() {}
 
-    JetVetoedTracksAssociationDRVertex (double fDr);
-    ~JetVetoedTracksAssociationDRVertex () {}
-
-    void produce (
-        reco::JetTracksAssociation::Container* fAssociation,
-        const std::vector<edm::RefToBase<reco::Jet> >& fJets,
-        const std::vector<reco::TrackRef>& fTracks,
-        TrackClassifier & classifier
-    ) const;
+  void produce(reco::JetTracksAssociation::Container *fAssociation,
+               const std::vector<edm::RefToBase<reco::Jet>> &fJets,
+               const std::vector<reco::TrackRef> &fTracks,
+               TrackClassifier &classifier) const;
 
 private:
-    /// fidutial dR between track in the vertex and jet's reference direction
-    double mDeltaR2Threshold;
+  /// fidutial dR between track in the vertex and jet's reference direction
+  double mDeltaR2Threshold;
 };
 
 #endif

--- a/SimTracker/TrackHistory/interface/TrackCategories.h
+++ b/SimTracker/TrackHistory/interface/TrackCategories.h
@@ -5,109 +5,92 @@
 #include <ostream>
 #include <vector>
 
-class TrackCategories
-{
+class TrackCategories {
 
 public:
+  //! Categories available to vertex
+  enum Category {
+    Fake = 0,
+    Reconstructed = Fake,
+    Bad,
+    BadInnerHits,
+    SharedInnerHits,
+    SignalEvent,
+    Bottom,
+    Charm,
+    Light,
+    Muon,
+    TrackerSimHits,
+    BWeakDecay,
+    CWeakDecay,
+    ChargePionDecay,
+    ChargeKaonDecay,
+    TauDecay,
+    KsDecay,
+    LambdaDecay,
+    JpsiDecay,
+    XiDecay,
+    OmegaDecay,
+    SigmaPlusDecay,
+    SigmaMinusDecay,
+    LongLivedDecay,
+    KnownProcess,
+    UndefinedProcess,
+    UnknownProcess,
+    PrimaryProcess,
+    HadronicProcess,
+    DecayProcess,
+    ComptonProcess,
+    AnnihilationProcess,
+    EIoniProcess,
+    HIoniProcess,
+    MuIoniProcess,
+    PhotonProcess,
+    MuPairProdProcess,
+    ConversionsProcess,
+    EBremProcess,
+    SynchrotronRadiationProcess,
+    MuBremProcess,
+    MuNuclProcess,
+    FromBWeakDecayMuon,
+    FromCWeakDecayMuon,
+    DecayOnFlightMuon,
+    FromChargePionMuon,
+    FromChargeKaonMuon,
+    PrimaryVertex,
+    SecondaryVertex,
+    TertiaryVertex,
+    TierciaryVertex = TertiaryVertex,
+    Unknown
+  };
 
-    //! Categories available to vertex
-    enum Category
-    {
-        Fake = 0,
-        Reconstructed = Fake,
-        Bad,
-        BadInnerHits,
-        SharedInnerHits,
-        SignalEvent,
-        Bottom,
-        Charm,
-        Light,
-        Muon,
-        TrackerSimHits,
-        BWeakDecay,
-        CWeakDecay,
-        ChargePionDecay,
-        ChargeKaonDecay,
-        TauDecay,
-        KsDecay,
-        LambdaDecay,
-        JpsiDecay,
-        XiDecay,
-        OmegaDecay,
-        SigmaPlusDecay,
-        SigmaMinusDecay,
-        LongLivedDecay,
-        KnownProcess,
-        UndefinedProcess,
-        UnknownProcess,
-        PrimaryProcess,
-        HadronicProcess,
-        DecayProcess,
-        ComptonProcess,
-        AnnihilationProcess,
-        EIoniProcess,
-        HIoniProcess,
-        MuIoniProcess,
-        PhotonProcess,
-        MuPairProdProcess,
-        ConversionsProcess,
-        EBremProcess,
-        SynchrotronRadiationProcess,
-        MuBremProcess,
-        MuNuclProcess,
-        FromBWeakDecayMuon,
-        FromCWeakDecayMuon,
-        DecayOnFlightMuon,
-        FromChargePionMuon,
-        FromChargeKaonMuon,
-        PrimaryVertex,
-        SecondaryVertex,
-        TertiaryVertex,
-        TierciaryVertex = TertiaryVertex,
-        Unknown
-    };
+  //! Name of the different categories
+  static const char *const Names[];
 
-    //! Name of the different categories
-    static const char * const Names[];
+  //! Main types associated to the class
+  typedef std::vector<bool> Flags;
 
-    //! Main types associated to the class
-    typedef std::vector<bool> Flags;
+  //! Void constructor
+  TrackCategories() { reset(); }
 
-    //! Void constructor
-    TrackCategories()
-    {
-        reset();
-    }
+  //! Returns track flag for a given category
+  bool is(Category category) const { return flags_[category]; }
 
-    //! Returns track flag for a given category
-    bool is(Category category) const
-    {
-        return flags_[category];
-    }
-
-    //! Returns flags with the category descriptions
-    const Flags & flags() const
-    {
-        return flags_;
-    }
+  //! Returns flags with the category descriptions
+  const Flags &flags() const { return flags_; }
 
 protected:
+  //! Reset the categories flags
+  void reset() { flags_ = Flags(Unknown + 1, false); }
 
-    //! Reset the categories flags
-    void reset()
-    {
-        flags_ = Flags(Unknown + 1, false);
-    }
+  // Check for unkown classification
+  void unknownTrack();
 
-    // Check for unkown classification
-    void unknownTrack();
-
-    //! Flag containers
-    Flags flags_;
-
+  //! Flag containers
+  Flags flags_;
 };
 
 // Operation overload for printing the categories
-std::ostream & operator<< (std::ostream &, TrackCategories const &);
+std::ostream &operator<<(std::ostream &, TrackCategories const &);
 
 #endif

--- a/SimTracker/TrackHistory/interface/TrackClassifier.h
+++ b/SimTracker/TrackHistory/interface/TrackClassifier.h
@@ -6,8 +6,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
@@ -23,128 +23,115 @@
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
-
 class TrackTopology;
 
 //! Get track history and classify it in function of their .
-class TrackClassifier : public TrackCategories
-{
+class TrackClassifier : public TrackCategories {
 
 public:
+  //! Type to the associate category
+  typedef TrackCategories Categories;
 
-    //! Type to the associate category
-    typedef TrackCategories Categories;
+  //! Constructor by ParameterSet
+  TrackClassifier(edm::ParameterSet const &, edm::ConsumesCollector &&);
 
-    //! Constructor by ParameterSet
-    TrackClassifier(edm::ParameterSet const &,
-                    edm::ConsumesCollector&& );
+  //! Pre-process event information (for accessing reconstraction information)
+  void newEvent(edm::Event const &, edm::EventSetup const &);
 
-    //! Pre-process event information (for accessing reconstraction information)
-    void newEvent(edm::Event const &, edm::EventSetup const &);
+  //! Classify the RecoTrack in categories.
+  TrackClassifier const &evaluate(reco::TrackBaseRef const &);
 
-    //! Classify the RecoTrack in categories.
-    TrackClassifier const & evaluate (reco::TrackBaseRef const &);
+  //! Classify the TrackingParticle in categories.
+  TrackClassifier const &evaluate(TrackingParticleRef const &);
 
-    //! Classify the TrackingParticle in categories.
-    TrackClassifier const & evaluate (TrackingParticleRef const &);
+  //! Classify the RecoTrack in categories.
+  TrackClassifier const &evaluate(reco::TrackRef const &track) {
+    return evaluate(reco::TrackBaseRef(track));
+  }
 
-    //! Classify the RecoTrack in categories.
-    TrackClassifier const & evaluate (reco::TrackRef const & track)
-    {
-      return evaluate( reco::TrackBaseRef(track));
-    }
+  //! Returns a reference to the track history used in the classification.
+  TrackHistory const &history() const { return tracer_; }
 
-    //! Returns a reference to the track history used in the classification.
-    TrackHistory const & history() const
-    {
-        return tracer_;
-    }
-
-    //! Returns a reference to the track quality used in the classification.
-    TrackQuality const & quality() const
-    {
-        return quality_;
-    }
+  //! Returns a reference to the track quality used in the classification.
+  TrackQuality const &quality() const { return quality_; }
 
 private:
+  const edm::InputTag hepMCLabel_;
+  const edm::InputTag beamSpotLabel_;
 
-    const edm::InputTag hepMCLabel_;
-    const edm::InputTag beamSpotLabel_;
+  double badPull_;
+  double longLivedDecayLength_;
+  double vertexClusteringSqDistance_;
+  unsigned int numberOfInnerLayers_;
+  unsigned int minTrackerSimHits_;
 
-    double badPull_;
-    double longLivedDecayLength_;
-    double vertexClusteringSqDistance_;
-    unsigned int numberOfInnerLayers_;
-    unsigned int minTrackerSimHits_;
+  TrackHistory tracer_;
 
-    TrackHistory tracer_;
+  TrackQuality quality_;
 
-    TrackQuality quality_;
+  const G4toCMSLegacyProcTypeMap g4toCMSProcMap_;
 
-    const G4toCMSLegacyProcTypeMap g4toCMSProcMap_;
+  edm::ESHandle<MagneticField> magneticField_;
 
-    edm::ESHandle<MagneticField> magneticField_;
+  edm::Handle<edm::HepMCProduct> mcInformation_;
 
-    edm::Handle<edm::HepMCProduct> mcInformation_;
+  edm::ESHandle<ParticleDataTable> particleDataTable_;
 
-    edm::ESHandle<ParticleDataTable> particleDataTable_;
+  edm::ESHandle<TransientTrackBuilder> transientTrackBuilder_;
 
-    edm::ESHandle<TransientTrackBuilder> transientTrackBuilder_;
+  edm::Handle<reco::BeamSpot> beamSpot_;
 
-    edm::Handle<reco::BeamSpot> beamSpot_;
+  const TrackerTopology *tTopo_;
 
-    const TrackerTopology *tTopo_;
+  //! Classify all the tracks by their association and reconstruction
+  //! information
+  void reconstructionInformation(reco::TrackBaseRef const &);
 
-    //! Classify all the tracks by their association and reconstruction information
-    void reconstructionInformation(reco::TrackBaseRef const &);
+  //! Get all the information related to the simulation details
+  void simulationInformation();
 
-    //! Get all the information related to the simulation details
-    void simulationInformation();
+  //! Classify all the tracks by their reconstruction quality
+  void qualityInformation(reco::TrackBaseRef const &);
 
-    //! Classify all the tracks by their reconstruction quality
-    void qualityInformation(reco::TrackBaseRef const &);
+  //! Get hadron flavor of the initial hadron
+  void hadronFlavor();
 
-    //! Get hadron flavor of the initial hadron
-    void hadronFlavor();
+  //! Get all the information related to decay process
+  void processesAtGenerator();
 
-    //! Get all the information related to decay process
-    void processesAtGenerator();
+  //! Get information about conversion and other interactions
+  void processesAtSimulation();
 
-    //! Get information about conversion and other interactions
-    void processesAtSimulation();
+  //! Get geometrical information about the vertices
+  void vertexInformation();
 
-    //! Get geometrical information about the vertices
-    void vertexInformation();
+  //! Auxiliary class holding simulated primary vertices
+  struct GeneratedPrimaryVertex {
 
-    //! Auxiliary class holding simulated primary vertices
-    struct GeneratedPrimaryVertex
-    {
+    GeneratedPrimaryVertex(double x1, double y1, double z1)
+        : x(x1), y(y1), z(z1), ptsq(0), nGenTrk(0) {}
 
-        GeneratedPrimaryVertex(double x1,double y1,double z1): x(x1), y(y1), z(z1), ptsq(0), nGenTrk(0) {}
+    bool operator<(GeneratedPrimaryVertex const &reference) const {
+      return ptsq < reference.ptsq;
+    }
 
-        bool operator< ( GeneratedPrimaryVertex const & reference) const
-        {
-            return ptsq < reference.ptsq;
-        }
+    double x, y, z;
+    double ptsq;
+    int nGenTrk;
 
-        double x, y, z;
-        double ptsq;
-        int nGenTrk;
+    HepMC::FourVector ptot;
 
-        HepMC::FourVector ptot;
+    std::vector<int> finalstateParticles;
+    std::vector<int> simTrackIndex;
+    std::vector<int> genVertex;
+  };
 
-        std::vector<int> finalstateParticles;
-        std::vector<int> simTrackIndex;
-        std::vector<int> genVertex;
-    };
+  std::vector<GeneratedPrimaryVertex> genpvs_;
 
-    std::vector<GeneratedPrimaryVertex> genpvs_;
-
-    // Auxiliary function to get the generated primary vertex
-    bool isFinalstateParticle(const HepMC::GenParticle *);
-    bool isCharged(const HepMC::GenParticle *);
-    void genPrimaryVertices();
-
+  // Auxiliary function to get the generated primary vertex
+  bool isFinalstateParticle(const HepMC::GenParticle *);
+  bool isCharged(const HepMC::GenParticle *);
+  void genPrimaryVertices();
 };
 
 #endif

--- a/SimTracker/TrackHistory/interface/TrackHistory.h
+++ b/SimTracker/TrackHistory/interface/TrackHistory.h
@@ -3,10 +3,10 @@
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
@@ -14,95 +14,82 @@
 #include "SimTracker/TrackHistory/interface/Utils.h"
 
 //! This class traces the simulated and generated history of a given track.
-class TrackHistory : public HistoryBase
-{
+class TrackHistory : public HistoryBase {
 
 public:
+  //! Constructor by pset.
+  /* Creates a TrackHistory with association given by pset.
 
-    //! Constructor by pset.
-    /* Creates a TrackHistory with association given by pset.
+     /param[in] pset with the configuration values
+  */
+  TrackHistory(const edm::ParameterSet &, edm::ConsumesCollector &&);
 
-       /param[in] pset with the configuration values
-    */
-    TrackHistory(const edm::ParameterSet &,
-                 edm::ConsumesCollector&& );
+  //! Pre-process event information (for accessing reconstruction information)
+  void newEvent(const edm::Event &, const edm::EventSetup &);
 
-    //! Pre-process event information (for accessing reconstruction information)
-    void newEvent(const edm::Event &, const edm::EventSetup &);
+  //! Evaluate track history using a TrackingParticleRef.
+  /* Return false when the history cannot be determined upto a given depth.
+     If not depth is pass to the function no restriction are apply to it.
 
-    //! Evaluate track history using a TrackingParticleRef.
-    /* Return false when the history cannot be determined upto a given depth.
-       If not depth is pass to the function no restriction are apply to it.
-
-       /param[in] TrackingParticleRef of a simulated track
-       /param[in] depth of the track history
-       /param[out] boolean that is true when history can be determined
-    */
-    bool evaluate(TrackingParticleRef tpr)
-    {
-        if ( enableSimToReco_ )
-        {
-            std::pair<reco::TrackBaseRef, double> result =  match(tpr, simToReco_, bestMatchByMaxValue_);
-            recotrack_ = result.first;
-            quality_ =  result.second;
-        }
-        return HistoryBase::evaluate(tpr);
+     /param[in] TrackingParticleRef of a simulated track
+     /param[in] depth of the track history
+     /param[out] boolean that is true when history can be determined
+  */
+  bool evaluate(TrackingParticleRef tpr) {
+    if (enableSimToReco_) {
+      std::pair<reco::TrackBaseRef, double> result =
+          match(tpr, simToReco_, bestMatchByMaxValue_);
+      recotrack_ = result.first;
+      quality_ = result.second;
     }
+    return HistoryBase::evaluate(tpr);
+  }
 
+  //! Evaluate reco::Track history using a given association.
+  /* Return false when the track association is not possible (fake track).
 
-    //! Evaluate reco::Track history using a given association.
-    /* Return false when the track association is not possible (fake track).
+     /param[in] TrackRef to a reco::track
+     /param[out] boolean that is false when a fake track is detected
+  */
+  bool evaluate(reco::TrackBaseRef);
 
-       /param[in] TrackRef to a reco::track
-       /param[out] boolean that is false when a fake track is detected
-    */
-    bool evaluate (reco::TrackBaseRef);
+  //! Return a reference to the reconstructed track.
+  const reco::TrackBaseRef &recoTrack() const { return recotrack_; }
 
-    //! Return a reference to the reconstructed track.
-    const reco::TrackBaseRef & recoTrack() const
-    {
-        return recotrack_;
-    }
-    
-    // return the TrackingParticle to which the Track was matched
-    const std::pair<TrackingParticleRef, double>  getMatchedTrackingParticle() const
-    {
-    	std::pair<TrackingParticleRef, double> result;
-    	result.first = trackingParticle_;
-    	result.second = quality_;
-    	
-    	return result;
-    }
+  // return the TrackingParticle to which the Track was matched
+  const std::pair<TrackingParticleRef, double>
+  getMatchedTrackingParticle() const {
+    std::pair<TrackingParticleRef, double> result;
+    result.first = trackingParticle_;
+    result.second = quality_;
 
-    double quality() const
-    {
-        return quality_;
-    }
+    return result;
+  }
+
+  double quality() const { return quality_; }
 
 private:
+  bool newEvent_;
 
-    bool newEvent_;
+  bool bestMatchByMaxValue_;
 
-    bool bestMatchByMaxValue_;
+  bool enableRecoToSim_, enableSimToReco_;
 
-    bool enableRecoToSim_, enableSimToReco_;
+  double quality_;
 
-    double quality_;
+  edm::InputTag trackProducer_;
 
-    edm::InputTag trackProducer_;
+  edm::InputTag trackingTruth_;
 
-    edm::InputTag trackingTruth_;
+  edm::InputTag trackAssociator_;
 
-    edm::InputTag trackAssociator_;
+  reco::TrackBaseRef recotrack_;
 
-    reco::TrackBaseRef recotrack_;
-    
-    TrackingParticleRef trackingParticle_;
+  TrackingParticleRef trackingParticle_;
 
-    reco::RecoToSimCollection recoToSim_;
+  reco::RecoToSimCollection recoToSim_;
 
-    reco::SimToRecoCollection simToReco_;
-
+  reco::SimToRecoCollection simToReco_;
 };
 
 #endif

--- a/SimTracker/TrackHistory/interface/TrackQuality.h
+++ b/SimTracker/TrackHistory/interface/TrackQuality.h
@@ -2,22 +2,22 @@
  *  TrackQuality.h
  *
  *  Created by Christophe Saout on 9/25/08.
- *  2007 __MyCompanyName__. 
+ *  2007 __MyCompanyName__.
  *
  */
 
 #ifndef TrackQuality_h
 #define TrackQuality_h
 
-#include <vector>
 #include <memory>
+#include <vector>
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 
-#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
@@ -25,75 +25,72 @@
 class TrackerTopology;
 
 //! This class analyses the reconstruction quality for a given track
-class TrackQuality
-{
+class TrackQuality {
 public:
-    typedef std::vector<TrackingParticleRef> SimParticleTrail;
+  typedef std::vector<TrackingParticleRef> SimParticleTrail;
 
-    struct Layer
-    {
-        enum SubDet
-        {
-            Invalid = 0,
-            PixelBarrel, PixelForward,
-            StripTIB, StripTID, StripTOB, StripTEC,
-            MuonDT, MuonCSC, MuonRPCBarrel, MuonRPCEndcap
-        };
-
-        enum State
-        {
-            Unknown = 0,
-            Good,
-            Missed,
-            Noise,
-            Bad,
-            Dead,
-            Shared,
-            Misassoc
-        };
-
-        struct Hit
-        {
-            short int recHitId;
-            State state;
-        };
-
-        SubDet subDet;
-        short int layer;
-        std::vector<Hit> hits;
+  struct Layer {
+    enum SubDet {
+      Invalid = 0,
+      PixelBarrel,
+      PixelForward,
+      StripTIB,
+      StripTID,
+      StripTOB,
+      StripTEC,
+      MuonDT,
+      MuonCSC,
+      MuonRPCBarrel,
+      MuonRPCEndcap
     };
 
+    enum State {
+      Unknown = 0,
+      Good,
+      Missed,
+      Noise,
+      Bad,
+      Dead,
+      Shared,
+      Misassoc
+    };
+
+    struct Hit {
+      short int recHitId;
+      State state;
+    };
+
+    SubDet subDet;
+    short int layer;
+    std::vector<Hit> hits;
+  };
+
 public:
-    //! Constructor by pset.
-    /* Creates a TrackQuality object from a pset.
+  //! Constructor by pset.
+  /* Creates a TrackQuality object from a pset.
 
-       /param[in] pset with the configuration values
-    */
-    TrackQuality(const edm::ParameterSet &, edm::ConsumesCollector& iC);
+     /param[in] pset with the configuration values
+  */
+  TrackQuality(const edm::ParameterSet &, edm::ConsumesCollector &iC);
 
-    //! Pre-process event information (for accessing reconstruction information)
-    void newEvent(const edm::Event &, const edm::EventSetup &);
+  //! Pre-process event information (for accessing reconstruction information)
+  void newEvent(const edm::Event &, const edm::EventSetup &);
 
-    //! Compute information about the track reconstruction quality
-    void evaluate(SimParticleTrail const &, reco::TrackBaseRef const &, const TrackerTopology *tTopo);
+  //! Compute information about the track reconstruction quality
+  void evaluate(SimParticleTrail const &, reco::TrackBaseRef const &,
+                const TrackerTopology *tTopo);
 
-    //! Return the number of layers with simulated and/or reconstructed hits
-    unsigned int numberOfLayers() const
-    {
-        return layers_.size();
-    }
+  //! Return the number of layers with simulated and/or reconstructed hits
+  unsigned int numberOfLayers() const { return layers_.size(); }
 
-    //! Return information about the given layer by index
-    const Layer &layer(unsigned int index) const
-    {
-        return layers_[index];
-    }
+  //! Return information about the given layer by index
+  const Layer &layer(unsigned int index) const { return layers_[index]; }
 
 private:
-    TrackerHitAssociator::Config trackerHitAssociatorConfig_;
-    std::unique_ptr<TrackerHitAssociator> associator_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
+  std::unique_ptr<TrackerHitAssociator> associator_;
 
-    std::vector<Layer> layers_;
+  std::vector<Layer> layers_;
 };
 
 #endif

--- a/SimTracker/TrackHistory/interface/Utils.h
+++ b/SimTracker/TrackHistory/interface/Utils.h
@@ -6,40 +6,44 @@
 #include <vector>
 
 //! Generic matching function
-template<typename Reference, typename Association>
-std::pair<typename Association::data_type::first_type, double> match (Reference key, Association association, bool bestMatchByMaxValue)
-{
-    typename Association::data_type::first_type value;
+template <typename Reference, typename Association>
+std::pair<typename Association::data_type::first_type, double>
+match(Reference key, Association association, bool bestMatchByMaxValue) {
+  typename Association::data_type::first_type value;
 
-    typename Association::const_iterator pos = association.find(key);
+  typename Association::const_iterator pos = association.find(key);
 
-    if (pos == association.end()) return std::pair<typename Association::data_type::first_type, double> (value, 0);
+  if (pos == association.end())
+    return std::pair<typename Association::data_type::first_type, double>(value,
+                                                                          0);
 
-    const std::vector<typename Association::data_type> & matches = pos->val;
+  const std::vector<typename Association::data_type> &matches = pos->val;
 
-    double q = bestMatchByMaxValue ? -1e30 : 1e30;
+  double q = bestMatchByMaxValue ? -1e30 : 1e30;
 
-    for (std::size_t i = 0; i < matches.size(); ++i)
-        if (bestMatchByMaxValue ? (matches[i].second > q) : (matches[i].second < q))
-        {
-            value = matches[i].first;
-            q = matches[i].second;
-        }
+  for (std::size_t i = 0; i < matches.size(); ++i)
+    if (bestMatchByMaxValue ? (matches[i].second > q)
+                            : (matches[i].second < q)) {
+      value = matches[i].first;
+      q = matches[i].second;
+    }
 
-    return std::pair<typename Association::data_type::first_type, double> (value, q);
+  return std::pair<typename Association::data_type::first_type, double>(value,
+                                                                        q);
 }
 
-//! Class that maps the native Geant4 process types to the legacy CMS process types
+//! Class that maps the native Geant4 process types to the legacy CMS process
+//! types
 class G4toCMSLegacyProcTypeMap {
-  public:
-    typedef std::map<unsigned int,unsigned int> MapType;
+public:
+  typedef std::map<unsigned int, unsigned int> MapType;
 
-    G4toCMSLegacyProcTypeMap();
+  G4toCMSLegacyProcTypeMap();
 
-    const unsigned int processId(unsigned int g4ProcessId) const;
+  const unsigned int processId(unsigned int g4ProcessId) const;
 
-  private:
-    MapType m_map;
+private:
+  MapType m_map;
 };
 
 #endif

--- a/SimTracker/TrackHistory/interface/VertexCategories.h
+++ b/SimTracker/TrackHistory/interface/VertexCategories.h
@@ -2,97 +2,80 @@
 #ifndef VertexCategories_h
 #define VertexCategories_h
 
-#include <vector>
 #include <ostream>
+#include <vector>
 
-class VertexCategories
-{
+class VertexCategories {
 
 public:
+  //! Categories available to vertexes
+  enum Category {
+    Fake = 0,
+    Reconstructed = Fake,
+    SignalEvent,
+    BWeakDecay,
+    CWeakDecay,
+    TauDecay,
+    KsDecay,
+    LambdaDecay,
+    JpsiDecay,
+    XiDecay,
+    OmegaDecay,
+    SigmaPlusDecay,
+    SigmaMinusDecay,
+    LongLivedDecay,
+    KnownProcess,
+    UndefinedProcess,
+    UnknownProcess,
+    PrimaryProcess,
+    HadronicProcess,
+    DecayProcess,
+    ComptonProcess,
+    AnnihilationProcess,
+    EIoniProcess,
+    HIoniProcess,
+    MuIoniProcess,
+    PhotonProcess,
+    MuPairProdProcess,
+    ConversionsProcess,
+    EBremProcess,
+    SynchrotronRadiationProcess,
+    MuBremProcess,
+    MuNuclProcess,
+    PrimaryVertex,
+    SecondaryVertex,
+    TertiaryVertex,
+    TierciaryVertex = TertiaryVertex,
+    Unknown
+  };
 
-    //! Categories available to vertexes
-    enum Category
-    {
-        Fake = 0,
-        Reconstructed = Fake,
-        SignalEvent,
-        BWeakDecay,
-        CWeakDecay,
-        TauDecay,
-        KsDecay,
-        LambdaDecay,
-        JpsiDecay,
-        XiDecay,
-        OmegaDecay,
-        SigmaPlusDecay,
-        SigmaMinusDecay,
-        LongLivedDecay,
-        KnownProcess,
-        UndefinedProcess,
-        UnknownProcess,
-        PrimaryProcess,
-        HadronicProcess,
-        DecayProcess,
-        ComptonProcess,
-        AnnihilationProcess,
-        EIoniProcess,
-        HIoniProcess,
-        MuIoniProcess,
-        PhotonProcess,
-        MuPairProdProcess,
-        ConversionsProcess,
-        EBremProcess,
-        SynchrotronRadiationProcess,
-        MuBremProcess,
-        MuNuclProcess,
-        PrimaryVertex,
-        SecondaryVertex,
-        TertiaryVertex,
-        TierciaryVertex = TertiaryVertex,
-        Unknown
-    };
+  //! Name of the different categories
+  static const char *const Names[];
 
-    //! Name of the different categories
-    static const char * const Names[];
+  //! Main types associated to the class
+  typedef std::vector<bool> Flags;
 
-    //! Main types associated to the class
-    typedef std::vector<bool> Flags;
+  //! Void constructor
+  VertexCategories() { reset(); }
 
-    //! Void constructor
-    VertexCategories()
-    {
-        reset();
-    }
+  //! Returns track flag for a given category
+  bool is(Category category) const { return flags_[category]; }
 
-    //! Returns track flag for a given category
-    bool is(Category category) const
-    {
-        return flags_[category];
-    }
-
-    //! Returns flags with the category descriptions
-    const Flags & flags() const
-    {
-        return flags_;
-    }
+  //! Returns flags with the category descriptions
+  const Flags &flags() const { return flags_; }
 
 protected:
+  //! Reset the categories flags
+  void reset() { flags_ = Flags(Unknown + 1, false); }
 
-    //! Reset the categories flags
-    void reset()
-    {
-        flags_ = Flags(Unknown + 1, false);
-    }
+  // Check for unkown classification
+  void unknownVertex();
 
-    // Check for unkown classification
-    void unknownVertex();
-
-    //! Flag containers
-    Flags flags_;
-
+  //! Flag containers
+  Flags flags_;
 };
 
 // Operation overload for printing the categories
-std::ostream & operator<< (std::ostream &, VertexCategories const &);
+std::ostream &operator<<(std::ostream &, VertexCategories const &);
 
 #endif

--- a/SimTracker/TrackHistory/interface/VertexClassifier.h
+++ b/SimTracker/TrackHistory/interface/VertexClassifier.h
@@ -15,99 +15,89 @@
 #include "SimTracker/TrackHistory/interface/VertexHistory.h"
 
 //! Get track history and classify it in function of their .
-class VertexClassifier : public VertexCategories
-{
+class VertexClassifier : public VertexCategories {
 
 public:
+  //! Type to the associate category
+  typedef VertexCategories Categories;
 
-    //! Type to the associate category
-    typedef VertexCategories Categories;
+  //! Constructor by ParameterSet
+  VertexClassifier(edm::ParameterSet const &pset, edm::ConsumesCollector &&);
 
-    //! Constructor by ParameterSet
-    VertexClassifier(edm::ParameterSet const & pset,
-                     edm::ConsumesCollector&&);
+  virtual ~VertexClassifier() {}
 
-    virtual ~VertexClassifier() {}
+  //! Pre-process event information (for accessing reconstraction information)
+  virtual void newEvent(edm::Event const &, edm::EventSetup const &);
 
-    //! Pre-process event information (for accessing reconstraction information)
-    virtual void newEvent(edm::Event const &, edm::EventSetup const &);
+  //! Classify the RecoVertex in categories.
+  VertexClassifier const &evaluate(reco::VertexBaseRef const &);
 
-    //! Classify the RecoVertex in categories.
-    VertexClassifier const & evaluate (reco::VertexBaseRef const &);
+  //! Classify the TrackingVertex in categories.
+  VertexClassifier const &evaluate(TrackingVertexRef const &);
 
-    //! Classify the TrackingVertex in categories.
-    VertexClassifier const & evaluate (TrackingVertexRef const &);
+  //! Classify the RecoVertex in categories.
+  VertexClassifier const &evaluate(reco::VertexRef const &vertex) {
+    return evaluate(reco::VertexBaseRef(vertex));
+  }
 
-    //! Classify the RecoVertex in categories.
-    VertexClassifier const & evaluate (reco::VertexRef const & vertex)
-    {
-        return evaluate( reco::VertexBaseRef(vertex) );
-    }
-
-    //! Returns a reference to the vertex history used in the classification.
-    VertexHistory const & history() const
-    {
-        return tracer_;
-    }
+  //! Returns a reference to the vertex history used in the classification.
+  VertexHistory const &history() const { return tracer_; }
 
 private:
+  VertexHistory tracer_;
 
-    VertexHistory tracer_;
+  const G4toCMSLegacyProcTypeMap g4toCMSProcMap_;
 
-    const G4toCMSLegacyProcTypeMap g4toCMSProcMap_;
+  const edm::InputTag hepMCLabel_;
 
-    const edm::InputTag hepMCLabel_;
+  double longLivedDecayLength_;
+  double vertexClusteringDistance_;
 
-    double longLivedDecayLength_;
-    double vertexClusteringDistance_;
+  edm::Handle<edm::HepMCProduct> mcInformation_;
 
-    edm::Handle<edm::HepMCProduct> mcInformation_;
+  edm::ESHandle<ParticleDataTable> particleDataTable_;
 
-    edm::ESHandle<ParticleDataTable> particleDataTable_;
+  //! Get reconstruction information
+  void reconstructionInformation(reco::TrackBaseRef const &);
 
-    //! Get reconstruction information
-    void reconstructionInformation(reco::TrackBaseRef const &);
+  //! Get all the information related to the simulation details
+  void simulationInformation();
 
-    //! Get all the information related to the simulation details
-    void simulationInformation();
+  //! Get all the information related to decay process
+  void processesAtGenerator();
 
-    //! Get all the information related to decay process
-    void processesAtGenerator();
+  //! Get information about conversion and other interactions
+  void processesAtSimulation();
 
-    //! Get information about conversion and other interactions
-    void processesAtSimulation();
+  //! Get geometrical information about the vertices
+  void vertexInformation();
 
-    //! Get geometrical information about the vertices
-    void vertexInformation();
+  //! Auxiliary class holding simulated primary vertices
+  struct GeneratedPrimaryVertex {
+    GeneratedPrimaryVertex(double x1, double y1, double z1)
+        : x(x1), y(y1), z(z1), ptsq(0), nGenTrk(0) {}
 
-    //! Auxiliary class holding simulated primary vertices
-    struct GeneratedPrimaryVertex
-    {
-        GeneratedPrimaryVertex(double x1,double y1,double z1): x(x1), y(y1), z(z1), ptsq(0), nGenTrk(0) {}
+    bool operator<(GeneratedPrimaryVertex const &reference) const {
+      return ptsq < reference.ptsq;
+    }
 
-        bool operator< ( GeneratedPrimaryVertex const & reference) const
-        {
-            return ptsq < reference.ptsq;
-        }
+    double x, y, z;
+    double ptsq;
+    int nGenTrk;
 
-        double x, y, z;
-        double ptsq;
-        int nGenTrk;
+    HepMC::FourVector ptot;
 
-        HepMC::FourVector ptot;
+    std::vector<int> finalstateParticles;
+    std::vector<int> simTrackIndex;
+    std::vector<int> genVertex;
+  };
 
-        std::vector<int> finalstateParticles;
-        std::vector<int> simTrackIndex;
-        std::vector<int> genVertex;
-    };
+  std::vector<GeneratedPrimaryVertex> genpvs_;
 
-    std::vector<GeneratedPrimaryVertex> genpvs_;
-
-    // Auxiliary function to get the generated primary vertex
-    bool isFinalstateParticle(const HepMC::GenParticle *);
-    bool isCharged(const HepMC::GenParticle *);
-    void genPrimaryVertices();
-
+  // Auxiliary function to get the generated primary vertex
+  bool isFinalstateParticle(const HepMC::GenParticle *);
+  bool isCharged(const HepMC::GenParticle *);
+  void genPrimaryVertices();
 };
 
 #endif

--- a/SimTracker/TrackHistory/interface/VertexClassifierByProxy.h
+++ b/SimTracker/TrackHistory/interface/VertexClassifierByProxy.h
@@ -8,102 +8,94 @@
 
 //! Get track history and classification by proxy
 template <typename Collection>
-class VertexClassifierByProxy : public VertexClassifier
-{
+class VertexClassifierByProxy : public VertexClassifier {
 
 public:
+  //! Association type.
+  typedef edm::AssociationMap<
+      edm::OneToMany<Collection, reco::VertexCollection>>
+      Association;
 
-    //! Association type.
-    typedef edm::AssociationMap<edm::OneToMany<Collection, reco::VertexCollection> > Association;
+  //! Constructor by ParameterSet.
+  VertexClassifierByProxy(edm::ParameterSet const &config,
+                          edm::ConsumesCollector &&collector)
+      : VertexClassifier(config, std::move(collector)),
+        proxy_(config.getUntrackedParameter<edm::InputTag>("vertexProducer")) {
+    collector.consumes<Association>(proxy_);
+  }
 
-    //! Constructor by ParameterSet.
-    VertexClassifierByProxy(edm::ParameterSet const & config,
-                            edm::ConsumesCollector&& collector) : VertexClassifier(config,std::move(collector)),
-            proxy_( config.getUntrackedParameter<edm::InputTag>("vertexProducer") ) {
-      collector.consumes<Association>(proxy_);
+  //! Pre-process event information (for accessing reconstraction information).
+  void newEvent(edm::Event const &event,
+                edm::EventSetup const &config) override {
+    // Get the association part of the proxy to the collection
+    event.getByLabel(proxy_, proxyHandler_);
+    // Call the previous new event
+    VertexClassifier::newEvent(event, config);
+  }
+
+  //! Classify the TrackingVertex in categories.
+  VertexClassifierByProxy<Collection> const &
+  evaluate(TrackingVertexRef const &vertex) {
+    VertexClassifier::evaluate(vertex);
+    return *this;
+  }
+
+  //! Classify any vertexes in categories.
+  VertexClassifierByProxy<Collection> const &
+  evaluate(edm::Ref<Collection> const &vertex, std::size_t index) {
+    const reco::VertexRefVector *vertexes = nullptr;
+
+    try {
+      // Get a reference to the vector of associated vertexes
+      vertexes = &(proxyHandler_->find(vertex)->val);
+    } catch (edm::Exception &e) {
+      // If association fails define the vertex as unknown
+      reset();
+      unknownVertex();
+      return *this;
     }
 
-    //! Pre-process event information (for accessing reconstraction information).
-    void newEvent(edm::Event const & event, edm::EventSetup const & config) override
-    {
-        // Get the association part of the proxy to the collection
-        event.getByLabel(proxy_, proxyHandler_);
-        // Call the previous new event
-        VertexClassifier::newEvent(event, config);
+    // Evaluate the history for a given index
+    VertexClassifier::evaluate(vertexes->at(index));
+
+    return *this;
+  }
+
+  //! Classify any vertexes in categories.
+  VertexClassifierByProxy<Collection> const &
+  evaluate(edm::Ref<Collection> const &vertex) {
+    const reco::VertexRefVector *vertexes = nullptr;
+
+    try {
+      // Get a reference to the vector of associated vertexes
+      vertexes = &(proxyHandler_->find(vertex)->val);
+    } catch (edm::Exception &e) {
+      // If association fails define the vertex as unknown
+      reset();
+      unknownVertex();
+      return *this;
     }
 
-    //! Classify the TrackingVertex in categories.
-    VertexClassifierByProxy<Collection> const & evaluate (TrackingVertexRef const & vertex)
-    {
-        VertexClassifier::evaluate(vertex);
-        return *this;
+    // Loop over all the associated vertexes
+    for (std::size_t index = 0; index < vertexes->size(); ++index) {
+      // Copy the last status for all the flags
+      Flags flags(flags_);
+
+      // Evaluate the history for a given index
+      VertexClassifier::evaluate(vertexes->at(index));
+
+      // Combine OR the flag information
+      for (std::size_t i = 0; i < flags_.size(); ++i)
+        flags_[i] = flags_[i] | flags[i];
     }
 
-    //! Classify any vertexes in categories.
-    VertexClassifierByProxy<Collection> const & evaluate (edm::Ref<Collection> const & vertex, std::size_t index)
-    {
-        const reco::VertexRefVector * vertexes = nullptr;
-
-        try
-        {
-            // Get a reference to the vector of associated vertexes
-            vertexes = &(proxyHandler_->find(vertex)->val);
-        }
-        catch (edm::Exception& e)
-        {
-            // If association fails define the vertex as unknown
-            reset();
-            unknownVertex();
-            return *this;
-        }
-
-        // Evaluate the history for a given index
-        VertexClassifier::evaluate( vertexes->at(index) );
-
-        return *this;
-    }
-
-    //! Classify any vertexes in categories.
-    VertexClassifierByProxy<Collection> const & evaluate (edm::Ref<Collection> const & vertex)
-    {
-        const reco::VertexRefVector * vertexes = nullptr;
-
-        try
-        {
-            // Get a reference to the vector of associated vertexes
-            vertexes = &(proxyHandler_->find(vertex)->val);
-        }
-        catch (edm::Exception& e)
-        {
-            // If association fails define the vertex as unknown
-            reset();
-            unknownVertex();
-            return *this;
-        }
-
-        // Loop over all the associated vertexes
-        for (std::size_t index = 0; index < vertexes->size(); ++index)
-        {
-            // Copy the last status for all the flags
-            Flags flags(flags_);
-
-            // Evaluate the history for a given index
-            VertexClassifier::evaluate( vertexes->at(index) );
-
-            // Combine OR the flag information
-            for (std::size_t i = 0; i < flags_.size(); ++i)
-                flags_[i] = flags_[i] | flags[i];
-        }
-
-        return *this;
-    }
+    return *this;
+  }
 
 private:
+  const edm::InputTag proxy_;
 
-    const edm::InputTag proxy_;
-
-    edm::Handle<Association> proxyHandler_;
-
+  edm::Handle<Association> proxyHandler_;
 };
 
 #endif

--- a/SimTracker/TrackHistory/interface/VertexHistory.h
+++ b/SimTracker/TrackHistory/interface/VertexHistory.h
@@ -4,94 +4,81 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "SimDataFormats/Associations/interface/VertexAssociation.h"
 #include "SimTracker/TrackHistory/interface/HistoryBase.h"
 #include "SimTracker/TrackHistory/interface/Utils.h"
-#include "SimDataFormats/Associations/interface/VertexAssociation.h"
 
 //! This class traces the simulated and generated history of a given track.
-class VertexHistory : public HistoryBase
-{
+class VertexHistory : public HistoryBase {
 
 public:
+  //! Constructor by pset.
+  /* Creates a VertexHistory with association given by pset.
 
-    //! Constructor by pset.
-    /* Creates a VertexHistory with association given by pset.
+     /param[in] config with the configuration values
+  */
+  VertexHistory(const edm::ParameterSet &, edm::ConsumesCollector &&);
 
-       /param[in] config with the configuration values
-    */
-    VertexHistory(const edm::ParameterSet &,
-                  edm::ConsumesCollector&&);
+  //! Pre-process event information (for accessing reconstruction information)
+  void newEvent(const edm::Event &, const edm::EventSetup &);
 
-    //! Pre-process event information (for accessing reconstruction information)
-    void newEvent(const edm::Event &, const edm::EventSetup &);
+  //! Evaluate track history using a TrackingParticleRef.
+  /* Return false when the history cannot be determined upto a given depth.
+     If not depth is pass to the function no restriction are apply to it.
 
-    //! Evaluate track history using a TrackingParticleRef.
-    /* Return false when the history cannot be determined upto a given depth.
-       If not depth is pass to the function no restriction are apply to it.
+     /param[in] trackingVertexRef of a simulated track
+     /param[in] depth of the vertex history
+     /param[out] boolean that is true when history can be determined
+  */
+  bool evaluate(TrackingVertexRef tvr) {
+    if (enableSimToReco_) {
 
-       /param[in] trackingVertexRef of a simulated track
-       /param[in] depth of the vertex history
-       /param[out] boolean that is true when history can be determined
-    */
-    bool evaluate(TrackingVertexRef tvr)
-    {
-        if ( enableSimToReco_ )
-        {
-
-            std::pair<reco::VertexBaseRef, double> result =  match(tvr, simToReco_, bestMatchByMaxValue_);
-            recovertex_ = result.first;
-            quality_ =  result.second;
-        }
-        return HistoryBase::evaluate(tvr);
+      std::pair<reco::VertexBaseRef, double> result =
+          match(tvr, simToReco_, bestMatchByMaxValue_);
+      recovertex_ = result.first;
+      quality_ = result.second;
     }
+    return HistoryBase::evaluate(tvr);
+  }
 
+  //! Evaluate reco::Vertex history using a given association.
+  /* Return false when the track association is not possible (fake track).
 
-    //! Evaluate reco::Vertex history using a given association.
-    /* Return false when the track association is not possible (fake track).
+     /param[in] VertexRef to a reco::track
+     /param[out] boolean that is false when a fake track is detected
+  */
+  bool evaluate(reco::VertexBaseRef);
 
-       /param[in] VertexRef to a reco::track
-       /param[out] boolean that is false when a fake track is detected
-    */
-    bool evaluate (reco::VertexBaseRef);
+  //! Return a reference to the reconstructed track.
+  const reco::VertexBaseRef &recoVertex() const { return recovertex_; }
 
-    //! Return a reference to the reconstructed track.
-    const reco::VertexBaseRef & recoVertex() const
-    {
-        return recovertex_;
-    }
-
-    //! Return the quality of the match.
-    double quality() const
-    {
-        return quality_;
-    }
-
+  //! Return the quality of the match.
+  double quality() const { return quality_; }
 
 private:
+  bool bestMatchByMaxValue_;
 
-    bool bestMatchByMaxValue_;
+  bool enableRecoToSim_, enableSimToReco_;
 
-    bool enableRecoToSim_, enableSimToReco_;
+  double quality_;
 
-    double quality_;
+  edm::InputTag vertexProducer_;
 
-    edm::InputTag vertexProducer_;
+  edm::InputTag trackingTruth_;
 
-    edm::InputTag trackingTruth_;
+  edm::InputTag vertexAssociator_;
 
-    edm::InputTag vertexAssociator_;
+  reco::VertexBaseRef recovertex_;
 
-    reco::VertexBaseRef recovertex_;
+  reco::VertexRecoToSimCollection recoToSim_;
 
-    reco::VertexRecoToSimCollection recoToSim_;
-
-    reco::VertexSimToRecoCollection simToReco_;
+  reco::VertexSimToRecoCollection simToReco_;
 };
 
 #endif

--- a/SimTracker/TrackHistory/plugins/CategorySelectors.cc
+++ b/SimTracker/TrackHistory/plugins/CategorySelectors.cc
@@ -4,7 +4,6 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -16,31 +15,36 @@
 #include "SimTracker/TrackHistory/interface/VertexClassifier.h"
 #include "SimTracker/TrackHistory/interface/VertexClassifierByProxy.h"
 
-namespace reco
-{
-namespace modules
-{
+namespace reco {
+namespace modules {
 
 // Generic TrackCategory selector
 
-typedef ObjectSelector<CategoryCriteria<TrackCollection, TrackClassifier> > TrackCategorySelector;
+typedef ObjectSelector<CategoryCriteria<TrackCollection, TrackClassifier>>
+    TrackCategorySelector;
 DEFINE_FWK_MODULE(TrackCategorySelector);
 
-typedef ObjectSelector<CategoryCriteria<TrackingParticleCollection, TrackClassifier> > TrackingParticleCategorySelector;
+typedef ObjectSelector<
+    CategoryCriteria<TrackingParticleCollection, TrackClassifier>>
+    TrackingParticleCategorySelector;
 DEFINE_FWK_MODULE(TrackingParticleCategorySelector);
 
 // Generic VertexCategory selector
 
-typedef ObjectSelector<CategoryCriteria<VertexCollection, VertexClassifier> > VertexCategorySelector;
+typedef ObjectSelector<CategoryCriteria<VertexCollection, VertexClassifier>>
+    VertexCategorySelector;
 DEFINE_FWK_MODULE(VertexCategorySelector);
 
-typedef ObjectSelector<CategoryCriteria<TrackingVertexCollection, VertexClassifier> > TrackingVertexCategorySelector;
+typedef ObjectSelector<
+    CategoryCriteria<TrackingVertexCollection, VertexClassifier>>
+    TrackingVertexCategorySelector;
 DEFINE_FWK_MODULE(TrackingVertexCategorySelector);
 
 typedef ObjectSelector<
-CategoryCriteria<SecondaryVertexTagInfoCollection, VertexClassifierByProxy<SecondaryVertexTagInfoCollection> >
-> SecondaryVertexTagInfoCategorySelector;
+    CategoryCriteria<SecondaryVertexTagInfoCollection,
+                     VertexClassifierByProxy<SecondaryVertexTagInfoCollection>>>
+    SecondaryVertexTagInfoCategorySelector;
 DEFINE_FWK_MODULE(SecondaryVertexTagInfoCategorySelector);
 
-}
-}
+} // namespace modules
+} // namespace reco

--- a/SimTracker/TrackHistory/plugins/GenTrackMatcher.cc
+++ b/SimTracker/TrackHistory/plugins/GenTrackMatcher.cc
@@ -6,14 +6,12 @@
  *
  */
 
-
-#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/Common/interface/Association.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "SimTracker/TrackHistory/interface/TrackHistory.h"
 
-namespace edm
-{
+namespace edm {
 class ParameterSet;
 }
 
@@ -21,76 +19,74 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-class GenTrackMatcher : public edm::stream::EDProducer<>
-{
+class GenTrackMatcher : public edm::stream::EDProducer<> {
 public:
-    /// constructor
-    GenTrackMatcher( const edm::ParameterSet & );
+  /// constructor
+  GenTrackMatcher(const edm::ParameterSet &);
 
 private:
-    void produce( edm::Event& evt, const edm::EventSetup& es ) override;
-    TrackHistory tracer_;
-    edm::EDGetTokenT<View<Track>> tracks_;
-    edm::EDGetTokenT<GenParticleCollection> genParticles_;
-    edm::EDGetTokenT<vector<int>> genParticleInts_;
-    typedef edm::Association<reco::GenParticleCollection> GenParticleMatch;
+  void produce(edm::Event &evt, const edm::EventSetup &es) override;
+  TrackHistory tracer_;
+  edm::EDGetTokenT<View<Track>> tracks_;
+  edm::EDGetTokenT<GenParticleCollection> genParticles_;
+  edm::EDGetTokenT<vector<int>> genParticleInts_;
+  typedef edm::Association<reco::GenParticleCollection> GenParticleMatch;
 };
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
 
-GenTrackMatcher::GenTrackMatcher(const ParameterSet & p) :
-        tracer_(p,consumesCollector()),
-        tracks_(consumes<View<Track>>(p.getUntrackedParameter<edm::InputTag>("trackProducer"))),
-        genParticles_(consumes<GenParticleCollection>(p.getUntrackedParameter<edm::InputTag>("genParticles"))),
-        genParticleInts_(consumes<vector<int>>(p.getUntrackedParameter<edm::InputTag>("genParticles")))
-{
-    produces<GenParticleMatch>();
+GenTrackMatcher::GenTrackMatcher(const ParameterSet &p)
+    : tracer_(p, consumesCollector()),
+      tracks_(consumes<View<Track>>(
+          p.getUntrackedParameter<edm::InputTag>("trackProducer"))),
+      genParticles_(consumes<GenParticleCollection>(
+          p.getUntrackedParameter<edm::InputTag>("genParticles"))),
+      genParticleInts_(consumes<vector<int>>(
+          p.getUntrackedParameter<edm::InputTag>("genParticles"))) {
+  produces<GenParticleMatch>();
 }
 
-void GenTrackMatcher::produce(Event& evt, const EventSetup& es)
-{
-    Handle<View<Track> > tracks;
-    evt.getByToken(tracks_, tracks);
-    Handle<vector<int> > barCodes;
-    evt.getByToken(genParticles_, barCodes);
-    Handle<GenParticleCollection> genParticles;
-    evt.getByToken(genParticles_, genParticles);
-    unique_ptr<GenParticleMatch> match(new GenParticleMatch(GenParticleRefProd(genParticles)));
-    GenParticleMatch::Filler filler(*match);
-    size_t n = tracks->size();
-    vector<int> indices(n,-1);
-    tracer_.newEvent(evt, es);
-    for (size_t i = 0; i < n; ++ i )
-    {
-        RefToBase<Track> track(tracks, i);
-        if (tracer_.evaluate(track))
-        {
-            const HepMC::GenParticle * particle = tracer_.genParticle();
-            if (particle)
-            {
-                int barCode = particle->barcode();
-                vector<int>::const_iterator b = barCodes->begin(), e = barCodes->end(), f = find( b, e, barCode );
-                if (f == e) {
-                  edm::EDConsumerBase::Labels labels;
-                  labelsForToken(genParticles_, labels);
-                  throw edm::Exception(errors::InvalidReference)
-                    << "found matching particle with barcode" << *f
-                    << " which has not been found in " << labels.module;
-                }
-                indices[i] = *f;
-            }
+void GenTrackMatcher::produce(Event &evt, const EventSetup &es) {
+  Handle<View<Track>> tracks;
+  evt.getByToken(tracks_, tracks);
+  Handle<vector<int>> barCodes;
+  evt.getByToken(genParticles_, barCodes);
+  Handle<GenParticleCollection> genParticles;
+  evt.getByToken(genParticles_, genParticles);
+  unique_ptr<GenParticleMatch> match(
+      new GenParticleMatch(GenParticleRefProd(genParticles)));
+  GenParticleMatch::Filler filler(*match);
+  size_t n = tracks->size();
+  vector<int> indices(n, -1);
+  tracer_.newEvent(evt, es);
+  for (size_t i = 0; i < n; ++i) {
+    RefToBase<Track> track(tracks, i);
+    if (tracer_.evaluate(track)) {
+      const HepMC::GenParticle *particle = tracer_.genParticle();
+      if (particle) {
+        int barCode = particle->barcode();
+        vector<int>::const_iterator b = barCodes->begin(), e = barCodes->end(),
+                                    f = find(b, e, barCode);
+        if (f == e) {
+          edm::EDConsumerBase::Labels labels;
+          labelsForToken(genParticles_, labels);
+          throw edm::Exception(errors::InvalidReference)
+              << "found matching particle with barcode" << *f
+              << " which has not been found in " << labels.module;
         }
+        indices[i] = *f;
+      }
     }
-    filler.insert(tracks, indices.begin(), indices.end());
-    filler.fill();
-    evt.put(std::move(match));
+  }
+  filler.insert(tracks, indices.begin(), indices.end());
+  filler.fill();
+  evt.put(std::move(match));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( GenTrackMatcher );
-
+DEFINE_FWK_MODULE(GenTrackMatcher);

--- a/SimTracker/TrackHistory/plugins/JetVetoedTracksAssociatorAtVertex.cc
+++ b/SimTracker/TrackHistory/plugins/JetVetoedTracksAssociatorAtVertex.cc
@@ -9,66 +9,70 @@
 #include "DataFormats/Common/interface/EDProductfwd.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/JetReco/interface/Jet.h"
-#include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/JetReco/interface/JetTracksAssociation.h"
+#include "DataFormats/TrackReco/interface/Track.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 #include "SimTracker/TrackHistory/interface/JetVetoedTracksAssociatorDRVertex.h"
 
-class JetVetoedTracksAssociatorAtVertex : public edm::stream::EDProducer<>
-{
+class JetVetoedTracksAssociatorAtVertex : public edm::stream::EDProducer<> {
 public:
-    JetVetoedTracksAssociatorAtVertex(const edm::ParameterSet&);
-    ~JetVetoedTracksAssociatorAtVertex() override;
-    void produce(edm::Event&, const edm::EventSetup&) override;
+  JetVetoedTracksAssociatorAtVertex(const edm::ParameterSet &);
+  ~JetVetoedTracksAssociatorAtVertex() override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
+
 private:
-    edm::EDGetTokenT<edm::View<reco::Jet>> mJets;
-    edm::EDGetTokenT<reco::TrackCollection> mTracks;
-    JetVetoedTracksAssociationDRVertex mAssociator;
-    TrackClassifier classifier;
+  edm::EDGetTokenT<edm::View<reco::Jet>> mJets;
+  edm::EDGetTokenT<reco::TrackCollection> mTracks;
+  JetVetoedTracksAssociationDRVertex mAssociator;
+  TrackClassifier classifier;
 };
 
-JetVetoedTracksAssociatorAtVertex::JetVetoedTracksAssociatorAtVertex(const edm::ParameterSet& fConfig)
-        : mJets (consumes<edm::View<reco::Jet>>(fConfig.getParameter<edm::InputTag> ("jets"))),
-        mTracks (consumes<reco::TrackCollection>(fConfig.getParameter<edm::InputTag> ("tracks"))),
-        mAssociator (fConfig.getParameter<double> ("coneSize")),
-        classifier(fConfig,consumesCollector())
-{
-    produces<reco::JetTracksAssociation::Container> ();
+JetVetoedTracksAssociatorAtVertex::JetVetoedTracksAssociatorAtVertex(
+    const edm::ParameterSet &fConfig)
+    : mJets(consumes<edm::View<reco::Jet>>(
+          fConfig.getParameter<edm::InputTag>("jets"))),
+      mTracks(consumes<reco::TrackCollection>(
+          fConfig.getParameter<edm::InputTag>("tracks"))),
+      mAssociator(fConfig.getParameter<double>("coneSize")),
+      classifier(fConfig, consumesCollector()) {
+  produces<reco::JetTracksAssociation::Container>();
 }
 
 JetVetoedTracksAssociatorAtVertex::~JetVetoedTracksAssociatorAtVertex() {}
 
-void JetVetoedTracksAssociatorAtVertex::produce(edm::Event& fEvent, const edm::EventSetup& fSetup)
-{
-    // Gather contextual information for TrackCategories
-    classifier.newEvent(fEvent, fSetup);
+void JetVetoedTracksAssociatorAtVertex::produce(edm::Event &fEvent,
+                                                const edm::EventSetup &fSetup) {
+  // Gather contextual information for TrackCategories
+  classifier.newEvent(fEvent, fSetup);
 
-    edm::Handle <edm::View <reco::Jet> > jets_h;
-    fEvent.getByToken (mJets, jets_h);
-    edm::Handle <reco::TrackCollection> tracks_h;
-    fEvent.getByToken (mTracks, tracks_h);
+  edm::Handle<edm::View<reco::Jet>> jets_h;
+  fEvent.getByToken(mJets, jets_h);
+  edm::Handle<reco::TrackCollection> tracks_h;
+  fEvent.getByToken(mTracks, tracks_h);
 
-    std::unique_ptr<reco::JetTracksAssociation::Container> jetTracks (new reco::JetTracksAssociation::Container (reco::JetRefBaseProd(jets_h)));
+  std::unique_ptr<reco::JetTracksAssociation::Container> jetTracks(
+      new reco::JetTracksAssociation::Container(reco::JetRefBaseProd(jets_h)));
 
-    // format inputs
-    std::vector <edm::RefToBase<reco::Jet> > allJets;
-    allJets.reserve (jets_h->size());
-    for (unsigned i = 0; i < jets_h->size(); ++i) allJets.push_back (jets_h->refAt(i));
-    std::vector <reco::TrackRef> allTracks;
-    allTracks.reserve (tracks_h->size());
-    for (unsigned i = 0; i < tracks_h->size(); ++i) allTracks.push_back (reco::TrackRef (tracks_h, i));
-    // run algo
-    mAssociator.produce (&*jetTracks, allJets, allTracks, classifier);
-    // store output
-    fEvent.put(std::move(jetTracks));
+  // format inputs
+  std::vector<edm::RefToBase<reco::Jet>> allJets;
+  allJets.reserve(jets_h->size());
+  for (unsigned i = 0; i < jets_h->size(); ++i)
+    allJets.push_back(jets_h->refAt(i));
+  std::vector<reco::TrackRef> allTracks;
+  allTracks.reserve(tracks_h->size());
+  for (unsigned i = 0; i < tracks_h->size(); ++i)
+    allTracks.push_back(reco::TrackRef(tracks_h, i));
+  // run algo
+  mAssociator.produce(&*jetTracks, allJets, allTracks, classifier);
+  // store output
+  fEvent.put(std::move(jetTracks));
 }
 
 DEFINE_FWK_MODULE(JetVetoedTracksAssociatorAtVertex);
-

--- a/SimTracker/TrackHistory/plugins/QualityCutsAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/QualityCutsAnalyzer.cc
@@ -15,10 +15,10 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "TrackingTools/IPTools/interface/IPTools.h"
@@ -33,218 +33,212 @@
 // class decleration
 //
 
-class QualityCutsAnalyzer : public edm::one::EDAnalyzer<>
-{
+class QualityCutsAnalyzer : public edm::one::EDAnalyzer<> {
 
 public:
-
-    explicit QualityCutsAnalyzer(const edm::ParameterSet&);
-    ~QualityCutsAnalyzer() override;
+  explicit QualityCutsAnalyzer(const edm::ParameterSet &);
+  ~QualityCutsAnalyzer() override;
 
 private:
+  void beginJob() override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void endJob() override;
 
-    void beginJob() override ;
-    void analyze(const edm::Event&, const edm::EventSetup&) override;
-    void endJob() override;
+  // Member data
 
-    // Member data
+  typedef std::vector<int> vint;
+  typedef std::vector<std::string> vstring;
 
-    typedef std::vector<int> vint;
-    typedef std::vector<std::string> vstring;
+  edm::InputTag trackProducer_;
+  edm::InputTag primaryVertexProducer_;
+  edm::InputTag jetTracksAssociation_;
 
-    edm::InputTag trackProducer_;
-    edm::InputTag primaryVertexProducer_;
-    edm::InputTag jetTracksAssociation_;
+  std::string rootFile_;
 
-    std::string rootFile_;
+  int minimumNumberOfHits_, minimumNumberOfPixelHits_;
+  double minimumTransverseMomentum_, maximumChiSquared_;
 
-    int minimumNumberOfHits_, minimumNumberOfPixelHits_;
-    double minimumTransverseMomentum_, maximumChiSquared_;
+  bool useAllQualities_;
+  reco::TrackBase::TrackQuality trackQuality_;
 
-    bool useAllQualities_;
-    reco::TrackBase::TrackQuality trackQuality_;
+  void LoopOverJetTracksAssociation(
+      const edm::ESHandle<TransientTrackBuilder> &,
+      const edm::Handle<reco::VertexCollection> &,
+      const edm::Handle<reco::JetTracksAssociationCollection> &);
 
-    void
-    LoopOverJetTracksAssociation(
-        const edm::ESHandle<TransientTrackBuilder> &,
-        const edm::Handle<reco::VertexCollection> &,
-        const edm::Handle<reco::JetTracksAssociationCollection> &
-    );
+  // Histograms for optimization
 
-    // Histograms for optimization
+  struct histogram_element_t {
+    double sdl;            // Signed decay length
+    double dta;            // Distance to jet axis
+    double tip;            // Transverse impact parameter
+    double lip;            // Longitudinal impact parameter
+    double ips;            // Impact parameter significance.
+    double pt;             // Transverse momentum
+    double chi2;           // Chi^2
+    std::size_t hits;      // Number of hits
+    std::size_t pixelhits; // Number of hits
 
-    struct histogram_element_t
-    {
-        double sdl;  // Signed decay length
-        double dta;  // Distance to jet axis
-        double tip;  // Transverse impact parameter
-        double lip;  // Longitudinal impact parameter
-        double ips;  // Impact parameter significance.
-        double pt;   // Transverse momentum
-        double chi2; // Chi^2
-        std::size_t hits;      // Number of hits
-        std::size_t pixelhits; // Number of hits
+    histogram_element_t(double d, double a, double t, double l, double i,
+                        double p, double c, std::size_t h, std::size_t x) {
+      sdl = d;
+      dta = a;
+      tip = t;
+      lip = l;
+      ips = i;
+      pt = p;
+      chi2 = c;
+      hits = h;
+      pixelhits = x;
+    }
 
-        histogram_element_t(double d, double a, double t, double l, double i, double p, double c, std::size_t h, std::size_t x)
-        {
-            sdl = d;
-            dta = a;
-            tip = t;
-            lip = l;
-            ips = i;
-            pt = p;
-            chi2 = c;
-            hits = h;
-            pixelhits = x;
-        }
+    histogram_element_t(const histogram_element_t &orig) {
+      sdl = orig.sdl;
+      dta = orig.dta;
+      tip = orig.tip;
+      lip = orig.lip;
+      ips = orig.ips;
+      pt = orig.pt;
+      chi2 = orig.chi2;
+      hits = orig.hits;
+      pixelhits = orig.pixelhits;
+    }
+  };
 
-        histogram_element_t(const histogram_element_t & orig)
-        {
-            sdl = orig.sdl;
-            dta = orig.dta;
-            tip = orig.tip;
-            lip = orig.lip;
-            ips = orig.ips;
-            pt = orig.pt;
-            chi2 = orig.chi2;
-            hits = orig.hits;
-            pixelhits = orig.pixelhits;
-        }
-    };
+  typedef std::vector<std::vector<histogram_element_t>> histogram_data_t;
+  histogram_data_t histogram_data_;
 
-    typedef std::vector<std::vector<histogram_element_t> > histogram_data_t;
-    histogram_data_t histogram_data_;
+  class histogram_t {
 
-    class histogram_t
-    {
+    TH1F *sdl;
+    TH1F *dta;
+    TH1F *tip;
+    TH1F *lip;
+    TH1F *ips;
+    TH1F *pixelhits;
+    TH1F *pt_1gev;
+    TH1F *chi2;
+    TH1F *hits;
 
-        TH1F* sdl;
-        TH1F* dta;
-        TH1F* tip;
-        TH1F* lip;
-        TH1F* ips;
-        TH1F* pixelhits;
-        TH1F* pt_1gev;
-        TH1F* chi2;
-        TH1F* hits;
+  public:
+    histogram_t(const std::string &particleType) {
+      std::string name, title;
+      name = std::string("hits_") + particleType;
+      title = std::string("Hit distribution for ") + particleType;
+      hits = new TH1F(name.c_str(), title.c_str(), 19, -0.5, 18.5);
 
-    public:
+      name = std::string("chi2_") + particleType;
+      title = std::string("Chi2 distribution for ") + particleType;
+      chi2 = new TH1F(name.c_str(), title.c_str(), 100, 0., 30.);
 
-        histogram_t(const std::string & particleType)
-        {
-            std::string name, title;
-            name = std::string("hits_") + particleType;
-            title = std::string("Hit distribution for ") + particleType;
-            hits = new TH1F(name.c_str(), title.c_str(), 19, -0.5, 18.5);
+      name = std::string("pixelhits_") + particleType;
+      title = std::string("Pixel hits distribution for ") + particleType;
+      pixelhits = new TH1F(name.c_str(), title.c_str(), 21, -0.5, 20.5);
 
-            name = std::string("chi2_") + particleType;
-            title = std::string("Chi2 distribution for ") + particleType;
-            chi2 = new TH1F(name.c_str(), title.c_str(), 100, 0., 30.);
+      name = std::string("pt_1Gev_") + particleType;
+      title = std::string("Pt distribution close 1Gev for ") + particleType;
+      pt_1gev = new TH1F(name.c_str(), title.c_str(), 100, 0., 2.);
 
-            name = std::string("pixelhits_") + particleType;
-            title = std::string("Pixel hits distribution for ") + particleType;
-            pixelhits = new TH1F(name.c_str(), title.c_str(), 21, -0.5, 20.5);
+      name = std::string("tip_") + particleType;
+      title = std::string("Transverse impact parameter distribution for ") +
+              particleType;
+      tip = new TH1F(name.c_str(), title.c_str(), 100, -0.3, 0.3);
 
-            name = std::string("pt_1Gev_") + particleType;
-            title = std::string("Pt distribution close 1Gev for ") + particleType;
-            pt_1gev = new TH1F(name.c_str(), title.c_str(), 100, 0., 2.);
+      name = std::string("lip_") + particleType;
+      title = std::string("Longitudinal impact parameter distribution for ") +
+              particleType;
+      lip = new TH1F(name.c_str(), title.c_str(), 100, -1., 1.);
 
-            name = std::string("tip_") + particleType;
-            title = std::string("Transverse impact parameter distribution for ") + particleType;
-            tip = new TH1F(name.c_str(), title.c_str(), 100, -0.3, 0.3);
+      name = std::string("ips_") + particleType;
+      title = std::string("IPS distribution for ") + particleType;
+      ips = new TH1F(name.c_str(), title.c_str(), 100, -25.0, 25.0);
 
-            name = std::string("lip_") + particleType;
-            title = std::string("Longitudinal impact parameter distribution for ") + particleType;
-            lip = new TH1F(name.c_str(), title.c_str(), 100, -1., 1.);
+      name = std::string("sdl_") + particleType;
+      title = std::string("Decay length distribution for ") + particleType;
+      sdl = new TH1F(name.c_str(), title.c_str(), 100, -5., 5.);
 
-            name = std::string("ips_") + particleType;
-            title = std::string("IPS distribution for ") + particleType;
-            ips = new TH1F(name.c_str(), title.c_str(), 100, -25.0, 25.0);
+      name = std::string("dta_") + particleType;
+      title = std::string("Distance to jet distribution for ") + particleType;
+      dta = new TH1F(name.c_str(), title.c_str(), 100, 0.0, 0.2);
+    }
 
-            name = std::string("sdl_") + particleType;
-            title = std::string("Decay length distribution for ") + particleType;
-            sdl = new TH1F(name.c_str(), title.c_str(), 100, -5., 5.);
+    ~histogram_t() {
+      delete hits;
+      delete chi2;
+      delete pixelhits;
+      delete pt_1gev;
+      delete tip;
+      delete lip;
+      delete ips;
+      delete sdl;
+      delete dta;
+    }
 
-            name = std::string("dta_") + particleType;
-            title = std::string("Distance to jet distribution for ") + particleType;
-            dta = new TH1F(name.c_str(), title.c_str(), 100, 0.0, 0.2);
-        }
+    void Fill(const histogram_element_t &data) {
+      hits->Fill(data.hits);
+      chi2->Fill(data.chi2);
+      pixelhits->Fill(data.pt);
+      pt_1gev->Fill(data.pt);
+      ips->Fill(data.ips);
+      tip->Fill(data.tip);
+      lip->Fill(data.lip);
+      sdl->Fill(data.sdl);
+      dta->Fill(data.dta);
+    }
 
-        ~histogram_t()
-        {
-            delete hits;
-            delete chi2;
-            delete pixelhits;
-            delete pt_1gev;
-            delete tip;
-            delete lip;
-            delete ips;
-            delete sdl;
-            delete dta;
-        }
+    void Write() {
+      hits->Write();
+      chi2->Write();
+      pixelhits->Write();
+      pt_1gev->Write();
+      ips->Write();
+      tip->Write();
+      lip->Write();
+      sdl->Write();
+      dta->Write();
+    }
+  };
 
-        void Fill(const histogram_element_t & data)
-        {
-            hits->Fill(data.hits);
-            chi2->Fill(data.chi2);
-            pixelhits->Fill(data.pt);
-            pt_1gev->Fill(data.pt);
-            ips->Fill(data.ips);
-            tip->Fill(data.tip);
-            lip->Fill(data.lip);
-            sdl->Fill(data.sdl);
-            dta->Fill(data.dta);
-        }
-
-        void Write()
-        {
-            hits->Write();
-            chi2->Write();
-            pixelhits->Write();
-            pt_1gev->Write();
-            ips->Write();
-            tip->Write();
-            lip->Write();
-            sdl->Write();
-            dta->Write();
-        }
-    };
-
-    // Track classification.
-    TrackClassifier classifier_;
-
+  // Track classification.
+  TrackClassifier classifier_;
 };
-
 
 //
 // constructors and destructor
 //
-QualityCutsAnalyzer::QualityCutsAnalyzer(const edm::ParameterSet& config) : classifier_(config,consumesCollector())
-{
-    trackProducer_         = config.getUntrackedParameter<edm::InputTag> ( "trackProducer" );
-    consumes<edm::View<reco::Track>>(trackProducer_);
-    primaryVertexProducer_ = config.getUntrackedParameter<edm::InputTag> ( "primaryVertexProducer" );
-    consumes<reco::VertexCollection>(primaryVertexProducer_);
-    jetTracksAssociation_  = config.getUntrackedParameter<edm::InputTag> ( "jetTracksAssociation" );
-    consumes<reco::JetTracksAssociationCollection>(jetTracksAssociation_);
+QualityCutsAnalyzer::QualityCutsAnalyzer(const edm::ParameterSet &config)
+    : classifier_(config, consumesCollector()) {
+  trackProducer_ = config.getUntrackedParameter<edm::InputTag>("trackProducer");
+  consumes<edm::View<reco::Track>>(trackProducer_);
+  primaryVertexProducer_ =
+      config.getUntrackedParameter<edm::InputTag>("primaryVertexProducer");
+  consumes<reco::VertexCollection>(primaryVertexProducer_);
+  jetTracksAssociation_ =
+      config.getUntrackedParameter<edm::InputTag>("jetTracksAssociation");
+  consumes<reco::JetTracksAssociationCollection>(jetTracksAssociation_);
 
-    rootFile_ = config.getUntrackedParameter<std::string> ( "rootFile" );
+  rootFile_ = config.getUntrackedParameter<std::string>("rootFile");
 
-    minimumNumberOfHits_       = config.getUntrackedParameter<int> ( "minimumNumberOfHits" );
-    minimumNumberOfPixelHits_  = config.getUntrackedParameter<int> ( "minimumNumberOfPixelHits" );
-    minimumTransverseMomentum_ = config.getUntrackedParameter<double> ( "minimumTransverseMomentum" );
-    maximumChiSquared_         = config.getUntrackedParameter<double> ( "maximumChiSquared" );
+  minimumNumberOfHits_ =
+      config.getUntrackedParameter<int>("minimumNumberOfHits");
+  minimumNumberOfPixelHits_ =
+      config.getUntrackedParameter<int>("minimumNumberOfPixelHits");
+  minimumTransverseMomentum_ =
+      config.getUntrackedParameter<double>("minimumTransverseMomentum");
+  maximumChiSquared_ =
+      config.getUntrackedParameter<double>("maximumChiSquared");
 
-    std::string trackQualityType = config.getUntrackedParameter<std::string>("trackQualityClass"); //used
-    trackQuality_ =  reco::TrackBase::qualityByName(trackQualityType);
-    useAllQualities_ = false;
+  std::string trackQualityType =
+      config.getUntrackedParameter<std::string>("trackQualityClass"); // used
+  trackQuality_ = reco::TrackBase::qualityByName(trackQualityType);
+  useAllQualities_ = false;
 
-    std::transform(trackQualityType.begin(), trackQualityType.end(), trackQualityType.begin(), (int(*)(int)) std::tolower);
-    if (trackQualityType == "any")
-    {
-        std::cout << "Using any" << std::endl;
-        useAllQualities_ = true;
-    }
+  std::transform(trackQualityType.begin(), trackQualityType.end(),
+                 trackQualityType.begin(), (int (*)(int))std::tolower);
+  if (trackQualityType == "any") {
+    std::cout << "Using any" << std::endl;
+    useAllQualities_ = true;
+  }
 }
 
 QualityCutsAnalyzer::~QualityCutsAnalyzer() {}
@@ -254,167 +248,158 @@ QualityCutsAnalyzer::~QualityCutsAnalyzer() {}
 //
 
 // ------------ method called to for each event  ------------
-void
-QualityCutsAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup)
-{
-    // Track collection
-    edm::Handle<edm::View<reco::Track> > trackCollection;
-    event.getByLabel(trackProducer_,trackCollection);
-    // Primary vertex
-    edm::Handle<reco::VertexCollection> primaryVertexCollection;
-    event.getByLabel(primaryVertexProducer_, primaryVertexCollection);
-    // Jet to tracks associator
-    edm::Handle<reco::JetTracksAssociationCollection> jetTracks;
-    event.getByLabel(jetTracksAssociation_, jetTracks);
-    // Trasient track builder
-    edm::ESHandle<TransientTrackBuilder> TTbuilder;
-    setup.get<TransientTrackRecord>().get("TransientTrackBuilder", TTbuilder);
+void QualityCutsAnalyzer::analyze(const edm::Event &event,
+                                  const edm::EventSetup &setup) {
+  // Track collection
+  edm::Handle<edm::View<reco::Track>> trackCollection;
+  event.getByLabel(trackProducer_, trackCollection);
+  // Primary vertex
+  edm::Handle<reco::VertexCollection> primaryVertexCollection;
+  event.getByLabel(primaryVertexProducer_, primaryVertexCollection);
+  // Jet to tracks associator
+  edm::Handle<reco::JetTracksAssociationCollection> jetTracks;
+  event.getByLabel(jetTracksAssociation_, jetTracks);
+  // Trasient track builder
+  edm::ESHandle<TransientTrackBuilder> TTbuilder;
+  setup.get<TransientTrackRecord>().get("TransientTrackBuilder", TTbuilder);
 
-    // Setting up event information for the track categories.
-    classifier_.newEvent(event, setup);
+  // Setting up event information for the track categories.
+  classifier_.newEvent(event, setup);
 
-    LoopOverJetTracksAssociation(
-        TTbuilder,
-        primaryVertexCollection,
-        jetTracks
-    );
+  LoopOverJetTracksAssociation(TTbuilder, primaryVertexCollection, jetTracks);
 }
 
+// ------------ method called once each job just before starting event loop
+// ------------
+void QualityCutsAnalyzer::beginJob() { histogram_data_.resize(6); }
 
-// ------------ method called once each job just before starting event loop  ------------
-void
-QualityCutsAnalyzer::beginJob()
-{
-    histogram_data_.resize(6);
-}
+// ------------ method called once each job just after ending the event loop
+// ------------
+void QualityCutsAnalyzer::endJob() {
+  TFile file(rootFile_.c_str(), "RECREATE");
+  file.cd();
 
-
-// ------------ method called once each job just after ending the event loop  ------------
-void
-QualityCutsAnalyzer::endJob()
-{
-    TFile file(rootFile_.c_str(), "RECREATE");
-    file.cd();
-
-    // saving the histograms
-    for (std::size_t i=0; i<6; i++)
-    {
-        std::string particle;
-        if (i == 0)
-            particle = std::string("B_tracks");
-        else if (i == 1)
-            particle = std::string("C_tracks");
-        else if (i == 2)
-            particle = std::string("nonB_tracks");
-        else if (i == 3)
-            particle = std::string("displaced_tracks");
-        else if (i == 4)
-            particle = std::string("bad_tracks");
-        else
-            particle = std::string("fake_tracks");
-
-        histogram_t histogram(particle);
-
-        for (std::size_t j=0; j<histogram_data_[i].size(); j++)
-            histogram.Fill(histogram_data_[i][j]);
-
-        histogram.Write();
-    }
-
-    file.Flush();
-}
-
-
-void
-QualityCutsAnalyzer::LoopOverJetTracksAssociation(
-    const edm::ESHandle<TransientTrackBuilder> & TTbuilder,
-    const edm::Handle<reco::VertexCollection> & primaryVertexProducer_,
-    const edm::Handle<reco::JetTracksAssociationCollection> & jetTracksAssociation
-)
-{
-    const TransientTrackBuilder * bproduct = TTbuilder.product();
-
-    // getting the primary vertex
-    // use first pv of the collection
-    reco::Vertex pv;
-
-    if (!primaryVertexProducer_->empty())
-    {
-        PrimaryVertexSorter pvs;
-        std::vector<reco::Vertex> sortedList = pvs.sortedList(*(primaryVertexProducer_.product()));
-        pv = (sortedList.front());
-    }
+  // saving the histograms
+  for (std::size_t i = 0; i < 6; i++) {
+    std::string particle;
+    if (i == 0)
+      particle = std::string("B_tracks");
+    else if (i == 1)
+      particle = std::string("C_tracks");
+    else if (i == 2)
+      particle = std::string("nonB_tracks");
+    else if (i == 3)
+      particle = std::string("displaced_tracks");
+    else if (i == 4)
+      particle = std::string("bad_tracks");
     else
-    { // create a dummy PV
-        // cout << "NO PV FOUND" << endl;
-        reco::Vertex::Error e;
-        e(0,0)=0.0015*0.0015;
-        e(1,1)=0.0015*0.0015;
-        e(2,2)=15.*15.;
-        reco::Vertex::Point p(0,0,0);
-        pv = reco::Vertex(p,e,1,1,1);
+      particle = std::string("fake_tracks");
+
+    histogram_t histogram(particle);
+
+    for (std::size_t j = 0; j < histogram_data_[i].size(); j++)
+      histogram.Fill(histogram_data_[i][j]);
+
+    histogram.Write();
+  }
+
+  file.Flush();
+}
+
+void QualityCutsAnalyzer::LoopOverJetTracksAssociation(
+    const edm::ESHandle<TransientTrackBuilder> &TTbuilder,
+    const edm::Handle<reco::VertexCollection> &primaryVertexProducer_,
+    const edm::Handle<reco::JetTracksAssociationCollection>
+        &jetTracksAssociation) {
+  const TransientTrackBuilder *bproduct = TTbuilder.product();
+
+  // getting the primary vertex
+  // use first pv of the collection
+  reco::Vertex pv;
+
+  if (!primaryVertexProducer_->empty()) {
+    PrimaryVertexSorter pvs;
+    std::vector<reco::Vertex> sortedList =
+        pvs.sortedList(*(primaryVertexProducer_.product()));
+    pv = (sortedList.front());
+  } else { // create a dummy PV
+    // cout << "NO PV FOUND" << endl;
+    reco::Vertex::Error e;
+    e(0, 0) = 0.0015 * 0.0015;
+    e(1, 1) = 0.0015 * 0.0015;
+    e(2, 2) = 15. * 15.;
+    reco::Vertex::Point p(0, 0, 0);
+    pv = reco::Vertex(p, e, 1, 1, 1);
+  }
+
+  reco::JetTracksAssociationCollection::const_iterator it =
+      jetTracksAssociation->begin();
+
+  int i = 0;
+
+  for (; it != jetTracksAssociation->end(); it++, i++) {
+    // get jetTracks object
+    reco::JetTracksAssociationRef jetTracks(jetTracksAssociation, i);
+
+    double pvZ = pv.z();
+    GlobalVector direction(jetTracks->first->px(), jetTracks->first->py(),
+                           jetTracks->first->pz());
+
+    // get the tracks associated to the jet
+    reco::TrackRefVector tracks = jetTracks->second;
+    for (std::size_t index = 0; index < tracks.size(); index++) {
+      edm::RefToBase<reco::Track> track(tracks[index]);
+
+      double pt = tracks[index]->pt();
+      double chi2 = tracks[index]->normalizedChi2();
+      int hits = tracks[index]->hitPattern().numberOfValidHits();
+      int pixelHits = tracks[index]->hitPattern().numberOfValidPixelHits();
+
+      if (hits < minimumNumberOfHits_ ||
+          pixelHits < minimumNumberOfPixelHits_ ||
+          pt < minimumTransverseMomentum_ || chi2 > maximumChiSquared_ ||
+          (!useAllQualities_ && !tracks[index]->quality(trackQuality_)))
+        continue;
+
+      const reco::TransientTrack transientTrack =
+          bproduct->build(&(*tracks[index]));
+      double dta = -IPTools::jetTrackDistance(transientTrack, direction, pv)
+                        .second.value();
+      double sdl = IPTools::signedDecayLength3D(transientTrack, direction, pv)
+                       .second.value();
+      double ips =
+          IPTools::signedImpactParameter3D(transientTrack, direction, pv)
+              .second.value();
+      double d0 = IPTools::signedTransverseImpactParameter(transientTrack,
+                                                           direction, pv)
+                      .second.value();
+      double dz = tracks[index]->dz() - pvZ;
+
+      // Classify the reco track;
+      classifier_.evaluate(edm::RefToBase<reco::Track>(tracks[index]));
+
+      // Check for the different categories
+      if (classifier_.is(TrackClassifier::Fake))
+        histogram_data_[5].push_back(histogram_element_t(
+            sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
+      else if (classifier_.is(TrackClassifier::BWeakDecay))
+        histogram_data_[0].push_back(histogram_element_t(
+            sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
+      else if (classifier_.is(TrackClassifier::Bad))
+        histogram_data_[4].push_back(histogram_element_t(
+            sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
+      else if (!classifier_.is(TrackClassifier::CWeakDecay) &&
+               !classifier_.is(TrackClassifier::PrimaryVertex))
+        histogram_data_[3].push_back(histogram_element_t(
+            sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
+      else if (classifier_.is(TrackClassifier::CWeakDecay))
+        histogram_data_[1].push_back(histogram_element_t(
+            sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
+      else
+        histogram_data_[2].push_back(histogram_element_t(
+            sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
     }
-
-    reco::JetTracksAssociationCollection::const_iterator it = jetTracksAssociation->begin();
-
-    int i=0;
-
-    for (; it != jetTracksAssociation->end(); it++, i++)
-    {
-        // get jetTracks object
-        reco::JetTracksAssociationRef jetTracks(jetTracksAssociation, i);
-
-        double pvZ = pv.z();
-        GlobalVector direction(jetTracks->first->px(), jetTracks->first->py(), jetTracks->first->pz());
-
-        // get the tracks associated to the jet
-        reco::TrackRefVector tracks = jetTracks->second;
-        for (std::size_t index = 0; index < tracks.size(); index++)
-        {
-            edm::RefToBase<reco::Track> track(tracks[index]);
-
-            double pt = tracks[index]->pt();
-            double chi2 = tracks[index]->normalizedChi2();
-            int hits = tracks[index]->hitPattern().numberOfValidHits();
-            int pixelHits = tracks[index]->hitPattern().numberOfValidPixelHits();
-
-            if (
-                hits < minimumNumberOfHits_ ||
-                pixelHits < minimumNumberOfPixelHits_ ||
-                pt < minimumTransverseMomentum_ ||
-                chi2 >  maximumChiSquared_ ||
-                (!useAllQualities_ && !tracks[index]->quality(trackQuality_))
-            ) continue;
-
-            const reco::TransientTrack transientTrack = bproduct->build(&(*tracks[index]));
-            double dta = - IPTools::jetTrackDistance(transientTrack, direction, pv).second.value();
-            double sdl = IPTools::signedDecayLength3D(transientTrack, direction, pv).second.value();
-            double ips = IPTools::signedImpactParameter3D(transientTrack, direction, pv).second.value();
-            double d0 = IPTools::signedTransverseImpactParameter(transientTrack, direction, pv).second.value();
-            double dz = tracks[index]->dz() - pvZ;
-
-            // Classify the reco track;
-            classifier_.evaluate( edm::RefToBase<reco::Track>(tracks[index]) );
-
-            // Check for the different categories
-            if ( classifier_.is(TrackClassifier::Fake) )
-                histogram_data_[5].push_back(histogram_element_t(sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
-            else if ( classifier_.is(TrackClassifier::BWeakDecay) )
-                histogram_data_[0].push_back(histogram_element_t(sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
-            else if ( classifier_.is(TrackClassifier::Bad) )
-                histogram_data_[4].push_back(histogram_element_t(sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
-            else if (
-                !classifier_.is(TrackClassifier::CWeakDecay) &&
-                !classifier_.is(TrackClassifier::PrimaryVertex)
-            )
-                histogram_data_[3].push_back(histogram_element_t(sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
-            else if ( classifier_.is(TrackClassifier::CWeakDecay) )
-                histogram_data_[1].push_back(histogram_element_t(sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
-            else
-                histogram_data_[2].push_back(histogram_element_t(sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
-
-        }
-    }
+  }
 }
 
 DEFINE_FWK_MODULE(QualityCutsAnalyzer);

--- a/SimTracker/TrackHistory/plugins/SVTagInfoValidationAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/SVTagInfoValidationAnalyzer.cc
@@ -1,32 +1,32 @@
-#include <map>
-#include <string>
-#include <cmath>
-#include <Math/Functions.h>
-#include <Math/SVector.h>
-#include <Math/SMatrix.h>
-#include "TH1F.h"
+#include "DataFormats/BTauReco/interface/SecondaryVertexTagInfo.h"
 #include "TH1D.h"
+#include "TH1F.h"
 #include "TH2D.h"
 #include "TMath.h"
-#include "DataFormats/BTauReco/interface/SecondaryVertexTagInfo.h"
+#include <Math/Functions.h>
+#include <Math/SMatrix.h>
+#include <Math/SVector.h>
+#include <cmath>
+#include <map>
+#include <string>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
-#include "SimTracker/TrackHistory/interface/VertexClassifierByProxy.h"
 #include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/Math/interface/Vector.h"
-#include "TROOT.h"
 #include "Math/VectorUtil.h"
-#include <TVector3.h>
+#include "SimTracker/TrackHistory/interface/VertexClassifierByProxy.h"
+#include "TROOT.h"
 #include <Math/GenVector/PxPyPzE4D.h>
 #include <Math/GenVector/PxPyPzM4D.h>
-#include "DataFormats/Math/interface/LorentzVector.h"
+#include <TVector3.h>
 //
 // class decleration
 //
@@ -34,168 +34,189 @@ using namespace reco;
 using namespace std;
 using namespace edm;
 
-class SVTagInfoValidationAnalyzer : public edm::one::EDAnalyzer<>
-{
+class SVTagInfoValidationAnalyzer : public edm::one::EDAnalyzer<> {
 
 public:
-
-    explicit SVTagInfoValidationAnalyzer(const edm::ParameterSet&);
+  explicit SVTagInfoValidationAnalyzer(const edm::ParameterSet &);
 
 private:
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void endJob() override;
+  // Member data
 
-    void analyze(const edm::Event&, const edm::EventSetup&) override;
-    void endJob() override ;
-    // Member data
+  VertexClassifierByProxy<reco::SecondaryVertexTagInfoCollection> classifier_;
 
-    VertexClassifierByProxy<reco::SecondaryVertexTagInfoCollection> classifier_;
+  Int_t numberVertexClassifier_;
+  edm::InputTag trackingTruth_;
+  edm::InputTag svTagInfoProducer_;
 
-    Int_t numberVertexClassifier_;
-    edm::InputTag trackingTruth_;
-    edm::InputTag svTagInfoProducer_;
+  // Get the file service
+  edm::Service<TFileService> fs_;
 
-    // Get the file service
-    edm::Service<TFileService> fs_;
+  Int_t n_event;
+  Int_t rs_total_nall;
+  Int_t rs_total_nsv;
+  Int_t rs_total_nbv;
+  Int_t rs_total_nbsv;
+  Int_t rs_total_ncv;
+  Int_t rs_total_nlv;
+  Int_t total_nfake;
 
-    Int_t n_event;
-    Int_t rs_total_nall ; 
-    Int_t rs_total_nsv ;
-    Int_t rs_total_nbv ;
-    Int_t rs_total_nbsv ;
-    Int_t rs_total_ncv ;
-    Int_t rs_total_nlv ;
-    Int_t total_nfake ;
-
-    Int_t sr_total_nall ; 
-    Int_t sr_total_nsv ;
-    Int_t sr_total_nbv ;
-    Int_t sr_total_nbsv ;
-    Int_t sr_total_ncv ;
-    Int_t sr_total_nlv ;
-    Int_t total_nmiss ;
-        
+  Int_t sr_total_nall;
+  Int_t sr_total_nsv;
+  Int_t sr_total_nbv;
+  Int_t sr_total_nbsv;
+  Int_t sr_total_ncv;
+  Int_t sr_total_nlv;
+  Int_t total_nmiss;
 
   // Bookeeping of all the histograms per category
   void bookRecoToSim(std::string const &);
-    void bookSimToReco(std::string const &);
+  void bookSimToReco(std::string const &);
 
-    // Fill all histogram per category
-    void fillRecoToSim(std::string const &, reco::Vertex const &, TrackingVertexRef const &);
-    void fillSimToReco(std::string const &, reco::VertexBaseRef const &, TrackingVertexRef const &);
+  // Fill all histogram per category
+  void fillRecoToSim(std::string const &, reco::Vertex const &,
+                     TrackingVertexRef const &);
+  void fillSimToReco(std::string const &, reco::VertexBaseRef const &,
+                     TrackingVertexRef const &);
 
-    // Histogram handlers
-    std::map<std::string, TH1D *> TH1Index_;
-
+  // Histogram handlers
+  std::map<std::string, TH1D *> TH1Index_;
 };
 
+SVTagInfoValidationAnalyzer::SVTagInfoValidationAnalyzer(
+    const edm::ParameterSet &config)
+    : classifier_(config, consumesCollector()) {
+  // Initialize counters
+  n_event = 0;
+  rs_total_nall = 0;
+  rs_total_nsv = 0;
+  rs_total_nbv = 0;
+  rs_total_nbsv = 0;
+  rs_total_ncv = 0;
+  rs_total_nlv = 0;
+  total_nfake = 0;
 
-SVTagInfoValidationAnalyzer::SVTagInfoValidationAnalyzer(const edm::ParameterSet& config) : classifier_(config, consumesCollector())
-{
-  //Initialize counters
-    n_event = 0;
-    rs_total_nall = 0; 
-    rs_total_nsv = 0;
-    rs_total_nbv = 0;
-    rs_total_nbsv = 0;
-    rs_total_ncv = 0;
-    rs_total_nlv = 0;
-    total_nfake = 0;
+  sr_total_nall = 0;
+  sr_total_nsv = 0;
+  sr_total_nbv = 0;
+  sr_total_nbsv = 0;
+  sr_total_ncv = 0;
+  sr_total_nlv = 0;
+  total_nmiss = 0;
 
-    sr_total_nall = 0; 
-    sr_total_nsv = 0;
-    sr_total_nbv = 0;
-    sr_total_nbsv = 0;
-    sr_total_ncv = 0;
-    sr_total_nlv = 0;
-    total_nmiss = 0;
+  // Get the track collection
+  svTagInfoProducer_ =
+      config.getUntrackedParameter<edm::InputTag>("svTagInfoProducer");
+  consumes<reco::SecondaryVertexTagInfoCollection>(svTagInfoProducer_);
 
-    // Get the track collection
-    svTagInfoProducer_ = config.getUntrackedParameter<edm::InputTag> ( "svTagInfoProducer" );
-    consumes<reco::SecondaryVertexTagInfoCollection>(svTagInfoProducer_);
+  // Name of the traking pariticle collection
+  trackingTruth_ = config.getUntrackedParameter<edm::InputTag>("trackingTruth");
+  consumes<TrackingVertexCollection>(trackingTruth_);
 
-    // Name of the traking pariticle collection
-    trackingTruth_ = config.getUntrackedParameter<edm::InputTag> ( "trackingTruth" );
-    consumes<TrackingVertexCollection>(trackingTruth_);
+  // Number of track categories
+  numberVertexClassifier_ = VertexCategories::Unknown + 1;
 
-    // Number of track categories
-    numberVertexClassifier_ = VertexCategories::Unknown+1;
+  // Define histogram for counting categories
+  TH1Index_["VertexClassifier"] = fs_->make<TH1D>(
+      "VertexClassifier", "Frequency for the different track categories",
+      numberVertexClassifier_, -0.5, numberVertexClassifier_ - 0.5);
 
-    // Define histogram for counting categories
-    TH1Index_["VertexClassifier"] = fs_->make<TH1D>(
-                                        "VertexClassifier",
-                                        "Frequency for the different track categories",
-                                        numberVertexClassifier_,
-                                        -0.5,
-                                        numberVertexClassifier_ - 0.5
-                                    );
-    
-    //--- RecoToSim
-    TH1Index_["rs_All_MatchQuality"]= fs_->make<TH1D>( "rs_All_MatchQuality", "Quality of Match", 51, -0.01, 1.01 );
-    TH1Index_["rs_All_FlightDistance2d"]= fs_->make<TH1D>( "rs_All_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5 );
-    TH1Index_["rs_SecondaryVertex_FlightDistance2d"]= fs_->make<TH1D>( "rs_SecondaryVertex_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5 );
-    TH1Index_["rs_BSV_FlightDistance2d"]= fs_->make<TH1D>( "rs_BSV_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5 );
-    TH1Index_["rs_BWeakDecay_FlightDistance2d"]= fs_->make<TH1D>( "rs_BWeakDecay_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5 );
-    TH1Index_["rs_CWeakDecay_FlightDistance2d"]= fs_->make<TH1D>( "rs_CWeakDecay_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5 );
-    TH1Index_["rs_Light_FlightDistance2d"]= fs_->make<TH1D>( "rs_Light_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5 );
+  //--- RecoToSim
+  TH1Index_["rs_All_MatchQuality"] = fs_->make<TH1D>(
+      "rs_All_MatchQuality", "Quality of Match", 51, -0.01, 1.01);
+  TH1Index_["rs_All_FlightDistance2d"] = fs_->make<TH1D>(
+      "rs_All_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5);
+  TH1Index_["rs_SecondaryVertex_FlightDistance2d"] =
+      fs_->make<TH1D>("rs_SecondaryVertex_FlightDistance2d",
+                      "Transverse flight distance [cm]", 100, 0, 5);
+  TH1Index_["rs_BSV_FlightDistance2d"] = fs_->make<TH1D>(
+      "rs_BSV_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5);
+  TH1Index_["rs_BWeakDecay_FlightDistance2d"] =
+      fs_->make<TH1D>("rs_BWeakDecay_FlightDistance2d",
+                      "Transverse flight distance [cm]", 100, 0, 5);
+  TH1Index_["rs_CWeakDecay_FlightDistance2d"] =
+      fs_->make<TH1D>("rs_CWeakDecay_FlightDistance2d",
+                      "Transverse flight distance [cm]", 100, 0, 5);
+  TH1Index_["rs_Light_FlightDistance2d"] =
+      fs_->make<TH1D>("rs_Light_FlightDistance2d",
+                      "Transverse flight distance [cm]", 100, 0, 5);
 
-    TH1Index_["rs_All_nRecVtx"]= fs_->make<TH1D>( "rs_All_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5 );
-    TH1Index_["rs_SecondaryVertex_nRecVtx"]= fs_->make<TH1D>( "rs_SecondaryVertex_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5 );
-    TH1Index_["rs_BSV_nRecVtx"]= fs_->make<TH1D>( "rs_BSV_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5 );
-    TH1Index_["rs_BWeakDecay_nRecVtx"]= fs_->make<TH1D>( "rs_BWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5 );
-    TH1Index_["rs_CWeakDecay_nRecVtx"]= fs_->make<TH1D>( "rs_CWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5 );
-    TH1Index_["rs_Light_nRecVtx"]= fs_->make<TH1D>( "rs_Light_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5 );
+  TH1Index_["rs_All_nRecVtx"] = fs_->make<TH1D>(
+      "rs_All_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["rs_SecondaryVertex_nRecVtx"] =
+      fs_->make<TH1D>("rs_SecondaryVertex_nRecVtx",
+                      "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["rs_BSV_nRecVtx"] = fs_->make<TH1D>(
+      "rs_BSV_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["rs_BWeakDecay_nRecVtx"] = fs_->make<TH1D>(
+      "rs_BWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["rs_CWeakDecay_nRecVtx"] = fs_->make<TH1D>(
+      "rs_CWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["rs_Light_nRecVtx"] = fs_->make<TH1D>(
+      "rs_Light_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
 
+  //--- SimToReco
+  TH1Index_["sr_All_MatchQuality"] = fs_->make<TH1D>(
+      "sr_All_MatchQuality", "Quality of Match", 51, -0.01, 1.01);
+  TH1Index_["sr_All_nRecVtx"] = fs_->make<TH1D>(
+      "sr_All_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["sr_SecondaryVertex_nRecVtx"] =
+      fs_->make<TH1D>("sr_SecondaryVertex_nRecVtx",
+                      "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["sr_BSV_nRecVtx"] = fs_->make<TH1D>(
+      "sr_BSV_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["sr_BWeakDecay_nRecVtx"] = fs_->make<TH1D>(
+      "sr_BWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["sr_CWeakDecay_nRecVtx"] = fs_->make<TH1D>(
+      "sr_CWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["sr_Light_nRecVtx"] = fs_->make<TH1D>(
+      "sr_Light_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
 
-    //--- SimToReco
-    TH1Index_["sr_All_MatchQuality"]= fs_->make<TH1D>( "sr_All_MatchQuality", "Quality of Match", 51, -0.01, 1.01);
-    TH1Index_["sr_All_nRecVtx"]= fs_->make<TH1D>( "sr_All_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5 );
-    TH1Index_["sr_SecondaryVertex_nRecVtx"]= fs_->make<TH1D>( "sr_SecondaryVertex_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5 );
-    TH1Index_["sr_BSV_nRecVtx"]= fs_->make<TH1D>( "sr_BSV_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5 );
-    TH1Index_["sr_BWeakDecay_nRecVtx"]= fs_->make<TH1D>( "sr_BWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5 );
-    TH1Index_["sr_CWeakDecay_nRecVtx"]= fs_->make<TH1D>( "sr_CWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5 );
-    TH1Index_["sr_Light_nRecVtx"]= fs_->make<TH1D>( "sr_Light_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5 );  
+  // Set the proper categories names
+  for (Int_t i = 0; i < numberVertexClassifier_; ++i)
+    TH1Index_["VertexClassifier"]->GetXaxis()->SetBinLabel(
+        i + 1, VertexCategories::Names[i]);
 
+  // book histograms
+  bookRecoToSim("rs_All");
+  bookRecoToSim("rs_SecondaryVertex");
+  bookRecoToSim("rs_BSV");
+  bookRecoToSim("rs_BWeakDecay");
+  bookRecoToSim("rs_CWeakDecay");
+  bookRecoToSim("rs_Light");
 
-    // Set the proper categories names
-    for (Int_t i = 0; i < numberVertexClassifier_; ++i)
-        TH1Index_["VertexClassifier"]->GetXaxis()->SetBinLabel(i+1, VertexCategories::Names[i]);
+  bookSimToReco("sr_All");
+  bookSimToReco("sr_SecondaryVertex");
+  bookSimToReco("sr_BSV");
+  bookSimToReco("sr_BWeakDecay");
+  bookSimToReco("sr_CWeakDecay");
+  bookSimToReco("sr_Light");
+}
 
-    // book histograms
-    bookRecoToSim("rs_All");
-    bookRecoToSim("rs_SecondaryVertex");
-    bookRecoToSim("rs_BSV");
-    bookRecoToSim("rs_BWeakDecay");
-    bookRecoToSim("rs_CWeakDecay");
-    bookRecoToSim("rs_Light");
-
-    bookSimToReco("sr_All"); 
-    bookSimToReco("sr_SecondaryVertex");
-    bookSimToReco("sr_BSV");  
-    bookSimToReco("sr_BWeakDecay");  
-    bookSimToReco("sr_CWeakDecay");  
-    bookSimToReco("sr_Light");  
-}   
-
-
-void SVTagInfoValidationAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup)
-{
+void SVTagInfoValidationAnalyzer::analyze(const edm::Event &event,
+                                          const edm::EventSetup &setup) {
   ++n_event;
 
-  std::cout << "*** Analyzing " << event.id() << " n_event = " << n_event << std::endl << std::endl;
+  std::cout << "*** Analyzing " << event.id() << " n_event = " << n_event
+            << std::endl
+            << std::endl;
 
   // Set the classifier for a new event
   classifier_.newEvent(event, setup);
-  
 
   // Vertex collection
   edm::Handle<reco::SecondaryVertexTagInfoCollection> svTagInfoCollection;
   event.getByLabel(svTagInfoProducer_, svTagInfoCollection);
 
   // Get a constant reference to the track history associated to the classifier
-  VertexHistory const & tracer = classifier_.history();
+  VertexHistory const &tracer = classifier_.history();
 
-  cout << "* Event " << n_event << " ; svTagInfoCollection->size() = " << svTagInfoCollection->size() << endl; 
-  
-  int rs_nall = 0; 
+  cout << "* Event " << n_event
+       << " ; svTagInfoCollection->size() = " << svTagInfoCollection->size()
+       << endl;
+
+  int rs_nall = 0;
   int rs_nsv = 0;
   int rs_nbv = 0;
   int rs_nbsv = 0;
@@ -203,7 +224,7 @@ void SVTagInfoValidationAnalyzer::analyze(const edm::Event& event, const edm::Ev
   int rs_nlv = 0;
   int nfake = 0;
 
-  int sr_nall = 0; 
+  int sr_nall = 0;
   int sr_nsv = 0;
   int sr_nbv = 0;
   int sr_nbsv = 0;
@@ -212,192 +233,202 @@ void SVTagInfoValidationAnalyzer::analyze(const edm::Event& event, const edm::Ev
   int nmiss = 0;
 
   // Loop over the svTagInfo collection.
-  for (std::size_t index = 0; index < svTagInfoCollection->size(); ++index){
+  for (std::size_t index = 0; index < svTagInfoCollection->size(); ++index) {
 
     reco::SecondaryVertexTagInfoRef svTagInfo(svTagInfoCollection, index);
 
     // Loop over the vertexes in svTagInfo
-    for ( std::size_t vindex = 0; vindex < svTagInfo->nVertices(); ++vindex ){
+    for (std::size_t vindex = 0; vindex < svTagInfo->nVertices(); ++vindex) {
 
- 
       // Classify the vertices
       classifier_.evaluate(svTagInfo, vindex);
 
-      //quality of the match
+      // quality of the match
       double rs_quality = tracer.quality();
- 
 
       // Fill the histogram with the categories
       for (Int_t i = 0; i != numberVertexClassifier_; ++i) {
 
-	if ( classifier_.is( (VertexCategories::Category) i ) ) {
+        if (classifier_.is((VertexCategories::Category)i)) {
 
-	  TH1Index_["VertexClassifier"]->Fill(i);
-	}
+          TH1Index_["VertexClassifier"]->Fill(i);
+        }
       }
-      if ( !classifier_.is(VertexCategories::Fake) ) {
+      if (!classifier_.is(VertexCategories::Fake)) {
 
         cout << "R2S: MatchQuality = " << rs_quality << endl;
 
-        TH1Index_["rs_All_MatchQuality"]->Fill( rs_quality );
-	fillRecoToSim("rs_All", svTagInfo->secondaryVertex(vindex), tracer.simVertex());
-	TH1Index_["rs_All_FlightDistance2d"]->Fill( svTagInfo->flightDistance( vindex, true ).value() );
+        TH1Index_["rs_All_MatchQuality"]->Fill(rs_quality);
+        fillRecoToSim("rs_All", svTagInfo->secondaryVertex(vindex),
+                      tracer.simVertex());
+        TH1Index_["rs_All_FlightDistance2d"]->Fill(
+            svTagInfo->flightDistance(vindex, true).value());
         rs_nall++;
 
-	if ( classifier_.is(VertexCategories::SecondaryVertex) ) {
+        if (classifier_.is(VertexCategories::SecondaryVertex)) {
 
-	  //cout << "    R2S VertexCategories::SecondaryVertex" << endl;
-	  fillRecoToSim("rs_SecondaryVertex", svTagInfo->secondaryVertex(vindex), tracer.simVertex());
-	  TH1Index_["rs_SecondaryVertex_FlightDistance2d"]->Fill( svTagInfo->flightDistance( vindex, true ).value() );
+          // cout << "    R2S VertexCategories::SecondaryVertex" << endl;
+          fillRecoToSim("rs_SecondaryVertex",
+                        svTagInfo->secondaryVertex(vindex), tracer.simVertex());
+          TH1Index_["rs_SecondaryVertex_FlightDistance2d"]->Fill(
+              svTagInfo->flightDistance(vindex, true).value());
           rs_nsv++;
-	}
-        
-	if ( classifier_.is(VertexCategories::BWeakDecay) ) {
+        }
 
-	  //cout << "    R2S VertexCategories::BWeakDecay" << endl;
-	  fillRecoToSim("rs_BWeakDecay", svTagInfo->secondaryVertex(vindex), tracer.simVertex());
-	  TH1Index_["rs_BWeakDecay_FlightDistance2d"]->Fill( svTagInfo->flightDistance( vindex, true ).value() );
+        if (classifier_.is(VertexCategories::BWeakDecay)) {
+
+          // cout << "    R2S VertexCategories::BWeakDecay" << endl;
+          fillRecoToSim("rs_BWeakDecay", svTagInfo->secondaryVertex(vindex),
+                        tracer.simVertex());
+          TH1Index_["rs_BWeakDecay_FlightDistance2d"]->Fill(
+              svTagInfo->flightDistance(vindex, true).value());
           rs_nbv++;
 
-          if ( classifier_.is(VertexCategories::SecondaryVertex) ) {
-	    //cout << "    R2S VertexCategories::BWeakDecay SecondaryVertex" << endl;
-	    fillRecoToSim("rs_BSV", svTagInfo->secondaryVertex(vindex), tracer.simVertex());
-            TH1Index_["rs_BSV_FlightDistance2d"]->Fill( svTagInfo->flightDistance( vindex, true ).value() );
-	    rs_nbsv++;	 
+          if (classifier_.is(VertexCategories::SecondaryVertex)) {
+            // cout << "    R2S VertexCategories::BWeakDecay SecondaryVertex" <<
+            // endl;
+            fillRecoToSim("rs_BSV", svTagInfo->secondaryVertex(vindex),
+                          tracer.simVertex());
+            TH1Index_["rs_BSV_FlightDistance2d"]->Fill(
+                svTagInfo->flightDistance(vindex, true).value());
+            rs_nbsv++;
+          }
+        } // BWeakDecay
 
-          }          
-	}//BWeakDecay
+        else if (classifier_.is(VertexCategories::CWeakDecay)) {
 
-	else if ( classifier_.is(VertexCategories::CWeakDecay) ) {
-
-	  //cout << "    R2S VertexCategories::CWeakDecay" << endl;
-	  fillRecoToSim("rs_CWeakDecay", svTagInfo->secondaryVertex(vindex), tracer.simVertex());
-	  TH1Index_["rs_CWeakDecay_FlightDistance2d"]->Fill( svTagInfo->flightDistance( vindex, true ).value() );
+          // cout << "    R2S VertexCategories::CWeakDecay" << endl;
+          fillRecoToSim("rs_CWeakDecay", svTagInfo->secondaryVertex(vindex),
+                        tracer.simVertex());
+          TH1Index_["rs_CWeakDecay_FlightDistance2d"]->Fill(
+              svTagInfo->flightDistance(vindex, true).value());
           rs_ncv++;
 
-	}                
-	else {
-	  //cout << "    R2S Light (rest of categories)" << endl;
-	  fillRecoToSim("rs_Light", svTagInfo->secondaryVertex(vindex), tracer.simVertex());
-	  TH1Index_["rs_Light_FlightDistance2d"]->Fill( svTagInfo->flightDistance( vindex, true ).value() );
+        } else {
+          // cout << "    R2S Light (rest of categories)" << endl;
+          fillRecoToSim("rs_Light", svTagInfo->secondaryVertex(vindex),
+                        tracer.simVertex());
+          TH1Index_["rs_Light_FlightDistance2d"]->Fill(
+              svTagInfo->flightDistance(vindex, true).value());
           rs_nlv++;
-	}
-      }//end if classifier
+        }
+      } // end if classifier
 
       else {
         cout << "    VertexCategories::Fake!!" << endl;
         nfake++;
       }
 
-   }//end loop over vertices in svTagInfo
+    } // end loop over vertices in svTagInfo
 
-  }//loop over svTagInfo
+  } // loop over svTagInfo
 
-  TH1Index_["rs_All_nRecVtx"]->Fill( rs_nall );
-  TH1Index_["rs_SecondaryVertex_nRecVtx"]->Fill( rs_nsv );
-  TH1Index_["rs_BWeakDecay_nRecVtx"]->Fill( rs_nbv );
-  TH1Index_["rs_BSV_nRecVtx"]->Fill( rs_nbsv );
-  TH1Index_["rs_CWeakDecay_nRecVtx"]->Fill( rs_ncv );  
-  TH1Index_["rs_Light_nRecVtx"]->Fill( rs_nlv );  
-  cout << endl;  
+  TH1Index_["rs_All_nRecVtx"]->Fill(rs_nall);
+  TH1Index_["rs_SecondaryVertex_nRecVtx"]->Fill(rs_nsv);
+  TH1Index_["rs_BWeakDecay_nRecVtx"]->Fill(rs_nbv);
+  TH1Index_["rs_BSV_nRecVtx"]->Fill(rs_nbsv);
+  TH1Index_["rs_CWeakDecay_nRecVtx"]->Fill(rs_ncv);
+  TH1Index_["rs_Light_nRecVtx"]->Fill(rs_nlv);
+  cout << endl;
 
   //----------------------------------------------------------------
   // SIM TO RECO!
 
   // Vertex collection
-  edm::Handle<TrackingVertexCollection>  TVCollection;
+  edm::Handle<TrackingVertexCollection> TVCollection;
   event.getByLabel(trackingTruth_, TVCollection);
-    
+
   // Loop over the TV collection.
-  for (std::size_t index = 0; index < TVCollection->size(); ++index){
-        
+  for (std::size_t index = 0; index < TVCollection->size(); ++index) {
+
     TrackingVertexRef trackingVertex(TVCollection, index);
 
     classifier_.evaluate(trackingVertex);
- 	
+
     double sr_quality = tracer.quality();
- 
-    if ( classifier_.is(VertexCategories::Reconstructed) ) {
+
+    if (classifier_.is(VertexCategories::Reconstructed)) {
 
       cout << "S2R: MatchQuality = " << sr_quality << endl;
 
-      //cout << "    S2R VertexCategories::Reconstructed" << endl;
-      TH1Index_["sr_All_MatchQuality"]->Fill( sr_quality );      
+      // cout << "    S2R VertexCategories::Reconstructed" << endl;
+      TH1Index_["sr_All_MatchQuality"]->Fill(sr_quality);
       fillSimToReco("sr_All", tracer.recoVertex(), trackingVertex);
       sr_nall++;
 
-      if ( classifier_.is(VertexCategories::SecondaryVertex) ) {
+      if (classifier_.is(VertexCategories::SecondaryVertex)) {
 
-	//cout << "    S2R VertexCategories::Reconstructed::SecondaryVertex" << endl;
-        fillSimToReco("sr_SecondaryVertex", tracer.recoVertex(), trackingVertex);
+        // cout << "    S2R VertexCategories::Reconstructed::SecondaryVertex" <<
+        // endl;
+        fillSimToReco("sr_SecondaryVertex", tracer.recoVertex(),
+                      trackingVertex);
         sr_nsv++;
       }
 
-      if ( classifier_.is(VertexCategories::BWeakDecay) ) {
+      if (classifier_.is(VertexCategories::BWeakDecay)) {
 
-	//cout << "    S2R VertexCategories::Reconstructed::BWeakDecay" << endl;
+        // cout << "    S2R VertexCategories::Reconstructed::BWeakDecay" <<
+        // endl;
         fillSimToReco("sr_BWeakDecay", tracer.recoVertex(), trackingVertex);
         sr_nbv++;
 
-        if ( classifier_.is(VertexCategories::SecondaryVertex) ) {
+        if (classifier_.is(VertexCategories::SecondaryVertex)) {
 
-	  //cout << "    S2R VertexCategories::Reconstructed::BWeakDecay SecondaryVertex" << endl;
-         fillSimToReco("sr_BSV", tracer.recoVertex(), trackingVertex);
-         sr_nbsv++;
-	}
-    
-      }//BWeakDecay
+          // cout << "    S2R VertexCategories::Reconstructed::BWeakDecay
+          // SecondaryVertex" << endl;
+          fillSimToReco("sr_BSV", tracer.recoVertex(), trackingVertex);
+          sr_nbsv++;
+        }
 
-      else if ( classifier_.is(VertexCategories::CWeakDecay) ) {
+      } // BWeakDecay
 
-	//cout << "    S2R VertexCategories::CWeakDecay" << endl;
-	fillSimToReco("sr_CWeakDecay", tracer.recoVertex(), trackingVertex);
+      else if (classifier_.is(VertexCategories::CWeakDecay)) {
+
+        // cout << "    S2R VertexCategories::CWeakDecay" << endl;
+        fillSimToReco("sr_CWeakDecay", tracer.recoVertex(), trackingVertex);
         sr_ncv++;
       }
- 
+
       else {
 
-	//cout << "    S2R Light (rest of categories)" << endl;
-	fillSimToReco("sr_Light", tracer.recoVertex(), trackingVertex);
+        // cout << "    S2R Light (rest of categories)" << endl;
+        fillSimToReco("sr_Light", tracer.recoVertex(), trackingVertex);
         sr_nlv++;
       }
 
-    }//Reconstructed
+    } // Reconstructed
     else {
-      //cout << "##### Not reconstructed!" << endl;
+      // cout << "##### Not reconstructed!" << endl;
       nmiss++;
     }
 
-  }//TVCollection.size()
+  } // TVCollection.size()
 
-  TH1Index_["sr_All_nRecVtx"]->Fill( sr_nall );
-  TH1Index_["sr_SecondaryVertex_nRecVtx"]->Fill( sr_nsv );
-  TH1Index_["sr_BWeakDecay_nRecVtx"]->Fill( sr_nbv );
-  TH1Index_["sr_BSV_nRecVtx"]->Fill( sr_nbsv );
-  TH1Index_["sr_CWeakDecay_nRecVtx"]->Fill( sr_ncv );  
-  TH1Index_["sr_Light_nRecVtx"]->Fill( rs_nlv );  
+  TH1Index_["sr_All_nRecVtx"]->Fill(sr_nall);
+  TH1Index_["sr_SecondaryVertex_nRecVtx"]->Fill(sr_nsv);
+  TH1Index_["sr_BWeakDecay_nRecVtx"]->Fill(sr_nbv);
+  TH1Index_["sr_BSV_nRecVtx"]->Fill(sr_nbsv);
+  TH1Index_["sr_CWeakDecay_nRecVtx"]->Fill(sr_ncv);
+  TH1Index_["sr_Light_nRecVtx"]->Fill(rs_nlv);
 
-  rs_total_nall += rs_nall;  
+  rs_total_nall += rs_nall;
   rs_total_nsv += rs_nsv;
   rs_total_nbv += rs_nbv;
   rs_total_nbsv += rs_nbsv;
-  rs_total_ncv += rs_ncv ;
+  rs_total_ncv += rs_ncv;
   rs_total_nlv += rs_nlv;
   total_nfake += nfake;
 
-  sr_total_nall += sr_nall; 
+  sr_total_nall += sr_nall;
   sr_total_nsv += sr_nsv;
   sr_total_nbv += sr_nbv;
   sr_total_nbsv += sr_nbsv;
   sr_total_ncv += sr_ncv;
   sr_total_nlv += sr_nlv;
   total_nmiss += nmiss;
-
-
 }
 
-
-void SVTagInfoValidationAnalyzer::bookRecoToSim(std::string const & prefix){
+void SVTagInfoValidationAnalyzer::bookRecoToSim(std::string const &prefix) {
   // Book pull histograms
 
   std::string name = prefix + "_Pullx";
@@ -407,20 +438,24 @@ void SVTagInfoValidationAnalyzer::bookRecoToSim(std::string const & prefix){
   name = prefix + "_Pullz";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -10., 10.);
 
-   name = prefix + "_Resx";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
+  name = prefix + "_Resx";
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
   name = prefix + "_Resy";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05); 
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
   name = prefix + "_Resz";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05); 
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
 
   name = prefix + "_Chi2Norm";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, 0, 10.); 
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, 0, 10.);
   name = prefix + "_Chi2Prob";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, 0., 1.); 
- 
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, 0., 1.);
+
   name = prefix + "_nRecTrks";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
 
   name = prefix + "_AverageTrackWeight";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.1, 1.1);
@@ -429,7 +464,8 @@ void SVTagInfoValidationAnalyzer::bookRecoToSim(std::string const & prefix){
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 65, 0., 6.5);
 
   name = prefix + "_RecPt";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
 
   name = prefix + "_RecEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
@@ -438,34 +474,34 @@ void SVTagInfoValidationAnalyzer::bookRecoToSim(std::string const & prefix){
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 21, -0.5, 20.5);
 
   name = prefix + "_RecTrackPt";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
 
   name = prefix + "_RecTrackEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
 
   name = prefix + "_nSimTrks";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5); 
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
 
   name = prefix + "_SimPt";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
 
   name = prefix + "_SimEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
 
   name = prefix + "_SimCharge";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 21, -0.5, 20.5);
-  
+
   name = prefix + "_SimTrackPt";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 500, 0., 500.);
 
   name = prefix + "_SimTrackEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
-
-
 }
 
-
-void SVTagInfoValidationAnalyzer::bookSimToReco(std::string const & prefix){
+void SVTagInfoValidationAnalyzer::bookSimToReco(std::string const &prefix) {
   // Book pull histograms
 
   std::string name = prefix + "_Pullx";
@@ -475,20 +511,24 @@ void SVTagInfoValidationAnalyzer::bookSimToReco(std::string const & prefix){
   name = prefix + "_Pullz";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -10., 10.);
 
-   name = prefix + "_Resx";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
+  name = prefix + "_Resx";
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
   name = prefix + "_Resy";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05); 
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
   name = prefix + "_Resz";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05); 
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
 
   name = prefix + "_Chi2Norm";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, 0, 10.); 
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, 0, 10.);
   name = prefix + "_Chi2Prob";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, 0., 1.); 
- 
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, 0., 1.);
+
   name = prefix + "_nRecTrks";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
 
   name = prefix + "_AverageTrackWeight";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.1, 1.1);
@@ -497,7 +537,8 @@ void SVTagInfoValidationAnalyzer::bookSimToReco(std::string const & prefix){
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 65, 0., 6.5);
 
   name = prefix + "_RecPt";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
 
   name = prefix + "_RecEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
@@ -506,111 +547,118 @@ void SVTagInfoValidationAnalyzer::bookSimToReco(std::string const & prefix){
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 21, -0.5, 20.5);
 
   name = prefix + "_RecTrackPt";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
 
   name = prefix + "_RecTrackEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
 
   name = prefix + "_nSimTrks";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5); 
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
 
   name = prefix + "_SimPt";
-  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
+  TH1Index_[name] =
+      fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
 
   name = prefix + "_SimEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
 
   name = prefix + "_SimCharge";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 21, -0.5, 20.5);
-  
+
   name = prefix + "_SimTrackPt";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 500, 0., 500.);
 
   name = prefix + "_SimTrackEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
-
-
 }
 
+void SVTagInfoValidationAnalyzer::fillRecoToSim(
+    std::string const &prefix, reco::Vertex const &vertex,
+    TrackingVertexRef const &simVertex) {
 
-void SVTagInfoValidationAnalyzer::fillRecoToSim(std::string const & prefix, reco::Vertex const & vertex, TrackingVertexRef const & simVertex)
-{
- 
-  double pullx = (vertex.x() - simVertex->position().x())/vertex.xError();
-  double pully = (vertex.y() - simVertex->position().y())/vertex.yError();
-  double pullz = (vertex.z() - simVertex->position().z())/vertex.zError();
+  double pullx = (vertex.x() - simVertex->position().x()) / vertex.xError();
+  double pully = (vertex.y() - simVertex->position().y()) / vertex.yError();
+  double pullz = (vertex.z() - simVertex->position().z()) / vertex.zError();
 
   double resx = vertex.x() - simVertex->position().x();
   double resy = vertex.y() - simVertex->position().y();
   double resz = vertex.z() - simVertex->position().z();
 
   double chi2norm = vertex.normalizedChi2();
-  double chi2prob = ChiSquaredProbability( vertex.chi2(), vertex.ndof() ); 
+  double chi2prob = ChiSquaredProbability(vertex.chi2(), vertex.ndof());
 
- double sum_weight = 0.;
- double weight = 0.;
- double tracksize =  vertex.tracksSize();
- math::XYZVector momentum;
- math::XYZTLorentzVector sum;
- int charge = 0;
+  double sum_weight = 0.;
+  double weight = 0.;
+  double tracksize = vertex.tracksSize();
+  math::XYZVector momentum;
+  math::XYZTLorentzVector sum;
+  int charge = 0;
   double thePiMass = 0.13957;
-  for ( reco::Vertex::trackRef_iterator recDaughter = vertex.tracks_begin() ; recDaughter != vertex.tracks_end(); ++recDaughter) {
+  for (reco::Vertex::trackRef_iterator recDaughter = vertex.tracks_begin();
+       recDaughter != vertex.tracks_end(); ++recDaughter) {
 
-    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> > vec;
+    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double>> vec;
 
-    vec.SetPx( (**recDaughter).px() );
-    vec.SetPy( (**recDaughter).py() );
-    vec.SetPz( (**recDaughter).pz() );
-    vec.SetM(thePiMass); 
+    vec.SetPx((**recDaughter).px());
+    vec.SetPy((**recDaughter).py());
+    vec.SetPz((**recDaughter).pz());
+    vec.SetM(thePiMass);
 
     sum += vec;
-  
-    weight = vertex.trackWeight(*recDaughter); 
+
+    weight = vertex.trackWeight(*recDaughter);
     sum_weight += weight;
 
     math::XYZVector p;
     p = (**recDaughter).momentum();
-    momentum += p; 
+    momentum += p;
 
     charge += (*recDaughter)->charge();
 
-    TH1Index_[prefix + "_RecTrackPt"]->Fill( (*recDaughter)->pt() );
-    TH1Index_[prefix + "_RecTrackEta"]->Fill( (*recDaughter)->eta() );      
-  }//end loop to recDaughters
-  //cout << "                   average sum of weights = " << sum_weight/tracksize << endl; 
-  
+    TH1Index_[prefix + "_RecTrackPt"]->Fill((*recDaughter)->pt());
+    TH1Index_[prefix + "_RecTrackEta"]->Fill((*recDaughter)->eta());
+  } // end loop to recDaughters
+  // cout << "                   average sum of weights = " <<
+  // sum_weight/tracksize << endl;
+
   double mass = sum.M();
-  double pt = sqrt( momentum.Perp2() );
+  double pt = sqrt(momentum.Perp2());
   double eta = momentum.Eta();
 
   math::XYZVector simmomentum;
   int simcharge = 0;
-  for ( TrackingVertex::tp_iterator simDaughter = simVertex->daughterTracks_begin(); simDaughter != simVertex->daughterTracks_end(); ++simDaughter ){
+  for (TrackingVertex::tp_iterator simDaughter =
+           simVertex->daughterTracks_begin();
+       simDaughter != simVertex->daughterTracks_end(); ++simDaughter) {
 
     math::XYZVector p;
     p = (**simDaughter).momentum();
-    simmomentum += p; 
+    simmomentum += p;
 
     simcharge += (*simDaughter)->charge();
 
-    TH1Index_[prefix + "_SimTrackPt"]->Fill( (*simDaughter)->pt() );
-    TH1Index_[prefix + "_SimTrackEta"]->Fill( (*simDaughter)->eta() );   
+    TH1Index_[prefix + "_SimTrackPt"]->Fill((*simDaughter)->pt());
+    TH1Index_[prefix + "_SimTrackEta"]->Fill((*simDaughter)->eta());
   }
 
-  double simpt = sqrt( simmomentum.Perp2() );
+  double simpt = sqrt(simmomentum.Perp2());
   double simeta = simmomentum.Eta();
 
-  //cout << "[fillRecoToSim]  vertex.tracksSize() = " << vertex.tracksSize() << " ; simVertex->nDaughterTracks() = " << simVertex->nDaughterTracks() << endl;  
+  // cout << "[fillRecoToSim]  vertex.tracksSize() = " << vertex.tracksSize() <<
+  // " ; simVertex->nDaughterTracks() = " << simVertex->nDaughterTracks() <<
+  // endl;
 
-  TH1Index_[prefix + "_nRecTrks"]->Fill( vertex.tracksSize() );
-  TH1Index_[prefix + "_nSimTrks"]->Fill( simVertex->nDaughterTracks() );
+  TH1Index_[prefix + "_nRecTrks"]->Fill(vertex.tracksSize());
+  TH1Index_[prefix + "_nSimTrks"]->Fill(simVertex->nDaughterTracks());
   TH1Index_[prefix + "_Pullx"]->Fill(pullx);
   TH1Index_[prefix + "_Pully"]->Fill(pully);
   TH1Index_[prefix + "_Pullz"]->Fill(pullz);
   TH1Index_[prefix + "_Resx"]->Fill(resx);
   TH1Index_[prefix + "_Resy"]->Fill(resy);
   TH1Index_[prefix + "_Resz"]->Fill(resz);
-  TH1Index_[prefix + "_AverageTrackWeight"]->Fill( sum_weight/tracksize );   
+  TH1Index_[prefix + "_AverageTrackWeight"]->Fill(sum_weight / tracksize);
   TH1Index_[prefix + "_Chi2Norm"]->Fill(chi2norm);
   TH1Index_[prefix + "_Chi2Prob"]->Fill(chi2prob);
   TH1Index_[prefix + "_RecPt"]->Fill(pt);
@@ -619,89 +667,94 @@ void SVTagInfoValidationAnalyzer::fillRecoToSim(std::string const & prefix, reco
   TH1Index_[prefix + "_Mass"]->Fill(mass);
   TH1Index_[prefix + "_SimPt"]->Fill(simpt);
   TH1Index_[prefix + "_SimEta"]->Fill(simeta);
-  TH1Index_[prefix + "_SimCharge"]->Fill(simcharge);  
+  TH1Index_[prefix + "_SimCharge"]->Fill(simcharge);
 }
 
+void SVTagInfoValidationAnalyzer::fillSimToReco(
+    std::string const &prefix, reco::VertexBaseRef const &vertex,
+    TrackingVertexRef const &simVertex) {
 
-void SVTagInfoValidationAnalyzer::fillSimToReco(std::string const & prefix, reco::VertexBaseRef const & vertex, TrackingVertexRef const & simVertex)
-{
-
-  double pullx = (vertex->x() - simVertex->position().x())/vertex->xError();
-  double pully = (vertex->y() - simVertex->position().y())/vertex->yError();
-  double pullz = (vertex->z() - simVertex->position().z())/vertex->zError();
+  double pullx = (vertex->x() - simVertex->position().x()) / vertex->xError();
+  double pully = (vertex->y() - simVertex->position().y()) / vertex->yError();
+  double pullz = (vertex->z() - simVertex->position().z()) / vertex->zError();
 
   double resx = vertex->x() - simVertex->position().x();
   double resy = vertex->y() - simVertex->position().y();
   double resz = vertex->z() - simVertex->position().z();
 
   double chi2norm = vertex->normalizedChi2();
-  double chi2prob = ChiSquaredProbability(vertex->chi2(), vertex->ndof()); 
+  double chi2prob = ChiSquaredProbability(vertex->chi2(), vertex->ndof());
 
   double sum_weight = 0.;
   double weight = 0.;
-  double tracksize =  vertex->tracksSize();
+  double tracksize = vertex->tracksSize();
   math::XYZVector momentum;
   math::XYZTLorentzVector sum;
   int charge = 0;
   double thePiMass = 0.13957;
-  for ( reco::Vertex::trackRef_iterator recDaughter = vertex->tracks_begin() ; recDaughter != vertex->tracks_end(); ++recDaughter ) {
+  for (reco::Vertex::trackRef_iterator recDaughter = vertex->tracks_begin();
+       recDaughter != vertex->tracks_end(); ++recDaughter) {
 
-    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> > vec;
+    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double>> vec;
 
-    vec.SetPx( (**recDaughter).px() );
-    vec.SetPy( (**recDaughter).py() );
-    vec.SetPz( (**recDaughter).pz() );
-    vec.SetM(thePiMass); 
+    vec.SetPx((**recDaughter).px());
+    vec.SetPy((**recDaughter).py());
+    vec.SetPz((**recDaughter).pz());
+    vec.SetM(thePiMass);
 
     sum += vec;
-  
-    weight = vertex->trackWeight(*recDaughter); 
+
+    weight = vertex->trackWeight(*recDaughter);
     sum_weight += weight;
 
     math::XYZVector p;
     p = (**recDaughter).momentum();
-    momentum += p; 
+    momentum += p;
 
     charge += (*recDaughter)->charge();
 
-    TH1Index_[prefix + "_RecTrackPt"]->Fill( (*recDaughter)->pt() );
-    TH1Index_[prefix + "_RecTrackEta"]->Fill( (*recDaughter)->eta() );  
-  
+    TH1Index_[prefix + "_RecTrackPt"]->Fill((*recDaughter)->pt());
+    TH1Index_[prefix + "_RecTrackEta"]->Fill((*recDaughter)->eta());
   }
-  //cout << "                   average sum of weights = " << sum_weight/tracksize << endl; 
+  // cout << "                   average sum of weights = " <<
+  // sum_weight/tracksize << endl;
 
   double mass = sum.M();
-  double pt = sqrt( momentum.Perp2() );
+  double pt = sqrt(momentum.Perp2());
   double eta = momentum.Eta();
 
-   math::XYZVector simmomentum;
+  math::XYZVector simmomentum;
   int simcharge = 0;
-  for ( TrackingVertex::tp_iterator simDaughter = simVertex->daughterTracks_begin(); simDaughter != simVertex->daughterTracks_end(); ++simDaughter ){
+  for (TrackingVertex::tp_iterator simDaughter =
+           simVertex->daughterTracks_begin();
+       simDaughter != simVertex->daughterTracks_end(); ++simDaughter) {
 
     math::XYZVector p;
     p = (**simDaughter).momentum();
-    simmomentum += p; 
+    simmomentum += p;
 
     simcharge += (*simDaughter)->charge();
 
-    TH1Index_[prefix + "_SimTrackPt"]->Fill( (*simDaughter)->pt() );
-    TH1Index_[prefix + "_SimTrackEta"]->Fill( (*simDaughter)->eta() );   
+    TH1Index_[prefix + "_SimTrackPt"]->Fill((*simDaughter)->pt());
+    TH1Index_[prefix + "_SimTrackEta"]->Fill((*simDaughter)->eta());
   }
 
-  double simpt = sqrt( simmomentum.Perp2() );
+  double simpt = sqrt(simmomentum.Perp2());
   double simeta = simmomentum.Eta();
 
-  //cout << "[fillSimToReco]  vertex->tracksSize() = " << vertex->tracksSize() << " ; simVertex->nDaughterTracks() = " << simVertex->nDaughterTracks() << endl;  
+  // cout << "[fillSimToReco]  vertex->tracksSize() = " << vertex->tracksSize()
+  // << " ; simVertex->nDaughterTracks() = " << simVertex->nDaughterTracks() <<
+  // endl;
 
-  TH1Index_[prefix + "_nRecTrks"]->Fill( vertex->tracksSize() );
-  TH1Index_[prefix + "_nSimTrks"]->Fill( simVertex->nDaughterTracks() );
+  TH1Index_[prefix + "_nRecTrks"]->Fill(vertex->tracksSize());
+  TH1Index_[prefix + "_nSimTrks"]->Fill(simVertex->nDaughterTracks());
   TH1Index_[prefix + "_Pullx"]->Fill(pullx);
   TH1Index_[prefix + "_Pully"]->Fill(pully);
   TH1Index_[prefix + "_Pullz"]->Fill(pullz);
   TH1Index_[prefix + "_Resx"]->Fill(resx);
   TH1Index_[prefix + "_Resy"]->Fill(resy);
   TH1Index_[prefix + "_Resz"]->Fill(resz);
-  TH1Index_[prefix + "_AverageTrackWeight"]->Fill( sum_weight/tracksize );   
+  TH1Index_[prefix + "_AverageTrackWeight"]->Fill(sum_weight / tracksize);
   TH1Index_[prefix + "_Chi2Norm"]->Fill(chi2norm);
   TH1Index_[prefix + "_Chi2Prob"]->Fill(chi2prob);
   TH1Index_[prefix + "_RecPt"]->Fill(pt);
@@ -710,33 +763,42 @@ void SVTagInfoValidationAnalyzer::fillSimToReco(std::string const & prefix, reco
   TH1Index_[prefix + "_Mass"]->Fill(mass);
   TH1Index_[prefix + "_SimPt"]->Fill(simpt);
   TH1Index_[prefix + "_SimEta"]->Fill(simeta);
-  TH1Index_[prefix + "_SimCharge"]->Fill(simcharge);  
-
+  TH1Index_[prefix + "_SimCharge"]->Fill(simcharge);
 }
 
-
-void 
-SVTagInfoValidationAnalyzer::endJob() {
+void SVTagInfoValidationAnalyzer::endJob() {
 
   std::cout << std::endl;
-  std::cout << " ====== Total Number of analyzed events: " << n_event << " ====== " << std::endl;
-  std::cout << " ====== Total Number of R2S All:                         " << rs_total_nall << " ====== " << std::endl;
-  std::cout << " ====== Total Number of R2S SecondaryVertex:             " << rs_total_nsv  << " ====== " << std::endl;
-  std::cout << " ====== Total Number of R2S BWeakDecay:                  " << rs_total_nbv  << " ====== " << std::endl;
-  std::cout << " ====== Total Number of R2S BWeakDecay::SecondaryVertex: " << rs_total_nbsv << " ====== " << std::endl;
-  std::cout << " ====== Total Number of R2S CWeakDecay:                  " << rs_total_ncv  << " ====== " << std::endl;
-  std::cout << " ====== Total Number of R2S Light:                       " << rs_total_nlv  << " ====== " << std::endl;
-  std::cout << std::endl; 
-  std::cout << " ====== Total Number of S2R All:                         " << sr_total_nall << " ====== " << std::endl;
-  std::cout << " ====== Total Number of S2R SecondaryVertex:             " << sr_total_nsv  << " ====== " << std::endl;
-  std::cout << " ====== Total Number of S2R BWeakDecay:                  " << sr_total_nbv  << " ====== " << std::endl;
-  std::cout << " ====== Total Number of S2R BWeakDecay::SecondaryVertex: " << sr_total_nbsv << " ====== " << std::endl;
-  std::cout << " ====== Total Number of S2R CWeakDecay:                  " << sr_total_ncv  << " ====== " << std::endl;
-  std::cout << " ====== Total Number of S2R Light:                       " << sr_total_nlv  << " ====== " << std::endl;
-  std::cout << std::endl; 
-  std::cout << " ====== Total Number of Fake Vertices:              " << total_nfake   << " ====== " << std::endl;
- 
-} 
-
+  std::cout << " ====== Total Number of analyzed events: " << n_event
+            << " ====== " << std::endl;
+  std::cout << " ====== Total Number of R2S All:                         "
+            << rs_total_nall << " ====== " << std::endl;
+  std::cout << " ====== Total Number of R2S SecondaryVertex:             "
+            << rs_total_nsv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of R2S BWeakDecay:                  "
+            << rs_total_nbv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of R2S BWeakDecay::SecondaryVertex: "
+            << rs_total_nbsv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of R2S CWeakDecay:                  "
+            << rs_total_ncv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of R2S Light:                       "
+            << rs_total_nlv << " ====== " << std::endl;
+  std::cout << std::endl;
+  std::cout << " ====== Total Number of S2R All:                         "
+            << sr_total_nall << " ====== " << std::endl;
+  std::cout << " ====== Total Number of S2R SecondaryVertex:             "
+            << sr_total_nsv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of S2R BWeakDecay:                  "
+            << sr_total_nbv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of S2R BWeakDecay::SecondaryVertex: "
+            << sr_total_nbsv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of S2R CWeakDecay:                  "
+            << sr_total_ncv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of S2R Light:                       "
+            << sr_total_nlv << " ====== " << std::endl;
+  std::cout << std::endl;
+  std::cout << " ====== Total Number of Fake Vertices:              "
+            << total_nfake << " ====== " << std::endl;
+}
 
 DEFINE_FWK_MODULE(SVTagInfoValidationAnalyzer);

--- a/SimTracker/TrackHistory/plugins/SecondaryVertexTagInfoProxy.cc
+++ b/SimTracker/TrackHistory/plugins/SecondaryVertexTagInfoProxy.cc
@@ -8,80 +8,79 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 
 //
 // class decleration
 //
 
-class SecondaryVertexTagInfoProxy : public edm::global::EDProducer<>
-{
+class SecondaryVertexTagInfoProxy : public edm::global::EDProducer<> {
 public:
-
-    explicit SecondaryVertexTagInfoProxy(const edm::ParameterSet&);
+  explicit SecondaryVertexTagInfoProxy(const edm::ParameterSet &);
 
 private:
+  void produce(edm::StreamID, edm::Event &,
+               const edm::EventSetup &) const override;
 
-    void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-
-    edm::EDGetTokenT<reco::SecondaryVertexTagInfoCollection> svTagInfoCollection_;
+  edm::EDGetTokenT<reco::SecondaryVertexTagInfoCollection> svTagInfoCollection_;
 };
 
+SecondaryVertexTagInfoProxy::SecondaryVertexTagInfoProxy(
+    const edm::ParameterSet &config) {
+  // Get the cfg parameter
+  svTagInfoCollection_ = consumes<reco::SecondaryVertexTagInfoCollection>(
+      config.getUntrackedParameter<edm::InputTag>("svTagInfoProducer"));
 
-SecondaryVertexTagInfoProxy::SecondaryVertexTagInfoProxy(const edm::ParameterSet& config)
-{
-    // Get the cfg parameter
-    svTagInfoCollection_ = consumes<reco::SecondaryVertexTagInfoCollection>(config.getUntrackedParameter<edm::InputTag> ( "svTagInfoProducer" ));
-
-    // Declare the type of objects to be produced.
-    produces<reco::VertexCollection>();
-    produces<edm::AssociationMap<edm::OneToMany<reco::SecondaryVertexTagInfoCollection, reco::VertexCollection> > >();
+  // Declare the type of objects to be produced.
+  produces<reco::VertexCollection>();
+  produces<edm::AssociationMap<edm::OneToMany<
+      reco::SecondaryVertexTagInfoCollection, reco::VertexCollection>>>();
 }
 
+void SecondaryVertexTagInfoProxy::produce(edm::StreamID, edm::Event &event,
+                                          const edm::EventSetup &setup) const {
+  // Vertex collection
+  edm::Handle<reco::SecondaryVertexTagInfoCollection> svTagInfoCollection;
+  event.getByToken(svTagInfoCollection_, svTagInfoCollection);
 
-void SecondaryVertexTagInfoProxy::produce(edm::StreamID, edm::Event& event, const edm::EventSetup& setup) const
-{
-    // Vertex collection
-    edm::Handle<reco::SecondaryVertexTagInfoCollection> svTagInfoCollection;
-    event.getByToken(svTagInfoCollection_, svTagInfoCollection);
+  // Auto pointers to the collection to be added to the event
+  std::unique_ptr<reco::VertexCollection> proxy(new reco::VertexCollection);
+  std::unique_ptr<edm::AssociationMap<edm::OneToMany<
+      reco::SecondaryVertexTagInfoCollection, reco::VertexCollection>>>
+      assoc(
+          new edm::AssociationMap<edm::OneToMany<
+              reco::SecondaryVertexTagInfoCollection, reco::VertexCollection>>);
 
-    // Auto pointers to the collection to be added to the event
-    std::unique_ptr<reco::VertexCollection> proxy (new reco::VertexCollection);
-    std::unique_ptr<edm::AssociationMap<edm::OneToMany<reco::SecondaryVertexTagInfoCollection, reco::VertexCollection> > >
-    assoc (new edm::AssociationMap<edm::OneToMany<reco::SecondaryVertexTagInfoCollection, reco::VertexCollection> >);
+  // Get a reference before to put in the event
+  reco::VertexRefProd vertexRefProd =
+      event.getRefBeforePut<reco::VertexCollection>();
 
-    // Get a reference before to put in the event
-    reco::VertexRefProd vertexRefProd = event.getRefBeforePut<reco::VertexCollection>();
+  // General index
+  std::size_t index = 0;
 
-    // General index
-    std::size_t index = 0;
+  // Loop over SecondaryVertexTagInfo collection
+  for (std::size_t svIndex = 0; svIndex < svTagInfoCollection->size();
+       ++svIndex) {
+    // Reference to svTagInfo
+    reco::SecondaryVertexTagInfoRef svTagInfo(svTagInfoCollection, svIndex);
 
-    // Loop over SecondaryVertexTagInfo collection
-    for (std::size_t svIndex = 0; svIndex < svTagInfoCollection->size(); ++svIndex)
-    {
-        // Reference to svTagInfo
-        reco::SecondaryVertexTagInfoRef svTagInfo(svTagInfoCollection, svIndex);
-
-        // Loop over the vertexes and add them to the new collection
-        for (unsigned int vIndex = 0; vIndex < svTagInfo->nVertices(); ++vIndex)
-        {
-            proxy->push_back(svTagInfo->secondaryVertex(vIndex));
-            assoc->insert(svTagInfo, reco::VertexRef(vertexRefProd, index));
-            ++index;
-        }
+    // Loop over the vertexes and add them to the new collection
+    for (unsigned int vIndex = 0; vIndex < svTagInfo->nVertices(); ++vIndex) {
+      proxy->push_back(svTagInfo->secondaryVertex(vIndex));
+      assoc->insert(svTagInfo, reco::VertexRef(vertexRefProd, index));
+      ++index;
     }
+  }
 
-    // Adding the collection to the event
-    event.put(std::move(proxy));
-    event.put(std::move(assoc));
+  // Adding the collection to the event
+  event.put(std::move(proxy));
+  event.put(std::move(assoc));
 }
 
-
-//define this as a plug-in
+// define this as a plug-in
 DEFINE_FWK_MODULE(SecondaryVertexTagInfoProxy);

--- a/SimTracker/TrackHistory/plugins/TrackCategoriesAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/TrackCategoriesAnalyzer.cc
@@ -8,8 +8,8 @@
 #include "TH1F.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
@@ -21,90 +21,78 @@
 // class decleration
 //
 
-class TrackCategoriesAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources>
-{
+class TrackCategoriesAnalyzer
+    : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
-
-    explicit TrackCategoriesAnalyzer(const edm::ParameterSet&);
-    ~TrackCategoriesAnalyzer() override;
+  explicit TrackCategoriesAnalyzer(const edm::ParameterSet &);
+  ~TrackCategoriesAnalyzer() override;
 
 private:
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
 
-    void analyze(const edm::Event&, const edm::EventSetup&) override;
+  // Member data
 
-    // Member data
+  edm::EDGetTokenT<edm::View<reco::Track>> trackProducer_;
 
-    edm::EDGetTokenT<edm::View<reco::Track> > trackProducer_;
+  std::size_t totalTracks_;
 
-    std::size_t totalTracks_;
+  TrackClassifier classifier_;
 
-    TrackClassifier classifier_;
+  TH1F *trackCategories_;
 
-    TH1F * trackCategories_;
-
-    Int_t numberTrackCategories_;
+  Int_t numberTrackCategories_;
 };
 
+TrackCategoriesAnalyzer::TrackCategoriesAnalyzer(
+    const edm::ParameterSet &config)
+    : classifier_(config, consumesCollector()) {
+  // Get the track collection
+  trackProducer_ = consumes<edm::View<reco::Track>>(
+      config.getUntrackedParameter<edm::InputTag>("trackProducer"));
 
-TrackCategoriesAnalyzer::TrackCategoriesAnalyzer(const edm::ParameterSet& config) : classifier_(config,consumesCollector())
-{
-    // Get the track collection
-    trackProducer_ = consumes<edm::View<reco::Track>>(config.getUntrackedParameter<edm::InputTag> ( "trackProducer" ));
+  // Get the file service
+  usesResource("TFileService");
+  edm::Service<TFileService> fs;
 
-    // Get the file service
-    usesResource("TFileService");
-    edm::Service<TFileService> fs;
+  // Create a sub directory associated to the analyzer
+  TFileDirectory directory = fs->mkdir("TrackCategoriesAnalyzer");
 
-    // Create a sub directory associated to the analyzer
-    TFileDirectory directory = fs->mkdir( "TrackCategoriesAnalyzer" );
+  // Number of track categories
+  numberTrackCategories_ = TrackCategories::Unknown + 1;
 
-    // Number of track categories
-    numberTrackCategories_ = TrackCategories::Unknown+1;
+  // Define a new histograms
+  trackCategories_ = fs->make<TH1F>(
+      "Frequency", "Frequency for the different track categories",
+      numberTrackCategories_, -0.5, numberTrackCategories_ - 0.5);
 
-    // Define a new histograms
-    trackCategories_ = fs->make<TH1F>(
-                           "Frequency",
-                           "Frequency for the different track categories",
-                           numberTrackCategories_,
-                           -0.5,
-                           numberTrackCategories_ - 0.5
-                       );
-
-    // Set the proper categories names
-    for (Int_t i = 0; i < numberTrackCategories_; ++i)
-        trackCategories_->GetXaxis()->SetBinLabel(i+1, TrackCategories::Names[i]);
+  // Set the proper categories names
+  for (Int_t i = 0; i < numberTrackCategories_; ++i)
+    trackCategories_->GetXaxis()->SetBinLabel(i + 1, TrackCategories::Names[i]);
 }
 
+TrackCategoriesAnalyzer::~TrackCategoriesAnalyzer() {}
 
-TrackCategoriesAnalyzer::~TrackCategoriesAnalyzer() { }
+void TrackCategoriesAnalyzer::analyze(const edm::Event &event,
+                                      const edm::EventSetup &setup) {
+  // Track collection
+  edm::Handle<edm::View<reco::Track>> trackCollection;
+  event.getByToken(trackProducer_, trackCollection);
 
+  // Set the classifier for a new event
+  classifier_.newEvent(event, setup);
 
-void TrackCategoriesAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup)
-{
-    // Track collection
-    edm::Handle<edm::View<reco::Track> > trackCollection;
-    event.getByToken(trackProducer_, trackCollection);
+  // Loop over the track collection.
+  for (std::size_t index = 0; index < trackCollection->size(); index++) {
+    edm::RefToBase<reco::Track> track(trackCollection, index);
 
-    // Set the classifier for a new event
-    classifier_.newEvent(event, setup);
+    // Classify the tracks
+    classifier_.evaluate(track);
 
-    // Loop over the track collection.
-    for (std::size_t index = 0; index < trackCollection->size(); index++)
-    {
-        edm::RefToBase<reco::Track> track(trackCollection, index);
-
-        // Classify the tracks
-        classifier_.evaluate(track);
-
-        // Fill the histogram with the categories
-        for (Int_t i = 0; i != numberTrackCategories_; ++i)
-            if (
-                classifier_.is( (TrackCategories::Category) i )
-            )
-                trackCategories_->Fill(i);
-    }
+    // Fill the histogram with the categories
+    for (Int_t i = 0; i != numberTrackCategories_; ++i)
+      if (classifier_.is((TrackCategories::Category)i))
+        trackCategories_->Fill(i);
+  }
 }
-
 
 DEFINE_FWK_MODULE(TrackCategoriesAnalyzer);
-

--- a/SimTracker/TrackHistory/plugins/TrackHistoryAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/TrackHistoryAnalyzer.cc
@@ -8,8 +8,8 @@
 // system include files
 #include <iostream>
 #include <memory>
-#include <string>
 #include <sstream>
+#include <string>
 #include <vector>
 
 // user include files
@@ -17,12 +17,12 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
@@ -32,308 +32,270 @@
 // class decleration
 //
 
-class TrackHistoryAnalyzer : public edm::one::EDAnalyzer<>
-{
+class TrackHistoryAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-
-    explicit TrackHistoryAnalyzer(const edm::ParameterSet&);
-    ~TrackHistoryAnalyzer() override;
+  explicit TrackHistoryAnalyzer(const edm::ParameterSet &);
+  ~TrackHistoryAnalyzer() override;
 
 private:
+  virtual void beginRun(const edm::Run &, const edm::EventSetup &);
+  void beginJob() override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
 
-    virtual void beginRun(const edm::Run&, const edm::EventSetup&);
-    void beginJob() override ;
-    void analyze(const edm::Event&, const edm::EventSetup&) override;
+  // Member data
 
-    // Member data
+  edm::InputTag trackProducer_;
 
-    edm::InputTag trackProducer_;
+  std::size_t totalTracks_;
 
-    std::size_t totalTracks_;
+  edm::ESHandle<ParticleDataTable> pdt_;
 
-    edm::ESHandle<ParticleDataTable> pdt_;
+  std::string particleString(int) const;
 
-    std::string particleString(int) const;
+  TrackClassifier classifier_;
 
-    TrackClassifier classifier_;
+  std::string vertexString(const TrackingParticleRefVector &,
+                           const TrackingParticleRefVector &) const;
 
-    std::string vertexString(
-        const TrackingParticleRefVector&,
-        const TrackingParticleRefVector&
-    ) const;
-
-    std::string vertexString(
-        HepMC::GenVertex::particles_in_const_iterator,
-        HepMC::GenVertex::particles_in_const_iterator,
-        HepMC::GenVertex::particles_out_const_iterator,
-        HepMC::GenVertex::particles_out_const_iterator
-    ) const;
+  std::string
+      vertexString(HepMC::GenVertex::particles_in_const_iterator,
+                   HepMC::GenVertex::particles_in_const_iterator,
+                   HepMC::GenVertex::particles_out_const_iterator,
+                   HepMC::GenVertex::particles_out_const_iterator) const;
 };
 
-
-TrackHistoryAnalyzer::TrackHistoryAnalyzer(const edm::ParameterSet& config) : classifier_(config,consumesCollector())
-{
-    trackProducer_ = config.getUntrackedParameter<edm::InputTag> ( "trackProducer" );
-    consumes<edm::View<reco::Track>>(trackProducer_);
+TrackHistoryAnalyzer::TrackHistoryAnalyzer(const edm::ParameterSet &config)
+    : classifier_(config, consumesCollector()) {
+  trackProducer_ = config.getUntrackedParameter<edm::InputTag>("trackProducer");
+  consumes<edm::View<reco::Track>>(trackProducer_);
 }
 
+TrackHistoryAnalyzer::~TrackHistoryAnalyzer() {}
 
-TrackHistoryAnalyzer::~TrackHistoryAnalyzer() { }
+void TrackHistoryAnalyzer::analyze(const edm::Event &event,
+                                   const edm::EventSetup &setup) {
+  // Track collection
+  edm::Handle<edm::View<reco::Track>> trackCollection;
+  event.getByLabel(trackProducer_, trackCollection);
 
+  // Set the classifier for a new event
+  classifier_.newEvent(event, setup);
 
-void TrackHistoryAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup)
-{
-    // Track collection
-    edm::Handle<edm::View<reco::Track> > trackCollection;
-    event.getByLabel(trackProducer_, trackCollection);
+  // Get a constant reference to the track history associated to the classifier
+  TrackHistory const &tracer = classifier_.history();
 
-    // Set the classifier for a new event
-    classifier_.newEvent(event, setup);
+  // Loop over the track collection.
+  for (std::size_t index = 0; index < trackCollection->size(); index++) {
+    std::cout << std::endl
+              << "History for track #" << index << " : " << std::endl;
 
-    // Get a constant reference to the track history associated to the classifier
-    TrackHistory const & tracer = classifier_.history();
+    // Classify the track and detect for fakes
+    if (!classifier_.evaluate(reco::TrackBaseRef(trackCollection, index))
+             .is(TrackClassifier::Fake)) {
+      // Get the list of TrackingParticles associated to
+      TrackHistory::SimParticleTrail simParticles(tracer.simParticleTrail());
 
-    // Loop over the track collection.
-    for (std::size_t index = 0; index < trackCollection->size(); index++)
-    {
-        std::cout << std::endl << "History for track #" << index << " : " << std::endl;
+      // Loop over all simParticles
+      for (std::size_t hindex = 0; hindex < simParticles.size(); hindex++) {
+        std::cout << "  simParticles [" << hindex
+                  << "] : " << particleString(simParticles[hindex]->pdgId())
+                  << std::endl;
+      }
 
-        // Classify the track and detect for fakes
-        if ( ! classifier_.evaluate( reco::TrackBaseRef(trackCollection, index) ).is(TrackClassifier::Fake) )
-        {
-            // Get the list of TrackingParticles associated to
-            TrackHistory::SimParticleTrail simParticles(tracer.simParticleTrail());
+      // Get the list of TrackingVertexes associated to
+      TrackHistory::SimVertexTrail simVertexes(tracer.simVertexTrail());
 
-            // Loop over all simParticles
-            for (std::size_t hindex=0; hindex<simParticles.size(); hindex++)
-            {
-                std::cout << "  simParticles [" << hindex << "] : "
-                          << particleString(simParticles[hindex]->pdgId())
-                          << std::endl;
-            }
-
-            // Get the list of TrackingVertexes associated to
-            TrackHistory::SimVertexTrail simVertexes(tracer.simVertexTrail());
-
-            // Loop over all simVertexes
-            if ( !simVertexes.empty() )
-            {
-                for (std::size_t hindex=0; hindex<simVertexes.size(); hindex++)
-                {
-                    std::cout << "  simVertex    [" << hindex << "] : "
-                              << vertexString(
-                                  simVertexes[hindex]->sourceTracks(),
-                                  simVertexes[hindex]->daughterTracks()
-                              )
-                              << std::endl;
-                }
-            }
-            else
-                std::cout << "  simVertex no found" << std::endl;
-
-            // Get the list of GenParticles associated to
-            TrackHistory::GenParticleTrail genParticles(tracer.genParticleTrail());
-
-            // Loop over all genParticles
-            for (std::size_t hindex=0; hindex<genParticles.size(); hindex++)
-            {
-                std::cout << "  genParticles [" << hindex << "] : "
-                          << particleString(genParticles[hindex]->pdg_id())
-                          << std::endl;
-            }
-
-            // Get the list of TrackingVertexes associated to
-            TrackHistory::GenVertexTrail genVertexes(tracer.genVertexTrail());
-
-            // Loop over all simVertexes
-            if ( !genVertexes.empty() )
-            {
-                for (std::size_t hindex=0; hindex<genVertexes.size(); hindex++)
-                {
-                    std::cout << "  genVertex    [" << hindex << "] : "
-                              << vertexString(
-                                  genVertexes[hindex]->particles_in_const_begin(),
-                                  genVertexes[hindex]->particles_in_const_end(),
-                                  genVertexes[hindex]->particles_out_const_begin(),
-                                  genVertexes[hindex]->particles_out_const_end()
-                              )
-                              << std::endl;
-                }
-            }
-            else
-                std::cout << "  genVertex no found" << std::endl;
+      // Loop over all simVertexes
+      if (!simVertexes.empty()) {
+        for (std::size_t hindex = 0; hindex < simVertexes.size(); hindex++) {
+          std::cout << "  simVertex    [" << hindex << "] : "
+                    << vertexString(simVertexes[hindex]->sourceTracks(),
+                                    simVertexes[hindex]->daughterTracks())
+                    << std::endl;
         }
-        else
-            std::cout << "  fake track" << std::endl;
+      } else
+        std::cout << "  simVertex no found" << std::endl;
 
-        std::cout << "  track categories : " << classifier_;
-        std::cout << std::endl;
-    }
+      // Get the list of GenParticles associated to
+      TrackHistory::GenParticleTrail genParticles(tracer.genParticleTrail());
+
+      // Loop over all genParticles
+      for (std::size_t hindex = 0; hindex < genParticles.size(); hindex++) {
+        std::cout << "  genParticles [" << hindex
+                  << "] : " << particleString(genParticles[hindex]->pdg_id())
+                  << std::endl;
+      }
+
+      // Get the list of TrackingVertexes associated to
+      TrackHistory::GenVertexTrail genVertexes(tracer.genVertexTrail());
+
+      // Loop over all simVertexes
+      if (!genVertexes.empty()) {
+        for (std::size_t hindex = 0; hindex < genVertexes.size(); hindex++) {
+          std::cout << "  genVertex    [" << hindex << "] : "
+                    << vertexString(
+                           genVertexes[hindex]->particles_in_const_begin(),
+                           genVertexes[hindex]->particles_in_const_end(),
+                           genVertexes[hindex]->particles_out_const_begin(),
+                           genVertexes[hindex]->particles_out_const_end())
+                    << std::endl;
+        }
+      } else
+        std::cout << "  genVertex no found" << std::endl;
+    } else
+      std::cout << "  fake track" << std::endl;
+
+    std::cout << "  track categories : " << classifier_;
+    std::cout << std::endl;
+  }
 }
 
-
-void
-TrackHistoryAnalyzer::beginRun(const edm::Run& run, const edm::EventSetup& setup)
-{
-    // Get the particles table.
-    setup.getData( pdt_ );
+void TrackHistoryAnalyzer::beginRun(const edm::Run &run,
+                                    const edm::EventSetup &setup) {
+  // Get the particles table.
+  setup.getData(pdt_);
 }
 
-void
-TrackHistoryAnalyzer::beginJob()
-{
-    totalTracks_ = 0;
-}
+void TrackHistoryAnalyzer::beginJob() { totalTracks_ = 0; }
 
+std::string TrackHistoryAnalyzer::particleString(int pdgId) const {
+  ParticleData const *pid;
 
-std::string TrackHistoryAnalyzer::particleString(int pdgId) const
-{
-    ParticleData const * pid;
+  std::ostringstream vDescription;
 
-    std::ostringstream vDescription;
+  HepPDT::ParticleID particleType(pdgId);
 
-    HepPDT::ParticleID particleType(pdgId);
-
-    if (particleType.isValid())
-    {
-        pid = pdt_->particle(particleType);
-        if (pid)
-            vDescription << pid->name();
-        else
-            vDescription << pdgId;
-    }
+  if (particleType.isValid()) {
+    pid = pdt_->particle(particleType);
+    if (pid)
+      vDescription << pid->name();
     else
-        vDescription << pdgId;
+      vDescription << pdgId;
+  } else
+    vDescription << pdgId;
 
-    return vDescription.str();
+  return vDescription.str();
 }
 
+std::string
+TrackHistoryAnalyzer::vertexString(const TrackingParticleRefVector &in,
+                                   const TrackingParticleRefVector &out) const {
+  ParticleData const *pid;
 
-std::string TrackHistoryAnalyzer::vertexString(
-    const TrackingParticleRefVector& in,
-    const TrackingParticleRefVector& out
-) const
-{
-    ParticleData const * pid;
+  std::ostringstream vDescription;
 
-    std::ostringstream vDescription;
+  for (std::size_t j = 0; j < in.size(); j++) {
+    if (!j)
+      vDescription << "(";
 
-    for (std::size_t j = 0; j < in.size(); j++)
-    {
-        if (!j) vDescription << "(";
+    HepPDT::ParticleID particleType(in[j]->pdgId());
 
-        HepPDT::ParticleID particleType(in[j]->pdgId());
+    if (particleType.isValid()) {
+      pid = pdt_->particle(particleType);
+      if (pid)
+        vDescription << pid->name();
+      else
+        vDescription << in[j]->pdgId();
+    } else
+      vDescription << in[j]->pdgId();
 
-        if (particleType.isValid())
-        {
-            pid = pdt_->particle(particleType);
-            if (pid)
-                vDescription << pid->name();
-            else
-                vDescription << in[j]->pdgId();
-        }
-        else
-            vDescription << in[j]->pdgId();
+    if (j == in.size() - 1)
+      vDescription << ")";
+    else
+      vDescription << ",";
+  }
 
-        if (j == in.size() - 1) vDescription << ")";
-        else vDescription << ",";
-    }
+  vDescription << "->";
 
-    vDescription << "->";
+  for (std::size_t j = 0; j < out.size(); j++) {
+    if (!j)
+      vDescription << "(";
 
-    for (std::size_t j = 0; j < out.size(); j++)
-    {
-        if (!j) vDescription << "(";
+    HepPDT::ParticleID particleType(out[j]->pdgId());
 
-        HepPDT::ParticleID particleType(out[j]->pdgId());
+    if (particleType.isValid()) {
+      pid = pdt_->particle(particleType);
+      if (pid)
+        vDescription << pid->name();
+      else
+        vDescription << out[j]->pdgId();
+    } else
+      vDescription << out[j]->pdgId();
 
-        if (particleType.isValid())
-        {
-            pid = pdt_->particle(particleType);
-            if (pid)
-                vDescription << pid->name();
-            else
-                vDescription << out[j]->pdgId();
-        }
-        else
-            vDescription << out[j]->pdgId();
+    if (j == out.size() - 1)
+      vDescription << ")";
+    else
+      vDescription << ",";
+  }
 
-        if (j == out.size() - 1) vDescription << ")";
-        else vDescription << ",";
-    }
-
-    return vDescription.str();
+  return vDescription.str();
 }
-
 
 std::string TrackHistoryAnalyzer::vertexString(
     HepMC::GenVertex::particles_in_const_iterator in_begin,
     HepMC::GenVertex::particles_in_const_iterator in_end,
     HepMC::GenVertex::particles_out_const_iterator out_begin,
-    HepMC::GenVertex::particles_out_const_iterator out_end
-) const
-{
-    ParticleData const * pid;
+    HepMC::GenVertex::particles_out_const_iterator out_end) const {
+  ParticleData const *pid;
 
-    std::ostringstream vDescription;
+  std::ostringstream vDescription;
 
-    std::size_t j = 0;
+  std::size_t j = 0;
 
-    HepMC::GenVertex::particles_in_const_iterator in, itmp;
+  HepMC::GenVertex::particles_in_const_iterator in, itmp;
 
-    for (in = in_begin; in != in_end; in++, j++)
-    {
-        if (!j) vDescription << "(";
+  for (in = in_begin; in != in_end; in++, j++) {
+    if (!j)
+      vDescription << "(";
 
-        HepPDT::ParticleID particleType((*in)->pdg_id());
+    HepPDT::ParticleID particleType((*in)->pdg_id());
 
-        if (particleType.isValid())
-        {
-            pid = pdt_->particle(particleType);
-            if (pid)
-                vDescription << pid->name();
-            else
-                vDescription << (*in)->pdg_id();
-        }
-        else
-            vDescription << (*in)->pdg_id();
+    if (particleType.isValid()) {
+      pid = pdt_->particle(particleType);
+      if (pid)
+        vDescription << pid->name();
+      else
+        vDescription << (*in)->pdg_id();
+    } else
+      vDescription << (*in)->pdg_id();
 
-        itmp = in;
+    itmp = in;
 
-        if (++itmp == in_end) vDescription << ")";
-        else vDescription << ",";
-    }
+    if (++itmp == in_end)
+      vDescription << ")";
+    else
+      vDescription << ",";
+  }
 
-    vDescription << "->";
-    j = 0;
+  vDescription << "->";
+  j = 0;
 
-    HepMC::GenVertex::particles_out_const_iterator out, otmp;
+  HepMC::GenVertex::particles_out_const_iterator out, otmp;
 
-    for (out = out_begin; out != out_end; out++, j++)
-    {
-        if (!j) vDescription << "(";
+  for (out = out_begin; out != out_end; out++, j++) {
+    if (!j)
+      vDescription << "(";
 
-        HepPDT::ParticleID particleType((*out)->pdg_id());
+    HepPDT::ParticleID particleType((*out)->pdg_id());
 
-        if (particleType.isValid())
-        {
-            pid = pdt_->particle(particleType);
-            if (pid)
-                vDescription << pid->name();
-            else
-                vDescription << (*out)->pdg_id();
-        }
-        else
-            vDescription << (*out)->pdg_id();
+    if (particleType.isValid()) {
+      pid = pdt_->particle(particleType);
+      if (pid)
+        vDescription << pid->name();
+      else
+        vDescription << (*out)->pdg_id();
+    } else
+      vDescription << (*out)->pdg_id();
 
-        otmp = out;
+    otmp = out;
 
-        if (++otmp == out_end) vDescription << ")";
-        else vDescription << ",";
-    }
+    if (++otmp == out_end)
+      vDescription << ")";
+    else
+      vDescription << ",";
+  }
 
-    return vDescription.str();
+  return vDescription.str();
 }
-
 
 DEFINE_FWK_MODULE(TrackHistoryAnalyzer);

--- a/SimTracker/TrackHistory/plugins/TrackingParticleBHadronRefSelector.cc
+++ b/SimTracker/TrackHistory/plugins/TrackingParticleBHadronRefSelector.cc
@@ -1,8 +1,8 @@
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "DataFormats/Common/interface/EDProductfwd.h"
@@ -13,13 +13,13 @@
 
 #include "HepPDT/ParticleID.hh"
 
-class TrackingParticleBHadronRefSelector: public edm::stream::EDProducer<> {
+class TrackingParticleBHadronRefSelector : public edm::stream::EDProducer<> {
 public:
-  TrackingParticleBHadronRefSelector(const edm::ParameterSet& iConfig);
+  TrackingParticleBHadronRefSelector(const edm::ParameterSet &iConfig);
 
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
-  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
 
 private:
   edm::EDGetTokenT<TrackingParticleCollection> tpToken_;
@@ -27,36 +27,39 @@ private:
   HistoryBase tracer_;
 };
 
-
-TrackingParticleBHadronRefSelector::TrackingParticleBHadronRefSelector(const edm::ParameterSet& iConfig):
-  tpToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("src")))
-{
+TrackingParticleBHadronRefSelector::TrackingParticleBHadronRefSelector(
+    const edm::ParameterSet &iConfig)
+    : tpToken_(consumes<TrackingParticleCollection>(
+          iConfig.getParameter<edm::InputTag>("src"))) {
   tracer_.depth(-2); // as in SimTracker/TrackHistory/src/TrackClassifier.cc
 
   produces<TrackingParticleRefVector>();
 }
 
-void TrackingParticleBHadronRefSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void TrackingParticleBHadronRefSelector::fillDescriptions(
+    edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("mix", "MergedTrackTruth"));
   descriptions.add("trackingParticleBHadronRefSelectorDefault", desc);
 }
 
-void TrackingParticleBHadronRefSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void TrackingParticleBHadronRefSelector::produce(
+    edm::Event &iEvent, const edm::EventSetup &iSetup) {
   edm::Handle<TrackingParticleCollection> h_tps;
   iEvent.getByToken(tpToken_, h_tps);
 
   auto ret = std::make_unique<TrackingParticleRefVector>();
 
   // Logic is similar to SimTracker/TrackHistory
-  for(size_t i=0, end=h_tps->size(); i<end; ++i) {
+  for (size_t i = 0, end = h_tps->size(); i < end; ++i) {
     auto tpRef = TrackingParticleRef(h_tps, i);
-    if(tracer_.evaluate(tpRef)) { // ignore TP if history can not be traced
+    if (tracer_.evaluate(tpRef)) { // ignore TP if history can not be traced
       // following is from TrackClassifier::processesAtGenerator()
-      HistoryBase::RecoGenParticleTrail const & recoGenParticleTrail = tracer_.recoGenParticleTrail();
-      for(const auto& particle: recoGenParticleTrail) {
+      HistoryBase::RecoGenParticleTrail const &recoGenParticleTrail =
+          tracer_.recoGenParticleTrail();
+      for (const auto &particle : recoGenParticleTrail) {
         HepPDT::ParticleID particleID(particle->pdgId());
-        if(particleID.hasBottom()) {
+        if (particleID.hasBottom()) {
           ret->push_back(tpRef);
           break;
         }

--- a/SimTracker/TrackHistory/plugins/TrackingParticleCategoriesAnalyser.cc
+++ b/SimTracker/TrackHistory/plugins/TrackingParticleCategoriesAnalyser.cc
@@ -8,8 +8,8 @@
 #include "TH1F.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
@@ -21,89 +21,80 @@
 // class decleration
 //
 
-class TrackingParticleCategoriesAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources>
-{
+class TrackingParticleCategoriesAnalyzer
+    : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
-
-    explicit TrackingParticleCategoriesAnalyzer(const edm::ParameterSet&);
-    ~TrackingParticleCategoriesAnalyzer() override;
+  explicit TrackingParticleCategoriesAnalyzer(const edm::ParameterSet &);
+  ~TrackingParticleCategoriesAnalyzer() override;
 
 private:
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
 
-    void analyze(const edm::Event&, const edm::EventSetup&) override;
+  // Member data
 
-    // Member data
+  edm::EDGetTokenT<TrackingParticleCollection> trackingTruth_;
 
-    edm::EDGetTokenT<TrackingParticleCollection> trackingTruth_;
+  std::size_t totalTrakingParticles_;
 
-    std::size_t totalTrakingParticles_;
+  TrackClassifier classifier_;
 
-    TrackClassifier classifier_;
+  TH1F *trackingParticleCategories_;
 
-    TH1F * trackingParticleCategories_;
-
-    Int_t numberTrackingParticleCategories_;
+  Int_t numberTrackingParticleCategories_;
 };
 
+TrackingParticleCategoriesAnalyzer::TrackingParticleCategoriesAnalyzer(
+    const edm::ParameterSet &config)
+    : classifier_(config, consumesCollector()) {
+  // Get the track collection
+  trackingTruth_ = consumes<TrackingParticleCollection>(
+      config.getUntrackedParameter<edm::InputTag>("trackingTruth"));
 
-TrackingParticleCategoriesAnalyzer::TrackingParticleCategoriesAnalyzer(const edm::ParameterSet& config) : classifier_(config,consumesCollector())
-{
-    // Get the track collection
-    trackingTruth_ = consumes<TrackingParticleCollection>(config.getUntrackedParameter<edm::InputTag> ( "trackingTruth" ));
+  // Get the file service
+  usesResource("TFileService");
+  edm::Service<TFileService> fs;
 
-    // Get the file service
-    usesResource("TFileService");
-    edm::Service<TFileService> fs;
+  // Create a sub directory associated to the analyzer
+  TFileDirectory directory = fs->mkdir("TrackingParticleCategoriesAnalyzer");
 
-    // Create a sub directory associated to the analyzer
-    TFileDirectory directory = fs->mkdir( "TrackingParticleCategoriesAnalyzer" );
+  // Number of track categories
+  numberTrackingParticleCategories_ = TrackCategories::Unknown + 1;
 
-    // Number of track categories
-    numberTrackingParticleCategories_ = TrackCategories::Unknown+1;
+  // Define a new histograms
+  trackingParticleCategories_ = fs->make<TH1F>(
+      "Frequency", "Frequency for the different track categories",
+      numberTrackingParticleCategories_, -0.5,
+      numberTrackingParticleCategories_ - 0.5);
 
-    // Define a new histograms
-    trackingParticleCategories_ = fs->make<TH1F>(
-                           "Frequency",
-                           "Frequency for the different track categories",
-                           numberTrackingParticleCategories_,
-                           -0.5,
-                           numberTrackingParticleCategories_ - 0.5
-                       );
-
-    // Set the proper categories names
-    for (Int_t i = 0; i < numberTrackingParticleCategories_; ++i)
-        trackingParticleCategories_->GetXaxis()->SetBinLabel(i+1, TrackCategories::Names[i]);
+  // Set the proper categories names
+  for (Int_t i = 0; i < numberTrackingParticleCategories_; ++i)
+    trackingParticleCategories_->GetXaxis()->SetBinLabel(
+        i + 1, TrackCategories::Names[i]);
 }
 
+TrackingParticleCategoriesAnalyzer::~TrackingParticleCategoriesAnalyzer() {}
 
-TrackingParticleCategoriesAnalyzer::~TrackingParticleCategoriesAnalyzer() { }
+void TrackingParticleCategoriesAnalyzer::analyze(const edm::Event &event,
+                                                 const edm::EventSetup &setup) {
+  // Track collection
+  edm::Handle<TrackingParticleCollection> TPCollection;
+  event.getByToken(trackingTruth_, TPCollection);
 
+  // Set the classifier for a new event
+  classifier_.newEvent(event, setup);
 
-void TrackingParticleCategoriesAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup)
-{
-    // Track collection
-    edm::Handle<TrackingParticleCollection> TPCollection;
-    event.getByToken(trackingTruth_, TPCollection);
+  // Loop over the track collection.
+  for (std::size_t index = 0; index < TPCollection->size(); index++) {
+    TrackingParticleRef trackingParticle(TPCollection, index);
 
-    // Set the classifier for a new event
-    classifier_.newEvent(event, setup);
+    // Classify the tracks
+    classifier_.evaluate(trackingParticle);
 
-    // Loop over the track collection.
-    for (std::size_t index = 0; index < TPCollection->size(); index++)
-    {
-        TrackingParticleRef trackingParticle(TPCollection, index);
-
-        // Classify the tracks
-        classifier_.evaluate(trackingParticle);
-
-        // Fill the histogram with the categories
-        for (Int_t i = 0; i != numberTrackingParticleCategories_; ++i)
-            if (
-                classifier_.is( (TrackCategories::Category) i )
-            )
-                trackingParticleCategories_->Fill(i);
-    }
+    // Fill the histogram with the categories
+    for (Int_t i = 0; i != numberTrackingParticleCategories_; ++i)
+      if (classifier_.is((TrackCategories::Category)i))
+        trackingParticleCategories_->Fill(i);
+  }
 }
-
 
 DEFINE_FWK_MODULE(TrackingParticleCategoriesAnalyzer);

--- a/SimTracker/TrackHistory/plugins/VertexHistoryAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/VertexHistoryAnalyzer.cc
@@ -8,20 +8,20 @@
 // system include files
 #include <iostream>
 #include <memory>
-#include <string>
 #include <sstream>
+#include <string>
 #include <vector>
 
 // user include files
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
@@ -31,302 +31,266 @@
 // class decleration
 //
 
-class VertexHistoryAnalyzer : public edm::one::EDAnalyzer<>
-{
+class VertexHistoryAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-
-    explicit VertexHistoryAnalyzer(const edm::ParameterSet&);
+  explicit VertexHistoryAnalyzer(const edm::ParameterSet &);
 
 private:
+  virtual void beginRun(const edm::Run &, const edm::EventSetup &);
+  void beginJob() override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
 
-    virtual void beginRun(const edm::Run&,const edm::EventSetup&);
-    void beginJob() override ;
-    void analyze(const edm::Event&, const edm::EventSetup&) override;
+  // Member data
 
-    // Member data
+  VertexClassifier classifier_;
 
-    VertexClassifier classifier_;
+  edm::InputTag vertexProducer_;
 
-    edm::InputTag vertexProducer_;
+  edm::ESHandle<ParticleDataTable> pdt_;
 
-    edm::ESHandle<ParticleDataTable> pdt_;
+  std::string particleString(int) const;
 
-    std::string particleString(int) const;
+  std::string vertexString(const TrackingParticleRefVector &,
+                           const TrackingParticleRefVector &) const;
 
-    std::string vertexString(
-        const TrackingParticleRefVector&,
-        const TrackingParticleRefVector&
-    ) const;
-
-    std::string vertexString(
-        HepMC::GenVertex::particles_in_const_iterator,
-        HepMC::GenVertex::particles_in_const_iterator,
-        HepMC::GenVertex::particles_out_const_iterator,
-        HepMC::GenVertex::particles_out_const_iterator
-    ) const;
+  std::string
+      vertexString(HepMC::GenVertex::particles_in_const_iterator,
+                   HepMC::GenVertex::particles_in_const_iterator,
+                   HepMC::GenVertex::particles_out_const_iterator,
+                   HepMC::GenVertex::particles_out_const_iterator) const;
 };
 
-
-VertexHistoryAnalyzer::VertexHistoryAnalyzer(const edm::ParameterSet& config) : classifier_(config,consumesCollector())
-{
-    vertexProducer_ = config.getUntrackedParameter<edm::InputTag> ("vertexProducer");
-    consumes<edm::View<reco::Vertex>>(vertexProducer_);
+VertexHistoryAnalyzer::VertexHistoryAnalyzer(const edm::ParameterSet &config)
+    : classifier_(config, consumesCollector()) {
+  vertexProducer_ =
+      config.getUntrackedParameter<edm::InputTag>("vertexProducer");
+  consumes<edm::View<reco::Vertex>>(vertexProducer_);
 }
 
+void VertexHistoryAnalyzer::analyze(const edm::Event &event,
+                                    const edm::EventSetup &setup) {
+  // Set the classifier for a new event
+  classifier_.newEvent(event, setup);
 
-void VertexHistoryAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup)
-{
-    // Set the classifier for a new event
-    classifier_.newEvent(event, setup);
+  // Vertex collection
+  edm::Handle<edm::View<reco::Vertex>> vertexCollection;
+  event.getByLabel(vertexProducer_, vertexCollection);
 
-    // Vertex collection
-    edm::Handle<edm::View<reco::Vertex> > vertexCollection;
-    event.getByLabel(vertexProducer_, vertexCollection);
+  // Get a constant reference to the track history associated to the classifier
+  VertexHistory const &tracer = classifier_.history();
 
-    // Get a constant reference to the track history associated to the classifier
-    VertexHistory const & tracer = classifier_.history();
+  // Loop over the track collection.
+  for (std::size_t index = 0; index < vertexCollection->size(); index++) {
+    std::cout << std::endl
+              << "History for vertex #" << index << " : " << std::endl;
 
-    // Loop over the track collection.
-    for (std::size_t index = 0; index < vertexCollection->size(); index++)
-    {
-        std::cout << std::endl << "History for vertex #" << index << " : " << std::endl;
+    // Classify the track and detect for fakes
+    if (!classifier_.evaluate(reco::VertexBaseRef(vertexCollection, index))
+             .is(VertexClassifier::Fake)) {
+      // Get the list of TrackingParticles associated to
+      VertexHistory::SimParticleTrail simParticles(tracer.simParticleTrail());
 
-        // Classify the track and detect for fakes
-        if ( !classifier_.evaluate( reco::VertexBaseRef(vertexCollection, index) ).is(VertexClassifier::Fake) )
-        {
-            // Get the list of TrackingParticles associated to
-            VertexHistory::SimParticleTrail simParticles(tracer.simParticleTrail());
+      // Loop over all simParticles
+      for (std::size_t hindex = 0; hindex < simParticles.size(); hindex++) {
+        std::cout << "  simParticles [" << hindex
+                  << "] : " << particleString(simParticles[hindex]->pdgId())
+                  << std::endl;
+      }
 
-            // Loop over all simParticles
-            for (std::size_t hindex=0; hindex<simParticles.size(); hindex++)
-            {
-                std::cout << "  simParticles [" << hindex << "] : "
-                          << particleString(simParticles[hindex]->pdgId())
-                          << std::endl;
-            }
+      // Get the list of TrackingVertexes associated to
+      VertexHistory::SimVertexTrail simVertexes(tracer.simVertexTrail());
 
-            // Get the list of TrackingVertexes associated to
-            VertexHistory::SimVertexTrail simVertexes(tracer.simVertexTrail());
-
-            // Loop over all simVertexes
-            if ( !simVertexes.empty() )
-            {
-                for (std::size_t hindex=0; hindex<simVertexes.size(); hindex++)
-                {
-                    std::cout << "  simVertex    [" << hindex << "] : "
-                              << vertexString(
-                                  simVertexes[hindex]->sourceTracks(),
-                                  simVertexes[hindex]->daughterTracks()
-                              )
-                              << std::endl;
-                }
-            }
-            else
-                std::cout << "  simVertex no found" << std::endl;
-
-            // Get the list of GenParticles associated to
-            VertexHistory::GenParticleTrail genParticles(tracer.genParticleTrail());
-
-            // Loop over all genParticles
-            for (std::size_t hindex=0; hindex<genParticles.size(); hindex++)
-            {
-                std::cout << "  genParticles [" << hindex << "] : "
-                          << particleString(genParticles[hindex]->pdg_id())
-                          << std::endl;
-            }
-
-            // Get the list of TrackingVertexes associated to
-            VertexHistory::GenVertexTrail genVertexes(tracer.genVertexTrail());
-
-            // Loop over all simVertexes
-            if ( !genVertexes.empty() )
-            {
-                for (std::size_t hindex=0; hindex<genVertexes.size(); hindex++)
-                {
-                    std::cout << "  genVertex    [" << hindex << "] : "
-                              << vertexString(
-                                  genVertexes[hindex]->particles_in_const_begin(),
-                                  genVertexes[hindex]->particles_in_const_end(),
-                                  genVertexes[hindex]->particles_out_const_begin(),
-                                  genVertexes[hindex]->particles_out_const_end()
-                              )
-                              << std::endl;
-                }
-            }
-            else
-                std::cout << "  genVertex no found" << std::endl;
+      // Loop over all simVertexes
+      if (!simVertexes.empty()) {
+        for (std::size_t hindex = 0; hindex < simVertexes.size(); hindex++) {
+          std::cout << "  simVertex    [" << hindex << "] : "
+                    << vertexString(simVertexes[hindex]->sourceTracks(),
+                                    simVertexes[hindex]->daughterTracks())
+                    << std::endl;
         }
-        else
-            std::cout << "  fake vertex" << std::endl;
+      } else
+        std::cout << "  simVertex no found" << std::endl;
 
-        std::cout << "  vertex categories : " << classifier_;
-        std::cout << std::endl;
-    }
+      // Get the list of GenParticles associated to
+      VertexHistory::GenParticleTrail genParticles(tracer.genParticleTrail());
+
+      // Loop over all genParticles
+      for (std::size_t hindex = 0; hindex < genParticles.size(); hindex++) {
+        std::cout << "  genParticles [" << hindex
+                  << "] : " << particleString(genParticles[hindex]->pdg_id())
+                  << std::endl;
+      }
+
+      // Get the list of TrackingVertexes associated to
+      VertexHistory::GenVertexTrail genVertexes(tracer.genVertexTrail());
+
+      // Loop over all simVertexes
+      if (!genVertexes.empty()) {
+        for (std::size_t hindex = 0; hindex < genVertexes.size(); hindex++) {
+          std::cout << "  genVertex    [" << hindex << "] : "
+                    << vertexString(
+                           genVertexes[hindex]->particles_in_const_begin(),
+                           genVertexes[hindex]->particles_in_const_end(),
+                           genVertexes[hindex]->particles_out_const_begin(),
+                           genVertexes[hindex]->particles_out_const_end())
+                    << std::endl;
+        }
+      } else
+        std::cout << "  genVertex no found" << std::endl;
+    } else
+      std::cout << "  fake vertex" << std::endl;
+
+    std::cout << "  vertex categories : " << classifier_;
+    std::cout << std::endl;
+  }
 }
 
-
-void
-VertexHistoryAnalyzer::beginRun(const edm::Run& run, const edm::EventSetup& setup)
-{
-    // Get the particles table.
-    setup.getData( pdt_ );
+void VertexHistoryAnalyzer::beginRun(const edm::Run &run,
+                                     const edm::EventSetup &setup) {
+  // Get the particles table.
+  setup.getData(pdt_);
 }
 
-void
-VertexHistoryAnalyzer::beginJob()
-{
+void VertexHistoryAnalyzer::beginJob() {}
 
-}
+std::string VertexHistoryAnalyzer::particleString(int pdgId) const {
+  ParticleData const *pid;
 
+  std::ostringstream vDescription;
 
-std::string VertexHistoryAnalyzer::particleString(int pdgId) const
-{
-    ParticleData const * pid;
+  HepPDT::ParticleID particleType(pdgId);
 
-    std::ostringstream vDescription;
-
-    HepPDT::ParticleID particleType(pdgId);
-
-    if (particleType.isValid())
-    {
-        pid = pdt_->particle(particleType);
-        if (pid)
-            vDescription << pid->name();
-        else
-            vDescription << pdgId;
-    }
+  if (particleType.isValid()) {
+    pid = pdt_->particle(particleType);
+    if (pid)
+      vDescription << pid->name();
     else
-        vDescription << pdgId;
+      vDescription << pdgId;
+  } else
+    vDescription << pdgId;
 
-    return vDescription.str();
+  return vDescription.str();
 }
-
 
 std::string VertexHistoryAnalyzer::vertexString(
-    const TrackingParticleRefVector& in,
-    const TrackingParticleRefVector& out
-) const
-{
-    ParticleData const * pid;
+    const TrackingParticleRefVector &in,
+    const TrackingParticleRefVector &out) const {
+  ParticleData const *pid;
 
-    std::ostringstream vDescription;
+  std::ostringstream vDescription;
 
-    for (std::size_t j = 0; j < in.size(); j++)
-    {
-        if (!j) vDescription << "(";
+  for (std::size_t j = 0; j < in.size(); j++) {
+    if (!j)
+      vDescription << "(";
 
-        HepPDT::ParticleID particleType(in[j]->pdgId());
+    HepPDT::ParticleID particleType(in[j]->pdgId());
 
-        if (particleType.isValid())
-        {
-            pid = pdt_->particle(particleType);
-            if (pid)
-                vDescription << pid->name();
-            else
-                vDescription << in[j]->pdgId();
-        }
-        else
-            vDescription << in[j]->pdgId();
+    if (particleType.isValid()) {
+      pid = pdt_->particle(particleType);
+      if (pid)
+        vDescription << pid->name();
+      else
+        vDescription << in[j]->pdgId();
+    } else
+      vDescription << in[j]->pdgId();
 
-        if (j == in.size() - 1) vDescription << ")";
-        else vDescription << ",";
-    }
+    if (j == in.size() - 1)
+      vDescription << ")";
+    else
+      vDescription << ",";
+  }
 
-    vDescription << "->";
+  vDescription << "->";
 
-    for (std::size_t j = 0; j < out.size(); j++)
-    {
-        if (!j) vDescription << "(";
+  for (std::size_t j = 0; j < out.size(); j++) {
+    if (!j)
+      vDescription << "(";
 
-        HepPDT::ParticleID particleType(out[j]->pdgId());
+    HepPDT::ParticleID particleType(out[j]->pdgId());
 
-        if (particleType.isValid())
-        {
-            pid = pdt_->particle(particleType);
-            if (pid)
-                vDescription << pid->name();
-            else
-                vDescription << out[j]->pdgId();
-        }
-        else
-            vDescription << out[j]->pdgId();
+    if (particleType.isValid()) {
+      pid = pdt_->particle(particleType);
+      if (pid)
+        vDescription << pid->name();
+      else
+        vDescription << out[j]->pdgId();
+    } else
+      vDescription << out[j]->pdgId();
 
-        if (j == out.size() - 1) vDescription << ")";
-        else vDescription << ",";
-    }
+    if (j == out.size() - 1)
+      vDescription << ")";
+    else
+      vDescription << ",";
+  }
 
-    return vDescription.str();
+  return vDescription.str();
 }
-
 
 std::string VertexHistoryAnalyzer::vertexString(
     HepMC::GenVertex::particles_in_const_iterator in_begin,
     HepMC::GenVertex::particles_in_const_iterator in_end,
     HepMC::GenVertex::particles_out_const_iterator out_begin,
-    HepMC::GenVertex::particles_out_const_iterator out_end
-) const
-{
-    ParticleData const * pid;
+    HepMC::GenVertex::particles_out_const_iterator out_end) const {
+  ParticleData const *pid;
 
-    std::ostringstream vDescription;
+  std::ostringstream vDescription;
 
-    std::size_t j = 0;
+  std::size_t j = 0;
 
-    HepMC::GenVertex::particles_in_const_iterator in, itmp;
+  HepMC::GenVertex::particles_in_const_iterator in, itmp;
 
-    for (in = in_begin; in != in_end; in++, j++)
-    {
-        if (!j) vDescription << "(";
+  for (in = in_begin; in != in_end; in++, j++) {
+    if (!j)
+      vDescription << "(";
 
-        HepPDT::ParticleID particleType((*in)->pdg_id());
+    HepPDT::ParticleID particleType((*in)->pdg_id());
 
-        if (particleType.isValid())
-        {
-            pid = pdt_->particle(particleType);
-            if (pid)
-                vDescription << pid->name();
-            else
-                vDescription << (*in)->pdg_id();
-        }
-        else
-            vDescription << (*in)->pdg_id();
+    if (particleType.isValid()) {
+      pid = pdt_->particle(particleType);
+      if (pid)
+        vDescription << pid->name();
+      else
+        vDescription << (*in)->pdg_id();
+    } else
+      vDescription << (*in)->pdg_id();
 
-        itmp = in;
+    itmp = in;
 
-        if (++itmp == in_end) vDescription << ")";
-        else vDescription << ",";
-    }
+    if (++itmp == in_end)
+      vDescription << ")";
+    else
+      vDescription << ",";
+  }
 
-    vDescription << "->";
-    j = 0;
+  vDescription << "->";
+  j = 0;
 
-    HepMC::GenVertex::particles_out_const_iterator out, otmp;
+  HepMC::GenVertex::particles_out_const_iterator out, otmp;
 
-    for (out = out_begin; out != out_end; out++, j++)
-    {
-        if (!j) vDescription << "(";
+  for (out = out_begin; out != out_end; out++, j++) {
+    if (!j)
+      vDescription << "(";
 
-        HepPDT::ParticleID particleType((*out)->pdg_id());
+    HepPDT::ParticleID particleType((*out)->pdg_id());
 
-        if (particleType.isValid())
-        {
-            pid = pdt_->particle(particleType);
-            if (pid)
-                vDescription << pid->name();
-            else
-                vDescription << (*out)->pdg_id();
-        }
-        else
-            vDescription << (*out)->pdg_id();
+    if (particleType.isValid()) {
+      pid = pdt_->particle(particleType);
+      if (pid)
+        vDescription << pid->name();
+      else
+        vDescription << (*out)->pdg_id();
+    } else
+      vDescription << (*out)->pdg_id();
 
-        otmp = out;
+    otmp = out;
 
-        if (++otmp == out_end) vDescription << ")";
-        else vDescription << ",";
-    }
+    if (++otmp == out_end)
+      vDescription << ")";
+    else
+      vDescription << ",";
+  }
 
-    return vDescription.str();
+  return vDescription.str();
 }
-
 
 DEFINE_FWK_MODULE(VertexHistoryAnalyzer);

--- a/SimTracker/TrackHistory/src/HistoryBase.cc
+++ b/SimTracker/TrackHistory/src/HistoryBase.cc
@@ -4,154 +4,140 @@
 
 #include "SimTracker/TrackHistory/interface/HistoryBase.h"
 
+void HistoryBase::traceRecoGenHistory(reco::GenParticle const *genParticle) {
+  // fill the trace of reco::GenParticle for correct reading of the History
+  // flags etc. This is called from the TrackingParticle->genParticle_begin()
+  // which is a reco::GenParticle
 
-void HistoryBase::traceRecoGenHistory(reco::GenParticle const * genParticle)
-{
-    // fill the trace of reco::GenParticle for correct reading of the History flags etc.
-    // This is called from the TrackingParticle->genParticle_begin() which is a reco::GenParticle
-    
-    // Take onlt genParticles with a status() smaller than "depth_". Typically depth is 2 and so you trace back untill you reach the hard partons
-    // see for status(): https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookGenParticleCandidate#GenPCand
-    if ( genParticle->status() <= abs(depth_) && (genParticle->pdgId() < 88 || genParticle->pdgId() > 99) )
-    {
-        //If the particle is already in the history, it is looping and you should stop
-        if ( recoGenParticleTrailHelper_.find(genParticle) != recoGenParticleTrailHelper_.end() ){
-           return;
-        }
-        recoGenParticleTrail_.push_back(genParticle);
-        recoGenParticleTrailHelper_.insert(genParticle);
-        // Get the genParticle's mother and trace its history
-        if (genParticle->mother() != nullptr){
-        	traceRecoGenHistory( (const reco::GenParticle *)genParticle->mother() );
-        }
+  // Take onlt genParticles with a status() smaller than "depth_". Typically
+  // depth is 2 and so you trace back untill you reach the hard partons see for
+  // status():
+  // https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookGenParticleCandidate#GenPCand
+  if (genParticle->status() <= abs(depth_) &&
+      (genParticle->pdgId() < 88 || genParticle->pdgId() > 99)) {
+    // If the particle is already in the history, it is looping and you should
+    // stop
+    if (recoGenParticleTrailHelper_.find(genParticle) !=
+        recoGenParticleTrailHelper_.end()) {
+      return;
     }
+    recoGenParticleTrail_.push_back(genParticle);
+    recoGenParticleTrailHelper_.insert(genParticle);
+    // Get the genParticle's mother and trace its history
+    if (genParticle->mother() != nullptr) {
+      traceRecoGenHistory((const reco::GenParticle *)genParticle->mother());
+    }
+  }
 }
 
-
-void HistoryBase::traceGenHistory(HepMC::GenParticle const * genParticle)
-{
-    // Third stop criteria: status abs(depth_) particles after the hadronization.
-    // The after hadronization is done by detecting the pdg_id pythia code from 88 to 99
-    if ( genParticle->status() <= abs(depth_) && (genParticle->pdg_id() < 88 || genParticle->pdg_id() > 99) )
-    {
-        genParticleTrail_.push_back(genParticle);
-        // Get the producer vertex and trace it history
-        traceGenHistory( genParticle->production_vertex() );
-    }
+void HistoryBase::traceGenHistory(HepMC::GenParticle const *genParticle) {
+  // Third stop criteria: status abs(depth_) particles after the hadronization.
+  // The after hadronization is done by detecting the pdg_id pythia code from 88
+  // to 99
+  if (genParticle->status() <= abs(depth_) &&
+      (genParticle->pdg_id() < 88 || genParticle->pdg_id() > 99)) {
+    genParticleTrail_.push_back(genParticle);
+    // Get the producer vertex and trace it history
+    traceGenHistory(genParticle->production_vertex());
+  }
 }
 
-
-void HistoryBase::traceGenHistory(HepMC::GenVertex const * genVertex)
-{
-    // Verify if has a vertex associated
-    if (genVertex)
-    {
-        // Skip if already exist in the collection
-        if ( genVertexTrailHelper_.find(genVertex) != genVertexTrailHelper_.end() )
-            return;
-        // Add vertex to the history
-        genVertexTrail_.push_back(genVertex);
-        genVertexTrailHelper_.insert(genVertex);
-        // Verify if the vertex has incoming particles
-        if ( genVertex->particles_in_size() )
-            traceGenHistory( *(genVertex->particles_in_const_begin()) );
-    }
+void HistoryBase::traceGenHistory(HepMC::GenVertex const *genVertex) {
+  // Verify if has a vertex associated
+  if (genVertex) {
+    // Skip if already exist in the collection
+    if (genVertexTrailHelper_.find(genVertex) != genVertexTrailHelper_.end())
+      return;
+    // Add vertex to the history
+    genVertexTrail_.push_back(genVertex);
+    genVertexTrailHelper_.insert(genVertex);
+    // Verify if the vertex has incoming particles
+    if (genVertex->particles_in_size())
+      traceGenHistory(*(genVertex->particles_in_const_begin()));
+  }
 }
 
+bool HistoryBase::traceSimHistory(TrackingParticleRef const &trackingParticle,
+                                  int depth) {
+  // first stop condition: if the required depth is reached
+  if (depth == depth_ && depth_ >= 0)
+    return true;
 
-bool HistoryBase::traceSimHistory(TrackingParticleRef const & trackingParticle, int depth)
-{
-    // first stop condition: if the required depth is reached
-    if ( depth == depth_ && depth_ >= 0 ) return true;
+  // second stop condition: if a gen particle is associated to the TP
+  if (!trackingParticle->genParticles().empty()) {
+    LogDebug("TrackHistory") << "Particle " << trackingParticle->pdgId()
+                             << " has a GenParicle image." << std::endl;
 
-    // second stop condition: if a gen particle is associated to the TP
-    if ( !trackingParticle->genParticles().empty() )
-    {
-        LogDebug("TrackHistory") << "Particle " << trackingParticle->pdgId() << " has a GenParicle image." 
-				 << std::endl;
+    traceRecoGenHistory(&(**(trackingParticle->genParticle_begin())));
+  }
 
-	traceRecoGenHistory(&(**(trackingParticle->genParticle_begin()))); 
+  LogDebug("TrackHistory") << "No GenParticle image for "
+                           << trackingParticle->pdgId() << std::endl;
 
-
-    }
-
-    LogDebug("TrackHistory") << "No GenParticle image for " << trackingParticle->pdgId() << std::endl;
-
-    // if no association between TP and genParticles is found: get a reference to the TP's parent vertex and trace its history
-    return traceSimHistory( trackingParticle->parentVertex(), depth );
+  // if no association between TP and genParticles is found: get a reference to
+  // the TP's parent vertex and trace its history
+  return traceSimHistory(trackingParticle->parentVertex(), depth);
 }
 
+bool HistoryBase::traceSimHistory(TrackingVertexRef const &trackingVertex,
+                                  int depth) {
+  // verify if the parent vertex exists
+  if (trackingVertex.isNonnull()) {
+    // save the vertex in the trail
+    simVertexTrail_.push_back(trackingVertex);
 
-bool HistoryBase::traceSimHistory(TrackingVertexRef const & trackingVertex, int depth)
-{
-    // verify if the parent vertex exists
-    if ( trackingVertex.isNonnull() )
-    {
-        // save the vertex in the trail
-        simVertexTrail_.push_back(trackingVertex);
+    if (!trackingVertex->sourceTracks().empty()) {
+      LogDebug("TrackHistory")
+          << "Moving on to the parent particle." << std::endl;
 
-        if ( !trackingVertex->sourceTracks().empty() )
-        {
-            LogDebug("TrackHistory") << "Moving on to the parent particle." << std::endl;
+      // select the original source in case of combined vertices
+      bool flag = false;
+      TrackingVertex::tp_iterator itd, its;
 
-            // select the original source in case of combined vertices
-            bool flag = false;
-            TrackingVertex::tp_iterator itd, its;
+      for (its = trackingVertex->sourceTracks_begin();
+           its != trackingVertex->sourceTracks_end(); its++) {
+        for (itd = trackingVertex->daughterTracks_begin();
+             itd != trackingVertex->daughterTracks_end(); itd++)
+          if (itd != its) {
+            flag = true;
+            break;
+          }
+        if (flag)
+          break;
+      }
 
-            for (its = trackingVertex->sourceTracks_begin(); its != trackingVertex->sourceTracks_end(); its++)
-            {
-                for (itd = trackingVertex->daughterTracks_begin(); itd != trackingVertex->daughterTracks_end(); itd++)
-                    if (itd != its)
-                    {
-                        flag = true;
-                        break;
-                    }
-                if (flag)
-                    break;
-            }
+      if (!flag)
+        return false;
 
-	    if(!flag)
-	      return false;
+      // verify if the new particle is not in the trail (looping partiles)
+      if (std::find(simParticleTrail_.begin(), simParticleTrail_.end(), *its) !=
+          simParticleTrail_.end()) {
+        LogDebug("TrackHistory")
+            << "WARNING: Looping track found." << std::endl;
+        return false;
+      }
 
-            // verify if the new particle is not in the trail (looping partiles)
-            if (
-                std::find(
-                    simParticleTrail_.begin(),
-                    simParticleTrail_.end(),
-                    *its
-                ) != simParticleTrail_.end()
-            )
-            {
-                LogDebug("TrackHistory") <<  "WARNING: Looping track found." << std::endl;
-                return false;
-            }
-
-            // save particle in the trail
-            simParticleTrail_.push_back(*its);
-            return traceSimHistory (*its, --depth);
-        }
-        else if ( !trackingVertex->genVertices().empty() )
-        {
-            // navigate over all the associated generated vertexes
-            LogDebug("TrackHistory") << "Vertex has " << trackingVertex->genVertices().size() << "GenVertex image." << std::endl;
-            for (
-                TrackingVertex::genv_iterator ivertex = trackingVertex->genVertices_begin();
-                ivertex != trackingVertex->genVertices_end();
-                ++ivertex
-            )
-                traceGenHistory(&(**(ivertex)));
-            return true;
-        }
-        else
-        {
-            LogDebug("TrackHistory") <<  "WARNING: Source track for tracking vertex cannot be found." << std::endl;
-        }
+      // save particle in the trail
+      simParticleTrail_.push_back(*its);
+      return traceSimHistory(*its, --depth);
+    } else if (!trackingVertex->genVertices().empty()) {
+      // navigate over all the associated generated vertexes
+      LogDebug("TrackHistory")
+          << "Vertex has " << trackingVertex->genVertices().size()
+          << "GenVertex image." << std::endl;
+      for (TrackingVertex::genv_iterator ivertex =
+               trackingVertex->genVertices_begin();
+           ivertex != trackingVertex->genVertices_end(); ++ivertex)
+        traceGenHistory(&(**(ivertex)));
+      return true;
+    } else {
+      LogDebug("TrackHistory")
+          << "WARNING: Source track for tracking vertex cannot be found."
+          << std::endl;
     }
-    else
-    {
-        LogDebug("TrackHistory") << " WARNING: Vertex cannot be found.";
-    }
+  } else {
+    LogDebug("TrackHistory") << " WARNING: Vertex cannot be found.";
+  }
 
-    return false;
+  return false;
 }
-

--- a/SimTracker/TrackHistory/src/JetVetoedTracksAssociatorDRVertex.cc
+++ b/SimTracker/TrackHistory/src/JetVetoedTracksAssociatorDRVertex.cc
@@ -1,47 +1,39 @@
 
 #include "SimTracker/TrackHistory/interface/JetVetoedTracksAssociatorDRVertex.h"
 
+JetVetoedTracksAssociationDRVertex::JetVetoedTracksAssociationDRVertex(
+    double dr)
+    : mDeltaR2Threshold(dr * dr) {}
 
-JetVetoedTracksAssociationDRVertex::JetVetoedTracksAssociationDRVertex (double dr) : mDeltaR2Threshold(dr*dr) {}
-
-
-void JetVetoedTracksAssociationDRVertex::produce (
-    reco::JetTracksAssociation::Container* fAssociation,
-    const std::vector<edm::RefToBase<reco::Jet> >& fJets,
-    const std::vector<reco::TrackRef>& fTracks,
-    TrackClassifier & classifier
-) const
-{
-    // cache tracks kinematics
-    std::vector <math::RhoEtaPhiVector> trackP3s;
-    trackP3s.reserve (fTracks.size());
-    for (unsigned i = 0; i < fTracks.size(); ++i)
-    {
-        const reco::Track* track = &*(fTracks[i]);
-        trackP3s.push_back (math::RhoEtaPhiVector (track->p(),track->eta(), track->phi()));
+void JetVetoedTracksAssociationDRVertex::produce(
+    reco::JetTracksAssociation::Container *fAssociation,
+    const std::vector<edm::RefToBase<reco::Jet>> &fJets,
+    const std::vector<reco::TrackRef> &fTracks,
+    TrackClassifier &classifier) const {
+  // cache tracks kinematics
+  std::vector<math::RhoEtaPhiVector> trackP3s;
+  trackP3s.reserve(fTracks.size());
+  for (unsigned i = 0; i < fTracks.size(); ++i) {
+    const reco::Track *track = &*(fTracks[i]);
+    trackP3s.push_back(
+        math::RhoEtaPhiVector(track->p(), track->eta(), track->phi()));
+  }
+  // loop on jets and associate
+  for (unsigned j = 0; j < fJets.size(); ++j) {
+    reco::TrackRefVector assoTracks;
+    const reco::Jet *jet = &*(fJets[j]);
+    double jetEta = jet->eta();
+    double jetPhi = jet->phi();
+    for (unsigned t = 0; t < fTracks.size(); ++t) {
+      double dR2 =
+          deltaR2(jetEta, jetPhi, trackP3s[t].eta(), trackP3s[t].phi());
+      classifier.evaluate(reco::TrackBaseRef(fTracks[t]));
+      if (dR2 < mDeltaR2Threshold &&
+          (classifier.is(TrackClassifier::BWeakDecay) ||
+           classifier.is(TrackClassifier::CWeakDecay) ||
+           classifier.is(TrackClassifier::PrimaryVertex)))
+        assoTracks.push_back(fTracks[t]);
     }
-    //loop on jets and associate
-    for (unsigned j = 0; j < fJets.size(); ++j)
-    {
-        reco::TrackRefVector assoTracks;
-        const reco::Jet* jet = &*(fJets[j]);
-        double jetEta = jet->eta();
-        double jetPhi = jet->phi();
-        for (unsigned t = 0; t < fTracks.size(); ++t)
-        {
-            double dR2 = deltaR2 (jetEta, jetPhi, trackP3s[t].eta(), trackP3s[t].phi());
-            classifier.evaluate( reco::TrackBaseRef(fTracks[t]) );
-            if (
-                dR2 < mDeltaR2Threshold &&
-                (
-                    classifier.is(TrackClassifier::BWeakDecay) ||
-                    classifier.is(TrackClassifier::CWeakDecay) ||
-                    classifier.is(TrackClassifier::PrimaryVertex)
-                )
-            ) assoTracks.push_back (fTracks[t]);
-        }
-        reco::JetTracksAssociation::setValue (fAssociation, fJets[j], assoTracks);
-    }
+    reco::JetTracksAssociation::setValue(fAssociation, fJets[j], assoTracks);
+  }
 }
-
-

--- a/SimTracker/TrackHistory/src/TrackCategories.cc
+++ b/SimTracker/TrackHistory/src/TrackCategories.cc
@@ -3,92 +3,82 @@
 
 #include "SimTracker/TrackHistory/interface/TrackCategories.h"
 
-const char * const TrackCategories::Names[] =
-{
-    "Fake",
-    "Bad",
-    "BadInnerHits",
-    "SharedInnerHits",
-    "SignalEvent",
-    "Bottom",
-    "Charm",
-    "Light",
-    "Muon",
-    "TrackerSimHits",
-    "BWeakDecay",
-    "CWeakDecay",
-    "ChargePionDecay",
-    "ChargeKaonDecay",
-    "TauDecay",
-    "KsDecay",
-    "LambdaDecay",
-    "JpsiDecay",
-    "XiDecay",
-    "OmegaDecay",
-    "SigmaPlusDecay",
-    "SigmaMinusDecay",
-    "LongLivedDecay",
-    "KnownProcess",
-    "UndefinedProcess",
-    "UnknownProcess",
-    "PrimaryProcess",
-    "HadronicProcess",
-    "DecayProcess",
-    "ComptonProcess",
-    "AnnihilationProcess",
-    "EIoniProcess",
-    "HIoniProcess",
-    "MuIoniProcess",
-    "PhotonProcess",
-    "MuPairProdProcess",
-    "ConversionsProcess",
-    "EBremProcess",
-    "SynchrotronRadiationProcess",
-    "MuBremProcess",
-    "MuNuclProcess",
-    "FromBWeakDecayMuon",
-    "FromCWeakDecayMuon",
-    "DecayOnFlightMuon",
-    "FromChargePionMuon",
-    "FromChargeKaonMuon",
-    "PrimaryVertex",
-    "SecondaryVertex",
-    "TertiaryVertex",
-    "Unknown"
-};
+const char *const TrackCategories::Names[] = {"Fake",
+                                              "Bad",
+                                              "BadInnerHits",
+                                              "SharedInnerHits",
+                                              "SignalEvent",
+                                              "Bottom",
+                                              "Charm",
+                                              "Light",
+                                              "Muon",
+                                              "TrackerSimHits",
+                                              "BWeakDecay",
+                                              "CWeakDecay",
+                                              "ChargePionDecay",
+                                              "ChargeKaonDecay",
+                                              "TauDecay",
+                                              "KsDecay",
+                                              "LambdaDecay",
+                                              "JpsiDecay",
+                                              "XiDecay",
+                                              "OmegaDecay",
+                                              "SigmaPlusDecay",
+                                              "SigmaMinusDecay",
+                                              "LongLivedDecay",
+                                              "KnownProcess",
+                                              "UndefinedProcess",
+                                              "UnknownProcess",
+                                              "PrimaryProcess",
+                                              "HadronicProcess",
+                                              "DecayProcess",
+                                              "ComptonProcess",
+                                              "AnnihilationProcess",
+                                              "EIoniProcess",
+                                              "HIoniProcess",
+                                              "MuIoniProcess",
+                                              "PhotonProcess",
+                                              "MuPairProdProcess",
+                                              "ConversionsProcess",
+                                              "EBremProcess",
+                                              "SynchrotronRadiationProcess",
+                                              "MuBremProcess",
+                                              "MuNuclProcess",
+                                              "FromBWeakDecayMuon",
+                                              "FromCWeakDecayMuon",
+                                              "DecayOnFlightMuon",
+                                              "FromChargePionMuon",
+                                              "FromChargeKaonMuon",
+                                              "PrimaryVertex",
+                                              "SecondaryVertex",
+                                              "TertiaryVertex",
+                                              "Unknown"};
 
-
-void TrackCategories::unknownTrack()
-{
-    // Check for all flags down
-    for (std::size_t index = 0; index < flags_.size() - 1; ++index)
-        if (flags_[index]) return;
-    // If all of them are down then it is a unkown track.
-    flags_[Unknown] = true;
+void TrackCategories::unknownTrack() {
+  // Check for all flags down
+  for (std::size_t index = 0; index < flags_.size() - 1; ++index)
+    if (flags_[index])
+      return;
+  // If all of them are down then it is a unkown track.
+  flags_[Unknown] = true;
 }
 
+std::ostream &operator<<(std::ostream &os, TrackCategories const &classifier) {
+  bool init = true;
 
-std::ostream & operator<< (std::ostream & os, TrackCategories const & classifier)
-{
-    bool init = true;
+  const TrackCategories::Flags &flags = classifier.flags();
 
-    const TrackCategories::Flags & flags = classifier.flags();
-
-    // Print out the classification for the track
-    for (std::size_t index = 0; index < flags.size(); ++index)
-    {
-        if (flags[index])
-        {
-            if (init)
-            {
-                os << TrackCategories::Names[index];
-                init = false;
-            }
-            else
-                os << "::" << TrackCategories::Names[index];
-        }
+  // Print out the classification for the track
+  for (std::size_t index = 0; index < flags.size(); ++index) {
+    if (flags[index]) {
+      if (init) {
+        os << TrackCategories::Names[index];
+        init = false;
+      } else
+        os << "::" << TrackCategories::Names[index];
     }
-    os << std::endl;
+  }
+  os << std::endl;
 
-    return os;
+  return os;
 }

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -7,136 +7,94 @@
 
 #include "SimTracker/TrackHistory/interface/TrackClassifier.h"
 
-#define update(a, b) do { (a) = (a) | (b); } while(0)
+#define update(a, b)                                                           \
+  do {                                                                         \
+    (a) = (a) | (b);                                                           \
+  } while (0)
 
-TrackClassifier::TrackClassifier(edm::ParameterSet const & config,
-                                 edm::ConsumesCollector&& collector) : TrackCategories(),
-        hepMCLabel_( config.getUntrackedParameter<edm::InputTag>("hepMC") ),
-        beamSpotLabel_( config.getUntrackedParameter<edm::InputTag>("beamSpot") ),
-        tracer_(config,std::move(collector)),
-        quality_(config, collector)
-{
-    collector.consumes<edm::HepMCProduct>(hepMCLabel_);
-    collector.consumes<reco::BeamSpot>(beamSpotLabel_);
+TrackClassifier::TrackClassifier(edm::ParameterSet const &config,
+                                 edm::ConsumesCollector &&collector)
+    : TrackCategories(),
+      hepMCLabel_(config.getUntrackedParameter<edm::InputTag>("hepMC")),
+      beamSpotLabel_(config.getUntrackedParameter<edm::InputTag>("beamSpot")),
+      tracer_(config, std::move(collector)), quality_(config, collector) {
+  collector.consumes<edm::HepMCProduct>(hepMCLabel_);
+  collector.consumes<reco::BeamSpot>(beamSpotLabel_);
 
-    // Set the history depth after hadronization
-    tracer_.depth(-2);
+  // Set the history depth after hadronization
+  tracer_.depth(-2);
 
-    // Set the maximum d0pull for the bad category
-    badPull_ = config.getUntrackedParameter<double>("badPull");
+  // Set the maximum d0pull for the bad category
+  badPull_ = config.getUntrackedParameter<double>("badPull");
 
-    // Set the minimum decay length for detecting long decays
-    longLivedDecayLength_ = config.getUntrackedParameter<double>("longLivedDecayLength");
+  // Set the minimum decay length for detecting long decays
+  longLivedDecayLength_ =
+      config.getUntrackedParameter<double>("longLivedDecayLength");
 
-    // Set the distance for clustering vertices
-    float vertexClusteringDistance = config.getUntrackedParameter<double>("vertexClusteringDistance");
-    vertexClusteringSqDistance_ = vertexClusteringDistance * vertexClusteringDistance;
+  // Set the distance for clustering vertices
+  float vertexClusteringDistance =
+      config.getUntrackedParameter<double>("vertexClusteringDistance");
+  vertexClusteringSqDistance_ =
+      vertexClusteringDistance * vertexClusteringDistance;
 
-    // Set the number of innermost layers to check for bad hits
-    numberOfInnerLayers_ = config.getUntrackedParameter<unsigned int>("numberOfInnerLayers");
+  // Set the number of innermost layers to check for bad hits
+  numberOfInnerLayers_ =
+      config.getUntrackedParameter<unsigned int>("numberOfInnerLayers");
 
-    // Set the minimum number of simhits in the tracker
-    minTrackerSimHits_ = config.getUntrackedParameter<unsigned int>("minTrackerSimHits");
+  // Set the minimum number of simhits in the tracker
+  minTrackerSimHits_ =
+      config.getUntrackedParameter<unsigned int>("minTrackerSimHits");
 }
 
+void TrackClassifier::newEvent(edm::Event const &event,
+                               edm::EventSetup const &setup) {
+  // Get the new event information for the tracer
+  tracer_.newEvent(event, setup);
 
-void TrackClassifier::newEvent ( edm::Event const & event, edm::EventSetup const & setup )
-{
-    // Get the new event information for the tracer
-    tracer_.newEvent(event, setup);
+  // Get the new event information for the track quality analyser
+  quality_.newEvent(event, setup);
 
-    // Get the new event information for the track quality analyser
-    quality_.newEvent(event, setup);
+  // Get hepmc of the event
+  event.getByLabel(hepMCLabel_, mcInformation_);
 
-    // Get hepmc of the event
-    event.getByLabel(hepMCLabel_, mcInformation_);
+  // Magnetic field
+  setup.get<IdealMagneticFieldRecord>().get(magneticField_);
 
-    // Magnetic field
-    setup.get<IdealMagneticFieldRecord>().get(magneticField_);
+  // Get the partivle data table
+  setup.getData(particleDataTable_);
 
-    // Get the partivle data table
-    setup.getData(particleDataTable_);
+  // get the beam spot
+  event.getByLabel(beamSpotLabel_, beamSpot_);
 
-    // get the beam spot
-    event.getByLabel(beamSpotLabel_, beamSpot_);
+  // Transient track builder
+  setup.get<TransientTrackRecord>().get("TransientTrackBuilder",
+                                        transientTrackBuilder_);
 
-    // Transient track builder
-    setup.get<TransientTrackRecord>().get("TransientTrackBuilder", transientTrackBuilder_);
+  // Create the list of primary vertices associated to the event
+  genPrimaryVertices();
 
-    // Create the list of primary vertices associated to the event
-    genPrimaryVertices();
-
-    //Retrieve tracker topology from geometry
-    edm::ESHandle<TrackerTopology> tTopoHand;
-    setup.get<TrackerTopologyRcd>().get(tTopoHand);
-    tTopo_=tTopoHand.product();
+  // Retrieve tracker topology from geometry
+  edm::ESHandle<TrackerTopology> tTopoHand;
+  setup.get<TrackerTopologyRcd>().get(tTopoHand);
+  tTopo_ = tTopoHand.product();
 }
 
+TrackClassifier const &
+TrackClassifier::evaluate(reco::TrackBaseRef const &track) {
+  // Initializing the category vector
+  reset();
 
-TrackClassifier const & TrackClassifier::evaluate (reco::TrackBaseRef const & track)
-{
-    // Initializing the category vector
-    reset();
-
-    // Associate and evaluate the track history (check for fakes)
-    if ( tracer_.evaluate(track) )
-    {
-        // Classify all the tracks by their association and reconstruction information
-        reconstructionInformation(track);
-
-        // Get all the information related to the simulation details
-        simulationInformation();
-
-        // Analyse the track reconstruction quality
-        qualityInformation(track);
-
-        // Get hadron flavor of the initial hadron
-        hadronFlavor();
-
-        // Get all the information related to decay process
-        processesAtGenerator();
-
-        // Get information about conversion and other interactions
-        processesAtSimulation();
-
-        // Get geometrical information about the vertices
-        vertexInformation();
-
-        // Check for unkown classification
-        unknownTrack();
-    }
-    else
-        flags_[Fake] = true;
-
-    return *this;
-}
-
-
-TrackClassifier const & TrackClassifier::evaluate (TrackingParticleRef const & track)
-{
-    // Initializing the category vector
-    reset();
-
-    // Trace the history for the given TP
-    tracer_.evaluate(track);
-
-    // Collect the associated reco track
-    const reco::TrackBaseRef & recotrack = tracer_.recoTrack();
-
-    // If there is a reco truck then evaluate the simulated history
-    if ( recotrack.isNonnull() )
-    {
-        flags_[Reconstructed] = true;
-        // Classify all the tracks by their association and reconstruction information
-        reconstructionInformation(recotrack);
-        // Analyse the track reconstruction quality
-        qualityInformation(recotrack);
-    }
-    else
-        flags_[Reconstructed] = false;
+  // Associate and evaluate the track history (check for fakes)
+  if (tracer_.evaluate(track)) {
+    // Classify all the tracks by their association and reconstruction
+    // information
+    reconstructionInformation(track);
 
     // Get all the information related to the simulation details
     simulationInformation();
+
+    // Analyse the track reconstruction quality
+    qualityInformation(track);
 
     // Get hadron flavor of the initial hadron
     hadronFlavor();
@@ -152,494 +110,520 @@ TrackClassifier const & TrackClassifier::evaluate (TrackingParticleRef const & t
 
     // Check for unkown classification
     unknownTrack();
+  } else
+    flags_[Fake] = true;
 
-    return *this;
+  return *this;
 }
 
+TrackClassifier const &
+TrackClassifier::evaluate(TrackingParticleRef const &track) {
+  // Initializing the category vector
+  reset();
 
-void TrackClassifier::reconstructionInformation(reco::TrackBaseRef const & track)
-{
-    TrackingParticleRef tpr = tracer_.simParticle();
+  // Trace the history for the given TP
+  tracer_.evaluate(track);
 
-    // Compute tracking particle parameters at point of closest approach to the beamline
+  // Collect the associated reco track
+  const reco::TrackBaseRef &recotrack = tracer_.recoTrack();
 
-    const SimTrack * assocTrack = &(*tpr->g4Track_begin());
+  // If there is a reco truck then evaluate the simulated history
+  if (recotrack.isNonnull()) {
+    flags_[Reconstructed] = true;
+    // Classify all the tracks by their association and reconstruction
+    // information
+    reconstructionInformation(recotrack);
+    // Analyse the track reconstruction quality
+    qualityInformation(recotrack);
+  } else
+    flags_[Reconstructed] = false;
 
-    FreeTrajectoryState ftsAtProduction(
-        GlobalPoint(
-            tpr->vertex().x(),
-            tpr->vertex().y(),
-            tpr->vertex().z()
-        ),
-        GlobalVector(
-            assocTrack->momentum().x(),
-            assocTrack->momentum().y(),
-            assocTrack->momentum().z()
-        ),
-        TrackCharge(track->charge()),
-        magneticField_.product()
-    );
+  // Get all the information related to the simulation details
+  simulationInformation();
 
-    try
-    {
-        TSCPBuilderNoMaterial tscpBuilder;
-        TrajectoryStateClosestToPoint tsAtClosestApproach = tscpBuilder(
-                    ftsAtProduction,
-                    GlobalPoint(beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0())
-                );
+  // Get hadron flavor of the initial hadron
+  hadronFlavor();
 
-        GlobalVector v = tsAtClosestApproach.theState().position()
-                         - GlobalPoint(beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0());
-        GlobalVector p = tsAtClosestApproach.theState().momentum();
+  // Get all the information related to decay process
+  processesAtGenerator();
 
-        // Simulated dxy
-        double dxySim = -v.x()*sin(p.phi()) + v.y()*cos(p.phi());
+  // Get information about conversion and other interactions
+  processesAtSimulation();
 
-        // Simulated dz
-        double dzSim = v.z() - (v.x()*p.x() + v.y()*p.y())*p.z()/p.perp2();
+  // Get geometrical information about the vertices
+  vertexInformation();
 
-        // Calculate the dxy pull
-        double dxyPull = std::abs(
-                             track->dxy( reco::TrackBase::Point(beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0()) ) - dxySim
-                         ) / track->dxyError();
+  // Check for unkown classification
+  unknownTrack();
 
-        // Calculate the dx pull
-        double dzPull = std::abs(
-                            track->dz( reco::TrackBase::Point(beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0()) ) - dzSim
-                        ) / track->dzError();
-
-        // Return true if d0Pull > badD0Pull sigmas
-        flags_[Bad] = (dxyPull > badPull_ || dzPull > badPull_);
-
-    }
-    catch (cms::Exception const&)
-    {
-        flags_[Bad] = true;
-    }
+  return *this;
 }
 
+void TrackClassifier::reconstructionInformation(
+    reco::TrackBaseRef const &track) {
+  TrackingParticleRef tpr = tracer_.simParticle();
 
-void TrackClassifier::simulationInformation()
-{
-    // Get the event id for the initial TP.
-    EncodedEventId eventId = tracer_.simParticle()->eventId();
-    // Check for signal events
-    flags_[SignalEvent] = !eventId.bunchCrossing() && !eventId.event();
-    // Check for muons
-    flags_[Muon] = (abs(tracer_.simParticle()->pdgId()) == 13);
-    // Check for the number of psimhit in tracker
-    flags_[TrackerSimHits] = tracer_.simParticle()->numberOfTrackerLayers() >= (int)minTrackerSimHits_;
+  // Compute tracking particle parameters at point of closest approach to the
+  // beamline
+
+  const SimTrack *assocTrack = &(*tpr->g4Track_begin());
+
+  FreeTrajectoryState ftsAtProduction(
+      GlobalPoint(tpr->vertex().x(), tpr->vertex().y(), tpr->vertex().z()),
+      GlobalVector(assocTrack->momentum().x(), assocTrack->momentum().y(),
+                   assocTrack->momentum().z()),
+      TrackCharge(track->charge()), magneticField_.product());
+
+  try {
+    TSCPBuilderNoMaterial tscpBuilder;
+    TrajectoryStateClosestToPoint tsAtClosestApproach = tscpBuilder(
+        ftsAtProduction,
+        GlobalPoint(beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0()));
+
+    GlobalVector v =
+        tsAtClosestApproach.theState().position() -
+        GlobalPoint(beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0());
+    GlobalVector p = tsAtClosestApproach.theState().momentum();
+
+    // Simulated dxy
+    double dxySim = -v.x() * sin(p.phi()) + v.y() * cos(p.phi());
+
+    // Simulated dz
+    double dzSim = v.z() - (v.x() * p.x() + v.y() * p.y()) * p.z() / p.perp2();
+
+    // Calculate the dxy pull
+    double dxyPull =
+        std::abs(track->dxy(reco::TrackBase::Point(
+                     beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0())) -
+                 dxySim) /
+        track->dxyError();
+
+    // Calculate the dx pull
+    double dzPull =
+        std::abs(track->dz(reco::TrackBase::Point(
+                     beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0())) -
+                 dzSim) /
+        track->dzError();
+
+    // Return true if d0Pull > badD0Pull sigmas
+    flags_[Bad] = (dxyPull > badPull_ || dzPull > badPull_);
+
+  } catch (cms::Exception const &) {
+    flags_[Bad] = true;
+  }
 }
 
+void TrackClassifier::simulationInformation() {
+  // Get the event id for the initial TP.
+  EncodedEventId eventId = tracer_.simParticle()->eventId();
+  // Check for signal events
+  flags_[SignalEvent] = !eventId.bunchCrossing() && !eventId.event();
+  // Check for muons
+  flags_[Muon] = (abs(tracer_.simParticle()->pdgId()) == 13);
+  // Check for the number of psimhit in tracker
+  flags_[TrackerSimHits] =
+      tracer_.simParticle()->numberOfTrackerLayers() >= (int)minTrackerSimHits_;
+}
 
-void TrackClassifier::qualityInformation(reco::TrackBaseRef const & track)
-{
-    // run the hit-by-hit reconstruction quality analysis
+void TrackClassifier::qualityInformation(reco::TrackBaseRef const &track) {
+  // run the hit-by-hit reconstruction quality analysis
   quality_.evaluate(tracer_.simParticleTrail(), track, tTopo_);
 
-    unsigned int maxLayers = std::min(numberOfInnerLayers_, quality_.numberOfLayers());
+  unsigned int maxLayers =
+      std::min(numberOfInnerLayers_, quality_.numberOfLayers());
 
-    // check the innermost layers for bad hits
-    for (unsigned int i = 0; i < maxLayers; i++)
-    {
-        const TrackQuality::Layer &layer = quality_.layer(i);
+  // check the innermost layers for bad hits
+  for (unsigned int i = 0; i < maxLayers; i++) {
+    const TrackQuality::Layer &layer = quality_.layer(i);
 
-        // check all hits in that layer
-        for (unsigned int j = 0; j < layer.hits.size(); j++)
-        {
-            const TrackQuality::Layer::Hit &hit = layer.hits[j];
+    // check all hits in that layer
+    for (unsigned int j = 0; j < layer.hits.size(); j++) {
+      const TrackQuality::Layer::Hit &hit = layer.hits[j];
 
-            // In those cases the bad hit was used by track reconstruction
-            if (hit.state == TrackQuality::Layer::Noise ||
-                    hit.state == TrackQuality::Layer::Misassoc)
-                flags_[BadInnerHits] = true;
-            else if (hit.state == TrackQuality::Layer::Shared)
-                flags_[SharedInnerHits] = true;
+      // In those cases the bad hit was used by track reconstruction
+      if (hit.state == TrackQuality::Layer::Noise ||
+          hit.state == TrackQuality::Layer::Misassoc)
+        flags_[BadInnerHits] = true;
+      else if (hit.state == TrackQuality::Layer::Shared)
+        flags_[SharedInnerHits] = true;
+    }
+  }
+}
+
+void TrackClassifier::hadronFlavor() {
+  // Get the initial hadron from the recoGenParticleTrail
+  const reco::GenParticle *particle = tracer_.recoGenParticle();
+
+  // Check for the initial hadron
+  if (particle) {
+    HepPDT::ParticleID pid(particle->pdgId());
+    flags_[Bottom] = pid.hasBottom();
+    flags_[Charm] = pid.hasCharm();
+    flags_[Light] = !pid.hasCharm() && !pid.hasBottom();
+  }
+}
+
+void TrackClassifier::processesAtGenerator() {
+  // pdgid of the "in" particle to the production vertex
+  int pdgid = 0;
+
+  // Get the generated particles from track history (reco::GenParticle in the
+  // recoGenParticleTrail)
+  TrackHistory::RecoGenParticleTrail const &recoGenParticleTrail =
+      tracer_.recoGenParticleTrail();
+
+  // Loop over the generated particles (reco::GenParticle in the
+  // recoGenParticleTrail)
+  for (TrackHistory::RecoGenParticleTrail::const_iterator iparticle =
+           recoGenParticleTrail.begin();
+       iparticle != recoGenParticleTrail.end(); ++iparticle) {
+    pdgid = std::abs((*iparticle)->pdgId());
+    // Get particle type
+    HepPDT::ParticleID particleID(pdgid);
+
+    // Check if the particle type is valid one
+    if (particleID.isValid()) {
+      // Get particle data
+      ParticleData const *particleData =
+          particleDataTable_->particle(particleID);
+      // Check if the particle exist in the table
+      if (particleData) {
+        // Check if their life time is bigger than longLivedDecayLength_
+        if (particleData->lifetime() > longLivedDecayLength_)
+          update(flags_[LongLivedDecay], true);
+        // Check for B and C weak decays
+        update(flags_[BWeakDecay], particleID.hasBottom());
+        update(flags_[CWeakDecay], particleID.hasCharm());
+        // Check for B and C pure leptonic decay
+        std::set<int> daughterIds;
+        size_t ndau = (*iparticle)->numberOfDaughters();
+        for (size_t i = 0; i < ndau; ++i) {
+          daughterIds.insert((*iparticle)->daughter(i)->pdgId());
         }
+        update(flags_[FromBWeakDecayMuon],
+               particleID.hasBottom() &&
+                   (daughterIds.find(13) != daughterIds.end()));
+        update(flags_[FromCWeakDecayMuon],
+               particleID.hasCharm() &&
+                   (daughterIds.find(13) != daughterIds.end()));
+      }
+      // Check Tau, Ks and Lambda decay
+      update(flags_[ChargePionDecay], pdgid == 211);
+      update(flags_[ChargeKaonDecay], pdgid == 321);
+      update(flags_[TauDecay], pdgid == 15);
+      update(flags_[KsDecay], pdgid == 310);
+      update(flags_[LambdaDecay], pdgid == 3122);
+      update(flags_[JpsiDecay], pdgid == 443);
+      update(flags_[XiDecay], pdgid == 3312);
+      update(flags_[SigmaPlusDecay], pdgid == 3222);
+      update(flags_[SigmaMinusDecay], pdgid == 3112);
     }
+  }
+  // Decays in flight
+  update(flags_[FromChargePionMuon], flags_[Muon] && flags_[ChargePionDecay]);
+  update(flags_[FromChargeKaonMuon], flags_[Muon] && flags_[ChargeKaonDecay]);
+  update(flags_[DecayOnFlightMuon],
+         (flags_[FromChargePionMuon] || flags_[FromChargeKaonMuon]));
 }
 
+void TrackClassifier::processesAtSimulation() {
+  TrackHistory::SimParticleTrail const &simParticleTrail =
+      tracer_.simParticleTrail();
 
-void TrackClassifier::hadronFlavor()
-{
-    // Get the initial hadron from the recoGenParticleTrail
-    const reco::GenParticle * particle = tracer_.recoGenParticle();
-
-    // Check for the initial hadron
-    if (particle)
-    {
-        HepPDT::ParticleID pid(particle->pdgId());
-        flags_[Bottom] = pid.hasBottom();
-        flags_[Charm] =  pid.hasCharm();
-        flags_[Light] = !pid.hasCharm() && !pid.hasBottom();
-    }
-}
-
-
-void TrackClassifier::processesAtGenerator()
-{
-    // pdgid of the "in" particle to the production vertex
+  // Loop over the simulated particles
+  for (TrackHistory::SimParticleTrail::const_iterator iparticle =
+           simParticleTrail.begin();
+       iparticle != simParticleTrail.end(); ++iparticle) {
+    // pdgid of the real source parent vertex
     int pdgid = 0;
 
-    // Get the generated particles from track history (reco::GenParticle in the recoGenParticleTrail)
-    TrackHistory::RecoGenParticleTrail const & recoGenParticleTrail = tracer_.recoGenParticleTrail();
+    // Get a reference to the TP's parent vertex
+    TrackingVertexRef const &parentVertex = (*iparticle)->parentVertex();
 
-    // Loop over the generated particles (reco::GenParticle in the recoGenParticleTrail)
-    for (TrackHistory::RecoGenParticleTrail::const_iterator iparticle = recoGenParticleTrail.begin(); iparticle != recoGenParticleTrail.end(); ++iparticle)
-    {
-                pdgid = std::abs((*iparticle)->pdgId());
-                // Get particle type
-                HepPDT::ParticleID particleID(pdgid);
+    // Look for the original source track
+    if (parentVertex.isNonnull()) {
+      // select the original source in case of combined vertices
+      bool flag = false;
+      TrackingVertex::tp_iterator itd, its;
 
-                // Check if the particle type is valid one
-                if (particleID.isValid())
-                {
-                    // Get particle data
-                    ParticleData const * particleData = particleDataTable_->particle(particleID);
-                    // Check if the particle exist in the table
-                    if (particleData)
-                    {
-                        // Check if their life time is bigger than longLivedDecayLength_
-                        if ( particleData->lifetime() > longLivedDecayLength_ )
-                            update(flags_[LongLivedDecay], true);
-                        // Check for B and C weak decays
-                        update(flags_[BWeakDecay], particleID.hasBottom());
-                        update(flags_[CWeakDecay], particleID.hasCharm());
-                        // Check for B and C pure leptonic decay
-                        std::set<int> daughterIds;
-                        size_t ndau = (*iparticle)->numberOfDaughters();
-                        for( size_t i = 0; i < ndau; ++ i ){
-    						daughterIds.insert((*iparticle)->daughter(i)->pdgId());
-    					}
-                        update(flags_[FromBWeakDecayMuon], particleID.hasBottom() && (daughterIds.find(13) != daughterIds.end()));
-                        update(flags_[FromCWeakDecayMuon], particleID.hasCharm() && (daughterIds.find(13) != daughterIds.end()));
-                    }
-                    // Check Tau, Ks and Lambda decay
-                    update(flags_[ChargePionDecay], pdgid == 211);
-                    update(flags_[ChargeKaonDecay], pdgid == 321);
-                    update(flags_[TauDecay], pdgid == 15);
-                    update(flags_[KsDecay], pdgid == 310);
-                    update(flags_[LambdaDecay], pdgid == 3122);
-                    update(flags_[JpsiDecay], pdgid == 443);
-                    update(flags_[XiDecay], pdgid == 3312);
-                    update(flags_[SigmaPlusDecay], pdgid == 3222);
-                    update(flags_[SigmaMinusDecay], pdgid == 3112);
-                }            
+      for (its = parentVertex->sourceTracks_begin();
+           its != parentVertex->sourceTracks_end(); ++its) {
+        for (itd = parentVertex->daughterTracks_begin();
+             itd != parentVertex->daughterTracks_end(); ++itd)
+          if (itd != its) {
+            flag = true;
+            break;
+          }
+        if (flag)
+          break;
+      }
+
+      // Collect the pdgid of the original source track
+      if (its != parentVertex->sourceTracks_end())
+        pdgid = std::abs((*its)->pdgId());
+      else
+        pdgid = 0;
     }
-    // Decays in flight
-    update(flags_[FromChargePionMuon], flags_[Muon] && flags_[ChargePionDecay]);
-    update(flags_[FromChargeKaonMuon], flags_[Muon] && flags_[ChargeKaonDecay]);
-    update(flags_[DecayOnFlightMuon], (flags_[FromChargePionMuon] || flags_[FromChargeKaonMuon]));
+
+    unsigned int processG4 = 0;
+
+    // Check existence of SimVerteces assigned
+    if (parentVertex->nG4Vertices() > 0) {
+      processG4 = (*(parentVertex->g4Vertices_begin())).processType();
+    }
+
+    unsigned int process = g4toCMSProcMap_.processId(processG4);
+
+    // Flagging all the different processes
+    update(flags_[KnownProcess], process != CMS::Undefined &&
+                                     process != CMS::Unknown &&
+                                     process != CMS::Primary);
+
+    update(flags_[UndefinedProcess], process == CMS::Undefined);
+    update(flags_[UnknownProcess], process == CMS::Unknown);
+    update(flags_[PrimaryProcess], process == CMS::Primary);
+    update(flags_[HadronicProcess], process == CMS::Hadronic);
+    update(flags_[DecayProcess], process == CMS::Decay);
+    update(flags_[ComptonProcess], process == CMS::Compton);
+    update(flags_[AnnihilationProcess], process == CMS::Annihilation);
+    update(flags_[EIoniProcess], process == CMS::EIoni);
+    update(flags_[HIoniProcess], process == CMS::HIoni);
+    update(flags_[MuIoniProcess], process == CMS::MuIoni);
+    update(flags_[PhotonProcess], process == CMS::Photon);
+    update(flags_[MuPairProdProcess], process == CMS::MuPairProd);
+    update(flags_[ConversionsProcess], process == CMS::Conversions);
+    update(flags_[EBremProcess], process == CMS::EBrem);
+    update(flags_[SynchrotronRadiationProcess],
+           process == CMS::SynchrotronRadiation);
+    update(flags_[MuBremProcess], process == CMS::MuBrem);
+    update(flags_[MuNuclProcess], process == CMS::MuNucl);
+
+    // Get particle type
+    HepPDT::ParticleID particleID(pdgid);
+
+    // Check if the particle type is valid one
+    if (particleID.isValid()) {
+      // Get particle data
+      ParticleData const *particleData =
+          particleDataTable_->particle(particleID);
+      // Special treatment for decays
+      if (process == CMS::Decay) {
+        // Check if the particle exist in the table
+        if (particleData) {
+          // Check if their life time is bigger than 1e-14
+          if (particleDataTable_->particle(particleID)->lifetime() >
+              longLivedDecayLength_)
+            update(flags_[LongLivedDecay], true);
+
+          // Check for B and C weak decays
+          update(flags_[BWeakDecay], particleID.hasBottom());
+          update(flags_[CWeakDecay], particleID.hasCharm());
+
+          // Check for B or C pure leptonic decays
+          int daughtId = abs((*iparticle)->pdgId());
+          update(flags_[FromBWeakDecayMuon],
+                 particleID.hasBottom() && daughtId == 13);
+          update(flags_[FromCWeakDecayMuon],
+                 particleID.hasCharm() && daughtId == 13);
+        }
+        // Check decays
+        update(flags_[ChargePionDecay], pdgid == 211);
+        update(flags_[ChargeKaonDecay], pdgid == 321);
+        update(flags_[TauDecay], pdgid == 15);
+        update(flags_[KsDecay], pdgid == 310);
+        update(flags_[LambdaDecay], pdgid == 3122);
+        update(flags_[JpsiDecay], pdgid == 443);
+        update(flags_[XiDecay], pdgid == 3312);
+        update(flags_[OmegaDecay], pdgid == 3334);
+        update(flags_[SigmaPlusDecay], pdgid == 3222);
+        update(flags_[SigmaMinusDecay], pdgid == 3112);
+      }
+    }
+  }
+  // Decays in flight
+  update(flags_[FromChargePionMuon], flags_[Muon] && flags_[ChargePionDecay]);
+  update(flags_[FromChargeKaonMuon], flags_[Muon] && flags_[ChargeKaonDecay]);
+  update(flags_[DecayOnFlightMuon],
+         flags_[FromChargePionMuon] || flags_[FromChargeKaonMuon]);
 }
 
+void TrackClassifier::vertexInformation() {
+  // Get the main primary vertex from the list
+  GeneratedPrimaryVertex const &genpv = genpvs_.back();
 
-void TrackClassifier::processesAtSimulation()
-{
-    TrackHistory::SimParticleTrail const & simParticleTrail = tracer_.simParticleTrail();
+  // Get the generated history of the tracks
+  const TrackHistory::GenParticleTrail &genParticleTrail =
+      tracer_.genParticleTrail();
 
-    // Loop over the simulated particles
-    for (
-        TrackHistory::SimParticleTrail::const_iterator iparticle = simParticleTrail.begin();
-        iparticle != simParticleTrail.end();
-        ++iparticle
-    )
-    {
-        // pdgid of the real source parent vertex
-        int pdgid = 0;
+  // Vertex counter
+  int counter = 0;
 
-        // Get a reference to the TP's parent vertex
-        TrackingVertexRef const & parentVertex = (*iparticle)->parentVertex();
+  // Unit transformation from mm to cm
+  double const mm = 0.1;
 
-        // Look for the original source track
-        if ( parentVertex.isNonnull() )
-        {
-            // select the original source in case of combined vertices
-            bool flag = false;
-            TrackingVertex::tp_iterator itd, its;
+  double oldX = genpv.x;
+  double oldY = genpv.y;
+  double oldZ = genpv.z;
 
-            for (its = parentVertex->sourceTracks_begin(); its != parentVertex->sourceTracks_end(); ++its)
-            {
-                for (itd = parentVertex->daughterTracks_begin(); itd != parentVertex->daughterTracks_end(); ++itd)
-                    if (itd != its)
-                    {
-                        flag = true;
-                        break;
-                    }
-                if (flag)
-                    break;
-            }
+  // Loop over the generated particles
+  for (TrackHistory::GenParticleTrail::const_reverse_iterator iparticle =
+           genParticleTrail.rbegin();
+       iparticle != genParticleTrail.rend(); ++iparticle) {
+    // Look for those with production vertex
+    HepMC::GenVertex *parent = (*iparticle)->production_vertex();
+    if (parent) {
+      HepMC::ThreeVector p = parent->point3d();
 
-            // Collect the pdgid of the original source track
-            if ( its != parentVertex->sourceTracks_end() )
-                pdgid = std::abs((*its)->pdgId());
-            else
-                pdgid = 0;
-        }
+      double distance2 = pow(p.x() * mm - genpv.x, 2) +
+                         pow(p.y() * mm - genpv.y, 2) +
+                         pow(p.z() * mm - genpv.z, 2);
+      double difference2 = pow(p.x() * mm - oldX, 2) +
+                           pow(p.y() * mm - oldY, 2) +
+                           pow(p.z() * mm - oldZ, 2);
 
-        unsigned int processG4 = 0;
+      // std::cout << "Distance2 : " << distance2 << " (" << p.x() * mm << ","
+      // << p.y() * mm << "," << p.z() * mm << ")" << std::endl; std::cout <<
+      // "Difference2 : " << difference2 << std::endl;
 
-	// Check existence of SimVerteces assigned
-        if(parentVertex->nG4Vertices() > 0) {
-	  processG4 = (*(parentVertex->g4Vertices_begin())).processType();
-	}
-	
-	unsigned int process = g4toCMSProcMap_.processId(processG4);
-
-        // Flagging all the different processes
-        update(
-            flags_[KnownProcess],
-            process != CMS::Undefined &&
-            process != CMS::Unknown &&
-            process != CMS::Primary
-        );
-
-        update(flags_[UndefinedProcess], process == CMS::Undefined);
-        update(flags_[UnknownProcess], process == CMS::Unknown);
-        update(flags_[PrimaryProcess], process == CMS::Primary);
-        update(flags_[HadronicProcess], process == CMS::Hadronic);
-        update(flags_[DecayProcess], process == CMS::Decay);
-        update(flags_[ComptonProcess], process == CMS::Compton);
-        update(flags_[AnnihilationProcess], process == CMS::Annihilation);
-        update(flags_[EIoniProcess], process == CMS::EIoni);
-        update(flags_[HIoniProcess], process == CMS::HIoni);
-        update(flags_[MuIoniProcess], process == CMS::MuIoni);
-        update(flags_[PhotonProcess], process == CMS::Photon);
-        update(flags_[MuPairProdProcess], process == CMS::MuPairProd);
-        update(flags_[ConversionsProcess], process == CMS::Conversions);
-        update(flags_[EBremProcess], process == CMS::EBrem);
-        update(flags_[SynchrotronRadiationProcess], process == CMS::SynchrotronRadiation);
-        update(flags_[MuBremProcess], process == CMS::MuBrem);
-        update(flags_[MuNuclProcess], process == CMS::MuNucl);
-
-        // Get particle type
-        HepPDT::ParticleID particleID(pdgid);
-
-        // Check if the particle type is valid one
-        if (particleID.isValid())
-        {
-            // Get particle data
-            ParticleData const * particleData = particleDataTable_->particle(particleID);
-            // Special treatment for decays
-            if (process == CMS::Decay)
-            {
-                // Check if the particle exist in the table
-                if (particleData)
-                {
-                    // Check if their life time is bigger than 1e-14
-                    if ( particleDataTable_->particle(particleID)->lifetime() > longLivedDecayLength_ )
-                        update(flags_[LongLivedDecay], true);
-
-                    // Check for B and C weak decays
-                    update(flags_[BWeakDecay], particleID.hasBottom());
-                    update(flags_[CWeakDecay], particleID.hasCharm());
-
-                    // Check for B or C pure leptonic decays
-                    int daughtId = abs((*iparticle)->pdgId());
-                    update(flags_[FromBWeakDecayMuon], particleID.hasBottom() && daughtId == 13);
-                    update(flags_[FromCWeakDecayMuon], particleID.hasCharm() && daughtId == 13);
-                }
-                // Check decays
-                update(flags_[ChargePionDecay], pdgid == 211);
-                update(flags_[ChargeKaonDecay], pdgid == 321);
-                update(flags_[TauDecay], pdgid == 15);
-                update(flags_[KsDecay], pdgid == 310);
-                update(flags_[LambdaDecay], pdgid == 3122);
-                update(flags_[JpsiDecay], pdgid == 443);
-                update(flags_[XiDecay], pdgid == 3312);
-                update(flags_[OmegaDecay], pdgid == 3334);
-                update(flags_[SigmaPlusDecay], pdgid == 3222);
-                update(flags_[SigmaMinusDecay], pdgid == 3112);
-            }
-        }
+      if (difference2 > vertexClusteringSqDistance_) {
+        if (distance2 > vertexClusteringSqDistance_)
+          counter++;
+        oldX = p.x() * mm;
+        oldY = p.y() * mm;
+        oldZ = p.z() * mm;
+      }
     }
-    // Decays in flight
-    update(flags_[FromChargePionMuon], flags_[Muon] && flags_[ChargePionDecay]);
-    update(flags_[FromChargeKaonMuon], flags_[Muon] && flags_[ChargeKaonDecay]);
-    update(flags_[DecayOnFlightMuon], flags_[FromChargePionMuon] || flags_[FromChargeKaonMuon]);
+  }
+
+  const TrackHistory::SimParticleTrail &simParticleTrail =
+      tracer_.simParticleTrail();
+
+  // Loop over the generated particles
+  for (TrackHistory::SimParticleTrail::const_reverse_iterator iparticle =
+           simParticleTrail.rbegin();
+       iparticle != simParticleTrail.rend(); ++iparticle) {
+    // Look for those with production vertex
+    TrackingParticle::Point p = (*iparticle)->vertex();
+
+    double distance2 = pow(p.x() - genpv.x, 2) + pow(p.y() - genpv.y, 2) +
+                       pow(p.z() - genpv.z, 2);
+    double difference2 =
+        pow(p.x() - oldX, 2) + pow(p.y() - oldY, 2) + pow(p.z() - oldZ, 2);
+
+    // std::cout << "Distance2 : " << distance2 << " (" << p.x() << "," << p.y()
+    // << "," << p.z() << ")" << std::endl; std::cout << "Difference2 : " <<
+    // difference2 << std::endl;
+
+    if (difference2 > vertexClusteringSqDistance_) {
+      if (distance2 > vertexClusteringSqDistance_)
+        counter++;
+      oldX = p.x();
+      oldY = p.y();
+      oldZ = p.z();
+    }
+  }
+
+  if (!counter)
+    flags_[PrimaryVertex] = true;
+  else if (counter == 1)
+    flags_[SecondaryVertex] = true;
+  else
+    flags_[TertiaryVertex] = true;
 }
 
-
-void TrackClassifier::vertexInformation()
-{
-    // Get the main primary vertex from the list
-    GeneratedPrimaryVertex const & genpv = genpvs_.back();
-
-    // Get the generated history of the tracks
-    const TrackHistory::GenParticleTrail & genParticleTrail = tracer_.genParticleTrail();
-
-    // Vertex counter
-    int counter = 0;
-
-    // Unit transformation from mm to cm
-    double const mm = 0.1;
-
-    double oldX = genpv.x;
-    double oldY = genpv.y;
-    double oldZ = genpv.z;
-
-    // Loop over the generated particles
-    for (
-        TrackHistory::GenParticleTrail::const_reverse_iterator iparticle = genParticleTrail.rbegin();
-        iparticle != genParticleTrail.rend();
-        ++iparticle
-    )
-    {
-        // Look for those with production vertex
-        HepMC::GenVertex * parent = (*iparticle)->production_vertex();
-        if (parent)
-        {
-            HepMC::ThreeVector p = parent->point3d();
-
-            double distance2   = pow(p.x() * mm - genpv.x, 2) + pow(p.y() * mm - genpv.y, 2) + pow(p.z() * mm - genpv.z, 2);
-            double difference2 = pow(p.x() * mm - oldX, 2)    + pow(p.y() * mm - oldY, 2)    + pow(p.z() * mm - oldZ, 2);
-
-            // std::cout << "Distance2 : " << distance2 << " (" << p.x() * mm << "," << p.y() * mm << "," << p.z() * mm << ")" << std::endl;
-            // std::cout << "Difference2 : " << difference2 << std::endl;
-
-            if ( difference2 > vertexClusteringSqDistance_ )
-            {
-                if ( distance2 > vertexClusteringSqDistance_ ) counter++;
-                oldX = p.x() * mm;
-                oldY = p.y() * mm;
-                oldZ = p.z() * mm;
-            }
-        }
-    }
-
-    const TrackHistory::SimParticleTrail & simParticleTrail = tracer_.simParticleTrail();
-
-    // Loop over the generated particles
-    for (
-        TrackHistory::SimParticleTrail::const_reverse_iterator iparticle = simParticleTrail.rbegin();
-        iparticle != simParticleTrail.rend();
-        ++iparticle
-    )
-    {
-        // Look for those with production vertex
-        TrackingParticle::Point p = (*iparticle)->vertex();
-
-        double distance2   = pow(p.x() - genpv.x, 2) + pow(p.y() - genpv.y, 2) + pow(p.z() - genpv.z, 2);
-        double difference2 = pow(p.x() - oldX, 2)    + pow(p.y() - oldY, 2)    + pow(p.z() - oldZ, 2);
-
-        // std::cout << "Distance2 : " << distance2 << " (" << p.x() << "," << p.y() << "," << p.z() << ")" << std::endl;
-        // std::cout << "Difference2 : " << difference2 << std::endl;
-
-        if ( difference2 > vertexClusteringSqDistance_ )
-        {
-            if ( distance2 > vertexClusteringSqDistance_ ) counter++;
-            oldX = p.x();
-            oldY = p.y();
-            oldZ = p.z();
-        }
-    }
-
-    if ( !counter )
-        flags_[PrimaryVertex] = true;
-    else if ( counter == 1 )
-        flags_[SecondaryVertex] = true;
-    else
-        flags_[TertiaryVertex] = true;
+bool TrackClassifier::isFinalstateParticle(const HepMC::GenParticle *p) {
+  return !p->end_vertex() && p->status() == 1;
 }
 
-
-bool TrackClassifier::isFinalstateParticle(const HepMC::GenParticle * p)
-{
-    return !p->end_vertex() && p->status() == 1;
+bool TrackClassifier::isCharged(const HepMC::GenParticle *p) {
+  const ParticleData *part = particleDataTable_->particle(p->pdg_id());
+  if (part)
+    return part->charge() != 0;
+  else {
+    // the new/improved particle table doesn't know anti-particles
+    return particleDataTable_->particle(-p->pdg_id()) != nullptr;
+  }
 }
 
+void TrackClassifier::genPrimaryVertices() {
+  genpvs_.clear();
 
-bool TrackClassifier::isCharged(const HepMC::GenParticle * p)
-{
-    const ParticleData * part = particleDataTable_->particle( p->pdg_id() );
-    if (part)
-        return part->charge()!=0;
-    else
-    {
-        // the new/improved particle table doesn't know anti-particles
-        return  particleDataTable_->particle( -p->pdg_id() ) != nullptr;
-    }
-}
+  const HepMC::GenEvent *event = mcInformation_->GetEvent();
 
+  if (event) {
+    int idx = 0;
 
-void TrackClassifier::genPrimaryVertices()
-{
-    genpvs_.clear();
+    // Loop over the different GenVertex
+    for (HepMC::GenEvent::vertex_const_iterator ivertex =
+             event->vertices_begin();
+         ivertex != event->vertices_end(); ++ivertex) {
+      bool hasParentVertex = false;
 
-    const HepMC::GenEvent * event = mcInformation_->GetEvent();
-
-    if (event)
-    {
-        int idx = 0;
-
-        // Loop over the different GenVertex
-        for ( HepMC::GenEvent::vertex_const_iterator ivertex = event->vertices_begin(); ivertex != event->vertices_end(); ++ivertex )
-        {
-            bool hasParentVertex = false;
-
-            // Loop over the parents looking to see if they are coming from a production vertex
-            for (
-                HepMC::GenVertex::particle_iterator iparent = (*ivertex)->particles_begin(HepMC::parents);
-                iparent != (*ivertex)->particles_end(HepMC::parents);
-                ++iparent
-            )
-                if ( (*iparent)->production_vertex() )
-                {
-                    hasParentVertex = true;
-                    break;
-                }
-
-            // Reject those vertices with parent vertices
-            if (hasParentVertex) continue;
-
-            // Get the position of the vertex
-            HepMC::FourVector pos = (*ivertex)->position();
-
-            double const mm = 0.1;
-
-            GeneratedPrimaryVertex pv(pos.x()*mm, pos.y()*mm, pos.z()*mm);
-
-            std::vector<GeneratedPrimaryVertex>::iterator ientry = genpvs_.begin();
-
-            // Search for a VERY close vertex in the list
-            for (; ientry != genpvs_.end(); ++ientry)
-            {
-                double distance2 = pow(pv.x - ientry->x, 2) + pow(pv.y - ientry->y, 2) + pow(pv.z - ientry->z, 2);
-                if ( distance2 < vertexClusteringSqDistance_ )
-                    break;
-            }
-
-            // Check if there is not a VERY close vertex and added to the list
-            if (ientry == genpvs_.end())
-                ientry = genpvs_.insert(ientry,pv);
-
-            // Add the vertex barcodes to the new or existent vertices
-            ientry->genVertex.push_back((*ivertex)->barcode());
-
-            // Collect final state descendants
-            for (
-                HepMC::GenVertex::particle_iterator idecendants  = (*ivertex)->particles_begin(HepMC::descendants);
-                idecendants != (*ivertex)->particles_end(HepMC::descendants);
-                ++idecendants
-            )
-            {
-                if (isFinalstateParticle(*idecendants))
-                    if ( find(ientry->finalstateParticles.begin(), ientry->finalstateParticles.end(), (*idecendants)->barcode()) == ientry->finalstateParticles.end() )
-                    {
-                        ientry->finalstateParticles.push_back((*idecendants)->barcode());
-                        HepMC::FourVector m = (*idecendants)->momentum();
-
-                        ientry->ptot.setPx(ientry->ptot.px() + m.px());
-                        ientry->ptot.setPy(ientry->ptot.py() + m.py());
-                        ientry->ptot.setPz(ientry->ptot.pz() + m.pz());
-                        ientry->ptot.setE(ientry->ptot.e() + m.e());
-                        ientry->ptsq += m.perp() * m.perp();
-
-                        if ( m.perp() > 0.8 && std::abs(m.pseudoRapidity()) < 2.5 && isCharged(*idecendants) ) ientry->nGenTrk++;
-                    }
-            }
-            idx++;
+      // Loop over the parents looking to see if they are coming from a
+      // production vertex
+      for (HepMC::GenVertex::particle_iterator iparent =
+               (*ivertex)->particles_begin(HepMC::parents);
+           iparent != (*ivertex)->particles_end(HepMC::parents); ++iparent)
+        if ((*iparent)->production_vertex()) {
+          hasParentVertex = true;
+          break;
         }
-    }
 
-    std::sort(genpvs_.begin(), genpvs_.end());
+      // Reject those vertices with parent vertices
+      if (hasParentVertex)
+        continue;
+
+      // Get the position of the vertex
+      HepMC::FourVector pos = (*ivertex)->position();
+
+      double const mm = 0.1;
+
+      GeneratedPrimaryVertex pv(pos.x() * mm, pos.y() * mm, pos.z() * mm);
+
+      std::vector<GeneratedPrimaryVertex>::iterator ientry = genpvs_.begin();
+
+      // Search for a VERY close vertex in the list
+      for (; ientry != genpvs_.end(); ++ientry) {
+        double distance2 = pow(pv.x - ientry->x, 2) + pow(pv.y - ientry->y, 2) +
+                           pow(pv.z - ientry->z, 2);
+        if (distance2 < vertexClusteringSqDistance_)
+          break;
+      }
+
+      // Check if there is not a VERY close vertex and added to the list
+      if (ientry == genpvs_.end())
+        ientry = genpvs_.insert(ientry, pv);
+
+      // Add the vertex barcodes to the new or existent vertices
+      ientry->genVertex.push_back((*ivertex)->barcode());
+
+      // Collect final state descendants
+      for (HepMC::GenVertex::particle_iterator idecendants =
+               (*ivertex)->particles_begin(HepMC::descendants);
+           idecendants != (*ivertex)->particles_end(HepMC::descendants);
+           ++idecendants) {
+        if (isFinalstateParticle(*idecendants))
+          if (find(ientry->finalstateParticles.begin(),
+                   ientry->finalstateParticles.end(),
+                   (*idecendants)->barcode()) ==
+              ientry->finalstateParticles.end()) {
+            ientry->finalstateParticles.push_back((*idecendants)->barcode());
+            HepMC::FourVector m = (*idecendants)->momentum();
+
+            ientry->ptot.setPx(ientry->ptot.px() + m.px());
+            ientry->ptot.setPy(ientry->ptot.py() + m.py());
+            ientry->ptot.setPz(ientry->ptot.pz() + m.pz());
+            ientry->ptot.setE(ientry->ptot.e() + m.e());
+            ientry->ptsq += m.perp() * m.perp();
+
+            if (m.perp() > 0.8 && std::abs(m.pseudoRapidity()) < 2.5 &&
+                isCharged(*idecendants))
+              ientry->nGenTrk++;
+          }
+      }
+      idx++;
+    }
+  }
+
+  std::sort(genpvs_.begin(), genpvs_.end());
 }

--- a/SimTracker/TrackHistory/src/TrackHistory.cc
+++ b/SimTracker/TrackHistory/src/TrackHistory.cc
@@ -2,87 +2,84 @@
 #include "SimTracker/Records/interface/TrackAssociatorRecord.h"
 #include "SimTracker/TrackHistory/interface/TrackHistory.h"
 
+TrackHistory::TrackHistory(const edm::ParameterSet &config,
+                           edm::ConsumesCollector &&collector)
+    : HistoryBase() {
+  // Name of the track collection
+  trackProducer_ = config.getUntrackedParameter<edm::InputTag>("trackProducer");
+  collector.consumes<edm::View<reco::Track>>(trackProducer_);
 
-TrackHistory::TrackHistory (
-  const edm::ParameterSet & config,
-  edm::ConsumesCollector&& collector
-) : HistoryBase()
-{
-    // Name of the track collection
-    trackProducer_ = config.getUntrackedParameter<edm::InputTag> ( "trackProducer" );
-    collector.consumes<edm::View<reco::Track> >(trackProducer_);
+  // Name of the traking pariticle collection
+  trackingTruth_ = config.getUntrackedParameter<edm::InputTag>("trackingTruth");
+  collector.consumes<TrackingParticleCollection>(trackingTruth_);
 
-    // Name of the traking pariticle collection
-    trackingTruth_ = config.getUntrackedParameter<edm::InputTag> ( "trackingTruth" );
-    collector.consumes<TrackingParticleCollection>(trackingTruth_);
+  // Track association record
+  trackAssociator_ =
+      config.getUntrackedParameter<edm::InputTag>("trackAssociator");
 
-    // Track association record
-    trackAssociator_ = config.getUntrackedParameter<edm::InputTag> ( "trackAssociator" );
+  // Association by max. value
+  bestMatchByMaxValue_ =
+      config.getUntrackedParameter<bool>("bestMatchByMaxValue");
 
-    // Association by max. value
-    bestMatchByMaxValue_ = config.getUntrackedParameter<bool> ( "bestMatchByMaxValue" );
+  // Enable RecoToSim association
+  enableRecoToSim_ = config.getUntrackedParameter<bool>("enableRecoToSim");
 
-    // Enable RecoToSim association
-    enableRecoToSim_ = config.getUntrackedParameter<bool> ( "enableRecoToSim" );
+  // Enable SimToReco association
+  enableSimToReco_ = config.getUntrackedParameter<bool>("enableSimToReco");
 
-    // Enable SimToReco association
-    enableSimToReco_ = config.getUntrackedParameter<bool> ( "enableSimToReco" );
+  if (enableRecoToSim_ or enableSimToReco_) {
+    collector.consumes<reco::TrackToTrackingParticleAssociator>(
+        trackAssociator_);
+  }
 
-    if(enableRecoToSim_ or enableSimToReco_) {
-      collector.consumes<reco::TrackToTrackingParticleAssociator>(trackAssociator_);
-    }
-
-    quality_ = 0.;
+  quality_ = 0.;
 }
 
+void TrackHistory::newEvent(const edm::Event &event,
+                            const edm::EventSetup &setup) {
+  if (enableRecoToSim_ || enableSimToReco_) {
+    // Track collection
+    edm::Handle<edm::View<reco::Track>> trackCollection;
+    event.getByLabel(trackProducer_, trackCollection);
 
-void TrackHistory::newEvent (
-    const edm::Event & event, const edm::EventSetup & setup
-)
-{
-    if ( enableRecoToSim_ || enableSimToReco_ )
-    {
-        // Track collection
-        edm::Handle<edm::View<reco::Track> > trackCollection;
-        event.getByLabel(trackProducer_, trackCollection);
+    // Tracking particle information
+    edm::Handle<TrackingParticleCollection> TPCollection;
+    event.getByLabel(trackingTruth_, TPCollection);
 
-        // Tracking particle information
-        edm::Handle<TrackingParticleCollection>  TPCollection;
-        event.getByLabel(trackingTruth_, TPCollection);
+    // Get the track associator
+    edm::Handle<reco::TrackToTrackingParticleAssociator> associator;
+    event.getByLabel(trackAssociator_, associator);
 
-        // Get the track associator
-        edm::Handle<reco::TrackToTrackingParticleAssociator> associator;
-        event.getByLabel(trackAssociator_, associator);
+    // Calculate the map between recotracks -> tp
+    if (enableRecoToSim_)
+      recoToSim_ =
+          associator->associateRecoToSim(trackCollection, TPCollection);
 
-        // Calculate the map between recotracks -> tp
-        if ( enableRecoToSim_ ) recoToSim_ = associator->associateRecoToSim(trackCollection, TPCollection);
-
-        // Calculate the map between recotracks <- tp
-        if ( enableSimToReco_ ) simToReco_ = associator->associateSimToReco(trackCollection, TPCollection );
-    }
+    // Calculate the map between recotracks <- tp
+    if (enableSimToReco_)
+      simToReco_ =
+          associator->associateSimToReco(trackCollection, TPCollection);
+  }
 }
 
-
-bool TrackHistory::evaluate ( reco::TrackBaseRef tr )
-{
-    if ( !enableRecoToSim_ ) return false;
-
-    std::pair<TrackingParticleRef, double> result =  match(tr, recoToSim_, bestMatchByMaxValue_);
-
-    TrackingParticleRef tpr( result.first );
-    quality_ = result.second;
-    trackingParticle_ = tpr;
-
-    if ( !tpr.isNull() )
-    {
-        HistoryBase::evaluate(tpr);
-
-        recotrack_ = tr;
-
-        return true;
-    }
-
+bool TrackHistory::evaluate(reco::TrackBaseRef tr) {
+  if (!enableRecoToSim_)
     return false;
+
+  std::pair<TrackingParticleRef, double> result =
+      match(tr, recoToSim_, bestMatchByMaxValue_);
+
+  TrackingParticleRef tpr(result.first);
+  quality_ = result.second;
+  trackingParticle_ = tpr;
+
+  if (!tpr.isNull()) {
+    HistoryBase::evaluate(tpr);
+
+    recotrack_ = tr;
+
+    return true;
+  }
+
+  return false;
 }
-
-

--- a/SimTracker/TrackHistory/src/TrackQuality.cc
+++ b/SimTracker/TrackHistory/src/TrackQuality.cc
@@ -2,7 +2,7 @@
  *  TrackQuality.cc
  *
  *  Created by Christophe Saout on 9/25/08.
- *  2007 __MyCompanyName__. 
+ *  2007 __MyCompanyName__.
  *
  */
 
@@ -15,19 +15,19 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/MuonDetId/interface/DTLayerId.h"
+#include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
+#include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-#include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
-#include "DataFormats/MuonDetId/interface/DTLayerId.h"
-#include "DataFormats/MuonDetId/interface/CSCDetId.h"
-#include "DataFormats/MuonDetId/interface/RPCDetId.h"
 
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
@@ -35,271 +35,245 @@
 
 // #define DEBUG_TRACK_QUALITY
 
-namespace
-{
+namespace {
 const uint32_t NonMatchedTrackId = (uint32_t)-1;
 
-struct MatchedHit
-{
-    DetId detId;
-    uint32_t simTrackId;
-    EncodedEventId collision;
-    int recHitId;
-    TrackQuality::Layer::State state;
+struct MatchedHit {
+  DetId detId;
+  uint32_t simTrackId;
+  EncodedEventId collision;
+  int recHitId;
+  TrackQuality::Layer::State state;
 
-    bool operator < (const MatchedHit &other) const
-    {
-        if (detId < other.detId)
-            return true;
-        else if (detId > other.detId)
-            return false;
-        else if (collision < other.collision)
-            return true;
-        else if (other.collision < collision)
-            return false;
-        else
-            return simTrackId < other.simTrackId;
-    }
+  bool operator<(const MatchedHit &other) const {
+    if (detId < other.detId)
+      return true;
+    else if (detId > other.detId)
+      return false;
+    else if (collision < other.collision)
+      return true;
+    else if (other.collision < collision)
+      return false;
+    else
+      return simTrackId < other.simTrackId;
+  }
 
-    bool operator == (const MatchedHit &other) const
-    {
-        return detId == other.detId &&
-               collision == other.collision &&
-               simTrackId == other.simTrackId;
-    }
+  bool operator==(const MatchedHit &other) const {
+    return detId == other.detId && collision == other.collision &&
+           simTrackId == other.simTrackId;
+  }
 };
-  /*
+/*
 static bool operator < (const MatchedHit &hit, DetId detId)
 {
-    return hit.detId < detId;
+  return hit.detId < detId;
 }
 static bool operator < (DetId detId, const MatchedHit &hit)
 {
-    return detId < hit.detId;
+  return detId < hit.detId;
 }
-  */
-}
+*/
+} // namespace
 
 typedef std::pair<TrackQuality::Layer::SubDet, short int> DetLayer;
 
 // in case multiple hits were found, figure out the highest priority
-static const int statePriorities[] =
-{
-    /* Unknown */  3,
-    /* Good */     5,
-    /* Missed */   0,
-    /* Noise */    7,
-    /* Bad */      2,
-    /* Dead */     4,
-    /* Shared */   6,
-    /* Misassoc */ 1
-};
+static const int statePriorities[] = {
+    /* Unknown */ 3,
+    /* Good */ 5,
+    /* Missed */ 0,
+    /* Noise */ 7,
+    /* Bad */ 2,
+    /* Dead */ 4,
+    /* Shared */ 6,
+    /* Misassoc */ 1};
 
-DetLayer getDetLayer(DetId detId, const TrackerTopology *tTopo)
-{
-    TrackQuality::Layer::SubDet det = TrackQuality::Layer::Invalid;
-    short int layer = 0;
+DetLayer getDetLayer(DetId detId, const TrackerTopology *tTopo) {
+  TrackQuality::Layer::SubDet det = TrackQuality::Layer::Invalid;
+  short int layer = 0;
 
-    switch (detId.det())
-    {
-    case DetId::Tracker:
-      layer=tTopo->layer(detId);
+  switch (detId.det()) {
+  case DetId::Tracker:
+    layer = tTopo->layer(detId);
+    break;
+
+  case DetId::Muon:
+    switch (detId.subdetId()) {
+    case MuonSubdetId::DT:
+      det = TrackQuality::Layer::MuonDT;
+      layer = DTLayerId(detId).layer();
       break;
 
-    case DetId::Muon:
-        switch (detId.subdetId())
-        {
-        case MuonSubdetId::DT:
-            det = TrackQuality::Layer::MuonDT;
-            layer = DTLayerId(detId).layer();
-            break;
+    case MuonSubdetId::CSC:
+      det = TrackQuality::Layer::MuonCSC;
+      layer = CSCDetId(detId).layer();
+      break;
 
-        case MuonSubdetId::CSC:
-            det = TrackQuality::Layer::MuonCSC;
-            layer = CSCDetId(detId).layer();
-            break;
-
-        case MuonSubdetId::RPC:
-            if (RPCDetId(detId).region())
-                det = TrackQuality::Layer::MuonRPCEndcap;
-            else
-                det = TrackQuality::Layer::MuonRPCBarrel;
-            layer = RPCDetId(detId).layer();
-            break;
-
-        default:
-            /* should not get here */
-            ;
-        }
-        break;
+    case MuonSubdetId::RPC:
+      if (RPCDetId(detId).region())
+        det = TrackQuality::Layer::MuonRPCEndcap;
+      else
+        det = TrackQuality::Layer::MuonRPCBarrel;
+      layer = RPCDetId(detId).layer();
+      break;
 
     default:
         /* should not get here */
         ;
     }
+    break;
 
-    return DetLayer(det, layer);
+  default:
+      /* should not get here */
+      ;
+  }
+
+  return DetLayer(det, layer);
 }
 
-TrackQuality::TrackQuality(const edm::ParameterSet &config,  edm::ConsumesCollector& iC) :
-        trackerHitAssociatorConfig_(config.getParameter<edm::ParameterSet>("hitAssociator"), std::move(iC))
-{
-}
+TrackQuality::TrackQuality(const edm::ParameterSet &config,
+                           edm::ConsumesCollector &iC)
+    : trackerHitAssociatorConfig_(
+          config.getParameter<edm::ParameterSet>("hitAssociator"),
+          std::move(iC)) {}
 
-void TrackQuality::newEvent(const edm::Event &ev, const edm::EventSetup &es)
-{
-    associator_.reset(new TrackerHitAssociator(ev, trackerHitAssociatorConfig_));
+void TrackQuality::newEvent(const edm::Event &ev, const edm::EventSetup &es) {
+  associator_.reset(new TrackerHitAssociator(ev, trackerHitAssociatorConfig_));
 }
 
 void TrackQuality::evaluate(SimParticleTrail const &spt,
                             reco::TrackBaseRef const &tr,
-			    const TrackerTopology *tTopo)
-{
-    std::vector<MatchedHit> matchedHits;
+                            const TrackerTopology *tTopo) {
+  std::vector<MatchedHit> matchedHits;
 
-    // iterate over reconstructed hits
-    for (trackingRecHit_iterator hit = tr->recHitsBegin();
-            hit != tr->recHitsEnd(); ++hit)
-    {
-        // on which module the hit lies
-        DetId detId = (*hit)->geographicalId();
+  // iterate over reconstructed hits
+  for (trackingRecHit_iterator hit = tr->recHitsBegin();
+       hit != tr->recHitsEnd(); ++hit) {
+    // on which module the hit lies
+    DetId detId = (*hit)->geographicalId();
 
-        // FIXME: check for double-sided modules?
+    // FIXME: check for double-sided modules?
 
-        // didn't find a hit on that module
-        if (!(*hit)->isValid())
-        {
-            MatchedHit matchedHit;
-            matchedHit.detId = detId;
-            matchedHit.simTrackId = NonMatchedTrackId;
-            // check why hit wasn't valid and propagate information
-            switch ((*hit)->getType())
-            {
-            case TrackingRecHit::inactive:
-                matchedHit.state = Layer::Dead;
-                break;
+    // didn't find a hit on that module
+    if (!(*hit)->isValid()) {
+      MatchedHit matchedHit;
+      matchedHit.detId = detId;
+      matchedHit.simTrackId = NonMatchedTrackId;
+      // check why hit wasn't valid and propagate information
+      switch ((*hit)->getType()) {
+      case TrackingRecHit::inactive:
+        matchedHit.state = Layer::Dead;
+        break;
 
-            case TrackingRecHit::bad:
-                matchedHit.state = Layer::Bad;
-                break;
+      case TrackingRecHit::bad:
+        matchedHit.state = Layer::Bad;
+        break;
 
-            default:
-                matchedHit.state = Layer::Missed;
-            }
-            matchedHit.recHitId = hit - tr->recHitsBegin();
-            matchedHits.push_back(matchedHit);
-            continue;
-        }
-
-        // find simulated tracks causing hit that was reconstructed
-        std::vector<SimHitIdpr> simIds = associator_->associateHitId(**hit);
-
-        // must be noise or so
-        if (simIds.empty())
-        {
-            MatchedHit matchedHit;
-            matchedHit.detId = detId;
-            matchedHit.simTrackId = NonMatchedTrackId;
-            matchedHit.state = Layer::Noise;
-            matchedHit.recHitId = hit - tr->recHitsBegin();
-            matchedHits.push_back(matchedHit);
-            continue;
-        }
-
-        // register all simulated tracks contributing
-        for (std::vector<SimHitIdpr>::const_iterator i = simIds.begin();
-                i != simIds.end(); ++i)
-        {
-            MatchedHit matchedHit;
-            matchedHit.detId = detId;
-            matchedHit.simTrackId = i->first;
-            matchedHit.collision = i->second;
-            // RecHit <-> SimHit matcher currently doesn't support muon system
-            if (detId.det() == DetId::Muon)
-                matchedHit.state = Layer::Unknown;
-            else
-                // assume hit was mismatched (until possible confirmation)
-                matchedHit.state = Layer::Misassoc;
-            matchedHit.recHitId = hit - tr->recHitsBegin();
-            matchedHits.push_back(matchedHit);
-        }
+      default:
+        matchedHit.state = Layer::Missed;
+      }
+      matchedHit.recHitId = hit - tr->recHitsBegin();
+      matchedHits.push_back(matchedHit);
+      continue;
     }
 
-    // sort hits found so far by module id
-    std::stable_sort(matchedHits.begin(), matchedHits.end());
+    // find simulated tracks causing hit that was reconstructed
+    std::vector<SimHitIdpr> simIds = associator_->associateHitId(**hit);
 
-    // in case we added missed modules, re-sort
-    std::stable_sort(matchedHits.begin(), matchedHits.end());
-
-    // prepare for ordering results by layer enum and layer/disk number
-    typedef std::multimap<DetLayer, const MatchedHit*> LayerHitMap;
-    LayerHitMap layerHitMap;
-
-    // iterate over all simulated/reconstructed hits again
-    for (std::vector<MatchedHit>::const_iterator hit = matchedHits.begin();
-            hit != matchedHits.end();)
-    {
-        // we can have multiple reco-to-sim matches per module, find best one
-        const MatchedHit *best = nullptr;
-
-        // this loop iterates over all subsequent hits in the same module
-        do
-        {
-            // update our best hit pointer
-            if (!best ||
-                    statePriorities[hit->state] > statePriorities[best->state] ||
-                    best->simTrackId == NonMatchedTrackId)
-            {
-                best = &*hit;
-            }
-            ++hit;
-        }
-        while (hit != matchedHits.end() &&
-                hit->detId == best->detId);
-
-        // ignore hit in case track reco was looking at the wrong module
-        if (best->simTrackId != NonMatchedTrackId ||
-                best->state != Layer::Missed)
-        {
-            layerHitMap.insert(std::make_pair(
-					      getDetLayer(best->detId,tTopo), best));
-        }
+    // must be noise or so
+    if (simIds.empty()) {
+      MatchedHit matchedHit;
+      matchedHit.detId = detId;
+      matchedHit.simTrackId = NonMatchedTrackId;
+      matchedHit.state = Layer::Noise;
+      matchedHit.recHitId = hit - tr->recHitsBegin();
+      matchedHits.push_back(matchedHit);
+      continue;
     }
 
-    layers_.clear();
+    // register all simulated tracks contributing
+    for (std::vector<SimHitIdpr>::const_iterator i = simIds.begin();
+         i != simIds.end(); ++i) {
+      MatchedHit matchedHit;
+      matchedHit.detId = detId;
+      matchedHit.simTrackId = i->first;
+      matchedHit.collision = i->second;
+      // RecHit <-> SimHit matcher currently doesn't support muon system
+      if (detId.det() == DetId::Muon)
+        matchedHit.state = Layer::Unknown;
+      else
+        // assume hit was mismatched (until possible confirmation)
+        matchedHit.state = Layer::Misassoc;
+      matchedHit.recHitId = hit - tr->recHitsBegin();
+      matchedHits.push_back(matchedHit);
+    }
+  }
+
+  // sort hits found so far by module id
+  std::stable_sort(matchedHits.begin(), matchedHits.end());
+
+  // in case we added missed modules, re-sort
+  std::stable_sort(matchedHits.begin(), matchedHits.end());
+
+  // prepare for ordering results by layer enum and layer/disk number
+  typedef std::multimap<DetLayer, const MatchedHit *> LayerHitMap;
+  LayerHitMap layerHitMap;
+
+  // iterate over all simulated/reconstructed hits again
+  for (std::vector<MatchedHit>::const_iterator hit = matchedHits.begin();
+       hit != matchedHits.end();) {
+    // we can have multiple reco-to-sim matches per module, find best one
+    const MatchedHit *best = nullptr;
+
+    // this loop iterates over all subsequent hits in the same module
+    do {
+      // update our best hit pointer
+      if (!best || statePriorities[hit->state] > statePriorities[best->state] ||
+          best->simTrackId == NonMatchedTrackId) {
+        best = &*hit;
+      }
+      ++hit;
+    } while (hit != matchedHits.end() && hit->detId == best->detId);
+
+    // ignore hit in case track reco was looking at the wrong module
+    if (best->simTrackId != NonMatchedTrackId || best->state != Layer::Missed) {
+      layerHitMap.insert(std::make_pair(getDetLayer(best->detId, tTopo), best));
+    }
+  }
+
+  layers_.clear();
 
 #ifdef DEBUG_TRACK_QUALITY
-    std::cout << "---------------------" << std::endl;
+  std::cout << "---------------------" << std::endl;
 #endif
-    // now prepare final collection
-    for (LayerHitMap::const_iterator hit = layerHitMap.begin();
-            hit != layerHitMap.end(); ++hit)
-    {
+  // now prepare final collection
+  for (LayerHitMap::const_iterator hit = layerHitMap.begin();
+       hit != layerHitMap.end(); ++hit) {
 #ifdef DEBUG_TRACK_QUALITY
-        std::cout
-            << "detLayer (" << hit->first.first << ", " << hit->first.second << ")"
-            << " [" << (uint32_t)hit->second->detId << "] sim(" << (int)hit->second->simTrackId << ")"
-            << " hit(" << hit->second->recHitId << ") -> " << hit->second->state << std::endl;
+    std::cout << "detLayer (" << hit->first.first << ", " << hit->first.second
+              << ")"
+              << " [" << (uint32_t)hit->second->detId << "] sim("
+              << (int)hit->second->simTrackId << ")"
+              << " hit(" << hit->second->recHitId << ") -> "
+              << hit->second->state << std::endl;
 #endif
 
-        // find out if we need to start a new layer
-        Layer *layer = layers_.empty() ? nullptr : &layers_.back();
-        if (!layer ||
-                hit->first.first != layer->subDet ||
-                hit->first.second != layer->layer)
-        {
-            Layer newLayer;
-            newLayer.subDet = hit->first.first;
-            newLayer.layer = hit->first.second;
-            layers_.push_back(newLayer);
-            layer = &layers_.back();
-        }
-
-        // create hit and add it to layer
-        Layer::Hit newHit;
-        newHit.recHitId = hit->second->recHitId;
-        newHit.state = hit->second->state;
-
-        layer->hits.push_back(newHit);
+    // find out if we need to start a new layer
+    Layer *layer = layers_.empty() ? nullptr : &layers_.back();
+    if (!layer || hit->first.first != layer->subDet ||
+        hit->first.second != layer->layer) {
+      Layer newLayer;
+      newLayer.subDet = hit->first.first;
+      newLayer.layer = hit->first.second;
+      layers_.push_back(newLayer);
+      layer = &layers_.back();
     }
+
+    // create hit and add it to layer
+    Layer::Hit newHit;
+    newHit.recHitId = hit->second->recHitId;
+    newHit.state = hit->second->state;
+
+    layer->hits.push_back(newHit);
+  }
 }

--- a/SimTracker/TrackHistory/src/Utils.cc
+++ b/SimTracker/TrackHistory/src/Utils.cc
@@ -2,69 +2,79 @@
 #include "SimTracker/TrackHistory/interface/CMSProcessTypes.h"
 #include "SimTracker/TrackHistory/interface/Utils.h"
 
-G4toCMSLegacyProcTypeMap::G4toCMSLegacyProcTypeMap()
-{
+G4toCMSLegacyProcTypeMap::G4toCMSLegacyProcTypeMap() {
   // Geant4Process -> CmsProcess
-  m_map[0]   = CMS::Primary;              // "Primary"         -> "Primary"
-  m_map[91]  = CMS::Unknown;              // "Transportation"  -> "Unknown"
-  m_map[92]  = CMS::Unknown;              // "CoupleTrans"     -> "Unknown" => DOUBLE-CHECK THIS
-  m_map[1]   = CMS::Unknown;              // "CoulombScat"     -> "Unknown" => DOUBLE-CHECK THIS
-  m_map[2]   = CMS::EIoni;                // "Ionisation"      -> "EIoni" => WHAT ABOUT MuIoni?
-  m_map[3]   = CMS::EBrem;                // "Brems"           -> "EBrem" => WHAT ABOUT MuBrem?
-  m_map[4]   = CMS::MuPairProd;           // "PairProdCharged" -> "MuPairProd" => DOUBLE-CHECK THIS
-  m_map[5]   = CMS::Annihilation;         // "Annih"           -> "Annihilation"
-  m_map[6]   = CMS::Annihilation;         // "AnnihToMuMu"     -> "Annihilation"
-  m_map[7]   = CMS::Annihilation;         // "AnnihToHad"      -> "Annihilation"
-  m_map[8]   = CMS::Hadronic;             // "NuclearStopp"    -> "Hadronic" => DOUBLE-CHECK THIS
-  m_map[10]  = CMS::Unknown;              // "Msc"             -> "Unknown" => DOUBLE-CHECK THIS
-  m_map[11]  = CMS::Unknown;              // "Rayleigh"        -> "Unknown" => DOUBLE-CHECK THIS
-  m_map[12]  = CMS::Photon;               // "PhotoElectric"   -> "Photon"
-  m_map[13]  = CMS::Compton;              // "Compton"         -> "Compton"
-  m_map[14]  = CMS::Conversions;          // "Conv"            -> "Conversions"
-  m_map[15]  = CMS::Conversions;          // "ConvToMuMu"      -> "Conversions"
-  m_map[21]  = CMS::Unknown;              // "Cerenkov"        -> "Unknown" => DOUBLE-CHECK THIS
-  m_map[22]  = CMS::Unknown;              // "Scintillation"   -> "Unknown" => DOUBLE-CHECK THIS
-  m_map[23]  = CMS::SynchrotronRadiation; // "SynchRad"        -> "SynchrotronRadiation"
-  m_map[24]  = CMS::SynchrotronRadiation; // "TransRad"        -> "SynchrotronRadiation" => DOUBLE-CHECK THIS
-  m_map[31]  = CMS::Unknown;              // "OpAbsorp"        -> "Unknown" => NOT USED IN CMS
-  m_map[32]  = CMS::Unknown;              // "OpBoundary"      -> "Unknown" => NOT USED IN CMS
-  m_map[33]  = CMS::Unknown;              // "OpRayleigh"      -> "Unknown" => NOT USED IN CMS
-  m_map[34]  = CMS::Unknown;              // "OpWLS"           -> "Unknown" => NOT USED IN CMS
-  m_map[35]  = CMS::Unknown;              // "OpMieHG"         -> "Unknown" => NOT USED IN CMS
-  m_map[51]  = CMS::Unknown;              // "DNAElastic"      -> "Unknown" => NOT USED IN CMS
-  m_map[52]  = CMS::Unknown;              // "DNAExcit"        -> "Unknown" => NOT USED IN CMS
-  m_map[53]  = CMS::Unknown;              // "DNAIonisation"   -> "Unknown" => NOT USED IN CMS
-  m_map[54]  = CMS::Unknown;              // "DNAVibExcit"     -> "Unknown" => NOT USED IN CMS
-  m_map[55]  = CMS::Unknown;              // "DNAAttachment"   -> "Unknown" => NOT USED IN CMS
-  m_map[56]  = CMS::Unknown;              // "DNAChargeDec"    -> "Unknown" => NOT USED IN CMS
-  m_map[57]  = CMS::Unknown;              // "DNAChargeInc"    -> "Unknown" => NOT USED IN CMS
-  m_map[111] = CMS::Hadronic;             // "HadElastic"      -> "Hadronic"
-  m_map[121] = CMS::Hadronic;             // "HadInelastic"    -> "Hadronic"
-  m_map[131] = CMS::Hadronic;             // "HadCapture"      -> "Hadronic"
-  m_map[141] = CMS::Hadronic;             // "HadFission"      -> "Hadronic"
-  m_map[151] = CMS::Hadronic;             // "HadAtRest"       -> "Hadronic"
-  m_map[161] = CMS::Hadronic;             // "HadCEX"          -> "Hadronic"
-  m_map[201] = CMS::Decay;                // "Decay"           -> "Decay"
-  m_map[202] = CMS::Decay;                // "DecayWSpin"      -> "Decay"
-  m_map[203] = CMS::Decay;                // "DecayPiWSpin"    -> "Decay"
-  m_map[210] = CMS::Decay;                // "DecayRadio"      -> "Decay"
-  m_map[211] = CMS::Decay;                // "DecayUnKnown"    -> "Decay"
-  m_map[231] = CMS::Decay;                // "DecayExt"        -> "Decay"
-  m_map[301] = CMS::Unknown;              // "GFlash"          -> "Unknown"
-  m_map[401] = CMS::Unknown;              // "StepLimiter"     -> "Unknown"
-  m_map[402] = CMS::Unknown;              // "UsrSpecCuts"     -> "Unknown"
-  m_map[403] = CMS::Unknown;              // "NeutronKiller"   -> "Unknown"
+  m_map[0] = CMS::Primary;  // "Primary"         -> "Primary"
+  m_map[91] = CMS::Unknown; // "Transportation"  -> "Unknown"
+  m_map[92] =
+      CMS::Unknown; // "CoupleTrans"     -> "Unknown" => DOUBLE-CHECK THIS
+  m_map[1] =
+      CMS::Unknown;      // "CoulombScat"     -> "Unknown" => DOUBLE-CHECK THIS
+  m_map[2] = CMS::EIoni; // "Ionisation"      -> "EIoni" => WHAT ABOUT MuIoni?
+  m_map[3] = CMS::EBrem; // "Brems"           -> "EBrem" => WHAT ABOUT MuBrem?
+  m_map[4] =
+      CMS::MuPairProd; // "PairProdCharged" -> "MuPairProd" => DOUBLE-CHECK THIS
+  m_map[5] = CMS::Annihilation; // "Annih"           -> "Annihilation"
+  m_map[6] = CMS::Annihilation; // "AnnihToMuMu"     -> "Annihilation"
+  m_map[7] = CMS::Annihilation; // "AnnihToHad"      -> "Annihilation"
+  m_map[8] =
+      CMS::Hadronic; // "NuclearStopp"    -> "Hadronic" => DOUBLE-CHECK THIS
+  m_map[10] =
+      CMS::Unknown; // "Msc"             -> "Unknown" => DOUBLE-CHECK THIS
+  m_map[11] =
+      CMS::Unknown; // "Rayleigh"        -> "Unknown" => DOUBLE-CHECK THIS
+  m_map[12] = CMS::Photon;      // "PhotoElectric"   -> "Photon"
+  m_map[13] = CMS::Compton;     // "Compton"         -> "Compton"
+  m_map[14] = CMS::Conversions; // "Conv"            -> "Conversions"
+  m_map[15] = CMS::Conversions; // "ConvToMuMu"      -> "Conversions"
+  m_map[21] =
+      CMS::Unknown; // "Cerenkov"        -> "Unknown" => DOUBLE-CHECK THIS
+  m_map[22] =
+      CMS::Unknown; // "Scintillation"   -> "Unknown" => DOUBLE-CHECK THIS
+  m_map[23] =
+      CMS::SynchrotronRadiation; // "SynchRad"        -> "SynchrotronRadiation"
+  m_map[24] =
+      CMS::SynchrotronRadiation; // "TransRad"        -> "SynchrotronRadiation"
+                                 // => DOUBLE-CHECK THIS
+  m_map[31] = CMS::Unknown; // "OpAbsorp"        -> "Unknown" => NOT USED IN CMS
+  m_map[32] = CMS::Unknown; // "OpBoundary"      -> "Unknown" => NOT USED IN CMS
+  m_map[33] = CMS::Unknown; // "OpRayleigh"      -> "Unknown" => NOT USED IN CMS
+  m_map[34] = CMS::Unknown; // "OpWLS"           -> "Unknown" => NOT USED IN CMS
+  m_map[35] = CMS::Unknown; // "OpMieHG"         -> "Unknown" => NOT USED IN CMS
+  m_map[51] = CMS::Unknown; // "DNAElastic"      -> "Unknown" => NOT USED IN CMS
+  m_map[52] = CMS::Unknown; // "DNAExcit"        -> "Unknown" => NOT USED IN CMS
+  m_map[53] = CMS::Unknown; // "DNAIonisation"   -> "Unknown" => NOT USED IN CMS
+  m_map[54] = CMS::Unknown; // "DNAVibExcit"     -> "Unknown" => NOT USED IN CMS
+  m_map[55] = CMS::Unknown; // "DNAAttachment"   -> "Unknown" => NOT USED IN CMS
+  m_map[56] = CMS::Unknown; // "DNAChargeDec"    -> "Unknown" => NOT USED IN CMS
+  m_map[57] = CMS::Unknown; // "DNAChargeInc"    -> "Unknown" => NOT USED IN CMS
+  m_map[111] = CMS::Hadronic; // "HadElastic"      -> "Hadronic"
+  m_map[121] = CMS::Hadronic; // "HadInelastic"    -> "Hadronic"
+  m_map[131] = CMS::Hadronic; // "HadCapture"      -> "Hadronic"
+  m_map[141] = CMS::Hadronic; // "HadFission"      -> "Hadronic"
+  m_map[151] = CMS::Hadronic; // "HadAtRest"       -> "Hadronic"
+  m_map[161] = CMS::Hadronic; // "HadCEX"          -> "Hadronic"
+  m_map[201] = CMS::Decay;    // "Decay"           -> "Decay"
+  m_map[202] = CMS::Decay;    // "DecayWSpin"      -> "Decay"
+  m_map[203] = CMS::Decay;    // "DecayPiWSpin"    -> "Decay"
+  m_map[210] = CMS::Decay;    // "DecayRadio"      -> "Decay"
+  m_map[211] = CMS::Decay;    // "DecayUnKnown"    -> "Decay"
+  m_map[231] = CMS::Decay;    // "DecayExt"        -> "Decay"
+  m_map[301] = CMS::Unknown;  // "GFlash"          -> "Unknown"
+  m_map[401] = CMS::Unknown;  // "StepLimiter"     -> "Unknown"
+  m_map[402] = CMS::Unknown;  // "UsrSpecCuts"     -> "Unknown"
+  m_map[403] = CMS::Unknown;  // "NeutronKiller"   -> "Unknown"
 }
 
-const unsigned int G4toCMSLegacyProcTypeMap::processId(unsigned int g4ProcessId) const
-{
+const unsigned int
+G4toCMSLegacyProcTypeMap::processId(unsigned int g4ProcessId) const {
   MapType::const_iterator it = m_map.find(g4ProcessId);
 
-  if( it == m_map.end() )
-  {
-    edm::LogError("UnknownProcessType") << "Encountered an unknown process type: " << g4ProcessId << ". Mapping it to 'Undefined'.";
+  if (it == m_map.end()) {
+    edm::LogError("UnknownProcessType")
+        << "Encountered an unknown process type: " << g4ProcessId
+        << ". Mapping it to 'Undefined'.";
     return CMS::Undefined;
-  }
-  else
+  } else
     return it->second;
 }

--- a/SimTracker/TrackHistory/src/VertexCategories.cc
+++ b/SimTracker/TrackHistory/src/VertexCategories.cc
@@ -3,77 +3,67 @@
 
 #include "SimTracker/TrackHistory/interface/VertexCategories.h"
 
-const char * const VertexCategories::Names[] =
-{
-    "Fake",
-    "SignalEvent",
-    "BWeakDecay",
-    "CWeakDecay",
-    "TauDecay",
-    "KsDecay",
-    "LambdaDecay",
-    "JpsiDecay",
-    "XiDecay",
-    "OmegaDecay",
-    "SigmaPlusDecay",
-    "SigmaMinusDecay",
-    "LongLivedDecay",
-    "KnownProcess",
-    "UndefinedProcess",
-    "UnknownProcess",
-    "PrimaryProcess",
-    "HadronicProcess",
-    "DecayProcess",
-    "ComptonProcess",
-    "AnnihilationProcess",
-    "EIoniProcess",
-    "HIoniProcess",
-    "MuIoniProcess",
-    "PhotonProcess",
-    "MuPairProdProcess",
-    "ConversionsProcess",
-    "EBremProcess",
-    "SynchrotronRadiationProcess",
-    "MuBremProcess",
-    "MuNuclProcess",
-    "PrimaryVertex",
-    "SecondaryVertex",
-    "TertiaryVertex",
-    "Unknown"
-};
+const char *const VertexCategories::Names[] = {"Fake",
+                                               "SignalEvent",
+                                               "BWeakDecay",
+                                               "CWeakDecay",
+                                               "TauDecay",
+                                               "KsDecay",
+                                               "LambdaDecay",
+                                               "JpsiDecay",
+                                               "XiDecay",
+                                               "OmegaDecay",
+                                               "SigmaPlusDecay",
+                                               "SigmaMinusDecay",
+                                               "LongLivedDecay",
+                                               "KnownProcess",
+                                               "UndefinedProcess",
+                                               "UnknownProcess",
+                                               "PrimaryProcess",
+                                               "HadronicProcess",
+                                               "DecayProcess",
+                                               "ComptonProcess",
+                                               "AnnihilationProcess",
+                                               "EIoniProcess",
+                                               "HIoniProcess",
+                                               "MuIoniProcess",
+                                               "PhotonProcess",
+                                               "MuPairProdProcess",
+                                               "ConversionsProcess",
+                                               "EBremProcess",
+                                               "SynchrotronRadiationProcess",
+                                               "MuBremProcess",
+                                               "MuNuclProcess",
+                                               "PrimaryVertex",
+                                               "SecondaryVertex",
+                                               "TertiaryVertex",
+                                               "Unknown"};
 
-
-void VertexCategories::unknownVertex()
-{
-    // Check for all flags down
-    for (std::size_t index = 0; index < flags_.size() - 1; ++index)
-        if (flags_[index]) return;
-    // If all of them are down then it is a unkown track.
-    flags_[Unknown] = true;
+void VertexCategories::unknownVertex() {
+  // Check for all flags down
+  for (std::size_t index = 0; index < flags_.size() - 1; ++index)
+    if (flags_[index])
+      return;
+  // If all of them are down then it is a unkown track.
+  flags_[Unknown] = true;
 }
 
+std::ostream &operator<<(std::ostream &os, VertexCategories const &classifier) {
+  bool init = true;
 
-std::ostream & operator<< (std::ostream & os, VertexCategories const & classifier)
-{
-    bool init = true;
+  const VertexCategories::Flags &flags = classifier.flags();
 
-    const VertexCategories::Flags & flags = classifier.flags();
-
-    // Print out the classification for the track
-    for (std::size_t index = 0; index < flags.size(); ++index)
-    {
-        if (flags[index])
-        {
-            if (init)
-            {
-                os << VertexCategories::Names[index];
-                init = false;
-            }
-            else
-                os << "::" << VertexCategories::Names[index];
-        }
+  // Print out the classification for the track
+  for (std::size_t index = 0; index < flags.size(); ++index) {
+    if (flags[index]) {
+      if (init) {
+        os << VertexCategories::Names[index];
+        init = false;
+      } else
+        os << "::" << VertexCategories::Names[index];
     }
-    os << std::endl;
+  }
+  os << std::endl;
 
-    return os;
+  return os;
 }

--- a/SimTracker/TrackHistory/src/VertexClassifier.cc
+++ b/SimTracker/TrackHistory/src/VertexClassifier.cc
@@ -10,88 +10,50 @@
 
 #include "SimTracker/TrackHistory/interface/VertexClassifier.h"
 
+#define update(a, b)                                                           \
+  do {                                                                         \
+    (a) = (a) | (b);                                                           \
+  } while (0)
 
-#define update(a, b) do { (a) = (a) | (b); } while(0)
+VertexClassifier::VertexClassifier(edm::ParameterSet const &config,
+                                   edm::ConsumesCollector &&collector)
+    : VertexCategories(), tracer_(config, std::move(collector)),
+      hepMCLabel_(config.getUntrackedParameter<edm::InputTag>("hepMC")) {
+  collector.consumes<edm::HepMCProduct>(hepMCLabel_);
+  // Set the history depth after hadronization
+  tracer_.depth(-2);
 
+  // Set the minimum decay length for detecting long decays
+  longLivedDecayLength_ =
+      config.getUntrackedParameter<double>("longLivedDecayLength");
 
-VertexClassifier::VertexClassifier(edm::ParameterSet const & config,
-                                   edm::ConsumesCollector&& collector) : 
-        VertexCategories(), 
-        tracer_(config,std::move(collector)),
-        hepMCLabel_( config.getUntrackedParameter<edm::InputTag>("hepMC") )
-{
-    collector.consumes<edm::HepMCProduct>(hepMCLabel_);
-    // Set the history depth after hadronization
-    tracer_.depth(-2);
-
-    // Set the minimum decay length for detecting long decays
-    longLivedDecayLength_ = config.getUntrackedParameter<double>("longLivedDecayLength");
-
-    // Set the distance for clustering vertices
-    vertexClusteringDistance_ = config.getUntrackedParameter<double>("vertexClusteringDistance");
+  // Set the distance for clustering vertices
+  vertexClusteringDistance_ =
+      config.getUntrackedParameter<double>("vertexClusteringDistance");
 }
 
+void VertexClassifier::newEvent(edm::Event const &event,
+                                edm::EventSetup const &setup) {
+  // Get the new event information for the tracer
+  tracer_.newEvent(event, setup);
 
-void VertexClassifier::newEvent(edm::Event const & event, edm::EventSetup const & setup)
-{
-    // Get the new event information for the tracer
-    tracer_.newEvent(event, setup);
+  // Get hepmc of the event
+  event.getByLabel(hepMCLabel_, mcInformation_);
 
-    // Get hepmc of the event
-    event.getByLabel(hepMCLabel_, mcInformation_);
+  // Get the partivle data table
+  setup.getData(particleDataTable_);
 
-    // Get the partivle data table
-    setup.getData(particleDataTable_);
-
-    // Create the list of primary vertices associated to the event
-    genPrimaryVertices();
+  // Create the list of primary vertices associated to the event
+  genPrimaryVertices();
 }
 
+VertexClassifier const &
+VertexClassifier::evaluate(reco::VertexBaseRef const &vertex) {
+  // Initializing the category vector
+  reset();
 
-VertexClassifier const & VertexClassifier::evaluate (reco::VertexBaseRef const & vertex)
-{
-    // Initializing the category vector
-    reset();
-
-    // Associate and evaluate the vertex history (check for fakes)
-    if ( tracer_.evaluate(vertex) )
-    {
-        // Get all the information related to the simulation details
-        simulationInformation();
-
-        // Get all the information related to decay process
-        processesAtGenerator();
-
-        // Get information about conversion and other interactions
-        processesAtSimulation();
-
-        // Get geometrical information about the vertices
-        vertexInformation();
-
-        // Check for unkown classification
-        unknownVertex();
-    }
-    else
-        flags_[Fake] = true;
-
-    return *this;
-}
-
-
-VertexClassifier const & VertexClassifier::evaluate (TrackingVertexRef const & vertex)
-{
-    // Initializing the category vector
-    reset();
-
-    // Trace the history for the given TP
-    tracer_.evaluate(vertex);
-
-    // Check for a reconstructed track
-    if ( tracer_.recoVertex().isNonnull() )
-        flags_[Reconstructed] = true;
-    else
-        flags_[Reconstructed] = false;
-
+  // Associate and evaluate the vertex history (check for fakes)
+  if (tracer_.evaluate(vertex)) {
     // Get all the information related to the simulation details
     simulationInformation();
 
@@ -106,433 +68,436 @@ VertexClassifier const & VertexClassifier::evaluate (TrackingVertexRef const & v
 
     // Check for unkown classification
     unknownVertex();
+  } else
+    flags_[Fake] = true;
 
-    return *this;
+  return *this;
 }
 
+VertexClassifier const &
+VertexClassifier::evaluate(TrackingVertexRef const &vertex) {
+  // Initializing the category vector
+  reset();
 
-void VertexClassifier::simulationInformation()
-{
-    // Get the event id for the initial TP.
-    EncodedEventId eventId = tracer_.simVertex()->eventId();
-    // Check for signal events
-    flags_[SignalEvent] = !eventId.bunchCrossing() && !eventId.event();
+  // Trace the history for the given TP
+  tracer_.evaluate(vertex);
+
+  // Check for a reconstructed track
+  if (tracer_.recoVertex().isNonnull())
+    flags_[Reconstructed] = true;
+  else
+    flags_[Reconstructed] = false;
+
+  // Get all the information related to the simulation details
+  simulationInformation();
+
+  // Get all the information related to decay process
+  processesAtGenerator();
+
+  // Get information about conversion and other interactions
+  processesAtSimulation();
+
+  // Get geometrical information about the vertices
+  vertexInformation();
+
+  // Check for unkown classification
+  unknownVertex();
+
+  return *this;
 }
 
-
-void VertexClassifier::processesAtGenerator()
-{
-    // Get the generated vetices from track history
-    VertexHistory::GenVertexTrail const & genVertexTrail = tracer_.genVertexTrail();
-
-    // Loop over the generated vertices
-    for (
-        VertexHistory::GenVertexTrail::const_iterator ivertex = genVertexTrail.begin();
-        ivertex != genVertexTrail.end();
-        ++ivertex
-    )
-    {
-        // Get the pointer to the vertex by removing the const-ness (no const methos in HepMC::GenVertex)
-        HepMC::GenVertex * vertex = const_cast<HepMC::GenVertex *>(*ivertex);
-
-        // Loop over the sources looking for specific decays
-        for (
-            HepMC::GenVertex::particle_iterator iparent = vertex->particles_begin(HepMC::parents);
-            iparent != vertex->particles_end(HepMC::parents);
-            ++iparent
-        )
-        {
-            // Collect the pdgid of the parent
-            int pdgid = std::abs((*iparent)->pdg_id());
-            // Get particle type
-            HepPDT::ParticleID particleID(pdgid);
-
-            // Check if the particle type is valid one
-            if (particleID.isValid())
-            {
-                // Get particle data
-                ParticleData const * particleData = particleDataTable_->particle(particleID);
-                // Check if the particle exist in the table
-                if (particleData)
-                {
-                    // Check if their life time is bigger than longLivedDecayLength_
-                    if ( particleData->lifetime() > longLivedDecayLength_ )
-                    {
-                        // Check for B, C weak decays and long lived decays
-                        update(flags_[BWeakDecay], particleID.hasBottom());
-                        update(flags_[CWeakDecay], particleID.hasCharm());
-                        update(flags_[LongLivedDecay], true);
-                    }
-                    // Check Tau, Ks and Lambda decay
-                    update(flags_[TauDecay], pdgid == 15);
-                    update(flags_[KsDecay], pdgid == 310);
-                    update(flags_[LambdaDecay], pdgid == 3122);
-                    update(flags_[JpsiDecay], pdgid == 443);
-                    update(flags_[XiDecay], pdgid == 3312);
-                    update(flags_[OmegaDecay], pdgid == 3334);
-                    update(flags_[SigmaPlusDecay], pdgid == 3222);
-                    update(flags_[SigmaMinusDecay], pdgid == 3112);
-                }
-            }
-        }
-    }
+void VertexClassifier::simulationInformation() {
+  // Get the event id for the initial TP.
+  EncodedEventId eventId = tracer_.simVertex()->eventId();
+  // Check for signal events
+  flags_[SignalEvent] = !eventId.bunchCrossing() && !eventId.event();
 }
 
+void VertexClassifier::processesAtGenerator() {
+  // Get the generated vetices from track history
+  VertexHistory::GenVertexTrail const &genVertexTrail =
+      tracer_.genVertexTrail();
 
-void VertexClassifier::processesAtSimulation()
-{
-    VertexHistory::SimVertexTrail const & simVertexTrail = tracer_.simVertexTrail();
+  // Loop over the generated vertices
+  for (VertexHistory::GenVertexTrail::const_iterator ivertex =
+           genVertexTrail.begin();
+       ivertex != genVertexTrail.end(); ++ivertex) {
+    // Get the pointer to the vertex by removing the const-ness (no const methos
+    // in HepMC::GenVertex)
+    HepMC::GenVertex *vertex = const_cast<HepMC::GenVertex *>(*ivertex);
 
-    for (
-        VertexHistory::SimVertexTrail::const_iterator ivertex = simVertexTrail.begin();
-        ivertex != simVertexTrail.end();
-        ++ivertex
-    )
-    {
-        // pdgid of the real source parent vertex
-        int pdgid = 0;
+    // Loop over the sources looking for specific decays
+    for (HepMC::GenVertex::particle_iterator iparent =
+             vertex->particles_begin(HepMC::parents);
+         iparent != vertex->particles_end(HepMC::parents); ++iparent) {
+      // Collect the pdgid of the parent
+      int pdgid = std::abs((*iparent)->pdg_id());
+      // Get particle type
+      HepPDT::ParticleID particleID(pdgid);
 
-        // select the original source in case of combined vertices
-        bool flag = false;
-        TrackingVertex::tp_iterator itd, its;
-
-        for (its = (*ivertex)->sourceTracks_begin(); its != (*ivertex)->sourceTracks_end(); ++its)
-        {
-            for (itd = (*ivertex)->daughterTracks_begin(); itd != (*ivertex)->daughterTracks_end(); ++itd)
-                if (itd != its)
-                {
-                    flag = true;
-                    break;
-                }
-            if (flag)
-                break;
+      // Check if the particle type is valid one
+      if (particleID.isValid()) {
+        // Get particle data
+        ParticleData const *particleData =
+            particleDataTable_->particle(particleID);
+        // Check if the particle exist in the table
+        if (particleData) {
+          // Check if their life time is bigger than longLivedDecayLength_
+          if (particleData->lifetime() > longLivedDecayLength_) {
+            // Check for B, C weak decays and long lived decays
+            update(flags_[BWeakDecay], particleID.hasBottom());
+            update(flags_[CWeakDecay], particleID.hasCharm());
+            update(flags_[LongLivedDecay], true);
+          }
+          // Check Tau, Ks and Lambda decay
+          update(flags_[TauDecay], pdgid == 15);
+          update(flags_[KsDecay], pdgid == 310);
+          update(flags_[LambdaDecay], pdgid == 3122);
+          update(flags_[JpsiDecay], pdgid == 443);
+          update(flags_[XiDecay], pdgid == 3312);
+          update(flags_[OmegaDecay], pdgid == 3334);
+          update(flags_[SigmaPlusDecay], pdgid == 3222);
+          update(flags_[SigmaMinusDecay], pdgid == 3112);
         }
-        // Collect the pdgid of the original source track
-        if ( its != (*ivertex)->sourceTracks_end() )
-            pdgid = std::abs((*its)->pdgId());
-        else
-            pdgid = 0;
-
-	// Geant4 process type is selected using first Geant4 vertex assigned to 
-        // the TrackingVertex
-	unsigned int processG4 = 0;
-	
-        if((*ivertex)->nG4Vertices() > 0) {
-	  processG4 = (*(*ivertex)->g4Vertices_begin()).processType();
-	}
-	
-	unsigned int process = g4toCMSProcMap_.processId(processG4);
-	
-	// Flagging all the different processes
-	update(
-	       flags_[KnownProcess],
-	       process != CMS::Undefined &&
-	       process != CMS::Unknown &&
-	       process != CMS::Primary
-	       );
-
-	update(flags_[UndefinedProcess], process == CMS::Undefined);
-	update(flags_[UnknownProcess], process == CMS::Unknown);
-	update(flags_[PrimaryProcess], process == CMS::Primary);
-	update(flags_[HadronicProcess], process == CMS::Hadronic);
-	update(flags_[DecayProcess], process == CMS::Decay);
-	update(flags_[ComptonProcess], process == CMS::Compton);
-	update(flags_[AnnihilationProcess], process == CMS::Annihilation);
-	update(flags_[EIoniProcess], process == CMS::EIoni);
-	update(flags_[HIoniProcess], process == CMS::HIoni);
-	update(flags_[MuIoniProcess], process == CMS::MuIoni);
-	update(flags_[PhotonProcess], process == CMS::Photon);
-	update(flags_[MuPairProdProcess], process == CMS::MuPairProd);
-	update(flags_[ConversionsProcess], process == CMS::Conversions);
-	update(flags_[EBremProcess], process == CMS::EBrem);
-	update(flags_[SynchrotronRadiationProcess], process == CMS::SynchrotronRadiation);
-	update(flags_[MuBremProcess], process == CMS::MuBrem);
-	update(flags_[MuNuclProcess], process == CMS::MuNucl);
-
-
-        // Loop over the simulated particles
-        for (
-            TrackingVertex::tp_iterator iparticle = (*ivertex)->daughterTracks_begin();
-            iparticle != (*ivertex)->daughterTracks_end();
-            ++iparticle
-        )
-        {
-
-            if ( (*iparticle)->numberOfTrackerLayers() )
-            {
-
-                // Special treatment for decays
-                if (process == CMS::Decay)
-                {
-                    // Get particle type
-                    HepPDT::ParticleID particleID(pdgid);
-                    // Check if the particle type is valid one
-                    if (particleID.isValid())
-                    {
-                        // Get particle data
-                        ParticleData const * particleData = particleDataTable_->particle(particleID);
-                        // Check if the particle exist in the table
-                        if (particleData)
-                        {
-                            // Check if their life time is bigger than 1e-14
-                            if ( particleDataTable_->particle(particleID)->lifetime() > longLivedDecayLength_ )
-                            {
-                                // Check for B, C weak decays and long lived decays
-                                update(flags_[BWeakDecay], particleID.hasBottom());
-                                update(flags_[CWeakDecay], particleID.hasCharm());
-                                update(flags_[LongLivedDecay], true);
-                            }
-                            // Check Tau, Ks and Lambda decay
-                            update(flags_[TauDecay], pdgid == 15);
-                            update(flags_[KsDecay], pdgid == 310);
-                            update(flags_[LambdaDecay], pdgid == 3122);
-                            update(flags_[JpsiDecay], pdgid == 443);
-                            update(flags_[XiDecay], pdgid == 3312);
-                            update(flags_[OmegaDecay], pdgid == 3334);
-                            update(flags_[SigmaPlusDecay], pdgid == 3222);
-                            update(flags_[SigmaMinusDecay], pdgid == 3112);
-                        }
-                    }
-                }
-            }
-        }
+      }
     }
+  }
 }
 
+void VertexClassifier::processesAtSimulation() {
+  VertexHistory::SimVertexTrail const &simVertexTrail =
+      tracer_.simVertexTrail();
 
-void VertexClassifier::vertexInformation()
-{
-    // Helper class for clusterization
-    typedef std::multimap<double, HepMC::ThreeVector> Clusters;
-    typedef std::pair<double, HepMC::ThreeVector> ClusterPair;
+  for (VertexHistory::SimVertexTrail::const_iterator ivertex =
+           simVertexTrail.begin();
+       ivertex != simVertexTrail.end(); ++ivertex) {
+    // pdgid of the real source parent vertex
+    int pdgid = 0;
 
-    Clusters clusters;
+    // select the original source in case of combined vertices
+    bool flag = false;
+    TrackingVertex::tp_iterator itd, its;
 
-    // Get the main primary vertex from the list
-    GeneratedPrimaryVertex const & genpv = genpvs_.back();
-
-    // Get the generated history of the tracks
-    const VertexHistory::GenVertexTrail & genVertexTrail = tracer_.genVertexTrail();
-
-    // Unit transformation from mm to cm
-    double const mm = 0.1;
-
-    // Loop over the generated vertexes
-    for (
-        VertexHistory::GenVertexTrail::const_iterator ivertex = genVertexTrail.begin();
-        ivertex != genVertexTrail.end();
-        ++ivertex
-    )
-    {
-        // Check vertex exist
-        if (*ivertex)
-        {
-            // Measure the distance2 respecto the primary vertex
-            HepMC::ThreeVector p = (*ivertex)->point3d();
-            double distance = sqrt( pow(p.x() * mm - genpv.x, 2) + pow(p.y() * mm - genpv.y, 2) + pow(p.z() * mm - genpv.z, 2) );
-
-            // If there is not any clusters add the first vertex.
-            if ( clusters.empty() )
-            {
-                clusters.insert( ClusterPair(distance, HepMC::ThreeVector(p.x() * mm, p.y() * mm, p.z() * mm)) );
-                continue;
-            }
-
-            // Check if there is already a cluster in the given distance from primary vertex
-            Clusters::const_iterator icluster = clusters.lower_bound(distance - vertexClusteringDistance_);
-
-            if ( icluster == clusters.upper_bound(distance + vertexClusteringDistance_) )
-            {
-                clusters.insert ( ClusterPair(distance, HepMC::ThreeVector(p.x() * mm, p.y() * mm, p.z() * mm)) );
-                continue;
-            }
-
-            bool cluster = false;
-
-            // Looping over the vertex clusters of a given distance from primary vertex
-            for (;
-                    icluster != clusters.upper_bound(distance + vertexClusteringDistance_);
-                    ++icluster
-                )
-            {
-                double difference = sqrt (
-                                        pow(p.x() * mm - icluster->second.x(), 2) +
-                                        pow(p.y() * mm - icluster->second.y(), 2) +
-                                        pow(p.z() * mm - icluster->second.z(), 2)
-                                    );
-
-                if ( difference < vertexClusteringDistance_ )
-                {
-                    cluster = true;
-                    break;
-                }
-            }
-
-            if (!cluster) clusters.insert ( ClusterPair(distance, HepMC::ThreeVector(p.x() * mm, p.y() * mm, p.z() * mm)) );
+    for (its = (*ivertex)->sourceTracks_begin();
+         its != (*ivertex)->sourceTracks_end(); ++its) {
+      for (itd = (*ivertex)->daughterTracks_begin();
+           itd != (*ivertex)->daughterTracks_end(); ++itd)
+        if (itd != its) {
+          flag = true;
+          break;
         }
+      if (flag)
+        break;
     }
-
-    const VertexHistory::SimVertexTrail & simVertexTrail = tracer_.simVertexTrail();
-
-    // Loop over the generated particles
-    for (
-        VertexHistory::SimVertexTrail::const_reverse_iterator ivertex = simVertexTrail.rbegin();
-        ivertex != simVertexTrail.rend();
-        ++ivertex
-    )
-    {
-        // Look for those with production vertex
-        TrackingVertex::LorentzVector p = (*ivertex)->position();
-
-        double distance = sqrt( pow(p.x() - genpv.x, 2) + pow(p.y() - genpv.y, 2) + pow(p.z() - genpv.z, 2) );
-
-        // If there is not any clusters add the first vertex.
-        if ( clusters.empty() )
-        {
-            clusters.insert( ClusterPair(distance, HepMC::ThreeVector(p.x(), p.y(), p.z())) );
-            continue;
-        }
-
-        // Check if there is already a cluster in the given distance from primary vertex
-        Clusters::const_iterator icluster = clusters.lower_bound(distance - vertexClusteringDistance_);
-
-        if ( icluster == clusters.upper_bound(distance + vertexClusteringDistance_) )
-        {
-            clusters.insert ( ClusterPair(distance, HepMC::ThreeVector(p.x(), p.y(), p.z())) );
-            continue;
-        }
-
-        bool cluster = false;
-
-        // Looping over the vertex clusters of a given distance from primary vertex
-        for (;
-                icluster != clusters.upper_bound(distance + vertexClusteringDistance_);
-                ++icluster
-            )
-        {
-            double difference = sqrt (
-                                    pow(p.x() - icluster->second.x(), 2) +
-                                    pow(p.y() - icluster->second.y(), 2) +
-                                    pow(p.z() - icluster->second.z(), 2)
-                                );
-
-            if ( difference < vertexClusteringDistance_ )
-            {
-                cluster = true;
-                break;
-            }
-        }
-
-        if (!cluster) clusters.insert ( ClusterPair(distance, HepMC::ThreeVector(p.x(), p.y(), p.z())) );
-    }
-
-    if ( clusters.size() == 1 )
-        flags_[PrimaryVertex] = true;
-    else if ( clusters.size() == 2 )
-        flags_[SecondaryVertex] = true;
+    // Collect the pdgid of the original source track
+    if (its != (*ivertex)->sourceTracks_end())
+      pdgid = std::abs((*its)->pdgId());
     else
-        flags_[TertiaryVertex] = true;
-}
+      pdgid = 0;
 
+    // Geant4 process type is selected using first Geant4 vertex assigned to
+    // the TrackingVertex
+    unsigned int processG4 = 0;
 
-bool VertexClassifier::isFinalstateParticle(const HepMC::GenParticle * p)
-{
-    return !p->end_vertex() && p->status() == 1;
-}
-
-
-bool VertexClassifier::isCharged(const HepMC::GenParticle * p)
-{
-    const ParticleData * part = particleDataTable_->particle( p->pdg_id() );
-    if (part)
-        return part->charge()!=0;
-    else
-    {
-        // the new/improved particle table doesn't know anti-particles
-        return  particleDataTable_->particle( -p->pdg_id() ) != nullptr;
+    if ((*ivertex)->nG4Vertices() > 0) {
+      processG4 = (*(*ivertex)->g4Vertices_begin()).processType();
     }
-}
 
+    unsigned int process = g4toCMSProcMap_.processId(processG4);
 
-void VertexClassifier::genPrimaryVertices()
-{
-    genpvs_.clear();
+    // Flagging all the different processes
+    update(flags_[KnownProcess], process != CMS::Undefined &&
+                                     process != CMS::Unknown &&
+                                     process != CMS::Primary);
 
-    const HepMC::GenEvent * event = mcInformation_->GetEvent();
+    update(flags_[UndefinedProcess], process == CMS::Undefined);
+    update(flags_[UnknownProcess], process == CMS::Unknown);
+    update(flags_[PrimaryProcess], process == CMS::Primary);
+    update(flags_[HadronicProcess], process == CMS::Hadronic);
+    update(flags_[DecayProcess], process == CMS::Decay);
+    update(flags_[ComptonProcess], process == CMS::Compton);
+    update(flags_[AnnihilationProcess], process == CMS::Annihilation);
+    update(flags_[EIoniProcess], process == CMS::EIoni);
+    update(flags_[HIoniProcess], process == CMS::HIoni);
+    update(flags_[MuIoniProcess], process == CMS::MuIoni);
+    update(flags_[PhotonProcess], process == CMS::Photon);
+    update(flags_[MuPairProdProcess], process == CMS::MuPairProd);
+    update(flags_[ConversionsProcess], process == CMS::Conversions);
+    update(flags_[EBremProcess], process == CMS::EBrem);
+    update(flags_[SynchrotronRadiationProcess],
+           process == CMS::SynchrotronRadiation);
+    update(flags_[MuBremProcess], process == CMS::MuBrem);
+    update(flags_[MuNuclProcess], process == CMS::MuNucl);
 
-    if (event)
-    {
-        int idx = 0;
+    // Loop over the simulated particles
+    for (TrackingVertex::tp_iterator iparticle =
+             (*ivertex)->daughterTracks_begin();
+         iparticle != (*ivertex)->daughterTracks_end(); ++iparticle) {
 
-        // Loop over the different GenVertex
-        for ( HepMC::GenEvent::vertex_const_iterator ivertex = event->vertices_begin(); ivertex != event->vertices_end(); ++ivertex )
-        {
-            bool hasParentVertex = false;
+      if ((*iparticle)->numberOfTrackerLayers()) {
 
-            // Loop over the parents looking to see if they are coming from a production vertex
-            for (
-                HepMC::GenVertex::particle_iterator iparent = (*ivertex)->particles_begin(HepMC::parents);
-                iparent != (*ivertex)->particles_end(HepMC::parents);
-                ++iparent
-            )
-                if ( (*iparent)->production_vertex() )
-                {
-                    hasParentVertex = true;
-                    break;
-                }
-
-            // Reject those vertices with parent vertices
-            if (hasParentVertex) continue;
-
-            // Get the position of the vertex
-            HepMC::FourVector pos = (*ivertex)->position();
-
-            double const mm = 0.1;
-
-            GeneratedPrimaryVertex pv(pos.x()*mm, pos.y()*mm, pos.z()*mm);
-
-            std::vector<GeneratedPrimaryVertex>::iterator ientry = genpvs_.begin();
-
-            // Search for a VERY close vertex in the list
-            for (; ientry != genpvs_.end(); ++ientry)
-            {
-                double distance = sqrt( pow(pv.x - ientry->x, 2) + pow(pv.y - ientry->y, 2) + pow(pv.z - ientry->z, 2) );
-                if ( distance < vertexClusteringDistance_ )
-                    break;
+        // Special treatment for decays
+        if (process == CMS::Decay) {
+          // Get particle type
+          HepPDT::ParticleID particleID(pdgid);
+          // Check if the particle type is valid one
+          if (particleID.isValid()) {
+            // Get particle data
+            ParticleData const *particleData =
+                particleDataTable_->particle(particleID);
+            // Check if the particle exist in the table
+            if (particleData) {
+              // Check if their life time is bigger than 1e-14
+              if (particleDataTable_->particle(particleID)->lifetime() >
+                  longLivedDecayLength_) {
+                // Check for B, C weak decays and long lived decays
+                update(flags_[BWeakDecay], particleID.hasBottom());
+                update(flags_[CWeakDecay], particleID.hasCharm());
+                update(flags_[LongLivedDecay], true);
+              }
+              // Check Tau, Ks and Lambda decay
+              update(flags_[TauDecay], pdgid == 15);
+              update(flags_[KsDecay], pdgid == 310);
+              update(flags_[LambdaDecay], pdgid == 3122);
+              update(flags_[JpsiDecay], pdgid == 443);
+              update(flags_[XiDecay], pdgid == 3312);
+              update(flags_[OmegaDecay], pdgid == 3334);
+              update(flags_[SigmaPlusDecay], pdgid == 3222);
+              update(flags_[SigmaMinusDecay], pdgid == 3112);
             }
-
-            // Check if there is not a VERY close vertex and added to the list
-            if (ientry == genpvs_.end())
-                ientry = genpvs_.insert(ientry,pv);
-
-            // Add the vertex barcodes to the new or existent vertices
-            ientry->genVertex.push_back((*ivertex)->barcode());
-
-            // Collect final state descendants
-            for (
-                HepMC::GenVertex::particle_iterator idecendants  = (*ivertex)->particles_begin(HepMC::descendants);
-                idecendants != (*ivertex)->particles_end(HepMC::descendants);
-                ++idecendants
-            )
-            {
-                if (isFinalstateParticle(*idecendants))
-                    if ( find(ientry->finalstateParticles.begin(), ientry->finalstateParticles.end(), (*idecendants)->barcode()) == ientry->finalstateParticles.end() )
-                    {
-                        ientry->finalstateParticles.push_back((*idecendants)->barcode());
-                        HepMC::FourVector m = (*idecendants)->momentum();
-
-                        ientry->ptot.setPx(ientry->ptot.px() + m.px());
-                        ientry->ptot.setPy(ientry->ptot.py() + m.py());
-                        ientry->ptot.setPz(ientry->ptot.pz() + m.pz());
-                        ientry->ptot.setE(ientry->ptot.e() + m.e());
-                        ientry->ptsq += m.perp() * m.perp();
-
-                        if ( m.perp() > 0.8 && std::abs(m.pseudoRapidity()) < 2.5 && isCharged(*idecendants) ) ientry->nGenTrk++;
-                    }
-            }
-            idx++;
+          }
         }
+      }
+    }
+  }
+}
+
+void VertexClassifier::vertexInformation() {
+  // Helper class for clusterization
+  typedef std::multimap<double, HepMC::ThreeVector> Clusters;
+  typedef std::pair<double, HepMC::ThreeVector> ClusterPair;
+
+  Clusters clusters;
+
+  // Get the main primary vertex from the list
+  GeneratedPrimaryVertex const &genpv = genpvs_.back();
+
+  // Get the generated history of the tracks
+  const VertexHistory::GenVertexTrail &genVertexTrail =
+      tracer_.genVertexTrail();
+
+  // Unit transformation from mm to cm
+  double const mm = 0.1;
+
+  // Loop over the generated vertexes
+  for (VertexHistory::GenVertexTrail::const_iterator ivertex =
+           genVertexTrail.begin();
+       ivertex != genVertexTrail.end(); ++ivertex) {
+    // Check vertex exist
+    if (*ivertex) {
+      // Measure the distance2 respecto the primary vertex
+      HepMC::ThreeVector p = (*ivertex)->point3d();
+      double distance =
+          sqrt(pow(p.x() * mm - genpv.x, 2) + pow(p.y() * mm - genpv.y, 2) +
+               pow(p.z() * mm - genpv.z, 2));
+
+      // If there is not any clusters add the first vertex.
+      if (clusters.empty()) {
+        clusters.insert(ClusterPair(
+            distance, HepMC::ThreeVector(p.x() * mm, p.y() * mm, p.z() * mm)));
+        continue;
+      }
+
+      // Check if there is already a cluster in the given distance from primary
+      // vertex
+      Clusters::const_iterator icluster =
+          clusters.lower_bound(distance - vertexClusteringDistance_);
+
+      if (icluster ==
+          clusters.upper_bound(distance + vertexClusteringDistance_)) {
+        clusters.insert(ClusterPair(
+            distance, HepMC::ThreeVector(p.x() * mm, p.y() * mm, p.z() * mm)));
+        continue;
+      }
+
+      bool cluster = false;
+
+      // Looping over the vertex clusters of a given distance from primary
+      // vertex
+      for (; icluster !=
+             clusters.upper_bound(distance + vertexClusteringDistance_);
+           ++icluster) {
+        double difference = sqrt(pow(p.x() * mm - icluster->second.x(), 2) +
+                                 pow(p.y() * mm - icluster->second.y(), 2) +
+                                 pow(p.z() * mm - icluster->second.z(), 2));
+
+        if (difference < vertexClusteringDistance_) {
+          cluster = true;
+          break;
+        }
+      }
+
+      if (!cluster)
+        clusters.insert(ClusterPair(
+            distance, HepMC::ThreeVector(p.x() * mm, p.y() * mm, p.z() * mm)));
+    }
+  }
+
+  const VertexHistory::SimVertexTrail &simVertexTrail =
+      tracer_.simVertexTrail();
+
+  // Loop over the generated particles
+  for (VertexHistory::SimVertexTrail::const_reverse_iterator ivertex =
+           simVertexTrail.rbegin();
+       ivertex != simVertexTrail.rend(); ++ivertex) {
+    // Look for those with production vertex
+    TrackingVertex::LorentzVector p = (*ivertex)->position();
+
+    double distance = sqrt(pow(p.x() - genpv.x, 2) + pow(p.y() - genpv.y, 2) +
+                           pow(p.z() - genpv.z, 2));
+
+    // If there is not any clusters add the first vertex.
+    if (clusters.empty()) {
+      clusters.insert(
+          ClusterPair(distance, HepMC::ThreeVector(p.x(), p.y(), p.z())));
+      continue;
     }
 
-    std::sort(genpvs_.begin(), genpvs_.end());
+    // Check if there is already a cluster in the given distance from primary
+    // vertex
+    Clusters::const_iterator icluster =
+        clusters.lower_bound(distance - vertexClusteringDistance_);
+
+    if (icluster ==
+        clusters.upper_bound(distance + vertexClusteringDistance_)) {
+      clusters.insert(
+          ClusterPair(distance, HepMC::ThreeVector(p.x(), p.y(), p.z())));
+      continue;
+    }
+
+    bool cluster = false;
+
+    // Looping over the vertex clusters of a given distance from primary vertex
+    for (;
+         icluster != clusters.upper_bound(distance + vertexClusteringDistance_);
+         ++icluster) {
+      double difference = sqrt(pow(p.x() - icluster->second.x(), 2) +
+                               pow(p.y() - icluster->second.y(), 2) +
+                               pow(p.z() - icluster->second.z(), 2));
+
+      if (difference < vertexClusteringDistance_) {
+        cluster = true;
+        break;
+      }
+    }
+
+    if (!cluster)
+      clusters.insert(
+          ClusterPair(distance, HepMC::ThreeVector(p.x(), p.y(), p.z())));
+  }
+
+  if (clusters.size() == 1)
+    flags_[PrimaryVertex] = true;
+  else if (clusters.size() == 2)
+    flags_[SecondaryVertex] = true;
+  else
+    flags_[TertiaryVertex] = true;
+}
+
+bool VertexClassifier::isFinalstateParticle(const HepMC::GenParticle *p) {
+  return !p->end_vertex() && p->status() == 1;
+}
+
+bool VertexClassifier::isCharged(const HepMC::GenParticle *p) {
+  const ParticleData *part = particleDataTable_->particle(p->pdg_id());
+  if (part)
+    return part->charge() != 0;
+  else {
+    // the new/improved particle table doesn't know anti-particles
+    return particleDataTable_->particle(-p->pdg_id()) != nullptr;
+  }
+}
+
+void VertexClassifier::genPrimaryVertices() {
+  genpvs_.clear();
+
+  const HepMC::GenEvent *event = mcInformation_->GetEvent();
+
+  if (event) {
+    int idx = 0;
+
+    // Loop over the different GenVertex
+    for (HepMC::GenEvent::vertex_const_iterator ivertex =
+             event->vertices_begin();
+         ivertex != event->vertices_end(); ++ivertex) {
+      bool hasParentVertex = false;
+
+      // Loop over the parents looking to see if they are coming from a
+      // production vertex
+      for (HepMC::GenVertex::particle_iterator iparent =
+               (*ivertex)->particles_begin(HepMC::parents);
+           iparent != (*ivertex)->particles_end(HepMC::parents); ++iparent)
+        if ((*iparent)->production_vertex()) {
+          hasParentVertex = true;
+          break;
+        }
+
+      // Reject those vertices with parent vertices
+      if (hasParentVertex)
+        continue;
+
+      // Get the position of the vertex
+      HepMC::FourVector pos = (*ivertex)->position();
+
+      double const mm = 0.1;
+
+      GeneratedPrimaryVertex pv(pos.x() * mm, pos.y() * mm, pos.z() * mm);
+
+      std::vector<GeneratedPrimaryVertex>::iterator ientry = genpvs_.begin();
+
+      // Search for a VERY close vertex in the list
+      for (; ientry != genpvs_.end(); ++ientry) {
+        double distance =
+            sqrt(pow(pv.x - ientry->x, 2) + pow(pv.y - ientry->y, 2) +
+                 pow(pv.z - ientry->z, 2));
+        if (distance < vertexClusteringDistance_)
+          break;
+      }
+
+      // Check if there is not a VERY close vertex and added to the list
+      if (ientry == genpvs_.end())
+        ientry = genpvs_.insert(ientry, pv);
+
+      // Add the vertex barcodes to the new or existent vertices
+      ientry->genVertex.push_back((*ivertex)->barcode());
+
+      // Collect final state descendants
+      for (HepMC::GenVertex::particle_iterator idecendants =
+               (*ivertex)->particles_begin(HepMC::descendants);
+           idecendants != (*ivertex)->particles_end(HepMC::descendants);
+           ++idecendants) {
+        if (isFinalstateParticle(*idecendants))
+          if (find(ientry->finalstateParticles.begin(),
+                   ientry->finalstateParticles.end(),
+                   (*idecendants)->barcode()) ==
+              ientry->finalstateParticles.end()) {
+            ientry->finalstateParticles.push_back((*idecendants)->barcode());
+            HepMC::FourVector m = (*idecendants)->momentum();
+
+            ientry->ptot.setPx(ientry->ptot.px() + m.px());
+            ientry->ptot.setPy(ientry->ptot.py() + m.py());
+            ientry->ptot.setPz(ientry->ptot.pz() + m.pz());
+            ientry->ptot.setE(ientry->ptot.e() + m.e());
+            ientry->ptsq += m.perp() * m.perp();
+
+            if (m.perp() > 0.8 && std::abs(m.pseudoRapidity()) < 2.5 &&
+                isCharged(*idecendants))
+              ientry->nGenTrk++;
+          }
+      }
+      idx++;
+    }
+  }
+
+  std::sort(genpvs_.begin(), genpvs_.end());
 }

--- a/SimTracker/TrackHistory/src/VertexHistory.cc
+++ b/SimTracker/TrackHistory/src/VertexHistory.cc
@@ -1,94 +1,89 @@
 
-#include "SimTracker/TrackHistory/interface/VertexHistory.h"
 #include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 #include "SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h"
+#include "SimTracker/TrackHistory/interface/VertexHistory.h"
 
-VertexHistory::VertexHistory (
-  const edm::ParameterSet & config,
-  edm::ConsumesCollector&& collector
-) : HistoryBase()
-{
-    // Name of the track collection
-    vertexProducer_ = config.getUntrackedParameter<edm::InputTag> ( "vertexProducer" );
+VertexHistory::VertexHistory(const edm::ParameterSet &config,
+                             edm::ConsumesCollector &&collector)
+    : HistoryBase() {
+  // Name of the track collection
+  vertexProducer_ =
+      config.getUntrackedParameter<edm::InputTag>("vertexProducer");
 
-    // Name of the traking pariticle collection
-    trackingTruth_ = config.getUntrackedParameter<edm::InputTag> ( "trackingTruth" );
+  // Name of the traking pariticle collection
+  trackingTruth_ = config.getUntrackedParameter<edm::InputTag>("trackingTruth");
 
-    // Vertex association record
-    vertexAssociator_ = config.getUntrackedParameter<edm::InputTag> ( "vertexAssociator" );
+  // Vertex association record
+  vertexAssociator_ =
+      config.getUntrackedParameter<edm::InputTag>("vertexAssociator");
 
-    // Association by max. value
-    bestMatchByMaxValue_ = config.getUntrackedParameter<bool> ( "bestMatchByMaxValue" );
+  // Association by max. value
+  bestMatchByMaxValue_ =
+      config.getUntrackedParameter<bool>("bestMatchByMaxValue");
 
-    // Enable RecoToSim association
-    enableRecoToSim_ = config.getUntrackedParameter<bool> ( "enableRecoToSim" );
+  // Enable RecoToSim association
+  enableRecoToSim_ = config.getUntrackedParameter<bool>("enableRecoToSim");
 
-    // Enable SimToReco association
-    enableSimToReco_ = config.getUntrackedParameter<bool> ( "enableSimToReco" );
+  // Enable SimToReco association
+  enableSimToReco_ = config.getUntrackedParameter<bool>("enableSimToReco");
 
-    if(enableRecoToSim_ or enableSimToReco_) {
-      collector.consumes<edm::View<reco::Vertex>>(vertexProducer_);
-      collector.consumes<TrackingVertexCollection>(trackingTruth_);
-      collector.consumes<reco::VertexToTrackingVertexAssociator>(vertexAssociator_);
-    }
+  if (enableRecoToSim_ or enableSimToReco_) {
+    collector.consumes<edm::View<reco::Vertex>>(vertexProducer_);
+    collector.consumes<TrackingVertexCollection>(trackingTruth_);
+    collector.consumes<reco::VertexToTrackingVertexAssociator>(
+        vertexAssociator_);
+  }
 
-    quality_ = 0.;
+  quality_ = 0.;
 }
 
+void VertexHistory::newEvent(const edm::Event &event,
+                             const edm::EventSetup &setup) {
+  if (enableRecoToSim_ || enableSimToReco_) {
+    // Vertex collection
+    edm::Handle<edm::View<reco::Vertex>> vertexCollection;
+    event.getByLabel(vertexProducer_, vertexCollection);
 
-void VertexHistory::newEvent (
-    const edm::Event & event, const edm::EventSetup & setup
-)
-{
-    if ( enableRecoToSim_ || enableSimToReco_ )
-    {
-        // Vertex collection
-        edm::Handle<edm::View<reco::Vertex> > vertexCollection;
-        event.getByLabel(vertexProducer_, vertexCollection);
+    // Tracking particle information
+    edm::Handle<TrackingVertexCollection> TVCollection;
+    event.getByLabel(trackingTruth_, TVCollection);
 
-        // Tracking particle information
-        edm::Handle<TrackingVertexCollection>  TVCollection;
-        event.getByLabel(trackingTruth_, TVCollection);
+    // Get the track associator
+    edm::Handle<reco::VertexToTrackingVertexAssociator> vertexAssociator;
+    event.getByLabel(vertexAssociator_, vertexAssociator);
 
-        // Get the track associator
-        edm::Handle<reco::VertexToTrackingVertexAssociator> vertexAssociator;
-        event.getByLabel(vertexAssociator_, vertexAssociator);
-
-        if ( enableRecoToSim_ )
-        {
-            // Calculate the map between recovertex -> simvertex
-            recoToSim_ = vertexAssociator->associateRecoToSim(vertexCollection, TVCollection);
-        }
-
-        if ( enableSimToReco_ )
-        {
-            // Calculate the map between recovertex <- simvertex
-            simToReco_ = vertexAssociator->associateSimToReco(vertexCollection, TVCollection);
-        }
-
+    if (enableRecoToSim_) {
+      // Calculate the map between recovertex -> simvertex
+      recoToSim_ =
+          vertexAssociator->associateRecoToSim(vertexCollection, TVCollection);
     }
+
+    if (enableSimToReco_) {
+      // Calculate the map between recovertex <- simvertex
+      simToReco_ =
+          vertexAssociator->associateSimToReco(vertexCollection, TVCollection);
+    }
+  }
 }
 
+bool VertexHistory::evaluate(reco::VertexBaseRef tv) {
 
-bool VertexHistory::evaluate (reco::VertexBaseRef tv)
-{
-
-    if ( !enableRecoToSim_ ) return false;
-
-    std::pair<TrackingVertexRef, double> result =  match(tv, recoToSim_, bestMatchByMaxValue_);
-
-    TrackingVertexRef tvr( result.first );
-    quality_ = result.second;
-
-    if ( !tvr.isNull() )
-    {
-        HistoryBase::evaluate(tvr);
-
-        recovertex_ = tv;
-
-        return true;
-    }
-
+  if (!enableRecoToSim_)
     return false;
-}
 
+  std::pair<TrackingVertexRef, double> result =
+      match(tv, recoToSim_, bestMatchByMaxValue_);
+
+  TrackingVertexRef tvr(result.first);
+  quality_ = result.second;
+
+  if (!tvr.isNull()) {
+    HistoryBase::evaluate(tvr);
+
+    recovertex_ = tv;
+
+    return true;
+  }
+
+  return false;
+}

--- a/SimTracker/TrackHistory/src/classes.h
+++ b/SimTracker/TrackHistory/src/classes.h
@@ -5,14 +5,13 @@
 #include "SimTracker/TrackHistory/interface/TrackCategories.h"
 #include "SimTracker/TrackHistory/interface/VertexCategories.h"
 
-
 namespace SimTracker_TrackHistory {
-  struct dictionary {
-    // Dictionaires for Track and Vertex categories
+struct dictionary {
+  // Dictionaires for Track and Vertex categories
 
-    std::vector<TrackCategories> dummy01;
-    std::vector<VertexCategories> dummy02;
-    edm::Wrapper<std::vector<TrackCategories> > dummy03;
-    edm::Wrapper<std::vector<VertexCategories> > dummy04;
-  };
-}
+  std::vector<TrackCategories> dummy01;
+  std::vector<VertexCategories> dummy02;
+  edm::Wrapper<std::vector<TrackCategories>> dummy03;
+  edm::Wrapper<std::vector<VertexCategories>> dummy04;
+};
+} // namespace SimTracker_TrackHistory


### PR DESCRIPTION
Applying code-format for CMSSW category simulation.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/165//console

cms-bot has successfully run the following:
- scram build code-checks
- scram build code-format-all
- scram build
