### PR TITLE
Migrate Geometry/HcalCommonData to EventSetup consumes

### DIFF
--- a/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
+++ b/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
@@ -20,7 +20,6 @@
 
 #include <FWCore/Framework/interface/ModuleFactory.h>
 #include <FWCore/Framework/interface/ESProducer.h>
-#include <FWCore/Framework/interface/ESHandle.h>
 
 #include <Geometry/HcalCommonData/interface/HcalDDDSimConstants.h>
 #include <Geometry/Records/interface/HcalSimNumberingRecord.h>
@@ -35,11 +34,13 @@ public:
   static void fillDescriptions( edm::ConfigurationDescriptions & );
 
   ReturnType produce(const HcalSimNumberingRecord&);
+
+private:
+  edm::ESGetToken<HcalParameters, HcalParametersRcd> parToken_;
 };
 
-HcalDDDSimConstantsESModule::HcalDDDSimConstantsESModule(const edm::ParameterSet&) {
-  setWhatProduced(this);
-}
+HcalDDDSimConstantsESModule::HcalDDDSimConstantsESModule(const edm::ParameterSet&)
+    : parToken_{setWhatProduced(this).consumesFrom<HcalParameters, HcalParametersRcd>(edm::ESInputTag{})} {}
 
 void HcalDDDSimConstantsESModule::fillDescriptions( edm::ConfigurationDescriptions & descriptions ) {
   edm::ParameterSetDescription desc;
@@ -47,14 +48,9 @@ void HcalDDDSimConstantsESModule::fillDescriptions( edm::ConfigurationDescriptio
 }
 
 // ------------ method called to produce the data  ------------
-HcalDDDSimConstantsESModule::ReturnType
-HcalDDDSimConstantsESModule::produce(const HcalSimNumberingRecord& iRecord) {
-
-  const HcalParametersRcd& parRecord = iRecord.getRecord<HcalParametersRcd>();
-  edm::ESHandle<HcalParameters> parHandle;
-  parRecord.get(parHandle);
-
-  return std::make_unique<HcalDDDSimConstants>(parHandle.product());
+HcalDDDSimConstantsESModule::ReturnType HcalDDDSimConstantsESModule::produce(const HcalSimNumberingRecord& iRecord) {
+  const auto& par = iRecord.get(parToken_);
+  return std::make_unique<HcalDDDSimConstants>(&par);
 }
 
 //define this as a plug-in

--- a/Geometry/HcalCommonData/plugins/HcalParametersESModule.cc
+++ b/Geometry/HcalCommonData/plugins/HcalParametersESModule.cc
@@ -1,7 +1,6 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/ModuleFactory.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "CondFormats/GeometryObjects/interface/HcalParameters.h"
@@ -23,12 +22,14 @@ public:
   static void fillDescriptions( edm::ConfigurationDescriptions & );
   
   ReturnType produce( const HcalParametersRcd & );
+
+private:
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvToken_;
 };
 
-HcalParametersESModule::HcalParametersESModule( const edm::ParameterSet& ) {
+HcalParametersESModule::HcalParametersESModule( const edm::ParameterSet& )
+    : cpvToken_{setWhatProduced(this).consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag{})} {
   edm::LogInfo("HCAL") << "HcalParametersESModule::HcalParametersESModule";
-
-  setWhatProduced(this);
 }
 
 HcalParametersESModule::~HcalParametersESModule() {}
@@ -42,8 +43,7 @@ HcalParametersESModule::ReturnType
 HcalParametersESModule::produce( const HcalParametersRcd& iRecord ) {
   edm::LogInfo("HcalESModule")
     <<  "HcalParametersESModule::produce(const HcalParametersRcd& iRecord)";
-  edm::ESTransientHandle<DDCompactView> cpv;
-  iRecord.getRecord<IdealGeometryRecord>().get( cpv );
+  edm::ESTransientHandle<DDCompactView> cpv = iRecord.getTransientHandle(cpvToken_);
   
   auto ptp = std::make_unique<HcalParameters>();
   HcalParametersFromDD builder;

--- a/Geometry/HcalCommonData/test/HcalParametersAnalyzer.cc
+++ b/Geometry/HcalCommonData/test/HcalParametersAnalyzer.cc
@@ -1,6 +1,5 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "CondFormats/GeometryObjects/interface/HcalParameters.h"
 #include "Geometry/Records/interface/HcalParametersRcd.h"
@@ -11,19 +10,20 @@ public:
   explicit HcalParametersAnalyzer( const edm::ParameterSet& );
   ~HcalParametersAnalyzer( void ) override;
   
-  void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
-  void endJob() override {}    
+
+private:
+  edm::ESGetToken<HcalParameters, HcalParametersRcd> parToken_;
 };
 
-HcalParametersAnalyzer::HcalParametersAnalyzer( const edm::ParameterSet& ) {}
+HcalParametersAnalyzer::HcalParametersAnalyzer( const edm::ParameterSet& )
+  : parToken_{esConsumes<HcalParameters, HcalParametersRcd>(edm::ESInputTag{})} {}
 
 HcalParametersAnalyzer::~HcalParametersAnalyzer( void ) {}
 
 void HcalParametersAnalyzer::analyze( const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup ) {
-  edm::ESHandle<HcalParameters> parHandle;
-  iSetup.get<HcalParametersRcd>().get( parHandle );
-  const HcalParameters* pars ( parHandle.product());
+  const auto& parR = iSetup.getData(parToken_);
+  const HcalParameters* pars = &parR;
 
   std::cout << "rHB: ";
   for( const auto& it : pars->rHB ) {

--- a/Geometry/HcalCommonData/test/HcalRecNumberingTester.cc
+++ b/Geometry/HcalCommonData/test/HcalRecNumberingTester.cc
@@ -45,24 +45,23 @@ public:
   explicit HcalRecNumberingTester( const edm::ParameterSet& );
   ~HcalRecNumberingTester() override;
 
-  void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
-  void endJob() override {}
+
+private:
+  edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> token_;
 };
 
-HcalRecNumberingTester::HcalRecNumberingTester(const edm::ParameterSet& ) {}
+HcalRecNumberingTester::HcalRecNumberingTester(const edm::ParameterSet& ):
+  token_{esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord>(edm::ESInputTag{})} {}
 
 HcalRecNumberingTester::~HcalRecNumberingTester() {}
 
 // ------------ method called to produce the data  ------------
 void HcalRecNumberingTester::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
 
-  edm::ESHandle<HcalDDDRecConstants> pHSNDC;
-  iSetup.get<HcalRecNumberingRecord>().get(pHSNDC);
-
-  if (pHSNDC.isValid()) {
+  if (auto pHSNDC = iSetup.getHandle(token_)) {
     edm::LogVerbatim("HcalGeom") << "about to de-reference the edm::ESHandle<HcalDDDRecConstants> pHSNDC";
-    const HcalDDDRecConstants hdc (*pHSNDC);
+    const HcalDDDRecConstants& hdc (*pHSNDC);
     edm::LogVerbatim("HcalGeom") << "about to getPhiOff and getPhiBin for 0..2";
     int neta = hdc.getNEta();
     edm::LogVerbatim("HcalGeom") << neta << " eta bins with phi off set for "

--- a/Geometry/HcalCommonData/test/HcalSimNumberingTester.cc
+++ b/Geometry/HcalCommonData/test/HcalSimNumberingTester.cc
@@ -44,12 +44,14 @@ public:
   explicit HcalSimNumberingTester( const edm::ParameterSet& );
   ~HcalSimNumberingTester() override;
 
-  void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
-  void endJob() override {}
+
+private:
+  edm::ESGetToken<HcalDDDSimConstants, HcalSimNumberingRecord> token_;
 };
 
-HcalSimNumberingTester::HcalSimNumberingTester(const edm::ParameterSet& ) {}
+HcalSimNumberingTester::HcalSimNumberingTester(const edm::ParameterSet& )
+  : token_{esConsumes<HcalDDDSimConstants, HcalSimNumberingRecord>(edm::ESInputTag{})} {}
 
 
 HcalSimNumberingTester::~HcalSimNumberingTester() {}
@@ -57,10 +59,7 @@ HcalSimNumberingTester::~HcalSimNumberingTester() {}
 // ------------ method called to produce the data  ------------
 void HcalSimNumberingTester::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
 
-  edm::ESHandle<HcalDDDSimConstants> pHSNDC;
-  iSetup.get<HcalSimNumberingRecord>().get( pHSNDC );
-
-  if (pHSNDC.isValid()) {
+  if (auto pHSNDC = iSetup.getHandle(token_)) {
     edm::LogVerbatim("HcalGeom") << "about to de-reference the edm::ESHandle<HcalDDDSimConstants> pHSNDC";
     const HcalDDDSimConstants hdc (*pHSNDC);
     edm::LogVerbatim("HcalGeom") << "about to getConst for 0..1";


### PR DESCRIPTION
#### PR description:

This PR migrates all ES and ED modules in Geometry/HcalCommonData to EventSetup consumes (#26584).

#### PR validation:

Limited matrix runs.