### PR TITLE
[HeaderCheck][CORE] Cleanup headers to avoid header inconsistency errors

### DIFF
--- a/FWCore/Framework/interface/ESConsumesCollector.h
+++ b/FWCore/Framework/interface/ESConsumesCollector.h
@@ -36,6 +36,7 @@
 #include "FWCore/Utilities/interface/Transition.h"
 
 #include <vector>
+#include <memory>
 namespace edm {
   using ESConsumesInfo =
       std::vector<std::tuple<edm::eventsetup::EventSetupRecordKey, edm::eventsetup::DataKey, std::string> >;


### PR DESCRIPTION
Added missing `memory` include to make `scram build check-headers` happy. 