### PR TITLE
Get rid of useless repeated config_.exists() in SiPixelRawToDigi.cc

### DIFF
--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -51,12 +51,10 @@ SiPixelRawToDigi::SiPixelRawToDigi( const edm::ParameterSet& conf )
   
   includeErrors = config_.getParameter<bool>("IncludeErrors");
   useQuality = config_.getParameter<bool>("UseQualityInfo");
-  if (config_.exists("ErrorList")) {
-    tkerrorlist = config_.getParameter<std::vector<int> > ("ErrorList");
-  }
-  if (config_.exists("UserErrorList")) {
-    usererrorlist = config_.getParameter<std::vector<int> > ("UserErrorList");
-  }
+
+  tkerrorlist = config_.getParameter<std::vector<int> > ("ErrorList");
+  usererrorlist = config_.getParameter<std::vector<int> > ("UserErrorList");
+
   tFEDRawDataCollection = consumes <FEDRawDataCollection> (config_.getParameter<edm::InputTag>("InputLabel"));
   
   //start counters
@@ -73,11 +71,8 @@ SiPixelRawToDigi::SiPixelRawToDigi( const edm::ParameterSet& conf )
   }
   
   // regions
-  if (config_.exists("Regions")) {
-    if(!config_.getParameter<edm::ParameterSet>("Regions").getParameterNames().empty())
-    {
-      regions_ = new PixelUnpackingRegions(config_, consumesCollector());
-    }
+  if(!config_.getParameter<edm::ParameterSet>("Regions").getParameterNames().empty()) {
+    regions_ = new PixelUnpackingRegions(config_, consumesCollector());
   }
 
   // Timing
@@ -89,18 +84,13 @@ SiPixelRawToDigi::SiPixelRawToDigi( const edm::ParameterSet& conf )
   }
 
   // Control the usage of pilot-blade data, FED=40
-  usePilotBlade = false; 
-  if (config_.exists("UsePilotBlade")) {
-    usePilotBlade = config_.getParameter<bool> ("UsePilotBlade");
-    if(usePilotBlade) edm::LogInfo("SiPixelRawToDigi")  << " Use pilot blade data (FED 40)";
-  }
+  usePilotBlade = config_.getParameter<bool> ("UsePilotBlade");
+  if(usePilotBlade) edm::LogInfo("SiPixelRawToDigi")  << " Use pilot blade data (FED 40)";
 
   // Control the usage of phase1
-  usePhase1 = false;
-  if (config_.exists("UsePhase1")) {
-    usePhase1 = config_.getParameter<bool> ("UsePhase1");
-    if(usePhase1) edm::LogInfo("SiPixelRawToDigi")  << " Using phase1";
-  }
+  usePhase1 = config_.getParameter<bool> ("UsePhase1");
+  if(usePhase1) edm::LogInfo("SiPixelRawToDigi")  << " Using phase1";
+
   //CablingMap could have a label //Tav
   cablingMapLabel = config_.getParameter<std::string> ("CablingMapLabel");
 
@@ -197,7 +187,6 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
   auto usererror_detidcollection = std::make_unique<DetIdCollection>();
   auto disabled_channelcollection = std::make_unique<edmNew::DetSetVector<PixelFEDChannel> >();
 
-  //PixelDataFormatter formatter(cabling_.get()); // phase 0 only
   PixelDataFormatter formatter(cabling_.get(), usePhase1); // for phase 1 & 0
 
   formatter.setErrorStatus(includeErrors);


### PR DESCRIPTION
#### PR description:

During the review of #26606/#26679 I noticed a number of useless checks for the existence of configuration parameters, not needed any more since those parameters are now always defined by the fillDescriptions method of the class.

In order not to interfere and delay the approval of #26679, this technical/cosmetic change has been kept separated here: from the practical point of view, no changes in outputs can be expected.

#### PR validation:

It builds
