### PR TITLE
preserve integer divisions compatible with python3 syntax

### DIFF
--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -317,7 +317,7 @@ def getPTAveVPSet(thresholds = [30, 60, 80, 100, 160, 220, 300], flavour="HFJEC"
             )
             ret.append(recoPF) 
             '''
-            recoThr = t/2
+            recoThr = t//2
             recoPFtopology  =  cms.PSet(
                 triggerSelection = cms.string(partialPathName+"*"),
                 handlerType = cms.string("RecoPFJetWithJEC"),
@@ -363,7 +363,7 @@ def getPTAveVPSet(thresholds = [30, 60, 80, 100, 160, 220, 300], flavour="HFJEC"
 
             # RecoCandidateCounter
             ''' example on how to count objects
-            recoThr = t/2
+            recoThr = t//2
             recoPFJetCnt  =  cms.PSet(
                 triggerSelection = cms.string(partialPathName+"*"),
                 handlerType = cms.string("RecoCandidateCounter"),

--- a/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
+++ b/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
@@ -22,7 +22,7 @@ me0TriggerPseudoDigis = me0Segments.clone(
 ## 1.2 is to make the matching window safely the two nearest strips
 ## 0.35 is the size of an ME0 chamber in radians
 ## nStrips is divided by 2 since we use 2-strip trigger pads
-nStrips = simMuonME0PseudoReDigisCoarse.numberOfStrips.value()/2
+nStrips = simMuonME0PseudoReDigisCoarse.numberOfStrips.value()//2
 maxPhi = 1.2*0.35/nStrips
 me0TriggerPseudoDigis.algo_psets[1].algo_pset.maxPhiAdditional = cms.double(maxPhi)
 me0TriggerPseudoDigis.algo_psets[1].algo_pset.maxPhiSeeds = cms.double(maxPhi)


### PR DESCRIPTION
these are the only cases I see if cf*.py files where the division behavior would otherwise change in python3 vs python2 (I'm still looking for others... and of course there are the non-cf* files)