### PR TITLE
drop provenance checks when not needed in DeepFlavourTagInfoProducer

### DIFF
--- a/RecoBTag/FeatureTools/plugins/DeepFlavourTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepFlavourTagInfoProducer.cc
@@ -152,6 +152,15 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
 
   edm::Handle<ShallowTagInfoCollection> shallow_tag_infos;
   iEvent.getByToken(shallow_tag_info_token_, shallow_tag_infos);
+  double negative_cut = 0;//used only with flip_
+  if (flip_){//FIXME: Check if can do even less often than once per event
+    const edm::Provenance *prov = shallow_tag_infos.provenance();
+    const edm::ParameterSet& psetFromProvenance = edm::parameterSet(*prov);
+    negative_cut = ( ( psetFromProvenance.getParameter<edm::ParameterSet>("computer")
+                       ).getParameter<edm::ParameterSet>("trackSelection")
+                     ).getParameter<double>("sip3dSigMax");
+  }
+
 
   edm::Handle<edm::ValueMap<float>> puppi_value_map;
   if (use_puppi_value_map_) {
@@ -273,12 +282,6 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
     features.n_pf_features.clear();
     features.n_pf_features.resize(n_sorted.size());
 
-
-    const edm::Provenance *prov = shallow_tag_infos.provenance();
-    const edm::ParameterSet& psetFromProvenance = edm::parameterSet(*prov);
-    double negative_cut = ( ( psetFromProvenance.getParameter<edm::ParameterSet>("computer")
-			      ).getParameter<edm::ParameterSet>("trackSelection")
-			    ).getParameter<double>("sip3dSigMax");
 
   for (unsigned int i = 0; i <  jet.numberOfDaughters(); i++){
 


### PR DESCRIPTION
do provenance check only once per collection retrieval and only when the negative tagging is running.

in a recent performance inspection the provenance check was found to dominate the CPU use in the ```DeepFlavourTagInfoProducer::produce``` calls
https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/CMSSW_10_6_0_pre2-sign1069.136.8311.step2.1000.pp/487

This check is used only in the analysis mode with pfNegativeDeepFlavourTagInfos. 
This PR moves the check out of the loop to be done just once per event and only with the ```flip``` flag set for running negative tagging.

