### PR TITLE
Restore fed error treatment for phase0 pixel detector

### DIFF
--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -22,29 +22,29 @@ public:
 
   ErrorChecker();
 
-  void setErrorStatus(bool ErrorStatus);
+  void setErrorStatus(bool ErrorStatus) override;
 
-  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors);
+  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) override;
 
-  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors);
+  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) override;
 
-  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors);
+  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) override;
 
   bool checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
 		const SiPixelFedCabling* theCablingTree,
-		Word32& errorWord, Errors& errors);
+		Word32& errorWord, Errors& errors) override;
 
 
 
   void conversionError(int fedId, const SiPixelFrameConverter* converter, 
-		       int status, Word32& errorWord, Errors& errors);
+		       int status, Word32& errorWord, Errors& errors) override;
 
 private:
 
   bool includeErrors;
 
   cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, 
-	 	          int errorType, const Word32 & word) const;
+	 	          int errorType, const Word32 & word) const override;
 
 };
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -12,8 +12,6 @@
 class ErrorChecker : public ErrorCheckerBase {
 
 public:
-//  typedef unsigned int Word32;
-//  typedef long long Word64;
   typedef cms_uint32_t Word32;
   typedef cms_uint64_t Word64;
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -17,8 +17,6 @@ class SiPixelFedCabling;
 class ErrorCheckerBase {
 
 public:
-//  typedef unsigned int Word32;
-//  typedef long long Word64;
   typedef cms_uint32_t Word32;
   typedef cms_uint64_t Word64;
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerBase.h
@@ -1,0 +1,54 @@
+#ifndef ErrorCheckerBase_H
+#define ErrorCheckerBase_H
+/** \class ErrorCheckerBase
+ *
+ *  
+ */
+
+#include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
+
+#include <vector>
+#include <map>
+
+
+class SiPixelFrameConverter;
+class SiPixelFedCabling;
+
+class ErrorCheckerBase {
+
+public:
+//  typedef unsigned int Word32;
+//  typedef long long Word64;
+  typedef cms_uint32_t Word32;
+  typedef cms_uint64_t Word64;
+
+  typedef std::vector<SiPixelRawDataError> DetErrors;
+  typedef std::map<cms_uint32_t, DetErrors> Errors;
+
+  virtual ~ErrorCheckerBase() {};
+
+  virtual void setErrorStatus(bool ErrorStatus)=0;
+
+  virtual bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors)=0;
+
+  virtual bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors)=0;
+
+  virtual bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors)=0;
+
+  virtual bool checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
+		const SiPixelFedCabling* theCablingTree,
+		Word32& errorWord, Errors& errors)=0;
+
+
+
+  virtual void conversionError(int fedId, const SiPixelFrameConverter* converter, 
+		       int status, Word32& errorWord, Errors& errors)=0;
+
+private:
+
+  virtual  cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, 
+	 	          int errorType, const Word32 & word) const =0;
+
+};
+
+#endif

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -1,6 +1,6 @@
-#ifndef ErrorChecker_H
-#define ErrorChecker_H
-/** \class ErrorChecker
+#ifndef ErrorCheckerPhase0_H
+#define ErrorCheckerPhase0_H
+/** \class ErrorCheckerPhase0
  *
  *  
  */
@@ -9,7 +9,7 @@
 #include "FWCore/Utilities/interface/typedefs.h"
 
 
-class ErrorChecker : public ErrorCheckerBase {
+class ErrorCheckerPhase0 : public ErrorCheckerBase {
 
 public:
 //  typedef unsigned int Word32;
@@ -20,7 +20,7 @@ public:
   typedef std::vector<SiPixelRawDataError> DetErrors;
   typedef std::map<cms_uint32_t, DetErrors> Errors;
 
-  ErrorChecker();
+  ErrorCheckerPhase0();
 
   void setErrorStatus(bool ErrorStatus);
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -22,29 +22,29 @@ public:
 
   ErrorCheckerPhase0();
 
-  void setErrorStatus(bool ErrorStatus);
+  void setErrorStatus(bool ErrorStatus) override;
 
-  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors);
+  bool checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) override;
 
-  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors);
+  bool checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) override;
 
-  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors);
+  bool checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) override;
 
   bool checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
 		const SiPixelFedCabling* theCablingTree,
-		Word32& errorWord, Errors& errors);
+		Word32& errorWord, Errors& errors) override;
 
 
 
   void conversionError(int fedId, const SiPixelFrameConverter* converter, 
-		       int status, Word32& errorWord, Errors& errors);
+		       int status, Word32& errorWord, Errors& errors) override;
 
 private:
 
   bool includeErrors;
 
   cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, 
-	 	          int errorType, const Word32 & word) const;
+	 	          int errorType, const Word32 & word) const override;
 
 };
 

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h
@@ -12,8 +12,6 @@
 class ErrorCheckerPhase0 : public ErrorCheckerBase {
 
 public:
-//  typedef unsigned int Word32;
-//  typedef long long Word64;
   typedef cms_uint32_t Word32;
   typedef cms_uint64_t Word64;
 

--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -39,6 +39,7 @@
 #include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h"
+#include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h"
 #include "FWCore/Utilities/interface/typedefs.h"
 #include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 
@@ -101,7 +102,7 @@ private:
   bool debug;
   int allDetDigis;
   int hasDetDigis;
-  ErrorChecker errorcheck;
+  std::unique_ptr<ErrorCheckerBase> errorcheck;
 
   // For the 32bit data format (moved from *.cc namespace, keep uppercase for compatibility)
   // Add special layer 1 roc for phase1

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
@@ -136,7 +136,7 @@ void SiPixelDigiToRaw::produce( edm::StreamID, edm::Event& ev,
 
   PixelDataFormatter::BadChannels badChannels;
   edm::Handle<PixelFEDChannelCollection> pixelFEDChannelCollectionHandle;
-  if (ev.getByToken(theBadPixelFEDChannelsToken, pixelFEDChannelCollectionHandle)){
+  if (usePhase1==true && ev.getByToken(theBadPixelFEDChannelsToken, pixelFEDChannelCollectionHandle)){
     for (auto const& fedChannels: *pixelFEDChannelCollectionHandle) {
       PixelDataFormatter::DetBadChannels detBadChannels;
       for(const auto& fedChannel: fedChannels) {

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
@@ -136,7 +136,7 @@ void SiPixelDigiToRaw::produce( edm::StreamID, edm::Event& ev,
 
   PixelDataFormatter::BadChannels badChannels;
   edm::Handle<PixelFEDChannelCollection> pixelFEDChannelCollectionHandle;
-  if (usePhase1==true && ev.getByToken(theBadPixelFEDChannelsToken, pixelFEDChannelCollectionHandle)){
+  if (usePhase1 && ev.getByToken(theBadPixelFEDChannelsToken, pixelFEDChannelCollectionHandle)){
     for (auto const& fedChannels: *pixelFEDChannelCollectionHandle) {
       PixelDataFormatter::DetBadChannels detBadChannels;
       for(const auto& fedChannel: fedChannels) {

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -252,7 +252,7 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
 	  for (auto const& aPixelError : errorDetSet) {
 	    // For the time being, we extend the error handling functionality with ErrorType 25
 	    // In the future, we should sort out how the usage of tkerrorlist can be generalized
-	    if (usePhase1==true && aPixelError.getType()==25) {
+	    if (usePhase1 && aPixelError.getType()==25) {
 	      assert(aPixelError.getFedId()==fedId);
 	      const sipixelobjects::PixelFEDCabling* fed = cabling_->fed(fedId);
 	      if (fed) {

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -252,7 +252,7 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
 	  for (auto const& aPixelError : errorDetSet) {
 	    // For the time being, we extend the error handling functionality with ErrorType 25
 	    // In the future, we should sort out how the usage of tkerrorlist can be generalized
-	    if (aPixelError.getType()==25) {
+	    if (usePhase1==true && aPixelError.getType()==25) {
 	      assert(aPixelError.getFedId()==fedId);
 	      const sipixelobjects::PixelFEDCabling* fed = cabling_->fed(fedId);
 	      if (fed) {

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
@@ -1,0 +1,298 @@
+#include "EventFilter/SiPixelRawToDigi/interface/ErrorCheckerPhase0.h"
+
+#include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/FEDRawData/interface/FEDHeader.h"
+#include "DataFormats/FEDRawData/interface/FEDTrailer.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <bitset>
+#include <sstream>
+#include <iostream>
+
+using namespace std;
+using namespace edm;
+using namespace sipixelobjects;
+
+namespace {
+  constexpr int CRC_bits = 1;
+  constexpr int LINK_bits = 6;
+  constexpr int ROC_bits  = 5;
+  constexpr int DCOL_bits = 5;
+  constexpr int PXID_bits = 8;
+  constexpr int ADC_bits  = 8;
+  constexpr int OMIT_ERR_bits = 1;
+  
+  constexpr int CRC_shift = 2;
+  constexpr int ADC_shift  = 0;
+  constexpr int PXID_shift = ADC_shift + ADC_bits;
+  constexpr int DCOL_shift = PXID_shift + PXID_bits;
+  constexpr int ROC_shift  = DCOL_shift + DCOL_bits;
+  constexpr int LINK_shift = ROC_shift + ROC_bits;
+  constexpr int OMIT_ERR_shift = 20;
+  
+  constexpr cms_uint32_t dummyDetId = 0xffffffff;
+  
+  constexpr ErrorCheckerPhase0::Word64 CRC_mask = ~(~ErrorCheckerPhase0::Word64(0) << CRC_bits);
+  constexpr ErrorCheckerPhase0::Word32 ERROR_mask = ~(~ErrorCheckerPhase0::Word32(0) << ROC_bits);
+  constexpr ErrorCheckerPhase0::Word32 LINK_mask = ~(~ErrorCheckerPhase0::Word32(0) << LINK_bits);
+  constexpr ErrorCheckerPhase0::Word32 ROC_mask  = ~(~ErrorCheckerPhase0::Word32(0) << ROC_bits);
+  constexpr ErrorCheckerPhase0::Word32 OMIT_ERR_mask = ~(~ErrorCheckerPhase0::Word32(0) << OMIT_ERR_bits);
+}  
+
+ErrorCheckerPhase0::ErrorCheckerPhase0() {
+
+  includeErrors = false;
+}
+
+void ErrorCheckerPhase0::setErrorStatus(bool ErrorStatus)
+{
+  includeErrors = ErrorStatus;
+}
+
+bool ErrorCheckerPhase0::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors)
+{
+  int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
+  if (CRC_BIT == 0) return true;
+  errorsInEvent = true;
+  if (includeErrors) {
+    int errorType = 39;
+    SiPixelRawDataError error(*trailer, errorType, fedId);
+    errors[dummyDetId].push_back(error);
+  }
+  return false;
+}
+
+bool ErrorCheckerPhase0::checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors)
+{
+  FEDHeader fedHeader( reinterpret_cast<const unsigned char*>(header));
+  if ( !fedHeader.check() ) return false; // throw exception?
+  if ( fedHeader.sourceID() != fedId) { 
+    LogDebug("PixelDataFormatter::interpretRawData, fedHeader.sourceID() != fedId")
+      <<", sourceID = " <<fedHeader.sourceID()
+      <<", fedId = "<<fedId<<", errorType = 32"; 
+    errorsInEvent = true;
+    if (includeErrors) {
+      int errorType = 32;
+      SiPixelRawDataError error(*header, errorType, fedId);
+      errors[dummyDetId].push_back(error);
+    }
+  }
+  return fedHeader.moreHeaders();
+}
+
+bool ErrorCheckerPhase0::checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors)
+{
+  FEDTrailer fedTrailer(reinterpret_cast<const unsigned char*>(trailer));
+  if ( !fedTrailer.check()) { 
+    if(includeErrors) {
+      int errorType = 33;
+      SiPixelRawDataError error(*trailer, errorType, fedId);
+      errors[dummyDetId].push_back(error);
+    }
+    errorsInEvent = true;
+    LogError("FedTrailerCheck")
+      <<"fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
+    return false; 
+  } 
+  if ( fedTrailer.fragmentLength()!= nWords) {
+    LogError("FedTrailerLenght")<< "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId << ", errorType = 34";
+    errorsInEvent = true;
+    if(includeErrors) {
+      int errorType = 34;
+      SiPixelRawDataError error(*trailer, errorType, fedId);
+      errors[dummyDetId].push_back(error);
+    }
+  }
+  return fedTrailer.moreTrailers();
+}
+
+bool ErrorCheckerPhase0::checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
+			    const SiPixelFedCabling* theCablingTree, Word32& errorWord, Errors& errors)
+{
+  int errorType = (errorWord >> ROC_shift) & ERROR_mask;
+  if LIKELY(errorType<25) return true;
+
+ switch (errorType) {
+    case(25) : {
+     LogDebug("")<<"  invalid ROC=25 found (errorType=25)";
+     errorsInEvent = true;
+     break;
+   }
+   case(26) : {
+     //LogDebug("")<<"  gap word found (errorType=26)";
+     return false;
+   }
+   case(27) : {
+     //LogDebug("")<<"  dummy word found (errorType=27)";
+     return false;
+   }
+   case(28) : {
+     LogDebug("")<<"  error fifo nearly full (errorType=28)";
+     errorsInEvent = true;
+     break;
+   }
+   case(29) : {
+     LogDebug("")<<"  timeout on a channel (errorType=29)";
+     errorsInEvent = true;
+     if ((errorWord >> OMIT_ERR_shift) & OMIT_ERR_mask) {
+       LogDebug("")<<"  ...first errorType=29 error, this gets masked out";
+       return false;
+     }
+     break;
+   }
+   case(30) : {
+     LogDebug("")<<"  TBM error trailer (errorType=30)";
+     errorsInEvent = true;
+     break;
+   }
+   case(31) : {
+     LogDebug("")<<"  event number error (errorType=31)";
+     errorsInEvent = true;
+     break;
+   }
+   default: return true;
+ };
+
+ if(includeErrors) {
+   // check to see if overflow error for type 30, change type to 40 if so
+   if(errorType==30) {
+     int StateMach_bits      = 4;
+     int StateMach_shift     = 8;
+     uint32_t StateMach_mask = ~(~uint32_t(0) << StateMach_bits);
+     int StateMach = (errorWord >> StateMach_shift) & StateMach_mask;
+     if( StateMach==4 || StateMach==9 ) errorType = 40;
+   }
+
+   // store error
+   SiPixelRawDataError error(errorWord, errorType, fedId);
+   cms_uint32_t detId;
+   detId = errorDetId(converter, errorType, errorWord);
+   errors[detId].push_back(error);
+ }
+ return false;
+}
+
+void ErrorCheckerPhase0::conversionError(int fedId, const SiPixelFrameConverter* converter, int status, Word32& errorWord, Errors& errors)
+{
+  switch (status) {
+  case(1) : {
+    LogDebug("ErrorCheckerPhase0::conversionError") << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
+    if(includeErrors) {
+      int errorType = 35;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
+    }
+    break;
+  }
+  case(2) : {
+    LogDebug("ErrorCheckerPhase0::conversionError")<< " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
+    if(includeErrors) {
+      int errorType = 36;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
+    }
+    break;
+  }
+  case(3) : {
+    LogDebug("ErrorCheckerPhase0::conversionError")<< " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
+    if(includeErrors) {
+      int errorType = 37;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
+    }
+    break;
+  }
+  case(4) : {
+    LogDebug("ErrorCheckerPhase0::conversionError")<< " Fed: " << fedId << "  dcol/pixel read out of order (errorType=38)";
+    if(includeErrors) {
+      int errorType = 38;
+      SiPixelRawDataError error(errorWord, errorType, fedId);
+      cms_uint32_t detId = errorDetId(converter, errorType, errorWord);
+      errors[detId].push_back(error);
+    }
+    break;
+  }
+  default: LogDebug("ErrorCheckerPhase0::conversionError")<<"  cabling check returned unexpected result, status = "<< status;
+  };
+}
+
+// this function finds the detId for an error word that cannot be processed in word2digi
+cms_uint32_t ErrorCheckerPhase0::errorDetId(const SiPixelFrameConverter* converter, 
+    int errorType, const Word32 & word) const
+{
+  if (!converter) return dummyDetId;
+
+  ElectronicIndex cabling;
+
+  switch (errorType) {
+    case  25 : case  30 : case  31 : case  36 : case 40 : {
+      // set dummy values for cabling just to get detId from link if in Barrel
+      cabling.dcol = 0;
+      cabling.pxid = 2;
+      cabling.roc  = 1;
+      cabling.link = (word >> LINK_shift) & LINK_mask;  
+
+      DetectorIndex detIdx;
+      int status = converter->toDetector(cabling, detIdx);
+      if (status) break;
+      if(DetId(detIdx.rawId).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) return detIdx.rawId;
+      break;
+    }
+    case  29 : {
+      int chanNmbr = 0;
+      const int DB0_shift = 0;
+      const int DB1_shift = DB0_shift + 1;
+      const int DB2_shift = DB1_shift + 1;
+      const int DB3_shift = DB2_shift + 1;
+      const int DB4_shift = DB3_shift + 1;
+      const cms_uint32_t DataBit_mask = ~(~cms_uint32_t(0) << 1);
+
+      int CH1 = (word >> DB0_shift) & DataBit_mask;
+      int CH2 = (word >> DB1_shift) & DataBit_mask;
+      int CH3 = (word >> DB2_shift) & DataBit_mask;
+      int CH4 = (word >> DB3_shift) & DataBit_mask;
+      int CH5 = (word >> DB4_shift) & DataBit_mask;
+      int BLOCK_bits      = 3;
+      int BLOCK_shift     = 8;
+      cms_uint32_t BLOCK_mask = ~(~cms_uint32_t(0) << BLOCK_bits);
+      int BLOCK = (word >> BLOCK_shift) & BLOCK_mask;
+      int localCH = 1*CH1+2*CH2+3*CH3+4*CH4+5*CH5;
+      if (BLOCK%2==0) chanNmbr=(BLOCK/2)*9+localCH;
+      else chanNmbr = ((BLOCK-1)/2)*9+4+localCH;
+      if ((chanNmbr<1)||(chanNmbr>36)) break;  // signifies unexpected result
+      
+      // set dummy values for cabling just to get detId from link if in Barrel
+      cabling.dcol = 0;
+      cabling.pxid = 2;
+      cabling.roc  = 1;
+      cabling.link = chanNmbr;  
+      DetectorIndex detIdx;
+      int status = converter->toDetector(cabling, detIdx);
+      if (status) break;
+      if(DetId(detIdx.rawId).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) return detIdx.rawId;
+      break;
+    }
+    case  37 : case  38: {
+      cabling.dcol = 0;
+      cabling.pxid = 2;
+      cabling.roc  = (word >> ROC_shift) & ROC_mask;
+      cabling.link = (word >> LINK_shift) & LINK_mask;
+
+      DetectorIndex detIdx;
+      int status = converter->toDetector(cabling, detIdx);
+      if (status) break;
+
+      return detIdx.rawId;
+      break;
+    }
+  default : break;
+  };
+  return dummyDetId;
+}

--- a/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorCheckerPhase0.cc
@@ -123,11 +123,9 @@ bool ErrorCheckerPhase0::checkROC(bool& errorsInEvent, int fedId, const SiPixelF
      break;
    }
    case(26) : {
-     //LogDebug("")<<"  gap word found (errorType=26)";
      return false;
    }
    case(27) : {
-     //LogDebug("")<<"  dummy word found (errorType=27)";
      return false;
    }
    case(28) : {

--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -100,12 +100,17 @@ PixelDataFormatter::PixelDataFormatter( const SiPixelFedCabling* map, bool phase
   PXID_mask = ~(~PixelDataFormatter::Word32(0) << PXID_bits);
   ADC_mask  = ~(~PixelDataFormatter::Word32(0) << ADC_bits);
 
+  if (phase1==true) {
+    errorcheck=std::unique_ptr<ErrorCheckerBase>(new ErrorChecker());
+  } else {
+    errorcheck=std::unique_ptr<ErrorCheckerBase>(new ErrorCheckerPhase0());
+  }
 }
 
 void PixelDataFormatter::setErrorStatus(bool ErrorStatus)
 {
   includeErrors = ErrorStatus;
-  errorcheck.setErrorStatus(includeErrors);
+  errorcheck->setErrorStatus(includeErrors);
 }
 
 void PixelDataFormatter::setQualityStatus(bool QualityStatus, const SiPixelQuality* QualityInfo)
@@ -135,7 +140,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 
   // check CRC bit
   const Word64* trailer = reinterpret_cast<const Word64* >(rawData.data())+(nWords-1);  
-  if(!errorcheck.checkCRC(errorsInEvent, fedId, trailer, errors)) return;
+  if(!errorcheck->checkCRC(errorsInEvent, fedId, trailer, errors)) return;
 
   // check headers
   const Word64* header = reinterpret_cast<const Word64* >(rawData.data()); header--;
@@ -143,7 +148,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
   while (moreHeaders) {
     header++;
     LogTrace("")<<"HEADER:  " <<  print(*header);
-    bool headerStatus = errorcheck.checkHeader(errorsInEvent, fedId, header, errors);
+    bool headerStatus = errorcheck->checkHeader(errorsInEvent, fedId, header, errors);
     moreHeaders = headerStatus;
   }
 
@@ -153,7 +158,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
   while (moreTrailers) {
     trailer--;
     LogTrace("")<<"TRAILER: " <<  print(*trailer);
-    bool trailerStatus = errorcheck.checkTrailer(errorsInEvent, fedId, nWords, trailer, errors);
+    bool trailerStatus = errorcheck->checkTrailer(errorsInEvent, fedId, nWords, trailer, errors);
     moreTrailers = trailerStatus;
   }
 
@@ -183,12 +188,12 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 
     if ( (nlink!=link) | (nroc!=roc) ) {  // new roc
       link = nlink; roc=nroc;
-      skipROC = LIKELY(roc<maxROCIndex) ? false : !errorcheck.checkROC(errorsInEvent, fedId, &converter, theCablingTree, ww, errors);
+      skipROC = LIKELY(roc<maxROCIndex) ? false : !errorcheck->checkROC(errorsInEvent, fedId, &converter, theCablingTree, ww, errors);
       if (skipROC) continue;
       rocp = converter.toRoc(link,roc);
       if UNLIKELY(!rocp) {
 	errorsInEvent = true;
-	errorcheck.conversionError(fedId, &converter, 2, ww, errors);
+	errorcheck->conversionError(fedId, &converter, 2, ww, errors);
 	skipROC=true;
 	continue;
       }
@@ -231,7 +236,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 	  LogDebug("PixelDataFormatter::interpretRawData") 
 	    << "status #3";
 	  errorsInEvent = true;
-	  errorcheck.conversionError(fedId, &converter, 3, ww, errors);
+	  errorcheck->conversionError(fedId, &converter, 3, ww, errors);
 	  continue;
 	}
       local = std::make_unique<LocalPixel>(localCR); // local pixel coordinate 
@@ -250,7 +255,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 	  LogDebug("PixelDataFormatter::interpretRawData") 
 	    << "status #3";
 	  errorsInEvent = true;
-	  errorcheck.conversionError(fedId, &converter, 3, ww, errors);
+	  errorcheck->conversionError(fedId, &converter, 3, ww, errors);
 	  continue;
 	}
       local = std::make_unique<LocalPixel>(localDP); // local pixel coordinate 

--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -100,7 +100,7 @@ PixelDataFormatter::PixelDataFormatter( const SiPixelFedCabling* map, bool phase
   PXID_mask = ~(~PixelDataFormatter::Word32(0) << PXID_bits);
   ADC_mask  = ~(~PixelDataFormatter::Word32(0) << ADC_bits);
 
-  if (phase1==true) {
+  if (phase1) {
     errorcheck=std::unique_ptr<ErrorCheckerBase>(new ErrorChecker());
   } else {
     errorcheck=std::unique_ptr<ErrorCheckerBase>(new ErrorCheckerPhase0());


### PR DESCRIPTION
Resubmitting original [PR26606](https://github.com/cms-sw/cmssw/pull/26606/) without the format checks.

PR description:

The FED raw data format for phase 0 and phase 1 detectors are essentially the same with small differences for the bit-packing of the pixel hit information in layer 1. There is a difference also in the error assignment by the front-end (*). The former case has been treated in the PixelDataFormatter by setting the 'phase1' variable through python configuration files. The error decoding class, called ErrorChecker, however was not made aware of the difference, instead, was just simply updated to phase 1.
This PR fixes that: a base class is defined for the ErrorChecker, the present default code is kept with the same name deriving from this base, and a new derived class ErrorCheckerPhase0 is introduced to restore the phase 0 treatment. The proper error checker is instantiated by the PixelDataFormatter based on the value of 'phase1', so no change needs to be made in the python configurations.

FED error 25: in phase 1, FED error type 25 has been reinterpreted and used by the FED firmware to signal "dead" links. It is used to flag stuck TBMs. This error has a totally different meaning in phase 0. In this PR, the special treatment of this error type by raw-to-digi and digi-to-raw is cancelled for phase 0.

(*) Few error codes have different interpretation; and in phase 0 FPix, the error association with detId is ambiguous.
PR validation:

During the reconstruction of phase 0 data, when a rare type 25 error was encountered, the tracking code crashed. This PR fixes that. The FED25 error packing in simulation, and unpacking in simulation and data for phase 1 should be unchanged, are being validated by @tsusa.

@tsusa @mmusich @dkotlins