### PR TITLE
Migrate Geometry/HGCalGeometry to EventSetup consumes

### DIFF
--- a/Geometry/HGCalGeometry/plugins/FastTimeGeometryESProducer.cc
+++ b/Geometry/HGCalGeometry/plugins/FastTimeGeometryESProducer.cc
@@ -22,7 +22,6 @@
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloTopology/interface/FastTimeTopology.h"
@@ -47,20 +46,20 @@ public:
 
 private:
   // ----------member data ---------------------------
-  std::string        name_;
-  int                type_;
+  edm::ESGetToken<FastTimeTopology, IdealGeometryRecord> topologyToken_;
 };
 
 
 FastTimeGeometryESProducer::FastTimeGeometryESProducer(const edm::ParameterSet& iConfig) {
 
-  name_     = iConfig.getUntrackedParameter<std::string>("Name");
-  type_     = iConfig.getUntrackedParameter<int>("Type");
+  auto name     = iConfig.getUntrackedParameter<std::string>("Name");
 #ifdef EDM_ML_DEBUG
-  std::cout <<"constructing FastTimeGeometry for " << name_ << " Type "
-	    << type_ << std::endl;
+  auto type     = iConfig.getUntrackedParameter<int>("Type");
+  std::cout <<"constructing FastTimeGeometry for " << name << " Type "
+	    << type << std::endl;
 #endif
-  setWhatProduced(this, name_);
+  auto cc = setWhatProduced(this, name);
+  topologyToken_ = cc.consumes<FastTimeTopology>(edm::ESInputTag{"", name});
 }
 
 
@@ -75,14 +74,13 @@ FastTimeGeometryESProducer::~FastTimeGeometryESProducer() { }
 FastTimeGeometryESProducer::ReturnType
 FastTimeGeometryESProducer::produce(const IdealGeometryRecord& iRecord ) {
 
-  edm::ESHandle<FastTimeTopology> topo;
-  iRecord.get(name_,topo);
+  const auto& topo = iRecord.get(topologyToken_);
 
   FastTimeGeometryLoader builder;
 #ifdef EDM_ML_DEBUG
-  std::cout << "Create FastTimeGeometry (*topo)" << std::endl;
+  std::cout << "Create FastTimeGeometry (topo)" << std::endl;
 #endif
-  return ReturnType(builder.build(*topo));
+  return ReturnType(builder.build(topo));
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(FastTimeGeometryESProducer);

--- a/Geometry/HGCalGeometry/test/HGCalGeometryCheck.cc
+++ b/Geometry/HGCalGeometry/test/HGCalGeometryCheck.cc
@@ -9,11 +9,11 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/transform.h"
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/HGCalCommonData/interface/HGCalGeometryMode.h"
@@ -33,11 +33,9 @@ public:
   ~HGCalGeometryCheck() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  void beginJob() override {}
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override {}
   void endRun(edm::Run const&, edm::EventSetup const&) override {}
-  void endJob() override {}
   
 private:
   void doTest(const HGCalGeometry* geom, ForwardSubdetector subdet);
@@ -45,6 +43,7 @@ private:
   void doTestScint(const HGCalGeometry* geom, DetId::Detector det);
   
   const std::vector<std::string>        nameDetectors_;
+  const std::vector<edm::ESGetToken<HGCalGeometry, IdealGeometryRecord>> geomTokens_;
   const double                          rmin_, rmax_, zmin_, zmax_;
   const int                             nbinR_, nbinZ_;
   const bool                            ifNose_, verbose_;
@@ -55,6 +54,9 @@ private:
 
 HGCalGeometryCheck::HGCalGeometryCheck(const edm::ParameterSet& iC)  :
   nameDetectors_(iC.getParameter<std::vector<std::string> >("detectorNames")),
+  geomTokens_{edm::vector_transform(nameDetectors_, [this](const std::string& name) {
+      return esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", name});
+    })},
   rmin_(iC.getUntrackedParameter<double>("rMin",0.0)),
   rmax_(iC.getUntrackedParameter<double>("rMax",300.0)),
   zmin_(iC.getUntrackedParameter<double>("zMin",300.0)),
@@ -96,69 +98,63 @@ void HGCalGeometryCheck::beginRun(const edm::Run&,
 				    nbinR_,rmin_,rmax_));
 
   for (unsigned int ih=0; ih <nameDetectors_.size(); ++ih) {
-    edm::ESHandle<HGCalGeometry> geomH;
-    iSetup.get<IdealGeometryRecord>().get(nameDetectors_[ih],geomH);
-    const HGCalGeometry* geom = (geomH.product());
-    if (!geomH.isValid()) {
+    const auto& geomR = iSetup.getData(geomTokens_[ih]);
+    const HGCalGeometry* geom = &geomR;
+    int layerF = geom->topology().dddConstants().firstLayer();
+    int layerL = geom->topology().dddConstants().lastLayer(true);
+    edm::LogVerbatim("HGCalGeom") 
+      << nameDetectors_[ih] << " with layers in the range " << layerF << ":"
+      << layerL;
+    sprintf (name, "RZ_%s", nameDetectors_[ih].c_str());
+    sprintf (title, "R vs Z for %s", nameDetectors_[ih].c_str());
+    h_RZ_.emplace_back(fs->make<TH2D>(name, title,nbinZ_,zmin_,zmax_,
+      				nbinR_,rmin_,rmax_));
+    HGCalGeometryMode::GeometryMode mode = geom->topology().dddConstants().geomMode();
+    unsigned int k(0);
+    for (int lay=layerF; lay<=layerL; ++lay, ++k) {
+      sprintf (name, "Mod_%s_L%d", nameDetectors_[ih].c_str(), lay);
+      sprintf (title, "Modules in layer %d in %s", lay, nameDetectors_[ih].c_str());
+      h_Mod_.emplace_back(fs->make<TH1D>(name,title,200,-50,50));
+      
+      auto zz = geom->topology().dddConstants().waferZ(lay,true);
+      auto rr = geom->topology().dddConstants().rangeR(zz, true);
       edm::LogVerbatim("HGCalGeom") 
-	<< "Cannot get valid HGCalGeometry Object for " << name;
-    } else {
-      int layerF = geom->topology().dddConstants().firstLayer();
-      int layerL = geom->topology().dddConstants().lastLayer(true);
-      edm::LogVerbatim("HGCalGeom") 
-	<< nameDetectors_[ih] << " with layers in the range " << layerF << ":"
-	<< layerL;
-      sprintf (name, "RZ_%s", nameDetectors_[ih].c_str());
-      sprintf (title, "R vs Z for %s", nameDetectors_[ih].c_str());
-      h_RZ_.emplace_back(fs->make<TH2D>(name, title,nbinZ_,zmin_,zmax_,
-					nbinR_,rmin_,rmax_));
-      HGCalGeometryMode::GeometryMode mode = geom->topology().dddConstants().geomMode();
-      unsigned int k(0);
-      for (int lay=layerF; lay<=layerL; ++lay, ++k) {
-	sprintf (name, "Mod_%s_L%d", nameDetectors_[ih].c_str(), lay);
-	sprintf (title, "Modules in layer %d in %s", lay, nameDetectors_[ih].c_str());
- 	h_Mod_.emplace_back(fs->make<TH1D>(name,title,200,-50,50));
-	
-	auto zz = geom->topology().dddConstants().waferZ(lay,true);
-	auto rr = geom->topology().dddConstants().rangeR(zz, true);
-	edm::LogVerbatim("HGCalGeom") 
-	  << "Layer " << lay << " R " << rr.first << ":" << rr.second
-	  << " Z " << zz;
-	double r = rr.first;
-	while (r <= rr.second) {
-	  h_RZ_[0]->Fill(zz,r);
-	  h_RZ_[ih+1]->Fill(zz,r);
-	  for (int k=0; k<100; ++k) {
-	    double phi = 2*k*M_PI/100.0;
-	    GlobalPoint global1(r*cos(phi),r*sin(phi),zz);
-	    DetId       id = geom->getClosestCell(global1);
-	    if (ifNose_) {
-	      HFNoseDetId detId = HFNoseDetId(id);
-	      h_Mod_.back()->Fill(detId.waferU());
-	      h_Mod_.back()->Fill(detId.waferV());
-	      if (verbose_) 
-		edm::LogVerbatim("HGCalGeom") << "R: " << r << " ID " << detId;
-	    } else if ((mode == HGCalGeometryMode::Hexagon) ||
-		       (mode == HGCalGeometryMode::HexagonFull)) {
-	      HGCalDetId detId = HGCalDetId(id);
-	      h_Mod_.back()->Fill(detId.wafer());
-	      if (verbose_) 
-		edm::LogVerbatim("HGCalGeom") << "R: " << r << " ID " << detId;
-	    } else if (mode == HGCalGeometryMode::Trapezoid) {
-	      HGCScintillatorDetId detId = HGCScintillatorDetId(id);
-	      h_Mod_.back()->Fill(detId.ieta());
-	      if (verbose_) 
-		edm::LogVerbatim("HGCalGeom") << "R: " << r << " ID " << detId;
-	    } else {
-	      HGCSiliconDetId detId = HGCSiliconDetId(id);
-	      h_Mod_.back()->Fill(detId.waferU());
-	      h_Mod_.back()->Fill(detId.waferV());
-	      if (verbose_) 
-		edm::LogVerbatim("HGCalGeom") << "R: " << r << " ID " << detId;
-	    }
-	  }
-	  r += 1.0;
-	}
+        << "Layer " << lay << " R " << rr.first << ":" << rr.second
+        << " Z " << zz;
+      double r = rr.first;
+      while (r <= rr.second) {
+        h_RZ_[0]->Fill(zz,r);
+        h_RZ_[ih+1]->Fill(zz,r);
+        for (int k=0; k<100; ++k) {
+          double phi = 2*k*M_PI/100.0;
+          GlobalPoint global1(r*cos(phi),r*sin(phi),zz);
+          DetId       id = geom->getClosestCell(global1);
+          if (ifNose_) {
+            HFNoseDetId detId = HFNoseDetId(id);
+            h_Mod_.back()->Fill(detId.waferU());
+            h_Mod_.back()->Fill(detId.waferV());
+            if (verbose_) 
+              edm::LogVerbatim("HGCalGeom") << "R: " << r << " ID " << detId;
+          } else if ((mode == HGCalGeometryMode::Hexagon) ||
+      	       (mode == HGCalGeometryMode::HexagonFull)) {
+            HGCalDetId detId = HGCalDetId(id);
+            h_Mod_.back()->Fill(detId.wafer());
+            if (verbose_) 
+              edm::LogVerbatim("HGCalGeom") << "R: " << r << " ID " << detId;
+          } else if (mode == HGCalGeometryMode::Trapezoid) {
+            HGCScintillatorDetId detId = HGCScintillatorDetId(id);
+            h_Mod_.back()->Fill(detId.ieta());
+            if (verbose_) 
+              edm::LogVerbatim("HGCalGeom") << "R: " << r << " ID " << detId;
+          } else {
+            HGCSiliconDetId detId = HGCSiliconDetId(id);
+            h_Mod_.back()->Fill(detId.waferU());
+            h_Mod_.back()->Fill(detId.waferV());
+            if (verbose_) 
+              edm::LogVerbatim("HGCalGeom") << "R: " << r << " ID " << detId;
+          }
+        }
+        r += 1.0;
       }
     }
   }

--- a/Geometry/HGCalGeometry/test/HGCalGeometryCornerTester.cc
+++ b/Geometry/HGCalGeometry/test/HGCalGeometryCornerTester.cc
@@ -8,8 +8,6 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
@@ -23,18 +21,16 @@ public:
   explicit HGCalGeometryCornerTester(const edm::ParameterSet& );
   ~HGCalGeometryCornerTester() override;
 
-  void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
-  void endJob() override {}
   
 private:
   void doTest(const HGCalGeometry* geom);
-  const std::string    name_;
+  const edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
   const int            cornerType_;
 };
 
 HGCalGeometryCornerTester::HGCalGeometryCornerTester(const edm::ParameterSet& iC) : 
-  name_(iC.getParameter<std::string>("detector")),
+  geomToken_{esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", iC.getParameter<std::string>("detector")})},
   cornerType_(iC.getParameter<int>("cornerType")) { }
 
 HGCalGeometryCornerTester::~HGCalGeometryCornerTester() {}
@@ -42,15 +38,8 @@ HGCalGeometryCornerTester::~HGCalGeometryCornerTester() {}
 void HGCalGeometryCornerTester::analyze(const edm::Event& , 
 					const edm::EventSetup& iSetup ) {
 
-  edm::ESHandle<HGCalGeometry> geomH;
-  iSetup.get<IdealGeometryRecord>().get(name_,geomH);
-  const HGCalGeometry* geom = (geomH.product());
-  if (!geomH.isValid()) {
-    std::cout << "Cannot get valid HGCalGeometry Object for " << name_
-	      << std::endl;
-  } else {
-    doTest(geom);
-  }
+  const HGCalGeometry& geom = iSetup.getData(geomToken_);
+  doTest(&geom);
 }
 
 void HGCalGeometryCornerTester::doTest(const HGCalGeometry* geom) {


### PR DESCRIPTION
#### PR description:

This PR migrates all ES and ED modules in Geometry/HGCalGeometry to EventSetup consumes (#26584).

In addition removed some dead code.

#### PR validation:

Limited matrix runs.