### PR TITLE
Prevent simultaneous execution of Rivet modules (10_2_X)

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/RivetAnalyzer.h
+++ b/GeneratorInterface/RivetInterface/interface/RivetAnalyzer.h
@@ -1,7 +1,7 @@
 #ifndef GeneratorInterface_RivetInterface_RivetAnalyzer
 #define GeneratorInterface_RivetInterface_RivetAnalyzer
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "Rivet/AnalysisHandler.hh"
 
 //DQM services
@@ -18,7 +18,7 @@
 #include <vector>
 #include <string>
 
-class RivetAnalyzer : public edm::EDAnalyzer
+class RivetAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns,edm::one::SharedResources>
 {
   public:
   RivetAnalyzer(const edm::ParameterSet&);

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -28,13 +28,15 @@ using namespace Rivet;
 using namespace edm;
 using namespace std;
 
-class HTXSRivetProducer : public edm::one::EDProducer<edm::one::WatchRuns> {
+class HTXSRivetProducer : public edm::one::EDProducer<edm::one::WatchRuns,edm::one::SharedResources> {
 public:
     
     explicit HTXSRivetProducer(const edm::ParameterSet& cfg) : 
         _hepmcCollection(consumes<HepMCProduct>(cfg.getParameter<edm::InputTag>("HepMCCollection"))),
         _lheRunInfo(consumes<LHERunInfoProduct,edm::InRun>(cfg.getParameter<edm::InputTag>("LHERunInfo")))
     {
+        usesResource("Rivet");
+        
         _HTXS = new Rivet::HiggsTemplateCrossSections();
         
         _isFirstEvent = true;

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -20,7 +20,7 @@ ParticleLevelProducer::ParticleLevelProducer(const edm::ParameterSet& pset):
   srcToken_(consumes<edm::HepMCProduct>(pset.getParameter<edm::InputTag>("src"))),
   rivetAnalysis_(new Rivet::RivetAnalysis(pset))
 {
-  usesResource();
+  usesResource("Rivet");
 
   genVertex_ = reco::Particle::Point(0,0,0);
 

--- a/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
@@ -22,6 +22,8 @@ _doFinalize(pset.getParameter<bool>("DoFinalize")),
 _produceDQM(pset.getParameter<bool>("ProduceDQMOutput")),
 _xsection(-1.)
 {
+  usesResource("Rivet");
+  
   //retrive the analysis name from paarmeter set
   std::vector<std::string> analysisNames = pset.getParameter<std::vector<std::string> >("AnalysisNames");
   


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/26597, fixes crashes in nanoAod production.

Edit: #26597 is not merged yet.
