### PR TITLE
[HeaderCheck][RECO1] Cleanup headers to avoid header inconsistency errors

### DIFF
--- a/RecoTracker/CkfPattern/interface/bqueue.h
+++ b/RecoTracker/CkfPattern/interface/bqueue.h
@@ -1,2 +1,0 @@
-#error header has moved to TrackingTools/PatternTools/interface/bqueue.h
-#include "TrackingTools/PatternTools/interface/bqueue.h"

--- a/RecoTracker/MeasurementDet/interface/NonPropagatingDetMeasurements.h
+++ b/RecoTracker/MeasurementDet/interface/NonPropagatingDetMeasurements.h
@@ -1,1 +1,0 @@
-#error "HEAEDER moved in RecoTracker/MeasurementDet/plugin, please remove"

--- a/RecoTracker/MeasurementDet/interface/OnDemandMeasurementTracker.h
+++ b/RecoTracker/MeasurementDet/interface/OnDemandMeasurementTracker.h
@@ -1,1 +1,0 @@
-#error "HEAEDER moved in RecoTracker/MeasurementDet/plugin, please remove"

--- a/RecoTracker/MeasurementDet/interface/RecHitPropagator.h
+++ b/RecoTracker/MeasurementDet/interface/RecHitPropagator.h
@@ -1,1 +1,0 @@
-#error "HEAEDER moved in RecoTracker/MeasurementDet/plugin, please remove"

--- a/RecoTracker/MeasurementDet/interface/StripClusterAboveU.h
+++ b/RecoTracker/MeasurementDet/interface/StripClusterAboveU.h
@@ -1,1 +1,0 @@
-#error "HEAEDER moved in RecoTracker/MeasurementDet/plugin, please remove"

--- a/RecoTracker/Record/interface/Records.h
+++ b/RecoTracker/Record/interface/Records.h
@@ -1,4 +1,0 @@
-#include "RecoTracker/Records/interface/CkfComponentsRecord.h"
-#include "RecoTracker/Records/interface/MultiRecHitRecord.h"
-#include "RecoTracker/Records/interface/NavigationSchoolRecord.h"
-#include "RecoTracker/Records/interface/TrackerRecoGeometryRecord.h"

--- a/RecoTracker/TkSeedGenerator/interface/SeedFromConsecutiveHitsCreator.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedFromConsecutiveHitsCreator.h
@@ -1,1 +1,0 @@
-#error "moved to plugins: please remove reference"

--- a/RecoTracker/TkSeedGenerator/interface/SeedFromConsecutiveHitsStraightLineCreator.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedFromConsecutiveHitsStraightLineCreator.h
@@ -1,1 +1,0 @@
-#error "moved to plugins: please remove reference"

--- a/RecoTracker/TkSeedGenerator/interface/SeedFromConsecutiveHitsTripletOnlyCreator.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedFromConsecutiveHitsTripletOnlyCreator.h
@@ -1,1 +1,0 @@
-#error "moved to plugins: please remove reference"


### PR DESCRIPTION
- removed obsolete headers
- all of these are already marked to be delete
  -  RecoTracker/Record/interface/Records.h is not used by any thing
