### PR TITLE
Output BadFED Channel only for Phase 1

### DIFF
--- a/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
+++ b/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
@@ -27,7 +27,7 @@ _pixelCommon = cms.VPSet(
     cms.PSet(type = cms.string('PixelDigiSimLinkedmDetSetVector'))
 )
 simSiPixelDigis = cms.EDAlias(
-    mix = _pixelCommon + [cms.PSet(type = cms.string('PixelFEDChanneledmNewDetSetVector'))]
+    mix = _pixelCommon
 ) 
 simSiStripDigis = cms.EDAlias(
     mix = cms.VPSet(
@@ -52,8 +52,8 @@ genPUProtons = cms.EDAlias(
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(simCastorDigis, mix = None)
 
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(simSiPixelDigis, mix = _pixelCommon) 
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(simSiPixelDigis, mix = _pixelCommon + [cms.PSet(type = cms.string('PixelFEDChanneledmNewDetSetVector'))])
 
 # no castor,pixel,strip digis in fastsim
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/SimGeneral/MixingModule/python/aliases_cfi.py
+++ b/SimGeneral/MixingModule/python/aliases_cfi.py
@@ -27,7 +27,7 @@ _pixelCommon = cms.VPSet(
     cms.PSet(type = cms.string('PixelDigiSimLinkedmDetSetVector'))
 )
 simSiPixelDigis = cms.EDAlias(
-    mix = _pixelCommon + [cms.PSet(type = cms.string('PixelFEDChanneledmNewDetSetVector'))]
+    mix = _pixelCommon
 ) 
 simSiStripDigis = cms.EDAlias(
     mix = cms.VPSet(
@@ -83,8 +83,8 @@ from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
 (~phase2_hfnose).toModify(simHFNoseUnsuppressedDigis, mix = None)
 
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(simSiPixelDigis, mix = _pixelCommon) 
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(simSiPixelDigis, mix = _pixelCommon + [cms.PSet(type = cms.string('PixelFEDChanneledmNewDetSetVector'))])
 
 # no castor,pixel,strip digis in fastsim
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -117,7 +117,8 @@ namespace cms
     }
     
     _pixeldigialgo.reset(new SiPixelDigitizerAlgorithm(iConfig));
-    mixMod.produces<PixelFEDChannelCollection>();
+    if (NumberOfEndcapDisks != 2)
+      mixMod.produces<PixelFEDChannelCollection>();
   }
   
   SiPixelDigitizer::~SiPixelDigitizer(){  


### PR DESCRIPTION
This PR is follow up of the PRs: #25466, #25524, #25748, #26275 and #26606. It outputs the BadFEDChannels only for Phase 1 pixel detector as in the Phase 0 detector error 25 has different meaning. The aliases cfg files in SimGeneral/MixingModule are changed accordingly.
 
runTheMatrix and addOn tests were successfully run.


