### PR TITLE
print statement fixes and preserve integer division with python3

### DIFF
--- a/DQMServices/FwkIO/test/read_merged_file1_file3_file2_cfg.py
+++ b/DQMServices/FwkIO/test/read_merged_file1_file3_file2_cfg.py
@@ -33,7 +33,7 @@ readLumiElements=list()
 for i in range(0,10):
     readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                           #file3, which is run 2 has means shifted by 1
-                                          means = cms.untracked.vdouble([i+x/20 for x in range(0,30)]),
+                                          means = cms.untracked.vdouble([i+x//20 for x in range(0,30)]),
                                           entries=cms.untracked.vdouble([1 for x in range(0,30)])
                                           ))
 

--- a/DQMServices/FwkIO/test/read_merged_file1_file3_file4_cfg.py
+++ b/DQMServices/FwkIO/test/read_merged_file1_file3_file4_cfg.py
@@ -53,7 +53,7 @@ readLumiElements=list()
 for i in range(0,10):
     readLumiElements.append(cms.untracked.PSet(name=cms.untracked.string("Foo"+str(i)),
                                           #file3, which is run 2 has means shifted by 1
-                                          means = cms.untracked.vdouble([(i+x/10-x/20-x/20) for x in range(0,30)]),
+                                          means = cms.untracked.vdouble([(i+x//10-x//20-x//20) for x in range(0,30)]),
                                           entries=cms.untracked.vdouble([1 for x in range(0,30)])
                                           ))
 

--- a/Validation/Geometry/test/runP_Tracker_cfg.py
+++ b/Validation/Geometry/test/runP_Tracker_cfg.py
@@ -2,7 +2,7 @@
 #
 # for t in {'BeamPipe','Tracker','PixBar','PixFwdMinus','PixFwdPlus','TIB','TOB','TIDB','TIDF','TEC','TkStrct','InnerServices'}; do cmsRun runP_Tracker_cfg.py geom=XYZ label=$t >& /dev/null &; done
 
-
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing
 import sys, re
@@ -62,9 +62,9 @@ process.MessageLogger = cms.Service(
     )
 
 if options.label not in _ALLOWED_LABELS:
-    print "\n*** Error, '%s' not registered as a valid components to monitor." % options.label
-    print "Allowed components:", _ALLOWED_LABELS
-    print
+    print("\n*** Error, '%s' not registered as a valid components to monitor." % options.label)
+    print("Allowed components:", _ALLOWED_LABELS)
+    print()
     raise RuntimeError("Unknown label")
 
 _components = _LABELS2COMPS[options.label]


### PR DESCRIPTION
Fixes failing unit test in DEVEL IBs - the Validation/Geometry unit tests will still fail as our root build does not yet have pyroot working with python3.