### PR TITLE
Updating DT Online-DQM to work with slice test data

### DIFF
--- a/DQM/DTMonitorModule/interface/DTDigiTask.h
+++ b/DQM/DTMonitorModule/interface/DTDigiTask.h
@@ -156,6 +156,9 @@ private:
   bool lookForSyncNoise;
   bool filterSyncNoise;
 
+  bool sliceTestMode;
+  int  tdcPedestal;
+
   bool doLayerTimeBoxes;
 
   std::map<DTChamberId, int> nSynchNoiseEvents;

--- a/DQM/DTMonitorModule/python/dtDigiTask_TP_cfi.py
+++ b/DQM/DTMonitorModule/python/dtDigiTask_TP_cfi.py
@@ -33,6 +33,10 @@ dtTPmonitor = DQMEDAnalyzer('DTDigiTask',
     doInTimeOccupancies = cms.untracked.bool(True),                                
     # switch on the mode for running on test pulses (different top folder)
     testPulseMode = cms.untracked.bool(True),
+    # switch on the mode for running on slice test (different top folder and customizations)
+    sliceTestMode = cms.untracked.bool(False),
+    # time pedestal to be subtracted if sliceTestMode is true
+    tdcPedestal = cms.untracked.int32(105100),
     # switch for filtering on synch noise events (threshold on # of digis per chamber)
     filterSyncNoise = cms.untracked.bool(False),
     # threshold on # of digis per chamber to define sync noise

--- a/DQM/DTMonitorModule/python/dtDigiTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtDigiTask_cfi.py
@@ -32,13 +32,17 @@ dtDigiMonitor = DQMEDAnalyzer('DTDigiTask',
     doInTimeOccupancies = cms.untracked.bool(False),                                
     # switch on the mode for running on test pulses (different top folder)
     testPulseMode = cms.untracked.bool(False),
+    # switch on the mode for running on slice test (different top folder and customizations)
+    sliceTestMode = cms.untracked.bool(False),
+    # time pedestal to be subtracted if sliceTestMode is true
+    tdcPedestal = cms.untracked.int32(105100),
     # switch for filtering on synch noise events (threshold on # of digis per chamber)
     filterSyncNoise = cms.untracked.bool(False),
     # look for synch noise events
     lookForSyncNoise = cms.untracked.bool(False),
     # threshold on # of digis per chamber to define sync noise
     maxTDCHitsPerChamber = cms.untracked.int32(100),
-    # switch for time boxes with layer granularity (commissioning only)                           
+    # switch for time boxes with layer granularity (commissioning only)
     doLayerTimeBoxes = cms.untracked.bool(False)
 )
 

--- a/DQM/DTMonitorModule/python/slice_test_customizations_cff.py
+++ b/DQM/DTMonitorModule/python/slice_test_customizations_cff.py
@@ -1,0 +1,34 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms                                                
+
+def customise_for_slice_test(process): 
+
+    print("[customise_for_slice_test]: cloning unpacker and DTDigiTask + customising AB7 sequence")
+
+    # This is commented out as the AB7 unpacker is not in CMSSW
+    # at present, the following lines need to be uncommented in the P5 setup
+
+    # from EventFilter.DTRawToDigi.dtab7unpacker_cfi import dtAB7unpacker
+    # process.dtAB7Unpacker = dtAB7unpacker.clone()
+
+    # Here using the uROS unpacker as proxy, the following lines
+    # need to be commented out in the setup running @ P5
+
+    from EventFilter.DTRawToDigi.dturosunpacker_cfi import dturosunpacker
+    process.dtAB7Unpacker = dturosunpacker.clone()
+    
+    from DQM.DTMonitorModule.dtDigiTask_cfi import dtDigiMonitor
+    process.dtAB7DigiMonitor = dtDigiMonitor.clone()
+
+    process.dtAB7DigiMonitor.dtDigiLabel = cms.InputTag("dtAB7Unpacker")
+    process.dtAB7DigiMonitor.sliceTestMode = True
+
+    process.dtAB7DigiMonitor.performPerWireT0Calibration = False
+
+    if hasattr(process,"dtDQMTask") :
+        print("[customise_for_slice_test]: extending dtDQMTask sequence to include AB7 monitoring")
+        process.dtDQMTask.replace(process.dtDigiMonitor, process.dtDigiMonitor +\
+                                                         process.dtAB7Unpacker +\
+                                                         process.dtAB7DigiMonitor) 
+
+    return process

--- a/DQM/DTMonitorModule/python/test/dtDqmPythonTypes.py
+++ b/DQM/DTMonitorModule/python/test/dtDqmPythonTypes.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+from FWCore.ParameterSet.Types import PSet
+import FWCore.ParameterSet.Config as cms
+
+class DTDQMConfig( PSet ):
+
+  # constructor
+
+  def __init__( self ):
+    PSet.__init__( self )       
+    self.__processAB7Digis = False
+    self.__processAB7TPs   = False
+    self.__runWithLargeTB  = False
+    self.__tbTDCPedestal   = 0
+  
+  # getters
+  
+  def getProcessAB7Digis( self ):
+    return self.__processAB7Digis
+    
+  def getProcessAB7TPs( self ):
+    return self.__processAB7TPs
+
+  def getRunWithLargeTB( self ):
+    return self.__runWithLargeTB
+
+  def getTBTDCPedestal( self ):
+    return self.__tbTDCPedestal
+    
+  # setters
+
+  def setProcessAB7Digis( self, processAB7Digis ):
+      self.__processAB7Digis = processAB7Digis
+    
+  def setProcessAB7TPs( self, processAB7TPs ):
+      self.__processAB7TPs = processAB7TPs
+    
+  def setRunWithLargeTB( self,runWithLargeTB ):
+      self.__runWithLargeTB = runWithLargeTB
+
+  def setTBTDCPedestal( self, tbTDCPedestal ):
+      self.__tbTDCPedestal = tbTDCPedestal
+    
+  # str and repr
+
+  def __str__( self ):
+    return "DTDQMConfig: processAB7Digis='%r' processAB7TPs='%r' runWithLargeTB='%r' tbTDCPedestal='%d'" % (self.__processAB7Digis, \
+                                                                                                            self.__processAB7TPs,   \
+                                                                                                            self.__runWithLargeTB,  \
+                                                                                                            self.__tbTDCPedestal)
+    
+  def __repr__( self ):
+    return "DTDQMConfig: processAB7Digis='%r' processAB7TPs='%r' runWithLargeTB='%r' tbTDCPedestal='%d'" % (self.__processAB7Digis, \
+                                                                                                            self.__processAB7TPs,   \
+                                                                                                            self.__runWithLargeTB,  \
+                                                                                                            self.__tbTDCPedestal)

--- a/DQM/DTMonitorModule/python/test/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/DTMonitorModule/python/test/dt_dqm_sourceclient-live_cfg.py
@@ -1,0 +1,112 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("DTDQM")
+
+#----------------------------
+#### Event Source
+#----------------------------
+# for live online DQM in P5
+process.load("DQM.DTMonitorModule.test.inputsource_live_cfi")
+
+# for testing in lxplus
+#process.load("DQM.Integration.config.fileinputsource_cfi")
+
+#----------------------------
+#### DQM Environment
+#----------------------------
+process.load("DQM.Integration.config.environment_cfi")
+process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/dt_reference.root'
+#process.DQMStore.referenceFileName = "DT_reference.root"
+
+#----------------------------
+#### DQM Live Environment
+#----------------------------
+process.dqmEnv.subSystemFolder = 'DT'
+process.dqmSaver.tag = "DT"
+#-----------------------------
+
+# Enable HLT*Mu* filtering to monitor on Muon events
+# OR HLT_Physics* to monitor FEDs in commissioning runs
+# process.source.SelectEvents = cms.untracked.vstring("HLT*Mu*","HLT_*Physics*")
+
+# DT reco and DQM sequences
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+process.load("Configuration/StandardSequences/MagneticField_cff")
+process.load("DQM.DTMonitorModule.dt_dqm_sourceclient_common_cff")
+#---- for P5 (online) DB access
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
+#---- for offline DB: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+
+# message logger
+process.MessageLogger = cms.Service("MessageLogger",
+                                    destinations = cms.untracked.vstring('cout'),
+                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('WARNING'))
+                                    )
+
+process.dqmmodules = cms.Sequence(process.dqmEnv + process.dqmSaver)
+
+process.dtDQMPathPhys = cms.Path(process.unpackers + process.dqmmodules + process.physicsEventsFilter *  process.dtDQMPhysSequence)
+
+#process.dtDQMPathCalib = cms.Path(process.unpackers + process.dqmmodules + process.calibrationEventsFilter * process.dtDQMCalib)
+
+process.twinMuxStage2Digis.DTTM7_FED_Source = cms.InputTag("rawDataCollector")
+process.dtunpacker.inputLabel = cms.InputTag("rawDataCollector")
+process.gtDigis.DaqGtInputTag = cms.InputTag("rawDataCollector")
+process.scalersRawToDigi.scalersInputTag = cms.InputTag("rawDataCollector")
+
+print("Running with run type = ", process.runType.getRunType())
+
+#----------------------------
+#### pp run settings 
+#----------------------------
+
+if (process.runType.getRunType() == process.runType.pp_run):
+    process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/dt_reference_pp.root'
+
+
+#----------------------------
+#### cosmic run settings 
+#----------------------------
+
+if (process.runType.getRunType() == process.runType.cosmic_run):
+    process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/dt_reference_cosmic.root'
+
+
+#----------------------------
+#### HI run settings 
+#----------------------------
+
+if (process.runType.getRunType() == process.runType.hi_run):
+    process.twinMuxStage2Digis.DTTM7_FED_Source = cms.InputTag("rawDataRepacker")
+    process.dtunpacker.inputLabel = cms.InputTag("rawDataRepacker")
+    process.gtDigis.DaqGtInputTag = cms.InputTag("rawDataRepacker")
+    process.scalersRawToDigi.scalersInputTag = cms.InputTag("rawDataRepacker")
+    
+    process.dtDigiMonitor.ResetCycle = cms.untracked.int32(9999)
+
+    process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/dt_reference_hi.root'
+
+
+### process customisations included here
+from DQM.Integration.config.online_customizations_cfi import *
+process = customise(process)
+
+### DT slice test specific customisations
+if (process.dtDqmConfig.getProcessAB7Digis()) :
+    from DQM.DTMonitorModule.slice_test_customizations_cff import *
+    process = customise_for_slice_test(process)
+
+### DT digi customisation
+if (process.dtDqmConfig.getRunWithLargeTB()) :
+    process.dtDigiMonitor.maxTTMounts = 6400
+
+if (process.dtDqmConfig.getProcessAB7Digis()) :
+
+    if (process.dtDqmConfig.getRunWithLargeTB()) :
+        process.dtAB7DigiMonitor.maxTTMounts = 6400
+
+    process.dtAB7DigiMonitor.tdcPedestal = process.dtDqmConfig.getTBTDCPedestal()

--- a/DQM/DTMonitorModule/python/test/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/DTMonitorModule/python/test/dt_dqm_sourceclient-live_cfg.py
@@ -19,6 +19,8 @@ process.load("DQM.DTMonitorModule.test.inputsource_live_cfi")
 process.load("DQM.Integration.config.environment_cfi")
 process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/dt_reference.root'
 #process.DQMStore.referenceFileName = "DT_reference.root"
+process.dqmRunConfig.collectorHost = 'fu-c2f11-23-01.cms'
+process.dqmSaver.path = "./"
 
 #----------------------------
 #### DQM Live Environment

--- a/DQM/DTMonitorModule/python/test/inputsource_live_cfi.py
+++ b/DQM/DTMonitorModule/python/test/inputsource_live_cfi.py
@@ -1,0 +1,129 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+import sys
+
+from DQM.Integration.config.dqmPythonTypes import RunType 
+from DQM.DTMonitorModule.test.dtDqmPythonTypes import DTDQMConfig 
+
+options = VarParsing.VarParsing('analysis')
+
+# options.inputFiles are inherited from 'analysis'
+options.register('runNumber',
+                 111,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run number.")
+
+options.register('runInputDir',
+                 '/tmp',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Directory where the DQM files will appear.")
+
+options.register('scanOnce',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Don't repeat file scans: use what was found during the initial scan. EOR file is ignored and the state is set to 'past end of run'.")
+
+options.register('minEventsPerLumi',
+                 1, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "If scanOnce is tue, sets the minimal # of events per LS to be processed before switching to the next LS (and file).")
+
+options.register('skipFirstLumis',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the begining of the processing. ")
+
+# Parameters for runType
+
+options.register ('runkey',
+          'pp_run',
+          VarParsing.VarParsing.multiplicity.singleton,
+          VarParsing.VarParsing.varType.string,
+          "Run Keys of CMS")
+
+# parameters for DT configuration
+
+options.register('processAB7Digis',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Enable processing of AB7 DT digi data (duplicate occupancy plot and other customisations to DT digi monitoring)")
+
+options.register('processAB7TPs',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Enable processing of AB7 DT local trigger data (DOES NOTHING FOR NOW)")
+
+options.register('runWithLargeTimeBox',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Runs DTDigiTask with a timebox plot window of 6400 TDC Counts")
+
+options.register('timeBoxTDCPedestal',
+                 105100, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Pedestal to subtract to TDC counts for AB7")
+
+
+options.parseArguments()
+
+runType = RunType()
+if not options.runkey.strip():
+  options.runkey = 'pp_run'
+
+dtDqmConfig = DTDQMConfig()
+dtDqmConfig.setProcessAB7Digis(options.processAB7Digis)
+dtDqmConfig.setProcessAB7TPs(options.processAB7TPs)
+
+dtDqmConfig.setRunWithLargeTB(options.runWithLargeTimeBox)
+dtDqmConfig.setTBTDCPedestal(options.timeBoxTDCPedestal)
+
+runType.setRunType(options.runkey.strip())
+
+if not options.inputFiles:
+    # Input source
+    nextLumiTimeoutMillis = 240000
+    endOfRunKills = True
+    
+    if options.scanOnce:
+        endOfRunKills = False
+        nextLumiTimeoutMillis = 0
+        minEventsPerLumi = options.minEventsPerLumi
+    
+    source = cms.Source("DQMStreamerReader",
+        runNumber = cms.untracked.uint32(options.runNumber),
+        runInputDir = cms.untracked.string(options.runInputDir),
+        SelectEvents = cms.untracked.vstring('*'),
+        streamLabel = cms.untracked.string('streamDQM'),
+        scanOnce = cms.untracked.bool(options.scanOnce),
+        minEventsPerLumi = cms.untracked.int32(minEventsPerLumi),
+        delayMillis = cms.untracked.uint32(500),
+        nextLumiTimeoutMillis = cms.untracked.int32(nextLumiTimeoutMillis),
+        skipFirstLumis = cms.untracked.bool(options.skipFirstLumis),
+        deleteDatFiles = cms.untracked.bool(False),
+        endOfRunKills  = cms.untracked.bool(endOfRunKills),
+    )
+else:
+    print("The list of input files is provided. Disabling discovery and running on everything.")
+    files = map(lambda x: "file://" + x, options.inputFiles)
+    source = cms.Source("PoolSource",
+        fileNames = cms.untracked.vstring(files),
+        secondaryFileNames = cms.untracked.vstring()
+    )
+
+print("Source:", source)
+
+print("RunType:", runType)
+
+print("DTDQMConfig:", dtDqmConfig)
+

--- a/DQM/DTMonitorModule/src/DTDigiTask.cc
+++ b/DQM/DTMonitorModule/src/DTDigiTask.cc
@@ -90,6 +90,12 @@ DTDigiTask::DTDigiTask(const edm::ParameterSet& ps){
   filterSyncNoise = ps.getUntrackedParameter<bool>("filterSyncNoise", false);
   // look for synch noisy events, produce histograms but do not filter them
   lookForSyncNoise = ps.getUntrackedParameter<bool>("lookForSyncNoise", false);
+
+  // switch on the mode for running on slice test (different top folder and other customizations)
+  sliceTestMode = ps.getUntrackedParameter<bool>("sliceTestMode", false);
+  // time pedestal to be subtracted if sliceTestMode is true
+  tdcPedestal = ps.getUntrackedParameter<int>("tdcPedestal", 105100);
+
   // switch on production of time-boxes with layer granularity
   doLayerTimeBoxes = ps.getUntrackedParameter<bool>("doLayerTimeBoxes", false);
 
@@ -613,7 +619,12 @@ void DTDigiTask::analyze(const edm::Event& event, const edm::EventSetup& c) {
         tdcTime += int(round(t0));
       }
 
-
+      if (sliceTestMode)
+	{
+	  tdcTime -= tdcPedestal;
+	  tdcTime = std::max(1,std::min(maxTTMounts-1,tdcTime));
+	  // std::cout << tdcTime << std::endl;
+	}
 
       // Fill Time-Boxes
       // NOTE: avoid to fill TB and PhotoPeak with noise. Occupancy are filled anyway
@@ -732,6 +743,7 @@ string DTDigiTask::triggerSource() {
 string DTDigiTask::topFolder() const {
 
   if(tpMode) return string("DT/10-TestPulses/");
+  else if(sliceTestMode) return string("DT/01-SliceTestDigi/");
   return string("DT/01-Digi/");
 
 }


### PR DESCRIPTION
#### PR description:

This PR includes recent changes to the `DTDigiTask` module alongside with the necessary DQM configuration file changes to prepare the DT DQM to process data from the [DT slice test](https://indico.cern.ch/event/791284/timetable/?view=standard#57-muon-general-plan-for-commi).
Though the DQM monitoring for the DT slice test will initially be performed only exploiting a "private" DT-DQM deployment @ P5, a PR is anyhow prepared to keep the DQM code in the release as much "up to date" as possible.

The PR only affects Online-DQM code, and the updates are not supposed to change the behaviour of the DT-DQM, if it is run on data other than the slice test one. So no changes are expected.  

#### PR validation:

The PR has been tested within a private deployment of the DT Online-DQM.

