### PR TITLE
Store L1 prefiring weights in 2016 and 2017 MINIAOD

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2016_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_cff.py
@@ -6,7 +6,8 @@ from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTconditions_2016
 from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
+from Configuration.Eras.Modifier_run2_L1prefiring_cff import run2_L1prefiring
 
 Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific,
- stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_muon_2016)
+ stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_muon_2016, run2_L1prefiring)
 

--- a/Configuration/Eras/python/Era_Run2_2018_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_cff.py
@@ -11,7 +11,8 @@ from Configuration.Eras.Modifier_run2_SiPixel_2018_cff import run2_SiPixel_2018
 from Configuration.Eras.Modifier_run2_HLTconditions_2018_cff import run2_HLTconditions_2018
 from Configuration.Eras.Modifier_run2_muon_2018_cff import run2_muon_2018
 from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
+from Configuration.Eras.Modifier_run2_L1prefiring_cff import run2_L1prefiring
 
-Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017]), 
+Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017, run2_L1prefiring]),
 run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018, 
 run2_HLTconditions_2018, run2_muon_2018)

--- a/Configuration/Eras/python/Modifier_run2_L1prefiring_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_L1prefiring_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_L1prefiring =  cms.Modifier()
+

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -82,6 +82,8 @@ MicroEventContent = cms.PSet(
         'keep recoForwardProtons_ctppsProtons_*_*',
 	# displacedStandAlone muon collection for EXO
 	'keep recoTracks_displacedStandAloneMuons__*',
+        # L1 prefiring weights
+        'keep *_prefiringweight_*_*',
     )
 )
 

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -462,6 +462,14 @@ def miniAOD_customizeCommon(process):
     process.load("RecoEgamma.EgammaTools.slimmedEgammaFromMultiCl_cff")
     phase2_hgcal.toModify(task, func=lambda t: t.add(process.slimmedEgammaFromMultiClTask))
 
+    # L1 pre-firing weights for 2016 and 2017
+    from Configuration.Eras.Modifier_run2_L1prefiring_cff import run2_L1prefiring
+    from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
+    from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
+    process.load("PhysicsTools.PatUtils.L1ECALPrefiringWeightProducer_cff")
+    stage1L1Trigger.toModify(process.prefiringweight, DataEra = "2016BtoH")
+    stage2L1Trigger_2017.toModify(process.prefiringweight, DataEra = "2017BtoF")
+    run2_L1prefiring.toModify(task, func=lambda t: t.add(process.prefiringweight))
 
 def miniAOD_customizeMC(process):
     task = getPatAlgosToolsTask(process)


### PR DESCRIPTION
This PR adds L1 prefiring weights to MINIAOD event content for 2016 and 2017 datasets.

A new modifier `run2_L1prefiring` is defined to trigger this evaluation, and added to the`Run2_2016` and `Run2_2017` eras.
Existing trigger modifiers are then used to customise its payload configuration, that is different for each year.
